### PR TITLE
[MP][Observability] Update grafana observability example panel

### DIFF
--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -265,9 +265,10 @@ per-instance and per-model Prometheus metric slicing (e.g.
 
 ## L0 ↔ L1 Throughput Histograms
 
-Sampled (default 1%) per-request throughput of GPU↔CPU copies via
+Per-request throughput of GPU↔CPU copies via
 `L0L1ThroughputSubscriber`. Correlates `MP_{STORE,RETRIEVE}_START` → `MP_{STORE,RETRIEVE}_END`
 pairs by `session_id`, computes `total_bytes / (end_ts - start_ts)` in GB/s.
+Every request contributes one sample (no sampling).
 START/END events fire on the GPU cupy stream (`publish_on_stream`), so
 timestamps reflect true GPU-stream copy time — not Python/lock overhead.
 
@@ -278,8 +279,8 @@ per-worker, per-device, and per-model slicing in Prometheus (e.g.
 
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|
-| `lmcache_mp.l0_l1_store_throughput_gbs` | `lmcache_mp_l0_l1_store_throughput_gbs` | Histogram | `MP_STORE_START` → `MP_STORE_END` | `total_bytes / (end_ts - start_ts) / 1e9` per sampled request |
-| `lmcache_mp.l0_l1_load_throughput_gbs` | `lmcache_mp_l0_l1_load_throughput_gbs` | Histogram | `MP_RETRIEVE_START` → `MP_RETRIEVE_END` | `total_bytes / (end_ts - start_ts) / 1e9` per sampled request |
+| `lmcache_mp.l0_l1_store_throughput_gbs` | `lmcache_mp_l0_l1_store_throughput_gbs` | Histogram | `MP_STORE_START` → `MP_STORE_END` | `total_bytes / (end_ts - start_ts) / 1e9` per request |
+| `lmcache_mp.l0_l1_load_throughput_gbs` | `lmcache_mp_l0_l1_load_throughput_gbs` | Histogram | `MP_RETRIEVE_START` → `MP_RETRIEVE_END` | `total_bytes / (end_ts - start_ts) / 1e9` per request |
 
 **What it answers:** What GPU↔CPU throughput is each vLLM worker actually
 achieving for KV store/load? Does it match the theoretical PCIe bandwidth?
@@ -289,13 +290,14 @@ Are some workers or GPUs underperforming?
 
 ## L1 ↔ L2 Throughput Histograms
 
-Sampled (default 1%) per-task throughput of L1↔L2 transfers via
+Per-task throughput of L1↔L2 transfers via
 `L2ThroughputSubscriber`. The store path correlates `L2_STORE_SUBMITTED` →
 `L2_STORE_COMPLETED` by `(adapter_index, task_id)`. The load path
 correlates the new per-adapter `L2_LOAD_TASK_SUBMITTED` →
 `L2_LOAD_TASK_COMPLETED` events by `(request_id, adapter_index)`; the
 pre-existing request-level `L2_PREFETCH_LOAD_*` events aggregate across
 adapters and cannot attribute throughput to a specific `l2_name`.
+Every task contributes one sample (no sampling).
 
 Unlike the L0↔L1 histograms, these timestamps span **submit → complete**,
 so `(end_ts - start_ts)` includes adapter queue, network, and disk I/O
@@ -310,8 +312,8 @@ registered adapter type (e.g. `"fs"`, `"nixl_store"`, `"mooncake_store"`)
 
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|
-| `lmcache_mp.l2_store_throughput_gbs` | `lmcache_mp_l2_store_throughput_gbs` | Histogram | `L2_STORE_SUBMITTED` → `L2_STORE_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per sampled task |
-| `lmcache_mp.l2_load_throughput_gbs` | `lmcache_mp_l2_load_throughput_gbs` | Histogram | `L2_LOAD_TASK_SUBMITTED` → `L2_LOAD_TASK_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per sampled (request, adapter) pair |
+| `lmcache_mp.l2_store_throughput_gbs` | `lmcache_mp_l2_store_throughput_gbs` | Histogram | `L2_STORE_SUBMITTED` → `L2_STORE_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per task |
+| `lmcache_mp.l2_load_throughput_gbs` | `lmcache_mp_l2_load_throughput_gbs` | Histogram | `L2_LOAD_TASK_SUBMITTED` → `L2_LOAD_TASK_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per (request, adapter) pair |
 
 **What it answers:** What end-to-end throughput is each L2 adapter
 delivering? Which backends are keeping up with demand, and which are

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -447,12 +447,13 @@ in Prometheus (e.g.
 L0 ↔ L1 Throughput Histograms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sampled (default 1%) per-request throughput of GPU↔CPU copies via
-``L0L1ThroughputSubscriber``. Each sampled request contributes one sample
-to the appropriate histogram: ``total_bytes / (end_ts - start_ts)`` in
-GB/s. Timestamps come from ``MP_{STORE,RETRIEVE}_{START,END}`` events
-published on the GPU cupy stream, so they reflect true GPU-stream copy
-time — not Python/lock overhead.
+Per-request throughput of GPU↔CPU copies via
+``L0L1ThroughputSubscriber``. Every store/retrieve request contributes
+one sample to the appropriate histogram:
+``total_bytes / (end_ts - start_ts)`` in GB/s. Timestamps come from
+``MP_{STORE,RETRIEVE}_{START,END}`` events published on the GPU cupy
+stream, so they reflect true GPU-stream copy time — not Python/lock
+overhead.
 
 All throughput histograms are emitted with ``engine_id`` (vLLM worker
 instance id), ``device`` (e.g. ``"cuda:3"``), and ``model_name`` OTel
@@ -469,15 +470,15 @@ Prometheus (e.g.
      - Description
    * - ``lmcache_mp.l0_l1_store_throughput_gbs``
      - Histogram
-     - GPU→CPU (L0→L1) store throughput in GB/s per sampled request.
+     - GPU→CPU (L0→L1) store throughput in GB/s per request.
    * - ``lmcache_mp.l0_l1_load_throughput_gbs``
      - Histogram
-     - CPU→GPU (L1→L0) load throughput in GB/s per sampled request.
+     - CPU→GPU (L1→L0) load throughput in GB/s per request.
 
 L1 ↔ L2 Throughput Histograms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sampled (default 1%) per-task throughput of L1↔L2 transfers via
+Per-task throughput of L1↔L2 transfers via
 ``L2ThroughputSubscriber``. The store path correlates
 ``L2_STORE_SUBMITTED`` → ``L2_STORE_COMPLETED`` by
 ``(adapter_index, task_id)``. The load path correlates the per-adapter
@@ -506,10 +507,10 @@ attribute — the registered adapter type (e.g. ``"fs"``, ``"nixl_store"``,
      - Description
    * - ``lmcache_mp.l2_store_throughput_gbs``
      - Histogram
-     - L1→L2 store throughput in GB/s per sampled task.
+     - L1→L2 store throughput in GB/s per task.
    * - ``lmcache_mp.l2_load_throughput_gbs``
      - Histogram
-     - L2→L1 load throughput in GB/s per sampled (request, adapter) pair.
+     - L2→L1 load throughput in GB/s per (request, adapter) pair.
 
 Engine Counters
 ~~~~~~~~~~~~~~~

--- a/examples/observability/grafana/provisioning/dashboards/lmcache.json
+++ b/examples/observability/grafana/provisioning/dashboards/lmcache.json
@@ -22,17 +22,27 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 100,
       "title": "System Health",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Rate of L1 allocation failures (OOM), L1 read failures, and L2 prefetch failures. Non-zero values indicate unhealthy cache operations.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -44,35 +54,68 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
       "id": 1,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -98,11 +141,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "L1 cache memory consumption in bytes and usage ratio (0–1).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "L1 eviction loop iterations and triggered runs per second.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -114,51 +162,206 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 0.9 }
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_eviction_loop_ticks_total[$__rate_interval])",
+          "legendFormat": "eviction loop ticks/s",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_eviction_loop_triggered_total[$__rate_interval])",
+          "legendFormat": "eviction loop triggered/s",
+          "refId": "B"
+        }
+      ],
+      "title": "L1 Eviction Loop",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "L1 cache memory consumption in bytes and usage ratio (0\u20131).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
             ]
           }
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "L1 memory bytes" },
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/L1 memory bytes/"
+            },
             "properties": [
-              { "id": "unit", "value": "bytes" },
-              { "id": "custom.axisPlacement", "value": "left" }
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "left"
+              }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "L1 usage ratio" },
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/L1 usage ratio/"
+            },
             "properties": [
-              { "id": "unit", "value": "percentunit" },
-              { "id": "custom.axisPlacement", "value": "right" },
-              { "id": "min", "value": 0 },
-              { "id": "max", "value": 1 }
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              }
             ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
       "id": 2,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "targets": [
         {
@@ -178,11 +381,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "L2 store pipeline: tasks submitted vs completed, and keys succeeded vs failed.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "L1 cache key-level operations: reads, writes, and evictions per second.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -194,41 +402,184 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_read_keys_total[$__rate_interval])",
+          "legendFormat": "L1 reads/s [{{service_instance_id}}]",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_write_keys_total[$__rate_interval])",
+          "legendFormat": "L1 writes/s [{{service_instance_id}}]",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_evicted_keys_total[$__rate_interval])",
+          "legendFormat": "L1 evictions/s [{{service_instance_id}}]",
+          "refId": "C"
+        }
+      ],
+      "title": "L1 Cache Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "L2 store pipeline: tasks submitted vs completed, and keys succeeded vs failed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "ops"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "failed keys/s" },
+            "matcher": {
+              "id": "byName",
+              "options": "failed keys/s"
+            },
             "properties": [
-              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
             ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
       "id": 3,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -266,11 +617,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "L2 prefetch pipeline: lookups submitted, keys looked up vs hit, load tasks, keys loaded vs failed.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -282,41 +638,80 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "ops"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "failed keys/s" },
+            "matcher": {
+              "id": "byName",
+              "options": "failed keys/s"
+            },
             "properties": [
-              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
             ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
       "id": 4,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -366,11 +761,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Current in-flight L2 store tasks, L2 load tasks, active prefetch jobs, and reserved memory for in-flight loads.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -382,42 +782,81 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "inflight load memory" },
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/inflight load memory/"
+            },
             "properties": [
-              { "id": "unit", "value": "bytes" },
-              { "id": "custom.axisPlacement", "value": "right" }
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
             ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 17 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
       "id": 5,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "targets": [
         {
@@ -449,11 +888,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "EventBus queue depth and drain lag. Rising drain lag means the event processing thread is falling behind. Also shows L1 eviction loop activity.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "EventBus queue depth, drain lag, dropped events, and subscriber exceptions.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -465,42 +909,81 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "drain lag" },
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/drain lag/"
+            },
             "properties": [
-              { "id": "unit", "value": "s" },
-              { "id": "custom.axisPlacement", "value": "right" }
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
             ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 17 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
       "id": 6,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "targets": [
         {
@@ -526,98 +1009,232 @@
           "expr": "rate(lmcache_mp_event_bus_subscriber_exceptions_total[$__rate_interval])",
           "legendFormat": "subscriber exceptions/s ({{subscriber_name}})",
           "refId": "D"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(lmcache_mp_l1_eviction_loop_ticks_total[$__rate_interval])",
-          "legendFormat": "eviction loop ticks/s",
-          "refId": "E"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(lmcache_mp_l1_eviction_loop_triggered_total[$__rate_interval])",
-          "legendFormat": "eviction loop triggered/s",
-          "refId": "F"
         }
       ],
-      "title": "Event Bus & Eviction Loop",
+      "title": "Event Bus",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "L1 cache key-level operations: reads, writes, and evictions per second.",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 200,
+      "title": "Performance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Average L0 (GPU) to L1 (CPU) transfer throughput per request, measured on the GPU cupy stream.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "GB/s",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
-          "unit": "ops"
+          "unit": "GBs"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
-      "id": 7,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 10,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(lmcache_mp_l1_read_keys_total[$__rate_interval])",
-          "legendFormat": "L1 reads/s [{{service_instance_id}}]",
+          "expr": "rate(lmcache_mp_l0_l1_store_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l0_l1_store_throughput_gbs_GB_per_second_count[$__rate_interval])",
+          "legendFormat": "L0\u2192L1 store ({{device}})",
           "refId": "A"
         },
         {
           "editorMode": "code",
-          "expr": "rate(lmcache_mp_l1_write_keys_total[$__rate_interval])",
-          "legendFormat": "L1 writes/s [{{service_instance_id}}]",
+          "expr": "rate(lmcache_mp_l0_l1_load_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l0_l1_load_throughput_gbs_GB_per_second_count[$__rate_interval])",
+          "legendFormat": "L1\u2192L0 load ({{device}})",
           "refId": "B"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(lmcache_mp_l1_evicted_keys_total[$__rate_interval])",
-          "legendFormat": "L1 evictions/s [{{service_instance_id}}]",
-          "refId": "C"
         }
       ],
-      "title": "L1 Cache Operations",
+      "title": "L0 \u2194 L1 Throughput (GB/s)",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Average L1 (CPU) to L2 (remote/disk) transfer throughput per task. Includes adapter queue wait + network/disk I/O.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "GB/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "GBs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_store_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l2_store_throughput_gbs_GB_per_second_count[$__rate_interval])",
+          "legendFormat": "L1\u2192L2 store ({{l2_name}})",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_load_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l2_load_throughput_gbs_GB_per_second_count[$__rate_interval])",
+          "legendFormat": "L2\u2192L1 load ({{l2_name}})",
+          "refId": "B"
+        }
+      ],
+      "title": "L1 \u2194 L2 Throughput (GB/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Chunks loaded into the engine, and lookup token counts (requested vs hit).",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -629,34 +1246,64 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
       "id": 8,
       "options": {
-        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -682,144 +1329,16 @@
       "type": "timeseries"
     },
     {
-      "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
-      "id": 200,
-      "title": "Performance",
-      "type": "row"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Average L0 (GPU) to L1 (CPU) transfer throughput per request, measured on the GPU cupy stream.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Token-level cache hit rate: fraction of requested tokens found in L1+L2 during lookup (contiguous prefix hits only).",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "GB/s",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+          "color": {
+            "mode": "palette-classic"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null }
-            ]
-          },
-          "unit": "GBs"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 34 },
-      "id": 10,
-      "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "rate(lmcache_mp_l0_l1_store_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l0_l1_store_throughput_gbs_GB_per_second_count[$__rate_interval])",
-          "legendFormat": "L0→L1 store ({{device}})",
-          "refId": "A"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(lmcache_mp_l0_l1_load_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l0_l1_load_throughput_gbs_GB_per_second_count[$__rate_interval])",
-          "legendFormat": "L1→L0 load ({{device}})",
-          "refId": "B"
-        }
-      ],
-      "title": "L0 ↔ L1 Throughput (GB/s)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Average L1 (CPU) to L2 (remote/disk) transfer throughput per task. Includes adapter queue wait + network/disk I/O.",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "GB/s",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null }
-            ]
-          },
-          "unit": "GBs"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 34 },
-      "id": 11,
-      "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "rate(lmcache_mp_l2_store_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l2_store_throughput_gbs_GB_per_second_count[$__rate_interval])",
-          "legendFormat": "L1→L2 store ({{l2_name}})",
-          "refId": "A"
-        },
-        {
-          "editorMode": "code",
-          "expr": "rate(lmcache_mp_l2_load_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l2_load_throughput_gbs_GB_per_second_count[$__rate_interval])",
-          "legendFormat": "L2→L1 load ({{l2_name}})",
-          "refId": "B"
-        }
-      ],
-      "title": "L1 ↔ L2 Throughput (GB/s)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "L1 key-level I/O operations per second (reads and writes).",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -831,34 +1350,168 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_lookup_hit_tokens_total[$__rate_interval]) / rate(lmcache_mp_lookup_requested_tokens_total[$__rate_interval])",
+          "legendFormat": "L1+L2 token hit rate [{{service_instance_id}}]",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "L1 key-level I/O operations per second (reads and writes).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "iops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 42 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
       "id": 12,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -878,11 +1531,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "L2 adapter-level I/O operations per second (store and load task completions).",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -894,34 +1552,65 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "iops"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 42 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
       "id": 13,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
@@ -941,79 +1630,28 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "description": "Token-level cache hit rate: fraction of requested tokens found in L1+L2 during lookup (contiguous prefix hits only).",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
-          },
-          "mappings": [],
-          "min": 0,
-          "max": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 0.5 },
-              { "color": "green", "value": 0.8 }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 42 },
-      "id": 14,
-      "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
-      },
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "rate(lmcache_mp_lookup_hit_tokens_total[$__rate_interval]) / rate(lmcache_mp_lookup_requested_tokens_total[$__rate_interval])",
-          "legendFormat": "L1+L2 token hit rate [{{service_instance_id}}]",
-          "refId": "A"
-        }
-      ],
-      "title": "Cache Hit Rate",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
       "id": 300,
       "title": "Production Insights",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Average GPU KV cache block lifetime, idle time before eviction, and time gap between consecutive accesses.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -1025,34 +1663,65 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 51 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 59
+      },
       "id": 20,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "targets": [
         {
@@ -1078,11 +1747,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Average L1 chunk lifetime, idle time before eviction, and time gap between consecutive touches.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -1094,34 +1768,65 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 51 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 59
+      },
       "id": 21,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "targets": [
         {
@@ -1147,11 +1852,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Time from L1 chunk eviction to next reuse of the same slot. Capped at max_evict_reuse_wait. Helps size the L1 cache: if this is consistently low, more L1 capacity would improve hit rates.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -1163,34 +1873,65 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 59 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 67
+      },
       "id": 22,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "targets": [
         {
@@ -1216,11 +1957,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Time and access-count gaps between consecutive reads of the same chunk at the StorageManager level. Tagged by cache_salt. Helps evaluate cache retention effectiveness.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -1232,43 +1978,86 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "s"
         },
         "overrides": [
           {
-            "matcher": { "id": "byRegexp", "options": "/chunks/" },
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/chunks/"
+            },
             "properties": [
-              { "id": "unit", "value": "short" },
-              { "id": "custom.axisPlacement", "value": "right" },
-              { "id": "custom.axisLabel", "value": "chunks" }
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "chunks"
+              }
             ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 59 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 67
+      },
       "id": 23,
       "options": {
-        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
       "targets": [
         {
@@ -1289,15 +2078,27 @@
     },
     {
       "collapsed": true,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 67 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
       "id": 400,
+      "title": "CacheBlend (expand if using blend_server)",
+      "type": "row",
       "panels": [
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "description": "CacheBlend lookup, retrieve, and store operation rates including success, failure, and hit metrics.",
           "fieldConfig": {
             "defaults": {
-              "color": { "mode": "palette-classic" },
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
@@ -1309,41 +2110,80 @@
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
-                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
-                "scaleDistribution": { "type": "linear" },
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "auto",
                 "showValues": false,
                 "spanNulls": false,
-                "stacking": { "group": "A", "mode": "none" },
-                "thresholdsStyle": { "mode": "off" }
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "color": "green", "value": null }
+                  {
+                    "color": "green",
+                    "value": null
+                  }
                 ]
               },
               "unit": "ops"
             },
             "overrides": [
               {
-                "matcher": { "id": "byRegexp", "options": "/failure/" },
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/failure/"
+                },
                 "properties": [
-                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
                 ]
               }
             ]
           },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 68 },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
           "id": 30,
           "options": {
-            "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-            "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": true,
+              "mode": "multi",
+              "sort": "desc"
+            }
           },
           "targets": [
             {
@@ -1417,11 +2257,16 @@
           "type": "timeseries"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "description": "CacheBlend token-level hit rate and chunk throughput for store and retrieve paths.",
           "fieldConfig": {
             "defaults": {
-              "color": { "mode": "palette-classic" },
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
@@ -1433,42 +2278,82 @@
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
-                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
                 "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 2,
                 "pointSize": 5,
-                "scaleDistribution": { "type": "linear" },
+                "scaleDistribution": {
+                  "type": "linear"
+                },
                 "showPoints": "auto",
                 "showValues": false,
                 "spanNulls": false,
-                "stacking": { "group": "A", "mode": "none" },
-                "thresholdsStyle": { "mode": "off" }
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
               },
               "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "color": "green", "value": null }
+                  {
+                    "color": "green",
+                    "value": null
+                  }
                 ]
               },
               "unit": "percentunit"
             },
             "overrides": [
               {
-                "matcher": { "id": "byRegexp", "options": "/chunks/" },
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/chunks/"
+                },
                 "properties": [
-                  { "id": "unit", "value": "ops" },
-                  { "id": "custom.axisPlacement", "value": "right" }
+                  {
+                    "id": "unit",
+                    "value": "ops"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  }
                 ]
               }
             ]
           },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 68 },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
           "id": 31,
           "options": {
-            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
-            "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
           },
           "targets": [
             {
@@ -1511,30 +2396,43 @@
           "title": "CacheBlend Hit Rate & Chunks",
           "type": "timeseries"
         }
-      ],
-      "title": "CacheBlend (expand if using blend_server)",
-      "type": "row"
+      ]
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 68 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
       "id": 500,
       "title": "Request Traces",
       "type": "row"
     },
     {
-      "datasource": { "uid": "tempo" },
+      "datasource": {
+        "uid": "tempo"
+      },
       "description": "Waterfall view of per-request spans. Each trace shows the root 'request' span with child spans: mp.lookup_prefetch, mp.retrieve, mp.store. Click a row to open the full waterfall in Tempo.",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
       },
