### PR TITLE
[MP][DSV4] Support hybrid KV cache manager (SupportsHMA)

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -651,33 +651,16 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         logger.info("Registering kv caches!")
 
-        # Build per-positional-layer logical block size and namespace from
-        # ``self._kv_cache_config.kv_cache_groups``. Under the hybrid
-        # manager, each ``KVCacheGroupSpec`` reports its own
-        # ``KVCacheSpec.block_size`` and pulls block IDs from its own
-        # ``BlockPool``; LMCache needs both signals to keep one transfer
-        # kernel per ``(physical_bs, logical_bs, namespace)`` triple.
-        # Without ``logical_bs`` we'd merge V4's C4A-main and per-layer-SWA
-        # layers (both physical ``bs=64``); without ``namespace`` we'd
-        # merge V4 gids 1 and 2 (every spec field matches, separate
-        # ``req_to_blocks`` dicts).
-        #
-        # Layers absent from ``kv_caches`` keep their sentinel entries
-        # (logical_bs=0, namespace=-1); the LMCache-side consumer rejects
-        # any non-positive / negative entry at registration, so a partial
-        # cover surfaces as a loud failure. If no hint is populated we drop
-        # both lists so single-group engines fall back to the legacy
-        # 5-tuple identity.
+        # Build per-positional-layer hints from ``kv_cache_groups``: under
+        # HMA each ``KVCacheGroupSpec`` has its own block_size, BlockPool
+        # namespace, and sliding_window. LMCache needs all three to key
+        # one transfer kernel per ``(physical_bs, logical_bs, namespace,
+        # window)`` tuple. Sentinels (logical_bs=0, namespace=-1) for
+        # uncovered layers trigger a loud failure on the LMCache side.
         per_layer_logical_block_size: list[int] | None = None
         per_layer_kv_cache_group_id: list[int] | None = None
         per_layer_sliding_window: list[int] | None = None
         kv_cache_config = getattr(self, "_kv_cache_config", None)
-        # We always publish the per-layer ``sliding_window`` so LMCache
-        # can shrink each SWA-flavored group's per-chunk MemoryObj slot
-        # to just the last ``ceil(window / logical_block_size)`` blocks
-        # (the SWA-suffix-only optimization). Full-attention groups
-        # report ``sliding_window == 0`` and the LMCache consumer keeps
-        # the prior full-chunk behavior for those.
         if kv_cache_config is not None and getattr(
             kv_cache_config, "kv_cache_groups", None
         ):
@@ -686,21 +669,15 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             num_positional = len(kv_cache_layer_names)
             per_layer_logical_block_size = [0] * num_positional
             per_layer_kv_cache_group_id = [-1] * num_positional
-            # Sentinel 0 means "no sliding-window cap" (= full
-            # attention). The LMCache consumer reads
-            # ``sliding_window == 0`` as "store full chunk", which
-            # matches the existing behavior for non-SWA layers.
+            # 0 = full attention (no SWA suffix-only optimization).
             per_layer_sliding_window = [0] * num_positional
             for gid, group in enumerate(kv_cache_config.kv_cache_groups):
                 spec = getattr(group, "kv_cache_spec", None)
                 spec_block_size = getattr(spec, "block_size", None)
                 if spec_block_size is None:
                     continue
-                # ``KVCacheSpec.sliding_window`` lives on the spec
-                # directly (``SlidingWindowMLASpec`` etc.), or — when vLLM
-                # has wrapped per-layer specs into
-                # ``UniformTypeKVCacheSpecs`` — on the wrapped inner
-                # specs (uniform by construction).
+                # ``sliding_window`` may live on the spec directly or on
+                # inner specs of a ``UniformTypeKVCacheSpecs`` wrapper.
                 spec_sliding_window = getattr(spec, "sliding_window", None)
                 if spec_sliding_window is None:
                     inner_specs = getattr(spec, "kv_cache_specs", None)
@@ -724,12 +701,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                         per_layer_logical_block_size[pos] = int(spec_block_size)
                         per_layer_kv_cache_group_id[pos] = gid
                         per_layer_sliding_window[pos] = int(spec_sliding_window)
-            # If neither list got populated (no usable specs), drop
-            # all hints so the consumer falls back to the prior
-            # behavior cleanly. Layers that ended up with sentinel
-            # values (some specs missing block_size, some layer names
-            # absent from kv_caches) will trigger a loud ValueError
-            # on the LMCache side.
+            # No usable specs: drop hints, fall back to legacy 5-tuple.
             if not any(per_layer_logical_block_size) and all(
                 ns == -1 for ns in per_layer_kv_cache_group_id
             ):

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 import enum
+import os
 
 # Third Party
 from vllm.config import VllmConfig
@@ -12,6 +13,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -77,23 +79,25 @@ if TYPE_CHECKING:
 logger = lmcache_init_logger(__name__)
 
 
+def _swa_suffix_only_mode() -> bool:
+    """Experimental gate: when ``LMCACHE_SWA_SUFFIX_ONLY=1`` is set, the
+    connector advertises each layer's ``sliding_window`` to LMCache so
+    LMCache can store/retrieve only the last ``ceil(window /
+    logical_block_size)`` blocks per chunk for sliding-window groups —
+    instead of the full ``lmcache_chunk_size // logical_block_size``
+    blocks. The SWA mask kernel-side guarantees positions older than
+    ``window`` are never read, so the truncated KV is sufficient for
+    correct decode after a full hit, and for the first ``window`` steps
+    of a partial-hit recompute (after which the recompute path moves
+    the window forward into freshly-recomputed positions and the cache
+    is no longer touched). On DeepSeek-V4 (``chunk_size=1024``,
+    ``window``s of 8/128/256), this collapses gid 3's per-chunk SWA
+    payload from ~236 MiB to ~1.85 MiB. Has no effect on
+    full-attention groups (``sliding_window == 0``)."""
+    return os.environ.get("LMCACHE_SWA_SUFFIX_ONLY") == "1"
+
+
 # Helper functions
-def reformat_block_ids(block_ids: tuple[list[int], ...] | None) -> list[int]:
-    if block_ids is None:
-        return []
-    assert isinstance(block_ids, tuple), (
-        f"Expected block_ids to be a tuple of lists, but got {type(block_ids)}"
-    )
-
-    if len(block_ids) > 1:
-        raise RuntimeError(
-            "LMCacheMPConnector only works without hybrid kv cache manager. "
-            "Please pass --disable-hybrid-kv-cache-manager when starting vllm"
-        )
-
-    return block_ids[0]
-
-
 def extract_world_size_and_kv_rank(
     world_size: int,
     rank: int,
@@ -203,9 +207,25 @@ class LMCacheMPRequestTracker:
     all_token_ids: ConstantList[int]
     block_hashes: ConstantList["BlockHash"]
 
-    # Block ids and hashes will be updated at update_states_after_alloc and
-    # during the generation
-    allocated_block_ids: list[int] = field(default_factory=list)
+    # Per-vLLM-kv-cache-group block IDs allocated to this request.
+    # The dict is keyed by the engine-side ``kv_cache_group_id``, and
+    # each value is the (in-order) list of block IDs allocated for that
+    # group. For non-hybrid models, only key ``0`` is ever populated —
+    # the dict has a single entry that mirrors the prior flat-list
+    # semantics. For DeepSeek-V4 with the hybrid manager active, vLLM
+    # emits 5 disjoint namespaces (one per ``KVCacheGroupSpec``) and
+    # each gid has its own list here.
+    #
+    # Per-gid list lengths are NOT equal: each gid has its own
+    # ``KVCacheSpec.block_size`` and vLLM extends each gid's list by
+    # ``cdiv(scheduled_tokens, gid.block_size)`` per scheduling event.
+    # All gids advance in lockstep at the *coarse* (scheduler) block
+    # boundary — i.e. after vLLM allocates a coarse chunk of
+    # ``scheduler_block_size`` tokens, every gid's list grows by the
+    # number of gid-blocks that span that coarse chunk. Coarse-block
+    # indexing in :class:`LMCacheMPRequestMetadata` relies on this
+    # alignment.
+    allocated_block_ids: dict[int, list[int]] = field(default_factory=dict)
 
     # Number of scheduled tokens in this request. We keep tracking this to
     # avoid saving half-full blocks.
@@ -230,7 +250,7 @@ class LMCacheMPRequestTracker:
         self.cache_salt: str = request.cache_salt or ""
         self.all_token_ids = request.all_token_ids
         self.block_hashes = ConstantList(request.block_hashes)
-        self.allocated_block_ids = []
+        self.allocated_block_ids = {}
         self.num_stored_blocks = 0
         self.num_vllm_hit_blocks = 0
         self.num_lmcache_hit_blocks = 0
@@ -267,14 +287,55 @@ class LMCacheMPRequestTracker:
         """
         self.num_stored_blocks += num_new_blocks
 
-    def append_block_ids(
+    def append_block_ids_per_group(
         self,
-        new_block_ids: list[int],
-    ):
-        """Update the block ids for the current request
-        This function will be called when processing the cached requests.
+        new_block_ids_per_group: tuple[list[int], ...],
+    ) -> None:
+        """Append per-gid block IDs allocated by vLLM since the last call.
+
+        ``new_block_ids_per_group`` is the structure vLLM hands us via
+        :meth:`KVCacheBlocks.get_block_ids` (or the matching
+        ``cached_reqs.new_block_ids[idx]`` slice): one list per
+        ``KVCacheGroupSpec``, in scheduler-fixed order. Each per-gid
+        list is appended to the matching slot in
+        :attr:`allocated_block_ids`, creating new gid entries on
+        first sight.
+
+        For non-hybrid models the tuple has length 1 and only key 0 is
+        ever populated, so this collapses to the prior single-list
+        ``extend`` semantics.
+
+        Args:
+            new_block_ids_per_group: Per-gid lists of newly allocated
+                block IDs. Empty inner lists are allowed (gid had no
+                new blocks this step) and are silently no-oped.
         """
-        self.allocated_block_ids.extend(new_block_ids)
+        for gid, group_block_ids in enumerate(new_block_ids_per_group):
+            if not group_block_ids:
+                continue
+            self.allocated_block_ids.setdefault(gid, []).extend(group_block_ids)
+
+    def num_allocated_blocks_per_group(self) -> dict[int, int]:
+        """Return ``{gid: len(allocated_block_ids[gid])}`` for every
+        gid that has been touched. Used by callers that need to know
+        per-gid block counts (e.g. to compute slice boundaries or
+        avoid double-appending when ``update_state_after_alloc`` is
+        called twice for an async-load request)."""
+        return {gid: len(blocks) for gid, blocks in self.allocated_block_ids.items()}
+
+    def total_allocated_blocks(self) -> int:
+        """Return the total block count across all gids. Useful for
+        legacy log lines that report a single number; do not use as a
+        chunking-grid quantity (each gid has its own scheduler block
+        size).
+
+        For non-hybrid models this equals
+        ``len(allocated_block_ids[0])``; for hybrid models it is the
+        sum of per-gid counts and reflects how many bytes vLLM has
+        materialised in total, *not* the number of token-aligned
+        chunks LMCache should consider.
+        """
+        return sum(len(blocks) for blocks in self.allocated_block_ids.values())
 
     ####
     # For debugging
@@ -284,7 +345,7 @@ class LMCacheMPRequestTracker:
             f"LMCacheMPRequestTracker(request_id={self.request_id}, "
             f"num_tokens={len(self.all_token_ids)}, "
             f"num_block_hashes={len(self.block_hashes)}, "
-            f"num_allocated_blocks={len(self.allocated_block_ids)}, "
+            f"num_allocated_blocks_per_group={self.num_allocated_blocks_per_group()}, "
             f"num_stored_blocks={self.num_stored_blocks}, "
             f"vllm_hit_blocks={self.num_vllm_hit_blocks}, "
             f"lmcache_hit_blocks={self.num_lmcache_hit_blocks}, "
@@ -303,10 +364,73 @@ class LMCacheMPRequestMetadata:
     cache_salt: str = ""
 
     @staticmethod
+    def _per_gid_slice(
+        tracker: "LMCacheMPRequestTracker",
+        gid_to_block_size: dict[int, int],
+        vllm_block_size: int,
+        start: int,
+        end: int,
+    ) -> list[list[int]]:
+        """Slice ``tracker.allocated_block_ids`` per gid for the
+        coarse range ``[start, end)`` (units: ``vllm_block_size``).
+
+        The fundamental relation: gid ``g``'s block ID grid has
+        granularity ``gid_block_size_g``; vLLM's ``cache_config
+        .block_size`` is the GCD of all gid block sizes (= 4 on V4
+        HMA, 256 on non-hybrid). One coarse-block range of
+        ``[start, end)`` covers ``(end - start) * vllm_block_size``
+        tokens, which translates to a per-gid range of
+        ``(end - start) * vllm_block_size / gid_block_size_g``
+        gid-block IDs.
+
+        When ``gid_block_size_g >= vllm_block_size`` (e.g. gid 0 on
+        V4: 256 vs 4) we *divide* by ``gid_block_size_g //
+        vllm_block_size``; the legacy ``multiplier = vllm_block_size
+        // gid_block_size_g`` evaluates to 0 here and silently
+        emits an empty slice — which trips the LMCache server's
+        per-namespace kernel constraint check.
+
+        When ``gid_block_size_g <= vllm_block_size`` (e.g. gid 3 on
+        V4: 4 vs 4) we *multiply*. When the two are equal, both
+        branches produce the same answer.
+
+        Args:
+            tracker: The request tracker holding per-gid block-ID
+                lists.
+            gid_to_block_size: Mapping from gid to that gid's
+                ``KVCacheSpec.block_size``.
+            vllm_block_size: ``cache_config.block_size``, the GCD
+                grain at which ``start`` and ``end`` are expressed.
+            start: First coarse block (inclusive), in
+                ``vllm_block_size`` units.
+            end: Last coarse block (exclusive), same units.
+
+        Returns:
+            One list per gid (in ``sorted(gid_to_block_size.keys())``
+            order) holding that gid's block-ID slice for
+            ``[start, end)``.
+        """
+        block_ids_per_group: list[list[int]] = []
+        for gid in sorted(gid_to_block_size.keys()):
+            gid_bs = gid_to_block_size[gid]
+            if gid_bs >= vllm_block_size:
+                ratio = gid_bs // vllm_block_size
+                gid_start = start // ratio
+                gid_end = end // ratio
+            else:
+                ratio = vllm_block_size // gid_bs
+                gid_start = start * ratio
+                gid_end = end * ratio
+            gid_blocks = tracker.allocated_block_ids.get(gid, [])
+            block_ids_per_group.append(gid_blocks[gid_start:gid_end])
+        return block_ids_per_group
+
+    @staticmethod
     def GetStoreMetadata(
         tracker: LMCacheMPRequestTracker,
         blocks_in_chunk: int,
         vllm_block_size: int,
+        gid_to_block_size: dict[int, int],
     ) -> "LMCacheMPRequestMetadata | None":
         """
         Generate the store metadata for the current request tracker.
@@ -314,7 +438,16 @@ class LMCacheMPRequestMetadata:
         Args:
             tracker: The request tracker to generate the metadata from.
             blocks_in_chunk: the number of blocks in a LMCache data chunk
-            vllm_block_size: the block size used in vLLM
+                (``lmcache_chunk_size // vllm_block_size`` — coarse-block
+                units).
+            vllm_block_size: the scheduler block size used in vLLM (the
+                ``--block-size`` CLI flag), equal to
+                ``lcm(group.block_size for group in kv_cache_groups)``
+                under HMA.
+            gid_to_block_size: ``{gid: KVCacheSpec.block_size}`` for
+                every kv_cache_group exposed to the connector. Used to
+                translate coarse-block ranges into per-gid slice ranges.
+                For non-hybrid models this is ``{0: vllm_block_size}``.
         """
         # Store the blocks that has block hashes
         # NOTE: the invariant here is that `num_stored_blocks` should
@@ -341,9 +474,25 @@ class LMCacheMPRequestMetadata:
         computed_blocks = tracker.num_scheduled_tokens // vllm_block_size + max(
             tracker.num_vllm_hit_blocks, tracker.num_lmcache_hit_blocks
         )
+        # Coarse-block count of the request: smallest gid count after
+        # normalising each per-gid list length back to coarse units. Any
+        # gid whose ``KVCacheSpec.block_size`` divides
+        # ``vllm_block_size`` evenly contributes a coarse count of
+        # ``len(allocated_block_ids[gid]) * gid_block_size //
+        # vllm_block_size``. Take the min as a conservative bound — if
+        # vLLM ever returns lists of inconsistent coarse counts (a bug),
+        # we'd silently store half-aligned data otherwise.
+        per_gid_lengths = tracker.num_allocated_blocks_per_group()
+        if per_gid_lengths:
+            coarse_block_count = min(
+                length * gid_to_block_size[gid] // vllm_block_size
+                for gid, length in per_gid_lengths.items()
+            )
+        else:
+            coarse_block_count = 0
         min_available_blocks = min(
             len(tracker.block_hashes),
-            len(tracker.allocated_block_ids),
+            coarse_block_count,
             computed_blocks,
         )
         num_staging_blocks = min_available_blocks - tracker.num_stored_blocks
@@ -352,13 +501,20 @@ class LMCacheMPRequestMetadata:
         if num_chunks >= 1:
             start = tracker.num_stored_blocks
             end = start + num_chunks * blocks_in_chunk
-            block_ids = tracker.allocated_block_ids[start:end]
+            # Build per-gid block-ID slice. ``_per_gid_slice`` handles
+            # both ``gid_bs >= vllm_block_size`` (V4 hybrid main /
+            # indexer-k / SWA-64 against vllm_bs=4) and
+            # ``gid_bs <= vllm_block_size`` (non-hybrid: vllm_bs=256
+            # equals gid 0's bs=256, multiplier=1).
+            block_ids_per_group = LMCacheMPRequestMetadata._per_gid_slice(
+                tracker, gid_to_block_size, vllm_block_size, start, end
+            )
             start_token_idx = start * vllm_block_size
             end_token_idx = end * vllm_block_size
             token_ids = list(tracker.all_token_ids)
             op = LoadStoreOp(
                 token_ids=token_ids,
-                block_ids=block_ids,
+                block_ids=block_ids_per_group,
                 start=start_token_idx,
                 end=end_token_idx,
             )
@@ -381,6 +537,7 @@ class LMCacheMPRequestMetadata:
         tracker: LMCacheMPRequestTracker,
         blocks_in_chunk: int,
         vllm_block_size: int,
+        gid_to_block_size: dict[int, int],
     ) -> "LMCacheMPRequestMetadata | None":
         """
         Generate the retrieve metadata for the current request tracker.
@@ -388,7 +545,11 @@ class LMCacheMPRequestMetadata:
         Args:
             tracker: The request tracker to generate the metadata from.
             blocks_in_chunk: the number of blocks in a LMCache data chunk
-            vllm_block_size: the block size used in vLLM
+                (coarse-block units).
+            vllm_block_size: the scheduler block size used in vLLM.
+            gid_to_block_size: ``{gid: KVCacheSpec.block_size}`` for
+                every kv_cache_group exposed to the connector. See
+                :meth:`GetStoreMetadata` for usage.
         """
         if not tracker.is_ready_for_retrieving():
             return None
@@ -409,7 +570,9 @@ class LMCacheMPRequestMetadata:
             "number of LMCache hit blocks. "
         )
         if end > start:
-            block_ids = tracker.allocated_block_ids[start:end]
+            block_ids_per_group = LMCacheMPRequestMetadata._per_gid_slice(
+                tracker, gid_to_block_size, vllm_block_size, start, end
+            )
             start_token_idx = start * vllm_block_size
             end_token_idx = end * vllm_block_size
             token_ids = list(tracker.all_token_ids)
@@ -424,7 +587,7 @@ class LMCacheMPRequestMetadata:
 
             op = LoadStoreOp(
                 token_ids=token_ids,
-                block_ids=block_ids,
+                block_ids=block_ids_per_group,
                 start=start_token_idx,
                 end=end_token_idx,
                 skip_first_n_tokens=skip_first_n_tokens,
@@ -468,9 +631,24 @@ class LMCacheMPConnectorMetadata(KVConnectorMetadata):
         return self.__str__()
 
 
-class LMCacheMPConnector(KVConnectorBase_V1):
+class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     """
     The connector for LMCache multi-process mode.
+
+    Inherits :class:`SupportsHMA` so the scheduler will route per-group
+    block-id tuples through :meth:`request_finished_all_groups`. Note that
+    declaring ``SupportsHMA`` does NOT by itself flip vLLM's hybrid-mode
+    default — :func:`vllm.config.vllm.VllmConfig._verify_kv_cache_config`
+    still auto-disables HMA whenever ``kv_transfer_config`` is set unless
+    the user explicitly passes ``--no-disable-hybrid-kv-cache-manager``.
+    What inheriting buys us is: with that flag set, the scheduler stops
+    asserting ``len(kv_cache_groups) == 1`` at the request-finished site
+    and we get the full per-group block-id tuple instead.
+
+    Per-group threading through STORE/RETRIEVE is NOT yet wired up
+    (deferred to a follow-up). With HMA on, store/retrieve will currently
+    crash or produce wrong data; this commit only turns on observability
+    so we can see what arrives at registration.
 
     Extra configs (kv_transfer_config.extra_config):
     - lmcache.mp.host: the host of the LMCache server.
@@ -516,6 +694,30 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         self.vllm_block_size = vllm_config.cache_config.block_size
 
+        # Per-gid block_size lookup: ``self._kv_cache_config.kv_cache_groups``
+        # exposes one ``KVCacheSpec.block_size`` per group. For non-hybrid
+        # models there is exactly one group with ``block_size ==
+        # vllm_block_size``. For DeepSeek-V4 with the hybrid manager
+        # active there are 5 groups with mixed block sizes (256 / 64 /
+        # 64 / 4 / 8 in our verified probe). The metadata generators
+        # use this to translate coarse-block indices (in
+        # ``vllm_block_size`` units) into per-gid slice ranges.
+        self._gid_to_block_size: dict[int, int] = {}
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
+        if kv_cache_config is not None and getattr(
+            kv_cache_config, "kv_cache_groups", None
+        ):
+            for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+                spec = getattr(group, "kv_cache_spec", None)
+                spec_block_size = getattr(spec, "block_size", None)
+                if spec_block_size is not None:
+                    self._gid_to_block_size[gid] = int(spec_block_size)
+        if not self._gid_to_block_size:
+            # Single-group fallback: pretend gid 0 exists at the
+            # scheduler block size. Keeps non-hybrid models on the
+            # same code path (one gid, multiplier 1).
+            self._gid_to_block_size = {0: self.vllm_block_size}
+
     @property
     def role(self) -> KVConnectorRole:
         return self._role
@@ -546,7 +748,147 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             kv_caches: dictionary of layer names, kv cache
         """
         logger.info("Registering kv caches!")
-        self.worker_adapter.register_kv_caches(kv_caches)
+
+        # Build per-positional-layer logical (scheduler) block size and
+        # block-ID namespace from ``self._kv_cache_config.kv_cache_groups``.
+        # Under hybrid KV cache management, each ``KVCacheGroupSpec``
+        # reports its own ``KVCacheSpec.block_size`` and contributes its
+        # own ``BlockPool`` slice; layers from different groups can
+        # share the same physical tensor shape (via layer-tuple
+        # aliasing) but were allocated against different scheduler
+        # block sizes, and even when both block sizes match they may
+        # still pull block IDs from disjoint pools (e.g. DeepSeek-V4's
+        # vLLM gids 1 and 2 — the even+MTP and odd SWA layers, which
+        # share every spec field but have separate ``req_to_blocks``
+        # dicts).
+        #
+        # LMCache needs both signals to keep one transfer-kernel
+        # dispatch unit per ``(physical_bs, logical_bs, namespace)``
+        # triple. Without ``logical_bs`` it would merge the C4A-main
+        # and per-layer-SWA layers (both physical ``shape[1] = 64``);
+        # without ``namespace`` it would merge gids 1 and 2 even after
+        # the logical_bs split. See
+        # :class:`~lmcache.v1.gpu_connector.utils.LayoutHints`'s
+        # ``per_layer_logical_block_size`` and
+        # ``per_layer_kv_cache_group_id`` fields for the consumer side.
+        #
+        # When the engine produced only one ``KVCacheGroupSpec`` (the
+        # non-hybrid case), every layer ends up with the same block
+        # size and the same namespace, which collapses LMCache's
+        # grouping back to the prior 5-tuple identity behavior.
+        #
+        # If a layer name in any group does not appear in the
+        # registered ``kv_caches`` dict (i.e. that layer's KV cache is
+        # not exposed to the connector), it's silently skipped — its
+        # entry in the per-layer lists stays at the sentinel value
+        # (logical_bs=0, namespace=-1). The LMCache-side consumer
+        # rejects any non-positive logical_bs entry or negative
+        # namespace entry with ``ValueError`` at registration, so a
+        # partial cover surfaces as a loud registration failure rather
+        # than silent miscount. If neither hint is populated we drop
+        # both entirely so single-group engines fall back to the prior
+        # 5-tuple identity behavior.
+        per_layer_logical_block_size: list[int] | None = None
+        per_layer_kv_cache_group_id: list[int] | None = None
+        per_layer_sliding_window: list[int] | None = None
+        kv_cache_config = getattr(self, "_kv_cache_config", None)
+        # When ``LMCACHE_SWA_SUFFIX_ONLY=1`` is set, also publish the
+        # per-layer sliding_window so LMCache can shrink each
+        # SWA-flavored group's per-chunk MemoryObj slot to just the
+        # last ``ceil(window / logical_block_size)`` blocks. Outside
+        # this mode the field is omitted and LMCache falls back to
+        # the full-chunk behavior.
+        emit_sliding_window = _swa_suffix_only_mode()
+        if kv_cache_config is not None and getattr(
+            kv_cache_config, "kv_cache_groups", None
+        ):
+            kv_cache_layer_names = list(kv_caches.keys())
+            name_to_idx = {name: idx for idx, name in enumerate(kv_cache_layer_names)}
+            num_positional = len(kv_cache_layer_names)
+            per_layer_logical_block_size = [0] * num_positional
+            per_layer_kv_cache_group_id = [-1] * num_positional
+            if emit_sliding_window:
+                # Sentinel 0 means "no sliding-window cap" (= full
+                # attention). The LMCache consumer reads
+                # ``sliding_window == 0`` as "store full chunk", which
+                # matches the existing behavior.
+                per_layer_sliding_window = [0] * num_positional
+            for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+                spec = getattr(group, "kv_cache_spec", None)
+                spec_block_size = getattr(spec, "block_size", None)
+                if spec_block_size is None:
+                    continue
+                # ``KVCacheSpec.sliding_window`` exists on
+                # ``SlidingWindowMLASpec`` and friends; full-attention
+                # specs either omit it or set it to ``None``/0. When
+                # vLLM has unified per-layer specs into a
+                # ``UniformTypeKVCacheSpecs``, the wrapper doesn't
+                # expose ``sliding_window`` itself — peek into one of
+                # the per-layer specs in ``kv_cache_specs`` (they are
+                # uniform by construction; see
+                # ``UniformTypeKVCacheSpecs.is_uniform_type``).
+                spec_sliding_window = getattr(spec, "sliding_window", None)
+                if spec_sliding_window is None:
+                    inner_specs = getattr(spec, "kv_cache_specs", None)
+                    if inner_specs:
+                        # Any one entry suffices given the uniformity
+                        # invariant.
+                        first_inner = next(iter(inner_specs.values()))
+                        spec_sliding_window = getattr(
+                            first_inner, "sliding_window", None
+                        )
+                spec_sliding_window = spec_sliding_window or 0
+                if emit_sliding_window:
+                    logger.info(
+                        "LMCACHE_SWA_SUFFIX_ONLY: gid=%d spec=%s "
+                        "block_size=%s sliding_window=%d",
+                        gid,
+                        type(spec).__name__,
+                        spec_block_size,
+                        spec_sliding_window,
+                    )
+                for name in group.layer_names:
+                    pos = name_to_idx.get(name)
+                    if pos is not None:
+                        per_layer_logical_block_size[pos] = int(spec_block_size)
+                        per_layer_kv_cache_group_id[pos] = gid
+                        if per_layer_sliding_window is not None:
+                            per_layer_sliding_window[pos] = int(spec_sliding_window)
+            # If neither list got populated (no usable specs), drop
+            # both hints so the consumer falls back to the prior
+            # behavior cleanly. Layers that ended up with sentinel
+            # values (some specs missing block_size, some layer names
+            # absent from kv_caches) will trigger a loud ValueError
+            # on the LMCache side.
+            if not any(per_layer_logical_block_size) and all(
+                ns == -1 for ns in per_layer_kv_cache_group_id
+            ):
+                per_layer_logical_block_size = None
+                per_layer_kv_cache_group_id = None
+                per_layer_sliding_window = None
+
+        extra_layout_hints: dict[str, object] | None = None
+        if (
+            per_layer_logical_block_size is not None
+            or per_layer_kv_cache_group_id is not None
+            or per_layer_sliding_window is not None
+        ):
+            extra_layout_hints = {}
+            if per_layer_logical_block_size is not None:
+                extra_layout_hints["per_layer_logical_block_size"] = (
+                    per_layer_logical_block_size
+                )
+            if per_layer_kv_cache_group_id is not None:
+                extra_layout_hints["per_layer_kv_cache_group_id"] = (
+                    per_layer_kv_cache_group_id
+                )
+            if per_layer_sliding_window is not None:
+                extra_layout_hints["per_layer_sliding_window"] = (
+                    per_layer_sliding_window
+                )
+        self.worker_adapter.register_kv_caches(
+            kv_caches, extra_layout_hints=extra_layout_hints
+        )
         return
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
@@ -820,13 +1162,21 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         # We must only append the NEW blocks beyond what's already tracked
         # to avoid duplication, which would corrupt the store path's block indexing.
         tracker = self._get_request_tracker(request.request_id)
-        block_ids = reformat_block_ids(blocks.get_block_ids())
+        per_gid_block_ids = blocks.get_block_ids()  # tuple[list[int], ...]
 
-        # Only append blocks beyond what's already tracked
-        existing_count = len(tracker.allocated_block_ids)
-        new_block_ids = block_ids[existing_count:]
-        if new_block_ids:
-            tracker.append_block_ids(new_block_ids)
+        # Only append blocks beyond what's already tracked, per-gid.
+        # ``KVCacheBlocks.get_block_ids()`` returns ALL blocks vLLM has
+        # allocated for the request so far; on the second call (async
+        # load completion) some prefix has already been recorded on
+        # this tracker and must not be re-appended. Per-gid existing
+        # counts let us advance each gid independently.
+        existing_per_gid = tracker.num_allocated_blocks_per_group()
+        new_per_gid: list[list[int]] = []
+        for gid, gid_blocks in enumerate(per_gid_block_ids):
+            existing = existing_per_gid.get(gid, 0)
+            new_per_gid.append(list(gid_blocks[existing:]))
+        if any(new_per_gid):
+            tracker.append_block_ids_per_group(tuple(new_per_gid))
 
         # Update the state of the tracker
         condition = tracker.needs_retrieve()
@@ -950,6 +1300,56 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         return True, return_params
 
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        :class:`SupportsHMA` variant of :meth:`request_finished`. Receives
+        per-group block IDs as ``tuple[list[int], ...]``; the scheduler
+        dispatches to this method instead of ``request_finished`` whenever
+        the connector inherits :class:`SupportsHMA`.
+
+        Cleanup is by ``request_id`` only — neither the per-request
+        tracker nor the LMCache session manager needs the block IDs at
+        this point, so this implementation simply forwards to the same
+        cleanup path as the single-group variant. Once per-group STORE/
+        RETRIEVE threading lands, this method will become the natural
+        site to flush any per-group offload state that hasn't been
+        committed yet.
+
+        The transfer-params extraction is identical to
+        ``request_finished``; the per-group ``block_ids`` argument is
+        intentionally unused here (the per-group counts that go into
+        ``num_lmcache_extra_cached_tokens`` come from the tracker, not
+        from the freshly-passed block IDs).
+        """
+        params: dict[str, Any] | None = getattr(request, "kv_transfer_params", None)
+        return_params: dict[str, Any] | None = {} if params is not None else None
+
+        if (
+            params is not None
+            and return_params is not None
+            and "num_lmcache_extra_cached_tokens" in params
+        ):
+            request_tracker = self._get_request_tracker(request.request_id)
+            num_extra_cached_blocks = max(
+                0,
+                request_tracker.num_lmcache_hit_blocks
+                - request_tracker.num_vllm_hit_blocks,
+            )
+            return_params["num_lmcache_extra_cached_tokens"] = (
+                num_extra_cached_blocks * self.vllm_block_size
+            )
+
+        # Clean up request tracker to prevent memory leak
+        self._cleanup_request_tracker(request.request_id)
+        # Notify LMCache to end the session for this request
+        self.scheduler_adapter.end_session(request.request_id)
+
+        return True, return_params
+
     def take_events(self) -> Iterable["KVCacheEvent"]:
         """
         Take the KV cache events from the connector.
@@ -1031,6 +1431,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
                 request_tracker,
                 blocks_per_chunk,
                 vllm_block_size=self.vllm_block_size,
+                gid_to_block_size=self._gid_to_block_size,
             )
             if r_metadata is not None:
                 metadata.add_request_metadata(r_metadata)
@@ -1050,7 +1451,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             request_tracker.increase_num_scheduled_tokens(num_new_tokens)
 
             r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
-                request_tracker, blocks_per_chunk, self.vllm_block_size
+                request_tracker,
+                blocks_per_chunk,
+                self.vllm_block_size,
+                self._gid_to_block_size,
             )
             if r_meta is not None:
                 metadata.add_request_metadata(r_meta)
@@ -1066,10 +1470,15 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         for idx, request_id in enumerate(cached_reqs.req_ids):
             request_tracker = self._get_request_tracker(request_id)
 
-            # Update block ids
-            new_block_ids = reformat_block_ids(cached_reqs.new_block_ids[idx])
+            # Update block ids: cached_reqs.new_block_ids[idx] is
+            # ``tuple[list[int], ...] | None``, one list per
+            # ``KVCacheGroupSpec``. For non-hybrid models the tuple has
+            # length 1; for hybrid it has the per-gid breakdown.
+            new_block_ids_per_group = cached_reqs.new_block_ids[idx]
+            if new_block_ids_per_group is None:
+                new_block_ids_per_group = ()
             if request_id not in cached_reqs.resumed_req_ids:
-                request_tracker.append_block_ids(new_block_ids)
+                request_tracker.append_block_ids_per_group(new_block_ids_per_group)
 
             # Use the incremental num_scheduled_tokens to
             # stay consistent with _process_new_requests.
@@ -1077,7 +1486,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             request_tracker.increase_num_scheduled_tokens(num_new_tokens)
 
             r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
-                request_tracker, blocks_per_chunk, self.vllm_block_size
+                request_tracker,
+                blocks_per_chunk,
+                self.vllm_block_size,
+                self._gid_to_block_size,
             )
 
             if r_meta is not None:
@@ -1091,6 +1503,15 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         For new requests: all allocated_block_ids and token_ids are new.
         For cached requests: only newly appended block_ids and token_ids.
+
+        L0 telemetry currently consumes a flat list of block IDs at
+        ``vllm_block_size`` granularity, so we report the gid 0
+        ("primary") namespace's blocks here. For non-hybrid models this
+        is the only namespace and equals the prior flat list. For
+        hybrid models (e.g. DeepSeek-V4), gid 0 corresponds to the
+        scheduler-block-size group (block_size == vllm_block_size); the
+        other gids' block IDs live at a finer grid and are not
+        currently exposed via the L0 channel.
         """
         records: list[RequestAllocationRecord] = []
 
@@ -1101,12 +1522,13 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             tracker = self.request_trackers.get(new_request.req_id)
             if tracker is None:
                 continue
-            num_blocks = len(tracker.allocated_block_ids)
+            primary_block_ids = tracker.allocated_block_ids.get(0, [])
+            num_blocks = len(primary_block_ids)
             total_tokens = num_blocks * self.vllm_block_size
             records.append(
                 RequestAllocationRecord(
                     req_id=new_request.req_id,
-                    new_block_ids=list(tracker.allocated_block_ids),
+                    new_block_ids=list(primary_block_ids),
                     new_token_ids=list(tracker.all_token_ids[:total_tokens]),
                 )
             )
@@ -1117,23 +1539,28 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         # can correctly identify block content.
         cached_reqs = scheduler_output.scheduled_cached_reqs
         for idx, request_id in enumerate(cached_reqs.req_ids):
-            new_block_ids = reformat_block_ids(cached_reqs.new_block_ids[idx])
-            if not new_block_ids:
+            new_block_ids_per_group = cached_reqs.new_block_ids[idx]
+            # gid 0 = primary (vllm_block_size) namespace.
+            new_primary_block_ids = (
+                list(new_block_ids_per_group[0]) if new_block_ids_per_group else []
+            )
+            if not new_primary_block_ids:
                 continue
             tracker = self.request_trackers.get(request_id)
             if tracker is None:
                 continue
-            # The new blocks sit at the end of the request's block list.
+            # The new blocks sit at the end of the request's gid 0 list.
             # Compute the token range they cover.
-            total_blocks = len(tracker.allocated_block_ids)
-            num_new_blocks = len(new_block_ids)
+            primary_block_ids = tracker.allocated_block_ids.get(0, [])
+            total_blocks = len(primary_block_ids)
+            num_new_blocks = len(new_primary_block_ids)
             start_token = (total_blocks - num_new_blocks) * self.vllm_block_size
             end_token = total_blocks * self.vllm_block_size
             new_token_ids = list(tracker.all_token_ids[start_token:end_token])
             records.append(
                 RequestAllocationRecord(
                     req_id=request_id,
-                    new_block_ids=new_block_ids,
+                    new_block_ids=new_primary_block_ids,
                     new_token_ids=new_token_ids,
                 )
             )

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 import enum
-import os
 
 # Third Party
 from vllm.config import VllmConfig
@@ -77,24 +76,6 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 logger = lmcache_init_logger(__name__)
-
-
-def _swa_suffix_only_mode() -> bool:
-    """Experimental gate: when ``LMCACHE_SWA_SUFFIX_ONLY=1`` is set, the
-    connector advertises each layer's ``sliding_window`` to LMCache so
-    LMCache can store/retrieve only the last ``ceil(window /
-    logical_block_size)`` blocks per chunk for sliding-window groups —
-    instead of the full ``lmcache_chunk_size // logical_block_size``
-    blocks. The SWA mask kernel-side guarantees positions older than
-    ``window`` are never read, so the truncated KV is sufficient for
-    correct decode after a full hit, and for the first ``window`` steps
-    of a partial-hit recompute (after which the recompute path moves
-    the window forward into freshly-recomputed positions and the cache
-    is no longer touched). On DeepSeek-V4 (``chunk_size=1024``,
-    ``window``s of 8/128/256), this collapses gid 3's per-chunk SWA
-    payload from ~236 MiB to ~1.85 MiB. Has no effect on
-    full-attention groups (``sliding_window == 0``)."""
-    return os.environ.get("LMCACHE_SWA_SUFFIX_ONLY") == "1"
 
 
 # Helper functions
@@ -792,13 +773,12 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         per_layer_kv_cache_group_id: list[int] | None = None
         per_layer_sliding_window: list[int] | None = None
         kv_cache_config = getattr(self, "_kv_cache_config", None)
-        # When ``LMCACHE_SWA_SUFFIX_ONLY=1`` is set, also publish the
-        # per-layer sliding_window so LMCache can shrink each
-        # SWA-flavored group's per-chunk MemoryObj slot to just the
-        # last ``ceil(window / logical_block_size)`` blocks. Outside
-        # this mode the field is omitted and LMCache falls back to
-        # the full-chunk behavior.
-        emit_sliding_window = _swa_suffix_only_mode()
+        # We always publish the per-layer ``sliding_window`` so LMCache
+        # can shrink each SWA-flavored group's per-chunk MemoryObj slot
+        # to just the last ``ceil(window / logical_block_size)`` blocks
+        # (the SWA-suffix-only optimization). Full-attention groups
+        # report ``sliding_window == 0`` and the LMCache consumer keeps
+        # the prior full-chunk behavior for those.
         if kv_cache_config is not None and getattr(
             kv_cache_config, "kv_cache_groups", None
         ):
@@ -807,12 +787,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             num_positional = len(kv_cache_layer_names)
             per_layer_logical_block_size = [0] * num_positional
             per_layer_kv_cache_group_id = [-1] * num_positional
-            if emit_sliding_window:
-                # Sentinel 0 means "no sliding-window cap" (= full
-                # attention). The LMCache consumer reads
-                # ``sliding_window == 0`` as "store full chunk", which
-                # matches the existing behavior.
-                per_layer_sliding_window = [0] * num_positional
+            # Sentinel 0 means "no sliding-window cap" (= full
+            # attention). The LMCache consumer reads
+            # ``sliding_window == 0`` as "store full chunk", which
+            # matches the existing behavior for non-SWA layers.
+            per_layer_sliding_window = [0] * num_positional
             for gid, group in enumerate(kv_cache_config.kv_cache_groups):
                 spec = getattr(group, "kv_cache_spec", None)
                 spec_block_size = getattr(spec, "block_size", None)
@@ -838,24 +817,22 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                             first_inner, "sliding_window", None
                         )
                 spec_sliding_window = spec_sliding_window or 0
-                if emit_sliding_window:
-                    logger.info(
-                        "LMCACHE_SWA_SUFFIX_ONLY: gid=%d spec=%s "
-                        "block_size=%s sliding_window=%d",
-                        gid,
-                        type(spec).__name__,
-                        spec_block_size,
-                        spec_sliding_window,
-                    )
+                logger.info(
+                    "register_kv_caches: gid=%d spec=%s "
+                    "block_size=%s sliding_window=%d",
+                    gid,
+                    type(spec).__name__,
+                    spec_block_size,
+                    spec_sliding_window,
+                )
                 for name in group.layer_names:
                     pos = name_to_idx.get(name)
                     if pos is not None:
                         per_layer_logical_block_size[pos] = int(spec_block_size)
                         per_layer_kv_cache_group_id[pos] = gid
-                        if per_layer_sliding_window is not None:
-                            per_layer_sliding_window[pos] = int(spec_sliding_window)
+                        per_layer_sliding_window[pos] = int(spec_sliding_window)
             # If neither list got populated (no usable specs), drop
-            # both hints so the consumer falls back to the prior
+            # all hints so the consumer falls back to the prior
             # behavior cleanly. Layers that ended up with sentinel
             # values (some specs missing block_size, some layer names
             # absent from kv_caches) will trigger a loud ValueError

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -188,24 +188,15 @@ class LMCacheMPRequestTracker:
     all_token_ids: ConstantList[int]
     block_hashes: ConstantList["BlockHash"]
 
-    # Per-vLLM-kv-cache-group block IDs allocated to this request.
-    # The dict is keyed by the engine-side ``kv_cache_group_id``, and
-    # each value is the (in-order) list of block IDs allocated for that
-    # group. For non-hybrid models, only key ``0`` is ever populated —
-    # the dict has a single entry that mirrors the prior flat-list
-    # semantics. For DeepSeek-V4 with the hybrid manager active, vLLM
-    # emits 5 disjoint namespaces (one per ``KVCacheGroupSpec``) and
-    # each gid has its own list here.
+    # Per-vLLM-kv-cache-group block IDs allocated to this request, keyed
+    # by engine-side ``kv_cache_group_id``. Non-hybrid models populate
+    # only key ``0`` (mirroring the prior flat-list semantics); V4
+    # hybrid-on emits 5 disjoint namespaces with one list per gid.
     #
-    # Per-gid list lengths are NOT equal: each gid has its own
-    # ``KVCacheSpec.block_size`` and vLLM extends each gid's list by
-    # ``cdiv(scheduled_tokens, gid.block_size)`` per scheduling event.
-    # All gids advance in lockstep at the *coarse* (scheduler) block
-    # boundary — i.e. after vLLM allocates a coarse chunk of
-    # ``scheduler_block_size`` tokens, every gid's list grows by the
-    # number of gid-blocks that span that coarse chunk. Coarse-block
-    # indexing in :class:`LMCacheMPRequestMetadata` relies on this
-    # alignment.
+    # Per-gid list lengths differ — each gid has its own
+    # ``KVCacheSpec.block_size`` — but every gid advances in lockstep at
+    # the coarse-scheduler-block boundary, which coarse-block indexing in
+    # :class:`LMCacheMPRequestMetadata` relies on.
     allocated_block_ids: dict[int, list[int]] = field(default_factory=dict)
 
     # Number of scheduled tokens in this request. We keep tracking this to
@@ -274,22 +265,11 @@ class LMCacheMPRequestTracker:
     ) -> None:
         """Append per-gid block IDs allocated by vLLM since the last call.
 
-        ``new_block_ids_per_group`` is the structure vLLM hands us via
-        :meth:`KVCacheBlocks.get_block_ids` (or the matching
-        ``cached_reqs.new_block_ids[idx]`` slice): one list per
-        ``KVCacheGroupSpec``, in scheduler-fixed order. Each per-gid
-        list is appended to the matching slot in
-        :attr:`allocated_block_ids`, creating new gid entries on
-        first sight.
-
-        For non-hybrid models the tuple has length 1 and only key 0 is
-        ever populated, so this collapses to the prior single-list
-        ``extend`` semantics.
-
-        Args:
-            new_block_ids_per_group: Per-gid lists of newly allocated
-                block IDs. Empty inner lists are allowed (gid had no
-                new blocks this step) and are silently no-oped.
+        ``new_block_ids_per_group`` is the per-gid tuple from
+        :meth:`KVCacheBlocks.get_block_ids` (one list per
+        ``KVCacheGroupSpec``, scheduler-fixed order). Empty inner lists
+        are silently no-oped. Non-hybrid models pass a length-1 tuple
+        and this collapses to the prior single-list ``extend`` semantics.
         """
         for gid, group_block_ids in enumerate(new_block_ids_per_group):
             if not group_block_ids:
@@ -352,44 +332,18 @@ class LMCacheMPRequestMetadata:
         start: int,
         end: int,
     ) -> list[list[int]]:
-        """Slice ``tracker.allocated_block_ids`` per gid for the
-        coarse range ``[start, end)`` (units: ``vllm_block_size``).
+        """Slice ``tracker.allocated_block_ids`` per gid for the coarse
+        range ``[start, end)`` (in ``vllm_block_size`` units).
 
-        The fundamental relation: gid ``g``'s block ID grid has
-        granularity ``gid_block_size_g``; vLLM's ``cache_config
-        .block_size`` is the GCD of all gid block sizes (= 4 on V4
-        HMA, 256 on non-hybrid). One coarse-block range of
-        ``[start, end)`` covers ``(end - start) * vllm_block_size``
-        tokens, which translates to a per-gid range of
-        ``(end - start) * vllm_block_size / gid_block_size_g``
-        gid-block IDs.
+        ``vllm_block_size`` is the GCD of all gid block sizes (4 on V4
+        hybrid-on, 256 on non-hybrid). For each gid, divide if
+        ``gid_block_size_g >= vllm_block_size`` (V4 dense gid 0: 256/4),
+        multiply if smaller. The legacy "multiply by
+        ``vllm_block_size // gid_block_size_g``" formula silently emits
+        empty slices when the divisor ratio is < 1.
 
-        When ``gid_block_size_g >= vllm_block_size`` (e.g. gid 0 on
-        V4: 256 vs 4) we *divide* by ``gid_block_size_g //
-        vllm_block_size``; the legacy ``multiplier = vllm_block_size
-        // gid_block_size_g`` evaluates to 0 here and silently
-        emits an empty slice — which trips the LMCache server's
-        per-namespace kernel constraint check.
-
-        When ``gid_block_size_g <= vllm_block_size`` (e.g. gid 3 on
-        V4: 4 vs 4) we *multiply*. When the two are equal, both
-        branches produce the same answer.
-
-        Args:
-            tracker: The request tracker holding per-gid block-ID
-                lists.
-            gid_to_block_size: Mapping from gid to that gid's
-                ``KVCacheSpec.block_size``.
-            vllm_block_size: ``cache_config.block_size``, the GCD
-                grain at which ``start`` and ``end`` are expressed.
-            start: First coarse block (inclusive), in
-                ``vllm_block_size`` units.
-            end: Last coarse block (exclusive), same units.
-
-        Returns:
-            One list per gid (in ``sorted(gid_to_block_size.keys())``
-            order) holding that gid's block-ID slice for
-            ``[start, end)``.
+        Returns one list per gid in ``sorted(gid_to_block_size.keys())``
+        order, holding that gid's block-ID slice for ``[start, end)``.
         """
         block_ids_per_group: list[list[int]] = []
         for gid in sorted(gid_to_block_size.keys()):
@@ -413,56 +367,35 @@ class LMCacheMPRequestMetadata:
         vllm_block_size: int,
         gid_to_block_size: dict[int, int],
     ) -> "LMCacheMPRequestMetadata | None":
-        """
-        Generate the store metadata for the current request tracker.
+        """Generate the store metadata for the current request tracker.
 
         Args:
-            tracker: The request tracker to generate the metadata from.
-            blocks_in_chunk: the number of blocks in a LMCache data chunk
-                (``lmcache_chunk_size // vllm_block_size`` — coarse-block
-                units).
-            vllm_block_size: the scheduler block size used in vLLM (the
-                ``--block-size`` CLI flag), equal to
-                ``lcm(group.block_size for group in kv_cache_groups)``
-                under HMA.
-            gid_to_block_size: ``{gid: KVCacheSpec.block_size}`` for
-                every kv_cache_group exposed to the connector. Used to
-                translate coarse-block ranges into per-gid slice ranges.
-                For non-hybrid models this is ``{0: vllm_block_size}``.
+            tracker: The request tracker.
+            blocks_in_chunk: ``lmcache_chunk_size // vllm_block_size``
+                (coarse-block units).
+            vllm_block_size: ``cache_config.block_size`` — the GCD of
+                all gid block sizes under HMA.
+            gid_to_block_size: ``{gid: KVCacheSpec.block_size}`` per
+                exposed kv_cache_group; ``{0: vllm_block_size}`` for
+                non-hybrid models.
         """
-        # Store the blocks that has block hashes
-        # NOTE: the invariant here is that `num_stored_blocks` should
-        # always be a multiple of `blocks_in_chunk`
-        # TODO: This should be checked every time we update the num_stored_blocks
+        # Store the blocks that have block hashes.
+        # INVARIANT: ``num_stored_blocks`` should always be a multiple of
+        # ``blocks_in_chunk``.
+        # TODO: This should be checked every time we update num_stored_blocks.
         #
-        # Why computed_blocks uses max(num_vllm_hit_blocks, num_lmcache_hit_blocks):
-        #
-        # Both values represent a prefix of blocks whose KV data is already
-        # available (either from vLLM APC or from LMCache), so they must NOT
-        # be summed (that would double-count the overlapping prefix).
-        #
-        # * num_lmcache_hit_blocks: LMCache-hit blocks are already counted in
-        #   num_stored_blocks (set during lookup), so they must be included
-        #   here to keep the upper bound consistent.  They are NOT re-stored.
-        # * num_vllm_hit_blocks: LMCache stores in units of chunks (N blocks),
-        #   so num_lmcache_hit_blocks is rounded DOWN to the nearest chunk
-        #   boundary.  When vLLM APC hits more blocks than that rounded value
-        #   (e.g. APC=44 blocks, LMCache=32 blocks after chunk alignment),
-        #   using only num_lmcache_hit_blocks would set the upper bound too
-        #   low and silently skip the APC-hit blocks that fall between the
-        #   two values, causing under-storing.  Taking the max ensures we
-        #   always use the tighter (larger) of the two hit counts.
+        # ``computed_blocks`` uses ``max(num_vllm_hit_blocks,
+        # num_lmcache_hit_blocks)`` rather than summing: both are prefix-hit
+        # counts and would double-count the overlap. We take the tighter
+        # (larger) bound — using only ``num_lmcache_hit_blocks`` would skip
+        # APC-hit blocks past the chunk-aligned LMCache boundary and
+        # under-store.
         computed_blocks = tracker.num_scheduled_tokens // vllm_block_size + max(
             tracker.num_vllm_hit_blocks, tracker.num_lmcache_hit_blocks
         )
-        # Coarse-block count of the request: smallest gid count after
-        # normalising each per-gid list length back to coarse units. Any
-        # gid whose ``KVCacheSpec.block_size`` divides
-        # ``vllm_block_size`` evenly contributes a coarse count of
-        # ``len(allocated_block_ids[gid]) * gid_block_size //
-        # vllm_block_size``. Take the min as a conservative bound — if
-        # vLLM ever returns lists of inconsistent coarse counts (a bug),
-        # we'd silently store half-aligned data otherwise.
+        # Coarse-block count: each gid's allocated-block count converted
+        # back to coarse units (``len * gid_bs // vllm_block_size``); take
+        # the min as a conservative bound against inconsistent gid lengths.
         per_gid_lengths = tracker.num_allocated_blocks_per_group()
         if per_gid_lengths:
             coarse_block_count = min(
@@ -613,30 +546,22 @@ class LMCacheMPConnectorMetadata(KVConnectorMetadata):
 
 
 class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
-    """
-    The connector for LMCache multi-process mode.
+    """The connector for LMCache multi-process mode.
 
-    Inherits :class:`SupportsHMA` so the scheduler will route per-group
-    block-id tuples through :meth:`request_finished_all_groups`. Note that
-    declaring ``SupportsHMA`` does NOT by itself flip vLLM's hybrid-mode
-    default — :func:`vllm.config.vllm.VllmConfig._verify_kv_cache_config`
-    still auto-disables HMA whenever ``kv_transfer_config`` is set unless
-    the user explicitly passes ``--no-disable-hybrid-kv-cache-manager``.
-    What inheriting buys us is: with that flag set, the scheduler stops
-    asserting ``len(kv_cache_groups) == 1`` at the request-finished site
-    and we get the full per-group block-id tuple instead.
+    Inherits :class:`SupportsHMA` so the scheduler routes per-group
+    block-id tuples through :meth:`request_finished_all_groups` and
+    relaxes the ``len(kv_cache_groups) == 1`` assertion at the
+    request-finished site. Note that ``SupportsHMA`` alone does not flip
+    vLLM's hybrid-mode default — vLLM auto-disables hybrid whenever
+    ``kv_transfer_config`` is set unless the user explicitly passes
+    ``--no-disable-hybrid-kv-cache-manager``.
 
-    Per-group threading through STORE/RETRIEVE is NOT yet wired up
-    (deferred to a follow-up). With HMA on, store/retrieve will currently
-    crash or produce wrong data; this commit only turns on observability
-    so we can see what arrives at registration.
+    Extra configs (``kv_transfer_config.extra_config``):
 
-    Extra configs (kv_transfer_config.extra_config):
-    - lmcache.mp.host: the host of the LMCache server.
-    - lmcache.mp.port: the port of the LMCache server.
-    - lmcache.mp.mq_timeout: timeout (seconds) for message queue requests.
-    - lmcache.mp.heartbeat_interval: interval (seconds) between server
-      heartbeat pings.
+    - ``lmcache.mp.host``: LMCache server host.
+    - ``lmcache.mp.port``: LMCache server port.
+    - ``lmcache.mp.mq_timeout``: timeout (s) for message queue requests.
+    - ``lmcache.mp.heartbeat_interval``: heartbeat interval (s).
     """
 
     def __init__(
@@ -675,14 +600,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         self.vllm_block_size = vllm_config.cache_config.block_size
 
-        # Per-gid block_size lookup: ``self._kv_cache_config.kv_cache_groups``
-        # exposes one ``KVCacheSpec.block_size`` per group. For non-hybrid
-        # models there is exactly one group with ``block_size ==
-        # vllm_block_size``. For DeepSeek-V4 with the hybrid manager
-        # active there are 5 groups with mixed block sizes (256 / 64 /
-        # 64 / 4 / 8 in our verified probe). The metadata generators
-        # use this to translate coarse-block indices (in
-        # ``vllm_block_size`` units) into per-gid slice ranges.
+        # Per-gid block-size lookup. Non-hybrid: one entry equal to
+        # ``vllm_block_size``. V4 hybrid-on: 5 entries (256/64/64/4/8 on
+        # our verified probe). Used by metadata generators to translate
+        # coarse-block ranges into per-gid slice ranges.
         self._gid_to_block_size: dict[int, int] = {}
         kv_cache_config = getattr(self, "_kv_cache_config", None)
         if kv_cache_config is not None and getattr(
@@ -730,45 +651,23 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         logger.info("Registering kv caches!")
 
-        # Build per-positional-layer logical (scheduler) block size and
-        # block-ID namespace from ``self._kv_cache_config.kv_cache_groups``.
-        # Under hybrid KV cache management, each ``KVCacheGroupSpec``
-        # reports its own ``KVCacheSpec.block_size`` and contributes its
-        # own ``BlockPool`` slice; layers from different groups can
-        # share the same physical tensor shape (via layer-tuple
-        # aliasing) but were allocated against different scheduler
-        # block sizes, and even when both block sizes match they may
-        # still pull block IDs from disjoint pools (e.g. DeepSeek-V4's
-        # vLLM gids 1 and 2 — the even+MTP and odd SWA layers, which
-        # share every spec field but have separate ``req_to_blocks``
-        # dicts).
+        # Build per-positional-layer logical block size and namespace from
+        # ``self._kv_cache_config.kv_cache_groups``. Under the hybrid
+        # manager, each ``KVCacheGroupSpec`` reports its own
+        # ``KVCacheSpec.block_size`` and pulls block IDs from its own
+        # ``BlockPool``; LMCache needs both signals to keep one transfer
+        # kernel per ``(physical_bs, logical_bs, namespace)`` triple.
+        # Without ``logical_bs`` we'd merge V4's C4A-main and per-layer-SWA
+        # layers (both physical ``bs=64``); without ``namespace`` we'd
+        # merge V4 gids 1 and 2 (every spec field matches, separate
+        # ``req_to_blocks`` dicts).
         #
-        # LMCache needs both signals to keep one transfer-kernel
-        # dispatch unit per ``(physical_bs, logical_bs, namespace)``
-        # triple. Without ``logical_bs`` it would merge the C4A-main
-        # and per-layer-SWA layers (both physical ``shape[1] = 64``);
-        # without ``namespace`` it would merge gids 1 and 2 even after
-        # the logical_bs split. See
-        # :class:`~lmcache.v1.gpu_connector.utils.LayoutHints`'s
-        # ``per_layer_logical_block_size`` and
-        # ``per_layer_kv_cache_group_id`` fields for the consumer side.
-        #
-        # When the engine produced only one ``KVCacheGroupSpec`` (the
-        # non-hybrid case), every layer ends up with the same block
-        # size and the same namespace, which collapses LMCache's
-        # grouping back to the prior 5-tuple identity behavior.
-        #
-        # If a layer name in any group does not appear in the
-        # registered ``kv_caches`` dict (i.e. that layer's KV cache is
-        # not exposed to the connector), it's silently skipped — its
-        # entry in the per-layer lists stays at the sentinel value
-        # (logical_bs=0, namespace=-1). The LMCache-side consumer
-        # rejects any non-positive logical_bs entry or negative
-        # namespace entry with ``ValueError`` at registration, so a
-        # partial cover surfaces as a loud registration failure rather
-        # than silent miscount. If neither hint is populated we drop
-        # both entirely so single-group engines fall back to the prior
-        # 5-tuple identity behavior.
+        # Layers absent from ``kv_caches`` keep their sentinel entries
+        # (logical_bs=0, namespace=-1); the LMCache-side consumer rejects
+        # any non-positive / negative entry at registration, so a partial
+        # cover surfaces as a loud failure. If no hint is populated we drop
+        # both lists so single-group engines fall back to the legacy
+        # 5-tuple identity.
         per_layer_logical_block_size: list[int] | None = None
         per_layer_kv_cache_group_id: list[int] | None = None
         per_layer_sliding_window: list[int] | None = None
@@ -797,21 +696,15 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 spec_block_size = getattr(spec, "block_size", None)
                 if spec_block_size is None:
                     continue
-                # ``KVCacheSpec.sliding_window`` exists on
-                # ``SlidingWindowMLASpec`` and friends; full-attention
-                # specs either omit it or set it to ``None``/0. When
-                # vLLM has unified per-layer specs into a
-                # ``UniformTypeKVCacheSpecs``, the wrapper doesn't
-                # expose ``sliding_window`` itself — peek into one of
-                # the per-layer specs in ``kv_cache_specs`` (they are
-                # uniform by construction; see
-                # ``UniformTypeKVCacheSpecs.is_uniform_type``).
+                # ``KVCacheSpec.sliding_window`` lives on the spec
+                # directly (``SlidingWindowMLASpec`` etc.), or — when vLLM
+                # has wrapped per-layer specs into
+                # ``UniformTypeKVCacheSpecs`` — on the wrapped inner
+                # specs (uniform by construction).
                 spec_sliding_window = getattr(spec, "sliding_window", None)
                 if spec_sliding_window is None:
                     inner_specs = getattr(spec, "kv_cache_specs", None)
                     if inner_specs:
-                        # Any one entry suffices given the uniformity
-                        # invariant.
                         first_inner = next(iter(inner_specs.values()))
                         spec_sliding_window = getattr(
                             first_inner, "sliding_window", None
@@ -1141,12 +1034,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         tracker = self._get_request_tracker(request.request_id)
         per_gid_block_ids = blocks.get_block_ids()  # tuple[list[int], ...]
 
-        # Only append blocks beyond what's already tracked, per-gid.
-        # ``KVCacheBlocks.get_block_ids()`` returns ALL blocks vLLM has
-        # allocated for the request so far; on the second call (async
-        # load completion) some prefix has already been recorded on
-        # this tracker and must not be re-appended. Per-gid existing
-        # counts let us advance each gid independently.
+        # Append only the new blocks per-gid. ``KVCacheBlocks.get_block_ids()``
+        # returns the cumulative set; on the second call (async load
+        # completion) the prefix is already tracked and must not be
+        # re-appended.
         existing_per_gid = tracker.num_allocated_blocks_per_group()
         new_per_gid: list[list[int]] = []
         for gid, gid_blocks in enumerate(per_gid_block_ids):

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1216,9 +1216,7 @@ class LMCacheMPWorkerAdapter:
         # carries the per-gid structure verbatim. See the unhealthy
         # branch above for rationale on flattening at this layer.
         flat_block_ids: list[int] = [
-            block_id
-            for group_block_ids in op.block_ids
-            for block_id in group_block_ids
+            block_id for group_block_ids in op.block_ids for block_id in group_block_ids
         ]
         self.retrieve_futures[request_id] = (future, flat_block_ids)
 

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -834,6 +834,11 @@ class LMCacheMPWorkerAdapter:
 
         # Registered kv caches from vLLM
         self.kv_caches: dict[str, torch.Tensor] = {}
+        # Engine-supplied layout-hint overrides cached by
+        # ``register_kv_caches`` so the heartbeat recovery path re-
+        # registers with the same hints (e.g.
+        # ``per_layer_logical_block_size`` for hybrid KV cache groups).
+        self.extra_layout_hints: dict[str, object] | None = None
 
         # Transport context for transfer operations.
         self.transfer_ctx: TransferContext | None = None
@@ -940,13 +945,29 @@ class LMCacheMPWorkerAdapter:
             == 0
         )
 
-    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
+    def register_kv_caches(
+        self,
+        kv_caches: dict[str, torch.Tensor],
+        extra_layout_hints: dict[str, object] | None = None,
+    ) -> None:
         """
         Register the kv caches with LMCache server.
 
         Args:
             kv_caches: A dict of kv caches to register. The keys are the
                 layer names and the values are the corresponding tensors.
+            extra_layout_hints: Optional engine-supplied additions to the
+                :class:`~lmcache.v1.gpu_connector.utils.LayoutHints`
+                dict produced by :func:`vllm_layout_hints`. Keys present
+                here override the auto-detected ones (e.g. ``kv_layout``)
+                — callers should use this to add fields the adapter
+                cannot derive on its own, such as
+                ``per_layer_logical_block_size`` (required for vLLM's
+                hybrid KV cache manager; see the field docstring on
+                :class:`~lmcache.v1.gpu_connector.utils.LayoutHints`).
+                Pass ``None`` to use only the auto-detected hints. The
+                hints are cached on the adapter so the heartbeat
+                recovery path re-registers with the same set.
 
         Raises:
             ConnectionError: if the server does not respond within
@@ -954,6 +975,7 @@ class LMCacheMPWorkerAdapter:
         """
         logger.info("Registering kv caches")
         self.kv_caches = kv_caches
+        self.extra_layout_hints = extra_layout_hints
         self._send_register_kv_caches_request(kv_caches)
 
     def _send_register_kv_caches_request(
@@ -962,7 +984,9 @@ class LMCacheMPWorkerAdapter:
         """Submit a REGISTER_KV_CACHE request and wait for the response.
 
         Shared by the public ``register_kv_caches`` entry point and the
-        recovery path inside ``is_healthy``.
+        recovery path inside ``is_healthy``. Uses
+        ``self.extra_layout_hints`` (cached by ``register_kv_caches``)
+        so the recovery path re-registers with identical hints.
 
         Args:
             kv_caches: The KV cache dict to register.
@@ -977,6 +1001,8 @@ class LMCacheMPWorkerAdapter:
         layout_hints["inference_engine_logical_block_size"] = (
             self.vllm_logical_block_size
         )
+        if self.extra_layout_hints:
+            layout_hints.update(self.extra_layout_hints)
         try:
             self.transfer_ctx.register(
                 self.instance_id,

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -395,8 +395,24 @@ class LoadStoreOp:
     token_ids: list[int]
     """Token IDs for the load/store operation"""
 
-    block_ids: list[int]
-    """Block ids for the load/store operation"""
+    block_ids: list[list[int]]
+    """Block IDs for the load/store operation, grouped by engine-side
+    ``kv_cache_group_id``.
+
+    The outer list is indexed by gid (``block_ids[gid]``) and matches
+    the order the engine reported the gids in at registration time
+    (i.e. the same order as
+    :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_kv_cache_group_id`
+    enumerates them). Each inner list contains the block IDs vLLM
+    allocated for that gid over the chunk range ``[start, end)``.
+
+    For non-hybrid models the engine has a single namespace and this
+    is a length-1 outer list whose inner list mirrors the prior flat
+    ``list[int]`` semantics. For hybrid models (vLLM with
+    ``--no-disable-hybrid-kv-cache-manager`` on DeepSeek-V4) the
+    outer list has one entry per ``KVCacheGroupSpec`` with that
+    gid's own scheduler-block-size granularity.
+    """
 
     start: int = 0
     """Start token index"""
@@ -408,7 +424,28 @@ class LoadStoreOp:
     """Number of tokens to skip writing at the beginning of the retrieve
     range. Used to avoid overwriting APC-shared GPU blocks during retrieve."""
 
+    @property
+    def total_block_count(self) -> int:
+        """Sum of block counts across all engine namespaces.
+
+        Equal to ``sum(len(group_blocks) for group_blocks in
+        self.block_ids)``. Note this is the count of engine block
+        IDs across gids, not the number of LMCache transfer-kernel
+        groups (which can differ when several gids share a
+        scheduler block size). For non-hybrid models this equals
+        ``len(self.block_ids[0])``.
+        """
+        return sum(len(group_blocks) for group_blocks in self.block_ids)
+
     def __len__(self) -> int:
+        """Number of engine-side ``kv_cache_group``s present in this op.
+
+        Returns 1 for non-hybrid models and equals the engine's
+        kv_cache_group count for hybrid models. Note this is a change
+        in semantics from prior versions where ``__len__`` returned
+        the total block count; see :attr:`total_block_count` for
+        that quantity.
+        """
         return len(self.block_ids)
 
 
@@ -1141,7 +1178,15 @@ class LMCacheMPWorkerAdapter:
         self._ensure_heartbeat_started()
 
         if not self.is_healthy:
-            self.error_block_ids.update(op.block_ids)
+            # ``op.block_ids`` is now a list[list[int]] grouped by gid;
+            # ``self.error_block_ids`` is a flat set[int]. Flatten on
+            # update — error reporting back to vLLM is namespace-blind
+            # under the current API, so the flat union is the best we
+            # can do at this layer. (A future revision could thread the
+            # gid through the error channel; for now it matches the
+            # prior single-gid behavior for non-hybrid models.)
+            for group_block_ids in op.block_ids:
+                self.error_block_ids.update(group_block_ids)
             return
 
         assert op.token_ids is not None
@@ -1167,7 +1212,15 @@ class LMCacheMPWorkerAdapter:
             self.blocks_in_chunk,
             skip_first_n_tokens=op.skip_first_n_tokens,
         )
-        self.retrieve_futures[request_id] = (future, list(op.block_ids))
+        # Stash a flattened block-id list for error reporting; the wire
+        # carries the per-gid structure verbatim. See the unhealthy
+        # branch above for rationale on flattening at this layer.
+        flat_block_ids: list[int] = [
+            block_id
+            for group_block_ids in op.block_ids
+            for block_id in group_block_ids
+        ]
+        self.retrieve_futures[request_id] = (future, flat_block_ids)
 
     @_lmcache_nvtx_annotate
     def batched_submit_store_requests(

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -914,13 +914,10 @@ class LMCacheMPWorkerAdapter:
             "LMCache chunk size should be a multiple of vLLM block size"
         )
         self.blocks_in_chunk = chunk_size // vllm_block_size
-        # Retain the vLLM logical block size so we can ship it to the
-        # LMCache server in ``register_kv_caches`` — the server uses it
-        # (as ``layout_hints["inference_engine_logical_block_size"]``)
-        # to derive per-group compression ratios when some KV layer
-        # groups compress multiple logical tokens into a single physical
-        # slot (``shape_desc.bs <
-        # inference_engine_logical_block_size``).
+        # Retained so we can ship it as
+        # ``layout_hints["inference_engine_logical_block_size"]`` in
+        # ``register_kv_caches``; the server uses it as the global
+        # fallback when deriving per-group compression ratios.
         self.vllm_logical_block_size = vllm_block_size
 
         # Health state (shared with heartbeat thread)
@@ -1039,11 +1036,8 @@ class LMCacheMPWorkerAdapter:
             self.vllm_logical_block_size
         )
         if self.extra_layout_hints:
-            # ``LayoutHints`` is a TypedDict with a fixed set of known keys;
-            # extra hints from the connector populate those same keys at
-            # runtime, but mypy cannot verify that against an arbitrary
-            # ``dict[str, object]``. Cast widens the LHS to a plain dict
-            # so ``.update`` accepts the connector-supplied dict in-place.
+            # Cast widens the TypedDict LHS to a plain dict so ``.update``
+            # accepts the connector-supplied ``dict[str, object]`` in place.
             cast("dict[str, object]", layout_hints).update(self.extra_layout_hints)
         try:
             self.transfer_ctx.register(
@@ -1183,13 +1177,9 @@ class LMCacheMPWorkerAdapter:
         self._ensure_heartbeat_started()
 
         if not self.is_healthy:
-            # ``op.block_ids`` is now a list[list[int]] grouped by gid;
-            # ``self.error_block_ids`` is a flat set[int]. Flatten on
-            # update — error reporting back to vLLM is namespace-blind
-            # under the current API, so the flat union is the best we
-            # can do at this layer. (A future revision could thread the
-            # gid through the error channel; for now it matches the
-            # prior single-gid behavior for non-hybrid models.)
+            # ``op.block_ids`` is per-gid (``list[list[int]]``);
+            # ``error_block_ids`` is namespace-blind, so we flatten the
+            # union for error reporting back to vLLM.
             for group_block_ids in op.block_ids:
                 self.error_block_ids.update(group_block_ids)
             return

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
 from dataclasses import dataclass
-from typing import Any, Callable, NoReturn
+from typing import Any, Callable, NoReturn, cast
 import enum
 import os
 import threading
@@ -1039,7 +1039,12 @@ class LMCacheMPWorkerAdapter:
             self.vllm_logical_block_size
         )
         if self.extra_layout_hints:
-            layout_hints.update(self.extra_layout_hints)
+            # ``LayoutHints`` is a TypedDict with a fixed set of known keys;
+            # extra hints from the connector populate those same keys at
+            # runtime, but mypy cannot verify that against an arbitrary
+            # ``dict[str, object]``. Cast widens the LHS to a plain dict
+            # so ``.update`` accepts the connector-supplied dict in-place.
+            cast("dict[str, object]", layout_hints).update(self.extra_layout_hints)
         try:
             self.transfer_ctx.register(
                 self.instance_id,
@@ -1151,7 +1156,7 @@ class LMCacheMPWorkerAdapter:
             key,
             self.instance_id,
             self.kv_caches,
-            op.block_ids,
+            op.block_ids,  # type: ignore[arg-type]
             event,
             self.blocks_in_chunk,
         )
@@ -1207,7 +1212,7 @@ class LMCacheMPWorkerAdapter:
             key,
             self.instance_id,
             self.kv_caches,
-            op.block_ids,
+            op.block_ids,  # type: ignore[arg-type]
             event,
             self.blocks_in_chunk,
             skip_first_n_tokens=op.skip_first_n_tokens,

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -81,6 +81,29 @@ class LayoutHints(TypedDict, total=False):
             KV layer groups compress multiple logical tokens into a
             single physical slot
             (``shape_desc.bs < inference_engine_logical_block_size``).
+            Single global value: every group derives compression
+            against this same ``ie_logical_block_size``. Adequate for
+            engines where every KV layer group shares one scheduler
+            block size (e.g. vLLM with hybrid KV cache manager
+            disabled). When a single global value cannot describe the
+            engine's per-layer scheduler block sizes (vLLM HMA=on, where
+            different ``KVCacheGroupSpec``s use different
+            ``block_size`` values), use ``per_layer_logical_block_size``
+            instead. When both are set, ``per_layer_logical_block_size``
+            takes precedence for grouping and chunking.
+        per_layer_logical_block_size: Optional list of length
+            ``num_layers`` carrying the *scheduler-side* tokens-per-block
+            of each layer (vLLM: each layer's
+            ``KVCacheGroupSpec.kv_cache_spec.block_size``). When
+            present, the LMCache server keys layer grouping on a
+            per-layer logical block size instead of one global value,
+            and chunking math (``blocks_per_chunk_g = lmcache_chunk_size
+            // logical_bs_g``) becomes per-group. Required when the
+            engine has KV layer groups with mixed scheduler block sizes
+            (DeepSeek-V4 with vLLM hybrid KV cache manager active).
+            Each entry must be a positive int. Layers with the same
+            ``logical_block_size`` and identical other identity fields
+            are grouped together.
     """
 
     kv_layout: Literal["NHD", "HND"]
@@ -88,6 +111,7 @@ class LayoutHints(TypedDict, total=False):
     tokens_per_block: int
     head_dim: int
     inference_engine_logical_block_size: int
+    per_layer_logical_block_size: list[int]
 
 
 def attempt_permute_to_contiguous_view(

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -118,6 +118,32 @@ class LayoutHints(TypedDict, total=False):
             gids). Each entry must be a non-negative int. When absent,
             every layer is treated as namespace 0 (preserving
             behavior on engines without hybrid KV cache groupings).
+        per_layer_sliding_window: Optional per-layer sliding-window
+            attention size in tokens, or ``0`` for full-attention
+            layers. When non-zero for a group, LMCache stores and
+            retrieves only the *last*
+            ``ceil(sliding_window / logical_block_size)`` blocks of
+            each chunk for that group, instead of all
+            ``lmcache_chunk_size // logical_block_size`` blocks. The
+            kernel-time SWA mask in the serving engine never reads
+            positions older than ``sliding_window`` from the current
+            decode position, so the truncated payload is sufficient:
+            a full hit's last cached chunk holds positions ``[L -
+            last_chunk_size + 1, L]`` of which only the last
+            ``window`` are ever accessed; a partial hit only reads
+            the cached SWA tail for the first ``window`` recompute
+            steps before the window slides into recomputed positions.
+            On DeepSeek-V4 (``chunk_size=1024``,
+            ``window in {8, 128, 256}``), this collapses gid 3's
+            per-chunk SWA payload from ~236 MiB to ~1.85 MiB.
+            Two layers with the same other fields but different
+            ``sliding_window`` values cannot share an LMCache group
+            because their per-chunk byte budgets differ — the value
+            joins :data:`LayerGroupIdentity` as an extra component.
+            The list length MUST equal the number of layers; entry
+            ``i`` is the window for the i-th positional layer. When
+            absent, every layer is treated as ``sliding_window = 0``
+            and behavior is identical to the prior 7-tuple grouping.
     """
 
     kv_layout: Literal["NHD", "HND"]
@@ -127,6 +153,7 @@ class LayoutHints(TypedDict, total=False):
     inference_engine_logical_block_size: int
     per_layer_logical_block_size: list[int]
     per_layer_kv_cache_group_id: list[int]
+    per_layer_sliding_window: list[int]
 
 
 def attempt_permute_to_contiguous_view(

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -73,77 +73,36 @@ class LayoutHints(TypedDict, total=False):
         head_dim: Per-head dimension. Used by TRT-LLM (same).
         inference_engine_logical_block_size: Inference-engine-side block
             size (logical tokens per engine block; for vLLM this is
-            ``cache_config.block_size``). Carried inside
-            ``LayoutHints`` (instead of as a standalone
-            ``REGISTER_KV_CACHE`` argument) so that engines without a
-            logical block-size concept can simply omit it. The server
-            uses it to derive per-group compression ratios when some
-            KV layer groups compress multiple logical tokens into a
-            single physical slot
+            ``cache_config.block_size``). Used to derive per-group
+            compression ratios when KV layer groups compress multiple
+            logical tokens into a single physical slot
             (``shape_desc.bs < inference_engine_logical_block_size``).
-            Single global value: every group derives compression
-            against this same ``ie_logical_block_size``. Adequate for
-            engines where every KV layer group shares one scheduler
-            block size (e.g. vLLM with hybrid KV cache manager
-            disabled). When a single global value cannot describe the
-            engine's per-layer scheduler block sizes (vLLM HMA=on, where
-            different ``KVCacheGroupSpec``s use different
-            ``block_size`` values), use ``per_layer_logical_block_size``
-            instead. When both are set, ``per_layer_logical_block_size``
-            takes precedence for grouping and chunking.
-        per_layer_logical_block_size: Optional list of length
-            ``num_layers`` carrying the *scheduler-side* tokens-per-block
-            of each layer (vLLM: each layer's
-            ``KVCacheGroupSpec.kv_cache_spec.block_size``). When
-            present, the LMCache server keys layer grouping on a
-            per-layer logical block size instead of one global value,
-            and chunking math (``blocks_per_chunk_g = lmcache_chunk_size
-            // logical_bs_g``) becomes per-group. Required when the
-            engine has KV layer groups with mixed scheduler block sizes
-            (DeepSeek-V4 with vLLM hybrid KV cache manager active).
-            Each entry must be a positive int. Layers with the same
-            ``logical_block_size`` and identical other identity fields
-            are grouped together.
-        per_layer_kv_cache_group_id: Optional list of length
-            ``num_layers`` carrying the engine-side block-ID *namespace*
-            handle for each layer. On vLLM with the hybrid KV cache
-            manager active, each ``KVCacheGroupSpec`` allocates block
-            IDs from a disjoint ``BlockPool`` namespace; two layers
-            with otherwise identical identity may still pull block IDs
-            from independent pools and must therefore land in different
-            LMCache groups. The hint participates in
-            :data:`LayerGroupIdentity` as the namespace disambiguator
-            (DeepSeek-V4 hybrid manager: even+MTP-SWA layers vs odd-SWA
-            layers share every other identity field but use distinct
-            gids). Each entry must be a non-negative int. When absent,
-            every layer is treated as namespace 0 (preserving
-            behavior on engines without hybrid KV cache groupings).
-        per_layer_sliding_window: Optional per-layer sliding-window
-            attention size in tokens, or ``0`` for full-attention
-            layers. When non-zero for a group, LMCache stores and
-            retrieves only the *last*
+            Single global value; for engines with mixed scheduler block
+            sizes use ``per_layer_logical_block_size`` instead, which
+            takes precedence when both are set.
+        per_layer_logical_block_size: Optional length-``num_layers``
+            list of each layer's scheduler-side tokens-per-block
+            (vLLM: ``KVCacheGroupSpec.kv_cache_spec.block_size``).
+            Required when KV layer groups have mixed scheduler block
+            sizes (DeepSeek-V4 with vLLM HMA active); LMCache then
+            keys grouping on per-layer logical block size and chunking
+            becomes per-group.
+        per_layer_kv_cache_group_id: Optional length-``num_layers``
+            list of each layer's engine-side block-ID namespace
+            handle. On vLLM HMA, each ``KVCacheGroupSpec`` allocates
+            block IDs from a disjoint ``BlockPool``; layers with
+            otherwise identical identity but different namespaces
+            must land in different LMCache groups. When absent, every
+            layer is treated as namespace 0.
+        per_layer_sliding_window: Optional per-layer SWA size in
+            tokens (``0`` for full-attention). When non-zero, LMCache
+            stores/retrieves only the last
             ``ceil(sliding_window / logical_block_size)`` blocks of
-            each chunk for that group, instead of all
-            ``lmcache_chunk_size // logical_block_size`` blocks. The
-            kernel-time SWA mask in the serving engine never reads
-            positions older than ``sliding_window`` from the current
-            decode position, so the truncated payload is sufficient:
-            a full hit's last cached chunk holds positions ``[L -
-            last_chunk_size + 1, L]`` of which only the last
-            ``window`` are ever accessed; a partial hit only reads
-            the cached SWA tail for the first ``window`` recompute
-            steps before the window slides into recomputed positions.
-            On DeepSeek-V4 (``chunk_size=1024``,
-            ``window in {8, 128, 256}``), this collapses gid 3's
-            per-chunk SWA payload from ~236 MiB to ~1.85 MiB.
-            Two layers with the same other fields but different
-            ``sliding_window`` values cannot share an LMCache group
-            because their per-chunk byte budgets differ — the value
-            joins :data:`LayerGroupIdentity` as an extra component.
-            The list length MUST equal the number of layers; entry
-            ``i`` is the window for the i-th positional layer. When
-            absent, every layer is treated as ``sliding_window = 0``
-            and behavior is identical to the prior 7-tuple grouping.
+            each chunk — sufficient because the engine's SWA mask
+            never reads positions older than ``sliding_window``.
+            Joins :data:`LayerGroupIdentity` since differing windows
+            imply differing per-chunk byte budgets. When absent,
+            treated as ``0``.
     """
 
     kv_layout: Literal["NHD", "HND"]

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -104,6 +104,20 @@ class LayoutHints(TypedDict, total=False):
             Each entry must be a positive int. Layers with the same
             ``logical_block_size`` and identical other identity fields
             are grouped together.
+        per_layer_kv_cache_group_id: Optional list of length
+            ``num_layers`` carrying the engine-side block-ID *namespace*
+            handle for each layer. On vLLM with the hybrid KV cache
+            manager active, each ``KVCacheGroupSpec`` allocates block
+            IDs from a disjoint ``BlockPool`` namespace; two layers
+            with otherwise identical identity may still pull block IDs
+            from independent pools and must therefore land in different
+            LMCache groups. The hint participates in
+            :data:`LayerGroupIdentity` as the namespace disambiguator
+            (DeepSeek-V4 hybrid manager: even+MTP-SWA layers vs odd-SWA
+            layers share every other identity field but use distinct
+            gids). Each entry must be a non-negative int. When absent,
+            every layer is treated as namespace 0 (preserving
+            behavior on engines without hybrid KV cache groupings).
     """
 
     kv_layout: Literal["NHD", "HND"]
@@ -112,6 +126,7 @@ class LayoutHints(TypedDict, total=False):
     head_dim: int
     inference_engine_logical_block_size: int
     per_layer_logical_block_size: list[int]
+    per_layer_kv_cache_group_id: list[int]
 
 
 def attempt_permute_to_contiguous_view(

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -35,10 +35,10 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 }
 
 
-# The 5-tuple that uniquely identifies a set of kernel-equivalent layers:
+# The 7-tuple that uniquely identifies a set of kernel-equivalent layers:
 # ``(kv_size, num_heads, head_size, block_size, logical_block_size,
-# dtype)``. Two layers share a transfer-kernel launch iff they share
-# this identity — see the grouping loop in
+# kv_cache_group_id, dtype)``. Two layers share a transfer-kernel
+# launch iff they share this identity — see the grouping loop in
 # :meth:`KVLayerGroupsManager.__init__` for the derivation.
 #
 # The fifth slot (``logical_block_size``) is the *scheduler-side*
@@ -52,11 +52,27 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 # grid while the SWA layers use a 64-token grid). Two layers with the
 # same physical layout but different scheduler grids are
 # kernel-incompatible — one ``LoadStoreOp`` cannot index both — so the
-# logical block size must participate in the identity tuple. When the
-# hint is absent, every layer's logical block size defaults to its
-# physical ``bs`` and the 6-tuple collapses to the prior 5-tuple
-# behavior.
-LayerGroupIdentity = tuple[int, int, int, int, int, torch.dtype]
+# logical block size must participate in the identity tuple.
+#
+# The sixth slot (``kv_cache_group_id``) is the engine's per-layer
+# block-ID namespace handle. Two layers may share an LMCache transfer-
+# kernel group only if a single ``LoadStoreOp``'s ``block_ids``
+# correctly indexes both — which is true iff they share a namespace.
+# It comes from
+# :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_kv_cache_group_id`
+# when the engine supplies it, otherwise every layer is treated as
+# namespace 0. On DeepSeek-V4 with the hybrid manager active, the
+# even-indexed-plus-MTP SWA layers (vLLM gid 1) and the odd-indexed
+# SWA layers (vLLM gid 2) have identical ``KVCacheSpec`` field values
+# — same ``block_size``, ``sliding_window``, ``head_size``, dtype, and
+# physical ``shape[1]`` — but pull block IDs from disjoint pools.
+# Without this slot they merge into one LMCache group and a STORE op
+# carrying gid 1's block IDs would silently mis-index gid 2's layers.
+#
+# When neither hint is provided, every layer's logical block size
+# defaults to its physical ``bs`` and every layer's namespace defaults
+# to 0, so the 7-tuple collapses to the prior 5-tuple grouping.
+LayerGroupIdentity = tuple[int, int, int, int, int, int, torch.dtype]
 
 
 @dataclass
@@ -131,6 +147,18 @@ class KVLayerGroupInfo:
     indicates the field has not been populated yet (left in for
     backwards compatibility with no-arg constructors); the manager
     always sets a positive value at construction."""
+    kv_cache_group_id: int = 0
+    """Engine-side block-ID namespace handle for this group. Stamped
+    from
+    :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_kv_cache_group_id`
+    at registration. Two LMCache groups with different
+    ``kv_cache_group_id`` values reflect layers whose
+    ``LoadStoreOp.block_ids`` come from disjoint engine-side
+    ``BlockPool``-allocated namespaces — they cannot be merged into one
+    transfer-kernel launch even when every other field matches.
+    Defaults to 0 when the engine does not provide the hint, in which
+    case all layers share namespace 0 and grouping behaves identically
+    to the prior 6-tuple identity."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -148,7 +176,8 @@ class KVLayerGroupInfo:
             f"dtype={self.dtype}, "
             f"compress_ratio={self.compress_ratio}, "
             f"physical_chunk_size={self.physical_chunk_size}, "
-            f"logical_bs={self.logical_block_size})"
+            f"logical_bs={self.logical_block_size}, "
+            f"kv_cache_group_id={self.kv_cache_group_id})"
         )
 
     @property
@@ -167,9 +196,10 @@ class KVLayerGroupsManager:
 
     At construction time, every layer in ``kv_caches`` is bucketed by its
     :data:`LayerGroupIdentity` (``(kv_size, num_heads, head_size,
-    block_size, logical_block_size, dtype)``). Each bucket becomes one
-    :class:`KVLayerGroupInfo` holding the layer indices, a shared
-    :class:`PageBufferShapeDesc`, and the group's torch dtype.
+    block_size, logical_block_size, kv_cache_group_id, dtype)``). Each
+    bucket becomes one :class:`KVLayerGroupInfo` holding the layer
+    indices, a shared :class:`PageBufferShapeDesc`, and the group's
+    torch dtype.
 
     Downstream consumers (``VLLMPagedMemGPUConnectorV3``,
     ``GPUCacheContext``, the multiprocess server) iterate
@@ -228,11 +258,19 @@ class KVLayerGroupsManager:
                   Required when the engine has KV layer groups with
                   mixed scheduler block sizes (vLLM hybrid manager
                   active on DeepSeek-V4).
+                * ``per_layer_kv_cache_group_id`` (optional list of
+                  length ``num_layers``). When present, each layer's
+                  engine-side block-ID *namespace* handle joins the
+                  identity tuple, so layers whose ``KVCacheSpec``
+                  field values fully match but pull block IDs from
+                  disjoint engine-side namespaces (e.g.
+                  DeepSeek-V4's vLLM gids 1 and 2: even+MTP vs odd
+                  SWA layers) end up in different LMCache groups.
 
-                ``None`` (or a hints dict without either key) means
-                every group is treated as non-compressed
+                ``None`` (or a hints dict without any of the above)
+                means every group is treated as non-compressed
                 (``compress_ratio == 1``, ``logical_block_size ==
-                shape_desc.bs``).
+                shape_desc.bs``, ``kv_cache_group_id == 0``).
             lmcache_logical_chunk_size: Logical tokens per LMCache chunk
                 (one logical token = one inference-engine token).
                 Together with ``compress_ratio`` it determines each
@@ -277,6 +315,7 @@ class KVLayerGroupsManager:
         # shape but different scheduler grids land in distinct LMCache
         # groups (DeepSeek-V4 hybrid manager active).
         per_layer_logical_bs: "list[int] | None" = None
+        per_layer_namespace: "list[int] | None" = None
         if layout_hints is not None:
             logical_hint = layout_hints.get("per_layer_logical_block_size")
             if logical_hint is not None:
@@ -299,14 +338,37 @@ class KVLayerGroupsManager:
                     )
                 per_layer_logical_bs = list(logical_hint)
 
+            ns_hint = layout_hints.get("per_layer_kv_cache_group_id")
+            if ns_hint is not None:
+                if len(ns_hint) != num_layers:
+                    raise ValueError(
+                        "per_layer_kv_cache_group_id length "
+                        f"({len(ns_hint)}) does not match num_layers "
+                        f"({num_layers}); each registered layer must "
+                        "have exactly one block-ID namespace entry"
+                    )
+                bad = [i for i, ns in enumerate(ns_hint) if ns < 0]
+                if bad:
+                    raise ValueError(
+                        "per_layer_kv_cache_group_id has invalid "
+                        f"(negative) entries at positions {bad[:8]}"
+                        + ("..." if len(bad) > 8 else "")
+                        + "; namespace IDs must be non-negative"
+                    )
+                per_layer_namespace = list(ns_hint)
+
         groups_dict = self._group_layers_by_identity(
-            kv_caches, gpu_kv_format, num_layers, per_layer_logical_bs
+            kv_caches,
+            gpu_kv_format,
+            num_layers,
+            per_layer_logical_bs,
+            per_layer_namespace,
         )
 
         # Emit groups in order of their first-appearing layer so that group
         # indices remain deterministic across runs.
         for group_idx, (
-            (_, _, _, bs, group_logical_bs, dt),
+            (_, _, _, bs, group_logical_bs, group_namespace, dt),
             indices,
         ) in enumerate(sorted(groups_dict.items(), key=lambda kv: kv[1][0])):
             block_stride_elems = resolve_block_stride_and_log_layout(
@@ -341,6 +403,7 @@ class KVLayerGroupsManager:
                     compress_ratio=compress_ratio,
                     physical_chunk_size=physical_chunk_size,
                     logical_block_size=group_logical_bs,
+                    kv_cache_group_id=group_namespace,
                 )
             )
 
@@ -440,20 +503,22 @@ class KVLayerGroupsManager:
         gpu_kv_format: "lmc_ops.GPUKVFormat",
         num_layers: int,
         per_layer_logical_bs: "list[int] | None" = None,
+        per_layer_namespace: "list[int] | None" = None,
     ) -> dict[LayerGroupIdentity, list[int]]:
         """Partition layer indices by :data:`LayerGroupIdentity`.
 
         Linear single pass over ``kv_caches``; layers sharing the same
         ``(kv_size, num_heads, head_size, block_size,
-        logical_block_size, dtype)`` signature land in the same bucket.
-        When ``per_layer_logical_bs`` is None, each layer's
-        ``logical_block_size`` defaults to its physical block size,
-        making the 6-tuple effectively a 5-tuple (preserving prior
-        grouping behavior on engines without the hint). The returned
-        dict's value lists are later passed by reference into
-        :class:`KVLayerGroupInfo` instances, so the dict itself is
-        garbage-collected after ``__init__`` returns while the lists
-        stay alive on each group.
+        logical_block_size, kv_cache_group_id, dtype)`` signature land
+        in the same bucket. When ``per_layer_logical_bs`` is None, each
+        layer's ``logical_block_size`` defaults to its physical block
+        size; when ``per_layer_namespace`` is None, each layer's
+        namespace defaults to 0. With both defaults, the 7-tuple is
+        effectively a 5-tuple (preserving prior grouping behavior on
+        engines without these hints). The returned dict's value lists
+        are later passed by reference into :class:`KVLayerGroupInfo`
+        instances, so the dict itself is garbage-collected after
+        ``__init__`` returns while the lists stay alive on each group.
         """
         # First Party
         from lmcache.v1.gpu_connector.utils import (
@@ -477,7 +542,14 @@ class KVLayerGroupsManager:
                 if per_layer_logical_bs is not None
                 else bs
             )
-            groups_dict[(kv_size, nh, hs, bs, logical_bs, dt)].append(idx)
+            namespace = (
+                per_layer_namespace[idx]
+                if per_layer_namespace is not None
+                else 0
+            )
+            groups_dict[
+                (kv_size, nh, hs, bs, logical_bs, namespace, dt)
+            ].append(idx)
         return groups_dict
 
     @property

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -606,14 +606,10 @@ class KVLayerGroupsManager:
             dt = get_dtype(kv_caches, gpu_kv_format, idx)
             bs = get_block_size(kv_caches, gpu_kv_format, idx)
             logical_bs = (
-                per_layer_logical_bs[idx]
-                if per_layer_logical_bs is not None
-                else bs
+                per_layer_logical_bs[idx] if per_layer_logical_bs is not None else bs
             )
             namespace = (
-                per_layer_namespace[idx]
-                if per_layer_namespace is not None
-                else 0
+                per_layer_namespace[idx] if per_layer_namespace is not None else 0
             )
             sliding_window = (
                 per_layer_sliding_window[idx]

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -35,154 +35,68 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 }
 
 
-# The 8-tuple that uniquely identifies a set of kernel-equivalent layers:
-# ``(kv_size, num_heads, head_size, block_size, logical_block_size,
-# kv_cache_group_id, sliding_window, dtype)``. Two layers share a
-# transfer-kernel launch iff they share this identity — see the
-# grouping loop in :meth:`KVLayerGroupsManager.__init__` for the
-# derivation.
+# 8-tuple identity for kernel-equivalent layers. Two layers share a
+# transfer-kernel launch iff their identities match. The first five fields
+# (``kv_size, num_heads, head_size, block_size, dtype``) are the legacy
+# kernel-shape signature. The other three came from the DeepSeek-V4
+# hybrid-KV-cache work and default to safe values that collapse the tuple
+# to the legacy 5-tuple when the engine doesn't supply hints:
 #
-# The fifth slot (``logical_block_size``) is the *scheduler-side*
-# block size — i.e. the granularity at which the serving engine hands
-# out block IDs for this layer. It comes from
-# :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_logical_block_size`
-# when the engine supplies it, otherwise it defaults to the physical
-# block size (``bs``). On DeepSeek-V4 with vLLM's *hybrid manager
-# active*, several physical-equivalent layer sets receive block IDs at
-# different scheduler grids (e.g. dense-MLA layers use a 256-token
-# grid while the SWA layers use a 64-token grid). Two layers with the
-# same physical layout but different scheduler grids are
-# kernel-incompatible — one ``LoadStoreOp`` cannot index both — so the
-# logical block size must participate in the identity tuple.
-#
-# The sixth slot (``kv_cache_group_id``) is the engine's per-layer
-# block-ID namespace handle. Two layers may share an LMCache transfer-
-# kernel group only if a single ``LoadStoreOp``'s ``block_ids``
-# correctly indexes both — which is true iff they share a namespace.
-# It comes from
-# :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_kv_cache_group_id`
-# when the engine supplies it, otherwise every layer is treated as
-# namespace 0. On DeepSeek-V4 with the hybrid manager active, the
-# even-indexed-plus-MTP SWA layers (vLLM gid 1) and the odd-indexed
-# SWA layers (vLLM gid 2) have identical ``KVCacheSpec`` field values
-# — same ``block_size``, ``sliding_window``, ``head_size``, dtype, and
-# physical ``shape[1]`` — but pull block IDs from disjoint pools.
-# Without this slot they merge into one LMCache group and a STORE op
-# carrying gid 1's block IDs would silently mis-index gid 2's layers.
-#
-# The seventh slot (``sliding_window``) is the SWA window size in
-# tokens, or 0 for full-attention layers. It comes from
-# :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_sliding_window`.
-# When non-zero, the SWA-suffix-only optimization kicks in for that
-# group (store/retrieve the last ``ceil(window/logical_bs)`` blocks
-# per chunk instead of all). Layers with different windows have
-# different per-chunk byte budgets and so cannot share a transfer
-# group. When absent, every layer is treated as ``sliding_window = 0``
-# and the 8-tuple collapses to the prior 7-tuple identity.
-#
-# When neither hint set is provided, every layer's logical block size
-# defaults to its physical ``bs``, every layer's namespace defaults to
-# 0, and every layer's sliding_window defaults to 0, so the 8-tuple
-# collapses to the prior 5-tuple grouping (kv_size, nh, hs, bs, dtype).
+# - ``logical_block_size`` — scheduler-side tokens per block. Defaults to
+#   physical ``bs``. Required when the engine hands different scheduler
+#   grids to physically-equivalent layers (V4 dense-MLA at 256 vs SWA at 64);
+#   one ``LoadStoreOp.block_ids`` cannot index two grids.
+# - ``kv_cache_group_id`` — engine-side block-ID namespace handle.
+#   Defaults to 0. Two layers in different namespaces cannot share a launch
+#   even when every other field matches (V4 vLLM gid 1 vs gid 2: same spec
+#   shape, disjoint ``BlockPool``-allocated IDs).
+# - ``sliding_window`` — SWA window size in tokens, ``0`` for full attention.
+#   Non-zero activates SWA-suffix-only stores/retrieves; layers with
+#   different windows have different per-chunk byte budgets.
 LayerGroupIdentity = tuple[int, int, int, int, int, int, int, torch.dtype]
 
 
 @dataclass
 class KVLayerGroupInfo:
-    """A single transfer-kernel dispatch unit: a set of KV layers that can
-    ride one kernel launch with one ``PageBufferShapeDesc``.
+    """One transfer-kernel dispatch unit: a set of KV layers that share a
+    :data:`LayerGroupIdentity` and ride one kernel launch with one
+    ``PageBufferShapeDesc``. Treat as immutable after construction.
 
-    Membership is decided by :class:`KVLayerGroupsManager` according to
-    :data:`LayerGroupIdentity`; every layer referenced by
-    ``layer_indices`` shares the same
-    ``(kv_size, num_heads, head_size, block_size, dtype)`` signature.
-    Consumers use ``layer_indices`` to pull the matching device pointers
-    out of ``kv_caches`` (via
-    :func:`~lmcache.v1.gpu_connector.utils.get_group_data_ptrs`) and
-    feed them to the kernel alongside ``shape_desc``.
-
-    ``dtype`` is carried alongside ``shape_desc`` because
-    ``PageBufferShapeDesc.element_size`` is a byte width, which cannot
-    distinguish dtypes that share a byte count (e.g. bfloat16 and
-    float16 are both 2 bytes). Kernel template instantiation keys on the
-    torch dtype, not the byte width, so we keep it explicit.
-
-    Treat instances as immutable after construction; callers may hold
-    references for the lifetime of the manager.
+    ``dtype`` is carried separately from ``shape_desc.element_size``
+    because the latter is byte width — bfloat16 and float16 both report 2
+    — and kernel template instantiation keys on the torch dtype.
     """
 
     layer_indices: list[int]
-    """0-based layer indices belonging to this group, in the order the
-    kernel should iterate them. Fed to ``get_group_data_ptrs`` to build
-    the per-group pointer array."""
+    """0-based layer indices in this group, in kernel-iteration order."""
     shape_desc: "lmc_ops.PageBufferShapeDesc"
-    """Kernel-facing shape descriptor shared by every layer in the group.
-    All eight fields (``kv_size, nl, nb, bs, nh, hs, element_size,
-    block_stride_elems``) are stamped once at construction. Note that
-    ``shape_desc.bs`` carries the **physical** block size (the on-GPU
-    tensor's per-block slot count); the *logical* (scheduler) block
-    size lives on :attr:`logical_block_size` and is used by chunking
-    arithmetic, which runs upstream of the kernel."""
+    """Kernel-facing shape descriptor. ``shape_desc.bs`` is the physical
+    block size; the scheduler-side block size lives on
+    :attr:`logical_block_size` and the two coincide when ``compress_ratio == 1``."""
     dtype: torch.dtype
-    """Torch dtype of the KV cache tensors for this group. Used for
-    kernel template instantiation; see class docstring for why we keep
-    this alongside ``shape_desc.element_size``."""
+    """Torch dtype for kernel template instantiation."""
     compress_ratio: int = 1
-    """Logical-tokens-per-physical-slot for this group. ``1`` for
-    non-compressed groups (one logical token per physical slot);
-    greater than ``1`` for compressed groups where each physical slot
-    packs ``compress_ratio`` logical tokens (e.g. DeepSeek V4
-    compressor / indexer caches). Derived from this group's
-    :attr:`logical_block_size` and ``shape_desc.bs`` at
-    :class:`KVLayerGroupsManager` construction time:
-    ``compress_ratio = logical_block_size // shape_desc.bs``."""
+    """``logical_block_size // shape_desc.bs``. ``1`` for non-compressed
+    groups; greater for V4 compressor / indexer caches."""
     physical_chunk_size: int = 0
-    """Number of *physical* slots in one LMCache chunk for this group
-    (= ``lmcache_logical_chunk_size // compress_ratio``). This is what
-    the block-level transfer kernel must be told, not the logical
-    ``lmcache_logical_chunk_size`` which counts vLLM tokens. ``0``
-    means the field has not been populated yet; ``GPUCacheContext``
-    fills it in after construction once ``lmcache_logical_chunk_size``
-    is known."""
+    """Physical slots per LMCache chunk
+    (``lmcache_logical_chunk_size // compress_ratio``). Set by
+    ``GPUCacheContext`` after construction."""
     logical_block_size: int = 0
-    """Scheduler-side tokens-per-block for this group, i.e. the
-    granularity at which the serving engine hands out block IDs for
-    these layers. Equals ``shape_desc.bs`` (physical) when the engine
-    does not provide a per-layer hint via
-    :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_logical_block_size`,
-    so existing single-group call sites are unaffected. When the hint
-    is present, this field carries the engine's per-layer
-    ``KVCacheSpec.block_size`` for the represented layer — which is
-    what chunking math (``blocks_per_chunk_g = lmcache_chunk_size //
-    logical_block_size``) must use, and what the connector's
-    ``LoadStoreOp.block_ids`` are stride-compatible with. ``0``
-    indicates the field has not been populated yet (left in for
-    backwards compatibility with no-arg constructors); the manager
-    always sets a positive value at construction."""
+    """Scheduler-side tokens per block. Equals ``shape_desc.bs`` when
+    no per-layer hint is supplied; otherwise carries the engine's
+    ``KVCacheSpec.block_size`` for layers in this group, which is what
+    ``LoadStoreOp.block_ids`` is stride-compatible with."""
     kv_cache_group_id: int = 0
-    """Engine-side block-ID namespace handle for this group. Stamped
-    from
-    :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_kv_cache_group_id`
-    at registration. Two LMCache groups with different
-    ``kv_cache_group_id`` values reflect layers whose
-    ``LoadStoreOp.block_ids`` come from disjoint engine-side
-    ``BlockPool``-allocated namespaces — they cannot be merged into one
-    transfer-kernel launch even when every other field matches.
-    Defaults to 0 when the engine does not provide the hint, in which
-    case all layers share namespace 0 and grouping behaves identically
-    to the prior 6-tuple identity."""
+    """Engine-side block-ID namespace handle. Layers in different
+    namespaces cannot share a kernel launch even when every other field
+    matches (e.g. V4's two SWA gids share spec but pull from disjoint
+    ``BlockPool``-allocated IDs)."""
     sliding_window: int = 0
-    """Sliding-window attention window size in tokens, or ``0`` for
-    full-attention groups. When non-zero, the SWA-suffix-only
-    optimization activates for this group: store/retrieve only the
-    last ``ceil(sliding_window / logical_block_size)`` blocks per
-    chunk instead of all ``lmcache_chunk_size // logical_block_size``
-    blocks. Stamped from
-    :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_sliding_window`
-    at registration. Two groups with different ``sliding_window``
-    values cannot share a transfer-kernel launch (their per-chunk
-    byte budgets differ); the field is the 7th component of
-    :data:`LayerGroupIdentity`."""
+    """SWA window size in tokens, ``0`` for full attention. Non-zero
+    activates the SWA-suffix-only optimization for this group: store/retrieve
+    only the last ``ceil(sliding_window / logical_block_size)`` blocks per
+    chunk."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -219,36 +133,16 @@ class KVLayerGroupInfo:
 def _validate_uniform_layer_format(kv_caches: "DiscoverableKVCache") -> None:
     """Verify every layer tensor in ``kv_caches`` shares the same ``.dim()``.
 
-    LMCache currently assumes a single :class:`~lmcache.c_ops.GPUKVFormat`
-    per engine: :func:`normalize_kv_and_discover_format` inspects the
-    first tensor it can find and returns one format,
-    :data:`LayerGroupIdentity` does not include the format, and the
-    transfer-kernel call sites read a single ``gpu_kv_format_`` from the
-    GPU context. If the engine ever hands LMCache layers with divergent
-    formats, the kernel would silently use the first layer's format for
-    every layer and produce a corrupt KV cache at retrieve time.
-
-    This helper enforces the assumption at registration time. It walks
-    every leaf tensor in ``kv_caches`` and checks that the dim count
-    matches the first tensor's. Distinct formats with the same dim count
-    (e.g. axis-permuted variants) are not detected here — distinguishing
-    them would require duplicating the format-detection logic from
-    :func:`normalize_kv_and_discover_format` per leaf, which is not
-    warranted while no such mixed-format engine exists. The realistic
-    mixed case today is MLA (no TWO axis) versus MHA (TWO axis), which
-    differ in dim count and so are caught.
-
-    Args:
-        kv_caches: KV cache structure (single tensor or arbitrarily
-            nested list of tensors). Empty structures are accepted
-            silently — the early-return in
-            :meth:`KVLayerGroupsManager.__init__` already handles the
-            zero-layer case.
+    LMCache currently assumes a single
+    :class:`~lmcache.c_ops.GPUKVFormat` per engine — format is detected
+    once from the first tensor and reused for every kernel call. A
+    mixed-format engine would silently miscompile every layer past the
+    first, so we fail loudly at registration time if any leaf tensor's
+    dim count diverges. The realistic mixed case is MLA (no TWO axis)
+    vs MHA (TWO axis), which differ in dim count.
 
     Raises:
-        ValueError: If two leaf tensors disagree on ``.dim()``. The
-            message names the first divergent layer index and both dim
-            counts.
+        ValueError: if two leaf tensors disagree on ``.dim()``.
     """
     leaf_dims: list[int] = []
 
@@ -276,22 +170,13 @@ def _validate_uniform_layer_format(kv_caches: "DiscoverableKVCache") -> None:
 class KVLayerGroupsManager:
     """Partition a model's KV layers into transfer-kernel dispatch units.
 
-    At construction time, every layer in ``kv_caches`` is bucketed by its
-    :data:`LayerGroupIdentity` (``(kv_size, num_heads, head_size,
-    block_size, logical_block_size, kv_cache_group_id, sliding_window,
-    dtype)``). Each bucket becomes one :class:`KVLayerGroupInfo`
-    holding the layer indices, a shared :class:`PageBufferShapeDesc`,
-    and the group's torch dtype.
-
-    Downstream consumers (``VLLMPagedMemGPUConnectorV3``,
-    ``GPUCacheContext``, the multiprocess server) iterate
-    ``self.kv_layer_groups`` and issue one transfer-kernel launch per
-    group. The manager itself is a pure metadata object — it does not
-    own any GPU buffers or perform any transfers.
-
-    Layout parsing is delegated entirely to
-    :mod:`lmcache.v1.gpu_connector.utils`; this class only drives the
-    grouping and look-up.
+    Each layer in ``kv_caches`` is bucketed by its :data:`LayerGroupIdentity`;
+    each bucket becomes one :class:`KVLayerGroupInfo`. Downstream consumers
+    (``VLLMPagedMemGPUConnectorV3``, ``GPUCacheContext``, the multiprocess
+    server) iterate ``self.kv_layer_groups`` and issue one transfer-kernel
+    launch per group. The manager is a pure metadata object — no GPU buffers,
+    no transfers. Layout parsing lives in
+    :mod:`lmcache.v1.gpu_connector.utils`.
     """
 
     def __init__(
@@ -302,64 +187,36 @@ class KVLayerGroupsManager:
         layout_hints: "LayoutHints | None" = None,
         lmcache_logical_chunk_size: int = 256,
     ) -> None:
-        """Partition layers into groups keyed by
-        :data:`LayerGroupIdentity`.
+        """Partition layers into groups keyed by :data:`LayerGroupIdentity`.
 
-        For each layer ``i`` in ``kv_caches``, read
-        ``(kv_size, num_heads, head_size, dtype)`` via the format-aware
-        accessors in ``utils.py``. Layers with identical identities are
-        bucketed together; each bucket becomes one
-        :class:`KVLayerGroupInfo`.
-
-        Groups are emitted in the order of their first-appearing layer,
-        so group indices are deterministic across runs.
+        Groups are emitted in the order of their first-appearing layer, so
+        group indices are deterministic across runs.
 
         Args:
-            kv_caches: KV cache structure accepted by
-                :func:`normalize_kv_and_discover_format`.
+            kv_caches: KV cache structure (see
+                :func:`normalize_kv_and_discover_format`).
             gpu_kv_format: Format returned by
                 :func:`normalize_kv_and_discover_format`.
             num_blocks: Number of paged blocks. Stamped into every
-                ``shape_desc.nb``. Each group's ``shape_desc.bs`` is
-                discovered per-layer via :func:`get_block_size`, so
-                compressed and non-compressed groups can coexist.
+                ``shape_desc.nb``. ``shape_desc.bs`` is discovered per-layer
+                so compressed and non-compressed groups can coexist.
             layout_hints: Engine-provided hints. The manager reads:
 
-                * ``inference_engine_logical_block_size`` (single
-                  global value, used as the *fallback* per-layer
-                  logical block size when the per-layer hint is
-                  absent and as the legacy single-source-of-truth
-                  for non-hybrid engines).
-                * ``per_layer_logical_block_size`` (optional list of
-                  length ``num_layers``). When present, each
-                  layer's scheduler-side block size is used to key
-                  layer grouping (so layers with same physical
-                  shape but different scheduler grids end up in
-                  separate groups) and to derive that group's
-                  ``compress_ratio = logical_bs_g // physical_bs_g``.
-                  Required when the engine has KV layer groups with
-                  mixed scheduler block sizes (vLLM hybrid manager
-                  active on DeepSeek-V4).
-                * ``per_layer_kv_cache_group_id`` (optional list of
-                  length ``num_layers``). When present, each layer's
-                  engine-side block-ID *namespace* handle joins the
-                  identity tuple, so layers whose ``KVCacheSpec``
-                  field values fully match but pull block IDs from
-                  disjoint engine-side namespaces (e.g.
-                  DeepSeek-V4's vLLM gids 1 and 2: even+MTP vs odd
-                  SWA layers) end up in different LMCache groups.
-                * ``per_layer_sliding_window`` (optional list of
-                  length ``num_layers``). When present, each layer's
-                  SWA window size joins the identity tuple, so
-                  layers with different windows end up in different
-                  LMCache groups. Non-zero entries activate the
+                * ``inference_engine_logical_block_size`` — global fallback
+                  used when the per-layer hint is absent.
+                * ``per_layer_logical_block_size`` — list of length
+                  ``num_layers``. Required when the engine emits mixed
+                  scheduler block sizes (vLLM hybrid manager on V4).
+                * ``per_layer_kv_cache_group_id`` — list of length
+                  ``num_layers``. Splits layers that share spec but pull
+                  block IDs from disjoint namespaces (V4 gids 1 and 2).
+                * ``per_layer_sliding_window`` — list of length
+                  ``num_layers``. Non-zero entries activate the
                   SWA-suffix-only optimization for that group.
 
-                ``None`` (or a hints dict without any of the above)
-                means every group is treated as non-compressed
-                (``compress_ratio == 1``, ``logical_block_size ==
-                shape_desc.bs``, ``kv_cache_group_id == 0``,
-                ``sliding_window == 0``).
+                Absent hints collapse the identity to the legacy 5-tuple:
+                ``compress_ratio=1``, ``logical_block_size=shape_desc.bs``,
+                ``kv_cache_group_id=0``, ``sliding_window=0``.
             lmcache_logical_chunk_size: Logical tokens per LMCache chunk
                 (one logical token = one inference-engine token).
                 Together with ``compress_ratio`` it determines each
@@ -377,12 +234,9 @@ class KVLayerGroupsManager:
             resolve_block_stride_and_log_layout,
         )
 
-        # Pull the inference-engine logical block size out of
-        # ``layout_hints`` once; ``None`` means no compression info
-        # available and every group is treated as non-compressed below.
-        # The attribute is finalised after the group-building loop
-        # below, where ``None`` is replaced by the first group's
-        # physical ``bs`` so the public ``int`` contract holds.
+        # Pull the global fallback hint. ``None`` is replaced by the first
+        # group's physical ``bs`` after the grouping loop so the public
+        # ``int`` contract holds.
         self.inference_engine_logical_block_size_: "int | None" = (
             layout_hints.get("inference_engine_logical_block_size")
             if layout_hints
@@ -395,19 +249,11 @@ class KVLayerGroupsManager:
             logger.debug("No KV caches available, skipping KV layer groups building")
             return
 
-        # Enforce the single-format-per-engine invariant at registration
-        # time. See :func:`_validate_uniform_layer_format` for the
-        # rationale and the failure mode this prevents.
         _validate_uniform_layer_format(kv_caches)
 
-        # Resolve the per-layer logical block size hint, if present.
-        # When absent, every layer's logical block size will default to
-        # its physical ``bs`` (effectively reproducing the prior
-        # 5-tuple grouping behavior on engines that don't supply the
-        # hint). When present, the per-layer values participate in
-        # :data:`LayerGroupIdentity` so layers with same physical
-        # shape but different scheduler grids land in distinct LMCache
-        # groups (DeepSeek-V4 hybrid manager active).
+        # Resolve per-layer hints. Absent hints leave the fields at None
+        # and the grouping loop falls back to the legacy 5-tuple identity
+        # (one group per physical shape, namespace 0, full attention).
         per_layer_logical_bs: "list[int] | None" = None
         per_layer_namespace: "list[int] | None" = None
         per_layer_sliding_window: "list[int] | None" = None
@@ -481,8 +327,8 @@ class KVLayerGroupsManager:
             per_layer_sliding_window,
         )
 
-        # Emit groups in order of their first-appearing layer so that group
-        # indices remain deterministic across runs.
+        # Emit groups in order of first-appearing layer for deterministic
+        # group indices across runs.
         for group_idx, (
             (
                 _,
@@ -550,43 +396,17 @@ class KVLayerGroupsManager:
     ) -> tuple[int, int]:
         """Resolve ``(compress_ratio, physical_chunk_size)`` for one group.
 
-        ``compress_ratio`` is per-group:
-        ``compress_ratio_g = logical_block_size // bs``. Each layer
-        group has its own ``logical_block_size`` (carried by the
-        identity tuple); when ``per_layer_logical_block_size`` is not
-        provided the manager defaults each group's
-        ``logical_block_size`` to its physical ``bs``, so
-        ``compress_ratio == 1`` and the per-group formula is identical
-        to the prior global formula.
+        ``compress_ratio = logical_block_size // bs`` per group. When the
+        engine provides neither the per-layer nor global hint (typically
+        a non-vLLM engine or a tool/test setup), this falls back to
+        ``compress_ratio = 1`` even if ``logical_block_size > bs``, to
+        preserve the legacy non-compressed default.
 
-        ``ie_logical_block_size`` is consulted only when its presence
-        differs from the per-layer hint's: if the engine provides
-        neither the per-layer hint nor a global value (i.e. a
-        non-vLLM engine), ``compress_ratio`` falls back to 1 even
-        when ``logical_block_size > bs`` — preserving the old
-        non-compressed default for tools and tests that don't
-        provide hints.
-
-        ``physical_chunk_size`` is then
-        ``lmcache_logical_chunk_size // compress_ratio``, the per-chunk
-        physical slot count fed to the block-level transfer kernel.
-
-        Args:
-            group_idx: Group index (used in error messages and logs).
-            bs: This group's physical block size (``shape_desc.bs``).
-            logical_block_size: This group's logical (scheduler-side)
-                block size.
-            ie_logical_block_size: Optional global hint — if both this
-                and the per-layer hint are absent, the group falls
-                back to ``compress_ratio == 1``.
-            lmcache_logical_chunk_size: Logical tokens per LMCache
-                chunk (one logical token = one engine token).
-
-        Returns:
-            ``(compress_ratio, physical_chunk_size)`` tuple.
+        ``physical_chunk_size = lmcache_logical_chunk_size // compress_ratio``
+        is the per-chunk physical slot count fed to the transfer kernel.
 
         Raises:
-            ValueError: If ``logical_block_size`` is not a multiple of
+            ValueError: if ``logical_block_size`` is not a multiple of
                 ``bs``, or if ``lmcache_logical_chunk_size`` is not a
                 multiple of the resulting ``compress_ratio``.
         """
@@ -634,21 +454,12 @@ class KVLayerGroupsManager:
     ) -> dict[LayerGroupIdentity, list[int]]:
         """Partition layer indices by :data:`LayerGroupIdentity`.
 
-        Linear single pass over ``kv_caches``; layers sharing the same
-        ``(kv_size, num_heads, head_size, block_size,
-        logical_block_size, kv_cache_group_id, sliding_window, dtype)``
-        signature land in the same bucket. When ``per_layer_logical_bs``
-        is None, each layer's ``logical_block_size`` defaults to its
-        physical block size; when ``per_layer_namespace`` is None,
-        each layer's namespace defaults to 0; when
-        ``per_layer_sliding_window`` is None, every layer is treated
-        as ``sliding_window = 0`` (full attention). With all three
-        defaults, the 8-tuple is effectively a 5-tuple (preserving
-        prior grouping behavior on engines without these hints). The
-        returned dict's value lists are later passed by reference into
-        :class:`KVLayerGroupInfo` instances, so the dict itself is
-        garbage-collected after ``__init__`` returns while the lists
-        stay alive on each group.
+        Single pass over ``kv_caches``. Hints default safely: absent
+        ``per_layer_logical_bs`` falls back to physical ``bs``, absent
+        ``per_layer_namespace`` to 0, absent ``per_layer_sliding_window``
+        to 0 (full attention) — all three defaults collapse the 8-tuple
+        to the legacy 5-tuple. The returned dict's value lists are passed
+        by reference into ``KVLayerGroupInfo`` instances.
         """
         # First Party
         from lmcache.v1.gpu_connector.utils import (

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -216,6 +216,63 @@ class KVLayerGroupInfo:
         return self.shape_desc.nh * self.shape_desc.hs
 
 
+def _validate_uniform_layer_format(kv_caches: "DiscoverableKVCache") -> None:
+    """Verify every layer tensor in ``kv_caches`` shares the same ``.dim()``.
+
+    LMCache currently assumes a single :class:`~lmcache.c_ops.GPUKVFormat`
+    per engine: :func:`normalize_kv_and_discover_format` inspects the
+    first tensor it can find and returns one format,
+    :data:`LayerGroupIdentity` does not include the format, and the
+    transfer-kernel call sites read a single ``gpu_kv_format_`` from the
+    GPU context. If the engine ever hands LMCache layers with divergent
+    formats, the kernel would silently use the first layer's format for
+    every layer and produce a corrupt KV cache at retrieve time.
+
+    This helper enforces the assumption at registration time. It walks
+    every leaf tensor in ``kv_caches`` and checks that the dim count
+    matches the first tensor's. Distinct formats with the same dim count
+    (e.g. axis-permuted variants) are not detected here — distinguishing
+    them would require duplicating the format-detection logic from
+    :func:`normalize_kv_and_discover_format` per leaf, which is not
+    warranted while no such mixed-format engine exists. The realistic
+    mixed case today is MLA (no TWO axis) versus MHA (TWO axis), which
+    differ in dim count and so are caught.
+
+    Args:
+        kv_caches: KV cache structure (single tensor or arbitrarily
+            nested list of tensors). Empty structures are accepted
+            silently — the early-return in
+            :meth:`KVLayerGroupsManager.__init__` already handles the
+            zero-layer case.
+
+    Raises:
+        ValueError: If two leaf tensors disagree on ``.dim()``. The
+            message names the first divergent layer index and both dim
+            counts.
+    """
+    leaf_dims: list[int] = []
+
+    def _walk(node: "DiscoverableKVCache") -> None:
+        if isinstance(node, torch.Tensor):
+            leaf_dims.append(node.dim())
+            return
+        for sub in node:
+            _walk(sub)
+
+    _walk(kv_caches)
+    if len(leaf_dims) <= 1:
+        return
+    first = leaf_dims[0]
+    for i, d in enumerate(leaf_dims[1:], start=1):
+        if d != first:
+            raise ValueError(
+                f"All layer tensors must share the same gpu_kv_format; "
+                f"layer 0 has tensor dim {first} but layer {i} has dim "
+                f"{d}. Mixed-format engines are not currently supported "
+                f"by LMCache."
+            )
+
+
 class KVLayerGroupsManager:
     """Partition a model's KV layers into transfer-kernel dispatch units.
 
@@ -337,6 +394,11 @@ class KVLayerGroupsManager:
         if num_layers == 0:
             logger.debug("No KV caches available, skipping KV layer groups building")
             return
+
+        # Enforce the single-format-per-engine invariant at registration
+        # time. See :func:`_validate_uniform_layer_format` for the
+        # rationale and the failure mode this prevents.
+        _validate_uniform_layer_format(kv_caches)
 
         # Resolve the per-layer logical block size hint, if present.
         # When absent, every layer's logical block size will default to

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -35,11 +35,28 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 }
 
 
-# The 4-tuple that uniquely identifies a set of kernel-equivalent layers:
-# ``(kv_size, num_heads, head_size, block_size, dtype)``. Two layers share a transfer-
-# kernel launch iff they share this identity — see the grouping loop in
+# The 5-tuple that uniquely identifies a set of kernel-equivalent layers:
+# ``(kv_size, num_heads, head_size, block_size, logical_block_size,
+# dtype)``. Two layers share a transfer-kernel launch iff they share
+# this identity — see the grouping loop in
 # :meth:`KVLayerGroupsManager.__init__` for the derivation.
-LayerGroupIdentity = tuple[int, int, int, int, torch.dtype]
+#
+# The fifth slot (``logical_block_size``) is the *scheduler-side*
+# block size — i.e. the granularity at which the serving engine hands
+# out block IDs for this layer. It comes from
+# :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_logical_block_size`
+# when the engine supplies it, otherwise it defaults to the physical
+# block size (``bs``). On DeepSeek-V4 with vLLM's *hybrid manager
+# active*, several physical-equivalent layer sets receive block IDs at
+# different scheduler grids (e.g. dense-MLA layers use a 256-token
+# grid while the SWA layers use a 64-token grid). Two layers with the
+# same physical layout but different scheduler grids are
+# kernel-incompatible — one ``LoadStoreOp`` cannot index both — so the
+# logical block size must participate in the identity tuple. When the
+# hint is absent, every layer's logical block size defaults to its
+# physical ``bs`` and the 6-tuple collapses to the prior 5-tuple
+# behavior.
+LayerGroupIdentity = tuple[int, int, int, int, int, torch.dtype]
 
 
 @dataclass
@@ -73,7 +90,11 @@ class KVLayerGroupInfo:
     shape_desc: "lmc_ops.PageBufferShapeDesc"
     """Kernel-facing shape descriptor shared by every layer in the group.
     All eight fields (``kv_size, nl, nb, bs, nh, hs, element_size,
-    block_stride_elems``) are stamped once at construction."""
+    block_stride_elems``) are stamped once at construction. Note that
+    ``shape_desc.bs`` carries the **physical** block size (the on-GPU
+    tensor's per-block slot count); the *logical* (scheduler) block
+    size lives on :attr:`logical_block_size` and is used by chunking
+    arithmetic, which runs upstream of the kernel."""
     dtype: torch.dtype
     """Torch dtype of the KV cache tensors for this group. Used for
     kernel template instantiation; see class docstring for why we keep
@@ -83,9 +104,10 @@ class KVLayerGroupInfo:
     non-compressed groups (one logical token per physical slot);
     greater than ``1`` for compressed groups where each physical slot
     packs ``compress_ratio`` logical tokens (e.g. DeepSeek V4
-    compressor / indexer caches). Derived from
-    ``inference_engine_logical_block_size`` carried in ``layout_hints``
-    at :class:`KVLayerGroupsManager` construction time."""
+    compressor / indexer caches). Derived from this group's
+    :attr:`logical_block_size` and ``shape_desc.bs`` at
+    :class:`KVLayerGroupsManager` construction time:
+    ``compress_ratio = logical_block_size // shape_desc.bs``."""
     physical_chunk_size: int = 0
     """Number of *physical* slots in one LMCache chunk for this group
     (= ``lmcache_logical_chunk_size // compress_ratio``). This is what
@@ -94,6 +116,21 @@ class KVLayerGroupInfo:
     means the field has not been populated yet; ``GPUCacheContext``
     fills it in after construction once ``lmcache_logical_chunk_size``
     is known."""
+    logical_block_size: int = 0
+    """Scheduler-side tokens-per-block for this group, i.e. the
+    granularity at which the serving engine hands out block IDs for
+    these layers. Equals ``shape_desc.bs`` (physical) when the engine
+    does not provide a per-layer hint via
+    :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_logical_block_size`,
+    so existing single-group call sites are unaffected. When the hint
+    is present, this field carries the engine's per-layer
+    ``KVCacheSpec.block_size`` for the represented layer — which is
+    what chunking math (``blocks_per_chunk_g = lmcache_chunk_size //
+    logical_block_size``) must use, and what the connector's
+    ``LoadStoreOp.block_ids`` are stride-compatible with. ``0``
+    indicates the field has not been populated yet (left in for
+    backwards compatibility with no-arg constructors); the manager
+    always sets a positive value at construction."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -110,7 +147,8 @@ class KVLayerGroupInfo:
             f"block_stride_elems={sd.block_stride_elems}), "
             f"dtype={self.dtype}, "
             f"compress_ratio={self.compress_ratio}, "
-            f"physical_chunk_size={self.physical_chunk_size})"
+            f"physical_chunk_size={self.physical_chunk_size}, "
+            f"logical_bs={self.logical_block_size})"
         )
 
     @property
@@ -129,9 +167,9 @@ class KVLayerGroupsManager:
 
     At construction time, every layer in ``kv_caches`` is bucketed by its
     :data:`LayerGroupIdentity` (``(kv_size, num_heads, head_size,
-    dtype)``). Each bucket becomes one :class:`KVLayerGroupInfo` holding
-    the layer indices, a shared :class:`PageBufferShapeDesc`, and the
-    group's torch dtype.
+    block_size, logical_block_size, dtype)``). Each bucket becomes one
+    :class:`KVLayerGroupInfo` holding the layer indices, a shared
+    :class:`PageBufferShapeDesc`, and the group's torch dtype.
 
     Downstream consumers (``VLLMPagedMemGPUConnectorV3``,
     ``GPUCacheContext``, the multiprocess server) iterate
@@ -173,14 +211,28 @@ class KVLayerGroupsManager:
                 ``shape_desc.nb``. Each group's ``shape_desc.bs`` is
                 discovered per-layer via :func:`get_block_size`, so
                 compressed and non-compressed groups can coexist.
-            layout_hints: Engine-provided hints. The manager only reads
-                ``inference_engine_logical_block_size`` (logical tokens
-                per inference-engine block) from it to derive each
-                group's ``compress_ratio`` and ``physical_chunk_size``.
-                ``None`` (or a hints dict without that key — e.g.
-                non-vLLM engines, or vLLM deployments with no mixed
-                compression) means every group is treated as
-                non-compressed (``compress_ratio == 1``).
+            layout_hints: Engine-provided hints. The manager reads:
+
+                * ``inference_engine_logical_block_size`` (single
+                  global value, used as the *fallback* per-layer
+                  logical block size when the per-layer hint is
+                  absent and as the legacy single-source-of-truth
+                  for non-hybrid engines).
+                * ``per_layer_logical_block_size`` (optional list of
+                  length ``num_layers``). When present, each
+                  layer's scheduler-side block size is used to key
+                  layer grouping (so layers with same physical
+                  shape but different scheduler grids end up in
+                  separate groups) and to derive that group's
+                  ``compress_ratio = logical_bs_g // physical_bs_g``.
+                  Required when the engine has KV layer groups with
+                  mixed scheduler block sizes (vLLM hybrid manager
+                  active on DeepSeek-V4).
+
+                ``None`` (or a hints dict without either key) means
+                every group is treated as non-compressed
+                (``compress_ratio == 1``, ``logical_block_size ==
+                shape_desc.bs``).
             lmcache_logical_chunk_size: Logical tokens per LMCache chunk
                 (one logical token = one inference-engine token).
                 Together with ``compress_ratio`` it determines each
@@ -216,15 +268,47 @@ class KVLayerGroupsManager:
             logger.debug("No KV caches available, skipping KV layer groups building")
             return
 
+        # Resolve the per-layer logical block size hint, if present.
+        # When absent, every layer's logical block size will default to
+        # its physical ``bs`` (effectively reproducing the prior
+        # 5-tuple grouping behavior on engines that don't supply the
+        # hint). When present, the per-layer values participate in
+        # :data:`LayerGroupIdentity` so layers with same physical
+        # shape but different scheduler grids land in distinct LMCache
+        # groups (DeepSeek-V4 hybrid manager active).
+        per_layer_logical_bs: "list[int] | None" = None
+        if layout_hints is not None:
+            logical_hint = layout_hints.get("per_layer_logical_block_size")
+            if logical_hint is not None:
+                if len(logical_hint) != num_layers:
+                    raise ValueError(
+                        "per_layer_logical_block_size length "
+                        f"({len(logical_hint)}) does not match "
+                        f"num_layers ({num_layers}); each registered "
+                        "layer must have exactly one logical block "
+                        "size entry"
+                    )
+                bad = [i for i, bs in enumerate(logical_hint) if bs <= 0]
+                if bad:
+                    raise ValueError(
+                        "per_layer_logical_block_size has invalid "
+                        f"(non-positive) entries at positions {bad[:8]}"
+                        + ("..." if len(bad) > 8 else "")
+                        + "; every registered layer must be covered by "
+                        "exactly one engine-side block size"
+                    )
+                per_layer_logical_bs = list(logical_hint)
+
         groups_dict = self._group_layers_by_identity(
-            kv_caches, gpu_kv_format, num_layers
+            kv_caches, gpu_kv_format, num_layers, per_layer_logical_bs
         )
 
         # Emit groups in order of their first-appearing layer so that group
         # indices remain deterministic across runs.
-        for group_idx, ((_, _, _, bs, dt), indices) in enumerate(
-            sorted(groups_dict.items(), key=lambda kv: kv[1][0])
-        ):
+        for group_idx, (
+            (_, _, _, bs, group_logical_bs, dt),
+            indices,
+        ) in enumerate(sorted(groups_dict.items(), key=lambda kv: kv[1][0])):
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,
                 gpu_kv_format,
@@ -244,6 +328,7 @@ class KVLayerGroupsManager:
             compress_ratio, physical_chunk_size = self._derive_compression_metadata(
                 group_idx=group_idx,
                 bs=bs,
+                logical_block_size=group_logical_bs,
                 ie_logical_block_size=self.inference_engine_logical_block_size_,
                 lmcache_logical_chunk_size=lmcache_logical_chunk_size,
             )
@@ -255,6 +340,7 @@ class KVLayerGroupsManager:
                     dtype=dt,
                     compress_ratio=compress_ratio,
                     physical_chunk_size=physical_chunk_size,
+                    logical_block_size=group_logical_bs,
                 )
             )
 
@@ -269,29 +355,65 @@ class KVLayerGroupsManager:
     def _derive_compression_metadata(
         group_idx: int,
         bs: int,
+        logical_block_size: int,
         ie_logical_block_size: "int | None",
         lmcache_logical_chunk_size: int,
     ) -> tuple[int, int]:
         """Resolve ``(compress_ratio, physical_chunk_size)`` for one group.
 
-        ``compress_ratio`` falls back to ``1`` when
-        ``ie_logical_block_size`` is absent (no compression info
-        available); otherwise it equals
-        ``ie_logical_block_size // bs`` and the divisibility invariants
-        are enforced loudly. ``physical_chunk_size`` is then
+        ``compress_ratio`` is per-group:
+        ``compress_ratio_g = logical_block_size // bs``. Each layer
+        group has its own ``logical_block_size`` (carried by the
+        identity tuple); when ``per_layer_logical_block_size`` is not
+        provided the manager defaults each group's
+        ``logical_block_size`` to its physical ``bs``, so
+        ``compress_ratio == 1`` and the per-group formula is identical
+        to the prior global formula.
+
+        ``ie_logical_block_size`` is consulted only when its presence
+        differs from the per-layer hint's: if the engine provides
+        neither the per-layer hint nor a global value (i.e. a
+        non-vLLM engine), ``compress_ratio`` falls back to 1 even
+        when ``logical_block_size > bs`` — preserving the old
+        non-compressed default for tools and tests that don't
+        provide hints.
+
+        ``physical_chunk_size`` is then
         ``lmcache_logical_chunk_size // compress_ratio``, the per-chunk
         physical slot count fed to the block-level transfer kernel.
+
+        Args:
+            group_idx: Group index (used in error messages and logs).
+            bs: This group's physical block size (``shape_desc.bs``).
+            logical_block_size: This group's logical (scheduler-side)
+                block size.
+            ie_logical_block_size: Optional global hint — if both this
+                and the per-layer hint are absent, the group falls
+                back to ``compress_ratio == 1``.
+            lmcache_logical_chunk_size: Logical tokens per LMCache
+                chunk (one logical token = one engine token).
+
+        Returns:
+            ``(compress_ratio, physical_chunk_size)`` tuple.
+
+        Raises:
+            ValueError: If ``logical_block_size`` is not a multiple of
+                ``bs``, or if ``lmcache_logical_chunk_size`` is not a
+                multiple of the resulting ``compress_ratio``.
         """
-        if ie_logical_block_size is None:
+        if ie_logical_block_size is None and logical_block_size == bs:
+            # Neither the global nor the per-layer hint was supplied
+            # for this group's layers (per-layer defaults to physical
+            # bs when no hint is provided): treat as non-compressed.
             compress_ratio = 1
         else:
-            if ie_logical_block_size % bs != 0:
+            if logical_block_size % bs != 0:
                 raise ValueError(
-                    f"inference engine logical block size "
-                    f"{ie_logical_block_size} must be a multiple of "
-                    f"group {group_idx} physical slot count {bs}"
+                    f"group {group_idx}: logical block size "
+                    f"{logical_block_size} must be a multiple of "
+                    f"physical slot count {bs}"
                 )
-            compress_ratio = ie_logical_block_size // bs
+            compress_ratio = logical_block_size // bs
         if lmcache_logical_chunk_size % compress_ratio != 0:
             raise ValueError(
                 f"lmcache_logical_chunk_size {lmcache_logical_chunk_size} "
@@ -302,10 +424,10 @@ class KVLayerGroupsManager:
         if compress_ratio != 1:
             logger.info(
                 "group %d: compressed "
-                "(inference_engine_logical_block_size=%d -> "
-                "slots=%d, compress_ratio=%d, physical_chunk_size=%d)",
+                "(logical_block_size=%d -> physical_bs=%d, "
+                "compress_ratio=%d, physical_chunk_size=%d)",
                 group_idx,
-                ie_logical_block_size,
+                logical_block_size,
                 bs,
                 compress_ratio,
                 physical_chunk_size,
@@ -317,15 +439,21 @@ class KVLayerGroupsManager:
         kv_caches: "DiscoverableKVCache",
         gpu_kv_format: "lmc_ops.GPUKVFormat",
         num_layers: int,
+        per_layer_logical_bs: "list[int] | None" = None,
     ) -> dict[LayerGroupIdentity, list[int]]:
         """Partition layer indices by :data:`LayerGroupIdentity`.
 
         Linear single pass over ``kv_caches``; layers sharing the same
-        ``(kv_size, num_heads, head_size, block_size, dtype)`` signature
-        land in the same bucket. The returned dict's value lists are
-        later passed by reference into :class:`KVLayerGroupInfo`
-        instances, so the dict itself is garbage-collected after
-        ``__init__`` returns while the lists stay alive on each group.
+        ``(kv_size, num_heads, head_size, block_size,
+        logical_block_size, dtype)`` signature land in the same bucket.
+        When ``per_layer_logical_bs`` is None, each layer's
+        ``logical_block_size`` defaults to its physical block size,
+        making the 6-tuple effectively a 5-tuple (preserving prior
+        grouping behavior on engines without the hint). The returned
+        dict's value lists are later passed by reference into
+        :class:`KVLayerGroupInfo` instances, so the dict itself is
+        garbage-collected after ``__init__`` returns while the lists
+        stay alive on each group.
         """
         # First Party
         from lmcache.v1.gpu_connector.utils import (
@@ -344,7 +472,12 @@ class KVLayerGroupsManager:
             hs = get_head_size(kv_caches, gpu_kv_format, idx)
             dt = get_dtype(kv_caches, gpu_kv_format, idx)
             bs = get_block_size(kv_caches, gpu_kv_format, idx)
-            groups_dict[(kv_size, nh, hs, bs, dt)].append(idx)
+            logical_bs = (
+                per_layer_logical_bs[idx]
+                if per_layer_logical_bs is not None
+                else bs
+            )
+            groups_dict[(kv_size, nh, hs, bs, logical_bs, dt)].append(idx)
         return groups_dict
 
     @property
@@ -518,6 +651,7 @@ def parse_kvcache_shape_spec(
                 layer_indices=indices,
                 shape_desc=shape_desc,
                 dtype=dtype,
+                logical_block_size=bs,
             )
         )
         layer_offset += layer_count

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -35,11 +35,12 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 }
 
 
-# The 7-tuple that uniquely identifies a set of kernel-equivalent layers:
+# The 8-tuple that uniquely identifies a set of kernel-equivalent layers:
 # ``(kv_size, num_heads, head_size, block_size, logical_block_size,
-# kv_cache_group_id, dtype)``. Two layers share a transfer-kernel
-# launch iff they share this identity — see the grouping loop in
-# :meth:`KVLayerGroupsManager.__init__` for the derivation.
+# kv_cache_group_id, sliding_window, dtype)``. Two layers share a
+# transfer-kernel launch iff they share this identity — see the
+# grouping loop in :meth:`KVLayerGroupsManager.__init__` for the
+# derivation.
 #
 # The fifth slot (``logical_block_size``) is the *scheduler-side*
 # block size — i.e. the granularity at which the serving engine hands
@@ -69,10 +70,21 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 # Without this slot they merge into one LMCache group and a STORE op
 # carrying gid 1's block IDs would silently mis-index gid 2's layers.
 #
-# When neither hint is provided, every layer's logical block size
-# defaults to its physical ``bs`` and every layer's namespace defaults
-# to 0, so the 7-tuple collapses to the prior 5-tuple grouping.
-LayerGroupIdentity = tuple[int, int, int, int, int, int, torch.dtype]
+# The seventh slot (``sliding_window``) is the SWA window size in
+# tokens, or 0 for full-attention layers. It comes from
+# :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_sliding_window`.
+# When non-zero, the SWA-suffix-only optimization kicks in for that
+# group (store/retrieve the last ``ceil(window/logical_bs)`` blocks
+# per chunk instead of all). Layers with different windows have
+# different per-chunk byte budgets and so cannot share a transfer
+# group. When absent, every layer is treated as ``sliding_window = 0``
+# and the 8-tuple collapses to the prior 7-tuple identity.
+#
+# When neither hint set is provided, every layer's logical block size
+# defaults to its physical ``bs``, every layer's namespace defaults to
+# 0, and every layer's sliding_window defaults to 0, so the 8-tuple
+# collapses to the prior 5-tuple grouping (kv_size, nh, hs, bs, dtype).
+LayerGroupIdentity = tuple[int, int, int, int, int, int, int, torch.dtype]
 
 
 @dataclass
@@ -159,6 +171,18 @@ class KVLayerGroupInfo:
     Defaults to 0 when the engine does not provide the hint, in which
     case all layers share namespace 0 and grouping behaves identically
     to the prior 6-tuple identity."""
+    sliding_window: int = 0
+    """Sliding-window attention window size in tokens, or ``0`` for
+    full-attention groups. When non-zero, the SWA-suffix-only
+    optimization activates for this group: store/retrieve only the
+    last ``ceil(sliding_window / logical_block_size)`` blocks per
+    chunk instead of all ``lmcache_chunk_size // logical_block_size``
+    blocks. Stamped from
+    :data:`~lmcache.v1.gpu_connector.utils.LayoutHints.per_layer_sliding_window`
+    at registration. Two groups with different ``sliding_window``
+    values cannot share a transfer-kernel launch (their per-chunk
+    byte budgets differ); the field is the 7th component of
+    :data:`LayerGroupIdentity`."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -177,7 +201,8 @@ class KVLayerGroupInfo:
             f"compress_ratio={self.compress_ratio}, "
             f"physical_chunk_size={self.physical_chunk_size}, "
             f"logical_bs={self.logical_block_size}, "
-            f"kv_cache_group_id={self.kv_cache_group_id})"
+            f"kv_cache_group_id={self.kv_cache_group_id}, "
+            f"sliding_window={self.sliding_window})"
         )
 
     @property
@@ -196,10 +221,10 @@ class KVLayerGroupsManager:
 
     At construction time, every layer in ``kv_caches`` is bucketed by its
     :data:`LayerGroupIdentity` (``(kv_size, num_heads, head_size,
-    block_size, logical_block_size, kv_cache_group_id, dtype)``). Each
-    bucket becomes one :class:`KVLayerGroupInfo` holding the layer
-    indices, a shared :class:`PageBufferShapeDesc`, and the group's
-    torch dtype.
+    block_size, logical_block_size, kv_cache_group_id, sliding_window,
+    dtype)``). Each bucket becomes one :class:`KVLayerGroupInfo`
+    holding the layer indices, a shared :class:`PageBufferShapeDesc`,
+    and the group's torch dtype.
 
     Downstream consumers (``VLLMPagedMemGPUConnectorV3``,
     ``GPUCacheContext``, the multiprocess server) iterate
@@ -266,11 +291,18 @@ class KVLayerGroupsManager:
                   disjoint engine-side namespaces (e.g.
                   DeepSeek-V4's vLLM gids 1 and 2: even+MTP vs odd
                   SWA layers) end up in different LMCache groups.
+                * ``per_layer_sliding_window`` (optional list of
+                  length ``num_layers``). When present, each layer's
+                  SWA window size joins the identity tuple, so
+                  layers with different windows end up in different
+                  LMCache groups. Non-zero entries activate the
+                  SWA-suffix-only optimization for that group.
 
                 ``None`` (or a hints dict without any of the above)
                 means every group is treated as non-compressed
                 (``compress_ratio == 1``, ``logical_block_size ==
-                shape_desc.bs``, ``kv_cache_group_id == 0``).
+                shape_desc.bs``, ``kv_cache_group_id == 0``,
+                ``sliding_window == 0``).
             lmcache_logical_chunk_size: Logical tokens per LMCache chunk
                 (one logical token = one inference-engine token).
                 Together with ``compress_ratio`` it determines each
@@ -316,6 +348,7 @@ class KVLayerGroupsManager:
         # groups (DeepSeek-V4 hybrid manager active).
         per_layer_logical_bs: "list[int] | None" = None
         per_layer_namespace: "list[int] | None" = None
+        per_layer_sliding_window: "list[int] | None" = None
         if layout_hints is not None:
             logical_hint = layout_hints.get("per_layer_logical_block_size")
             if logical_hint is not None:
@@ -357,18 +390,48 @@ class KVLayerGroupsManager:
                     )
                 per_layer_namespace = list(ns_hint)
 
+            sw_hint = layout_hints.get("per_layer_sliding_window")
+            if sw_hint is not None:
+                if len(sw_hint) != num_layers:
+                    raise ValueError(
+                        "per_layer_sliding_window length "
+                        f"({len(sw_hint)}) does not match num_layers "
+                        f"({num_layers}); each registered layer must "
+                        "have exactly one sliding-window entry"
+                    )
+                bad = [i for i, sw in enumerate(sw_hint) if sw < 0]
+                if bad:
+                    raise ValueError(
+                        "per_layer_sliding_window has invalid "
+                        f"(negative) entries at positions {bad[:8]}"
+                        + ("..." if len(bad) > 8 else "")
+                        + "; sliding windows must be non-negative "
+                        "(0 = full attention)"
+                    )
+                per_layer_sliding_window = list(sw_hint)
+
         groups_dict = self._group_layers_by_identity(
             kv_caches,
             gpu_kv_format,
             num_layers,
             per_layer_logical_bs,
             per_layer_namespace,
+            per_layer_sliding_window,
         )
 
         # Emit groups in order of their first-appearing layer so that group
         # indices remain deterministic across runs.
         for group_idx, (
-            (_, _, _, bs, group_logical_bs, group_namespace, dt),
+            (
+                _,
+                _,
+                _,
+                bs,
+                group_logical_bs,
+                group_namespace,
+                group_sliding_window,
+                dt,
+            ),
             indices,
         ) in enumerate(sorted(groups_dict.items(), key=lambda kv: kv[1][0])):
             block_stride_elems = resolve_block_stride_and_log_layout(
@@ -404,6 +467,7 @@ class KVLayerGroupsManager:
                     physical_chunk_size=physical_chunk_size,
                     logical_block_size=group_logical_bs,
                     kv_cache_group_id=group_namespace,
+                    sliding_window=group_sliding_window,
                 )
             )
 
@@ -504,21 +568,25 @@ class KVLayerGroupsManager:
         num_layers: int,
         per_layer_logical_bs: "list[int] | None" = None,
         per_layer_namespace: "list[int] | None" = None,
+        per_layer_sliding_window: "list[int] | None" = None,
     ) -> dict[LayerGroupIdentity, list[int]]:
         """Partition layer indices by :data:`LayerGroupIdentity`.
 
         Linear single pass over ``kv_caches``; layers sharing the same
         ``(kv_size, num_heads, head_size, block_size,
-        logical_block_size, kv_cache_group_id, dtype)`` signature land
-        in the same bucket. When ``per_layer_logical_bs`` is None, each
-        layer's ``logical_block_size`` defaults to its physical block
-        size; when ``per_layer_namespace`` is None, each layer's
-        namespace defaults to 0. With both defaults, the 7-tuple is
-        effectively a 5-tuple (preserving prior grouping behavior on
-        engines without these hints). The returned dict's value lists
-        are later passed by reference into :class:`KVLayerGroupInfo`
-        instances, so the dict itself is garbage-collected after
-        ``__init__`` returns while the lists stay alive on each group.
+        logical_block_size, kv_cache_group_id, sliding_window, dtype)``
+        signature land in the same bucket. When ``per_layer_logical_bs``
+        is None, each layer's ``logical_block_size`` defaults to its
+        physical block size; when ``per_layer_namespace`` is None,
+        each layer's namespace defaults to 0; when
+        ``per_layer_sliding_window`` is None, every layer is treated
+        as ``sliding_window = 0`` (full attention). With all three
+        defaults, the 8-tuple is effectively a 5-tuple (preserving
+        prior grouping behavior on engines without these hints). The
+        returned dict's value lists are later passed by reference into
+        :class:`KVLayerGroupInfo` instances, so the dict itself is
+        garbage-collected after ``__init__`` returns while the lists
+        stay alive on each group.
         """
         # First Party
         from lmcache.v1.gpu_connector.utils import (
@@ -547,8 +615,13 @@ class KVLayerGroupsManager:
                 if per_layer_namespace is not None
                 else 0
             )
+            sliding_window = (
+                per_layer_sliding_window[idx]
+                if per_layer_sliding_window is not None
+                else 0
+            )
             groups_dict[
-                (kv_size, nh, hs, bs, logical_bs, namespace, dt)
+                (kv_size, nh, hs, bs, logical_bs, namespace, sliding_window, dt)
             ].append(idx)
         return groups_dict
 

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -37,22 +37,16 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 
 # 8-tuple identity for kernel-equivalent layers. Two layers share a
 # transfer-kernel launch iff their identities match. The first five fields
-# (``kv_size, num_heads, head_size, block_size, dtype``) are the legacy
-# kernel-shape signature. The other three came from the DeepSeek-V4
-# hybrid-KV-cache work and default to safe values that collapse the tuple
-# to the legacy 5-tuple when the engine doesn't supply hints:
+# are the legacy kernel-shape signature; the other three came from the
+# DeepSeek-V4 hybrid-KV-cache work and collapse to defaults when the engine
+# supplies no hints, recovering the legacy 5-tuple behavior:
 #
-# - ``logical_block_size`` — scheduler-side tokens per block. Defaults to
-#   physical ``bs``. Required when the engine hands different scheduler
-#   grids to physically-equivalent layers (V4 dense-MLA at 256 vs SWA at 64);
-#   one ``LoadStoreOp.block_ids`` cannot index two grids.
-# - ``kv_cache_group_id`` — engine-side block-ID namespace handle.
-#   Defaults to 0. Two layers in different namespaces cannot share a launch
-#   even when every other field matches (V4 vLLM gid 1 vs gid 2: same spec
-#   shape, disjoint ``BlockPool``-allocated IDs).
-# - ``sliding_window`` — SWA window size in tokens, ``0`` for full attention.
-#   Non-zero activates SWA-suffix-only stores/retrieves; layers with
-#   different windows have different per-chunk byte budgets.
+# - ``logical_block_size`` (default = physical ``bs``): scheduler-side
+#   tokens per block. ``LoadStoreOp.block_ids`` is keyed at this stride.
+# - ``kv_cache_group_id`` (default 0): engine-side block-ID namespace.
+#   Disjoint namespaces cannot share a launch (V4 vLLM gids 1 vs 2).
+# - ``sliding_window`` (default 0): SWA window in tokens; non-zero
+#   activates SWA-suffix-only stores/retrieves.
 LayerGroupIdentity = tuple[int, int, int, int, int, int, int, torch.dtype]
 
 

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -267,6 +267,47 @@ class GPUCacheContext:
         """
         return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
 
+    def blocks_per_chunk_full(self, group_idx: int) -> int:
+        """Returns the per-chunk count of inference-engine *logical* blocks
+        for the given group, computed against this group's
+        ``logical_block_size``: ``lmcache_logical_chunk_size //
+        logical_block_size_g``.
+
+        This is the count of block IDs the engine hands out for one
+        LMCache chunk's worth of logical tokens in this group's
+        scheduler namespace. Per-group rather than global because, with
+        vLLM's hybrid KV cache manager active, different
+        ``KVCacheGroupSpec``s use different scheduler block sizes (e.g.
+        DeepSeek-V4: gid 0 = 256, gid 1/2 = 64, gid 3 = 4, gid 4 = 8).
+
+        Args:
+            group_idx: 0-based group index.
+
+        Raises:
+            IndexError: If *group_idx* is out of range.
+            ValueError: If the per-group ``logical_block_size`` is
+                non-positive (programmer error from registration).
+        """
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        if group.logical_block_size <= 0:
+            raise ValueError(
+                f"group {group_idx} has invalid logical_block_size "
+                f"{group.logical_block_size}; expected a positive int "
+                "set at construction time"
+            )
+        return self.lmcache_logical_chunk_size // group.logical_block_size
+
+    def blocks_per_chunk(self, group_idx: int) -> int:
+        """Returns the per-chunk count of inference-engine *logical*
+        blocks the server will iterate when staging block IDs for this
+        group. Currently identical to :meth:`blocks_per_chunk_full`;
+        kept as a separate accessor so the SWA-suffix-only optimization
+        (Step 4 of the V4 hybrid-on migration) can return a smaller
+        truncated count for groups with ``sliding_window > 0`` without
+        renaming every call site.
+        """
+        return self.blocks_per_chunk_full(group_idx)
+
     @property
     def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
         """Returns the KV layer groups manager."""

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -139,12 +139,7 @@ class GPUCacheContext:
             # tokens into one physical slot internally. For SWA
             # groups the truncated logical-token count is
             # ``blocks_per_chunk(g) * logical_block_size``.
-            if group.sliding_window > 0:
-                logical_tokens_g = (
-                    self.blocks_per_chunk(group_idx) * group.logical_block_size
-                )
-            else:
-                logical_tokens_g = lmcache_logical_chunk_size
+            logical_tokens_g = self.storage_logical_tokens_per_chunk(group_idx)
             shape = self.get_kv_buffer_shape(logical_tokens_g, group_idx)
             byte_size = shape.numel() * group.dtype.itemsize
             self.tmp_chunk_group_offsets_.append(
@@ -399,19 +394,45 @@ class GPUCacheContext:
         start = chunk_idx * self.tmp_chunk_bytes_
         return self.tmp_gpu_buffer_[start : start + self.tmp_chunk_bytes_]
 
+    def storage_logical_tokens_per_chunk(self, group_idx: int) -> int:
+        """Return the per-chunk logical-token count this group's tmp
+        buffer slot is sized for.
+
+        For full-attention groups (``sliding_window == 0``) this is
+        ``lmcache_logical_chunk_size`` — the full chunk's logical
+        tokens. For SWA groups, this is the SWA-truncated count
+        (= ``blocks_per_chunk(g) * logical_block_size_g``), matching
+        the truncated payload that the store/retrieve loops actually
+        move and the truncated tmp slot we sized at construction.
+
+        Distinct from :meth:`get_physical_chunk_size`, which returns
+        the per-chunk *physical* slot count fed to the kernel
+        (= ``blocks_per_chunk(g) * physical_block_size_g`` for SWA,
+        ``lmcache_logical_chunk_size // compress_ratio`` for non-SWA).
+        """
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        if group.sliding_window <= 0:
+            return self.lmcache_logical_chunk_size
+        return self.blocks_per_chunk(group_idx) * group.logical_block_size
+
     def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
         """
         Returns a view of the temporary GPU buffer for the given group,
         sized for a single chunk. The chunk holds
-        ``lmcache_logical_chunk_size`` logical tokens which, for a
-        compressed group, correspond to ``group.physical_chunk_size``
-        physical slots.
+        ``storage_logical_tokens_per_chunk(g)`` logical tokens which,
+        for a compressed group, correspond to that group's
+        ``physical_chunk_size`` physical slots. For SWA groups the
+        per-chunk slot was sized at construction to the truncated
+        SWA-suffix payload (``blocks_per_chunk(g) *
+        logical_block_size``), so this view fits cleanly inside the
+        slot.
 
         Args:
             group_idx: Index of the KV layer group (default 0).
         """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        logical_tokens_g = self.storage_logical_tokens_per_chunk(group_idx)
+        shape = self.get_kv_buffer_shape(logical_tokens_g, group_idx)
         start = self.tmp_chunk_group_offsets_[group_idx]
         end = self.tmp_chunk_group_offsets_[group_idx + 1]
         return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
@@ -422,7 +443,8 @@ class GPUCacheContext:
         """
         Returns a list of ``batch_size`` non-overlapping views into the
         pre-allocated temporary GPU buffer for the given group, each
-        sized for ``lmcache_logical_chunk_size`` tokens.
+        sized for the group's storage-logical-tokens-per-chunk count
+        (full chunk for non-SWA, SWA-truncated for SWA groups).
 
         Args:
             batch_size: Number of concurrent requests (must be <= max_batch_size).
@@ -433,7 +455,8 @@ class GPUCacheContext:
                 f"batch_size {batch_size} exceeds max_batch_size {self.max_batch_size}"
             )
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        logical_tokens_g = self.storage_logical_tokens_per_chunk(group_idx)
+        shape = self.get_kv_buffer_shape(logical_tokens_g, group_idx)
         g_start = self.tmp_chunk_group_offsets_[group_idx]
         g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
         chunk = self.tmp_chunk_bytes_

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -125,15 +125,27 @@ class GPUCacheContext:
         # Byte size of one chunk entry (= one chunk across all groups).
         # tmp_chunk_group_offsets_[g] is the byte offset of group g within
         # a single chunk; tmp_chunk_group_offsets_[num_groups] ==
-        # tmp_chunk_bytes_.
+        # tmp_chunk_bytes_. For SWA groups (``sliding_window > 0``) the
+        # per-chunk byte budget is truncated to the trailing
+        # ``ceil(window / logical_bs)`` blocks, so we size the tmp slot
+        # to that truncated count rather than the full chunk's logical
+        # token count.
         self.tmp_chunk_group_offsets_: list[int] = [0]
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
             # ``get_kv_buffer_shape`` takes *logical* tokens; for
             # compressed groups it folds ``compress_ratio`` logical
-            # tokens into one physical slot internally.
-            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
+            # tokens into one physical slot internally. For SWA
+            # groups the truncated logical-token count is
+            # ``blocks_per_chunk(g) * logical_block_size``.
+            if group.sliding_window > 0:
+                logical_tokens_g = (
+                    self.blocks_per_chunk(group_idx) * group.logical_block_size
+                )
+            else:
+                logical_tokens_g = lmcache_logical_chunk_size
+            shape = self.get_kv_buffer_shape(logical_tokens_g, group_idx)
             byte_size = shape.numel() * group.dtype.itemsize
             self.tmp_chunk_group_offsets_.append(
                 self.tmp_chunk_group_offsets_[-1] + byte_size
@@ -259,13 +271,25 @@ class GPUCacheContext:
         return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
 
     def get_physical_chunk_size(self, group_idx: int) -> int:
-        """Returns the per-chunk physical slot count for the given group.
+        """Returns the per-chunk physical slot count for the given group,
+        adjusted for SWA-suffix truncation when applicable.
 
-        Equal to ``lmcache_logical_chunk_size // compress_ratio``; for
-        non-compressed groups this is just ``lmcache_logical_chunk_size``.
-        This is the value the block-level transfer kernel must be told.
+        For non-SWA groups (``sliding_window == 0``) this is
+        ``lmcache_logical_chunk_size // compress_ratio`` —
+        i.e. the full untruncated chunk's physical slot count.
+
+        For SWA groups (``sliding_window > 0``), the per-chunk payload
+        is truncated to the *last* ``ceil(sliding_window /
+        logical_block_size)`` blocks of each chunk; the kernel chunk
+        token count therefore shrinks to ``blocks_per_chunk(g) *
+        physical_block_size_g``. The kernel-side constraint
+        ``num_blocks_per_object * shape_desc.bs == kernel_chunk_tokens``
+        still holds because both sides scale with the truncation.
         """
-        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        if group.sliding_window <= 0:
+            return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
+        return self.blocks_per_chunk(group_idx) * group.shape_desc.bs
 
     def blocks_per_chunk_full(self, group_idx: int) -> int:
         """Returns the per-chunk count of inference-engine *logical* blocks
@@ -275,10 +299,17 @@ class GPUCacheContext:
 
         This is the count of block IDs the engine hands out for one
         LMCache chunk's worth of logical tokens in this group's
-        scheduler namespace. Per-group rather than global because, with
-        vLLM's hybrid KV cache manager active, different
-        ``KVCacheGroupSpec``s use different scheduler block sizes (e.g.
-        DeepSeek-V4: gid 0 = 256, gid 1/2 = 64, gid 3 = 4, gid 4 = 8).
+        scheduler namespace, BEFORE any SWA-suffix truncation. For
+        full-attention groups this equals :meth:`blocks_per_chunk`;
+        for SWA groups :meth:`blocks_per_chunk` returns a smaller
+        truncated count, but ``blocks_per_chunk_full`` always
+        returns the full pre-truncation value (used by callers that
+        need to address the full chunk's worth of engine block IDs).
+
+        Per-group rather than global because, with vLLM's hybrid KV
+        cache manager active, different ``KVCacheGroupSpec``s use
+        different scheduler block sizes (e.g. DeepSeek-V4: gid 0 =
+        256, gid 1/2 = 64, gid 3 = 4, gid 4 = 8).
 
         Args:
             group_idx: 0-based group index.
@@ -300,13 +331,25 @@ class GPUCacheContext:
     def blocks_per_chunk(self, group_idx: int) -> int:
         """Returns the per-chunk count of inference-engine *logical*
         blocks the server will iterate when staging block IDs for this
-        group. Currently identical to :meth:`blocks_per_chunk_full`;
-        kept as a separate accessor so the SWA-suffix-only optimization
-        (Step 4 of the V4 hybrid-on migration) can return a smaller
-        truncated count for groups with ``sliding_window > 0`` without
-        renaming every call site.
+        group.
+
+        For full-attention groups (``sliding_window == 0``) this is
+        identical to :meth:`blocks_per_chunk_full`. For SWA groups,
+        this returns ``ceil(sliding_window / logical_block_size_g)``
+        — the count of trailing blocks per chunk that the
+        SWA-suffix-only optimization stores and retrieves. Capped at
+        ``blocks_per_chunk_full`` so the count never exceeds the
+        full chunk's block count when ``sliding_window`` is larger
+        than ``lmcache_chunk_size``.
         """
-        return self.blocks_per_chunk_full(group_idx)
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        if group.sliding_window <= 0:
+            return self.blocks_per_chunk_full(group_idx)
+        # ceil(sliding_window / logical_block_size)
+        suffix_blocks = (
+            group.sliding_window + group.logical_block_size - 1
+        ) // group.logical_block_size
+        return min(suffix_blocks, self.blocks_per_chunk_full(group_idx))
 
     @property
     def kv_layer_groups_manager(self) -> KVLayerGroupsManager:

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -418,6 +418,62 @@ class GPUCacheContext:
         buf.copy_(cpu_tensor, non_blocking=True)
         return buf
 
+    def stage_block_ids_per_namespace(
+        self, per_gid_block_ids: list[list[int]]
+    ) -> list[torch.Tensor]:
+        """Copy each engine namespace's block IDs into non-overlapping
+        slots of the shared GPU buffer and return one staged tensor per
+        namespace.
+
+        The outer list of ``per_gid_block_ids`` is indexed by
+        engine-side ``kv_cache_group_id`` (gid). Inner lists are
+        concatenated into the shared buffer at successive offsets, so
+        each gid's staged tensor is a non-overlapping view of the same
+        underlying allocation. This matches the wire format of
+        :class:`~lmcache.integration.vllm.vllm_multi_process_adapter.LoadStoreOp.block_ids`
+        — outer index = gid, inner = block IDs for that gid in chunk
+        order.
+
+        For non-hybrid engines the outer list has length 1 and this
+        reduces to a single staged tensor — equivalent to
+        :meth:`stage_block_ids` on the single inner list.
+
+        Args:
+            per_gid_block_ids: Per-namespace block IDs, indexed by
+                engine-side ``kv_cache_group_id``.
+
+        Returns:
+            A list parallel to *per_gid_block_ids* of int64 GPU tensor
+            views into the pre-allocated buffer. Each view is a slice
+            ``self.block_ids_buffer_[offset : offset+len_g]`` and shares
+            storage with the buffer.
+
+        Raises:
+            ValueError: If the total block count exceeds the
+                pre-allocated buffer.
+        """
+        # Pack everything into one CPU array, then copy once. This is
+        # cheaper than per-gid memcpy because each namespace can be
+        # short (V4 hybrid-on: gid 4 has only ~32 blocks per chunk).
+        offsets: list[int] = [0]
+        flat: array.array = array.array("l")
+        for group_block_ids in per_gid_block_ids:
+            flat.extend(group_block_ids)
+            offsets.append(len(flat))
+        total = offsets[-1]
+        if total > self.block_ids_buffer_.shape[0]:
+            raise ValueError(
+                f"per-namespace block ID total {total} exceeds the "
+                f"pre-allocated buffer size {self.block_ids_buffer_.shape[0]}"
+            )
+        buf = self.block_ids_buffer_[:total]
+        cpu_tensor = torch.frombuffer(flat, dtype=torch.long)
+        buf.copy_(cpu_tensor, non_blocking=True)
+        return [
+            self.block_ids_buffer_[offsets[i] : offsets[i + 1]]
+            for i in range(len(per_gid_block_ids))
+        ]
+
     def get_kv_buffer_shape(
         self, logical_num_tokens: int, group_idx: int = 0
     ) -> torch.Size:

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -110,35 +110,27 @@ class GPUCacheContext:
             _MAX_BLOCK_IDS, dtype=torch.long, device=self.device_
         )
 
-        # Temporary GPU buffer for transfers — a single flat uint8 buffer
-        # laid out in chunk-major order so that each chunk's data matches
-        # the layout of a MemoryObj.raw_data (all groups concatenated):
+        # Temporary GPU buffer for transfers — a flat uint8 buffer in
+        # chunk-major order, matching ``MemoryObj.raw_data`` layout:
         #
         #   [ chunk_0: group_0_bytes | group_1_bytes | ... ]
         #   [ chunk_1: group_0_bytes | group_1_bytes | ... ]
-        #   ...
         #
-        # This lets callers copy an entire chunk to/from a MemoryObj with a
-        # single memcpy, without needing to know the per-group layout.
-        # max_batch_size is the max number of chunks processed concurrently.
+        # Lets callers memcpy an entire chunk to/from a MemoryObj without
+        # touching the per-group layout. max_batch_size is the max number
+        # of chunks processed concurrently.
         self.max_batch_size = 4
-        # Byte size of one chunk entry (= one chunk across all groups).
-        # tmp_chunk_group_offsets_[g] is the byte offset of group g within
-        # a single chunk; tmp_chunk_group_offsets_[num_groups] ==
-        # tmp_chunk_bytes_. For SWA groups (``sliding_window > 0``) the
-        # per-chunk byte budget is truncated to the trailing
-        # ``ceil(window / logical_bs)`` blocks, so we size the tmp slot
-        # to that truncated count rather than the full chunk's logical
-        # token count.
+        # Byte size of one chunk entry (one chunk across all groups).
+        # ``tmp_chunk_group_offsets_[g]`` is group g's byte offset; the
+        # last entry equals ``tmp_chunk_bytes_``. SWA groups
+        # (``sliding_window > 0``) get the truncated ``bpc * logical_bs``
+        # budget instead of the full chunk's logical-token count.
         self.tmp_chunk_group_offsets_: list[int] = [0]
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            # ``get_kv_buffer_shape`` takes *logical* tokens; for
-            # compressed groups it folds ``compress_ratio`` logical
-            # tokens into one physical slot internally. For SWA
-            # groups the truncated logical-token count is
-            # ``blocks_per_chunk(g) * logical_block_size``.
+            # ``get_kv_buffer_shape`` takes logical tokens; SWA groups
+            # supply the truncated count.
             logical_tokens_g = self.storage_logical_tokens_per_chunk(group_idx)
             shape = self.get_kv_buffer_shape(logical_tokens_g, group_idx)
             byte_size = shape.numel() * group.dtype.itemsize
@@ -587,12 +579,9 @@ class GPUCacheContext:
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            # ``get_kv_buffer_shape`` now takes *logical* tokens, so
-            # query ``compress_ratio`` logical tokens (= 1 physical
-            # slot) and then divide the resulting bytes back by
-            # ``compress_ratio`` to recover the per-logical-token
-            # contribution. Equivalent to the old
-            # ``physical_slot_bytes // compress_ratio`` formulation.
+            # ``get_kv_buffer_shape`` takes logical tokens; query
+            # ``compress_ratio`` logical tokens (= 1 physical slot) then
+            # divide back to recover the per-logical-token contribution.
             numels = self.get_kv_buffer_shape(group.compress_ratio, group_idx).numel()
             slot_bytes = numels * group.dtype.itemsize
             total += slot_bytes // group.compress_ratio

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -104,11 +104,15 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Payload:
         #   - key: KeyType - Cache key to store
         #   - instance_id: int - Unique identifier for the vLLM instance
-        #   - gpu_block_ids: list[int] - GPU block IDs containing the data
+        #   - gpu_block_ids: list[list[int]] - GPU block IDs containing the
+        #     data, grouped by engine-side ``kv_cache_group_id``. Outer
+        #     list is indexed by gid in registration order; for non-hybrid
+        #     models this is a length-1 list whose inner list mirrors the
+        #     prior flat ``list[int]`` semantics.
         #   - event_ipc_handle: bytes - CUDA event IPC handle for synchronization
         # Returns: tuple[bytes, bool] - (CUDA event handle, success flag)
         "STORE": ProtocolDefinition(
-            payload_classes=[KeyType, int, list[int], bytes],
+            payload_classes=[KeyType, int, list[list[int]], bytes],
             response_class=tuple[bytes, bool],
             handler_type=HandlerType.BLOCKING,
         ),
@@ -116,13 +120,15 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Payload:
         #   - key: KeyType - Cache key to retrieve
         #   - instance_id: int - Unique identifier for the vLLM instance
-        #   - gpu_block_ids: list[int] - GPU block IDs to store retrieved data
+        #   - gpu_block_ids: list[list[int]] - GPU block IDs to store
+        #     retrieved data, grouped by engine-side
+        #     ``kv_cache_group_id``. See STORE above for the layout.
         #   - event_ipc_handle: bytes - CUDA event IPC handle for synchronization
         #   - skip_first_n_tokens: int - Number of tokens to skip writing at the
         #     start of the retrieve range (to avoid overwriting APC-shared blocks)
         # Returns: tuple[bytes, bool] - (CUDA event handle, success flag)
         "RETRIEVE": ProtocolDefinition(
-            payload_classes=[KeyType, int, list[int], bytes, int],
+            payload_classes=[KeyType, int, list[list[int]], bytes, int],
             response_class=tuple[bytes, bool],
             handler_type=HandlerType.BLOCKING,
         ),

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -652,14 +652,11 @@ class MPCacheEngine:
                     else:
                         continue
 
-                    # Per-LMCache-group dispatch. Each group picks its own
-                    # ``blocks_per_chunk_g`` (full for full-attention,
-                    # SWA-suffix count for SWA groups), its own physical
-                    # kernel chunk size, and its block-ID slice from the
-                    # namespace-staged tensor for ``group.kv_cache_group_id``.
-                    # SWA groups slice the last ``bpc_g`` of each
-                    # ``bpc_full_g``-sized chunk; ``blocks_per_chunk_full(g)``
-                    # is the un-truncated count used to step between chunks.
+                    # Per-group dispatch: each group has its own
+                    # ``blocks_per_chunk_g``, physical kernel chunk size,
+                    # and namespace-staged block-ID slice. SWA groups
+                    # take the trailing ``bpc_g`` of each ``bpc_full_g``
+                    # chunk slot.
                     for group_idx, group in enumerate(groups):
                         bpc_g = gpu_context.blocks_per_chunk(group_idx)
                         bpc_full_g = gpu_context.blocks_per_chunk_full(group_idx)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -571,9 +571,15 @@ class MPCacheEngine:
         # ``blocks_per_chunk`` is counted in inference-engine-side
         # blocks (each block addresses
         # ``inference_engine_logical_block_size`` *logical* tokens).
-        # For compressed groups the per-group physical slot count
-        # differs, but the block-id indexing is shared with the engine
-        # and therefore uses the engine logical block size here.
+        # The block-id indexing is shared with the engine, so we use
+        # the global engine block size here for slicing the flat
+        # ``gpu_block_ids`` list. Per-group ``logical_block_size``
+        # variation (e.g. vLLM hybrid KV cache manager active on
+        # DeepSeek-V4) is plumbed through ``compress_ratio`` and
+        # ``physical_chunk_size`` per group, but the wire format is
+        # still a single flat block-id list keyed on the engine's
+        # global block size — fixing this is the per-gid LoadStoreOp
+        # wire-format change (Step 3 of the V4 hybrid-on migration).
         blocks_per_chunk = (
             self.chunk_size
             // gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -143,9 +143,8 @@ def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayo
     shapes: list[torch.Size] = []
     for group_idx in range(num_groups):
         if num_tokens == gpu_context.lmcache_logical_chunk_size:
-            # Chunked store/retrieve hot path: use the per-group
-            # storage logical-token count, which is the SWA-truncated
-            # value for SWA groups and the full chunk otherwise.
+            # Chunk hot path: per-group storage token count is SWA-truncated
+            # for SWA groups, full chunk otherwise.
             logical_tokens_g = gpu_context.storage_logical_tokens_per_chunk(group_idx)
             shapes.append(gpu_context.get_kv_buffer_shape(logical_tokens_g, group_idx))
         else:
@@ -176,16 +175,12 @@ class _PrefetchJob:
     handle: PrefetchHandle
     world_size: int
     request_id: str
-    # Number of tokens submitted for lookup (denominator for the L1+L2
-    # token-level hit-rate metric).  Equals ``len(chunk_hashes) * chunk_size``
-    # on the happy path; 0 for early-exit paths (no GPU context matches
-    # or chunk_hashes is empty).  Consumed at ``MP_LOOKUP_PREFETCH_END``
-    # emission time in ``query_prefetch_status``.
+    # Tokens submitted for lookup (denominator of the L1+L2 hit-rate
+    # metric). ``len(chunk_hashes) * chunk_size`` on the happy path; 0 for
+    # early-exit paths.
     requested_tokens: int
-    # Captured at lookup time so the ``MP_LOOKUP_PREFETCH_END`` event can
-    # carry them as labels.  ``model_name`` lets dashboards slice hit rate
-    # per model in multi-model deployments; ``cache_salt`` slices per
-    # tenant / isolation domain (an empty string means no salt set).
+    # Labels carried on ``MP_LOOKUP_PREFETCH_END`` so dashboards can slice
+    # hit rate per model and per tenant. Empty ``cache_salt`` = no salt.
     model_name: str = ""
     cache_salt: str = ""
 
@@ -595,12 +590,9 @@ class MPCacheEngine:
             check_interprocess_event_support()
             event = torch_dev.Event(interprocess=True)
 
-            # Stage block IDs per engine-side namespace once before the
-            # loop. Each LMCache group's ``kv_cache_group_id`` indexes
-            # into this list. For non-hybrid engines there is a single
-            # namespace and a single staged tensor; for V4 hybrid-on
-            # there are 5 namespaces and 5 staged tensors with
-            # heterogeneous lengths.
+            # Stage block IDs per engine-side namespace once. Each LMCache
+            # group's ``kv_cache_group_id`` indexes into this list (one
+            # entry for non-hybrid engines, one per gid for V4 hybrid-on).
             staged_block_ids_per_namespace = gpu_context.stage_block_ids_per_namespace(
                 gpu_block_ids
             )
@@ -660,27 +652,14 @@ class MPCacheEngine:
                     else:
                         continue
 
-                    # Per-LMCache-group dispatch. Each group selects:
-                    #   * its own ``blocks_per_chunk_g``: full
-                    #     (chunk_size // logical_block_size_g) for
-                    #     full-attention groups, or the SWA-suffix
-                    #     count (ceil(window / logical_bs)) for SWA
-                    #     groups. ``blocks_per_chunk_full(g)`` always
-                    #     returns the un-truncated count (used to step
-                    #     between chunks in the engine's namespace),
-                    #     while ``blocks_per_chunk(g)`` returns the
-                    #     possibly-truncated count actually consumed.
-                    #   * its own physical kernel chunk size (=
-                    #     ``get_physical_chunk_size(g)``), fed to the
-                    #     kernel; for SWA groups this is the truncated
-                    #     ``bpc_g * physical_bs_g`` so the kernel
-                    #     constraint
-                    #     ``num_blocks_per_object * shape_desc.bs ==
-                    #     kernel_chunk`` holds.
-                    #   * its block-ID slice from the staged tensor for
-                    #     ``group.kv_cache_group_id``. For SWA groups
-                    #     we slice the *last* ``bpc_g`` of each
-                    #     ``bpc_full_g``-sized chunk.
+                    # Per-LMCache-group dispatch. Each group picks its own
+                    # ``blocks_per_chunk_g`` (full for full-attention,
+                    # SWA-suffix count for SWA groups), its own physical
+                    # kernel chunk size, and its block-ID slice from the
+                    # namespace-staged tensor for ``group.kv_cache_group_id``.
+                    # SWA groups slice the last ``bpc_g`` of each
+                    # ``bpc_full_g``-sized chunk; ``blocks_per_chunk_full(g)``
+                    # is the un-truncated count used to step between chunks.
                     for group_idx, group in enumerate(groups):
                         bpc_g = gpu_context.blocks_per_chunk(group_idx)
                         bpc_full_g = gpu_context.blocks_per_chunk_full(group_idx)
@@ -844,15 +823,10 @@ class MPCacheEngine:
             ),
         )
 
-        # ``skip_*_in_chunk`` is expressed in engine-block units
-        # (logical tokens), which is what the kernel's
-        # ``skip_blocks_in_chunk`` argument expects regardless
-        # of per-group compression. Per-group ``logical_block_size``
-        # may differ on V4 hybrid-on (e.g. SWA gids use 64 vs dense
-        # gid 0's 256), but ``skip_first_n_tokens`` is itself
-        # token-aligned to the *coarsest* group's block size, so we
-        # use the global ``ie_logical_block_size`` for the skip math
-        # and validate per-group divisibility inside the loop.
+        # ``skip_first_n_tokens`` is token-aligned to the coarsest group's
+        # block size, so we compute the skip in engine-block units against
+        # the global ``ie_logical_block_size`` and validate per-group
+        # divisibility inside the loop.
         ie_logical_block_size = (
             gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
         )
@@ -1146,17 +1120,14 @@ class MPCacheEngine:
             )
             return
 
-        # Total chunk-aligned tokens submitted for lookup; surfaces as the
-        # denominator of the L1+L2 token-level hit-rate via the
-        # ``requested_tokens`` field on ``MP_LOOKUP_PREFETCH_END``.  Sub-chunk
-        # trailing tokens are intentionally excluded — they cannot hit at
-        # chunk granularity.
+        # Chunk-aligned token count surfaces as the hit-rate denominator
+        # on ``MP_LOOKUP_PREFETCH_END``; sub-chunk trailing tokens cannot
+        # hit and are excluded by design.
         requested_tokens = len(chunk_hashes) * self.chunk_size
 
-        # Publish lookup event via EventBus for observability subscribers.
-        # Guard with has_subscribers() to avoid allocating the metadata dict
-        # (including dtype/shape list comprehensions) when no subscriber is
-        # listening (e.g. lookup hash logger is disabled).
+        # Publish lookup event for observability subscribers. Guard with
+        # has_subscribers() so we don't build the metadata dict
+        # (including list comprehensions) when nothing is listening.
         if self._event_bus.has_subscribers(EventType.MP_LOOKUP):
             self._event_bus.publish(
                 Event(

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -601,8 +601,8 @@ class MPCacheEngine:
             # namespace and a single staged tensor; for V4 hybrid-on
             # there are 5 namespaces and 5 staged tensors with
             # heterogeneous lengths.
-            staged_block_ids_per_namespace = (
-                gpu_context.stage_block_ids_per_namespace(gpu_block_ids)
+            staged_block_ids_per_namespace = gpu_context.stage_block_ids_per_namespace(
+                gpu_block_ids
             )
 
             # Wait for vLLM to finish
@@ -684,8 +684,8 @@ class MPCacheEngine:
                     for group_idx, group in enumerate(groups):
                         bpc_g = gpu_context.blocks_per_chunk(group_idx)
                         bpc_full_g = gpu_context.blocks_per_chunk_full(group_idx)
-                        kernel_chunk_tokens = (
-                            gpu_context.get_physical_chunk_size(group_idx)
+                        kernel_chunk_tokens = gpu_context.get_physical_chunk_size(
+                            group_idx
                         )
                         ns_block_ids_gpu = staged_block_ids_per_namespace[
                             group.kv_cache_group_id
@@ -903,9 +903,7 @@ class MPCacheEngine:
                 for group_idx, group in enumerate(groups):
                     bpc_g = gpu_context.blocks_per_chunk(group_idx)
                     bpc_full_g = gpu_context.blocks_per_chunk_full(group_idx)
-                    kernel_chunk_tokens = (
-                        gpu_context.get_physical_chunk_size(group_idx)
-                    )
+                    kernel_chunk_tokens = gpu_context.get_physical_chunk_size(group_idx)
                     ns_block_ids_gpu = staged_block_ids_per_namespace[
                         group.kv_cache_group_id
                     ]
@@ -914,14 +912,12 @@ class MPCacheEngine:
                         # from each ``bpc_full_g``-sized chunk slot in
                         # ``ns_block_ids_gpu``. Build a flat gather index
                         # ``[batch_len * bpc_g]`` once per kernel call.
-                        chunk_offsets = (
-                            torch.arange(
-                                batch_len,
-                                device=ns_block_ids_gpu.device,
-                                dtype=torch.long,
-                            )
-                            * bpc_full_g
-                            + (start_chunk_id * bpc_full_g + (bpc_full_g - bpc_g))
+                        chunk_offsets = torch.arange(
+                            batch_len,
+                            device=ns_block_ids_gpu.device,
+                            dtype=torch.long,
+                        ) * bpc_full_g + (
+                            start_chunk_id * bpc_full_g + (bpc_full_g - bpc_g)
                         )
                         within_chunk = torch.arange(
                             bpc_g,
@@ -997,8 +993,8 @@ class MPCacheEngine:
             # ``store`` for the same pattern. The closure-captured
             # ``staged_block_ids_per_namespace`` is consumed inside
             # ``_retrieve_loop``.
-            staged_block_ids_per_namespace = (
-                gpu_context.stage_block_ids_per_namespace(gpu_block_ids)
+            staged_block_ids_per_namespace = gpu_context.stage_block_ids_per_namespace(
+                gpu_block_ids
             )
 
             # Not all backends support interprocess Events (CUDA IPC specific)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -537,7 +537,7 @@ class MPCacheEngine:
         self,
         key: IPCCacheEngineKey,
         instance_id: int,
-        gpu_block_ids: list[int],
+        gpu_block_ids: list[list[int]],
         event_ipc_handle: bytes,
     ) -> tuple[bytes, bool]:
         """
@@ -547,7 +547,17 @@ class MPCacheEngine:
             key (IPCCacheEngineKey): The IPC key for the KV cache blocks.
                 Must have worker_id != None (worker store operation).
             instance_id (int): The GPU instance ID (such as PID).
-            gpu_block_ids (list[int]): The GPU block IDs to store.
+            gpu_block_ids (list[list[int]]): GPU block IDs to store,
+                grouped by engine-side ``kv_cache_group_id``. The outer
+                list is indexed by gid in registration order. For
+                non-hybrid models this is a list of length 1 whose
+                inner list mirrors the prior flat ``list[int]``
+                semantics. For hybrid models (e.g. DeepSeek-V4 with
+                the hybrid manager active) the outer list has one
+                entry per ``kv_cache_group`` with the gid's own
+                scheduler-block-size granularity. Each LMCache group
+                fetches its block IDs from
+                ``gpu_block_ids[group.kv_cache_group_id]``.
             event_ipc_handle (bytes): The IPC handle of the event to wait on.
 
         Returns:
@@ -568,23 +578,6 @@ class MPCacheEngine:
         gpu_context = context.gpu_context
         model_name = context.model_name
 
-        # ``blocks_per_chunk`` is counted in inference-engine-side
-        # blocks (each block addresses
-        # ``inference_engine_logical_block_size`` *logical* tokens).
-        # The block-id indexing is shared with the engine, so we use
-        # the global engine block size here for slicing the flat
-        # ``gpu_block_ids`` list. Per-group ``logical_block_size``
-        # variation (e.g. vLLM hybrid KV cache manager active on
-        # DeepSeek-V4) is plumbed through ``compress_ratio`` and
-        # ``physical_chunk_size`` per group, but the wire format is
-        # still a single flat block-id list keyed on the engine's
-        # global block size — fixing this is the per-gid LoadStoreOp
-        # wire-format change (Step 3 of the V4 hybrid-on migration).
-        blocks_per_chunk = (
-            self.chunk_size
-            // gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
-        )
-
         with (
             torch_dev.device(gpu_context.device),
             torch_dev.stream(gpu_context.stream),
@@ -593,8 +586,15 @@ class MPCacheEngine:
             check_interprocess_event_support()
             event = torch_dev.Event(interprocess=True)
 
-            # Stage all block_ids to GPU once before the loop
-            all_block_ids_gpu = gpu_context.stage_block_ids(gpu_block_ids)
+            # Stage block IDs per engine-side namespace once before the
+            # loop. Each LMCache group's ``kv_cache_group_id`` indexes
+            # into this list. For non-hybrid engines there is a single
+            # namespace and a single staged tensor; for V4 hybrid-on
+            # there are 5 namespaces and 5 staged tensors with
+            # heterogeneous lengths.
+            staged_block_ids_per_namespace = (
+                gpu_context.stage_block_ids_per_namespace(gpu_block_ids)
+            )
 
             # Wait for vLLM to finish
             # Not all backends support IPC event handles (CUDA IPC specific)
@@ -644,27 +644,59 @@ class MPCacheEngine:
                 # skipped (not in reserved_dict), making block_ids
                 # non-contiguous. Batching would require torch.cat to
                 # reassemble block_ids, negating the benefit.
-                num_groups = gpu_context.kv_layer_groups_manager.num_groups
+                groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
                 for idx, obj_key in enumerate(obj_keys):
                     if obj_key in reserved_dict:
                         memory_obj = reserved_dict[obj_key]
                     else:
                         continue
 
-                    chunk_block_ids_gpu = all_block_ids_gpu[
-                        idx * blocks_per_chunk : (idx + 1) * blocks_per_chunk
-                    ]
+                    # Per-LMCache-group dispatch. Each group selects:
+                    #   * its own ``blocks_per_chunk_g`` (= chunk_size //
+                    #     logical_block_size_g) — the engine block-ID
+                    #     count this group consumes per chunk;
+                    #   * its own physical kernel chunk size
+                    #     (= ``get_physical_chunk_size(g)``), fed to the
+                    #     kernel so the constraint
+                    #     ``num_blocks_per_object * shape_desc.bs ==
+                    #     kernel_chunk`` holds for any (logical,
+                    #     physical) combination;
+                    #   * its block-ID slice from the staged tensor for
+                    #     ``group.kv_cache_group_id``.
+                    for group_idx, group in enumerate(groups):
+                        bpc_g = gpu_context.blocks_per_chunk(group_idx)
+                        kernel_chunk_tokens = (
+                            gpu_context.get_physical_chunk_size(group_idx)
+                        )
+                        ns_block_ids_gpu = staged_block_ids_per_namespace[
+                            group.kv_cache_group_id
+                        ]
+                        chunk_block_ids_gpu = ns_block_ids_gpu[
+                            idx * bpc_g : (idx + 1) * bpc_g
+                        ]
+                        if chunk_block_ids_gpu.shape[0] != bpc_g:
+                            logger.error(
+                                "STORE chunk_block_ids_gpu underflow: "
+                                "group_idx=%d gid=%d idx=%d "
+                                "blocks_per_chunk=%d got=%d "
+                                "ns_block_ids_len=%d "
+                                "logical_bs=%d physical_bs=%d "
+                                "lmcache_chunk_size=%d slice=[%d:%d]",
+                                group_idx,
+                                group.kv_cache_group_id,
+                                idx,
+                                bpc_g,
+                                chunk_block_ids_gpu.shape[0],
+                                ns_block_ids_gpu.shape[0],
+                                group.logical_block_size,
+                                group.shape_desc.bs,
+                                self.chunk_size,
+                                idx * bpc_g,
+                                (idx + 1) * bpc_g,
+                            )
 
-                    # Copy from GPU paged buffer to tmp buffer, then to CPU — per group
-                    for group_idx in range(num_groups):
                         tmp_buffer = gpu_context.get_tmp_chunk_gpu_buffer(group_idx)
                         group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                        # Kernel contract: ``group_lmcache_chunk_size`` here is the
-                        # number of *physical* slots per chunk for this group
-                        # (= logical chunk_size // compress_ratio).
-                        group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                            group_idx
-                        )
                         lmc_ops.multi_layer_block_kv_transfer(
                             group_kv_pointers,
                             [tmp_buffer.data_ptr()],
@@ -672,7 +704,7 @@ class MPCacheEngine:
                             gpu_context.device,
                             lmc_ops.TransferDirection.D2H,
                             gpu_context.get_shape_desc(group_idx),
-                            group_lmcache_chunk_size,
+                            kernel_chunk_tokens,
                             gpu_context.gpu_kv_format_,
                             0,
                         )
@@ -725,7 +757,7 @@ class MPCacheEngine:
         self,
         key: IPCCacheEngineKey,
         instance_id: int,
-        gpu_block_ids: list[int],
+        gpu_block_ids: list[list[int]],
         event_ipc_handle: bytes,
         skip_first_n_tokens: int = 0,
     ) -> tuple[bytes, bool]:
@@ -736,7 +768,9 @@ class MPCacheEngine:
             key (IPCCacheEngineKey): The IPC key for the KV cache blocks.
                 Must have worker_id != None (worker retrieve operation).
             instance_id (int): The GPU instance ID (such as PID).
-            gpu_block_ids (list[int]): The GPU block IDs to retrieve into.
+            gpu_block_ids (list[list[int]]): GPU block IDs to retrieve
+                into, grouped by engine-side ``kv_cache_group_id``. See
+                :meth:`store` for the full layout description.
             event_ipc_handle (bytes): The IPC handle of the event to wait on.
             skip_first_n_tokens (int): Number of tokens to skip writing at
                 the start of the retrieve range. This avoids overwriting
@@ -788,15 +822,19 @@ class MPCacheEngine:
         # ``skip_*_in_chunk`` is expressed in engine-block units
         # (logical tokens), which is what the kernel's
         # ``skip_blocks_in_chunk`` argument expects regardless
-        # of per-group compression.
+        # of per-group compression. Per-group ``logical_block_size``
+        # may differ on V4 hybrid-on (e.g. SWA gids use 64 vs dense
+        # gid 0's 256), but ``skip_first_n_tokens`` is itself
+        # token-aligned to the *coarsest* group's block size, so we
+        # use the global ``ie_logical_block_size`` for the skip math
+        # and validate per-group divisibility inside the loop.
         ie_logical_block_size = (
             gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
         )
-        blocks_per_chunk = self.chunk_size // ie_logical_block_size
 
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
             _BATCH_SIZE = gpu_context.max_batch_size
-            num_groups = gpu_context.kv_layer_groups_manager.num_groups
+            groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
             for batch_idx, memory_obj_batch in enumerate(
                 batched_iteration(memory_objs, batch_size=_BATCH_SIZE)
             ):
@@ -826,13 +864,9 @@ class MPCacheEngine:
                         skip_tokens_in_chunk,
                         skip_tokens_in_chunk // ie_logical_block_size,
                     )
-                skip_blocks_in_chunk = skip_tokens_in_chunk // ie_logical_block_size
 
                 start_chunk_id = batch_idx * _BATCH_SIZE
                 end_chunk_id = start_chunk_id + batch_len
-                chunk_block_ids_gpu = all_block_ids_gpu[
-                    start_chunk_id * blocks_per_chunk : end_chunk_id * blocks_per_chunk
-                ]
 
                 # Copy from CPU to GPU tmp buffers, then scatter to paged KV — per group
                 # H2D copy: each memory_obj maps to its own batch slot
@@ -841,14 +875,56 @@ class MPCacheEngine:
                         memory_obj,
                         gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=chunk_idx),
                     )
-                for group_idx in range(num_groups):
+                for group_idx, group in enumerate(groups):
+                    bpc_g = gpu_context.blocks_per_chunk(group_idx)
+                    kernel_chunk_tokens = (
+                        gpu_context.get_physical_chunk_size(group_idx)
+                    )
+                    ns_block_ids_gpu = staged_block_ids_per_namespace[
+                        group.kv_cache_group_id
+                    ]
+                    chunk_block_ids_gpu = ns_block_ids_gpu[
+                        start_chunk_id * bpc_g : end_chunk_id * bpc_g
+                    ]
+                    if chunk_block_ids_gpu.shape[0] != batch_len * bpc_g:
+                        logger.error(
+                            "RETRIEVE chunk_block_ids_gpu underflow: "
+                            "group_idx=%d gid=%d batch_idx=%d "
+                            "blocks_per_chunk=%d batch_len=%d got=%d "
+                            "ns_block_ids_len=%d "
+                            "logical_bs=%d physical_bs=%d "
+                            "lmcache_chunk_size=%d slice=[%d:%d]",
+                            group_idx,
+                            group.kv_cache_group_id,
+                            batch_idx,
+                            bpc_g,
+                            batch_len,
+                            chunk_block_ids_gpu.shape[0],
+                            ns_block_ids_gpu.shape[0],
+                            group.logical_block_size,
+                            group.shape_desc.bs,
+                            self.chunk_size,
+                            start_chunk_id * bpc_g,
+                            end_chunk_id * bpc_g,
+                        )
+                    # Per-group skip math: convert the global token-units
+                    # skip into this group's logical block units.
+                    if skip_tokens_in_chunk % group.logical_block_size != 0:
+                        logger.error(
+                            "skip_first_n_tokens (%d) is not aligned to "
+                            "group %d logical_block_size (%d); rounding down",
+                            skip_first_n_tokens,
+                            group_idx,
+                            group.logical_block_size,
+                        )
+                    skip_blocks_in_chunk_g = (
+                        skip_tokens_in_chunk // group.logical_block_size
+                    )
+
                     tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
                         batch_len, group_idx
                     )
                     group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                    group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                        group_idx
