### PR TITLE
feat: add vllm DP support

### DIFF
--- a/lmcache/integration/vllm/tests/test_dp_offset.py
+++ b/lmcache/integration/vllm/tests/test_dp_offset.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from types import SimpleNamespace
+
+# First Party
+from lmcache.integration.vllm.utils import (
+    compute_dp_device_offset,
+    get_dp_local_rank,
+)
+
+
+def _make_parallel_config(
+    *,
+    data_parallel_rank_local=None,
+    data_parallel_index=None,
+    tensor_parallel_size: int = 1,
+    pipeline_parallel_size: int = 1,
+    nnodes_within_dp: int = 1,
+    distributed_executor_backend: str | None = "mp",
+    data_parallel_backend: str | None = "mp",
+) -> SimpleNamespace:
+    """Build a duck-typed stand-in for vLLM's ``ParallelConfig``.
+
+    Only the attributes consulted by ``get_dp_local_rank`` and
+    ``compute_dp_device_offset`` need to exist.
+    """
+    return SimpleNamespace(
+        data_parallel_rank_local=data_parallel_rank_local,
+        data_parallel_index=data_parallel_index,
+        tensor_parallel_size=tensor_parallel_size,
+        pipeline_parallel_size=pipeline_parallel_size,
+        nnodes_within_dp=nnodes_within_dp,
+        distributed_executor_backend=distributed_executor_backend,
+        data_parallel_backend=data_parallel_backend,
+    )
+
+
+# -- get_dp_local_rank --------------------------------------------------------
+
+
+def test_get_dp_local_rank_prefers_explicit_attr() -> None:
+    cfg = _make_parallel_config(data_parallel_rank_local=3, data_parallel_index=7)
+    assert get_dp_local_rank(cfg) == 3
+
+
+def test_get_dp_local_rank_falls_back_to_index() -> None:
+    cfg = _make_parallel_config(data_parallel_rank_local=None, data_parallel_index=5)
+    assert get_dp_local_rank(cfg) == 5
+
+
+def test_get_dp_local_rank_defaults_to_zero() -> None:
+    cfg = _make_parallel_config(data_parallel_rank_local=None, data_parallel_index=None)
+    assert get_dp_local_rank(cfg) == 0
+
+
+def test_get_dp_local_rank_missing_attributes() -> None:
+    # ``ParallelConfig`` on older vLLM may not expose either attribute at all.
+    cfg = SimpleNamespace()
+    assert get_dp_local_rank(cfg) == 0
+
+
+# -- compute_dp_device_offset ------------------------------------------------
+
+
+def test_dp_offset_zero_when_dp_disabled() -> None:
+    # dp_local_rank == 0 implies a zero offset regardless of TP/PP.
+    cfg = _make_parallel_config(
+        data_parallel_rank_local=0,
+        tensor_parallel_size=4,
+        pipeline_parallel_size=2,
+    )
+    assert compute_dp_device_offset(cfg) == 0
+
+
+def test_dp_offset_with_tp_only() -> None:
+    # DP1 with TP=2 → DP offset = 1 * 2 * 1 = 2
+    cfg = _make_parallel_config(
+        data_parallel_rank_local=1,
+        tensor_parallel_size=2,
+        pipeline_parallel_size=1,
+    )
+    assert compute_dp_device_offset(cfg) == 2
+
+
+def test_dp_offset_with_tp_and_pp() -> None:
+    # DP2 with TP=2, PP=2 → DP offset = 2 * 2 * 2 = 8
+    cfg = _make_parallel_config(
+        data_parallel_rank_local=2,
+        tensor_parallel_size=2,
+        pipeline_parallel_size=2,
+    )
+    assert compute_dp_device_offset(cfg) == 8
+
+
+def test_dp_offset_uses_index_fallback() -> None:
+    # When ``data_parallel_rank_local`` is None, fall back to
+    # ``data_parallel_index`` (matches vLLM gpu_worker logic).
+    cfg = _make_parallel_config(
+        data_parallel_rank_local=None,
+        data_parallel_index=1,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+    )
+    assert compute_dp_device_offset(cfg) == 1
+
+
+def test_dp_offset_zero_for_ray_executor() -> None:
+    # Ray actors already isolate each worker to a single visible device.
+    cfg = _make_parallel_config(
+        data_parallel_rank_local=1,
+        tensor_parallel_size=2,
+        distributed_executor_backend="ray",
+    )
+    assert compute_dp_device_offset(cfg) == 0
+
+
+def test_dp_offset_zero_for_external_launcher() -> None:
+    # torchrun / external launchers handle GPU pinning via LOCAL_RANK.
+    cfg = _make_parallel_config(
+        data_parallel_rank_local=1,
+        tensor_parallel_size=2,
+        distributed_executor_backend="external_launcher",
+    )
+    assert compute_dp_device_offset(cfg) == 0
+
+
+def test_dp_offset_zero_for_ray_dp_backend() -> None:
+    # Ray DP coordinator also implies Ray-managed GPU placement.
+    cfg = _make_parallel_config(
+        data_parallel_rank_local=1,
+        tensor_parallel_size=2,
+        data_parallel_backend="ray",
+    )
+    assert compute_dp_device_offset(cfg) == 0
+
+
+def test_dp_offset_zero_for_multi_node_dp() -> None:
+    # Multi-node DP: ``dp_local_rank * tp * pp`` is no longer a valid local
+    # device index, so vLLM skips the adjustment and so do we.
+    cfg = _make_parallel_config(
+        data_parallel_rank_local=1,
+        tensor_parallel_size=2,
+        nnodes_within_dp=2,
+    )
+    assert compute_dp_device_offset(cfg) == 0
+
+
+def test_dp_offset_handles_missing_optional_attributes() -> None:
+    # Older vLLM versions may not expose ``nnodes_within_dp`` /
+    # ``data_parallel_backend``; the helper must default safely.
+    cfg = SimpleNamespace(
+        data_parallel_rank_local=1,
+        tensor_parallel_size=2,
+        pipeline_parallel_size=1,
+        distributed_executor_backend="mp",
+    )
+    assert compute_dp_device_offset(cfg) == 2

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -372,10 +372,10 @@ def compute_dp_device_offset(parallel_config: "ParallelConfig") -> int:
     index by ``dp_local_rank * tp_size * pp_size`` so that DP replica ``k``
     on a single node binds to GPUs ``[k*W, (k+1)*W)`` where
     ``W = tp_size * pp_size``. LMCache must apply the **same** offset when
