### PR TITLE
[Feat][MP] Use io_uring fixed buffers for MP raw_block payload I/O

### DIFF
--- a/benchmarks/storage_backend_io/README.md
+++ b/benchmarks/storage_backend_io/README.md
@@ -115,7 +115,7 @@ python benchmarks/storage_backend_io/storage_backend_io_benchmark.py \
   --backend rust_raw_block_read \
   --raw-device /dev/nvme1n1 \
   --chunk-size 256 \
-  --alignement 4096 \
+  --alignment 4096 \
   --raw-odirect \
   --output-json /tmp/rust_raw_block_read_posix.json
 
@@ -127,7 +127,7 @@ python benchmarks/storage_backend_io/storage_backend_io_benchmark.py \
   --raw-device /dev/nvme1n1 \
   --raw-odirect \
   --chunk-size 256 \
-  --alignement 4096 \
+  --alignment 4096 \
   --use-uring \
   --output-json /tmp/rust_raw_block_read_uring.json
 
@@ -150,11 +150,12 @@ PY
 ```
 ### Notes
 
-- There is a limit on the number of fixed buffers that can be registered. For unprivileged users its 16384.
-- Buffer registration and de-registration is time consuming.
+- `--use-uring` toggles the legacy `rust_raw_block.use_uring` backend option
+  in this non-MP benchmark.
+- MP L1 fixed-buffer registration is exercised by the `raw_block` L2 adapter
+  with `io_engine="io_uring"` and `enable_zero_copy=true`, not by this script.
 
 ## Output
 
 The script prints a summary and optionally writes JSON results if `--output-json` is provided.
 ```
-

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -23,7 +23,8 @@ StoreController / PrefetchController
                 |
                 v
          lmcache_rust_raw_block_io
-      (pwrite_from_buffer / pread_into)
+ (pwrite_from_buffer / pread_into
+  or io_uring fixed-buffer payload I/O)
                 |
                 v
          raw block device / file
@@ -59,6 +60,8 @@ The implementation is split into:
 - lock refcounts used by MP lookup/load/unlock
 - metadata checkpointing and recovery
 - direct reads and writes through the Rust binding
+- best-effort io_uring fixed-buffer payload I/O when the MP L1 arena is
+  registered and the target/source object lies inside it
 
 This avoids maintaining separate raw-block implementations for MP and non-MP
 mode.
@@ -75,6 +78,14 @@ mode.
 
 The adapter uses caller-provided `MemoryObj` buffers for load operations. It
 does not allocate destination buffers on the load path.
+
+When configured with `io_engine="io_uring"` and `enable_zero_copy=true`, the
+adapter registers the MP L1 memory descriptor once with `RawBlockCore`. If that
+registration succeeds, payload writes use `batched_write()` plus
+`wait_iouring()`, and payload reads use `read_uring()` when the object buffer is
+CPU memory inside the registered L1 arena. Headers still use the existing header
+write path, and any unsuitable payload buffer falls back to the non-fixed
+`pwrite_from_buffer` / `pread_into` path.
 
 ## Locking Model
 
@@ -101,8 +112,9 @@ Rules:
 
 The on-device format is intentionally unchanged by the MP adapter work.
 
-Recovered keys are exposed to the shared L2 eviction policy on adapter startup,
-so reclaimed slots come from global L2 eviction or explicit `delete()` calls.
+Recovered keys are exposed to this adapter's L2 eviction policy on startup, so
+reclaimed slots come from the adapter's L2 eviction controller or explicit
+`delete()` calls.
 
 ## Configuration
 
@@ -124,6 +136,9 @@ The MP adapter is configured through `--l2-adapter` JSON:
   "meta_enable_periodic": true,
   "load_checkpoint_on_init": true,
   "meta_verify_on_load": true,
+  "enable_zero_copy": true,
+  "io_engine": "io_uring",
+  "iouring_queue_depth": 256,
   "num_store_workers": 2,
   "num_lookup_workers": 1,
   "num_load_workers": 4
@@ -140,6 +155,9 @@ Important validation rules:
   of loading the latest on-device metadata checkpoint
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
+- fixed-buffer io_uring is only attempted when `io_engine="io_uring"` and
+  `enable_zero_copy=true`; registration failure is a warning and falls back to
+  the non-fixed path
 
 ## Relationship to Non-MP Mode
 

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -249,6 +249,7 @@ the DAX device, but they are unreachable after the LMCache server restarts.
   metrics count occupied slots.
 - Lookups acquire DAX-side external locks. ``submit_unlock`` releases those
   locks after load/retrieve completes, making entries evictable again.
+
 ``fs_native`` -- Native C++ file-system connector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -340,6 +341,14 @@ device or pre-sized file using the Rust raw-device I/O bindings. It reuses the
 existing raw-block metadata checkpoint model and writes directly into the
 caller-provided load buffers during prefetch.
 
+When ``io_engine`` is ``"io_uring"`` and ``enable_zero_copy`` is true, the MP
+adapter registers the L1 CPU arena as an io_uring fixed-buffer region at startup.
+Payload stores and loads whose ``MemoryObj`` buffers are CPU-resident, inside
+that registered arena, and compatible with the active ``O_DIRECT`` alignment use
+``WriteFixed`` / ``ReadFixed`` through the Rust io_uring worker. Slot headers
+still use the regular header write path, and any unsuitable payload buffer falls
+back to the existing non-fixed path.
+
 **Required fields:**
 
 - ``device_path``: Raw device path or pre-sized file path.
@@ -360,7 +369,9 @@ caller-provided load buffers during prefetch.
 - ``load_checkpoint_on_init``: Load an existing on-device metadata checkpoint
   during startup (default ``true``). Set to ``false`` to start with an empty
   in-memory index instead.
-- ``enable_zero_copy``: Try aligned direct-buffer I/O when possible.
+- ``enable_zero_copy``: Try aligned direct-buffer I/O when possible. With
+  ``io_engine="io_uring"`` in MP mode, this also enables best-effort L1 arena
+  fixed-buffer registration for payload I/O.
 - ``io_engine``: Rust raw-block I/O engine. Valid values are ``"posix"``
   (default synchronous ``pread``/``pwrite`` path), ``"io_uring"`` (direct Rust
   io_uring syscall path).
@@ -374,10 +385,13 @@ caller-provided load buffers during prefetch.
   per-TP device-path mappings in MP mode.
 - ``raw_block`` remains ``"type": "raw_block"`` for both supported engines.
 - ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
-  through ``RawBlockCore``. Slot reclamation is driven by the shared/global
-  L2 eviction controller or explicit ``delete()`` calls.
+  through ``RawBlockCore``. Slot reclamation is driven by this adapter's L2
+  eviction controller or explicit ``delete()`` calls.
 - If ``use_odirect`` is enabled, the server's ``--l1-align-bytes`` should be
   at least ``block_align``.
+- Fixed-buffer registration is best-effort. If the kernel, memory limits, or
+  buffer properties reject registration, ``raw_block`` logs a warning and keeps
+  serving through the non-fixed raw-block path.
 - ``persist_enabled`` must remain ``true`` for this adapter.
 
 **Configuration examples:**
@@ -386,7 +400,7 @@ caller-provided load buffers during prefetch.
 
     --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "block_align": 4096, "header_bytes": 4096, "meta_total_bytes": 268435456, "use_odirect": true, "num_store_workers": 2, "num_lookup_workers": 1, "num_load_workers": 4}'
 
-    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "iouring_queue_depth": 256, "use_odirect": true}'
+    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "iouring_queue_depth": 256, "use_odirect": true, "enable_zero_copy": true}'
 
     --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "load_checkpoint_on_init": false, "eviction": {"eviction_policy": "LRU", "trigger_watermark": 0.9, "eviction_ratio": 0.1}}'
 
@@ -746,7 +760,7 @@ drops by ``eviction_ratio``.
      - Full support. Useful for testing eviction behaviour without
        real storage hardware.
    * - ``raw_block``
-     - Full shared/global eviction support. ``delete`` recycles raw-block
+     - Full per-adapter L2 eviction support. ``delete`` recycles raw-block
        slots; locked entries are skipped and retried on the next cycle.
    * - ``s3``
      - ``delete`` removes objects from the bucket and frees aggregate

--- a/examples/kv_cache_reuse/local_backends/README.md
+++ b/examples/kv_cache_reuse/local_backends/README.md
@@ -11,4 +11,5 @@ LMCache should be able to reduce the generation time of the second and following
 
    # WARNING: This will erase the content of target device.
 - `python rust_backend_offload.py --disk_path=/dev/nvme0n1` - posix disk offloading
-- `python rust_backend_offload.py --disk_path=/dev/nvme0n1 --use_uring` - io_uring disk offloading
+- `python rust_backend_offload.py --disk_path=/dev/nvme0n1 --use_uring` - pass
+  the legacy raw-block `use_uring` option to the non-MP backend

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -323,6 +323,22 @@ class RawBlockL2Adapter(L2AdapterInterface):
 
         try:
             self._core = RawBlockCore(config.to_core_config(), key_namespace="object")
+            if (
+                l1_memory_desc is not None
+                and config.io_engine == "io_uring"
+                and config.enable_zero_copy
+            ):
+                try:
+                    self._core.register_fixed_buffer_region(
+                        int(l1_memory_desc.ptr),
+                        int(l1_memory_desc.size),
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "raw_block failed to register L1 arena as io_uring "
+                        "fixed buffer; falling back to non-fixed I/O: %s",
+                        e,
+                    )
             self._max_capacity_bytes = int(
                 self._core.report_status().get("usable_capacity_bytes", 0)
             )

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -250,6 +250,8 @@ class RawBlockCore:
 
         self._raw = None
         self._closed = False
+        self._fixed_buffer_region: tuple[int, int] | None = None
+        self._fixed_buffer_registered: bool = False
 
         self._meta_seq: int = 0
         self._meta_dirty_total: int = 0
@@ -297,6 +299,49 @@ class RawBlockCore:
                 iouring_queue_depth=self.iouring_queue_depth,
             )
         return self._raw