-                    )
 
                     lmc_ops.multi_layer_block_kv_transfer(
                         group_kv_pointers,
@@ -857,17 +933,22 @@ class MPCacheEngine:
                         gpu_context.device,
                         lmc_ops.TransferDirection.H2D,
                         gpu_context.get_shape_desc(group_idx),
-                        group_lmcache_chunk_size,
+                        kernel_chunk_tokens,
                         gpu_context.gpu_kv_format_,
-                        skip_blocks_in_chunk,
+                        skip_blocks_in_chunk_g,
                     )
 
         with (
             torch_dev.device(gpu_context.device),
             torch_dev.stream(gpu_context.stream),
         ):
-            # Stage all block_ids to GPU once before the loop
-            all_block_ids_gpu = gpu_context.stage_block_ids(gpu_block_ids)
+            # Stage block IDs per namespace once before the loop. See
+            # ``store`` for the same pattern. The closure-captured
+            # ``staged_block_ids_per_namespace`` is consumed inside
+            # ``_retrieve_loop``.
+            staged_block_ids_per_namespace = (
+                gpu_context.stage_block_ids_per_namespace(gpu_block_ids)
+            )
 
             # Not all backends support interprocess Events (CUDA IPC specific)
             check_interprocess_event_support()

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -142,16 +142,11 @@ def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayo
     groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
     shapes: list[torch.Size] = []
     for group_idx in range(num_groups):
-        group = groups[group_idx]
-        if (
-            group.sliding_window > 0
-            and num_tokens == gpu_context.lmcache_logical_chunk_size
-        ):
-            # SWA-suffix path: the MemoryObj for this chunk holds only
-            # the trailing ``bpc_g * logical_bs_g`` logical tokens.
-            logical_tokens_g = (
-                gpu_context.blocks_per_chunk(group_idx) * group.logical_block_size
-            )
+        if num_tokens == gpu_context.lmcache_logical_chunk_size:
+            # Chunked store/retrieve hot path: use the per-group
+            # storage logical-token count, which is the SWA-truncated
+            # value for SWA groups and the full chunk otherwise.
+            logical_tokens_g = gpu_context.storage_logical_tokens_per_chunk(group_idx)
             shapes.append(gpu_context.get_kv_buffer_shape(logical_tokens_g, group_idx))
         else:
             shapes.append(gpu_context.get_kv_buffer_shape(num_tokens, group_idx))

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -125,6 +125,11 @@ def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayo
     """Get the memory layout description for a given GPU context and number of tokens.
 
     Supports multiple KV layer groups with different shapes and dtypes.
+    For SWA groups (``sliding_window > 0``), the per-group token
+    dimension shrinks to the SWA-suffix-only payload's logical token
+    count when ``num_tokens == lmcache_chunk_size`` (the chunked
+    store/retrieve hot path); other call sites that pass arbitrary
+    token counts get the un-truncated layout.
 
     Args:
         gpu_context: The GPU cache context containing the KV cache information.
@@ -134,14 +139,23 @@ def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayo
         MemoryLayoutDesc: The memory layout description containing shapes and dtypes.
     """
     num_groups = gpu_context.kv_layer_groups_manager.num_groups
