### PR TITLE
Add raw-block payload checksum validation

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -42,6 +42,7 @@ from lmcache.v1.storage_backend.raw_block import (
     RawBlockCoreConfig,
     decode_object_key,
     encode_object_key,
+    normalize_raw_block_consistency_level,
     normalize_raw_block_io_engine,
     validate_raw_block_io_options,
 )
@@ -82,6 +83,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         meta_enable_periodic: bool = True,
         load_checkpoint_on_init: bool = True,
         meta_verify_on_load: bool = True,
+        consistency_level: str = "default",
         enable_zero_copy: bool = True,
         io_engine: str = "posix",
         iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH,
@@ -106,6 +108,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_enable_periodic: Whether to run the checkpoint thread.
             load_checkpoint_on_init: Whether to load existing checkpoint metadata.
             meta_verify_on_load: Whether recovery verifies slot headers.
+            consistency_level: Slot validation level: ``"default"`` or
+                ``"payload_checksum"``.
             enable_zero_copy: Whether to use aligned direct-buffer I/O.
             io_engine: Raw-block I/O engine: ``"posix"`` or ``"io_uring"``.
             iouring_queue_depth: Queue depth for the Rust io_uring engine.
@@ -128,6 +132,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         self.meta_enable_periodic = bool(meta_enable_periodic)
         self.load_checkpoint_on_init = bool(load_checkpoint_on_init)
         self.meta_verify_on_load = bool(meta_verify_on_load)
+        self.consistency_level = normalize_raw_block_consistency_level(
+            consistency_level
+        )
         self.enable_zero_copy = bool(enable_zero_copy)
         self.io_engine = normalize_raw_block_io_engine(io_engine)
         self.iouring_queue_depth = int(iouring_queue_depth)
@@ -163,6 +170,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             d.get("io_engine"),
             use_iouring=d.get("use_iouring"),
             use_uring=d.get("use_uring"),
+        )
+        consistency_level = normalize_raw_block_consistency_level(
+            d.get("consistency_level")
         )
         iouring_queue_depth = int(
             d.get("iouring_queue_depth", DEFAULT_IOURING_QUEUE_DEPTH)
@@ -211,6 +221,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_enable_periodic=bool(d.get("meta_enable_periodic", True)),
             load_checkpoint_on_init=bool(d.get("load_checkpoint_on_init", True)),
             meta_verify_on_load=bool(d.get("meta_verify_on_load", True)),
+            consistency_level=consistency_level,
             enable_zero_copy=bool(d.get("enable_zero_copy", True)),
             io_engine=io_engine,
             iouring_queue_depth=iouring_queue_depth,
@@ -245,6 +256,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "on startup (default true)\n"
             "- meta_verify_on_load (bool): validate slot headers on recovery "
             "(default true)\n"
+            '- consistency_level (str): "default" or "payload_checksum" slot '
+            "validation on recovery (default default)\n"
             "- enable_zero_copy (bool): use aligned direct buffers when possible "
             "(default true)\n"
             "- io_engine (str): posix or io_uring (default posix)\n"
@@ -273,6 +286,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_enable_periodic=self.meta_enable_periodic,
             load_checkpoint_on_init=self.load_checkpoint_on_init,
             meta_verify_on_load=self.meta_verify_on_load,
+            consistency_level=self.consistency_level,
             io_engine=self.io_engine,
             iouring_queue_depth=self.iouring_queue_depth,
         )

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -26,6 +26,7 @@ from lmcache.v1.storage_backend.raw_block import (
     RawBlockKeySpec,
     decode_legacy_key,
     encode_legacy_key,
+    normalize_raw_block_consistency_level,
     normalize_raw_block_io_engine,
     round_up,
     validate_raw_block_io_options,
@@ -227,6 +228,9 @@ class RustRawBlockBackend(StoragePluginInterface):
         iouring_queue_depth = int(
             extra.get("rust_raw_block.iouring_queue_depth", DEFAULT_IOURING_QUEUE_DEPTH)
         )
+        consistency_level = normalize_raw_block_consistency_level(
+            extra.get("rust_raw_block.consistency_level")
+        )
         validate_raw_block_io_options(
             iouring_queue_depth=iouring_queue_depth,
         )
@@ -285,6 +289,7 @@ class RustRawBlockBackend(StoragePluginInterface):
             meta_verify_on_load=bool(
                 extra.get("rust_raw_block.meta_verify_on_load", True)
             ),
+            consistency_level=consistency_level,
             io_engine=io_engine,
             iouring_queue_depth=iouring_queue_depth,
         )

