### PR TITLE
Added HFbucket MP

### DIFF
--- a/docs/source/kv_cache/storage_backends/hfbucket.rst
+++ b/docs/source/kv_cache/storage_backends/hfbucket.rst
@@ -91,6 +91,90 @@ either ``hfbucket`` or an instance-qualified name such as ``hfbucket.prod``.
   existence and size metadata.
 
 
+MP Mode Configuration
+---------------------
+
+In multi-process (MP) mode, Hugging Face Buckets are configured as an L2
+adapter through a JSON spec passed to the LMCache server. This is separate from
+the non-MP ``remote_storage_plugins`` configuration above. Each
+``--l2-adapter`` argument takes a JSON object whose ``"type": "hfbucket"``
+field selects the HFBucket adapter.
+
+.. code-block:: json
+
+   {
+     "type": "hfbucket",
+     "bucket_handle": "hf://buckets/my-org/lmcache-kv/prod",
+     "token_env": "HF_TOKEN",
+     "create_bucket_if_missing": false,
+     "download_tmp_dir": "/tmp/lmcache-hfbucket-mp",
+     "metadata_cache_ttl_secs": 30,
+     "num_workers": 4,
+     "max_capacity_gb": 500,
+     "eviction": {
+       "eviction_policy": "LRU",
+       "trigger_watermark": 0.85,
+       "eviction_ratio": 0.2
+     }
+   }
+
+HFBucket L2 Adapter Fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* **type** (required): must be ``"hfbucket"``.
+* **bucket_handle** (required): Hugging Face Bucket handle in
+  ``hf://buckets/<namespace>/<bucket>[/<prefix>]`` format.
+* **token_env**: environment variable used to resolve the Hugging Face access
+  token (default ``"HF_TOKEN"``).
+* **token**: optional direct token fallback. ``token_env`` takes precedence
+  when the environment variable is set. Prefer ``token_env`` for production
+  deployments so secrets do not live in adapter JSON.
+* **create_bucket_if_missing**: lazily create the bucket on the first store
+  operation (default ``false``). This only helps when the bucket is missing and
+  the token has permission to create it; it does not fix invalid credentials,
+  invalid handles, or network failures.
+* **download_tmp_dir**: root directory for temporary load downloads (default
+  ``/tmp/lmcache-hfbucket-mp``). The MP adapter downloads bucket files into
+  per-task temporary files and then copies their bytes into the destination
+  ``MemoryObj`` buffers supplied by the MP controller.
+* **metadata_cache_ttl_secs**: TTL for cached exact path-size metadata (default
+  ``30``). Set this lower when another process may modify the same bucket
+  prefix outside LMCache and fresher metadata is more important than reducing
+  Hugging Face metadata calls.
+* **num_workers**: number of worker threads used for blocking Hugging Face Hub
+  bucket API calls (default ``4``). The HFBucket Python APIs are synchronous,
+  so MP mode runs upload, lookup, load, and delete work on a bounded thread
+  pool behind the adapter's eventfd-based completion interface.
+* **max_capacity_gb**: capacity used by ``get_usage()`` for watermark-based L2
+  eviction. Set to ``0`` (default) to disable aggregate capacity tracking;
+  ``get_usage()`` then reports the adapter as not providing an eviction signal.
+* **eviction**: optional sub-dict enabling the L2 eviction controller for this
+  adapter. When present, keys that are currently being loaded are protected by
+  the lookup-and-lock path and skipped by ``delete()`` until they are unlocked.
+
+Differences vs Non-MP HFBucket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Hugging Face bucket operations are synchronous but the adapter makes submission
+  non-blocking by running the blocking calls on worker threads.
+* MP loads do not allocate and return new memory. The MP controller provides
+  destination ``MemoryObj`` buffers, and the adapter copies downloaded bytes
+  into those buffers.
+* Keys are identified by ``ObjectKey`` (``model_name`` + ``kv_rank`` +
+  ``chunk_hash`` + optional ``cache_salt``) rather than ``CacheEngineKey``.
+  The serialized MP object name is
+  ``<model>@<kv_rank_hex>@<chunk_hash_hex>[@<cache_salt>]`` and is then
+  encoded for the bucket path. This naming is not compatible with the non-MP
+  HFBucket connector's ``CacheEngineKey`` object names, so a bucket prefix
+  populated by non-MP LMCache cannot be read directly by MP LMCache and vice
+  versa.
+* Full object writes are batch based. Hugging Face batch writes are not
+  transactional, so a failed store task may still leave some objects in the
+  bucket. The MP adapter reconciles backend metadata after such failures so
+  any objects that actually landed are counted for usage and later deletion 
+  (submitted store task is still reported as failed).
+
+
 Notes
 -----
 

--- a/docs/source/mp/l2_storage.rst
+++ b/docs/source/mp/l2_storage.rst
@@ -543,6 +543,59 @@ S3-compatible endpoint (MinIO, Ceph RGW, etc.).
     # Local MinIO over plain HTTP
     --l2-adapter '{"type": "s3", "s3_endpoint": "minio.local:9000", "s3_region": "us-east-1", "disable_tls": true, "aws_access_key_id": "minio", "aws_secret_access_key": "minio123"}'
 
+``hfbucket`` -- Hugging Face Buckets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An L2 adapter that stores KV cache objects in a `Hugging Face Bucket
+<https://huggingface.co/docs/hub/storage-backends>`_ using the
+``huggingface_hub`` bucket APIs.  Blocking Hub calls run on a bounded thread
+pool driven by an asyncio loop on a daemon thread, so the L2 controller thread
+is never blocked on network I/O.
+
+Object names are derived from the MP ``ObjectKey`` as
+``<model>@<kv_rank_hex>@<chunk_hash_hex>[@<cache_salt>]`` and then encoded with
+the standard HFBucket object-name encoding plus the optional bucket prefix.
+Because Hugging Face batch writes are not transactional, a store task that
+partially fails reconciles backend metadata so that any objects that actually
+landed are still counted for usage accounting and later deletion.
+
+This is a persistent remote backend best suited to warm and cold KV cache
+tiers; prefer a lower-latency local adapter for the hottest cache tier.
+
+**Required fields:**
+
+- ``bucket_handle``: Bucket location in the form
+  ``hf://buckets/<namespace>/<bucket>[/<prefix>]``.
+
+**Optional fields:**
+
+- ``token_env`` (string, default ``"HF_TOKEN"``): Environment variable used to
+  resolve the Hugging Face access token.
+- ``token`` (string): Direct token fallback used when ``token_env`` is unset.
+- ``create_bucket_if_missing`` (bool, default ``false``): Create the bucket
+  lazily on the first store instead of requiring it to exist.
+- ``download_tmp_dir`` (string): Root directory for temporary load downloads.
+- ``metadata_cache_ttl_secs`` (float, default ``30.0``): TTL for the
+  path-size metadata cache that backs lookups and usage accounting.
+- ``num_workers`` (int, default ``4``): Number of worker threads for blocking
+  Hugging Face Hub API calls.
+- ``max_capacity_gb`` (float, default ``0.0``): Aggregate capacity used by
+  ``get_usage()``.  A value of ``0`` disables aggregate eviction.
+- ``eviction`` (dict): Optional eviction policy, see ``L2AdapterConfigBase``.
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    # Minimal: use an existing bucket with a token from $HF_TOKEN
+    --l2-adapter '{"type": "hfbucket", "bucket_handle": "hf://buckets/my-org/lmcache-kv/prod"}'
+
+    # Create the bucket on first store and bound the worker pool
+    --l2-adapter '{"type": "hfbucket", "bucket_handle": "hf://buckets/my-org/lmcache-kv/prod", "create_bucket_if_missing": true, "num_workers": 8}'
+
+    # Enable aggregate eviction with a capacity cap
+    --l2-adapter '{"type": "hfbucket", "bucket_handle": "hf://buckets/my-org/lmcache-kv/prod", "max_capacity_gb": 50, "eviction": {"eviction_policy": "LRU", "trigger_watermark": 0.9, "eviction_ratio": 0.1}}'
+
 ``mock`` -- Mock adapter for testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -777,6 +830,12 @@ drops by ``eviction_ratio``.
        when ``max_capacity_gb`` is ``0`` (disabled); set a non-zero
        ``max_capacity_gb`` to enable the watermark-triggered eviction
        controller.