-    shapes = [
-        gpu_context.get_kv_buffer_shape(num_tokens, group_idx)
-        for group_idx in range(num_groups)
-    ]
-    dtypes = [
-        gpu_context.kv_layer_groups_manager.kv_layer_groups[group_idx].dtype
-        for group_idx in range(num_groups)
-    ]
+    groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
+    shapes: list[torch.Size] = []
+    for group_idx in range(num_groups):
+        group = groups[group_idx]
+        if (
+            group.sliding_window > 0
+            and num_tokens == gpu_context.lmcache_logical_chunk_size
+        ):
+            # SWA-suffix path: the MemoryObj for this chunk holds only
+            # the trailing ``bpc_g * logical_bs_g`` logical tokens.
+            logical_tokens_g = (
+                gpu_context.blocks_per_chunk(group_idx) * group.logical_block_size
+            )
+            shapes.append(gpu_context.get_kv_buffer_shape(logical_tokens_g, group_idx))
+        else:
+            shapes.append(gpu_context.get_kv_buffer_shape(num_tokens, group_idx))
+    dtypes = [groups[group_idx].dtype for group_idx in range(num_groups)]
     return MemoryLayoutDesc(shapes=shapes, dtypes=dtypes)
 
 
@@ -652,28 +666,41 @@ class MPCacheEngine:
                         continue
 
                     # Per-LMCache-group dispatch. Each group selects:
-                    #   * its own ``blocks_per_chunk_g`` (= chunk_size //
-                    #     logical_block_size_g) — the engine block-ID
-                    #     count this group consumes per chunk;
-                    #   * its own physical kernel chunk size
-                    #     (= ``get_physical_chunk_size(g)``), fed to the
-                    #     kernel so the constraint
+                    #   * its own ``blocks_per_chunk_g``: full
+                    #     (chunk_size // logical_block_size_g) for
+                    #     full-attention groups, or the SWA-suffix
+                    #     count (ceil(window / logical_bs)) for SWA
+                    #     groups. ``blocks_per_chunk_full(g)`` always
+                    #     returns the un-truncated count (used to step
+                    #     between chunks in the engine's namespace),
+                    #     while ``blocks_per_chunk(g)`` returns the
+                    #     possibly-truncated count actually consumed.
+                    #   * its own physical kernel chunk size (=
+                    #     ``get_physical_chunk_size(g)``), fed to the
+                    #     kernel; for SWA groups this is the truncated
+                    #     ``bpc_g * physical_bs_g`` so the kernel
+                    #     constraint
                     #     ``num_blocks_per_object * shape_desc.bs ==
-                    #     kernel_chunk`` holds for any (logical,
-                    #     physical) combination;
+                    #     kernel_chunk`` holds.
                     #   * its block-ID slice from the staged tensor for
-                    #     ``group.kv_cache_group_id``.
+                    #     ``group.kv_cache_group_id``. For SWA groups
+                    #     we slice the *last* ``bpc_g`` of each
+                    #     ``bpc_full_g``-sized chunk.
                     for group_idx, group in enumerate(groups):
                         bpc_g = gpu_context.blocks_per_chunk(group_idx)
+                        bpc_full_g = gpu_context.blocks_per_chunk_full(group_idx)
                         kernel_chunk_tokens = (
                             gpu_context.get_physical_chunk_size(group_idx)
                         )
                         ns_block_ids_gpu = staged_block_ids_per_namespace[
                             group.kv_cache_group_id
                         ]
-                        chunk_block_ids_gpu = ns_block_ids_gpu[
-                            idx * bpc_g : (idx + 1) * bpc_g
-                        ]
+                        # For non-SWA: slice [idx*bpc_g, (idx+1)*bpc_g)
+                        # For SWA: slice [idx*bpc_full_g + (bpc_full_g - bpc_g),
+                        #                 idx*bpc_full_g + bpc_full_g)
+                        chunk_start = idx * bpc_full_g + (bpc_full_g - bpc_g)
+                        chunk_end = chunk_start + bpc_g
+                        chunk_block_ids_gpu = ns_block_ids_gpu[chunk_start:chunk_end]
                         if chunk_block_ids_gpu.shape[0] != bpc_g:
                             logger.error(
                                 "STORE chunk_block_ids_gpu underflow: "
@@ -681,7 +708,8 @@ class MPCacheEngine:
                                 "blocks_per_chunk=%d got=%d "
                                 "ns_block_ids_len=%d "
                                 "logical_bs=%d physical_bs=%d "
-                                "lmcache_chunk_size=%d slice=[%d:%d]",
+                                "lmcache_chunk_size=%d slice=[%d:%d] "
+                                "sliding_window=%d bpc_full=%d",
                                 group_idx,
                                 group.kv_cache_group_id,
                                 idx,
@@ -691,8 +719,10 @@ class MPCacheEngine:
                                 group.logical_block_size,
                                 group.shape_desc.bs,
                                 self.chunk_size,
-                                idx * bpc_g,
-                                (idx + 1) * bpc_g,
+                                chunk_start,
+                                chunk_end,
+                                group.sliding_window,
+                                bpc_full_g,
                             )
 
                         tmp_buffer = gpu_context.get_tmp_chunk_gpu_buffer(group_idx)
@@ -877,15 +907,40 @@ class MPCacheEngine:
                     )
                 for group_idx, group in enumerate(groups):
                     bpc_g = gpu_context.blocks_per_chunk(group_idx)
+                    bpc_full_g = gpu_context.blocks_per_chunk_full(group_idx)
                     kernel_chunk_tokens = (
                         gpu_context.get_physical_chunk_size(group_idx)
                     )
                     ns_block_ids_gpu = staged_block_ids_per_namespace[
                         group.kv_cache_group_id
                     ]
-                    chunk_block_ids_gpu = ns_block_ids_gpu[
-                        start_chunk_id * bpc_g : end_chunk_id * bpc_g
-                    ]
+                    if group.sliding_window > 0 and bpc_g != bpc_full_g:
+                        # SWA-suffix: pick the trailing ``bpc_g`` block IDs
+                        # from each ``bpc_full_g``-sized chunk slot in
+                        # ``ns_block_ids_gpu``. Build a flat gather index
+                        # ``[batch_len * bpc_g]`` once per kernel call.
+                        chunk_offsets = (
+                            torch.arange(
+                                batch_len,
+                                device=ns_block_ids_gpu.device,
+                                dtype=torch.long,
+                            )
+                            * bpc_full_g
+                            + (start_chunk_id * bpc_full_g + (bpc_full_g - bpc_g))
+                        )
+                        within_chunk = torch.arange(
+                            bpc_g,
+                            device=ns_block_ids_gpu.device,
+                            dtype=torch.long,
+                        )
+                        gather_idx = (
+                            chunk_offsets[:, None] + within_chunk[None, :]
+                        ).reshape(-1)
+                        chunk_block_ids_gpu = ns_block_ids_gpu[gather_idx]
+                    else:
+                        chunk_block_ids_gpu = ns_block_ids_gpu[
+                            start_chunk_id * bpc_g : end_chunk_id * bpc_g
+                        ]
                     if chunk_block_ids_gpu.shape[0] != batch_len * bpc_g:
                         logger.error(
                             "RETRIEVE chunk_block_ids_gpu underflow: "
@@ -893,7 +948,8 @@ class MPCacheEngine:
                             "blocks_per_chunk=%d batch_len=%d got=%d "
                             "ns_block_ids_len=%d "
                             "logical_bs=%d physical_bs=%d "
-                            "lmcache_chunk_size=%d slice=[%d:%d]",
+                            "lmcache_chunk_size=%d "
+                            "sliding_window=%d bpc_full=%d",
                             group_idx,
                             group.kv_cache_group_id,
                             batch_idx,
@@ -904,8 +960,8 @@ class MPCacheEngine:
                             group.logical_block_size,
                             group.shape_desc.bs,
                             self.chunk_size,
-                            start_chunk_id * bpc_g,
-                            end_chunk_id * bpc_g,
+                            group.sliding_window,
+                            bpc_full_g,
                         )
                     # Per-group skip math: convert the global token-units
                     # skip into this group's logical block units.

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -1266,7 +1266,7 @@ def test_cb_lookup_v2_cannot_find_normal_store(
     store_key = create_cache_key(token_ids, request_id="isolation-normal-v2")
     client.submit_request(
         RequestType.STORE,
-        [store_key, registered_instance, list(range(16)), event.ipc_handle()],
+        [store_key, registered_instance, [list(range(16))], event.ipc_handle()],
         get_response_class(RequestType.STORE),
     ).to_cuda_future().result(timeout=DEFAULT_TIMEOUT)
 
@@ -1937,7 +1937,8 @@ def test_cb_store_final_v2_then_normal_lookup(
     # Normal RETRIEVE
     retrieve_key = create_cb_cache_key(token_ids, request_id="final-norm-retrieve-v2")
     pages_per_chunk = 16
-    gpu_block_ids = list(range(pages_per_chunk))
+    # Per-namespace nested-list block IDs (single namespace for non-hybrid).
+    gpu_block_ids = [list(range(pages_per_chunk))]
     event2 = torch.cuda.Event(interprocess=True)
     event2.record()
 

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -193,7 +193,9 @@ def store_keys(
     for i, key in enumerate(keys):
         start = i * BLOCKS_PER_KEY
         end = start + BLOCKS_PER_KEY
-        block_ids = gpu_block_ids[start:end]
+        # ``store`` now expects a per-namespace nested list; non-hybrid
+        # tests use a single namespace so wrap in a length-1 outer list.
+        block_ids = [gpu_block_ids[start:end]]
         future = client.submit_request(
             RequestType.STORE,
             [key, instance_id, block_ids, event.ipc_handle()],
@@ -216,7 +218,8 @@ def retrieve_keys(
     for i, key in enumerate(keys):
         start = i * BLOCKS_PER_KEY
         end = start + BLOCKS_PER_KEY
-        block_ids = gpu_block_ids[start:end]
+        # Same nested-list shape as ``store`` above.
+        block_ids = [gpu_block_ids[start:end]]
         future = client.submit_request(
             RequestType.RETRIEVE,
             [key, instance_id, block_ids, event.ipc_handle(), 0],

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -448,13 +448,15 @@ def test_mq_unregister_kv_cache_multiple_clients():
 def test_mq_store():
     """
     Test MessageQueue with STORE request type.
-    STORE takes (key: KeyType, gpu_id: int, gpu_block_ids: list[int],
+    STORE takes (key: KeyType, gpu_id: int, gpu_block_ids: list[list[int]],
     event_ipc_handle: bytes) and returns (bytes, bool).
     """
     # Create test key
     key = create_cache_key(0)
     gpu_id = 0
-    gpu_block_ids = [0, 1, 2]
+    # Per-gid wire format: outer list indexed by namespace; non-hybrid
+    # tests use a single namespace.
+    gpu_block_ids = [[0, 1, 2]]
     test_handle = b"\x00" * 64
 
     # Create test helper and register handler
@@ -473,13 +475,13 @@ def test_mq_store():
 def test_mq_retrieve():
     """
     Test MessageQueue with RETRIEVE request type.
-    RETRIEVE takes (key: KeyType, gpu_id: int, gpu_block_ids: list[int],
+    RETRIEVE takes (key: KeyType, gpu_id: int, gpu_block_ids: list[list[int]],
     event_ipc_handle: bytes) and returns (bytes, bool).
     """
     # Create test key
     key = create_cache_key(0)
     gpu_id = 0
-    gpu_block_ids = [0, 1, 2]
+    gpu_block_ids = [[0, 1, 2]]
     test_handle = b"\x00" * 64
 
     # Create test helper and register handler

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -109,7 +109,7 @@ def unregister_kv_cache_handler(gpu_id: int) -> None:
 
 
 def store_handler(
-    key: KeyType, gpu_id: int, gpu_block_ids: list[int], ipc_handle: bytes
+    key: KeyType, gpu_id: int, gpu_block_ids: list[list[int]], ipc_handle: bytes
 ) -> tuple[bytes, bool]:
     """
     Dummy handler for STORE requests.
@@ -117,7 +117,7 @@ def store_handler(
     Args:
         key: Cache key to store
         gpu_id: GPU device ID
-        gpu_block_ids: List of GPU block IDs
+        gpu_block_ids: Per-namespace list of GPU block IDs
         ipc_handle: CUDA event IPC handle
 
     Returns:
@@ -142,7 +142,7 @@ def store_handler(
 def retrieve_handler(
     key: KeyType,
     gpu_id: int,
-    gpu_block_ids: list[int],
+    gpu_block_ids: list[list[int]],
     event_handler: bytes,
     skip_first_n_tokens: int = 0,
 ) -> tuple[bytes, bool]:
@@ -152,7 +152,7 @@ def retrieve_handler(
     Args:
         key: Cache key to retrieve
         gpu_id: GPU device ID
-        gpu_block_ids: List of GPU block IDs
+        gpu_block_ids: Per-namespace list of GPU block IDs
         event_handler: CUDA event IPC handle
         skip_first_n_tokens: Number of tokens to skip at retrieve start
 

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -140,6 +140,48 @@ class TestKVLayerGroupsManager:
         assert sd1.hs == 64
 
 
+class TestUniformLayerFormatValidation:
+    """Tests for the per-layer dim-uniformity check.
+
+    The check enforces LMCache's single-format-per-engine invariant:
+    every layer tensor must share the same ``.dim()``. Mixed dim counts
+    indicate divergent ``GPUKVFormat`` (e.g. MLA without TWO axis mixed
+    with MHA carrying TWO axis), which is currently unsupported.
+    """
+
+    def test_uniform_layers_accepted(self):
+        """Sanity: a list of same-dim tensors constructs without raising."""
+        tensors = [
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.float16) for _ in range(3)
+        ]
+        manager = _build_manager(tensors, num_blocks=32)
+        assert len(manager.kv_layer_groups) == 1
+
+    def test_mixed_dim_tensors_raise(self):
+        """Mixing a 5-D MHA tensor with a 4-D MLA-style tensor must raise."""
+        tensors = [
+            # MHA-style: [TWO, NB, BS, NH, HS]
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
+            # MLA-style: [NB, BS, NH, HS] (no TWO axis)
+            torch.randn(32, 256, 8, 64, dtype=torch.float16),
+        ]
+        with pytest.raises(
+            ValueError,
+            match=r"layer 1 has dim 4|Mixed-format engines",
+        ):
+            _build_manager(tensors, num_blocks=32)
+
+    def test_mixed_dim_message_names_first_divergent_layer(self):
+        """The error message points at the first layer that diverges."""
+        tensors = [
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
+            torch.randn(32, 256, 8, 64, dtype=torch.float16),  # diverges here
+        ]
+        with pytest.raises(ValueError, match=r"layer 2 has dim 4"):
+            _build_manager(tensors, num_blocks=32)
+
+
 class TestPerLayerLogicalBlockSize:
     """Tests for the ``per_layer_logical_block_size`` LayoutHints field.
 

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -322,6 +322,67 @@ class TestPerLayerKvCacheGroupId:
             )
 
 
+class TestPerLayerSlidingWindow:
+    """Tests for the ``per_layer_sliding_window`` LayoutHints field.
+
+    The hint adds the SWA window size to LayerGroupIdentity so layers
+    with different windows end up in distinct LMCache groups, and
+    activates the SWA-suffix-only optimization for groups with
+    non-zero windows.
+    """
+
+    def test_hint_absent_collapses_to_full(self):
+        """No hint = legacy behavior: all layers treated as full-attention
+        (sliding_window=0)."""
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(2)
+        ]
+        manager = _build_manager(tensors, num_blocks=32)
+        assert len(manager.kv_layer_groups) == 1
+        assert manager.kv_layer_groups[0].sliding_window == 0
+
+    def test_hint_splits_layers_by_window(self):
+        """Two sets of identical-shape layers with different windows
+        end up in distinct groups."""
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(4)
+        ]
+        layout_hints = {
+            "per_layer_sliding_window": [128, 128, 0, 0],
+        }
+        manager = _build_manager(
+            tensors,
+            num_blocks=32,
+            layout_hints=layout_hints,
+        )
+        assert len(manager.kv_layer_groups) == 2
+        groups_by_window = {g.sliding_window: g for g in manager.kv_layer_groups}
+        assert groups_by_window[128].layer_indices == [0, 1]
+        assert groups_by_window[0].layer_indices == [2, 3]
+
+    def test_window_length_mismatch_raises(self):
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(2)
+        ]
+        with pytest.raises(ValueError, match="length"):
+            _build_manager(
+                tensors,
+                num_blocks=32,
+                layout_hints={"per_layer_sliding_window": [128]},
+            )
+
+    def test_window_negative_raises(self):
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(2)
+        ]
+        with pytest.raises(ValueError, match="negative"):
+            _build_manager(
+                tensors,
+                num_blocks=32,
+                layout_hints={"per_layer_sliding_window": [128, -1]},
+            )
+
+
 class TestParseKvcacheShapeSpec:
     """Test cases for parse_kvcache_shape_spec function."""
 

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -230,6 +230,98 @@ class TestPerLayerLogicalBlockSize:
             )
 
 
+class TestPerLayerKvCacheGroupId:
+    """Tests for the ``per_layer_kv_cache_group_id`` LayoutHints field.
+
+    The hint adds the engine's per-layer block-ID namespace to
+    LayerGroupIdentity, so layers whose physical-and-logical identity
+    matches but whose engine-side block IDs come from disjoint pools
+    end up in distinct LMCache groups.
+    """
+
+    def test_hint_absent_collapses_namespaces(self):
+        """No hint = legacy behavior: every layer namespace is 0 and
+        physically-identical layers collapse to a single group."""
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(4)
+        ]
+        manager = _build_manager(tensors, num_blocks=32)
+        assert len(manager.kv_layer_groups) == 1
+        assert manager.kv_layer_groups[0].kv_cache_group_id == 0
+
+    def test_hint_splits_layers_by_namespace(self):
+        """Two sets of identical-shape layers from disjoint engine
+        namespaces split into distinct LMCache groups."""
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(4)
+        ]
+        # Layers 0, 1 in namespace 1; layers 2, 3 in namespace 2.
+        layout_hints = {
+            "per_layer_kv_cache_group_id": [1, 1, 2, 2],
+        }
+        manager = _build_manager(
+            tensors,
+            num_blocks=32,
+            layout_hints=layout_hints,
+        )
+        assert len(manager.kv_layer_groups) == 2
+        groups_by_ns = {g.kv_cache_group_id: g for g in manager.kv_layer_groups}
+        assert groups_by_ns[1].layer_indices == [0, 1]
+        assert groups_by_ns[2].layer_indices == [2, 3]
+
+    def test_namespace_combined_with_logical_bs(self):
+        """Both hints together: layers must match on every identity
+        field including namespace AND logical_block_size."""
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(4)
+        ]
+        # 4 layers all physical-identical. Namespace 1 with logical
+        # bs 64; namespace 1 with logical bs 256; namespace 2 with
+        # logical bs 64; namespace 2 with logical bs 64. Expected
+        # groups: {(ns=1, lbs=64): [0]}, {(ns=1, lbs=256): [1]},
+        # {(ns=2, lbs=64): [2, 3]}.
+        layout_hints = {
+            "per_layer_kv_cache_group_id": [1, 1, 2, 2],
+            "per_layer_logical_block_size": [64, 256, 64, 64],
+        }
+        manager = _build_manager(
+            tensors,
+            num_blocks=32,
+            layout_hints=layout_hints,
+            lmcache_logical_chunk_size=1024,
+        )
+        assert len(manager.kv_layer_groups) == 3
+        groups_by_id = {
+            (g.kv_cache_group_id, g.logical_block_size): g
+            for g in manager.kv_layer_groups
+        }
+        assert groups_by_id[(1, 64)].layer_indices == [0]
+        assert groups_by_id[(1, 256)].layer_indices == [1]
+        assert groups_by_id[(2, 64)].layer_indices == [2, 3]
+
+    def test_namespace_length_mismatch_raises(self):
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(2)
+        ]
+        with pytest.raises(ValueError, match="length"):
+            _build_manager(
+                tensors,
+                num_blocks=32,
+                layout_hints={"per_layer_kv_cache_group_id": [1]},
+            )
+
+    def test_namespace_negative_raises(self):
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(2)
+        ]
+        with pytest.raises(ValueError, match="negative"):
+            _build_manager(
+                tensors,
+                num_blocks=32,
+                layout_hints={"per_layer_kv_cache_group_id": [0, -1]},
+            )
+
+
 class TestParseKvcacheShapeSpec:
     """Test cases for parse_kvcache_shape_spec function."""
 

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.kv_layer_groups import (
     KVLayerGroupInfo,
     KVLayerGroupsManager,
@@ -20,7 +21,7 @@ def _build_manager(
     tensors: list[torch.Tensor],
     *,
     num_blocks: int,
-    layout_hints: dict | None = None,
+    layout_hints: LayoutHints | None = None,
     lmcache_logical_chunk_size: int = 256,
 ) -> KVLayerGroupsManager:
     """Build a manager using the per-layer NHD format.

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -20,6 +20,8 @@ def _build_manager(
     tensors: list[torch.Tensor],
     *,
     num_blocks: int,
+    layout_hints: dict | None = None,
+    lmcache_logical_chunk_size: int = 256,
 ) -> KVLayerGroupsManager:
     """Build a manager using the per-layer NHD format.
 
@@ -35,6 +37,8 @@ def _build_manager(
         tensors,
         gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         num_blocks=num_blocks,
+        layout_hints=layout_hints,
+        lmcache_logical_chunk_size=lmcache_logical_chunk_size,
     )
 
 
@@ -133,6 +137,97 @@ class TestKVLayerGroupsManager:
         sd1 = manager.get_shape_desc(1)
         assert sd1.nh == 16
         assert sd1.hs == 64
+
+
+class TestPerLayerLogicalBlockSize:
+    """Tests for the ``per_layer_logical_block_size`` LayoutHints field.
+
+    The hint extends LayerGroupIdentity with the engine's scheduler-side
+    block size: layers with the same physical shape but different
+    scheduler block sizes (e.g. vLLM's hybrid KV cache manager handing
+    different ``KVCacheGroupSpec.block_size`` values to different
+    layers) end up in distinct LMCache groups.
+    """
+
+    def test_hint_absent_collapses_to_5tuple(self):
+        """No hint = legacy behavior: layers with matching physical
+        identity collapse to a single group."""
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(4)
+        ]
+        manager = _build_manager(tensors, num_blocks=32)
+        assert len(manager.kv_layer_groups) == 1
+        group = manager.kv_layer_groups[0]
+        assert group.layer_indices == [0, 1, 2, 3]
+        # logical_block_size defaults to physical bs when no hint
+        assert group.logical_block_size == 64
+        assert group.shape_desc.bs == 64
+        assert group.compress_ratio == 1
+
+    def test_hint_splits_layers_by_logical_bs(self):
+        """Two layers with same physical shape but different logical
+        block sizes split into distinct groups."""
+        # 4 layers all with physical bs=64. Hint says first 2 layers
+        # use scheduler block size 256 (i.e. compressed: 4 logical
+        # tokens per physical slot) and the other 2 use 64 (uncompressed).
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(4)
+        ]
+        layout_hints = {
+            "per_layer_logical_block_size": [256, 256, 64, 64],
+        }
+        manager = _build_manager(
+            tensors,
+            num_blocks=32,
+            layout_hints=layout_hints,
+            lmcache_logical_chunk_size=1024,
+        )
+        assert len(manager.kv_layer_groups) == 2
+        groups_by_logical_bs = {
+            g.logical_block_size: g for g in manager.kv_layer_groups
+        }
+        compressed = groups_by_logical_bs[256]
+        uncompressed = groups_by_logical_bs[64]
+        assert compressed.layer_indices == [0, 1]
+        assert compressed.compress_ratio == 4
+        assert compressed.physical_chunk_size == 256
+        assert uncompressed.layer_indices == [2, 3]
+        assert uncompressed.compress_ratio == 1
+        assert uncompressed.physical_chunk_size == 1024
+
+    def test_hint_length_mismatch_raises(self):
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(2)
+        ]
+        with pytest.raises(ValueError, match="length"):
+            _build_manager(
+                tensors,
+                num_blocks=32,
+                layout_hints={"per_layer_logical_block_size": [64]},
+            )
+
+    def test_hint_non_positive_raises(self):
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(2)
+        ]
+        with pytest.raises(ValueError, match="non-positive"):
+            _build_manager(
+                tensors,
+                num_blocks=32,
+                layout_hints={"per_layer_logical_block_size": [64, 0]},
+            )
+
+    def test_logical_bs_not_multiple_of_physical_raises(self):
+        tensors = [
+            torch.randn(2, 32, 64, 8, 128, dtype=torch.float16) for _ in range(1)
+        ]
+        with pytest.raises(ValueError, match="multiple"):
+            _build_manager(
+                tensors,
+                num_blocks=32,
+                layout_hints={"per_layer_logical_block_size": [100]},
+                lmcache_logical_chunk_size=400,
+            )
 
 
 class TestParseKvcacheShapeSpec:

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -138,7 +138,7 @@ def test_submit_store_request_tracks_returned_future(fake_adapter, monkeypatch):
     fake_future = MagicMock()
     transfer_ctx.submit_store.return_value = fake_future
     adapter.transfer_ctx = transfer_ctx
-    op = LoadStoreOp(token_ids=[1, 2, 3, 4], block_ids=[0], start=0, end=4)
+    op = LoadStoreOp(token_ids=[1, 2, 3, 4], block_ids=[[0]], start=0, end=4)
 
     adapter.submit_store_request("req-1", op, event=MagicMock())
 
@@ -160,7 +160,7 @@ def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatc
     adapter.transfer_ctx = transfer_ctx
     op = LoadStoreOp(
         token_ids=[1, 2, 3, 4],
-        block_ids=[0],
+        block_ids=[[0]],
         start=0,
         end=4,
         skip_first_n_tokens=1,


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables LMCache MP to work with vLLM's hybrid KV cache manager
(`SupportsHMA`) — required for DeepSeek-V4-Flash, which exposes 5
`KVCacheGroupSpec`s with mixed scheduler block sizes (256 / 64 / 4 / 8),
two pairs of physically identical SWA layer groups in disjoint
block-ID namespaces, and an `as_strided` `page_size_padded` MLA
layout.

Rebased on top of the day-0 V4 support landed in #3171
(`block_stride_elems` kernel + `compress_ratio` /
`physical_chunk_size` plumbing); that PR works for V4 with
`--disable-hybrid-kv-cache-manager`. This PR adds the missing pieces
for `--no-disable-hybrid-kv-cache-manager`.

The work is split into eight small commits for review:

1. **Per-group `logical_block_size` in `LayerGroupIdentity`** —
   `LayerGroupIdentity` extends from a 5-tuple to a 6-tuple, adding
   the engine's *scheduler-side* block size (`KVCacheSpec.block_size`).
   Layers with same physical layout but different scheduler grids
   (V4 hybrid: dense MLA = 256-token grid, SWA = 64-token grid) now
   land in distinct LMCache groups. `_derive_compression_metadata`
   keys `compress_ratio` on the per-group `logical_bs / physical_bs`
   instead of one global `inference_engine_logical_block_size`.

2. **Per-group `kv_cache_group_id` namespace in `LayerGroupIdentity`** —
   identity extends to a 7-tuple, adding the engine's per-layer
   block-ID *namespace* handle. Two physically-identical layer sets
   that allocate from disjoint vLLM `BlockPool` namespaces (V4: gid 1
   even+MTP-SWA vs gid 2 odd-SWA) now land in distinct LMCache groups
   so a STORE op carrying gid 1's block IDs cannot mis-index gid 2's
   layers.

3. **Per-gid `LoadStoreOp` wire format + per-LMCache-group dispatch** —
   `LoadStoreOp.block_ids` changes from `list[int]` to
   `list[list[int]]` indexed by engine-side gid in registration
   order. New `GPUCacheContext.stage_block_ids_per_namespace` packs
   all namespaces into the shared GPU buffer at non-overlapping
   offsets. `MPCacheEngine.store` / `retrieve` loop per LMCache group
   with each group's own `blocks_per_chunk(g)`, kernel chunk size
   (= `get_physical_chunk_size(g)`), and namespace slice
   (`staged[group.kv_cache_group_id]`). This is a **breaking RPC
   change**: old servers cannot accept the new ops or vice versa.

4. **SWA-suffix-only store/retrieve** — for SWA groups
   (`sliding_window > 0`), store and retrieve only the trailing
   `ceil(window / logical_bs)` blocks of each chunk instead of the
   full chunk. The kernel-time SWA mask in the serving engine never
   reads positions older than `sliding_window`, so the truncated
   payload is sufficient. `LayerGroupIdentity` extends to an 8-tuple
   including `sliding_window`. Originally introduced behind an
   `LMCACHE_SWA_SUFFIX_ONLY=1` env-var gate; promoted to default in
   commit 8 after end-to-end verification. On V4-Flash
   (chunk_size=1024, windows of 8/128/256), this collapses gid 3's
   per-chunk SWA payload from ~236 MiB to ~1.85 MiB.

5. **Fix tmp buffer shape for SWA-truncated groups** — discovered
   during end-to-end smoke testing: `get_tmp_chunk_gpu_buffer`
   computed shape from `lmcache_logical_chunk_size` but the per-group
   tmp slot was sized at construction to the SWA-truncated payload.
   Mismatch caused `RuntimeError: shape '[1, 22, 1024, 584]' is
   invalid for input of size 1644544` on store. Fixed via a single
   `storage_logical_tokens_per_chunk(g)` helper used everywhere.

6. **Lint fixes** — `ruff-format` reformatted a few short ternaries;
   one mypy fix in `_build_manager`'s test helper signature.

7. **Port hybrid-on (`SupportsHMA`) to LMCache-side
   `lmcache_mp_connector`** — LMCache PR #3235 added an in-tree copy
   of the vLLM-side `LMCacheMPConnector` at
   `lmcache/integration/vllm/lmcache_mp_connector.py`, intended as
   the LMCache-tracked entrypoint users pin via
   `kv_connector_module_path`. That copy was forked off the
   pre-hybrid vLLM-side connector, so it still asserted a single
   `KVCacheGroupSpec` and was incompatible with this PR's per-gid
   wire format. This commit ports the full hybrid-on path to the
   LMCache-side copy: `SupportsHMA` inheritance, per-gid request
   tracker, per-gid `LoadStoreOp.block_ids`, `_per_gid_slice` with
   the divide-or-multiply rule for the GCD-collapsed
   `cache_config.block_size`, `register_kv_caches` forwarding
   `extra_layout_hints`, `request_finished_all_groups`, and the L0
   "primary namespace" reporting on gid 0. **No corresponding vLLM
   PR is required** — users pin via:

   ```
   --kv-transfer-config '{"kv_connector":"LMCacheMPConnector",
                          "kv_connector_module_path":
                            "lmcache.integration.vllm.lmcache_mp_connector",
                          ...}'
   ```

   The static `lmcache_mp_connector_0180.py` /
   `lmcache_mp_connector_0201.py` snapshots are intentionally NOT
   touched — those older vLLM revisions cannot drive HMA at all and
   keep their flat-list semantics; they hard-fail the moment
   `len(kv_cache_groups) > 1`, which is the right behavior.

8. **Make SWA-suffix-only the default** — drop the
   `LMCACHE_SWA_SUFFIX_ONLY=1` env-var gate introduced in commit 4
   and unconditionally publish `per_layer_sliding_window` via
   `extra_layout_hints`. Verified end-to-end (token IDs identical,
   max|Δlogprob| = 5.04e-04, well below the #13 noise floor) so the
   optimization is safe to enable by default. Full-attention groups
   (`sliding_window == 0`) are byte-for-byte unaffected. No off-switch
   env var — users who need the prior behavior can pin to a previous
   LMCache release.

Hybrid-OFF behavior is preserved by single-group/single-namespace
defaults: when no per-layer hint is supplied, every layer's
`logical_block_size` defaults to its physical `bs`, every namespace
to 0, every `sliding_window` to 0, so the 8-tuple identity collapses
to the prior 5-tuple grouping.

**Special notes for your reviewers**:

- **No companion vLLM PR is required.** Commit 7 adds the full
  hybrid-on path to the LMCache-tree connector at
  `lmcache/integration/vllm/lmcache_mp_connector.py`. Users opt into
  the LMCache-tracked copy via `kv_connector_module_path`, so the
  in-tree vLLM `LMCacheMPConnector` does not need any patches.
  Verified end-to-end: with a vanilla upstream vLLM (no local
  changes), DeepSeek-V4-Flash + `--no-disable-hybrid-kv-cache-manager`
  + LMCacheMPConnector gives 2.31×–16.47× speedups (see table
  below).
- **Backward compat**: every non-V4 / single-namespace caller hits
  a length-1 `gpu_block_ids` list, lands on namespace 0, has
  `logical == physical`, has `sliding_window == 0`, and sees
  byte-for-byte identical buffer offsets and kernel args. V3.2
  behavior is preserved (verified locally).
- **Wire format break**: protocol payload type for `STORE` /
  `RETRIEVE` updated from `list[int]` to `list[list[int]]`. Old
  LMCache servers cannot accept new ops, and new servers cannot
  accept old ops. No compat shim because the MP RPC is internal —
  same versioning approach as #3171's `vllm_block_size`-payload
  addition.

**Verified end-to-end on DeepSeek-V4-Flash, tp=4, fp8, block_size=256,
`--no-disable-hybrid-kv-cache-manager`, lmcache `chunk_size=1024`,
default-on SWA-suffix**:

Probe-confirmed layer grouping (logged at `register_kv_caches`):
- 8 LMCache groups with the expected 8-tuple split:
  - gid 0 splits into 3 groups (3 dense-MLA layer flavors at
    physical_bs ∈ {64, 64, 2}, logical_bs=256, namespace=0,
    sliding_window=0)
  - gid 1 (22 even+MTP-SWA layers) and gid 2 (21 odd-SWA layers)
    split despite identical specs; logical_bs=64, namespace ∈ {1, 2},
    sliding_window=128
  - gid 3 (compressor states for CSA) splits into 2 groups by hidden
    dim (hs ∈ {512, 2048}); physical_bs=4, logical_bs=4, namespace=3,
    sliding_window=8
  - gid 4 (compressor states for HCA): physical_bs=8, logical_bs=8,
    namespace=4, sliding_window=128

TTFT measurements via `deterministic_ttft.py` (single cold/warm pair
on identical token IDs to bypass `vllm bench serve`'s seed
non-determinism):

| Mode (LMCache-side connector, vanilla upstream vLLM) | Prompt    | Cold TTFT  | Warm TTFT  | Saved          | Speedup |
|------------------------------------------------------|-----------|-----------:|-----------:|---------------:|--------:|
| Hybrid OFF                                           | 9216 tok  | 1337.8 ms  |  520.5 ms  |  817 ms (61.1%) | **2.57×**  |
| Hybrid ON, default-on SWA-suffix                     | 9216 tok  | 1321.6 ms  |  573.2 ms  |  748 ms (56.6%) | **2.31×**  |
| Hybrid ON, default-on SWA-suffix                     | 30000 tok | 2862.0 ms  |  173.7 ms  | 2688 ms (93.9%) | **16.47×** |

The speedup ratio scales with prompt length — prefill is roughly
O(L²) in attention, retrieve is roughly O(L) in H2D bandwidth. The
SWA-suffix optimization compounds at long prompts where the
bandwidth savings (especially gid 3's ~128× per-chunk reduction
from 236 MiB to 1.85 MiB) exceed the per-call gather overhead.

Correctness via `partial_hit_harness.py` (cold-pass reference vs
LMCache-hit replay, comparing token IDs and per-token logprobs):
- token IDs identical (32/32), max|Δlogprob| = 5.04e-04 (well under
  the 4e-1 threshold from the documented #13 noise floor)

Zero `Cannot store keys` / `Cannot retrieve keys` /
`chunk_block_ids_gpu underflow` exceptions in any of the verification
runs.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

**Tests**:

- `tests/v1/test_kv_layer_groups_manager.py` — extended with
  `TestPerLayerLogicalBlockSize` (5 tests), `TestPerLayerKvCacheGroupId`
  (4 tests), `TestPerLayerSlidingWindow` (4 tests). All 34 tests
  pass.
- `tests/v1/multiprocess/test_cache_server.py`,
  `tests/v1/multiprocess/test_mq.py`,
  `tests/v1/multiprocess/test_mq_handler_helpers.py`,
  `tests/v1/multiprocess/test_blend_server_v2.py` — updated to wrap
  flat block-ID lists in length-1 nested form for the new wire
  protocol.
- All 403 tests in `tests/v1/multiprocess/` +
  `test_kv_layer_groups_manager` + `test_vllm_mp_adapter` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)