### PR TITLE
[CI]: route unit job to k8s queue

### DIFF
--- a/.buildkite/k3_tests/unit/pipeline.yml
+++ b/.buildkite/k3_tests/unit/pipeline.yml
@@ -5,7 +5,7 @@ steps:
   - label: ":test_tube: Unit Tests"
     command: .buildkite/k3_tests/unit/run.sh
     timeout_in_minutes: 60
-    agents: { queue: "k3-h200-local" }
+    agents: { queue: "k8s" }
     plugins:
       - kubernetes:
           podSpec:

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -30,10 +30,6 @@ source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt
 
 # ── Run unit tests with coverage ─────────────────────────────
-# test_gds_backend is skipped: this CI host has no nvidia-fs kernel
-# module, so cuFileHandleRegister fails with CU_FILE_IO_NOT_SUPPORTED
-# (err=5027) regardless of compat_mode. Re-enable once the host is
-# provisioned with nvidia-fs (or migrated to a GDS-capable node).
 LMCACHE_TRACK_USAGE="false" \
 pytest --maxfail=1 --cov=lmcache \
     --cov-report term --cov-report=html:coverage-test \
@@ -41,8 +37,7 @@ pytest --maxfail=1 --cov=lmcache \
     --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
     --ignore=tests/v1/test_nixl_storage.py \
     --ignore=tests/skipped \
-    --ignore=tests/v1/storage_backend/test_eic.py \
-    --ignore=tests/v1/storage_backend/test_gds_backend.py
+    --ignore=tests/v1/storage_backend/test_eic.py
 
 cat << EOF | buildkite-agent annotate --style "info"
   Read the <a href="artifact://coverage-test/index.html">uploaded coverage report</a>

--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -30,6 +30,10 @@ source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt
 
 # ── Run unit tests with coverage ─────────────────────────────
+# test_gds_backend is skipped: this CI host has no nvidia-fs kernel
+# module, so cuFileHandleRegister fails with CU_FILE_IO_NOT_SUPPORTED
+# (err=5027) regardless of compat_mode. Re-enable once the host is
+# provisioned with nvidia-fs (or migrated to a GDS-capable node).
 LMCACHE_TRACK_USAGE="false" \
 pytest --maxfail=1 --cov=lmcache \
     --cov-report term --cov-report=html:coverage-test \
@@ -37,7 +41,8 @@ pytest --maxfail=1 --cov=lmcache \
     --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
     --ignore=tests/v1/test_nixl_storage.py \
     --ignore=tests/skipped \
-    --ignore=tests/v1/storage_backend/test_eic.py
+    --ignore=tests/v1/storage_backend/test_eic.py \
+    --ignore=tests/v1/storage_backend/test_gds_backend.py
 
 cat << EOF | buildkite-agent annotate --style "info"
   Read the <a href="artifact://coverage-test/index.html">uploaded coverage report</a>

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -4,10 +4,13 @@ from typing import Optional
 from unittest.mock import MagicMock
 import asyncio
 import ctypes
+import functools
 import inspect
+import os
 import random
 import socket
 import string
+import tempfile
 import threading
 import uuid
 
@@ -49,11 +52,71 @@ if lmc_ops is None:
     lmc_ops = MockCOps()
 
 
+def _probe_cufile_register() -> bool:
+    """
+    Try to actually register a cuFile handle on a real file in the test
+    scratch dir. Returns True iff cuFileHandleRegister succeeds.
+
+    Importability of cufile / libcufile.so is necessary but not sufficient:
+    on hosts without nvidia-fs (or on a non-GDS-capable filesystem),
+    cuFileHandleRegister fails at runtime with CU_FILE_IO_NOT_SUPPORTED
+    (err=5027). This probe matches the exact path tests will exercise.
+    """
+    try:
+        # Third Party
+        import cufile
+    except Exception:
+        return False
+
+    probe_dir = os.environ.get("LMCACHE_TEST_TMPDIR") or tempfile.gettempdir()
+    if not os.path.isdir(probe_dir):
+        return False
+
+    try:
+        fd, probe_path = tempfile.mkstemp(dir=probe_dir, prefix="cufile-probe-")
+    except OSError:
+        return False
+
+    try:
+        try:
+            os.write(fd, b"\0" * 4096)
+        finally:
+            os.close(fd)
+        # Mirror production: GdsBackend opens with mode "r+" and
+        # use_direct_io=True (see gds_backend.py:950). If the FS doesn't
+        # support GDS+O_DIRECT, register fails here exactly as in tests.
+        cu = cufile.CuFile(probe_path, "r+", use_direct_io=True)
+        try:
+            cu.open()
+        except Exception:
+            # Register failed. cu._handle may hold the raw fd from os.open
+            # without a registered cuFile handle; close it ourselves and
+            # null the state so __del__ doesn't try to deregister None.
+            raw_fd = getattr(cu, "_handle", None)
+            if raw_fd is not None:
+                try:
+                    os.close(raw_fd)
+                except OSError:
+                    pass
+                cu._handle = None
+            return False
+        cu.close()
+        return True
+    finally:
+        try:
+            os.unlink(probe_path)
+        except OSError:
+            pass
+
+
+@functools.lru_cache(maxsize=1)
 def has_cufile() -> bool:
     """
-    True only when NVIDIA cuFile is available:
+    True only when NVIDIA cuFile is usable on this host's test scratch dir:
     - python package `cufile` importable
     - dynamic library `libcufile.so` loadable
+    - cuFileHandleRegister succeeds on a real file in LMCACHE_TEST_TMPDIR
+      (or the system tmpdir as a fallback)
     """
     try:
         # Third Party
@@ -66,7 +129,7 @@ def has_cufile() -> bool:
     except OSError:
         return False
 
-    return True
+    return _probe_cufile_register()
 
 
 def has_hipfile() -> bool:


### PR DESCRIPTION
The k3-unit-tests pipeline-level config targets the k8s queue for the upload step, but the inner job spec still pinned agents.queue to k3-h200-local. With no agents on k3-h200-local, every spawned unit-test job sat indefinitely as 'waiting'. Align with the other k3 pipelines (blend, multiprocess, integration, comprehensive, correctness) which all run on k8s.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