+   * - ``hfbucket``
+     - ``delete`` removes objects from the bucket and frees aggregate
+       byte accounting. ``get_usage`` reports ``usage_fraction == -1.0``
+       when ``max_capacity_gb`` is ``0`` (disabled); set a non-zero
+       ``max_capacity_gb`` to enable the watermark-triggered eviction
+       controller. Locked keys (in-flight loads) are skipped.
    * - ``dax``
      - Full support. ``delete`` removes unlocked keys from the in-memory
        index immediately and recycles fixed slots once active read borrows

--- a/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
@@ -1,0 +1,877 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Hugging Face Buckets L2 adapter for LMCache MP mode.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+import asyncio
+import os
+import shutil
+import tempfile
+import threading
+import time
+
+if TYPE_CHECKING:
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.base import (
+    L2AdapterInterface,
+    L2TaskId,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
+    register_l2_adapter_factory,
+)
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
+from lmcache.v1.storage_backend.connector.hfbucket_connector import (
+    HFBucketClient,
+    HFBucketClientInterface,
+    HFBucketLocation,
+    encode_hfbucket_object_name,
+    parse_hfbucket_handle,
+)
+
+logger = init_logger(__name__)
+
+# Use a separate temp root from non-MP HFBucket to avoid collisions.
+_DEFAULT_DOWNLOAD_TMP_DIR = Path(tempfile.gettempdir()) / "lmcache-hfbucket-mp"
+_METADATA_CACHE_PRUNE_INTERVAL = 128
+
+
+@dataclass(frozen=True)
+class _CachedObjectMetadata:
+    """Cached object size entry with expiration metadata."""
+
+    size_bytes: int
+    expires_at: float
+
+
+class _PartialStoreFailure(RuntimeError):
+    """Raised when a failed HFBucket batch store still wrote some objects."""
+
+    def __init__(
+        self,
+        message: str,
+        stored_keys: list[ObjectKey],
+        stored_sizes: list[int],
+    ) -> None:
+        super().__init__(message)
+        self.stored_keys = stored_keys
+        self.stored_sizes = stored_sizes
+
+
+def _object_key_to_string(key: ObjectKey) -> str:
+    """Serialize an MP ``ObjectKey`` to the shared L2 object-name format.
+
+    Unsalted keys use ``<model_name>@<kv_rank_hex>@<chunk_hash_hex>``. Salted
+    keys append ``@<cache_salt>`` so tenants/users with identical token chunks
+    do not collide in the backing bucket.
+    """
+    base = f"{key.model_name}@{key.kv_rank:08x}@{key.chunk_hash.hex()}"
+    if key.cache_salt:
+        return f"{base}@{key.cache_salt}"
+    return base
+
+
+def _object_key_to_bucket_path(key: ObjectKey, location: HFBucketLocation) -> str:
+    """Return the HFBucket object path for an MP object key."""
+    encoded = encode_hfbucket_object_name(_object_key_to_string(key))
+    if location.object_prefix:
+        return f"{location.object_prefix}/{encoded}"
+    return encoded
+
+
+def _resolve_hf_token(token_env: str, token: str | None) -> str | None:
+    """Resolve Hugging Face token from env-first adapter config."""
+    env_token = os.environ.get(token_env, "") if token_env else ""
+    if env_token:
+        return env_token
+    return token
+
+
+def _get_path_info_path(path_info: object) -> str:
+    """Read a Hugging Face path-info object's path field defensively."""
+    path = getattr(path_info, "path", "")
+    return path if isinstance(path, str) else ""
+
+
+def _get_path_info_type(path_info: object) -> str:
+    """Read a Hugging Face path-info object's type field defensively."""
+    obj_type = getattr(path_info, "type", "")
+    return obj_type if isinstance(obj_type, str) else ""
+
+
+def _get_path_info_size(path_info: object) -> int:
+    """Read a Hugging Face path-info object's size field defensively."""
+    size = getattr(path_info, "size", 0)
+    return size if isinstance(size, int) else 0
+
+
+def _is_not_found_error(exc: Exception) -> bool:
+    """Return whether an exception represents a missing bucket/object."""
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code == 404
+
+    direct_status_code = getattr(exc, "status_code", None)
+    if isinstance(direct_status_code, int):
+        return direct_status_code == 404
+
+    return "404" in str(exc)
+
+
+class HFBucketL2AdapterConfig(L2AdapterConfigBase):
+    """Configuration for the HFBucket MP L2 adapter.
+
+    Fields:
+    - ``bucket_handle``: ``hf://buckets/<namespace>/<bucket>[/<prefix>]``.
+    - ``token_env``: environment variable used to resolve the HF token.
+    - ``token``: optional direct token fallback.
+    - ``create_bucket_if_missing``: create the bucket lazily on first store.
+    - ``download_tmp_dir``: root directory for temporary load downloads.
+    - ``metadata_cache_ttl_secs``: TTL for path-size metadata cache.
+    - ``num_workers``: worker threads for blocking Hugging Face API calls.
+    - ``max_capacity_gb``: capacity used by inherited L2 usage accounting.
+    """
+
+    def __init__(
+        self,
+        bucket_handle: str,
+        token_env: str = "HF_TOKEN",
+        token: Optional[str] = None,
+        create_bucket_if_missing: bool = False,
+        download_tmp_dir: str = str(_DEFAULT_DOWNLOAD_TMP_DIR),
+        metadata_cache_ttl_secs: float = 30.0,
+        num_workers: int = 4,
+        max_capacity_gb: float = 0.0,
+    ) -> None:
+        self.bucket_handle = bucket_handle
+        self.bucket_location = parse_hfbucket_handle(bucket_handle)
+        self.token_env = token_env
+        self.token = token
+        self.create_bucket_if_missing = create_bucket_if_missing
+        self.download_tmp_dir = Path(download_tmp_dir)
+        self.metadata_cache_ttl_secs = metadata_cache_ttl_secs
+        self.num_workers = num_workers
+        self.max_capacity_gb = max_capacity_gb
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "HFBucketL2AdapterConfig":
+        """Parse a config object from ``--l2-adapter`` JSON."""
+        bucket_handle = d.get("bucket_handle")
+        if not isinstance(bucket_handle, str) or not bucket_handle:
+            raise ValueError("bucket_handle must be a non-empty string")
+
+        token_env = d.get("token_env", "HF_TOKEN")
+        if not isinstance(token_env, str):
+            raise ValueError("token_env must be a string")
+
+        token = d.get("token")
+        if token is not None and not isinstance(token, str):
+            raise ValueError("token must be a string")
+
+        download_tmp_dir = d.get("download_tmp_dir", str(_DEFAULT_DOWNLOAD_TMP_DIR))
+        if not isinstance(download_tmp_dir, str) or not download_tmp_dir:
+            raise ValueError("download_tmp_dir must be a non-empty string")
+
+        metadata_cache_ttl_secs = d.get("metadata_cache_ttl_secs", 30.0)
+        if (
+            not isinstance(metadata_cache_ttl_secs, (int, float))
+            or isinstance(metadata_cache_ttl_secs, bool)
+            or metadata_cache_ttl_secs < 0
+        ):
+            raise ValueError("metadata_cache_ttl_secs must be a non-negative number")
+
+        num_workers = d.get("num_workers", 4)
+        if not isinstance(num_workers, int) or isinstance(num_workers, bool):
+            raise ValueError("num_workers must be a positive integer")
+        if num_workers <= 0:
+            raise ValueError("num_workers must be a positive integer")
+
+        max_capacity_gb = d.get("max_capacity_gb", 0.0)
+        if (
+            not isinstance(max_capacity_gb, (int, float))
+            or isinstance(max_capacity_gb, bool)
+            or max_capacity_gb < 0
+        ):
+            raise ValueError("max_capacity_gb must be a non-negative number")
+
+        create_bucket_if_missing = d.get("create_bucket_if_missing", False)
+        if not isinstance(create_bucket_if_missing, bool):
+            raise ValueError("create_bucket_if_missing must be a boolean")
+
+        cfg = cls(
+            bucket_handle=bucket_handle,
+            token_env=token_env,
+            token=token,
+            create_bucket_if_missing=create_bucket_if_missing,
+            download_tmp_dir=download_tmp_dir,
+            metadata_cache_ttl_secs=float(metadata_cache_ttl_secs),
+            num_workers=num_workers,
+            max_capacity_gb=float(max_capacity_gb),
+        )
+        cfg.eviction_config = cls._parse_eviction_config(d)
+        return cfg
+
+    @classmethod
+    def help(cls) -> str:
+        """Return CLI help text for this adapter type."""
+        return (
+            "HFBucket L2 adapter config fields:\n"
+            "- bucket_handle (str, required): "
+            "hf://buckets/<namespace>/<bucket>[/<prefix>]\n"
+            "- token_env (str): env var for HF token (default HF_TOKEN)\n"
+            "- token (str): direct token fallback\n"
+            "- create_bucket_if_missing (bool): create bucket on first store\n"
+            "- download_tmp_dir (str): temporary download root\n"
+            "- metadata_cache_ttl_secs (float): metadata cache TTL\n"
+            "- num_workers (int): blocking HF API worker threads\n"
+            "- max_capacity_gb (float): capacity for get_usage (0 = disabled)\n"
+            "- eviction (dict): optional, see L2AdapterConfigBase"
+        )
+
+
+class HFBucketL2Adapter(L2AdapterInterface):
+    """Hugging Face Buckets backed MP L2 adapter."""
+
+    def __init__(
+        self,
+        config: HFBucketL2AdapterConfig,
+        bucket_client: HFBucketClientInterface | None = None,
+    ) -> None:
+        super().__init__(max_capacity_bytes=int(config.max_capacity_gb * (1024**3)))
+        self._config = config
+        self._bucket_location = config.bucket_location
+        self._bucket_id = config.bucket_location.bucket_id
+        self._object_prefix = config.bucket_location.object_prefix
+        self._create_bucket_if_missing = config.create_bucket_if_missing
+        self._metadata_cache_ttl_secs = config.metadata_cache_ttl_secs
+
+        if bucket_client is None:
+            token = _resolve_hf_token(config.token_env, config.token)
+            self._bucket_client: HFBucketClientInterface = HFBucketClient(token=token)
+        else:
+            self._bucket_client = bucket_client
+
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
+
+        self._next_task_id: L2TaskId = 0
+        self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
+        self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
+
+        self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
+        self._key_sizes: dict[ObjectKey, int] = {}
+        self._metadata_cache: dict[str, _CachedObjectMetadata] = {}
+        self._metadata_cache_updates = 0
+
+        self._bucket_create_checked = False
+        self._bucket_create_lock = threading.Lock()
+
+        self._lock = threading.Lock()
+        self._closed = False
+
+        self._download_tmp_root = config.download_tmp_dir.expanduser()
+        self._download_tmp_root.mkdir(parents=True, exist_ok=True)
+        self._download_session_dir = Path(
+            tempfile.mkdtemp(
+                prefix="hfbucket-mp-",
+                dir=self._download_tmp_root,
+            )
+        )
+
+        self._executor = ThreadPoolExecutor(
+            max_workers=config.num_workers,
+            thread_name_prefix="hfbucket-l2",
+        )
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._run_event_loop,
+            daemon=True,
+            name="hfbucket-l2-adapter-loop",
+        )
+        self._loop_thread.start()
+
+        logger.info(
+            "Initialized HFBucketL2Adapter (bucket_id=%s prefix=%r "
+            "workers=%d max_capacity_gb=%.2f)",
+            self._bucket_id,
+            self._object_prefix,
+            config.num_workers,
+            config.max_capacity_gb,
+        )
+
+    def get_store_event_fd(self) -> int:
+        return self._store_efd.fileno()
+
+    def get_lookup_and_lock_event_fd(self) -> int:
+        return self._lookup_efd.fileno()
+
+    def get_load_event_fd(self) -> int:
+        return self._load_efd.fileno()
+
+    def submit_store_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        with self._lock:
+            task_id = self._get_next_task_id_locked()
+            if self._closed:
+                self._completed_store_tasks[task_id] = False
+                closed = True
+            else:
+                closed = False
+
+        if closed:
+            self._store_efd.notify()
+            return task_id
+
+        asyncio.run_coroutine_threadsafe(
+            self._execute_store(list(keys), list(objects), task_id),
+            self._loop,
+        )
+        return task_id
+
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+        with self._lock:
+            completed = self._completed_store_tasks
+            self._completed_store_tasks = {}
+        return completed
+
+    def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
+        with self._lock:
+            task_id = self._get_next_task_id_locked()
+            if self._closed:
+                self._completed_lookup_tasks[task_id] = Bitmap(len(keys))
+                closed = True
+            else:
+                closed = False
+
+        if closed:
+            self._lookup_efd.notify()
+            return task_id
+
+        asyncio.run_coroutine_threadsafe(
+            self._execute_lookup(list(keys), task_id),
+            self._loop,
+        )
+        return task_id
+
+    def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Optional[Bitmap]:
+        with self._lock:
+            return self._completed_lookup_tasks.pop(task_id, None)
+
+    def submit_unlock(self, keys: list[ObjectKey]) -> None:
+        with self._lock:
+            for key in keys:
+                if key not in self._locked_keys:
+                    continue
+                if self._locked_keys[key] <= 1:
+                    del self._locked_keys[key]
+                else:
+                    self._locked_keys[key] -= 1
+
+    def submit_load_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        with self._lock:
+            task_id = self._get_next_task_id_locked()
+            if self._closed:
+                self._completed_load_tasks[task_id] = Bitmap(len(keys))
+                closed = True
+            else:
+                closed = False
+
+        if closed:
+            self._load_efd.notify()
+            return task_id
+
+        asyncio.run_coroutine_threadsafe(
+            self._execute_load(list(keys), list(objects), task_id),
+            self._loop,
+        )
+        return task_id
+
+    def query_load_result(self, task_id: L2TaskId) -> Optional[Bitmap]:
+        with self._lock:
+            return self._completed_load_tasks.pop(task_id, None)
+
+    def delete(self, keys: list[ObjectKey]) -> None:
+        if not keys:
+            return
+
+        with self._lock:
+            if self._closed:
+                return
+            deletable = [key for key in keys if self._locked_keys.get(key, 0) == 0]
+
+        if not deletable:
+            return
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._execute_delete(deletable),
+            self._loop,
+        )
+        try:
+            deleted_keys, deleted_sizes = future.result(timeout=30.0)
+        except Exception as exc:
+            logger.warning("HFBucketL2Adapter delete failed: %s", exc)
+            return
+
+        if deleted_keys:
+            self._notify_keys_deleted(deleted_keys, deleted_sizes)
+
+    def report_status(self) -> dict:
+        usage = self.get_usage()
+        with self._lock:
+            object_count = len(self._key_sizes)
+            locked_key_count = len(self._locked_keys)
+            closed = self._closed
+        return {
+            "is_healthy": self._loop_thread.is_alive() and not closed,
+            "type": "HFBucketL2Adapter",
+            "bucket_id": self._bucket_id,
+            "object_prefix": self._object_prefix,
+            "stored_object_count": object_count,
+            "locked_key_count": locked_key_count,
+            "current_size_bytes": usage.total_bytes_used,
+            "max_capacity_bytes": usage.total_capacity_bytes,
+        }
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        async def _stop_tasks() -> None:
+            tasks = [
+                task
+                for task in asyncio.all_tasks(self._loop)
+                if task is not asyncio.current_task()
+            ]
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        if self._loop.is_running():
+            try:
+                asyncio.run_coroutine_threadsafe(_stop_tasks(), self._loop).result(
+                    timeout=5
+                )
+            except Exception:
+                pass
+            self._loop.call_soon_threadsafe(self._loop.stop)
+
+        self._loop_thread.join(timeout=5)
+        try:
+            self._loop.close()
+        except Exception:
+            pass
+
+        self._executor.shutdown(wait=True, cancel_futures=True)
+
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
+
+        with self._lock:
+            self._metadata_cache.clear()
+            self._key_sizes.clear()
+            self._locked_keys.clear()
+
+        shutil.rmtree(self._download_session_dir, ignore_errors=True)
+        logger.info("HFBucketL2Adapter closed")
+
+    def _run_event_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def _get_next_task_id_locked(self) -> L2TaskId:
+        task_id = self._next_task_id
+        self._next_task_id += 1
+        return task_id
+
+    async def _execute_store(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+        task_id: L2TaskId,
+    ) -> None:
+        try:
+            stored_keys, stored_sizes = await self._loop.run_in_executor(
+                self._executor,
+                self._store_batch_sync,
+                keys,
+                objects,
+            )
+            success = True
+        except _PartialStoreFailure as exc:
+            logger.exception("HFBucketL2Adapter store task partially failed")
+            stored_keys = exc.stored_keys
+            stored_sizes = exc.stored_sizes
+            success = False
+        except Exception:
+            logger.exception("HFBucketL2Adapter store task failed")
+            stored_keys = []
+            stored_sizes = []
+            success = False
+
+        with self._lock:
+            self._completed_store_tasks[task_id] = success
+
+        if stored_keys:
+            self._notify_keys_stored(stored_keys, stored_sizes)
+        self._store_efd.notify()
+
+    async def _execute_lookup(
+        self,
+        keys: list[ObjectKey],
+        task_id: L2TaskId,
+    ) -> None:
+        bitmap = Bitmap(len(keys))
+        try:
+            sizes = await self._loop.run_in_executor(
+                self._executor,
+                self._resolve_object_sizes_sync,
+                keys,
+            )
+        except Exception:
+            logger.exception("HFBucketL2Adapter lookup task failed")
+            sizes = [0] * len(keys)
+
+        accessed: list[ObjectKey] = []
+        with self._lock:
+            for i, (key, size) in enumerate(zip(keys, sizes, strict=True)):
+                if size <= 0:
+                    continue
+                bitmap.set(i)
+                self._locked_keys[key] += 1
+                accessed.append(key)
+            self._completed_lookup_tasks[task_id] = bitmap
+
+        self._lookup_efd.notify()
+        if accessed:
+            self._notify_keys_accessed(accessed)
+
+    async def _execute_load(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+        task_id: L2TaskId,
+    ) -> None:
+        try:
+            bitmap = await self._loop.run_in_executor(
+                self._executor,
+                self._load_batch_sync,
+                keys,
+                objects,
+            )
+        except Exception:
+            logger.exception("HFBucketL2Adapter load task failed")
+            bitmap = Bitmap(len(keys))
+
+        with self._lock:
+            self._completed_load_tasks[task_id] = bitmap
+        self._load_efd.notify()
+
+    async def _execute_delete(
+        self,
+        keys: list[ObjectKey],
+    ) -> tuple[list[ObjectKey], list[int]]:
+        return await self._loop.run_in_executor(
+            self._executor,
+            self._delete_batch_sync,
+            keys,
+        )
+
+    def _store_batch_sync(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> tuple[list[ObjectKey], list[int]]:
+        self._ensure_bucket_for_writes()
+
+        additions: list[tuple[bytes, str]] = []
+        indexed: list[tuple[ObjectKey, str, int]] = []
+        for key, obj in zip(keys, objects, strict=True):
+            object_path = _object_key_to_bucket_path(key, self._bucket_location)
+            data = memoryview(obj.byte_array).cast("B").tobytes()
+            additions.append((data, object_path))
+            indexed.append((key, object_path, len(data)))
+
+        if not additions:
+            return [], []
+
+        try:
+            self._bucket_client.upload_files(self._bucket_id, additions)
+        except Exception as exc:
+            # Hugging Face batch writes are not transactional: a request can
+            # write part of the batch and then fail. Fetch fresh backend
+            # metadata, update accounting for objects that really landed, and
+            # still report the submitted store task as failed.
+            stored_keys, stored_sizes = self._reconcile_failed_store(indexed)
+            raise _PartialStoreFailure(
+                "HFBucket batch upload failed after partial reconciliation",
+                stored_keys,
+                stored_sizes,
+            ) from exc
+
+        stored_keys: list[ObjectKey] = []
+        stored_sizes: list[int] = []
+        with self._lock:
+            for key, object_path, size in indexed:
+                was_new = key not in self._key_sizes
+                self._key_sizes[key] = size
+                self._set_cached_object_size_locked(object_path, size)
+                if was_new:
+                    stored_keys.append(key)
+                    stored_sizes.append(size)
+
+        return stored_keys, stored_sizes
+
+    def _resolve_object_sizes_sync(self, keys: list[ObjectKey]) -> list[int]:
+        object_paths = [
+            _object_key_to_bucket_path(key, self._bucket_location) for key in keys
+        ]
+
+        cached: dict[str, int] = {}
+        unresolved_paths: list[str] = []
+        with self._lock:
+            for object_path in object_paths:
+                cached_size = self._get_cached_object_size_locked(object_path)
+                if cached_size is None:
+                    unresolved_paths.append(object_path)
+                else:
+                    cached[object_path] = cached_size
+
+        if unresolved_paths:
+            fetched = self._fetch_object_sizes_sync(unresolved_paths)
+            with self._lock:
+                for object_path, size in fetched.items():
+                    self._set_cached_object_size_locked(object_path, size)
+            cached.update(fetched)
+
+        return [cached.get(object_path, 0) for object_path in object_paths]
+
+    def _fetch_object_sizes_sync(self, object_paths: list[str]) -> dict[str, int]:
+        if not object_paths:
+            return {}
+
+        try:
+            path_infos = self._bucket_client.get_paths_info(
+                self._bucket_id,
+                object_paths,
+            )
+        except Exception as exc:
+            if _is_not_found_error(exc):
+                return {object_path: 0 for object_path in object_paths}
+            raise
+
+        size_by_path: dict[str, int] = {}
+        for path_info in path_infos:
+            if _get_path_info_type(path_info) != "file":
+                continue
+            path = _get_path_info_path(path_info)
+            if path:
+                size_by_path[path] = _get_path_info_size(path_info)
+
+        return {
+            object_path: size_by_path.get(object_path, 0)
+            for object_path in object_paths
+        }
+
+    def _load_batch_sync(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> Bitmap:
+        bitmap = Bitmap(len(keys))
+        object_paths = [
+            _object_key_to_bucket_path(key, self._bucket_location) for key in keys
+        ]
+
+        batch_dir = Path(
+            tempfile.mkdtemp(prefix="load-", dir=self._download_session_dir)
+        )
+        local_paths: list[tuple[int, Path]] = []
+        files: list[tuple[str, str]] = []
+        for index, object_path in enumerate(object_paths):
+            local_path = batch_dir / f"{index}.bin"
+            local_paths.append((index, local_path))
+            files.append((object_path, str(local_path)))
+
+        try:
+            try:
+                self._bucket_client.download_files(self._bucket_id, files)
+            except Exception as exc:
+                if not _is_not_found_error(exc):
+                    logger.warning("Batch download from hfbucket raised: %s", exc)
+
+            for index, local_path in local_paths:
+                if not local_path.exists():
+                    continue
+
+                data = local_path.read_bytes()
+                dst = memoryview(objects[index].byte_array).cast("B")
+                if len(data) != len(dst):
+                    logger.error(
+                        "Downloaded object %s has %d bytes, expected %d bytes; "
+                        "rejecting load",
+                        object_paths[index],
+                        len(data),
+                        len(dst),
+                    )
+                    with self._lock:
+                        self._set_cached_object_size_locked(
+                            object_paths[index],
+                            len(data),
+                        )
+                    continue
+
+                dst[:] = data
+                bitmap.set(index)
+                with self._lock:
+                    self._set_cached_object_size_locked(
+                        object_paths[index],
+                        len(data),
+                    )
+
+            return bitmap
+        finally:
+            shutil.rmtree(batch_dir, ignore_errors=True)
+
+    def _delete_batch_sync(
+        self,
+        keys: list[ObjectKey],
+    ) -> tuple[list[ObjectKey], list[int]]:
+        object_paths = [
+            _object_key_to_bucket_path(key, self._bucket_location) for key in keys
+        ]
+
+        try:
+            self._bucket_client.delete_files(self._bucket_id, object_paths)
+        except Exception as exc:
+            if not _is_not_found_error(exc):
+                raise
+
+        deleted_keys: list[ObjectKey] = []
+        deleted_sizes: list[int] = []
+        with self._lock:
+            for key, object_path in zip(keys, object_paths, strict=True):
+                size = self._key_sizes.pop(key, None)
+                self._set_cached_object_size_locked(object_path, 0)
+                deleted_keys.append(key)
+                deleted_sizes.append(size if size is not None else 0)
+
+        return deleted_keys, deleted_sizes
+
+    def _ensure_bucket_for_writes(self) -> None:
+        if not self._create_bucket_if_missing or self._bucket_create_checked:
+            return
+
+        with self._bucket_create_lock:
+            if self._bucket_create_checked:
+                return
+            self._bucket_client.create_bucket(self._bucket_id)
+            self._bucket_create_checked = True
+
+    def _refresh_cached_sizes(self, keys: list[ObjectKey]) -> None:
+        try:
+            self._resolve_object_sizes_sync(keys)
+        except Exception:
+            logger.debug("Failed to refresh hfbucket object sizes", exc_info=True)
+
+    def _reconcile_failed_store(
+        self,
+        indexed: list[tuple[ObjectKey, str, int]],
+    ) -> tuple[list[ObjectKey], list[int]]:
+        object_paths = [object_path for _, object_path, _ in indexed]
+        try:
+            sizes_by_path = self._fetch_object_sizes_sync(object_paths)
+        except Exception:
+            logger.debug("Failed to reconcile partial hfbucket store", exc_info=True)
+            return [], []
+
+        stored_keys: list[ObjectKey] = []
+        stored_sizes: list[int] = []
+        with self._lock:
+            for key, object_path, _expected_size in indexed:
+                size = sizes_by_path.get(object_path, 0)
+                self._set_cached_object_size_locked(object_path, size)
+                if size <= 0:
+                    continue
+
+                # Only notify net-new keys. Existing keys already contributed
+                # to byte accounting, and cache objects should be fixed size.
+                was_new = key not in self._key_sizes
+                self._key_sizes[key] = size
+                if was_new:
+                    stored_keys.append(key)
+                    stored_sizes.append(size)
+
+        return stored_keys, stored_sizes
+
+    def _get_cached_object_size_locked(self, object_path: str) -> int | None:
+        entry = self._metadata_cache.get(object_path)
+        if entry is None:
+            return None
+        if entry.expires_at <= time.monotonic():
+            self._metadata_cache.pop(object_path, None)
+            return None
+        return entry.size_bytes
+
+    def _set_cached_object_size_locked(self, object_path: str, size: int) -> None:
+        expires_at = time.monotonic() + self._metadata_cache_ttl_secs
+        self._metadata_cache[object_path] = _CachedObjectMetadata(
+            size_bytes=size,
+            expires_at=expires_at,
+        )
+        self._metadata_cache_updates += 1
+        if self._metadata_cache_updates % _METADATA_CACHE_PRUNE_INTERVAL == 0:
+            self._prune_expired_cache_entries_locked(time.monotonic())
+
+    def _prune_expired_cache_entries_locked(self, now: float) -> None:
+        expired = [
+            object_path
+            for object_path, entry in self._metadata_cache.items()
+            if entry.expires_at <= now
+        ]
+        for object_path in expired:
+            self._metadata_cache.pop(object_path, None)
+
+
+register_l2_adapter_type("hfbucket", HFBucketL2AdapterConfig)
+
+
+def _create_hfbucket_l2_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+) -> L2AdapterInterface:
+    """Create an HFBucket L2 adapter from registry config."""
+    return HFBucketL2Adapter(config)  # type: ignore[arg-type]
+
+
+register_l2_adapter_factory("hfbucket", _create_hfbucket_l2_adapter)

--- a/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
     L2TaskId,
@@ -275,7 +276,7 @@ class HFBucketL2Adapter(L2AdapterInterface):
         self._load_efd = create_event_notifier()
 
         self._next_task_id: L2TaskId = 0
-        self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
 
@@ -337,7 +338,7 @@ class HFBucketL2Adapter(L2AdapterInterface):
         with self._lock:
             task_id = self._get_next_task_id_locked()
             if self._closed:
-                self._completed_store_tasks[task_id] = False
+                self._completed_store_tasks[task_id] = L2StoreResult(False, 0)
                 closed = True
             else:
                 closed = False
@@ -352,7 +353,7 @@ class HFBucketL2Adapter(L2AdapterInterface):
         )
         return task_id
 
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
         with self._lock:
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
@@ -539,8 +540,12 @@ class HFBucketL2Adapter(L2AdapterInterface):
             stored_sizes = []
             success = False
 
+        bytes_transferred = sum(stored_sizes)
         with self._lock:
-            self._completed_store_tasks[task_id] = success
+            self._completed_store_tasks[task_id] = L2StoreResult(
+                success,
+                bytes_transferred,
+            )
 
         if stored_keys:
             self._notify_keys_stored(stored_keys, stored_sizes)
@@ -632,11 +637,11 @@ class HFBucketL2Adapter(L2AdapterInterface):
             # write part of the batch and then fail. Fetch fresh backend
             # metadata, update accounting for objects that really landed, and
             # still report the submitted store task as failed.
-            stored_keys, stored_sizes = self._reconcile_failed_store(indexed)
+            reconciled_keys, reconciled_sizes = self._reconcile_failed_store(indexed)
             raise _PartialStoreFailure(
                 "HFBucket batch upload failed after partial reconciliation",
-                stored_keys,
-                stored_sizes,
+                reconciled_keys,
+                reconciled_sizes,
             ) from exc
 
         stored_keys: list[ObjectKey] = []

--- a/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
@@ -734,29 +734,45 @@ class HFBucketL2Adapter(L2AdapterInterface):
                 if not local_path.exists():
                     continue
 
-                data = local_path.read_bytes()
                 dst = memoryview(objects[index].byte_array).cast("B")
-                if len(data) != len(dst):
+                file_size = local_path.stat().st_size
+                if file_size != len(dst):
                     logger.error(
                         "Downloaded object %s has %d bytes, expected %d bytes; "
                         "rejecting load",
                         object_paths[index],
-                        len(data),
+                        file_size,
                         len(dst),
                     )
                     with self._lock:
                         self._set_cached_object_size_locked(
                             object_paths[index],
-                            len(data),
+                            file_size,
                         )
                     continue
 
-                dst[:] = data
+                with local_path.open("rb") as f:
+                    bytes_read = f.readinto(dst)
+                if bytes_read != len(dst):
+                    logger.error(
+                        "Downloaded object %s read %d bytes, expected %d bytes; "
+                        "rejecting load",
+                        object_paths[index],
+                        bytes_read,
+                        len(dst),
+                    )
+                    with self._lock:
+                        self._set_cached_object_size_locked(
+                            object_paths[index],
+                            bytes_read,
+                        )
+                    continue
+
                 bitmap.set(index)
                 with self._lock:
                     self._set_cached_object_size_locked(
                         object_paths[index],
-                        len(data),
+                        file_size,
                     )
 
             return bitmap

--- a/tests/v1/distributed/test_hfbucket_l2_adapter.py
+++ b/tests/v1/distributed/test_hfbucket_l2_adapter.py
@@ -2,6 +2,7 @@
 """Unit tests for the HFBucket MP L2 adapter."""
 
 # Standard
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 import select
@@ -24,6 +25,7 @@ from lmcache.v1.distributed.l2_adapters.hfbucket_l2_adapter import (
 )
 from lmcache.v1.memory_management import (
     MemoryFormat,
+    MemoryObj,
     MemoryObjMetadata,
     TensorMemoryObj,
 )