-      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 69 },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 77
+      },
       "id": 50,
       "options": {
         "dedupStrategy": "none",
         "sortBy": [
-          { "desc": true, "displayName": "Start time" }
+          {
+            "desc": true,
+            "displayName": "Start time"
+          }
         ],
         "spanFilters": {
           "criticalPathOnly": false,

--- a/examples/observability/grafana/provisioning/dashboards/lmcache.json
+++ b/examples/observability/grafana/provisioning/dashboards/lmcache.json
@@ -17,19 +17,22 @@
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "links": [],
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "System Health",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Rate of L1 allocation failures (OOM), L1 read failures, and L2 prefetch failures. Non-zero values indicate unhealthy cache operations.",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -39,271 +42,570 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
+            "scaleDistribution": { "type": "linear" },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "lmcache_mp_l2_load_throughput_gbs_GB_per_second_sum / lmcache_mp_l2_load_throughput_gbs_GB_per_second_count",
-          "legendFormat": "{{l2_name}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "L2 Read Throughput (GB/s)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "lmcache_mp_l2_store_throughput_gbs_GB_per_second_sum / lmcache_mp_l2_store_throughput_gbs_GB_per_second_count",
-          "legendFormat": "{{l2_name}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "L2 Write Throughput (GB/s)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
             ]
           },
           "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      },
-      "id": 3,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 1,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
       },
-      "pluginVersion": "12.4.2",
       "targets": [
         {
-          "expr": "rate(lmcache_mp_l1_read_keys_total[30s])",
-          "legendFormat": "l1 reads/s",
+          "editorMode": "code",
+          "expr": "sum by (service_instance_id) (rate(lmcache_mp_l1_allocation_failure_total[$__rate_interval])) or vector(0)",
+          "legendFormat": "L1 alloc failure [{{service_instance_id}}]",
           "refId": "A"
         },
         {
-          "expr": "rate(lmcache_mp_l1_write_keys_total[30s])",
-          "legendFormat": "l1 writes/s",
+          "editorMode": "code",
+          "expr": "sum by (service_instance_id) (rate(lmcache_mp_l1_read_failure_total[$__rate_interval])) or vector(0)",
+          "legendFormat": "L1 read failure [{{service_instance_id}}]",
           "refId": "B"
         },
         {
-          "expr": "rate(lmcache_mp_l1_evicted_keys_total[30s])",
-          "legendFormat": "l1 evictions/s",
+          "editorMode": "code",
+          "expr": "sum by (service_instance_id) (rate(lmcache_mp_l2_prefetch_failure_total[$__rate_interval])) or vector(0)",
+          "legendFormat": "L2 prefetch failure [{{service_instance_id}}]",
+          "refId": "C"
+        }
+      ],
+      "title": "Failure Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "L1 cache memory consumption in bytes and usage ratio (0–1).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.9 }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "L1 memory bytes" },
+            "properties": [
+              { "id": "unit", "value": "bytes" },
+              { "id": "custom.axisPlacement", "value": "left" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "L1 usage ratio" },
+            "properties": [
+              { "id": "unit", "value": "percentunit" },
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "min", "value": 0 },
+              { "id": "max", "value": 1 }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_l1_memory_usage_bytes",
+          "legendFormat": "L1 memory bytes [{{service_instance_id}}]",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_l1_usage_ratio",
+          "legendFormat": "L1 usage ratio [{{service_instance_id}}]",
+          "refId": "B"
+        }
+      ],
+      "title": "L1 Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "L2 store pipeline: tasks submitted vs completed, and keys succeeded vs failed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "failed keys/s" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_store_tasks_total[$__rate_interval])",
+          "legendFormat": "tasks submitted/s",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_store_completed_total[$__rate_interval])",
+          "legendFormat": "tasks completed/s ({{l2_name}})",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_store_keys_total[$__rate_interval])",
+          "legendFormat": "keys submitted/s",
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_store_succeeded_keys_total[$__rate_interval])",
+          "legendFormat": "succeeded keys/s",
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_store_failed_keys_total[$__rate_interval])",
+          "legendFormat": "failed keys/s",
+          "refId": "E"
+        }
+      ],
+      "title": "L2 Store Pipeline",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "L2 prefetch pipeline: lookups submitted, keys looked up vs hit, load tasks, keys loaded vs failed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "failed keys/s" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_prefetch_lookups_total[$__rate_interval])",
+          "legendFormat": "lookups/s",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_prefetch_lookup_keys_total[$__rate_interval])",
+          "legendFormat": "lookup keys/s",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_prefetch_hit_keys_total[$__rate_interval])",
+          "legendFormat": "hit keys/s",
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_prefetch_load_tasks_total[$__rate_interval])",
+          "legendFormat": "load tasks/s",
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_prefetch_load_keys_total[$__rate_interval])",
+          "legendFormat": "load keys submitted/s",
+          "refId": "E"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_prefetch_loaded_keys_total[$__rate_interval])",
+          "legendFormat": "loaded keys/s",
+          "refId": "F"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_prefetch_failed_keys_total[$__rate_interval])",
+          "legendFormat": "failed keys/s",
+          "refId": "G"
+        }
+      ],
+      "title": "L2 Prefetch Pipeline",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Current in-flight L2 store tasks, L2 load tasks, active prefetch jobs, and reserved memory for in-flight loads.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "inflight load memory" },
+            "properties": [
+              { "id": "unit", "value": "bytes" },
+              { "id": "custom.axisPlacement", "value": "right" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 17 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_num_inflight_l2_stores",
+          "legendFormat": "inflight L2 stores ({{l2_name}}) [{{service_instance_id}}]",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_num_inflight_l2_loads",
+          "legendFormat": "inflight L2 loads ({{l2_name}}) [{{service_instance_id}}]",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_active_prefetch_jobs",
+          "legendFormat": "active prefetch jobs [{{service_instance_id}}]",
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_inflight_load_memory_usage_bytes",
+          "legendFormat": "inflight load memory [{{service_instance_id}}]",
+          "refId": "D"
+        }
+      ],
+      "title": "Inflight Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "EventBus queue depth and drain lag. Rising drain lag means the event processing thread is falling behind. Also shows L1 eviction loop activity.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "drain lag" },
+            "properties": [
+              { "id": "unit", "value": "s" },
+              { "id": "custom.axisPlacement", "value": "right" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 17 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_event_bus_queue_depth",
+          "legendFormat": "event bus queue depth",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_event_bus_drain_lag_seconds",
+          "legendFormat": "drain lag",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_event_bus_dropped_events_total[$__rate_interval])",
+          "legendFormat": "dropped events/s",
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_event_bus_subscriber_exceptions_total[$__rate_interval])",
+          "legendFormat": "subscriber exceptions/s ({{subscriber_name}})",
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_eviction_loop_ticks_total[$__rate_interval])",
+          "legendFormat": "eviction loop ticks/s",
+          "refId": "E"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_eviction_loop_triggered_total[$__rate_interval])",
+          "legendFormat": "eviction loop triggered/s",
+          "refId": "F"
+        }
+      ],
+      "title": "Event Bus & Eviction Loop",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "L1 cache key-level operations: reads, writes, and evictions per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_read_keys_total[$__rate_interval])",
+          "legendFormat": "L1 reads/s [{{service_instance_id}}]",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_write_keys_total[$__rate_interval])",
+          "legendFormat": "L1 writes/s [{{service_instance_id}}]",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_evicted_keys_total[$__rate_interval])",
+          "legendFormat": "L1 evictions/s [{{service_instance_id}}]",
           "refId": "C"
         }
       ],
@@ -311,14 +613,11 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "uid": "prometheus"
-      },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Chunks loaded into the engine, and lookup token counts (requested vs hit).",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
@@ -328,110 +627,920 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
             "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
+            "scaleDistribution": { "type": "linear" },
             "showPoints": "auto",
             "showValues": false,
             "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
+              { "color": "green", "value": null }
             ]
           },
-          "unit": "short"
+          "unit": "ops"
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      },
-      "id": 4,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 8,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
       },
-      "pluginVersion": "12.4.2",
       "targets": [
         {
-          "expr": "lmcache_mp_active_prefetch_jobs",
-          "legendFormat": "active prefetch jobs",
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_lookup_requested_tokens_total[$__rate_interval])",
+          "legendFormat": "lookup requested tokens/s [{{service_instance_id}}]",
           "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_lookup_hit_tokens_total[$__rate_interval])",
+          "legendFormat": "lookup hit tokens/s [{{service_instance_id}}]",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_num_chunks_loaded_total[$__rate_interval])",
+          "legendFormat": "chunks loaded/s [{{service_instance_id}}]",
+          "refId": "C"
         }
       ],
-      "title": "Active Prefetch Jobs",
+      "title": "Lookup & Engine Activity",
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "uid": "tempo"
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "id": 200,
+      "title": "Performance",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Average L0 (GPU) to L1 (CPU) transfer throughput per request, measured on the GPU cupy stream.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "GB/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "GBs"
+        },
+        "overrides": []
       },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 34 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l0_l1_store_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l0_l1_store_throughput_gbs_GB_per_second_count[$__rate_interval])",
+          "legendFormat": "L0→L1 store ({{device}})",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l0_l1_load_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l0_l1_load_throughput_gbs_GB_per_second_count[$__rate_interval])",
+          "legendFormat": "L1→L0 load ({{device}})",
+          "refId": "B"
+        }
+      ],
+      "title": "L0 ↔ L1 Throughput (GB/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Average L1 (CPU) to L2 (remote/disk) transfer throughput per task. Includes adapter queue wait + network/disk I/O.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "GB/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "GBs"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 34 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_store_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l2_store_throughput_gbs_GB_per_second_count[$__rate_interval])",
+          "legendFormat": "L1→L2 store ({{l2_name}})",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_load_throughput_gbs_GB_per_second_sum[$__rate_interval]) / rate(lmcache_mp_l2_load_throughput_gbs_GB_per_second_count[$__rate_interval])",
+          "legendFormat": "L2→L1 load ({{l2_name}})",
+          "refId": "B"
+        }
+      ],
+      "title": "L1 ↔ L2 Throughput (GB/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "L1 key-level I/O operations per second (reads and writes).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 42 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_read_keys_total[$__rate_interval])",
+          "legendFormat": "L1 read IOPS [{{service_instance_id}}]",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_write_keys_total[$__rate_interval])",
+          "legendFormat": "L1 write IOPS [{{service_instance_id}}]",
+          "refId": "B"
+        }
+      ],
+      "title": "L1 IOPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "L2 adapter-level I/O operations per second (store and load task completions).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 42 },
+      "id": 13,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_store_completed_total[$__rate_interval])",
+          "legendFormat": "L2 store IOPS ({{l2_name}})",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l2_load_completed_total[$__rate_interval])",
+          "legendFormat": "L2 load IOPS ({{l2_name}})",
+          "refId": "B"
+        }
+      ],
+      "title": "L2 IOPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Token-level cache hit rate: fraction of requested tokens found in L1+L2 during lookup (contiguous prefix hits only).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 42 },
+      "id": 14,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_lookup_hit_tokens_total[$__rate_interval]) / rate(lmcache_mp_lookup_requested_tokens_total[$__rate_interval])",
+          "legendFormat": "L1+L2 token hit rate [{{service_instance_id}}]",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
+      "id": 300,
+      "title": "Production Insights",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Average GPU KV cache block lifetime, idle time before eviction, and time gap between consecutive accesses.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 51 },
+      "id": 20,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l0_block_lifetime_seconds_sum[$__rate_interval]) / rate(lmcache_mp_l0_block_lifetime_seconds_count[$__rate_interval])",
+          "legendFormat": "avg block lifetime",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l0_block_idle_before_evict_seconds_sum[$__rate_interval]) / rate(lmcache_mp_l0_block_idle_before_evict_seconds_count[$__rate_interval])",
+          "legendFormat": "avg idle before evict",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l0_block_reuse_gap_seconds_sum[$__rate_interval]) / rate(lmcache_mp_l0_block_reuse_gap_seconds_count[$__rate_interval])",
+          "legendFormat": "avg reuse gap",
+          "refId": "C"
+        }
+      ],
+      "title": "L0 (GPU) Block Lifecycle",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Average L1 chunk lifetime, idle time before eviction, and time gap between consecutive touches.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 51 },
+      "id": 21,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_chunk_lifetime_seconds_sum[$__rate_interval]) / rate(lmcache_mp_l1_chunk_lifetime_seconds_count[$__rate_interval])",
+          "legendFormat": "avg chunk lifetime",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_chunk_idle_before_evict_seconds_sum[$__rate_interval]) / rate(lmcache_mp_l1_chunk_idle_before_evict_seconds_count[$__rate_interval])",
+          "legendFormat": "avg idle before evict",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_chunk_reuse_gap_seconds_sum[$__rate_interval]) / rate(lmcache_mp_l1_chunk_reuse_gap_seconds_count[$__rate_interval])",
+          "legendFormat": "avg reuse gap",
+          "refId": "C"
+        }
+      ],
+      "title": "L1 Chunk Lifecycle",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Time from L1 chunk eviction to next reuse of the same slot. Capped at max_evict_reuse_wait. Helps size the L1 cache: if this is consistently low, more L1 capacity would improve hit rates.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 59 },
+      "id": 22,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_l1_chunk_evict_reuse_gap_seconds_sum[$__rate_interval]) / rate(lmcache_mp_l1_chunk_evict_reuse_gap_seconds_count[$__rate_interval])",
+          "legendFormat": "avg evict-to-reuse gap",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, rate(lmcache_mp_l1_chunk_evict_reuse_gap_seconds_bucket[$__rate_interval]))",
+          "legendFormat": "p50 evict-to-reuse gap",
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, rate(lmcache_mp_l1_chunk_evict_reuse_gap_seconds_bucket[$__rate_interval]))",
+          "legendFormat": "p95 evict-to-reuse gap",
+          "refId": "C"
+        }
+      ],
+      "title": "L1 Evict-to-Reuse Gap",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Time and access-count gaps between consecutive reads of the same chunk at the StorageManager level. Tagged by cache_salt. Helps evaluate cache retention effectiveness.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": "/chunks/" },
+            "properties": [
+              { "id": "unit", "value": "short" },
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "custom.axisLabel", "value": "chunks" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 59 },
+      "id": 23,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_real_reuse_gap_seconds_sum[$__rate_interval]) / rate(lmcache_mp_real_reuse_gap_seconds_count[$__rate_interval])",
+          "legendFormat": "avg reuse gap seconds ({{cache_salt}})",
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "rate(lmcache_mp_real_reuse_gap_chunks_sum[$__rate_interval]) / rate(lmcache_mp_real_reuse_gap_chunks_count[$__rate_interval])",
+          "legendFormat": "avg reuse gap chunks ({{cache_salt}})",
+          "refId": "B"
+        }
+      ],
+      "title": "SM Real Reuse Gap",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 67 },
+      "id": 400,
+      "panels": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "CacheBlend lookup, retrieve, and store operation rates including success, failure, and hit metrics.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byRegexp", "options": "/failure/" },
+                "properties": [
+                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                ]
+              }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 68 },
+          "id": 30,
+          "options": {
+            "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_lookup_requests_total[$__rate_interval])",
+              "legendFormat": "lookup requests/s",
+              "refId": "A"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_lookup_fingerprint_hits_total[$__rate_interval])",
+              "legendFormat": "fingerprint hits/s",
+              "refId": "B"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_lookup_storage_hits_total[$__rate_interval])",
+              "legendFormat": "storage hits/s",
+              "refId": "C"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_lookup_stale_chunks_total[$__rate_interval])",
+              "legendFormat": "stale chunks/s",
+              "refId": "D"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_store_pre_computed_requests_total[$__rate_interval])",
+              "legendFormat": "store_pre_computed requests/s",
+              "refId": "E"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_store_final_requests_total[$__rate_interval])",
+              "legendFormat": "store_final requests/s",
+              "refId": "F"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_retrieve_requests_total[$__rate_interval])",
+              "legendFormat": "retrieve requests/s",
+              "refId": "G"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_retrieve_failures_total[$__rate_interval])",
+              "legendFormat": "retrieve failure/s",
+              "refId": "H"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_store_pre_computed_failures_total[$__rate_interval])",
+              "legendFormat": "store_pre_computed failure/s",
+              "refId": "I"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_store_final_failures_total[$__rate_interval])",
+              "legendFormat": "store_final failure/s",
+              "refId": "J"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_lookup_no_gpu_context_errors_total[$__rate_interval])",
+              "legendFormat": "no GPU context errors/s",
+              "refId": "K"
+            }
+          ],
+          "title": "CacheBlend Operations",
+          "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "description": "CacheBlend token-level hit rate and chunk throughput for store and retrieve paths.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": { "type": "linear" },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": { "group": "A", "mode": "none" },
+                "thresholdsStyle": { "mode": "off" }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byRegexp", "options": "/chunks/" },
+                "properties": [
+                  { "id": "unit", "value": "ops" },
+                  { "id": "custom.axisPlacement", "value": "right" }
+                ]
+              }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 68 },
+          "id": 31,
+          "options": {
+            "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "hideZeros": false, "mode": "multi", "sort": "none" }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_lookup_hit_tokens_total[$__rate_interval]) / rate(lmcache_blend_lookup_requested_tokens_total[$__rate_interval])",
+              "legendFormat": "blend token hit rate",
+              "refId": "A"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_retrieve_chunks_total[$__rate_interval])",
+              "legendFormat": "retrieve chunks/s",
+              "refId": "B"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_store_pre_computed_chunks_total[$__rate_interval])",
+              "legendFormat": "store_pre_computed chunks/s",
+              "refId": "C"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_store_final_chunks_total[$__rate_interval])",
+              "legendFormat": "store_final chunks/s",
+              "refId": "D"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_fingerprints_registered_total[$__rate_interval])",
+              "legendFormat": "fingerprints registered chunks/s",
+              "refId": "E"
+            },
+            {
+              "editorMode": "code",
+              "expr": "rate(lmcache_blend_chunks_evicted_total[$__rate_interval])",
+              "legendFormat": "evicted chunks/s",
+              "refId": "F"
+            }
+          ],
+          "title": "CacheBlend Hit Rate & Chunks",
+          "type": "timeseries"
+        }
+      ],
+      "title": "CacheBlend (expand if using blend_server)",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 68 },
+      "id": 500,
+      "title": "Request Traces",
+      "type": "row"
+    },
+    {
+      "datasource": { "uid": "tempo" },
       "description": "Waterfall view of per-request spans. Each trace shows the root 'request' span with child spans: mp.lookup_prefetch, mp.retrieve, mp.store. Click a row to open the full waterfall in Tempo.",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
       },
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      },
-      "id": 5,
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 69 },
+      "id": 50,
       "options": {
         "dedupStrategy": "none",
         "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Start time"
-          }
+          { "desc": true, "displayName": "Start time" }
         ],
         "spanFilters": {
           "criticalPathOnly": false,
           "matchesOnly": false
         }
       },