-    it calls ``torch.cuda.set_device`` so its buffers / events / streams
-    live on the same physical GPU as the corresponding vLLM worker —
-    otherwise CUDA operations fail with ``Event device index does not
-    match recording stream's device index``.
+    it sets the active device so its buffers / events / streams live on
+    the same physical GPU as the corresponding vLLM worker — otherwise
+    CUDA operations fail with ``Event device index does not match
+    recording stream's device index``.
 
     However, vLLM only performs this shift in a specific configuration:
 
@@ -409,9 +409,12 @@ def compute_dp_device_offset(parallel_config: "ParallelConfig") -> int:
         or dp_backend == "ray"
     ):
         return 0
+    dp_local_rank = get_dp_local_rank(parallel_config)
+    if dp_local_rank == 0:
+        return 0
     tp_size = parallel_config.tensor_parallel_size
     pp_size = parallel_config.pipeline_parallel_size
-    return get_dp_local_rank(parallel_config) * tp_size * pp_size
+    return dp_local_rank * tp_size * pp_size
 
 
 def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int, int]:

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -7,7 +7,7 @@ import string
 import threading
 
 if TYPE_CHECKING:
-    from vllm.config import ModelConfig, VllmConfig
+    from vllm.config import ModelConfig, ParallelConfig, VllmConfig
     from vllm.multimodal.inputs import PlaceholderRange
     from vllm.v1.request import Request
 
@@ -264,13 +264,17 @@ def create_lmcache_metadata(
                 kv_transfer_config, "kv_connector_extra_config", None
             )
 
+    # Compute local_worker_id with DP offset so the metadata reflects the
+    # actual local GPU device (matches vLLM's gpu_worker DP adjustment).
+    local_worker_id = parallel_cfg.rank + compute_dp_device_offset(parallel_cfg)
+
     # Create metadata
     metadata = LMCacheMetadata(
         model_name=model_cfg.model,
         world_size=parallel_cfg.world_size,
         local_world_size=parallel_cfg.world_size,
         worker_id=parallel_cfg.rank,
-        local_worker_id=parallel_cfg.rank,
+        local_worker_id=local_worker_id,
         kv_dtype=kv_dtype,
         kv_shape=kv_shape,
         use_mla=use_mla,
@@ -339,9 +343,81 @@ def get_size_bytes(shapes: list[torch.Size], kv_dtypes: list[torch.dtype]):
     )
 
 
