### PR TITLE
[MP][Observability] Drop inflated L2 store throughput on fast-path

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -231,6 +231,27 @@ class L2AdapterInterface(ABC):
         """
         pass
 
+    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
+        """Report bytes actually transferred per completed store task.
+
+        Optional. Default returns ``{}``, which leaves the L2 throughput
+        subscriber to fall back on submitted-bytes accounting.
+
+        Adapters that fast-path duplicate keys (e.g. skip the write when
+        the key already exists in the backend) SHOULD override this so
+        the throughput histogram reflects real work, not skipped no-ops.
+        A task with all keys fast-pathed reports ``0`` here, which the
+        subscriber treats as "no useful sample" and skips.
+
+        Returns:
+            dict[L2TaskId, int]: task id -> bytes actually written. Keys
+            present here MUST also appear in the next
+            ``pop_completed_store_tasks`` call (they share the same
+            per-task completion record), and the returned dict should be
+            cleared on read, mirroring ``pop_completed_store_tasks``.
+        """
+        return {}
+
     #####################
     # Lookup and Lock Interface
     #####################

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -287,6 +287,11 @@ class FSL2Adapter(L2AdapterInterface):
         # Task bookkeeping
         self._next_task_id: L2TaskId = 0
         self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        # Bytes actually written per completed store task.  Excludes
+        # duplicate-key fast-paths (see ``_execute_store``).  Reported to
+        # the L2 throughput subscriber via ``pop_completed_store_task_bytes``
+        # so the histogram reflects real disk I/O, not skipped no-ops.
+        self._completed_store_task_bytes: dict[L2TaskId, int] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()
@@ -344,6 +349,12 @@ class FSL2Adapter(L2AdapterInterface):
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
         return completed
+
+    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
+        with self._lock:
+            completed_bytes = self._completed_store_task_bytes
+            self._completed_store_task_bytes = {}
+        return completed_bytes
 
     # ------------------------------------------------------------------
     # Lookup and Lock Interface
@@ -568,6 +579,7 @@ class FSL2Adapter(L2AdapterInterface):
         task_id: L2TaskId,
     ) -> None:
         success = True
+        bytes_written = 0
         try:
             for key, obj in zip(keys, objects, strict=True):
                 file_path, tmp_path = self._key_to_file_and_tmp_path(key)
@@ -606,6 +618,7 @@ class FSL2Adapter(L2AdapterInterface):
                             await f.write(buf)
 
                     await aiofiles.os.replace(tmp_path, file_path)
+                    bytes_written += size
                     logger.debug(
                         "FSL2Adapter stored key %s (%d bytes)",
                         file_path.name,
@@ -628,6 +641,7 @@ class FSL2Adapter(L2AdapterInterface):
 
         with self._lock:
             self._completed_store_tasks[task_id] = success
+            self._completed_store_task_bytes[task_id] = bytes_written
         self._store_efd.notify()
 
     # ---- lookup ---------------------------------------------------------

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -125,6 +125,7 @@ class MockL2Adapter(L2AdapterInterface):
         # Task ID management
         self._next_task_id: L2TaskId = 0
         self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_store_task_bytes: dict[L2TaskId, int] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()  # lock for all shared state
@@ -195,6 +196,12 @@ class MockL2Adapter(L2AdapterInterface):
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
         return completed
+
+    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
+        with self._lock:
+            completed_bytes = self._completed_store_task_bytes
+            self._completed_store_task_bytes = {}
+        return completed_bytes
 
     def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
         with self._lock:
@@ -434,6 +441,11 @@ class MockL2Adapter(L2AdapterInterface):
         await asyncio.sleep(delay_seconds)
         with self._lock:
             self._completed_store_tasks[task_id] = success
+            # ``total_bytes`` counts only objects actually written into
+            # ``self._memory_objects`` — duplicates and capacity-skipped
+            # keys are excluded.  Reporting this lets the L2 throughput
+            # subscriber distinguish real I/O from fast-pathed no-ops.
+            self._completed_store_task_bytes[task_id] = total_bytes
 
         if stored_keys:
             self._notify_keys_stored(stored_keys, stored_sizes)

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -458,6 +458,12 @@ class NixlStoreL2Adapter(L2AdapterInterface):
         # Task ID management
         self._next_task_id: L2TaskId = 0
         self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        # Bytes actually transferred per completed store task.  Excludes
+        # keys that were fast-pathed (already present in
+        # ``_memory_objects``) and any pool-exhaustion fallouts.  Surfaces
+        # to the L2 throughput subscriber so its histogram reflects real
+        # NIXL transfers, not skipped no-ops.
+        self._completed_store_task_bytes: dict[L2TaskId, int] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()  # lock for all shared state
@@ -525,6 +531,12 @@ class NixlStoreL2Adapter(L2AdapterInterface):
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
         return completed
+
+    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
+        with self._lock:
+            completed_bytes = self._completed_store_task_bytes
+            self._completed_store_task_bytes = {}
+        return completed_bytes
 
     #####################
     # Lookup and Lock Interface
@@ -766,6 +778,7 @@ class NixlStoreL2Adapter(L2AdapterInterface):
                 # Nothing to store (all keys already existed or pool empty)
                 with self._lock:
                     self._completed_store_tasks[task_id] = True
+                    self._completed_store_task_bytes[task_id] = 0
                 self._signal_store_event()
                 return
 
@@ -787,17 +800,20 @@ class NixlStoreL2Adapter(L2AdapterInterface):
             if stored_keys:
                 stored_sizes = [obj.size for obj in storage_objs]
                 self._notify_keys_stored(stored_keys, stored_sizes)
+            bytes_transferred = sum(obj.size for obj in storage_objs)
 
         # success is only set to false for transfer failures
         except Exception:
             logger.exception("NIXL store task %d failed", task_id)
             success = False
+            bytes_transferred = 0
 
             # free storage indices if transfer fails
             self.nixl_agent.pool.batched_free(storage_indices_flat)
 
         with self._lock:
             self._completed_store_tasks[task_id] = success
+            self._completed_store_task_bytes[task_id] = bytes_transferred
 
         self._signal_store_event()
 

--- a/lmcache/v1/distributed/l2_adapters/serde_wrapper.py
+++ b/lmcache/v1/distributed/l2_adapters/serde_wrapper.py
@@ -132,6 +132,10 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
 
         # User-visible completion queues (drained by controller polls).
         self._completed_store: dict[L2TaskId, bool] = {}
+        # Bytes actually transferred per completed store task, forwarded
+        # from the inner adapter so wrapped fast-path adapters still
+        # expose accurate throughput data.
+        self._completed_store_bytes: dict[L2TaskId, int] = {}
         self._completed_load: dict[L2TaskId, Bitmap] = {}
 
         self._stop_flag = threading.Event()
@@ -217,6 +221,12 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
         with self._lock:
             result = self._completed_store
             self._completed_store = {}
+        return result
+
+    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
+        with self._lock:
+            result = self._completed_store_bytes
+            self._completed_store_bytes = {}
         return result
 
     # ------------------------------------------------------------------
@@ -457,6 +467,7 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
         """Drain inner store completions; release temp read locks (auto-
         delete) and finalize the wrapped tasks."""
         completed = self._inner.pop_completed_store_tasks()
+        inner_bytes = self._inner.pop_completed_store_task_bytes()
         for inner_id, success in completed.items():
             with self._lock:
                 wrapped_id = self._inner_to_store.pop(inner_id, None)
@@ -473,7 +484,7 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
                 continue
             if state is not None:
                 self._l1_manager.finish_read(state.temp_keys)
-            self._finalize_store(wrapped_id, success)
+            self._finalize_store(wrapped_id, success, inner_bytes.get(inner_id))
 
     def _drain_inner_load(self) -> None:
         """Drain inner load completions; on per-key success submit
@@ -607,10 +618,22 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
         except Exception:
             logger.exception("Serde wrapper: failed releasing write-locked temps")
 
-    def _finalize_store(self, wrapped_id: L2TaskId, success: bool) -> None:
+    def _finalize_store(
+        self,
+        wrapped_id: L2TaskId,
+        success: bool,
+        bytes_transferred: int | None = None,
+    ) -> None:
         with self._lock:
             self._store_tasks.pop(wrapped_id, None)
             self._completed_store[wrapped_id] = success
+            # Only record bytes when the inner adapter reported them.
+            # Absence in the dict signals "unknown" to the controller,
+            # which then falls back to submitted-bytes accounting.  A 0
+            # here means "transferred nothing" -- the subscriber drops
+            # those samples.
+            if bytes_transferred is not None:
+                self._completed_store_bytes[wrapped_id] = bytes_transferred
         try:
             self._store_efd.notify()
         except OSError:

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -182,6 +182,12 @@ class InFlightStoreTask:
     l2_store_result: bool | None = None
     """L2 outcome (True=success, False=failure, None=still in flight)."""
 
+    l2_bytes_transferred: int | None = None
+    """Bytes actually transferred by the adapter for this task.  ``None``
+    means the adapter does not track per-task transfer bytes (default
+    behavior for non fast-path adapters); consumers fall back to the
+    submitted-bytes count from the SUBMITTED event."""
+
 
 # Main class
 
@@ -522,6 +528,7 @@ class StoreController(StorageControllerInterface):
         for adapter_index in signaled_adapters:
             adapter = self._l2_adapters[adapter_index]
             completed = adapter.pop_completed_store_tasks()
+            bytes_map = adapter.pop_completed_store_task_bytes()
             for task_id, success in completed.items():
                 task = self._in_flight_tasks.get((adapter_index, task_id))
                 if task is None:
@@ -532,6 +539,8 @@ class StoreController(StorageControllerInterface):
                     )
                     continue
                 task.l2_store_result = success
+                if task_id in bytes_map:
+                    task.l2_bytes_transferred = bytes_map[task_id]
 
     def _advance_request(
         self,
@@ -561,14 +570,26 @@ class StoreController(StorageControllerInterface):
         self._status_in_flight_count -= 1
 
         l2_name = self._adapter_descriptors[adapter_index].type_name
+        # Adapters that fast-path duplicate keys report ``bytes_transferred``
+        # so the L2 throughput subscriber can use real-work bytes for the
+        # histogram instead of submitted bytes (which inflates dt-based
+        # throughput when the adapter skipped the write).  Adapters that
+        # don't report bytes leave this at ``None`` -- the field is then
+        # omitted from the event so consumers fall back to the submitted
+        # bytes carried on the SUBMITTED event.
+        completion_meta: dict[str, object] = {
+            "adapter_index": adapter_index,
+            "task_id": task_id,
+            "l2_name": l2_name,
+        }
+        if task.l2_bytes_transferred is not None:
+            completion_meta["bytes_transferred"] = task.l2_bytes_transferred
         if success:
             self._event_bus.publish(
                 Event(
                     event_type=EventType.L2_STORE_COMPLETED,
                     metadata={
-                        "adapter_index": adapter_index,
-                        "task_id": task_id,
-                        "l2_name": l2_name,
+                        **completion_meta,
                         "succeeded_count": len(task.keys),
                         "failed_count": 0,
                     },
@@ -588,9 +609,7 @@ class StoreController(StorageControllerInterface):
                 Event(
                     event_type=EventType.L2_STORE_COMPLETED,
                     metadata={
-                        "adapter_index": adapter_index,
-                        "task_id": task_id,
-                        "l2_name": l2_name,
+                        **completion_meta,
                         "succeeded_count": 0,
                         "failed_count": len(task.keys),
                     },

--- a/lmcache/v1/mp_observability/subscribers/metrics/l2_throughput.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l2_throughput.py
@@ -21,6 +21,17 @@ Implementation:
   - ``(end_ts - start_ts)`` spans submit -> complete and therefore
     includes adapter queue, network, and disk time — not just transfer.
     The histogram is "bytes / end-to-end latency", not raw transfer rate.
+
+Fast-path adapters:
+  Some adapters (``mock``, ``fs``, ``nixl_store``) skip writes for keys
+  that are already present, which makes ``dt`` collapse to near-zero and
+  inflates store throughput (the controller asked to store N bytes but
+  the adapter actually transferred 0).  When ``L2_STORE_COMPLETED``
+  carries ``bytes_transferred``, the store path uses it instead of the
+  submitted bytes; if ``bytes_transferred == 0`` the sample is dropped
+  (no work, no useful throughput data).  When the field is absent
+  (adapter doesn't track it), behavior matches the load path -- submitted
+  bytes / dt.
 """
 
 # Future
@@ -90,11 +101,16 @@ class L2ThroughputSubscriber(EventSubscriber):
         key = self._store_key(event)
         if key is None:
             return
+        # If the adapter reports per-task transfer bytes, prefer that
+        # over submitted bytes.  ``None`` means "adapter doesn't track" ->
+        # fall back to submitted-bytes accounting (the load-path code).
+        bytes_transferred = event.metadata.get("bytes_transferred")
         self._record(
             event=event,
             correlation_key=key,
             pending=self._pending_store,
             hist=self._store_hist,
+            override_bytes=bytes_transferred,
         )
 
     # -- Load path (L2->L1) ------------------------------------------------
@@ -150,13 +166,19 @@ class L2ThroughputSubscriber(EventSubscriber):
         correlation_key: tuple[int, int],
         pending: dict[tuple[int, int], tuple[float, int]],
         hist: Any,
+        override_bytes: int | None = None,
     ) -> None:
         pending_entry = pending.pop(correlation_key, None)
         if pending_entry is None:
             return  # no matching SUBMITTED event;
         t_start, total_bytes = pending_entry
 
-        if total_bytes <= 0:
+        # ``override_bytes`` carries the adapter-reported transfer bytes
+        # for fast-path-aware adapters.  ``None`` -> use submitted bytes
+        # (current behavior).  ``0`` -> adapter fast-pathed everything,
+        # there is no real throughput to record -- drop the sample.
+        effective_bytes = total_bytes if override_bytes is None else override_bytes
+        if effective_bytes <= 0:
             return
 
         dt = event.timestamp - t_start
@@ -168,4 +190,4 @@ class L2ThroughputSubscriber(EventSubscriber):
         if l2_name is not None:
             attrs["l2_name"] = str(l2_name)
 
-        hist.record(total_bytes / dt / 1e9, attributes=attrs)
+        hist.record(effective_bytes / dt / 1e9, attributes=attrs)

--- a/tests/v1/mp_observability/subscribers/metrics/test_l2_throughput.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_l2_throughput.py
@@ -56,19 +56,25 @@ def _store_completed(
     t: float,
     adapter_index: int = 0,
     l2_name: str = "fs",
+    bytes_transferred: int | None = None,
 ) -> Event:
-    # L2_STORE_COMPLETED does not carry total_bytes; the subscriber
-    # looks up the bytes it cached at SUBMITTED time.
+    # ``bytes_transferred`` is populated by fast-path-aware adapters (see
+    # ``store_controller._finalize_store``).  Absence means the subscriber
+    # falls back to the submitted-bytes accounting it cached at SUBMITTED
+    # time.
+    metadata: dict = {
+        "adapter_index": adapter_index,
+        "task_id": task_id,
+        "l2_name": l2_name,
+        "succeeded_count": 1,
+        "failed_count": 0,
+    }
+    if bytes_transferred is not None:
+        metadata["bytes_transferred"] = bytes_transferred
     return Event(
         event_type=EventType.L2_STORE_COMPLETED,
         timestamp=t,
-        metadata={
-            "adapter_index": adapter_index,
-            "task_id": task_id,
-            "l2_name": l2_name,
-            "succeeded_count": 1,
-            "failed_count": 0,
-        },
+        metadata=metadata,
     )
 
 
@@ -333,6 +339,68 @@ class TestEdgeCases:
         assert (0, 5) not in subscriber._pending_store
         # Load pending dict untouched — different key space (request_id).
         assert (5, 0) in subscriber._pending_load
+
+
+# ---------------------------------------------------------------------------
+# bytes_transferred override (fast-path-aware adapters)
+# ---------------------------------------------------------------------------
+
+
+class TestStoreBytesTransferred:
+    """Store path prefers ``bytes_transferred`` from the COMPLETED event
+    over the submitted-bytes cache when the adapter populates it."""
+
+    def test_uses_bytes_transferred_when_present(self, subscriber):
+        count_before = _total_count(_STORE_METRIC)
+        sum_before = _sum(_STORE_METRIC)
+
+        # Submitted = 10 GB but adapter actually transferred only 1 GB
+        # (rest were fast-pathed duplicates).  Over 0.25 s -> 4 GB/s,
+        # not 40 GB/s.
+        subscriber._on_store_submitted(
+            _store_submitted(task_id=10, t=0.0, total_bytes=10_000_000_000)
+        )
+        subscriber._on_store_completed(
+            _store_completed(task_id=10, t=0.25, bytes_transferred=1_000_000_000)
+        )
+
+        assert _total_count(_STORE_METRIC) == count_before + 1
+        assert _sum(_STORE_METRIC) - sum_before == pytest.approx(4.0, rel=1e-6)
+
+    def test_zero_bytes_transferred_drops_sample(self, subscriber):
+        count_before = _total_count(_STORE_METRIC)
+        sum_before = _sum(_STORE_METRIC)
+
+        # Adapter fast-pathed every key -- no real work, drop the sample
+        # even though submitted bytes and dt look reasonable.
+        subscriber._on_store_submitted(
+            _store_submitted(task_id=11, t=0.0, total_bytes=10_000_000_000)
+        )
+        subscriber._on_store_completed(
+            _store_completed(task_id=11, t=0.1, bytes_transferred=0)
+        )
+
+        assert _total_count(_STORE_METRIC) == count_before
+        assert _sum(_STORE_METRIC) == sum_before
+        # Pending dict still drained even when sample dropped.
+        assert (0, 11) not in subscriber._pending_store
+
+    def test_absent_field_falls_back_to_submitted_bytes(self, subscriber):
+        # Adapters that don't track per-task transfer bytes omit the
+        # field; behavior matches the load path -- submitted bytes / dt.
+        count_before = _total_count(_STORE_METRIC)
+        sum_before = _sum(_STORE_METRIC)
+
+        # 2 GB in 0.1 s -> 20 GB/s
+        subscriber._on_store_submitted(
+            _store_submitted(task_id=12, t=0.0, total_bytes=2_000_000_000)
+        )
+        subscriber._on_store_completed(
+            _store_completed(task_id=12, t=0.1)  # no bytes_transferred
+        )
+
+        assert _total_count(_STORE_METRIC) == count_before + 1
+        assert _sum(_STORE_METRIC) - sum_before == pytest.approx(20.0, rel=1e-6)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Some L2 adapters (mock, fs, nixl_store) skip the write when a key is already present in the backend.  That fast-path collapses the time between L2_STORE_SUBMITTED and L2_STORE_COMPLETED to near-zero, while the submitted-bytes count carried on SUBMITTED stays unchanged.  The L2 throughput subscriber computes ``bytes / dt`` and the result blows up -- locally I saw mean store throughput at 52.9 GB/s on a mock adapter pinned to 4 GB/s, with bimodal samples in the 100-250 GB/s bucket from duplicate-store batches.

Plumb the bytes actually transferred per task from the adapter through to the subscriber so the histogram reflects real work:

  * ``L2AdapterInterface.pop_completed_store_task_bytes`` (default ``{}``) lets adapters opt-in to per-task transfer reporting.  Adapters without a fast-path keep the current behavior.
  * mock / fs / nixl_store override it and accumulate ``total_bytes`` over actually-written keys in their existing store coroutines.
  * ``SerdeWrapper`` forwards inner reports, preserving "unknown" when the inner adapter doesn't track.
  * ``StoreController`` queries both maps when draining and surfaces ``bytes_transferred`` on ``L2_STORE_COMPLETED`` when known.
  * ``L2ThroughputSubscriber._on_store_completed`` prefers the override when present: ``>0`` records ``bytes_transferred / dt``, ``0`` drops the sample (no useful throughput from a no-op), absent falls back to submitted-bytes / dt.

After the change the local script shows mean store throughput 3.98 GB/s (matching the mock's ``--mock-bandwidth-gb 4``) and the 100-250 GB/s outlier bucket is empty.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
