### PR TITLE
ci(k3-unit-tests): skip test_gds_backend until host has nvidia-fs

### DIFF
--- a/.buildkite/k3_tests/unit/run.sh
+++ b/.buildkite/k3_tests/unit/run.sh
@@ -30,6 +30,10 @@ source .buildkite/k3_harness/setup-lmcache-only-env.sh
 uv pip install -r requirements/test.txt
 
 # ── Run unit tests with coverage ─────────────────────────────
+# test_gds_backend is skipped: this CI host has no nvidia-fs kernel
+# module, so cuFileHandleRegister fails with CU_FILE_IO_NOT_SUPPORTED
+# (err=5027) regardless of compat_mode. Re-enable once the host is
+# provisioned with nvidia-fs (or migrated to a GDS-capable node).
 LMCACHE_TRACK_USAGE="false" \
 pytest --maxfail=1 --cov=lmcache \
     --cov-report term --cov-report=html:coverage-test \
@@ -37,7 +41,8 @@ pytest --maxfail=1 --cov=lmcache \
     --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \
     --ignore=tests/v1/test_nixl_storage.py \
     --ignore=tests/skipped \
-    --ignore=tests/v1/storage_backend/test_eic.py
+    --ignore=tests/v1/storage_backend/test_eic.py \
+    --ignore=tests/v1/storage_backend/test_gds_backend.py
 
 cat << EOF | buildkite-agent annotate --style "info"
   Read the <a href="artifact://coverage-test/index.html">uploaded coverage report</a>


### PR DESCRIPTION
**What this PR does / why we need it**:

`tests/v1/storage_backend/test_gds_backend.py` is failing on the new k3-unit-tests CI host (build [#736](https://buildkite.com/lmcache/k3-unit-tests/builds/736#019e0f2e-4565-450e-bc12-2ef0db55fb93)) with:

```
RuntimeError: cuFileHandleRegister failed (cuFile err=5027, cuda_err=0)
```

`5027` is `CU_FILE_IO_NOT_SUPPORTED`. Diagnostic on the host (`gdscheck -p`, `lsmod`, `/proc/driver/nvidia-fs`):

- `nvidia_fs` kernel module is **not loaded**
- No `/dev/nvidia-fs*`, no `/proc/driver/nvidia-fs/`
- `gdscheck` reports every storage class (`NVMe`, `NVMeOF`, `BeeGFS`, `WekaFS`, ...) as **Unsupported**
- GPU is RTX PRO 6000 Blackwell — different node from the previous H200 host where this test passed

`properties.use_compat_mode = true` is already set in `/etc/cufile.json`, but cuFile still refuses to register a handle on the `/scratch` hostPath without a GDS-capable substrate. There is no application-side knob that fixes this — the host needs `nvidia-fs` provisioned, or this CI needs to move to a GDS-capable node.

This PR adds `--ignore=tests/v1/storage_backend/test_gds_backend.py` to `unit/run.sh` so the rest of the unit suite can run while the host is being fixed.

**Special notes for your reviewers**:

- Drop the `--ignore` once the host has `nvidia-fs` loaded (verify with `gdscheck -p` reporting at least one Supported FS, and `lsmod | grep nvidia_fs`).
- The `LMCACHE_TEST_TMPDIR=/scratch/...` plumbing is left in place so the test will work as soon as the host is fixed and the ignore is removed.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests