### PR TITLE
[Fix] Persist cached_positions in GDS backend metadata instead of dropping it to None

### DIFF
--- a/docs/source/kv_cache/storage_backends/gds.rst
+++ b/docs/source/kv_cache/storage_backends/gds.rst
@@ -268,3 +268,21 @@ backends are ``cufile`` (NVIDIA cuFile) and ``hipfile`` (AMD hipFile):
     gds_backend: "cufile"   # or "hipfile"
 
 Note that under this mode it would still use CUDA APIs to map and do operations the pre-registered GPU memory.
+
+
+Cache compatibility on metadata version bump
+--------------------------------------------
+
+The on-disk metadata format now records ``cached_positions`` (required for
+correct position-independent KV reuse). To avoid serving stale
+entries that lack it, the GDS metadata version was bumped to version 2: entries written by
+older LMCache versions are **rejected on read**, treated as cache misses, and
+transparently recomputed and re-stored in the new format.
+
+.. warning::
+
+   After upgrading to a version with this change, existing GDS cache entries
+   are ignored but **not deleted**, so they keep occupying disk. Clear the
+   GDS cache directory (``gds_path``, and every path when using the
+   comma-separated multi-path form) after upgrading. New entries are written
+   in the new format automatically.

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -90,9 +90,22 @@ def get_fstype(path):
     return best_fstype
 
 
-def pack_metadata(tensor, fmt: MemoryFormat, **extra_metadata) -> bytes:
+def pack_metadata(
+    tensor,
+    fmt: MemoryFormat,
+    cached_positions: Optional[torch.Tensor] = None,
+    **extra_metadata,
+) -> bytes:
     if tensor.dtype not in torch_dtypes:
         raise RuntimeError(f"unhandled dtype {tensor.dtype}")
+
+    # cached_positions: 1-D int tensor of per-token original positions
+    # (len == chunk token count). Stored as a JSON string since the
+    # safetensors-compatible "__metadata__" must be str->str; its size is
+    # bounded by the fixed metadata block (enforced by the check below).
+    meta_extra = dict(extra_metadata)
+    if cached_positions is not None:
+        meta_extra["cached_positions"] = json.dumps(cached_positions.tolist())
 
     # Metadata
     data_size = tensor.numel() * tensor.element_size()
@@ -101,12 +114,27 @@ def pack_metadata(tensor, fmt: MemoryFormat, **extra_metadata) -> bytes:
         "shape": list(tensor.size()),
         "data_offsets": [0, data_size],
         "fmt": fmt.value,
-        "__metadata__": extra_metadata,
+        "__metadata__": meta_extra,
     }
     meta = {"kvcache": tensor_meta}
     str_meta = json.dumps(meta).encode("utf-8")
     meta_len = len(str_meta)
-    assert meta_len <= _METADATA_MAX_SIZE - 8
+    # cached_positions impacts header size. Serialized it is roughly
+    #   bytes ~= num_tokens * (digits_per_position + 2)
+    # where num_tokens is this chunk's token count (<= chunk_size).
+    # Against the ~3800B left in the fixed 4096B block, this overflows only for a
+    # large configured chunk_size (default 256 fits even ~1M-scale positions).
+    # Quick recovery: lower chunk_size so fewer tokens land per chunk.
+    # Proper fix when error actually happened:
+    # positions are near-always a contiguous arange, so store
+    # them compactly as (start, length) instead of the full list.
+    if meta_len > _METADATA_MAX_SIZE - 8:
+        raise ValueError(
+            f"Packed GDS metadata is {meta_len} bytes, which exceeds the "
+            f"{_METADATA_MAX_SIZE - 8} byte limit. This usually means the "
+            f"chunk's cached_positions is too large to fit in the fixed-size "
+            f"GDS metadata block."
+        )
 
     # Align to _METADATA_MAX_SIZE - 8
     str_meta += b" " * (_METADATA_MAX_SIZE - 8 - meta_len)
@@ -460,15 +488,18 @@ class GdsBackend(AllocatorBackendInterface):
             f"shape={shape}, dtype={dtype}, size={size}, fmt={fmt}, "
             f"extra_metadata={extra_metadata}"
         )
-        # TODO(extra_metadata)
-        # TODO(Jiayi): need to support `cached_positions`.
-        # Currently we just fill it as None.
+        cached_positions_json = extra_metadata.get("cached_positions")
+        cached_positions = (
+            torch.tensor(json.loads(cached_positions_json), dtype=torch.long)
+            if cached_positions_json is not None
+            else None
+        )
         metadata = DiskCacheMetadata(
             filename.removesuffix(_METADATA_FILE_SUFFIX),
             size,
             shape,
             dtype,
-            None,
+            cached_positions,
             fmt,
         )
         with self.hot_lock:
