### PR TITLE
[Tool] Add on/off-CPU flame-graph profiling into bench l2 adapter 

### DIFF
--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -1164,21 +1164,23 @@ Options
      - *(unset)*
      - Run only the specified operation. When omitted, all three
        operations are run in the order ``store -> lookup -> load``.
-   * - ``--profile-enabled``
-     - *(off)*
-     - Capture a flame graph of the measured phases. The benchmark
-       profiles itself and renders an SVG. See
+   * - ``--flamegraph {on,off}``
+     - ``off``
+     - Capture a flame graph of the measured phases (``on``) or run the
+       benchmark normally (``off``). When ``on``, the benchmark profiles
+       itself and renders an SVG. Default ``off`` leaves benchmark
+       behavior unchanged. See
        :ref:`Profiling / flame charts <lmcache-bench-l2-profiling>`.
-   * - ``--profile-mode {on-cpu,off-cpu}``
+   * - ``--flamegraph-mode {on-cpu,off-cpu}``
      - ``on-cpu``
-     - Flame-graph mode for ``--profile-enabled``. ``on-cpu`` shows
+     - Flame-graph mode for ``--flamegraph on``. ``on-cpu`` shows
        where CPU time goes; ``off-cpu`` shows time blocked on I/O /
        locks (best for I/O-bound adapters).
-   * - ``--profile-output PATH``
+   * - ``--flamegraph-output PATH``
      - *(auto)*
      - SVG output path. Default:
        ``/tmp/lmcache_bench_flames/<adapter>.<mode>.svg``.
-   * - ``--profile-flamegraph-dir DIR``
+   * - ``--flamegraph-dir DIR``
      - *($FLAMEGRAPH_DIR or ~/FlameGraph)*
      - Directory with the FlameGraph scripts (``flamegraph.pl``,
        ``stackcollapse-perf.pl``).
@@ -1313,19 +1315,19 @@ loaded data can be compared against the original store pattern.
 Profiling / flame charts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When ``--profile-enabled`` is passed, the benchmark profiles the L2
+When ``--flamegraph on`` is passed, the benchmark profiles the L2
 adapter's performance and renders a flame graph of the measured phases:
 
 .. code-block:: bash
 
    lmcache bench l2 \
        --l2-adapter '{"type":"fs","base_path":"/data/lmcache-bench"}' \
-       --rounds 300 --profile-enabled --profile-mode on-cpu
+       --rounds 300 --flamegraph on --flamegraph-mode on-cpu
    #   [Profile] on-cpu recording started (pid=12345) -> .../FSL2Adapter.oncpu.svg
    #   [Profile] wrote /tmp/lmcache_bench_flames/FSL2Adapter.oncpu.svg
 
 The recorder samples every thread of the process (including native
-worker threads). Two modes are available via ``--profile-mode``:
+worker threads). Two modes are available via ``--flamegraph-mode``:
 
 * **on-cpu** (default) -- ``perf record``; where CPU cycles go
   (serialization, copies, hashing).
@@ -1335,24 +1337,27 @@ worker threads). Two modes are available via ``--profile-mode``:
 
 Recording covers only the measured store/lookup/load work, so make the
 run long enough to collect samples (a few seconds is plenty -- use a
-large ``--rounds``). The SVG is written to ``--profile-output`` (default
-``/tmp/lmcache_bench_flames/<adapter>.<mode>.svg``).
+large ``--rounds``). The SVG is written to ``--flamegraph-output``
+(default ``/tmp/lmcache_bench_flames/<adapter>.<mode>.svg``).
 
 **Requirements.** Rendering needs Brendan Gregg's
 `FlameGraph <https://github.com/brendangregg/FlameGraph>`__ scripts
-(``--profile-flamegraph-dir`` or ``FLAMEGRAPH_DIR``, default
-``~/FlameGraph``). ``on-cpu`` needs ``perf`` (and
-``kernel.perf_event_paranoid`` low enough to profile non-root, or run
-as root); ``off-cpu`` needs ``bcc`` (``offcputime-bpfcc``) and ``sudo``.
-If the toolchain is missing, the benchmark prints ``[Profile] disabled:
-...`` and runs normally without a flame graph.
+(``--flamegraph-dir`` or ``FLAMEGRAPH_DIR``, default ``~/FlameGraph``;
+auto-cloned to a temp directory when absent). ``on-cpu`` needs ``perf``
+(and ``kernel.perf_event_paranoid`` low enough to profile non-root, or
+run as root); ``off-cpu`` needs ``bcc`` (``offcputime-bpfcc``) and
+``sudo``. The required tools are checked up front: when ``--flamegraph
+on`` is requested but a tool is missing, the benchmark exits with a
+non-zero status and an actionable message naming the missing tool
+instead of running unprofiled. The default ``--flamegraph off`` skips
+all of this and leaves benchmark behavior unchanged.
 
 .. note::
 
    When comparing a change, profile each variant with the same
-   ``--rounds`` and ``--profile-mode`` and distinct ``--profile-output``
-   paths (e.g. ``baseline.svg`` vs ``after.svg``) so the two flame
-   graphs are directly comparable.
+   ``--rounds`` and ``--flamegraph-mode`` and distinct
+   ``--flamegraph-output`` paths (e.g. ``baseline.svg`` vs
+   ``after.svg``) so the two flame graphs are directly comparable.
 
 
 Exit codes
@@ -1371,5 +1376,7 @@ Exit codes
      - Adapter creation failed, round-trip verification failed, or
        an operation hit a fatal error (e.g. all rounds timed out).
    * - ``2``
-     - The ``--l2-adapter`` JSON / ``L2_ADAPTER_JSON`` env var was
-       missing or could not be parsed.
+     - Invalid invocation: the ``--l2-adapter`` JSON / ``L2_ADAPTER_JSON``
+       env var was missing or could not be parsed, an option value was
+       invalid, or ``--flamegraph on`` was requested but the profiling
+       toolchain is unavailable.

--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -1313,10 +1313,8 @@ loaded data can be compared against the original store pattern.
 Profiling / flame charts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Because ``lmcache bench l2`` drives the adapter through its real
-submit/wait path in a single process, it can profile **itself** and
-render a flame graph of the measured phases -- one command, one
-terminal, no externally attached profiler. Pass ``--profile-enabled``:
+When ``--profile-enabled`` is passed, the benchmark profiles the L2
+adapter's performance and renders a flame graph of the measured phases:
 
 .. code-block:: bash
 
@@ -1327,14 +1325,13 @@ terminal, no externally attached profiler. Pass ``--profile-enabled``:
    #   [Profile] wrote /tmp/lmcache_bench_flames/FSL2Adapter.oncpu.svg
 
 The recorder samples every thread of the process (including native
-worker threads), so there is nothing adapter-specific to target. Two
-modes are available via ``--profile-mode``:
+worker threads). Two modes are available via ``--profile-mode``:
 
 * **on-cpu** (default) -- ``perf record``; where CPU cycles go
   (serialization, copies, hashing).
 * **off-cpu** -- ``offcputime-bpfcc`` (bcc); time spent blocked
   (waiting on I/O, locks, eventfds). Often the more informative view
-  for I/O-bound adapters such as ``fs``, ``s3`` or ``valkey``.
+  for I/O-bound adapters such as ``fs`` and ``s3``.
 
 Recording covers only the measured store/lookup/load work, so make the
 run long enough to collect samples (a few seconds is plenty -- use a

--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -1164,6 +1164,24 @@ Options
      - *(unset)*
      - Run only the specified operation. When omitted, all three
        operations are run in the order ``store -> lookup -> load``.
+   * - ``--profile-enabled``
+     - *(off)*
+     - Capture a flame graph of the measured phases. The benchmark
+       profiles itself and renders an SVG. See
+       :ref:`Profiling / flame charts <lmcache-bench-l2-profiling>`.
+   * - ``--profile-mode {on-cpu,off-cpu}``
+     - ``on-cpu``
+     - Flame-graph mode for ``--profile-enabled``. ``on-cpu`` shows
+       where CPU time goes; ``off-cpu`` shows time blocked on I/O /
+       locks (best for I/O-bound adapters).
+   * - ``--profile-output PATH``
+     - *(auto)*
+     - SVG output path. Default:
+       ``/tmp/lmcache_bench_flames/<adapter>.<mode>.svg``.
+   * - ``--profile-flamegraph-dir DIR``
+     - *($FLAMEGRAPH_DIR or ~/FlameGraph)*
+     - Directory with the FlameGraph scripts (``flamegraph.pl``,
+       ``stackcollapse-perf.pl``).
 
 
 Adapter JSON spec
@@ -1288,6 +1306,56 @@ round against the byte pattern that ``store`` wrote (see
 Verification is **off** by default because the stricter byte pattern
 requires both the store and load object batches to stay resident so the
 loaded data can be compared against the original store pattern.
+
+
+.. _lmcache-bench-l2-profiling:
+
+Profiling / flame charts
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because ``lmcache bench l2`` drives the adapter through its real
+submit/wait path in a single process, it can profile **itself** and
+render a flame graph of the measured phases -- one command, one
+terminal, no externally attached profiler. Pass ``--profile-enabled``:
+
+.. code-block:: bash
+
+   lmcache bench l2 \
+       --l2-adapter '{"type":"fs","base_path":"/data/lmcache-bench"}' \
+       --rounds 300 --profile-enabled --profile-mode on-cpu
+   #   [Profile] on-cpu recording started (pid=12345) -> .../FSL2Adapter.oncpu.svg
+   #   [Profile] wrote /tmp/lmcache_bench_flames/FSL2Adapter.oncpu.svg
+
+The recorder samples every thread of the process (including native
+worker threads), so there is nothing adapter-specific to target. Two
+modes are available via ``--profile-mode``:
+
+* **on-cpu** (default) -- ``perf record``; where CPU cycles go
+  (serialization, copies, hashing).
+* **off-cpu** -- ``offcputime-bpfcc`` (bcc); time spent blocked
+  (waiting on I/O, locks, eventfds). Often the more informative view
+  for I/O-bound adapters such as ``fs``, ``s3`` or ``valkey``.
+
+Recording covers only the measured store/lookup/load work, so make the
+run long enough to collect samples (a few seconds is plenty -- use a
+large ``--rounds``). The SVG is written to ``--profile-output`` (default
+``/tmp/lmcache_bench_flames/<adapter>.<mode>.svg``).
+
+**Requirements.** Rendering needs Brendan Gregg's
+`FlameGraph <https://github.com/brendangregg/FlameGraph>`__ scripts
+(``--profile-flamegraph-dir`` or ``FLAMEGRAPH_DIR``, default
+``~/FlameGraph``). ``on-cpu`` needs ``perf`` (and
+``kernel.perf_event_paranoid`` low enough to profile non-root, or run
+as root); ``off-cpu`` needs ``bcc`` (``offcputime-bpfcc``) and ``sudo``.
+If the toolchain is missing, the benchmark prints ``[Profile] disabled:
+...`` and runs normally without a flame graph.
+
+.. note::
+
+   When comparing a change, profile each variant with the same
+   ``--rounds`` and ``--profile-mode`` and distinct ``--profile-output``
+   paths (e.g. ``baseline.svg`` vs ``after.svg``) so the two flame
+   graphs are directly comparable.
 
 
 Exit codes

--- a/lmcache/cli/commands/bench/l2_adapter_bench/command.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/command.py
@@ -453,6 +453,15 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
 
     try:
         if profiler is not None:
+            # Pre-build the payload buffers before the recorder starts so
+            # the one-time tensor allocation + fill (benchmark harness work,
+            # not the adapter) is kept out of the flame graph. The batches
+            # are reused across rounds, so this is the only build; warming
+            # it here keeps the recording focused on adapter I/O.
+            if args.only is None or args.only == "store":
+                _store_objs(0)
+            if args.only is None or args.only == "load":
+                _load_objs(0)
             profiler.start(log)
 
         # ---- Store ----

--- a/lmcache/cli/commands/bench/l2_adapter_bench/command.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/command.py
@@ -153,42 +153,42 @@ def register_l2_parser(
         help="Run only the specified operation (default: run all).",
     )
     parser.add_argument(
-        "--profile-enabled",
-        action="store_true",
+        "--flamegraph",
+        choices=["on", "off"],
+        default="off",
         help=(
-            "Capture a flame graph of the measured phases. The benchmark "
-            "profiles itself and renders an SVG -- no second terminal or "
-            "external profiler needed. Default: off."
+            "Capture a flame graph of the measured phases if turned on. The benchmark "
+            "profiles itself and renders an SVG"
         ),
     )
     parser.add_argument(
-        "--profile-mode",
+        "--flamegraph-mode",
         choices=["on-cpu", "off-cpu"],
         default="on-cpu",
         help=(
-            "Flame-graph mode for --profile-enabled. 'on-cpu' (perf "
+            "Flame-graph mode if enabled flame graph profiling. 'on-cpu' (perf "
             "record) shows where CPU time goes; 'off-cpu' (perf off-CPU "
             "via offcputime-bpfcc) shows time blocked on I/O / locks and "
             "is best for I/O-bound adapters. Default: on-cpu."
         ),
     )
     parser.add_argument(
-        "--profile-output",
+        "--flamegraph-output",
         default="",
         metavar="PATH",
         help=(
-            "SVG output path for --profile-enabled. Default: "
+            "SVG output path for '--flamegraph on'. Default: "
             "/tmp/lmcache_bench_flames/<adapter>.<mode>.svg."
         ),
     )
     parser.add_argument(
-        "--profile-flamegraph-dir",
+        "--flamegraph-dir",
         default="",
         metavar="DIR",
         help=(
             "Directory with the FlameGraph scripts (flamegraph.pl, "
             "stackcollapse-perf.pl). Default: $FLAMEGRAPH_DIR or "
-            "~/FlameGraph."
+            "~/FlameGraph, else auto-cloned into a temp directory."
         ),
     )
 
@@ -227,6 +227,7 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
     from lmcache.cli.commands.bench.l2_adapter_bench.profiling import (
         FlameProfiler,
         ProfileError,
+        check_profiling_deps,
         default_output_path,
         resolve_flamegraph_dir,
     )
@@ -307,6 +308,26 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
     l1_buffer = make_aligned_tensor(2 * keys_per_round * data_size, l1_align_bytes)
     l1_memory_desc = create_l1_memory_desc(l1_buffer, align_bytes=l1_align_bytes)
 
+    # Resolve and validate the flame-graph toolchain up front, before any
+    # adapter (and its worker threads) is created. A user who explicitly
+    # passes ``--flamegraph on`` gets a fast, actionable failure if a
+    # required tool is missing, rather than a benchmark that silently runs
+    # unprofiled. When ``--flamegraph`` is off (default), none of this runs
+    # and the benchmark behaves exactly as before.
+    flamegraph_on = getattr(args, "flamegraph", "off") == "on"
+    flamegraph_dir = ""
+    if flamegraph_on:
+        try:
+            check_profiling_deps(args.flamegraph_mode)
+            flamegraph_dir = resolve_flamegraph_dir(args.flamegraph_dir, log)
+        except ProfileError as e:
+            print(
+                "Error: --flamegraph on was requested but the profiling "
+                f"toolchain is unavailable:\n  {e}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
     log("\n[Init] Creating adapter...")
     try:
         adapter = create_l2_adapter(adapter_cfg, l1_memory_desc=l1_memory_desc)
@@ -317,25 +338,35 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
 
     # Optional self-profiling: record a flame graph of the measured
     # phases. Built here, after the adapter (and its worker threads)
-    # exist, so the recorder attaches to a fully-started process. On a
-    # toolchain error we warn and continue the benchmark unprofiled.
+    # exist, so the recorder attaches to a fully-started process. The
+    # toolchain was already validated above, so a ProfileError here is a
+    # late failure (e.g. the output directory is not writable); since the
+    # user explicitly requested a flame graph we fail loudly rather than
+    # downgrade, closing the adapter we just opened first.
     profiler: FlameProfiler | None = None
-    if getattr(args, "profile_enabled", False):
+    if flamegraph_on:
         adapter_name = type(adapter).__name__
         try:
             profiler = FlameProfiler(
-                mode=args.profile_mode,
+                mode=args.flamegraph_mode,
                 output=(
-                    args.profile_output
-                    or default_output_path(adapter_name, args.profile_mode)
+                    args.flamegraph_output
+                    or default_output_path(adapter_name, args.flamegraph_mode)
                 ),
-                flamegraph_dir=resolve_flamegraph_dir(args.profile_flamegraph_dir, log),
+                flamegraph_dir=flamegraph_dir,
                 pid=os.getpid(),
-                title=f"{args.profile_mode} ({adapter_name})",
+                title=f"{args.flamegraph_mode} ({adapter_name})",
             )
         except ProfileError as e:
-            print(f"[Profile] disabled: {e}", file=sys.stderr)
-            profiler = None
+            print(
+                f"Error: cannot start flame-graph profiling: {e}",
+                file=sys.stderr,
+            )
+            try:
+                adapter.close()
+            except Exception:
+                pass
+            sys.exit(2)
 
     # ------------------------------------------------------------------
     # Idx layout

--- a/lmcache/cli/commands/bench/l2_adapter_bench/command.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/command.py
@@ -152,6 +152,45 @@ def register_l2_parser(
         default=None,
         help="Run only the specified operation (default: run all).",
     )
+    parser.add_argument(
+        "--profile-enabled",
+        action="store_true",
+        help=(
+            "Capture a flame graph of the measured phases. The benchmark "
+            "profiles itself and renders an SVG -- no second terminal or "
+            "external profiler needed. Default: off."
+        ),
+    )
+    parser.add_argument(
+        "--profile-mode",
+        choices=["on-cpu", "off-cpu"],
+        default="on-cpu",
+        help=(
+            "Flame-graph mode for --profile-enabled. 'on-cpu' (perf "
+            "record) shows where CPU time goes; 'off-cpu' (perf off-CPU "
+            "via offcputime-bpfcc) shows time blocked on I/O / locks and "
+            "is best for I/O-bound adapters. Default: on-cpu."
+        ),
+    )
+    parser.add_argument(
+        "--profile-output",
+        default="",
+        metavar="PATH",
+        help=(
+            "SVG output path for --profile-enabled. Default: "
+            "/tmp/lmcache_bench_flames/<adapter>.<mode>.svg."
+        ),
+    )
+    parser.add_argument(
+        "--profile-flamegraph-dir",
+        default="",
+        metavar="DIR",
+        help=(
+            "Directory with the FlameGraph scripts (flamegraph.pl, "
+            "stackcollapse-perf.pl). Default: $FLAMEGRAPH_DIR or "
+            "~/FlameGraph."
+        ),
+    )
 
     # Common ``--format / --output / --quiet`` flags. Attached only
     # to the L2 subparser; the ``engine`` and ``kvcache`` subparsers
@@ -184,6 +223,12 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
         make_memory_objects,
         make_object_keys,
         verify_round_trip,
+    )
+    from lmcache.cli.commands.bench.l2_adapter_bench.profiling import (
+        FlameProfiler,
+        ProfileError,
+        default_output_path,
+        resolve_flamegraph_dir,
     )
     from lmcache.cli.commands.bench.l2_adapter_bench.runner import (
         bench_load,
@@ -269,6 +314,28 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
     except Exception as e:
         print(f"[Init] Failed to create adapter: {e}", file=sys.stderr)
         sys.exit(1)
+
+    # Optional self-profiling: record a flame graph of the measured
+    # phases. Built here, after the adapter (and its worker threads)
+    # exist, so the recorder attaches to a fully-started process. On a
+    # toolchain error we warn and continue the benchmark unprofiled.
+    profiler: FlameProfiler | None = None
+    if getattr(args, "profile_enabled", False):
+        adapter_name = type(adapter).__name__
+        try:
+            profiler = FlameProfiler(
+                mode=args.profile_mode,
+                output=(
+                    args.profile_output
+                    or default_output_path(adapter_name, args.profile_mode)
+                ),
+                flamegraph_dir=resolve_flamegraph_dir(args.profile_flamegraph_dir, log),
+                pid=os.getpid(),
+                title=f"{args.profile_mode} ({adapter_name})",
+            )
+        except ProfileError as e:
+            print(f"[Profile] disabled: {e}", file=sys.stderr)
+            profiler = None
 
     # ------------------------------------------------------------------
     # Idx layout
@@ -385,6 +452,9 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
     last_load_round_keys: list[list] | None = None
 
     try:
+        if profiler is not None:
+            profiler.start(log)
+
         # ---- Store ----
         if args.only is None or args.only == "store":
             log(f"[Store] Running {warmup} warmup + {rounds} measurement rounds...")
@@ -436,6 +506,11 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
             last_load_round_keys = _build_round_keys(total_rounds - 1)
             log("")
 
+        # Stop profiling before verification / summary so the flame
+        # graph reflects only the measured store/lookup/load work.
+        if profiler is not None:
+            profiler.stop(log)
+
         # ---- Round-trip verification (last measured round only) ----
         if (
             not args.skip_verify
@@ -471,6 +546,10 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
             results=results,
         )
     finally:
+        # Idempotent: a no-op if profiling already stopped on the normal
+        # path; tears the recorder down if a phase raised.
+        if profiler is not None:
+            profiler.stop(log)
         log("[Cleanup] Closing adapter...")
         try:
             adapter.close()

--- a/lmcache/cli/commands/bench/l2_adapter_bench/profiling.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/profiling.py
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""
+"""Profiling tools for benchmarking lmcache performance.
 
-Profiling tools for benching marking lmcache performance
-
-When ``--profile-enabled`` is set, the benchmark records a flame graph of
+When ``--flamegraph on`` is set, the benchmark records a flame graph of
 its own measured phases and renders it to an SVG, so no second terminal
 or externally attached profiler is needed.
 
@@ -48,6 +46,52 @@ class ProfileError(RuntimeError):
     """Raised when the profiling toolchain is missing or misconfigured."""
 
 
+def check_profiling_deps(mode: str) -> None:
+    """Validate that the external tools required for *mode* are present.
+
+    This is a runtime check meant to run *before* the benchmark spins up
+    any adapter, so a missing dependency fails fast with an actionable
+    message instead of producing an empty flame graph midway through a
+    run.
+
+    Args:
+        mode: ``"on-cpu"`` or ``"off-cpu"``.
+
+    Raises:
+        ProfileError: If ``mode`` is invalid or a required tool is
+            missing. The message names the missing tool and how to
+            install it or which mode to use instead.
+    """
+    if mode not in _MODE_TAG:
+        raise ProfileError(
+            f"invalid flame-graph mode: {mode!r} (expected 'on-cpu' or 'off-cpu')"
+        )
+    if mode == "on-cpu" and shutil.which("perf") is None:
+        raise ProfileError(
+            "perf not found on PATH (needed for on-cpu flame graphs). "
+            "Install it (e.g. 'apt install linux-perf' or the linux-tools "
+            "package matching your kernel) or use --flamegraph-mode off-cpu."
+        )
+    if mode == "off-cpu":
+        if shutil.which("sudo") is None:
+            raise ProfileError(
+                "sudo not found on PATH (needed for off-cpu flame graphs, "
+                "which load a BPF program). Install sudo or use "
+                "--flamegraph-mode on-cpu."
+            )
+        # offcputime-bpfcc usually lives in /usr/sbin, which is not on the
+        # user's PATH but is reachable under sudo; check both so a missing
+        # tool surfaces here instead of as an empty flame graph.
+        if shutil.which("offcputime-bpfcc") is None and not os.path.exists(
+            "/usr/sbin/offcputime-bpfcc"
+        ):
+            raise ProfileError(
+                "offcputime-bpfcc not found (needed for off-cpu flame "
+                "graphs). Install bcc / bpfcc-tools (e.g. 'apt install "
+                "bpfcc-tools') or use --flamegraph-mode on-cpu."
+            )
+
+
 # Upstream FlameGraph repo, shallow-cloned on demand when the scripts
 # are not already present locally.
 _FLAMEGRAPH_REPO = "https://github.com/brendangregg/FlameGraph"
@@ -68,7 +112,7 @@ def _clone_flamegraph(dest: str, log: Callable[[str], None]) -> None:
     if shutil.which("git") is None:
         raise ProfileError(
             "git not found; cannot auto-clone FlameGraph. Clone "
-            f"{_FLAMEGRAPH_REPO} manually and pass --profile-flamegraph-dir "
+            f"{_FLAMEGRAPH_REPO} manually and pass --flamegraph-dir "
             "or set FLAMEGRAPH_DIR."
         )
     os.makedirs(os.path.dirname(dest), exist_ok=True)
@@ -90,14 +134,14 @@ def _clone_flamegraph(dest: str, log: Callable[[str], None]) -> None:
 def resolve_flamegraph_dir(explicit: str, log: Callable[[str], None]) -> str:
     """Resolve the FlameGraph scripts directory, auto-cloning if needed.
 
-    Resolution order: the explicit ``--profile-flamegraph-dir`` value,
+    Resolution order: the explicit ``--flamegraph-dir`` value,
     then ``$FLAMEGRAPH_DIR``, then ``~/FlameGraph``, then the managed temp
     clone under ``/tmp/lmcache_flamegraph/FlameGraph``. When none of these
     contains ``flamegraph.pl`` and no directory was given explicitly, the
     repo is shallow-cloned into the managed temp location.
 
     Args:
-        explicit: Directory passed via ``--profile-flamegraph-dir``; may
+        explicit: Directory passed via ``--flamegraph-dir``; may
             be an empty string when the flag was not given.
         log: Progress logger (suppressed under ``--quiet``).
 
@@ -111,7 +155,7 @@ def resolve_flamegraph_dir(explicit: str, log: Callable[[str], None]) -> str:
     if explicit:
         if not _has_flamegraph(explicit):
             raise ProfileError(
-                f"flamegraph.pl not found under --profile-flamegraph-dir {explicit}"
+                f"flamegraph.pl not found under --flamegraph-dir {explicit}"
             )
         return explicit
 
@@ -172,23 +216,7 @@ class FlameProfiler:
             ProfileError: If ``mode`` is invalid or a required tool is
                 unavailable.
         """
-        if mode not in _MODE_TAG:
-            raise ProfileError(f"invalid profile mode: {mode!r}")
-        if mode == "on-cpu" and shutil.which("perf") is None:
-            raise ProfileError("perf not found on PATH (needed for on-cpu)")
-        if mode == "off-cpu":
-            if shutil.which("sudo") is None:
-                raise ProfileError("sudo not found on PATH (needed for off-cpu)")
-            # offcputime-bpfcc usually lives in /usr/sbin, which is not on
-            # the user's PATH but is reachable under sudo; check both so a
-            # missing tool surfaces here instead of as an empty flame graph.
-            if shutil.which("offcputime-bpfcc") is None and not os.path.exists(
-                "/usr/sbin/offcputime-bpfcc"
-            ):
-                raise ProfileError(
-                    "offcputime-bpfcc not found; install bcc / bpfcc-tools "
-                    "for off-cpu profiling."
-                )
+        check_profiling_deps(mode)
 
         self._mode = mode
         self._output = output

--- a/lmcache/cli/commands/bench/l2_adapter_bench/profiling.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/profiling.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+
+Profiling tools for benching marking lmcache performance
+
+When ``--profile-enabled`` is set, the benchmark records a flame graph of
+its own measured phases and renders it to an SVG, so no second terminal
+or externally attached profiler is needed.
+
+Two modes are supported:
+
+* ``on-cpu``  -- ``perf record`` sampling; shows where CPU time goes
+  (serialization, copies, hashing).
+* ``off-cpu`` -- ``offcputime-bpfcc`` (bcc); shows time spent blocked
+  off-CPU (waiting on I/O, locks, eventfds), usually the more
+  informative view for I/O-bound L2 adapters.
+
+Rendering uses Brendan Gregg's FlameGraph scripts (``flamegraph.pl`` and,
+for on-CPU, ``stackcollapse-perf.pl``). ``off-cpu`` additionally requires
+``sudo`` because ``offcputime-bpfcc`` loads a BPF program.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Callable
+import os
+import shutil
+import signal
+import subprocess
+import time
+
+# Sampling frequency for ``perf record`` (on-CPU), in Hz.
+_PERF_FREQ_HZ = 999
+# Seconds to wait for a recorder to flush and exit after SIGINT.
+_STOP_TIMEOUT_SEC = 60
+# Seconds to let the off-CPU BPF program load before the work starts.
+_OFFCPU_SETTLE_SEC = 1.0
+# Rendered flame-graph width, in pixels.
+_FLAME_WIDTH_PX = 1600
+
+# Per-mode tag used in default output filenames.
+_MODE_TAG = {"on-cpu": "oncpu", "off-cpu": "offcpu"}
+
+
+class ProfileError(RuntimeError):
+    """Raised when the profiling toolchain is missing or misconfigured."""
+
+
+# Upstream FlameGraph repo, shallow-cloned on demand when the scripts
+# are not already present locally.
+_FLAMEGRAPH_REPO = "https://github.com/brendangregg/FlameGraph"
+
+
+def _managed_flamegraph_dir() -> str:
+    """Return the temp path where FlameGraph is auto-cloned."""
+    return "/tmp/lmcache_flamegraph/FlameGraph"
+
+
+def _has_flamegraph(flamegraph_dir: str) -> bool:
+    """Return True if ``flamegraph.pl`` exists under *flamegraph_dir*."""
+    return os.path.isfile(os.path.join(flamegraph_dir, "flamegraph.pl"))
+
+
+def _clone_flamegraph(dest: str, log: Callable[[str], None]) -> None:
+    """Shallow-clone the FlameGraph repo into *dest*."""
+    if shutil.which("git") is None:
+        raise ProfileError(
+            "git not found; cannot auto-clone FlameGraph. Clone "
+            f"{_FLAMEGRAPH_REPO} manually and pass --profile-flamegraph-dir "
+            "or set FLAMEGRAPH_DIR."
+        )
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    log(f"[Profile] FlameGraph not found; cloning {_FLAMEGRAPH_REPO} -> {dest}")
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth", "1", _FLAMEGRAPH_REPO, dest],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as e:
+        detail = e.stderr.decode(errors="replace").strip() if e.stderr else str(e)
+        raise ProfileError(f"git clone of FlameGraph failed: {detail}") from e
+    if not _has_flamegraph(dest):
+        raise ProfileError(f"clone completed but flamegraph.pl missing in {dest}")
+
+
+def resolve_flamegraph_dir(explicit: str, log: Callable[[str], None]) -> str:
+    """Resolve the FlameGraph scripts directory, auto-cloning if needed.
+
+    Resolution order: the explicit ``--profile-flamegraph-dir`` value,
+    then ``$FLAMEGRAPH_DIR``, then ``~/FlameGraph``, then the managed temp
+    clone under ``/tmp/lmcache_flamegraph/FlameGraph``. When none of these
+    contains ``flamegraph.pl`` and no directory was given explicitly, the
+    repo is shallow-cloned into the managed temp location.
+
+    Args:
+        explicit: Directory passed via ``--profile-flamegraph-dir``; may
+            be an empty string when the flag was not given.
+        log: Progress logger (suppressed under ``--quiet``).
+
+    Returns:
+        A directory that contains ``flamegraph.pl``.
+
+    Raises:
+        ProfileError: If an explicit directory lacks the scripts, or the
+            scripts are missing and the auto-clone fails.
+    """
+    if explicit:
+        if not _has_flamegraph(explicit):
+            raise ProfileError(
+                f"flamegraph.pl not found under --profile-flamegraph-dir {explicit}"
+            )
+        return explicit
+
+    for candidate in (
+        os.environ.get("FLAMEGRAPH_DIR", ""),
+        os.path.expanduser("~/FlameGraph"),
+        _managed_flamegraph_dir(),
+    ):
+        if candidate and _has_flamegraph(candidate):
+            return candidate
+
+    # Not found anywhere: auto-clone into the managed cache location.
+    dest = _managed_flamegraph_dir()
+    _clone_flamegraph(dest, log)
+    return dest
+
+
+def default_output_path(adapter_name: str, mode: str) -> str:
+    """Build the default SVG output path for a profiling run.
+
+    Args:
+        adapter_name: Adapter class name, used in the filename.
+        mode: ``"on-cpu"`` or ``"off-cpu"``.
+
+    Returns:
+        An absolute path under ``/tmp/lmcache_bench_flames``.
+    """
+    tag = _MODE_TAG.get(mode, mode)
+    return f"/tmp/lmcache_bench_flames/{adapter_name}.{tag}.svg"
+
+
+class FlameProfiler:
+    """Struct wrapper for managing flame-chart profiling.
+
+    It starts a separate process to profile the target process, and
+    renders the captured data to a flame chart.
+    """
+
+    def __init__(
+        self,
+        *,
+        mode: str,
+        output: str,
+        flamegraph_dir: str,
+        pid: int,
+        title: str,
+    ) -> None:
+        """Validate the toolchain and prepare output paths.
+
+        Args:
+            mode: ``"on-cpu"`` or ``"off-cpu"``.
+            output: SVG output path.
+            flamegraph_dir: Directory holding the FlameGraph scripts.
+            pid: Process id to profile (the benchmark process itself).
+            title: Flame-graph title.
+
+        Raises:
+            ProfileError: If ``mode`` is invalid or a required tool is
+                unavailable.
+        """
+        if mode not in _MODE_TAG:
+            raise ProfileError(f"invalid profile mode: {mode!r}")
+        if mode == "on-cpu" and shutil.which("perf") is None:
+            raise ProfileError("perf not found on PATH (needed for on-cpu)")
+        if mode == "off-cpu":
+            if shutil.which("sudo") is None:
+                raise ProfileError("sudo not found on PATH (needed for off-cpu)")
+            # offcputime-bpfcc usually lives in /usr/sbin, which is not on
+            # the user's PATH but is reachable under sudo; check both so a
+            # missing tool surfaces here instead of as an empty flame graph.
+            if shutil.which("offcputime-bpfcc") is None and not os.path.exists(
+                "/usr/sbin/offcputime-bpfcc"
+            ):
+                raise ProfileError(
+                    "offcputime-bpfcc not found; install bcc / bpfcc-tools "
+                    "for off-cpu profiling."
+                )
+
+        self._mode = mode
+        self._output = output
+        self._flamegraph_dir = flamegraph_dir
+        self._pid = pid
+        self._title = title
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._raw_fh: object = None
+        # Intermediate capture file (perf.data for on-cpu, folded
+        # stacks for off-cpu); removed after a successful render.
+        suffix = ".perf.data" if mode == "on-cpu" else ".folded"
+        self._raw_path = output + suffix
+        self._stopped = False
+
+        out_dir = os.path.dirname(os.path.abspath(output))
+        os.makedirs(out_dir, exist_ok=True)
+
+    def start(self, log: Callable[[str], None]) -> None:
+        """Start the background recorder targeting the profiled process."""
+        if self._mode == "on-cpu":
+            self._proc = subprocess.Popen(
+                [
+                    "perf",
+                    "record",
+                    "-F",
+                    str(_PERF_FREQ_HZ),
+                    "-g",
+                    "-p",
+                    str(self._pid),
+                    "-o",
+                    self._raw_path,
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            self._raw_fh = open(self._raw_path, "wb")
+            self._proc = subprocess.Popen(
+                ["sudo", "offcputime-bpfcc", "-df", "-p", str(self._pid)],
+                stdout=self._raw_fh,  # type: ignore[arg-type]
+                stderr=subprocess.DEVNULL,
+            )
+            # The BPF program takes a moment to load; give it time so the
+            # first stretch of the measured phase is not missed.
+            time.sleep(_OFFCPU_SETTLE_SEC)
+        log(
+            f"[Profile] {self._mode} recording started (pid={self._pid}) "
+            f"-> {self._output}"
+        )
+
+    def stop(self, log: Callable[[str], None]) -> None:
+        """Stop the recorder and render the SVG. Idempotent."""
+        if self._stopped:
+            return
+        self._stopped = True
+        if self._proc is None:
+            return
+
+        # SIGINT makes both perf and offcputime-bpfcc flush their output
+        # and exit cleanly (sudo forwards the signal to offcputime).
+        try:
+            self._proc.send_signal(signal.SIGINT)
+        except ProcessLookupError:
+            pass
+        try:
+            self._proc.wait(timeout=_STOP_TIMEOUT_SEC)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait()
+        if self._raw_fh is not None:
+            self._raw_fh.close()  # type: ignore[attr-defined]
+            self._raw_fh = None
+
+        log("[Profile] rendering flame graph...")
+        try:
+            self._render()
+        except ProfileError as e:
+            log(f"[Profile] render failed: {e}")
+            return
+        for leftover in (self._raw_path, self._raw_path + ".old"):
+            try:
+                os.remove(leftover)
+            except OSError:
+                pass
+        log(f"[Profile] wrote {self._output}")
+
+    def _render(self) -> None:
+        """Render the captured stacks into viewable flamechart at path at self._path"""
+        flamegraph_pl = os.path.join(self._flamegraph_dir, "flamegraph.pl")
+        try:
+            with open(self._output, "wb") as svg:
+                if self._mode == "on-cpu":
+                    collapse_pl = os.path.join(
+                        self._flamegraph_dir, "stackcollapse-perf.pl"
+                    )
+                    script = subprocess.Popen(
+                        ["perf", "script", "-i", self._raw_path],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    collapse = subprocess.Popen(
+                        [collapse_pl],
+                        stdin=script.stdout,
+                        stdout=subprocess.PIPE,
+                    )
+                    flame = subprocess.Popen(
+                        [
+                            flamegraph_pl,
+                            "--title",
+                            self._title,
+                            "--width",
+                            str(_FLAME_WIDTH_PX),
+                        ],
+                        stdin=collapse.stdout,
+                        stdout=svg,
+                    )
+                    flame.communicate()
+                    rc = flame.returncode
+                else:
+                    with open(self._raw_path, "rb") as folded:
+                        flame = subprocess.Popen(
+                            [
+                                flamegraph_pl,
+                                "--color=io",
+                                "--countname",
+                                "us",
+                                "--title",
+                                self._title,
+                                "--width",
+                                str(_FLAME_WIDTH_PX),
+                            ],
+                            stdin=folded,
+                            stdout=svg,
+                        )
+                        flame.communicate()
+                        rc = flame.returncode
+        except OSError as e:
+            raise ProfileError(str(e)) from e
+        if rc != 0:
+            raise ProfileError(f"flamegraph.pl exited with code {rc}")

--- a/tests/cli/commands/bench/l2_adapter_bench/test_profiling.py
+++ b/tests/cli/commands/bench/l2_adapter_bench/test_profiling.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test for the L2 adapter benchmark flame-graph profiler."""
+
+# Standard
+from pathlib import Path
+import os
+import shutil
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.bench.l2_adapter_bench.profiling import (
+    FlameProfiler,
+    ProfileError,
+    check_profiling_deps,
+)
+
+
+def test_check_profiling_deps_missing_tool_is_actionable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing tool names the tool and how to recover.
+
+    Runs on any machine: the toolchain is faked absent via monkeypatch,
+    so this never skips and always exercises the error path.
+    """
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+    with pytest.raises(ProfileError) as excinfo:
+        check_profiling_deps("on-cpu")
+
+    message = str(excinfo.value)
+    assert "perf" in message
+    # Actionable: points at the fallback mode.
+    assert "off-cpu" in message
+
+
+def test_flame_profiler_builds_with_real_toolchain(tmp_path: Path) -> None:
+    if shutil.which("perf") is None:
+        pytest.skip("perf not installed; flame-graph profiling unavailable")
+
+    scripts_dir = tmp_path / "FlameGraph"
+    scripts_dir.mkdir()
+    (scripts_dir / "flamegraph.pl").write_text("#!/usr/bin/perl\n")
+    output = tmp_path / "flames" / "out.svg"
+
+    FlameProfiler(
+        mode="on-cpu",
+        output=str(output),
+        flamegraph_dir=str(scripts_dir),
+        pid=os.getpid(),
+        title="test",
+    )
+
+    # The component validated the toolchain and prepared the output dir.
+    assert output.parent.is_dir()


### PR DESCRIPTION
**What this PR does / why we need it**:
~~Tools used for this pr: https://github.com/LMCache/LMCache/pull/3271. Add tools for get flame chart
  when perf storage backend, also extend current iouring benchmark tool~~

Flame chart is a widely used performance analysis tool, add it as a general profiling tool in bench l2 adapter, As suggested by yihua https://github.com/LMCache/LMCache/pull/3272#issuecomment-4548825024


**Special notes for your reviewers**:
Example command 

```
lmcache bench l2  --l2-adapter '{"type":"fs","base_path":"/tmp/bench_fs"}'     --num-keys 32 --data-size-kb 256 --rounds 5 --warmup-rounds 2     --flamegraph on --flamegraph-mode off-cpu \ 
```

Example Result:

**FS adapter:**
OnCpu:
[![fs oncpu](https://github.com/user-attachments/assets/0bfb9490-6123-44e2-9a1f-f91a216d1a5b)](https://github.com/user-attachments/assets/0bfb9490-6123-44e2-9a1f-f91a216d1a5b)
Off Cpu:
[![fs offcpu](https://github.com/user-attachments/assets/86b96b1b-877a-4190-ac4d-93ec6f7cb2b2)](https://github.com/user-attachments/assets/86b96b1b-877a-4190-ac4d-93ec6f7cb2b2)

**Raw block**
The ~27% rwsem_down_read contention comes from running raw_block on an ext4 file (inode i_rwsem serializing O_DIRECT writes), not from raw_block itself, a real raw block device has no inode lock. Not an adapter bottleneck. My config issue. Just added for showing general info of perfing raw block adapter

on cpu:
[![rawblock oncpu](https://github.com/user-attachments/assets/50dc4158-fc29-47f6-874e-efa14eb1b71e)](https://github.com/user-attachments/assets/50dc4158-fc29-47f6-874e-efa14eb1b71e)

offcpu:
[![rawblock offcpu](https://github.com/user-attachments/assets/5b96c4f5-20be-4248-9580-44d6198bd5e8)](https://github.com/user-attachments/assets/5b96c4f5-20be-4248-9580-44d6198bd5e8)


I originally planned to bundle some adapter-level optimization with this PR. 

Based on the profiling here, I will hold this for now. (Disclaimer: measured on GCP instances.) 

Both the fs and raw_block adapters are pinned at the local SSD's write-bandwidth ceiling. The off-CPU flame charts show the O_DIRECT write path ,most directly iomap_dio_rw  dominating blocked time (~74% for fs, and the write-syscall branch ~63% for raw_block), with throughput hitting the raw dd device ceiling (~390 MB/s). This is clearly device/I/O-bound rather than CPU- or software-bound, so optimizing the adapter code wouldn't move the needle here.


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
