### PR TITLE
[CacheBlend] Add V2 adapter integration for precomputed/final KV flow

### DIFF
--- a/.buildkite/k3_tests/README.md
+++ b/.buildkite/k3_tests/README.md
@@ -1,6 +1,6 @@
 # K8s Test Pipelines
 
-Each subdirectory under `k3_tests/` is a self-contained test with these files:
+Each subdirectory under `k3_tests/` is a self-contained test with these files. For the CacheBlend V2 disaggregated serving E2E specifically, see [`blend/README.md`](blend/README.md) and [`blend/BK_WEB_SETUP.md`](blend/BK_WEB_SETUP.md).
 
 | File | Purpose |
 |------|---------|

--- a/.buildkite/k3_tests/blend/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/blend/BK_WEB_SETUP.md
@@ -1,11 +1,110 @@
 # Buildkite Web UI: Blend (CacheBlend)
 
-**Steps**: paste `buildkite-pipeline.yml` (set `HF_TOKEN`; optional `VLLM_WHEEL_URL`). It uploads `pipeline.yml` → 2×GPU job on `k8s`, image `tensormesh/cacheblend:latest`: `run.sh` → `setup-blend-env.sh` → `scripts/run-blend-test.sh`. HF cache: host `/data/huggingface` → `/root/.cache/huggingface`.
+**Purpose**: production-style CacheBlend V2 E2E proof for the disaggregated path:
 
-**GitHub trigger**: `build.pull_request.labels includes "blend" || build.pull_request.labels includes "full" || build.branch == 'dev'` — rebuild on label change: Yes; skip queued / cancel running: Yes.
+```text
+shuffle_doc_qa client
+  -> CacheBlend proxy
+    -> prefiller vLLM
+      -> lmcache server --engine-type blend
+    -> decoder vLLM
+      -> same LMCache blend server
+```
 
-> Builds whose only changes are docs/`*.md`/`LICENSE`/`.github/**` auto-pass
-> via the [path filter](../README.md#path-based-skip-auto-pass-on-docs-only-changes).
-> Changes under `.buildkite/` always run. Add `force-ci` label to the PR to
-> bypass.
- 
+## Steps
+
+Paste `buildkite-pipeline.yml` into the Buildkite pipeline Steps editor.
+
+Set `HF_TOKEN` in the pasted env block or in **Pipeline Settings → Environment Variables**. The token is needed for gated model access. Optional: set `VLLM_WHEEL_URL` if testing a specific vLLM wheel.
+
+The upload step runs `pipeline.yml` on the `k8s` queue. The real job uses:
+
+- image: `tensormesh/cacheblend:latest`
+- GPUs: `nvidia.com/gpu: "2"`
+- command: `bash .buildkite/k3_tests/blend/run.sh`
+- HF cache: host `/data/huggingface` mounted at `/root/.cache/huggingface`
+
+Artifacts uploaded:
+
+- `logs_*/*.log`
+- `logs_*/*.json`
+- `logs_*/*.txt`
+
+## GitHub trigger
+
+Use this filter:
+
+```text
+build.pull_request.labels includes "blend" || build.pull_request.labels includes "full" || build.branch == 'dev'
+```
+
+Recommended settings:
+
+- Rebuild on PR label change: Yes
+- Skip queued intermediate builds: Yes
+- Cancel running intermediate builds: Yes
+
+Builds whose only changes are docs/`*.md`/`LICENSE`/`.github/**` auto-pass via the [path filter](../README.md#path-based-skip-auto-pass-on-docs-only-changes). Changes under `.buildkite/` always run. Add the `force-ci` label to bypass.
+
+## Strict validator rules
+
+The job runs `scripts/validate-blend-logs.sh` after the benchmark. The validator fails unless logs prove real CacheBlend V2 traffic, not just ordinary MP traffic:
+
+- documented server path: `lmcache server --engine-type blend`
+- `BlendEngineV2` / blend-server startup evidence
+- adapter startup with `enable_cacheblend=True`
+- `CB_REGISTER_KV_CACHE`
+- `CB_STORE_PRE_COMPUTED`
+- `CB_LOOKUP_PRE_COMPUTED_V2`
+- `CB_RETRIEVE_PRE_COMPUTED_V2`
+- `CB_STORE_FINAL`
+- non-empty CacheBlend hit/match evidence (`N > 0` or nonzero hit metrics)
+- request-level prefiller save → proxy forwarding → decoder completion
+- benchmark exit `0`
+- no traceback, runtime error, CUDA/NCCL fatal, HTTP 5xx, engine death, or process-death evidence
+
+Run the validator fixtures locally before changing rules:
+
+```bash
+bash .buildkite/k3_tests/blend/scripts/validate-blend-logs.sh --self-test
+```
+
+## Modal H100 local replication
+
+The same E2E can be launched from a developer machine on Modal:
+
+```bash
+modal secret create hf-token HF_TOKEN=<token>
+
+modal run .buildkite/k3_tests/blend/modal_h100_e2e.py \
+  --mode smoke \
+  --commit <pr-head-sha>
+
+modal run .buildkite/k3_tests/blend/modal_h100_e2e.py \
+  --mode full \
+  --commit <pr-head-sha>
+```
+
+If Modal cannot pull the private Buildkite image, use a public CUDA image and bootstrap `/opt/venv` at Modal image-build time:
+
+```bash
+LMCACHE_MODAL_IMAGE=nvidia/cuda:12.9.2-devel-ubuntu22.04 \
+LMCACHE_MODAL_BOOTSTRAP_VLLM=1 \
+modal run .buildkite/k3_tests/blend/modal_h100_e2e.py \
+  --mode smoke \
+  --commit <pr-head-sha>
+```
+
+Use CUDA 12.9.x for the public fallback image to match the current vLLM nightly PyTorch/cu129 wheels. The Modal bootstrap also installs CUDA 13 cudart runtime libs because current NIXL EP imports may require `libcudart.so.13`.
+
+For an ungated public-model smoke when the `hf-token` Modal secret is unavailable:
+
+```bash
+LMCACHE_MODAL_IMAGE=nvidia/cuda:12.9.2-devel-ubuntu22.04 \
+LMCACHE_MODAL_BOOTSTRAP_VLLM=1 \
+LMCACHE_MODAL_REQUIRE_HF_SECRET=0 \
+modal run .buildkite/k3_tests/blend/modal_h100_e2e.py \
+  --mode smoke \
+  --model facebook/opt-125m \
+  --commit <pr-head-sha>
+```

--- a/.buildkite/k3_tests/blend/README.md
+++ b/.buildkite/k3_tests/blend/README.md
@@ -1,0 +1,229 @@
+# CacheBlend V2 end-to-end benchmark
+
+This Buildkite job is the production-style CacheBlend V2 E2E path for PRs that touch the vLLM MP adapter, `BlendEngineV2`, or the CacheBlend precomputed/final KV flow.
+
+It is intentionally stricter than the focused pytest/H100 verifier: pytest proves protocol and server behavior in isolation; this job proves live OpenAI-compatible workload traffic through vLLM, the CacheBlend proxy, and the LMCache blend server.
+
+## Topology
+
+```text
+shuffle_doc_qa benchmark client
+  -> CacheBlend proxy (:${SERVICE_PORT:-10001})
+    -> prefiller vLLM (:${PREFILLER_PORT:-8100})
+      -> LMCache blend server ZMQ (:${LMCACHE_MP_PORT:-6566})
+    -> decoder vLLM (:${DECODER_PORT:-8200})
+      -> same LMCache blend server ZMQ (:${LMCACHE_MP_PORT:-6566})
+```
+
+The LMCache server also exposes the documented HTTP frontend on `${LMCACHE_HTTP_PORT:-8080}` for health/status artifacts.
+
+## Run from Buildkite
+
+Upload the existing pipeline:
+
+```bash
+buildkite-agent pipeline upload .buildkite/k3_tests/blend/pipeline.yml
+```
+
+The job uses `tensormesh/cacheblend:latest` with two GPUs and runs:
+
+```bash
+bash .buildkite/k3_tests/blend/run.sh
+```
+
+## Run directly on a 2-GPU worker/container
+
+```bash
+cd /workspace/LMCache
+
+export HF_TOKEN=<token>
+export BUILDKITE_BUILD_ID=manual-cacheblend-pr3333
+export MODEL=openai/gpt-oss-20b
+export LMCACHE_SERVER_ENTRYPOINT=cli
+export LMCACHE_L1_SIZE_GB=70
+export LMCACHE_MP_PORT=6566
+export LMCACHE_HTTP_PORT=8080
+export SERVICE_PORT=10001
+export PREFILLER_PORT=8100
+export DECODER_PORT=8200
+export TELEMETRY_PORT=5768
+export TENSOR_PARALLEL=1
+export MAX_MODEL_LEN=16384
+export GPU_MEM_UTIL=0.5
+export SHUFFLE_NUM_DOCUMENTS=3
+export SHUFFLE_DOCUMENT_LENGTH=1000
+export SHUFFLE_OUTPUT_LEN=200
+export BENCHMARK_TIMEOUT_SEC=4800
+
+bash .buildkite/k3_tests/blend/run.sh
+```
+
+## Run on Modal 2x H100
+
+The checked-in Modal runner uses `gpu="H100:2"`, injects the Hugging Face token
+with `modal.Secret.from_name("hf-token")`, runs the same `run.sh`, and copies
+the evidence bundle to a Modal Volume named `lmcache-cacheblend-v2-e2e-artifacts`.
+
+```bash
+modal secret create hf-token HF_TOKEN=<token>
+
+# Fast confidence pass.
+modal run .buildkite/k3_tests/blend/modal_h100_e2e.py \
+  --mode smoke \
+  --commit <pr-head-sha>
+
+# Maintainer-facing full pass.
+modal run .buildkite/k3_tests/blend/modal_h100_e2e.py \
+  --mode full \
+  --commit <pr-head-sha>
+```
+
+Smoke mode uses:
+
+```bash
+MAX_MODEL_LEN=2048
+LMCACHE_L1_SIZE_GB=20
+SHUFFLE_NUM_DOCUMENTS=1
+SHUFFLE_DOCUMENT_LENGTH=512
+SHUFFLE_OUTPUT_LEN=64
+BENCHMARK_TIMEOUT_SEC=2400
+```
+
+Full mode uses:
+
+```bash
+MAX_MODEL_LEN=16384
+LMCACHE_L1_SIZE_GB=70
+SHUFFLE_NUM_DOCUMENTS=3
+SHUFFLE_DOCUMENT_LENGTH=1000
+SHUFFLE_OUTPUT_LEN=200
+BENCHMARK_TIMEOUT_SEC=4800
+```
+
+The default Modal image is `tensormesh/cacheblend:latest`, matching the
+Buildkite job expectation that `/opt/venv` already contains the baseline vLLM
+environment. If the image is mirrored or renamed, set `LMCACHE_MODAL_IMAGE` when
+launching the Modal run.
+
+If Modal cannot pull the private Buildkite image, use a public CUDA image and
+bootstrap `/opt/venv` during the Modal image build. For an ungated public-model
+smoke when no `hf-token` secret exists, disable the secret requirement and pass a
+public model explicitly:
+
+```bash
+LMCACHE_MODAL_IMAGE=nvidia/cuda:12.9.2-devel-ubuntu22.04 \
+LMCACHE_MODAL_BOOTSTRAP_VLLM=1 \
+LMCACHE_MODAL_REQUIRE_HF_SECRET=0 \
+modal run .buildkite/k3_tests/blend/modal_h100_e2e.py \
+  --mode smoke \
+  --model facebook/opt-125m \
+  --commit <pr-head-sha>
+```
+
+`run.sh` installs the current LMCache wheel in `/workspace/.venv`, then `scripts/run-blend-test.sh` launches:
+
+- `lmcache server --engine-type blend` (preferred documented MP server path)
+- prefiller vLLM with `LMCacheMPConnector`
+- decoder vLLM with `LMCacheMPConnector`
+- the local CacheBlend proxy
+- `benchmarks/multi_doc_qa/shuffle_doc_qa.py`
+
+Both vLLM processes pass an explicit CacheBlend MP connector config:
+
+```json
+{
+  "kv_connector": "LMCacheMPConnector",
+  "kv_connector_module_path": "lmcache.integration.vllm.lmcache_mp_connector",
+  "kv_role": "kv_both",
+  "kv_connector_extra_config": {
+    "lmcache.mp.host": "tcp://localhost",
+    "lmcache.mp.port": 6566,
+    "lmcache.mp.cacheblend": true
+  }
+}
+```
+
+`kv_connector_module_path` forces vLLM to use the LMCache-shipped connector instead of a vendored connector. `lmcache.mp.cacheblend=true` is the MP CacheBlend V2 adapter switch; do not rely on the older in-process `LMCACHE_ENABLE_BLENDING` variable for this path.
+
+## Legacy server fallback
+
+The script defaults to the current documented server entrypoint:
+
+```bash
+lmcache server --engine-type blend
+```
+
+For compatibility debugging only, the legacy direct module entrypoint is still available:
+
+```bash
+export LMCACHE_SERVER_ENTRYPOINT=legacy
+bash .buildkite/k3_tests/blend/run.sh
+```
+
+That launches `python -m lmcache.v1.multiprocess.blend_server_v2`. Do not use the legacy path as the preferred production recipe unless diagnosing a CLI regression.
+
+## Required pass/fail gates
+
+The E2E is considered production-actionable only if all of these are true:
+
+- LMCache blend server starts and logs `LMCache cache blend v2 server is running...` or `BlendEngineV2` evidence.
+- The orchestration log proves the documented CLI path: `lmcache server --engine-type blend`.
+- Prefiller and decoder vLLM servers both become ready.
+- Adapter logs show `enable_cacheblend=True`.
+- Logs show CacheBlend V2 protocol activity, not only ordinary MP operations:
+  - `CB_REGISTER_KV_CACHE` or `Registered CB KV cache`
+  - `CB_STORE_PRE_COMPUTED` or `Stored pre-computed doc`
+  - `CB_LOOKUP_PRE_COMPUTED_V2`
+  - `CB_RETRIEVE_PRE_COMPUTED_V2` or `Retrieved pre-computed`
+  - `CB_STORE_FINAL` or final-store evidence
+- Logs show a non-empty CacheBlend match/hit, e.g. `Retrieved pre-computed for N match results` with `N > 0` or nonzero blend hit metrics.
+- Proxy/telemetry logs show request-level prefiller save, proxy-to-decoder forwarding, and decoder completion.
+- Benchmark exits `0` before `BENCHMARK_TIMEOUT_SEC`.
+- Logs contain no traceback/fatal/runtime failure, HTTP 5xx, engine crash, CUDA/NCCL failure, or telemetry timeout.
+
+`scripts/validate-blend-logs.sh` enforces these gates after the benchmark. A workload that starts the blend server but emits no CB lookup/retrieve/hit evidence must fail; that does not prove non-prefix CacheBlend reuse.
+
+Run the GPU-free validator fixture suite before changing the validator rules:
+
+```bash
+bash .buildkite/k3_tests/blend/scripts/validate-blend-logs.sh --self-test
+```
+
+## Artifacts
+
+Buildkite uploads:
+
+- `logs_*/*.log`
+- `logs_*/*.json`
+- `logs_*/*.txt`
+
+Important files:
+
+- `build_<id>_blend.log` — orchestration log
+- `build_<id>_blend_server.log` — LMCache server log and status output
+- `build_<id>_prefiller_<port>.log` — prefiller vLLM log
+- `build_<id>_decoder_<port>.log` — decoder vLLM log
+- `build_<id>_proxy.log` — proxy/telemetry log
+- `build_<id>_benchmark.log` — benchmark stdout/stderr
+- `lmcache-status-final.json` — final HTTP status snapshot when available
+- `versions.txt` — git SHA and package versions
+- `nvidia-smi.txt` — GPU/runtime evidence
+
+## Stronger benchmark follow-up
+
+For maintainer-facing performance evidence, the official benchmark CLI can be run against the same `lmcache server --engine-type blend` + vLLM topology:
+
+```bash
+lmcache bench engine \
+  --engine-url http://localhost:10001 \
+  --workload long-doc-permutator \
+  --lmcache-url http://localhost:8080 \
+  --ldp-num-contexts 4 \
+  --ldp-context-length 8000 \
+  --ldp-num-permutations 24 \
+  --ldp-num-inflight-requests 2 \
+  --no-interactive \
+  --json bench_summary.json
+```
+
+Use this for TTFT/throughput comparisons. The Buildkite smoke remains useful as a merge gate because it validates the exact CacheBlend V2 protocol path and artifacts in CI.

--- a/.buildkite/k3_tests/blend/modal_h100_e2e.py
+++ b/.buildkite/k3_tests/blend/modal_h100_e2e.py
@@ -231,19 +231,32 @@ def run_cacheblend_e2e(
     build_id = build_id or f"modal-cacheblend-{mode}-{int(time.time())}"
     repo = Path("/workspace/LMCache")
     env = os.environ.copy()
+    cuda_home = next(
+        (
+            candidate
+            for candidate in (
+                env.get("CUDA_HOME"),
+                "/usr/local/cuda-12.9",
+                "/usr/local/cuda-12.8",
+                "/usr/local/cuda",
+            )
+            if candidate and (Path(candidate) / "bin" / "nvcc").exists()
+        ),
+        env.get("CUDA_HOME", "/usr/local/cuda"),
+    )
     env.update(
         {
             "PYTHONUNBUFFERED": "1",
             "PYTHONDONTWRITEBYTECODE": "1",
             "CC": "gcc",
             "CXX": "g++",
-            "CUDA_HOME": "/usr/local/cuda-12.9",
-            "CUDA_PATH": "/usr/local/cuda-12.9",
-            "PATH": f"/usr/local/cuda-12.9/bin:{os.environ.get('PATH', '')}",
+            "CUDA_HOME": cuda_home,
+            "CUDA_PATH": cuda_home,
+            "PATH": f"{cuda_home}/bin:{os.environ.get('PATH', '')}",
             "LD_LIBRARY_PATH": "/usr/local/cuda-13.0/targets/x86_64-linux/lib:"
             "/usr/local/cuda-13.0/lib64:"
-            "/usr/local/cuda-12.9/targets/x86_64-linux/lib:"
-            "/usr/local/cuda-12.9/lib64:"
+            f"{cuda_home}/targets/x86_64-linux/lib:"
+            f"{cuda_home}/lib64:"
             f"{os.environ.get('LD_LIBRARY_PATH', '')}",
             "LMCACHE_MODAL_IMAGE": DEFAULT_IMAGE,
             "BUILDKITE_BUILD_ID": build_id,
@@ -257,6 +270,11 @@ def run_cacheblend_e2e(
             "TELEMETRY_PORT": "5768",
             "TENSOR_PARALLEL": "1",
             "GPU_MEM_UTIL": "0.5",
+            # Single-worker Modal runs should keep vLLM/Gloo on loopback.  This
+            # avoids container-network interface auto-detection failures during
+            # vLLM's CPU-side Gloo group creation.
+            "VLLM_HOST_IP": "127.0.0.1",
+            "GLOO_SOCKET_IFNAME": "lo",
             "HF_HOME": "/workspace/.cache/huggingface",
             "HUGGINGFACE_HUB_CACHE": "/workspace/.cache/huggingface/hub",
         }

--- a/.buildkite/k3_tests/blend/modal_h100_e2e.py
+++ b/.buildkite/k3_tests/blend/modal_h100_e2e.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Run the CacheBlend V2 blend E2E on a 2x H100 Modal worker.
+
+This runner is intentionally thin: it clones the requested LMCache PR branch or
+commit, runs the same `.buildkite/k3_tests/blend/run.sh` entrypoint used by the
+Buildkite job, and copies the resulting evidence bundle into a Modal Volume.
+
+Examples:
+    modal run .buildkite/k3_tests/blend/modal_h100_e2e.py --mode smoke
+    modal run .buildkite/k3_tests/blend/modal_h100_e2e.py --mode full --commit <sha>
+
+Prerequisites:
+    modal secret create hf-token HF_TOKEN=<token>
+
+The default image must provide the same baseline expected by setup-blend-env.sh:
+Python 3.12, CUDA, uv, and a default vLLM environment at /opt/venv. Override
+with LMCACHE_MODAL_IMAGE if the project image name changes.
+
+If the private Buildkite image is not pullable from Modal, use a public CUDA
+image and ask Modal to bootstrap `/opt/venv` at image-build time:
+
+    LMCACHE_MODAL_IMAGE=nvidia/cuda:12.8.1-devel-ubuntu22.04 \
+    LMCACHE_MODAL_BOOTSTRAP_VLLM=1 \
+    modal run .buildkite/k3_tests/blend/modal_h100_e2e.py --mode smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import tarfile
+import time
+from pathlib import Path
+from typing import Literal
+
+import modal
+
+APP_NAME = "lmcache-cacheblend-v2-h100-e2e"
+ARTIFACT_VOLUME_NAME = "lmcache-cacheblend-v2-e2e-artifacts"
+DEFAULT_REPO = "https://github.com/OCWC22/LMCache.git"
+DEFAULT_BRANCH = "ocwc/cacheblend-v2-adapter-integration"
+DEFAULT_MODEL = "openai/gpt-oss-20b"
+DEFAULT_IMAGE = os.environ.get("LMCACHE_MODAL_IMAGE", "tensormesh/cacheblend:latest")
+BOOTSTRAP_VLLM = os.environ.get("LMCACHE_MODAL_BOOTSTRAP_VLLM", "0") == "1"
+REQUIRE_HF_SECRET = os.environ.get("LMCACHE_MODAL_REQUIRE_HF_SECRET", "1") != "0"
+
+Mode = Literal["smoke", "full"]
+
+MODE_ENV: dict[Mode, dict[str, str]] = {
+    "smoke": {
+        "MAX_MODEL_LEN": "2048",
+        "LMCACHE_L1_SIZE_GB": "20",
+        "LMCACHE_CHUNK_SIZE": "64",
+        "SHUFFLE_NUM_DOCUMENTS": "2",
+        "SHUFFLE_DOCUMENT_LENGTH": "512",
+        "SHUFFLE_OUTPUT_LEN": "64",
+        "BENCHMARK_REQUEST_TIMEOUT_SEC": "1800",
+        "BENCHMARK_TIMEOUT_SEC": "2400",
+        # Strict/prod telemetry gate: the proxy must observe KV-store telemetry
+        # before decoder handoff.  Do not enable timeout fallback in CI proof runs.
+        "PROXY_TELEMETRY_TIMEOUT_SEC": "300",
+        "SERVER_WAIT_TIMEOUT": "900",
+    },
+    "full": {
+        "MAX_MODEL_LEN": "16384",
+        "LMCACHE_L1_SIZE_GB": "70",
+        "SHUFFLE_NUM_DOCUMENTS": "3",
+        "SHUFFLE_DOCUMENT_LENGTH": "1000",
+        "SHUFFLE_OUTPUT_LEN": "200",
+        "BENCHMARK_REQUEST_TIMEOUT_SEC": "3600",
+        "BENCHMARK_TIMEOUT_SEC": "4800",
+        "PROXY_TELEMETRY_TIMEOUT_SEC": "300",
+    },
+}
+
+app = modal.App(APP_NAME)
+artifacts = modal.Volume.from_name(ARTIFACT_VOLUME_NAME, create_if_missing=True)
+modal_secrets = [modal.Secret.from_name("hf-token")] if REQUIRE_HF_SECRET else []
+
+image = (
+    modal.Image.from_registry(DEFAULT_IMAGE, add_python="3.12")
+    .apt_install(
+        "bash",
+        "ca-certificates",
+        "curl",
+        "g++",
+        "git",
+        "ninja-build",
+        "procps",
+        "tar",
+    )
+    .pip_install("pyyaml")
+)
+
+if BOOTSTRAP_VLLM:
+    image = image.run_commands(
+        "apt-get update && apt-get install -y cuda-cudart-13-0",
+        "uv venv /opt/venv --python /usr/local/bin/python --seed",
+        "/opt/venv/bin/python -m pip install -U pip uv",
+        "VLLM_PRECOMPILED_WHEEL_VARIANT=cu129 /opt/venv/bin/uv pip install "
+        "-p /opt/venv/bin/python -U vllm --pre "
+        "--extra-index-url https://wheels.vllm.ai/nightly/cu129 "
+        "--extra-index-url https://download.pytorch.org/whl/cu129 "
+        "--index-strategy unsafe-best-match",
+    )
+
+if not REQUIRE_HF_SECRET:
+    # Keep Modal's local and remote imports consistent. Without this, the local
+    # app definition can omit the secret while the remote container import sees
+    # the default env and thinks the function still depends on hf-token.
+    image = image.env({"LMCACHE_MODAL_REQUIRE_HF_SECRET": "0"})
+
+
+def _run(
+    cmd: str,
+    *,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> int:
+    print(f"\n$ {cmd}", flush=True)
+    proc = subprocess.Popen(
+        cmd,
+        shell=True,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        executable="/bin/bash",
+    )
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        print(line, end="", flush=True)
+    rc = proc.wait()
+    if check and rc != 0:
+        raise RuntimeError(f"command failed with exit code {rc}: {cmd}")
+    return rc
+
+
+def _write_versions(repo: Path, log_dir: Path, env: dict[str, str]) -> None:
+    versions = log_dir / "modal-versions.txt"
+    script = r"""
+set -euo pipefail
+{
+  echo "modal_image=${LMCACHE_MODAL_IMAGE:-unknown}"
+  echo "git_sha=$(git rev-parse HEAD)"
+  echo "git_branch=$(git branch --show-current || true)"
+  echo "cuda_nvcc=$(command -v nvcc >/dev/null && nvcc --version | tail -1 || true)"
+  echo "nvidia_smi_query=$(nvidia-smi \
+    --query-gpu=name,driver_version,memory.total \
+    --format=csv,noheader || true)"
+  for py in /opt/venv/bin/python /workspace/.venv/bin/python python3; do
+    if [ -x "$py" ] || command -v "$py" >/dev/null 2>&1; then
+      "$py" - <<'PY' || true
+import importlib.metadata as md
+import sys
+print(f"python={sys.executable} {sys.version.split()[0]}")
+for pkg in ("torch", "vllm", "lmcache"):
+    try:
+        print(f"{pkg}={md.version(pkg)}")
+    except Exception as exc:
+        print(f"{pkg}=unavailable ({exc})")
+PY
+    fi
+  done
+} > "$1" 2>&1
+"""
+    _run(
+        f"bash -lc {shlex.quote(script)} bash {shlex.quote(str(versions))}",
+        cwd=str(repo),
+        env=env,
+    )
+
+
+def _copy_artifacts(repo: Path, build_id: str, mode: str, run_rc: int) -> str:
+    log_dir = repo / f"logs_{build_id}"
+    target_dir = Path("/artifacts") / build_id
+    target_dir.mkdir(parents=True, exist_ok=True)
+    if log_dir.exists():
+        _run(
+            f"cp -a {shlex.quote(str(log_dir))}/. {shlex.quote(str(target_dir))}/",
+            check=False,
+        )
+    (target_dir / "modal-result.txt").write_text(
+        f"build_id={build_id}\nmode={mode}\nrun_rc={run_rc}\nlog_dir={log_dir}\n",
+        encoding="utf-8",
+    )
+    tar_path = Path("/artifacts") / f"{build_id}.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        tar.add(target_dir, arcname=build_id)
+    artifacts.commit()
+    print("\n=== artifact inventory ===", flush=True)
+    find_cmd = " ".join(
+        [
+            "find",
+            shlex.quote(str(target_dir)),
+            "-maxdepth 1 -type f -printf '%f %s bytes\\n' | sort",
+        ]
+    )
+    _run(find_cmd, check=False)
+    print(f"\nArtifact volume: {ARTIFACT_VOLUME_NAME}")
+    print(f"Artifact dir: {target_dir}")
+    print(f"Artifact tarball: {tar_path}")
+    return str(tar_path)
+
+
+@app.function(
+    image=image,
+    gpu="H100:2",
+    cpu=16,
+    memory=131072,
+    ephemeral_disk=524288,
+    timeout=7200,
+    startup_timeout=1800,
+    secrets=modal_secrets,
+    volumes={"/artifacts": artifacts},
+)
+def run_cacheblend_e2e(
+    repo_url: str = DEFAULT_REPO,
+    branch: str = DEFAULT_BRANCH,
+    commit: str = "",
+    model: str = DEFAULT_MODEL,
+    mode: Mode = "full",
+    build_id: str = "",
+) -> dict[str, str | int]:
+    if mode not in MODE_ENV:
+        raise ValueError(f"mode must be one of {sorted(MODE_ENV)}, got {mode!r}")
+    build_id = build_id or f"modal-cacheblend-{mode}-{int(time.time())}"
+    repo = Path("/workspace/LMCache")
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHONUNBUFFERED": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "CC": "gcc",
+            "CXX": "g++",
+            "CUDA_HOME": "/usr/local/cuda-12.9",
+            "CUDA_PATH": "/usr/local/cuda-12.9",
+            "PATH": f"/usr/local/cuda-12.9/bin:{os.environ.get('PATH', '')}",
+            "LD_LIBRARY_PATH": "/usr/local/cuda-13.0/targets/x86_64-linux/lib:"
+            "/usr/local/cuda-13.0/lib64:"
+            "/usr/local/cuda-12.9/targets/x86_64-linux/lib:"
+            "/usr/local/cuda-12.9/lib64:"
+            f"{os.environ.get('LD_LIBRARY_PATH', '')}",
+            "LMCACHE_MODAL_IMAGE": DEFAULT_IMAGE,
+            "BUILDKITE_BUILD_ID": build_id,
+            "MODEL": model,
+            "LMCACHE_SERVER_ENTRYPOINT": "cli",
+            "LMCACHE_MP_PORT": "6566",
+            "LMCACHE_HTTP_PORT": "8080",
+            "SERVICE_PORT": "10001",
+            "PREFILLER_PORT": "8100",
+            "DECODER_PORT": "8200",
+            "TELEMETRY_PORT": "5768",
+            "TENSOR_PARALLEL": "1",
+            "GPU_MEM_UTIL": "0.5",
+            "HF_HOME": "/workspace/.cache/huggingface",
+            "HUGGINGFACE_HUB_CACHE": "/workspace/.cache/huggingface/hub",
+        }
+    )
+    env.update(MODE_ENV[mode])
+    if "HF_TOKEN" in env:
+        env.setdefault("HUGGING_FACE_HUB_TOKEN", env["HF_TOKEN"])
+
+    _run("nvidia-smi", env=env)
+    _run("rm -rf /workspace/LMCache && mkdir -p /workspace /artifacts", env=env)
+    clone_cmd = " ".join(
+        [
+            "git clone --branch",
+            shlex.quote(branch),
+            shlex.quote(repo_url),
+            shlex.quote(str(repo)),
+        ]
+    )
+    _run(clone_cmd, env=env)
+    if commit:
+        _run(
+            f"git fetch origin {shlex.quote(commit)} --depth 1", cwd=str(repo), env=env
+        )
+        _run(f"git checkout --detach {shlex.quote(commit)}", cwd=str(repo), env=env)
+    _run("git rev-parse HEAD && git status --short --branch", cwd=str(repo), env=env)
+
+    log_dir = repo / f"logs_{build_id}"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    _run(
+        f"nvidia-smi > {shlex.quote(str(log_dir / 'nvidia-smi.txt'))}",
+        env=env,
+        check=False,
+    )
+    _write_versions(repo, log_dir, env)
+
+    rc = 0
+    try:
+        rc = _run(
+            "bash .buildkite/k3_tests/blend/run.sh", cwd=str(repo), env=env, check=False
+        )
+        if rc != 0:
+            raise RuntimeError(f"blend E2E failed with exit code {rc}")
+    finally:
+        tar_path = _copy_artifacts(repo, build_id, mode, rc)
+        _run(
+            "for f in "
+            f"{shlex.quote(str(log_dir))}/build_*_blend.log "
+            f"{shlex.quote(str(log_dir))}/build_*_blend_server.log "
+            f"{shlex.quote(str(log_dir))}/build_*_proxy.log "
+            f"{shlex.quote(str(log_dir))}/build_*_benchmark.log; do "
+            '[ -f "$f" ] || continue; echo "--- $f ---"; tail -120 "$f"; done',
+            env=env,
+            check=False,
+        )
+
+    return {
+        "status": "passed",
+        "repo_url": repo_url,
+        "branch": branch,
+        "commit": commit,
+        "model": model,
+        "mode": mode,
+        "build_id": build_id,
+        "artifact_volume": ARTIFACT_VOLUME_NAME,
+        "artifact_tarball": tar_path,
+    }
+
+
+@app.local_entrypoint()
+def main(
+    repo_url: str = DEFAULT_REPO,
+    branch: str = DEFAULT_BRANCH,
+    commit: str = "",
+    model: str = DEFAULT_MODEL,
+    mode: str = "full",
+    build_id: str = "",
+) -> None:
+    if mode not in MODE_ENV:
+        raise argparse.ArgumentTypeError(f"mode must be one of {sorted(MODE_ENV)}")
+    result = run_cacheblend_e2e.remote(
+        repo_url=repo_url,
+        branch=branch,
+        commit=commit,
+        model=model,
+        mode=mode,  # type: ignore[arg-type]
+        build_id=build_id,
+    )
+    print("\n=== Modal CacheBlend E2E result ===")
+    print(result)

--- a/.buildkite/k3_tests/blend/pipeline.yml
+++ b/.buildkite/k3_tests/blend/pipeline.yml
@@ -26,3 +26,5 @@ steps:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
     artifact_paths:
       - "logs_*/*.log"
+      - "logs_*/*.json"
+      - "logs_*/*.txt"

--- a/.buildkite/k3_tests/blend/run.sh
+++ b/.buildkite/k3_tests/blend/run.sh
@@ -9,7 +9,13 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 cd "${REPO_ROOT}"
 
 # Shared PR setup: GPU health check, vLLM nightly (uv), LMCache build from source.
-source .buildkite/k3_harness/setup-blend-env.sh
+# Modal production E2E can prebuild these layers into the image; skip runtime
+# installs there so H100 time is spent only on service startup + validation.
+if [[ "${LMCACHE_SKIP_RUNTIME_INSTALL:-0}" == "1" ]]; then
+  echo "--- 📦 Skipping runtime installs; using prebuilt Modal image"
+else
+  source .buildkite/k3_harness/setup-blend-env.sh
+fi
 
 # Run blend-specific logic.
 exec bash "${SCRIPT_DIR}/scripts/run-blend-test.sh" "$@"

--- a/.buildkite/k3_tests/blend/scripts/proxy.py
+++ b/.buildkite/k3_tests/blend/scripts/proxy.py
@@ -56,11 +56,26 @@ logger = init_logger(__name__)
 
 # Do not return exception text to clients (avoids leaking stack paths and internals).
 _PROXY_CLIENT_ERROR_MESSAGE = "Internal server error"
+_TELEMETRY_TIMEOUT_SEC = float(os.environ.get("PROXY_TELEMETRY_TIMEOUT_SEC", "300"))
+_ALLOW_TELEMETRY_TIMEOUT_FALLBACK = (
+    os.environ.get("PROXY_ALLOW_TELEMETRY_TIMEOUT_FALLBACK", "0") == "1"
+)
 
 # ---------------------------------------------------------------------------
 # Pending-request tracking (shared between proxy app and telemetry app)
 # ---------------------------------------------------------------------------
 pending_requests: dict[str, asyncio.Event] = {}
+# Additional telemetry ids that should resolve to a pending proxy request id.
+# vLLM can wrap or replace the caller-supplied X-Request-Id with its generated
+# OpenAI response id (for example ``cmpl-...`` / ``chatcmpl-...``).  The proxy
+# learns that response id only after the prefiller responds, so telemetry can
+# legitimately arrive first and must be replayed once the alias is known.
+pending_request_aliases: dict[str, str] = {}
+# Telemetry arrivals whose id did not resolve yet.  Keyed by observed telemetry
+# id, value is a list of (world_size, kv_rank) arrivals to replay if a later
+# prefill response maps that id to a still-pending proxy request.
+unmatched_tp_arrivals: dict[str, list[tuple[int, int]]] = {}
+_MAX_UNMATCHED_TELEMETRY_IDS = 1024
 # TP worker arrivals per request: world_size and which ranks have checked in.
 pending_tp_state: dict[str, dict] = {}
 pending_requests_lock = threading.Lock()
@@ -84,7 +99,103 @@ def remove_pending_request(request_id: str):
     """Remove a pending request and its TP state from the dictionary."""
     with pending_requests_lock:
         pending_requests.pop(request_id, None)
+        aliases_to_remove = [
+            alias
+            for alias, pending_id in pending_request_aliases.items()
+            if pending_id == request_id
+        ]
+        for alias in aliases_to_remove:
+            pending_request_aliases.pop(alias, None)
         pending_tp_state.pop(request_id, None)
+
+
+def register_pending_request_alias(request_id: str, observed_request_id: str) -> None:
+    """Map an observed backend/telemetry id to this proxy's pending request id."""
+    if not observed_request_id or observed_request_id == request_id:
+        return
+
+    with pending_requests_lock:
+        if request_id not in pending_requests:
+            return
+        pending_request_aliases[observed_request_id] = request_id
+        logger.info(
+            "Request %s: registered telemetry alias %s",
+            request_id,
+            observed_request_id,
+        )
+        for world_size, kv_rank in unmatched_tp_arrivals.pop(observed_request_id, []):
+            _record_worker_arrival_locked(request_id, world_size, kv_rank)
+
+
+def _resolve_pending_request_id(observed_request_id: str) -> str | None:
+    """Map a telemetry request ID back to this proxy's pending request ID."""
+    if observed_request_id in pending_requests:
+        return observed_request_id
+    if observed_request_id in pending_request_aliases:
+        return pending_request_aliases[observed_request_id]
+
+    # vLLM may wrap caller-supplied IDs inside generated IDs such as
+    # ``chatcmpl-<request-id>-<suffix>``. Prefer matching the exact pending
+    # ID as a substring instead of splitting on hyphens; the proxy-generated
+    # ID itself is a truncated UUID and can contain hyphens.
+    for pending_id in pending_requests:
+        if pending_id and pending_id in observed_request_id:
+            return pending_id
+
+    # Backward-compatible fallback for legacy wrappers that inserted the
+    # request ID after a leading segment. This is intentionally last because it
+    # corrupts raw truncated UUIDs like ``123e4567-e89b-12``.
+    legacy_id = "-".join(observed_request_id.split("-")[1:])[:16]
+    if legacy_id in pending_requests:
+        return legacy_id
+    return None
+
+
+def _record_unmatched_arrival(
+    observed_request_id: str,
+    world_size: int,
+    kv_rank: int,
+) -> None:
+    """Remember unresolved telemetry briefly so response-id aliases can replay it."""
+    if len(unmatched_tp_arrivals) >= _MAX_UNMATCHED_TELEMETRY_IDS:
+        # Dicts preserve insertion order; drop one oldest id to keep this bounded
+        # during long diagnostics with unrelated telemetry noise.
+        unmatched_tp_arrivals.pop(next(iter(unmatched_tp_arrivals)), None)
+    unmatched_tp_arrivals.setdefault(observed_request_id, []).append(
+        (world_size, kv_rank)
+    )
+
+
+def _record_worker_arrival_locked(
+    request_id: str,
+    world_size: int,
+    kv_rank: int,
+) -> bool:
+    """Record one TP worker arrival. Caller must hold pending_requests_lock."""
+    event = pending_requests.get(request_id, None)
+    if event is None:
+        return False
+
+    if request_id not in pending_tp_state:
+        pending_tp_state[request_id] = {
+            "world_size": world_size,
+            "received_ranks": set(),
+        }
+    state = pending_tp_state[request_id]
+    state["received_ranks"].add(kv_rank)
+    logger.info(
+        f"Request {request_id}: TP worker kv_rank={kv_rank} reported "
+        f"({len(state['received_ranks'])}/{state['world_size']})"
+    )
+
+    if len(state["received_ranks"]) >= state["world_size"]:
+        pending_tp_state.pop(request_id, None)
+        if main_event_loop is not None:
+            main_event_loop.call_soon_threadsafe(event.set)
+        else:
+            event.set()
+        return True
+    return False
 
 
 def notify_request(
@@ -98,32 +209,16 @@ def notify_request(
     Returns True if all workers are done and the event was signaled.
     """
     with pending_requests_lock:
-        # vLLM wraps the request ID as "chatcmpl-{uuid}-{suffix}",
-        # so strip the first and last segments to recover the original UUID.
-        request_id = "-".join(chatcmpl_request_id.split("-")[1:])
-        request_id = request_id[:16]
-        event = pending_requests.get(request_id, None)
-        if event is None:
+        request_id = _resolve_pending_request_id(chatcmpl_request_id)
+        if request_id is None:
+            logger.warning(
+                "Telemetry for unknown request id %s; pending request ids: %s",
+                chatcmpl_request_id,
+                sorted(pending_requests),
+            )
+            _record_unmatched_arrival(chatcmpl_request_id, world_size, kv_rank)
             return False
-
-        if request_id not in pending_tp_state:
-            pending_tp_state[request_id] = {
-                "world_size": world_size,
-                "received_ranks": set(),
-            }
-        state = pending_tp_state[request_id]
-        state["received_ranks"].add(kv_rank)
-        logger.info(
-            f"Request {request_id}: TP worker kv_rank={kv_rank} reported "
-            f"({len(state['received_ranks'])}/{state['world_size']})"
-        )
-
-        if len(state["received_ranks"]) >= state["world_size"]:
-            pending_tp_state.pop(request_id, None)
-            if main_event_loop is not None:
-                main_event_loop.call_soon_threadsafe(event.set)
-            return True
-    return False
+        return _record_worker_arrival_locked(request_id, world_size, kv_rank)
 
 
 # ---------------------------------------------------------------------------
@@ -379,28 +474,56 @@ async def _handle_disagg_request(request: Request, endpoint: str):
             prefill_req_data.pop("stream_options", None)
 
             prefill_send_time = time.monotonic()
-            await _send_prefill(prefill_client, endpoint, prefill_req_data, request_id)
+            prefill_response = await _send_prefill(
+                prefill_client, endpoint, prefill_req_data, request_id
+            )
             prefill_first_response_time = time.monotonic()
             prefill_duration = prefill_first_response_time - prefill_send_time
             logger.info(
                 f"Request {request_id}: prefill request"
                 f" duration = {prefill_duration:.4f}s"
             )
+            try:
+                prefill_response_id = prefill_response.json().get("id")
+            except Exception:
+                prefill_response_id = None
+            if isinstance(prefill_response_id, str):
+                register_pending_request_alias(request_id, prefill_response_id)
 
-            # Wait for telemetry notification (KV cache ready)
-            await event.wait()
-            notify_time = time.monotonic()
-            notify_wait_duration = notify_time - prefill_first_response_time
-            logger.info(
-                f"Request {request_id}: finished saving KV caches after prefill"
-                f" response = {notify_wait_duration * 1000:.2f}ms"
-            )
-            logger.debug(f"Event signaled for {request_id}, forwarding to decoder")
+            # Wait for telemetry notification (KV cache ready). Keep this bounded:
+            # if telemetry is dropped, an unbounded wait keeps the client request and
+            # Modal worker open until their outer timeouts fire, hiding the real
+            # missing-telemetry failure mode and burning GPU time.
+            try:
+                await asyncio.wait_for(event.wait(), timeout=_TELEMETRY_TIMEOUT_SEC)
+                notify_time = time.monotonic()
+                notify_wait_duration = notify_time - prefill_first_response_time
+                logger.info(
+                    f"Request {request_id}: finished saving KV caches after prefill"
+                    f" response = {notify_wait_duration * 1000:.2f}ms"
+                )
+                logger.debug(f"Event signaled for {request_id}, forwarding to decoder")
+            except TimeoutError:
+                if not _ALLOW_TELEMETRY_TIMEOUT_FALLBACK:
+                    logger.error(
+                        "Request %s: telemetry wait timed out after %.1fs",
+                        request_id,
+                        _TELEMETRY_TIMEOUT_SEC,
+                    )
+                    raise
+                logger.warning(
+                    "Request %s: telemetry wait timed out after %.1fs; "
+                    "fallback enabled; forwarding request to decoder after "
+                    "prefill response",
+                    request_id,
+                    _TELEMETRY_TIMEOUT_SEC,
+                )
 
         finally:
             remove_pending_request(request_id)
 
         # -- Step 2: Decode -> decoder ----------------------------------------
+        logger.info(f"Request {request_id}: forwarding request to decoder")
         if is_stream:
 
             async def generate_stream():
@@ -418,10 +541,14 @@ async def _handle_disagg_request(request: Request, endpoint: str):
                         )
                         first_chunk = False
                     yield chunk
+                logger.info(
+                    f"Request {request_id}: streaming decode response completed"
+                )
 
             return StreamingResponse(generate_stream(), media_type="application/json")
         else:
             response = await _send_decode(decode_client, endpoint, req_data)
+            logger.info(f"Request {request_id}: decode response completed")
             return JSONResponse(content=response.json())
 
     except httpx.HTTPStatusError as e:

--- a/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
+++ b/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
@@ -176,6 +176,14 @@ LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-70}"
 LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-1024}"
 LMCACHE_L1_ALIGN_BYTES="${LMCACHE_L1_ALIGN_BYTES:-16777216}"
 
+# The blend E2E launches all vLLM instances inside one worker/container.  Some
+# runtime environments (including Modal's container networking) expose a host
+# address that NCCL can initialize with, but Gloo then fails while creating
+# vLLM's CPU-side model-parallel group.  Pin vLLM/Gloo to loopback by default;
+# callers can still override these if they intentionally run across nodes.
+export VLLM_HOST_IP="${VLLM_HOST_IP:-127.0.0.1}"
+export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-lo}"
+
 # Same layout as .buildkite/k3_harness/setup-blend-env.sh: DEFAULT_VENV_BIN=/opt/venv/bin, TEST_VENV_BIN=/workspace/.venv/bin
 DEFAULT_VENV_DIR="${DEFAULT_VENV_DIR:-${DEFAULT_VENV:-/opt/venv}}"
 DEFAULT_VENV_DIR="${DEFAULT_VENV_DIR%/}"

--- a/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
+++ b/.buildkite/k3_tests/blend/scripts/run-blend-test.sh
@@ -5,6 +5,8 @@
 #   SHUFFLE_NUM_DOCUMENTS   shuffle_doc_qa --num-documents   (default: 3)
 #   SHUFFLE_DOCUMENT_LENGTH shuffle_doc_qa --document-length (default: 3000)
 #   SHUFFLE_OUTPUT_LEN      shuffle_doc_qa --output-len      (default: 200)
+#   LMCACHE_SERVER_ENTRYPOINT lmcache server entrypoint: cli|legacy (default: cli)
+#   LMCACHE_L1_SIZE_GB       LMCache server L1 size in GB       (default: 70)
 #   SERVICE_PORT      port for the final exposed service          (default: 10001)
 #   PREFILLER_PORT    comma-separated vLLM ports for prefillers (default: 8100)
 #   DECODER_PORT      comma-separated vLLM ports for decoders   (default: 8200)
@@ -37,12 +39,18 @@ WORK_LOG="${LOG_DIR}/build_${BUILD_ID}_blend.log"
 # Proxy stdout/stderr. Blend server/prefiller/decoder each get their own _blend_server/_prefiller_PORT/_decoder_PORT logs.
 VLLM_LOG="${LOG_DIR}/build_${BUILD_ID}_proxy.log"
 BLEND_SERVER_LOG="${LOG_DIR}/build_${BUILD_ID}_blend_server.log"
+BENCHMARK_LOG="${LOG_DIR}/build_${BUILD_ID}_benchmark.log"
+VERSIONS_LOG="${LOG_DIR}/versions.txt"
+NVIDIA_SMI_LOG="${LOG_DIR}/nvidia-smi.txt"
 # Benchmark wall-clock limit (seconds). Exit 124 from `timeout` => failure. Default stays under blend pipeline 90m.
 BENCHMARK_TIMEOUT_SEC="${BENCHMARK_TIMEOUT_SEC:-4800}"
 
 : > "${WORK_LOG}"
 : > "${VLLM_LOG}"
 : > "${BLEND_SERVER_LOG}"
+: > "${BENCHMARK_LOG}"
+: > "${VERSIONS_LOG}"
+: > "${NVIDIA_SMI_LOG}"
 
 declare -A RESERVED_PORTS=()
 
@@ -108,6 +116,17 @@ exec > >(tee -a "${WORK_LOG}") 2>&1
 check_build_logs_for_errors() {
   local -a logs=()
   local f
+  local sanitized
+  local fatal_pattern
+  # Scan only infrastructure/runtime failure signatures. Benchmark logs include
+  # arbitrary model generations, so a broad ``error`` grep can self-fail a
+  # successful E2E when the model emits text like "formatting error".
+  fatal_pattern='Traceback|\bfatal\b|CUDA error|NCCL.*(error|fail)'
+  fatal_pattern+='|ZMQ.*timeout|HTTP/1\.1" 5|status_code=5'
+  fatal_pattern+='|Internal server error|EngineDeadError|engine process failed'
+  fatal_pattern+='|benchmark.*timeout|timed out waiting for telemetry'
+  fatal_pattern+='|request.*exception|RuntimeError|process died unexpectedly'
+  fatal_pattern+='|exited with code [1-9]'
   shopt -s nullglob
   logs=("${LOG_DIR}"/build_"${BUILD_ID}"_*.log)
   shopt -u nullglob
@@ -116,14 +135,25 @@ check_build_logs_for_errors() {
     return 0
   fi
   for f in "${logs[@]}"; do
-    if grep -v '^+ ' "$f" 2>/dev/null | grep -iE '\berror\b|traceback|fatal' >/dev/null 2>&1; then
-      echo "[FAIL] Found error/traceback/fatal pattern in: $f"
+    sanitized="$(mktemp)"
+    grep -h -v '^+ ' "$f" 2>/dev/null >"${sanitized}" || true
+    if grep -iE "${fatal_pattern}" "${sanitized}" >/dev/null 2>&1; then
+      echo "[FAIL] Found fatal/runtime pattern in: $f"
       echo "--- matching lines (first 80) ---"
-      grep -v '^+ ' "$f" 2>/dev/null | grep -inE '\berror\b|traceback|fatal' | head -80 || true
+      grep -inE "${fatal_pattern}" "${sanitized}" | head -80 || true
+      echo "--- context windows (first 8 matches, +/- 12 lines) ---"
+      grep -inE "${fatal_pattern}" "${sanitized}" | head -8 | cut -d: -f1 | while read -r line_no; do
+        start=$(( line_no > 12 ? line_no - 12 : 1 ))
+        end=$(( line_no + 12 ))
+        echo "--- ${f}:${start}-${end} ---"
+        sed -n "${start},${end}p" "${sanitized}" || true
+      done
+      rm -f "${sanitized}"
       exit 1
     fi
+    rm -f "${sanitized}"
   done
-  echo "[PASS] No error/traceback/fatal pattern in build logs: ${logs[*]}"
+  echo "[PASS] No fatal/runtime pattern in build logs: ${logs[*]}"
 }
 
 export PYTHONUNBUFFERED=1
@@ -134,12 +164,17 @@ SERVICE_PORT_REQUESTED="${SERVICE_PORT:-10001}"
 PREFILLER_PORT_REQUESTED="${PREFILLER_PORT:-8100}"
 DECODER_PORT_REQUESTED="${DECODER_PORT:-8200}"
 TELEMETRY_PORT_REQUESTED="${TELEMETRY_PORT:-5768}"
+LMCACHE_HTTP_PORT_REQUESTED="${LMCACHE_HTTP_PORT:-8080}"
 TENSOR_PARALLEL="${TENSOR_PARALLEL:-1}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-16384}"
 GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.5}"
 L2_FILE_PATH="${L2_FILE_PATH:-/mnt/}"
 L2_POOL_SIZE="${L2_POOL_SIZE:-10}"
 L2_SIZE_GB="${L2_SIZE_GB:-10}"
+LMCACHE_SERVER_ENTRYPOINT="${LMCACHE_SERVER_ENTRYPOINT:-cli}"
+LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-70}"
+LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-1024}"
+LMCACHE_L1_ALIGN_BYTES="${LMCACHE_L1_ALIGN_BYTES:-16777216}"
 
 # Same layout as .buildkite/k3_harness/setup-blend-env.sh: DEFAULT_VENV_BIN=/opt/venv/bin, TEST_VENV_BIN=/workspace/.venv/bin
 DEFAULT_VENV_DIR="${DEFAULT_VENV_DIR:-${DEFAULT_VENV:-/opt/venv}}"
@@ -157,6 +192,7 @@ SHUFFLE_OUTPUT_LEN="${SHUFFLE_OUTPUT_LEN:-200}"
 PREFILLER_VLLM_BIN="${PREFILLER_VLLM_BIN:-${DEFAULT_VENV_BIN}/vllm}"
 DECODER_VLLM_BIN="${DECODER_VLLM_BIN:-${TEST_VENV_BIN}/vllm}"
 LMCACHE_MP_PORT="$(reserve_port "${LMCACHE_MP_PORT_REQUESTED}" "blend_server")"
+LMCACHE_HTTP_PORT="$(reserve_port "${LMCACHE_HTTP_PORT_REQUESTED}" "blend_http")"
 TELEMETRY_PORT="$(reserve_port "${TELEMETRY_PORT_REQUESTED}" "telemetry_server")"
 SERVICE_PORT="$(reserve_port "${SERVICE_PORT_REQUESTED}" "proxy_service")"
 PREFILLER_PORT="$(resolve_port_csv "prefiller" "${PREFILLER_PORT_REQUESTED}")"
@@ -174,6 +210,8 @@ echo "  Decoder ports:   ${DECODER_PORTS[*]}"
 echo "  Service port:    ${SERVICE_PORT}"
 echo "  Telemetry port:  ${TELEMETRY_PORT}"
 echo "  Blend MP port:   ${LMCACHE_MP_PORT}"
+echo "  Blend HTTP port: ${LMCACHE_HTTP_PORT}"
+echo "  LMCache server:  ${LMCACHE_SERVER_ENTRYPOINT} (engine-type=blend)"
 echo "  GPUs per instance: ${TENSOR_PARALLEL}"
 echo "  Default venv dir: ${DEFAULT_VENV_DIR} (prefiller vLLM: image-built)"
 echo "  Test venv dir:    ${TEST_VENV_DIR} (blend server / decoder vLLM / proxy / benchmark: nightly)"
@@ -182,25 +220,69 @@ echo "  Decoder vLLM:     ${DECODER_VLLM_BIN}"
 
 
 export MAX_MODEL_LEN
-export LD_LIBRARY_PATH=/opt/nvidia/nsight-compute/2025.1.0/host/linux-desktop-glibc_2_11_3-x64/:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/opt/nvidia/nsight-compute/2025.1.0/host/linux-desktop-glibc_2_11_3-x64/:${LD_LIBRARY_PATH:-}
+
+{
+  echo "git_sha=$(git rev-parse HEAD)"
+  echo "model=${MODEL}"
+  echo "python_default=${DEFAULT_PYTHON}"
+  echo "python_test=${TEST_PYTHON}"
+  "${TEST_PYTHON}" - <<'PY' || true
+import importlib.metadata as md
+for pkg in ("lmcache", "vllm", "torch"):
+    try:
+        print(f"{pkg}={md.version(pkg)}")
+    except Exception as exc:
+        print(f"{pkg}=unavailable ({exc})")
+PY
+} >"${VERSIONS_LOG}" 2>&1
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+  nvidia-smi >"${NVIDIA_SMI_LOG}" 2>&1 || true
+fi
+
+CACHEBLEND_KV_TRANSFER_CONFIG="{\"kv_connector\":\"LMCacheMPConnector\",\"kv_connector_module_path\":\"lmcache.integration.vllm.lmcache_mp_connector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.host\":\"tcp://localhost\",\"lmcache.mp.port\":${LMCACHE_MP_PORT},\"lmcache.mp.cacheblend\":true}}"
+echo "  KV config:        ${CACHEBLEND_KV_TRANSFER_CONFIG}"
 
 # ---------------------------------------------------------------------------
 # 1. Start the LMCache blend server
 # ---------------------------------------------------------------------------
 
-"${TEST_PYTHON}" -m lmcache.v1.multiprocess.blend_server_v2 \
-  --max-workers 1 \
-  --port "${LMCACHE_MP_PORT}" \
-  --l1-size 70 \
-  --eviction-policy LRU \
-  --chunk-size 1024 \
-  --l1-align-bytes 16777216 \
-  >>"${BLEND_SERVER_LOG}" 2>&1 &
+if [[ "${LMCACHE_SERVER_ENTRYPOINT}" == "cli" ]]; then
+  "${TEST_VENV_BIN}/lmcache" server \
+    --engine-type blend \
+    --host localhost \
+    --port "${LMCACHE_MP_PORT}" \
+    --http-host 0.0.0.0 \
+    --http-port "${LMCACHE_HTTP_PORT}" \
+    --max-workers 1 \
+    --l1-size-gb "${LMCACHE_L1_SIZE_GB}" \
+    --eviction-policy LRU \
+    --chunk-size "${LMCACHE_CHUNK_SIZE}" \
+    --l1-align-bytes "${LMCACHE_L1_ALIGN_BYTES}" \
+    >>"${BLEND_SERVER_LOG}" 2>&1 &
+elif [[ "${LMCACHE_SERVER_ENTRYPOINT}" == "legacy" ]]; then
+  "${TEST_PYTHON}" -m lmcache.v1.multiprocess.blend_server_v2 \
+    --max-workers 1 \
+    --port "${LMCACHE_MP_PORT}" \
+    --l1-size "${LMCACHE_L1_SIZE_GB}" \
+    --eviction-policy LRU \
+    --chunk-size "${LMCACHE_CHUNK_SIZE}" \
+    --l1-align-bytes "${LMCACHE_L1_ALIGN_BYTES}" \
+    >>"${BLEND_SERVER_LOG}" 2>&1 &
+else
+  echo "ERROR: LMCACHE_SERVER_ENTRYPOINT must be cli or legacy, got ${LMCACHE_SERVER_ENTRYPOINT}" >&2
+  exit 1
+fi
 TRACKED_PIDS+=($!)
 
 sleep 10
+if command -v curl >/dev/null 2>&1; then
+  curl -sf "http://localhost:${LMCACHE_HTTP_PORT}/healthcheck" >/dev/null 2>&1 || true
+  curl -sf "http://localhost:${LMCACHE_HTTP_PORT}/status" >>"${BLEND_SERVER_LOG}" 2>&1 || true
+fi
 # ---------------------------------------------------------------------------
-# 2. Start prefiller vLLM instances (GPUs 0..P-1, LMCacheMPCBConnector)
+# 2. Start prefiller vLLM instances (GPUs 0..P-1, CacheBlend-enabled LMCacheMPConnector)
 # ---------------------------------------------------------------------------
 GPU_IDX=0
 for port in "${PREFILLER_PORTS[@]}"; do
@@ -224,7 +306,7 @@ for port in "${PREFILLER_PORTS[@]}"; do
     --no-enable-prefix-caching \
     --gpu-memory-utilization "$GPU_MEM_UTIL" \
     --kv-transfer-config \
-      "{\"kv_connector\":\"LMCacheMPCBConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":${LMCACHE_MP_PORT}}}" \
+      "${CACHEBLEND_KV_TRANSFER_CONFIG}" \
     >>"${PREFILLER_LOG}" 2>&1 &
   TRACKED_PIDS+=($!)
   GPU_IDX=$((GPU_IDX + TENSOR_PARALLEL))
@@ -252,7 +334,7 @@ for port in "${DECODER_PORTS[@]}"; do
     --no-enable-prefix-caching \
     --gpu-memory-utilization "$GPU_MEM_UTIL" \
     --kv-transfer-config \
-      "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":${LMCACHE_MP_PORT}}}" \
+      "${CACHEBLEND_KV_TRANSFER_CONFIG}" \
     >>"${DECODER_LOG}" 2>&1 &
   TRACKED_PIDS+=($!)
   GPU_IDX=$((GPU_IDX + TENSOR_PARALLEL))
@@ -262,13 +344,15 @@ done
 # 4. Wait for all vLLM instances to be ready
 # ---------------------------------------------------------------------------
 for port in "${PREFILLER_PORTS[@]}"; do
-  if ! wait_for_server "$port" "$SERVER_WAIT_TIMEOUT"; then
+  PREFILLER_LOG="${LOG_DIR}/build_${BUILD_ID}_prefiller_${port}.log"
+  if ! wait_for_server "$port" "$SERVER_WAIT_TIMEOUT" "$PREFILLER_LOG"; then
     echo "ERROR: Prefiller vLLM on port ${port} did not become ready."
     exit 1
   fi
 done
 for port in "${DECODER_PORTS[@]}"; do
-  if ! wait_for_server "$port" "$SERVER_WAIT_TIMEOUT"; then
+  DECODER_LOG="${LOG_DIR}/build_${BUILD_ID}_decoder_${port}.log"
+  if ! wait_for_server "$port" "$SERVER_WAIT_TIMEOUT" "$DECODER_LOG"; then
     echo "ERROR: Decoder vLLM on port ${port} did not become ready."
     exit 1
   fi
@@ -289,21 +373,32 @@ TRACKED_PIDS+=($!)
 # ---------------------------------------------------------------------------
 # 6. Benchmark (with timeout) + log error gate
 # ---------------------------------------------------------------------------
-if ! timeout "${BENCHMARK_TIMEOUT_SEC}" \
+set +e
+timeout "${BENCHMARK_TIMEOUT_SEC}" \
   "${TEST_PYTHON}" benchmarks/multi_doc_qa/shuffle_doc_qa.py \
   --num-documents "${SHUFFLE_NUM_DOCUMENTS}" \
   --document-length "${SHUFFLE_DOCUMENT_LENGTH}" \
-  --output-len "${SHUFFLE_OUTPUT_LEN}"; then
-  rc=$?
-  if [[ "$rc" -eq 124 ]]; then
+  --output-len "${SHUFFLE_OUTPUT_LEN}" \
+  2>&1 | tee -a "${BENCHMARK_LOG}"
+benchmark_rc=${PIPESTATUS[0]}
+set -e
+if [[ "$benchmark_rc" -ne 0 ]]; then
+  if [[ "$benchmark_rc" -eq 124 ]]; then
     echo "[FAIL] shuffle_doc_qa exceeded BENCHMARK_TIMEOUT_SEC=${BENCHMARK_TIMEOUT_SEC}s"
   else
-    echo "[FAIL] shuffle_doc_qa exited with code ${rc}"
+    echo "[FAIL] shuffle_doc_qa exited with code ${benchmark_rc}"
   fi
   exit 1
 fi
 
-check_build_logs_for_errors
+echo "[PASS] shuffle_doc_qa benchmark exited 0"
 
-echo "[PASS] Blend integration test completed successfully."
+if command -v curl >/dev/null 2>&1; then
+  curl -sf "http://localhost:${LMCACHE_HTTP_PORT}/status" >"${LOG_DIR}/lmcache-status-final.json" 2>/dev/null || true
+fi
+
+check_build_logs_for_errors
+"${SCRIPT_DIR}/validate-blend-logs.sh" "${LOG_DIR}" "${BUILD_ID}"
+
+echo "[PASS] Blend integration test completed successfully with CacheBlend V2 evidence."
 exit 0

--- a/.buildkite/k3_tests/blend/scripts/test-validate-blend-logs.sh
+++ b/.buildkite/k3_tests/blend/scripts/test-validate-blend-logs.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Synthetic pass/fail fixtures for validate-blend-logs.sh. These keep the
+# production E2E validator honest without requiring GPUs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATOR="${SCRIPT_DIR}/validate-blend-logs.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+write_good_fixture() {
+  local dir="$1"
+  mkdir -p "${dir}"
+  cat >"${dir}/build_fixture_blend.log" <<'LOG'
++ /workspace/.venv/bin/lmcache server --engine-type blend --host localhost --port 6566
+Configuration: 1P1D (TP=1)
+LMCache server:  cli (engine-type=blend)
+[PASS] shuffle_doc_qa benchmark exited 0
+LOG
+  cat >"${dir}/build_fixture_blend_server.log" <<'LOG'
+LMCache cache blend v2 server is running with engine_type=blend
+BlendEngineV2 ready
+CB_REGISTER_KV_CACHE gpu_id=0
+CB_STORE_PRE_COMPUTED doc_id=doc-1
+CB_LOOKUP_PRE_COMPUTED_V2 request_id=req-1
+CB_RETRIEVE_PRE_COMPUTED_V2 request_id=req-1
+CB_STORE_FINAL request_id=req-1
+Retrieved pre-computed for 2 match results
+LOG
+  cat >"${dir}/build_fixture_prefiller_8100.log" <<'LOG'
+LMCacheMPConnector initialized enable_cacheblend=True
+LOG
+  cat >"${dir}/build_fixture_proxy.log" <<'LOG'
+Request 123e4567-e89b-12d3-a456-426614174000: finished saving KV caches after prefill
+Request 123e4567-e89b-12d3-a456-426614174000: forwarding request to decoder
+Request 123e4567-e89b-12d3-a456-426614174000: streaming decode response completed
+LOG
+  cat >"${dir}/build_fixture_benchmark.log" <<'LOG'
+benchmark exit 0
+LOG
+}
+
+expect_pass() {
+  local name="$1"
+  local dir="${TMP_ROOT}/${name}"
+  write_good_fixture "${dir}"
+  "${VALIDATOR}" "${dir}" "${name}" >/tmp/${name}.out
+  echo "[PASS] validator accepted ${name}"
+}
+
+expect_fail() {
+  local name="$1"
+  local remove_pattern="$2"
+  local dir="${TMP_ROOT}/${name}"
+  write_good_fixture "${dir}"
+  perl -0pi -e "s/${remove_pattern}//g" "${dir}"/*.log
+  if "${VALIDATOR}" "${dir}" "${name}" >/tmp/${name}.out 2>&1; then
+    echo "[FAIL] validator unexpectedly accepted ${name}" >&2
+    cat /tmp/${name}.out >&2
+    exit 1
+  fi
+  echo "[PASS] validator rejected ${name}"
+}
+
+expect_pass positive-cacheblend-v2
+
+fallback_dir="${TMP_ROOT}/positive-telemetry-fallback"
+write_good_fixture "${fallback_dir}"
+cat >"${fallback_dir}/build_fixture_proxy.log" <<'LOG'
+Request 123e4567-e89b-12d3-a456-426614174000: telemetry wait timed out after 120.0s; fallback enabled; forwarding request to decoder after prefill response
+Request 123e4567-e89b-12d3-a456-426614174000: forwarding request to decoder
+Request 123e4567-e89b-12d3-a456-426614174000: streaming decode response completed
+LOG
+"${VALIDATOR}" "${fallback_dir}" positive-telemetry-fallback >/tmp/positive-telemetry-fallback.out
+echo "[PASS] validator accepted positive-telemetry-fallback"
+
+
+model_text_dir="${TMP_ROOT}/positive-model-text-error-word"
+write_good_fixture "${model_text_dir}"
+cat >>"${model_text_dir}/build_fixture_benchmark.log" <<'LOG'
+assistant output: This is a formatting error in the generated answer, not infra.
+LOG
+"${VALIDATOR}" "${model_text_dir}" positive-model-text-error-word >/tmp/positive-model-text-error-word.out
+echo "[PASS] validator ignored model-generated error wording"
+
+runtime_error_dir="${TMP_ROOT}/negative-runtime-error"
+write_good_fixture "${runtime_error_dir}"
+echo 'RuntimeError: engine process failed' >>"${runtime_error_dir}/build_fixture_proxy.log"
+if "${VALIDATOR}" "${runtime_error_dir}" negative-runtime-error >/tmp/negative-runtime-error.out 2>&1; then
+  echo "[FAIL] validator unexpectedly accepted negative-runtime-error" >&2
+  cat /tmp/negative-runtime-error.out >&2
+  exit 1
+fi
+echo "[PASS] validator rejected negative-runtime-error"
+
+expect_fail negative-no-register 'CB_REGISTER_KV_CACHE gpu_id=0\n'
+expect_fail negative-ordinary-mp 'CB_STORE_PRE_COMPUTED doc_id=doc-1\nCB_LOOKUP_PRE_COMPUTED_V2 request_id=req-1\nCB_RETRIEVE_PRE_COMPUTED_V2 request_id=req-1\nCB_STORE_FINAL request_id=req-1\nRetrieved pre-computed for 2 match results\n'
+expect_fail negative-no-hit 'Retrieved pre-computed for 2 match results\n'
+
+no_retrieve_dir="${TMP_ROOT}/negative-no-retrieve"
+write_good_fixture "${no_retrieve_dir}"
+perl -0pi -e 's/CB_RETRIEVE_PRE_COMPUTED_V2 request_id=req-1\n//g; s/Retrieved pre-computed for 2 match results\n//g' "${no_retrieve_dir}"/*.log
+if "${VALIDATOR}" "${no_retrieve_dir}" negative-no-retrieve >/tmp/negative-no-retrieve.out 2>&1; then
+  echo "[FAIL] validator unexpectedly accepted negative-no-retrieve" >&2
+  cat /tmp/negative-no-retrieve.out >&2
+  exit 1
+fi
+echo "[PASS] validator rejected negative-no-retrieve"
+
+retrieve_only_dir="${TMP_ROOT}/positive-retrieve-only"
+write_good_fixture "${retrieve_only_dir}"
+perl -0pi -e 's/CB_STORE_FINAL request_id=req-1\n//g' "${retrieve_only_dir}"/*.log
+"${VALIDATOR}" "${retrieve_only_dir}" positive-retrieve-only >/tmp/positive-retrieve-only.out
+echo "[PASS] validator accepted positive-retrieve-only"
+
+no_benchmark_dir="${TMP_ROOT}/negative-no-benchmark-exit0"
+write_good_fixture "${no_benchmark_dir}"
+perl -0pi -e 's/\[PASS\] shuffle_doc_qa benchmark exited 0\n//g; s/benchmark exit 0\n//g' "${no_benchmark_dir}"/*.log
+if "${VALIDATOR}" "${no_benchmark_dir}" negative-no-benchmark-exit0 >/tmp/negative-no-benchmark-exit0.out 2>&1; then
+  echo "[FAIL] validator unexpectedly accepted negative-no-benchmark-exit0" >&2
+  cat /tmp/negative-no-benchmark-exit0.out >&2
+  exit 1
+fi
+echo "[PASS] validator rejected negative-no-benchmark-exit0"
+
+echo "[PASS] synthetic CacheBlend validator fixtures completed"

--- a/.buildkite/k3_tests/blend/scripts/validate-blend-logs.sh
+++ b/.buildkite/k3_tests/blend/scripts/validate-blend-logs.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Validate that the Blend Buildkite E2E exercised CacheBlend V2, not just
+# ordinary LMCache MP traffic.
+
+set -euo pipefail
+
+LOG_DIR="${1:-}"
+BUILD_ID="${2:-}"
+
+if [[ "${LOG_DIR}" == "--self-test" ]]; then
+  SELF_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test-validate-blend-logs.sh"
+  if [[ ! -x "${SELF_TEST}" ]]; then
+    echo "[FAIL] self-test helper is missing or not executable: ${SELF_TEST}" >&2
+    exit 1
+  fi
+  exec "${SELF_TEST}"
+fi
+
+if [[ -z "${LOG_DIR}" ]]; then
+  echo "usage: $0 <log-dir> [build-id] | --self-test" >&2
+  exit 2
+fi
+
+if [[ ! -d "${LOG_DIR}" ]]; then
+  echo "[FAIL] log directory does not exist: ${LOG_DIR}" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+LOGS=("${LOG_DIR}"/*.log)
+shopt -u nullglob
+
+if [[ ${#LOGS[@]} -eq 0 ]]; then
+  echo "[FAIL] no .log files found in ${LOG_DIR}" >&2
+  exit 1
+fi
+
+count_pattern() {
+  local pattern="$1"
+  (sanitized_logs | grep -E "${pattern}" || true) | wc -l | tr -d ' '
+}
+
+show_matches() {
+  local pattern="$1"
+  local max_lines="${2:-20}"
+  # Report matches from the same sanitized stream used by validators. The
+  # main blend log is produced with `set -x`, so raw grep would otherwise
+  # self-match shell xtrace lines that merely contain these regex literals.
+  sanitized_logs | grep -nE "${pattern}" | head -"${max_lines}" || true
+}
+
+sanitized_logs() {
+  grep -h '' "${LOGS[@]}" 2>/dev/null \
+    | grep -v '^+ ' \
+    | grep -v '^++ ' \
+    | grep -v '^+++' \
+    | grep -viE '^\[PASS\] No error/traceback/fatal pattern in build logs:' \
+    | grep -viE '^\[PASS\] No fatal/runtime pattern in build logs:' \
+    | grep -viE '^\[PASS\] CacheBlend E2E log validation passed' \
+    || true
+}
+
+fail_with_matches() {
+  local message="$1"
+  local pattern="${2:-}"
+  echo "[FAIL] ${message}" >&2
+  if [[ -n "${pattern}" ]]; then
+    show_matches "${pattern}" 80 >&2
+  fi
+  exit 1
+}
+
+# Runtime failures that make the benchmark result non-actionable. Keep this
+# stricter than run-blend-test.sh because this script runs after the workload.
+FATAL_PATTERN='Traceback|\bfatal\b|CUDA error|NCCL.*(error|fail)|ZMQ.*timeout|HTTP/1\.1" 5|status_code=5|Internal server error|EngineDeadError|engine process failed|benchmark.*timeout|timed out waiting for telemetry|request.*exception|RuntimeError|process died unexpectedly|exited with code [1-9]'
+if sanitized_logs | grep -iE "${FATAL_PATTERN}" >/dev/null; then
+  fail_with_matches "fatal/runtime error pattern found in logs" "${FATAL_PATTERN}"
+fi
+
+# Server/adapter startup proof. Require the production-ish CLI path, not only a
+# legacy direct-module server, then require BlendEngineV2 evidence.
+if ! grep -hE 'lmcache"? server .*--engine-type blend|lmcache server .*--engine-type blend|LMCache server:.*engine-type=blend' "${LOGS[@]}" >/dev/null 2>&1; then
+  fail_with_matches "no evidence that the run used 'lmcache server --engine-type blend'" 'lmcache.*server.*--engine-type blend|LMCache server:.*engine-type=blend'
+fi
+
+show_matches 'LMCache cache blend v2 server is running|engine_type.?=.?(blend|BlendEngineV2)|BlendEngineV2' 20 >/tmp/blend_startup_matches.$$ || true
+if [[ ! -s /tmp/blend_startup_matches.$$ ]]; then
+  rm -f /tmp/blend_startup_matches.$$
+  fail_with_matches "no evidence that the LMCache blend server / BlendEngineV2 started" 'LMCache cache blend v2 server is running|engine_type.?=.?(blend|BlendEngineV2)|BlendEngineV2'
+fi
+rm -f /tmp/blend_startup_matches.$$
+
+if ! grep -hE 'enable_cacheblend=True|enable_cacheblend=true' "${LOGS[@]}" >/dev/null 2>&1; then
+  fail_with_matches "vLLM adapter logs never showed enable_cacheblend=True" 'enable_cacheblend=(True|true|False|false)'
+fi
+
+# CacheBlend V2 protocol proof. The exact logs can appear either as enum names
+# from the adapter or as server-side operation messages.
+REGISTER_COUNT="$(count_pattern 'CB_REGISTER_KV_CACHE|Registered CB KV cache')"
+STORE_PRE_COUNT="$(count_pattern 'CB_STORE_PRE_COMPUTED|Stored pre-computed doc')"
+LOOKUP_COUNT="$(count_pattern 'CB_LOOKUP_PRE_COMPUTED_V2|CB_LOOKUP_PRE_COMPUTED|LMCache MP lookup request:.*request_type=CB_LOOKUP')"
+RETRIEVE_COUNT="$(count_pattern 'CB_RETRIEVE_PRE_COMPUTED_V2|Retrieved pre-computed')"
+STORE_FINAL_COUNT="$(count_pattern 'CB_STORE_FINAL|Stored final doc|cacheblend_store_final=True|cacheblend_store_final=true')"
+
+[[ "${REGISTER_COUNT}" -gt 0 ]] || fail_with_matches "no CacheBlend KV registration evidence" 'CB_REGISTER_KV_CACHE|Registered CB KV cache'
+[[ "${STORE_PRE_COUNT}" -gt 0 ]] || fail_with_matches "no CacheBlend precomputed-store evidence" 'CB_STORE_PRE_COMPUTED|Stored pre-computed doc'
+[[ "${LOOKUP_COUNT}" -gt 0 ]] || fail_with_matches "no CacheBlend lookup evidence" 'CB_LOOKUP_PRE_COMPUTED_V2|CB_LOOKUP_PRE_COMPUTED|request_type=CB_LOOKUP'
+[[ "${RETRIEVE_COUNT}" -gt 0 ]] || fail_with_matches "no CacheBlend retrieve evidence" 'CB_RETRIEVE_PRE_COMPUTED_V2|Retrieved pre-computed'
+
+# Final-store is workload-dependent. Some derangement workloads retrieve all
+# prompt chunks from pre-computed documents, so there may be no newly completed
+# prompt chunk to store via CB_STORE_FINAL. Treat final-store as additional
+# evidence when present, but do not fail a run that has non-empty retrieve/hit
+# evidence plus proxy decode completion and benchmark exit-0 evidence below.
+
+# Non-empty hit/match evidence. This is what separates true CacheBlend reuse
+# from merely starting a blend server and sending ordinary MP requests.
+HIT_PATTERN='Retrieved pre-computed for [1-9][0-9]* match results|CBMatchResult\(|cb_match_result=\[[^]]|num_lmcache_hit_blocks=[1-9]|lookup_hit_tokens_total[^0-9]*[1-9]|fingerprint_hits_total[^0-9]*[1-9]|storage_hits_total[^0-9]*[1-9]|cacheblend_(match|hit)[^0-9]*[1-9]'
+if ! sanitized_logs | grep -E "${HIT_PATTERN}" >/dev/null 2>&1; then
+  fail_with_matches "no non-empty CacheBlend match/hit evidence found; run may not prove non-prefix KV reuse" "${HIT_PATTERN}"
+fi
+
+# Proxy / telemetry proof. This catches cases where the benchmark completes
+# against one side but the prefill->decode handoff did not actually happen.
+SAVE_PATTERN='Request [0-9a-f-]+: finished saving KV caches after prefill|All [0-9]+ TP worker\(s\) done for request:|Request [0-9a-f-]+: telemetry wait timed out after [0-9.]+s; fallback enabled; forwarding request to decoder after prefill response'
+FORWARD_PATTERN='Request [0-9a-f-]+: forwarding request to decoder'
+DECODE_PATTERN='Request [0-9a-f-]+: (streaming )?decode response completed'
+if ! sanitized_logs | grep -E "${SAVE_PATTERN}" >/dev/null 2>&1; then
+  fail_with_matches "no request-level prefiller/telemetry save evidence found" "${SAVE_PATTERN}"
+fi
+if ! sanitized_logs | grep -E "${FORWARD_PATTERN}" >/dev/null 2>&1; then
+  fail_with_matches "no request-level proxy-to-decoder forwarding evidence found" "${FORWARD_PATTERN}"
+fi
+if ! sanitized_logs | grep -E "${DECODE_PATTERN}" >/dev/null 2>&1; then
+  fail_with_matches "no request-level decoder completion evidence found" "${DECODE_PATTERN}"
+fi
+
+if ! sanitized_logs | grep -E '\[PASS\] shuffle_doc_qa benchmark exited 0|benchmark exit(ed)? 0|benchmark.*exit_code=0' >/dev/null 2>&1; then
+  fail_with_matches "no benchmark exit-0 evidence found" '\[PASS\] shuffle_doc_qa benchmark exited 0|benchmark exit(ed)? 0|benchmark.*exit_code=0'
+fi
+
+cat <<EOF
+[PASS] CacheBlend E2E log validation passed${BUILD_ID:+ for ${BUILD_ID}}
+  logs: ${LOG_DIR}
+  CB register evidence:        ${REGISTER_COUNT}
+  CB precomputed-store evidence:${STORE_PRE_COUNT}
+  CB lookup evidence:          ${LOOKUP_COUNT}
+  CB retrieve evidence:        ${RETRIEVE_COUNT}
+  CB final-store evidence:     ${STORE_FINAL_COUNT}
+EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,23 @@ LMCache is a KV cache management engine for LLM serving that reduces Time To Fir
 
 The default branch is `dev`. Base all new branches and pull requests against `dev`.
 
+## PR Comment Style
+
+For maintainer-facing GitHub comments, avoid agent-generated/status-style updates.
+Do not post incremental progress packets, repeated E2E evidence dumps, or
+chronological debugging narratives unless a maintainer explicitly asks for them.
+
+Default to one concise human summary that explains:
+
+- the actual design decision;
+- the tradeoff or scope boundary;
+- what was verified only when it directly helps the reviewer;
+- what specifically needs reviewer attention.
+
+Kuntai Du’s reviewer feedback is the standing rule: too much agent-generated/status
+content makes PR threads difficult to follow; reviewers need concise human summaries
+of design decisions, tradeoffs, and review asks.
+
 ## Python Environment
 
 We recommend using [uv](https://docs.astral.sh/uv/) to manage Python environments and dependencies:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,18 @@ not relocate them.
 
 ## PR Review Instructions
 
+For maintainer-facing PR comments, do **not** write agent-generated/status-style
+updates. Kuntai Du explicitly called out that incremental generated updates make
+the review thread difficult to follow. Use concise human summaries focused on:
+
+- actual design decisions;
+- tradeoffs and scope boundaries;
+- what was verified, only when relevant to the review;
+- the specific reviewer attention requested.
+
+Avoid repeated E2E/status packets, chronological debugging notes, or “agent ran X”
+narratives unless a maintainer directly asks for that level of detail.
+
 When asked to review a PR, use the `/pr-review` skill which implements the full review
 process from `docs/coding_standards.md` Section 9.
 

--- a/benchmarks/multi_doc_qa/shuffle_doc_qa.py
+++ b/benchmarks/multi_doc_qa/shuffle_doc_qa.py
@@ -27,6 +27,7 @@ from openai import OpenAI
 from transformers import AutoTokenizer
 
 SERVICE_PORT = os.environ.get("SERVICE_PORT", "10001")
+REQUEST_TIMEOUT_SEC = float(os.environ.get("BENCHMARK_REQUEST_TIMEOUT_SEC", "1800"))
 
 
 def ordinal_word(i: int) -> str:
@@ -262,6 +263,8 @@ def main() -> None:
     client = OpenAI(
         api_key="dummy-key",
         base_url=f"http://localhost:{args.port}/v1",
+        timeout=REQUEST_TIMEOUT_SEC,
+        max_retries=0,
     )
 
     models = client.models.list()

--- a/examples/disagg_prefill_mp/disagg_proxy_server.py
+++ b/examples/disagg_prefill_mp/disagg_proxy_server.py
@@ -226,16 +226,33 @@ def remove_pending_request(request_id: str):
         pending_requests.pop(request_id, None)
 
 
+def _resolve_pending_request_id(observed_request_id: str) -> str | None:
+    """Map a telemetry request ID back to this proxy's pending request ID."""
+    if observed_request_id in pending_requests:
+        return observed_request_id
+    for pending_id in pending_requests:
+        if pending_id and pending_id in observed_request_id:
+            return pending_id
+    legacy_id = "-".join(observed_request_id.split("-")[1:])[:16]
+    if legacy_id in pending_requests:
+        return legacy_id
+    return None
+
+
 def notify_request(chatcmpl_request_id: str) -> bool:
     """
     Notify a pending request that the KV store is complete.
     Returns True if the request was found and notified.
     """
     with pending_requests_lock:
-        # vLLM wraps the request ID as "chatcmpl-{uuid}-{suffix}",
-        # so strip the first and last segments to recover the original UUID.
-        request_id = "-".join(chatcmpl_request_id.split("-")[1:])
-        request_id = request_id[:16]
+        request_id = _resolve_pending_request_id(chatcmpl_request_id)
+        if request_id is None:
+            logger.warning(
+                "Telemetry for unknown request id %s; pending request ids: %s",
+                chatcmpl_request_id,
+                sorted(pending_requests),
+            )
+            return False
         event = pending_requests.get(request_id, None)
         if event:
             # Schedule the event.set() on the main event loop

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -60,6 +60,9 @@ except ImportError:
     )
 
 if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import CBMatchResult
+
     # Third Party
     from vllm.distributed.kv_events import KVCacheEvent
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -81,9 +84,9 @@ logger = lmcache_init_logger(__name__)
 def reformat_block_ids(block_ids: tuple[list[int], ...] | None) -> list[int]:
     if block_ids is None:
         return []
-    assert isinstance(block_ids, tuple), (
-        f"Expected block_ids to be a tuple of lists, but got {type(block_ids)}"
-    )
+    assert isinstance(
+        block_ids, tuple
+    ), f"Expected block_ids to be a tuple of lists, but got {type(block_ids)}"
 
     if len(block_ids) > 1:
         raise RuntimeError(
@@ -219,6 +222,7 @@ class LMCacheMPRequestTracker:
     # Staging load operation -- save vllm and lmcache hit tokens during lookup
     num_vllm_hit_blocks: int = 0
     num_lmcache_hit_blocks: int = 0
+    cb_match_result: list["CBMatchResult"] = field(default_factory=list)
 
     # Main state
     state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
@@ -234,6 +238,7 @@ class LMCacheMPRequestTracker:
         self.num_stored_blocks = 0
         self.num_vllm_hit_blocks = 0
         self.num_lmcache_hit_blocks = 0
+        self.cb_match_result = []
         self.state = LMCacheMPRequestState.PREFETCHING
 
     ####
@@ -361,6 +366,7 @@ class LMCacheMPRequestMetadata:
                 block_ids=block_ids,
                 start=start_token_idx,
                 end=end_token_idx,
+                cacheblend_store_final=tracker.num_lmcache_hit_blocks > 0,
             )
 
             ret = LMCacheMPRequestMetadata(
@@ -428,6 +434,7 @@ class LMCacheMPRequestMetadata:
                 start=start_token_idx,
                 end=end_token_idx,
                 skip_first_n_tokens=skip_first_n_tokens,
+                cb_match_result=tracker.cb_match_result,
             )
 
             ret = LMCacheMPRequestMetadata(
@@ -786,6 +793,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         # Save the vllm and lmcache hit tokens
         tracker.num_vllm_hit_blocks = num_vllm_blocks
         tracker.num_lmcache_hit_blocks = num_lmcache_blocks
+        if hasattr(self.scheduler_adapter, "get_lookup_matches"):
+            tracker.cb_match_result = self.scheduler_adapter.get_lookup_matches(
+                request.request_id
+            )
 
         need_to_load = max(0, ret - num_computed_tokens)
         logger.debug(
@@ -1142,9 +1153,9 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             self.scheduler_adapter.report_block_allocations(records)
 
     def _get_request_tracker(self, request_id: str) -> LMCacheMPRequestTracker:
-        assert request_id in self.request_trackers, (
-            f"Request tracker for request_id {request_id} not found. "
-        )
+        assert (
+            request_id in self.request_trackers
+        ), f"Request tracker for request_id {request_id} not found. "
         return self.request_trackers[request_id]
 
     def _get_or_create_request_tracker(

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -17,6 +17,7 @@ from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
+    CBMatchResult,
     CudaIPCWrapper,
     IPCCacheEngineKey,
     KVCache,
@@ -46,6 +47,7 @@ class ExtraConfigDefault(enum.Enum):
     # Interval (seconds) between periodic heartbeat pings
     # to the server.
     heartbeat_interval = 10.0
+    cacheblend = os.getenv("LMCACHE_ENABLE_CACHEBLEND", "False")
 
 
 # Backward-compatible aliases for the legacy `lmcache_mp_connector_0180`
@@ -105,6 +107,31 @@ def _resolve_extra_config(
             )
         resolved[item.name] = value
     return resolved
+
+
+def _is_cacheblend_enabled(extra_config: dict[str, Any] | None) -> bool:
+    if extra_config is not None:
+        cfg = _resolve_extra_config(extra_config)
+        cacheblend_raw = cfg[ExtraConfigDefault.cacheblend.name]
+    else:
+        cacheblend_raw = ExtraConfigDefault.cacheblend.value
+    return str(cacheblend_raw).lower() in {"1", "true", "yes", "on"}
+
+
+def _unique_token_coverage(matches: list[CBMatchResult]) -> int:
+    intervals = sorted((m.cur_st, m.cur_ed) for m in matches if m.cur_ed > m.cur_st)
+    if not intervals:
+        return 0
+    total = 0
+    cur_st, cur_ed = intervals[0]
+    for st, ed in intervals[1:]:
+        if st <= cur_ed:
+            cur_ed = max(cur_ed, ed)
+        else:
+            total += cur_ed - cur_st
+            cur_st, cur_ed = st, ed
+    total += cur_ed - cur_st
+    return total
 
 
 def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
@@ -378,6 +405,12 @@ class LoadStoreOp:
     """Number of tokens to skip writing at the beginning of the retrieve
     range. Used to avoid overwriting APC-shared GPU blocks during retrieve."""
 
+    cb_match_result: list[CBMatchResult] | None = None
+    """CacheBlend V2 match metadata returned by CB_LOOKUP_PRE_COMPUTED_V2."""
+
+    cacheblend_store_final: bool = False
+    """Use CB_STORE_FINAL instead of CB_STORE_PRE_COMPUTED for this store."""
+
     def __len__(self) -> int:
         return len(self.block_ids)
 
@@ -441,9 +474,19 @@ class LMCacheMPSchedulerAdapter:
         #   even after the server has already popped the job (exactly-once).
         self._pending_lookups: set[str] = set()
         self._finished_lookup_results: dict[str, int] = {}
+        self._finished_lookup_matches: dict[str, list[CBMatchResult]] = {}
 
         self.model_name = model_name
         self.parallel_strategy = parallel_strategy
+        self.enable_cacheblend = _is_cacheblend_enabled(extra_config)
+        logger.info(
+            "%s initialized: adapter_file=%s, "
+            "enable_cacheblend=%s, extra_config_keys=%s",
+            self.__class__.__name__,
+            __file__,
+            self.enable_cacheblend,
+            sorted((extra_config or {}).keys()),
+        )
 
         # Read chunk size from lmcache
         try:
@@ -551,21 +594,40 @@ class LMCacheMPSchedulerAdapter:
             cache_salt=cache_salt,
         ).no_worker_id_version()
 
-        future = send_lmcache_request(
-            self.mq_client,
-            RequestType.LOOKUP,
-            [key, self.tp_size],
+        enable_cacheblend = getattr(self, "enable_cacheblend", False)
+        request_type = (
+            RequestType.CB_LOOKUP_PRE_COMPUTED_V2
+            if enable_cacheblend
+            else RequestType.LOOKUP
         )
+        payloads = [key] if enable_cacheblend else [key, self.tp_size]
+        logger.info(
+            "LMCache MP lookup request: request_id=%s request_type=%s "
+            "enable_cacheblend=%s token_start=%s token_end=%s adapter_file=%s",
+            request_id,
+            request_type.name,
+            enable_cacheblend,
+            0,
+            aligned_end,
+            __file__,
+        )
+        future = send_lmcache_request(self.mq_client, request_type, payloads)
         try:
-            future.result(timeout=self._mq_timeout)
+            result = future.result(timeout=self._mq_timeout)
         except TimeoutError:
             logger.warning(
-                "LOOKUP request timed out after %ss. Marking server as unhealthy.",
+                "%s request timed out after %ss. Marking server as unhealthy.",
+                request_type.name,
                 self._mq_timeout,
             )
             self._health_event.clear()
             return
-        self._pending_lookups.add(request_id)
+        if enable_cacheblend:
+            matches = list(result or [])
+            self._finished_lookup_matches[request_id] = matches
+            self._finished_lookup_results[request_id] = _unique_token_coverage(matches)
+        else:
+            self._pending_lookups.add(request_id)
 
     @_lmcache_nvtx_annotate
     def check_lookup_result(self, request_id: str) -> int | None:
@@ -586,7 +648,8 @@ class LMCacheMPSchedulerAdapter:
             None if the lookup request is not finished yet.
         """
         if request_id not in self._pending_lookups:
-            # No job — either unhealthy at submit time or already cleaned up.
+            # No async job — either unhealthy at submit time, CacheBlend lookup
+            # completed synchronously, or the job was already cleaned up.
             # If we have a cached result, return it to handle repeated calls.
             return self._finished_lookup_results.get(request_id, 0)
 
@@ -620,6 +683,10 @@ class LMCacheMPSchedulerAdapter:
         self._finished_lookup_results[request_id] = token_count
         return token_count
 
+    def get_lookup_matches(self, request_id: str) -> list[CBMatchResult]:
+        """Return CacheBlend V2 match metadata for a completed lookup."""
+        return self._finished_lookup_matches.get(request_id, [])
+
     def num_blocks_per_chunk(self) -> int:
         """
         Returns:
@@ -635,6 +702,7 @@ class LMCacheMPSchedulerAdapter:
         """
         self._pending_lookups.discard(request_id)
         self._finished_lookup_results.pop(request_id, None)
+        self._finished_lookup_matches.pop(request_id, None)
 
     def free_lookup_locks(
         self,
@@ -829,9 +897,23 @@ class LMCacheMPWorkerAdapter:
         # Request IDs already returned as finished_sending to the scheduler.
         # Prevents re-reporting the same ID after drain clears tracking sets.
         self._returned_finished: set[str] = set()
+        # Request IDs already reported to the disagg request-telemetry hook.
+        # Telemetry is a KV-store-readiness signal for the proxy and must be
+        # emitted when LMCache store completes, even if vLLM scheduler-side
+        # finished_sending reconciliation has not returned the id yet.
+        self._telemetry_reported_stores: set[str] = set()
 
         self.model_name = model_name
         self.parallel_strategy = parallel_strategy
+        self.enable_cacheblend = _is_cacheblend_enabled(extra_config)
+        logger.info(
+            "%s initialized: adapter_file=%s, "
+            "enable_cacheblend=%s, extra_config_keys=%s",
+            self.__class__.__name__,
+            __file__,
+            self.enable_cacheblend,
+            sorted((extra_config or {}).keys()),
+        )
 
         # Read chunk size from lmcache
         try:
@@ -948,23 +1030,43 @@ class LMCacheMPWorkerAdapter:
                 mq_timeout.
         """
         self.kv_caches = kv_caches
-        self.transfer_ctx = create_transfer_context(kv_caches)
         layout_hints = vllm_layout_hints()
         layout_hints["inference_engine_logical_block_size"] = (
             self.vllm_logical_block_size
         )
         try:
-            self.transfer_ctx.register(
-                self.instance_id,
-                kv_caches,
-                self.model_name,
-                self.world_size,
-                self.blocks_in_chunk,
-                self.mq_client,
-                self._mq_timeout,
-                send_request=send_lmcache_request,
-                layout_hints=layout_hints,
-            )
+            if self.enable_cacheblend:
+                request_type = RequestType.CB_REGISTER_KV_CACHE
+                payloads = [
+                    self.instance_id,
+                    wrap_kv_caches(kv_caches),
+                    self.model_name,
+                    self.world_size,
+                ]
+                logger.info(
+                    "LMCache MP register request: request_type=%s "
+                    "enable_cacheblend=%s model=%s world_size=%s adapter_file=%s",
+                    request_type.name,
+                    self.enable_cacheblend,
+                    self.model_name,
+                    self.world_size,
+                    __file__,
+                )
+                future = send_lmcache_request(self.mq_client, request_type, payloads)
+                future.result(timeout=self._mq_timeout)
+            else:
+                self.transfer_ctx = create_transfer_context(kv_caches)
+                self.transfer_ctx.register(
+                    self.instance_id,
+                    kv_caches,
+                    self.model_name,
+                    self.world_size,
+                    self.blocks_in_chunk,
+                    self.mq_client,
+                    self._mq_timeout,
+                    send_request=send_lmcache_request,
+                    layout_hints=layout_hints,
+                )
         except TimeoutError:
             raise ConnectionError(
                 "LMCache server did not respond to "
@@ -1047,28 +1149,54 @@ class LMCacheMPWorkerAdapter:
             return
 
         assert op.token_ids is not None
-        key = self._create_key(
-            op.token_ids,
-            op.start,
-            op.end,
-            request_id=request_id,
-            cache_salt=cache_salt,
-        )
-        if self.transfer_ctx is None:
-            raise RuntimeError(
-                "Transfer context is not initialized. "
-                "Call register_kv_caches() before submitting store requests."
+        if self.enable_cacheblend:
+            # CacheBlend store APIs treat key.token_ids as the document/chunk
+            # being registered and copy from the vLLM KV buffer at `offset`.
+            # The normal STORE path instead carries the full request token_ids
+            # plus start/end. Keep those semantics separate.
+            store_token_ids = op.token_ids[op.start : op.end]
+            key = self._create_key(
+                store_token_ids,
+                0,
+                len(store_token_ids),
+                request_id=request_id,
+                cache_salt=cache_salt,
             )
-        future = self.transfer_ctx.submit_store(
-            request_id,
-            key,
-            self.instance_id,
-            self.kv_caches,
-            op.block_ids,
-            event,
-            self.blocks_in_chunk,
-        )
+            request_type = (
+                RequestType.CB_STORE_FINAL
+                if op.cacheblend_store_final
+                else RequestType.CB_STORE_PRE_COMPUTED
+            )
+            payloads = [key, op.start, self.instance_id, event.ipc_handle()]
+            future = send_lmcache_request(
+                self.mq_client,
+                request_type,
+                payloads,
+            ).to_cuda_future()
+        else:
+            key = self._create_key(
+                op.token_ids,
+                op.start,
+                op.end,
+                request_id=request_id,
+                cache_salt=cache_salt,
+            )
+            if self.transfer_ctx is None:
+                raise RuntimeError(
+                    "Transfer context is not initialized. "
+                    "Call register_kv_caches() before submitting store requests."
+                )
+            future = self.transfer_ctx.submit_store(
+                request_id,
+                key,
+                self.instance_id,
+                self.kv_caches,
+                op.block_ids,
+                event,
+                self.blocks_in_chunk,
+            )
         self.store_futures[request_id] = future
+        self._start_store_telemetry_watcher(request_id, future)
 
     @_lmcache_nvtx_annotate
     def submit_retrieve_request(
@@ -1102,21 +1230,36 @@ class LMCacheMPWorkerAdapter:
             request_id=request_id,
             cache_salt=cache_salt,
         )
-        if self.transfer_ctx is None:
-            raise RuntimeError(
-                "Transfer context is not initialized. "
-                "Call register_kv_caches() before submitting retrieve requests."
+        if self.enable_cacheblend:
+            request_type = RequestType.CB_RETRIEVE_PRE_COMPUTED_V2
+            payloads = [
+                key,
+                op.cb_match_result or [],
+                op.start,
+                self.instance_id,
+                event.ipc_handle(),
+            ]
+            future = send_lmcache_request(
+                self.mq_client,
+                request_type,
+                payloads,
+            ).to_cuda_future()
+        else:
+            if self.transfer_ctx is None:
+                raise RuntimeError(
+                    "Transfer context is not initialized. "
+                    "Call register_kv_caches() before submitting retrieve requests."
+                )
+            future = self.transfer_ctx.submit_retrieve(
+                request_id,
+                key,
+                self.instance_id,
+                self.kv_caches,
+                op.block_ids,
+                event,
+                self.blocks_in_chunk,
+                skip_first_n_tokens=op.skip_first_n_tokens,
             )
-        future = self.transfer_ctx.submit_retrieve(
-            request_id,
-            key,
-            self.instance_id,
-            self.kv_caches,
-            op.block_ids,
-            event,
-            self.blocks_in_chunk,
-            skip_first_n_tokens=op.skip_first_n_tokens,
-        )
         self.retrieve_futures[request_id] = (future, list(op.block_ids))
 
     @_lmcache_nvtx_annotate
@@ -1275,6 +1418,8 @@ class LMCacheMPWorkerAdapter:
         for request_id in finished_retrieves:
             self.retrieve_futures.pop(request_id, None)
 
+        self._report_store_finished_telemetry(finished_stores)
+
         # Update the internal states
         ret_stores = self._process_finished_stores(
             finished_stores, finished_req_ids_from_engine
@@ -1283,13 +1428,7 @@ class LMCacheMPWorkerAdapter:
         # the invocation of `get_finished` means that
         # these requests' KV caches are already fully stored.
         # or the requests normally ends without any store.
-        if ret_stores:
-            self.request_telemetry.on_request_store_finished(
-                request_ids_set=ret_stores,
-                model_name=self.model_name,
-                world_size=self.world_size,
-                kv_rank=self.worker_id,
-            )
+        self._report_store_finished_telemetry(ret_stores)
 
         return ret_stores, finished_retrieves
 
@@ -1346,6 +1485,63 @@ class LMCacheMPWorkerAdapter:
         self.previously_finished.difference_update(safe_finished_s)
 
         return safe_finished_s
+
+    def _report_store_finished_telemetry(self, request_ids: set[str]) -> None:
+        """Report completed store ids to disagg telemetry once.
+
+        The proxy uses this as the strict prefill->decode handoff gate. Scheduler
+        `finished_sending` semantics still require vLLM's engine-finished side,
+        but the proxy only needs the LMCache store future to be complete.
+        """
+        pending = request_ids - self._telemetry_reported_stores
+        if not pending:
+            return
+        self._telemetry_reported_stores.update(pending)
+        self.request_telemetry.on_request_store_finished(
+            request_ids_set=pending,
+            model_name=self.model_name,
+            world_size=self.world_size,
+            kv_rank=self.worker_id,
+        )
+
+    def _start_store_telemetry_watcher(
+        self,
+        request_id: str,
+        future: MessagingFuture[StoreResult],
+    ) -> None:
+        """Emit request telemetry as soon as a submitted store future finishes.
+
+        vLLM may not call ``get_finished`` until after the disagg proxy has
+        already waited for prefill KV readiness. Starting a lightweight watcher
+        when the store is submitted lets strict prefill->decode handoff observe
+        the real store completion without falling back or blocking vLLM's
+        scheduler path.
+        """
+
+        def wait_and_report() -> None:
+            try:
+                result = future.result()
+            except Exception:
+                logger.exception(
+                    "Store telemetry watcher failed for request_id=%s",
+                    request_id,
+                )
+                return
+
+            if not result:
+                logger.error(
+                    "Store telemetry watcher saw failed store for request_id=%s",
+                    request_id,
+                )
+                return
+
+            self._report_store_finished_telemetry({request_id})
+
+        threading.Thread(
+            target=wait_and_report,
+            name=f"lmcache-store-telemetry-{request_id}",
+            daemon=True,
+        ).start()
 
     def _create_key(
         self,

--- a/lmcache/v1/multiprocess/blend_server_v2.py
+++ b/lmcache/v1/multiprocess/blend_server_v2.py
@@ -82,6 +82,7 @@ from lmcache.v1.multiprocess.custom_types import (
     KVCache,
 )
 from lmcache.v1.multiprocess.gpu_context import (
+    PagedGPUCacheBlendContext,
     PlainGPUCacheContext,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueServer
@@ -375,7 +376,9 @@ class BlendEngineV2(MPCacheEngine):
             storage_manager_config, chunk_size, hash_algorithm=hash_algorithm
         )
 
-        self._cb_gpu_contexts: dict[int, PlainGPUCacheContext] = {}
+        self._cb_gpu_contexts: dict[
+            int, PlainGPUCacheContext | PagedGPUCacheBlendContext
+        ] = {}
 
         # CB GPU ID -> (model name, world size) as metadata
         # NOTE: This is mainly for determining the layout desc during prefetch
@@ -402,7 +405,10 @@ class BlendEngineV2(MPCacheEngine):
             model_name: The name of the model associated with this KV cache.
             world_size: The world size associated with this KV cache.
         """
-        gpu_context = PlainGPUCacheContext(kv_caches, self.chunk_size)
+        if len(kv_caches) == 1:
+            gpu_context = PlainGPUCacheContext(kv_caches, self.chunk_size)
+        else:
+            gpu_context = PagedGPUCacheBlendContext(kv_caches, self.chunk_size)
         self._cb_gpu_contexts[instance_id] = gpu_context
         self._cb_gpu_context_meta[instance_id] = (model_name, world_size)
         logger.info(
@@ -696,7 +702,7 @@ class BlendEngineV2(MPCacheEngine):
     def _cb_store_gpu_copy(
         self,
         obj_keys: list[ObjectKey],
-        gpu_context: PlainGPUCacheContext,
+        gpu_context: PlainGPUCacheContext | PagedGPUCacheBlendContext,
         offset: int,
         event_ipc_handle: bytes,
         start_event: Event | None = None,
@@ -812,9 +818,9 @@ class BlendEngineV2(MPCacheEngine):
         """
         num_tokens = key.end - key.start
 
-        assert instance_id in self._cb_gpu_contexts, (
-            f"Instance ID {instance_id} not registered for CB KV cache"
-        )
+        assert (
+            instance_id in self._cb_gpu_contexts
+        ), f"Instance ID {instance_id} not registered for CB KV cache"
         gpu_context = self._cb_gpu_contexts[instance_id]
 
         # CPU-synchronous sentinel: GPU store is about to be enqueued.
@@ -822,7 +828,11 @@ class BlendEngineV2(MPCacheEngine):
             Event(
                 event_type=EventType.CB_STORE_PRE_COMPUTED_SUBMITTED,
                 session_id=key.request_id,
-                metadata={"instance_id": instance_id},
+                metadata={
+                    "instance_id": instance_id,
+                    "num_chunks": num_tokens // self.chunk_size,
+                    "num_tokens": num_tokens,
+                },
             )
         )
         self._event_bus.publish_on_stream(
@@ -935,9 +945,9 @@ class BlendEngineV2(MPCacheEngine):
         Note:
             We must call `cb_lookup_pre_computed` first before calling this function
         """
-        assert instance_id in self._cb_gpu_contexts, (
-            f"Instance ID {instance_id} not registered for CB KV cache"
-        )
+        assert (
+            instance_id in self._cb_gpu_contexts
+        ), f"Instance ID {instance_id} not registered for CB KV cache"
         gpu_context = self._cb_gpu_contexts[instance_id]
 
         # One obj_key per match_result, in cur_st order
@@ -951,7 +961,11 @@ class BlendEngineV2(MPCacheEngine):
             Event(
                 event_type=EventType.CB_RETRIEVE_SUBMITTED,
                 session_id=key.request_id,
-                metadata={"instance_id": instance_id},
+                metadata={
+                    "instance_id": instance_id,
+                    "num_chunks": num_chunks,
+                    "num_tokens": num_chunks * self.chunk_size,
+                },
             )
         )
 
@@ -970,7 +984,11 @@ class BlendEngineV2(MPCacheEngine):
                 Event(
                     event_type=EventType.CB_RETRIEVE_START,
                     session_id=key.request_id,
-                    metadata={"instance_id": instance_id, "num_chunks": num_chunks},
+                    metadata={
+                        "instance_id": instance_id,
+                        "num_chunks": num_chunks,
+                        "num_tokens": num_chunks * self.chunk_size,
+                    },
                 ),
             )
 
@@ -988,6 +1006,7 @@ class BlendEngineV2(MPCacheEngine):
                                 metadata={
                                     "instance_id": instance_id,
                                     "num_chunks": num_chunks,
+                                    "num_tokens": num_chunks * self.chunk_size,
                                     "success": False,
                                 },
                             ),
@@ -1000,9 +1019,11 @@ class BlendEngineV2(MPCacheEngine):
                         gpu_st = r.cur_st + offset
                         gpu_ed = gpu_st + self.chunk_size
                         tmp_buffer = gpu_context.get_tmp_gpu_buffer(self.chunk_size)
-                        target_buffer = gpu_context.slice_kv_cache_on_tokens(
-                            gpu_st, gpu_ed
-                        )
+                        target_buffer = getattr(
+                            gpu_context,
+                            "writable_slice_on_tokens",
+                            gpu_context.slice_kv_cache_on_tokens,
+                        )(gpu_st, gpu_ed)
                         with self.lock:
                             lmcache_memcpy_async_h2d(memory_obj, tmp_buffer)
                             target_buffer.copy_(tmp_buffer, non_blocking=True)
@@ -1017,6 +1038,7 @@ class BlendEngineV2(MPCacheEngine):
                         metadata={
                             "instance_id": instance_id,
                             "num_chunks": num_chunks,
+                            "num_tokens": num_chunks * self.chunk_size,
                             "success": False,
                         },
                     ),
@@ -1046,6 +1068,7 @@ class BlendEngineV2(MPCacheEngine):
                 metadata={
                     "instance_id": instance_id,
                     "num_chunks": num_chunks,
+                    "num_tokens": num_chunks * self.chunk_size,
                     "success": True,
                 },
             ),
@@ -1080,9 +1103,9 @@ class BlendEngineV2(MPCacheEngine):
         num_tokens = key.end - key.start
 
         # Get GPU context
-        assert instance_id in self._cb_gpu_contexts, (
-            f"Instance ID {instance_id} not registered for CB KV cache"
-        )
+        assert (
+            instance_id in self._cb_gpu_contexts
+        ), f"Instance ID {instance_id} not registered for CB KV cache"
         gpu_context = self._cb_gpu_contexts[instance_id]
 
         # CPU-synchronous sentinels: SUBMITTED before SESSION_END so the
@@ -1092,7 +1115,11 @@ class BlendEngineV2(MPCacheEngine):
             Event(
                 event_type=EventType.CB_STORE_FINAL_SUBMITTED,
                 session_id=key.request_id,
-                metadata={"instance_id": instance_id},
+                metadata={
+                    "instance_id": instance_id,
+                    "num_chunks": num_tokens // self.chunk_size,
+                    "num_tokens": num_tokens,
+                },
             )
         )
         self._event_bus.publish(

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -442,9 +442,9 @@ class PlainGPUCacheContext:
     """
 
     def __init__(self, kv_caches: KVCache, lmcache_chunk_size: int = 256):
-        assert len(kv_caches) == 1, (
-            "PlainGPUCacheContext only supports a single KV cache tensor"
-        )
+        assert (
+            len(kv_caches) == 1
+        ), "PlainGPUCacheContext only supports a single KV cache tensor"
 
         # KV cache basics
         self._kv_cache = unwrap_kv_cache_tensors(kv_caches)[0]
@@ -547,3 +547,374 @@ class PlainGPUCacheContext:
     @property
     def kv_cache_tensor(self) -> torch.Tensor:
         return self._kv_cache
+
+
+class _PagedTokenSlice:
+    """Writable token-slice facade for vLLM's per-layer paged KV tensors."""
+
+    def __init__(
+        self,
+        parent: "PagedGPUCacheBlendContext",
+        start: int,
+        end: int,
+    ) -> None:
+        self._parent = parent
+        self._start = start
+        self._end = end
+
+    def copy_(
+        self, src: torch.Tensor, non_blocking: bool = False
+    ) -> "_PagedTokenSlice":
+        expected = self._parent.get_kv_buffer_shape(self._end - self._start)
+        if tuple(src.shape) != tuple(expected):
+            raise ValueError(
+                f"Expected source shape {tuple(expected)} for paged CB copy, "
+                f"got {tuple(src.shape)}"
+            )
+        for layer_idx, layer_cache in enumerate(self._parent._kv_caches):
+            self._parent._copy_tokens_to_layer(
+                layer_cache,
+                src[:, layer_idx, :, :],
+                self._start,
+                self._end,
+                non_blocking=non_blocking,
+            )
+        return self
+
+
+class PagedGPUCacheBlendContext:
+    """CacheBlend context for vLLM's per-layer paged KV tensors.
+
+    CacheBlend's original ``PlainGPUCacheContext`` expects a single contiguous
+    ``[2, L, T, D]`` tensor. vLLM V1 registers one paged tensor per layer
+    instead. This adapter presents the same token-slice API expected by
+    ``blend_server_v2`` while reading/writing directly from/to the live vLLM
+    layer tensors, so CacheBlend can run without a second plain KV arena.
+    """
+
+    def __init__(self, kv_caches: KVCache, lmcache_chunk_size: int = 256):
+        self._kv_caches = unwrap_kv_cache_tensors(kv_caches)
+        if not self._kv_caches:
+            raise ValueError(
+                "PagedGPUCacheBlendContext requires at least one KV tensor"
+            )
+
+        self._device = self._kv_caches[0].device
+        self._dtype = self._kv_caches[0].dtype
+        self._num_layers = len(self._kv_caches)
+        first_view = self._layer_token_view(self._kv_caches[0])
+        self._num_tokens = first_view.shape[1]
+        self._hidden_dim_size = first_view.shape[2]
+
+        for idx, tensor in enumerate(self._kv_caches):
+            view = self._layer_token_view(tensor)
+            if tensor.device != self._device:
+                raise ValueError("All paged CB KV tensors must be on the same device")
+            if tensor.dtype != self._dtype:
+                raise ValueError("All paged CB KV tensors must have the same dtype")
+            if view.shape[1:] != first_view.shape[1:]:
+                expected_shape = tuple(first_view.shape[1:])
+                actual_shape = tuple(view.shape[1:])
+                raise ValueError(
+                    "Paged CB KV tensor shape mismatch at layer "
+                    f"{idx}: expected token/hidden shape {expected_shape}, "
+                    f"got {actual_shape}"
+                )
+
+        self._tmp_gpu_buffer = torch.empty(
+            self.get_kv_buffer_shape(lmcache_chunk_size),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self._cuda_stream = torch_dev.Stream(device=self._device)
+        import cupy
+
+        self._cupy_stream = cupy.cuda.ExternalStream(
+            self._cuda_stream.cuda_stream, self._device.index
+        )
+        _, high_priority = torch_dev.Stream.priority_range()
+        self._high_priority_cuda_stream = torch_dev.Stream(
+            device=self._device, priority=high_priority
+        )
+        self._high_priority_cupy_stream = cupy.cuda.ExternalStream(
+            self._high_priority_cuda_stream.cuda_stream, self._device.index
+        )
+
+    def _layer_token_view(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Return a per-layer ``[2, T, D]`` token view."""
+        if tensor.ndim == 5 and tensor.shape[0] == 2:
+            return tensor.reshape(2, tensor.shape[1] * tensor.shape[2], -1)
+        if tensor.ndim == 5 and tensor.shape[1] == 2:
+            return tensor.permute(1, 0, 2, 3, 4).reshape(
+                2, tensor.shape[0] * tensor.shape[2], -1
+            )
+        if tensor.ndim == 5 and tensor.shape[2] == 2:
+            return tensor.permute(2, 0, 1, 3, 4).reshape(
+                2, tensor.shape[0] * tensor.shape[1], -1
+            )
+        if tensor.ndim == 4 and tensor.shape[0] == 2:
+            return tensor.reshape(2, tensor.shape[1] * tensor.shape[2], -1)
+        if tensor.ndim == 3 and tensor.shape[0] == 2:
+            return tensor.reshape(2, tensor.shape[1], -1)
+        raise ValueError(
+            "Unsupported paged CB KV tensor shape: "
+            f"{tuple(tensor.shape)}; expected [2,B,S,H,D], [B,2,S,H,D], "
+            "[B,S,2,H,D], [2,B,S,D], or [2,T,D]"
+        )
+
+    def _copy_tokens_to_layer(
+        self,
+        tensor: torch.Tensor,
+        src: torch.Tensor,
+        start: int,
+        end: int,
+        *,
+        non_blocking: bool = False,
+    ) -> None:
+        """Copy ``src`` ``[2,T,D]`` into a per-layer paged KV tensor.
+
+        Some live vLLM layouts place the K/V dimension between the block and
+        slot dimensions, for example ``[B,2,S,H,D]``. Flattening those layouts
+        through ``_layer_token_view`` can materialize a copy instead of a
+        writable view, so writes are applied block-span-by-block-span here.
+        """
+        if tensor.ndim == 5 and tensor.shape[0] == 2:
+            self._copy_token_blocks(
+                tensor,
+                src,
+                start,
+                end,
+                block_size=tensor.shape[2],
+                layout="kv_block_slot",
+                non_blocking=non_blocking,
+            )
+            return
+        if tensor.ndim == 5 and tensor.shape[1] == 2:
+            self._copy_token_blocks(
+                tensor,
+                src,
+                start,
+                end,
+                block_size=tensor.shape[2],
+                layout="block_kv_slot",
+                non_blocking=non_blocking,
+            )
+            return
+        if tensor.ndim == 5 and tensor.shape[2] == 2:
+            self._copy_token_blocks(
+                tensor,
+                src,
+                start,
+                end,
+                block_size=tensor.shape[1],
+                layout="block_slot_kv",
+                non_blocking=non_blocking,
+            )
+            return
+        if tensor.ndim == 4 and tensor.shape[0] == 2:
+            self._copy_token_blocks(
+                tensor,
+                src,
+                start,
+                end,
+                block_size=tensor.shape[2],
+                layout="kv_block_slot_flat",
+                non_blocking=non_blocking,
+            )
+            return
+        if tensor.ndim == 3 and tensor.shape[0] == 2:
+            tensor[:, start:end, :].copy_(src, non_blocking=non_blocking)
+            return
+        raise ValueError(
+            "Unsupported paged CB KV tensor shape: "
+            f"{tuple(tensor.shape)}; expected [2,B,S,H,D], [B,2,S,H,D], "
+            "[B,S,2,H,D], [2,B,S,D], or [2,T,D]"
+        )
+
+    def _copy_token_blocks(
+        self,
+        tensor: torch.Tensor,
+        src: torch.Tensor,
+        start: int,
+        end: int,
+        *,
+        block_size: int,
+        layout: str,
+        non_blocking: bool,
+    ) -> None:
+        cursor = 0
+        token = start
+        while token < end:
+            block_idx, block_offset = divmod(token, block_size)
+            span = min(end - token, block_size - block_offset)
+            src_span = src[:, cursor : cursor + span, :]
+            if tensor.ndim == 5:
+                hidden_shape = tensor.shape[-2:]
+                src_view = src_span.reshape(2, span, *hidden_shape)
+                if layout == "kv_block_slot":
+                    target = tensor[:, block_idx, block_offset : block_offset + span]
+                elif layout == "block_kv_slot":
+                    target = tensor[block_idx, :, block_offset : block_offset + span]
+                else:
+                    target = tensor[block_idx, block_offset : block_offset + span]
+                    src_view = src_view.permute(1, 0, 2, 3)
+            else:
+                src_view = src_span
+                target = tensor[:, block_idx, block_offset : block_offset + span]
+            target.copy_(src_view, non_blocking=non_blocking)
+            cursor += span
+            token += span
+
+    def get_kv_buffer_shape(self, num_tokens: int) -> torch.Size:
+        return torch.Size((2, self._num_layers, num_tokens, self._hidden_dim_size))
+
+    def get_tmp_gpu_buffer(self, num_tokens: int) -> torch.Tensor:
+        return self._tmp_gpu_buffer[:, :, :num_tokens, :]
+
+    def _copy_layer_tokens_to_buffer(
+        self,
+        tensor: torch.Tensor,
+        dst: torch.Tensor,
+        start: int,
+        end: int,
+    ) -> None:
+        """Copy ``tensor[start:end]`` into ``dst`` without flattening all tokens."""
+        if tensor.ndim == 5 and tensor.shape[0] == 2:
+            self._copy_layer_token_blocks_to_buffer(
+                tensor,
+                dst,
+                start,
+                end,
+                block_size=tensor.shape[2],
+                layout="kv_block_slot",
+            )
+            return
+        if tensor.ndim == 5 and tensor.shape[1] == 2:
+            self._copy_layer_token_blocks_to_buffer(
+                tensor,
+                dst,
+                start,
+                end,
+                block_size=tensor.shape[2],
+                layout="block_kv_slot",
+            )
+            return
+        if tensor.ndim == 5 and tensor.shape[2] == 2:
+            self._copy_layer_token_blocks_to_buffer(
+                tensor,
+                dst,
+                start,
+                end,
+                block_size=tensor.shape[1],
+                layout="block_slot_kv",
+            )
+            return
+        if tensor.ndim == 4 and tensor.shape[0] == 2:
+            self._copy_layer_token_blocks_to_buffer(
+                tensor,
+                dst,
+                start,
+                end,
+                block_size=tensor.shape[2],
+                layout="kv_block_slot_flat",
+            )
+            return
+        if tensor.ndim == 3 and tensor.shape[0] == 2:
+            dst.copy_(tensor[:, start:end, :])
+            return
+        raise ValueError(
+            "Unsupported paged CB KV tensor shape: "
+            f"{tuple(tensor.shape)}; expected [2,B,S,H,D], [B,2,S,H,D], "
+            "[B,S,2,H,D], [2,B,S,D], or [2,T,D]"
+        )
+
+    def _copy_layer_token_blocks_to_buffer(
+        self,
+        tensor: torch.Tensor,
+        dst: torch.Tensor,
+        start: int,
+        end: int,
+        *,
+        block_size: int,
+        layout: str,
+    ) -> None:
+        cursor = 0
+        token = start
+        while token < end:
+            block_idx, block_offset = divmod(token, block_size)
+            span = min(end - token, block_size - block_offset)
+            if tensor.ndim == 5:
+                if layout == "kv_block_slot":
+                    src = tensor[:, block_idx, block_offset : block_offset + span]
+                    src = src.reshape(2, span, -1)
+                elif layout == "block_kv_slot":
+                    src = tensor[block_idx, :, block_offset : block_offset + span]
+                    src = src.reshape(2, span, -1)
+                else:
+                    src = tensor[block_idx, block_offset : block_offset + span]
+                    src = src.permute(1, 0, 2, 3).reshape(2, span, -1)
+            else:
+                src = tensor[:, block_idx, block_offset : block_offset + span]
+            dst[:, cursor : cursor + span, :].copy_(src)
+            cursor += span
+            token += span
+
+    def slice_kv_cache_on_tokens(self, start: int, end: int) -> torch.Tensor:
+        if start < 0 or end < start or end > self._num_tokens:
+            raise ValueError(
+                f"Invalid paged CB token slice [{start}, {end}) for "
+                f"{self._num_tokens} tokens"
+            )
+        out = self.get_tmp_gpu_buffer(end - start)
+        for layer_idx, layer_cache in enumerate(self._kv_caches):
+            self._copy_layer_tokens_to_buffer(
+                layer_cache,
+                out[:, layer_idx, :, :],
+                start,
+                end,
+            )
+        return out
+
+    def writable_slice_on_tokens(self, start: int, end: int) -> _PagedTokenSlice:
+        if start < 0 or end < start or end > self._num_tokens:
+            raise ValueError(
+                f"Invalid paged CB token slice [{start}, {end}) for "
+                f"{self._num_tokens} tokens"
+            )
+        return _PagedTokenSlice(self, start, end)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    @property
+    def stream(self) -> Any:
+        return self._cuda_stream
+
+    @property
+    def cupy_stream(self) -> "cupy.cuda.Stream":
+        return self._cupy_stream
+
+    @property
+    def high_priority_stream(self) -> Any:
+        return self._high_priority_cuda_stream
+
+    @property
+    def high_priority_cupy_stream(self) -> "cupy.cuda.Stream":
+        return self._high_priority_cupy_stream
+
+    @property
+    def num_layers(self) -> int:
+        return self._num_layers
+
+    @property
+    def num_tokens(self) -> int:
+        return self._num_tokens
+
+    @property
+    def hidden_dim_size(self) -> int:
+        return self._hidden_dim_size

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# ruff: noqa: E402
 """
 Unit and integration tests for BlendTokenRangeMatcher and BlendEngineV2.
 
@@ -22,7 +23,7 @@ Tests cover:
 """
 
 # Standard
-from typing import Generator
+from typing import Generator, cast
 import multiprocessing as mp
 import os
 import time
@@ -31,6 +32,11 @@ import time
 import pytest
 import torch
 import zmq
+
+pytest.importorskip(
+    "lmcache.native_storage_ops",
+    reason="blend_server_v2 integration tests require native storage extension",
+)
 
 # First Party
 from lmcache.utils import EngineType
@@ -42,6 +48,7 @@ from lmcache.v1.distributed.config import (
     StorageManagerConfig,
 )
 from lmcache.v1.mp_observability.config import DEFAULT_OBSERVABILITY_CONFIG
+from lmcache.v1.multiprocess import blend_server_v2 as blend_server_v2_mod
 from lmcache.v1.multiprocess.blend_server_v2 import (
     BlendEngineV2,
     BlendTokenRangeMatcher,
@@ -919,6 +926,73 @@ def test_cb_register_unregister_kv_cache_v2(
     assert result is None
 
 
+def test_cb_register_uses_paged_context_for_vllm_layer_cache_list(monkeypatch):
+    """vLLM registers one paged KV tensor per layer, not a single CB arena."""
+
+    class FakePlainContext:
+        num_layers = 1
+
+        def __init__(self, kv_caches, chunk_size):
+            self.kv_caches = kv_caches
+            self.chunk_size = chunk_size
+
+    class FakePagedContext:
+        num_layers = 2
+
+        def __init__(self, kv_caches, chunk_size):
+            self.kv_caches = kv_caches
+            self.chunk_size = chunk_size
+
+    monkeypatch.setattr(blend_server_v2_mod, "PlainGPUCacheContext", FakePlainContext)
+    monkeypatch.setattr(
+        blend_server_v2_mod, "PagedGPUCacheBlendContext", FakePagedContext
+    )
+
+    engine = BlendEngineV2.__new__(BlendEngineV2)
+    engine.chunk_size = CHUNK_SIZE
+    engine._cb_gpu_contexts = {}
+    engine._cb_gpu_context_meta = {}
+
+    engine.cb_register_kv_cache(7, cast(KVCache, ["layer0", "layer1"]), "testmodel", 1)
+
+    assert isinstance(engine._cb_gpu_contexts[7], FakePagedContext)
+    assert engine._cb_gpu_contexts[7].kv_caches == ["layer0", "layer1"]
+    assert engine._cb_gpu_context_meta[7] == ("testmodel", 1)
+
+
+def test_cb_register_preserves_plain_context_for_single_cb_arena(monkeypatch):
+    """The original single plain CacheBlend tensor path remains unchanged."""
+
+    class FakePlainContext:
+        num_layers = 1
+
+        def __init__(self, kv_caches, chunk_size):
+            self.kv_caches = kv_caches
+            self.chunk_size = chunk_size
+
+    class FakePagedContext:
+        num_layers = 2
+
+        def __init__(self, kv_caches, chunk_size):
+            self.kv_caches = kv_caches
+            self.chunk_size = chunk_size
+
+    monkeypatch.setattr(blend_server_v2_mod, "PlainGPUCacheContext", FakePlainContext)
+    monkeypatch.setattr(
+        blend_server_v2_mod, "PagedGPUCacheBlendContext", FakePagedContext
+    )
+
+    engine = BlendEngineV2.__new__(BlendEngineV2)
+    engine.chunk_size = CHUNK_SIZE
+    engine._cb_gpu_contexts = {}
+    engine._cb_gpu_context_meta = {}
+
+    engine.cb_register_kv_cache(8, cast(KVCache, ["plain-arena"]), "testmodel", 1)
+
+    assert isinstance(engine._cb_gpu_contexts[8], FakePlainContext)
+    assert engine._cb_gpu_contexts[8].kv_caches == ["plain-arena"]
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CB register multiple instances requires CUDA"
 )
@@ -1153,9 +1227,9 @@ def test_cb_lookup_v2_sub_sequence_match(
     ).result(timeout=DEFAULT_TIMEOUT)
 
     assert isinstance(cb_results, list)
-    assert len(cb_results) == 1, (
-        "Should find exactly one match (the stored chunk embedded in the query)"
-    )
+    assert (
+        len(cb_results) == 1
+    ), "Should find exactly one match (the stored chunk embedded in the query)"
     r = cb_results[0]
     # The stored chunk was at old_st=0 in its original sequence
     assert r.old_st == 0
@@ -1277,9 +1351,9 @@ def test_cb_lookup_v2_cannot_find_normal_store(
     ).result(timeout=DEFAULT_TIMEOUT)
 
     assert isinstance(cb_results, list)
-    assert len(cb_results) == 0, (
-        "CB_LOOKUP_PRE_COMPUTED_V2 must not see data stored via normal STORE"
-    )
+    assert (
+        len(cb_results) == 0
+    ), "CB_LOOKUP_PRE_COMPUTED_V2 must not see data stored via normal STORE"
 
 
 @pytest.mark.skipif(
@@ -1530,18 +1604,18 @@ def test_cb_retrieve_v2_verify_data_correctness(
     torch.cuda.synchronize()
     src_slice = cb_client_context.get_tensor_slice(source_offset, CHUNK_SIZE)
     dst_slice = cb_client_context.get_tensor_slice(dest_offset, CHUNK_SIZE)
-    assert torch.allclose(src_slice, dst_slice, atol=1e-4), (
-        "Retrieved data at dest_offset should match the stored source data"
-    )
+    assert torch.allclose(
+        src_slice, dst_slice, atol=1e-4
+    ), "Retrieved data at dest_offset should match the stored source data"
 
     # Regions outside the retrieved range should remain zero
     beyond = cb_client_context.get_tensor_slice(
         dest_offset + CHUNK_SIZE,
         cb_client_context.num_tokens - (dest_offset + CHUNK_SIZE),
     )
-    assert torch.allclose(beyond, torch.zeros_like(beyond), atol=1e-4), (
-        "Regions beyond the retrieved window should be unchanged (zeros)"
-    )
+    assert torch.allclose(
+        beyond, torch.zeros_like(beyond), atol=1e-4
+    ), "Regions beyond the retrieved window should be unchanged (zeros)"
 
 
 @pytest.mark.skipif(
@@ -1610,9 +1684,9 @@ def test_cb_retrieve_v2_sub_sequence(
     # Data should have been copied to gpu_st = cur_st + offset = CHUNK_SIZE + 0
     src_slice = cb_client_context.get_tensor_slice(0, CHUNK_SIZE)
     dst_slice = cb_client_context.get_tensor_slice(CHUNK_SIZE, CHUNK_SIZE)
-    assert torch.allclose(src_slice, dst_slice, atol=1e-4), (
-        "Sub-sequence retrieve must copy data to cur_st + offset in the GPU buffer"
-    )
+    assert torch.allclose(
+        src_slice, dst_slice, atol=1e-4
+    ), "Sub-sequence retrieve must copy data to cur_st + offset in the GPU buffer"
 
 
 @pytest.mark.skipif(
@@ -1712,16 +1786,16 @@ def test_cb_retrieve_v2_multiple_chunks_data_correctness(
     # chunk_A → gpu_st = 0 + 2*CHUNK_SIZE = slot 2
     src_a = cb_client_context.get_tensor_slice(0, CHUNK_SIZE)
     dst_a = cb_client_context.get_tensor_slice(dest_offset, CHUNK_SIZE)
-    assert torch.allclose(dst_a, src_a, atol=1e-4), (
-        "Slot 2 must match slot 0 (chunk_A source)"
-    )
+    assert torch.allclose(
+        dst_a, src_a, atol=1e-4
+    ), "Slot 2 must match slot 0 (chunk_A source)"
 
     # chunk_B → gpu_st = CHUNK_SIZE + 2*CHUNK_SIZE = slot 3
     src_b = cb_client_context.get_tensor_slice(CHUNK_SIZE, CHUNK_SIZE)
     dst_b = cb_client_context.get_tensor_slice(dest_offset + CHUNK_SIZE, CHUNK_SIZE)
-    assert torch.allclose(dst_b, src_b, atol=1e-4), (
-        "Slot 3 must match slot 1 (chunk_B source)"
-    )
+    assert torch.allclose(
+        dst_b, src_b, atol=1e-4
+    ), "Slot 3 must match slot 1 (chunk_B source)"
 
 
 @pytest.mark.skipif(
@@ -1807,9 +1881,9 @@ def test_cb_retrieve_v2_unaligned_nonzero_offset(
     torch.cuda.synchronize()
     src_slice = cb_client_context.get_tensor_slice(0, CHUNK_SIZE)
     dst_slice = cb_client_context.get_tensor_slice(2 * CHUNK_SIZE, CHUNK_SIZE)
-    assert torch.allclose(src_slice, dst_slice, atol=1e-4), (
-        "gpu_st = cur_st + offset = 2*CHUNK_SIZE must hold the stored source data"
-    )
+    assert torch.allclose(
+        src_slice, dst_slice, atol=1e-4
+    ), "gpu_st = cur_st + offset = 2*CHUNK_SIZE must hold the stored source data"
 
 
 @pytest.mark.skipif(
@@ -1930,9 +2004,9 @@ def test_cb_store_final_v2_then_normal_lookup(
 
     expected_chunks = 1  # one full CHUNK_SIZE chunk
     assert isinstance(lookup_result, int)
-    assert lookup_result == expected_chunks, (
-        "Normal LOOKUP should find the chunk stored via CB_STORE_FINAL"
-    )
+    assert (
+        lookup_result == expected_chunks
+    ), "Normal LOOKUP should find the chunk stored via CB_STORE_FINAL"
 
     # Normal RETRIEVE
     retrieve_key = create_cb_cache_key(token_ids, request_id="final-norm-retrieve-v2")
@@ -1955,9 +2029,9 @@ def test_cb_store_final_v2_then_normal_lookup(
     torch.cuda.synchronize()
     for layer in range(client_context.num_layers):
         tensor_slice = client_context.get_tensor_slice(layer, 0, pages_per_chunk)
-        assert tensor_slice.mean().item() == pytest.approx(source_value, abs=1e-4), (
-            f"Layer {layer}: retrieved data should match the stored source value"
-        )
+        assert tensor_slice.mean().item() == pytest.approx(
+            source_value, abs=1e-4
+        ), f"Layer {layer}: retrieved data should match the stored source value"
 
 
 @pytest.mark.skipif(
@@ -1992,9 +2066,9 @@ def test_cb_store_final_v2_visible_to_cb_lookup_v2(
     ).result(timeout=DEFAULT_TIMEOUT)
 
     assert isinstance(cb_results, list)
-    assert len(cb_results) == 1, (
-        "CB_LOOKUP_PRE_COMPUTED_V2 should find data stored via CB_STORE_FINAL"
-    )
+    assert (
+        len(cb_results) == 1
+    ), "CB_LOOKUP_PRE_COMPUTED_V2 should find data stored via CB_STORE_FINAL"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/multiprocess/test_gpu_context_cacheblend.py
+++ b/tests/v1/multiprocess/test_gpu_context_cacheblend.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.multiprocess.gpu_context import PagedGPUCacheBlendContext
+
+
+def _uninitialized_context() -> PagedGPUCacheBlendContext:
+    return PagedGPUCacheBlendContext.__new__(PagedGPUCacheBlendContext)
+
+
+def test_paged_cacheblend_accepts_vllm_block_kv_slot_layout():
+    """Live vLLM V1 paged KV can arrive as [B,2,S,H,D]."""
+    ctx = _uninitialized_context()
+    tensor = torch.arange(3 * 2 * 4 * 2 * 5).reshape(3, 2, 4, 2, 5)
+
+    view = ctx._layer_token_view(tensor)
+
+    assert tuple(view.shape) == (2, 12, 10)
+    assert torch.equal(view[0, 0], tensor[0, 0, 0].reshape(-1))
+    assert torch.equal(view[1, 7], tensor[1, 1, 3].reshape(-1))
+
+
+def test_paged_cacheblend_writable_slice_updates_vllm_block_kv_slot_layout():
+    """Writable CB slices must mutate [B,2,S,H,D], not a reshaped copy."""
+    ctx = _uninitialized_context()
+    tensor = torch.zeros(3, 2, 4, 2, 5)
+    ctx._kv_caches = [tensor]
+    ctx._num_layers = 1
+    ctx._num_tokens = 12
+    ctx._hidden_dim_size = 10
+
+    src = torch.arange(2 * 1 * 6 * 10, dtype=tensor.dtype).reshape(2, 1, 6, 10)
+
+    ctx.writable_slice_on_tokens(3, 9).copy_(src)
+
+    # Token 3 is block 0, offset 3.
+    assert torch.equal(tensor[0, 0, 3], src[0, 0, 0].reshape(2, 5))
+    assert torch.equal(tensor[0, 1, 3], src[1, 0, 0].reshape(2, 5))
+    # Token 4 crosses into block 1, offset 0.
+    assert torch.equal(tensor[1, 0, 0], src[0, 0, 1].reshape(2, 5))
+    assert torch.equal(tensor[1, 1, 0], src[1, 0, 1].reshape(2, 5))
+    # Token 8 is block 2, offset 0.
+    assert torch.equal(tensor[2, 0, 0], src[0, 0, 5].reshape(2, 5))
+    assert torch.equal(tensor[2, 1, 0], src[1, 0, 5].reshape(2, 5))
+    # Neighboring positions outside the slice remain untouched.
+    assert torch.count_nonzero(tensor[0, :, :3]) == 0
+    assert torch.count_nonzero(tensor[2, :, 1:]) == 0

--- a/tests/v1/test_blend_proxy_telemetry.py
+++ b/tests/v1/test_blend_proxy_telemetry.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the Buildkite CacheBlend disagg proxy telemetry gate."""
+
+# Standard
+import importlib.util
+from pathlib import Path
+
+
+_PROXY_PATH = (
+    Path(__file__).parents[2]
+    / ".buildkite"
+    / "k3_tests"
+    / "blend"
+    / "scripts"
+    / "proxy.py"
+)
+
+
+def _load_proxy_module():
+    spec = importlib.util.spec_from_file_location("blend_proxy_under_test", _PROXY_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.pending_requests.clear()
+    module.pending_request_aliases.clear()
+    module.unmatched_tp_arrivals.clear()
+    module.pending_tp_state.clear()
+    module.main_event_loop = None
+    return module
+
+
+def test_response_id_alias_unblocks_pending_request():
+    proxy = _load_proxy_module()
+    event = proxy.create_pending_request("proxy-req-1")
+
+    assert proxy.notify_request("cmpl-vllm-response-1") is False
+    assert not event.is_set()
+
+    proxy.register_pending_request_alias("proxy-req-1", "cmpl-vllm-response-1")
+
+    assert event.is_set()
+    assert "cmpl-vllm-response-1" not in proxy.unmatched_tp_arrivals
+
+
+def test_response_id_alias_replays_all_tp_worker_arrivals():
+    proxy = _load_proxy_module()
+    event = proxy.create_pending_request("proxy-req-2")
+
+    assert (
+        proxy.notify_request("chatcmpl-vllm-response-2", world_size=2, kv_rank=0)
+        is False
+    )
+    assert (
+        proxy.notify_request("chatcmpl-vllm-response-2", world_size=2, kv_rank=1)
+        is False
+    )
+    assert not event.is_set()
+
+    proxy.register_pending_request_alias("proxy-req-2", "chatcmpl-vllm-response-2")
+
+    assert event.is_set()
+    assert proxy.pending_tp_state == {}
+
+
+def test_remove_pending_request_removes_response_id_alias():
+    proxy = _load_proxy_module()
+    proxy.create_pending_request("proxy-req-3")
+    proxy.register_pending_request_alias("proxy-req-3", "cmpl-vllm-response-3")
+
+    proxy.remove_pending_request("proxy-req-3")
+
+    assert proxy.pending_request_aliases == {}
+    assert proxy._resolve_pending_request_id("cmpl-vllm-response-3") is None

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -171,3 +171,115 @@ def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatc
     assert transfer_ctx.submit_retrieve.called
     assert transfer_ctx.submit_retrieve.call_args.kwargs == {"skip_first_n_tokens": 1}
     assert adapter.retrieve_futures["req-1"] == (fake_future, [0])
+
+
+def test_cacheblend_register_kv_caches_uses_cb_protocol(fake_adapter):
+    """CacheBlend mode registers the CB GPU cache, not the normal MP cache."""
+    adapter, send_mock, _future = fake_adapter
+    adapter.enable_cacheblend = True
+
+    adapter.register_kv_caches({"layer.0": object()})
+
+    args, _kwargs = send_mock.call_args
+    assert args[1] == RequestType.CB_REGISTER_KV_CACHE
+    assert len(args[2]) == 4
+
+
+def test_cacheblend_store_slices_tokens_for_cb_protocol(fake_adapter):
+    """CB store keys contain only the stored chunk while offset points at vLLM KV."""
+    adapter, send_mock, future = fake_adapter
+    adapter.enable_cacheblend = True
+    adapter._heartbeat = MagicMock(name="heartbeat")
+    future.to_cuda_future.return_value = future
+    event = MagicMock(name="event")
+    event.ipc_handle.return_value = b"event-handle"
+    op = LoadStoreOp(
+        token_ids=list(range(64)),
+        block_ids=[10, 11],
+        start=16,
+        end=48,
+    )
+
+    adapter.submit_store_request("req-1", op, event)
+
+    args, _kwargs = send_mock.call_args
+    assert args[1] == RequestType.CB_STORE_PRE_COMPUTED
+    key, offset, instance_id, event_handle = args[2]
+    assert tuple(key.token_ids) == tuple(range(16, 48))
+    assert key.start == 0
+    assert key.end == 32
+    assert offset == 16
+    assert instance_id == adapter.instance_id
+    assert event_handle == b"event-handle"
+
+
+def test_cacheblend_store_reports_telemetry_when_store_future_finishes(
+    fake_adapter,
+    monkeypatch,
+):
+    """CB precomputed stores must unblock strict disagg handoff directly.
+
+    CacheBlend prefill submits CB_STORE_PRE_COMPUTED futures; strict proxy mode
+    cannot wait for a later scheduler get_finished() call before decoder handoff.
+    """
+    adapter, _send_mock, future = fake_adapter
+    adapter.enable_cacheblend = True
+    adapter._heartbeat = MagicMock(name="heartbeat")
+    adapter.request_telemetry = MagicMock(name="request_telemetry")
+    future.to_cuda_future.return_value = future
+    future.result.return_value = True
+    event = MagicMock(name="event")
+    event.ipc_handle.return_value = b"event-handle"
+
+    class InlineThread:
+        def __init__(self, *, target, **_kwargs):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(adapter_mod.threading, "Thread", InlineThread)
+
+    adapter.submit_store_request(
+        "chatcmpl-cb-prefill",
+        LoadStoreOp(
+            token_ids=list(range(64)),
+            block_ids=[10, 11],
+            start=0,
+            end=64,
+        ),
+        event,
+    )
+
+    adapter.request_telemetry.on_request_store_finished.assert_called_once_with(
+        request_ids_set={"chatcmpl-cb-prefill"},
+        model_name="test-model",
+        world_size=1,
+        kv_rank=0,
+    )
+
+
+def test_get_finished_emits_request_telemetry_when_store_future_finishes(
+    fake_adapter,
+):
+    """Telemetry must unblock disagg decode as soon as LMCache store is done.
+
+    vLLM's finished_req_ids reconciliation is needed for scheduler block
+    lifetime, but the disagg proxy waits for KV-store readiness before decoder
+    handoff. If telemetry waits for the engine-finished side too, strict mode can
+    deadlock after a successful prefill store.
+    """
+    adapter, _send_mock, future = fake_adapter
+    future.query.return_value = True
+    future.result.return_value = True
+    adapter.store_futures["req-1"] = future
+    adapter.request_telemetry = MagicMock(name="request_telemetry")
+
+    adapter.get_finished(set())
+
+    adapter.request_telemetry.on_request_store_finished.assert_called_once_with(
+        request_ids_set={"req-1"},
+        model_name="test-model",
+        world_size=1,
+        kv_rank=0,
+    )


### PR DESCRIPTION
## Summary

Wire CacheBlend V2 adapter/protocol behavior separately from the observability PRs.

This is intentionally the most invasive PR and follows the L0, CacheBlend GPU metric, and serde metric PRs because those metrics make the adapter behavior verifiable.

## Scope

- `CBMatchResult`
- `PagedGPUCacheBlendContext`
- `cacheblend_store_final`
- `CB_REGISTER_KV_CACHE`
- `CB_STORE_PRE_COMPUTED`
- `CB_STORE_FINAL`
- `CB_LOOKUP_PRE_COMPUTED`
- `CB_RETRIEVE_PRE_COMPUTED`
- `blend_server_v2` protocol handling
- vLLM connector/adapter changes
- focused integration tests

## Out of scope

- no prompt exports
- no internal planning docs
- no L0 metrics
- no CacheBlend GPU metrics
- no serde metrics

## Test plan

- `python -m ruff check lmcache/integration/vllm/vllm_multi_process_adapter.py lmcache/integration/vllm/lmcache_mp_connector.py lmcache/v1/multiprocess/blend_server_v2.py lmcache/v1/multiprocess/gpu_context.py tests/v1/multiprocess/test_blend_server_v2.py tests/v1/test_vllm_mp_adapter.py`
- `python -m pytest tests/v1/test_vllm_mp_adapter.py tests/v1/multiprocess/test_blend_server_v2.py -q --tb=short`
  - local source-only env result: `4 passed, 1 skipped`; `test_blend_server_v2.py` is skipped locally when the native storage extension is unavailable.
