### PR TITLE
docs: daily drift check — multi-process mode (2026-05-13 + 2026-05-14)

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/overall.md
+++ b/docs/design/v1/distributed/l2_adapters/overall.md
@@ -66,6 +66,7 @@ silently misroute events.
 ```
 submit_store_task(keys, objects) -> L2TaskId
 pop_completed_store_tasks() -> dict[L2TaskId, bool]
+pop_completed_store_task_bytes() -> dict[L2TaskId, int]   # optional
 ```
 
 - **Caller provides buffers:** The `objects` list contains `MemoryObj` references
@@ -74,6 +75,16 @@ pop_completed_store_tasks() -> dict[L2TaskId, bool]
   The bool in the completion dict is `True` for success, `False` for failure.
 - **Pop semantics:** `pop_completed_store_tasks()` drains all completed tasks.
   Each task appears exactly once.
+- **Bytes-transferred reporting (optional):**
+  `pop_completed_store_task_bytes()` is an opt-in hook on
+  `L2AdapterInterface`. The default implementation returns `{}`, in which
+  case the StoreController omits `bytes_transferred` from
+  `L2_STORE_COMPLETED` and the throughput subscriber falls back to the
+  submitted `total_bytes`. Adapters that fast-path duplicate keys (e.g.
+  skip the write when the key already exists) SHOULD override it and
+  report the bytes actually written per task — including `0` when every
+  key was fast-pathed — so the L2 store throughput histogram reflects
+  real work rather than inflated `bytes / ~0` samples.
 
 ### Lookup and Lock Operations
 

--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -116,7 +116,7 @@ helper.
 | Helper | Returns | Notes |
 |---|---|---|
 | `get_group_data_ptrs(kv, fmt, layer_indices)` | `list[int]` | Pointer array in **kernel-expected order**: `[base]` for cross-layer (`layer_indices` ignored), `[K_0…K_N, V_0…V_N]` for SGLang MHA, per-layer flat elsewhere. Matches the dispatch in `csrc/mp_mem_kernels.cu:161-169`. The pointer-array shape is a property of the format — callers never ask "does this format have per-layer pointers?". |
-| `make_page_buffer_shape_desc(kv, fmt, layer_idx, num_layers_in_group, num_blocks, block_size)` | `PageBufferShapeDesc` | The kernel-facing shape struct. |
+| `make_page_buffer_shape_desc(kv, fmt, layer_idx, num_layers_in_group, num_blocks, block_size, block_stride_elems)` | `PageBufferShapeDesc` | The kernel-facing shape struct. ``block_stride_elems`` carries the per-block dim-0 element stride; pass the value returned by `resolve_block_stride_and_log_layout` so groups with different physical block sizes (e.g. a compressed DeepSeek V4 indexer group alongside dense layers) share a single GPU pool. |
 
 ### Contiguity
 
@@ -151,12 +151,17 @@ helper.
 ## Consumers
 
 - **`lmcache/v1/kv_layer_groups.py::KVLayerGroupsManager.__init__`** —
-  partitions layers by the 4-tuple `(kv_size, num_heads, head_size,
-  dtype)` using `is_mla`, `get_num_heads`, `get_head_size`, and
-  `get_dtype` with each layer's index. Builds a `PageBufferShapeDesc`
-  per group via `make_page_buffer_shape_desc`. The real constructor is
-  the only way in — no test-only shortcuts, no cached topology fields;
-  the manager exposes only `kv_layer_groups`, `num_groups`, and
+  partitions layers by the 5-tuple `(kv_size, num_heads, head_size,
+  block_size, dtype)` using `is_mla`, `get_num_heads`, `get_head_size`,
+  `get_block_size`, and `get_dtype` with each layer's index. Including
+  `block_size` in the identity lets compressed groups (e.g. a DeepSeek
+  V4 indexer with a smaller physical slot count) sit alongside
+  non-compressed groups under a single `GPUCacheContext`. Builds a
+  `PageBufferShapeDesc` per group via `make_page_buffer_shape_desc`,
+  passing the `block_stride_elems` resolved by
+  `resolve_block_stride_and_log_layout`. The real constructor is the
+  only way in — no test-only shortcuts, no cached topology fields; the
+  manager exposes only `kv_layer_groups`, `num_groups`, and
   `get_shape_desc`.
 - **`lmcache/v1/multiprocess/gpu_context.py::GPUCacheContext`** —
   constructs the manager directly at init, delegates

--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -71,7 +71,14 @@ Producers:
 | EventType | Metadata keys | Types |
 |---|---|---|
 | `L2_STORE_SUBMITTED` | `adapter_index`, `task_id`, `l2_name`, `key_count`, `total_bytes` | `int`, `int`, `str`, `int`, `int` |
-| `L2_STORE_COMPLETED` | `adapter_index`, `task_id`, `l2_name`, `succeeded_count`, `failed_count` | `int`, `int`, `str`, `int`, `int` |
+| `L2_STORE_COMPLETED` | `adapter_index`, `task_id`, `l2_name`, `succeeded_count`, `failed_count`, `bytes_transferred` *(optional)* | `int`, `int`, `str`, `int`, `int`, `int` |
+
+`bytes_transferred` is present only when the L2 adapter overrides
+`pop_completed_store_task_bytes()` to report the bytes actually written
+on the fast path (e.g. when duplicate keys are skipped). Adapters that
+don't track per-task transfer bytes omit the field, and consumers fall
+back to the `total_bytes` value carried on the matching
+`L2_STORE_SUBMITTED` event.
 
 ---
 

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -310,9 +310,22 @@ registered adapter type (e.g. `"fs"`, `"nixl_store"`, `"mooncake_store"`)
 — enabling per-adapter-type slicing in Prometheus (e.g.
 `lmcache_mp_l2_store_throughput_gbs{l2_name="nixl_store"}`).
 
+**Store-path fast-path accounting.** Some adapters (`mock`, `fs`,
+`nixl_store`) skip the write when a key is already present in the
+backend, collapsing `(completed_ts - submitted_ts)` to near-zero while
+the submitted `total_bytes` count stays unchanged. To avoid inflated
+throughput samples, those adapters override
+`L2AdapterInterface.pop_completed_store_task_bytes()` and the
+`L2_STORE_COMPLETED` event then carries a `bytes_transferred` field
+covering only the bytes actually written. When `bytes_transferred` is
+present, the store path records `bytes_transferred / dt`; when it is
+`0` (every key fast-pathed) the sample is dropped entirely. When the
+field is absent (adapter doesn't track it) the subscriber falls back
+to the submitted `total_bytes`, matching the load-path calculation.
+
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|
-| `lmcache_mp.l2_store_throughput_gbs` | `lmcache_mp_l2_store_throughput_gbs` | Histogram | `L2_STORE_SUBMITTED` → `L2_STORE_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per task |
+| `lmcache_mp.l2_store_throughput_gbs` | `lmcache_mp_l2_store_throughput_gbs` | Histogram | `L2_STORE_SUBMITTED` → `L2_STORE_COMPLETED` | `effective_bytes / (completed_ts - submitted_ts) / 1e9` per task, where `effective_bytes` is `bytes_transferred` when reported (samples with `bytes_transferred == 0` are dropped) and otherwise `total_bytes` from the SUBMITTED event |
 | `lmcache_mp.l2_load_throughput_gbs` | `lmcache_mp_l2_load_throughput_gbs` | Histogram | `L2_LOAD_TASK_SUBMITTED` → `L2_LOAD_TASK_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per (request, adapter) pair |
 
 **What it answers:** What end-to-end throughput is each L2 adapter

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -498,6 +498,22 @@ attribute — the registered adapter type (e.g. ``"fs"``, ``"nixl_store"``,
 ``"mooncake_store"``) — enabling per-backend slicing in Prometheus (e.g.
 ``lmcache_mp_l2_store_throughput_gbs{l2_name="nixl_store"}``).
 
+.. note::
+   **Store-path fast-path accounting.** Some adapters (``mock``, ``fs``,
+   ``nixl_store``) skip the write when a key is already present in the
+   backend.  That fast-path collapses
+   ``(completed_ts - submitted_ts)`` to near-zero while the submitted
+   ``total_bytes`` stays unchanged, which would inflate the store
+   throughput samples.  Those adapters report the bytes actually
+   written via the optional
+   ``L2AdapterInterface.pop_completed_store_task_bytes()`` hook, and the
+   throughput subscriber prefers that value over the submitted bytes.
+   Tasks where every key was fast-pathed report ``0`` bytes and the
+   corresponding samples are dropped (no useful throughput data) rather
+   than recorded as a spike.  Adapters without a fast-path don't
+   override the hook and the subscriber keeps using the submitted
+   ``total_bytes``.
+
 .. list-table::
    :header-rows: 1
    :widths: 40 15 45
@@ -507,7 +523,9 @@ attribute — the registered adapter type (e.g. ``"fs"``, ``"nixl_store"``,
      - Description
    * - ``lmcache_mp.l2_store_throughput_gbs``
      - Histogram
-     - L1→L2 store throughput in GB/s per task.
+     - L1→L2 store throughput in GB/s per task.  Uses adapter-reported
+       transferred bytes when available; otherwise the submitted
+       ``total_bytes``.  Tasks with zero transferred bytes are dropped.
    * - ``lmcache_mp.l2_load_throughput_gbs``
      - Histogram
      - L2→L1 load throughput in GB/s per (request, adapter) pair.


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine.
**Human review is required before merge — do not merge as-is.**

Per the routine's dedup rule, today's (2026-05-14) drift item is
appended to this still-open 2026-05-13 PR rather than filed as a
parallel daily PR. Reviewer can take the two commits independently.

---

### Drift batch 1 — from 2026-05-13 (commit [`71b291e`](https://github.com/ApostaC/LMCache/commit/71b291e05365e121e68ad61bd0902a7b0ef15bab))

[PR #3257](https://github.com/LMCache/LMCache/pull/3257) (commit
[`ae24dad`](https://github.com/LMCache/LMCache/commit/ae24dad7cde6ee87595d8db893d260c9509d9517))
landed on 2026-05-11 and introduced two new contract surfaces that the
existing docs don't describe:

1. An optional `bytes_transferred` field on the `L2_STORE_COMPLETED`
   event.
2. An optional `L2AdapterInterface.pop_completed_store_task_bytes()`
   hook that adapters override to opt into per-task transferred-bytes
   reporting.

The L2 throughput subscriber prefers `bytes_transferred` over the
submitted `total_bytes` when present, and drops the sample entirely
when it is `0`.

#### `docs/source/` (user-facing) drift

- **`docs/source/mp/observability.rst`** — *L1↔L2 Throughput
  Histograms* section
  ([current `dev`](https://github.com/LMCache/LMCache/blob/b16de35f0f6a1b502a348312a250d96a19009f5b/docs/source/mp/observability.rst#L478-L513))
  describes only the submit-vs-complete latency timing. There is no
  mention of fast-path adapters that skip duplicate writes or that
  `lmcache_mp.l2_store_throughput_gbs` now drops zero-bytes samples
  rather than inflating to ~`bytes / 0` GB/s.

#### `docs/design/` drift

- **`docs/design/v1/mp_observability/EVENTS.md`** — `L2_STORE_COMPLETED`
  row
  ([line 74 on `dev`](https://github.com/LMCache/LMCache/blob/b16de35f0f6a1b502a348312a250d96a19009f5b/docs/design/v1/mp_observability/EVENTS.md#L74))
  lists only `adapter_index`, `task_id`, `l2_name`, `succeeded_count`,
  `failed_count`. It does not mention the new optional `bytes_transferred`
  metadata key emitted from
  [`store_controller.py:580-617`](https://github.com/LMCache/LMCache/blob/b16de35f0f6a1b502a348312a250d96a19009f5b/lmcache/v1/distributed/storage_controllers/store_controller.py#L580-L617).
- **`docs/design/v1/mp_observability/METRICS.md`** — the L1↔L2
  throughput section
  ([lines 291-316 on `dev`](https://github.com/LMCache/LMCache/blob/b16de35f0f6a1b502a348312a250d96a19009f5b/docs/design/v1/mp_observability/METRICS.md#L291-L316))
  formulates the store-path calculation as `total_bytes / dt`, which is
  no longer accurate. The current subscriber logic
  ([`l2_throughput.py:100-114`](https://github.com/LMCache/LMCache/blob/b16de35f0f6a1b502a348312a250d96a19009f5b/lmcache/v1/mp_observability/subscribers/metrics/l2_throughput.py#L100-L114)
  and
  [`l2_throughput.py:164-193`](https://github.com/LMCache/LMCache/blob/b16de35f0f6a1b502a348312a250d96a19009f5b/lmcache/v1/mp_observability/subscribers/metrics/l2_throughput.py#L164-L193))
  records `bytes_transferred / dt` when the override is present, drops
  the sample if `bytes_transferred == 0`, and falls back to
  `total_bytes / dt` otherwise.
- **`docs/design/v1/distributed/l2_adapters/overall.md`** — the *Store
  Operations* contract
  ([lines 64-77 on `dev`](https://github.com/LMCache/LMCache/blob/b16de35f0f6a1b502a348312a250d96a19009f5b/docs/design/v1/distributed/l2_adapters/overall.md#L64-L77))
  lists only `submit_store_task` and `pop_completed_store_tasks`. It is
  missing the new optional `pop_completed_store_task_bytes()` hook
  defined on
  [`L2AdapterInterface` in `base.py:234-247`](https://github.com/LMCache/LMCache/blob/b16de35f0f6a1b502a348312a250d96a19009f5b/lmcache/v1/distributed/l2_adapters/base.py#L234-L247),
  which adapters such as `mock`, `fs`, and `nixl_store` already override.

---

### Drift batch 2 — from 2026-05-14 (commit [`8630e6d`](https://github.com/ApostaC/LMCache/commit/8630e6dc381bd1c87d0daebcb6709358973c97be))

[PR #3171](https://github.com/LMCache/LMCache/pull/3171) (commit
[`384d79d`](https://github.com/LMCache/LMCache/commit/384d79df5c3a023ccfebedc2b69b094b0d7b7084),
"[MP][Feat] Support DeepSeek V4 with per-group compressed KV layout")
landed on 2026-05-14 and made two contract changes that the
`gpu_connector` layout-invariant design doc had not absorbed.

#### `docs/design/` drift

- **`docs/design/v1/gpu_connector/layout-invariant.md`** — two stale
  claims, both inside this single design page:
  - The helper table under *Pointer and descriptor builders*
    ([line 119 on `dev`](https://github.com/LMCache/LMCache/blob/384d79df5c3a023ccfebedc2b69b094b0d7b7084/docs/design/v1/gpu_connector/layout-invariant.md#L119))
    listed the `make_page_buffer_shape_desc` signature **without**
    the new `block_stride_elems` parameter. The merged code in
    [`lmcache/v1/kv_layer_groups.py` (init body)](https://github.com/LMCache/LMCache/blob/384d79df5c3a023ccfebedc2b69b094b0d7b7084/lmcache/v1/kv_layer_groups.py)
    now passes `block_stride_elems=resolve_block_stride_and_log_layout(...)`
    into the helper.
  - The Consumers bullet for `KVLayerGroupsManager.__init__`
    ([line 154 on `dev`](https://github.com/LMCache/LMCache/blob/384d79df5c3a023ccfebedc2b69b094b0d7b7084/docs/design/v1/gpu_connector/layout-invariant.md#L154))
    said *"partitions layers by the 4-tuple `(kv_size, num_heads,
    head_size, dtype)`"*. The merged code now keys on a **5-tuple**:
    [`LayerGroupIdentity = tuple[int, int, int, int, torch.dtype]`](https://github.com/LMCache/LMCache/blob/384d79df5c3a023ccfebedc2b69b094b0d7b7084/lmcache/v1/kv_layer_groups.py)
    with `(kv_size, num_heads, head_size, block_size, dtype)`, and
    `_group_layers_by_identity` now also reads `get_block_size` per
    layer. Including `block_size` in the identity is what lets a
    compressed DeepSeek V4 indexer group sit alongside non-compressed
    groups under a single `GPUCacheContext`.

#### Audit-clean (no drift) for 2026-05-14

The following PRs were audited but introduced no doc drift in the
multi-process scope (verified, not just skimmed):

- **PR #3227** (Mooncake L2 `per_op_workers`) — `docs/source/mp/l2_storage.rst`
  already documents the new key with the four lane names and
  per-op example.
- **PR #3235** (`lmcache_mp_connector` for dev) — doc update landed
  in `docs/source/getting_started/quickstart.rst` and matches code.
  No mp/* page claims a specific connector module path.
- **PR #3244** (`/api/` purge follow-up) — all quota router
  decorators on `dev` are at bare paths (`/quota{/{cache_salt}}`),
  matching `docs/source/mp/http_api.rst`. No stale `/api/...`
  references remain.

---

## Proposed fix (applied in this PR — two commits)

Docs-only updates that mirror the new contracts. Both commits are DCO-
signed and authored by ApostaC.

**Commit 1 (2026-05-13)** — already in this PR:

- Add the optional `bytes_transferred` field to the
  `L2_STORE_COMPLETED` row in `EVENTS.md` and explain when it is
  present vs. absent.
- Describe the fast-path accounting rule in `METRICS.md` and rewrite
  the `l2_store_throughput_gbs` calculation column to match the actual
  subscriber logic (override + drop-on-zero + fallback).
- List `pop_completed_store_task_bytes()` in the *Store Operations*
  section of `overall.md` with the override guidance copied from the
  `L2AdapterInterface` docstring.
- Add a `.. note::` to `docs/source/mp/observability.rst` so users
  understand why some fast-path store tasks now contribute no sample.

**Commit 2 (2026-05-14)** — appended today:

- Update the helper table in `layout-invariant.md` to add
  `block_stride_elems` to the `make_page_buffer_shape_desc` signature,
  with a one-line note that it carries per-block dim-0 stride and
  should be sourced from `resolve_block_stride_and_log_layout`.
- Rewrite the `KVLayerGroupsManager.__init__` consumers bullet to
  describe the **5-tuple** identity, list `get_block_size` among the
  per-layer accessors used, and explain why `block_size` is part of
  the identity now (mixed-compression groups under one
  `GPUCacheContext`).

No code files are touched. The proposed wording follows the existing
behavior in code — no behavior change is implied.

## Generated by

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Branch: `ApostaC:docs/drift-check-2026-05-13`
(commit-2 appended on 2026-05-14 per the routine's dedup-or-update
rule). Human review is still required before merge; please leave this
PR in draft until reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ctEaRNj5PHbgxt8rdQLtY)_