@@ -628,6 +659,7 @@ class GdsBackend(AllocatorBackendInterface):
                     fmt,
                     self.gds_base_pointer,
                     memory_obj.metadata.address,
+                    memory_obj.metadata.cached_positions,
                 )
             except Exception as e:
                 logger.error(
@@ -710,9 +742,11 @@ class GdsBackend(AllocatorBackendInterface):
         shape = memory_obj.metadata.shape
         dtype = memory_obj.metadata.dtype
         fmt = memory_obj.metadata.fmt
+        cached_positions = memory_obj.metadata.cached_positions
         with self.hot_lock:
-            # TODO(Jiayi): need to support `cached_positions`.
-            self.hot_cache[key] = DiskCacheMetadata(path, size, shape, dtype, None, fmt)
+            self.hot_cache[key] = DiskCacheMetadata(
+                path, size, shape, dtype, cached_positions, fmt
+            )
 
     def submit_prefetch_task(
         self,
@@ -855,6 +889,14 @@ class GdsBackend(AllocatorBackendInterface):
                 )
             memory_obj.ref_count_down()
             return None
+
+        # Re-attach cached_positions (used e.g. for CacheBlend RoPE
+        # re-positioning) from the index, mirroring the other persistent
+        # backends. Entries from older files carry None.
+        with self.hot_lock:
+            entry = self.hot_cache.get(key)
+        if entry is not None:
+            memory_obj.metadata.cached_positions = entry.cached_positions
         return memory_obj
 
     def get_non_blocking(
@@ -938,6 +980,7 @@ class GdsBackend(AllocatorBackendInterface):
         fmt: MemoryFormat,
         base_pointer: int,
         device_offset: int,
+        cached_positions: Optional[torch.Tensor] = None,
     ):
         if base_pointer is None:
             addr = ctypes.c_void_p(kv_chunk.data_ptr())
@@ -950,7 +993,10 @@ class GdsBackend(AllocatorBackendInterface):
         # TODO: We can add the chunk's metadata here, e.g. Tensor parallelism shard
         # and pipeline parallelism index.
         metadata = pack_metadata(
-            kv_chunk, fmt=fmt, lmcache_version=str(_METADATA_VERSION)
+            kv_chunk,
+            fmt=fmt,
+            cached_positions=cached_positions,
+            lmcache_version=str(_METADATA_VERSION),
         )
         try:
             with open(tmp_path, "wb") as f:

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -38,7 +38,9 @@ logger = init_logger(__name__)
 _METADATA_FILE_SUFFIX = ".metadata"
 _DATA_FILE_SUFFIX = ".kvcache.safetensors"
 _WEKA_DATA_FILE_SUFFIX = ".weka1"
-_METADATA_VERSION = 1
+# v2 adds cached_positions. Bumped from 1 so pre-v2 entries (which lack it)
+# are rejected on read rather than served with cached_positions=None.
+_METADATA_VERSION = 2
 _METADATA_MAX_SIZE = 4096  # reserve 4K for metadata.
 # TODO: It is possible to read this 4KB block without triggering read-ahead by
 # various means.
@@ -91,7 +93,7 @@ def get_fstype(path):
 
 
 def pack_metadata(
-    tensor,
+    tensor: torch.Tensor,
     fmt: MemoryFormat,
     cached_positions: Optional[torch.Tensor] = None,
     **extra_metadata,

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -98,12 +98,15 @@ def async_loop():
 def gds_backend(temp_gds_path, async_loop):
     config = create_test_config(temp_gds_path)
     metadata = create_test_metadata()
-    return GdsBackend(
+    backend = GdsBackend(
         config=config,
         loop=async_loop,
         metadata=metadata,
         dst_device="cuda:0",
     )
+    yield backend
+    # close() drains in-flight tasks.
+    backend.close()
 
 
 @pytest.mark.skipif(

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -856,7 +856,7 @@ class TestGdsMultiPath:
             metadata_bytes = pack_metadata(
                 dummy_tensor,
                 fmt=MemoryFormat.KV_2LTD,
-                lmcache_version="1",
+                lmcache_version=str(_METADATA_VERSION),
             )
             meta_path = os.path.join(
                 subdir,
@@ -885,6 +885,47 @@ class TestGdsMultiPath:
         finally:
             for p in paths:
                 shutil.rmtree(p, ignore_errors=True)
+
+    def test_old_version_entries_are_rejected(self, async_loop):
+        """Pre-change GDS entries with older _METADATA_VERSION must be rejected"""
+        path = tempfile.mkdtemp(dir=_TEST_TMPDIR)
+        try:
+            key = CacheEngineKey(
+                model_name="testmodel",
+                world_size=3,
+                worker_id=1,
+                chunk_hash=4321,
+                dtype=torch.bfloat16,
+            )
+            hash_str = str(key.chunk_hash)
+            l1_dir, l2_dir = hash_str[:2], hash_str[2:4]
+            key_str = urllib.parse.quote(key.to_string(), safe="")
+            subdir = os.path.join(path, l1_dir, l2_dir)
+            os.makedirs(subdir, exist_ok=True)
+
+            dummy_tensor = torch.zeros(2, 256, 8, 128, dtype=torch.bfloat16)
+            # Simulate a file written by an older metadata version.
+            metadata_bytes = pack_metadata(
+                dummy_tensor,
+                fmt=MemoryFormat.KV_2LTD,
+                lmcache_version=str(_METADATA_VERSION - 1),
+            )
+            meta_path = os.path.join(
+                subdir, key_str + _DATA_FILE_SUFFIX + _METADATA_FILE_SUFFIX
+            )
+            with open(meta_path, "wb") as f:
+                f.write(metadata_bytes)
+
+            backend = self._make_backend(path, "cuda:0", async_loop)
+            try:
+                time.sleep(1)  # let the startup scan run
+                assert not backend.contains(key), (
+                    "Old-version GDS entries must be rejected, not served"
+                )
+            finally:
+                backend.close()
+        finally:
+            shutil.rmtree(path, ignore_errors=True)
 
     def test_try_to_read_metadata_finds_across_all_paths(self, async_loop):
         """contains() fallback finds metadata on a non-affinity path.
@@ -915,7 +956,7 @@ class TestGdsMultiPath:
             metadata_bytes = pack_metadata(
                 dummy_tensor,
                 fmt=MemoryFormat.KV_2LTD,
-                lmcache_version="1",
+                lmcache_version=str(_METADATA_VERSION),
             )
             meta_path = os.path.join(
                 subdir,

--- a/tests/v1/test_gds.py
+++ b/tests/v1/test_gds.py
@@ -2,6 +2,7 @@
 # Standard
 from pathlib import Path
 import asyncio
+import json
 import os
 import shutil
 import tempfile
@@ -49,6 +50,34 @@ def test_gds_backend_metadata():
                 assert size == tensor.size()
                 assert dtype == tensor.dtype
                 assert expected_nbytes == nbytes
+
+
+def test_gds_metadata_cached_positions_roundtrip():
+    # cached_positions can be successfully restored
+    # after a pack/unpack round trip so that
+    # position-dependent reuse
+    # (e.g. CacheBlend RoPE re-positioning) works.
+    tensor = torch.randn(2, 8)
+    positions = torch.arange(5, 13, dtype=torch.long)
+    packed = pack_metadata(
+        tensor,
+        fmt=MemoryFormat.KV_2LTD,
+        cached_positions=positions,
+        lmcache_version="1",
+    )
+    _, _, _, _, extra = unpack_metadata(packed)
+    assert "cached_positions" in extra
+    decoded = torch.tensor(json.loads(extra["cached_positions"]), dtype=torch.long)
+    assert torch.equal(decoded, positions)
+
+
+def test_gds_metadata_without_cached_positions_is_backward_compatible():
+    # Files written before cached_positions existed simply omit the key;
+    # they must still pack/unpack and decode to "no positions".
+    tensor = torch.randn(2, 8)
+    packed = pack_metadata(tensor, fmt=MemoryFormat.KV_2LTD, lmcache_version="1")
+    _, _, _, _, extra = unpack_metadata(packed)
+    assert "cached_positions" not in extra
 
 
 @pytest.mark.skip(reason="We need to add this test back after implementing prefetch")

--- a/tests/v1/test_gds.py
+++ b/tests/v1/test_gds.py
@@ -63,7 +63,6 @@ def test_gds_metadata_cached_positions_roundtrip():
         tensor,
         fmt=MemoryFormat.KV_2LTD,
         cached_positions=positions,
-        lmcache_version="1",
     )
     _, _, _, _, extra = unpack_metadata(packed)
     assert "cached_positions" in extra
@@ -71,11 +70,11 @@ def test_gds_metadata_cached_positions_roundtrip():
     assert torch.equal(decoded, positions)
 
 
-def test_gds_metadata_without_cached_positions_is_backward_compatible():
-    # Files written before cached_positions existed simply omit the key;
-    # they must still pack/unpack and decode to "no positions".
+def test_gds_metadata_without_cached_positions_omits_key():
+    # When position caching is off, no positions are passed and the key is
+    # simply omitted (it decodes back to None on read).
     tensor = torch.randn(2, 8)
-    packed = pack_metadata(tensor, fmt=MemoryFormat.KV_2LTD, lmcache_version="1")
+    packed = pack_metadata(tensor, fmt=MemoryFormat.KV_2LTD)
     _, _, _, _, extra = unpack_metadata(packed)
     assert "cached_positions" not in extra
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now in gpu_connector the `cache_positions` flag is hardcoded to True always, but the GDS
  backend doesn't support it.

Support `cached_positions` in the GDS backend, same as all other storage backends.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
