### PR TITLE
[Operator][CI] Date-based nightly tag and release-driven flow

### DIFF
--- a/.github/workflows/operator_nightly.yml
+++ b/.github/workflows/operator_nightly.yml
@@ -41,9 +41,8 @@ jobs:
       - name: Compute nightly tag
         id: tag
         run: |
-          DATE=$(date -u +%Y%m%d)
-          SHA=$(git rev-parse --short HEAD)
-          echo "TAG=nightly-${DATE}-${SHA}" >> "$GITHUB_OUTPUT"
+          DATE=$(date -u +%Y-%m-%d)
+          echo "TAG=nightly-${DATE}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/.github/workflows/operator_release.yml
+++ b/.github/workflows/operator_release.yml
@@ -1,9 +1,8 @@
 name: "Operator: Release"
 
 on:
-  push:
-    tags:
-      - "operator-v*"
+  release:
+    types: [published]
 
 env:
   IMAGE_NAME: lmcache/lmcache-operator
@@ -19,6 +18,8 @@ defaults:
 jobs:
   release:
     name: Build, push, and release
+    # Filter out main lmcache `v*` releases — only fire for operator-prefixed tags.
+    if: startsWith(github.ref_name, 'operator-v')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -63,11 +64,9 @@ jobs:
       - name: Build installer manifest
         run: make build-installer IMG=${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
 
-      - name: Create GitHub Release
+      - name: Attach installer to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: "Operator ${{ steps.version.outputs.VERSION }}"
-          generate_release_notes: true
           files: operator/dist/install.yaml
 
       - name: Update latest release alias


### PR DESCRIPTION
**What this PR does / why we need it**:

Two small CI cleanups for the operator release pipeline, motivated by aligning it with the main lmcache release flow:

1. **Nightly image tag** (`operator_nightly.yml`) — change `lmcache/lmcache-operator:nightly-YYYYMMDD-<sha>` to `lmcache/lmcache-operator:nightly-YYYY-MM-DD`. Drops the short SHA suffix and uses dashed dates so tags are predictable and easy to reference (the `:nightly` rolling tag is unchanged).

2. **Stable release trigger** (`operator_release.yml`) — switch from `push.tags: operator-v*` to `release.types: [published]` so the operator follows the same GitHub-Release-driven flow as `publish.yml` (PyPI / Docker). Adds an `if: startsWith(github.ref_name, 'operator-v')` guard so lmcache's `v*` releases don't accidentally fire the operator pipeline. Also stops the workflow from overwriting the user-authored release title/notes — it now only attaches `install.yaml` to the existing release.

**Special notes for your reviewers**:

After this change, the operator release flow is consistent with the main project:

1. GitHub UI → **Releases → Draft a new release**
2. Choose a tag → type `operator-v0.x.y` → "Create new tag on publish" (target `dev`)
3. Write title + notes (or "Generate release notes")
4. **Publish release** → fires the workflow → builds and pushes `:v0.x.y` + `:latest`, attaches `install.yaml`, updates the rolling `operator-latest` release pointer.

The previous `git push origin operator-v0.x.y` flow no longer triggers the workflow on its own — the release event is what fires it now.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests