### PR TITLE
 [Observability] Surface CB-registered GPU contexts in /api/statusreport cb server status

### DIFF
--- a/lmcache/cli/commands/bench/engine_bench/config.py
+++ b/lmcache/cli/commands/bench/engine_bench/config.py
@@ -173,6 +173,10 @@ def resolve_tokens_per_gb(lmcache_url: str, model_name: str) -> int:
 
     gpu_meta = data.get("gpu_context_meta", {})
     if not gpu_meta:
+        # CB-only deployments (engine_type="blend") populate
+        # cb_gpu_context_meta instead of gpu_context_meta.
+        gpu_meta = data.get("cb_gpu_context_meta", {})
+    if not gpu_meta:
         raise RuntimeError(
             "No model info returned by LMCache server; "
             "is the server running with a model loaded?"

--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -174,6 +174,9 @@ class KVCacheDescriber:
         """Per-model KV cache layout sections."""
         gpu_meta = self.data.get("gpu_context_meta", {})
         if not gpu_meta:
+            # CB-only deployments populate cb_gpu_context_meta instead.
+            gpu_meta = self.data.get("cb_gpu_context_meta", {})
+        if not gpu_meta:
             return
 
         # Deduplicate by (model_name, world_size) — multiple GPU IDs
@@ -210,17 +213,21 @@ class KVCacheDescriber:
                 "GPU KV tensor shape",
                 layout.get("gpu_kv_concrete_shape"),
             )
-            sec.add("num_layers", "Num layers", layout["num_layers"])
-            sec.add("block_size", "Block size", layout["block_size"])
-            sec.add("hidden_dim_sizes", "Hidden dim sizes", layout["hidden_dim_sizes"])
-            sec.add("dtype", "Dtype", layout["dtype"])
-            sec.add("is_mla", "MLA", layout["is_mla"])
-            sec.add("num_blocks", "Num blocks", layout["num_blocks"])
-            sec.add(
-                "cache_size_per_token",
-                "Cache size per token (bytes)",
-                layout["cache_size_per_token"],
-            )
+            # CB-only contexts ship a singular ``hidden_dim_size``; wrap to
+            # match the plural list-shape used by the regular path.
+            if "hidden_dim_sizes" not in layout and "hidden_dim_size" in layout:
+                layout = dict(layout, hidden_dim_sizes=[layout["hidden_dim_size"]])
+            for _key, _label in (
+                ("num_layers", "Num layers"),
+                ("block_size", "Block size"),
+                ("hidden_dim_sizes", "Hidden dim sizes"),
+                ("dtype", "Dtype"),
+                ("is_mla", "MLA"),
+                ("num_blocks", "Num blocks"),
+                ("cache_size_per_token", "Cache size per token (bytes)"),
+            ):
+                if _key in layout:
+                    sec.add(_key, _label, layout[_key])
 
     def add_l2_adapters(self) -> None:
         """L2 adapter sections."""

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -426,6 +426,43 @@ class BlendEngineV2(MPCacheEngine):
                 instance_id,
             )
 
+    def report_status(self) -> dict:
+        """Return a status dict for the entire cache engine.
+
+        Extends the base dict with ``registered_cb_gpu_ids`` and
+        ``cb_gpu_context_meta`` so CB-only deployments are distinguishable
+        from "no engine connected" to ``/api/status`` clients.
+        """
+        status = super().report_status()
+
+        cb_gpu_context_meta: dict[str, dict] = {}
+        for gpu_id, meta in self._cb_gpu_context_meta.items():
+            model_name, world_size = meta
+            entry: dict = {
+                "model_name": model_name,
+                "world_size": world_size,
+            }
+            ctx = self._cb_gpu_contexts.get(gpu_id)
+            if ctx is not None:
+                # bytes per token = 2 (K+V) * num_layers * hidden_dim_size *
+                # itemsize; num_tokens is the cache capacity, not a per-token
+                # cost.
+                cache_size_per_token = (
+                    2 * ctx.num_layers * ctx.hidden_dim_size * ctx.dtype.itemsize
+                )
+                entry["kv_cache_layout"] = {
+                    "num_layers": ctx.num_layers,
+                    "num_tokens": ctx.num_tokens,
+                    "hidden_dim_size": ctx.hidden_dim_size,
+                    "dtype": str(ctx.dtype),
+                    "cache_size_per_token": cache_size_per_token,
+                }
+            cb_gpu_context_meta[str(gpu_id)] = entry
+
+        status["registered_cb_gpu_ids"] = list(self._cb_gpu_contexts.keys())
+        status["cb_gpu_context_meta"] = cb_gpu_context_meta
+        return status
+
     def cb_lookup_pre_computed(self, key: IPCCacheEngineKey) -> list[CBMatchResult]:
         """
         Lookup the pre-computed chunks in the underlying storage.

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -43,6 +43,7 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.mp_observability.config import DEFAULT_OBSERVABILITY_CONFIG
 from lmcache.v1.multiprocess.blend_server_v2 import (
+    BlendEngineV2,
     BlendTokenRangeMatcher,
     _unique_token_coverage,
 )
@@ -1908,3 +1909,137 @@ def test_cb_store_final_v2_visible_to_cb_lookup_v2(
     assert len(cb_results) == 1, (
         "CB_LOOKUP_PRE_COMPUTED_V2 should find data stored via CB_STORE_FINAL"
     )
+
+
+# ---------------------------------------------------------------------------
+# 8. report_status() – CB-extended fields
+# ---------------------------------------------------------------------------
+#
+# These tests construct a BlendEngineV2 directly in the test process because
+# report_status() is invoked in-process by the FastAPI /api/status handler,
+# not over ZMQ. CUDA IPC unwrapping is bypassed via a monkeypatched
+# unwrap_kv_cache_tensors so the public cb_register_kv_cache path can run
+# without a cross-process producer.
+
+
+@pytest.fixture(scope="function")
+def in_process_blend_engine() -> Generator[BlendEngineV2, None, None]:
+    """Build a BlendEngineV2 in-process for direct method-call tests."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    config = StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=int(CPU_BUFFER_SIZE * 1024**3),
+                use_lazy=True,
+            ),
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+    )
+    engine = BlendEngineV2(
+        storage_manager_config=config,
+        chunk_size=CHUNK_SIZE,
+    )
+    try:
+        yield engine
+    finally:
+        engine.close()
+
+
+@pytest.fixture(scope="function")
+def local_kv_cache_unwrap(monkeypatch, cb_client_context: CBClientContext):
+    """Bypass CUDA IPC unwrap so PlainGPUCacheContext can be built in-process.
+
+    Returns the local tensor that will back any KVCache the test registers.
+    """
+    # First Party
+    from lmcache.v1.multiprocess import gpu_context as gpu_context_mod
+
+    local_tensor = cb_client_context.gpu_kv_cache
+
+    def _local_unwrap(_kv_caches):
+        return [local_tensor]
+
+    monkeypatch.setattr(gpu_context_mod, "unwrap_kv_cache_tensors", _local_unwrap)
+    return local_tensor
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="report_status CB tests require CUDA"
+)
+def test_report_status_no_cb_registrations(
+    in_process_blend_engine: BlendEngineV2,
+):
+    """Without any CB registration, the new fields are present and empty."""
+    status = in_process_blend_engine.report_status()
+
+    assert "registered_cb_gpu_ids" in status
+    assert "cb_gpu_context_meta" in status
+    assert status["registered_cb_gpu_ids"] == []
+    assert status["cb_gpu_context_meta"] == {}
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="report_status CB tests require CUDA"
+)
+def test_report_status_surfaces_cb_registration(
+    in_process_blend_engine: BlendEngineV2,
+    cb_client_context: CBClientContext,
+    local_kv_cache_unwrap,
+):
+    """A CB-registered instance shows up in both new fields with correct shape."""
+    engine = in_process_blend_engine
+    instance_id = 4242
+
+    engine.cb_register_kv_cache(
+        instance_id,
+        cb_client_context.get_kv_cache(),
+        "testmodel",
+        1,
+    )
+
+    status = engine.report_status()
+
+    assert status["registered_cb_gpu_ids"] == [instance_id]
+
+    entry = status["cb_gpu_context_meta"][str(instance_id)]
+    assert entry["model_name"] == "testmodel"
+    assert entry["world_size"] == 1
+
+    layout = entry["kv_cache_layout"]
+    assert layout["num_layers"] == cb_client_context.num_layers
+    assert layout["num_tokens"] == cb_client_context.num_tokens
+    assert layout["hidden_dim_size"] == cb_client_context.hidden_dim
+    assert layout["dtype"] == str(cb_client_context.dtype)
+
+    itemsize = torch.zeros(1, dtype=cb_client_context.dtype).element_size()
+    expected_bytes_per_token = (
+        2 * cb_client_context.num_layers * cb_client_context.hidden_dim * itemsize
+    )
+    assert layout["cache_size_per_token"] == expected_bytes_per_token
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="report_status CB tests require CUDA"
+)
+def test_report_status_unregister_clears_cb_fields(
+    in_process_blend_engine: BlendEngineV2,
+    cb_client_context: CBClientContext,
+    local_kv_cache_unwrap,
+):
+    """Unregistering removes the entry from both new fields."""
+    engine = in_process_blend_engine
+    instance_id = 4243
+
+    engine.cb_register_kv_cache(
+        instance_id,
+        cb_client_context.get_kv_cache(),
+        "testmodel",
+        1,
+    )
+    engine.cb_unregister_kv_cache(instance_id)
+
+    status = engine.report_status()
+    assert status["registered_cb_gpu_ids"] == []
+    assert status["cb_gpu_context_meta"] == {}


### PR DESCRIPTION

  **What this PR does / why we need it**:

  `BlendEngineV2`'s inherited `report_status()` only sees normal vLLM-connector
  registrations, so CB-only deployments (`engine_type="blend"` with no
  `register_kv_cache` call) report empty `registered_gpu_ids` /
  `gpu_context_meta` even when a CB engine is actively connected —
  indistinguishable from "no engine connected at all" to `/api/status` clients.

  This PR overrides `BlendEngineV2.report_status()` to add two parallel fields
  populated from contexts registered via `cb_register_kv_cache`:

  - `registered_cb_gpu_ids`: list of CB instance IDs (disjoint from the base
    `registered_gpu_ids` namespace).
  - `cb_gpu_context_meta`: per-instance `model_name`, `world_size`, and a
    `kv_cache_layout` reflecting `PlainGPUCacheContext`'s
    `[2, num_layers, num_tokens, hidden_dim_size]` shape.