@@ -31,7 +33,6 @@ from lmcache.v1.platform import consume_fd
 from lmcache.v1.storage_backend.connector.hfbucket_connector import (
     parse_hfbucket_handle,
 )
-
 
 _TEST_BUCKET_HANDLE = "hf://buckets/test-org/test-bucket/prod"
 _TEST_BUCKET_LOCATION = parse_hfbucket_handle(_TEST_BUCKET_HANDLE)
@@ -64,8 +65,8 @@ class _FakeBucketClient:
     def get_paths_info(
         self,
         bucket_id: str,
-        paths: list[str],
-    ) -> list[_FakePathInfo]:
+        paths: Sequence[str],
+    ) -> list[object]:
         del bucket_id
         with self._lock:
             return [
@@ -74,7 +75,7 @@ class _FakeBucketClient:
                 if path in self.storage
             ]
 
-    def list_tree(self, bucket_id: str, prefix: str) -> list[_FakePathInfo]:
+    def list_tree(self, bucket_id: str, prefix: str) -> list[object]:
         del bucket_id
         with self._lock:
             return [
@@ -86,7 +87,7 @@ class _FakeBucketClient:
     def upload_files(
         self,
         bucket_id: str,
-        add: list[tuple[bytes, str]],
+        add: Sequence[tuple[bytes, str]],
     ) -> None:
         del bucket_id
         with self._lock:
@@ -101,13 +102,12 @@ class _FakeBucketClient:
     def download_files(
         self,
         bucket_id: str,
-        files: list[tuple[str, str]],
+        files: Sequence[tuple[str, str]],
     ) -> None:
         del bucket_id
         with self._lock:
             items = [
-                (remote, local, self.storage.get(remote))
-                for remote, local in files
+                (remote, local, self.storage.get(remote)) for remote, local in files
             ]
 
         for _remote, local, data in items:
@@ -118,7 +118,7 @@ class _FakeBucketClient:
     def delete_files(
         self,
         bucket_id: str,
-        delete: list[str],
+        delete: Sequence[str],
     ) -> None:
         del bucket_id
         with self._lock:
@@ -139,7 +139,7 @@ def create_object_key(chunk_id: int, model_name: str = "test/model") -> ObjectKe
     )
 
 
-def create_memory_obj(size: int = 16, fill_value: float = 1.0) -> TensorMemoryObj:
+def create_memory_obj(size: int = 16, fill_value: float = 1.0) -> MemoryObj:
     raw_data = torch.empty(size, dtype=torch.float32)
     raw_data.fill_(fill_value)
     metadata = MemoryObjMetadata(
@@ -231,9 +231,7 @@ class TestObjectKeySerialization:
         assert _object_key_to_string(base_key) != _object_key_to_string(salted)
 
     def test_bucket_path_uses_prefix_and_encoding(self) -> None:
-        cfg = HFBucketL2AdapterConfig(
-            bucket_handle=_TEST_BUCKET_HANDLE
-        )
+        cfg = HFBucketL2AdapterConfig(bucket_handle=_TEST_BUCKET_HANDLE)
         key = create_object_key(1)
         path = _object_key_to_bucket_path(key, cfg.bucket_location)
         assert path.startswith("prod/")
@@ -256,7 +254,7 @@ class TestStoreLookupLoad:
 
         tid = adapter.submit_store_task([key], [obj])
         assert wait_for_event_fd(adapter.get_store_event_fd())
-        assert adapter.pop_completed_store_tasks() == {tid: True}
+        assert adapter.pop_completed_store_tasks()[tid].is_successful()
 
         tid = adapter.submit_lookup_and_lock_task([key])
         assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
@@ -331,7 +329,7 @@ class TestStoreLookupLoad:
 
         tid = adapter.submit_store_task(keys, objs)
         assert wait_for_event_fd(adapter.get_store_event_fd())
-        assert adapter.pop_completed_store_tasks() == {tid: False}
+        assert not adapter.pop_completed_store_tasks()[tid].is_successful()
 
         assert fake_client.contains(bucket_path_for_key(keys[0]))
         assert not fake_client.contains(bucket_path_for_key(keys[1]))
@@ -509,7 +507,7 @@ class TestConfig:
         assert cfg.num_workers == 8
         assert cfg.max_capacity_gb == 2.5
 
-    #strict boolean parsing
+    # strict boolean parsing
     def test_from_dict_rejects_string_boolean(self) -> None:
         with pytest.raises(ValueError, match="create_bucket_if_missing"):
             HFBucketL2AdapterConfig.from_dict(

--- a/tests/v1/distributed/test_hfbucket_l2_adapter.py
+++ b/tests/v1/distributed/test_hfbucket_l2_adapter.py
@@ -1,0 +1,572 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the HFBucket MP L2 adapter."""
+
+# Standard
+from dataclasses import dataclass
+from pathlib import Path
+import select
+import threading
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.l2_adapters import hfbucket_l2_adapter as hfmod
+from lmcache.v1.distributed.l2_adapters.hfbucket_l2_adapter import (
+    HFBucketL2Adapter,
+    HFBucketL2AdapterConfig,
+    _object_key_to_bucket_path,
+    _object_key_to_string,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd
+from lmcache.v1.storage_backend.connector.hfbucket_connector import (
+    parse_hfbucket_handle,
+)
+
+
+_TEST_BUCKET_HANDLE = "hf://buckets/test-org/test-bucket/prod"
+_TEST_BUCKET_LOCATION = parse_hfbucket_handle(_TEST_BUCKET_HANDLE)
+
+
+@dataclass(frozen=True)
+class _FakePathInfo:
+    path: str
+    type: str
+    size: int
+
+
+class _FakeBucketClient:
+    """In-memory HFBucket client used by adapter unit tests."""
+
+    def __init__(self) -> None:
+        self.storage: dict[str, bytes] = {}
+        self.created_buckets: list[str] = []
+        self.deleted_paths: list[str] = []
+        self.fail_upload_after: int | None = None
+        self._lock = threading.Lock()
+
+    def create_bucket(self, bucket_id: str) -> None:
+        with self._lock:
+            self.created_buckets.append(bucket_id)
+
+    def bucket_info(self, bucket_id: str) -> object:
+        return {"bucket_id": bucket_id}
+
+    def get_paths_info(
+        self,
+        bucket_id: str,
+        paths: list[str],
+    ) -> list[_FakePathInfo]:
+        del bucket_id
+        with self._lock:
+            return [
+                _FakePathInfo(path=path, type="file", size=len(self.storage[path]))
+                for path in paths
+                if path in self.storage
+            ]
+
+    def list_tree(self, bucket_id: str, prefix: str) -> list[_FakePathInfo]:
+        del bucket_id
+        with self._lock:
+            return [
+                _FakePathInfo(path=path, type="file", size=len(data))
+                for path, data in self.storage.items()
+                if not prefix or path.startswith(prefix)
+            ]
+
+    def upload_files(
+        self,
+        bucket_id: str,
+        add: list[tuple[bytes, str]],
+    ) -> None:
+        del bucket_id
+        with self._lock:
+            for index, (data, path) in enumerate(add, start=1):
+                self.storage[path] = bytes(data)
+                if (
+                    self.fail_upload_after is not None
+                    and index >= self.fail_upload_after
+                ):
+                    raise RuntimeError("injected partial upload failure")
+
+    def download_files(
+        self,
+        bucket_id: str,
+        files: list[tuple[str, str]],
+    ) -> None:
+        del bucket_id
+        with self._lock:
+            items = [
+                (remote, local, self.storage.get(remote))
+                for remote, local in files
+            ]
+
+        for _remote, local, data in items:
+            if data is None:
+                continue
+            Path(local).write_bytes(data)
+
+    def delete_files(
+        self,
+        bucket_id: str,
+        delete: list[str],
+    ) -> None:
+        del bucket_id
+        with self._lock:
+            for path in delete:
+                self.deleted_paths.append(path)
+                self.storage.pop(path, None)
+
+    def contains(self, path: str) -> bool:
+        with self._lock:
+            return path in self.storage
+
+
+def create_object_key(chunk_id: int, model_name: str = "test/model") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name=model_name,
+        kv_rank=0,
+    )
+
+
+def create_memory_obj(size: int = 16, fill_value: float = 1.0) -> TensorMemoryObj:
+    raw_data = torch.empty(size, dtype=torch.float32)
+    raw_data.fill_(fill_value)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=size * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+def bucket_path_for_key(key: ObjectKey) -> str:
+    return _object_key_to_bucket_path(key, _TEST_BUCKET_LOCATION)
+
+
+def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
+    poll = select.poll()
+    poll.register(event_fd, select.POLLIN)
+    events = poll.poll(timeout * 1000)
+    if events:
+        try:
+            consume_fd(event_fd)
+        except BlockingIOError:
+            pass
+        return True
+    return False
+
+
+@pytest.fixture
+def fake_client() -> _FakeBucketClient:
+    return _FakeBucketClient()
+
+
+@pytest.fixture
+def adapter(tmp_path: Path, fake_client: _FakeBucketClient):
+    cfg = HFBucketL2AdapterConfig(
+        bucket_handle=_TEST_BUCKET_HANDLE,
+        download_tmp_dir=str(tmp_path),
+        metadata_cache_ttl_secs=30,
+        num_workers=2,
+        max_capacity_gb=0.001,
+    )
+    adapter = HFBucketL2Adapter(cfg, bucket_client=fake_client)
+    yield adapter
+    adapter.close()
+
+
+class _RecordingListener(L2AdapterListener):
+    def __init__(self) -> None:
+        self.stored: list[list[ObjectKey]] = []
+        self.accessed: list[list[ObjectKey]] = []
+        self.deleted: list[list[ObjectKey]] = []
+
+    def on_l2_keys_stored(self, keys):
+        self.stored.append(list(keys))
+
+    def on_l2_keys_accessed(self, keys):
+        self.accessed.append(list(keys))
+
+    def on_l2_keys_deleted(self, keys):
+        self.deleted.append(list(keys))
+
+
+class TestObjectKeySerialization:
+    def test_format(self) -> None:
+        key = ObjectKey(
+            chunk_hash=b"\x00\x01\x02\x03",
+            model_name="llama",
+            kv_rank=255,
+        )
+        assert _object_key_to_string(key) == "llama@000000ff@00010203"
+
+    def test_cache_salt_appended(self) -> None:
+        base_key = ObjectKey(
+            chunk_hash=b"\x00\x01\x02\x03",
+            model_name="llama",
+            kv_rank=255,
+        )
+        salted = ObjectKey(
+            chunk_hash=b"\x00\x01\x02\x03",
+            model_name="llama",
+            kv_rank=255,
+            cache_salt="user-42",
+        )
+        assert _object_key_to_string(base_key) == "llama@000000ff@00010203"
+        assert _object_key_to_string(salted) == "llama@000000ff@00010203@user-42"
+        assert _object_key_to_string(base_key) != _object_key_to_string(salted)
+
+    def test_bucket_path_uses_prefix_and_encoding(self) -> None:
+        cfg = HFBucketL2AdapterConfig(
+            bucket_handle=_TEST_BUCKET_HANDLE
+        )
+        key = create_object_key(1)
+        path = _object_key_to_bucket_path(key, cfg.bucket_location)
+        assert path.startswith("prod/")
+        assert "/" not in path.removeprefix("prod/")
+
+
+class TestEventFdInterface:
+    def test_three_distinct_fds(self, adapter: HFBucketL2Adapter) -> None:
+        a = adapter.get_store_event_fd()
+        b = adapter.get_lookup_and_lock_event_fd()
+        c = adapter.get_load_event_fd()
+        assert a >= 0 and b >= 0 and c >= 0
+        assert len({a, b, c}) == 3
+
+
+class TestStoreLookupLoad:
+    def test_roundtrip_single_key(self, adapter: HFBucketL2Adapter) -> None:
+        key = create_object_key(1)
+        obj = create_memory_obj(fill_value=3.14)
+
+        tid = adapter.submit_store_task([key], [obj])
+        assert wait_for_event_fd(adapter.get_store_event_fd())
+        assert adapter.pop_completed_store_tasks() == {tid: True}
+
+        tid = adapter.submit_lookup_and_lock_task([key])
+        assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+        bm = adapter.query_lookup_and_lock_result(tid)
+        assert bm is not None and bm.test(0) is True
+
+        dst = create_memory_obj(fill_value=0.0)
+        tid = adapter.submit_load_task([key], [dst])
+        assert wait_for_event_fd(adapter.get_load_event_fd())
+        bm = adapter.query_load_result(tid)
+        assert bm is not None and bm.test(0) is True
+        assert torch.allclose(dst.tensor, torch.full((16,), 3.14))
+
+    def test_partial_hits(self, adapter: HFBucketL2Adapter) -> None:
+        stored = [create_object_key(0), create_object_key(2)]
+        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
+        adapter.submit_store_task(stored, objs)
+        wait_for_event_fd(adapter.get_store_event_fd())
+        adapter.pop_completed_store_tasks()
+
+        keys = [create_object_key(i) for i in range(4)]
+        tid = adapter.submit_lookup_and_lock_task(keys)
+        wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+        bm = adapter.query_lookup_and_lock_result(tid)
+        assert bm is not None
+        assert bm.test(0) is True
+        assert bm.test(1) is False
+        assert bm.test(2) is True
+        assert bm.test(3) is False
+
+    def test_load_miss_returns_zero_bit(self, adapter: HFBucketL2Adapter) -> None:
+        key = create_object_key(99)
+        dst = create_memory_obj()
+        tid = adapter.submit_load_task([key], [dst])
+        wait_for_event_fd(adapter.get_load_event_fd())
+        bm = adapter.query_load_result(tid)
+        assert bm is not None and bm.test(0) is False
+
+    def test_load_size_mismatch_returns_zero_bit(
+        self,
+        adapter: HFBucketL2Adapter,
+        fake_client: _FakeBucketClient,
+    ) -> None:
+        key = create_object_key(7)
+        object_path = bucket_path_for_key(key)
+        fake_client.storage[object_path] = b"too-small"
+
+        dst = create_memory_obj()
+        tid = adapter.submit_load_task([key], [dst])
+        wait_for_event_fd(adapter.get_load_event_fd())
+        bm = adapter.query_load_result(tid)
+        assert bm is not None and bm.test(0) is False
+
+    def test_query_lookup_returns_none_after_pop(
+        self,
+        adapter: HFBucketL2Adapter,
+    ) -> None:
+        key = create_object_key(1)
+        tid = adapter.submit_lookup_and_lock_task([key])
+        wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+        assert adapter.query_lookup_and_lock_result(tid) is not None
+        assert adapter.query_lookup_and_lock_result(tid) is None
+
+    def test_partial_store_failure_accounts_written_keys(
+        self,
+        adapter: HFBucketL2Adapter,
+        fake_client: _FakeBucketClient,
+    ) -> None:
+        fake_client.fail_upload_after = 1
+        keys = [create_object_key(0), create_object_key(1)]
+        objs = [create_memory_obj(), create_memory_obj()]
+
+        tid = adapter.submit_store_task(keys, objs)
+        assert wait_for_event_fd(adapter.get_store_event_fd())
+        assert adapter.pop_completed_store_tasks() == {tid: False}
+
+        assert fake_client.contains(bucket_path_for_key(keys[0]))
+        assert not fake_client.contains(bucket_path_for_key(keys[1]))
+        assert adapter.get_usage().total_bytes_used == 64
+
+
+class TestEviction:
+    def _store(self, adapter: HFBucketL2Adapter, key: ObjectKey) -> None:
+        adapter.submit_store_task([key], [create_memory_obj()])
+        wait_for_event_fd(adapter.get_store_event_fd())
+        adapter.pop_completed_store_tasks()
+
+    def _lookup(self, adapter: HFBucketL2Adapter, key: ObjectKey):
+        tid = adapter.submit_lookup_and_lock_task([key])
+        wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+        return adapter.query_lookup_and_lock_result(tid)
+
+    def test_delete_removes_key(
+        self,
+        adapter: HFBucketL2Adapter,
+        fake_client: _FakeBucketClient,
+    ) -> None:
+        key = create_object_key(1)
+        self._store(adapter, key)
+        object_path = bucket_path_for_key(key)
+        assert fake_client.contains(object_path)
+
+        adapter.delete([key])
+        assert not fake_client.contains(object_path)
+
+    def test_lock_blocks_delete(
+        self,
+        adapter: HFBucketL2Adapter,
+        fake_client: _FakeBucketClient,
+    ) -> None:
+        key = create_object_key(1)
+        self._store(adapter, key)
+        bm = self._lookup(adapter, key)
+        assert bm is not None and bm.test(0) is True
+
+        deletes_before = len(fake_client.deleted_paths)
+        adapter.delete([key])
+        assert len(fake_client.deleted_paths) == deletes_before
+
+        adapter.submit_unlock([key])
+        adapter.delete([key])
+        object_path = bucket_path_for_key(key)
+        assert not fake_client.contains(object_path)
+
+    def test_refcount_unlock(
+        self,
+        adapter: HFBucketL2Adapter,
+        fake_client: _FakeBucketClient,
+    ) -> None:
+        key = create_object_key(1)
+        self._store(adapter, key)
+        self._lookup(adapter, key)
+        self._lookup(adapter, key)
+
+        adapter.submit_unlock([key])
+        adapter.delete([key])
+        object_path = bucket_path_for_key(key)
+        assert fake_client.contains(object_path)
+
+        adapter.submit_unlock([key])
+        adapter.delete([key])
+        assert not fake_client.contains(object_path)
+
+    def test_delete_on_unknown_key(self, adapter: HFBucketL2Adapter) -> None:
+        adapter.delete([create_object_key(42)])
+
+
+class TestGetUsage:
+    def test_disabled_returns_minus_one(self, tmp_path: Path) -> None:
+        cfg = HFBucketL2AdapterConfig(
+            bucket_handle="hf://buckets/test-org/test-bucket",
+            download_tmp_dir=str(tmp_path),
+            max_capacity_gb=0.0,
+        )
+        adapter = HFBucketL2Adapter(cfg, bucket_client=_FakeBucketClient())
+        try:
+            usage = adapter.get_usage()
+            # 0/0 is defined as -1.0 to indicate disabled
+            assert usage.usage_fraction == -1.0
+            assert usage.total_bytes_used == 0
+            assert usage.total_capacity_bytes == 0
+        finally:
+            adapter.close()
+
+    def test_usage_grows_on_store_and_shrinks_on_delete(
+        self,
+        adapter: HFBucketL2Adapter,
+    ) -> None:
+        keys = [create_object_key(i) for i in range(4)]
+        objs = [create_memory_obj() for _ in range(4)]
+
+        adapter.submit_store_task(keys, objs)
+        wait_for_event_fd(adapter.get_store_event_fd())
+        adapter.pop_completed_store_tasks()
+
+        total = 4 * 64
+        capacity = int(0.001 * 1024**3)
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == total
+        assert usage.total_capacity_bytes == capacity
+        assert usage.usage_fraction == pytest.approx(total / capacity)
+
+        adapter.delete(keys)
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == 0
+        assert usage.usage_fraction == 0.0
+
+
+class TestListener:
+    def test_stored_accessed_and_deleted_fire(
+        self,
+        adapter: HFBucketL2Adapter,
+    ) -> None:
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
+
+        key = create_object_key(1)
+        adapter.submit_store_task([key], [create_memory_obj()])
+        wait_for_event_fd(adapter.get_store_event_fd())
+        adapter.pop_completed_store_tasks()
+        time.sleep(0.05)
+        assert any(key in batch for batch in listener.stored)
+
+        tid = adapter.submit_lookup_and_lock_task([key])
+        wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+        adapter.query_lookup_and_lock_result(tid)
+        time.sleep(0.05)
+        assert any(key in batch for batch in listener.accessed)
+        accessed_count = len(listener.accessed)
+
+        dst = create_memory_obj(fill_value=0.0)
+        tid = adapter.submit_load_task([key], [dst])
+        wait_for_event_fd(adapter.get_load_event_fd())
+        adapter.query_load_result(tid)
+        time.sleep(0.05)
+        assert len(listener.accessed) == accessed_count
+
+        adapter.submit_unlock([key])
+        adapter.delete([key])
+        assert any(key in batch for batch in listener.deleted)
+
+
+class TestConfig:
+    def test_from_dict_requires_bucket_handle(self) -> None:
+        with pytest.raises(ValueError):
+            HFBucketL2AdapterConfig.from_dict({"type": "hfbucket"})
+
+    def test_from_dict_parses_all_fields(self) -> None:
+        cfg = HFBucketL2AdapterConfig.from_dict(
+            {
+                "type": "hfbucket",
+                "bucket_handle": _TEST_BUCKET_HANDLE,
+                "token_env": "HF_TEST_TOKEN",
+                "token": "direct-token",
+                "create_bucket_if_missing": True,
+                "download_tmp_dir": "/tmp/hf",
+                "metadata_cache_ttl_secs": 12.5,
+                "num_workers": 8,
+                "max_capacity_gb": 2.5,
+            }
+        )
+        assert cfg.bucket_handle == _TEST_BUCKET_HANDLE
+        assert cfg.bucket_location.bucket_id == "test-org/test-bucket"
+        assert cfg.bucket_location.object_prefix == "prod"
+        assert cfg.token_env == "HF_TEST_TOKEN"
+        assert cfg.token == "direct-token"
+        assert cfg.create_bucket_if_missing is True
+        assert cfg.download_tmp_dir == Path("/tmp/hf")
+        assert cfg.metadata_cache_ttl_secs == 12.5
+        assert cfg.num_workers == 8
+        assert cfg.max_capacity_gb == 2.5
+
+    #strict boolean parsing
+    def test_from_dict_rejects_string_boolean(self) -> None:
+        with pytest.raises(ValueError, match="create_bucket_if_missing"):
+            HFBucketL2AdapterConfig.from_dict(
+                {
+                    "type": "hfbucket",
+                    "bucket_handle": _TEST_BUCKET_HANDLE,
+                    "create_bucket_if_missing": "false",
+                }
+            )
+
+    def test_help_nonempty(self) -> None:
+        assert isinstance(HFBucketL2AdapterConfig.help(), str)
+        assert "bucket_handle" in HFBucketL2AdapterConfig.help()
+
+
+class TestFactoryRegistration:
+    def test_create_l2_adapter_registers_hfbucket(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ) -> None:
+        # First Party
+        from lmcache.v1.distributed.l2_adapters import create_l2_adapter
+
+        monkeypatch.setattr(
+            hfmod,
+            "HFBucketClient",
+            lambda token=None: _FakeBucketClient(),
+        )
+        cfg = HFBucketL2AdapterConfig.from_dict(
+            {
+                "type": "hfbucket",
+                "bucket_handle": _TEST_BUCKET_HANDLE,
+                "download_tmp_dir": str(tmp_path),
+                "num_workers": 1,
+            }
+        )
+        adapter = create_l2_adapter(cfg)
+        try:
+            assert isinstance(adapter, HFBucketL2Adapter)
+        finally:
+            adapter.close()
+
+
+class TestCleanup:
+    def test_close_cleans_temp_dir(
+        self,
+        tmp_path: Path,
+        fake_client: _FakeBucketClient,
+    ) -> None:
+        cfg = HFBucketL2AdapterConfig(
+            bucket_handle=_TEST_BUCKET_HANDLE,
+            download_tmp_dir=str(tmp_path),
+        )
+        adapter = HFBucketL2Adapter(cfg, bucket_client=fake_client)
+        assert list(tmp_path.iterdir())
+
+        adapter.close()
+
+        assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds MP L2 adapter support for Hugging Face Buckets. Uses existing HFBucket client semantics: an asyncio loop on a daemon thread, a bounded thread pool for blocking Hugging Face Hub bucket calls, 3 eventfds, refcounted `submit_unlock`, real bucket deletes for eviction, and `get_usage()` using `max_capacity_gb`. 

Object naming uses MP `ObjectKey` as `<model>@<kv_rank_hex>@<chunk_hash_hex>[@<cache_salt>]`, then applies the existing HFBucket object-name encoding and optional bucket prefix. 

Because Hugging Face batch writes are not transactional, failed store tasks reconcile backend metadata so any objects that actually landed are still counted for usage and later deletion.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