+def get_dp_local_rank(parallel_config: "ParallelConfig") -> int:
+    """
+    Return the data parallel rank local to this node, or 0 if DP is disabled
+    or unavailable on the running vLLM version.
+
+    Mirrors the logic vLLM uses in ``gpu_worker.py`` to compute its worker
+    device index under data parallelism. Used by LMCache to derive the
+    correct local GPU device when DP > 1.
+
+    Args:
+        parallel_config: vLLM ``ParallelConfig``.
+
+    Returns:
+        int: The local DP rank for the current process (0 if DP is not used).
+    """
+    dp_local_rank = getattr(parallel_config, "data_parallel_rank_local", None)
+    if dp_local_rank is None:
+        dp_local_rank = getattr(parallel_config, "data_parallel_index", 0) or 0
+    return int(dp_local_rank)
+
+
+def compute_dp_device_offset(parallel_config: "ParallelConfig") -> int:
+    """
+    Compute the local GPU index offset introduced by data parallelism.
+
+    vLLM's ``gpu_worker.init_device`` shifts each worker's local device
+    index by ``dp_local_rank * tp_size * pp_size`` so that DP replica ``k``
+    on a single node binds to GPUs ``[k*W, (k+1)*W)`` where
+    ``W = tp_size * pp_size``. LMCache must apply the **same** offset when
+    it calls ``torch.cuda.set_device`` so its buffers / events / streams
+    live on the same physical GPU as the corresponding vLLM worker —
+    otherwise CUDA operations fail with ``Event device index does not
+    match recording stream's device index``.
+
+    However, vLLM only performs this shift in a specific configuration:
+
+    - ``nnodes_within_dp == 1`` — each DP replica fits on a single node.
+      With multi-node DP, ``dp_local_rank * W`` is no longer a valid
+      device index on the current node.
+    - ``distributed_executor_backend`` is not ``ray`` or
+      ``external_launcher`` — Ray and external launchers (e.g. torchrun)
+      already isolate each worker to its own visible device, so the
+      offset is unnecessary and would over-index.
+    - ``data_parallel_backend != "ray"`` — same reasoning for the DP
+      coordinator backend.
+
+    Outside those conditions vLLM leaves the device index untouched, and
+    so does LMCache. In that case this function returns 0.
+
+    Args:
+        parallel_config: vLLM ``ParallelConfig`` for the current process.
+
+    Returns:
+        int: Device index offset to add to ``parallel_config.rank``. Zero
+        when DP is disabled, when running on a backend that handles GPU
+        isolation externally, or when DP spans multiple nodes.
+    """
+    nnodes_within_dp = getattr(parallel_config, "nnodes_within_dp", 1) or 1
+    executor_backend = getattr(parallel_config, "distributed_executor_backend", None)
+    dp_backend = getattr(parallel_config, "data_parallel_backend", None)
+    if (
+        nnodes_within_dp != 1
+        or executor_backend in ("ray", "external_launcher")
+        or dp_backend == "ray"
+    ):
+        return 0
+    tp_size = parallel_config.tensor_parallel_size
+    pp_size = parallel_config.pipeline_parallel_size
+    return get_dp_local_rank(parallel_config) * tp_size * pp_size
+
+
 def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int, int]:
     """
-    Calculate the local worker id and local world size.
+    Calculate the local worker id (i.e. local GPU device index) and the
+    local world size for the current LMCache worker.
 
     Current assumption (TODO: add custom logic in the future):
     - Tensor Parallel is intra-node
@@ -356,20 +432,25 @@ def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int,
     parallel_config = vllm_config.parallel_config
     global_rank = parallel_config.rank
     global_world_size = parallel_config.world_size
+    tp_size = parallel_config.tensor_parallel_size
+    pp_size = parallel_config.pipeline_parallel_size
     num_gpus = torch_dev.device_count()
+
+    # DP offset: see ``compute_dp_device_offset`` for the rationale and the
+    # set of vLLM backends where this offset is (or isn't) required.
+    dp_offset = compute_dp_device_offset(parallel_config)
+
     if global_world_size <= num_gpus:
-        # single node case
-        return parallel_config.rank, parallel_config.world_size
+        # single node case (per DP replica)
+        return parallel_config.rank + dp_offset, parallel_config.world_size
     else:
-        tp_size = parallel_config.tensor_parallel_size
-        pp_size = parallel_config.pipeline_parallel_size
         local_world_size = global_world_size // pp_size
         assert local_world_size == tp_size, (
             "LMCache is operating under the assumption that the "
             "local world size is equal to the tensor parallel size "
             "in multi-node deployment."
         )
-        local_worker_id = global_rank % local_world_size
+        local_worker_id = (global_rank % local_world_size) + dp_offset
         return local_worker_id, local_world_size
 
 


### PR DESCRIPTION


<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Under DP, vLLM's gpu_worker shifts each worker's local device by `dp_local_rank * tp_size * pp_size` so DP replica k binds to GPUs [k*W, (k+1)*W). LMCache however used parallel_config.rank directly as local_worker_id and then called torch.cuda.set_device, which left LMCache on cuda:0 while the DP>0 worker was on cuda:1+. The mismatched device for CUDA events/streams produced:

  RuntimeError: Event device index does not match recording stream's
  device index

Mirror vLLM's adjustment by adding compute_dp_device_offset(), gated on the same conditions vLLM uses (single-node-per-DP, non-Ray / non-external_launcher executor backend). For ray / external_launcher the runtime already isolates each worker to a single visible device, so no offset is applied. Both call sites (create_lmcache_metadata, calculate_local_rank_and_world_size) now share this helper.

Add unit tests covering DP enabled/disabled, TP-only, TP+PP, Ray, external_launcher, Ray DP backend, multi-node DP, and missing optional attributes on older vLLM versions.

Verified end-to-end with vLLM data parallelism (DP); works as expected.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