+
+    def register_fixed_buffer_region(self, ptr: int, size: int) -> bool:
+        """Register one L1 arena region for io_uring fixed-buffer payload I/O.
+
+        Args:
+            ptr: Base address of the host-memory L1 arena.
+            size: Size of the arena in bytes.
+
+        Returns:
+            True when registration succeeds. False when the core is not using
+            io_uring or zero-copy is disabled.
+
+        Raises:
+            ValueError: If ``ptr`` or ``size`` are invalid, or the pointer does
+                not satisfy O_DIRECT alignment when O_DIRECT is enabled.
+            Exception: Propagates errors raised by the Rust raw-block device
+                registration call.
+        """
+        if self.io_engine != "io_uring":
+            return False
+        if not self.enable_zero_copy:
+            return False
+
+        ptr = int(ptr)
+        size = int(size)
+        if ptr <= 0:
+            raise ValueError("fixed-buffer ptr must be positive")
+        if size <= 0:
+            raise ValueError("fixed-buffer size must be positive")
+        if self.use_odirect and ptr % self.block_align != 0:
+            raise ValueError(
+                "fixed-buffer ptr must be block-aligned when use_odirect=true"
+            )
+
+        self._rawdev().register_fixed_buffers([ptr], [size])
+        self._fixed_buffer_region = (ptr, size)
+        self._fixed_buffer_registered = True
+        logger.info(
+            "RawBlockCore registered io_uring fixed-buffer region: ptr=%#x size=%d",
+            ptr,
+            size,
+        )
+        return True
 
     def contains_key(self, encoded_key: str, *, lock: bool = False) -> bool:
         """Return whether one encoded key is present in the raw-block index.
@@ -596,33 +641,51 @@ class RawBlockCore:
                         if self.use_odirect
                         else payload_len
                     )
-                    buf = memoryview(objs[i].byte_array)
-                    try:
-                        buf = buf.cast("B")
-                    except Exception:
-                        pass
-
-                    direct_view = self._build_direct_odirect_view(
+                    fixed_view = self._build_fixed_iouring_view(
                         memory_obj=objs[i],
                         payload_len=payload_len,
                         total_len=total_len,
-                        buffer_len=len(buf),
                         zero_tail=False,
                     )
-                    if direct_view is not None:
-                        raw_dev.pread_into(
+                    if fixed_view is not None:
+                        raw_dev.read_uring(
                             entry.offset + self.header_bytes,
-                            direct_view,
-                            total_len if len(direct_view) >= total_len else payload_len,
-                            total_len,
-                        )
-                    else:
-                        raw_dev.pread_into(
-                            entry.offset + self.header_bytes,
-                            buf,
+                            fixed_view,
                             payload_len,
                             total_len,
                         )
+                    else:
+                        buf = memoryview(objs[i].byte_array)
+                        try:
+                            buf = buf.cast("B")
+                        except Exception:
+                            pass
+
+                        direct_view = self._build_direct_odirect_view(
+                            memory_obj=objs[i],
+                            payload_len=payload_len,
+                            total_len=total_len,
+                            buffer_len=len(buf),
+                            zero_tail=False,
+                        )
+                        if direct_view is not None:
+                            raw_dev.pread_into(
+                                entry.offset + self.header_bytes,
+                                direct_view,
+                                (
+                                    total_len
+                                    if len(direct_view) >= total_len
+                                    else payload_len
+                                ),
+                                total_len,
+                            )
+                        else:
+                            raw_dev.pread_into(
+                                entry.offset + self.header_bytes,
+                                buf,
+                                payload_len,
+                                total_len,
+                            )
                     objs[i].metadata.cached_positions = entry.meta.cached_positions
                     results[i] = True
                 except Exception as e:
@@ -726,7 +789,7 @@ class RawBlockCore:
     def report_status(self) -> dict:
         """Return raw-block health, layout, metadata, and in-flight counters."""
         with self._lock:
-            return {
+            status = {
                 "is_healthy": not self._closed,
                 "type": "RawBlockCore",
                 "key_namespace": self.key_namespace,
@@ -752,7 +815,16 @@ class RawBlockCore:
                 "enable_zero_copy": self.enable_zero_copy,
                 "io_engine": self.io_engine,
                 "iouring_queue_depth": self.iouring_queue_depth,
+                "fixed_buffer_registered": self._fixed_buffer_registered,
+                "fixed_buffer_region": self._fixed_buffer_region,
             }
+        raw = self._raw
+        if raw is not None and hasattr(raw, "io_stats"):
+            try:
+                status["io_stats"] = raw.io_stats()
+            except Exception as e:
+                status["io_stats_error"] = str(e)
+        return status
 
     def close(self) -> None:
         """Stop checkpointing, write a final checkpoint, and close the device."""
@@ -853,6 +925,78 @@ class RawBlockCore:
         except Exception:
             return None
 
+    def _fixed_region_contains(self, ptr: int, length: int) -> bool:
+        region = self._fixed_buffer_region
+        if region is None:
+            return False
+
+        base, size = region
+        return base <= ptr and ptr + length <= base + size
+
+    def _memory_obj_data_ptr(self, memory_obj: MemoryObj) -> int:
+        ptr_val = getattr(memory_obj, "data_ptr", None)
+        if callable(ptr_val):
+            ptr_val = ptr_val()
+
+        if ptr_val is None:
+            return 0
+
+        return int(ptr_val)
+
+    def _build_fixed_iouring_view(
+        self,
+        memory_obj: MemoryObj,
+        payload_len: int,
+        total_len: int,
+        *,
+        zero_tail: bool,
+    ) -> Optional[memoryview]:
+        """Build a total-length host-memory view inside the registered L1 arena."""
+        if self.io_engine != "io_uring":
+            return None
+        if not self.enable_zero_copy:
+            return None
+        if not self._fixed_buffer_registered:
+            return None
+
+        try:
+            raw_tensor = memory_obj.raw_tensor
+            if raw_tensor is not None and raw_tensor.device.type != "cpu":
+                return None
+        except Exception:
+            return None
+
+        try:
+            ptr = self._memory_obj_data_ptr(memory_obj)
+        except Exception:
+            return None
+
+        if ptr <= 0:
+            return None
+        if self.use_odirect:
+            if ptr % self.block_align != 0:
+                return None
+            if total_len % self.block_align != 0:
+                return None
+
+        try:
+            physical_size = int(memory_obj.get_physical_size())
+        except Exception:
+            return None
+
+        if physical_size < total_len:
+            return None
+        if not self._fixed_region_contains(ptr, total_len):
+            return None
+
+        try:
+            raw = (ctypes.c_ubyte * total_len).from_address(ptr)
+            if zero_tail and total_len > payload_len:
+                ctypes.memset(ptr + payload_len, 0, total_len - payload_len)
+            return memoryview(raw)
+        except Exception:
+            return None
+
     def _prepare_write_payload(self, memory_obj: MemoryObj) -> tuple[Any, int, int]:
         """Prepare the payload buffer and lengths for a raw-block write.
 
@@ -922,12 +1066,26 @@ class RawBlockCore:
                     else len(header)
                 )
                 raw_dev.pwrite_from_buffer(offset, header, len(header), hdr_total)
