### PR TITLE
[Feat] raw_block: incremental base+delta checkpoint format

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -90,19 +90,61 @@ Rules:
 
 ## Persistence and Recovery
 
-`RawBlockCore` keeps the existing metadata checkpoint model:
+`RawBlockCore` checkpoints its in-memory state into a fixed metadata region at
+the head of the device. The model is:
 
-- metadata region reserved on the same device
-- periodic checkpointing
-- optional checkpoint load on startup
-- optional verification on load
-- recovery by loading the latest durable checkpoint and rebuilding the in-memory
-  index
-
-The on-device format is intentionally unchanged by the MP adapter work.
+- metadata region reserved on the same device, sized by `meta_total_bytes`
+- periodic checkpointing from a background thread, plus on-`close` flush
+- optional checkpoint load on startup (`load_checkpoint_on_init`)
+- optional per-slot header verification on load (`meta_verify_on_load`)
+- recovery rebuilds the in-memory index from the latest durable base plus any
+  durable delta records that follow it
 
 Recovered keys are exposed to the shared L2 eviction policy on adapter startup,
 so reclaimed slots come from global L2 eviction or explicit `delete()` calls.
+
+### On-device checkpoint format
+
+The metadata region is split into two equal-size mirrors. Within each mirror::
+
+    [ header (one block) ][ payload (round_up to block_align) ][ delta tail ]
+
+The delta tail starts implicitly at the block-aligned end of the base payload
+and runs to the mirror's end. There is no separate delta region.
+
+- Base header (`_META_HEADER_STRUCT`, 32 B): magic, version, monotonic seq,
+  payload length, and CRC32 over the payload. The two mirrors are read on
+  startup and the higher-seq valid one wins, giving a torn-write-safe ping-pong
+  flip.
+- Delta record header (`_DELTA_RECORD_HEADER_STRUCT`, 52 B): magic `LMCD`,
+  record version, parent `base_seq`, parent `base_crc`, monotonic
+  `delta_seq`, `prev_record_crc`, payload length and CRC32, op count, flags,
+  total blocks, reserved. Each record is block-aligned and binds itself to its
+  base via both `base_seq` *and* `base_crc`, so a stale tail surviving a mirror
+  flip is rejected even when the seq number happens to collide.
+  `prev_record_crc` chains records together and is anchored at `base_crc` for
+  the first record, catching tail bytes that look valid in isolation.
+- Compaction is a mirror flip: write a fresh full base into the inactive
+  mirror, zero the new mirror's tail head so it is unambiguously empty, then
+  commit the new header. A torn compaction leaves the previous active mirror
+  untouched as the durable winner.
+- Compaction triggers: tail full, oversized record, more than
+  `meta_full_checkpoint_max_deltas` deltas accumulated, or more than
+  `meta_full_checkpoint_interval_sec` since the last full base.
+- Backwards compatibility: a disk written by older code that has no delta
+  records reads naturally as "zero deltas applied" -- the tail bytes do not
+  carry the `LMCD` magic, replay stops on the first record, and the loaded
+  state matches the base alone.
+
+### Replay
+
+On open, the active mirror is selected by valid header with the higher
+`base_seq`. Its base payload is decoded into the in-memory index, then the
+delta tail is walked record-by-record. Replay stops at the first record that
+fails any check (bad magic, mismatched `base_seq` or `base_crc`, broken hash
+chain, non-monotonic `delta_seq`, oversized payload, CRC mismatch, or read
+error); everything earlier is durable and applied, everything after is treated
+as torn or stale.
 
 ## Configuration
 
@@ -122,6 +164,8 @@ The MP adapter is configured through `--l2-adapter` JSON:
   "meta_version": 1,
   "meta_checkpoint_interval_sec": 60,
   "meta_enable_periodic": true,
+  "meta_full_checkpoint_interval_sec": 600,
+  "meta_full_checkpoint_max_deltas": 1024,
   "load_checkpoint_on_init": true,
   "meta_verify_on_load": true,
   "num_store_workers": 2,
@@ -140,6 +184,11 @@ Important validation rules:
   of loading the latest on-device metadata checkpoint
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
+- `meta_full_checkpoint_max_deltas` bounds worst-case replay cost; raising it
+  reduces compaction frequency at the cost of more delta records to apply on
+  recovery
+- `meta_full_checkpoint_interval_sec` bounds worst-case staleness of the base
+  payload independent of mutation rate
 
 ## Relationship to Non-MP Mode
 

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -91,6 +91,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         num_store_workers: int = 2,
         num_lookup_workers: int = 1,
         num_load_workers: int = 4,
+        meta_full_checkpoint_interval_sec: int = 600,
+        meta_full_checkpoint_max_deltas: int = 1024,
     ):
         """Initialize raw-block MP adapter configuration.
 
@@ -117,6 +119,10 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             num_store_workers: Number of store worker threads.
             num_lookup_workers: Number of lookup worker threads.
             num_load_workers: Number of load worker threads.
+            meta_full_checkpoint_interval_sec: Force a full base compaction
+                at least this often, regardless of delta volume.
+            meta_full_checkpoint_max_deltas: Force compaction after this many
+                delta records since the last full base.
         """
         super().__init__()
         self.device_path = device_path
@@ -144,6 +150,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         self.num_store_workers = int(num_store_workers)
         self.num_lookup_workers = int(num_lookup_workers)
         self.num_load_workers = int(num_load_workers)
+        self.meta_full_checkpoint_interval_sec = int(meta_full_checkpoint_interval_sec)
+        self.meta_full_checkpoint_max_deltas = int(meta_full_checkpoint_max_deltas)
 
     @classmethod
     def from_dict(cls, d: dict) -> "RawBlockL2AdapterConfig":
@@ -230,6 +238,12 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             num_store_workers=worker_counts["num_store_workers"],
             num_lookup_workers=worker_counts["num_lookup_workers"],
             num_load_workers=worker_counts["num_load_workers"],
+            meta_full_checkpoint_interval_sec=int(
+                d.get("meta_full_checkpoint_interval_sec", 600)
+            ),
+            meta_full_checkpoint_max_deltas=int(
+                d.get("meta_full_checkpoint_max_deltas", 1024)
+            ),
         )
 
     @classmethod
@@ -270,7 +284,11 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "< 0: auto detect limit splitting)\n"
             "- num_store_workers (int): store worker threads (default 2)\n"
             "- num_lookup_workers (int): lookup worker threads (default 1)\n"
-            "- num_load_workers (int): load worker threads (default 4)"
+            "- num_load_workers (int): load worker threads (default 4)\n"
+            "- meta_full_checkpoint_interval_sec (int): force full compaction "
+            "at least this often (default 600)\n"
+            "- meta_full_checkpoint_max_deltas (int): compact after this many "
+            "delta records (default 1024)"
         )
 
     def to_core_config(self) -> RawBlockCoreConfig:
@@ -295,6 +313,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             iouring_queue_depth=self.iouring_queue_depth,
             use_uring_cmd=self.use_uring_cmd,
             max_data_transfer_size=self.max_data_transfer_size,
+            meta_full_checkpoint_interval_sec=self.meta_full_checkpoint_interval_sec,
+            meta_full_checkpoint_max_deltas=self.meta_full_checkpoint_max_deltas,
         )
 
 

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -314,6 +314,12 @@ class RustRawBlockBackend(StoragePluginInterface):
             io_engine=io_engine,
             iouring_queue_depth=iouring_queue_depth,
             use_uring_cmd=use_uring_cmd,
+            meta_full_checkpoint_interval_sec=int(
+                extra.get("rust_raw_block.meta_full_checkpoint_interval_sec", 600)
+            ),
+            meta_full_checkpoint_max_deltas=int(
+                extra.get("rust_raw_block.meta_full_checkpoint_max_deltas", 1024)
+            ),
         )
 
     def _warn_if_loaded_metadata_looks_cross_rank(self) -> None:

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -40,7 +40,20 @@ logger = init_logger(__name__)
 
 _DEFAULT_META_MAGIC = b"LMCIDX01"
 _DEFAULT_META_VERSION = 1
+# Single base-header version. Each mirror is laid out as
+# ``[ header (one block) ][ payload (rounded up to block_align) ][ delta tail ]``;
+# the tail starts implicitly at ``align_up(header + payload, block_align)`` and
+# extends to the mirror end. Disks written by older code with no tail bytes
+# read as "zero deltas" naturally, so no separate version is needed.
 _META_HEADER_STRUCT = struct.Struct("<8sIQQI")
+_DELTA_RECORD_MAGIC = b"LMCD"
+# Delta record header bound to its base via ``base_seq`` and ``base_crc`` so a
+# stale tail surviving from a previous base (after a mirror flip) is rejected
+# even when the seq number is reused. ``prev_record_crc`` chains records and
+# is anchored at ``base_crc`` for the first record, catching tail bytes that
+# happen to look valid in isolation.
+_DELTA_RECORD_HEADER_STRUCT = struct.Struct("<4sIQIQIIIHHII")
+_DELTA_RECORD_VERSION = 1
 RAW_BLOCK_IO_ENGINES = frozenset({"posix", "io_uring"})
 DEFAULT_IOURING_QUEUE_DEPTH = 256
 
@@ -149,6 +162,11 @@ class RawBlockCoreConfig:
     io_engine: str = "posix"
     iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH
     use_uring_cmd: bool = False
+    # Incremental checkpoint controls. Bound replay cost (max_deltas) and
+    # worst-case staleness (interval_sec); other compaction triggers come for
+    # free from the per-mirror tail filling up.
+    meta_full_checkpoint_interval_sec: int = 600
+    meta_full_checkpoint_max_deltas: int = 1024
 
 
 @dataclass
@@ -171,6 +189,29 @@ class RawBlockPutManyResult:
 
     results: list[bool]
     stored_keys: list[str]
+
+
+@dataclass(frozen=True)
+class _MetaLayout:
+    """On-device metadata region geometry.
+
+    The metadata region is split into ``len(base_copy_offsets)`` equal-size
+    mirrors. Within each mirror the layout is::
+
+        [ header (one block) ][ payload (round_up to block_align) ][ delta tail ]
+
+    The delta tail starts implicitly at the block-aligned end of the base
+    payload and extends to the mirror's end, so its size depends on the
+    current base payload length. There is no separate region.
+    """
+
+    block_align: int
+    base_copy_bytes: int
+    base_copy_offsets: tuple[int, ...]
+
+    @property
+    def base_payload_capacity(self) -> int:
+        return self.base_copy_bytes - self.block_align
 
 
 class RawBlockCore:
@@ -229,6 +270,12 @@ class RawBlockCore:
             )
             self.use_odirect = False
         self.key_namespace = key_namespace
+        self.meta_full_checkpoint_interval_sec = int(
+            config.meta_full_checkpoint_interval_sec
+        )
+        self.meta_full_checkpoint_max_deltas = int(
+            config.meta_full_checkpoint_max_deltas
+        )
 
         if not self.device_path:
             raise ValueError("RawBlockCore requires a non-empty device_path")
