### PR TITLE
[CLI] Fix slim install imports and smoke-test wheel in CI

### DIFF
--- a/.github/workflows/build_cli_artifacts.yml
+++ b/.github/workflows/build_cli_artifacts.yml
@@ -5,6 +5,15 @@ name: Build CLI Artifacts
 
 on:
     workflow_call:
+    pull_request:
+        branches:
+            - dev
+            - "release-**"
+        paths:
+            - 'lmcache/cli/**.py'
+            - 'pyproject_cli.toml'
+            - 'requirements/cli.txt'
+            - '.github/workflows/build_cli_artifacts.yml'
 
 env:
     LC_ALL: en_US.UTF-8
@@ -12,6 +21,11 @@ env:
 defaults:
     run:
         shell: bash
+
+# Cancel stale runs per ref; PR and dev-push refs differ, so workflow_call is unaffected.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions:
     contents: read
@@ -64,8 +78,22 @@ jobs:
             - name: Smoke-test CLI wheel (no torch)
               run: |
                 pip install dist/lmcache_cli-*.whl
+
+                # CLI wheel must be pure-Python.
+                if unzip -l dist/lmcache_cli-*.whl | grep -E '\.(so|pyd)$'; then
+                  echo "::error::CLI wheel contains compiled extensions; should be pure-Python"
+                  exit 1
+                fi
+
                 python -c "import lmcache"
                 lmcache --help
+
+                # Slim-supported subcommands only (server is full-only).
+                for cmd in mock kvcache describe ping query bench tool trace; do
+                  echo "::group::lmcache $cmd --help"
+                  lmcache "$cmd" --help
+                  echo "::endgroup::"
+                done
 
             - name: Upload CLI release artifacts to GHA
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/lmcache/cli/commands/bench/__init__.py
+++ b/lmcache/cli/commands/bench/__init__.py
@@ -26,8 +26,16 @@ from lmcache.cli.commands.bench.engine_bench.stats import (
     StatsCollector,
 )
 from lmcache.cli.commands.bench.engine_bench.workloads import create_workload
-from lmcache.cli.commands.test_cache import TestCacheCommand
 from lmcache.logging import init_logger
+
+# Gated for slim install — TestCacheCommand pulls torch/MP runtime.
+_TEST_CACHE_IMPORT_ERROR: ImportError | None = None
+try:
+    # First Party
+    from lmcache.cli.commands.test_cache import TestCacheCommand
+except ImportError as _exc:
+    _TEST_CACHE_IMPORT_ERROR = _exc
+    TestCacheCommand = None  # type: ignore[assignment,misc]
 
 logger = init_logger(__name__)
 
@@ -37,10 +45,10 @@ class BenchCommand(BaseCommand):
 
     def __init__(self) -> None:
         super().__init__()
-        # Stateless delegate for the ``kvcache`` sub-target.
-        # Cached once to avoid redundant instantiation across
-        # ``help()``, ``add_arguments()`` and ``execute()``.
-        self._kvcache_delegate = TestCacheCommand()
+        # None on slim install; _register_kvcache registers a stub instead.
+        self._kvcache_delegate = (
+            TestCacheCommand() if TestCacheCommand is not None else None
+        )
 
     def name(self) -> str:
         return "bench"
@@ -329,13 +337,20 @@ class BenchCommand(BaseCommand):
         self,
         subparsers: argparse._SubParsersAction,
     ) -> None:
-        """Register ``lmcache bench kvcache`` subcommand.
-
-        Arguments and execution are delegated to
-        :class:`~lmcache.cli.commands.test_cache.TestCacheCommand` so
-        the per-chunk store/retrieve/checksum logic lives in a single
-        place.
+        """Register ``lmcache bench kvcache``. Delegates to
+        :class:`TestCacheCommand`, or registers a stub on slim install.
         """
+        if self._kvcache_delegate is None:
+            subparsers.add_parser(
+                "kvcache",
+                help="(requires full lmcache install)",
+                description=(
+                    "End-to-end sanity test for the LMCache MP cache server. "
+                    "Requires the full `lmcache` package; not available in "
+                    "the `lmcache-cli` install."
+                ),
+            ).set_defaults(func=self.execute)
+            return
         parser = subparsers.add_parser(
             "kvcache",
             help=self._kvcache_delegate.help(),
@@ -350,6 +365,16 @@ class BenchCommand(BaseCommand):
 
     def _bench_kvcache(self, args: argparse.Namespace) -> None:
         """Dispatch ``lmcache bench kvcache`` to ``TestCacheCommand``."""
+        if self._kvcache_delegate is None:
+            print(
+                "ERROR: `lmcache bench kvcache` needs the full LMCache "
+                "package, but only the `lmcache-cli` shell is installed.\n"
+                "  Install the full package with `pip install lmcache` "
+                "and try again.\n"
+                f"  Original import error: {_TEST_CACHE_IMPORT_ERROR}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
         self._kvcache_delegate.execute(args)
 
     def execute(self, args: argparse.Namespace) -> None:

--- a/lmcache/cli/commands/bench/__init__.py
+++ b/lmcache/cli/commands/bench/__init__.py
@@ -374,7 +374,7 @@ class BenchCommand(BaseCommand):
                 f"  Original import error: {_TEST_CACHE_IMPORT_ERROR}",
                 file=sys.stderr,
             )
-            sys.exit(2)
+            sys.exit(1)
         self._kvcache_delegate.execute(args)
 
     def execute(self, args: argparse.Namespace) -> None:

--- a/lmcache/cli/commands/server.py
+++ b/lmcache/cli/commands/server.py
@@ -47,17 +47,17 @@ class ServerCommand(BaseCommand):
                 add_http_frontend_args,
                 add_mp_server_args,
             )
+
+            add_mp_server_args(parser)
+            add_storage_manager_args(parser)
+            add_http_frontend_args(parser)
+            add_observability_args(parser)
         except ImportError as e:
             print(
                 f"Failed to import server dependencies: {e}. "
                 "Install the full lmcache package to use 'lmcache server'."
             )
             return
-
-        add_mp_server_args(parser)
-        add_storage_manager_args(parser)
-        add_http_frontend_args(parser)
-        add_observability_args(parser)
 
     def execute(self, args: argparse.Namespace) -> None:
         """Parse CLI arguments into config objects and launch the HTTP server.

--- a/requirements/cli.txt
+++ b/requirements/cli.txt
@@ -1,2 +1,3 @@
 matplotlib
 openai
+sortedcontainers


### PR DESCRIPTION
 Description:
  ## Summary

  - `bench/__init__.py`: gate `TestCacheCommand` import (pulls torch). On slim install, `lmcache bench
  kvcache` becomes a stub with an install hint.
  - `server.py`: move `add_*_args(parser)` calls inside the `try` block so an `ImportError` doesn't leave
  dangling references.
  - `requirements/cli.txt`: add `sortedcontainers`.
  - `build_cli_artifacts.yml`: run on PRs touching CLI paths; assert wheel is pure-Python (no
  `.so`/`.pyd`); run `--help` for all 8 slim subcommands.

  ## Test plan

  - [x] Built wheel from `pyproject_cli.toml`, installed in torch-free venv, ran all subcommand `--help`
  locally
