### PR TITLE
 [CI] allow PyTorch/NVIDIA egress endpoints in release workflows

### DIFF
--- a/.github/workflows/build_main_artifacts.yml
+++ b/.github/workflows/build_main_artifacts.yml
@@ -32,14 +32,18 @@ jobs:
                   api.github.com:443
                   github.com:443
                   registry-1.docker.io:443
+                  index.docker.io:443
                   production.cloudflare.docker.com:443
                   auth.docker.io:443
                   azure.archive.ubuntu.com:80
                   pypi.org:443
+                  pypi.nvidia.com:443
                   files.pythonhosted.org:443
                   codeload.github.com:443
                   objects.githubusercontent.com:443
                   releases.githubusercontent.com:443
+                  download.pytorch.org:443
+                  download-r2.pytorch.org:443
 
             - name: Checkout code
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -25,6 +25,7 @@ jobs:
             uploads.github.com:443
             github.com:443
             registry-1.docker.io:443
+            index.docker.io:443
             production.cloudflare.docker.com:443
             auth.docker.io:443
             azure.archive.ubuntu.com:80

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -341,6 +341,7 @@ jobs:
                 allowed-endpoints: >
                   github.com:443
                   registry-1.docker.io:443
+                  index.docker.io:443
                   production.cloudflare.docker.com:443
                   auth.docker.io:443
                   azure.archive.ubuntu.com:80
@@ -350,6 +351,7 @@ jobs:
                   releases.astral.sh:443
                   objects.githubusercontent.com:443
                   pypi.org:443
+                  pypi.nvidia.com:443
                   files.pythonhosted.org:443
                   release-assets.githubusercontent.com:443
                   wrapdb.mesonbuild.com:443


### PR DESCRIPTION
 

  Description:
  ## Summary
  - `Build main / Build artifacts` in the v0.4.5 release run failed at `cibuildwheel`
    because harden-runner blocked egress to `download.pytorch.org` — the index
    required by `PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu130`
    (added in #3275, the cu13 swap).
  - Add `download.pytorch.org`, `download-r2.pytorch.org`, `pypi.nvidia.com`,
    and `index.docker.io` to the harden-runner allowlists in
    `build_main_artifacts.yml`, `nightly_build.yml`, and `publish.yml`'s
    `publish-image` job, matching what `build_cu129_artifacts.yml` already allows.
 