### PR TITLE
[CD] switch all workflows to egress audit mode

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -35,12 +35,7 @@ jobs:
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           disable-sudo-and-containers: false
-          egress-policy: block
-          allowed-endpoints: >
-            github.com:443
-            registry-1.docker.io:443
-            production.cloudflare.docker.com:443
-            auth.docker.io:443
+          egress-policy: audit
 
       - name: "Checkout"
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/build_cli_artifacts.yml
+++ b/.github/workflows/build_cli_artifacts.yml
@@ -39,14 +39,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                 disable-sudo-and-containers: false
-                egress-policy: block
-                allowed-endpoints: >
-                  api.github.com:443
-                  github.com:443
-                  azure.archive.ubuntu.com:80
-                  pypi.org:443
-                  files.pythonhosted.org:443
-                  objects.githubusercontent.com:443
+                egress-policy: audit
 
             - name: Checkout code
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/build_cu129_artifacts.yml
+++ b/.github/workflows/build_cu129_artifacts.yml
@@ -28,23 +28,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                 disable-sudo-and-containers: false
-                egress-policy: block
-                allowed-endpoints: >
-                  api.github.com:443
-                  github.com:443
-                  registry-1.docker.io:443
-                  index.docker.io:443
-                  production.cloudflare.docker.com:443
-                  auth.docker.io:443
-                  azure.archive.ubuntu.com:80
-                  pypi.org:443
-                  files.pythonhosted.org:443
-                  codeload.github.com:443
-                  objects.githubusercontent.com:443
-                  releases.githubusercontent.com:443
-                  download.pytorch.org:443
-                  download-r2.pytorch.org:443
-                  pypi.nvidia.com:443
+                egress-policy: audit
 
             - name: Checkout code
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit
 
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -66,7 +66,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit
 
       - name: Fetch doc artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/build_main_artifacts.yml
+++ b/.github/workflows/build_main_artifacts.yml
@@ -27,23 +27,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                 disable-sudo-and-containers: false
-                egress-policy: block
-                allowed-endpoints: >
-                  api.github.com:443
-                  github.com:443
-                  registry-1.docker.io:443
-                  index.docker.io:443
-                  production.cloudflare.docker.com:443
-                  auth.docker.io:443
-                  azure.archive.ubuntu.com:80
-                  pypi.org:443
-                  pypi.nvidia.com:443
-                  files.pythonhosted.org:443
-                  codeload.github.com:443
-                  objects.githubusercontent.com:443
-                  releases.githubusercontent.com:443
-                  download.pytorch.org:443
-                  download-r2.pytorch.org:443
+                egress-policy: audit
 
             - name: Checkout code
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -47,14 +47,7 @@ jobs:
           uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
           with:
             disable-sudo-and-containers: true
-            egress-policy: block
-            allowed-endpoints: >
-              github.com:443
-              pypi.org:443
-              files.pythonhosted.org:443
-              crates.io:443
-              index.crates.io:443
-              static.crates.io:443
+            egress-policy: audit
 
         - name: Checkout code
           uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,31 +63,7 @@ jobs:
       uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
       with:
         disable-sudo-and-containers: true
-        egress-policy: block
-        allowed-endpoints: >
-          github.com:443
-          api.github.com:443
-          objects.githubusercontent.com:443
-          github-releases.githubusercontent.com:443
-          raw.githubusercontent.com:443
-          packages.githubusercontent.com:443
-          pypi.org:443
-          files.pythonhosted.org:443
-          registry.npmjs.org:443
-          registry-1.docker.io:443
-          production.cloudflare.docker.com:443
-          auth.docker.io:443
-          azure.archive.ubuntu.com:80
-          security.ubuntu.com:80
-          storage.googleapis.com:443
-          *.github.com:443
-          *.githubusercontent.com:443
-          pypi.org:443
-          files.pythonhosted.org:443
-          registry.npmjs.org:443
-          *.docker.io:443
-          *.ubuntu.com:80
-          storage.googleapis.com:443
+        egress-policy: audit
 
     - name: Checkout repository
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -19,24 +19,7 @@ jobs:
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           disable-sudo-and-containers: false
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            uploads.github.com:443
-            github.com:443
-            registry-1.docker.io:443
-            index.docker.io:443
-            production.cloudflare.docker.com:443
-            auth.docker.io:443
-            azure.archive.ubuntu.com:80
-            pypi.org:443
-            files.pythonhosted.org:443
-            objects.githubusercontent.com:443
-            releases.githubusercontent.com:443
-            codeload.github.com:443
-            download.pytorch.org:443
-            download-r2.pytorch.org:443
-            pypi.nvidia.com:443
+          egress-policy: audit
 
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -138,27 +121,7 @@ jobs:
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
             disable-sudo-and-containers: false
