### PR TITLE
docs: daily drift check — multi-process mode (2026-05-18)

### DIFF
--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -13,7 +13,7 @@
 │        └──────────────────┴──────────────────┘                  │
 │                           │                                     │
 │                     torch_dev (unified entry)                   │
-│                     torch_device_type ("cuda"/"xpu"/"hpu")      │
+│                  torch_device_type ("cuda"/"xpu"/"hpu"/"cpu")   │
 │                                                                 │
 │  [Monkey Patch Point]                                           │
 │  New hardware can be added by extending _detect_device()        │
@@ -93,7 +93,39 @@
 torch_device_type == "cuda"  -->  VLLMPagedMemGPUConnectorV2/V3
 torch_device_type == "xpu"   -->  VLLMPagedMemXPUConnectorV2
 torch_device_type == "hpu"   -->  VLLMPagedMemHPUConnector
+torch_device_type == "cpu"   -->  (no GPU connector; raises RuntimeError)
 ```
+
+## CPU-Only Stub Fallback
+
+`_detect_device()` also accepts a CPU-only environment where none of the
+supported accelerators (CUDA, XPU, HPU) is available. In that case
+`torch_device_type` is `"cpu"` and `torch_dev` is either:
+
+- `lmcache.v1.platform.cpu.stub_cpu_device.StubCPUDevice` — when `torch`
+  is importable but no GPU is detected. The stub implements the subset of
+  the `torch.cuda` / `torch.xpu` / `torch.hpu` surface used by the middle
+  layer (`Event`, `Stream`, `device`, `synchronize`, `set_device`,
+  `current_device`, `device_count`, `get_device_properties`,
+  `empty_cache`), as no-op or constant returns. `is_available()` is
+  `False`, so any `hasattr(torch_dev, 'xxx')` consumer that gates on the
+  real device's availability stays on the degraded path.
+- `None` — when `torch` itself is not importable (the `lmcache-cli`
+  slim install). The CLI surface (`lmcache ping`, `lmcache describe`,
+  `lmcache query`, `lmcache bench engine`) tolerates this; engine and
+  storage paths do not.
+
+The stub is intended for L1-adapter-only flows (e.g., end-to-end MP
+server smoke tests on a CPU-only host) and CLI loading without torch. It
+is **not** a CPU connector: there is no entry for `"cpu"` in
+`gpu_connector/__init__.py`, so calling `CreateGPUConnector` with
+`torch_device_type == "cpu"` raises `RuntimeError("No supported cpu
+connector found.")`.
+
+`normalize_kv_and_discover_format` also hardcodes `kv_layout = "HND"`
+when `torch_device_type == "cpu"`, because vLLM's
+`get_kv_cache_layout()` reports `NHD` for its CPU attention backend
+which is wrong for that backend's actual KV cache layout.
 
 ## Adding New Hardware
 


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine.
**Human review is required before merge — do not merge as-is.**

One drift item was introduced between the previous drift sweep
(2026-05-15, [PR #3296](https://github.com/LMCache/LMCache/pull/3296),
covering `dev` HEAD [`3090e89`](https://github.com/LMCache/LMCache/commit/3090e89634c1ab43b56819462fe4eeae7bcdf1ae))
and today's `dev` HEAD ([`c9cfa3a`](https://github.com/LMCache/LMCache/commit/c9cfa3af12422a513a0c3cf7c60d143957ee8514)).
It is a design-doc gap in the multi-hardware architecture page; no new
user-facing (`docs/source/`) drift was found in today's window.

Today's PR is filed as a separate draft (not appended to #3296 / #3273)
because the item is independent of the items already under review on
those branches and rebasing them would require force-pushing reviewed
commits. The dedup rule asks us to merge only when the **same** items
are still open, which is not the case here.

---

### `docs/design/` drift

#### `docs/design/ARCHITECTURE_MULTI_HARDWARE.md` — missing `"cpu"` device type from #3280

[PR #3280](https://github.com/LMCache/LMCache/pull/3280) (commit
[`516b498`](https://github.com/LMCache/LMCache/commit/516b498cb45764754acccae17c23e24e6235cf15),
"feat: add StubCPUDevice to allow import/startup fallback in CPU-only
environments") merged today and extended `_detect_device()` with a
**new fourth value** for `torch_device_type`: `"cpu"`. Two flavours of
this path now exist, neither of which the multi-hardware architecture
design page describes:

1. `torch` importable but no GPU available — `torch_dev` is set to
   [`lmcache.v1.platform.cpu.stub_cpu_device.StubCPUDevice`](https://github.com/LMCache/LMCache/blob/c9cfa3af12422a513a0c3cf7c60d143957ee8514/lmcache/v1/platform/cpu/stub_cpu_device.py),
   a drop-in for `torch.cuda` / `torch.xpu` / `torch.hpu` that
   implements the subset of the device API used by the middle layer
   (`Event`, `Stream`, `device`, `synchronize`, `set_device`, …) as
   no-op / constant returns. `StubCPUDevice.is_available()` returns
   `False`, so `hasattr(torch_dev, 'xxx')` consumers still take the
   degraded path. See the new `_detect_device()` branch at
   [`lmcache/__init__.py#L49-L54`](https://github.com/LMCache/LMCache/blob/c9cfa3af12422a513a0c3cf7c60d143957ee8514/lmcache/__init__.py#L49-L54).
2. `torch` not importable (the `lmcache-cli` slim install) —
   `_detect_device()` returns `(None, "cpu")`. See
   [`lmcache/__init__.py#L37-L41`](https://github.com/LMCache/LMCache/blob/c9cfa3af12422a513a0c3cf7c60d143957ee8514/lmcache/__init__.py#L37-L41).

The same PR also hardcodes `kv_layout = "HND"` in
`normalize_kv_and_discover_format` when `torch_device_type == "cpu"`,
to work around vLLM's `get_kv_cache_layout()` returning `NHD` for its
CPU attention backend. See
[`lmcache/v1/gpu_connector/utils.py#L527-L540`](https://github.com/LMCache/LMCache/blob/c9cfa3af12422a513a0c3cf7c60d143957ee8514/lmcache/v1/gpu_connector/utils.py#L527-L540).

The stale doc locations:

- [`docs/design/ARCHITECTURE_MULTI_HARDWARE.md` line 16](https://github.com/LMCache/LMCache/blob/c9cfa3af12422a513a0c3cf7c60d143957ee8514/docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L16)
  — the entry-block diagram lists only
  `torch_device_type ("cuda"/"xpu"/"hpu")`.
- [`docs/design/ARCHITECTURE_MULTI_HARDWARE.md` lines 92-96](https://github.com/LMCache/LMCache/blob/c9cfa3af12422a513a0c3cf7c60d143957ee8514/docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L92-L96)
  — the Connector Routing block does not mention what happens for
  `torch_device_type == "cpu"`. `CreateGPUConnector` has no `"cpu"`
  branch and falls through to `raise RuntimeError(f"No supported
  {torch_device_type} connector found.")` at
  [`lmcache/v1/gpu_connector/__init__.py#L139`](https://github.com/LMCache/LMCache/blob/c9cfa3af12422a513a0c3cf7c60d143957ee8514/lmcache/v1/gpu_connector/__init__.py#L139).

#### `docs/source/` (user-facing) drift

None new today. The user-facing items still pending are tracked on the
two existing open draft PRs ([#3296](https://github.com/LMCache/LMCache/pull/3296)
for the Intel-XPU install typos and `nixl_endpoint_list` config row;
[#3273](https://github.com/LMCache/LMCache/pull/3273) for the
`bytes_transferred` event and `layout-invariant.md` 5-tuple identity).

---

## Proposed fix (applied in this PR — one commit)

A single doc-only commit
([`2744e46`](https://github.com/ApostaC/LMCache/commit/2744e46f7bebaaf4299d577b27ba5ac52e7bd80b)),
DCO-signed and authored by ApostaC:

- **`docs/design/ARCHITECTURE_MULTI_HARDWARE.md`** — extend the
  entry-block `torch_device_type` enumeration to include `"cpu"`; add a
  `"cpu"` row to the Connector Routing block explaining that no GPU
  connector is registered for it; add a new "CPU-Only Stub Fallback"
  section describing the two flavours (`StubCPUDevice` vs. `None`),
  the intended use (L1-adapter-only flows / CLI loading without
  torch), and the hardcoded `HND` layout override in
  `normalize_kv_and_discover_format`. Wording mirrors the
  PR #3280 commit message and the new code itself — no behaviour
  change is implied.

No code files are touched.

## Audit-clean (no drift) commits in today's window

The following dev commits between
[`3090e89`](https://github.com/LMCache/LMCache/commit/3090e89634c1ab43b56819462fe4eeae7bcdf1ae)
(2026-05-15) and
[`c9cfa3a`](https://github.com/LMCache/LMCache/commit/c9cfa3af12422a513a0c3cf7c60d143957ee8514)
(2026-05-18) were audited and introduced no new MP doc drift:

- **PR #3306** (typo fixes `non-blcocking`, `Memoryobjs`,
  `pareant_allocator`, `storage-manger`, `trak`, etc.) — the affected
  identifiers are not referenced by any `docs/source/` or
  `docs/design/` page; the thread name
  `"storage-manger-event-loop"` → `"storage-manager-event-loop"`
  is internal-only and not documented.
- **PR #3294** (Defer `test_cache` runtime imports so `lmcache-cli`
  loads without torch) — affects only `lmcache bench kvcache`
  registration on slim install. `docs/source/cli/bench_kvcache.rst`
  already makes no claim about slim-install availability, and the
  stub command's help message ("requires full lmcache install")
  matches the install matrix in `docs/source/getting_started/cli.rst`.
- **PR #2282** ([Doc] Fix typo in `p2p_init_ports`) — a doc-only fix
  that already lands in
  [`docs/source/kv_cache_management/index.rst`](https://github.com/LMCache/LMCache/blob/c9cfa3af12422a513a0c3cf7c60d143957ee8514/docs/source/kv_cache_management/index.rst).
- **PR #3265** (Chinese translation pipeline) — adds
  `tools/translate_docs_zh.py`, a translation workflow, and Sphinx
  conf/CSS/JS scaffolding under `docs/source/locale/`. No
  English-content drift; the pipeline does not touch existing prose.
- **PR #3289** (Operator end-to-end smoke suite) — CI test workflow
  under `.buildkite/` / `.github/`; no doc surface.
- **PR #3298** ([CI] pin vLLM CUDA wheel variant) — CI-only.
- **PR #3299** ([CD] add `sm_120` to cu129 wheel build) — CD-only;
  the docs install matrix in `docs/source/getting_started/installation.rst`
  does not enumerate SM versions.
- **PR #3293** ([Operator][CI] Date-based nightly tag / release flow) —
  release-workflow only.
- **PR #3297** ([CD] switch all workflows to egress audit mode) —
  CI/CD policy only.

## Generated by

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Branch: `ApostaC:docs/drift-check-2026-05-18`.
Human review is still required before merge; please leave this PR in
draft until reviewed.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSkJTT8y3C9c5aW3gzC5qh)_