### PR TITLE
Support binary buffer objects in local disk backend

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -937,7 +937,7 @@ class BytesBufferMemoryObj(MemoryObj):
                 shape=bytes_shape,
                 dtype=None,
                 address=0,
-                phy_size=0,
+                phy_size=len(self.raw_data),
                 ref_count=1,
                 pin_count=0,
                 fmt=MemoryFormat.BINARY_BUFFER,

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -2,7 +2,7 @@
 # Standard
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union, cast
 import asyncio
 import os
 import threading
@@ -36,6 +36,51 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 _DEFAULT_THREAD_COUNT = 4
+
+
+def _validate_disk_metadata(
+    key: CacheEngineKey,
+    dtype: Optional[torch.dtype],
+    shape: Optional[torch.Size],
+    fmt: Optional[MemoryFormat],
+) -> bool:
+    if shape is None or fmt is None:
+        logger.error(
+            "Corrupted disk metadata for key %s: shape=%s, fmt=%s.",
+            key,
+            shape,
+            fmt,
+        )
+        return False
+
+    if fmt != MemoryFormat.BINARY_BUFFER and dtype is None:
+        logger.error(
+            "Corrupted disk metadata for key %s: dtype is missing for "
+            "memory format %s.",
+            key,
+            fmt,
+        )
+        return False
+
+    return True
+
+
+def _get_disk_load_dtypes(
+    key: CacheEngineKey,
+    dtype: Optional[torch.dtype],
+    fmt: MemoryFormat,
+) -> Optional[Union[torch.dtype, list[torch.dtype]]]:
+    if fmt == MemoryFormat.BINARY_BUFFER:
+        return []
+
+    if dtype is None:
+        logger.error(
+            "Missing dtype while loading non-binary disk object for key %s.",
+            key,
+        )
+        return None
+
+    return dtype
 
 
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
@@ -290,7 +335,7 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
         size: int,
         shape: torch.Size,
-        dtype: torch.dtype,
+        dtype: Optional[torch.dtype],
         fmt: MemoryFormat,
         cached_positions: Optional[torch.Tensor] = None,
     ) -> None:
