### PR TITLE
[CI]: expose prefiller/decoder/proxy logs as artifacts

### DIFF
--- a/.buildkite/k3_tests/comprehensive/scripts/run-single-config.sh
+++ b/.buildkite/k3_tests/comprehensive/scripts/run-single-config.sh
@@ -135,12 +135,12 @@ if [[ "$feature_type" == "pd" ]]; then
     # Prefiller needs UCX_TLS for NIXL transport
     prefiller_docker=$(echo "$prefiller_docker" | yq -y ". + {\"env\": (.env + [\"UCX_TLS=cuda_ipc,cuda_copy,tcp\"])}")
     start_single_server "$prefiller_docker" "$prefiller_vllm" "$PORT1" "0" \
-        "/tmp/build_${BUILD_ID}_${CFG_NAME%.yaml}_prefiller.log"
+        "${REPO_ROOT}/${CFG_NAME%.yaml}-prefiller.log"
 
     echo "--- Starting decoder on port $PORT2 (GPU 1)"
     decoder_docker=$(echo "$decoder_docker" | yq -y ". + {\"env\": (.env + [\"UCX_TLS=cuda_ipc,cuda_copy,tcp\"])}")
     start_single_server "$decoder_docker" "$decoder_vllm" "$PORT2" "1" \
-        "/tmp/build_${BUILD_ID}_${CFG_NAME%.yaml}_decoder.log"
+        "${REPO_ROOT}/${CFG_NAME%.yaml}-decoder.log"
 
     # Start disagg proxy
     echo "--- Starting PD proxy on port $PORT"
@@ -151,7 +151,7 @@ if [[ "$feature_type" == "pd" ]]; then
         --decoder-init-port "$init" \
         --decoder-alloc-port "$alloc" \
         --proxy-port "$proxy" \
-        > "/tmp/build_${BUILD_ID}_${CFG_NAME%.yaml}_proxy.log" 2>&1 &
+        > "${REPO_ROOT}/${CFG_NAME%.yaml}-proxy.log" 2>&1 &
     PIDS+=($!)
     sleep 10
 

--- a/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
@@ -8,7 +8,7 @@
 #   2. Snapshot lmcache_mp_l1_write_keys_total via /metrics.
 #   3. Kill the LMCache server, relaunch on the same port.
 #   4. Wait for the new server to be ready and for the worker to
-#      re-register (poll /api/status until gpu_context_meta is non-empty).
+#      re-register (poll /status until gpu_context_meta is non-empty).
 #   5. Run the same bench round again.
 #   6. Snapshot the metric again.
 #   7. Assert run2 > 0 and run2 >= 0.8 * run1.
@@ -131,7 +131,7 @@ EOF
 wait_for_lmcache_http() {
     local deadline=$(( $(date +%s) + 60 ))
     while [ "$(date +%s)" -lt "$deadline" ]; do
-        if curl -sf "http://localhost:${LMCACHE_HTTP_PORT}/api/healthcheck" > /dev/null 2>&1; then
+        if curl -sf "http://localhost:${LMCACHE_HTTP_PORT}/healthcheck" > /dev/null 2>&1; then
             echo "LMCache HTTP healthy"
             return 0
         fi
@@ -142,7 +142,7 @@ wait_for_lmcache_http() {
 }
 
 wait_for_worker_reregister() {
-    # Poll /api/status until gpu_context_meta has at least one entry,
+    # Poll /status until gpu_context_meta has at least one entry,
     # which proves the vLLM worker re-registered with the new server.
     local deadline=$(( $(date +%s) + RECOVER_TIMEOUT ))
     while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -150,7 +150,7 @@ wait_for_worker_reregister() {
         count=$(python3 - <<EOF 2>/dev/null
 import json, urllib.request
 try:
-    body = urllib.request.urlopen("http://localhost:${LMCACHE_HTTP_PORT}/api/status", timeout=5).read()
+    body = urllib.request.urlopen("http://localhost:${LMCACHE_HTTP_PORT}/status", timeout=5).read()
     data = json.loads(body)
     print(len(data.get("gpu_context_meta", {})))
 except Exception:


### PR DESCRIPTION
**What this PR does / why we need it**:

Server-side logs from the comprehensive PD test (prefiller, decoder, disagg proxy) are not reliably showing up in the Buildkite Artifacts tab. They were being written to `/tmp` and then `cp`'d to `REPO_ROOT` inside the script's `EXIT` trap so the existing `artifact_paths: ["*.log", ...]` glob would catch them. That `cp` is silent (`|| true`), races against pod teardown, and PD failures often leave us without the very logs we need to debug.

This PR writes those three logs directly to `REPO_ROOT` under stable names so they are unconditionally captured by the existing `*.log` artifact glob — no new globs, no trap dependency.

After merge, every comprehensive PD build will have these in Artifacts:
- `pd-prefiller.log`
- `pd-decoder.log`
- `pd-proxy.log`

**Special notes for your reviewers**:

- Single-server and P2P log paths are unchanged on purpose; they hit a different code path and aren't currently a debugging pain point.
- The runner's tee'd stdout (`pd.log`) and the workload `response.txt` continue to be uploaded as before.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests