### PR TITLE
docs: daily drift check — multi-process mode (2026-05-15)

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -353,7 +353,7 @@ Settings for using Nixl as a storage backend instead of disaggregated prefill. T
    * - nixl_pool_size
      - Number of files or objects in the storage pool
    * - nixl_endpoint_list
-     - List of object-storage endpoint URLs for per-worker distribution. Overrides ``nixl_backend_params.endpoint_override`` when set.
+     - List of object-storage endpoint URLs for per-worker distribution. Each TP worker selects an entry round-robin by ``local_worker_id``, overriding ``nixl_backend_params.endpoint_override``. Only applied when ``nixl_backend`` is ``"OBJ"`` (silently ignored otherwise). Each entry must start with ``http://`` or ``https://``; an empty list raises ``ValueError`` at engine init.
 
 
 Additional Storage Configurations

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -209,7 +209,7 @@ Install LMCache
 
                 .. code-block:: bash
 
-                    docker pull docker pull intel/vllm:0.17.0-xpu
+                    docker pull intel/vllm:0.17.0-xpu
 
         See :ref:`docker_deployment` for running the container and ROCm images.
 

--- a/docs/source/production/docker_deployment.rst
+++ b/docs/source/production/docker_deployment.rst
@@ -55,7 +55,7 @@ Validated environment: ``rocm/vllm-dev:nightly_0624_rc2_0624_rc2_20250620``, MI3
 XPU (Intel)
 -----------
 
-The `Intel vLLM XPU hub<https://hub.docker.com/r/intel/vllm>`__ offers a prebuilt, optimized docker image designed for validating inference performance on the Intel GPU accelerators like ARC770, B60/B70, and future products.
+The `Intel vLLM XPU hub <https://hub.docker.com/r/intel/vllm>`__ offers a prebuilt, optimized docker image designed for validating inference performance on the Intel GPU accelerators like ARC770, B60/B70, and future products.
 
 Validated environment: ``intel/vllm:0.17.0-xpu``, Intel B60 GPU, vLLM V1.
 


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine.
**Human review is required before merge — do not merge as-is.**

Three doc drifts were introduced between yesterday's drift sweep
(2026-05-14, [PR #3273](https://github.com/LMCache/LMCache/pull/3273))
and today's `dev` HEAD ([`3090e89`](https://github.com/LMCache/LMCache/commit/3090e89634c1ab43b56819462fe4eeae7bcdf1ae)).
Two are obvious user-facing regressions in the Intel-XPU install
instructions merged today; the third is a multi-process-relevant gap
in the new `nixl_endpoint_list` config row.

Today's PR is filed as a separate draft (not appended to #3273) because
the items are independent of yesterday's batches and rebasing #3273's
branch onto current `dev` would require a force-push of two already-
reviewed commits. The dedup rule asks us to merge only when the **same**
items are still open, which is not the case here.

---

### `docs/source/` (user-facing) drift

#### 1. Duplicated `docker pull` token in Intel XPU stable-install block

[PR #2902](https://github.com/LMCache/LMCache/pull/2902) (commit
[`3090e89`](https://github.com/LMCache/LMCache/commit/3090e89634c1ab43b56819462fe4eeae7bcdf1ae),
"Add sycl implementation of memory_kernels for Intel XPU") merged today
and added a new *Intel XPU* tab under the docker-stable install block.
The shipped command has the verb duplicated:

- [`docs/source/getting_started/installation.rst#L212`](https://github.com/LMCache/LMCache/blob/3090e89634c1ab43b56819462fe4eeae7bcdf1ae/docs/source/getting_started/installation.rst#L212)
  reads ``docker pull docker pull intel/vllm:0.17.0-xpu``. Copy-pasted
  by a user it errors out (`"docker pull": invalid reference format`).
  The other tabs (CUDA 13.0, CUDA 12.9, ROCm) all have a single
  `docker pull`, so this is clearly a typo in the new tab rather than
  intended new syntax.

#### 2. Malformed reStructuredText external link in the new XPU docker section

Same PR (#2902) added an *XPU (Intel)* section to the docker deployment
page with a broken external-link role:

- [`docs/source/production/docker_deployment.rst#L58`](https://github.com/LMCache/LMCache/blob/3090e89634c1ab43b56819462fe4eeae7bcdf1ae/docs/source/production/docker_deployment.rst#L58)
  reads `` `Intel vLLM XPU hub<https://hub.docker.com/r/intel/vllm>`__ ``.
  Sphinx's `external-link` role requires a **space** between the link
  text and the angle-bracketed URL — without it the URL becomes part of
  the rendered link text and the hyperlink resolves to nothing. The two
  other Sphinx links on the same page (e.g.
  [`docs/source/production/docker_deployment.rst#L18-L19`](https://github.com/LMCache/LMCache/blob/3090e89634c1ab43b56819462fe4eeae7bcdf1ae/docs/source/production/docker_deployment.rst#L18-L19))
  follow the correct ``` `text <URL>`__ ``` form.

#### 3. `nixl_endpoint_list` table description omits real OBJ-only / validation constraints

[PR #2861](https://github.com/LMCache/LMCache/pull/2861) (commit
[`f02ad53`](https://github.com/LMCache/LMCache/commit/f02ad538782171e219a0e5ec97fc6d7a694ea063),
"[CORE] Add `nixl_endpoint_list` for per-worker object-storage endpoint
distribution") landed last night and is a **multi-process feature** —
each TP worker selects a different object-storage endpoint at engine
init. The new `nixl_endpoint_list` row in the configurations table
describes only half of the contract.

- [`docs/source/api_reference/configurations.rst#L355-L356`](https://github.com/LMCache/LMCache/blob/3090e89634c1ab43b56819462fe4eeae7bcdf1ae/docs/source/api_reference/configurations.rst#L355-L356)
  says only *"List of object-storage endpoint URLs for per-worker
  distribution. Overrides `nixl_backend_params.endpoint_override` when
  set."* The actual config-parse code at
  [`lmcache/v1/storage_backend/nixl_storage_backend.py#L115-L152`](https://github.com/LMCache/LMCache/blob/3090e89634c1ab43b56819462fe4eeae7bcdf1ae/lmcache/v1/storage_backend/nixl_storage_backend.py#L115-L152)
  enforces four extra constraints that the table is silent about:
  1. The override is gated on `backend == "OBJ"`. With any other
     `nixl_backend` value the list is **silently ignored** — no log,
     no warning, no error. That's a real footgun for users who set
     `nixl_endpoint_list` together with `nixl_backend: "POSIX"` and
     wonder why all workers hit the same endpoint.
  2. Distribution is round-robin by `local_worker_id`
     (worker-within-host), not by the global `worker_id`. This matters
     for multi-host deployments where each host may have its own
     endpoint pool.
  3. An empty list raises `ValueError("nixl_endpoint_list is set but
     empty")` — useful to know when validating a config.
  4. Each entry must start with `http://` or `https://`; anything else
     raises `ValueError(... "must start with 'http://' or 'https://'")`.

  The nearby narrative page
  [`docs/source/kv_cache/storage_backends/nixl.rst#L114-L142`](https://github.com/LMCache/LMCache/blob/3090e89634c1ab43b56819462fe4eeae7bcdf1ae/docs/source/kv_cache/storage_backends/nixl.rst#L114-L142)
  *does* mention OBJ and `local_worker_id`, but a reader who consults
  only the config reference would miss all four constraints.

### `docs/design/` drift

None new today. Audit covered the same MP-relevant code paths as
yesterday's sweep; no design page was rendered stale by the commits in
the window.

---

## Proposed fix (applied in this PR — one commit)

A single doc-only commit ([`fa234c7`](https://github.com/ApostaC/LMCache/commit/fa234c7215d68d365a7956b339f729ff5aad0875)),
DCO-signed and authored by ApostaC:

- **`installation.rst`** — drop the duplicated `docker pull` token.
- **`docker_deployment.rst`** — insert the missing space in the RST
  external-link role so the URL becomes a real hyperlink.
- **`configurations.rst`** — expand the `nixl_endpoint_list` row to
  state the OBJ-only restriction, the `local_worker_id` selector, the
  empty-list `ValueError`, and the URL-scheme requirement. Wording
  mirrors the existing prose in `nixl.rst` and the constructor
  docstring — no behaviour change implied.

No code files are touched.

## Audit-clean (no drift) commits in today's window

The following dev commits since 2026-05-14T16:25 UTC were audited and
introduced no new MP doc drift:

- **PR #3279** (slim install imports / CI smoke-test) — CI-only, no
  user-facing doc surface.
- **PR #3275** (CI default to cu13 wheels) — CI-only.
- **PR #3276** (revert of `[CLI][CB] propagate CLI kvcache clear to CB
  fingerprint table`) — removes `BlendEngineV2.clear()`; no doc claimed
  the removed `clear()`-emits-`CB_CHUNKS_EVICTED` semantics.
  `CB_CHUNKS_EVICTED` is still emitted from the lazy-eviction path in
  `blend_server_v2.py:660-675`, so
  `docs/design/v1/mp_observability/EVENTS.md:219` and
  `docs/design/v1/mp_observability/METRICS.md:504-511` remain accurate.
- **PR #2989** (unique `device_id` per OBJ register/deregister) —
  internal NIXL agent bookkeeping fix; no public surface in docs.
- **PR #3295** (CI egress allowlist) — release-workflow CI only.
- **PR #3287** (HPU `initialize_kvcaches_ptr`) — adds a method to the
  HPU connector matching the base class; no MP doc references HPU.

## Generated by

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Branch:
`ApostaC:docs/drift-check-2026-05-15`. Human review is still required
before merge; please leave this PR in draft until reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkzjC93LpugVVnLwnR12ci)_