@@ -329,8 +374,6 @@ class LocalDiskBackend(StorageBackendInterface):
             after the disk write completes. Callback exceptions are caught
             and logged.
         """
-        assert memory_obj.tensor is not None
-
         # skip repeated save
         if self.exists_in_put_tasks(key):
             logger.debug(f"Put task for {key} is already in progress.")
@@ -427,8 +470,10 @@ class LocalDiskBackend(StorageBackendInterface):
             dtype = disk_meta.dtype
             shape = disk_meta.shape
             fmt = disk_meta.fmt
-            assert dtype is not None
-            assert shape is not None
+            if not _validate_disk_metadata(key, dtype, shape, fmt):
+                return None
+            shape = cast(torch.Size, shape)
+            fmt = cast(MemoryFormat, fmt)
 
         # Load is performed outside the lock: it can block for a non-trivial
         # amount of time (CPU staging pool allocation + memcpy from disk) and
@@ -519,7 +564,14 @@ class LocalDiskBackend(StorageBackendInterface):
 
         try:
             buffer = memory_obj.byte_array
-            self.read_file(key, buffer, path)
+            self.read_file(
+                key,
+                buffer,
+                path,
+                use_odirect=self._use_odirect_for_memory_format(
+                    memory_obj.get_memory_format()
+                ),
+            )
 
             # Recover metadata (mirrors load_bytes_from_disk).
             with self.disk_lock:
@@ -546,53 +598,64 @@ class LocalDiskBackend(StorageBackendInterface):
 
         logger.debug(f"lookup_id: {lookup_id}; Prefetching {len(keys)} keys from disk.")
         for key in keys:
-            self.disk_lock.acquire()
-            assert key in self.dict, f"Key {key} not found in disk cache after pinning"
+            with self.disk_lock:
+                if key not in self.dict:
+                    logger.error("Key %s not found in disk cache after pinning.", key)
+                    break
 
-            path = self.dict[key].path
-            dtype = self.dict[key].dtype
-            shape = self.dict[key].shape
-            fmt = self.dict[key].fmt
+                disk_meta = self.dict[key]
+                path = disk_meta.path
+                dtype = disk_meta.dtype
+                shape = disk_meta.shape
+                fmt = disk_meta.fmt
 
-            assert dtype is not None
-            assert shape is not None
+                if not _validate_disk_metadata(key, dtype, shape, fmt):
+                    break
+                shape = cast(torch.Size, shape)
+                fmt = cast(MemoryFormat, fmt)
 
-            # busy_loop=False prevents spinning on the event loop thread;
-            # if staging memory is exhausted the caller will get a logged
-            # error rather than a silent deadlock.
-            memory_obj = self.local_cpu_backend.allocate(
-                shape,
-                dtype,
-                fmt,
-                busy_loop=False,
-            )
+                # busy_loop=False prevents spinning on the event loop thread;
+                # if staging memory is exhausted the caller will get a logged
+                # error rather than a silent deadlock.
+                dtypes = _get_disk_load_dtypes(key, dtype, fmt)
+                if dtypes is None:
+                    break
 
-            if memory_obj is None:
-                logger.error(
-                    "Memory allocation failed during async disk load for key %s. "
-                    "CPU staging pool may be exhausted (unpin() not called after "
-                    "a previous retrieve). Returning partial results.",
-                    key,
+                memory_obj = self.local_cpu_backend.allocate(
+                    shape,
+                    dtypes,
+                    fmt,
+                    busy_loop=False,
                 )
-                return mem_objs
 
-            self.dict[key].pin()
+                if memory_obj is None:
+                    logger.error(
+                        "Memory allocation failed during async disk load for key %s. "
+                        "CPU staging pool may be exhausted (unpin() not called after "
+                        "a previous retrieve). Returning partial results.",
+                        key,
+                    )
+                    break
 
-            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
-            # Update cache recency
-            self.cache_policy.update_on_hit(key, self.dict)
+                disk_meta.pin()
 
-            self.disk_lock.release()
+                # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
+                # Update cache recency
+                self.cache_policy.update_on_hit(key, self.dict)
+
             logger.debug(f"Prefetching {key} from disk.")
             memory_obj.pin()
             mem_objs.append(memory_obj)
             paths.append(path)
 
+        if not mem_objs:
+            return []
+
         return await self.disk_worker.submit_task(
             "prefetch",
             self.batched_async_load_bytes_from_disk,
             paths=paths,
-            keys=keys,
+            keys=keys[: len(mem_objs)],
             memory_objs=mem_objs,
         )
 
@@ -628,17 +691,20 @@ class LocalDiskBackend(StorageBackendInterface):
             write completes for this key. Callback exceptions are caught and
             logged.
         """
-        kv_chunk = memory_obj.tensor
-        assert kv_chunk is not None
         buffer = memory_obj.byte_array
         path = self._key_to_path(key)
+        fmt = memory_obj.metadata.fmt
 
         size = len(buffer)
         self.usage += size
         self.stats_monitor.update_local_storage_usage(self.usage)
 
         # TODO(Jiayi): need to add ref count in disk memory object
-        self.write_file(buffer, path)
+        self.write_file(
+            buffer,
+            path,
+            use_odirect=self._use_odirect_for_memory_format(fmt),
+        )
 
         # ref count down here because there's a ref_count_up in
         # `submit_put_task` above.
@@ -649,7 +715,6 @@ class LocalDiskBackend(StorageBackendInterface):
         size = memory_obj.get_physical_size()
         shape = memory_obj.metadata.shape
         dtype = memory_obj.metadata.dtype
-        fmt = memory_obj.metadata.fmt
         cached_positions = memory_obj.metadata.cached_positions
         memory_obj.ref_count_down()
 
@@ -680,7 +745,14 @@ class LocalDiskBackend(StorageBackendInterface):
         # TODO (Jiayi): handle the case where loading fails.
         for path, key, mem_obj in zip(paths, keys, memory_objs, strict=False):
             buffer = mem_obj.byte_array
-            self.read_file(key, buffer, path)
+            self.read_file(
+                key,
+                buffer,
+                path,
+                use_odirect=self._use_odirect_for_memory_format(
+                    mem_obj.get_memory_format()
+                ),
+            )
 
             # TODO(Jiayi): Please recover the metadata in a more
             # elegant way in the future.
@@ -696,7 +768,7 @@ class LocalDiskBackend(StorageBackendInterface):
         self,
         key: CacheEngineKey,
         path: str,
-        dtype: torch.dtype,
+        dtype: Optional[torch.dtype],
         shape: torch.Size,
         fmt: MemoryFormat,
     ) -> Optional[MemoryObj]:
@@ -704,11 +776,26 @@ class LocalDiskBackend(StorageBackendInterface):
         Load bytearray from disk.
         """
 
-        memory_obj = self.local_cpu_backend.allocate(shape, dtype, fmt)
-        assert memory_obj is not None, "Memory allocation failed during disk load."
+        dtypes = _get_disk_load_dtypes(key, dtype, fmt)
+        if dtypes is None:
+            return None
+
+        memory_obj = self.local_cpu_backend.allocate(shape, dtypes, fmt)
+        if memory_obj is None:
+            logger.error(
+                "Memory allocation failed during disk load for key %s. "
+                "CPU staging pool may be exhausted.",
+                key,
+            )
+            return None
 
         buffer = memory_obj.byte_array
-        self.read_file(key, buffer, path)
+        self.read_file(
+            key,
+            buffer,
+            path,
+            use_odirect=self._use_odirect_for_memory_format(fmt),
+        )
 
         # TODO(Jiayi): Please recover the metadata in a more
         # elegant way in the future.
@@ -717,10 +804,10 @@ class LocalDiskBackend(StorageBackendInterface):
 
         return memory_obj
 
-    def write_file(self, buffer, path):
+    def write_file(self, buffer: Any, path: str, use_odirect: bool) -> None:
         start_time = time.time()
         size = len(buffer)
-        if size % self.os_disk_bs != 0 or not self.use_odirect:
+        if size % self.os_disk_bs != 0 or not use_odirect:
             with open(path, "wb") as f:
                 f.write(buffer)
         else:
@@ -734,18 +821,24 @@ class LocalDiskBackend(StorageBackendInterface):
         )
 
     @_lmcache_nvtx_annotate
-    def read_file(self, key, buffer, path):
+    def read_file(
+        self,
+        key: CacheEngineKey,
+        buffer: Any,
+        path: str,
+        use_odirect: bool,
+    ) -> None:
         start_time = time.time()
         size = len(buffer)
         fblock_aligned = size % self.os_disk_bs == 0
-        if not fblock_aligned and self.use_odirect:
+        if not fblock_aligned and use_odirect:
             logger.warning(
                 "Cannot use O_DIRECT for this file, "
                 "size is not aligned to disk block size."
             )
 
         try:
-            if not fblock_aligned or not self.use_odirect:
+            if not fblock_aligned or not use_odirect:
                 with open(path, "rb") as f:
                     f.readinto(buffer)
             else:
@@ -763,6 +856,9 @@ class LocalDiskBackend(StorageBackendInterface):
             f"Disk read size: {size} bytes, "
             f"Bandwidth: {size / disk_read_time / 1e6:.2f} MB/s"
         )
+
+    def _use_odirect_for_memory_format(self, fmt: MemoryFormat) -> bool:
+        return self.use_odirect and fmt != MemoryFormat.BINARY_BUFFER
 
     def get_allocator_backend(self) -> LocalCPUBackend:
         return self.local_cpu_backend

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from typing import Optional
 from unittest.mock import MagicMock, patch
 import asyncio
 import os
 import shutil
 import tempfile
 import threading
+import time
 
 # Third Party
 import pytest
@@ -195,6 +197,85 @@ class TestLocalDiskBackend:
 
         assert result is None
 
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_binary_buffer_round_trips_through_disk(self, local_disk_backend):
+        """Test LocalDiskBackend stores and loads byte-buffer memory objects."""
+        payload = b"opaque hybrid state payload"
+        key = CacheEngineKey(
+            model_name="test_model",
+            world_size=1,
+            worker_id=0,
+            chunk_hash=0xB1A17,
+            dtype=torch.uint8,
+            request_configs={"lmcache.tag.kind": "binary-buffer"},
+        )
+        memory_obj = local_disk_backend.local_cpu_backend.allocate(
+            torch.Size([len(payload)]),
+            [],
+            MemoryFormat.BINARY_BUFFER,
+        )
+        assert memory_obj is not None
+        assert memory_obj.get_physical_size() == len(payload)
+        memory_obj.byte_array[:] = payload
+
+        local_disk_backend.submit_put_task(key, memory_obj)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not local_disk_backend.contains(key):
+            local_disk_backend.loop.run_until_complete(asyncio.sleep(0.01))
+
+        assert local_disk_backend.contains(key)
+        loaded = local_disk_backend.get_blocking(key)
+
+        assert loaded is not None
+        assert loaded.get_memory_format() == MemoryFormat.BINARY_BUFFER
+        assert loaded.tensor is None
+        assert bytes(loaded.byte_array) == payload
+        assert local_disk_backend.dict[key].size == len(payload)
+
+        local_disk_backend.loop.run_until_complete(
+            local_disk_backend.disk_worker.executor.shutdown_async()
+        )
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_binary_buffer_uses_buffered_io_with_odirect_enabled(
+        self, local_disk_backend
+    ):
+        """Byte-buffer payloads must not use O_DIRECT."""
+        local_disk_backend.use_odirect = True
+        payload = b"x" * local_disk_backend.os_disk_bs
+        key = CacheEngineKey(
+            model_name="test_model",
+            world_size=1,
+            worker_id=0,
+            chunk_hash=0xB1A18,
+            dtype=torch.uint8,
+            request_configs={"lmcache.tag.kind": "binary-buffer-odirect"},
+        )
+        memory_obj = local_disk_backend.local_cpu_backend.allocate(
+            torch.Size([len(payload)]),
+            [],
+            MemoryFormat.BINARY_BUFFER,
+        )
+        assert memory_obj is not None
+        memory_obj.byte_array[:] = payload
+
+        with patch("os.open", side_effect=AssertionError("O_DIRECT was used")):
+            local_disk_backend.submit_put_task(key, memory_obj)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not local_disk_backend.contains(key):
+                local_disk_backend.loop.run_until_complete(asyncio.sleep(0.01))
+
+            assert local_disk_backend.contains(key)
+            loaded = local_disk_backend.get_blocking(key)
+
+        assert loaded is not None
+        assert loaded.get_memory_format() == MemoryFormat.BINARY_BUFFER
+        assert bytes(loaded.byte_array) == payload
+
+        local_disk_backend.loop.run_until_complete(
+            local_disk_backend.disk_worker.executor.shutdown_async()
+        )
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
 
@@ -395,8 +476,9 @@ class TestGetBlockingCachePolicyUpdate:
         self,
         backend: LocalDiskBackend,
         key: CacheEngineKey,
-        shape: torch.Size,
-        dtype: torch.dtype,
+        shape: Optional[torch.Size],
+        dtype: Optional[torch.dtype],
+        fmt: Optional[MemoryFormat] = MemoryFormat.KV_2LTD,
     ) -> None:
         """Insert a key into backend.dict without writing anything to disk."""
         meta = DiskCacheMetadata(
@@ -405,7 +487,7 @@ class TestGetBlockingCachePolicyUpdate:
             shape=shape,
             dtype=dtype,
             cached_positions=None,
-            fmt=MemoryFormat.KV_2LTD,
+            fmt=fmt,
             pin_count=0,
         )
         with backend.disk_lock:
@@ -430,6 +512,66 @@ class TestGetBlockingCachePolicyUpdate:
 
         assert result is None
         mock_update.assert_not_called()
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_corrupted_metadata_returns_none_without_load(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Corrupted disk metadata must fail gracefully without loading bytes."""
+        key = create_test_key(104)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        self._inject_key(local_disk_backend, key, shape, None)
+
+        with patch.object(local_disk_backend, "load_bytes_from_disk") as mock_load:
+            with patch.object(
+                local_disk_backend.cache_policy, "update_on_hit"
+            ) as mock_update:
+                result = local_disk_backend.get_blocking(key)
+
+        assert result is None
+        mock_load.assert_not_called()
+        mock_update.assert_not_called()
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_batched_get_corrupted_metadata_returns_empty_and_releases_lock(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Async disk loads must not leak disk_lock when metadata is invalid."""
+        key = create_test_key(105)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        self._inject_key(local_disk_backend, key, shape, None)
+
+        result = local_disk_backend.loop.run_until_complete(
+            local_disk_backend.batched_get_non_blocking("lookup", [key])
+        )
+
+        assert result == []
+        acquired = local_disk_backend.disk_lock.acquire(blocking=False)
+        assert acquired
+        if acquired:
+            local_disk_backend.disk_lock.release()
+        local_disk_backend.loop.run_until_complete(
+            local_disk_backend.disk_worker.executor.shutdown_async()
+        )
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_load_bytes_allocation_failure_returns_none(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Disk load allocation failures must return None instead of asserting."""
+        key = create_test_key(106)
+        with patch.object(
+            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+        ):
+            result = local_disk_backend.load_bytes_from_disk(
+                key,
+                "/nonexistent/path.pt",
+                dtype=torch.bfloat16,
+                shape=torch.Size([28, 2, 256, 8, 128]),
+                fmt=MemoryFormat.KV_2LTD,
+            )
+
+        assert result is None
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
     def test_updates_cache_policy_on_successful_load(
@@ -587,10 +729,10 @@ class TestBatchedGetBlocking:
         lock = threading.Lock()
         original_read_file = local_disk_backend.read_file
 
-        def tracking_read_file(key, buffer, path):
+        def tracking_read_file(key, buffer, path, **kwargs):
             with lock:
                 thread_ids.append(threading.current_thread().ident)
-            return original_read_file(key, buffer, path)
+            return original_read_file(key, buffer, path, **kwargs)
 
         with patch.object(
             local_disk_backend, "read_file", side_effect=tracking_read_file


### PR DESCRIPTION
Adds BINARY_BUFFER support through single, concurrent blocking and asynchronous local-disk reads. Aligned binary buffers explicitly use buffered I/O even when use_odirect is enabled. The current dev atomic put registration and eviction path are preserved.

Reconciled with dev 0d1873659959f99af8862cea182a2fddfa35d8f8 on 2026-09-14. 45 focused local CPU tests passed using torch 2.13.0+cpu and CPU-only native extensions. Scoped pre-commit lint, formatting, typing and policy checks passed. The read-failure suite includes concurrent-replacement and unlink-failure regressions.

No AMD/CUDA execution is claimed. The earlier Buildkite AMD failures had no start time and zero started jobs; fresh upstream CI execution is required. The full Sphinx build rendered the changed storage page but failed on 31 unrelated repository documentation issues; it is not reported as passing. Maintainer re-review remains required.