@@ -292,15 +339,15 @@ class RawBlockCore:
             raise ValueError("meta_magic must be ASCII bytes") from e
 
         self._meta_copy_count: int = 2
-        self._meta_container_bytes: int = (
-            (self.meta_total_bytes // self._meta_copy_count) // self.block_align
-        ) * self.block_align
-        if self._meta_container_bytes <= self.block_align:
-            raise ValueError(
-                "meta_total_bytes must provide room for at least two metadata copies"
-            )
+        self._meta_layout: _MetaLayout = self._build_meta_layout()
 
         self._lock = threading.Lock()
+        # Serializes checkpoint writes (full + delta) against each other so
+        # concurrent ``_checkpoint_once`` calls (background loop + manual
+        # flush + close) cannot race on the delta tail offset or mirror seq.
+        # Held only across a single checkpoint attempt; never held during
+        # put/get critical sections (those use ``self._lock`` instead).
+        self._writer_lock = threading.Lock()
         self._index: dict[str, _Entry] = {}
         self._lock_refcnt: dict[str, int] = {}
         self._inflight: dict[str, _Inflight] = {}
@@ -321,6 +368,26 @@ class RawBlockCore:
         self._last_io_ts: float = time.monotonic()
         self._meta_stop_evt = threading.Event()
         self._meta_thread: Optional[threading.Thread] = None
+
+        # Pending mutations since the last successful checkpoint write. Each
+        # entry is a JSON-serializable op dict consumed by the delta encoder.
+        self._dirty_log: list[dict[str, Any]] = []
+        # Tail-append state. ``_active_mirror_idx`` is the mirror that holds
+        # the current authoritative base; deltas append after its base
+        # payload. ``_active_base_payload_total`` is ``round_up(payload_len)``
+        # for that base, so the tail starts at ``block_align +
+        # _active_base_payload_total`` within the mirror.
+        self._delta_seq: int = 0
+        self._delta_tail_off: int = 0
+        self._active_base_seq: int = 0
+        self._active_base_crc: int = 0
+        self._active_mirror_idx: int = 0
+        self._active_base_payload_total: int = 0
+        # CRC32 of the most recent successfully written/replayed delta record.
+        # Anchors the per-record hash chain used during replay; ``None`` means
+        # "next record chains from active_base_crc".
+        self._last_record_crc: Optional[int] = None
+        self._last_full_ts: float = time.monotonic()
 
         try:
             self._ensure_capacity_and_layout()
@@ -679,18 +746,20 @@ class RawBlockCore:
                     results[i] = False
                     continue
                 if inflight.canceled or not success:
-                    self._append_free_slot_locked(
-                        self._offset_to_slot(int(inflight.offset))
-                    )
+                    freed_slot = self._offset_to_slot(int(inflight.offset))
+                    self._append_free_slot_locked(freed_slot)
+                    self._record_freelist_push_locked(freed_slot)
                     self._meta_dirty_total += 1
                     results[i] = False
                     continue
 
-                self._index[key.encoded] = _Entry(
+                entry = _Entry(
                     offset=inflight.offset,
                     size=inflight.meta.size,
                     meta=inflight.meta,
                 )
+                self._index[key.encoded] = entry
+                self._record_put_op_locked(key.encoded, entry)
                 self._meta_dirty_total += 1
                 results[i] = True
                 stored_keys.append(key.encoded)
@@ -864,9 +933,9 @@ class RawBlockCore:
                     inflight.canceled = True
                 self._lock_refcnt.pop(encoded_key, None)
                 if removed_entry is not None:
-                    self._append_free_slot_locked(
-                        self._offset_to_slot(int(removed_entry.offset))
-                    )
+                    freed_slot = self._offset_to_slot(int(removed_entry.offset))
+                    self._append_free_slot_locked(freed_slot)
+                    self._record_delete_op_locked(encoded_key, freed_slot)
                     self._meta_dirty_total += 1
                 deleted.append(removed_entry is not None or inflight is not None)
         return deleted
@@ -888,7 +957,13 @@ class RawBlockCore:
             return (usage, usage)
 
     def checkpoint_now(self) -> None:
-        """Synchronously write a metadata checkpoint."""
+        """Synchronously persist pending metadata mutations.
+
+        Bypasses the idle-quiet check so callers can flush from non-quiet
+        code paths. Appends one delta record to the active mirror's tail
+        when the dirty log fits; otherwise compacts by writing a fresh full
+        base into the other mirror. No-op when nothing is dirty.
+        """
         self._checkpoint_once(force=True)
 
     def apply_loaded_state(self, data: dict[str, Any]) -> bool:
@@ -901,7 +976,11 @@ class RawBlockCore:
             True when the payload shape and layout match this core and all
             valid entries were applied. Invalid per-entry records are skipped.
         """
-        return self._apply_loaded_state(data)
+        if not self._apply_loaded_state(data):
+            return False
+        if self.meta_verify_on_load:
+            self._validate_loaded_entries()
+        return True
 
     def report_status(self) -> dict:
         """Return raw-block health, layout, metadata, and in-flight counters."""
@@ -927,6 +1006,11 @@ class RawBlockCore:
                 "metadata_seq": self._meta_seq,
                 "metadata_dirty_total": self._meta_dirty_total,
                 "metadata_persisted": self._meta_persisted,
+                "delta_seq": self._delta_seq,
+                "delta_tail_off": self._delta_tail_off,
+                "delta_tail_capacity": self._delta_tail_capacity_locked(),
+                "active_base_seq": self._active_base_seq,
+                "active_mirror_idx": self._active_mirror_idx,
                 "inflight_io_count": self._inflight_io_count,
                 "use_odirect": self.use_odirect,
                 "enable_zero_copy": self.enable_zero_copy,
@@ -936,7 +1020,13 @@ class RawBlockCore:
             }
 
     def close(self) -> None:
-        """Stop checkpointing, write a final checkpoint, and close the device."""
+        """Stop checkpointing, write a final checkpoint, and close the device.
+
+        The final write follows the same trigger logic as ``checkpoint_now``:
+        a small dirty log becomes one delta record, otherwise a full base
+        compaction. Either is sufficient for crash-consistent recovery on
+        the next mount.
+        """
         with self._lock:
             if self._closed:
                 return
@@ -1476,11 +1566,50 @@ class RawBlockCore:
         raise RuntimeError("No free slots available")
 
     def _append_free_slot_locked(self, slot: int) -> None:
-        """Add a slot to the free list while ``self._lock`` is held."""
+        """Add a slot to the free list while ``self._lock`` is held.
+
+        Fast path for trusted callers (delete, put-failure, validation drop)
+        that have just removed the entry that owned ``slot``. Skips the
+        index scan that ``_safe_append_free_slot_locked`` performs because
+        the caller already knows the slot is unowned.
+        """
         if slot < 0 or slot >= self._max_slots:
             return
         if slot in self._free_slots:
             return
+        self._free_slots.append(slot)
+
+    def _safe_append_free_slot_locked(
+        self, slot: int, active_offsets: set[int] | None = None
+    ) -> None:
+        """Add a slot to the free list, refusing slots an indexed entry owns.
+
+        Used when the slot index comes from external/untrusted input
+        (delta replay). Guards against malformed ``freed_slot`` values
+        that point at a re-allocated slot.
+
+        Args:
+            slot: Candidate free-list slot index.
+            active_offsets: Optional set of currently-indexed entry
+                offsets, kept in sync with put/delete ops by the
+                caller. When provided, the ownership check is O(1)
+                against the set instead of an O(N) scan over
+                ``self._index``. Used by the delta-replay loop to keep
+                recovery cost linear in the number of ops; pass None
+                from any other caller.
+        """
+        if slot < 0 or slot >= self._max_slots:
+            return
+        if slot in self._free_slots:
+            return
+        slot_offset = self._slot_to_offset(slot)
+        if active_offsets is not None:
+            if slot_offset in active_offsets:
+                return
+        else:
+            for entry in self._index.values():
+                if int(entry.offset) == slot_offset:
+                    return
         self._free_slots.append(slot)
 
     def _checkpoint_loop(self) -> None:
@@ -1494,16 +1623,125 @@ class RawBlockCore:
 
     def _meta_payload_capacity(self) -> int:
         """Return usable bytes in one metadata checkpoint payload area."""
-        return self._meta_container_bytes - self.block_align
+        return self._meta_layout.base_payload_capacity
+
+    def _entry_to_op_payload(self, entry: "_Entry") -> dict[str, Any]:
+        """Serialize an in-memory entry into the on-disk JSON form.
+
+        Used both by full-snapshot ``entries`` and by delta ``put`` ops so
+        the field schema stays in lockstep across both encodings.
+        """
+        meta = entry.meta
+        return {
+            "offset": int(entry.offset),
+            "size": int(meta.size),
+            "shape": list(meta.shape) if meta.shape is not None else None,
+            "dtype": self._checkpoint_dtype_name(meta.dtype),
+            "fmt": (
+                meta.fmt.name
+                if meta.fmt is not None and hasattr(meta.fmt, "name")
+                else str(meta.fmt)
+                if meta.fmt is not None
+                else None
+            ),
+            "cached_positions": (
+                meta.cached_positions.tolist()
+                if meta.cached_positions is not None
+                and hasattr(meta.cached_positions, "tolist")
+                else None
+            ),
+        }
+
+    def _record_put_op_locked(self, encoded_key: str, entry: "_Entry") -> None:
+        """Append a put op to the dirty log; caller holds ``self._lock``."""
+        op: dict[str, Any] = {"op": "put", "k": str(encoded_key)}
+        op.update(self._entry_to_op_payload(entry))
+        op["next_slot"] = int(self._next_slot)
+        self._dirty_log.append(op)
+
+    def _record_delete_op_locked(
+        self, encoded_key: str, freed_slot: Optional[int]
+    ) -> None:
+        """Append a delete op to the dirty log; caller holds ``self._lock``."""
+        op: dict[str, Any] = {
+            "op": "delete",
+            "k": str(encoded_key),
+            "next_slot": int(self._next_slot),
+        }
+        if freed_slot is not None:
+            op["freed_slot"] = int(freed_slot)
+        self._dirty_log.append(op)
+
+    def _record_freelist_push_locked(self, freed_slot: int) -> None:
+        """Append a freelist_push op (put-failure path); caller holds the lock."""
+        op: dict[str, Any] = {
+            "op": "freelist_push",
+            "freed_slot": int(freed_slot),
+            "next_slot": int(self._next_slot),
+        }
+        self._dirty_log.append(op)
+
+    def _clear_dirty_log_locked(self) -> None:
+        """Drop pending ops; caller holds ``self._lock``."""
+        self._dirty_log = []
 
     def _meta_container_offsets(self) -> list[int]:
         """Return byte offsets for mirrored metadata checkpoint containers."""
-        return [
-            idx * self._meta_container_bytes for idx in range(self._meta_copy_count)
-        ]
+        return list(self._meta_layout.base_copy_offsets)
+
+    def _build_meta_layout(self) -> _MetaLayout:
+        """Compute the on-device metadata region layout.
+
+        The metadata region is split evenly between two mirrors. Within each
+        mirror, deltas append after the base payload's block-aligned end, so
+        no separate region is needed and ``meta_total_bytes`` is split 50/50.
+        The data slot region begins at ``meta_total_bytes`` regardless,
+        preserving cross-version slot offsets.
+        """
+        copy_bytes = self._mirror_bytes()
+        if copy_bytes <= self.block_align:
+            raise ValueError(
+                "meta_total_bytes must provide room for at least two metadata copies"
+            )
+        offsets = tuple(idx * copy_bytes for idx in range(self._meta_copy_count))
+        return _MetaLayout(
+            block_align=self.block_align,
+            base_copy_bytes=copy_bytes,
+            base_copy_offsets=offsets,
+        )
+
+    def _mirror_bytes(self) -> int:
+        """Return the per-mirror size in bytes, block-aligned."""
+        return (
+            (self.meta_total_bytes // self._meta_copy_count) // self.block_align
+        ) * self.block_align
+
+    @staticmethod
+    def _pack_base_header(
+        magic: bytes, version: int, seq: int, payload_len: int, crc: int
+    ) -> bytes:
+        return _META_HEADER_STRUCT.pack(
+            magic, int(version), int(seq), int(payload_len), int(crc)
+        )
+
+    @staticmethod
+    def _unpack_base_header(buf: bytes) -> Optional[dict[str, int]]:
+        """Decode a base header buffer; returns None on malformed bytes."""
+        if len(buf) < _META_HEADER_STRUCT.size:
+            return None
+        magic, version, seq, payload_len, crc = _META_HEADER_STRUCT.unpack(
+            buf[: _META_HEADER_STRUCT.size]
+        )
+        return {
+            "magic": magic,
+            "version": int(version),
+            "seq": int(seq),
+            "payload_len": int(payload_len),
+            "crc": int(crc),
+        }
 
     def _read_meta_header(self, container_offset: int) -> Optional[dict[str, int]]:
-        """Read and validate a metadata checkpoint header."""
+        """Read and validate a metadata checkpoint header at ``container_offset``."""
         buf = bytearray(self.block_align)
         try:
             self._read_buffers(
@@ -1515,20 +1753,18 @@ class RawBlockCore:
         except Exception:
             return None
 
-        hdr = bytes(buf[: _META_HEADER_STRUCT.size])
-        magic, version, seq, payload_len, crc = _META_HEADER_STRUCT.unpack(hdr)
-        if magic != self.meta_magic or version != self.meta_version:
+        decoded = self._unpack_base_header(bytes(buf))
+        if decoded is None:
             return None
-
-        payload_cap = self._meta_payload_capacity()
-        if payload_len <= 0 or payload_len > payload_cap:
+        if decoded["magic"] != self.meta_magic:
             return None
-        return {
-            "seq": int(seq),
-            "payload_len": int(payload_len),
-            "crc": int(crc),
-            "container_offset": int(container_offset),
-        }
+        if decoded["version"] != self.meta_version:
+            return None
+        capacity = self._meta_layout.base_payload_capacity
+        if decoded["payload_len"] <= 0 or decoded["payload_len"] > capacity:
+            return None
+        decoded["container_offset"] = int(container_offset)
+        return decoded
 
     def _load_meta_payload(self, header: dict[str, int]) -> Optional[bytes]:
         """Load and CRC-validate a checkpoint payload for a metadata header."""
@@ -1549,11 +1785,17 @@ class RawBlockCore:
 
     def _select_latest_checkpoint(
         self,
-    ) -> tuple[Optional[dict[str, int]], Optional[bytes]]:
-        """Return the newest valid checkpoint header and payload."""
+    ) -> tuple[Optional[dict[str, int]], Optional[bytes], int]:
+        """Return the newest valid checkpoint header, payload, and mirror index.
+
+        Picks the mirror with the highest ``seq`` whose base payload validates.
+        Tail (delta) replay is performed by the caller against the selected
+        mirror.
+        """
         best_header: Optional[dict[str, int]] = None
         best_payload: Optional[bytes] = None
-        for offset in self._meta_container_offsets():
+        best_idx: int = 0
+        for idx, offset in enumerate(self._meta_layout.base_copy_offsets):
             header = self._read_meta_header(offset)
             if header is None:
                 continue
@@ -1563,7 +1805,8 @@ class RawBlockCore:
             if best_header is None or int(header["seq"]) > int(best_header["seq"]):
                 best_header = header
                 best_payload = payload
-        return best_header, best_payload
+                best_idx = idx
+        return best_header, best_payload, best_idx
 
     def _snapshot_state(self) -> tuple[dict[str, Any], int]:
         """Build a JSON-serializable checkpoint state snapshot."""
@@ -1583,28 +1826,7 @@ class RawBlockCore:
                 "next_slot": self._next_slot,
                 "free_slots": list(self._free_slots),
                 "entries": {
-                    encoded_key: {
-                        "offset": entry.offset,
-                        "size": entry.meta.size,
-                        "shape": list(entry.meta.shape)
-                        if entry.meta.shape is not None
-                        else None,
-                        "dtype": self._checkpoint_dtype_name(entry.meta.dtype),
-                        "fmt": (
-                            entry.meta.fmt.name
-                            if entry.meta.fmt is not None
-                            and hasattr(entry.meta.fmt, "name")
-                            else str(entry.meta.fmt)
-                            if entry.meta.fmt is not None
-                            else None
-                        ),
-                        "cached_positions": (
-                            entry.meta.cached_positions.tolist()
-                            if entry.meta.cached_positions is not None
-                            and hasattr(entry.meta.cached_positions, "tolist")
-                            else None
-                        ),
-                    }
+                    encoded_key: self._entry_to_op_payload(entry)
                     for encoded_key, entry in self._index.items()
                 },
             }
@@ -1625,7 +1847,33 @@ class RawBlockCore:
         return TORCH_DTYPE_TO_STR_DTYPE.get(dtype, str(dtype))
 
     def _write_checkpoint(self, payload: bytes, dirty_total_snapshot: int) -> bool:
-        """Write one checkpoint copy and advance persisted metadata counters."""
+        """Compact: write a fresh full base into the inactive mirror.
+
+        Order on disk:
+
+        1. Write the base payload to ``inactive_mirror + block_align``.
+        2. Zero the first block of the new mirror's delta tail so any
+           stale tail bytes from a previous incarnation cannot replay
+           against the new base. ``base_crc`` already filters them, but
+           the explicit zero makes recovery stop cleanly without scanning
+           the whole tail.
+        3. Commit the base header to ``inactive_mirror`` — the mirror
+           now holds the highest ``seq`` and becomes authoritative.
+
+        A crash before step 3 leaves the previous mirror authoritative.
+        A crash between steps 2 and 3 leaves the new payload on disk but
+        no header points at it, so it is ignored.
+
+        Args:
+            payload: Base snapshot bytes to persist.
+            dirty_total_snapshot: ``_meta_dirty_total`` value captured
+                when ``payload`` was built; used to advance
+                ``_meta_persisted``.
+
+        Returns:
+            True when the checkpoint committed; False when the payload
+            exceeds the per-mirror capacity.
+        """
         payload_cap = self._meta_payload_capacity()
         if len(payload) > payload_cap:
             logger.warning(
@@ -1638,7 +1886,7 @@ class RawBlockCore:
 
         next_seq = self._meta_seq + 1
         target_idx = int((next_seq - 1) % self._meta_copy_count)
-        target = self._meta_container_offsets()[target_idx]
+        target = self._meta_layout.base_copy_offsets[target_idx]
 
         payload_len = len(payload)
         payload_total_len = round_up(payload_len, self.block_align)
@@ -1646,44 +1894,539 @@ class RawBlockCore:
         crc = zlib.crc32(payload) & 0xFFFFFFFF
 
         header_block = bytearray(self.block_align)
-        header_block[: _META_HEADER_STRUCT.size] = _META_HEADER_STRUCT.pack(
-            self.meta_magic,
-            self.meta_version,
-            int(next_seq),
-            int(payload_len),
-            int(crc),
+        header_bytes = self._pack_base_header(
+            self.meta_magic, self.meta_version, next_seq, payload_len, crc
         )
+        header_block[: len(header_bytes)] = header_bytes
 
+        # Steps 1+2: write the base payload, and zero the first block of the
+        # new mirror's delta tail so stale tail bytes from a previous
+        # incarnation cannot replay against the new base. Routed through
+        # ``_write_buffers`` so it honours the configured io_engine (posix /
+        # io_uring / uring_cmd); the call blocks until the writes complete,
+        # so both are durable before the header is committed.
+        tail_start = target + self.block_align + payload_total_len
+        if tail_start + self.block_align <= target + self._meta_layout.base_copy_bytes:
+            zero_block = bytes(self.block_align)
+            self._write_buffers(
+                [payload_off, tail_start],
+                [payload, zero_block],
+                [payload_len, self.block_align],
+                [payload_total_len, self.block_align],
+            )
+        else:
+            self._write_buffers(
+                [payload_off],
+                [payload],
+                [payload_len],
+                [payload_total_len],
+            )
+
+        # Step 3: commit the base header last (a separate, ordered write).
+        # The mirror becomes authoritative only once this lands; a crash
+        # before it leaves the previous mirror authoritative.
         self._write_buffers(
-            [payload_off, target],
-            [payload, header_block],
-            [payload_len, self.block_align],
-            [payload_total_len, self.block_align],
+            [target],
+            [header_block],
+            [self.block_align],
+            [self.block_align],
         )
 
         with self._lock:
             self._meta_seq = int(next_seq)
             self._meta_persisted = max(self._meta_persisted, int(dirty_total_snapshot))
+            self._clear_dirty_log_locked()
+            self._delta_seq = 0
+            self._delta_tail_off = 0
+            self._active_base_seq = int(next_seq)
+            self._active_base_crc = int(crc)
+            self._active_mirror_idx = target_idx
+            self._active_base_payload_total = payload_total_len
+            self._last_record_crc = None
+            self._last_full_ts = time.monotonic()
         return True
 
     def _checkpoint_once(self, force: bool) -> bool:
-        """Write a metadata checkpoint when dirty and sufficiently idle."""
+        """Write a metadata checkpoint when dirty and sufficiently idle.
+
+        Tries to append one delta record after the active mirror's base
+        payload. Falls back to a full compaction (new base in the inactive
+        mirror) when the dirty log does not fit, when count/time thresholds
+        fire, or when no active base exists yet.
+
+        Holds ``self._writer_lock`` for the full attempt so concurrent
+        callers cannot collide on the tail offset or mirror seq.
+        """
+        with self._writer_lock:
+            with self._lock:
+                dirty = self._meta_dirty_total > self._meta_persisted
+                idle_ok = self._inflight_io_count == 0 and (
+                    time.monotonic() - self._last_io_ts
+                ) >= (self.meta_idle_quiet_ms / 1000.0)
+
+            if not dirty:
+                return False
+            if not force and not idle_ok:
+                return False
+
+            payload, op_count, dirty_total_snapshot = self._snapshot_dirty_log()
+            if payload is not None and not self._need_full_for_delta(payload):
+                if self._write_delta(payload, op_count, dirty_total_snapshot):
+                    return True
+                # Fall through to full compaction if delta append failed.
+
+            snapshot, dirty_total_snapshot = self._snapshot_state()
+            payload = json.dumps(
+                snapshot, separators=(",", ":"), ensure_ascii=True
+            ).encode("utf-8")
+            return self._write_checkpoint(payload, dirty_total_snapshot)
+
+    def _snapshot_dirty_log(
+        self,
+    ) -> tuple[Optional[bytes], int, int]:
+        """Atomically swap out the in-memory dirty log and JSON-encode it.
+
+        Returns a triple ``(payload, op_count, dirty_total_snapshot)``. When
+        no dirty ops are pending, ``payload`` is ``None``.
+        """
         with self._lock:
-            dirty = self._meta_dirty_total > self._meta_persisted
-            idle_ok = self._inflight_io_count == 0 and (
-                time.monotonic() - self._last_io_ts
-            ) >= (self.meta_idle_quiet_ms / 1000.0)
+            if not self._dirty_log:
+                return None, 0, self._meta_dirty_total
+            ops = self._dirty_log
+            self._dirty_log = []
+            dirty_total_snapshot = self._meta_dirty_total
+        try:
+            payload = json.dumps(
+                {"ops": ops}, separators=(",", ":"), ensure_ascii=True
+            ).encode("utf-8")
+        except Exception:
+            # Restore the log so a later compaction can retry.
+            with self._lock:
+                self._dirty_log = ops + self._dirty_log
+            raise
+        return payload, len(ops), dirty_total_snapshot
 
-        if not dirty:
-            return False
-        if not force and not idle_ok:
-            return False
+    def _need_full_for_delta(self, payload: bytes) -> bool:
+        """Decide whether the next checkpoint must be a full compaction."""
+        if self._meta_seq == 0:
+            return True
+        capacity = self._delta_tail_capacity_locked()
+        if capacity <= 0:
+            return True
+        record_bytes = self._delta_record_total_bytes(len(payload))
+        if record_bytes > capacity:
+            return True
+        if self._delta_tail_off + record_bytes > capacity:
+            return True
+        if self._delta_seq + 1 > self.meta_full_checkpoint_max_deltas:
+            return True
+        if (
+            time.monotonic() - self._last_full_ts
+            > self.meta_full_checkpoint_interval_sec
+        ):
+            return True
+        return False
 
-        snapshot, dirty_total_snapshot = self._snapshot_state()
-        payload = json.dumps(snapshot, separators=(",", ":"), ensure_ascii=True).encode(
-            "utf-8"
+    def _delta_record_total_bytes(self, payload_len: int) -> int:
+        """Block-aligned record size for a delta payload of ``payload_len`` bytes."""
+        return round_up(
+            _DELTA_RECORD_HEADER_STRUCT.size + int(payload_len), self.block_align
         )
-        return self._write_checkpoint(payload, dirty_total_snapshot)
+
+    def _delta_tail_start_off(self, mirror_idx: int, payload_total: int) -> int:
+        """Absolute offset where the active mirror's delta tail begins."""
+        mirror_off = self._meta_layout.base_copy_offsets[mirror_idx]
+        return mirror_off + self.block_align + int(payload_total)
+
+    def _delta_tail_capacity_locked(self) -> int:
+        """Return bytes available in the active mirror's delta tail."""
+        if self._meta_seq == 0:
+            return 0
+        used_by_base = self.block_align + self._active_base_payload_total
+        return max(0, self._meta_layout.base_copy_bytes - used_by_base)
+
+    def _replay_delta_log(self) -> int:
+        """Walk the active mirror's delta tail and apply each valid record.
+
+        Stops at the first record that fails any check (bad magic, stale
+        ``base_seq`` / ``base_crc``, broken hash chain, non-monotonic
+        ``delta_seq``, oversized payload, CRC mismatch, or read error).
+        Earlier records are durable and applied; anything past the stop
+        point is treated as torn or stale.
+
+        Returns the number of records successfully applied. Updates
+        ``self._delta_tail_off``, ``self._delta_seq`` and
+        ``self._last_record_crc``.
+        """
+        capacity = self._meta_layout.base_copy_bytes - (
+            self.block_align + self._active_base_payload_total
+        )
+        if capacity <= 0:
+            self._delta_tail_off = 0
+            self._delta_seq = 0
+            self._last_record_crc = None
+            return 0
+
+        tail_base = self._delta_tail_start_off(
+            self._active_mirror_idx, self._active_base_payload_total
+        )
+        off = 0
+        applied = 0
+        expected_next = self._delta_seq + 1
+        prev_crc = (
+            self._last_record_crc
+            if self._last_record_crc is not None
+            else self._active_base_crc
+        )
+
+        while off + _DELTA_RECORD_HEADER_STRUCT.size <= capacity:
+            absolute = tail_base + off
+            header = self._read_delta_header(absolute, expected_next, capacity, off)
+            if header is None:
+                break
+            if int(header["prev_record_crc"]) != int(prev_crc) & 0xFFFFFFFF:
+                break
+            record_bytes = int(header["record_bytes"])
+            buf = bytearray(record_bytes)
+            try:
+                self._rawdev().pread_into(absolute, buf, record_bytes, record_bytes)
+            except Exception:
+                break
+            ops = self._load_delta_ops(buf, header)
+            if ops is None:
+                break
+            if not self._apply_delta_ops(ops):
+                break
+
+            applied += 1
+            prev_crc = zlib.crc32(bytes(buf)) & 0xFFFFFFFF
+            self._delta_seq = int(header["delta_seq"])
+            off += record_bytes
+            expected_next = self._delta_seq + 1
+
+        self._delta_tail_off = off
+        if applied > 0:
+            self._last_record_crc = int(prev_crc) & 0xFFFFFFFF
+        return applied
+
+    def _read_delta_header(
+        self,
+        absolute_off: int,
+        expected_next_seq: int,
+        tail_capacity: int,
+        relative_off: int,
+    ) -> Optional[dict[str, int]]:
+        """Read and validate one delta record's header block.
+
+        Returns a dict with the validated fields plus the derived
+        ``record_bytes``, or None if any sanity check fails. The caller
+        treats None as "stop replay here".
+        """
+        buf = bytearray(self.block_align)
+        try:
+            self._rawdev().pread_into(
+                absolute_off, buf, self.block_align, self.block_align
+            )
+        except Exception:
+            return None
+
+        try:
+            (
+                magic,
+                rec_version,
+                base_seq,
+                base_crc,
+                delta_seq,
+                prev_record_crc,
+                payload_len,
+                payload_crc,
+                op_count,
+                flags,
+                total_blocks,
+                _reserved,
+            ) = _DELTA_RECORD_HEADER_STRUCT.unpack(
+                bytes(buf[: _DELTA_RECORD_HEADER_STRUCT.size])
+            )
+        except struct.error:
+            return None
+
+        if magic != _DELTA_RECORD_MAGIC:
+            return None
+        if rec_version != _DELTA_RECORD_VERSION:
+            return None
+        if int(base_seq) != self._active_base_seq:
+            return None
+        if int(base_crc) != int(self._active_base_crc) & 0xFFFFFFFF:
+            return None
+        if int(delta_seq) != expected_next_seq:
+            return None
+        if int(flags) != 0:
+            # Unknown flag bits => stop replay; future writers may add bits.
+            return None
+        if int(total_blocks) <= 0:
+            return None
+        record_bytes = int(total_blocks) * self.block_align
+        if relative_off + record_bytes > tail_capacity:
+            return None
+        max_payload = record_bytes - _DELTA_RECORD_HEADER_STRUCT.size
+        if int(payload_len) <= 0 or int(payload_len) > max_payload:
+            return None
+        if int(op_count) <= 0:
+            return None
+        return {
+            "delta_seq": int(delta_seq),
+            "prev_record_crc": int(prev_record_crc),
+            "payload_len": int(payload_len),
+            "payload_crc": int(payload_crc),
+            "op_count": int(op_count),
+            "record_bytes": int(record_bytes),
+        }
+
+    def _load_delta_ops(
+        self, record_buf: bytes | bytearray, header: dict[str, int]
+    ) -> Optional[list[Any]]:
+        """CRC-check and decode the ops list inside an already-read record."""
+        payload_len = header["payload_len"]
+        start = _DELTA_RECORD_HEADER_STRUCT.size
+        payload = bytes(record_buf[start : start + payload_len])
+        if (zlib.crc32(payload) & 0xFFFFFFFF) != header["payload_crc"]:
+            return None
+        try:
+            doc = json.loads(payload.decode("utf-8"))
+        except Exception:
+            return None
+        ops = doc.get("ops") if isinstance(doc, dict) else None
+        if not isinstance(ops, list):
+            return None
+        if header["op_count"] != len(ops):
+            return None
+        return ops
+
+    def _apply_delta_ops(self, ops: list[Any]) -> bool:
+        """Apply a decoded list of delta ops to the live in-memory state.
+
+        Builds a transient set of currently-indexed entry offsets and
+        keeps it in sync with put/delete ops as they apply, so the
+        slot-ownership check inside ``_safe_append_free_slot_locked``
+        runs in O(1) instead of scanning the whole index for every
+        ``freelist_push`` and explicit-``freed_slot`` ``delete`` op.
+        Recovery cost stays linear in the number of ops even when the
+        index already holds many keys.
+        """
+        with self._lock:
+            active_offsets: set[int] = {
+                int(entry.offset) for entry in self._index.values()
+            }
+            for op in ops:
+                if not isinstance(op, dict):
+                    return False
+                kind = op.get("op")
+                next_slot = op.get("next_slot")
+                if isinstance(next_slot, int) and next_slot > self._next_slot:
+                    self._next_slot = next_slot
+                if kind == "put":
+                    if not self._apply_delta_put_locked(op, active_offsets):
+                        return False
+                elif kind == "delete":
+                    self._apply_delta_delete_locked(op, active_offsets)
+                elif kind == "freelist_push":
+                    freed = op.get("freed_slot")
+                    if isinstance(freed, int):
+                        self._safe_append_free_slot_locked(int(freed), active_offsets)
+                else:
+                    logger.warning(
+                        "RawBlockCore: ignoring unknown delta op kind=%r", kind
+                    )
+        return True
+
+    def _apply_delta_put_locked(
+        self, op: dict[str, Any], active_offsets: set[int] | None = None
+    ) -> bool:
+        """Apply a put op while ``self._lock`` is held.
+
+        Args:
+            op: Decoded put-op dict with ``k``, ``offset``, ``size`` and
+                optional metadata fields.
+            active_offsets: Optional set of currently-indexed entry
+                offsets, kept in sync by the replay loop so subsequent
+                ``_safe_append_free_slot_locked`` calls can reject
+                slot reuse in O(1). When provided, this method updates
+                the set to reflect the put (adding the new offset and
+                discarding the prior offset on overwrite).
+
+        Returns:
+            True when the op applied; False on a malformed payload or
+            invalid checkpoint entry, in which case replay aborts at
+            the caller.
+        """
+        encoded_key = op.get("k")
+        offset = op.get("offset")
+        size = op.get("size")
+        if not isinstance(encoded_key, str):
+            return False
+        if not isinstance(offset, int) or not isinstance(size, int):
+            return False
+        if not self._is_valid_checkpoint_entry(int(offset), int(size)):
+            return False
+
+        meta = self._decode_put_op_meta(encoded_key, int(offset), int(size), op)
+        prior = self._index.get(encoded_key)
+        self._index[encoded_key] = _Entry(offset=int(offset), size=int(size), meta=meta)
+        if active_offsets is not None:
+            active_offsets.add(int(offset))
+
+        slot = self._offset_to_slot(int(offset))
+        if 0 <= slot < self._max_slots:
+            try:
+                self._free_slots.remove(slot)
+            except ValueError:
+                pass
+        if prior is not None and int(prior.offset) != int(offset):
+            old_slot = self._offset_to_slot(int(prior.offset))
+            if active_offsets is not None:
+                active_offsets.discard(int(prior.offset))
+            self._append_free_slot_locked(old_slot)
+        return True
+
+    def _decode_put_op_meta(
+        self, encoded_key: str, offset: int, size: int, op: dict[str, Any]
+    ) -> DiskCacheMetadata:
+        """Build a ``DiskCacheMetadata`` from a put-op dict's optional fields."""
+        shape_list = op.get("shape")
+        shape = torch.Size(list(shape_list)) if isinstance(shape_list, list) else None
+        fmt_name = op.get("fmt")
+        if isinstance(fmt_name, str) and fmt_name in MemoryFormat.__members__:
+            fmt = MemoryFormat[fmt_name]
+        else:
+            fmt = MemoryFormat.UNDEFINED
+        cached_positions_list = op.get("cached_positions")
+        cached_positions = (
+            torch.tensor(cached_positions_list, dtype=torch.long)
+            if isinstance(cached_positions_list, list)
+            else None
+        )
+        dtype = self._recover_checkpoint_dtype(encoded_key, op.get("dtype"))
+        return DiskCacheMetadata(
+            path=f"{self.device_path}@{offset}",
+            size=size,
+            shape=shape,
+            dtype=dtype,
+            cached_positions=cached_positions,
+            fmt=fmt,
+            pin_count=0,
+        )
+
+    def _apply_delta_delete_locked(
+        self, op: dict[str, Any], active_offsets: set[int] | None = None
+    ) -> None:
+        """Apply a delete op while ``self._lock`` is held.
+
+        Args:
+            op: Decoded delete-op dict with ``k`` and optional
+                ``freed_slot``.
+            active_offsets: Optional set of currently-indexed entry
+                offsets maintained by the replay loop. When provided,
+                the removed entry's offset is discarded from the set
+                so subsequent ``_safe_append_free_slot_locked`` calls
+                see the correct ownership view.
+        """
+        encoded_key = op.get("k")
+        if not isinstance(encoded_key, str):
+            return
+        removed = self._index.pop(encoded_key, None)
+        self._lock_refcnt.pop(encoded_key, None)
+        if removed is not None and active_offsets is not None:
+            active_offsets.discard(int(removed.offset))
+        freed_slot = op.get("freed_slot")
+        if isinstance(freed_slot, int):
+            self._safe_append_free_slot_locked(int(freed_slot), active_offsets)
+        elif removed is not None:
+            self._append_free_slot_locked(self._offset_to_slot(int(removed.offset)))
+
+    def _write_delta(
+        self,
+        payload: bytes,
+        op_count: int,
+        dirty_total_snapshot: int,
+    ) -> bool:
+        """Append a delta record to the active mirror's tail.
+
+        Caller must hold ``self._writer_lock``: this method reads
+        ``_delta_tail_off`` / ``_delta_seq`` / ``_last_record_crc`` outside
+        ``self._lock`` and relies on the writer lock to keep concurrent
+        checkpoints from racing on those fields or on the underlying device
+        offset.
+
+        On success, advances ``_delta_seq`` / ``_delta_tail_off`` /
+        ``_last_record_crc`` and the persisted-counter watermark. Returns
+        ``False`` if the record cannot fit; the caller should fall back to a
+        full compaction.
+        """
+        if self._meta_seq == 0:
+            return False
+        capacity = self._delta_tail_capacity_locked()
+        if capacity <= 0:
+            return False
+        record_bytes = self._delta_record_total_bytes(len(payload))
+        if record_bytes > capacity:
+            return False
+        if self._delta_tail_off + record_bytes > capacity:
+            return False
+
+        next_delta_seq = self._delta_seq + 1
+        payload_crc = zlib.crc32(payload) & 0xFFFFFFFF
+        total_blocks = record_bytes // self.block_align
+        prev_crc = (
+            self._last_record_crc
+            if self._last_record_crc is not None
+            else self._active_base_crc
+        )
+
+        record = bytearray(record_bytes)
+        _DELTA_RECORD_HEADER_STRUCT.pack_into(
+            record,
+            0,
+            _DELTA_RECORD_MAGIC,
+            _DELTA_RECORD_VERSION,
+            int(self._active_base_seq),
+            int(self._active_base_crc) & 0xFFFFFFFF,
+            int(next_delta_seq),
+            int(prev_crc) & 0xFFFFFFFF,
+            int(len(payload)),
+            int(payload_crc),
+            int(op_count),
+            0,
+            int(total_blocks),
+            0,
+        )
+        record[
+            _DELTA_RECORD_HEADER_STRUCT.size : _DELTA_RECORD_HEADER_STRUCT.size
+            + len(payload)
+        ] = payload
+
+        record_crc = zlib.crc32(bytes(record)) & 0xFFFFFFFF
+        write_off = (
+            self._delta_tail_start_off(
+                self._active_mirror_idx, self._active_base_payload_total
+            )
+            + self._delta_tail_off
+        )
+        try:
+            self._rawdev().pwrite_from_buffer(
+                write_off, bytes(record), record_bytes, record_bytes
+            )
+        except Exception as e:
+            logger.warning(
+                "RawBlockCore: delta write failed at off=%d: %s", write_off, e
+            )
+            return False
+
+        with self._lock:
+            self._delta_seq = next_delta_seq
+            self._delta_tail_off += record_bytes
+            self._last_record_crc = int(record_crc)
+            self._meta_persisted = max(self._meta_persisted, int(dirty_total_snapshot))
+        return True
 
     def _is_valid_checkpoint_entry(self, offset: int, size: int) -> bool:
         """Return whether a checkpoint entry references a valid data slot."""
@@ -1698,10 +2441,26 @@ class RawBlockCore:
         return 0 < size <= (self.slot_bytes - self.header_bytes)
 
     def _apply_loaded_state(self, data: dict[str, Any]) -> bool:
-        """Apply decoded checkpoint state after validating layout fields."""
+        """Apply decoded checkpoint state after validating layout fields.
+
+        Resets the active-base trackers; the device-load path overrides
+        them after this returns with values from the just-loaded base
+        header. External callers (``apply_loaded_state``) leave them
+        cleared so the next checkpoint writes a fresh full base — any
+        residual delta records on either mirror's tail are filtered by
+        ``base_seq`` / ``base_crc`` mismatch on the next mount.
+
+        Args:
+            data: Decoded checkpoint dictionary.
+        """
         if not isinstance(data, dict):
             return False
         if int(data.get("version", 0)) != 1:
+            logger.warning(
+                "Device metadata payload version mismatch (got %r, expected 1); "
+                "ignoring metadata",
+                data.get("version"),
+            )
             return False
         checkpoint_device_path = data.get("device_path")
         if checkpoint_device_path and checkpoint_device_path != self.device_path:
@@ -1827,9 +2586,23 @@ class RawBlockCore:
 
             self._meta_dirty_total = 0
             self._meta_persisted = 0
-
-        if self.meta_verify_on_load:
-            self._validate_loaded_entries()
+            self._clear_dirty_log_locked()
+            self._delta_seq = 0
+            self._delta_tail_off = 0
+            self._last_record_crc = None
+            # External callers may hand us an arbitrary state that does not
+            # match what's on disk. Reset the active-base trackers so the
+            # next checkpoint writes a fresh full base; any delta records
+            # still on disk under either mirror's tail will be filtered by
+            # ``base_seq`` / ``base_crc`` mismatch and skipped on the next
+            # mount. ``_load_checkpoint_from_device`` overrides these
+            # immediately after with the values from the just-loaded base
+            # header for the internal load path.
+            self._meta_seq = 0
+            self._active_base_seq = 0
+            self._active_base_crc = 0
+            self._active_base_payload_total = 0
+            self._active_mirror_idx = 0
         return True
 
     def _recover_checkpoint_dtype(
@@ -1908,10 +2681,13 @@ class RawBlockCore:
                 removed_entry = self._index.pop(encoded_key, None)
                 self._lock_refcnt.pop(encoded_key, None)
                 if removed_entry is not None:
-                    self._append_free_slot_locked(
-                        self._offset_to_slot(int(removed_entry.offset))
-                    )
-            self._meta_dirty_total += 1
+                    freed_slot = self._offset_to_slot(int(removed_entry.offset))
+                    self._append_free_slot_locked(freed_slot)
+                    self._record_delete_op_locked(encoded_key, freed_slot)
+            # One dirty event per dropped entry, matching the per-op accounting
+            # used by put/delete so ``metadata_dirty_total`` stays in sync with
+            # the dirty-log size.
+            self._meta_dirty_total += len(to_drop)
 
         logger.warning(
             "RawBlockCore dropped %d stale metadata entries after "
@@ -1920,8 +2696,14 @@ class RawBlockCore:
         )
 
     def _load_checkpoint_from_device(self) -> None:
-        """Load the newest valid checkpoint from the raw device if present."""
-        header, payload = self._select_latest_checkpoint()
+        """Load the newest valid checkpoint from the raw device if present.
+
+        Applies the base snapshot, replays the active mirror's delta tail,
+        then runs slot-header validation against the final state. Validating
+        before replay would let a subsequent delta op resurrect an entry
+        that the base validation just dropped.
+        """
+        header, payload, mirror_idx = self._select_latest_checkpoint()
         if header is None:
             logger.info("RawBlockCore: no valid on-device metadata checkpoint found")
             return
@@ -1933,14 +2715,31 @@ class RawBlockCore:
         except Exception:
             logger.warning("RawBlockCore: failed to decode metadata payload")
             return
-        if not self.apply_loaded_state(data):
+        if not self._apply_loaded_state(data):
             logger.warning("RawBlockCore: metadata payload rejected by checks")
             return
         self._meta_seq = int(header["seq"])
+        self._active_base_seq = self._meta_seq
+        self._active_base_crc = int(header["crc"]) & 0xFFFFFFFF
+        self._active_mirror_idx = int(mirror_idx)
+        self._active_base_payload_total = round_up(
+            int(header["payload_len"]), self.block_align
+        )
+        self._last_record_crc = None
+        self._last_full_ts = time.monotonic()
+
+        delta_count = self._replay_delta_log()
+
+        if self.meta_verify_on_load:
+            self._validate_loaded_entries()
+
         logger.info(
-            "RawBlockCore loaded checkpoint (entries=%d next_slot=%d seq=%d device=%s)",
+            "RawBlockCore loaded checkpoint (entries=%d next_slot=%d seq=%d "
+            "mirror=%d deltas_applied=%d device=%s)",
             len(self._index),
             self._next_slot,
             self._meta_seq,
+            mirror_idx,
+            delta_count,
             self.device_path,
         )

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -627,3 +627,163 @@ def test_raw_block_l2_adapter_error_bitmaps_keep_submitted_size():
             assert str(load_bitmap) == "00"
         finally:
             adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_incremental_multi_key_recovery():
+    """End-to-end MP path test for base+delta checkpoint recovery.
+
+    Mirrors the non-MP integration in
+    ``test_rust_raw_block_backend_incremental_multi_key_recovery`` but
+    drives the multi-process L2 adapter so the same incremental code path
+    is verified through the MP wrapper. Stores several keys with explicit
+    checkpoints between puts (triggering delta records after the first
+    full base), then reopens the adapter twice to confirm both the index
+    and on-disk payload bytes survive base+delta replay.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        config = RawBlockL2AdapterConfig(
+            device_path=dev_path,
+            slot_bytes=64 * 1024,
+            use_odirect=False,
+            block_align=4096,
+            header_bytes=4096,
+            meta_total_bytes=1 * 1024 * 1024,
+            meta_enable_periodic=False,
+            num_store_workers=2,
+            num_lookup_workers=1,
+            num_load_workers=2,
+            meta_full_checkpoint_max_deltas=1024,
+        )
+
+        keys = [_create_object_key(100 + i) for i in range(5)]
+        objects = [_create_memory_obj(fill_value=float(100 + i)) for i in range(5)]
+        expected_payloads = [bytes(o.byte_array) for o in objects]
+
+        adapter1 = RawBlockL2Adapter(config)
+        try:
+            for key, obj in zip(keys, objects, strict=False):
+                assert _run_store(adapter1, [key], [obj]) is True
+                # One checkpoint per put -> first becomes the full base, the
+                # rest land as delta records.
+                adapter1._core.checkpoint_now()
+            assert adapter1._core._meta_seq >= 1
+            assert adapter1._core._delta_seq >= 1, (
+                "MP adapter must emit delta records after the initial full"
+            )
+        finally:
+            adapter1.close()
+
+        adapter2 = RawBlockL2Adapter(config)
+        try:
+            _, lookup_bitmap = _run_lookup(adapter2, keys)
+            assert lookup_bitmap is not None
+            assert lookup_bitmap.get_indices_list() == list(range(len(keys))), (
+                "every recovered key must be present after delta replay"
+            )
+
+            load_buffers = [_create_memory_obj(fill_value=0.0) for _ in keys]
+            _, load_bitmap = _run_load(adapter2, keys, load_buffers)
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == list(range(len(keys)))
+            for buf, expected in zip(load_buffers, expected_payloads, strict=False):
+                assert bytes(buf.byte_array) == expected, (
+                    "recovered payload bytes must match the stored bytes"
+                )
+            adapter2.submit_unlock(keys)
+
+            # Add one more key and let close persist it via the trigger logic.
+            extra_key = _create_object_key(900)
+            extra_obj = _create_memory_obj(fill_value=99.0)
+            assert _run_store(adapter2, [extra_key], [extra_obj]) is True
+            expected_extra = bytes(extra_obj.byte_array)
+        finally:
+            adapter2.close()
+
+        adapter3 = RawBlockL2Adapter(config)
+        try:
+            all_keys = keys + [extra_key]
+            _, lookup_bitmap = _run_lookup(adapter3, all_keys)
+            assert lookup_bitmap is not None
+            assert lookup_bitmap.get_indices_list() == list(range(len(all_keys)))
+
+            load_buffers = [_create_memory_obj(fill_value=0.0) for _ in all_keys]
+            _, load_bitmap = _run_load(adapter3, all_keys, load_buffers)
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == list(range(len(all_keys)))
+            for buf, expected in zip(
+                load_buffers, expected_payloads + [expected_extra], strict=False
+            ):
+                assert bytes(buf.byte_array) == expected
+            adapter3.submit_unlock(all_keys)
+        finally:
+            adapter3.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_close_flushes_pending_via_delta():
+    """``close()`` on the MP adapter must persist a pending dirty log so the
+    next mount recovers the just-stored key. The trigger logic prefers a
+    delta record when the base+delta layout is active and the dirty log
+    fits in one record.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        config = RawBlockL2AdapterConfig(
+            device_path=dev_path,
+            slot_bytes=64 * 1024,
+            use_odirect=False,
+            block_align=4096,
+            header_bytes=4096,
+            meta_total_bytes=1 * 1024 * 1024,
+            meta_enable_periodic=False,
+            num_store_workers=1,
+            num_lookup_workers=1,
+            num_load_workers=1,
+        )
+
+        seed_key = _create_object_key(700)
+        seed_obj = _create_memory_obj(fill_value=7.0)
+        adapter1 = RawBlockL2Adapter(config)
+        try:
+            # First store + explicit checkpoint becomes the full base.
+            assert _run_store(adapter1, [seed_key], [seed_obj]) is True
+            adapter1._core.checkpoint_now()
+            assert adapter1._core._delta_seq == 0
+
+            # Second store stays in the dirty log; close() must flush it.
+            tail_key = _create_object_key(701)
+            tail_obj = _create_memory_obj(fill_value=8.0)
+            expected_tail = bytes(tail_obj.byte_array)
+            assert _run_store(adapter1, [tail_key], [tail_obj]) is True
+        finally:
+            adapter1.close()
+
+        adapter2 = RawBlockL2Adapter(config)
+        try:
+            assert adapter2._core._delta_seq >= 1, (
+                "close() must persist the pending mutation as a delta record"
+            )
+            _, lookup_bitmap = _run_lookup(adapter2, [seed_key, tail_key])
+            assert lookup_bitmap is not None
+            assert lookup_bitmap.get_indices_list() == [0, 1]
+
+            load_buffers = [
+                _create_memory_obj(fill_value=0.0),
+                _create_memory_obj(fill_value=0.0),
+            ]
+            _, load_bitmap = _run_load(adapter2, [seed_key, tail_key], load_buffers)
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0, 1]
+            assert bytes(load_buffers[0].byte_array) == bytes(seed_obj.byte_array)
+            assert bytes(load_buffers[1].byte_array) == expected_tail
+            adapter2.submit_unlock([seed_key, tail_key])
+        finally:
+            adapter2.close()

--- a/tests/v1/storage_backend/test_raw_block_incremental_checkpoint.py
+++ b/tests/v1/storage_backend/test_raw_block_incremental_checkpoint.py
@@ -1,0 +1,507 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the incremental (base + delta tail) checkpoint format.
+
+These exercise ``RawBlockCore`` directly through a fake raw-block device,
+covering the per-mirror tail-append layout, base/delta binding, replay,
+torn-write recovery, and compaction triggers.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import sys
+import types
+import zlib
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import DiskCacheMetadata
+from lmcache.v1.memory_management import MemoryFormat
+from lmcache.v1.storage_backend.raw_block import RawBlockCore, RawBlockCoreConfig
+from lmcache.v1.storage_backend.raw_block.core import (
+    _DELTA_RECORD_HEADER_STRUCT,
+    _DELTA_RECORD_MAGIC,
+    _DELTA_RECORD_VERSION,
+    _META_HEADER_STRUCT,
+    _Entry,
+)
+
+
+class _FakeRawBlockDevice:
+    """Purely in-memory device backing for unit tests."""
+
+    def __init__(self, buf: bytearray):
+        self._data = buf
+
+    def size_bytes(self) -> int:
+        return len(self._data)
+
+    def pread_into(self, offset, out, payload_len, total_len=None):
+        del total_len
+        out[:payload_len] = self._data[offset : offset + payload_len]
+
+    def pwrite_from_buffer(self, offset, data, payload_len=None, total_len=None):
+        del total_len
+        length = len(data) if payload_len is None else payload_len
+        self._data[offset : offset + length] = bytes(memoryview(data)[:length])
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.fixture
+def shared_device(monkeypatch):
+    """Install a shared in-memory device that survives across cores."""
+
+    holder: dict[str, bytearray] = {"buf": bytearray(2 * 1024 * 1024)}
+
+    def factory(path: str, **kwargs):
+        del path, kwargs
+        return _FakeRawBlockDevice(holder["buf"])
+
+    monkeypatch.setitem(
+        sys.modules,
+        "lmcache_rust_raw_block_io",
+        types.SimpleNamespace(RawBlockDevice=factory),
+    )
+    return holder
+
+
+def _config(**overrides) -> RawBlockCoreConfig:
+    base = dict(
+        device_path="/tmp/raw-block-incremental-test",
+        capacity_bytes=2 * 1024 * 1024,
+        block_align=4096,
+        header_bytes=4096,
+        slot_bytes=8192,
+        use_odirect=False,
+        enable_zero_copy=True,
+        meta_total_bytes=256 * 1024,
+        meta_magic=b"LMCIDX01",
+        meta_version=1,
+        meta_checkpoint_interval_sec=600,
+        meta_idle_quiet_ms=0,
+        meta_enable_periodic=False,
+        load_checkpoint_on_init=True,
+        meta_verify_on_load=False,
+        io_engine="posix",
+        iouring_queue_depth=256,
+        meta_full_checkpoint_max_deltas=10_000,
+    )
+    base.update(overrides)
+    return RawBlockCoreConfig(**base)
+
+
+def _put_locked(core: RawBlockCore, key: str, slot_idx: int, size: int = 512) -> None:
+    """Inject a synthetic indexed entry through the public dirty-log helpers."""
+    meta = DiskCacheMetadata(
+        path=f"{core.device_path}@{slot_idx}",
+        size=size,
+        shape=torch.Size((2, 16, 8, 128)),
+        dtype=torch.bfloat16,
+        cached_positions=None,
+        fmt=MemoryFormat.KV_T2D,
+        pin_count=0,
+    )
+    entry = _Entry(
+        offset=core._data_base_offset + slot_idx * core.slot_bytes,
+        size=size,
+        meta=meta,
+    )
+    with core._lock:
+        core._index[key] = entry
+        core._next_slot = max(core._next_slot, slot_idx + 1)
+        core._record_put_op_locked(key, entry)
+        core._meta_dirty_total += 1
+
+
+def _delete_locked(core: RawBlockCore, key: str) -> None:
+    with core._lock:
+        removed = core._index.pop(key, None)
+        if removed is None:
+            return
+        slot = core._offset_to_slot(int(removed.offset))
+        core._append_free_slot_locked(slot)
+        core._record_delete_op_locked(key, slot)
+        core._meta_dirty_total += 1
+
+
+def _active_tail_start(core: RawBlockCore) -> int:
+    return core._delta_tail_start_off(
+        core._active_mirror_idx, core._active_base_payload_total
+    )
+
+
+def test_layout_is_two_equal_mirrors(shared_device):
+    core = RawBlockCore(_config(), key_namespace="object")
+    try:
+        layout = core._meta_layout
+        assert len(layout.base_copy_offsets) == 2
+        assert layout.base_copy_offsets[0] == 0
+        assert layout.base_copy_offsets[1] == layout.base_copy_bytes
+        # The two mirrors share meta_total_bytes evenly, no separate region.
+        assert layout.base_copy_bytes * 2 <= core.meta_total_bytes
+    finally:
+        core.close()
+
+
+def test_first_checkpoint_is_full_then_subsequent_are_delta(shared_device):
+    core = RawBlockCore(_config(), key_namespace="object")
+    try:
+        _put_locked(core, "k0", slot_idx=0)
+        assert core._checkpoint_once(force=True) is True
+        assert core._meta_seq == 1
+        assert core._delta_seq == 0
+        assert core._active_base_seq == 1
+        assert core._active_base_crc != 0
+        first_mirror = core._active_mirror_idx
+
+        _put_locked(core, "k1", slot_idx=1)
+        assert core._checkpoint_once(force=True) is True
+        assert core._meta_seq == 1
+        assert core._delta_seq == 1
+        assert core._delta_tail_off > 0
+        # No mirror flip on a delta append.
+        assert core._active_mirror_idx == first_mirror
+
+        tail_off = _active_tail_start(core)
+        hdr_bytes = bytes(
+            shared_device["buf"][
+                tail_off : tail_off + _DELTA_RECORD_HEADER_STRUCT.size
+            ]
+        )
+        (
+            magic,
+            ver,
+            base_seq,
+            base_crc,
+            delta_seq,
+            prev_crc,
+            payload_len,
+            payload_crc,
+            op_count,
+            flags,
+            total_blocks,
+            reserved,
+        ) = _DELTA_RECORD_HEADER_STRUCT.unpack(hdr_bytes)
+        assert magic == _DELTA_RECORD_MAGIC
+        assert ver == _DELTA_RECORD_VERSION
+        assert base_seq == core._active_base_seq
+        assert base_crc == core._active_base_crc
+        assert delta_seq == 1
+        assert prev_crc == core._active_base_crc  # first record anchors at base_crc
+        assert flags == 0
+        assert total_blocks * core.block_align >= _DELTA_RECORD_HEADER_STRUCT.size
+        assert reserved == 0
+        # Payload CRC matches the bytes that follow the header.
+        payload_off = tail_off + _DELTA_RECORD_HEADER_STRUCT.size
+        payload = bytes(
+            shared_device["buf"][payload_off : payload_off + payload_len]
+        )
+        assert (zlib.crc32(payload) & 0xFFFFFFFF) == payload_crc
+        assert op_count == 1
+    finally:
+        core.close()
+
+
+def test_compaction_flips_mirror_and_resets_tail(shared_device):
+    core = RawBlockCore(
+        _config(meta_full_checkpoint_max_deltas=1), key_namespace="object"
+    )
+    try:
+        _put_locked(core, "k0", slot_idx=0)
+        assert core._checkpoint_once(force=True) is True
+        first_mirror = core._active_mirror_idx
+        first_seq = core._active_base_seq
+        first_crc = core._active_base_crc
+
+        # Append exactly one delta then trigger compaction by exceeding the
+        # max_deltas threshold on the next checkpoint.
+        _put_locked(core, "k1", slot_idx=1)
+        assert core._checkpoint_once(force=True) is True
+        assert core._delta_seq == 1
+
+        _put_locked(core, "k2", slot_idx=2)
+        assert core._checkpoint_once(force=True) is True
+        assert core._meta_seq == 2
+        assert core._delta_seq == 0
+        assert core._delta_tail_off == 0
+        assert core._active_mirror_idx != first_mirror
+        assert core._active_base_seq == first_seq + 1
+        assert core._active_base_crc != first_crc
+    finally:
+        core.close()
+
+
+def test_replay_across_reopen(shared_device):
+    cfg = _config()
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        for i in range(5):
+            _put_locked(core, f"k{i}", slot_idx=i)
+            assert core._checkpoint_once(force=True) is True
+        assert core._delta_seq == 4  # one full base + four deltas
+    finally:
+        core.close()
+
+    fresh = RawBlockCore(cfg, key_namespace="object")
+    try:
+        assert set(fresh._index.keys()) == {f"k{i}" for i in range(5)}
+        assert fresh._delta_seq == 4
+        assert fresh._meta_seq == 1
+        assert fresh._active_base_seq == 1
+    finally:
+        fresh.close()
+
+
+def test_torn_record_stops_replay_at_last_good(shared_device):
+    cfg = _config()
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        _put_locked(core, "k0", slot_idx=0)
+        core._checkpoint_once(force=True)
+        _put_locked(core, "k1", slot_idx=1)
+        core._checkpoint_once(force=True)  # delta_seq=1
+        _put_locked(core, "k2", slot_idx=2)
+        core._checkpoint_once(force=True)  # delta_seq=2
+
+        # Corrupt the last record's payload so replay stops after delta 1.
+        # The last record fills the final block_align block before tail_off;
+        # flipping a payload byte breaks payload_crc.
+        tail_base = _active_tail_start(core)
+        last_rec_off = tail_base + core._delta_tail_off - core.block_align
+        payload_byte = last_rec_off + _DELTA_RECORD_HEADER_STRUCT.size + 4
+        shared_device["buf"][payload_byte] ^= 0xFF
+    finally:
+        core.close()
+
+    fresh = RawBlockCore(cfg, key_namespace="object")
+    try:
+        # Last delta is rejected on CRC; first delta still applied.
+        assert "k0" in fresh._index
+        assert "k1" in fresh._index
+        assert "k2" not in fresh._index
+        assert fresh._delta_seq == 1
+    finally:
+        fresh.close()
+
+
+def test_stale_tail_after_external_override_is_filtered(shared_device):
+    cfg = _config()
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        _put_locked(core, "k0", slot_idx=0)
+        core._checkpoint_once(force=True)
+        _put_locked(core, "k1", slot_idx=1)
+        core._checkpoint_once(force=True)  # delta exists in mirror 0's tail
+    finally:
+        core.close()
+
+    # Externally override to a different state that lands a fresh full base.
+    overrider = RawBlockCore(cfg, key_namespace="object")
+    try:
+        overrider.apply_loaded_state(
+            {
+                "version": 1,
+                "device_path": cfg.device_path,
+                "slot_bytes": cfg.slot_bytes,
+                "meta_total_bytes": cfg.meta_total_bytes,
+                "meta_magic": "LMCIDX01",
+                "meta_version": 1,
+                "next_slot": 0,
+                "free_slots": [],
+                "entries": {},
+            }
+        )
+        # The override resets the active base. Now write a fresh full base.
+        _put_locked(overrider, "kx", slot_idx=0)
+        assert overrider._checkpoint_once(force=True) is True
+    finally:
+        overrider.close()
+
+    fresh = RawBlockCore(cfg, key_namespace="object")
+    try:
+        # The old delta records still on disk under the previous base_seq /
+        # base_crc must not resurrect "k1".
+        assert "k1" not in fresh._index
+        assert "kx" in fresh._index
+    finally:
+        fresh.close()
+
+
+def test_chain_break_stops_replay(shared_device):
+    cfg = _config()
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        _put_locked(core, "k0", slot_idx=0)
+        core._checkpoint_once(force=True)
+        _put_locked(core, "k1", slot_idx=1)
+        core._checkpoint_once(force=True)
+        _put_locked(core, "k2", slot_idx=2)
+        core._checkpoint_once(force=True)  # three deltas total
+
+        # Corrupt the prev_record_crc field of the SECOND record so the
+        # chain breaks between record 1 and record 2. Layout offsets in
+        # the header struct: magic(4) + ver(4) + base_seq(8) + base_crc(4)
+        # + delta_seq(8) → prev_record_crc starts at byte 28.
+        tail_base = _active_tail_start(core)
+        # Walk past first record. Read its total_blocks.
+        first_hdr = bytes(
+            shared_device["buf"][
+                tail_base : tail_base + _DELTA_RECORD_HEADER_STRUCT.size
+            ]
+        )
+        first_total_blocks = _DELTA_RECORD_HEADER_STRUCT.unpack(first_hdr)[10]
+        second_off = tail_base + first_total_blocks * core.block_align
+        # Flip a bit in prev_record_crc (offset 28..32 within the header).
+        for i in range(28, 32):
+            shared_device["buf"][second_off + i] ^= 0xFF
+    finally:
+        core.close()
+
+    fresh = RawBlockCore(cfg, key_namespace="object")
+    try:
+        assert "k0" in fresh._index
+        assert "k1" in fresh._index
+        assert "k2" not in fresh._index
+        assert fresh._delta_seq == 1
+    finally:
+        fresh.close()
+
+
+def test_compaction_on_max_deltas(shared_device):
+    cfg = _config(meta_full_checkpoint_max_deltas=3)
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        for i in range(6):
+            _put_locked(core, f"k{i}", slot_idx=i)
+            core._checkpoint_once(force=True)
+        # After 6 mutations: full + 3 deltas (compaction at delta 4) + ...
+        # We at least observe that compaction has happened (meta_seq > 1).
+        assert core._meta_seq >= 2
+    finally:
+        core.close()
+
+
+def test_compaction_on_full_tail(shared_device):
+    # A small mirror so the tail fills quickly.
+    cfg = _config(
+        meta_total_bytes=32 * 1024,  # 16KiB per mirror
+        meta_full_checkpoint_max_deltas=1_000_000,
+    )
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        compacted = False
+        for i in range(200):
+            _put_locked(core, f"k{i}", slot_idx=i)
+            core._checkpoint_once(force=True)
+            if core._meta_seq >= 2:
+                compacted = True
+                break
+        assert compacted, "expected at least one compaction once tail filled"
+    finally:
+        core.close()
+
+
+def test_close_flushes_pending_delta(shared_device):
+    cfg = _config()
+    core = RawBlockCore(cfg, key_namespace="object")
+    _put_locked(core, "k0", slot_idx=0)
+    core._checkpoint_once(force=True)
+    _put_locked(core, "k1", slot_idx=1)
+    # No explicit checkpoint -- close() must flush.
+    core.close()
+
+    fresh = RawBlockCore(cfg, key_namespace="object")
+    try:
+        assert "k0" in fresh._index
+        assert "k1" in fresh._index
+    finally:
+        fresh.close()
+
+
+def test_higher_seq_mirror_wins_on_load(shared_device):
+    cfg = _config()
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        # Force two compactions so both mirrors hold valid (different) bases.
+        _put_locked(core, "k0", slot_idx=0)
+        core._checkpoint_once(force=True)
+        # Set a tight max_deltas to force compaction on next checkpoint.
+        core.meta_full_checkpoint_max_deltas = 0
+        _put_locked(core, "k1", slot_idx=1)
+        core._checkpoint_once(force=True)  # compaction → mirror flip
+        assert core._meta_seq == 2
+        winning_mirror = core._active_mirror_idx
+    finally:
+        core.close()
+
+    fresh = RawBlockCore(cfg, key_namespace="object")
+    try:
+        assert fresh._meta_seq == 2
+        assert fresh._active_mirror_idx == winning_mirror
+        assert "k0" in fresh._index
+        assert "k1" in fresh._index
+    finally:
+        fresh.close()
+
+
+def test_base_header_decodes_under_single_format(shared_device):
+    cfg = _config()
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        _put_locked(core, "k0", slot_idx=0)
+        core._checkpoint_once(force=True)
+        mirror_off = core._meta_layout.base_copy_offsets[core._active_mirror_idx]
+        hdr = bytes(
+            shared_device["buf"][mirror_off : mirror_off + _META_HEADER_STRUCT.size]
+        )
+        magic, version, seq, payload_len, crc = _META_HEADER_STRUCT.unpack(hdr)
+        assert magic == cfg.meta_magic
+        assert version == cfg.meta_version
+        assert seq == 1
+        assert payload_len > 0
+        assert crc == core._active_base_crc
+    finally:
+        core.close()
+
+
+def test_delete_replays_through_delta(shared_device):
+    cfg = _config()
+    core = RawBlockCore(cfg, key_namespace="object")
+    try:
+        _put_locked(core, "k0", slot_idx=0)
+        _put_locked(core, "k1", slot_idx=1)
+        core._checkpoint_once(force=True)
+        _delete_locked(core, "k0")
+        core._checkpoint_once(force=True)
+    finally:
+        core.close()
+
+    fresh = RawBlockCore(cfg, key_namespace="object")
+    try:
+        assert "k0" not in fresh._index
+        assert "k1" in fresh._index
+    finally:
+        fresh.close()
+
+
+def test_status_exposes_tail_metrics(shared_device):
+    core = RawBlockCore(_config(), key_namespace="object")
+    try:
+        _put_locked(core, "k0", slot_idx=0)
+        core._checkpoint_once(force=True)
+        status = core.report_status()
+        assert "delta_seq" in status
+        assert "delta_tail_off" in status
+        assert "delta_tail_capacity" in status
+        assert "active_base_seq" in status
+        assert "active_mirror_idx" in status
+        assert status["active_base_seq"] == 1
+        assert status["delta_tail_capacity"] > 0
+    finally:
+        core.close()

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -1134,6 +1134,147 @@ def test_rust_raw_block_backend_device_checkpoint_roundtrip(
 @pytest.mark.skipif(
     not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
 )
+def test_rust_raw_block_backend_incremental_multi_key_recovery(
+    memory_allocator, loop_in_thread
+):
+    """End-to-end: incremental checkpoint recovers multi-key state with
+    real Rust raw-block IO.
+
+    Stores several keys across multiple checkpoint forms (full base + delta
+    records), then restarts the backend. Both the metadata index and the
+    on-disk payload bytes must match what was written.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(64 * 1024 * 1024)
+
+        base_cfg = LMCacheEngineConfig.from_defaults(
+            chunk_size=256,
+            local_cpu=True,
+            max_local_cpu_size=0.1,
+            lmcache_instance_id="test_rust_raw_block_multi_key_recovery",
+        )
+        base_cfg.extra_config = {
+            "rust_raw_block.device_path": dev_path,
+            "rust_raw_block.block_align": 4096,
+            "rust_raw_block.header_bytes": 4096,
+            "rust_raw_block.meta_total_bytes": 4 * 1024 * 1024,
+            "rust_raw_block.meta_enable_periodic": False,
+            # Loose enough thresholds to keep all checkpoints below as deltas.
+            "rust_raw_block.meta_full_checkpoint_max_deltas": 1024,
+        }
+        metadata = LMCacheMetadata(
+            model_name="test_model",
+            world_size=1,
+            local_world_size=1,
+            worker_id=0,
+            local_worker_id=0,
+            kv_dtype=torch.bfloat16,
+            kv_shape=(4, 2, 256, 8, 128),
+        )
+
+        local_cpu = LocalCPUBackend(
+            config=base_cfg,
+            metadata=metadata,
+            dst_device="cpu",
+            memory_allocator=memory_allocator,
+        )
+
+        backend1 = RustRawBlockBackend(
+            config=base_cfg,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+        alloc = AdHocMemoryAllocator(device="cpu")
+        keys: list[CacheEngineKey] = []
+        expected: dict[CacheEngineKey, bytes] = {}
+        try:
+            # First write -> forced full base.
+            for chunk_hash in (101, 202, 303, 404, 505, 606):
+                key = CacheEngineKey("test_model", 1, 0, chunk_hash, torch.bfloat16)
+                obj = alloc.allocate(
+                    [torch.Size([2, 16, 8, 128])],
+                    [torch.bfloat16],
+                    fmt=MemoryFormat.KV_T2D,
+                )
+                assert obj is not None and obj.tensor is not None
+                obj.tensor.fill_(chunk_hash & 0xFF)
+                expected[key] = bytes(obj.byte_array)
+                keys.append(key)
+
+                fut = backend1.batched_submit_put_task([key], [obj])[0]
+                fut.result(timeout=10)
+                # Force a checkpoint between every put so each commit lands as
+                # its own delta record (after the very first full base).
+                backend1._core.checkpoint_now()
+
+            assert backend1._core._meta_seq >= 1
+            assert backend1._core._delta_seq >= 1, (
+                "expected at least one delta record after the initial full"
+            )
+        finally:
+            backend1.close()
+
+        # Mount a fresh backend; recovery must restore every key and payload.
+        backend2 = RustRawBlockBackend(
+            config=base_cfg,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+        try:
+            for key, payload in expected.items():
+                assert backend2.contains(key), f"missing after recovery: {key}"
+                out = backend2.get_blocking(key)
+                assert out is not None
+                assert bytes(out.byte_array) == payload, (
+                    f"recovered payload mismatch for {key}"
+                )
+
+            # A second close + mount cycle exercises another full+delta path
+            # and confirms recovery is idempotent across restarts.
+            extra_key = CacheEngineKey("test_model", 1, 0, 707, torch.bfloat16)
+            extra_obj = alloc.allocate(
+                [torch.Size([2, 16, 8, 128])],
+                [torch.bfloat16],
+                fmt=MemoryFormat.KV_T2D,
+            )
+            assert extra_obj is not None and extra_obj.tensor is not None
+            extra_obj.tensor.fill_(0x77)
+            expected_extra = bytes(extra_obj.byte_array)
+            fut = backend2.batched_submit_put_task([extra_key], [extra_obj])[0]
+            fut.result(timeout=10)
+        finally:
+            backend2.close()
+
+        backend3 = RustRawBlockBackend(
+            config=base_cfg,
+            metadata=metadata,
+            local_cpu_backend=local_cpu,
+            loop=loop_in_thread,
+            dst_device="cpu",
+        )
+        try:
+            for key, payload in expected.items():
+                assert backend3.contains(key)
+                out = backend3.get_blocking(key)
+                assert out is not None
+                assert bytes(out.byte_array) == payload
+            assert backend3.contains(extra_key)
+            extra_out = backend3.get_blocking(extra_key)
+            assert extra_out is not None
+            assert bytes(extra_out.byte_array) == expected_extra
+        finally:
+            backend3.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
 def test_rust_raw_block_backend_skips_checkpoint_on_init(
     memory_allocator, loop_in_thread
 ):


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache! -->

**What this PR does / why we need it**:

The raw_block backend used to write a full JSON snapshot of every indexed
key on every checkpoint. Once the cache holds many keys, each checkpoint
serializes the whole index and pays O(N) disk writes regardless of how
much actually changed.

This PR introduces a v2 base+delta checkpoint layout. A full base mirror
is written on the first commit and on compaction; in between, each
checkpoint appends a small delta record covering only the keys that
mutated since the last full. Compaction back to a fresh base is triggered
by configurable thresholds (delta count, region usage watermark, time
since last full, oversize record, or first-write). The shared
`RawBlockCore` is reused so both the legacy non-MP plugin
(`RustRawBlockBackend`) and the multi-process L2 adapter
(`RawBlockL2Adapter`) pick up the change.

Existing v1 disks remain readable: `_select_latest_checkpoint` probes
both the v2 active offsets and the legacy v1 50/50 offsets so old data
loads transparently. The first new full migrates the format on disk —
no operator action required.

**Special notes for your reviewers**:

- Defaults: `meta_incremental_enabled=True` for any sufficiently sized
  meta region; falls back to v1 with a warning when the layout cannot fit
  two base mirrors plus a delta region.
- Crash safety: a dedicated `_writer_lock` serializes concurrent
  `_checkpoint_once` calls so they cannot race on the delta tail offset
  or mirror seq. Every full write zeroes the first delta block, so any
  stale records whose `base_seq` would otherwise collide with the new
  full's seq (e.g. after an external `apply_loaded_state`) are capped.
  Replay walks records left-to-right and stops on the first invalid CRC,
  magic, `base_seq`, or non-monotonic `delta_seq`. Slot-header validation
  runs *after* replay so deltas cannot resurrect a base entry the
  validator intended to drop.
- New config keys are surfaced through both the legacy
  `extra_config` plugin (`rust_raw_block.meta_*`) and
  `RawBlockL2AdapterConfig`; `RawBlockL2AdapterConfig.help()` and the
  constructor docstring describe each one.
- Recovery is exercised broadly:
  - Unit tests
    (`tests/v1/storage_backend/test_raw_block_incremental_checkpoint.py`)
    cover layout sizing, v1 fallback, full vs delta selection, replay
    round-trip, torn-write handling, stale `base_seq`, non-monotonic
    `delta_seq`, max-deltas / region-full / watermark compaction,
    v1 → v2 migration (both ping-pong parities), close-mount loops,
    multi-op delta records, PUT/DELETE/PUT same-key sequences, long
    delta chains, multi-compaction cycles, CRC-valid but JSON-invalid
    payloads, free-slot reuse, `load_checkpoint_on_init=False` with
    deltas, `apply_loaded_state` stale-delta isolation, and post-replay
    validation.
  - Rust extension integration tests verify the same recovery path on
    real raw-block I/O through both wrappers:
    `test_rust_raw_block_backend_v2_incremental_multi_key_recovery`
    (legacy plugin) and
    `test_raw_block_l2_adapter_v2_incremental_multi_key_recovery` +
    `test_raw_block_l2_adapter_close_flushes_pending_via_delta` (MP
    adapter).
- Tests reach into a few private members (e.g. `_lock`, `_dirty_log`,
  `_record_put_op_locked`) so they can drive the checkpoint pipeline
  through the fake raw-block device without standing up the full Rust
  IO path. Happy to move those behind a test-only helper if reviewers
  prefer.
- Local pre-commit equivalents (`ruff check`, `ruff format`, `isort`,
  `codespell`, SPDX header check) all pass on the changed files.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
