### PR TITLE
fix(gds): use parse_cache_key to handle LayerCacheEngineKey on restart

### DIFF
--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -21,7 +21,12 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
+from lmcache.utils import (
+    CacheEngineKey,
+    DiskCacheMetadata,
+    _lmcache_nvtx_annotate,
+    parse_cache_key,
+)
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import (
     CuFileMemoryAllocator,
@@ -391,7 +396,7 @@ class GdsBackend(AllocatorBackendInterface):
                         filename = os.path.basename(fentry.name)
                         key_str = urllib.parse.unquote(filename[: -len(target_suffix)])
                         try:
-                            key = CacheEngineKey.from_string(key_str)
+                            key = parse_cache_key(key_str)
                         except ValueError as e:
                             logger.error(
                                 f"Filename {filename} can't be converted "

--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -15,7 +15,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.utils import CacheEngineKey
+from lmcache.utils import CacheEngineKey, LayerCacheEngineKey
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
@@ -59,6 +59,18 @@ def create_test_key(key_id: int = 0) -> CacheEngineKey:
         worker_id=1,
         chunk_hash=key_id,
         dtype=torch.bfloat16,
+    )
+
+
+def create_test_layer_key(key_id: int = 0, layer_id: int = 0) -> LayerCacheEngineKey:
+    """Create a LayerCacheEngineKey for testing layer-wise GDS operations."""
+    return LayerCacheEngineKey(
+        model_name="testmodel",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=key_id,
+        dtype=torch.bfloat16,
+        layer_id=layer_id,
     )
 
 
@@ -656,6 +668,41 @@ class TestGdsBackend:
         )
         future.result(timeout=10)
         assert gds_backend.contains(key)
+
+    def test_scan_metadata_layer_key(self, temp_gds_path, async_loop):
+        """
+        _scan_metadata_subdir must reconstruct LayerCacheEngineKey filenames with
+        a trailing layer_id (e.g. ...@dtype@4).
+        """
+        config = create_test_config(temp_gds_path)
+        metadata = create_test_metadata()
+        backend = GdsBackend(
+            config=config,
+            loop=async_loop,
+            metadata=metadata,
+            dst_device="cuda:0",
+        )
+
+        layer_key = create_test_layer_key(0xABCD, 4)
+
+        memory_obj = create_test_memory_obj(device="cuda")
+        future = backend.submit_put_task(layer_key, memory_obj)
+        future.result(timeout=10)
+        memory_obj.ref_count_down()
+        # Wait for async metadata write to land
+        backend.close()
+
+        # Re-create backend, which triggers _scan_metadata
+        backend2 = GdsBackend(
+            config=config,
+            loop=async_loop,
+            metadata=metadata,
+            dst_device="cuda:0",
+        )
+        # Wait for the background scan to complete
+        time.sleep(1)
+        assert layer_key in backend2.hot_cache
+        backend2.close()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Problem
GDS backend stores KV cache files with keys formatted as `LayerCacheEngineKey.to_string()`, which appends a layer_id suffix (e.g., `@bfloat16@4`). On server restart, `_scan_metadata_subdir` scans these files and attempts to reconstruct the cache key from the filename.
However, the code was calling `CacheEngineKey.from_string()` unconditionally, which expects the 6th part of the string to be in `tag%value` format. When encountering a numeric layer_id like `@4`, it fails with:
Filename ... can't be converted back into cache key: Invalid key string: ...
This prevents `LayerCacheEngineKey` entries from being loaded into `hot_cache` on restart, causing cache misses for layer-wise stored KV caches.
## Fix
Use the existing `parse_cache_key()` utility instead of `CacheEngineKey.from_string()` directly. This utility correctly identifies when the 6th part is a numeric layer_id and dispatches to `LayerCacheEngineKey.from_string()`.
## Code Changes
- `lmcache/v1/storage_backend/gds_backend.py`: import `parse_cache_key` and use it in `_scan_metadata_subdir`
- `tests/v1/storage_backend/test_gds_backend.py`: add `create_test_layer_key()` helper and `test_scan_metadata_layer_key` test
## Test
```bash
pytest -xvs tests/v1/storage_backend/test_gds_backend.py::TestGdsBackend::test_scan_metadata_layer_key
- Writes a LayerCacheEngineKey via GDS
- Closes and recreates the backend to trigger _scan_metadata
- Verifies hot_cache correctly reconstructs the LayerCacheEngineKey