### PR TITLE
[CI] swap default to cu13 wheels and cu12.9 secondary

### DIFF
--- a/.github/workflows/build_cu129_artifacts.yml
+++ b/.github/workflows/build_cu129_artifacts.yml
@@ -1,10 +1,10 @@
-name: Build cu130 Artifacts
+name: Build cu129 Artifacts
 
-# Reusable workflow that builds the cu130 CUDA 13.0 wheel via cibuildwheel
-# against the pytorch manylinux cu13 base image.
-# Uploaded as the `release-cu130-artifacts` GHA artifact.
-# The cu13 wheel carries no local version suffix and is published to a
-# dedicated v{tag}-cu13 GitHub Release (not PyPI).
+# Reusable workflow that builds the cu129 CUDA 12.9 wheel via cibuildwheel
+# against the pytorch manylinux cu12.9 base image.
+# Uploaded as the `release-cu129-artifacts` GHA artifact.
+# The cu12.9 wheel carries no local version suffix and is published to a
+# dedicated v{tag}-cu12 GitHub Release (not PyPI).
 
 on:
     workflow_call:
@@ -20,8 +20,8 @@ permissions:
     contents: read
 
 jobs:
-    build-cu130-artifacts:
-        name: Build cu130 artifacts
+    build-cu129-artifacts:
+        name: Build cu129 artifacts
         runs-on: ubuntu-latest
         steps:
             - name: "Harden Runner"
@@ -84,15 +84,15 @@ jobs:
               run: |
                 rm -rf dist/
 
-            - name: Get base version for cu13 wheel
+            - name: Get base version for cu12.9 wheel
               run: |
                 BASE=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 | sed 's/^v//' || echo "0.0.0.dev")
-                echo "CU130_VERSION=${BASE}" >> "$GITHUB_ENV"
+                echo "CU129_VERSION=${BASE}" >> "$GITHUB_ENV"
 
-            - name: Build cu130 CUDA wheels with cibuildwheel
+            - name: Build cu12.9 CUDA wheels with cibuildwheel
               env:
-                CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda13.0
-                CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.CU130_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130'
+                CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda12.9
+                CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.CU129_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu129'
                 CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
                   auditwheel repair
                   --plat manylinux_2_28_x86_64
@@ -102,14 +102,14 @@ jobs:
                   --exclude libtorch_cpu.so
                   --exclude libc10.so
                   --exclude libc10_cuda.so
-                  --exclude libcudart.so.13
+                  --exclude libcudart.so.12
                   -w {dest_dir} {wheel}
                 CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
               run: |
                 python -m cibuildwheel --output-dir dist
 
-            - name: Upload cu130 release artifacts to GHA
+            - name: Upload cu12.9 release artifacts to GHA
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
-                name: release-cu130-artifacts
+                name: release-cu129-artifacts
                 path: dist/

--- a/.github/workflows/build_cu129_artifacts.yml
+++ b/.github/workflows/build_cu129_artifacts.yml
@@ -92,7 +92,7 @@ jobs:
             - name: Build cu12.9 CUDA wheels with cibuildwheel
               env:
                 CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda12.9
-                CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0" ENABLE_CXX11_ABI=1 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.CU129_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu129'
+                CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0" ENABLE_CXX11_ABI=1 LMCACHE_CUDA_MAJOR=12 SETUPTOOLS_SCM_PRETEND_VERSION=${{ env.CU129_VERSION }} PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu129'
                 CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
                   auditwheel repair
                   --plat manylinux_2_28_x86_64

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -66,36 +66,35 @@ jobs:
           pip install cibuildwheel
 
 
-      - name: Build cu12.9 nightly wheel
+      - name: Build cu13.0 nightly wheel
         env:
-          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1'
           CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
         run: |
-          python -m cibuildwheel --output-dir dist/cu129
+          python -m cibuildwheel --output-dir dist/cu130
 
-      - name: Publish cu12.9 wheels to rolling nightly release
+      - name: Publish cu13.0 wheels to rolling nightly release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh release delete nightly --yes --cleanup-tag --repo ${{ github.repository }} 2>/dev/null || true
           gh release create nightly \
             --repo ${{ github.repository }} \
