### PR TITLE
docs: daily drift check — multi-process mode (2026-05-08)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -243,7 +243,7 @@ The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
 Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
 ``fs_native``, ``mock``, ``mooncake_store``, ``s3``, ``resp``, ``plugin``,
-``native_plugin``.
+``native_plugin``, ``raw_block``, ``dax``.
 
 ``nixl_store`` -- NIXL-based persistent storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -188,6 +188,17 @@ L1 Metrics
    * - ``lmcache_mp.l1_evicted_keys``
      - Counter
      - Number of keys evicted by the EvictionController.
+   * - ``lmcache_mp.l1_eviction_loop_ticks``
+     - Counter
+     - L1 eviction-loop iterations (every cycle, regardless of whether
+       the watermark was crossed). Driven by ``L1_EVICTION_LOOP_TICK``.
+   * - ``lmcache_mp.l1_eviction_loop_triggered``
+     - Counter
+     - L1 eviction-loop iterations where ``usage >= watermark`` and the
+       eviction policy actually ran. The two counters distinguish "loop
+       is alive" from "eviction fired" — important when debugging
+       short-lived benchmarks that complete faster than the 1 Hz
+       polling cycle.
 
 L1 Chunk Lifecycle Histograms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -555,6 +566,14 @@ Adapters with no in-flight work emit no datapoint for that scrape.
      - Bytes currently held in L1.  Rising without plateauing typically
        indicates a leak; saturating at the configured ``--l1-size-gb``
        indicates working set exceeds capacity.
+   * - ``lmcache_mp.l1_usage_ratio``
+     - ObservableGauge
+     - L1 used/total ratio (``0.0``–``1.0``), sampled at scrape time
+       from ``L1Manager.get_memory_usage()``. Returns ``0.0`` when the
+       gauge target is not yet wired up or ``total_bytes`` is zero, so
+       the callback never raises during a scrape. Compare against the
+       eviction watermark (default ``0.8``) to read whether the
+       eviction loop is below or above its trigger threshold.
    * - ``lmcache_mp.num_inflight_l2_stores``
      - ObservableGauge (attrs: ``l2_name``, ``adapter_index``)
      - L2 store tasks currently executing, per adapter.  Sustained


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine. **Docs only — no code changes.** Needs a human reviewer before merge; please keep as draft until reviewed.

Two drift items this run, on two different MP doc pages, triggered by recent merges to `dev`:

| Item | File | Trigger PR |
| --- | --- | --- |
| Stale "Registered adapter types" summary list (missing `raw_block`, `dax`) | `docs/source/mp/configuration.rst` | #3161 (today) + #3119 (earlier) |
| Missing user-facing surface for new L1 eviction-loop counters and `l1_usage_ratio` gauge | `docs/source/mp/observability.rst` | #3196 (2026-05-07) |

### `docs/source/` (user-facing)

#### 1. Stale "Registered adapter types" list — #3161 (2026-05-07) + #3119 (earlier)

`docs/source/mp/configuration.rst:244-246` lists the registered L2 adapter types as a one-line summary at the top of the L2 Adapters reference. Today's #3161 (`[MP] daxbackend mp l2 support`, commit `ec7cc29`) registers a new `dax` adapter type via `register_l2_adapter_type("dax", DaxL2AdapterConfig)`, and #3119 had previously registered `raw_block`. Both adapters are fully documented further down on `docs/source/mp/l2_storage.rst` (full sections at lines 196 / 335, plus rows in the L2 Eviction Support table at lines 744 / 753), but the summary list at `configuration.rst:244-246` was never updated, so a reader scanning the configuration reference for the at-a-glance set of available types misses two real registered adapters.

The list of `register_l2_adapter_type(...)` call sites in `lmcache/v1/distributed/l2_adapters/` is the source of truth, and on current `dev` it covers: `nixl_store`, `nixl_store_dynamic`, `fs`, `fs_native`, `mock`, `mooncake_store`, `s3`, `resp`, `plugin`, `native_plugin`, `raw_block`, `dax`.

**Evidence (permalinked to `dev` HEAD `006dbca`):**

