### PR TITLE
[Distributed][Observability] Export serde encode/decode metrics

### DIFF
--- a/lmcache/v1/distributed/serde/async_processor.py
+++ b/lmcache/v1/distributed/serde/async_processor.py
@@ -24,6 +24,11 @@ from lmcache.v1.distributed.serde.base import (
     Serializer,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import (
+    get_event_bus,
+    is_observability_enabled,
+)
 from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
@@ -54,9 +59,11 @@ class AsyncSerdeProcessor(SerdeProcessor):
         serializer: Serializer,
         deserializer: Deserializer,
         max_workers: int = 1,
+        serde_type: str = "unknown",
     ) -> None:
         self._serializer = serializer
         self._deserializer = deserializer
+        self._serde_type = serde_type
 
         self._serialize_efd = create_event_notifier()
         self._deserialize_efd = create_event_notifier()
@@ -170,20 +177,43 @@ class AsyncSerdeProcessor(SerdeProcessor):
         signals the event notifier.
         """
         success = True
+        bytes_in = self._sum_object_sizes(src_objs)
+        bytes_out = 0
+        event_session_id = self._event_session_id(task_type, task_id)
+        self._publish_serde_event(
+            task_type,
+            is_start=True,
+            session_id=event_session_id,
+            num_objects=len(src_objs),
+        )
+        failure_reason = ""
         try:
             if task_type == _TaskType.SERIALIZE:
                 for src, dst in zip(src_objs, dst_objs, strict=True):
-                    self._serializer.serialize(src, dst)
+                    bytes_out += int(self._serializer.serialize(src, dst) or 0)
             else:
                 for src, dst in zip(src_objs, dst_objs, strict=True):
                     self._deserializer.deserialize(src, dst)
-        except Exception:
+                bytes_out = self._sum_object_sizes(dst_objs)
+        except Exception as exc:
             logger.exception(
                 "Serde task %d (%s) failed",
                 task_id,
                 task_type.name,
             )
             success = False
+            failure_reason = type(exc).__name__
+
+        self._publish_serde_event(
+            task_type,
+            is_start=False,
+            session_id=event_session_id,
+            num_objects=len(src_objs),
+            bytes_in=bytes_in,
+            bytes_out=bytes_out,
+            success=success,
+            failure_reason=failure_reason,
+        )
 
         if success:
             logger.debug(
@@ -216,3 +246,71 @@ class AsyncSerdeProcessor(SerdeProcessor):
             notifier.notify()
         except OSError:
             logger.exception("Failed to signal notifier for serde task %d", task_id)
+
+    @staticmethod
+    def _sum_object_sizes(objects: list[MemoryObj]) -> int:
+        """Return logical byte size for objects without failing the task."""
+        total = 0
+        for obj in objects:
+            try:
+                total += int(obj.get_size())
+            except Exception:
+                logger.debug("Serde: failed to read MemoryObj size", exc_info=True)
+        return total
+
+    def _event_session_id(
+        self,
+        task_type: _TaskType,
+        task_id: SerdeTaskId,
+    ) -> str:
+        """Return a process-local unique session id for serde start/end events."""
+        return f"serde-{id(self):x}-{task_type.name.lower()}-{task_id}"
+
+    def _publish_serde_event(
+        self,
+        task_type: _TaskType,
+        *,
+        is_start: bool,
+        session_id: str,
+        num_objects: int,
+        bytes_in: int = 0,
+        bytes_out: int = 0,
+        success: bool = True,
+        failure_reason: str = "",
+    ) -> None:
+        """Publish serde start/end events when MP observability is enabled."""
+        if not is_observability_enabled():
+            return
+        if task_type == _TaskType.SERIALIZE:
+            event_type = (
+                EventType.CB_SERDE_ENCODE_START
+                if is_start
+                else EventType.CB_SERDE_ENCODE_END
+            )
+        else:
+            event_type = (
+                EventType.CB_SERDE_DECODE_START
+                if is_start
+                else EventType.CB_SERDE_DECODE_END
+            )
+        metadata: dict[str, object] = {
+            "serde_type": self._serde_type,
+            "num_objects": num_objects,
+        }
+        if not is_start:
+            metadata.update(
+                {
+                    "bytes_in": bytes_in,
+                    "bytes_out": bytes_out,
+                    "success": success,
+                }
+            )
+            if not success and failure_reason:
+                metadata["failure_reason"] = failure_reason
+        get_event_bus().publish(
+            Event(
+                event_type=event_type,
+                session_id=session_id,
+                metadata=metadata,
+            )
+        )

--- a/lmcache/v1/distributed/serde/fp8.py
+++ b/lmcache/v1/distributed/serde/fp8.py
@@ -97,6 +97,7 @@ def _create_fp8_serde(kwargs: dict[str, object]) -> SerdeProcessor:
         Fp8QuantizationSerializer(fp8_dtype),
         Fp8QuantizationDeserializer(fp8_dtype),
         max_workers=max_workers,
+        serde_type="fp8",
     )
 
 

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -348,6 +348,7 @@ def init_observability(
             L2MetricsSubscriber,
             L2ThroughputSubscriber,
             LookupMetricsSubscriber,
+            SerdeMetricsSubscriber,
             SMLifecycleSubscriber,
         )
 
@@ -364,6 +365,7 @@ def init_observability(
         bus.register_subscriber(LookupMetricsSubscriber())
         bus.register_subscriber(SMLifecycleSubscriber(sample_rate=sample_rate))
         bus.register_subscriber(BlendMetricsSubscriber())
+        bus.register_subscriber(SerdeMetricsSubscriber())
         bus.register_subscriber(EngineMetricsSubscriber())
         bus.register_subscriber(EventBusSelfMetricsSubscriber(bus))
 

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -102,6 +102,12 @@ class EventType(Enum):
     CB_FINGERPRINTS_REGISTERED = "cb.fingerprints.registered"
     CB_CHUNKS_EVICTED = "cb.chunks.evicted"
 
+    # Cache Blending (CB) serde events — encode/decode transform observability
+    CB_SERDE_ENCODE_START = "cb.serde.encode.start"
+    CB_SERDE_ENCODE_END = "cb.serde.encode.end"
+    CB_SERDE_DECODE_START = "cb.serde.decode.start"
+    CB_SERDE_DECODE_END = "cb.serde.decode.end"
+
     # Cache Blending (CB) events — lifecycle sentinels (CPU-synchronous)
     CB_REQUEST_START = "cb.request.start"
     CB_STORE_PRE_COMPUTED_SUBMITTED = "cb.store_pre_computed.submitted"

--- a/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/__init__.py
@@ -36,6 +36,9 @@ from lmcache.v1.mp_observability.subscribers.metrics.l2_throughput import (
 from lmcache.v1.mp_observability.subscribers.metrics.lookup import (
     LookupMetricsSubscriber,
 )
+from lmcache.v1.mp_observability.subscribers.metrics.serde import (
+    SerdeMetricsSubscriber,
+)
 from lmcache.v1.mp_observability.subscribers.metrics.sm_lifecycle import (
     SMLifecycleSubscriber,
 )
@@ -54,5 +57,6 @@ __all__ = [
     "L2MetricsSubscriber",
     "L2ThroughputSubscriber",
     "LookupMetricsSubscriber",
+    "SerdeMetricsSubscriber",
     "SMLifecycleSubscriber",
 ]

--- a/lmcache/v1/mp_observability/subscribers/metrics/serde.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/serde.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serde metrics subscriber — OTel instruments for CB serde transforms.
+
+Metrics:
+
+- ``lmcache_blend.serde_encode_duration_seconds`` — histogram of KV→bytes
+  serialize wall time. Tagged by ``serde_type`` (fp8/naive/cachegen/kivi),
+  ``success``, and ``num_objects``.
+- ``lmcache_blend.serde_decode_duration_seconds`` — histogram of bytes→KV
+  deserialize wall time. Same tags as encode.
+- ``lmcache_blend.serde_bytes_in`` — counter of raw bytes fed into serde
+  (pre-compression size for encode, compressed size for decode).
+- ``lmcache_blend.serde_bytes_out`` — counter of bytes produced by serde
+  (compressed size for encode, raw size for decode).
+- ``lmcache_blend.serde_failures`` — counter of failed encode/decode ops.
+  Tagged by ``serde_type``, ``direction`` (encode/decode), ``failure_reason``.
+
+Together ``bytes_in / bytes_out`` gives the compression ratio per serde type,
+enabling dashboards like:
+
+    rate(lmcache_blend_serde_bytes_out_total[5m])
+    / rate(lmcache_blend_serde_bytes_in_total[5m])
+
+which should be < 1 for fp8/cachegen and = 1 for naive.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from dataclasses import dataclass
+
+# Third Party
+from opentelemetry import metrics
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventCallback, EventSubscriber
+
+logger = logging.getLogger(__name__)
+
+_MAX_PENDING_OPS = 10_000
+
+
+@dataclass
+class _PendingSerdeOp:
+    """Tracks an in-flight serde operation for duration measurement."""
+
+    direction: str  # "encode" or "decode"
+    serde_type: str
+    start_timestamp: float
+    num_objects: int
+
+
+class SerdeMetricsSubscriber(EventSubscriber):
+    """Maintains OTel instruments for CB serde/transform operations."""
+
+    def __init__(self) -> None:
+        meter = metrics.get_meter("lmcache.blend.serde")
+
+        self._encode_duration = meter.create_histogram(
+            "lmcache_blend.serde_encode_duration_seconds",
+            description="Duration of CB serde encode (serialize) operations",
+            unit="s",
+        )
+        self._decode_duration = meter.create_histogram(
+            "lmcache_blend.serde_decode_duration_seconds",
+            description="Duration of CB serde decode (deserialize) operations",
+            unit="s",
+        )
+        self._bytes_in = meter.create_counter(
+            "lmcache_blend.serde_bytes_in",
+            description=(
+                "Bytes fed into serde (pre-compression for encode, "
+                "compressed for decode)"
+            ),
+            unit="By",
+        )
+        self._bytes_out = meter.create_counter(
+            "lmcache_blend.serde_bytes_out",
+            description=(
+                "Bytes produced by serde (compressed for encode, raw for decode)"
+            ),
+            unit="By",
+        )
+        self._failures = meter.create_counter(
+            "lmcache_blend.serde_failures",
+            description=(
+                "Failed CB serde operations, tagged by serde_type/direction/reason"
+            ),
+        )
+
+        self._pending_ops: dict[str, _PendingSerdeOp] = {}
+
+    def get_subscriptions(self) -> dict[EventType, EventCallback]:
+        return {
+            EventType.CB_SERDE_ENCODE_START: self._on_encode_start,
+            EventType.CB_SERDE_ENCODE_END: self._on_encode_end,
+            EventType.CB_SERDE_DECODE_START: self._on_decode_start,
+            EventType.CB_SERDE_DECODE_END: self._on_decode_end,
+        }
+
+    # ------------------------------------------------------------------
+    # Encode path
+    # ------------------------------------------------------------------
+
+    def _on_encode_start(self, event: Event) -> None:
+        key = f"encode:{event.session_id}"
+        self._pending_ops[key] = _PendingSerdeOp(
+            direction="encode",
+            serde_type=event.metadata.get("serde_type", "unknown"),
+            start_timestamp=event.timestamp,
+            num_objects=event.metadata.get("num_objects", 1),
+        )
+        self._cap_pending_ops()
+
+    def _on_encode_end(self, event: Event) -> None:
+        serde_type = event.metadata.get("serde_type", "unknown")
+        success = bool(event.metadata.get("success", True))
+        bytes_in = event.metadata.get("bytes_in", 0)
+        bytes_out = event.metadata.get("bytes_out", 0)
+
+        # Duration
+        pending = self._pending_ops.pop(f"encode:{event.session_id}", None)
+        attrs = {
+            "serde_type": serde_type,
+            "success": success,
+            "num_objects": self._num_objects(event, pending),
+        }
+        if pending is not None and event.timestamp >= pending.start_timestamp:
+            self._encode_duration.record(
+                event.timestamp - pending.start_timestamp, attrs
+            )
+
+        # Bytes counters
+        if bytes_in:
+            self._bytes_in.add(
+                bytes_in, {"serde_type": serde_type, "direction": "encode"}
+            )
+        if bytes_out:
+            self._bytes_out.add(
+                bytes_out, {"serde_type": serde_type, "direction": "encode"}
+            )
+
+        # Failures
+        if not success:
+            reason = event.metadata.get("failure_reason", "unknown")
+            self._failures.add(
+                1,
+                {
+                    "serde_type": serde_type,
+                    "direction": "encode",
+                    "failure_reason": reason,
+                },
+            )
+
+    # ------------------------------------------------------------------
+    # Decode path
+    # ------------------------------------------------------------------
+
+    def _on_decode_start(self, event: Event) -> None:
+        key = f"decode:{event.session_id}"
+        self._pending_ops[key] = _PendingSerdeOp(
+            direction="decode",
+            serde_type=event.metadata.get("serde_type", "unknown"),
+            start_timestamp=event.timestamp,
+            num_objects=event.metadata.get("num_objects", 1),
+        )
+        self._cap_pending_ops()
+
+    def _on_decode_end(self, event: Event) -> None:
+        serde_type = event.metadata.get("serde_type", "unknown")
+        success = bool(event.metadata.get("success", True))
+        bytes_in = event.metadata.get("bytes_in", 0)
+        bytes_out = event.metadata.get("bytes_out", 0)
+
+        # Duration
+        pending = self._pending_ops.pop(f"decode:{event.session_id}", None)
+        attrs = {
+            "serde_type": serde_type,
+            "success": success,
+            "num_objects": self._num_objects(event, pending),
+        }
+        if pending is not None and event.timestamp >= pending.start_timestamp:
+            self._decode_duration.record(
+                event.timestamp - pending.start_timestamp, attrs
+            )
+
+        # Bytes counters
+        if bytes_in:
+            self._bytes_in.add(
+                bytes_in, {"serde_type": serde_type, "direction": "decode"}
+            )
+        if bytes_out:
+            self._bytes_out.add(
+                bytes_out, {"serde_type": serde_type, "direction": "decode"}
+            )
+
+        # Failures
+        if not success:
+            reason = event.metadata.get("failure_reason", "unknown")
+            self._failures.add(
+                1,
+                {
+                    "serde_type": serde_type,
+                    "direction": "decode",
+                    "failure_reason": reason,
+                },
+            )
+
+    def _cap_pending_ops(self) -> None:
+        """Evict oldest entries when _pending_ops exceeds the cap."""
+        evicted_count = 0
+        while len(self._pending_ops) > _MAX_PENDING_OPS:
+            oldest_key = next(iter(self._pending_ops))
+            del self._pending_ops[oldest_key]
+            evicted_count += 1
+        if evicted_count:
+            logger.warning(
+                "_pending_ops exceeded %d entries; evicted %d oldest entries",
+                _MAX_PENDING_OPS,
+                evicted_count,
+            )
+
+    @staticmethod
+    def _num_objects(event: Event, pending: _PendingSerdeOp | None) -> int:
+        """Return the object count for duration metric attributes."""
+        value = event.metadata.get("num_objects")
+        if value is None and pending is not None:
+            value = pending.num_objects
+        return int(value or 0)

--- a/tests/v1/distributed/serde/test_async_processor.py
+++ b/tests/v1/distributed/serde/test_async_processor.py
@@ -23,7 +23,14 @@ from lmcache.v1.distributed.serde import (
     Deserializer,
     Serializer,
 )
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.event_bus import EventBusConfig, init_event_bus
+from lmcache.v1.mp_observability.subscribers.metrics.serde import SerdeMetricsSubscriber
 from lmcache.v1.platform import consume_fd
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import (
+    counter_delta,
+    read_counters,
+)
 
 
 class _FakeSerializer(Serializer):
@@ -35,7 +42,7 @@ class _FakeSerializer(Serializer):
         if self._transform is not None:
             self._transform(self.calls)
         self.calls += 1
-        return 1
+        return dst.get_size() if hasattr(dst, "get_size") else 1
 
     def estimate_serialized_size(self, layout_desc: MemoryLayoutDesc) -> int:
         return 1
@@ -50,6 +57,14 @@ class _FakeDeserializer(Deserializer):
         if self._transform is not None:
             self._transform(self.calls)
         self.calls += 1
+
+
+class _SizedObject:
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def get_size(self) -> int:
+        return self._size
 
 
 def _wait_for_fd(fd: int, timeout_s: float = 2.0) -> bool:
@@ -139,3 +154,97 @@ def test_estimate_serialized_size_delegates_to_serializer() -> None:
         assert processor.estimate_serialized_size(layout) == 1
     finally:
         processor.close()
+
+
+def test_serde_event_session_ids_are_unique_per_processor() -> None:
+    """Concurrent processors must not collide in start/end correlation keys."""
+    bus = init_event_bus(EventBusConfig(enabled=True, max_queue_size=100))
+    session_ids: list[str] = []
+
+    def _record_session_id(event: Event) -> None:
+        session_ids.append(event.session_id)
+
+    bus.subscribe(EventType.CB_SERDE_ENCODE_START, _record_session_id)
+    processor_a = AsyncSerdeProcessor(
+        _FakeSerializer(), _FakeDeserializer(), serde_type="fp8"
+    )
+    processor_b = AsyncSerdeProcessor(
+        _FakeSerializer(), _FakeDeserializer(), serde_type="fp8"
+    )
+    try:
+        bus.start()
+        task_a = processor_a.submit_serialize(
+            [_SizedObject(4096)],
+            [_SizedObject(2048)],  # type: ignore[list-item]
+        )
+        task_b = processor_b.submit_serialize(
+            [_SizedObject(4096)],
+            [_SizedObject(2048)],  # type: ignore[list-item]
+        )
+        assert _wait_for_fd(processor_a.get_serialize_event_fd()), "fd A never signaled"
+        assert _wait_for_fd(processor_b.get_serialize_event_fd()), "fd B never signaled"
+        assert processor_a.query_serialize_result(task_a) is True
+        assert processor_b.query_serialize_result(task_b) is True
+        bus.stop()
+        assert len(session_ids) == 2
+        assert len(set(session_ids)) == 2
+    finally:
+        processor_a.close()
+        processor_b.close()
+        bus.stop()
+        init_event_bus(EventBusConfig(enabled=False))
+
+
+def test_serialize_emits_cb_serde_encode_metrics() -> None:
+    """AsyncSerdeProcessor must publish encode serde events on completion."""
+    bus = init_event_bus(EventBusConfig(enabled=True, max_queue_size=100))
+    bus.register_subscriber(SerdeMetricsSubscriber())
+    before = read_counters()
+    processor = AsyncSerdeProcessor(
+        _FakeSerializer(), _FakeDeserializer(), serde_type="fp8"
+    )
+    try:
+        bus.start()
+        task_id = processor.submit_serialize(
+            [_SizedObject(4096)],
+            [_SizedObject(2048)],  # type: ignore[list-item]
+        )
+        assert _wait_for_fd(processor.get_serialize_event_fd()), "fd never signaled"
+        assert processor.query_serialize_result(task_id) is True
+        bus.stop()
+        delta = counter_delta(before, read_counters())
+        assert delta.get("lmcache_blend.serde_bytes_in", 0) >= 4096
+        assert delta.get("lmcache_blend.serde_bytes_out", 0) >= 2048
+    finally:
+        processor.close()
+        bus.stop()
+        init_event_bus(EventBusConfig(enabled=False))
+
+
+def test_deserialize_failure_emits_cb_serde_decode_failure_metric() -> None:
+    """Serde decode failures must be visible as lmcache_blend.serde_failures."""
+
+    def _boom(_i: int) -> None:
+        raise RuntimeError("deserialize failed")
+
+    bus = init_event_bus(EventBusConfig(enabled=True, max_queue_size=100))
+    bus.register_subscriber(SerdeMetricsSubscriber())
+    before = read_counters()
+    processor = AsyncSerdeProcessor(
+        _FakeSerializer(), _FakeDeserializer(_boom), serde_type="cachegen"
+    )
+    try:
+        bus.start()
+        task_id = processor.submit_deserialize(
+            [_SizedObject(2048)],
+            [_SizedObject(4096)],  # type: ignore[list-item]
+        )
+        assert _wait_for_fd(processor.get_deserialize_event_fd()), "fd never signaled"
+        assert processor.query_deserialize_result(task_id) is False
+        bus.stop()
+        delta = counter_delta(before, read_counters())
+        assert delta.get("lmcache_blend.serde_failures", 0) >= 1
+    finally:
+        processor.close()
+        bus.stop()
+        init_event_bus(EventBusConfig(enabled=False))

--- a/tests/v1/distributed/serde/test_serde_wire_path.py
+++ b/tests/v1/distributed/serde/test_serde_wire_path.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused serde wire-path tests through AsyncSerdeProcessor + EventBus."""
+
+# Standard
+import select
+import time
+
+# First Party
+from lmcache.v1.distributed.serde import AsyncSerdeProcessor
+from lmcache.v1.mp_observability.event_bus import EventBusConfig, init_event_bus
+from lmcache.v1.mp_observability.subscribers.metrics.serde import SerdeMetricsSubscriber
+from lmcache.v1.platform import consume_fd
+from tests.v1.distributed.serde.test_async_processor import (
+    _FakeDeserializer,
+    _FakeSerializer,
+    _SizedObject,
+)
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import (
+    counter_delta,
+    read_counters,
+)
+
+
+def _wait_for_fd(fd: int, timeout_s: float = 2.0) -> bool:
+    poller = select.poll()
+    poller.register(fd, select.POLLIN)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if poller.poll(int(max(0, (deadline - time.monotonic()) * 1000))):
+            try:
+                consume_fd(fd)
+            except OSError:
+                pass
+            return True
+    return False
+
+
+def test_encode_wire_path_emits_serde_metrics() -> None:
+    bus = init_event_bus(EventBusConfig(enabled=True, max_queue_size=100))
+    bus.register_subscriber(SerdeMetricsSubscriber())
+    before = read_counters()
+    processor = AsyncSerdeProcessor(
+        _FakeSerializer(), _FakeDeserializer(), serde_type="fp8"
+    )
+    try:
+        bus.start()
+        task_id = processor.submit_serialize(
+            [_SizedObject(4096)],
+            [_SizedObject(2048)],  # type: ignore[list-item]
+        )
+        assert _wait_for_fd(processor.get_serialize_event_fd())
+        assert processor.query_serialize_result(task_id) is True
+        time.sleep(0.15)
+        delta = counter_delta(before, read_counters())
+        assert delta.get("lmcache_blend.serde_bytes_in", 0) >= 4096
+        assert delta.get("lmcache_blend.serde_bytes_out", 0) >= 2048
+    finally:
+        processor.close()
+        bus.stop()
+        init_event_bus(EventBusConfig(enabled=False))
+
+
+def test_decode_failure_wire_path_emits_failure_metric() -> None:
+    def _boom(_i: int) -> None:
+        raise RuntimeError("decode failed")
+
+    bus = init_event_bus(EventBusConfig(enabled=True, max_queue_size=100))
+    bus.register_subscriber(SerdeMetricsSubscriber())
+    before = read_counters()
+    processor = AsyncSerdeProcessor(
+        _FakeSerializer(), _FakeDeserializer(_boom), serde_type="cachegen"
+    )
+    try:
+        bus.start()
+        task_id = processor.submit_deserialize(
+            [_SizedObject(2048)],
+            [_SizedObject(4096)],  # type: ignore[list-item]
+        )
+        assert _wait_for_fd(processor.get_deserialize_event_fd())
+        assert processor.query_deserialize_result(task_id) is False
+        time.sleep(0.15)
+        delta = counter_delta(before, read_counters())
+        assert delta.get("lmcache_blend.serde_failures", 0) >= 1
+    finally:
+        processor.close()
+        bus.stop()
+        init_event_bus(EventBusConfig(enabled=False))

--- a/tests/v1/mp_observability/subscribers/metrics/test_serde.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_serde.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for SerdeMetricsSubscriber."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_observability.event import Event, EventType
+from lmcache.v1.mp_observability.subscribers.metrics.serde import SerdeMetricsSubscriber
+from tests.v1.mp_observability.subscribers.metrics.otel_setup import (
+    counter_delta,
+    read_counters,
+    reader as _reader,
+)
+
+
+def _histogram_count(name: str) -> int:
+    data = _reader.get_metrics_data()
+    if data is None:
+        return 0
+    total = 0
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name != name:
+                    continue
+                for dp in metric.data.data_points:
+                    total += int(getattr(dp, "count", 0))
+    return total
+
+
+def _event(
+    event_type: EventType, session_id: str, timestamp: float, **metadata
+) -> Event:
+    return Event(
+        event_type=event_type,
+        session_id=session_id,
+        timestamp=timestamp,
+        metadata=metadata,
+    )
+
+
+@pytest.fixture
+def subscriber() -> SerdeMetricsSubscriber:
+    return SerdeMetricsSubscriber()
+
+
+def test_subscribes_to_serde_start_and_end_events(subscriber: SerdeMetricsSubscriber):
+    assert set(subscriber.get_subscriptions()) == {
+        EventType.CB_SERDE_ENCODE_START,
+        EventType.CB_SERDE_ENCODE_END,
+        EventType.CB_SERDE_DECODE_START,
+        EventType.CB_SERDE_DECODE_END,
+    }
+
+
+def test_encode_start_end_records_duration_and_byte_counters(
+    subscriber: SerdeMetricsSubscriber,
+):
+    callbacks = subscriber.get_subscriptions()
+    before = read_counters()
+    before_hist = _histogram_count("lmcache_blend.serde_encode_duration_seconds")
+
+    callbacks[EventType.CB_SERDE_ENCODE_START](
+        _event(
+            EventType.CB_SERDE_ENCODE_START,
+            "encode-1",
+            10.0,
+            serde_type="fp8",
+            num_objects=2,
+        )
+    )
+    callbacks[EventType.CB_SERDE_ENCODE_END](
+        _event(
+            EventType.CB_SERDE_ENCODE_END,
+            "encode-1",
+            10.25,
+            serde_type="fp8",
+            bytes_in=4096,
+            bytes_out=2048,
+            success=True,
+        )
+    )
+
+    delta = counter_delta(before, read_counters())
+    assert (
+        _histogram_count("lmcache_blend.serde_encode_duration_seconds") - before_hist
+        == 1
+    )
+    assert delta.get("lmcache_blend.serde_bytes_in", 0) >= 4096
+    assert delta.get("lmcache_blend.serde_bytes_out", 0) >= 2048
+
+
+def test_decode_start_end_records_duration_and_byte_counters(
+    subscriber: SerdeMetricsSubscriber,
+):
+    callbacks = subscriber.get_subscriptions()
+    before = read_counters()
+    before_hist = _histogram_count("lmcache_blend.serde_decode_duration_seconds")
+
+    callbacks[EventType.CB_SERDE_DECODE_START](
+        _event(
+            EventType.CB_SERDE_DECODE_START,
+            "decode-1",
+            20.0,
+            serde_type="cachegen",
+            num_objects=1,
+        )
+    )
+    callbacks[EventType.CB_SERDE_DECODE_END](
+        _event(
+            EventType.CB_SERDE_DECODE_END,
+            "decode-1",
+            20.1,
+            serde_type="cachegen",
+            bytes_in=1024,
+            bytes_out=4096,
+            success=True,
+        )
+    )
+
+    delta = counter_delta(before, read_counters())
+    assert (
+        _histogram_count("lmcache_blend.serde_decode_duration_seconds") - before_hist
+        == 1
+    )
+    assert delta.get("lmcache_blend.serde_bytes_in", 0) >= 1024
+    assert delta.get("lmcache_blend.serde_bytes_out", 0) >= 4096
+
+
+def test_encode_failure_increments_failure_counter(subscriber: SerdeMetricsSubscriber):
+    before = read_counters()
+    subscriber.get_subscriptions()[EventType.CB_SERDE_ENCODE_END](
+        _event(
+            EventType.CB_SERDE_ENCODE_END,
+            "encode-fail",
+            30.0,
+            serde_type="fp8",
+            success=False,
+            failure_reason="ValueError",
+        )
+    )
+
+    delta = counter_delta(before, read_counters())
+    assert delta.get("lmcache_blend.serde_failures", 0) >= 1
+
+
+def test_decode_failure_increments_failure_counter(subscriber: SerdeMetricsSubscriber):
+    before = read_counters()
+    subscriber.get_subscriptions()[EventType.CB_SERDE_DECODE_END](
+        _event(
+            EventType.CB_SERDE_DECODE_END,
+            "decode-fail",
+            40.0,
+            serde_type="cachegen",
+            success=False,
+            failure_reason="RuntimeError",
+        )
+    )
+
+    delta = counter_delta(before, read_counters())
+    assert delta.get("lmcache_blend.serde_failures", 0) >= 1
+
+
+def test_pending_ops_are_bounded(subscriber: SerdeMetricsSubscriber, monkeypatch):
+    # Standard
+    import lmcache.v1.mp_observability.subscribers.metrics.serde as serde_mod
+
+    monkeypatch.setattr(serde_mod, "_MAX_PENDING_OPS", 2)
+    callbacks = subscriber.get_subscriptions()
+
+    for idx in range(4):
+        callbacks[EventType.CB_SERDE_ENCODE_START](
+            _event(
+                EventType.CB_SERDE_ENCODE_START,
+                f"encode-{idx}",
+                float(idx),
+                serde_type="fp8",
+            )
+        )
+
+    assert len(subscriber._pending_ops) == 2
+    assert "encode:encode-2" in subscriber._pending_ops
+    assert "encode:encode-3" in subscriber._pending_ops


### PR DESCRIPTION
## Summary

Export distributed serde encode/decode observability separately from L0 and CacheBlend GPU data-path metrics.

This PR answers:

- Did distributed serialization happen?
- How expensive was encode/decode?
- Did decode fail?
- Did wire-path payload handling work?

## Scope

- `SerdeMetricsSubscriber`
- serde encode/decode duration histograms
- serde encode/decode byte and failure counters
- EventBus publication from the async serde processor
- focused serde subscriber tests
- focused serde wire-path tests
- async processor serde tests directly required for event emission

## Out of scope

- no CacheBlend GPU data-path metrics
- no CB V2 adapter behavior changes
- no connector refactors
- no prompt exports or internal planning docs

## Test plan

- `python -m ruff check lmcache/v1/mp_observability/subscribers/metrics/serde.py lmcache/v1/mp_observability/event.py lmcache/v1/mp_observability/config.py lmcache/v1/mp_observability/subscribers/metrics/__init__.py lmcache/v1/distributed/serde/async_processor.py lmcache/v1/distributed/serde/fp8.py tests/v1/mp_observability/subscribers/metrics/test_serde.py tests/v1/distributed/serde/test_serde_wire_path.py tests/v1/distributed/serde/test_async_processor.py`
- `python -m pytest tests/v1/mp_observability/subscribers/metrics/test_serde.py tests/v1/distributed/serde/test_serde_wire_path.py tests/v1/distributed/serde/test_async_processor.py -q --tb=short`
  - local result: `17 passed`
