### PR TITLE
Fix typos and misspellings across codebase

### DIFF
--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -45,7 +45,7 @@ logger = init_logger(__name__)
 
 """
 The kv controller use `(instance_id, worker_id)` -> [location -> set[chunk_hash]] 
-as kv_pool. When the the number of instance is small and stable, the time complexity 
+as kv_pool. When the number of instances is small and stable, the time complexity 
 of `lookup` in kv controller is O(n). If the number of instance is large or unknown, 
 the time complexity will degrade to O(n^2), and the ReverseIndexKVController is a 
 better choice.

--- a/lmcache/v1/cache_controller/executor.py
+++ b/lmcache/v1/cache_controller/executor.py
@@ -79,7 +79,7 @@ class LMCacheClusterExecutor:
                 )
             sockets.append(socket)
 
-            # TODO(Jiayi): Need a way to trak event_id -> worker_event_id mapping
+            # TODO(Jiayi): Need a way to track event_id -> worker_event_id mapping
             # Also, we need to track worker_event_id status
             worker_event_id = f"Worker{worker_id}{msg.event_id}"
             serialized_msg = msgspec.msgpack.encode(
@@ -128,7 +128,7 @@ class LMCacheClusterExecutor:
                 )
             sockets.append(socket)
 
-            # TODO(Jiayi): Need a way to trak event_id -> worker_event_id mapping
+            # TODO(Jiayi): Need a way to track event_id -> worker_event_id mapping
             # Also, we need to track worker_event_id status
             worker_event_id = f"Worker{worker_id}{msg.event_id}"
             serialized_msg = msgspec.msgpack.encode(

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1706,7 +1706,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
                 self.batched_free(allocated_blocks, update_stats=False)
                 return None
 
-            # FIXME: think about whether pareant_allocator
+            # FIXME: think about whether parent_allocator
             # should be updated here.
             free_block.meta.shape = shapes[0]
             free_block.meta.dtype = dtypes[0]

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -165,11 +165,11 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
         transfer_spec: Any = None,
     ) -> list[MemoryObj]:
         """
-        A non-blcocking function to get the kv cache from the storage backend.
+        A non-blocking function to get the kv cache from the storage backend.
 
         :param list[CacheEngineKey] keys: The keys of the list of MemoryObjs.
 
-        :return: a list of Memoryobjs.
+        :return: a list of MemoryObj.
         """
         raise NotImplementedError
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -235,7 +235,7 @@ class StorageManager:
         self.thread = threading.Thread(
             target=start_loop_in_thread_with_exceptions,
             args=(self.loop,),
-            name="storage-manger-event-loop",
+            name="storage-manager-event-loop",
         )
         self.thread.start()
 


### PR DESCRIPTION
## Summary

Fix several typos and misspellings found in the codebase.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `abstract_backend.py` | 168 | `non-blcocking` | `non-blocking` |
| `abstract_backend.py` | 172 | `Memoryobjs` | `MemoryObj` |
| `memory_management.py` | 1709 | `pareant_allocator` | `parent_allocator` |
| `storage_manager.py` | 238 | `storage-manger` | `storage-manager` |
| `executor.py` | 82, 131 | `trak` | `track` |
| `kv_controller.py` | 48 | `the the` / `instance` | `the` / `instances` |

## Test

All pre-commit hooks pass (codespell, ruff, mypy, etc.).