- Today's `dax` registration (#3161): [`lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py#L572`](https://github.com/LMCache/LMCache/blob/006dbca7ea77637a59e9aea5c227eb927fc9a657/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py#L572)
- `raw_block` registration: [`lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py#L760`](https://github.com/LMCache/LMCache/blob/006dbca7ea77637a59e9aea5c227eb927fc9a657/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py#L760)
- Same-PR full reference for `dax` already exists at [`docs/source/mp/l2_storage.rst#L196-L249`](https://github.com/LMCache/LMCache/blob/006dbca7ea77637a59e9aea5c227eb927fc9a657/docs/source/mp/l2_storage.rst#L196-L249) and the L2 Eviction Support row at line 753.
- Stale doc location prior to this PR: `docs/source/mp/configuration.rst:244-246`.

#### 2. Missing user-facing surface for new L1 metrics — #3196 (2026-05-07)

#3196 (`[Observability] Expose blend token-level hit-rate counters`, commit `375243f`) lands three new `lmcache_mp.*` instruments — that is, on the namespace already documented in `docs/source/mp/observability.rst` — but only updates the mirrored design docs (`METRICS.md`, `EVENTS.md`, `DEBUG.md`) and the `lmcache_blend.*` namespace. The user-facing observability reference was not touched, so end users opening Prometheus / Grafana have no documented surface for these instruments:

| OTel metric | Type | Source |
| --- | --- | --- |
| `lmcache_mp.l1_eviction_loop_ticks` | Counter | `L1EvictionLoopSubscriber` (`L1_EVICTION_LOOP_TICK` event) |
| `lmcache_mp.l1_eviction_loop_triggered` | Counter | Same event, increments only when `triggered=True` |
| `lmcache_mp.l1_usage_ratio` | ObservableGauge | Callback on `L1Manager.get_memory_usage()` |

**Evidence (permalinked to `dev` HEAD `006dbca`):**

- L1 eviction-loop subscriber wiring both counters: [`lmcache/v1/mp_observability/subscribers/metrics/l1_eviction_loop.py#L18-L48`](https://github.com/LMCache/LMCache/blob/006dbca7ea77637a59e9aea5c227eb927fc9a657/lmcache/v1/mp_observability/subscribers/metrics/l1_eviction_loop.py#L18-L48)
- Eviction controller publishes `L1_EVICTION_LOOP_TICK` on every loop iteration with `triggered ∈ {True, False}`: [`lmcache/v1/distributed/storage_controllers/eviction_controller.py#L118-L172`](https://github.com/LMCache/LMCache/blob/006dbca7ea77637a59e9aea5c227eb927fc9a657/lmcache/v1/distributed/storage_controllers/eviction_controller.py#L118-L172)
- `lmcache_mp.l1_usage_ratio` registered via `register_gauge` against `L1Manager`: [`lmcache/v1/distributed/l1_manager.py#L209-L214`](https://github.com/LMCache/LMCache/blob/006dbca7ea77637a59e9aea5c227eb927fc9a657/lmcache/v1/distributed/l1_manager.py#L209-L214) (and the `_l1_usage_ratio_or_zero` helper above it that returns `0.0` when total is zero).
- L1 watermark default `0.8` (cited in the new gauge description): [`lmcache/v1/distributed/config.py#L67`](https://github.com/LMCache/LMCache/blob/006dbca7ea77637a59e9aea5c227eb927fc9a657/lmcache/v1/distributed/config.py#L67)
- Mirrored design doc (already correct, updated in #3196): [`docs/design/v1/mp_observability/METRICS.md#L101-L113`](https://github.com/LMCache/LMCache/blob/006dbca7ea77637a59e9aea5c227eb927fc9a657/docs/design/v1/mp_observability/METRICS.md#L101-L113)
- Stale doc location prior to this PR: `docs/source/mp/observability.rst` (`grep -nE "l1_eviction_loop|l1_usage_ratio" docs/source/mp/observability.rst` → 0 matches).

### `docs/design/`

No new drift observed. The mirrored design doc `docs/design/v1/mp_observability/METRICS.md` was updated in #3196 itself and accurately reflects all three new `lmcache_mp.*` instruments and their source events. The `dax` adapter has its own design doc at `docs/design/v1/distributed/l2_adapters/dax.md`, also added in #3161.

### Other commits checked, no drift

Sweep window: commits on `dev` since the prior drift-check PR's base (`7657836`, base of open #3219 from 2026-05-07).

- **#3160** (Add support for `AZURE_BLOB` NIXL backend, merged 2026-05-08) — Same-PR doc updates cover the surface comprehensively: `docs/source/mp/l2_storage.rst`, `docs/source/mp/configuration.rst`, `docs/source/kv_cache/storage_backends/nixl.rst`, and `docs/design/v1/distributed/l2_adapters/nixl_store.md`. The doc claim that `AZURE_BLOB` is supported by `nixl_store` but not by `nixl_store_dynamic` matches the code (`AZURE_BLOB` was allow-listed only in the static `NixlStoreL2Adapter`).
- **#3146** (fix: per-instance FastAPI app for TP=1 non-MP mode 503, merged 2026-05-08) — Internal correctness fix in `lmcache/v1/internal_api_server/api_server.py`; affects only the legacy non-MP path and does not change any documented endpoint or behavior. The MP-mode internal API server is unaffected; out of scope for this MP-mode drift check.
- **#3208** ([MP] Make vLLM be able to reconnect after LMCache restarts, merged 2026-05-07) — Adds idempotency to `MPCacheEngine.register_kv_cache` (re-registering an already-registered `instance_id` now warns and returns instead of raising). The `REGISTER_KV_CACHE` row in the `docs/source/mp/architecture.rst` ZMQ Protocol table says "Register GPU KV cache tensors for a vLLM instance.", which remains accurate; the reconnect refinement is an additional behaviour, not a contradiction. Open drift-check PR #3184 already plans to rewrite the same table; deliberately not touching it here to avoid conflicts.
- **#3196** `lmcache_blend.*` additions (`lookup_requested_tokens`, `lookup_hit_tokens`) — These extend an undocumented namespace (`docs/source/mp/observability.rst` does not surface any `lmcache_blend.*` metric). Not new drift introduced by #3196: the `lmcache_blend.lookup_requests` / `lookup_fingerprint_hits` / `lookup_storage_hits` / `lookup_stale_chunks` / `lookup_no_gpu_context_errors` counters predate it and were never user-documented either. Flagging here for visibility — the right fix is a new "CacheBlend Metrics" subsection on the user reference, which is broader than this surgical drift PR. If reviewers prefer one cross-cutting fix, I can broaden the scope in a follow-up.
- **#3211** (`[operator] Add gpuVendor field to support AMD GPUs`, merged 2026-05-07) — Operator change (`operator/api/v1alpha1/...`). Same-PR `operator/README.md` update covers the `gpuVendor` field. Not in the LMCache user-docs MP surface.
- **#3222** (`[CI] Fix flaky comprehensive tests`, merged 2026-05-07) — CI-only.
- **#3159** (merge of the 2026-04-28 drift-check PR, landed 2026-05-07) — Drift-check workflow PR; no docs other than the targeted fix.

### Existing open drift-check PRs

Verified non-overlapping:

- **#3219** (2026-05-07) — `docs/source/mp/l2_storage.rst` Mooncake field rename. Different file from item 1; different paragraph from anything this PR touches.
- **#3186** (2026-05-03) — `docs/source/mp/observability.rst` EventBus self-monitoring metrics. Targets a *new* subsection between `Observable Gauges` and `Prometheus Scrape Configuration`. Item 2 of this PR appends rows to existing `L1 Metrics` and `Observable Gauges` tables; the changes are on different lines and rebase cleanly either way.
- **#3184** (2026-05-02) — `docs/source/mp/architecture.rst` ZMQ Protocol table. Different file; #3208 was deliberately not addressed in this PR for that reason.
- **#3174** (2026-04-30 / 05-01) — `docs/source/mp/observability.rst` per-request hit-rate attributes (Tracing section) + `docs/source/mp/l2_storage.rst` Mooncake setup. Tracing section is far below where this PR edits the L1 Metrics and Observable Gauges tables, no conflict.

## Proposed fix

Applied in this PR. Surgical doc edits only — `docs/source/mp/configuration.rst` (+1 / −1) and `docs/source/mp/observability.rst` (+19 / −0):

- `configuration.rst`: append `` ``raw_block`` `` and `` ``dax`` `` to the registered adapter types one-line summary.
- `observability.rst` `L1 Metrics` table: add two rows for `lmcache_mp.l1_eviction_loop_ticks` and `lmcache_mp.l1_eviction_loop_triggered`, each with the description and the rationale for keeping them as separate counters (so short-lived benchmarks can still distinguish "loop is alive" from "eviction fired").
- `observability.rst` `Observable Gauges` table: add a row for `lmcache_mp.l1_usage_ratio` describing the `0.0`–`1.0` ratio, the `0.0` fallback path, and how to read it against the L1 watermark default (`0.8`, sourced from `lmcache/v1/distributed/config.py:67`).

## Notes for reviewers

- This was **auto-generated by the daily drift-check routine** and needs human review before merge.
- Author / committer: `ApostaC <yihua98@uchicago.edu>`. Commit carries a `Signed-off-by: ApostaC <yihua98@uchicago.edu>` trailer for DCO.
- No code changes — the new adapters and metrics are already wired up. This PR only makes the user-facing references match what the code actually registers and emits.

## Test plan

- [ ] `cd docs && make html` builds without new warnings on `mp/configuration.rst` and `mp/observability.rst`.
- [ ] Eyeball the rendered "Registered adapter types" sentence on `mp/configuration.rst`; confirm both `raw_block` and `dax` appear and the surrounding sentence still reads cleanly.
- [ ] Eyeball the rendered `L1 Metrics` and `Observable Gauges` tables on `mp/observability.rst`; confirm three new rows render and no rows are duplicated.
- [ ] Spot-check on a live `lmcache server` with metrics enabled: `curl -s :9090/metrics | grep -E 'l1_eviction_loop_(ticks|triggered)|l1_usage_ratio'` returns all three series.

---
_Generated by [Claude Code](https://claude.ai/code/session_aXfvU)_