--- a/lmcache/v1/storage_backend/raw_block/__init__.py
+++ b/lmcache/v1/storage_backend/raw_block/__init__.py
@@ -4,9 +4,11 @@
 from lmcache.v1.storage_backend.raw_block.core import (
     DEFAULT_IOURING_QUEUE_DEPTH,
     RAW_BLOCK_IO_ENGINES,
+    RawBlockConsistencyLevel,
     RawBlockCore,
     RawBlockCoreConfig,
     RawBlockPutManyResult,
+    normalize_raw_block_consistency_level,
     normalize_raw_block_io_engine,
     round_up,
     validate_raw_block_io_options,
@@ -25,6 +27,7 @@ from lmcache.v1.storage_backend.raw_block.key_codec import (
 __all__ = [
     "RawBlockCore",
     "RawBlockCoreConfig",
+    "RawBlockConsistencyLevel",
     "RAW_BLOCK_IO_ENGINES",
     "DEFAULT_IOURING_QUEUE_DEPTH",
     "RawBlockKeyNamespace",
@@ -35,6 +38,7 @@ __all__ = [
     "encode_legacy_key",
     "encode_object_key",
     "object_key_to_string",
+    "normalize_raw_block_consistency_level",
     "normalize_raw_block_io_engine",
     "round_up",
     "slot_identity_from_encoded_key",

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Standard
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Literal, Optional, cast
 import ctypes
 import json
 import struct
@@ -16,6 +16,7 @@ import zlib
 
 # Third Party
 import torch
+import xxhash
 
 # First Party
 from lmcache.logging import init_logger
@@ -38,8 +39,12 @@ logger = init_logger(__name__)
 _DEFAULT_META_MAGIC = b"LMCIDX01"
 _DEFAULT_META_VERSION = 1
 _META_HEADER_STRUCT = struct.Struct("<8sIQQI")
+_SLOT_HEADER_MAGIC_V1 = b"LMCBLK01"
+_SLOT_HEADER_MAGIC_V2 = b"LMCBLK02"
 RAW_BLOCK_IO_ENGINES = frozenset({"posix", "io_uring"})
 DEFAULT_IOURING_QUEUE_DEPTH = 256
+RAW_BLOCK_CONSISTENCY_LEVELS = frozenset({"default", "payload_checksum"})
+RawBlockConsistencyLevel = Literal["default", "payload_checksum"]
 
 
 def round_up(x: int, align: int) -> int:
@@ -104,6 +109,19 @@ def validate_raw_block_io_options(
         raise ValueError("iouring_queue_depth must be > 0")
 
 
+def normalize_raw_block_consistency_level(
+    level: Any = None,
+) -> RawBlockConsistencyLevel:
+    """Normalize the raw-block slot consistency level."""
+    if level is None or level == "":
+        return "default"
+    normalized = str(level).lower()
+    if normalized not in RAW_BLOCK_CONSISTENCY_LEVELS:
+        allowed = ", ".join(sorted(RAW_BLOCK_CONSISTENCY_LEVELS))
+        raise ValueError(f"consistency_level must be one of: {allowed}")
+    return cast(RawBlockConsistencyLevel, normalized)
+
+
 @dataclass(frozen=True)
 class RawBlockCoreConfig:
     """Configuration for RawBlockCore device layout, I/O, and checkpoints."""
@@ -122,6 +140,7 @@ class RawBlockCoreConfig:
     meta_idle_quiet_ms: int
     meta_enable_periodic: bool
     meta_verify_on_load: bool
+    consistency_level: RawBlockConsistencyLevel = "default"
     load_checkpoint_on_init: bool = True
     io_engine: str = "posix"
     iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH
@@ -132,6 +151,8 @@ class _Entry:
     offset: int
     size: int
     meta: DiskCacheMetadata
+    payload_checksum: Optional[int] = None
+    checksum_verified: bool = True
 
 
 @dataclass
@@ -147,6 +168,17 @@ class RawBlockPutManyResult:
 
     results: list[bool]
     stored_keys: list[str]
+
+
+@dataclass(frozen=True)
+class _PreparedWrite:
+    """Prepared raw-block payload and header for one slot write."""
+
+    header: bytes
+    buf: Any
+    payload_len: int
+    total_len: int
+    payload_checksum: Optional[int]
 
 
 class RawBlockCore:
@@ -195,16 +227,28 @@ class RawBlockCore:
         self.meta_enable_periodic = bool(config.meta_enable_periodic)
         self.load_checkpoint_on_init = bool(config.load_checkpoint_on_init)
         self.meta_verify_on_load = bool(config.meta_verify_on_load)
+        self.consistency_level = normalize_raw_block_consistency_level(
+            config.consistency_level
+        )
         self.io_engine = normalize_raw_block_io_engine(config.io_engine)
         self.iouring_queue_depth = int(config.iouring_queue_depth)
         self.key_namespace = key_namespace
 
         if not self.device_path:
             raise ValueError("RawBlockCore requires a non-empty device_path")
+        if (
+            self.consistency_level == "payload_checksum"
+            and not self.meta_verify_on_load
+        ):
+            raise ValueError(
+                "meta_verify_on_load must be true when consistency_level is "
+                '"payload_checksum"'
+            )
         if self.block_align <= 0:
             raise ValueError("block_align must be > 0")
-        if self.header_bytes < 24:
-            raise ValueError("header_bytes must be >= 24")
+        min_header_bytes = 32 if self.consistency_level == "payload_checksum" else 24
+        if self.header_bytes < min_header_bytes:
+            raise ValueError(f"header_bytes must be >= {min_header_bytes}")
         if self.header_bytes % self.block_align != 0:
             raise ValueError("header_bytes must be a multiple of block_align")
         if self.slot_bytes < self.header_bytes + 1:
@@ -491,14 +535,14 @@ class RawBlockCore:
                 )
                 self._inflight[key.encoded] = _Inflight(offset=offset, meta=meta)
 
-            success = self._write_one(key, obj, offset)
+            prepared = self._write_one(key, obj, offset)
 
             with self._lock:
                 inflight = self._inflight.pop(key.encoded, None)
                 if inflight is None:
                     results[i] = False
                     continue
-                if inflight.canceled or not success:
+                if inflight.canceled or prepared is None:
                     self._append_free_slot_locked(
                         self._offset_to_slot(int(inflight.offset))
                     )
@@ -510,6 +554,8 @@ class RawBlockCore:
                     offset=inflight.offset,
                     size=inflight.meta.size,
                     meta=inflight.meta,
+                    payload_checksum=prepared.payload_checksum,
+                    checksum_verified=True,
                 )
                 self._meta_dirty_total += 1
                 results[i] = True
@@ -578,15 +624,15 @@ class RawBlockCore:
 
         with self._lock:
             items = [
-                (encoded_key, self._index.get(encoded_key))
-                for encoded_key in encoded_keys
+                (i, encoded_key, self._index.get(encoded_key))
+                for i, encoded_key in enumerate(encoded_keys)
             ]
             self._inflight_io_count += 1
 
         results = [False] * len(encoded_keys)
         try:
             raw_dev = self._rawdev()
-            for i, (encoded_key, entry) in enumerate(items):
+            for i, encoded_key, entry in items:
                 if entry is None:
                     continue
                 try:
@@ -596,33 +642,49 @@ class RawBlockCore:
                         if self.use_odirect
                         else payload_len
                     )
-                    buf = memoryview(objs[i].byte_array)
-                    try:
-                        buf = buf.cast("B")
-                    except Exception:
-                        pass
-
-                    direct_view = self._build_direct_odirect_view(
-                        memory_obj=objs[i],
-                        payload_len=payload_len,
-                        total_len=total_len,
-                        buffer_len=len(buf),
-                        zero_tail=False,
-                    )
-                    if direct_view is not None:
-                        raw_dev.pread_into(
-                            entry.offset + self.header_bytes,
-                            direct_view,
-                            total_len if len(direct_view) >= total_len else payload_len,
-                            total_len,
-                        )
-                    else:
-                        raw_dev.pread_into(
-                            entry.offset + self.header_bytes,
-                            buf,
+                    if (
+                        self.consistency_level == "payload_checksum"
+                        and not entry.checksum_verified
+                    ):
+                        if not self._load_with_checksum_verification(
+                            raw_dev,
+                            encoded_key,
+                            entry,
+                            objs[i],
                             payload_len,
                             total_len,
+                        ):
+                            continue
+                    else:
+                        buf = memoryview(objs[i].byte_array)
+                        try:
+                            buf = buf.cast("B")
+                        except Exception:
+                            pass
+
+                        direct_view = self._build_direct_odirect_view(
+                            memory_obj=objs[i],
+                            payload_len=payload_len,
+                            total_len=total_len,
+                            buffer_len=len(buf),
+                            zero_tail=False,
                         )
+                        if direct_view is not None:
+                            raw_dev.pread_into(
+                                entry.offset + self.header_bytes,
+                                direct_view,
+                                total_len
+                                if len(direct_view) >= total_len
+                                else payload_len,
+                                total_len,
+                            )
+                        else:
+                            raw_dev.pread_into(
+                                entry.offset + self.header_bytes,
+                                buf,
+                                payload_len,
+                                total_len,
+                            )
                     objs[i].metadata.cached_positions = entry.meta.cached_positions
                     results[i] = True
                 except Exception as e:
@@ -895,9 +957,31 @@ class RawBlockCore:
                 buf = direct_view
         return buf, payload_len, total_len
 
+    def _prepare_write(
+        self,
+        slot_identity: int,
+        buf: Any,
+        payload_len: int,
+        total_len: int,
+    ) -> _PreparedWrite:
+        """Prepare header metadata for one raw-block write around a payload buffer."""
+        payload_checksum = self._compute_payload_checksum_for_header(buf, payload_len)
+        header = self._encode_header(
+            slot_identity,
+            payload_len,
+            payload_checksum,
+        )
+        return _PreparedWrite(
+            header=header,
+            buf=buf,
+            payload_len=payload_len,
+            total_len=total_len,
+            payload_checksum=payload_checksum,
+        )
+
     def _write_one(
         self, key: RawBlockKeySpec, memory_obj: MemoryObj, offset: int
-    ) -> bool:
+    ) -> Optional[_PreparedWrite]:
         """Write one object header and payload into a raw-block slot.
 
         Args:
@@ -906,58 +990,97 @@ class RawBlockCore:
             offset: Slot byte offset on the raw device.
 
         Returns:
-            True when both header and payload writes complete; false otherwise.
+            Prepared write metadata when both header and payload writes complete;
+            otherwise None.
         """
         try:
-            header = self._encode_header(key.slot_identity, len(memory_obj.byte_array))
             buf, payload_len, total_len = self._prepare_write_payload(memory_obj)
+            prepared = self._prepare_write(
+                key.slot_identity,
+                buf,
+                payload_len,
+                total_len,
+            )
 
             with self._lock:
                 self._inflight_io_count += 1
             try:
                 raw_dev = self._rawdev()
                 hdr_total = (
-                    round_up(len(header), self.block_align)
+                    round_up(len(prepared.header), self.block_align)
                     if self.use_odirect
-                    else len(header)
+                    else len(prepared.header)
                 )
-                raw_dev.pwrite_from_buffer(offset, header, len(header), hdr_total)
+                raw_dev.pwrite_from_buffer(
+                    offset,
+                    prepared.header,
+                    len(prepared.header),
+                    hdr_total,
+                )
                 raw_dev.pwrite_from_buffer(
                     offset + self.header_bytes,
-                    buf,
-                    payload_len,
-                    total_len,
+                    prepared.buf,
+                    prepared.payload_len,
+                    prepared.total_len,
                 )
             finally:
                 with self._lock:
                     self._inflight_io_count -= 1
                     self._last_io_ts = time.monotonic()
-            return True
+            return prepared
         except Exception as e:
             logger.error("RawBlockCore write failed for %s: %s", key.encoded, e)
-            return False
+            return None
 
-    def _encode_header(self, slot_identity: int, payload_len: int) -> bytes:
+    def _encode_header(
+        self,
+        slot_identity: int,
+        payload_len: int,
+        payload_checksum: Optional[int],
+    ) -> bytes:
         """Encode a fixed-size raw-block slot header."""
         hdr = bytearray(self.header_bytes)
-        hdr[0:8] = b"LMCBLK01"
+        if self.consistency_level == "payload_checksum":
+            hdr[0:8] = _SLOT_HEADER_MAGIC_V2
+        else:
+            hdr[0:8] = _SLOT_HEADER_MAGIC_V1
         hdr[8:16] = int(slot_identity & ((1 << 64) - 1)).to_bytes(
             8,
             "little",
             signed=False,
         )
         hdr[16:24] = int(payload_len).to_bytes(8, "little", signed=False)
+        if payload_checksum is not None:
+            hdr[24:32] = int(payload_checksum & ((1 << 64) - 1)).to_bytes(
+                8,
+                "little",
+                signed=False,
+            )
         return bytes(hdr)
 
-    def _decode_slot_header(self, hdr: bytes) -> Optional[tuple[int, int]]:
-        """Decode a raw-block slot header into identity and payload length."""
-        if len(hdr) < 24 or hdr[0:8] != b"LMCBLK01":
+    def _decode_slot_header(
+        self, hdr: bytes
+    ) -> Optional[tuple[int, int, Optional[int]]]:
+        """Decode a raw-block slot header into identity,
+        payload length, and checksum.
+        """
+        if len(hdr) < 24:
+            return None
+        magic = hdr[0:8]
+        if magic not in (_SLOT_HEADER_MAGIC_V1, _SLOT_HEADER_MAGIC_V2):
             return None
         slot_identity = int.from_bytes(hdr[8:16], "little", signed=False)
         payload_len = int.from_bytes(hdr[16:24], "little", signed=False)
-        return slot_identity, payload_len
+        if magic == _SLOT_HEADER_MAGIC_V1:
+            return slot_identity, payload_len, None
+        if len(hdr) < 32:
+            return None
+        payload_checksum = int.from_bytes(hdr[24:32], "little", signed=False)
+        return slot_identity, payload_len, payload_checksum
 
-    def _read_slot_header(self, offset: int) -> Optional[tuple[int, int]]:
+    def _read_slot_header(
+        self, offset: int
+    ) -> Optional[tuple[int, int, Optional[int]]]:
         """Read and decode the slot header at a raw-device offset."""
         buf = bytearray(self.header_bytes)
         try:
@@ -971,6 +1094,81 @@ class RawBlockCore:
             with self._lock:
                 self._inflight_io_count -= 1
                 self._last_io_ts = time.monotonic()
+
+    def _load_with_checksum_verification(
+        self,
+        raw_dev: Any,
+        encoded_key: str,
+        entry: _Entry,
+        dst_obj: MemoryObj,
+        payload_len: int,
+        total_len: int,
+    ) -> bool:
+        """
+        Load a recovered payload directly into the destination
+        and verify checksum.
+        """
+        if entry.payload_checksum is None:
+            self._drop_entry_after_checksum_mismatch(encoded_key, entry.offset)
+            return False
+
+        buf = memoryview(dst_obj.byte_array)
+        try:
+            buf = buf.cast("B")
+        except Exception:
+            pass
+
+        direct_view = self._build_direct_odirect_view(
+            memory_obj=dst_obj,
+            payload_len=payload_len,
+            total_len=total_len,
+            buffer_len=len(buf),
+            zero_tail=False,
+        )
+        checksum_view = direct_view if direct_view is not None else buf
+        raw_dev.pread_into(
+            entry.offset + self.header_bytes,
+            checksum_view,
+            total_len if len(checksum_view) >= total_len else payload_len,
+            total_len,
+        )
+        actual_checksum = xxhash.xxh3_64(
+            memoryview(checksum_view)[:payload_len]
+        ).intdigest()
+        if int(actual_checksum) != int(entry.payload_checksum):
+            logger.warning(
+                "RawBlockCore checksum mismatch for %s; dropping recovered entry",
+                encoded_key,
+            )
+            self._drop_entry_after_checksum_mismatch(encoded_key, entry.offset)
+            return False
+
+        with self._lock:
+            current_entry = self._index.get(encoded_key)
+            if current_entry is not None and int(current_entry.offset) == int(
+                entry.offset
+            ):
+                current_entry.checksum_verified = True
+        return True
+
+    def _drop_entry_after_checksum_mismatch(
+        self, encoded_key: str, offset: int
+    ) -> None:
+        """Remove one invalid recovered entry and return its slot to the free list."""
+        with self._lock:
+            removed_entry = self._index.pop(encoded_key, None)
+            self._lock_refcnt.pop(encoded_key, None)
+            if removed_entry is not None:
+                self._append_free_slot_locked(self._offset_to_slot(int(offset)))
+                self._meta_dirty_total += 1
+
+    def _compute_payload_checksum_for_header(
+        self, buf: Any, payload_len: int
+    ) -> Optional[int]:
+        """Return the payload checksum only when the consistency level requires it."""
+        if self.consistency_level != "payload_checksum":
+            return None
+        return xxhash.xxh3_64(memoryview(buf)[:payload_len]).intdigest()
 
     def _ensure_capacity_and_layout(self) -> None:
         """Open the device if needed and compute metadata/data layout."""
@@ -1113,6 +1311,7 @@ class RawBlockCore:
                 "meta_total_bytes": self.meta_total_bytes,
                 "meta_magic": self.meta_magic_text,
                 "meta_version": self.meta_version,
+                "consistency_level": self.consistency_level,
                 "data_base_offset": self._data_base_offset,
                 "next_slot": self._next_slot,
                 "free_slots": list(self._free_slots),
@@ -1253,6 +1452,17 @@ class RawBlockCore:
             return False
         if int(data.get("meta_version", self.meta_version)) != self.meta_version:
             logger.warning("Device metadata meta_version mismatch; ignoring metadata")
+            return False
+        checkpoint_consistency_level = normalize_raw_block_consistency_level(
+            data.get("consistency_level")
+        )
+        if checkpoint_consistency_level != self.consistency_level:
+            logger.warning(
+                "Device metadata consistency_level mismatch; "
+                "checkpoint=%s current=%s; ignoring metadata",
+                checkpoint_consistency_level,
+                self.consistency_level,
+            )
             return False
 
         try:
@@ -1415,6 +1625,7 @@ class RawBlockCore:
             if slot_hdr is None:
                 to_drop.append(encoded_key)
                 continue
+            slot_identity, payload_len, payload_checksum = slot_hdr
             try:
                 expected_identity = slot_identity_from_encoded_key(
                     encoded_key,
@@ -1423,12 +1634,27 @@ class RawBlockCore:
             except Exception:
                 to_drop.append(encoded_key)
                 continue
-            slot_identity, payload_len = slot_hdr
             if int(slot_identity) != int(expected_identity):
                 to_drop.append(encoded_key)
                 continue
             if int(payload_len) != int(entry.size):
                 to_drop.append(encoded_key)
+                continue
+            if (
+                self.consistency_level == "payload_checksum"
+                and payload_checksum is None
+            ):
+                to_drop.append(encoded_key)
+                continue
+            with self._lock:
+                current_entry = self._index.get(encoded_key)
+                if current_entry is not None and int(current_entry.offset) == int(
+                    entry.offset
+                ):
+                    current_entry.payload_checksum = payload_checksum
+                    current_entry.checksum_verified = (
+                        self.consistency_level != "payload_checksum"
+                    )
 
         if not to_drop:
             return

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -40,4 +40,5 @@ sortedcontainers
 torch
 transformers >= 5.4
 uvicorn
+xxhash
 httptools

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -22,6 +22,7 @@ import torch
 # First Party
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.memory_management import (
     AdHocMemoryAllocator,
     MemoryFormat,
@@ -36,9 +37,11 @@ from lmcache.v1.storage_backend.plugins.rust_raw_block_backend import (
     RustRawBlockBackend,
 )
 from lmcache.v1.storage_backend.raw_block import (
+    RawBlockConsistencyLevel,
     RawBlockCore,
     RawBlockCoreConfig,
     RawBlockKeySpec,
+    encode_object_key,
 )
 
 
@@ -84,7 +87,11 @@ def _install_fake_raw_block_device(monkeypatch, *, size_bytes: int = 64 * 1024):
     )
 
 
-def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
+def _make_raw_block_core(
+    *,
+    use_odirect: bool = False,
+    consistency_level: RawBlockConsistencyLevel = "default",
+) -> RawBlockCore:
     return RawBlockCore(
         RawBlockCoreConfig(
             device_path="/tmp/raw-block-boundary-test",
@@ -100,12 +107,24 @@ def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
             meta_checkpoint_interval_sec=60,
             meta_idle_quiet_ms=100,
             meta_enable_periodic=False,
+            consistency_level=consistency_level,
             load_checkpoint_on_init=True,
             meta_verify_on_load=True,
             io_engine="posix",
             iouring_queue_depth=256,
         ),
         key_namespace="object",
+    )
+
+
+def _make_object_key_spec(seed: int) -> RawBlockKeySpec:
+    return encode_object_key(
+        ObjectKey(
+            chunk_hash=bytes([seed]) * 32,
+            model_name="raw-block-test",
+            kv_rank=0,
+            cache_salt="",
+        )
     )
 
 
@@ -227,6 +246,182 @@ def test_raw_block_core_odirect_prepare_payload_boundaries(monkeypatch):
 
         with pytest.raises(RuntimeError, match="slot capacity"):
             core._prepare_write_payload(_make_byte_obj(payload_capacity + 1))
+    finally:
+        core.close()
+
+
+def test_raw_block_core_payload_checksum_consistency_stores_checksum(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=False, consistency_level="payload_checksum")
+    try:
+        key = _make_object_key_spec(11)
+        payload = _make_byte_obj(64)
+        payload.tensor.fill_(7)
+
+        result = core.put_many([key], [payload])
+        assert result.results == [True]
+
+        entry = core._index[key.encoded]
+        slot_hdr = core._read_slot_header(int(entry.offset))
+        assert slot_hdr is not None
+        _, payload_len, payload_checksum = slot_hdr
+        assert payload_len == 64
+        assert payload_checksum is not None
+    finally:
+        core.close()
+
+
+def test_raw_block_core_payload_checksum_validation_accepts_matching_payload(
+    monkeypatch,
+):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=False, consistency_level="payload_checksum")
+    try:
+        key = _make_object_key_spec(14)
+        payload = _make_byte_obj(64)
+        payload.tensor.fill_(5)
+
+        result = core.put_many([key], [payload])
+        assert result.results == [True]
+        assert core.contains_key(key.encoded) is True
+
+        core._validate_loaded_entries()
+
+        dst = _make_byte_obj(64)
+        loaded = core.load_many_into([key.encoded], [dst])
+        assert loaded == [True]
+        assert core.contains_key(key.encoded) is True
+    finally:
+        core.close()
+
+
+def test_raw_block_core_payload_checksum_drops_mismatch_on_first_read(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=False, consistency_level="payload_checksum")
+    try:
+        key = _make_object_key_spec(15)
+        payload = _make_byte_obj(64)
+        payload.tensor.fill_(9)
+
+        result = core.put_many([key], [payload])
+        assert result.results == [True]
+
+        core._validate_loaded_entries()
+        entry = core._index[key.encoded]
+        raw = core._rawdev()
+        raw.pwrite_from_buffer(entry.offset + core.header_bytes, b"\xaa" * 64, 64, 64)
+
+        dst = _make_byte_obj(64)
+        loaded = core.load_many_into([key.encoded], [dst])
+        assert loaded == [False]
+        assert core.contains_key(key.encoded) is False
+    finally:
+        core.close()
+
+
+def test_raw_block_core_payload_checksum_requires_32_byte_header(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    with pytest.raises(ValueError, match="header_bytes must be >= 32"):
+        RawBlockCore(
+            RawBlockCoreConfig(
+                device_path="/tmp/raw-block-boundary-test",
+                capacity_bytes=64 * 1024,
+                block_align=8,
+                header_bytes=24,
+                slot_bytes=4096,
+                use_odirect=False,
+                enable_zero_copy=True,
+                meta_total_bytes=16 * 1024,
+                meta_magic=b"LMCIDX01",
+                meta_version=1,
+                meta_checkpoint_interval_sec=60,
+                meta_idle_quiet_ms=100,
+                meta_enable_periodic=False,
+                consistency_level="payload_checksum",
+                load_checkpoint_on_init=True,
+                meta_verify_on_load=True,
+                io_engine="posix",
+                iouring_queue_depth=256,
+            ),
+            key_namespace="object",
+        )
+
+
+def test_raw_block_core_payload_checksum_requires_meta_verify_on_load(
+    monkeypatch,
+):
+    _install_fake_raw_block_device(monkeypatch)
+    with pytest.raises(ValueError, match="meta_verify_on_load must be true"):
+        RawBlockCore(
+            RawBlockCoreConfig(
+                device_path="/tmp/raw-block-boundary-test",
+                capacity_bytes=64 * 1024,
+                block_align=4096,
+                header_bytes=4096,
+                slot_bytes=8192,
+                use_odirect=False,
+                enable_zero_copy=True,
+                meta_total_bytes=16 * 1024,
+                meta_magic=b"LMCIDX01",
+                meta_version=1,
+                meta_checkpoint_interval_sec=60,
+                meta_idle_quiet_ms=100,
+                meta_enable_periodic=False,
+                consistency_level="payload_checksum",
+                load_checkpoint_on_init=True,
+                meta_verify_on_load=False,
+                io_engine="posix",
+                iouring_queue_depth=256,
+            ),
+            key_namespace="object",
+        )
+
+
+def test_raw_block_core_validate_loaded_entries_accepts_legacy_slot_header(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=False)
+    try:
+        key = _make_object_key_spec(12)
+        payload = _make_byte_obj(64)
+        payload.tensor.fill_(3)
+
+        result = core.put_many([key], [payload])
+        assert result.results == [True]
+        assert core.contains_key(key.encoded) is True
+
+        entry = core._index[key.encoded]
+        legacy_header = bytearray(core.header_bytes)
+        legacy_header[0:8] = b"LMCBLK01"
+        legacy_header[8:16] = int(key.slot_identity).to_bytes(8, "little", signed=False)
+        legacy_header[16:24] = int(entry.size).to_bytes(8, "little", signed=False)
+        raw = core._rawdev()
+        raw.pwrite_from_buffer(
+            entry.offset, legacy_header, len(legacy_header), len(legacy_header)
+        )
+        raw.pwrite_from_buffer(entry.offset + core.header_bytes, b"\xbb" * 64, 64, 64)
+
+        core._validate_loaded_entries()
+
+        assert core.contains_key(key.encoded) is True
+    finally:
+        core.close()
+
+
+def test_raw_block_core_default_consistency_uses_legacy_slot_header(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=False, consistency_level="default")
+    try:
+        key = _make_object_key_spec(13)
+        payload = _make_byte_obj(64)
+
+        result = core.put_many([key], [payload])
+        assert result.results == [True]
+
+        entry = core._index[key.encoded]
+        slot_hdr = core._read_slot_header(int(entry.offset))
+        assert slot_hdr is not None
+        _, _, payload_checksum = slot_hdr
+        assert payload_checksum is None
     finally:
         core.close()
 
@@ -1552,6 +1747,34 @@ def test_rust_raw_block_backend_recovers_legacy_key_dtype(
             assert loaded[0].metadata.dtype is torch.bfloat16
         finally:
             backend.close()
+
+
+def test_raw_block_core_rejects_checkpoint_consistency_level_mismatch(monkeypatch):
+    _install_fake_raw_block_device(monkeypatch)
+    core = _make_raw_block_core(use_odirect=False, consistency_level="payload_checksum")
+    try:
+        applied = core.apply_loaded_state(
+            {
+                "version": 1,
+                "device_path": core.device_path,
+                "capacity_bytes": core.capacity_bytes,
+                "block_align": core.block_align,
+                "header_bytes": core.header_bytes,
+                "slot_bytes": core.slot_bytes,
+                "meta_total_bytes": core.meta_total_bytes,
+                "meta_magic": core.meta_magic_text,
+                "meta_version": core.meta_version,
+                "consistency_level": "default",
+                "data_base_offset": core.data_base_offset,
+                "next_slot": 0,
+                "free_slots": [],
+                "entries": {},
+            }
+        )
+
+        assert applied is False
+    finally:
+        core.close()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds an optional `payload_checksum` consistency mode for the raw-block backend.

In the default mode, recovery validates only `slot_identity` and `payload_len` from the slot header, which does not detect stale or partially written payload contents after restart. 
In `payload_checksum` mode, raw-block additionally stores a payload checksum in the slot header and verifies recovered entries on the first read after recovery.

The current implementation uses `xxh3_64` as a lightweight integrity check while keeping the write path and on-device metadata format simple. 
The implementation intentionally keeps a single checksum per KV chunk because the goal is lightweight validation of recovered entries rather than a more complex chunk-based integrity or recovery mechanism.

The hash choice itself is not fixed, and the design remains open to adopting different hashes in the future if needed for different performance or reliability tradeoffs.

This PR also makes rollout behavior explicit by storing `consistency_level` in checkpoint metadata and rejecting recovery when the stored consistency level does not match the current configuration.


**Special notes for your reviewers**:

`payload_checksum` focuses on recovery-time validation of recovered entries, not continuous checksum verification on every read.

Key implementation choices:

- Supported consistency levels are `default` and `payload_checksum`.
- `payload_checksum` stores a payload checksum in the slot header.
- Recovery avoids full payload scans during startup and instead validates recovered entries lazily on the first read.
- On checksum mismatch, the recovered entry is dropped and treated as a cache miss.
- `payload_checksum` requires `meta_verify_on_load=True`, because header validation is responsible for loading checksum metadata into recovered entries.
- Checkpoint recovery is rejected if the stored `consistency_level` differs from the current configuration.
- The current implementation uses `xxh3_64`, but the design remains open to alternative hash implementations in the future.

Performance observations:

| Consistency Model | Backend | Write (MB/sec) | Read (MB/sec) |
|---|---|---:|---:|
| default | posix | 9632.46 | 7792.64 |
| payload_checksum | posix | 9653.50 | 6944.27 |
| default | uring | 9721.88 | 13782.36 |
| payload_checksum | uring | 9663.00 | 13018.09 |

- Write throughput remains effectively unchanged despite the additional payload checksum computation.
- Read throughput shows some regression on the posix path due to recovery-time checksum validation on the first recovered read, while the io_uring backend appears to amortize the additional validation overhead more effectively.
- The current implementation performs lazy validation for all recovered entries. Future optimizations could selectively pre-validate hot or frequently accessed entries during startup to further reduce critical-path recovery overhead.


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