-      "pluginVersion": "12.4.2",
       "targets": [
         {
           "limit": 20,
@@ -459,6 +1568,6 @@
   "timezone": "browser",
   "title": "LMCache",
   "uid": "lmcache-standard",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/examples/observability/otel-collector.yml
+++ b/examples/observability/otel-collector.yml
@@ -12,6 +12,8 @@ exporters:
 
   prometheus:
     endpoint: 0.0.0.0:8889
+    resource_to_telemetry_conversion:
+      enabled: true
 
 service:
   pipelines:

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -358,7 +358,7 @@ def init_observability(
         bus.register_subscriber(L1LifecycleSubscriber(sample_rate=sample_rate))
         bus.register_subscriber(L1FailureMetricsSubscriber())
         bus.register_subscriber(L1EvictionLoopSubscriber())
-        bus.register_subscriber(L0L1ThroughputSubscriber(sample_rate=sample_rate))
+        bus.register_subscriber(L0L1ThroughputSubscriber())
         bus.register_subscriber(L2MetricsSubscriber())
         bus.register_subscriber(L2FailureMetricsSubscriber())
         bus.register_subscriber(L2ThroughputSubscriber())

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -361,7 +361,7 @@ def init_observability(
         bus.register_subscriber(L0L1ThroughputSubscriber(sample_rate=sample_rate))
         bus.register_subscriber(L2MetricsSubscriber())
         bus.register_subscriber(L2FailureMetricsSubscriber())
-        bus.register_subscriber(L2ThroughputSubscriber(sample_rate=sample_rate))
+        bus.register_subscriber(L2ThroughputSubscriber())
         bus.register_subscriber(LookupMetricsSubscriber())
         bus.register_subscriber(SMMetricsSubscriber())
         bus.register_subscriber(SMLifecycleSubscriber(sample_rate=sample_rate))

--- a/lmcache/v1/mp_observability/subscribers/metrics/l0_l1_throughput.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l0_l1_throughput.py
@@ -17,8 +17,6 @@ Implementation:
   - START/END events fire on the GPU cupy stream (``publish_on_stream``),
     so their timestamps reflect true GPU-stream time for the D2H/H2D
     copies — not Python/lock overhead.
-  - Sampling decision made at START time via ``random.random() <
-    sample_rate``.  Unsampled sessions leave zero state.
 """
 
 # Future
@@ -26,7 +24,6 @@ from __future__ import annotations
 
 # Standard
 from typing import Any
-import random
 
 # Third Party
 from opentelemetry import metrics
@@ -37,21 +34,11 @@ from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
 
 
 class L0L1ThroughputSubscriber(EventSubscriber):
-    """Records L0↔L1 throughput by correlating MP_*_START→MP_*_END pairs.
+    """Records L0↔L1 throughput by correlating MP_*_START→MP_*_END pairs."""
 
-    Parameters:
-        sample_rate: Fraction of requests to track (0, 1.0].  Default 0.01
-            (1%), matching other lifecycle subscribers.
-    """
-
-    def __init__(self, sample_rate: float = 0.01) -> None:
-        assert 0 < sample_rate <= 1.0, (
-            f"sample_rate must be in (0, 1.0], got {sample_rate}"
-        )
-        self._sample_rate = sample_rate
-
-        # (session_id, device) -> t_start. Populated only for sampled
-        # sessions. Compound key avoids collisions when one MP server
+    def __init__(self) -> None:
+        # (session_id, device) -> t_start.
+        # Compound key avoids collisions when one MP server
         # handles the same request_id from multiple GPUs (TP/PP).
         self._pending_store: dict[tuple[str, str], float] = {}
         self._pending_load: dict[tuple[str, str], float] = {}
@@ -89,8 +76,6 @@ class L0L1ThroughputSubscriber(EventSubscriber):
     # -- Store path (L0→L1, GPU→CPU) ---------------------------------------
 
     def _on_store_start(self, event: Event) -> None:
-        if random.random() >= self._sample_rate:
-            return
         key = self._correlation_key(event)
         if key is not None:
             self._pending_store[key] = event.timestamp
@@ -105,8 +90,6 @@ class L0L1ThroughputSubscriber(EventSubscriber):
     # -- Retrieve path (L1→L0, CPU→GPU) ------------------------------------
 
     def _on_retrieve_start(self, event: Event) -> None:
-        if random.random() >= self._sample_rate:
-            return
         key = self._correlation_key(event)
         if key is not None:
             self._pending_load[key] = event.timestamp
@@ -144,7 +127,7 @@ class L0L1ThroughputSubscriber(EventSubscriber):
             return
         t_start = pending.pop(key, None)
         if t_start is None:
-            return  # session wasn't sampled
+            return  # No matching START event
 
         total_bytes = event.metadata.get("total_bytes", 0)
         if total_bytes <= 0:

--- a/lmcache/v1/mp_observability/subscribers/metrics/l2_throughput.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l2_throughput.py
@@ -21,8 +21,6 @@ Implementation:
   - ``(end_ts - start_ts)`` spans submit -> complete and therefore
     includes adapter queue, network, and disk time — not just transfer.
     The histogram is "bytes / end-to-end latency", not raw transfer rate.
-  - Sampling decision is made at SUBMITTED time; unsampled tasks leave
-    zero state.
 """
 
 # Future
@@ -30,7 +28,6 @@ from __future__ import annotations
 
 # Standard
 from typing import Any
-import random
 
 # Third Party
 from opentelemetry import metrics
@@ -41,25 +38,12 @@ from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
 
 
 class L2ThroughputSubscriber(EventSubscriber):
-    """Records L1↔L2 throughput by correlating SUBMITTED→COMPLETED pairs.
+    """Records L1↔L2 throughput by correlating SUBMITTED→COMPLETED pairs."""
 
-    Parameters:
-        sample_rate: Fraction of tasks to track (0, 1.0].  Default 0.01
-            (1%), matching other lifecycle subscribers.
-    """
-
-    def __init__(self, sample_rate: float = 0.01) -> None:
-        assert 0 < sample_rate <= 1.0, (
-            f"sample_rate must be in (0, 1.0], got {sample_rate}"
-        )
-        self._sample_rate = sample_rate
-
-        # (adapter_index, task_id) -> (t_start, total_bytes).  Populated
-        # only for sampled store tasks; bytes are read from SUBMITTED and
-        # retrieved at COMPLETED time.
+    def __init__(self) -> None:
+        # (adapter_index, task_id) -> (t_start, total_bytes).
         self._pending_store: dict[tuple[int, int], tuple[float, int]] = {}
-        # (request_id, adapter_index) -> (t_start, total_bytes).  Populated
-        # only for sampled load tasks.
+        # (request_id, adapter_index) -> (t_start, total_bytes).
         self._pending_load: dict[tuple[int, int], tuple[float, int]] = {}
 
         meter = metrics.get_meter("lmcache_mp.perf")
@@ -67,7 +51,7 @@ class L2ThroughputSubscriber(EventSubscriber):
             "lmcache_mp.l2_store_throughput_gbs",
             description=(
                 "Histogram of L1->L2 store throughput in GB/s, measured "
-                "per sampled task as total_bytes / (completed_ts - "
+                "per task as total_bytes / (completed_ts - "
                 "submitted_ts).  Spans adapter queue + network/disk I/O, "
                 "so this is end-to-end latency-based throughput."
             ),
@@ -77,7 +61,7 @@ class L2ThroughputSubscriber(EventSubscriber):
             "lmcache_mp.l2_load_throughput_gbs",
             description=(
                 "Histogram of L2->L1 load throughput in GB/s, measured "
-                "per sampled (request, adapter) pair as total_bytes / "
+                "per (request, adapter) pair as total_bytes / "
                 "(completed_ts - submitted_ts).  Spans adapter queue + "
                 "network/disk I/O."
             ),
@@ -97,8 +81,6 @@ class L2ThroughputSubscriber(EventSubscriber):
     # -- Store path (L1->L2) -----------------------------------------------
 
     def _on_store_submitted(self, event: Event) -> None:
-        if random.random() >= self._sample_rate:
-            return
         key = self._store_key(event)
         if key is not None:
             total_bytes = int(event.metadata.get("total_bytes", 0))
@@ -118,8 +100,6 @@ class L2ThroughputSubscriber(EventSubscriber):
     # -- Load path (L2->L1) ------------------------------------------------
 
     def _on_load_submitted(self, event: Event) -> None:
-        if random.random() >= self._sample_rate:
-            return
         key = self._load_key(event)
         if key is not None:
             total_bytes = int(event.metadata.get("total_bytes", 0))
@@ -173,7 +153,7 @@ class L2ThroughputSubscriber(EventSubscriber):
     ) -> None:
         pending_entry = pending.pop(correlation_key, None)
         if pending_entry is None:
-            return  # task wasn't sampled
+            return  # no matching SUBMITTED event;
         t_start, total_bytes = pending_entry
 
         if total_bytes <= 0:

--- a/tests/v1/mp_observability/subscribers/metrics/test_l0_l1_throughput.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l0_l1_throughput.py
@@ -8,7 +8,6 @@ deterministic; the end-to-end test drives through ``EventBus``.
 """
 
 # Standard
-from unittest.mock import patch
 import time
 
 # Third Party
@@ -108,7 +107,7 @@ def _attrs_of_nonzero_dps(name: str) -> list[dict]:
 
 @pytest.fixture
 def subscriber():
-    return L0L1ThroughputSubscriber(sample_rate=1.0)
+    return L0L1ThroughputSubscriber()
 
 
 # ---------------------------------------------------------------------------
@@ -128,12 +127,6 @@ class TestSubscriptions:
         subs = subscriber.get_subscriptions()
         assert EventType.L1_WRITE_RESERVED not in subs
         assert EventType.L1_READ_RESERVED not in subs
-
-    def test_rejects_invalid_sample_rate(self):
-        with pytest.raises(AssertionError):
-            L0L1ThroughputSubscriber(sample_rate=0.0)
-        with pytest.raises(AssertionError):
-            L0L1ThroughputSubscriber(sample_rate=1.5)
 
 
 # ---------------------------------------------------------------------------
@@ -224,42 +217,6 @@ class TestLoadThroughput:
             and a.get("model_name") == "test-model"
             for a in attrs
         )
-
-
-# ---------------------------------------------------------------------------
-# Sampling behavior
-# ---------------------------------------------------------------------------
-
-
-class TestSampling:
-    def test_unsampled_session_leaves_no_state(self):
-        # Force "random" to always fail the sample gate.
-        sub = L0L1ThroughputSubscriber(sample_rate=0.01)
-        with patch(
-            "lmcache.v1.mp_observability.subscribers.metrics."
-            "l0_l1_throughput.random.random",
-            return_value=0.99,
-        ):
-            sub._on_store_start(_start_event(EventType.MP_STORE_START, "req-skip", 0.0))
-
-        assert ("req-skip", "cuda:0") not in sub._pending_store
-
-    def test_unsampled_session_does_not_record(self):
-        sub = L0L1ThroughputSubscriber(sample_rate=0.01)
-        count_before = _total_count(_STORE_METRIC)
-
-        with patch(
-            "lmcache.v1.mp_observability.subscribers.metrics."
-            "l0_l1_throughput.random.random",
-            return_value=0.99,
-        ):
-            sub._on_store_start(_start_event(EventType.MP_STORE_START, "req-u", 0.0))
-        # END arrives but START wasn't tracked → no record.
-        sub._on_store_end(
-            _end_event(EventType.MP_STORE_END, "req-u", 0.1, total_bytes=10**9)
-        )
-
-        assert _total_count(_STORE_METRIC) == count_before
 
 
 # ---------------------------------------------------------------------------
@@ -399,7 +356,7 @@ class TestEdgeCases:
 class TestEventBusIntegration:
     def test_store_pair_via_bus_records_metric(self):
         bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
-        sub = L0L1ThroughputSubscriber(sample_rate=1.0)
+        sub = L0L1ThroughputSubscriber()
         bus.register_subscriber(sub)
 
         count_before = _total_count(_STORE_METRIC)

--- a/tests/v1/mp_observability/subscribers/metrics/test_l2_throughput.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l2_throughput.py
@@ -8,7 +8,6 @@ deterministic; the end-to-end test drives through ``EventBus``.
 """
 
 # Standard
-from unittest.mock import patch
 import time
 
 # Third Party
@@ -150,7 +149,7 @@ def _attrs_of_nonzero_dps(name: str) -> list[dict]:
 
 @pytest.fixture
 def subscriber():
-    return L2ThroughputSubscriber(sample_rate=1.0)
+    return L2ThroughputSubscriber()
 
 
 # ---------------------------------------------------------------------------
@@ -172,12 +171,6 @@ class TestSubscriptions:
         subs = subscriber.get_subscriptions()
         assert EventType.L2_PREFETCH_LOAD_SUBMITTED not in subs
         assert EventType.L2_PREFETCH_LOAD_COMPLETED not in subs
-
-    def test_rejects_invalid_sample_rate(self):
-        with pytest.raises(AssertionError):
-            L2ThroughputSubscriber(sample_rate=0.0)
-        with pytest.raises(AssertionError):
-            L2ThroughputSubscriber(sample_rate=1.5)
 
 
 # ---------------------------------------------------------------------------
@@ -249,41 +242,6 @@ class TestLoadThroughput:
 
         attrs = _attrs_of_nonzero_dps(_LOAD_METRIC)
         assert any(a.get("l2_name") == "mooncake_store" for a in attrs)
-
-
-# ---------------------------------------------------------------------------
-# Sampling behavior
-# ---------------------------------------------------------------------------
-
-
-class TestSampling:
-    def test_unsampled_task_leaves_no_state(self):
-        sub = L2ThroughputSubscriber(sample_rate=0.01)
-        with patch(
-            "lmcache.v1.mp_observability.subscribers.metrics."
-            "l2_throughput.random.random",
-            return_value=0.99,
-        ):
-            sub._on_store_submitted(_store_submitted(task_id=9, t=0.0))
-
-        assert (0, 9) not in sub._pending_store
-
-    def test_unsampled_task_does_not_record(self):
-        sub = L2ThroughputSubscriber(sample_rate=0.01)
-        count_before = _total_count(_STORE_METRIC)
-
-        with patch(
-            "lmcache.v1.mp_observability.subscribers.metrics."
-            "l2_throughput.random.random",
-            return_value=0.99,
-        ):
-            sub._on_store_submitted(
-                _store_submitted(task_id=11, t=0.0, total_bytes=10**9)
-            )
-        # COMPLETED arrives but SUBMITTED wasn't tracked.
-        sub._on_store_completed(_store_completed(task_id=11, t=0.1))
-
-        assert _total_count(_STORE_METRIC) == count_before
 
 
 # ---------------------------------------------------------------------------
@@ -385,7 +343,7 @@ class TestEdgeCases:
 class TestEventBusIntegration:
     def test_store_pair_via_bus_records_metric(self):
         bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
-        sub = L2ThroughputSubscriber(sample_rate=1.0)
+        sub = L2ThroughputSubscriber()
         bus.register_subscriber(sub)
 
         count_before = _total_count(_STORE_METRIC)


### PR DESCRIPTION
# Screenshot for the new observability dashboard

## System health

<img width="2000" height="1300" alt="image" src="https://github.com/user-attachments/assets/2004e1b3-11f2-4023-a212-754ade2b197d" />

## Performance monitoring

<img width="2000" height="1300" alt="image" src="https://github.com/user-attachments/assets/f00ac588-de93-461a-91c8-416019ca4e7a" />


## KV cache lifecycle insights

<img width="2700" height="1312" alt="image" src="https://github.com/user-attachments/assets/a944d983-19fb-49e8-8978-118def78587a" />




**What this PR does / why we need it**:

Refreshes the observability example so the Grafana dashboard reflects the
current set of MP observability metrics:

- Updates `examples/observability/grafana/.../lmcache.json` with the new
  panel layout.
- Enables `resource_to_telemetry_conversion` in the otel-collector example
  so resource attributes are exported as Prometheus labels (needed by the
  updated panels).
- Removes per-event sampling from `L0L1ThroughputSubscriber` and
  `L2ThroughputSubscriber`. The previous 1% sample rate made the
  throughput histograms too sparse to be useful on the dashboard;
  recording every START→END / SUBMITTED→COMPLETED pair gives a faithful
  view of L0↔L1 and L1↔L2 throughput.
- Updates `docs/source/mp/observability.rst` and
  `docs/design/v1/mp_observability/METRICS.md` to drop the "sampled
  (default 1%)" wording for these two throughput histograms.

**Special notes for your reviewers**:

The bulk of the diff is the dashboard JSON. The code change is limited to
dropping the `sample_rate` argument from the two throughput subscribers
and the matching `random.random()` gating in their START/SUBMITTED
handlers — other lifecycle subscribers (L1 chunk, L0 block, SM) keep
their existing sampling and the `--metrics-sample-rate` flag is
unchanged.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
