### PR TITLE
Improve code quality: simplify boolean return, replace assert, narrow exception

### DIFF
--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -265,10 +265,7 @@ def need_gpu_interm_buffer(lmcache_config: LMCacheEngineConfig):
     Check if the GPU Connector needs to create an intermediate
     buffer on the GPU
     """
-    if lmcache_config.enable_pd:
-        return False
-    else:
-        return True
+    return not lmcache_config.enable_pd
 
 
 def assert_layerwise_gpu_connector(gpu_connector: "GPUConnectorInterface"):

--- a/lmcache/v1/protocol.py
+++ b/lmcache/v1/protocol.py
@@ -92,7 +92,11 @@ def init_remote_metadata_info(num_groups: int):
 
 def get_remote_metadata_bytes():
     global REMOTE_METADATA_BYTES
-    assert REMOTE_METADATA_BYTES is not None
+    if REMOTE_METADATA_BYTES is None:
+        raise RuntimeError(
+            "REMOTE_METADATA_BYTES is not initialized. "
+            "Call init_remote_metadata_info() first."
+        )
     return REMOTE_METADATA_BYTES
 
 

--- a/lmcache/v1/storage_backend/connector/s3_connector.py
+++ b/lmcache/v1/storage_backend/connector/s3_connector.py
@@ -189,7 +189,7 @@ class S3Connector(RemoteConnector):
                 if name.lower() == "content-length":
                     try:
                         got["len"] = int(value)
-                    except Exception:
+                    except (ValueError, TypeError):
                         pass
 
         def on_done(error=None, **kwargs):
@@ -239,7 +239,7 @@ class S3Connector(RemoteConnector):
                 if name.lower() == "content-length":
                     try:
                         got["len"] = int(value)
-                    except Exception:
+                    except (ValueError, TypeError):
                         pass
 
         def on_done(error=None, **kwargs):


### PR DESCRIPTION
## Summary

Small code quality improvements to make the codebase more robust and idiomatic.

## Changes

### 1. Simplify boolean return in `gpu_connector/utils.py`
```python
# Before
if lmcache_config.enable_pd:
    return False
else:
    return True

# After
return not lmcache_config.enable_pd
```

### 2. Replace `assert` with `RuntimeError` in `protocol.py`
`assert` statements are stripped when Python runs with `-O` optimization flag, which would cause a silent failure. Replaced with an explicit `RuntimeError` to ensure the check always runs.

### 3. Narrow `except Exception` to `except (ValueError, TypeError)` in `s3_connector.py`
The `int(value)` conversion in the S3 connector's header callback was catching all exceptions silently. Since `int()` can only raise `ValueError` or `TypeError`, narrowing the catch avoids swallowing unexpected errors that should propagate.

## Test

All pre-commit hooks pass (codespell, ruff, mypy, etc.).