### PR TITLE
[Observability]: Add L2 Usage to SM

### DIFF
--- a/examples/observability/grafana/provisioning/dashboards/lmcache.json
+++ b/examples/observability/grafana/provisioning/dashboards/lmcache.json
@@ -1630,12 +1630,105 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current bytes held in each L2 adapter, sampled live from adapter.get_usage(). One line per adapter, tagged by ``l2_name``. Parallel to the L1 ``lmcache_mp_l1_memory_usage_bytes`` gauge.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "lmcache_mp_l2_usage_bytes",
+          "legendFormat": "{{l2_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "L2 Usage (current)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 66
       },
       "id": 300,
       "title": "Production Insights",
@@ -1704,7 +1797,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 59
+        "y": 67
       },
       "id": 20,
       "options": {
@@ -1809,7 +1902,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 59
+        "y": 67
       },
       "id": 21,
       "options": {
@@ -1914,7 +2007,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 67
+        "y": 75
       },
       "id": 22,
       "options": {
@@ -2040,7 +2133,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 67
+        "y": 75
       },
       "id": 23,
       "options": {
@@ -2082,7 +2175,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 75
+        "y": 83
       },
       "id": 400,
       "title": "CacheBlend (expand if using blend_server)",
@@ -2167,7 +2260,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 76
+            "y": 84
           },
           "id": 30,
           "options": {
@@ -2336,7 +2429,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 76
+            "y": 84
           },
           "id": 31,
           "options": {
@@ -2404,7 +2497,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 84
       },
       "id": 500,
       "title": "Request Traces",
@@ -2423,7 +2516,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 77
+        "y": 85
       },
       "id": 50,
       "options": {

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -40,6 +40,7 @@ from lmcache.v1.distributed.storage_controllers.store_policy import (
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
+from lmcache.v1.mp_observability.otel_init import register_gauge
 from lmcache.v1.mp_observability.trace.decorator import (
     enable_tracing,
     is_tracing_enabled,
@@ -119,7 +120,7 @@ class StorageManager:
         )
         self._l2_eviction_controller.start()
 
-        adapter_descriptors = [
+        self._adapter_descriptors = [
             AdapterDescriptor(index=i, config=ac)
             for i, ac in enumerate(config.l2_adapter_config.adapters)
         ]
@@ -127,7 +128,7 @@ class StorageManager:
         self._store_controller = StoreController(
             l1_manager=self._l1_manager,
             l2_adapters=self._l2_adapters,
-            adapter_descriptors=adapter_descriptors,
+            adapter_descriptors=self._adapter_descriptors,
             policy=create_store_policy(config.store_policy),
         )
         self._store_controller.start()
@@ -136,11 +137,23 @@ class StorageManager:
         self._prefetch_controller = PrefetchController(
             l1_manager=self._l1_manager,
             l2_adapters=self._l2_adapters,
-            adapter_descriptors=adapter_descriptors,
+            adapter_descriptors=self._adapter_descriptors,
             policy=create_prefetch_policy(config.prefetch_policy),
             max_in_flight=config.prefetch_max_in_flight,
         )
         self._prefetch_controller.start()
+
+        # L2 usage gauge — one observation per adapter, tagged by
+        # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
+        register_gauge(
+            "lmcache.l2",
+            "lmcache_mp.l2_usage_bytes",
+            (
+                "Bytes currently held in each L2 adapter, tagged by "
+                "``l2_name`` (one observation per adapter)."
+            ),
+            self.get_l2_usages,
+        )
 
     # External APIs for serving engine integration code to call
     @enable_tracing()
@@ -568,6 +581,35 @@ class StorageManager:
         storage manager creates the registry at construction time.
         """
         return self._quota_manager
+
+    def get_l2_usages(
+        self,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """Per-adapter L2 usage in OTel-observation shape.
+
+        Backing data for the ``lmcache_mp.l2_usage_bytes`` observable
+        gauge.  One entry per configured adapter.
+
+        Returns:
+            A list of ``(total_bytes_used, {"l2_name": <type_name>})``
+            tuples — empty when no L2 adapters are configured.  Adapters
+            whose ``get_usage()`` raises are skipped (the gauge prefers
+            silence over a poison observation).
+        """
+        out: list[tuple[int | float, dict[str, object]]] = []
+        for adapter, desc in zip(
+            self._l2_adapters, self._adapter_descriptors, strict=True
+        ):
+            try:
+                usage = adapter.get_usage()
+            except Exception:
+                logger.exception(
+                    "L2 adapter %s get_usage() failed; skipping in gauge",
+                    desc.type_name,
+                )
+                continue
+            out.append((int(usage.total_bytes_used), {"l2_name": desc.type_name}))
+        return out
 
     def get_usage_bytes_by_cache_salt(self) -> dict[str, int]:
         """Aggregate ``cache_salt`` byte usage across every L2 adapter.


### PR DESCRIPTION
L2 is missing the usage in observability as well as the ability to scan the existing keys on startup (for a later PR).

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