-            egress-policy: block
-            allowed-endpoints: >
-              github.com:443
-              registry-1.docker.io:443
-              production.cloudflare.docker.com:443
-              auth.docker.io:443
-              azure.archive.ubuntu.com:80
-              pypi.org:443
-              files.pythonhosted.org:443
-              wheels.vllm.ai:443
-              release-assets.githubusercontent.com:443
-              wrapdb.mesonbuild.com:443
-              nvcr.io:443
-              layers.nvcr.io:443
-              archive.ubuntu.com:80
-              security.ubuntu.com:80
-              astral.sh:443
-              releases.astral.sh:443
-              download.pytorch.org:443
-              download-r2.pytorch.org:443
-              pypi.nvidia.com:443
+            egress-policy: audit
 
       - name: Login to DockerHub
         if: vars.DOCKERHUB_USERNAME != ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,14 +118,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                 disable-sudo-and-containers: false
-                egress-policy: block
-                allowed-endpoints: >
-                  ghcr.io:443
-                  pkg-containers.githubusercontent.com:443
-                  test.pypi.org:443
-                  tuf-repo-cdn.sigstore.dev:443
-                  fulcio.sigstore.dev:443
-                  rekor.sigstore.dev:443
+                egress-policy: audit
 
             - name: Fetch release artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -157,14 +150,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                 disable-sudo-and-containers: false
-                egress-policy: block
-                allowed-endpoints: >
-                  ghcr.io:443
-                  pkg-containers.githubusercontent.com:443
-                  test.pypi.org:443
-                  tuf-repo-cdn.sigstore.dev:443
-                  fulcio.sigstore.dev:443
-                  rekor.sigstore.dev:443
+                egress-policy: audit
 
             - name: Fetch CLI release artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -200,16 +186,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                   disable-sudo-and-containers: false
-                  egress-policy: block
-                  allowed-endpoints: >
-                    api.github.com:443
-                    uploads.github.com:443
-                    ghcr.io:443
-                    pkg-containers.githubusercontent.com:443
-                    upload.pypi.org:443
-                    tuf-repo-cdn.sigstore.dev:443
-                    fulcio.sigstore.dev:443
-                    rekor.sigstore.dev:443
+                  egress-policy: audit
 
             - name: Fetch release artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -245,16 +222,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                   disable-sudo-and-containers: false
-                  egress-policy: block
-                  allowed-endpoints: >
-                    api.github.com:443
-                    uploads.github.com:443
-                    ghcr.io:443
-                    pkg-containers.githubusercontent.com:443
-                    upload.pypi.org:443
-                    tuf-repo-cdn.sigstore.dev:443
-                    fulcio.sigstore.dev:443
-                    rekor.sigstore.dev:443
+                  egress-policy: audit
 
             - name: Fetch CLI release artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -290,10 +258,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                   disable-sudo-and-containers: false
-                  egress-policy: block
-                  allowed-endpoints: >
-                    api.github.com:443
-                    uploads.github.com:443
+                  egress-policy: audit
 
             - name: Fetch cu12.9 release artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -337,29 +302,7 @@ jobs:
               uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
               with:
                 disable-sudo-and-containers: false
-                egress-policy: block
-                allowed-endpoints: >
-                  github.com:443
-                  registry-1.docker.io:443
-                  index.docker.io:443
-                  production.cloudflare.docker.com:443
-                  auth.docker.io:443
-                  azure.archive.ubuntu.com:80
-                  archive.ubuntu.com:80
-                  security.ubuntu.com:80
-                  astral.sh:443
-                  releases.astral.sh:443
-                  objects.githubusercontent.com:443
-                  pypi.org:443
-                  pypi.nvidia.com:443
-                  files.pythonhosted.org:443
-                  release-assets.githubusercontent.com:443
-                  wrapdb.mesonbuild.com:443
-                  nvcr.io:443
-                  layers.nvcr.io:443
-                  wheels.vllm.ai:443
-                  download.pytorch.org:443
-                  download-r2.pytorch.org:443
+                egress-policy: audit
 
             - name: Login to DockerHub
               uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,20 +37,7 @@ jobs:
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           disable-sudo-and-containers: false
-          egress-policy: block
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            index.docker.io:443
-            www.bestpractices.dev:443
-            oss-fuzz-build-logs.storage.googleapis.com:443
-            api.osv.dev:443
-            api.deps.dev:443
-            fulcio.sigstore.dev:443
-            tuf-repo-cdn.sigstore.dev:443
-            rekor.sigstore.dev:443
-            auth.docker.io:443
-            api.scorecard.dev:443
+          egress-policy: audit
 
       - name: "Checkout code"
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -25,9 +25,7 @@ jobs:
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           disable-sudo-and-containers: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
+          egress-policy: audit
 
       - name: "Stale Action"
         uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: "Harden Runner"
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
 
  Description:

  Summary

  - Change egress-policy: block → audit across all GitHub workflows
  - Remove the paired allowed-endpoints: allowlists (no longer enforced)
  - Drop stale "switch to block" TODOs in build_doc.yml and test.yml
