### PR TITLE
fix(hpu): implement device-specific initialize_kvcaches_ptr for HPU connector

### DIFF
--- a/lmcache/v1/gpu_connector/hpu_connector.py
+++ b/lmcache/v1/gpu_connector/hpu_connector.py
@@ -237,6 +237,11 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
         kv_size = 1 if self.use_mla else 2
         return torch.Size([kv_size, self.num_layers, num_tokens, self.hidden_dim_size])
 
+    def initialize_kvcaches_ptr(self, **kwargs):
+        """Initialize the kvcaches pointers if not already initialized."""
+        if "kvcaches" in kwargs:
+            self.kvcaches = kwargs["kvcaches"]
+
     def _validate_memory_format(self, memory_obj: MemoryObj) -> None:
         """Validate that the memory object has the expected format.
 
@@ -264,7 +269,11 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
         if self._attributes_initialized:
             return
 
-        self.device = kv_caches[0].device
+        first = kv_caches[0]
+        if isinstance(first, torch.Tensor):
+            self.device = first.device
+        else:
+            self.device = first[0].device
         assert self.device.type == "hpu", "The device should be HPU."
 
         # HPU vLLM provides kv_caches as List[TensorTuple(k_tensor, v_tensor)],

--- a/lmcache/v1/gpu_connector/hpu_connector.py
+++ b/lmcache/v1/gpu_connector/hpu_connector.py
@@ -237,7 +237,7 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
         kv_size = 1 if self.use_mla else 2
         return torch.Size([kv_size, self.num_layers, num_tokens, self.hidden_dim_size])
 
-    def initialize_kvcaches_ptr(self, **kwargs):
+    def initialize_kvcaches_ptr(self, **kwargs) -> None:
         """Initialize the kvcaches pointers if not already initialized."""
         if "kvcaches" in kwargs:
             self.kvcaches = kwargs["kvcaches"]
@@ -266,7 +266,7 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
                 )
 
     def _initialize_attributes(self, kv_caches: List[torch.Tensor]):
-        if self._attributes_initialized:
+        if self._attributes_initialized or not kv_caches:
             return
 
         first = kv_caches[0]


### PR DESCRIPTION
HPU vLLM passes kv_caches as List[TensorTuple(k, v)], not List[Tensor].
- Add HPU-specific initialize_kvcaches_ptr that skips attempt_permute_to_contiguous_view, which is CUDA-specific and degrades TensorTuple to plain list.
- Guard .device access in _initialize_attributes to handle both Tensor and TensorTuple formats.
