### PR TITLE
[CLI][CB] propagate CLI kvcache clear to CB fingerprint table

### DIFF
--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -332,6 +332,21 @@ class BlendTokenRangeMatcher:
         with self._lock:
             return token_hash in self._token_hash_to_compact_id
 
+    def clear(self) -> int:
+        """Drop every registered chunk and reset compact-ID allocation.
+
+        Returns:
+            Number of live (non-evicted) chunks removed.
+        """
+        with self._lock:
+            num_live = len(self._token_hash_to_compact_id)
+            self._table_id.fill(-1)
+            self._compact_id_to_slot.fill(-1)
+            self._chunk_token_hash = []
+            self._token_hash_to_start = {}
+            self._token_hash_to_compact_id = {}
+            return num_live
+
 
 def _unique_token_coverage(results: list[CBMatchResult]) -> int:
     """Return the number of unique query tokens covered by a set of CBMatchResults.
@@ -408,6 +423,24 @@ class BlendEngineV2(MPCacheEngine):
             instance_id,
             gpu_context.num_layers,
         )
+
+    def clear(self) -> None:
+        """Clear the CB fingerprint table, then storage.
+
+        Matcher is cleared first so any concurrent CB store that completes
+        between the two steps leaves a stale matcher entry (self-healed by
+        the lazy-eviction path in cb_lookup_pre_computed) rather than an
+        orphaned chunk in storage.
+        """
+        num_dropped = self._token_range_matcher.clear()
+        super().clear()
+        if num_dropped:
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.CB_CHUNKS_EVICTED,
+                    metadata={"num_chunks": num_dropped},
+                )
+            )
 
     def cb_unregister_kv_cache(self, instance_id: int) -> None:
         """

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -348,6 +348,41 @@ class TestBlendTokenRangeMatcher:
         matcher.remove_chunks([token_hash])
         assert matcher.has_chunk(token_hash) is False
 
+    def test_clear_returns_live_chunk_count_and_drops_matches(self):
+        """clear() drops every registered chunk and reports the live count."""
+        matcher = BlendTokenRangeMatcher(chunk_size=4)
+        hash_a = ObjectKey.IntHash2Bytes(7001)
+        hash_b = ObjectKey.IntHash2Bytes(7002)
+        matcher.on_new_token_hashes([1, 2, 3, 4, 5, 6, 7, 8], [hash_a, hash_b])
+
+        # Evict one before clear() so the count reflects only live entries.
+        matcher.remove_chunks([hash_a])
+        assert matcher.clear() == 1
+
+        assert matcher.match_sub_sequence([1, 2, 3, 4, 5, 6, 7, 8]) == []
+        assert matcher.has_chunk(hash_a) is False
+        assert matcher.has_chunk(hash_b) is False
+
+    def test_clear_then_register_works(self):
+        """After clear(), new registrations behave like a fresh matcher."""
+        matcher = BlendTokenRangeMatcher(chunk_size=4)
+        hash_a = ObjectKey.IntHash2Bytes(7101)
+        hash_b = ObjectKey.IntHash2Bytes(7102)
+
+        matcher.on_new_token_hashes([1, 2, 3, 4], [hash_a])
+        matcher.clear()
+
+        matcher.on_new_token_hashes([10, 20, 30, 40], [hash_b])
+        assert matcher.match_sub_sequence([1, 2, 3, 4]) == []
+        results = matcher.match_sub_sequence([10, 20, 30, 40])
+        assert len(results) == 1
+        assert results[0].hash == hash_b
+
+    def test_clear_on_empty_matcher_returns_zero(self):
+        """clear() on a never-populated matcher is a no-op returning 0."""
+        matcher = BlendTokenRangeMatcher(chunk_size=4)
+        assert matcher.clear() == 0
+
 
 class TestUniqueTokenCoverage:
     """Unit tests for _unique_token_coverage — the interval-merge helper that


### PR DESCRIPTION
 

  **What this PR does / why we need it**:

  `lmcache kvcache clear` only wiped the storage manager, leaving
  `BlendEngineV2`'s fingerprint table populated. Stale entries drained
  lazily one CB lookup at a time, inflating `fingerprints_registered`
  and `stale_chunks` in the meantime.

  - Add `BlendTokenRangeMatcher.clear()` for bulk reset.
  - Override `BlendEngineV2.clear()` to purge the matcher before storage
    and emit a single `CB_CHUNKS_EVICTED` event.

  **Special notes for your reviewers**:

  Matcher-first ordering is deliberate: a concurrent `cb_store_pre_computed`
  holds two separate locks across storage write and fingerprint register,
  so a race during clear can leave one side behind. The matcher-stale-vs-
  storage direction is self-healed by existing lazy eviction in
  `cb_lookup_pre_computed`; the reverse would orphan chunks in storage.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests