### PR TITLE
fix(v1): graceful skip on slot_mapping/token_ids desync in wait_for_save (fixes #3318)

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1121,7 +1121,17 @@ class LMCacheConnectorV1Impl:
 
             slot_mapping = request.slot_mapping
             assert isinstance(slot_mapping, torch.Tensor)
-            assert len(slot_mapping) == len(token_ids)
+            if len(slot_mapping) != len(token_ids):
+                logger.warning(
+                    "Skipping KV save for request %s: slot_mapping/token_ids "
+                    "length mismatch (slot_mapping=%d, token_ids=%d). Likely "
+                    "an upstream allocation/preemption desync; the engine "
+                    "stays alive and only this request's save is dropped.",
+                    request.req_id,
+                    len(slot_mapping),
+                    len(token_ids),
+                )
+                continue
 
             # TODO: have a pre-allocated buffer to hold the slot_mappings
             slot_mapping = slot_mapping.to(self.device)

--- a/tests/v1/test_v1_adapter_state_desync.py
+++ b/tests/v1/test_v1_adapter_state_desync.py
@@ -79,11 +79,15 @@ def _make_desync_request(
 def _make_connector(
     requests: list[SimpleNamespace],
 ) -> tuple[LMCacheConnectorV1Impl, _FakeEngine]:
-    metadata = LMCacheConnectorMetadata(requests=requests)
+    metadata = LMCacheConnectorMetadata(requests=requests)  # type: ignore[arg-type]
     engine = _FakeEngine()
     connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
     connector._parent = _FakeParent(metadata)
-    connector.lmcache_engine = engine
+    # ``lmcache_engine`` is a read-only property backed by ``self._manager``;
+    # inject the fake engine through the manager so the property resolves to it.
+    connector._manager = SimpleNamespace(  # type: ignore[assignment]
+        lmcache_engine=engine
+    )
     connector.kv_role = "kv_producer"
     connector.use_layerwise = False
     connector.enable_blending = False
@@ -102,9 +106,7 @@ def test_wait_for_save_skips_desynced_request_and_keeps_engine_alive(
 
     Regression for https://github.com/LMCache/LMCache/issues/3318.
     """
-    desync_req = _make_desync_request(
-        "req-desync", token_ids_len=4, slot_mapping_len=3
-    )
+    desync_req = _make_desync_request("req-desync", token_ids_len=4, slot_mapping_len=3)
     connector, engine = _make_connector([desync_req])
 
     with caplog.at_level(logging.WARNING):
@@ -123,4 +125,7 @@ def test_wait_for_save_skips_desynced_request_and_keeps_engine_alive(
         and "slot_mapping=3" in r.getMessage()
         and "token_ids=4" in r.getMessage()
         for r in warnings
-    ), f"Expected desync warning naming req-desync; got {[r.getMessage() for r in warnings]}"
+    ), (
+        "Expected desync warning naming req-desync; "
+        f"got {[r.getMessage() for r in warnings]}"
+    )

--- a/tests/v1/test_v1_adapter_state_desync.py
+++ b/tests/v1/test_v1_adapter_state_desync.py
@@ -98,45 +98,58 @@ def _make_connector(
     return connector, engine
 
 
-def test_wait_for_save_skips_desynced_request_and_keeps_engine_alive(
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_wait_for_save_skips_desynced_request_and_keeps_engine_alive() -> None:
     """Length mismatch must drop only the affected request's save, log a
     warning, and let ``wait_for_save`` return normally.
 
     Regression for https://github.com/LMCache/LMCache/issues/3318.
     """
-    # lmcache's ``init_logger`` sets ``propagate = False``, so ``caplog``
-    # (which attaches to the root logger) cannot see the adapter's records.
-    # Re-enable propagation for the duration of the test so the warning is
-    # captured; monkeypatch restores it afterwards.
-    monkeypatch.setattr(
-        logging.getLogger("lmcache.integration.vllm.vllm_v1_adapter"),
-        "propagate",
-        True,
-    )
+    # lmcache's ``init_logger`` sets ``propagate = False`` on the adapter
+    # logger so its records do not reach pytest's ``caplog`` (which
+    # attaches to the root logger). Toggling ``propagate`` is fragile --
+    # any lazy import that re-runs ``init_logger`` resets it. Attach a
+    # local handler directly to the named logger instead so we capture
+    # the warning regardless of how lmcache configures propagation.
+    captured_records: list[logging.LogRecord] = []
 
-    desync_req = _make_desync_request("req-desync", token_ids_len=4, slot_mapping_len=3)
-    connector, engine = _make_connector([desync_req])
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured_records.append(record)
 
-    with caplog.at_level(logging.WARNING):
+    handler = _ListHandler(level=logging.WARNING)
+    adapter_logger = logging.getLogger("lmcache.integration.vllm.vllm_v1_adapter")
+    # ``init_logger`` sets the logger level from ``LMCACHE_LOG_LEVEL`` (default
+    # INFO). If a prior import set it above WARNING, ``logger.warning`` would be
+    # filtered before reaching our handler. Force WARNING for the duration of
+    # the test and restore the original level in ``finally``.
+    original_level = adapter_logger.level
+    adapter_logger.setLevel(logging.WARNING)
+    adapter_logger.addHandler(handler)
+    try:
+        desync_req = _make_desync_request(
+            "req-desync", token_ids_len=4, slot_mapping_len=3
+        )
+        connector, engine = _make_connector([desync_req])
+
         connector.wait_for_save()
 
-    # 1. lookup_unpin still ran (pin balance preserved)
-    assert engine.unpinned == ["req-desync"]
+        # 1. lookup_unpin still ran (pin balance preserved)
+        assert engine.unpinned == ["req-desync"]
 
-    # 2. store was NOT called for the desynced request (save dropped)
-    assert engine.store_calls == []
+        # 2. store was NOT called for the desynced request (save dropped)
+        assert engine.store_calls == []
 
-    # 3. A warning was emitted naming the request and both lengths
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert any(
-        "req-desync" in r.getMessage()
-        and "slot_mapping=3" in r.getMessage()
-        and "token_ids=4" in r.getMessage()
-        for r in warnings
-    ), (
-        "Expected desync warning naming req-desync; "
-        f"got {[r.getMessage() for r in warnings]}"
-    )
+        # 3. A warning was emitted naming the request and both lengths
+        warnings = [r for r in captured_records if r.levelno == logging.WARNING]
+        assert any(
+            "req-desync" in r.getMessage()
+            and "slot_mapping=3" in r.getMessage()
+            and "token_ids=4" in r.getMessage()
+            for r in warnings
+        ), (
+            "Expected desync warning naming req-desync; "
+            f"got {[r.getMessage() for r in warnings]}"
+        )
+    finally:
+        adapter_logger.removeHandler(handler)
+        adapter_logger.setLevel(original_level)

--- a/tests/v1/test_v1_adapter_state_desync.py
+++ b/tests/v1/test_v1_adapter_state_desync.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for LMCache#3318.
+
+The vLLM v1 adapter previously asserted
+``len(slot_mapping) == len(token_ids)`` inside ``wait_for_save``. When the
+state desynced (e.g. upstream allocation failure or preemption-induced
+mismatch) the assertion fired as an unhandled ``AssertionError`` and
+killed the entire EngineCore process for every connected user.
+
+The fix replaces the assert with a logged ``continue`` so the engine
+stays alive and only the affected request's save is dropped. This test
+locks in that behavior by feeding ``wait_for_save`` a request whose
+``slot_mapping`` and ``token_ids`` lengths disagree and asserting:
+
+1. ``wait_for_save`` does not raise.
+2. A warning is emitted naming the request id and both lengths.
+3. ``lmcache_engine.store`` is not called for the desynced request
+   (the save is dropped, not silently corrupted).
+4. ``lookup_unpin`` is still called so the pin count stays balanced.
+"""
+
+# Standard
+from types import SimpleNamespace
+import logging
+
+# Third Party
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+
+# First Party
+from lmcache.integration.vllm.vllm_v1_adapter import (
+    LMCacheConnectorMetadata,
+    LMCacheConnectorV1Impl,
+    SaveSpec,
+)
+
+
+class _FakeParent:
+    def __init__(self, metadata: LMCacheConnectorMetadata) -> None:
+        self._connector_metadata = metadata
+
+    def _get_connector_metadata(self) -> LMCacheConnectorMetadata:
+        return self._connector_metadata
+
+
+class _FakeEngine:
+    """Records calls to ``lookup_unpin`` and ``store`` so the test can
+    assert which paths fired."""
+
+    def __init__(self) -> None:
+        self.unpinned: list[str] = []
+        self.store_calls: list[str] = []
+
+    def lookup_unpin(self, req_id: str) -> None:
+        self.unpinned.append(req_id)
+
+    def store(self, *args, **kwargs) -> None:
+        self.store_calls.append(kwargs.get("req_id", "<unknown>"))
+
+
+def _make_desync_request(
+    req_id: str, token_ids_len: int, slot_mapping_len: int
+) -> SimpleNamespace:
+    """Build a request whose ``token_ids`` and ``slot_mapping`` lengths
+    disagree, simulating a state desync."""
+    return SimpleNamespace(
+        req_id=req_id,
+        token_ids=list(range(token_ids_len)),
+        slot_mapping=torch.arange(slot_mapping_len, dtype=torch.long),
+        save_spec=SaveSpec(skip_leading_tokens=0, can_save=True),
+        disagg_spec=None,
+        is_last_prefill=True,
+        request_configs=None,
+    )
+
+
+def _make_connector(
+    requests: list[SimpleNamespace],
+) -> tuple[LMCacheConnectorV1Impl, _FakeEngine]:
+    metadata = LMCacheConnectorMetadata(requests=requests)
+    engine = _FakeEngine()
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector._parent = _FakeParent(metadata)
+    connector.lmcache_engine = engine
+    connector.kv_role = "kv_producer"
+    connector.use_layerwise = False
+    connector.enable_blending = False
+    connector.device = "cpu"
+    connector._lmcache_chunk_size = 8
+    connector.kv_caches = {"layer0": torch.zeros(1)}
+    connector.config = SimpleNamespace(pd_bidirectional=False)
+    return connector, engine
+
+
+def test_wait_for_save_skips_desynced_request_and_keeps_engine_alive(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Length mismatch must drop only the affected request's save, log a
+    warning, and let ``wait_for_save`` return normally.
+
+    Regression for https://github.com/LMCache/LMCache/issues/3318.
+    """
+    desync_req = _make_desync_request(
+        "req-desync", token_ids_len=4, slot_mapping_len=3
+    )
+    connector, engine = _make_connector([desync_req])
+
+    with caplog.at_level(logging.WARNING):
+        connector.wait_for_save()
+
+    # 1. lookup_unpin still ran (pin balance preserved)
+    assert engine.unpinned == ["req-desync"]
+
+    # 2. store was NOT called for the desynced request (save dropped)
+    assert engine.store_calls == []
+
+    # 3. A warning was emitted naming the request and both lengths
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "req-desync" in r.getMessage()
+        and "slot_mapping=3" in r.getMessage()
+        and "token_ids=4" in r.getMessage()
+        for r in warnings
+    ), f"Expected desync warning naming req-desync; got {[r.getMessage() for r in warnings]}"

--- a/tests/v1/test_v1_adapter_state_desync.py
+++ b/tests/v1/test_v1_adapter_state_desync.py
@@ -100,12 +100,23 @@ def _make_connector(
 
 def test_wait_for_save_skips_desynced_request_and_keeps_engine_alive(
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Length mismatch must drop only the affected request's save, log a
     warning, and let ``wait_for_save`` return normally.
 
     Regression for https://github.com/LMCache/LMCache/issues/3318.
     """
+    # lmcache's ``init_logger`` sets ``propagate = False``, so ``caplog``
+    # (which attaches to the root logger) cannot see the adapter's records.
+    # Re-enable propagation for the duration of the test so the warning is
+    # captured; monkeypatch restores it afterwards.
+    monkeypatch.setattr(
+        logging.getLogger("lmcache.integration.vllm.vllm_v1_adapter"),
+        "propagate",
+        True,
+    )
+
     desync_req = _make_desync_request("req-desync", token_ids_len=4, slot_mapping_len=3)
     connector, engine = _make_connector([desync_req])
 


### PR DESCRIPTION
## Summary

Fixes #3318. The vLLM v1 adapter's `wait_for_save` previously asserted `len(slot_mapping) == len(token_ids)` on the non-layerwise save path. When the engine hit an upstream state desync (allocation failure, preemption-induced mismatch, remote cache lag), the `AssertionError` was unhandled and killed the entire `EngineCore`, taking down every connected user.

## Repro (from #3318)

> 1. Initialize the vLLM engine with the v1 experimental backend and LMCache enabled.
> 2. Trigger a state desync (heavy preemption, LMCache allocation delay/failure).
> 3. Internal loop hits `vllm_v1_adapter.py` line ~1124.
> 4. Whole `EngineCore` is killed:
>
> ```
> AssertionError: Slot mapping and token IDs length mismatch!
> [INFO] vLLM EngineCore terminated unexpectedly (Killed).
> ```

## Fix

Replace the strict assert with a conditional `continue` that logs a warning naming the request id and both observed lengths. The engine stays alive and only the desynced request's save is dropped:

```python
if len(slot_mapping) != len(token_ids):
    logger.warning(
        "Skipping KV save for request %s: slot_mapping/token_ids "
        "length mismatch (slot_mapping=%d, token_ids=%d). Likely "
        "an upstream allocation/preemption desync; the engine "
        "stays alive and only this request's save is dropped.",
        request.req_id,
        len(slot_mapping),
        len(token_ids),
    )
    continue
```

This matches `docs/coding_standards.md` (\"No `assert` for validation\") — applied here as drop-the-save rather than raise, since the save path should be fail-soft toward the connected stream consumers (the alternative — raising — propagates back to `EngineCore` and reproduces the original kill).

## Test

`tests/v1/test_v1_adapter_state_desync.py` is a CPU-only regression test that:

- Feeds a length-mismatched request (`token_ids` len 4, `slot_mapping` len 3) into `wait_for_save` via fake parent / engine fixtures (same shape as the existing `tests/v1/test_vllm_layerwise_wait_for_save.py`).
- Asserts:
  1. `wait_for_save()` returns normally (no `AssertionError`).
  2. A warning is emitted naming the request id (`req-desync`) and both lengths.
  3. `lookup_unpin` still ran (pin balance preserved).
  4. `lmcache_engine.store` was **not** called for the desynced request (the save is dropped, not silently corrupted).

## Out of scope (intentional)

The same pattern (`assert len(slot_mapping) == len(token_ids)`) also appears at line 1023 inside `save_kv_layer` (the layerwise path). That one is **not** changed in this PR to keep the scope tight to #3318's reported failure mode (`wait_for_save`). A follow-up for the layerwise path can mirror this fix once we confirm the same desync class can hit it on the layerwise side.

## Local verification

The CPU regression test was authored against the existing layerwise test fixtures. It cannot run on this host (Mac without `vllm` and the `lmcache.c_ops` C extension), so it relies on the LMCache CI environment for validation. The fix itself was verified by:

- Reading the diff against the surrounding `wait_for_save` flow (`for request in connector_metadata.requests:` loop, with `lookup_unpin` already called and `save_spec.can_save` already gated above the changed line).
- Confirming the test mirrors `test_vllm_layerwise_wait_for_save.py`'s parent / engine / metadata fake pattern.

Closes #3318.