-                raw_dev.pwrite_from_buffer(
-                    offset + self.header_bytes,
-                    buf,
-                    payload_len,
-                    total_len,
+                fixed_view = self._build_fixed_iouring_view(
+                    memory_obj=memory_obj,
+                    payload_len=payload_len,
+                    total_len=total_len,
+                    zero_tail=True,
                 )
+                if fixed_view is not None:
+                    batch_id = raw_dev.batched_write(
+                        [offset + self.header_bytes],
+                        [fixed_view],
+                        [total_len],
+                    )
+                    raw_dev.wait_iouring(batch_id)
+                else:
+                    raw_dev.pwrite_from_buffer(
+                        offset + self.header_bytes,
+                        buf,
+                        payload_len,
+                        total_len,
+                    )
             finally:
                 with self._lock:
                     self._inflight_io_count -= 1

--- a/operator/README.md
+++ b/operator/README.md
@@ -308,12 +308,14 @@ spec:
         header_bytes: 4096
         meta_total_bytes: 268435456
         use_odirect: true
+        io_engine: io_uring
+        enable_zero_copy: true
         num_store_workers: 2
         num_lookup_workers: 1
         num_load_workers: 4
 ```
 
-Use an unmounted raw block device or a dedicated file path reserved for LMCache. With `use_odirect: true`, the LMCache server's `--l1-align-bytes` setting must be at least `block_align`.
+Use an unmounted raw block device or a dedicated file path reserved for LMCache. With `use_odirect: true`, the LMCache server's `--l1-align-bytes` setting must be at least `block_align`. With `io_engine: io_uring` and `enable_zero_copy: true`, raw_block attempts MP L1 fixed-buffer registration for payload I/O and falls back to non-fixed I/O if registration is unavailable.
 
 > [!NOTE]
 > Currently only a single L2 adapter is supported at a time. While LMCache multiprocess mode is designed to support multiple L2 adapters in cascade, this functionality is not yet fully tested. Once the multi-adapter pipeline is validated and performance is confirmed, the operator will be updated to support multiple adapters.

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -7,8 +7,10 @@ PyO3. It is used by both:
 - the MP `raw_block` L2 adapter (`RawBlockL2Adapter`) via `RawBlockCore`
 
 The Rust crate intentionally stays narrow: it owns the raw device handle and
-exposes blocking `pwrite_from_buffer` / `pread_into` primitives. Slotting,
-checkpointing, recovery, and MP task orchestration all live in Python.
+exposes blocking `pwrite_from_buffer` / `pread_into` primitives plus the
+io_uring queue, fixed-buffer registration, batched submission, wait, and stats
+APIs used by `RawBlockCore`. Slotting, checkpointing, recovery, and MP task
+orchestration all live in Python.
 
 ## I/O Engines
 
@@ -44,6 +46,14 @@ StoreController / PrefetchController
 This split lets LMCache reuse the same on-device metadata and recovery model in
 both non-MP and MP mode without duplicating the raw-block implementation.
 
+When MP `raw_block` is configured with `io_engine="io_uring"` and
+`enable_zero_copy=true`, `RawBlockL2Adapter` registers the L1 CPU arena as one
+fixed-buffer region. `RawBlockCore` uses that registration for payload writes
+and reads whose `MemoryObj` buffers are CPU-resident, inside the registered
+region, and compatible with `O_DIRECT` alignment when `use_odirect=true`.
+Headers continue to use the regular header write path, and unsuitable payloads
+fall back to the non-fixed path.
+
 ## Zero-Copy Data Path
 
 ```text
@@ -60,6 +70,21 @@ RawBlockDevice::pwrite_from_buffer / pread_into
                  |
                  v
 Block device or file
+```
+
+For MP io_uring fixed buffers, the payload path is:
+
+```text
+RawBlockL2Adapter
+        |
+        | registers MP L1 arena once
+        v
+RawBlockCore
+        |
+        | payload store: batched_write(...) + wait_iouring(...)
+        | payload load:  read_uring(...)
+        v
+io_uring WriteFixed / ReadFixed when buffer range matches
 ```
 
 ## How To Compare Performance
@@ -131,6 +156,7 @@ lmcache server \
     "meta_total_bytes": 268435456,
     "use_odirect": true,
     "io_engine": "io_uring",
+    "enable_zero_copy": true,
     "num_store_workers": 2,
     "num_lookup_workers": 1,
     "num_load_workers": 4
@@ -143,7 +169,10 @@ Notes:
   file used only by LMCache.
 - With `use_odirect=true`, LMCache MP L1 alignment must be at least
   `block_align`.
+- With `io_engine="io_uring"` and `enable_zero_copy=true`, fixed-buffer
+  registration is best-effort. Registration failures log a warning in the MP
+  adapter and fall back to the non-fixed I/O path.
 - Restart recovery uses the metadata checkpoint region on the same device.
-- Raw-block slot reclamation is driven by the shared/global L2 eviction
-  controller or explicit `delete()` calls.
+- Raw-block slot reclamation is driven by the adapter's L2 eviction controller
+  or explicit `delete()` calls.
 - `raw_block` remains the adapter type for both supported engines.

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -60,6 +60,23 @@ fn parse_use_iouring(io_engine: Option<String>, use_iouring: bool) -> PyResult<b
     }
 }
 
+fn fixed_buffer_index_for(
+    fixed_buffer_map: &HashMap<usize, (u16, usize)>,
+    ptr: usize,
+    len: usize,
+) -> Option<u16> {
+    let end = ptr.checked_add(len)?;
+
+    for (&base, &(idx, size)) in fixed_buffer_map.iter() {
+        let region_end = base.checked_add(size)?;
+        if ptr >= base && end <= region_end {
+            return Some(idx);
+        }
+    }
+
+    None
+}
+
 ///Per batch tracking for in flight I/O operation
 type BatchTracking = (Arc<AtomicU64>, Arc<Condvar>);
 
@@ -392,6 +409,30 @@ struct RawBlockDevice {
     batched_completions: Arc<Mutex<HashMap<u64, Vec<Arc<IoCompletion>>>>>,
     // Counter for generating unique batch IDs
     next_batch_id: Arc<AtomicU64>,
+    fixed_read_submissions: Arc<AtomicU64>,
+    fixed_write_submissions: Arc<AtomicU64>,
+    regular_read_submissions: Arc<AtomicU64>,
+    regular_write_submissions: Arc<AtomicU64>,
+}
+
+fn record_submission_stats(
+    sub: &IoSubmission,
+    fixed_read_submissions: &AtomicU64,
+    fixed_write_submissions: &AtomicU64,
+    regular_read_submissions: &AtomicU64,
+    regular_write_submissions: &AtomicU64,
+) {
+    if sub.is_write {
+        if sub.fixed_buffer_idx.is_some() {
+            fixed_write_submissions.fetch_add(1, Ordering::Relaxed);
+        } else {
+            regular_write_submissions.fetch_add(1, Ordering::Relaxed);
+        }
+    } else if sub.fixed_buffer_idx.is_some() {
+        fixed_read_submissions.fetch_add(1, Ordering::Relaxed);
+    } else {
+        regular_read_submissions.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 impl RawBlockDevice {
@@ -422,6 +463,10 @@ impl RawBlockDevice {
             return Err(os_err("open failed"));
         }
         let size = fd_size_bytes(fd)?;
+        let fixed_read_submissions = Arc::new(AtomicU64::new(0));
+        let fixed_write_submissions = Arc::new(AtomicU64::new(0));
+        let regular_read_submissions = Arc::new(AtomicU64::new(0));
+        let regular_write_submissions = Arc::new(AtomicU64::new(0));
 
         let (
             ring_opt,
@@ -457,6 +502,10 @@ impl RawBlockDevice {
             let in_flight_count_clone = Arc::clone(&in_flight_count);
             let in_flight_cvar_clone = Arc::clone(&in_flight_cvar);
             let batch_in_flight_clone = Arc::clone(&batch_in_flight);
+            let fixed_read_submissions_clone = Arc::clone(&fixed_read_submissions);
+            let fixed_write_submissions_clone = Arc::clone(&fixed_write_submissions);
+            let regular_read_submissions_clone = Arc::clone(&regular_read_submissions);
+            let regular_write_submissions_clone = Arc::clone(&regular_write_submissions);
             let ring_size = iouring_queue_depth;
 
             // Worker thread that handles io_uring submissions and completions.
@@ -540,6 +589,13 @@ impl RawBlockDevice {
                                         in_flight.insert(user_data, sub.clone());
                                         // Push a new SQE for the remaining data
                                         let ptr = sub.ptr_addr as *mut u8;
+                                        record_submission_stats(
+                                            &sub,
+                                            &fixed_read_submissions_clone,
+                                            &fixed_write_submissions_clone,
+                                            &regular_read_submissions_clone,
+                                            &regular_write_submissions_clone,
+                                        );
                                         let sqe = if sub.is_write {
                                             if let Some(idx) = sub.fixed_buffer_idx {
                                                 opcode::WriteFixed::new(
@@ -680,6 +736,13 @@ impl RawBlockDevice {
                             in_flight.insert(user_data, sub.clone());
 
                             let ptr = sub.ptr_addr as *mut u8;
+                            record_submission_stats(
+                                sub,
+                                &fixed_read_submissions_clone,
+                                &fixed_write_submissions_clone,
+                                &regular_read_submissions_clone,
+                                &regular_write_submissions_clone,
+                            );
                             let sqe = if sub.is_write {
                                 if let Some(idx) = sub.fixed_buffer_idx {
                                     opcode::WriteFixed::new(
@@ -958,6 +1021,10 @@ impl RawBlockDevice {
             next_batch_id: next_batch_id_opt.unwrap_or_else(|| Arc::new(AtomicU64::new(1))),
             batch_in_flight: batch_in_flight_opt
                 .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new()))),
+            fixed_read_submissions,
+            fixed_write_submissions,
+            regular_read_submissions,
+            regular_write_submissions,
         })
     }
 }
@@ -1000,6 +1067,35 @@ impl RawBlockDevice {
     // Expose cached size to Python.
     fn size_bytes(&self) -> PyResult<u64> {
         Ok(self.size)
+    }
+
+    fn io_stats(&self) -> PyResult<HashMap<String, u64>> {
+        let mut stats = HashMap::new();
+        stats.insert(
+            "fixed_read_submissions".to_string(),
+            self.fixed_read_submissions.load(Ordering::Relaxed),
+        );
+        stats.insert(
+            "fixed_write_submissions".to_string(),
+            self.fixed_write_submissions.load(Ordering::Relaxed),
+        );
+        stats.insert(
+            "regular_read_submissions".to_string(),
+            self.regular_read_submissions.load(Ordering::Relaxed),
+        );
+        stats.insert(
+            "regular_write_submissions".to_string(),
+            self.regular_write_submissions.load(Ordering::Relaxed),
+        );
+        stats.insert(
+            "fixed_buffers_registered".to_string(),
+            if self.fixed_buffers_registered.load(Ordering::Relaxed) {
+                1
+            } else {
+                0
+            },
+        );
+        Ok(stats)
     }
 
     /// Register fixed buffers for zero-copy io_uring operations.
@@ -1100,6 +1196,7 @@ impl RawBlockDevice {
 
         // Acquire buffer views to keep them alive until wait_iouring() completes
         let mut views = Vec::with_capacity(n);
+        let mut caps = Vec::with_capacity(n);
         for buffer in &buffers {
             let view = get_pybuffer(py, buffer, false)?;
             if view.buf.is_null() {
@@ -1109,6 +1206,7 @@ impl RawBlockDevice {
                 release_pybuffer(view);
                 return Err(PyValueError::new_err("null buffer pointer"));
             }
+            caps.push(view.len as usize);
             views.push(view);
         }
 
@@ -1173,11 +1271,19 @@ impl RawBlockDevice {
                 let ptr = ptrs[i] as *const u8;
                 let total_len = total_lens[i];
                 let offset = offsets[i];
+                let cap = caps[i];
+
+                if cap < total_len {
+                    return Err(PyValueError::new_err(format!(
+                        "input buffer too small: cap={} need={}",
+                        cap, total_len
+                    )));
+                }
 
                 let comp = Arc::new(IoCompletion::new());
 
                 // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
-                let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
+                let fixed_idx = fixed_buffer_index_for(&fixed_buffer_map, ptrs[i], total_len);
 
                 // Ensure O_DIRECT buffers are aligned
                 let (final_ptr, bounce_opt, fixed_idx) = if use_odirect {
@@ -1423,7 +1529,7 @@ impl RawBlockDevice {
         let fixed_idx = if use_fixed && ptr_aligned {
             let map = self.fixed_buffer_map.lock().unwrap();
             let ptr_addr = ptr as usize;
-            map.get(&ptr_addr).map(|(idx, _)| *idx)
+            fixed_buffer_index_for(&map, ptr_addr, total_len)
         } else {
             None
         };
@@ -1635,7 +1741,7 @@ impl RawBlockDevice {
                 let comp = Arc::new(IoCompletion::new());
 
                 // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
-                let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
+                let fixed_idx = fixed_buffer_index_for(&fixed_buffer_map, ptrs[i], total_len);
 
                 let sub = IoSubmission {
                     fd,
@@ -2020,6 +2126,25 @@ impl Drop for RawBlockDevice {
         if !self.closed.load(Ordering::Relaxed) {
             let _ = self.do_close();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_buffer_index_for_matches_registered_region_ranges() {
+        let mut map = HashMap::new();
+        let base = 0x1000usize;
+        map.insert(base, (3, 8192));
+
+        assert_eq!(fixed_buffer_index_for(&map, base, 4096), Some(3));
+        assert_eq!(fixed_buffer_index_for(&map, base + 4096, 1024), Some(3));
+        assert_eq!(fixed_buffer_index_for(&map, base + 8191, 1), Some(3));
+        assert_eq!(fixed_buffer_index_for(&map, base + 8191, 2), None);
+        assert_eq!(fixed_buffer_index_for(&map, usize::MAX - 4, 8), None);
+        assert_eq!(fixed_buffer_index_for(&HashMap::new(), base, 1), None);
     }
 }
 

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -13,7 +13,7 @@ import torch
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.config import EvictionConfig
-from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2AdapterListener
 from lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter import (
     RawBlockL2Adapter,
     RawBlockL2AdapterConfig,
@@ -116,6 +116,18 @@ def _create_complex_memory_obj(
     return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
 
 
+def _create_memory_obj_from_tensor(raw_data: torch.Tensor) -> TensorMemoryObj:
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([raw_data.numel()]),
+        dtype=raw_data.dtype,
+        address=0,
+        phy_size=raw_data.numel() * raw_data.element_size(),
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
 def _wait_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
     poll = select.poll()
     poll.register(event_fd, select.POLLIN)
@@ -134,6 +146,8 @@ def _make_config(
     *,
     slot_bytes: int = 64 * 1024,
     capacity_bytes: int = 0,
+    enable_zero_copy: bool = True,
+    io_engine: str = "posix",
 ) -> RawBlockL2AdapterConfig:
     return RawBlockL2AdapterConfig(
         device_path=device_path,
@@ -144,6 +158,8 @@ def _make_config(
         header_bytes=4096,
         meta_total_bytes=1 * 1024 * 1024,
         meta_enable_periodic=False,
+        enable_zero_copy=enable_zero_copy,
+        io_engine=io_engine,
         num_store_workers=2,
         num_lookup_workers=1,
         num_load_workers=2,
@@ -196,6 +212,126 @@ def test_raw_block_l2_adapter_config_explicit_io_engine_wins_over_legacy_flag():
 def test_raw_block_l2_adapter_config_validates_iouring_queue_depth():
     with pytest.raises(ValueError, match="iouring_queue_depth"):
         RawBlockL2AdapterConfig.from_dict(_config_dict(iouring_queue_depth=0))
+
+
+def test_raw_block_l2_adapter_registers_l1_region_for_iouring(monkeypatch) -> None:
+    created_cores = []
+
+    class FakeCore:
+        slot_bytes = 64 * 1024
+
+        def __init__(self, config, *, key_namespace) -> None:
+            del config, key_namespace
+            self.registered_regions: list[tuple[int, int]] = []
+            created_cores.append(self)
+
+        def register_fixed_buffer_region(self, ptr: int, size: int) -> bool:
+            self.registered_regions.append((ptr, size))
+            return True
+
+        def report_status(self) -> dict[str, object]:
+            return {
+                "is_healthy": True,
+                "usable_capacity_bytes": 0,
+                "registered_regions": list(self.registered_regions),
+            }
+
+        def snapshot_indexed_keys(self) -> list[str]:
+            return []
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter.RawBlockCore",
+        FakeCore,
+    )
+
+    config = RawBlockL2AdapterConfig(
+        device_path="/tmp/raw-block-test-device",
+        slot_bytes=64 * 1024,
+        use_odirect=False,
+        enable_zero_copy=True,
+        io_engine="io_uring",
+        meta_enable_periodic=False,
+    )
+    l1_desc = L1MemoryDesc(ptr=123456, size=1 << 20, align_bytes=4096)
+
+    adapter = RawBlockL2Adapter(config, l1_desc)
+    try:
+        assert created_cores[0].registered_regions == [(123456, 1 << 20)]
+        assert adapter.report_status()["core"]["registered_regions"] == [
+            (123456, 1 << 20)
+        ]
+    finally:
+        adapter.close()
+
+
+@pytest.mark.parametrize(
+    ("config_kwargs", "l1_desc"),
+    [
+        (
+            {"io_engine": "posix", "enable_zero_copy": True},
+            L1MemoryDesc(ptr=123456, size=1 << 20, align_bytes=4096),
+        ),
+        (
+            {"io_engine": "io_uring", "enable_zero_copy": False},
+            L1MemoryDesc(ptr=123456, size=1 << 20, align_bytes=4096),
+        ),
+        ({"io_engine": "io_uring", "enable_zero_copy": True}, None),
+    ],
+)
+def test_raw_block_l2_adapter_skips_l1_registration_when_disabled(
+    monkeypatch,
+    config_kwargs: dict[str, object],
+    l1_desc: L1MemoryDesc | None,
+) -> None:
+    created_cores = []
+
+    class FakeCore:
+        slot_bytes = 64 * 1024
+
+        def __init__(self, config, *, key_namespace) -> None:
+            del config, key_namespace
+            self.registered_regions: list[tuple[int, int]] = []
+            created_cores.append(self)
+
+        def register_fixed_buffer_region(self, ptr: int, size: int) -> bool:
+            self.registered_regions.append((ptr, size))
+            return True
+
+        def report_status(self) -> dict[str, object]:
+            return {
+                "is_healthy": True,
+                "usable_capacity_bytes": 0,
+                "registered_regions": list(self.registered_regions),
+            }
+
+        def snapshot_indexed_keys(self) -> list[str]:
+            return []
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "lmcache.v1.distributed.l2_adapters.raw_block_l2_adapter.RawBlockCore",
+        FakeCore,
+    )
+
+    config = RawBlockL2AdapterConfig(
+        device_path="/tmp/raw-block-test-device",
+        slot_bytes=64 * 1024,
+        use_odirect=False,
+        meta_enable_periodic=False,
+        enable_zero_copy=bool(config_kwargs["enable_zero_copy"]),
+        io_engine=str(config_kwargs["io_engine"]),
+    )
+
+    adapter = RawBlockL2Adapter(config, l1_desc)
+    try:
+        assert created_cores[0].registered_regions == []
+    finally:
+        adapter.close()
 
 
 def _run_store(adapter: RawBlockL2Adapter, keys, objects) -> bool:
@@ -261,6 +397,106 @@ def test_raw_block_l2_adapter_store_lookup_load_roundtrip():
             assert torch.count_nonzero(load_buffers[1].tensor) == 0
 
             adapter.submit_unlock([key1, key_miss, key3])
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_iouring_fixed_buffer_roundtrip_on_tmp_file() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        arena = torch.empty(8192, dtype=torch.uint8)
+        src_tensor = arena[128:1152]
+        dst_tensor = arena[4096:5120]
+        src_tensor.copy_(torch.arange(1024, dtype=torch.uint8))
+        dst_tensor.zero_()
+        src = _create_memory_obj_from_tensor(src_tensor)
+        dst = _create_memory_obj_from_tensor(dst_tensor)
+        l1_desc = L1MemoryDesc(
+            ptr=arena.data_ptr(),
+            size=arena.numel() * arena.element_size(),
+            align_bytes=1,
+        )
+
+        try:
+            adapter = RawBlockL2Adapter(
+                _make_config(dev_path, io_engine="io_uring"),
+                l1_desc,
+            )
+        except RuntimeError as e:
+            if "io_uring" in str(e):
+                pytest.skip(f"io_uring unavailable: {e}")
+            raise
+
+        try:
+            status = adapter.report_status()
+            if not status["core"].get("fixed_buffer_registered", False):
+                pytest.skip("io_uring fixed-buffer registration unavailable")
+
+            key = _create_object_key(101)
+            assert _run_store(adapter, [key], [src]) is True
+            load_task_id, load_bitmap = _run_load(adapter, [key], [dst])
+
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0]
+            assert adapter.query_load_result(load_task_id) is None
+            assert bytes(dst.byte_array) == bytes(src.byte_array)
+
+            stats = adapter.report_status()["core"]["io_stats"]
+            assert stats["fixed_buffers_registered"] == 1
+            assert stats["fixed_write_submissions"] >= 1
+            assert stats["fixed_read_submissions"] >= 1
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_iouring_load_outside_l1_region_falls_back() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        arena = torch.empty(2048, dtype=torch.uint8)
+        src_tensor = arena[128:1152]
+        src_tensor.copy_(torch.arange(1024, dtype=torch.uint8))
+        src = _create_memory_obj_from_tensor(src_tensor)
+        dst = _create_memory_obj_from_tensor(torch.empty(1024, dtype=torch.uint8))
+        l1_desc = L1MemoryDesc(
+            ptr=arena.data_ptr(),
+            size=arena.numel() * arena.element_size(),
+            align_bytes=1,
+        )
+
+        try:
+            adapter = RawBlockL2Adapter(
+                _make_config(dev_path, io_engine="io_uring"),
+                l1_desc,
+            )
+        except RuntimeError as e:
+            if "io_uring" in str(e):
+                pytest.skip(f"io_uring unavailable: {e}")
+            raise
+
+        try:
+            status = adapter.report_status()
+            if not status["core"].get("fixed_buffer_registered", False):
+                pytest.skip("io_uring fixed-buffer registration unavailable")
+
+            key = _create_object_key(102)
+            assert _run_store(adapter, [key], [src]) is True
+            _, load_bitmap = _run_load(adapter, [key], [dst])
+
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0]
+            assert bytes(dst.byte_array) == bytes(src.byte_array)
+
+            stats = adapter.report_status()["core"]["io_stats"]
+            assert stats["fixed_write_submissions"] >= 1
+            assert stats["fixed_read_submissions"] == 0
         finally:
             adapter.close()
 

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 # Standard
 from concurrent.futures import Future
+from typing import Any
 from unittest.mock import MagicMock, patch
 import asyncio
+import ctypes
+import mmap
 import os
 import struct
 import sys
@@ -53,23 +56,99 @@ def _has_ext() -> bool:
 
 
 class _FakeRawBlockDevice:
-    def __init__(self, path: str, *, size_bytes: int, **kwargs):
+    def __init__(self, path: str, *, size_bytes: int, **kwargs: Any) -> None:
         del path, kwargs
         self._data = bytearray(size_bytes)
+        self._next_batch_id = 1
+        self.registered_buffers: list[tuple[list[int], list[int]]] = []
+        self.pwrites: list[tuple[int, int, int]] = []
+        self.preads: list[tuple[int, int, int]] = []
+        self.batched_writes: list[tuple[list[int], list[int]]] = []
+        self.read_uring_calls: list[tuple[int, int, int]] = []
+        self.waited_batches: list[int] = []
 
-    def size_bytes(self):
+    def size_bytes(self) -> int:
         return len(self._data)
 
-    def pread_into(self, offset, out, payload_len, total_len=None):
-        del total_len
-        out[:payload_len] = self._data[offset : offset + payload_len]
+    def pread_into(
+        self,
+        offset: int,
+        out: Any,
+        payload_len: int,
+        total_len: int | None = None,
+    ) -> None:
+        total_len = payload_len if total_len is None else total_len
+        view = memoryview(out)
+        try:
+            view = view.cast("B")
+        except TypeError:
+            pass
+        view[:payload_len] = self._data[offset : offset + payload_len]
+        self.preads.append((offset, payload_len, total_len))
 
-    def pwrite_from_buffer(self, offset, data, payload_len=None, total_len=None):
-        del total_len
-        length = len(data) if payload_len is None else payload_len
-        self._data[offset : offset + length] = bytes(memoryview(data)[:length])
+    def pwrite_from_buffer(
+        self,
+        offset: int,
+        data: Any,
+        payload_len: int | None = None,
+        total_len: int | None = None,
+    ) -> None:
+        data_view = memoryview(data)
+        length = len(data_view) if payload_len is None else payload_len
+        total_len = length if total_len is None else total_len
+        self._data[offset : offset + length] = bytes(data_view[:length])
+        self.pwrites.append((offset, length, total_len))
 
-    def close(self):
+    def register_fixed_buffers(
+        self,
+        buffer_ptrs: list[int],
+        buffer_sizes: list[int],
+    ) -> None:
+        self.registered_buffers.append((list(buffer_ptrs), list(buffer_sizes)))
+
+    def batched_write(
+        self,
+        offsets: list[int],
+        buffers: list[Any],
+        total_lens: list[int],
+    ) -> int:
+        for offset, data, total_len in zip(offsets, buffers, total_lens, strict=False):
+            payload = bytes(memoryview(data)[:total_len])
+            self._data[offset : offset + total_len] = payload
+        self.batched_writes.append((list(offsets), list(total_lens)))
+        batch_id = self._next_batch_id
+        self._next_batch_id += 1
+        return batch_id
+
+    def wait_iouring(self, batch_id: int) -> None:
+        self.waited_batches.append(batch_id)
+
+    def read_uring(
+        self,
+        offset: int,
+        out: Any,
+        payload_len: int,
+        total_len: int | None = None,
+    ) -> None:
+        total_len = payload_len if total_len is None else total_len
+        view = memoryview(out)
+        try:
+            view = view.cast("B")
+        except TypeError:
+            pass
+        view[:payload_len] = self._data[offset : offset + payload_len]
+        self.read_uring_calls.append((offset, payload_len, total_len))
+
+    def io_stats(self) -> dict[str, int]:
+        return {
+            "fixed_read_submissions": len(self.read_uring_calls),
+            "fixed_write_submissions": len(self.batched_writes),
+            "regular_read_submissions": len(self.preads),
+            "regular_write_submissions": len(self.pwrites),
+            "fixed_buffers_registered": int(bool(self.registered_buffers)),
+        }
+
+    def close(self) -> None:
         return None
 
 
@@ -84,7 +163,12 @@ def _install_fake_raw_block_device(monkeypatch, *, size_bytes: int = 64 * 1024):
     )
 
 
-def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
+def _make_raw_block_core(
+    *,
+    use_odirect: bool = False,
+    enable_zero_copy: bool = True,
+    io_engine: str = "posix",
+) -> RawBlockCore:
     return RawBlockCore(
         RawBlockCoreConfig(
             device_path="/tmp/raw-block-boundary-test",
@@ -93,7 +177,7 @@ def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
             header_bytes=4096,
             slot_bytes=8192,
             use_odirect=use_odirect,
-            enable_zero_copy=True,
+            enable_zero_copy=enable_zero_copy,
             meta_total_bytes=16 * 1024,
             meta_magic=b"LMCIDX01",
             meta_version=1,
@@ -102,7 +186,7 @@ def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
             meta_enable_periodic=False,
             load_checkpoint_on_init=True,
             meta_verify_on_load=True,
-            io_engine="posix",
+            io_engine=io_engine,
             iouring_queue_depth=256,
         ),
         key_namespace="object",
@@ -231,6 +315,60 @@ def test_raw_block_core_odirect_prepare_payload_boundaries(monkeypatch):
         core.close()
 
 
+def test_raw_block_core_registers_fixed_buffer_region_and_reports_status(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(io_engine="io_uring")
+    try:
+        assert core.register_fixed_buffer_region(4096, 8192) is True
+
+        raw_dev = core._rawdev()
+        assert raw_dev.registered_buffers == [([4096], [8192])]
+
+        status = core.report_status()
+        assert status["fixed_buffer_registered"] is True
+        assert status["fixed_buffer_region"] == (4096, 8192)
+        assert status["io_stats"]["fixed_buffers_registered"] == 1
+    finally:
+        core.close()
+
+
+def test_raw_block_core_uses_fixed_iouring_payload_io(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(io_engine="io_uring")
+    try:
+        key = RawBlockKeySpec(encoded="fixed-key", slot_identity=1)
+        src = _make_byte_obj(1024)
+        assert src.raw_tensor is not None
+        src.raw_tensor.copy_(torch.arange(1024, dtype=torch.uint8))
+
+        assert core.register_fixed_buffer_region(
+            src.data_ptr,
+            src.get_physical_size(),
+        )
+        result = core.put_many([key], [src])
+        assert result.results == [True]
+
+        raw_dev = core._rawdev()
+        assert raw_dev.batched_writes == [
+            ([core.data_base_offset() + core.header_bytes], [1024])
+        ]
+        assert raw_dev.waited_batches == [1]
+
+        dst = _make_byte_obj(1024)
+        assert core.register_fixed_buffer_region(
+            dst.data_ptr,
+            dst.get_physical_size(),
+        )
+        assert core.load_many_into([key.encoded], [dst]) == [True]
+
+        assert raw_dev.read_uring_calls == [
+            (core.data_base_offset() + core.header_bytes, 1024, 1024)
+        ]
+        assert bytes(dst.byte_array) == bytes(src.byte_array)
+    finally:
+        core.close()
+
+
 @pytest.mark.skipif(
     not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
 )
@@ -259,6 +397,147 @@ def test_raw_block_device_all_io_engines_roundtrip_on_tmp_file(io_engine):
             dev.pread_into(4096, out, len(out), len(out))
             assert out == payload
         finally:
+            dev.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_raw_block_device_fixed_buffers_use_registered_region_on_tmp_file() -> None:
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as td:
+        dev_path = os.path.join(td, "raw-block-fixed-buffer.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(1024 * 1024)
+
+        try:
+            dev = RawBlockDevice(
+                dev_path,
+                writable=True,
+                use_odirect=False,
+                alignment=4096,
+                io_engine="io_uring",
+            )
+        except RuntimeError as e:
+            pytest.skip(f"io_uring unavailable: {e}")
+
+        try:
+            arena = bytearray(8192)
+            arena_view = (ctypes.c_ubyte * len(arena)).from_buffer(arena)
+            arena_ptr = ctypes.addressof(arena_view)
+            payload_len = 1024
+
+            write_view = memoryview(arena)[128 : 128 + payload_len]
+            expected = bytes((i % 251 for i in range(payload_len)))
+            write_view[:] = expected
+            read_view = memoryview(arena)[4096 : 4096 + payload_len]
+            read_view[:] = b"\x00" * payload_len
+
+            try:
+                dev.register_fixed_buffers([arena_ptr], [len(arena)])
+            except RuntimeError as e:
+                pytest.skip(f"io_uring fixed buffers unavailable: {e}")
+
+            batch_id = dev.batched_write([0], [write_view], [payload_len])
+            dev.wait_iouring(batch_id)
+            dev.read_uring(0, read_view, payload_len, payload_len)
+
+            assert read_view.tobytes() == expected
+            stats = dev.io_stats()
+            assert stats["fixed_buffers_registered"] == 1
+            assert stats["fixed_write_submissions"] >= 1
+            assert stats["fixed_read_submissions"] >= 1
+            assert stats["regular_write_submissions"] == 0
+            assert stats["regular_read_submissions"] == 0
+        finally:
+            dev.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_raw_block_device_batched_write_rejects_short_input_on_tmp_file() -> None:
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as td:
+        dev_path = os.path.join(td, "raw-block-short-input.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(1024 * 1024)
+
+        try:
+            dev = RawBlockDevice(
+                dev_path,
+                writable=True,
+                use_odirect=False,
+                alignment=4096,
+                io_engine="io_uring",
+            )
+        except RuntimeError as e:
+            pytest.skip(f"io_uring unavailable: {e}")
+
+        try:
+            with pytest.raises(ValueError, match="input buffer too small"):
+                dev.batched_write([0], [bytearray(8)], [16])
+        finally:
+            dev.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_raw_block_device_iouring_fixed_buffers_with_odirect_on_tmp_file() -> None:
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as td:
+        dev_path = os.path.join(td, "raw-block-odirect-fixed-buffer.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(1024 * 1024)
+
+        try:
+            dev = RawBlockDevice(
+                dev_path,
+                writable=True,
+                use_odirect=True,
+                alignment=4096,
+                io_engine="io_uring",
+            )
+        except (OSError, RuntimeError) as e:
+            pytest.skip(f"O_DIRECT io_uring unavailable: {e}")
+
+        arena = mmap.mmap(-1, 8192)
+        arena_view = (ctypes.c_ubyte * 8192).from_buffer(arena)
+        write_view = memoryview(arena)[:4096]
+        read_view = memoryview(arena)[4096:8192]
+        try:
+            arena_ptr = ctypes.addressof(arena_view)
+            if arena_ptr % 4096 != 0:
+                pytest.skip("mmap buffer is not 4096-byte aligned")
+
+            expected = bytes((i % 251 for i in range(4096)))
+            write_view[:] = expected
+            read_view[:] = b"\x00" * 4096
+
+            try:
+                dev.register_fixed_buffers([arena_ptr], [8192])
+                batch_id = dev.batched_write([0], [write_view], [4096])
+                dev.wait_iouring(batch_id)
+                dev.read_uring(0, read_view, 4096, 4096)
+            except (OSError, RuntimeError) as e:
+                pytest.skip(f"O_DIRECT fixed-buffer I/O unavailable: {e}")
+
+            assert read_view.tobytes() == expected
+            stats = dev.io_stats()
+            assert stats["fixed_write_submissions"] >= 1
+            assert stats["fixed_read_submissions"] >= 1
+        finally:
+            write_view.release()
+            read_view.release()
+            del arena_view
+            arena.close()
             dev.close()
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes MP `raw_block` faster when it is configured to use io_uring.

When `io_engine="io_uring"` and `enable_zero_copy=true`, LMCache now registers the MP L1 CPU memory area with the raw-block io_uring backend. If a KV cache buffer is inside that registered memory area, raw_block can use io_uring fixed-buffer reads and writes for the payload.

If fixed-buffer I/O cannot be used, LMCache keeps using the existing raw-block path.

This PR also updates the raw-block docs to describe the current behavior.

  **If applicable**:

  - [x] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests