### PR TITLE
fix: prevent TypeError crash when streaming response has zero visible content

### DIFF
--- a/benchmarks/multi_round_qa/multi-round-qa.py
+++ b/benchmarks/multi_round_qa/multi-round-qa.py
@@ -153,6 +153,9 @@ class RequestExecutor:
         tokens_out = tok.usage.completion_tokens
         tokens_prefill = tok.usage.prompt_tokens
 
+        if first_token_time is None:
+            first_token_time = time.time()
+
         return Response(
             body=words,
             ttft=first_token_time - start_time,

--- a/benchmarks/rag/rag.py
+++ b/benchmarks/rag/rag.py
@@ -196,6 +196,8 @@ class RequestExecutor:
         tokens_out = tok.usage.completion_tokens
         tokens_prefill = tok.usage.prompt_tokens
         finish_time = time.time()
+        if first_token_time is None:
+            first_token_time = finish_time
         return Response(
             request_id=request_id,
             body=words,


### PR DESCRIPTION
Issue: 
  An LLM inference engine (e.g., vLLM) returns a streaming chat-completion response where every SSE chunk has an empty delta.content string. This happens when max_tokens=1 and the single generated token is EOS, or when the model emits only tool-call deltas. Despite usage.completion_tokens > 0, no chunk ever carries visible text content.

  The benchmark script crashes with TypeError: unsupported operand type(s) for -: 'NoneType' and 'float' at the lines computing ttft and generation_time, because first_token_time remains None.


Root Cause: 
  first_token_time is initialized to None and is only assigned when chunk_message != "". The code unconditionally subtracts it from float values afterward, with no guard for the None case.


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
