### PR TITLE
[Bugfix][CB] Fix sep_tokens BPE-context bug in SegmentTokenDatabase

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -431,10 +431,22 @@ class SegmentTokenDatabase(TokenDatabase):
 
         self.tokenizer = AutoTokenizer.from_pretrained(metadata.model_name)
 
-        # TODO (Jiayi): figure out how to decide when
-        # to use `1:` (whether there's a special starting token
-        # in the beginning)
-        self.sep_tokens = self.tokenizer.encode(config.blend_special_str)[1:]
+        # Encode blend_special_str so the resulting tokens match the BPE
+        # merges that occur when it appears mid-text. We strip surrounding
+        # whitespace from the configured separator, prepend exactly one
+        # leading space to anchor space-prefixed BPE merges, and pass
+        # add_special_tokens=False so no BOS is added. The prior length-
+        # dependent slice (encode(...)[1:]) was tokenizer-specific: it
+        # stripped a leading BOS that some tokenizers prepend (Llama-2/3,
+        # Mistral, OPT) but produced start-of-string tokens that never
+        # appear mid-text on those tokenizers. Symptom: zero segments
+        # detected → entire prompt stored as one chunk → 0% retrieval.
+        # Verified on Llama-3, Qwen2.5, OPT-125m for both `"# #"` and
+        # `" # # "` separator forms.
+        self.sep_tokens = self.tokenizer.encode(
+            " " + config.blend_special_str.strip(),
+            add_special_tokens=False,
+        )
         self.sep_tokens = torch.tensor(self.sep_tokens, device="cpu")
         self.sep_len = len(self.sep_tokens)
 

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -132,3 +132,67 @@ def test_segment_token_database(prefix_length, chunk_lengths):
         assert key.chunk_hash == hashes[i]
         # print(st, starts[i])
         # print(ed, ends[i])
+
+
+@pytest.mark.parametrize(
+    "model_name", ["facebook/opt-125m", "Qwen/Qwen2.5-0.5B-Instruct"]
+)
+@pytest.mark.parametrize("blend_special_str", [" # # ", "# #"])
+@pytest.mark.skipif(
+    not hf_credentials_available(), reason="No Hugging Face credentials found"
+)
+def test_segment_token_database_sep_tokens_match_real_text(
+    model_name, blend_special_str
+):
+    """Regression test: ``SegmentTokenDatabase.sep_tokens`` must equal the
+    BPE token sequence produced when ``blend_special_str`` appears inside
+    a real prompt. The prior ``tokenizer.encode(blend_special_str)[1:]``
+    produced start-of-string tokens that never appear mid-text on tokenizers
+    with default-BOS prepending (Llama-2/3, Mistral, OPT) — silently
+    breaking CacheBlend retrieval to 0% on those models. Symptom: zero
+    segments detected → entire prompt stored as one chunk.
+
+    The fix encodes ``" " + blend_special_str.strip()`` with
+    ``add_special_tokens=False``: stripping surrounding whitespace
+    normalizes the common-but-fragile production setting ``" # # "``,
+    the leading space anchors the same BPE merge that occurs at every
+    mid-text occurrence, and ``add_special_tokens=False`` prevents BOS
+    being prepended in the first place.
+    """
+    cfg = LMCacheEngineConfig.from_legacy(blend_special_str=blend_special_str)
+    metadata = dumb_metadata_with_model_name(model_name)
+    db = SegmentTokenDatabase(cfg, metadata)
+    sep_tokens = db.sep_tokens.tolist()
+
+    # Production-shape user_content: passages joined by " # # " (matches the
+    # real CacheBlend RAG pattern). The configured blend_special_str may
+    # vary in whitespace (" # # " vs "# #"), but the literal text in mid-
+    # prompt is always the space-padded form — which the fix must handle.
+    sep_in_text = " # # "
+    user_content = (
+        "Reference passages:"
+        + sep_in_text
+        + sep_in_text.join(
+            [
+                "[Passage A]\nFirst passage text.",
+                "[Passage B]\nSecond passage text.",
+                "[Passage C]\nThird passage text.",
+            ]
+        )
+        + sep_in_text
+        + "Question: q?"
+    )
+    prompt_ids = db.tokenizer.encode(user_content, add_special_tokens=False)
+    n_seps_in_text = user_content.count(sep_in_text)
+
+    n = len(sep_tokens)
+    matches = sum(
+        1
+        for i in range(len(prompt_ids) - n + 1)
+        if prompt_ids[i : i + n] == sep_tokens
+    )
+    assert matches == n_seps_in_text, (
+        f"{model_name} blend_special_str={blend_special_str!r}: "
+        f"sep_tokens {sep_tokens} matched {matches} times in user_content "
+        f"(expected {n_seps_in_text}). prompt_ids[:30]={prompt_ids[:30]}"
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a tokenizer-context-sensitive bug in `SegmentTokenDatabase.__init__` that silently breaks CacheBlend retrieval to 0% on tokenizers with default-BOS prepending (Llama-2/3, Mistral, OPT). Symptom: zero segments detected → entire prompt stored as a single chunk → no cross-request reuse.

The bug has been latent because Qwen-family tokenizers don't prepend BOS by default, so `encode(s)[1:]` happens to leave a valid mid-text token, masking the issue in CacheBlend's primary published examples. Verified affected: Llama-3, OPT-125m. Verified working-by-accident: Qwen2.5.

## Root cause

Inside `SegmentTokenDatabase.__init__`:

```python
# TODO (Jiayi): figure out how to decide when
# to use `1:` (whether there's a special starting token
# in the beginning)
self.sep_tokens = self.tokenizer.encode(config.blend_special_str)[1:]
```

The `[1:]` slice strips a single leading token, presumably BOS. But:

1. On default-BOS tokenizers (Llama-3, OPT), `encode("# #")` produces e.g. `[BOS, '#', ' #']`. Slicing to `['#', ' #']` keeps a **start-of-string** `#` token (id 2 on Llama-3, 10431 on OPT) that **never appears mid-text** — every in-prompt occurrence of `#` is preceded by a word/space and merges into a different BPE token (id 674 / 849 respectively).
2. On no-BOS tokenizers (Qwen), the slice mis-strips a real content token, leaving a single token that happens to match space-prefixed `#` mid-text — explaining why Qwen-based examples work.
3. The common production configuration `blend_special_str = " # # "` (with surrounding spaces, used by the public CacheBlend RAG examples) makes it worse: even the bare encode-with-BOS-stripped path produces a 3-token sequence ending in a trailing-space token (id 220) that doesn't appear immediately after the second `#` in mid-text either.

Empirical confirmation across three tokenizers on a production-shape RAG prompt with 4 ` # # ` separators:

| Tokenizer | `blend=" # # "` old | `blend="# #"` old | `blend=" # # "` fix | `blend="# #"` fix |
|---|---:|---:|---:|---:|
| Llama-3.2-1B | 0/4 | 0/4 | **4/4** | **4/4** |
| Qwen2.5-0.5B | 0/4 | 8/4* | **4/4** | **4/4** |
| OPT-125m | 0/4 | 0/4 | **4/4** | **4/4** |

*Qwen `[671]` over-matches because the single-token marker hits both `#` tokens in each `# #` independently — over-segmentation, not the intended chunk boundaries.

## Fix

Replace the length-dependent slice with a tokenizer-agnostic encoding that:
- **strips surrounding whitespace** (`config.blend_special_str.strip()`) so a common production setting `" # # "` produces the same sep_tokens as the un-padded `"# #"`,
- **prepends exactly one leading space** so BPE merges anchor on the space-prefixed `' #'` form that occurs at every mid-text boundary,
- passes **`add_special_tokens=False`** so BOS is never inserted in the first place — no length-dependent slice needed.

```python
self.sep_tokens = self.tokenizer.encode(
    " " + config.blend_special_str.strip(),
    add_special_tokens=False,
)
```

This produces the right sep_tokens deterministically across the three tokenizers tested:

- Llama-3: `[674, 674]` (=`' #'`, `' #'`)
- Qwen2.5: `[671, 671]` (same)
- OPT-125m: `[849, 849]` (same)

…each matching exactly the 4 separator boundaries in the production RAG prompt.

## Verification

GPU end-to-end on `lmcache/vllm-openai:v0.4.3-lightweight` + Llama-3.3-70B-Instruct fp8 + 1×H100, with this fix and PR #3217 (the dim-fix) both applied. PR #3217 is required separately to avoid a downstream tensor-mismatch when retrieval engages on Llama; this PR is what makes retrieval engage in the first place on default-BOS tokenizers.

| Req | Total tokens | LMCache hit tokens | Hit rate |
|----:|-------------:|-------------------:|---------:|
| warmup | 36 | 0 | — |
| 1 | 1854 | 0 | 0% (cold) |
| 2 | 1865 | 936 | **50.2%** |
| 3 | 1855 | 1839 | **99.1%** |
| 4 | 1863 | 1839 | **98.7%** |
| 5 | 1862 | 1839 | **98.8%** |

Hit-rate progression matches the published Qwen3-8B baseline (0%, 49%, 99%, 99%, 99%) — the sep_tokens fix is the load-bearing piece that makes Llama behave like the working baseline.

CPU-only repro (parametric regression test included): \`tests/v1/test_token_database.py::test_segment_token_database_sep_tokens_match_real_text\` — parametrized over `(facebook/opt-125m, Qwen/Qwen2.5-0.5B-Instruct) × (" # # ", "# #")`. Asserts the resulting sep_tokens match all 4 separator boundaries in a production-shape RAG prompt. Runs in <1s without GPU.

**Special notes for your reviewers**:

- The fix is tokenizer-agnostic by construction — `add_special_tokens=False` prevents BOS injection regardless of tokenizer defaults; `.strip()` normalizes whitespace-padded blend strings; the leading space ensures BPE merges that occur in mid-text are produced.
- This bug has likely been present since `SegmentTokenDatabase` landed; the TODO above the line dates from the same era and called out exactly this uncertainty. The fix closes that TODO.
- Worth a maintainer pass on whether existing benchmark suites were running against tokenizers in the Qwen-family-by-accident bucket; their numbers may shift slightly if rerun (the over-segmentation case noted above goes away).
- Filed in parallel with PR #3217. They're independent fixes for separate bugs; #3217 fixes the `process_qkv` tensor-mismatch when retrieval engages, this one makes retrieval engage in the first place on default-BOS tokenizers.
- We've been carrying this as a downstream patch in our oneshot-pod boot script for several weeks of internal benching against Llama-3.3-70B; happy to add a third tokenizer to the test or any other shape change reviewers prefer.

**If applicable**:

- [ ] this PR contains user facing changes - docs added <!-- N/A: internal correctness fix, no API change -->
- [x] this PR contains unit tests