-            --title "Nightly $(date +'%Y-%m-%d') · CUDA 12.9" \
-            --notes "Nightly CUDA 12.9 wheels built from \`dev\` on $(date +'%Y-%m-%d').
+            --title "Nightly $(date +'%Y-%m-%d') · CUDA 13.0" \
+            --notes "Nightly CUDA 13.0 wheels built from \`dev\` on $(date +'%Y-%m-%d').
 
           \`\`\`
           uv pip install lmcache --pre \\
-            --extra-index-url https://download.pytorch.org/whl/cu129 \\
+            --extra-index-url https://download.pytorch.org/whl/cu130 \\
             --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/nightly \\
             --index-strategy unsafe-best-match
           \`\`\`" \
             --prerelease \
-            dist/cu129/*.whl
+            dist/cu130/*.whl
 
-      - name: Build cu13.0 nightly wheel
+      - name: Build cu12.9 nightly wheel
         env:
-          CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda13.0
-          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="8.0;8.6;8.9;9.0;10.0;12.0" ENABLE_CXX11_ABI=1 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130'
+          CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda12.9
+          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0" ENABLE_CXX11_ABI=1 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu129'
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
             auditwheel repair
             --plat manylinux_2_28_x86_64
@@ -105,30 +104,30 @@ jobs:
             --exclude libtorch_cpu.so
             --exclude libc10.so
             --exclude libc10_cuda.so
-            --exclude libcudart.so.13
+            --exclude libcudart.so.12
             -w {dest_dir} {wheel}
           CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
         run: |
-          python -m cibuildwheel --output-dir dist/cu130
+          python -m cibuildwheel --output-dir dist/cu129
 
-      - name: Publish cu13.0 wheels to rolling nightly-cu13 release
+      - name: Publish cu12.9 wheels to rolling nightly-cu129 release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          gh release delete nightly-cu13 --yes --cleanup-tag --repo ${{ github.repository }} 2>/dev/null || true
-          gh release create nightly-cu13 \
+          gh release delete nightly-cu129 --yes --cleanup-tag --repo ${{ github.repository }} 2>/dev/null || true
+          gh release create nightly-cu129 \
             --repo ${{ github.repository }} \
-            --title "Nightly $(date +'%Y-%m-%d') · CUDA 13.0" \
-            --notes "Nightly CUDA 13.0 wheels built from \`dev\` on $(date +'%Y-%m-%d').
+            --title "Nightly $(date +'%Y-%m-%d') · CUDA 12.9" \
+            --notes "Nightly CUDA 12.9 wheels built from \`dev\` on $(date +'%Y-%m-%d').
 
           \`\`\`
           uv pip install lmcache --pre \\
-            --extra-index-url https://download.pytorch.org/whl/cu130 \\
-            --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/nightly-cu13 \\
+            --extra-index-url https://download.pytorch.org/whl/cu129 \\
+            --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/nightly-cu129 \\
             --index-strategy unsafe-best-match
           \`\`\`" \
             --prerelease \
-            dist/cu130/*.whl
+            dist/cu129/*.whl
 
   nightly-build:
     name: Build image
@@ -191,36 +190,6 @@ jobs:
         run: |
           echo "NOW=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
-      - name: Build lmcache/vllm-openai container image
-        run: |
-          docker system prune -f --all
-          docker builder prune -af
-          docker build \
-          --build-arg CUDA_VERSION=12.9 --build-arg UBUNTU_VERSION=24.04 \
-          --target image-build \
-          --tag lmcache/vllm-openai:latest-nightly --tag lmcache/vllm-openai:nightly-${{ env.NOW }} \
-          --file docker/Dockerfile .
-
-      - name: Push lmcache/vllm-openai container image to DockerHub
-        run: |
-          docker push lmcache/vllm-openai:latest-nightly
-          docker push lmcache/vllm-openai:nightly-${{ env.NOW }}
-
-      - name: Build lmcache/standalone container image
-        run: |
-          docker system prune -f --all
-          docker builder prune -af
-          docker build \
-          --build-arg CUDA_VERSION=12.9 --build-arg UBUNTU_VERSION=24.04 \
-          --target lmcache-final \
-          --tag lmcache/standalone:nightly --tag lmcache/standalone:nightly-${{ env.NOW }} \
-          --file docker/Dockerfile.standalone .
-
-      - name: Push lmcache/standalone container image to DockerHub
-        run: |
-          docker push lmcache/standalone:nightly
-          docker push lmcache/standalone:nightly-${{ env.NOW }}
-
       - name: Build lmcache/vllm-openai container image (cu13 nightly)
         run: |
           docker system prune -f --all
@@ -230,13 +199,13 @@ jobs:
           --build-arg CUDA_VERSION=13.0 \
           --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
           --target image-build \
-          --tag lmcache/vllm-openai:latest-nightly-cu13 --tag lmcache/vllm-openai:nightly-${{ env.NOW }}-cu13 \
+          --tag lmcache/vllm-openai:latest-nightly --tag lmcache/vllm-openai:nightly-${{ env.NOW }} \
           --file docker/Dockerfile .
 
-      - name: Push lmcache/vllm-openai cu13 nightly image to DockerHub
+      - name: Push lmcache/vllm-openai container image to DockerHub
         run: |
-          docker push lmcache/vllm-openai:latest-nightly-cu13
-          docker push lmcache/vllm-openai:nightly-${{ env.NOW }}-cu13
+          docker push lmcache/vllm-openai:latest-nightly
+          docker push lmcache/vllm-openai:nightly-${{ env.NOW }}
 
       - name: Build lmcache/standalone container image (cu13 nightly)
         run: |
@@ -247,10 +216,42 @@ jobs:
           --build-arg CUDA_VERSION=13.0 \
           --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
           --target lmcache-final \
-          --tag lmcache/standalone:nightly-cu13 --tag lmcache/standalone:nightly-${{ env.NOW }}-cu13 \
+          --tag lmcache/standalone:nightly --tag lmcache/standalone:nightly-${{ env.NOW }} \
           --file docker/Dockerfile.standalone .
 
-      - name: Push lmcache/standalone cu13 nightly image to DockerHub
+      - name: Push lmcache/standalone container image to DockerHub
         run: |
-          docker push lmcache/standalone:nightly-cu13
-          docker push lmcache/standalone:nightly-${{ env.NOW }}-cu13
+          docker push lmcache/standalone:nightly
+          docker push lmcache/standalone:nightly-${{ env.NOW }}
+
+      - name: Build lmcache/vllm-openai container image (cu12.9 nightly)
+        run: |
+          docker system prune -f --all
+          docker builder prune -af
+          docker build \
+          --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
+          --build-arg CUDA_VERSION=12.9 --build-arg UBUNTU_VERSION=24.04 \
+          --target image-build \
+          --tag lmcache/vllm-openai:latest-nightly-cu129 --tag lmcache/vllm-openai:nightly-${{ env.NOW }}-cu129 \
+          --file docker/Dockerfile .
+
+      - name: Push lmcache/vllm-openai cu12.9 nightly image to DockerHub
+        run: |
+          docker push lmcache/vllm-openai:latest-nightly-cu129
+          docker push lmcache/vllm-openai:nightly-${{ env.NOW }}-cu129
+
+      - name: Build lmcache/standalone container image (cu12.9 nightly)
+        run: |
+          docker system prune -f --all
+          docker builder prune -af
+          docker build \
+          --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
+          --build-arg CUDA_VERSION=12.9 --build-arg UBUNTU_VERSION=24.04 \
+          --target lmcache-final \
+          --tag lmcache/standalone:nightly-cu129 --tag lmcache/standalone:nightly-${{ env.NOW }}-cu129 \
+          --file docker/Dockerfile.standalone .
+
+      - name: Push lmcache/standalone cu12.9 nightly image to DockerHub
+        run: |
+          docker push lmcache/standalone:nightly-cu129
+          docker push lmcache/standalone:nightly-${{ env.NOW }}-cu129

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build cu12.9 nightly wheel
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: docker.io/pytorch/manylinux2_28-builder:cuda12.9
-          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0" ENABLE_CXX11_ABI=1 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu129'
+          CIBW_ENVIRONMENT: 'TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0;10.0" ENABLE_CXX11_ABI=1 LMCACHE_CUDA_MAJOR=12 PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu129'
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >-
             auditwheel repair
             --plat manylinux_2_28_x86_64

--- a/.github/workflows/pr_full_build.yml
+++ b/.github/workflows/pr_full_build.yml
@@ -1,6 +1,6 @@
 name: PR Full Build
 
-# Build all release artifacts (sdist + CUDA wheel, CLI wheel, cu130 wheel)
+# Build all release artifacts (sdist + CUDA wheel, CLI wheel, cu129 wheel)
 # on PRs carrying the `full` label. The `full` label is added automatically
 # by automerge-labeler.yml when auto-merge is enabled on a code-change PR,
 # so this acts as a pre-merge sanity check that wheels still build.
@@ -38,10 +38,10 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'full')
         uses: ./.github/workflows/build_cli_artifacts.yml
 
-    build-cu130:
-        name: Build cu130
+    build-cu129:
+        name: Build cu129
         if: contains(github.event.pull_request.labels.*.name, 'full')
-        uses: ./.github/workflows/build_cu130_artifacts.yml
+        uses: ./.github/workflows/build_cu129_artifacts.yml
         # Fork PRs won't expose DOCKERHUB_TOKEN even with `inherit`; the login
-        # step in build_cu130_artifacts.yml guards on the token being non-empty.
+        # step in build_cu129_artifacts.yml guards on the token being non-empty.
         secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,11 +56,11 @@ jobs:
                         - '.github/workflows/publish.yml'
                         - '.github/workflows/build_main_artifacts.yml'
                         - '.github/workflows/build_cli_artifacts.yml'
-                        - '.github/workflows/build_cu130_artifacts.yml'
+                        - '.github/workflows/build_cu129_artifacts.yml'
                         - '!operator/**'
 
     # Build each artifact group in its own reusable workflow so that a
-    # failure in one (e.g. cu130) does not block publishing of the others.
+    # failure in one (e.g. cu129) does not block publishing of the others.
 
     build-main:
         needs: changes
@@ -74,12 +74,12 @@ jobs:
         name: Build CLI
         uses: ./.github/workflows/build_cli_artifacts.yml
 
-    build-cu130:
+    build-cu129:
         needs: changes
         if: needs.changes.outputs.lmcache == 'true'
-        name: Build cu130
-        uses: ./.github/workflows/build_cu130_artifacts.yml
-        # DockerHub creds needed for the cu130 manylinux image pull;
+        name: Build cu129
+        uses: ./.github/workflows/build_cu129_artifacts.yml
+        # DockerHub creds needed for the cu12.9 manylinux image pull;
         # reusable workflows do not auto-inherit secrets.
         secrets: inherit
 
@@ -273,9 +273,9 @@ jobs:
               with:
                 verbose: true
 
-    # Publish cu130 wheel to GitHub Release (not PyPI) when a release is published
-    publish-cu130-github-release:
-        name: Publish cu130 wheel to GitHub Release
+    # Publish cu12.9 wheel to GitHub Release (not PyPI) when a release is published
+    publish-cu129-github-release:
+        name: Publish cu129 wheel to GitHub Release
         if: |
             !failure() && !cancelled() &&
             needs.changes.outputs.lmcache == 'true' &&
@@ -283,7 +283,7 @@ jobs:
         permissions:
             contents: write
         runs-on: ubuntu-latest
-        needs: [changes, build-cu130, test, code-quality]
+        needs: [changes, build-cu129, test, code-quality]
 
         steps:
             - name: Harden Runner
@@ -295,27 +295,27 @@ jobs:
                     api.github.com:443
                     uploads.github.com:443
 
-            - name: Fetch cu130 release artifacts
+            - name: Fetch cu12.9 release artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
-                  name: release-cu130-artifacts
+                  name: release-cu129-artifacts
                   path: dist
 
-            - name: Publish cu13.0 wheel to dedicated GitHub Release
+            - name: Publish cu12.9 wheel to dedicated GitHub Release
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
-                  gh release create "${{ github.ref_name }}-cu13" \
+                  gh release create "${{ github.ref_name }}-cu12" \
                     --repo ${{ github.repository }} \
                     --latest=false \
-                    --title "Release ${{ github.ref_name }} · CUDA 13.0" \
-                    --notes "CUDA 13.0 wheel for LMCache ${{ github.ref_name }}.
+                    --title "Release ${{ github.ref_name }} · CUDA 12.9" \
+                    --notes "CUDA 12.9 wheel for LMCache ${{ github.ref_name }}.
 
                   \`\`\`
                   VERSION=${{ github.ref_name }}
                   uv pip install lmcache==${VERSION#v} \\
-                    --extra-index-url https://download.pytorch.org/whl/cu130 \\
-                    --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/${VERSION}-cu13 \\
+                    --extra-index-url https://download.pytorch.org/whl/cu129 \\
+                    --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/${VERSION}-cu12 \\
                     --index-strategy unsafe-best-match
                   \`\`\`" \
                     dist/*.whl
@@ -330,7 +330,7 @@ jobs:
             github.repository_owner == 'LMCache' && github.event.action == 'published'
 
         runs-on: ubuntu-latest
-        needs: [publish-pypi, publish-cu130-github-release]
+        needs: [publish-pypi, publish-cu129-github-release]
 
         steps:
             - name: "Harden Runner"
@@ -381,11 +381,12 @@ jobs:
               run: |
                 echo "LATEST_TAG=$(git tag --list 'v[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)" >> "$GITHUB_ENV"
 
-            - name: Build lmcache/vllm-openai container image (cu12.9)
+            - name: Build lmcache/vllm-openai container image (cu13)
               run: |
                 docker build \
-                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
-                --build-arg CUDA_VERSION=12.9 \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=13.0 \
+                --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
                 --target image-release \
                 --tag lmcache/vllm-openai:latest --tag lmcache/vllm-openai:${{ env.LATEST_TAG }} \
                 --file docker/Dockerfile .
@@ -416,11 +417,12 @@ jobs:
                 docker system prune -f --all
                 docker builder prune -af
 
-            - name: Build lmcache/standalone container image (cu12.9)
+            - name: Build lmcache/standalone container image (cu13)
               run: |
                 docker build \
-                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
-                --build-arg CUDA_VERSION=12.9 \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=13.0 \
+                --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
                 --target lmcache-final \
                 --tag lmcache/standalone:latest --tag lmcache/standalone:${{ env.LATEST_TAG }} \
                 --file docker/Dockerfile.standalone .
@@ -435,42 +437,40 @@ jobs:
                 docker system prune -f --all
                 docker builder prune -af
 
-            - name: Build lmcache/vllm-openai container image (cu13)
-              if: needs.publish-cu130-github-release.result == 'success'
+            - name: Build lmcache/vllm-openai container image (cu12.9)
+              if: needs.publish-cu129-github-release.result == 'success'
               run: |
                 docker build \
-                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
-                --build-arg CUDA_VERSION=13.0 \
-                --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=12.9 \
                 --build-arg LMCACHE_VERSION=${{ env.LATEST_TAG }} \
-                --target image-release-cu13 \
-                --tag lmcache/vllm-openai:latest-cu13 --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu13 \
+                --target image-release-cu12 \
+                --tag lmcache/vllm-openai:latest-cu12 --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu12 \
                 --file docker/Dockerfile .
 
-            - name: Push lmcache/vllm-openai cu13 container image to DockerHub
-              if: needs.publish-cu130-github-release.result == 'success'
+            - name: Push lmcache/vllm-openai cu12 container image to DockerHub
+              if: needs.publish-cu129-github-release.result == 'success'
               run: |
-                docker push lmcache/vllm-openai:latest-cu13
-                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu13
+                docker push lmcache/vllm-openai:latest-cu12
+                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu12
 
             - name: Clean up Docker layers and cache
               run: |
                 docker system prune -f --all
                 docker builder prune -af
 
-            - name: Build lmcache/standalone container image (cu13)
-              if: needs.publish-cu130-github-release.result == 'success'
+            - name: Build lmcache/standalone container image (cu12.9)
+              if: needs.publish-cu129-github-release.result == 'success'
               run: |
                 docker build \
-                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
-                --build-arg CUDA_VERSION=13.0 \
-                --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=12.9 \
                 --target lmcache-final \
-                --tag lmcache/standalone:latest-cu13 --tag lmcache/standalone:${{ env.LATEST_TAG }}-cu13 \
+                --tag lmcache/standalone:latest-cu12 --tag lmcache/standalone:${{ env.LATEST_TAG }}-cu12 \
                 --file docker/Dockerfile.standalone .
 
-            - name: Push lmcache/standalone cu13 container image to DockerHub
-              if: needs.publish-cu130-github-release.result == 'success'
+            - name: Push lmcache/standalone cu12 container image to DockerHub
+              if: needs.publish-cu129-github-release.result == 'success'
               run: |
-                docker push lmcache/standalone:latest-cu13
-                docker push lmcache/standalone:${{ env.LATEST_TAG }}-cu13
+                docker push lmcache/standalone:latest-cu12
+                docker push lmcache/standalone:${{ env.LATEST_TAG }}-cu12

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -305,7 +305,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
-                  gh release create "${{ github.ref_name }}-cu12" \
+                  gh release create "${{ github.ref_name }}-cu129" \
                     --repo ${{ github.repository }} \
                     --latest=false \
                     --title "Release ${{ github.ref_name }} · CUDA 12.9" \
@@ -315,7 +315,7 @@ jobs:
                   VERSION=${{ github.ref_name }}
                   uv pip install lmcache==${VERSION#v} \\
                     --extra-index-url https://download.pytorch.org/whl/cu129 \\
-                    --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/${VERSION}-cu12 \\
+                    --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/${VERSION}-cu129 \\
                     --index-strategy unsafe-best-match
                   \`\`\`" \
                     dist/*.whl
@@ -444,15 +444,15 @@ jobs:
                 --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
                 --build-arg CUDA_VERSION=12.9 \
                 --build-arg LMCACHE_VERSION=${{ env.LATEST_TAG }} \
-                --target image-release-cu12 \
-                --tag lmcache/vllm-openai:latest-cu12 --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu12 \
+                --target image-release-cu129 \
+                --tag lmcache/vllm-openai:latest-cu129 --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu129 \
                 --file docker/Dockerfile .
 
-            - name: Push lmcache/vllm-openai cu12 container image to DockerHub
+            - name: Push lmcache/vllm-openai cu129 container image to DockerHub
               if: needs.publish-cu129-github-release.result == 'success'
               run: |
-                docker push lmcache/vllm-openai:latest-cu12
-                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu12
+                docker push lmcache/vllm-openai:latest-cu129
+                docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu129
 
             - name: Clean up Docker layers and cache
               run: |
@@ -466,11 +466,11 @@ jobs:
                 --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.05-cuda12.9-devel-ubuntu24.04 \
                 --build-arg CUDA_VERSION=12.9 \
                 --target lmcache-final \
-                --tag lmcache/standalone:latest-cu12 --tag lmcache/standalone:${{ env.LATEST_TAG }}-cu12 \
+                --tag lmcache/standalone:latest-cu129 --tag lmcache/standalone:${{ env.LATEST_TAG }}-cu129 \
                 --file docker/Dockerfile.standalone .
 
-            - name: Push lmcache/standalone cu12 container image to DockerHub
+            - name: Push lmcache/standalone cu129 container image to DockerHub
               if: needs.publish-cu129-github-release.result == 'success'
               run: |
-                docker push lmcache/standalone:latest-cu12
-                docker push lmcache/standalone:${{ env.LATEST_TAG }}-cu12
+                docker push lmcache/standalone:latest-cu129
+                docker push lmcache/standalone:${{ env.LATEST_TAG }}-cu129

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -425,12 +425,15 @@ jobs:
                 --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
                 --target lmcache-final \
                 --tag lmcache/standalone:latest --tag lmcache/standalone:${{ env.LATEST_TAG }} \
+                --tag lmcache/standalone:latest-cu130 --tag lmcache/standalone:${{ env.LATEST_TAG }}-cu130 \
                 --file docker/Dockerfile.standalone .
 
             - name: Push lmcache/standalone container image to DockerHub
               run: |
                 docker push lmcache/standalone:latest
                 docker push lmcache/standalone:${{ env.LATEST_TAG }}
+                docker push lmcache/standalone:latest-cu130
+                docker push lmcache/standalone:${{ env.LATEST_TAG }}-cu130
 
             - name: Clean up Docker layers and cache
               run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,6 +79,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
     . /opt/venv/bin/activate && \
     CUDA_TAG=cu$(echo ${CUDA_VERSION} | tr -d '.') && \
+    export LMCACHE_CUDA_MAJOR=$(echo ${CUDA_VERSION} | cut -d. -f1) && \
     if [ "$VLLM_VERSION" = "nightly" ]; then \
         uv pip install --prerelease=allow \
             'vllm[runai,tensorizer,flashinfer]' \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,12 +118,14 @@ RUN . /opt/venv/bin/activate && \
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
 
-#################### vLLM IMAGE & LMCache (Release, cu12) #######################
-# Installs stable vLLM with cu12 index and lmcache from the v{tag}-cu12 GitHub Release.
+#################### vLLM IMAGE & LMCache (Release, cu129) ######################
+# Installs stable vLLM with cu129 index and lmcache from the v{tag}-cu129 GitHub Release.
 
-FROM base AS image-release-cu12
+FROM base AS image-release-cu129
 
-ARG CUDA_VERSION
+# Override the global CUDA_VERSION default (13.0) for this cu12.9 stage so local
+# builds that omit --build-arg CUDA_VERSION still resolve the correct torch index.
+ARG CUDA_VERSION=12.9
 ARG LMCACHE_VERSION
 
 RUN . /opt/venv/bin/activate && \
@@ -135,7 +137,7 @@ RUN . /opt/venv/bin/activate && \
         --index-strategy unsafe-best-match && \
     uv pip install lmcache==${VER} \
         --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
-        --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VER}-cu12 \
+        --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VER}-cu129 \
         --index-strategy unsafe-best-match --verbose
 
 WORKDIR /workspace

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,9 +6,9 @@
 # docs/source/getting_started/installation.rst
 # docs/production/docker_deployment.rst
 
-ARG CUDA_VERSION=12.9
+ARG CUDA_VERSION=13.0
 ARG UBUNTU_VERSION=24.04
-ARG NGC_VERSION=25.05
+ARG NGC_VERSION=25.09
 ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:${NGC_VERSION}-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 #################### BASE BUILD IMAGE ####################
@@ -40,7 +40,7 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
 WORKDIR /workspace
 
 # CUDA arch list used by torch
-ARG torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX'
+ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 
 #################### vLLM IMAGE & LMCache (Build) ##########################
@@ -96,25 +96,32 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
 
-#################### vLLM IMAGE & LMCache (Release, cu12) #######################
-# Integrate vLLM and LMCache stable releases, and expose vLLM OpenAI API
+#################### vLLM IMAGE & LMCache (Release, cu13) #######################
+# Integrate vLLM and LMCache stable releases, and expose vLLM OpenAI API.
+# The default lmcache wheel on PyPI is built against cu13; the cu13 torch
+# index is hinted explicitly so vLLM also resolves to its cu13 build.
 
 FROM base AS image-release
 
-# Install LMCache and vLLM stable releases.
-# It is imperative that LMCache uses the same torch version as the
-# vLLM stable release.
+ARG CUDA_VERSION
+
 RUN . /opt/venv/bin/activate && \
-    uv pip install --prerelease=allow vllm[runai,tensorizer,flashinfer] && \
-    uv pip install lmcache --verbose
+    CUDA_TAG=cu$(echo ${CUDA_VERSION} | tr -d '.') && \
+    uv pip install --prerelease=allow \
+        vllm[runai,tensorizer,flashinfer] \
+        --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+        --index-strategy unsafe-best-match && \
+    uv pip install lmcache \
+        --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+        --index-strategy unsafe-best-match --verbose
 
 WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
 
-#################### vLLM IMAGE & LMCache (Release, cu13) #######################
-# Installs stable vLLM with cu13 index and lmcache from the v{tag}-cu13 GitHub Release.
+#################### vLLM IMAGE & LMCache (Release, cu12) #######################
+# Installs stable vLLM with cu12 index and lmcache from the v{tag}-cu12 GitHub Release.
 
-FROM base AS image-release-cu13
+FROM base AS image-release-cu12
 
 ARG CUDA_VERSION
 ARG LMCACHE_VERSION
@@ -128,7 +135,7 @@ RUN . /opt/venv/bin/activate && \
         --index-strategy unsafe-best-match && \
     uv pip install lmcache==${VER} \
         --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
-        --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VER}-cu13 \
+        --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VER}-cu12 \
         --index-strategy unsafe-best-match --verbose
 
 WORKDIR /workspace

--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -1,9 +1,9 @@
 # The LMCache Standalone Dockerfile is used to build a LMCache image
 # without vLLM integration.
 
-ARG CUDA_VERSION=12.9
+ARG CUDA_VERSION=13.0
 ARG UBUNTU_VERSION=24.04
-ARG NGC_VERSION=25.05
+ARG NGC_VERSION=25.09
 ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:${NGC_VERSION}-cuda${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
 
 #################### BASE BUILD IMAGE ####################
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install ray nvidia-ml-py
 
 # CUDA arch list used by torch
-ARG torch_cuda_arch_list='7.0 7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX'
+ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX'
 ENV TORCH_CUDA_ARCH_LIST=${torch_cuda_arch_list}
 
 #################### LMCache Build ##########################

--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -80,6 +80,7 @@ WORKDIR /workspace/LMCache
 RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
     --mount=type=cache,target=/root/.cache/uv,id=uv-cache,sharing=locked \
     . /opt/venv/bin/activate && \
+    export LMCACHE_CUDA_MAJOR=$(echo ${CUDA_VERSION} | cut -d. -f1) && \
     python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
     python3 setup.py bdist_wheel --dist-dir=dist_lmcache
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -43,7 +43,7 @@ Install LMCache
                             VERSION=0.4.3  # replace with target release
                             uv pip install lmcache==${VERSION} \
                                 --extra-index-url https://download.pytorch.org/whl/cu129 \
-                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VERSION}-cu12 \
+                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VERSION}-cu129 \
                                 --index-strategy unsafe-best-match
 
                         .. note::
@@ -143,7 +143,7 @@ Install LMCache
 
                         .. code-block:: bash
 
-                            docker pull lmcache/vllm-openai:latest-cu12
+                            docker pull lmcache/vllm-openai:latest-cu129
 
             .. tab-item:: Nightly
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -18,7 +18,7 @@ Install LMCache
 
                 .. tab-set::
 
-                    .. tab-item:: CUDA 12.9  
+                    .. tab-item:: CUDA 13.0
 
                         .. code-block:: bash
 
@@ -31,9 +31,9 @@ Install LMCache
                             You're all set! You can now start using LMCache. For hands-on guides and more
                             usage examples, see the :ref:`quickstart_examples` section.
 
-                    .. tab-item:: CUDA 13.0
+                    .. tab-item:: CUDA 12.9
 
-                        The CUDA 13.0 wheel is published to a dedicated
+                        The CUDA 12.9 wheel is published to a dedicated
                         `GitHub Release <https://github.com/LMCache/LMCache/releases>`__ rather than PyPI.
 
                         .. code-block:: bash
@@ -42,13 +42,13 @@ Install LMCache
                             source .venv/bin/activate
                             VERSION=0.4.3  # replace with target release
                             uv pip install lmcache==${VERSION} \
-                                --extra-index-url https://download.pytorch.org/whl/cu130 \
-                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VERSION}-cu13 \
+                                --extra-index-url https://download.pytorch.org/whl/cu129 \
+                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VERSION}-cu12 \
                                 --index-strategy unsafe-best-match
 
                         .. note::
 
-                            ``--extra-index-url https://download.pytorch.org/whl/cu130`` ensures the CUDA 13.0
+                            ``--extra-index-url https://download.pytorch.org/whl/cu129`` ensures the CUDA 12.9
                             build of PyTorch is resolved. Without it, pip may select a mismatched CUDA variant.
 
             .. tab-item:: Nightly
@@ -59,17 +59,6 @@ Install LMCache
 
                 .. tab-set::
 
-                    .. tab-item:: CUDA 12.9
-
-                        .. code-block:: bash
-
-                            uv venv --python 3.12
-                            source .venv/bin/activate
-                            uv pip install lmcache --pre \
-                                --extra-index-url https://download.pytorch.org/whl/cu129 \
-                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly \
-                                --index-strategy unsafe-best-match
-
                     .. tab-item:: CUDA 13.0
 
                         .. code-block:: bash
@@ -78,7 +67,18 @@ Install LMCache
                             source .venv/bin/activate
                             uv pip install lmcache --pre \
                                 --extra-index-url https://download.pytorch.org/whl/cu130 \
-                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly-cu13 \
+                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly \
+                                --index-strategy unsafe-best-match
+
+                    .. tab-item:: CUDA 12.9
+
+                        .. code-block:: bash
+
+                            uv venv --python 3.12
+                            source .venv/bin/activate
+                            uv pip install lmcache --pre \
+                                --extra-index-url https://download.pytorch.org/whl/cu129 \
+                                --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/nightly-cu129 \
                                 --index-strategy unsafe-best-match
 
             .. tab-item:: From Source
@@ -133,33 +133,33 @@ Install LMCache
 
                 .. tab-set::
 
-                    .. tab-item:: CUDA 12.9
+                    .. tab-item:: CUDA 13.0
 
                         .. code-block:: bash
 
                             docker pull lmcache/vllm-openai
 
-                    .. tab-item:: CUDA 13.0
+                    .. tab-item:: CUDA 12.9
 
                         .. code-block:: bash
 
-                            docker pull lmcache/vllm-openai:latest-cu13
+                            docker pull lmcache/vllm-openai:latest-cu12
 
             .. tab-item:: Nightly
 
                 .. tab-set::
 
-                    .. tab-item:: CUDA 12.9
+                    .. tab-item:: CUDA 13.0
 
                         .. code-block:: bash
 
                             docker pull lmcache/vllm-openai:latest-nightly
 
-                    .. tab-item:: CUDA 13.0
+                    .. tab-item:: CUDA 12.9
 
                         .. code-block:: bash
 
-                            docker pull lmcache/vllm-openai:latest-nightly-cu13
+                            docker pull lmcache/vllm-openai:latest-nightly-cu129
 
             .. tab-item:: ROCm
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -88,7 +88,7 @@ Install LMCache
 
                 .. tab-set::
 
-                    .. tab-item:: CUDA
+                    .. tab-item:: CUDA 13.0
 
                         .. code-block:: bash
 
@@ -99,8 +99,29 @@ Install LMCache
                             source .venv/bin/activate
 
                             uv pip install -r requirements/build.txt
-                            uv pip install vllm  # pulls in required torch version
+                            uv pip install vllm  # pulls in required torch version (cu13)
                             uv pip install -e . --no-build-isolation
+
+                    .. tab-item:: CUDA 12.9
+
+                        .. code-block:: bash
+
+                            git clone https://github.com/LMCache/LMCache.git
+                            cd LMCache
+
+                            uv venv --python 3.12
+                            source .venv/bin/activate
+
+                            uv pip install -r requirements/build.txt
+                            # Pin vLLM (and torch) to the cu12.9 wheel index so the local
+                            # CUDA 12 toolchain matches what the extensions are built against.
+                            uv pip install vllm \
+                                --extra-index-url https://download.pytorch.org/whl/cu129 \
+                                --index-strategy unsafe-best-match
+                            # LMCACHE_CUDA_MAJOR=12 makes setup.py pick cupy-cuda12x / nixl-cu12
+                            # for install_requires instead of the cu13 defaults.
+                            LMCACHE_CUDA_MAJOR=12 \
+                                uv pip install -e . --no-build-isolation
 
                     .. tab-item:: ROCm
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ issues = "https://github.com/LMCache/LMCache"
 version_file = "lmcache/_version.py"
 # do not include +gREV local version, required for Test PyPI upload
 local_scheme = "no-local-version"
-# only treat vX.Y.Z-style tags as version anchors; ignores nightly/nightly-cu13 tags
+# only treat vX.Y.Z-style tags as version anchors; ignores nightly/nightly-cu129 tags
 tag_regex = "^v?(?P<version>\\d+\\.\\d+\\.\\d+.*)$"
 git_describe_command = ["git", "describe", "--tags", "--long", "--match", "v[0-9]*.[0-9]*", "--exclude", "v*-*"]
 
@@ -159,18 +159,18 @@ build = "cp3*-manylinux_x86_64"
 
 # see https://developer.nvidia.com/cuda-gpus for compute capabilities
 # "CUDA-Enabled Datacenter Products"
-# 7.0:  V100
 # 7.5:  T4
 # 8.0:  A100, A30
 # 8.6:  A40, A10, A16, A2
 # 8.9:  L4, L40, L40S
 # 9.0:  GH200, H200, H100
 # 10.0: GB200, B200
-environment = {TORCH_CUDA_ARCH_LIST = "7.0;7.5;8.0;8.6;8.9;9.0;10.0", ENABLE_CXX11_ABI = "1"}
+# 12.0: RTX 50-series (PTX)
+# CUDA 13 dropped support for compute capability 7.0 (Volta).
+environment = {TORCH_CUDA_ARCH_LIST = "8.0;8.6;8.9;9.0;10.0;12.0", ENABLE_CXX11_ABI = "1", PIP_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/cu130"}
 
-# Use the PyTorch manylinux image version '2_28' that contains CUDA 12.9
-# and torch 2.7 supports (https://pypi.org/project/torch/2.7.0/#files)
-manylinux-x86_64-image = "docker.io/pytorch/manylinux2_28-builder:cuda12.9"
+# Use the PyTorch manylinux image version '2_28' that contains CUDA 13.0
+manylinux-x86_64-image = "docker.io/pytorch/manylinux2_28-builder:cuda13.0"
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = """
@@ -182,6 +182,6 @@ auditwheel repair \
   --exclude libtorch_cpu.so \
   --exclude libc10.so \
   --exclude libc10_cuda.so \
-  --exclude libcudart.so.12 \
+  --exclude libcudart.so.13 \
   -w {dest_dir} {wheel}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ build = "cp3*-manylinux_x86_64"
 # 10.0: GB200, B200
 # 12.0: RTX 50-series (PTX)
 # CUDA 13 dropped support for compute capability 7.0 (Volta).
-environment = {TORCH_CUDA_ARCH_LIST = "8.0;8.6;8.9;9.0;10.0;12.0", ENABLE_CXX11_ABI = "1", PIP_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/cu130"}
+environment = {TORCH_CUDA_ARCH_LIST = "7.5;8.0;8.6;8.9;9.0;10.0;12.0", ENABLE_CXX11_ABI = "1", PIP_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/cu130"}
 
 # Use the PyTorch manylinux image version '2_28' that contains CUDA 13.0
 manylinux-x86_64-image = "docker.io/pytorch/manylinux2_28-builder:cuda13.0"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,7 +1,9 @@
 # Common project dependencies
 -r common.txt
-# Vendor-specific runtime deps (cupy, nixl) baked into install_requires
--r cuda_core.txt
+# Vendor-specific runtime deps (cupy, nixl) baked into install_requires.
+# Defaults to the cu13 list; the cu12.9 build path overrides via setup.py
+# (LMCACHE_CUDA_MAJOR=12) and does not consume cuda.txt directly.
+-r cuda13_core.txt
 
 # Dependencies for NVIDIA GPUs
 ray >= 2.9

--- a/requirements/cuda12_core.txt
+++ b/requirements/cuda12_core.txt
@@ -1,0 +1,6 @@
+# Vendor-specific runtime deps for CUDA 12.9 wheels. Selected by setup.py when
+# LMCACHE_CUDA_MAJOR=12. The cu13 default lives in cuda13_core.txt.
+
+cupy-cuda12x
+# nixl on PyPI is a meta-package that pulls nixl-cu12 (CUDA-only).
+nixl; python_version < "3.13"

--- a/requirements/cuda13_core.txt
+++ b/requirements/cuda13_core.txt
@@ -1,0 +1,6 @@
+# Vendor-specific runtime deps for CUDA 13 wheels. Selected by setup.py when
+# LMCACHE_CUDA_MAJOR is unset or "13" (the default, matching the PyPI build).
+# The cu12 analogue lives in cuda12_core.txt.
+
+cupy-cuda13x
+nixl-cu13; python_version < "3.13"

--- a/requirements/cuda_core.txt
+++ b/requirements/cuda_core.txt
@@ -1,9 +1,0 @@
-# Vendor-specific runtime deps baked into install_requires by setup.py
-# when building for CUDA (i.e. BUILD_WITH_HIP is unset).
-# Kept separate from cuda.txt so `pip install -e .` stays lightweight
-# (no ray/xformers/torchvision) while Docker's `pip install -r cuda.txt`
-# still pulls these through the -r chain.
-
-cupy-cuda12x
-# nixl on PyPI is a meta-package that pulls nixl-cu12 (CUDA-only).
-nixl; python_version < "3.13"

--- a/setup.py
+++ b/setup.py
@@ -309,7 +309,18 @@ if __name__ == "__main__":
     ext_modules, cmdclass = get_extension()
 
     install_requires = _read_requirements(ROOT_DIR / "requirements" / "common.txt")
-    core_file = "rocm_core.txt" if BUILD_WITH_HIP else "cuda_core.txt"
+    if BUILD_WITH_HIP:
+        core_file = "rocm_core.txt"
+    else:
+        # CUDA major selects between cu12 and cu13 vendor pins (cupy, nixl).
+        # Defaults to cu13 (the PyPI build); cu12.9 wheel builds set
+        # LMCACHE_CUDA_MAJOR=12 to pull cu12 wheels of those deps.
+        cuda_major = os.environ.get("LMCACHE_CUDA_MAJOR", "13")
+        if cuda_major not in ("12", "13"):
+            raise ValueError(
+                f"LMCACHE_CUDA_MAJOR must be '12' or '13', got '{cuda_major}'"
+            )
+        core_file = f"cuda{cuda_major}_core.txt"
     install_requires += _read_requirements(ROOT_DIR / "requirements" / core_file)
 
     setup(


### PR DESCRIPTION
### Release pipeline (`publish.yml`)

  ```mermaid
  flowchart LR
      T[Release published / tag v*] --> C[changes]
      C --> BM[build-main<br/>cu13 wheel]
      C --> BL[build-cli]
      C --> B9[build-cu129<br/>cu12.9 wheel]
      C --> TS[test + code-quality]

      BM & TS --> PP[publish-pypi<br/>lmcache → PyPI]
      BL & TS --> PC[publish-cli-pypi<br/>lmcache-cli → PyPI]
      B9 & TS --> PG[publish-cu129-github-release<br/>wheel → GH release v*-cu12]

      PP --> IM[publish-image → DockerHub]
      PG --> IM
      IM --> I1[vllm-openai: latest, vX.Y.Z, lightweight]
      IM --> I2[vllm-openai: latest-cu12, vX.Y.Z-cu12]
      IM --> I3[standalone: latest, vX.Y.Z, *-cu12]
  ```

  ### Nightly pipeline (`nightly_build.yml`)

  ```mermaid
  flowchart LR
      T[cron 07:30 UTC / workflow_dispatch] --> W[nightly-wheels]
      T --> B[nightly-build]

      W --> W1[cu13.0 wheel → GH release 'nightly']
      W --> W2[cu12.9 wheel → GH release 'nightly-cu129']

      B --> B1[vllm-openai:latest-nightly, :nightly-DATE]
      B --> B2[standalone:nightly, :nightly-DATE]
      B --> B3[vllm-openai:latest-nightly-cu129, :nightly-DATE-cu129]
      B --> B4[standalone:nightly-cu129, :nightly-DATE-cu129]
  ```