### PR TITLE
[CI] skip pipeline for operator-v* release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,9 @@ jobs:
         permissions:
             pull-requests: read
         outputs:
-            lmcache: ${{ github.event_name == 'release' || startsWith(github.ref, 'refs/tags/') || steps.filter.outputs.lmcache == 'true' }}
+            # Skip the whole pipeline for operator releases (tags like `operator-v*`).
+            # operator_release.yml handles those; this workflow is lmcache-only.
+            lmcache: ${{ !startsWith(github.ref_name, 'operator-') && (github.event_name == 'release' || startsWith(github.ref, 'refs/tags/') || steps.filter.outputs.lmcache == 'true') }}
         steps:
             - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
               if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
 Description:

  ## Summary

  - `publish.yml` listens on `release: published`, which fires for **every** GitHub release — including operator releases (`operator-v*`). Last operator cut
   triggered the lmcache PyPI publish pipeline and had to be cancelled manually.
  - Gate the `changes` job output on `!startsWith(github.ref_name, 'operator-')`. Every downstream job already keys off `needs.changes.outputs.lmcache`, so
  a single filter short-circuits the whole pipeline for operator tags.
  - `operator_release.yml` is the symmetric guard on the operator side (`if: startsWith(github.ref_name, 'operator-v')`) and is unchanged.

  ## Test plan

  - [ ] Confirm an `operator-v*` release skips all jobs (changes job runs, downstream jobs show "skipped").
  - [ ] Confirm a regular `v*` release still triggers build + publish-pypi + publish-image as before.
  - [ ] Confirm pushes to `dev` still trigger test-pypi publish (filter is no-op when `ref_name == 'dev'`).
