### PR TITLE
docs: daily drift check — multi-process mode (2026-05-19)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -408,6 +408,33 @@ On the vLLM side, specify the LMCache server host and port via the
         --kv-transfer-config \
         '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "127.0.0.1", "lmcache.mp.port": 6000}}'
 
+``LMCacheMPConnector`` reads the following keys from
+``kv_connector_extra_config``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 20 45
+
+   * - Key
+     - Default
+     - Description
+   * - ``lmcache.mp.host``
+     - ``tcp://localhost``
+     - Host (with ZMQ transport prefix) of the LMCache MP server.
+   * - ``lmcache.mp.port``
+     - ``5555``
+     - Port of the LMCache MP server. Must match the server's ``--port``.
+   * - ``lmcache.mp.mq_timeout``
+     - ``300.0``
+     - Timeout (seconds) for blocking message-queue requests, including
+       the initial chunk-size query and KV cache
+       registration/unregistration. If the server does not respond within
+       this window, the connector raises ``ConnectionError`` on startup.
+   * - ``lmcache.mp.heartbeat_interval``
+     - ``10.0``
+     - Interval (seconds) between periodic heartbeat pings sent from the
+       connector to the server.
+
 Environment Variables
 ---------------------
 


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine.
**Human review is required before merge — do not merge as-is.**

One new piece of `docs/source/` drift was introduced between the
previous drift sweep window
([2026-05-18 — PR #3309](https://github.com/LMCache/LMCache/pull/3309)
based on `dev` HEAD
[`c9cfa3a`](https://github.com/LMCache/LMCache/commit/c9cfa3af12422a513a0c3cf7c60d143957ee8514))
and today's `dev` HEAD
([`f9ce8cb`](https://github.com/LMCache/LMCache/commit/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a)).
It is user-facing — the MP `Configuration Reference` no longer enumerates
all `lmcache.mp.*` keys that `LMCacheMPConnector` actually reads.

Today's PR is filed as a separate draft (not appended to #3273 or
#3309) because the item is **independent** of the items already under
review on those branches: neither open PR touches `docs/source/mp/`
config pages, and rebasing them would require force-pushing reviewed
commits. The dedup rule asks us to merge only when the *same* items
are still open, which is not the case here.

---

### `docs/source/` drift

#### `docs/source/mp/configuration.rst` — missing `lmcache.mp.mq_timeout` / `lmcache.mp.heartbeat_interval` keys

[PR #3026](https://github.com/LMCache/LMCache/pull/3026)
("[MP] Add extra_config to construct lmcache mp adapter", commit
[`4d2d4f3`](https://github.com/LMCache/LMCache/commit/4d2d4f373c2487f89378c0ef1bf3d95a5c6ceea3))
merged today. It formalizes a new `lmcache.mp.*` extra-config namespace
inside the MP adapter via
[`ExtraConfigDefault`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/lmcache/integration/vllm/vllm_multi_process_adapter.py#L29-L43)
and a
[`_resolve_extra_config()`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/lmcache/integration/vllm/vllm_multi_process_adapter.py#L52-L100)
helper, listing two keys:

- `lmcache.mp.mq_timeout` (default `300.0` seconds) — timeout for
  blocking message-queue requests (initial chunk-size query, KV cache
  registration/unregistration). On timeout the connector raises
  `ConnectionError` with the message "LMCache server did not respond
  within {timeout}s." See
  [`vllm_multi_process_adapter.py#L445-L451`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/lmcache/integration/vllm/vllm_multi_process_adapter.py#L445-L451).
- `lmcache.mp.heartbeat_interval` (default `10.0` seconds) — interval
  between periodic heartbeat pings to the server.

The connector now passes the full `kv_connector_extra_config` dict
straight through to the adapter via the new
[`extra_config` parameter on `create_scheduler_adapter` / `create_worker_adapter`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/lmcache/integration/vllm/lmcache_mp_connector.py#L121-L180),
and the `LMCacheMPConnector` class docstring on `dev` already advertises
all four keys
([`lmcache_mp_connector.py#L472-L481`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/lmcache/integration/vllm/lmcache_mp_connector.py#L472-L481)).
The two legacy variants
[`lmcache_mp_connector_0180.py`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/lmcache/integration/vllm/lmcache_mp_connector_0180.py#L444-L482)
and
[`lmcache_mp_connector_0201.py`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/lmcache/integration/vllm/lmcache_mp_connector_0201.py#L466-L504)
read the same two keys via `get_from_extra_config(...)` with the same
defaults, so the doc surface is the same across all three connector
flavors.

The stale doc locations:

- [`docs/source/mp/configuration.rst` lines 399-409 on `dev`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/docs/source/mp/configuration.rst#L399-L409)
  — the *vLLM Client Configuration* section shows only a
  `lmcache.mp.host` / `lmcache.mp.port` example and never names the
  other two keys.
- A `grep -rn "mq_timeout\|heartbeat_interval" docs/` on
  [`f9ce8cb`](https://github.com/LMCache/LMCache/commit/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a)
  returns zero hits, confirming the keys are entirely undocumented
  outside the source tree.

The `docs/source/mp/quickstart.rst`, `deployment.rst`, and `operator.rst`
examples are not stale — they only demonstrate the `host`/`port` keys,
which still work. They simply do not need updating for this drift item.

#### `docs/design/` drift

None new today.

---

## Proposed fix (applied in this PR — one commit)

A single doc-only commit
([`3be77c8`](https://github.com/ApostaC/LMCache/commit/3be77c8220c36305945cc121f7f72f53d744796b)),
DCO-signed and authored by ApostaC:

- **`docs/source/mp/configuration.rst`** — append a `list-table` after
  the existing `vllm serve` example in *vLLM Client Configuration*
  that enumerates all four supported `kv_connector_extra_config` keys
  (`lmcache.mp.host`, `lmcache.mp.port`, `lmcache.mp.mq_timeout`,
  `lmcache.mp.heartbeat_interval`), their defaults, and the behavior
  they affect. Wording follows `ExtraConfigDefault` and the
  `LMCacheMPConnector` docstring verbatim; no behavior change is
  implied.

No code files are touched.

## Audit-clean (no drift) commits in today's window

The following `dev` commits between
[`c9cfa3a`](https://github.com/LMCache/LMCache/commit/c9cfa3af12422a513a0c3cf7c60d143957ee8514)
(2026-05-18) and
[`f9ce8cb`](https://github.com/LMCache/LMCache/commit/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a)
(2026-05-19) were audited and introduced no additional MP doc drift:

- **PR #3308** ([MP] Lazy import cupy for `gpu_cache_context`) — pure
  implementation refactor: moves `import cupy` to a `TYPE_CHECKING`
  guard with a lazy import inside `GPUCacheContext.__init__` /
  `PlainGPUCacheContext.__init__`, restores type hints via forward
  references. The
  [`raw_cuda_ipc.md`](https://github.com/LMCache/LMCache/blob/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a/docs/design/v1/multiprocess/raw_cuda_ipc.md)
  design doc mentions `cupy.ndarray` only as a representation detail
  on line 17 — unchanged by this PR.
- **PR #3315** ([CI] add signoff for doc translation workflow) — CI
  workflow only.
- **PR #3312** ([CI] skip LMCache main release pipeline for
  `operator-v*` release tags) — release workflow only.
- **PR #3311** ([CI] DCO sign-off commits from `sync_torch_version`
  workflow) — CI workflow only.
- **PR #3296** (the previous drift-check PR for 2026-05-15) — already
  merged; nothing further to audit.

## Generated by

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Branch: `ApostaC:docs/drift-check-2026-05-19`.
Human review is still required before merge; please leave this PR in
draft until reviewed.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012qmid2YGxXCRnMC9wiNkqv)_