### PR TITLE
[Fix] Harden raw-block device cleanup and alignment checks

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -132,6 +132,7 @@ The MP adapter is configured through `--l2-adapter` JSON:
 
 Important validation rules:
 
+- `block_align` must be a power of two
 - `slot_bytes`, `header_bytes`, and `meta_total_bytes` must be aligned to
   `block_align`
 - `slot_bytes >= header_bytes + 1`
@@ -140,6 +141,9 @@ Important validation rules:
   of loading the latest on-device metadata checkpoint
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
+- with `use_odirect=true`, raw-block I/O rejects offsets and total I/O lengths
+  that are not aligned to `block_align`; misaligned write buffers use an
+  aligned bounce buffer
 
 ## Relationship to Non-MP Mode
 

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -16,7 +16,8 @@ caller-provided load buffers during prefetch.
 - ``capacity_bytes``: Optional cap on the usable device bytes. Default ``0``
   means use the full device/file size.
 - ``use_odirect``: ``true`` or ``false`` (default ``true``).
-- ``block_align``: Device alignment in bytes (default ``4096``).
+- ``block_align``: Device alignment in bytes (default ``4096``). Must be a
+  power of two.
 - ``header_bytes``: Per-slot header reservation (default ``4096``).
 - ``meta_total_bytes``: Reserved metadata checkpoint region (default ``256MiB``).
 - ``meta_magic`` / ``meta_version``: Metadata checkpoint identity/version knobs.
@@ -48,8 +49,13 @@ caller-provided load buffers during prefetch.
 - ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
   through ``RawBlockCore``. Slot reclamation is driven by the shared/global
   L2 eviction controller or explicit ``delete()`` calls.
+- ``slot_bytes``, ``header_bytes``, and ``meta_total_bytes`` must be multiples
+  of ``block_align``.
 - If ``use_odirect`` is enabled, the server's ``--l1-align-bytes`` should be
   at least ``block_align``.
+- With ``O_DIRECT``, raw-block I/O rejects offsets and total I/O lengths that
+  are not multiples of ``block_align``. Misaligned write buffers use an aligned
+  bounce buffer.
 - ``persist_enabled`` must remain ``true`` for this adapter.
 - For ``use_uring_cmd=true``, ``device_path`` must use the NVMe character
   device node (e.g., ``/dev/ng0n1``) instead of the block device node

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -177,8 +177,10 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         use_uring_cmd = bool(d.get("use_uring_cmd", False))
         max_data_transfer_size = int(d.get("max_data_transfer_size", 0))
 
-        if block_align <= 0:
-            raise ValueError("block_align must be > 0")
+        if block_align <= 0 or (block_align & (block_align - 1)) != 0:
+            raise ValueError(
+                f"block_align must be a positive power of 2, got {block_align}"
+            )
         if slot_bytes % block_align != 0:
             raise ValueError("slot_bytes must be a multiple of block_align")
         if header_bytes % block_align != 0:

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -99,7 +99,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             slot_bytes: Fixed data-slot size in bytes.
             capacity_bytes: Optional cap on usable bytes; zero uses device size.
             use_odirect: Whether to open the raw path with O_DIRECT.
-            block_align: Required block alignment in bytes.
+            block_align: Required power-of-two block alignment in bytes.
             header_bytes: Per-slot header reservation in bytes.
             meta_total_bytes: Reserved metadata checkpoint region size.
             meta_magic: Eight-byte ASCII metadata checkpoint magic.
@@ -178,9 +178,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         max_data_transfer_size = int(d.get("max_data_transfer_size", 0))
 
         if block_align <= 0 or (block_align & (block_align - 1)) != 0:
-            raise ValueError(
-                f"block_align must be a positive power of 2, got {block_align}"
-            )
+            raise ValueError(f"block_align must be a power of 2, got {block_align}")
         if slot_bytes % block_align != 0:
             raise ValueError("slot_bytes must be a multiple of block_align")
         if header_bytes % block_align != 0:
@@ -245,7 +243,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "- capacity_bytes (int): optional usable capacity cap "
             "(default 0 = device size)\n"
             "- use_odirect (bool): enable O_DIRECT raw I/O (default true)\n"
-            "- block_align (int): required block alignment in bytes (default 4096)\n"
+            "- block_align (int): required power-of-two block alignment in "
+            "bytes (default 4096)\n"
             "- header_bytes (int): per-slot header reservation (default 4096)\n"
             "- meta_total_bytes (int): reserved metadata checkpoint region "
             "(default 256MiB)\n"

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -614,8 +614,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
         rust_block_align = int(extra.get("rust_raw_block.block_align", 4096))
         if not self._is_power_of_two(rust_block_align):
             raise ValueError(
-                "extra_config['rust_raw_block.block_align'] must be a positive "
-                "power of two when O_DIRECT or io_uring alignment is enabled"
+                "extra_config['rust_raw_block.block_align'] must be a power "
+                "of two when O_DIRECT or io_uring alignment is enabled"
             )
         return rust_block_align
 

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -232,8 +232,10 @@ class RawBlockCore:
 
         if not self.device_path:
             raise ValueError("RawBlockCore requires a non-empty device_path")
-        if self.block_align <= 0:
-            raise ValueError("block_align must be > 0")
+        if self.block_align <= 0 or (self.block_align & (self.block_align - 1)) != 0:
+            raise ValueError(
+                f"block_align must be a positive power of 2, got {self.block_align}"
+            )
         if self.header_bytes < 24:
             raise ValueError("header_bytes must be >= 24")
         if self.header_bytes % self.block_align != 0:

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -234,7 +234,7 @@ class RawBlockCore:
             raise ValueError("RawBlockCore requires a non-empty device_path")
         if self.block_align <= 0 or (self.block_align & (self.block_align - 1)) != 0:
             raise ValueError(
-                f"block_align must be a positive power of 2, got {self.block_align}"
+                f"block_align must be a power of 2, got {self.block_align}"
             )
         if self.header_bytes < 24:
             raise ValueError("header_bytes must be >= 24")

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -92,7 +92,11 @@ No fixed numbers are included here because results are host/device/workload depe
 ## Limitations
 
 - Linux only (`pread` / `pwrite`, O_DIRECT semantics).
-- O_DIRECT requires aligned offset, size, and user buffer address.
+- `alignment` and `block_align` must be powers of two, such as 4096.
+- O_DIRECT requires aligned offsets and I/O lengths. `batched_write` rejects
+  requests whose offset or `total_len` is not a multiple of the configured
+  alignment; misaligned write buffers are copied through an aligned bounce
+  buffer.
 
 ## Build
 
@@ -173,6 +177,8 @@ Notes:
   file used only by LMCache.
 - For `use_uring_cmd=true`, `device_path` must use the NVMe character
   device node (e.g., `/dev/ng0n1`) instead of the block device node.
+- `block_align` must be a power of two. `slot_bytes`, `header_bytes`, and
+  `meta_total_bytes` must be multiples of `block_align`.
 - With `use_odirect=true`, LMCache MP L1 alignment must be at least
   `block_align`.
 - Restart recovery uses the metadata checkpoint region on the same device.

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -2088,7 +2088,18 @@ impl RawBlockDevice {
                 // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
                 let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
 
-                // Ensure O_DIRECT buffers are aligned
+                if use_odirect {
+                    #[allow(clippy::manual_is_multiple_of)]
+                    if (offset as usize) % alignment != 0 {
+                        return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+                    }
+                    #[allow(clippy::manual_is_multiple_of)]
+                    if total_len % alignment != 0 {
+                        return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+                    }
+                }
+
+                // Misaligned pointer is handled via bounce buffer for writes
                 let (final_ptr, bounce_opt, fixed_idx) = if use_odirect {
                     let align = alignment;
                     #[allow(clippy::manual_is_multiple_of)]

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -204,6 +204,15 @@ def test_raw_block_l2_adapter_config_validates_iouring_queue_depth():
         RawBlockL2AdapterConfig.from_dict(_config_dict(iouring_queue_depth=0))
 
 
+@pytest.mark.parametrize("block_align", [0, -1, 3, 4095])
+def test_raw_block_l2_adapter_config_rejects_non_power_of_2_block_align(
+    block_align: int,
+) -> None:
+    """from_dict rejects block_align values that are not a positive power of 2."""
+    with pytest.raises(ValueError, match="block_align"):
+        RawBlockL2AdapterConfig.from_dict(_config_dict(block_align=block_align))
+
+
 def _run_store(adapter: RawBlockL2Adapter, keys, objects) -> bool:
     task_id = adapter.submit_store_task(keys, objects)
     assert _wait_event_fd(adapter.get_store_event_fd())

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -208,7 +208,7 @@ def test_raw_block_l2_adapter_config_validates_iouring_queue_depth():
 def test_raw_block_l2_adapter_config_rejects_non_power_of_2_block_align(
     block_align: int,
 ) -> None:
-    """from_dict rejects block_align values that are not a positive power of 2."""
+    """from_dict rejects invalid block_align values."""
     with pytest.raises(ValueError, match="block_align"):
         RawBlockL2AdapterConfig.from_dict(_config_dict(block_align=block_align))
 

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -2481,6 +2481,7 @@ def test_rust_raw_block_backend_batched_submit_rolls_back_only_unscheduled_refs(
 )
 def test_batched_write_rejects_misaligned_offset():
     """batched_write raises ValueError for a misaligned offset when use_odirect=True."""
+    # Third Party
     from lmcache_rust_raw_block_io import RawBlockDevice
 
     align = 4096
@@ -2509,6 +2510,7 @@ def test_batched_write_rejects_misaligned_offset():
 )
 def test_batched_write_rejects_misaligned_total_len():
     """batched_write rejects misaligned total_len with O_DIRECT enabled."""
+    # Third Party
     from lmcache_rust_raw_block_io import RawBlockDevice
 
     align = 4096

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -111,7 +111,6 @@ def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
     )
 
 
-
 @pytest.mark.parametrize("block_align", [0, -1, 3, 4095])
 def test_raw_block_core_rejects_non_power_of_2_block_align(block_align: int) -> None:
     """RawBlockCore rejects invalid block_align values."""
@@ -138,7 +137,6 @@ def test_raw_block_core_rejects_non_power_of_2_block_align(block_align: int) -> 
             ),
             key_namespace="object",
         )
-
 
 
 def _make_byte_obj(size: int) -> TensorMemoryObj:
@@ -2476,3 +2474,59 @@ def test_rust_raw_block_backend_batched_submit_rolls_back_only_unscheduled_refs(
         obj2.ref_count_down()
     finally:
         backend.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_batched_write_rejects_misaligned_offset():
+    """batched_write raises ValueError for a misaligned offset when use_odirect=True."""
+    from lmcache_rust_raw_block_io import RawBlockDevice
+
+    align = 4096
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        dev = RawBlockDevice(
+            dev_path,
+            writable=True,
+            use_odirect=True,
+            alignment=align,
+            io_engine="io_uring",
+        )
+        try:
+            buf = bytearray(align)
+            with pytest.raises(ValueError, match="aligned offset"):
+                dev.batched_write([1], [buf], [align])  # offset 1 is not aligned
+        finally:
+            dev.close()
+
+
+@pytest.mark.skipif(
+    not _has_ext(), reason="lmcache_rust_raw_block_io extension not installed"
+)
+def test_batched_write_rejects_misaligned_total_len():
+    """batched_write rejects misaligned total_len with O_DIRECT enabled."""
+    from lmcache_rust_raw_block_io import RawBlockDevice
+
+    align = 4096
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        dev = RawBlockDevice(
+            dev_path,
+            writable=True,
+            use_odirect=True,
+            alignment=align,
+            io_engine="io_uring",
+        )
+        try:
+            buf = bytearray(align)
+            with pytest.raises(ValueError, match="aligned total_len"):
+                dev.batched_write([0], [buf], [1])  # total_len 1 is not aligned
+        finally:
+            dev.close()

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -111,6 +111,36 @@ def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
     )
 
 
+
+@pytest.mark.parametrize("block_align", [0, -1, 3, 4095])
+def test_raw_block_core_rejects_non_power_of_2_block_align(block_align: int) -> None:
+    """RawBlockCore rejects invalid block_align values."""
+    with pytest.raises(ValueError, match="block_align"):
+        RawBlockCore(
+            RawBlockCoreConfig(
+                device_path="/tmp/dummy-does-not-need-to-exist",
+                capacity_bytes=64 * 1024,
+                block_align=block_align,
+                header_bytes=4096,
+                slot_bytes=8192,
+                use_odirect=False,
+                enable_zero_copy=True,
+                meta_total_bytes=16 * 1024,
+                meta_magic=b"LMCIDX01",
+                meta_version=1,
+                meta_checkpoint_interval_sec=60,
+                meta_idle_quiet_ms=100,
+                meta_enable_periodic=False,
+                load_checkpoint_on_init=False,
+                meta_verify_on_load=False,
+                io_engine="posix",
+                iouring_queue_depth=256,
+            ),
+            key_namespace="object",
+        )
+
+
+
 def _make_byte_obj(size: int) -> TensorMemoryObj:
     raw_data = torch.empty(size, dtype=torch.uint8)
     metadata = MemoryObjMetadata(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes several raw-block reliability and alignment issues:

- Requires `block_align` to be a power of two in raw-block config/core validation.
- Validates `batched_write()` offsets and total I/O lengths when `O_DIRECT` alignment is required.
- Adds regression tests for invalid block_align, and misaligned batched writes.
- Keeps raw-block alignment error/help text consistent across core, MP adapter config, LocalCPU raw-block alignment, tests, and docs.
- Documents the raw-block alignment rules for `block_align`, slot/header/metadata sizing, and `O_DIRECT` I/O.

**Special notes for your reviewers**:

The Rust raw-block tests require the `lmcache_rust_raw_block_io` extension. Tests that need it use the existing skip marker when the extension is unavailable.

`batched_write()` still uses an aligned bounce buffer for misaligned source buffer pointers, but now rejects misaligned offsets and `total_len` values under `O_DIRECT`.

Tested with:

```bash
pytest -q tests/v1/storage_backend/test_rust_raw_block_backend.py tests/v1/distributed/test_raw_block_l2_adapter.py
```

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
