### PR TITLE
feat(mp): add SHM-based NonGpuContext (server-side copy) 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,8 @@ repos:
     exclude: |
       (?x)^(
         lmcache/__init__\.py|
-        lmcache/.*/gpu_connector/.*
+        lmcache/.*/gpu_connector/.*|
+        lmcache/v1/platform/cuda/.*
       )$
 - repo: https://github.com/PyCQA/isort
   rev: 6.0.1

--- a/lmcache/cli/commands/bench/test_cache.py
+++ b/lmcache/cli/commands/bench/test_cache.py
@@ -1,10 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """``lmcache bench kvcache`` — end-to-end test for LMCache MP cache server.
 
-Supports **GPU** mode (``--mode gpu``).
-
-.. note::
-    CPU mode is planned but not yet implemented.
+Supports both **CPU** and **GPU** modes (``--mode cpu|gpu``).
 
 This command exercises the full store / retrieve data path:
 
@@ -16,6 +13,11 @@ This command exercises the full store / retrieve data path:
       5. CHECKSUM — verify KV cache integrity via HTTP API
 
 Usage examples::
+
+    # CPU mode: client allocates POSIX-SHM-backed KV cache and the
+    # server maps the same physical pages.
+    lmcache bench kvcache --rpc-url tcp://localhost:5555 \\
+        --mode cpu --num-tokens 512 --start 0 --end 3
 
     # GPU mode: real CUDA tensors + IPC
     lmcache bench kvcache --rpc-url tcp://localhost:5555 \\
@@ -35,9 +37,11 @@ from __future__ import annotations
 # Standard
 from typing import Any
 import argparse
+import ctypes
 import hashlib
 import itertools
 import json
+import os
 import sys
 import time
 import urllib.error
@@ -79,6 +83,11 @@ try:
     from lmcache.v1.multiprocess.futures import MessagingFuture
     from lmcache.v1.multiprocess.mq import MessageQueueClient
     from lmcache.v1.multiprocess.protocols.base import RequestType
+    from lmcache.v1.platform.cpu.shm import (
+        CpuShmTensorWrapper,
+        shm_create_readwrite,
+        shm_unlink,
+    )
 except ImportError as _exc:
     _IMPORT_ERROR = _exc
     # Fallback placeholder so ``add_arguments`` can still build its
@@ -257,34 +266,83 @@ def _allocate_gpu_kv_cache(
     return [_alloc(shape, dtype) for _ in range(num_layers)]
 
 
+def _allocate_cpu_shm_kv_cache(
+    groups: list[KVLayerGroupInfo],
+    shm_prefix: str,
+) -> tuple[list[torch.Tensor], list[CpuShmTensorWrapper], list[str]]:
+    """Allocate paged CPU KV cache tensors backed by POSIX SHM.
+
+    For each (group, layer) we ``shm_open`` a fresh segment and
+    ``mmap`` it into the client process. The returned tensors share
+    storage with the SHM mapping, and the matching
+    :class:`CpuShmTensorWrapper` instances tell the LMCache mp
+    server how to map the very same physical pages -- i.e. true
+    zero-copy across processes (matching the GPU CUDA-IPC path).
+
+    Returns:
+        ``(tensors, wrappers, shm_names)``. ``shm_names`` is kept
+        so the caller can ``shm_unlink`` on shutdown.
+    """
+    torch.random.manual_seed(42)
+    tensors: list[torch.Tensor] = []
+    wrappers: list[CpuShmTensorWrapper] = []
+    shm_names: list[str] = []
+    layer_idx = 0
+    for g_idx, g in enumerate(groups):
+        sd = g.shape_desc
+        g_shape = (sd.kv_size, sd.nb, sd.bs, sd.nh, sd.hs)
+        for _ in range(sd.nl):
+            n_elems = 1
+            for d in g_shape:
+                n_elems *= d
+            nbytes = n_elems * g.dtype.itemsize
+            name = "%s_%d_%d" % (shm_prefix, g_idx, layer_idx)
+            addr = shm_create_readwrite(name, nbytes)
+            buf_type = ctypes.c_uint8 * nbytes
+            buf = buf_type.from_address(addr)
+            flat = torch.frombuffer(buf, dtype=torch.uint8)
+            t = flat.view(g.dtype).reshape(g_shape)
+            # Initialise with deterministic random data so the
+            # cold/warm checksum compare in the bench loop is
+            # meaningful.
+            if g.dtype.is_floating_point:
+                t.copy_(torch.randn(g_shape, dtype=g.dtype))
+            else:
+                iinfo = torch.iinfo(g.dtype)
+                t.copy_(torch.randint(iinfo.min, iinfo.max + 1, g_shape, dtype=g.dtype))
+            tensors.append(t)
+            wrappers.append(CpuShmTensorWrapper(t, name))
+            shm_names.append(name)
+            layer_idx += 1
+    return tensors, wrappers, shm_names
+
+
 def _send_register_kv_cache(
     client: MessageQueueClient,
     instance_id: int = 0,
     model_name: str = _MODEL_NAME,
     world_size: int = _WORLD_SIZE,
     layout_hints: dict | None = None,
-    gpu_tensors: list[torch.Tensor] | None = None,
+    kv_caches: list[CudaIPCWrapper] | None = None,
 ) -> bool:
     """REGISTER_KV_CACHE — register a KV cache context.
 
-    In GPU mode real CUDA tensors are wrapped via
-    ``CudaIPCWrapper`` and sent over IPC.
+    The caller is responsible for building the wrappers:
 
-    .. note::
-        CPU mode (``gpu_tensors is None``) is not yet
-        supported.
+    * GPU mode: ``CudaIPCWrapper`` over real CUDA tensors.
+    * CPU mode: ``CpuShmTensorWrapper`` over POSIX-SHM-backed
+      tensors (see :func:`_allocate_cpu_shm_kv_cache`).
     """
+    if not kv_caches:
+        raise ValueError(
+            "kv_caches must be a non-empty list of wrappers "
+            "(CudaIPCWrapper for GPU, CpuShmTensorWrapper for CPU)"
+        )
+
     hints: dict = {"kv_layout": "NHD"}
     if layout_hints:
         hints.update(layout_hints)
 
-    if gpu_tensors is None:
-        # TODO(maobaolong): support CPU mode registration
-        raise NotImplementedError(
-            "CPU mode is not yet supported. Please use --mode gpu."
-        )
-
-    kv_caches = [CudaIPCWrapper(t) for t in gpu_tensors]
     # TODO(maobaolong): Make the engine type configurable
     payloads = [
         instance_id,
@@ -338,8 +396,15 @@ def _poll_prefetch_status(
     return None
 
 
-def _make_event_handle() -> bytes:
-    """Create a CUDA event IPC handle for GPU mode."""
+def _make_event_handle(use_gpu: bool = True) -> bytes:
+    """Create a CUDA event IPC handle for GPU mode.
+
+    CPU mode does not need a cross-process event (SHM mappings are
+    coherent without device-side sync), so an empty handle is
+    returned and the server treats it as a no-op.
+    """
+    if not use_gpu:
+        return b""
     check_interprocess_event_support()
     event = torch_dev.Event(interprocess=True)
     event.record()
@@ -351,12 +416,13 @@ def _send_store(
     key: IPCCacheEngineKey,
     block_offset: int = 0,
     block_size: int = 16,
+    use_gpu: bool = True,
 ) -> str:
     """STORE — store KV cache blocks. Returns status string."""
     num_tokens = key.end - key.start
     num_blocks = num_tokens // block_size
     block_ids = list(range(block_offset, block_offset + num_blocks))
-    payloads = [key, _INSTANCE_ID, block_ids, _make_event_handle()]
+    payloads = [key, _INSTANCE_ID, block_ids, _make_event_handle(use_gpu)]
     result = _call(client, RequestType.STORE, payloads)
     if result is _TIMEOUT:
         return "timeout"
@@ -370,6 +436,7 @@ def _send_retrieve(
     hit_chunks: int,
     block_offset: int = 0,
     block_size: int = 16,
+    use_gpu: bool = True,
 ) -> str:
     """RETRIEVE — retrieve KV cache blocks. Returns status."""
     hit_tokens = hit_chunks * chunk_size
@@ -379,7 +446,7 @@ def _send_retrieve(
         key,
         _INSTANCE_ID,
         block_ids,
-        _make_event_handle(),
+        _make_event_handle(use_gpu),
         0,  # skip_first_n_tokens
     ]
     result = _call(client, RequestType.RETRIEVE, payloads)
@@ -428,7 +495,7 @@ def _query_checksum(
         else:
             parts.append(str(item))
     block_ids = ",".join(parts)
-    # The MP /api/kvcache/check endpoint is block-native: its
+    # The MP /kvcache/check endpoint is block-native: its
     # chunk_size counts blocks per chunk, while our caller passes
     # in the server-side token-level chunk_size. Convert here.
     if chunk_size % block_size != 0:
@@ -439,7 +506,7 @@ def _query_checksum(
         return None
     chunk_size_blocks = chunk_size // block_size
     url = (
-        "%s/api/kvcache/check?block_ids=%s&block_size=%d&chunk_size=%d&layerwise=false"
+        "%s/kvcache/check?block_ids=%s&block_size=%d&chunk_size=%d&layerwise=false"
     ) % (
         http_base,
         block_ids,
@@ -481,6 +548,7 @@ def _process_request(
     http_base: str = "",
     block_size: int = 16,
     total_blocks: int = 1024,
+    use_gpu: bool = True,
 ) -> list[str] | None:
     """Run the full lookup -> retrieve/store flow."""
     token_ids = _build_token_ids(seq_no, num_tokens)
@@ -557,6 +625,7 @@ def _process_request(
             hit_chunks,
             block_offset=block_offset,
             block_size=block_size,
+            use_gpu=use_gpu,
         )
         retrieve_ms = (time.monotonic() - t1) * 1000
         print(
@@ -589,6 +658,7 @@ def _process_request(
             store_key,
             block_offset=store_block_off,
             block_size=block_size,
+            use_gpu=use_gpu,
         )
         store_ms = (time.monotonic() - t2) * 1000
         print(
@@ -707,9 +777,13 @@ class TestCacheCommand(BaseCommand):
         # implemented.
         parser.add_argument(
             "--mode",
-            choices=["gpu"],
+            choices=["cpu", "gpu"],
             default="gpu",
-            help="Run mode (default: gpu)",
+            help=(
+                "Run mode (default: gpu). In cpu mode the client allocates "
+                "POSIX-SHM-backed KV cache tensors and the server maps the "
+                "same physical pages."
+            ),
         )
         parser.add_argument(
             "--num-tokens",
@@ -786,7 +860,8 @@ class TestCacheCommand(BaseCommand):
     def execute(self, args: argparse.Namespace) -> None:
         """Run the end-to-end cache test loop."""
         _require_full_install()
-        if not torch_dev.is_available():
+        use_gpu = args.mode == "gpu"
+        if use_gpu and not torch_dev.is_available():
             print("ERROR: --mode gpu requires CUDA")
             sys.exit(1)
 
@@ -903,26 +978,39 @@ class TestCacheCommand(BaseCommand):
                 )
             )
 
-            # Allocate GPU tensors — one tensor per layer, shaped
-            # according to that layer's group in the spec (so
-            # heterogeneous ``nh`` / ``hs`` / ``dtype`` / ``kv_size``
-            # are honoured).
-            gpu_tensors = _allocate_gpu_kv_cache(
-                groups=layer_groups,
-            )
-            print(
-                "Allocated %d GPU tensors on %s"
-                % (
-                    len(gpu_tensors),
-                    gpu_tensors[0].device,
+            # Allocate KV tensors. GPU mode wraps real CUDA tensors
+            # via CUDA IPC; CPU mode allocates POSIX-SHM-backed
+            # tensors so the server can map the same physical pages.
+            kv_wrappers: list[CudaIPCWrapper]
+            shm_names: list[str] = []
+            if use_gpu:
+                allocated = _allocate_gpu_kv_cache(groups=layer_groups)
+                print(
+                    "Allocated %d GPU tensors on %s"
+                    % (len(allocated), allocated[0].device)
                 )
-            )
+                kv_wrappers = [CudaIPCWrapper(t) for t in allocated]
+                # Keep the CUDA tensors alive for the lifetime of the
+                # bench process -- storage may be reclaimed otherwise.
+                _kv_keepalive = allocated  # noqa: F841
+            else:
+                shm_prefix = CpuShmTensorWrapper.SHM_NAME_PREFIX + str(os.getpid())
+                cpu_tensors, cpu_wrappers, shm_names = _allocate_cpu_shm_kv_cache(
+                    groups=layer_groups, shm_prefix=shm_prefix
+                )
+                print(
+                    "Allocated %d CPU SHM tensors (prefix=%s)"
+                    % (len(cpu_tensors), shm_prefix)
+                )
+                kv_wrappers = list(cpu_wrappers)
+                # Same keepalive note as above.
+                _kv_keepalive = cpu_tensors  # noqa: F841
 
             # Register KV cache before any store/retrieve
             ok = _send_register_kv_cache(
                 client,
                 layout_hints=layout_hints,
-                gpu_tensors=gpu_tensors,
+                kv_caches=kv_wrappers,
             )
             print("REGISTER_KV_CACHE: %s" % ("OK" if ok else "FAIL"))
             print()
@@ -950,6 +1038,7 @@ class TestCacheCommand(BaseCommand):
                     http_base=http_base,
                     block_size=block_size,
                     total_blocks=num_blocks,
+                    use_gpu=use_gpu,
                 )
 
                 time.sleep(args.interval)
@@ -964,6 +1053,7 @@ class TestCacheCommand(BaseCommand):
                     http_base=http_base,
                     block_size=block_size,
                     total_blocks=num_blocks,
+                    use_gpu=use_gpu,
                 )
 
                 # Compare checksums
@@ -997,4 +1087,10 @@ class TestCacheCommand(BaseCommand):
         finally:
             client.close()
             ctx.term()
+            # Best-effort SHM cleanup so segments don't linger.
+            for _name in shm_names if "shm_names" in locals() else []:
+                try:
+                    shm_unlink(_name)
+                except OSError:
+                    pass
         print("Done.")

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -17,7 +17,6 @@ from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
-    CudaIPCWrapper,
     IPCCacheEngineKey,
     KVCache,
 )
@@ -28,6 +27,7 @@ from lmcache.v1.multiprocess.transfer_context import (
     create_transfer_context,
 )
 from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
+from lmcache.v1.platform import _registry as platform_registry
 
 logger = init_logger(__name__)
 
@@ -124,7 +124,19 @@ def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
         ),
     )
     logger.info("Wrapping %d KV cache tensors for IPC", len(kv_caches))
-    return [CudaIPCWrapper(tensor) for tensor in kv_caches.values()]
+    return [_wrap_one_kv_cache(tensor) for tensor in kv_caches.values()]
+
+
+def _wrap_one_kv_cache(tensor: torch.Tensor) -> Any:
+    """Dispatch by ``tensor.device.type`` via the platform registry.
+
+    Concrete factories self-register at import time (CUDA in
+    ``lmcache.v1.platform.cuda``, CPU SHM in
+    ``lmcache.v1.platform.cpu``), so this call site stays free of
+    if/elif chains and new accelerators plug in by registering a
+    sibling factory.
+    """
+    return platform_registry.get_kv_wrapper_factory(tensor.device.type)(tensor)
 
 
 def send_lmcache_request(

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -124,7 +124,40 @@ def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
         ),
     )
     logger.info("Wrapping %d KV cache tensors for IPC", len(kv_caches))
-    return [_wrap_one_kv_cache(tensor) for tensor in kv_caches.values()]
+    # Per-iteration resource management: if wrapping the N-th tensor
+    # raises, ``shm_unlink`` whatever earlier iterations already
+    # registered with POSIX SHM so the named segments do not outlive
+    # the failed batch. CUDA wrappers do not own a named segment and
+    # are skipped via the duck-typed ``shm_name`` check.
+    wrappers: KVCache = []
+    try:
+        for tensor in kv_caches.values():
+            wrappers.append(_wrap_one_kv_cache(tensor))
+    except BaseException:
+        _release_partial_kv_wrappers(wrappers)
+        raise
+    return wrappers
+
+
+def _release_partial_kv_wrappers(wrappers: list[Any]) -> None:
+    """Best-effort unlink of SHM segments owned by partially built wrappers.
+
+    Used by :func:`wrap_kv_caches` to roll back a half-finished batch
+    when a later iteration raises. Only POSIX-SHM-backed wrappers carry
+    a ``shm_name`` attribute, so other wrapper kinds (e.g. CUDA-IPC)
+    are silently skipped.
+    """
+    # First Party
+    from lmcache.v1.platform.cpu.shm import shm_unlink
+
+    for w in wrappers:
+        name = getattr(w, "shm_name", None)
+        if name is None:
+            continue
+        try:
+            shm_unlink(name)
+        except Exception:  # pragma: no cover - best effort
+            logger.debug("shm_unlink failed during rollback", exc_info=True)
 
 
 def _wrap_one_kv_cache(tensor: torch.Tensor) -> Any:

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -306,6 +306,7 @@ class PageBufferShapeDesc:
         "hs",
         "element_size",
         "block_stride_elems",
+        "dtype",
     )
 
     def __init__(self) -> None:
@@ -319,6 +320,10 @@ class PageBufferShapeDesc:
         # 0 means "unset — fall back to tight stride"; any downstream
         # consumer that needs exact addressing must check this.
         self.block_stride_elems: int = 0
+        # Python-only extension used by the pure-Python kernel fallback
+        # to disambiguate float16 vs bfloat16 (both have element_size==2);
+        # has no C++ counterpart in csrc/pybind.cpp.
+        self.dtype: torch.dtype | None = None
 
 
 def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:
@@ -1465,3 +1470,110 @@ def get_gpu_pci_bus_id(device_id: int = 0) -> str | None:
         pass
 
     return None
+
+
+# ------------------------------------------------------------------
+# GPU kernel stubs (no-op / pure-Python fallbacks on CPU-only platforms)
+# ------------------------------------------------------------------
+
+
+_ELEM_SIZE_TO_DTYPE = {
+    1: torch.uint8,
+    4: torch.float32,
+    8: torch.float64,
+}
+
+
+def multi_layer_block_kv_transfer(
+    paged_buffer_ptrs_tensor: torch.Tensor,
+    lmcache_objects_ptrs: list[int],
+    block_ids: torch.Tensor,
+    device: torch.device,
+    direction: TransferDirection,
+    shape_desc: "PageBufferShapeDesc",
+    lmcache_chunk_size: int,
+    gpu_kv_format: "GPUKVFormat",  # noqa: ARG001
+    skip_prefix_n_blocks: int = 0,
+) -> None:
+    """Pure-Python replacement for the CUDA block KV transfer kernel.
+
+    Transfers data between paged KV cache tensors and contiguous LMCache
+    memory objects.  Supports both CPU and CUDA device pointers.  Only
+    the ``NL_X_TWO_NB_BS_NH_HS`` layout is supported (the default for
+    ``CpuCacheContext``).
+
+    LMCache memory layout (contiguous, "2LTD"):
+        ``[2, NL, chunk_size, NH * HS]`` (in element units)
+    Paged buffer layout per layer (NL_X_TWO_NB_BS_NH_HS):
+        ``[2, NB, BS, NH, HS]``
+    """
+    num_objects = len(lmcache_objects_ptrs)
+    total_blocks = block_ids.shape[0]
+    if num_objects == 0 or total_blocks == 0:
+        return
+    blocks_per_obj = total_blocks // num_objects
+    nl = shape_desc.nl
+    bs = shape_desc.bs
+    nh = shape_desc.nh
+    hs = shape_desc.hs
+    nb = shape_desc.nb
+    elem_size = shape_desc.element_size
+    dtype = getattr(shape_desc, "dtype", None)
+    if dtype is None:
+        if elem_size == 2:
+            raise ValueError(
+                "element_size=2 is ambiguous (float16 vs bfloat16). "
+                "Set shape_desc.dtype explicitly."
+            )
+        if elem_size not in _ELEM_SIZE_TO_DTYPE:
+            raise ValueError("Unsupported element_size: %d" % elem_size)
+        dtype = _ELEM_SIZE_TO_DTYPE[elem_size]
+
+    layer_ptrs = paged_buffer_ptrs_tensor.tolist()
+    paged_shape = (2, nb, bs, nh, hs)
+    paged_tensors: list[torch.Tensor] = [
+        _tensor_from_ptr(int(ptr), paged_shape, dtype, device) for ptr in layer_ptrs
+    ]
+
+    block_ids_list = block_ids.tolist()
+    is_d2h = direction == TransferDirection.D2H
+
+    obj_shape = (2, nl, lmcache_chunk_size, nh * hs)
+    for obj_idx in range(num_objects):
+        obj_tensor = _tensor_from_ptr(
+            lmcache_objects_ptrs[obj_idx], obj_shape, dtype, device
+        )
+        blk_start = obj_idx * blocks_per_obj
+        for local_blk in range(blocks_per_obj):
+            flat_blk = blk_start + local_blk
+            if flat_blk < skip_prefix_n_blocks:
+                continue
+            engine_blk = block_ids_list[flat_blk]
+            t_st = local_blk * bs
+            t_ed = t_st + bs
+            for layer_idx in range(nl):
+                paged = paged_tensors[layer_idx]
+                for kv in range(2):
+                    if is_d2h:
+                        obj_tensor[kv, layer_idx, t_st:t_ed, :] = paged[
+                            kv, engine_blk, :, :, :
+                        ].reshape(bs, nh * hs)
+                    else:
+                        paged[kv, engine_blk, :, :, :] = obj_tensor[
+                            kv, layer_idx, t_st:t_ed, :
+                        ].reshape(bs, nh, hs)
+
+
+def record_event_on_stream(
+    cuda_stream_ptr: int,  # noqa: ARG001
+    event_type_name: str,  # noqa: ARG001
+    session_id: str,  # noqa: ARG001
+    str_metadata: dict,  # noqa: ARG001
+    int_metadata: dict,  # noqa: ARG001
+) -> None:
+    """No-op replacement for CUDA stream event recording."""
+
+
+def drain_recorded_events() -> list:
+    """No-op replacement: no native events to drain on CPU."""
+    return []

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -2058,6 +2058,10 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         shape_desc.nh = self.num_kv_heads
         shape_desc.hs = self.head_dim
         shape_desc.element_size = normalized.element_size()
+        try:
+            shape_desc.dtype = self.dtype
+        except AttributeError:
+            pass
         self.shape_desc = shape_desc
 
         self.paged_buffer_ptrs = torch.tensor(

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -1262,7 +1262,15 @@ def make_page_buffer_shape_desc(
         else get_num_heads(kv_caches, gpu_kv_format, layer_idx)
     )
     desc.hs = get_head_size(kv_caches, gpu_kv_format, layer_idx)
-    desc.element_size = get_dtype(kv_caches, gpu_kv_format, layer_idx).itemsize
+    dtype = get_dtype(kv_caches, gpu_kv_format, layer_idx)
+    desc.element_size = dtype.itemsize
+    # The C++ PageBufferShapeDesc has no ``dtype`` field, but the
+    # pure-Python CPU fallback (``non_cuda_equivalents``) does -- and
+    # needs it to disambiguate float16 vs bfloat16. Set best-effort.
+    try:
+        desc.dtype = dtype
+    except AttributeError:
+        pass
 
     resolved_stride = int(block_stride_elems) if block_stride_elems else 0
     desc.block_stride_elems = resolved_stride

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -511,6 +511,10 @@ def parse_kvcache_shape_spec(
         shape_desc.nh = nh
         shape_desc.hs = hs
         shape_desc.element_size = dtype.itemsize
+        try:
+            shape_desc.dtype = dtype
+        except AttributeError:
+            pass
 
         indices = list(range(layer_offset, layer_offset + layer_count))
         groups.append(

--- a/lmcache/v1/multiprocess/non_gpu_context.py
+++ b/lmcache/v1/multiprocess/non_gpu_context.py
@@ -103,9 +103,11 @@ def create_non_gpu_context(
 ) -> NonGpuContext:
     """Factory that returns the appropriate :class:`NonGpuContext` implementation.
 
-    Currently always returns a pickle-based implementation
-    (``NonGpuContextPickle``). A future SHM-capable PR
-    may probe for shared-memory availability and fall back to pickle.
+    Currently always returns :class:`NonGpuContextPickle`; the SHM
+    transport for non-GPU CPU caches has been folded into the
+    GPU protocol path (``REGISTER_KV_CACHE`` + ``STORE`` + ``RETRIEVE``)
+    via the :mod:`lmcache.v1.platform` registry, so this factory only
+    services the pickle fallback used by tests and unsupported hosts.
 
     Args:
         metadata: Layout metadata for the non-GPU context.

--- a/lmcache/v1/multiprocess/non_gpu_context.py
+++ b/lmcache/v1/multiprocess/non_gpu_context.py
@@ -103,11 +103,9 @@ def create_non_gpu_context(
 ) -> NonGpuContext:
     """Factory that returns the appropriate :class:`NonGpuContext` implementation.
 
-    Currently always returns :class:`NonGpuContextPickle`; the SHM
-    transport for non-GPU CPU caches has been folded into the
-    GPU protocol path (``REGISTER_KV_CACHE`` + ``STORE`` + ``RETRIEVE``)
-    via the :mod:`lmcache.v1.platform` registry, so this factory only
-    services the pickle fallback used by tests and unsupported hosts.
+    Currently always returns a pickle-based implementation
+    (``NonGpuContextPickle``). A future SHM-capable PR
+    may probe for shared-memory availability and fall back to pickle.
 
     Args:
         metadata: Layout metadata for the non-GPU context.

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -75,6 +75,7 @@ from lmcache.v1.multiprocess.protocols.engine import (
 )
 from lmcache.v1.multiprocess.session import SessionManager
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
+from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
@@ -297,7 +298,7 @@ class MPCacheEngine:
             )
             return
 
-        gpu_context = GPUCacheContext(
+        gpu_context = create_cache_context(
             kv_caches,
             self.chunk_size,
             layout_hints=layout_hints or None,

--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -163,7 +163,14 @@ class TokenHasher:
                 none_hash = kv_cache_utils.NONE_HASH
                 logger.info("Initialized NONE_HASH=%s from vLLM", none_hash)
                 return none_hash
-        except (ImportError, AttributeError, ValueError):
+        except (
+            ImportError,
+            AttributeError,
+            ValueError,
+            # torch._dynamo.device_interface raises AssertionError
+            # when CudaInterface is defined on non-CUDA platforms.
+            AssertionError,
+        ):
             pass
 
         # Fallback: compute none_hash using our hash function

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -6,6 +6,17 @@ exposes :class:`EventNotifier` -- a thin wake-up primitive used to
 signal background loops from other threads.  On Linux it is backed by
 ``os.eventfd``; on macOS / other POSIX systems it falls back to
 ``os.pipe``.  Callers never touch ``os.eventfd`` directly.
+
+Accelerator- and OS-specific implementations live in dedicated sub-
+packages so each can evolve independently:
+
+* :mod:`lmcache.v1.platform.cuda` -- CUDA-backed implementations.
+* :mod:`lmcache.v1.platform.cpu`  -- CPU-only fallbacks (POSIX SHM
+  KV-cache wrapper).
+
+Importing them here triggers their self-registration with
+:mod:`lmcache.v1.platform._registry`, so the multiprocess adapter
+can dispatch by ``tensor.device.type`` without any if/elif chain.
 """
 
 # First Party
@@ -17,3 +28,31 @@ from lmcache.v1.platform.event_notifier import consume_fd as consume_fd
 from lmcache.v1.platform.event_notifier import (
     create_event_notifier as create_event_notifier,
 )
+
+# Trigger backend self-registration with :mod:`_registry`.  The default
+# (``cpu``) backend must register first so accelerator backends can
+# transparently fall back to it.  Both imports are kept side-effect-only
+# so callers never need to know which sub-package is active.
+import lmcache.v1.platform.cpu  # noqa: F401,E402
+import lmcache.v1.platform.cuda  # noqa: F401,E402
+
+
+def __getattr__(name: str) -> object:
+    """Lazy re-export of platform cache utilities.
+
+    Deferred so that ``lmcache.c_ops`` (a compiled extension) is
+    fully available by the time the class is first used.
+    """
+    if name == "CpuCacheContext":
+        # First Party
+        from lmcache.v1.platform.cache_context import CpuCacheContext
+
+        return CpuCacheContext
+
+    if name == "create_cache_context":
+        # First Party
+        from lmcache.v1.platform.cache_context import create_cache_context
+
+        return create_cache_context
+
+    raise AttributeError(name)

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -45,7 +45,7 @@ def __getattr__(name: str) -> object:
     """
     if name == "CpuCacheContext":
         # First Party
-        from lmcache.v1.platform.cache_context import CpuCacheContext
+        from lmcache.v1.platform.cpu.cache_context import CpuCacheContext
 
         return CpuCacheContext
 

--- a/lmcache/v1/platform/_registry.py
+++ b/lmcache/v1/platform/_registry.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform backend registry.
+
+Each accelerator sub-package (``platform/cuda``, ``platform/cpu``,
+future ``platform/xpu`` ...) registers a concrete factory for the
+KV-cache IPC wrapper consumed by the multiprocess adapter.
+
+The :func:`get_kv_wrapper_factory` lookup keys on
+``tensor.device.type`` so the call site in
+:mod:`lmcache.integration.vllm.vllm_multi_process_adapter` stays free
+of any if/elif chain. Adding a new accelerator therefore requires
+*zero* changes to the dispatcher; it only needs to ship its own
+sub-package and register the right callable at import time.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any, Callable, Dict
+
+# Public sentinel used by callers who want the always-available
+# fall-back regardless of the running ``torch_device_type``.
+DEFAULT_BACKEND: str = "cpu"
+
+
+# KV-cache IPC wrapper factory per device type. Concrete sub-packages
+# self-register here (CUDA -> ``CudaIPCWrapper``, CPU -> POSIX-SHM
+# wrapper) so :func:`get_kv_wrapper_factory` can dispatch by
+# ``tensor.device.type`` without any if/elif chain in the call site.
+_KV_WRAPPER_FACTORIES: Dict[str, Callable[..., Any]] = {}
+
+# Per-backend availability predicate (e.g. CUDA's ``is_available``).
+# Missing entry == always available.
+_AVAILABILITY: Dict[str, Callable[[], bool]] = {}
+
+
+def register_availability(device_type: str, predicate: Callable[[], bool]) -> None:
+    _AVAILABILITY[device_type] = predicate
+
+
+def register_kv_wrapper(device_type: str, factory: Callable[..., Any]) -> None:
+    """Register a KV-cache IPC wrapper factory for ``device_type``.
+
+    The factory takes a single ``torch.Tensor`` and returns a wrapper
+    instance ready to be sent over the multiprocess wire.
+    """
+    _KV_WRAPPER_FACTORIES[device_type] = factory
+
+
+def is_available(device_type: str) -> bool:
+    pred = _AVAILABILITY.get(device_type)
+    if pred is None:
+        return True
+    try:
+        return bool(pred())
+    except Exception:
+        return False
+
+
+def get_kv_wrapper_factory(device_type: str) -> Callable[..., Any]:
+    """Pick the KV-cache wrapper factory for ``device_type``.
+
+    A missing entry means the caller is asking for a backend that
+    nobody registered (typically because the relevant sub-package was
+    not imported), which is a programming error and deserves an
+    explicit failure.
+    """
+    factory = _KV_WRAPPER_FACTORIES.get(device_type)
+    if factory is None:
+        raise ValueError(
+            "No KV-cache wrapper factory registered for device type %r" % device_type
+        )
+    return factory
+
+
+def snapshot() -> Dict[str, Dict[str, Callable[..., Any]]]:
+    """Return a deep-copy of the registry tables.
+
+    Test suites use this to install backend overrides without leaking
+    state across tests; pair with :func:`restore` in a ``finally`` /
+    fixture teardown clause.
+    """
+    return {
+        "kv_wrapper": dict(_KV_WRAPPER_FACTORIES),
+        "availability": dict(_AVAILABILITY),
+    }
+
+
+def restore(state: Dict[str, Dict[str, Callable[..., Any]]]) -> None:
+    """Restore registry tables to a previously :func:`snapshot`-ed state."""
+    _KV_WRAPPER_FACTORIES.clear()
+    _KV_WRAPPER_FACTORIES.update(state.get("kv_wrapper", {}))
+    _AVAILABILITY.clear()
+    _AVAILABILITY.update(state.get("availability", {}))

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CPU-only cache context for platforms without CUDA GPUs.
+"""Platform-agnostic cache-context factory.
 
-This module lives in the ``platform`` package because it is part of
-the cross-platform compatibility layer -- it provides the same public
-API as :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext`
-but keeps all tensors on CPU. Stream / Event objects are provided by
-:class:`~lmcache.v1.platform.cpu.stub_cpu_device.StubStream` so
-CPU-only hosts never import ``cupy`` or instantiate a real CUDA
-stream object.
+The concrete implementations live in their respective sub-packages:
+
+* :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext` --
+  CUDA-backed.
+* :class:`~lmcache.v1.platform.cpu.cache_context.CpuCacheContext` --
+  CPU-only fallback (POSIX-SHM-backed KV tensors).
+
+:func:`create_cache_context` keeps the dispatch out of the call site
+in :mod:`lmcache.v1.multiprocess.server` so adding a new accelerator
+only requires shipping a new sub-package + extending the wrapper
+isinstance check below.
 """
 
 # Future
@@ -16,326 +20,24 @@ from __future__ import annotations
 # Standard
 from typing import Any
 
-# Third Party
-import torch
-
 # First Party
-from lmcache.logging import init_logger
 from lmcache.utils import EngineType
-from lmcache.v1.gpu_connector.utils import (
-    get_group_data_ptrs,
-    normalize_kv_and_discover_format,
-)
-from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import KVCache
-from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
-import lmcache.c_ops as lmc_ops
-
-logger = init_logger(__name__)
-
-
-class CpuCacheContext:
-    """CPU-only cache context with the same public API as
-    :class:`GPUCacheContext`.
-
-    All tensors live on CPU. CUDA streams and cupy streams are
-    replaced by :class:`StubStream` no-op objects so callers can keep
-    using ``stream.synchronize()`` / ``wait_event(...)`` etc. without
-    branching on the active backend.
-
-    KV cache tensors are reconstructed from the
-    :class:`CpuShmTensorWrapper` instances sent by the client over
-    POSIX shared memory -- the server does **not** allocate the KV
-    cache itself. This mirrors the GPU-mode CUDA-IPC flow where the
-    client owns the buffers and the server only maps them.
-    """
-
-    def __init__(
-        self,
-        kv_caches: KVCache,
-        lmcache_logical_chunk_size: int = 256,
-    ) -> None:
-        if not kv_caches:
-            raise ValueError(
-                "CpuCacheContext requires a non-empty list of "
-                "CpuShmTensorWrapper; the legacy server-side "
-                "self-allocation path has been removed."
-            )
-
-        # First Party
-        from lmcache.v1.multiprocess.gpu_context import (
-            unwrap_kv_cache_tensors,
-        )
-
-        unwrapped = unwrap_kv_cache_tensors(kv_caches)
-        self.device_ = torch.device("cpu")
-        self.lmcache_logical_chunk_size = lmcache_logical_chunk_size
-        self.is_mla_ = False
-
-        # Discover layout & build KV layer groups via the same path
-        # GPUCacheContext uses, so we don't need to hand-roll any
-        # PageBufferShapeDesc here. ``EngineType.VLLM`` is fine for
-        # the CPU buffers wired through CpuShmTensorWrapper.
-        (
-            self.gpu_kv_format_,
-            kv_caches_normalized,
-        ) = normalize_kv_and_discover_format(
-            unwrapped,
-            EngineType.VLLM,
-            layout_hints=None,
-        )
-        self.kv_caches_: list[torch.Tensor] = list(kv_caches_normalized)
-        self.num_layers_ = len(self.kv_caches_)
-        # ``[2, num_blocks, block_size, num_heads, head_size]`` (NHD).
-        first = self.kv_caches_[0]
-        self.num_blocks_ = int(first.shape[1])
-        self.block_size_ = int(first.shape[2])
-        self.kv_layer_groups_manager_ = KVLayerGroupsManager(
-            self.kv_caches_,
-            gpu_kv_format=self.gpu_kv_format_,
-            num_blocks=self.num_blocks_,
-            layout_hints=None,
-            lmcache_logical_chunk_size=lmcache_logical_chunk_size,
-        )
-
-        # Per-group KV pointer tensors (CPU). Reuse the same helper
-        # GPUCacheContext relies on so the layout matches exactly.
-        self.group_kv_pointers_: list[torch.Tensor] = [
-            torch.tensor(
-                get_group_data_ptrs(
-                    self.kv_caches_,
-                    self.gpu_kv_format_,
-                    group.layer_indices,
-                ),
-                dtype=torch.long,
-            )
-            for group in self.kv_layer_groups_manager_.kv_layer_groups
-        ]
-
-        # Backwards-compat aliases (a few callers still expect these).
-        self.hidden_dim_sizes_: list[int] = [
-            group.hidden_dim_size
-            for group in self.kv_layer_groups_manager_.kv_layer_groups
-        ]
-        self.kv_cache_pointers_ = torch.tensor(
-            [t.data_ptr() for t in self.kv_caches_], dtype=torch.long
-        )
-
-        # Pre-allocated block IDs buffer (CPU).
-        _MAX_BLOCK_IDS = 1_000_000
-        self.block_ids_buffer_ = torch.empty(_MAX_BLOCK_IDS, dtype=torch.long)
-
-        # Temporary buffer for transfers (same layout as
-        # GPUCacheContext but on CPU).
-        self.max_batch_size = 4
-        self.tmp_chunk_group_offsets_: list[int] = [0]
-        for group_idx, group in enumerate(
-            self.kv_layer_groups_manager_.kv_layer_groups
-        ):
-            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
-            byte_size = shape.numel() * group.dtype.itemsize
-            self.tmp_chunk_group_offsets_.append(
-                self.tmp_chunk_group_offsets_[-1] + byte_size
-            )
-        self.tmp_chunk_bytes_ = self.tmp_chunk_group_offsets_[-1]
-        self.tmp_gpu_buffer_ = torch.empty(
-            self.tmp_chunk_bytes_ * self.max_batch_size,
-            dtype=torch.uint8,
-        )
-
-        # Mock streams. ``StubStream`` already implements the small
-        # subset of the API server-side code uses (``synchronize``,
-        # ``wait_event``, ``record_event`` ...), so we never import
-        # cupy or instantiate a real CUDA stream object here.
-        self.cuda_stream_: StubStream = StubStream(device="cpu")
-        self.cupy_stream_: StubStream = self.cuda_stream_
-        self.high_priority_cuda_stream_: StubStream = StubStream(
-            device="cpu", priority=0
-        )
-        self.high_priority_cupy_stream_: StubStream = self.high_priority_cuda_stream_
-
-        logger.info(
-            "CpuCacheContext: %d layers, blocks=%dx%d, dtype=%s (shm-backed)",
-            self.num_layers_,
-            self.num_blocks_,
-            self.block_size_,
-            self.kv_caches_[0].dtype,
-        )
-
-    # -- Properties (same API as GPUCacheContext) --
-
-    @property
-    def dtype(self) -> torch.dtype:
-        """Returns the dtype of the KV cache tensors."""
-        return self.kv_caches_[0].dtype
-
-    @property
-    def device(self) -> torch.device:
-        """Returns the device (always CPU)."""
-        return self.device_
-
-    @property
-    def kv_tensors(self) -> list[torch.Tensor]:
-        """Returns the list of per-layer KV cache tensors."""
-        return self.kv_caches_
-
-    @property
-    def kv_pointers(self) -> torch.Tensor:
-        """Returns a tensor of KV cache data pointers."""
-        return self.kv_cache_pointers_
-
-    @property
-    def stream(self) -> StubStream:
-        """Returns the (mock) CUDA stream."""
-        return self.cuda_stream_
-
-    @property
-    def cupy_stream(self) -> StubStream:
-        """Returns the (mock) external stream."""
-        return self.cupy_stream_
-
-    @property
-    def high_priority_stream(self) -> StubStream:
-        """Returns the (mock) high-priority CUDA stream."""
-        return self.high_priority_cuda_stream_
-
-    @property
-    def high_priority_cupy_stream(self) -> StubStream:
-        """Returns the (mock) high-priority external stream."""
-        return self.high_priority_cupy_stream_
-
-    @property
-    def block_size(self) -> int:
-        """Returns the block size (tokens per block)."""
-        return self.block_size_
-
-    @property
-    def num_layers(self) -> int:
-        """Returns the number of layers in the model."""
-        return self.num_layers_
-
-    @property
-    def num_blocks(self) -> int:
-        """Returns the number of blocks in the KV cache."""
-        return self.num_blocks_
-
-    @property
-    def is_mla(self) -> bool:
-        """Returns whether the model uses MLA."""
-        return self.is_mla_
-
-    @property
-    def hidden_dim_sizes(self) -> list[int]:
-        """Returns hidden dimension sizes per KV layer group."""
-        return self.hidden_dim_sizes_
-
-    @property
-    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
-        """Returns the KV layer groups manager."""
-        return self.kv_layer_groups_manager_
-
-    @property
-    def gpu_kv_format_name(self) -> str:
-        """Returns the GPU KV format enum name."""
-        return self.gpu_kv_format_.name
-
-    @property
-    def gpu_kv_shape(self) -> str:
-        """Returns the GPU KV cache layout description."""
-        return "NL_X_TWO_NB_BS_NH_HS"
-
-    @property
-    def attention_backend(self) -> str:
-        """Returns the attention backend name."""
-        return "cpu"
-
-    @property
-    def concrete_gpu_kv_shape(self) -> str:
-        """Returns the GPU KV shape with actual values."""
-        return "cpu-context"
-
-    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
-        """Returns the PageBufferShapeDesc for the given group."""
-        return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
-
-    def get_physical_chunk_size(self, group_idx: int) -> int:
-        """Returns the per-chunk physical slot count for the group."""
-        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
-
-    def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
-        """Returns the KV cache pointer tensor for the given group."""
-        return self.group_kv_pointers_[group_idx]
-
-    def get_kv_buffer_shape(self, num_tokens: int, group_idx: int = 0) -> torch.Size:
-        """Returns the KV buffer shape for the given token count."""
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        num_layers_in_group = group.num_layers
-        hidden_dim = self.hidden_dim_sizes_[group_idx]
-        return torch.Size((2, num_layers_in_group, num_tokens, hidden_dim))
-
-    def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
-        """Returns the flat uint8 temp buffer for the given chunk."""
-        if chunk_idx >= self.max_batch_size:
-            raise ValueError(
-                "chunk_idx %d >= max_batch_size %d" % (chunk_idx, self.max_batch_size)
-            )
-        start = chunk_idx * self.tmp_chunk_bytes_
-        return self.tmp_gpu_buffer_[start : start + self.tmp_chunk_bytes_]
-
-    def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
-        """Returns a typed view of the temp buffer for one chunk."""
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
-        start = self.tmp_chunk_group_offsets_[group_idx]
-        end = self.tmp_chunk_group_offsets_[group_idx + 1]
-        return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
-
-    def get_tmp_chunk_gpu_buffer_batched(
-        self, batch_size: int, group_idx: int = 0
-    ) -> list[torch.Tensor]:
-        """Returns a list of non-overlapping temp buffer views."""
-        if batch_size > self.max_batch_size:
-            raise ValueError(
-                "batch_size %d > max_batch_size %d" % (batch_size, self.max_batch_size)
-            )
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
-        g_start = self.tmp_chunk_group_offsets_[group_idx]
-        g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
-        chunk = self.tmp_chunk_bytes_
-        return [
-            self.tmp_gpu_buffer_[i * chunk + g_start : i * chunk + g_end]
-            .view(group.dtype)
-            .view(shape)
-            for i in range(batch_size)
-        ]
-
-    def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
-        """Copy block IDs into the pre-allocated buffer."""
-        n = len(block_ids)
-        cpu_tensor = torch.tensor(block_ids, dtype=torch.long)
-        buf = self.block_ids_buffer_[:n]
-        buf.copy_(cpu_tensor)
-        return buf
-
-    def cache_size_per_token(self) -> int:
-        """Returns cache size per token in bytes, summed across groups."""
-        total = 0
-        for group_idx, _group in enumerate(
-            self.kv_layer_groups_manager_.kv_layer_groups
-        ):
-            numels = self.get_kv_buffer_shape(1, group_idx).numel()
-            total += numels * _group.dtype.itemsize
-        return total
+from lmcache.v1.platform.cpu.cache_context import CpuCacheContext
 
 
 def create_cache_context(
-    kv_caches: Any,
-    chunk_size: int,
-    layout_hints: Any = None,
-    engine_type: Any = None,
+    kv_caches: KVCache,
+    lmcache_logical_chunk_size: int = 256,
+    layout_hints: LayoutHints | None = None,
+    engine_type: EngineType = EngineType.VLLM,
 ) -> Any:
     """Create the appropriate cache context.
+
+    The signature mirrors :class:`GPUCacheContext` so callers can
+    forward their kwargs verbatim and stay agnostic of the active
+    backend.
 
     Selection is driven by the wrapper type of *kv_caches*:
 
@@ -345,31 +47,17 @@ def create_cache_context(
       segments.
     * Otherwise (real ``CudaIPCWrapper`` instances) ->
       :class:`GPUCacheContext` is built.
-
-    Args:
-        kv_caches: Non-empty list of KV cache wrappers.
-        chunk_size: LMCache logical chunk size in tokens.
-        layout_hints: See :class:`LayoutHints`. Forwarded to
-            ``GPUCacheContext`` only.
-        engine_type: Forwarded to ``GPUCacheContext`` for serving-
-            engine-specific layout detection. Ignored in CPU mode.
     """
     # First Party
+    from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
     from lmcache.v1.platform.cpu.shm import CpuShmTensorWrapper
 
     if not kv_caches:
         raise ValueError("create_cache_context requires a non-empty kv_caches list")
 
-    if any(isinstance(w, CpuShmTensorWrapper) for w in kv_caches):
-        return CpuCacheContext(
-            kv_caches=kv_caches,
-            lmcache_logical_chunk_size=chunk_size,
-        )
-
-    # First Party
-    from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
-
-    kwargs: dict[str, Any] = {"layout_hints": layout_hints or None}
-    if engine_type is not None:
-        kwargs["engine_type"] = engine_type
-    return GPUCacheContext(kv_caches, chunk_size, **kwargs)
+    cls: type = (
+        CpuCacheContext
+        if any(isinstance(w, CpuShmTensorWrapper) for w in kv_caches)
+        else GPUCacheContext
+    )
+    return cls(kv_caches, lmcache_logical_chunk_size, layout_hints, engine_type)

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only cache context for platforms without CUDA GPUs.
+
+This module lives in the ``platform`` package because it is part of
+the cross-platform compatibility layer -- it provides the same public
+API as :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext`
+but keeps all tensors on CPU. Stream / Event objects are provided by
+:class:`~lmcache.v1.platform.cpu.stub_cpu_device.StubStream` so
+CPU-only hosts never import ``cupy`` or instantiate a real CUDA
+stream object.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import (
+    get_group_data_ptrs,
+    normalize_kv_and_discover_format,
+)
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
+import lmcache.c_ops as lmc_ops
+
+logger = init_logger(__name__)
+
+
+class CpuCacheContext:
+    """CPU-only cache context with the same public API as
+    :class:`GPUCacheContext`.
+
+    All tensors live on CPU. CUDA streams and cupy streams are
+    replaced by :class:`StubStream` no-op objects so callers can keep
+    using ``stream.synchronize()`` / ``wait_event(...)`` etc. without
+    branching on the active backend.
+
+    KV cache tensors are reconstructed from the
+    :class:`CpuShmTensorWrapper` instances sent by the client over
+    POSIX shared memory -- the server does **not** allocate the KV
+    cache itself. This mirrors the GPU-mode CUDA-IPC flow where the
+    client owns the buffers and the server only maps them.
+    """
+
+    def __init__(
+        self,
+        kv_caches: KVCache,
+        lmcache_logical_chunk_size: int = 256,
+    ) -> None:
+        if not kv_caches:
+            raise ValueError(
+                "CpuCacheContext requires a non-empty list of "
+                "CpuShmTensorWrapper; the legacy server-side "
+                "self-allocation path has been removed."
+            )
+
+        # First Party
+        from lmcache.v1.multiprocess.gpu_context import (
+            unwrap_kv_cache_tensors,
+        )
+
+        unwrapped = unwrap_kv_cache_tensors(kv_caches)
+        self.device_ = torch.device("cpu")
+        self.lmcache_logical_chunk_size = lmcache_logical_chunk_size
+        self.is_mla_ = False
+
+        # Discover layout & build KV layer groups via the same path
+        # GPUCacheContext uses, so we don't need to hand-roll any
+        # PageBufferShapeDesc here. ``EngineType.VLLM`` is fine for
+        # the CPU buffers wired through CpuShmTensorWrapper.
+        (
+            self.gpu_kv_format_,
+            kv_caches_normalized,
+        ) = normalize_kv_and_discover_format(
+            unwrapped,
+            EngineType.VLLM,
+            layout_hints=None,
+        )
+        self.kv_caches_: list[torch.Tensor] = list(kv_caches_normalized)
+        self.num_layers_ = len(self.kv_caches_)
+        # ``[2, num_blocks, block_size, num_heads, head_size]`` (NHD).
+        first = self.kv_caches_[0]
+        self.num_blocks_ = int(first.shape[1])
+        self.block_size_ = int(first.shape[2])
+        self.kv_layer_groups_manager_ = KVLayerGroupsManager(
+            self.kv_caches_,
+            gpu_kv_format=self.gpu_kv_format_,
+            num_blocks=self.num_blocks_,
+            layout_hints=None,
+            lmcache_logical_chunk_size=lmcache_logical_chunk_size,
+        )
+
+        # Per-group KV pointer tensors (CPU). Reuse the same helper
+        # GPUCacheContext relies on so the layout matches exactly.
+        self.group_kv_pointers_: list[torch.Tensor] = [
+            torch.tensor(
+                get_group_data_ptrs(
+                    self.kv_caches_,
+                    self.gpu_kv_format_,
+                    group.layer_indices,
+                ),
+                dtype=torch.long,
+            )
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+
+        # Backwards-compat aliases (a few callers still expect these).
+        self.hidden_dim_sizes_: list[int] = [
+            group.hidden_dim_size
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+        self.kv_cache_pointers_ = torch.tensor(
+            [t.data_ptr() for t in self.kv_caches_], dtype=torch.long
+        )
+
+        # Pre-allocated block IDs buffer (CPU).
+        _MAX_BLOCK_IDS = 1_000_000
+        self.block_ids_buffer_ = torch.empty(_MAX_BLOCK_IDS, dtype=torch.long)
+
+        # Temporary buffer for transfers (same layout as
+        # GPUCacheContext but on CPU).
+        self.max_batch_size = 4
+        self.tmp_chunk_group_offsets_: list[int] = [0]
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
+            byte_size = shape.numel() * group.dtype.itemsize
+            self.tmp_chunk_group_offsets_.append(
+                self.tmp_chunk_group_offsets_[-1] + byte_size
+            )
+        self.tmp_chunk_bytes_ = self.tmp_chunk_group_offsets_[-1]
+        self.tmp_gpu_buffer_ = torch.empty(
+            self.tmp_chunk_bytes_ * self.max_batch_size,
+            dtype=torch.uint8,
+        )
+
+        # Mock streams. ``StubStream`` already implements the small
+        # subset of the API server-side code uses (``synchronize``,
+        # ``wait_event``, ``record_event`` ...), so we never import
+        # cupy or instantiate a real CUDA stream object here.
+        self.cuda_stream_: StubStream = StubStream(device="cpu")
+        self.cupy_stream_: StubStream = self.cuda_stream_
+        self.high_priority_cuda_stream_: StubStream = StubStream(
+            device="cpu", priority=0
+        )
+        self.high_priority_cupy_stream_: StubStream = self.high_priority_cuda_stream_
+
+        logger.info(
+            "CpuCacheContext: %d layers, blocks=%dx%d, dtype=%s (shm-backed)",
+            self.num_layers_,
+            self.num_blocks_,
+            self.block_size_,
+            self.kv_caches_[0].dtype,
+        )
+
+    # -- Properties (same API as GPUCacheContext) --
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Returns the dtype of the KV cache tensors."""
+        return self.kv_caches_[0].dtype
+
+    @property
+    def device(self) -> torch.device:
+        """Returns the device (always CPU)."""
+        return self.device_
+
+    @property
+    def kv_tensors(self) -> list[torch.Tensor]:
+        """Returns the list of per-layer KV cache tensors."""
+        return self.kv_caches_
+
+    @property
+    def kv_pointers(self) -> torch.Tensor:
+        """Returns a tensor of KV cache data pointers."""
+        return self.kv_cache_pointers_
+
+    @property
+    def stream(self) -> StubStream:
+        """Returns the (mock) CUDA stream."""
+        return self.cuda_stream_
+
+    @property
+    def cupy_stream(self) -> StubStream:
+        """Returns the (mock) external stream."""
+        return self.cupy_stream_
+
+    @property
+    def high_priority_stream(self) -> StubStream:
+        """Returns the (mock) high-priority CUDA stream."""
+        return self.high_priority_cuda_stream_
+
+    @property
+    def high_priority_cupy_stream(self) -> StubStream:
+        """Returns the (mock) high-priority external stream."""
+        return self.high_priority_cupy_stream_
+
+    @property
+    def block_size(self) -> int:
+        """Returns the block size (tokens per block)."""
+        return self.block_size_
+
+    @property
+    def num_layers(self) -> int:
+        """Returns the number of layers in the model."""
+        return self.num_layers_
+
+    @property
+    def num_blocks(self) -> int:
+        """Returns the number of blocks in the KV cache."""
+        return self.num_blocks_
+
+    @property
+    def is_mla(self) -> bool:
+        """Returns whether the model uses MLA."""
+        return self.is_mla_
+
+    @property
+    def hidden_dim_sizes(self) -> list[int]:
+        """Returns hidden dimension sizes per KV layer group."""
+        return self.hidden_dim_sizes_
+
+    @property
+    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
+        """Returns the KV layer groups manager."""
+        return self.kv_layer_groups_manager_
+
+    @property
+    def gpu_kv_format_name(self) -> str:
+        """Returns the GPU KV format enum name."""
+        return self.gpu_kv_format_.name
+
+    @property
+    def gpu_kv_shape(self) -> str:
+        """Returns the GPU KV cache layout description."""
+        return "NL_X_TWO_NB_BS_NH_HS"
+
+    @property
+    def attention_backend(self) -> str:
+        """Returns the attention backend name."""
+        return "cpu"
+
+    @property
+    def concrete_gpu_kv_shape(self) -> str:
+        """Returns the GPU KV shape with actual values."""
+        return "cpu-context"
+
+    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
+        """Returns the PageBufferShapeDesc for the given group."""
+        return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
+
+    def get_physical_chunk_size(self, group_idx: int) -> int:
+        """Returns the per-chunk physical slot count for the group."""
+        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
+
+    def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
+        """Returns the KV cache pointer tensor for the given group."""
+        return self.group_kv_pointers_[group_idx]
+
+    def get_kv_buffer_shape(self, num_tokens: int, group_idx: int = 0) -> torch.Size:
+        """Returns the KV buffer shape for the given token count."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        num_layers_in_group = group.num_layers
+        hidden_dim = self.hidden_dim_sizes_[group_idx]
+        return torch.Size((2, num_layers_in_group, num_tokens, hidden_dim))
+
+    def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
+        """Returns the flat uint8 temp buffer for the given chunk."""
+        if chunk_idx >= self.max_batch_size:
+            raise ValueError(
+                "chunk_idx %d >= max_batch_size %d" % (chunk_idx, self.max_batch_size)
+            )
+        start = chunk_idx * self.tmp_chunk_bytes_
+        return self.tmp_gpu_buffer_[start : start + self.tmp_chunk_bytes_]
+
+    def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
+        """Returns a typed view of the temp buffer for one chunk."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        start = self.tmp_chunk_group_offsets_[group_idx]
+        end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
+
+    def get_tmp_chunk_gpu_buffer_batched(
+        self, batch_size: int, group_idx: int = 0
+    ) -> list[torch.Tensor]:
+        """Returns a list of non-overlapping temp buffer views."""
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                "batch_size %d > max_batch_size %d" % (batch_size, self.max_batch_size)
+            )
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        g_start = self.tmp_chunk_group_offsets_[group_idx]
+        g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        chunk = self.tmp_chunk_bytes_
+        return [
+            self.tmp_gpu_buffer_[i * chunk + g_start : i * chunk + g_end]
+            .view(group.dtype)
+            .view(shape)
+            for i in range(batch_size)
+        ]
+
+    def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
+        """Copy block IDs into the pre-allocated buffer."""
+        n = len(block_ids)
+        cpu_tensor = torch.tensor(block_ids, dtype=torch.long)
+        buf = self.block_ids_buffer_[:n]
+        buf.copy_(cpu_tensor)
+        return buf
+
+    def cache_size_per_token(self) -> int:
+        """Returns cache size per token in bytes, summed across groups."""
+        total = 0
+        for group_idx, _group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            numels = self.get_kv_buffer_shape(1, group_idx).numel()
+            total += numels * _group.dtype.itemsize
+        return total
+
+
+def create_cache_context(
+    kv_caches: Any,
+    chunk_size: int,
+    layout_hints: Any = None,
+    engine_type: Any = None,
+) -> Any:
+    """Create the appropriate cache context.
+
+    Selection is driven by the wrapper type of *kv_caches*:
+
+    * Any element is a :class:`CpuShmTensorWrapper` -> a
+      :class:`CpuCacheContext` is built and the underlying CPU
+      tensors are mapped from the client-owned POSIX shared-memory
+      segments.
+    * Otherwise (real ``CudaIPCWrapper`` instances) ->
+      :class:`GPUCacheContext` is built.
+
+    Args:
+        kv_caches: Non-empty list of KV cache wrappers.
+        chunk_size: LMCache logical chunk size in tokens.
+        layout_hints: See :class:`LayoutHints`. Forwarded to
+            ``GPUCacheContext`` only.
+        engine_type: Forwarded to ``GPUCacheContext`` for serving-
+            engine-specific layout detection. Ignored in CPU mode.
+    """
+    # First Party
+    from lmcache.v1.platform.cpu.shm import CpuShmTensorWrapper
+
+    if not kv_caches:
+        raise ValueError("create_cache_context requires a non-empty kv_caches list")
+
+    if any(isinstance(w, CpuShmTensorWrapper) for w in kv_caches):
+        return CpuCacheContext(
+            kv_caches=kv_caches,
+            lmcache_logical_chunk_size=chunk_size,
+        )
+
+    # First Party
+    from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
+
+    kwargs: dict[str, Any] = {"layout_hints": layout_hints or None}
+    if engine_type is not None:
+        kwargs["engine_type"] = engine_type
+    return GPUCacheContext(kv_caches, chunk_size, **kwargs)

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-specific platform primitives.
+
+Importing this package self-registers the POSIX-SHM KV-cache wrapper
+factory with :mod:`lmcache.v1.platform._registry`, so the dispatch
+in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
+pick the right wrapper based on ``tensor.device.type`` without any
+if/elif chain.
+"""
+
+# First Party
+from lmcache.v1.platform._registry import register_kv_wrapper
+
+
+def _kv_wrapper_factory(tensor):
+    """Indirect-dispatch wrapper.
+
+    Defers loading :mod:`lmcache.v1.platform.cpu.shm` (which pulls in
+    ``multiprocess.custom_types``) until first use, so importing this
+    package during ``lmcache/__init__.py``'s bootstrap does not race
+    other imports that touch ``torch_dev``.
+    """
+    # First Party
+    from lmcache.v1.platform.cpu.shm import migrate_to_shm_and_wrap
+
+    return migrate_to_shm_and_wrap(tensor)
+
+
+register_kv_wrapper("cpu", _kv_wrapper_factory)

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -316,7 +316,15 @@ class CpuCacheContext:
 
     def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
         """Copy block IDs into the pre-allocated buffer."""
+        if not block_ids:
+            raise ValueError("stage_block_ids requires a non-empty block_ids list")
         n = len(block_ids)
+        capacity = self.block_ids_buffer_.shape[0]
+        if n > capacity:
+            raise ValueError(
+                "stage_block_ids: %d block IDs exceeds buffer capacity %d"
+                % (n, capacity)
+            )
         cpu_tensor = torch.tensor(block_ids, dtype=torch.long)
         buf = self.block_ids_buffer_[:n]
         buf.copy_(cpu_tensor)

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only cache context for platforms without CUDA GPUs.
+
+This module lives in the ``platform.cpu`` sub-package because it is
+the CPU-specific implementation of the cross-platform cache context
+-- it provides the same public API as
+:class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext` but
+keeps all tensors on CPU. Stream / Event objects are provided by
+:class:`~lmcache.v1.platform.cpu.stub_cpu_device.StubStream` so
+CPU-only hosts never import ``cupy`` or instantiate a real CUDA
+stream object.
+
+The platform-agnostic dispatcher ``create_cache_context`` lives in
+:mod:`lmcache.v1.platform.cache_context`.
+"""
+
+# Future
+from __future__ import annotations
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import (
+    LayoutHints,
+    get_group_data_ptrs,
+    normalize_kv_and_discover_format,
+)
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
+import lmcache.c_ops as lmc_ops
+
+logger = init_logger(__name__)
+
+
+class CpuCacheContext:
+    """CPU-only cache context with the same public API as
+    :class:`GPUCacheContext`.
+
+    All tensors live on CPU. CUDA streams and cupy streams are
+    replaced by :class:`StubStream` no-op objects so callers can keep
+    using ``stream.synchronize()`` / ``wait_event(...)`` etc. without
+    branching on the active backend.
+
+    KV cache tensors are reconstructed from the
+    :class:`CpuShmTensorWrapper` instances sent by the client over
+    POSIX shared memory -- the server does **not** allocate the KV
+    cache itself. This mirrors the GPU-mode CUDA-IPC flow where the
+    client owns the buffers and the server only maps them.
+    """
+
+    def __init__(
+        self,
+        kv_caches: KVCache,
+        lmcache_logical_chunk_size: int = 256,
+        layout_hints: LayoutHints | None = None,
+        engine_type: EngineType = EngineType.VLLM,
+    ) -> None:
+        if not kv_caches:
+            raise ValueError(
+                "CpuCacheContext requires a non-empty list of "
+                "CpuShmTensorWrapper; the legacy server-side "
+                "self-allocation path has been removed."
+            )
+
+        # First Party
+        from lmcache.v1.multiprocess.gpu_context import (
+            unwrap_kv_cache_tensors,
+        )
+
+        unwrapped = unwrap_kv_cache_tensors(kv_caches)
+        self.device_ = torch.device("cpu")
+        self.lmcache_logical_chunk_size = lmcache_logical_chunk_size
+        self.is_mla_ = False
+
+        # Discover layout & build KV layer groups via the same path
+        # GPUCacheContext uses, so we don't need to hand-roll any
+        # PageBufferShapeDesc here. ``layout_hints`` / ``engine_type``
+        # are forwarded so the signature matches GPUCacheContext.
+        (
+            self.gpu_kv_format_,
+            kv_caches_normalized,
+        ) = normalize_kv_and_discover_format(
+            unwrapped,
+            engine_type,
+            layout_hints=layout_hints,
+        )
+        self.kv_caches_: list[torch.Tensor] = list(kv_caches_normalized)
+        self.num_layers_ = len(self.kv_caches_)
+        # ``[2, num_blocks, block_size, num_heads, head_size]`` (NHD).
+        first = self.kv_caches_[0]
+        self.num_blocks_ = int(first.shape[1])
+        self.block_size_ = int(first.shape[2])
+        self.kv_layer_groups_manager_ = KVLayerGroupsManager(
+            self.kv_caches_,
+            gpu_kv_format=self.gpu_kv_format_,
+            num_blocks=self.num_blocks_,
+            layout_hints=layout_hints,
+            lmcache_logical_chunk_size=lmcache_logical_chunk_size,
+        )
+
+        # Per-group KV pointer tensors (CPU). Reuse the same helper
+        # GPUCacheContext relies on so the layout matches exactly.
+        self.group_kv_pointers_: list[torch.Tensor] = [
+            torch.tensor(
+                get_group_data_ptrs(
+                    self.kv_caches_,
+                    self.gpu_kv_format_,
+                    group.layer_indices,
+                ),
+                dtype=torch.long,
+            )
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+
+        # Backwards-compat aliases (a few callers still expect these).
+        self.hidden_dim_sizes_: list[int] = [
+            group.hidden_dim_size
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+        self.kv_cache_pointers_ = torch.tensor(
+            [t.data_ptr() for t in self.kv_caches_], dtype=torch.long
+        )
+
+        # Pre-allocated block IDs buffer (CPU).
+        _MAX_BLOCK_IDS = 1_000_000
+        self.block_ids_buffer_ = torch.empty(_MAX_BLOCK_IDS, dtype=torch.long)
+
+        # Temporary buffer for transfers (same layout as
+        # GPUCacheContext but on CPU).
+        self.max_batch_size = 4
+        self.tmp_chunk_group_offsets_: list[int] = [0]
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
+            byte_size = shape.numel() * group.dtype.itemsize
+            self.tmp_chunk_group_offsets_.append(
+                self.tmp_chunk_group_offsets_[-1] + byte_size
+            )
+        self.tmp_chunk_bytes_ = self.tmp_chunk_group_offsets_[-1]
+        self.tmp_gpu_buffer_ = torch.empty(
+            self.tmp_chunk_bytes_ * self.max_batch_size,
+            dtype=torch.uint8,
+        )
+
+        # Mock streams. ``StubStream`` already implements the small
+        # subset of the API server-side code uses (``synchronize``,
+        # ``wait_event``, ``record_event`` ...), so we never import
+        # cupy or instantiate a real CUDA stream object here.
+        self.cuda_stream_: StubStream = StubStream(device="cpu")
+        self.cupy_stream_: StubStream = self.cuda_stream_
+        self.high_priority_cuda_stream_: StubStream = StubStream(
+            device="cpu", priority=0
+        )
+        self.high_priority_cupy_stream_: StubStream = self.high_priority_cuda_stream_
+
+        logger.info(
+            "CpuCacheContext: %d layers, blocks=%dx%d, dtype=%s (shm-backed)",
+            self.num_layers_,
+            self.num_blocks_,
+            self.block_size_,
+            self.kv_caches_[0].dtype,
+        )
+
+    # -- Properties (same API as GPUCacheContext) --
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Returns the dtype of the KV cache tensors."""
+        return self.kv_caches_[0].dtype
+
+    @property
+    def device(self) -> torch.device:
+        """Returns the device (always CPU)."""
+        return self.device_
+
+    @property
+    def kv_tensors(self) -> list[torch.Tensor]:
+        """Returns the list of per-layer KV cache tensors."""
+        return self.kv_caches_
+
+    @property
+    def kv_pointers(self) -> torch.Tensor:
+        """Returns a tensor of KV cache data pointers."""
+        return self.kv_cache_pointers_
+
+    @property
+    def stream(self) -> StubStream:
+        """Returns the (mock) CUDA stream."""
+        return self.cuda_stream_
+
+    @property
+    def cupy_stream(self) -> StubStream:
+        """Returns the (mock) external stream."""
+        return self.cupy_stream_
+
+    @property
+    def high_priority_stream(self) -> StubStream:
+        """Returns the (mock) high-priority CUDA stream."""
+        return self.high_priority_cuda_stream_
+
+    @property
+    def high_priority_cupy_stream(self) -> StubStream:
+        """Returns the (mock) high-priority external stream."""
+        return self.high_priority_cupy_stream_
+
+    @property
+    def block_size(self) -> int:
+        """Returns the block size (tokens per block)."""
+        return self.block_size_
+
+    @property
+    def num_layers(self) -> int:
+        """Returns the number of layers in the model."""
+        return self.num_layers_
+
+    @property
+    def num_blocks(self) -> int:
+        """Returns the number of blocks in the KV cache."""
+        return self.num_blocks_
+
+    @property
+    def is_mla(self) -> bool:
+        """Returns whether the model uses MLA."""
+        return self.is_mla_
+
+    @property
+    def hidden_dim_sizes(self) -> list[int]:
+        """Returns hidden dimension sizes per KV layer group."""
+        return self.hidden_dim_sizes_
+
+    @property
+    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
+        """Returns the KV layer groups manager."""
+        return self.kv_layer_groups_manager_
+
+    @property
+    def gpu_kv_format_name(self) -> str:
+        """Returns the GPU KV format enum name."""
+        return self.gpu_kv_format_.name
+
+    @property
+    def gpu_kv_shape(self) -> str:
+        """Returns the GPU KV cache layout description."""
+        return "NL_X_TWO_NB_BS_NH_HS"
+
+    @property
+    def attention_backend(self) -> str:
+        """Returns the attention backend name."""
+        return "cpu"
+
+    @property
+    def concrete_gpu_kv_shape(self) -> str:
+        """Returns the GPU KV shape with actual values."""
+        return "cpu-context"
+
+    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
+        """Returns the PageBufferShapeDesc for the given group."""
+        return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
+
+    def get_physical_chunk_size(self, group_idx: int) -> int:
+        """Returns the per-chunk physical slot count for the group."""
+        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
+
+    def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
+        """Returns the KV cache pointer tensor for the given group."""
+        return self.group_kv_pointers_[group_idx]
+
+    def get_kv_buffer_shape(self, num_tokens: int, group_idx: int = 0) -> torch.Size:
+        """Returns the KV buffer shape for the given token count."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        num_layers_in_group = group.num_layers
+        hidden_dim = self.hidden_dim_sizes_[group_idx]
+        return torch.Size((2, num_layers_in_group, num_tokens, hidden_dim))
+
+    def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
+        """Returns the flat uint8 temp buffer for the given chunk."""
+        if chunk_idx >= self.max_batch_size:
+            raise ValueError(
+                "chunk_idx %d >= max_batch_size %d" % (chunk_idx, self.max_batch_size)
+            )
+        start = chunk_idx * self.tmp_chunk_bytes_
+        return self.tmp_gpu_buffer_[start : start + self.tmp_chunk_bytes_]
+
+    def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
+        """Returns a typed view of the temp buffer for one chunk."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        start = self.tmp_chunk_group_offsets_[group_idx]
+        end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
+
+    def get_tmp_chunk_gpu_buffer_batched(
+        self, batch_size: int, group_idx: int = 0
+    ) -> list[torch.Tensor]:
+        """Returns a list of non-overlapping temp buffer views."""
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                "batch_size %d > max_batch_size %d" % (batch_size, self.max_batch_size)
+            )
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        g_start = self.tmp_chunk_group_offsets_[group_idx]
+        g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        chunk = self.tmp_chunk_bytes_
+        return [
+            self.tmp_gpu_buffer_[i * chunk + g_start : i * chunk + g_end]
+            .view(group.dtype)
+            .view(shape)
+            for i in range(batch_size)
+        ]
+
+    def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
+        """Copy block IDs into the pre-allocated buffer."""
+        n = len(block_ids)
+        cpu_tensor = torch.tensor(block_ids, dtype=torch.long)
+        buf = self.block_ids_buffer_[:n]
+        buf.copy_(cpu_tensor)
+        return buf
+
+    def cache_size_per_token(self) -> int:
+        """Returns cache size per token in bytes, summed across groups."""
+        total = 0
+        for group_idx, _group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            numels = self.get_kv_buffer_shape(1, group_idx).numel()
+            total += numels * _group.dtype.itemsize
+        return total

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -209,6 +209,11 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
         runs ``munmap`` once the tensor (and any views derived from it)
         is garbage-collected, so the per-process virtual address space
         does not leak across repeated ``to_tensor`` calls.
+
+        We rebuild the view through ``as_strided`` so the original
+        memory layout (stride / storage_offset / memory_format) is
+        replayed faithfully on the receiving side; reshape would
+        silently re-coalesce strides and lose, e.g., channels_last.
         """
         addr = shm_map_readwrite(self.shm_name, self.nbytes)
         # ``torch.frombuffer`` requires a writable buffer; build one
@@ -217,7 +222,8 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
         buf_type = ctypes.c_uint8 * self.nbytes
         buf = buf_type.from_address(addr)
         flat = torch.frombuffer(buf, dtype=torch.uint8)
-        out = flat.view(self.dtype).reshape(self.shape)
+        typed = flat.view(self.dtype)
+        out = torch.as_strided(typed, self.shape, self.stride, self.storage_offset)
         # Keep ``flat`` alive for the lifetime of ``out`` so its mmap
         # is not released while still in use, then munmap on cleanup.
         out._lmcache_shm_buf = flat  # type: ignore[attr-defined]
@@ -231,12 +237,19 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
 
 # Per-process registry of SHM segments we have created, so the same
 # tensor object is only migrated to SHM once even if the factory is
-# called multiple times. Keyed by ``id(tensor)`` for cheap lookups,
-# but we proactively delete the entry via ``weakref.finalize`` when
-# the tensor is garbage-collected -- this prevents CPython object-ID
-# reuse from causing a stale SHM name to be looked up and the next
-# ``shm_open(O_EXCL)`` to fail with ``EEXIST``.
-_CPU_SHM_NAMES: dict[int, str] = {}
+# called multiple times.
+#
+# Keyed by ``id(tensor)`` for cheap O(1) lookup, but each entry also
+# holds a ``weakref.ref`` to the original tensor and we *verify the
+# referent is still that exact object* before reusing the cached SHM
+# name. CPython recycles object IDs, so a fresh tensor allocated at
+# the same address as a previously migrated (now garbage-collected)
+# one would otherwise inherit a stale name -- and because
+# :func:`shm_create_readwrite` uses ``O_EXCL``, the next migration
+# would crash with ``EEXIST`` ("File exists"). The weakref-validated
+# lookup below makes that race impossible: a stale entry can only
+# point at a dead referent, which we treat as a miss.
+_CPU_SHM_NAMES: dict[int, tuple["weakref.ReferenceType[torch.Tensor]", str]] = {}
 _CPU_SHM_LOCK = threading.Lock()
 _CPU_SHM_COUNTER = itertools.count()
 
@@ -246,7 +259,8 @@ def _cleanup_shm_segment(tid: int, shm_name: str, addr: int, nbytes: int) -> Non
     with _CPU_SHM_LOCK:
         # Only drop the entry if it still points at *this* segment;
         # a future tensor reusing ``tid`` may already have replaced it.
-        if _CPU_SHM_NAMES.get(tid) == shm_name:
+        cached = _CPU_SHM_NAMES.get(tid)
+        if cached is not None and cached[1] == shm_name:
             _CPU_SHM_NAMES.pop(tid, None)
     shm_munmap(addr, nbytes)
     shm_unlink(shm_name)
@@ -257,15 +271,21 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
 
     Used as the registered ``"cpu"`` KV-wrapper factory: the LMCache mp
     server can mmap the same physical pages on the receiving side.
-    Idempotent per tensor identity via :data:`_CPU_SHM_NAMES`. The SHM
+    Idempotent per tensor identity (validated via a stored weakref so
+    Python's id-recycling cannot produce a stale-name hit). The SHM
     segment is released (``munmap`` + ``shm_unlink``) automatically
     when the migrated tensor is garbage-collected.
     """
     tid = id(tensor)
     with _CPU_SHM_LOCK:
-        shm_name = _CPU_SHM_NAMES.get(tid)
-        if shm_name is not None:
-            return CpuShmTensorWrapper(tensor, shm_name)
+        cached = _CPU_SHM_NAMES.get(tid)
+        if cached is not None:
+            ref, cached_name = cached
+            if ref() is tensor:
+                return CpuShmTensorWrapper(tensor, cached_name)
+            # Stale entry from a GC'd tensor whose id has been
+            # reused; drop it and fall through to allocate fresh.
+            _CPU_SHM_NAMES.pop(tid, None)
 
         nbytes = tensor.numel() * tensor.element_size()
         shm_name = "%s%d_%d" % (
@@ -291,7 +311,7 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
             shm_unlink(shm_name)
             raise
 
-        _CPU_SHM_NAMES[tid] = shm_name
+        _CPU_SHM_NAMES[tid] = (weakref.ref(tensor), shm_name)
         weakref.finalize(tensor, _cleanup_shm_segment, tid, shm_name, addr, nbytes)
         logger.info(
             "Migrated CPU KV cache tensor (nbytes=%d) to SHM %s",
@@ -300,3 +320,20 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
         )
 
     return CpuShmTensorWrapper(tensor, shm_name)
+
+
+def inject_stale_cache_entry_for_test(
+    tensor: torch.Tensor,
+    dead_ref: "weakref.ReferenceType[torch.Tensor]",
+    stale_shm_name: str,
+) -> None:
+    """Test-only hook: pre-seed the registry with a stale entry.
+
+    Lets unit tests reproduce the CPython id-reuse race -- where a
+    fresh tensor lands on the same id as a previously migrated and
+    garbage-collected one -- without the per-test global-state
+    surgery that would otherwise have to reach into the module's
+    private dict / lock.
+    """
+    with _CPU_SHM_LOCK:
+        _CPU_SHM_NAMES[id(tensor)] = (dead_ref, stale_shm_name)

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -38,6 +38,16 @@ logger = init_logger(__name__)
 # CPU-specific dependency on libc/librt lives next to the only place
 # that needs it. TODO(maobaolong): replace with ``posix_ipc`` once we
 # are willing to take that runtime dependency.
+#
+# We deliberately do not use stdlib ``mmap`` here: ``mmap.mmap`` would
+# work for the in-process side, but we still need ``shm_open`` /
+# ``shm_unlink`` (not exposed by stdlib), and we hand the raw address
+# to ``ctypes.from_address`` + ``torch.frombuffer`` to share storage
+# with the migrated tensor. So we keep the raw mmap pointers and
+# pair every successful mmap with a matching ``munmap`` -- on the
+# error paths via ``try/finally``, on the happy path via
+# ``weakref.finalize`` hooks attached to the migrated tensor and to
+# every ``CpuShmTensorWrapper.to_tensor()`` view.
 # ---------------------------------------------------------------------------
 
 _O_RDWR = os.O_RDWR
@@ -78,32 +88,51 @@ _MAP_FAILED = ctypes.c_void_p(-1).value
 
 
 def shm_create_readwrite(name: str, nbytes: int) -> int:
-    """Create + size a POSIX SHM segment, return mapped address."""
-    fd = _librt.shm_open(name.encode("ascii"), _O_RDWR | _O_CREAT | _O_EXCL, 0o600)
+    """Create + size a POSIX SHM segment, return mapped address.
+
+    Every failure path tears down whatever has already been allocated
+    (fd, named segment) so the caller never has to compensate.
+    """
+    name_b = name.encode("ascii")
+    fd = _librt.shm_open(name_b, _O_RDWR | _O_CREAT | _O_EXCL, 0o600)
     if fd < 0:
         raise OSError(ctypes.get_errno(), "shm_open(create) failed for %s" % name)
-    if _libc.ftruncate(fd, nbytes) != 0:
-        err = ctypes.get_errno()
+    addr = 0
+    try:
+        if _libc.ftruncate(fd, nbytes) != 0:
+            raise OSError(ctypes.get_errno(), "ftruncate failed for %s" % name)
+        addr = _libc.mmap(None, nbytes, _PROT_READ | _PROT_WRITE, _MAP_SHARED, fd, 0)
+        if addr in (0, _MAP_FAILED):
+            addr = 0
+            raise OSError(ctypes.get_errno(), "mmap failed for %s" % name)
+    except BaseException:
+        # Roll back whatever we have so far: the named segment is
+        # always created at this point; mmap may or may not have
+        # succeeded.
+        if addr:
+            _libc.munmap(ctypes.c_void_p(addr), nbytes)
+        _librt.shm_unlink(name_b)
+        raise
+    finally:
         _libc.close(fd)
-        _librt.shm_unlink(name.encode("ascii"))
-        raise OSError(err, "ftruncate failed for %s" % name)
-    addr = _libc.mmap(None, nbytes, _PROT_READ | _PROT_WRITE, _MAP_SHARED, fd, 0)
-    _libc.close(fd)
-    if addr in (0, _MAP_FAILED):
-        _librt.shm_unlink(name.encode("ascii"))
-        raise OSError(ctypes.get_errno(), "mmap failed for %s" % name)
     return addr
 
 
 def shm_map_readwrite(name: str, nbytes: int) -> int:
-    """Open an existing POSIX SHM segment, return mapped address."""
+    """Open an existing POSIX SHM segment, return mapped address.
+
+    The fd is always closed before returning (success or failure) so
+    we never leak a file descriptor even when ``mmap`` fails.
+    """
     fd = _librt.shm_open(name.encode("ascii"), _O_RDWR, 0o600)
     if fd < 0:
         raise OSError(ctypes.get_errno(), "shm_open(open) failed for %s" % name)
-    addr = _libc.mmap(None, nbytes, _PROT_READ | _PROT_WRITE, _MAP_SHARED, fd, 0)
-    _libc.close(fd)
-    if addr in (0, _MAP_FAILED):
-        raise OSError(ctypes.get_errno(), "mmap failed for %s" % name)
+    try:
+        addr = _libc.mmap(None, nbytes, _PROT_READ | _PROT_WRITE, _MAP_SHARED, fd, 0)
+        if addr in (0, _MAP_FAILED):
+            raise OSError(ctypes.get_errno(), "mmap failed for %s" % name)
+    finally:
+        _libc.close(fd)
     return addr
 
 
@@ -161,7 +190,7 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
         self.shm_name = shm_name
         # ``numel * element_size`` is the correct logical byte size; the
         # underlying storage may be larger when the tensor is a view.
-        self._nbytes = tensor.numel() * tensor.element_size()
+        self.nbytes = tensor.numel() * tensor.element_size()
 
         # CudaIPCWrapper interface fields. ``handle`` / ``device_uuid``
         # are unused on the CPU path but kept to satisfy the parent
@@ -181,18 +210,18 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
         is garbage-collected, so the per-process virtual address space
         does not leak across repeated ``to_tensor`` calls.
         """
-        addr = shm_map_readwrite(self.shm_name, self._nbytes)
+        addr = shm_map_readwrite(self.shm_name, self.nbytes)
         # ``torch.frombuffer`` requires a writable buffer; build one
         # via ctypes so the resulting torch tensor shares storage
         # with the SHM mapping (zero copy across processes).
-        buf_type = ctypes.c_uint8 * self._nbytes
+        buf_type = ctypes.c_uint8 * self.nbytes
         buf = buf_type.from_address(addr)
         flat = torch.frombuffer(buf, dtype=torch.uint8)
         out = flat.view(self.dtype).reshape(self.shape)
         # Keep ``flat`` alive for the lifetime of ``out`` so its mmap
         # is not released while still in use, then munmap on cleanup.
         out._lmcache_shm_buf = flat  # type: ignore[attr-defined]
-        weakref.finalize(out, shm_munmap, addr, self._nbytes)
+        weakref.finalize(out, shm_munmap, addr, self.nbytes)
         return out
 
 

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 # Standard
 import ctypes
 import ctypes.util
+import itertools
 import os
+import threading
+import weakref
 
 # Third Party
 import torch
@@ -66,8 +69,12 @@ _libc.mmap.argtypes = [
     ctypes.c_int64,
 ]
 _libc.mmap.restype = ctypes.c_void_p
+_libc.munmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+_libc.munmap.restype = ctypes.c_int
 _libc.close.argtypes = [ctypes.c_int]
 _libc.close.restype = ctypes.c_int
+
+_MAP_FAILED = ctypes.c_void_p(-1).value
 
 
 def shm_create_readwrite(name: str, nbytes: int) -> int:
@@ -82,7 +89,7 @@ def shm_create_readwrite(name: str, nbytes: int) -> int:
         raise OSError(err, "ftruncate failed for %s" % name)
     addr = _libc.mmap(None, nbytes, _PROT_READ | _PROT_WRITE, _MAP_SHARED, fd, 0)
     _libc.close(fd)
-    if addr in (0, ctypes.c_void_p(-1).value):
+    if addr in (0, _MAP_FAILED):
         _librt.shm_unlink(name.encode("ascii"))
         raise OSError(ctypes.get_errno(), "mmap failed for %s" % name)
     return addr
@@ -95,9 +102,16 @@ def shm_map_readwrite(name: str, nbytes: int) -> int:
         raise OSError(ctypes.get_errno(), "shm_open(open) failed for %s" % name)
     addr = _libc.mmap(None, nbytes, _PROT_READ | _PROT_WRITE, _MAP_SHARED, fd, 0)
     _libc.close(fd)
-    if addr in (0, ctypes.c_void_p(-1).value):
+    if addr in (0, _MAP_FAILED):
         raise OSError(ctypes.get_errno(), "mmap failed for %s" % name)
     return addr
+
+
+def shm_munmap(addr: int, nbytes: int) -> None:
+    """Best-effort ``munmap`` of a previously ``mmap``-ed SHM segment."""
+    if not addr or addr == _MAP_FAILED:
+        return
+    _libc.munmap(ctypes.c_void_p(addr), nbytes)
 
 
 def shm_unlink(name: str) -> None:
@@ -145,7 +159,9 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
             raise ValueError("CpuShmTensorWrapper requires a contiguous tensor")
 
         self.shm_name = shm_name
-        self._nbytes = tensor.untyped_storage().nbytes()
+        # ``numel * element_size`` is the correct logical byte size; the
+        # underlying storage may be larger when the tensor is a view.
+        self._nbytes = tensor.numel() * tensor.element_size()
 
         # CudaIPCWrapper interface fields. ``handle`` / ``device_uuid``
         # are unused on the CPU path but kept to satisfy the parent
@@ -158,7 +174,13 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
         self.device_uuid = "cpu"
 
     def to_tensor(self) -> torch.Tensor:
-        """Reconstruct the tensor by mapping the same SHM segment."""
+        """Reconstruct the tensor by mapping the same SHM segment.
+
+        The returned tensor owns the mmap: a ``weakref.finalize`` hook
+        runs ``munmap`` once the tensor (and any views derived from it)
+        is garbage-collected, so the per-process virtual address space
+        does not leak across repeated ``to_tensor`` calls.
+        """
         addr = shm_map_readwrite(self.shm_name, self._nbytes)
         # ``torch.frombuffer`` requires a writable buffer; build one
         # via ctypes so the resulting torch tensor shares storage
@@ -166,7 +188,12 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
         buf_type = ctypes.c_uint8 * self._nbytes
         buf = buf_type.from_address(addr)
         flat = torch.frombuffer(buf, dtype=torch.uint8)
-        return flat.view(self.dtype).reshape(self.shape)
+        out = flat.view(self.dtype).reshape(self.shape)
+        # Keep ``flat`` alive for the lifetime of ``out`` so its mmap
+        # is not released while still in use, then munmap on cleanup.
+        out._lmcache_shm_buf = flat  # type: ignore[attr-defined]
+        weakref.finalize(out, shm_munmap, addr, self._nbytes)
+        return out
 
 
 # ---------------------------------------------------------------------------
@@ -175,8 +202,25 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
 
 # Per-process registry of SHM segments we have created, so the same
 # tensor object is only migrated to SHM once even if the factory is
-# called multiple times. Maps id(tensor) -> shm_name.
+# called multiple times. Keyed by ``id(tensor)`` for cheap lookups,
+# but we proactively delete the entry via ``weakref.finalize`` when
+# the tensor is garbage-collected -- this prevents CPython object-ID
+# reuse from causing a stale SHM name to be looked up and the next
+# ``shm_open(O_EXCL)`` to fail with ``EEXIST``.
 _CPU_SHM_NAMES: dict[int, str] = {}
+_CPU_SHM_LOCK = threading.Lock()
+_CPU_SHM_COUNTER = itertools.count()
+
+
+def _cleanup_shm_segment(tid: int, shm_name: str, addr: int, nbytes: int) -> None:
+    """Release the mmap, unlink, and forget the cached SHM name."""
+    with _CPU_SHM_LOCK:
+        # Only drop the entry if it still points at *this* segment;
+        # a future tensor reusing ``tid`` may already have replaced it.
+        if _CPU_SHM_NAMES.get(tid) == shm_name:
+            _CPU_SHM_NAMES.pop(tid, None)
+    shm_munmap(addr, nbytes)
+    shm_unlink(shm_name)
 
 
 def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
@@ -184,28 +228,42 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
 
     Used as the registered ``"cpu"`` KV-wrapper factory: the LMCache mp
     server can mmap the same physical pages on the receiving side.
-    Idempotent per ``id(tensor)`` thanks to :data:`_CPU_SHM_NAMES`.
+    Idempotent per tensor identity via :data:`_CPU_SHM_NAMES`. The SHM
+    segment is released (``munmap`` + ``shm_unlink``) automatically
+    when the migrated tensor is garbage-collected.
     """
     tid = id(tensor)
-    shm_name = _CPU_SHM_NAMES.get(tid)
-    if shm_name is None:
-        nbytes = tensor.untyped_storage().nbytes()
+    with _CPU_SHM_LOCK:
+        shm_name = _CPU_SHM_NAMES.get(tid)
+        if shm_name is not None:
+            return CpuShmTensorWrapper(tensor, shm_name)
+
+        nbytes = tensor.numel() * tensor.element_size()
         shm_name = "%s%d_%d" % (
             CpuShmTensorWrapper.SHM_NAME_PREFIX,
             os.getpid(),
-            tid,
+            next(_CPU_SHM_COUNTER),
         )
         addr = shm_create_readwrite(shm_name, nbytes)
-        buf_type = ctypes.c_uint8 * nbytes
-        buf = buf_type.from_address(addr)
-        shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
-        tensor.set_(
-            shm_storage,
-            tensor.storage_offset(),
-            tensor.shape,
-            tensor.stride(),
-        )
+        try:
+            buf_type = ctypes.c_uint8 * nbytes
+            buf = buf_type.from_address(addr)
+            shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
+            tensor.set_(
+                shm_storage,
+                tensor.storage_offset(),
+                tensor.shape,
+                tensor.stride(),
+            )
+        except Exception:
+            # Make sure the SHM resources don't leak if migration fails
+            # part-way (e.g. ``set_`` rejects an unusual stride).
+            shm_munmap(addr, nbytes)
+            shm_unlink(shm_name)
+            raise
+
         _CPU_SHM_NAMES[tid] = shm_name
+        weakref.finalize(tensor, _cleanup_shm_segment, tid, shm_name, addr, nbytes)
         logger.info(
             "Migrated CPU KV cache tensor (nbytes=%d) to SHM %s",
             nbytes,

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only KV-cache IPC wrapper backed by POSIX shared memory.
+
+Mirrors the GPU-mode CUDA-IPC zero-copy semantics for hosts without an
+accelerator: client and LMCache mp server map the **same** physical
+pages so transfers are pointer-shuffles rather than memcpys.
+
+Self-registers a ``"cpu"`` factory with
+:mod:`lmcache.v1.platform._registry` at import time, so the
+multiprocess adapter can dispatch by ``tensor.device.type`` without
+any if/elif chain.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import ctypes
+import ctypes.util
+import os
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
+
+logger = init_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Hand-rolled POSIX shared-memory helpers (shm_open + mmap via ctypes).
+#
+# Kept here (rather than in ``multiprocess/custom_types``) so the
+# CPU-specific dependency on libc/librt lives next to the only place
+# that needs it. TODO(maobaolong): replace with ``posix_ipc`` once we
+# are willing to take that runtime dependency.
+# ---------------------------------------------------------------------------
+
+_O_RDWR = os.O_RDWR
+_O_CREAT = os.O_CREAT
+_O_EXCL = os.O_EXCL
+_PROT_READ = 0x1
+_PROT_WRITE = 0x2
+_MAP_SHARED = 0x01
+
+_libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+# macOS exposes shm_open in libSystem (== libc), Linux needs librt.
+_librt = _libc
+if not hasattr(_libc, "shm_open"):
+    _librt = ctypes.CDLL(ctypes.util.find_library("rt"), use_errno=True)
+
+_librt.shm_open.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_uint32]
+_librt.shm_open.restype = ctypes.c_int
+_librt.shm_unlink.argtypes = [ctypes.c_char_p]
+_librt.shm_unlink.restype = ctypes.c_int
+
+_libc.ftruncate.argtypes = [ctypes.c_int, ctypes.c_int64]
+_libc.ftruncate.restype = ctypes.c_int
+_libc.mmap.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int,
+    ctypes.c_int64,
+]
+_libc.mmap.restype = ctypes.c_void_p
+_libc.close.argtypes = [ctypes.c_int]
+_libc.close.restype = ctypes.c_int
+
+
+def shm_create_readwrite(name: str, nbytes: int) -> int:
+    """Create + size a POSIX SHM segment, return mapped address."""
+    fd = _librt.shm_open(name.encode("ascii"), _O_RDWR | _O_CREAT | _O_EXCL, 0o600)
+    if fd < 0:
+        raise OSError(ctypes.get_errno(), "shm_open(create) failed for %s" % name)
+    if _libc.ftruncate(fd, nbytes) != 0:
+        err = ctypes.get_errno()
+        _libc.close(fd)
+        _librt.shm_unlink(name.encode("ascii"))
+        raise OSError(err, "ftruncate failed for %s" % name)
+    addr = _libc.mmap(None, nbytes, _PROT_READ | _PROT_WRITE, _MAP_SHARED, fd, 0)
+    _libc.close(fd)
+    if addr in (0, ctypes.c_void_p(-1).value):
+        _librt.shm_unlink(name.encode("ascii"))
+        raise OSError(ctypes.get_errno(), "mmap failed for %s" % name)
+    return addr
+
+
+def shm_map_readwrite(name: str, nbytes: int) -> int:
+    """Open an existing POSIX SHM segment, return mapped address."""
+    fd = _librt.shm_open(name.encode("ascii"), _O_RDWR, 0o600)
+    if fd < 0:
+        raise OSError(ctypes.get_errno(), "shm_open(open) failed for %s" % name)
+    addr = _libc.mmap(None, nbytes, _PROT_READ | _PROT_WRITE, _MAP_SHARED, fd, 0)
+    _libc.close(fd)
+    if addr in (0, ctypes.c_void_p(-1).value):
+        raise OSError(ctypes.get_errno(), "mmap failed for %s" % name)
+    return addr
+
+
+def shm_unlink(name: str) -> None:
+    """Best-effort SHM segment removal."""
+    _librt.shm_unlink(name.encode("ascii"))
+
+
+# ---------------------------------------------------------------------------
+# Wrapper class                                                             #
+# ---------------------------------------------------------------------------
+
+
+class CpuShmTensorWrapper(CudaIPCWrapper):
+    """IPC wrapper for CPU tensors backed by POSIX shared memory.
+
+    Used by the ``lmcache bench kvcache --mode cpu`` path and the
+    vLLM CPU integration so that the client and the LMCache mp server
+    map the **same** physical pages for the KV cache, mirroring the
+    GPU-mode CUDA-IPC zero-copy semantics.
+
+    Subclassing :class:`CudaIPCWrapper` is load-bearing for the same
+    reason :class:`RawCudaIPCWrapper` does it: msgspec does not
+    support unions of custom ext-encoded types, so all wire-level
+    KV-cache wrappers must share the single ext code (1) registered
+    for ``CudaIPCWrapper``. Pickle preserves the subclass identity
+    so ``to_tensor`` dispatches correctly on both sides.
+    """
+
+    # POSIX shared-memory name (``/lmcache_...``) -- leading ``/`` is
+    # required by ``shm_open(3)`` on both Linux and macOS.
+    SHM_NAME_PREFIX = "/lmcache_kv_"
+
+    def __init__(self, tensor: torch.Tensor, shm_name: str) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import (
+            attempt_permute_to_contiguous_view,
+        )
+
+        tensor = attempt_permute_to_contiguous_view(tensor)
+        if tensor.device.type != "cpu":
+            raise ValueError(
+                "CpuShmTensorWrapper requires a CPU tensor, got %s" % tensor.device
+            )
+        if not tensor.is_contiguous():
+            raise ValueError("CpuShmTensorWrapper requires a contiguous tensor")
+
+        self.shm_name = shm_name
+        self._nbytes = tensor.untyped_storage().nbytes()
+
+        # CudaIPCWrapper interface fields. ``handle`` / ``device_uuid``
+        # are unused on the CPU path but kept to satisfy the parent
+        # contract used by equality checks.
+        self.handle = None
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+        self.device_uuid = "cpu"
+
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the tensor by mapping the same SHM segment."""
+        addr = shm_map_readwrite(self.shm_name, self._nbytes)
+        # ``torch.frombuffer`` requires a writable buffer; build one
+        # via ctypes so the resulting torch tensor shares storage
+        # with the SHM mapping (zero copy across processes).
+        buf_type = ctypes.c_uint8 * self._nbytes
+        buf = buf_type.from_address(addr)
+        flat = torch.frombuffer(buf, dtype=torch.uint8)
+        return flat.view(self.dtype).reshape(self.shape)
+
+
+# ---------------------------------------------------------------------------
+# Migrate-and-wrap factory (used by the multiprocess adapter)              #
+# ---------------------------------------------------------------------------
+
+# Per-process registry of SHM segments we have created, so the same
+# tensor object is only migrated to SHM once even if the factory is
+# called multiple times. Maps id(tensor) -> shm_name.
+_CPU_SHM_NAMES: dict[int, str] = {}
+
+
+def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
+    """Re-point ``tensor``'s storage at a POSIX SHM segment, then wrap.
+
+    Used as the registered ``"cpu"`` KV-wrapper factory: the LMCache mp
+    server can mmap the same physical pages on the receiving side.
+    Idempotent per ``id(tensor)`` thanks to :data:`_CPU_SHM_NAMES`.
+    """
+    tid = id(tensor)
+    shm_name = _CPU_SHM_NAMES.get(tid)
+    if shm_name is None:
+        nbytes = tensor.untyped_storage().nbytes()
+        shm_name = "%s%d_%d" % (
+            CpuShmTensorWrapper.SHM_NAME_PREFIX,
+            os.getpid(),
+            tid,
+        )
+        addr = shm_create_readwrite(shm_name, nbytes)
+        buf_type = ctypes.c_uint8 * nbytes
+        buf = buf_type.from_address(addr)
+        shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
+        tensor.set_(
+            shm_storage,
+            tensor.storage_offset(),
+            tensor.shape,
+            tensor.stride(),
+        )
+        _CPU_SHM_NAMES[tid] = shm_name
+        logger.info(
+            "Migrated CPU KV cache tensor (nbytes=%d) to SHM %s",
+            nbytes,
+            shm_name,
+        )
+
+    return CpuShmTensorWrapper(tensor, shm_name)

--- a/lmcache/v1/platform/cpu/stub_cpu_device.py
+++ b/lmcache/v1/platform/cpu/stub_cpu_device.py
@@ -116,6 +116,25 @@ class StubStream:
         self.device = device
         self.priority = priority
         self.cuda_stream = 0
+        # Mirrors the ``ptr`` attribute exposed by ``cupy.cuda.Stream``
+        # so callers (e.g. ``mp_observability.event_bus``) that pass a
+        # raw stream pointer to native recorders accept this stub
+        # without an isinstance check.
+        self.ptr = 0
+
+    def launch_host_func(self, callback: Any, arg: Any = None) -> None:
+        """Run ``callback(arg)`` synchronously.
+
+        ``cupy.cuda.Stream.launch_host_func`` schedules the callback
+        on the GPU stream's host-side completion queue; with no real
+        stream there's nothing to wait for, so we just invoke it
+        immediately. Exceptions are swallowed to mirror the cupy
+        contract (callbacks are best-effort and must not propagate).
+        """
+        try:
+            callback(arg)
+        except Exception:  # noqa: BLE001
+            pass
 
     def synchronize(self) -> None:
         """Block the host until all kernels on this stream complete.

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA-specific platform primitives.
+
+Importing this package self-registers a CUDA KV-cache wrapper
+factory with :mod:`lmcache.v1.platform._registry`, so the dispatch
+in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
+locate it by ``tensor.device.type``.
+"""
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.platform._registry import (
+    register_availability,
+    register_kv_wrapper,
+)
+
+
+def _kv_wrapper_factory(tensor):
+    """Indirect-dispatch wrapper.
+
+    Re-imports :class:`CudaIPCWrapper` on every call so test suites
+    that swap the symbol still see their override take effect.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
+
+    return CudaIPCWrapper(tensor)
+
+
+register_availability("cuda", lambda: torch.cuda.is_available())
+register_kv_wrapper("cuda", _kv_wrapper_factory)

--- a/tests/v1/multiprocess/test_non_cuda_context.py
+++ b/tests/v1/multiprocess/test_non_cuda_context.py
@@ -91,7 +91,7 @@ def test_wrap_kv_caches_wraps_all_tensors(monkeypatch: Any) -> None:
     kv_caches = _make_kv_caches()
     monkeypatch.setattr(
         adapter_mod,
-        "CudaIPCWrapper",
+        "_wrap_one_kv_cache",
         lambda tensor: ("wrapped", tensor),
     )
 

--- a/tests/v1/platform/__init__.py
+++ b/tests/v1/platform/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -80,12 +80,33 @@ def test_migrate_finalizer_unlinks_on_gc():
     src = torch.zeros((2, 2), dtype=torch.float32)
     w = migrate_to_shm_and_wrap(src)
     name = w.shm_name
-    nbytes = w._nbytes
+    nbytes = w.nbytes
     # Drop both references; the weakref.finalize hook should unlink.
     del src, w
     gc.collect()
     with pytest.raises(OSError):
         shm_map_readwrite(name, nbytes)
+
+
+def test_shm_create_cleans_up_on_existing_name():
+    """If ``shm_open(O_EXCL)`` fails the helper must not leave the fd open.
+
+    We exercise the failure path by creating a segment, then asking
+    ``shm_create_readwrite`` to recreate the same name -- it must
+    raise without leaking the file descriptor it briefly held.
+    """
+    name = "/lmcache_test_excl_%d" % os.getpid()
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        with pytest.raises(OSError):
+            shm_create_readwrite(name, 4096)
+    finally:
+        shm_unlink(name)
+    # And after unlink, the name is reusable again.
+    addr2 = shm_create_readwrite(name, 4096)
+    assert addr2 not in (0, None)
+    shm_unlink(name)
+    _ = addr  # silence unused-variable hint
 
 
 def test_to_tensor_view_carries_munmap_finalizer():

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache.v1.platform.cpu.shm``.
+
+Validates that the POSIX-SHM-backed wrapper can round-trip a CPU
+tensor in-process: the constructed wrapper's ``to_tensor()`` view
+sees writes made through the original tensor.
+"""
+
+# Standard
+import os
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.platform.cpu.shm import (
+    CpuShmTensorWrapper,
+    migrate_to_shm_and_wrap,
+    shm_create_readwrite,
+    shm_unlink,
+)
+
+
+def test_shm_create_unlink_roundtrip(tmp_path):
+    """``shm_create_readwrite`` succeeds and ``shm_unlink`` cleans up."""
+    name = "/lmcache_test_%d" % os.getpid()
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        assert addr not in (0, None)
+    finally:
+        shm_unlink(name)
+
+
+def test_migrate_to_shm_and_wrap_zero_copy_view():
+    """After migrate, writes via the original tensor are visible via wrapper."""
+    src = torch.zeros((2, 4, 4), dtype=torch.float32)
+    wrapper = migrate_to_shm_and_wrap(src)
+    try:
+        assert isinstance(wrapper, CpuShmTensorWrapper)
+        assert wrapper.shape == (2, 4, 4)
+        assert wrapper.dtype == torch.float32
+        # Mutate via the migrated source tensor; its storage is now the
+        # SHM segment, so the wrapper's reconstructed view must see it.
+        src.add_(7.0)
+        view = wrapper.to_tensor()
+        assert torch.equal(view, src)
+    finally:
+        shm_unlink(wrapper.shm_name)
+
+
+def test_migrate_is_idempotent_on_same_tensor():
+    """Re-wrapping the same tensor reuses the existing SHM segment."""
+    src = torch.zeros((3, 5), dtype=torch.float32)
+    w1 = migrate_to_shm_and_wrap(src)
+    try:
+        w2 = migrate_to_shm_and_wrap(src)
+        assert w1.shm_name == w2.shm_name
+    finally:
+        shm_unlink(w1.shm_name)
+
+
+def test_rejects_non_cpu_tensor():
+    """Construction rejects tensors that are not on CPU."""
+    if not torch.backends.mps.is_available():
+        pytest.skip("MPS not available; cannot synthesize a non-cpu tensor")
+    src = torch.zeros((2, 2), device="mps")
+    with pytest.raises(ValueError, match="CPU tensor"):
+        CpuShmTensorWrapper(src, "/lmcache_test_should_not_exist")
+
+
+def test_migrate_finalizer_unlinks_on_gc():
+    """Once the migrated tensor is GC-ed, its SHM segment is unlinked."""
+    # Standard
+    import gc
+
+    # First Party
+    from lmcache.v1.platform.cpu.shm import shm_map_readwrite
+
+    src = torch.zeros((2, 2), dtype=torch.float32)
+    w = migrate_to_shm_and_wrap(src)
+    name = w.shm_name
+    nbytes = w._nbytes
+    # Drop both references; the weakref.finalize hook should unlink.
+    del src, w
+    gc.collect()
+    with pytest.raises(OSError):
+        shm_map_readwrite(name, nbytes)
+
+
+def test_to_tensor_view_carries_munmap_finalizer():
+    """``to_tensor`` returns a tensor that releases its mmap on GC."""
+    # Standard
+    import gc
+    import weakref
+
+    src = torch.zeros((2, 2), dtype=torch.float32)
+    w = migrate_to_shm_and_wrap(src)
+    try:
+        view = w.to_tensor()
+        # The view must keep ``flat`` alive so its mmap stays valid.
+        assert hasattr(view, "_lmcache_shm_buf")
+        ref = weakref.ref(view)
+        del view
+        gc.collect()
+        assert ref() is None
+    finally:
+        del src
+        gc.collect()
+        shm_unlink(w.shm_name)

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -129,3 +129,89 @@ def test_to_tensor_view_carries_munmap_finalizer():
         del src
         gc.collect()
         shm_unlink(w.shm_name)
+
+
+def test_to_tensor_replays_stride_and_storage_offset():
+    """``to_tensor`` rebuilds the view via stride+offset (not reshape)."""
+    src = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4).contiguous()
+    w = migrate_to_shm_and_wrap(src)
+    try:
+        view = w.to_tensor()
+        assert tuple(view.stride()) == w.stride
+        assert int(view.storage_offset()) == w.storage_offset
+        assert torch.equal(view, src)
+    finally:
+        del src, view
+        shm_unlink(w.shm_name)
+
+
+def test_wrap_kv_caches_unlinks_partial_batch_on_failure(monkeypatch):
+    """If wrapping the N-th tensor raises, earlier SHM names are unlinked.
+
+    Drives :func:`wrap_kv_caches` with two CPU tensors and forces the
+    second factory call to raise; the first iteration's SHM segment
+    must be ``shm_unlink``-ed so the named segment does not outlive
+    the failed batch.
+    """
+    # First Party
+    from lmcache.integration.vllm import vllm_multi_process_adapter as adapter
+    from lmcache.v1.platform.cpu.shm import shm_map_readwrite
+
+    real_wrap = adapter._wrap_one_kv_cache
+    state = {"n": 0, "first_name": None}
+
+    def flaky_wrap(tensor):
+        state["n"] += 1
+        if state["n"] == 2:
+            raise RuntimeError("simulated migration failure")
+        w = real_wrap(tensor)
+        state["first_name"] = w.shm_name
+        return w
+
+    monkeypatch.setattr(adapter, "_wrap_one_kv_cache", flaky_wrap)
+
+    t1 = torch.zeros((2, 2), dtype=torch.float32)
+    t2 = torch.zeros((2, 2), dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="simulated migration failure"):
+        adapter.wrap_kv_caches({"a": t1, "b": t2})
+
+    # The first iteration's SHM segment must no longer be openable.
+    nbytes = t1.numel() * t1.element_size()
+    with pytest.raises(OSError):
+        shm_map_readwrite(state["first_name"], nbytes)
+
+
+def test_migrate_ignores_stale_entry_from_id_reuse():
+    """A cached entry whose weakref is dead must not be reused.
+
+    Simulates CPython recycling an object id by injecting a stale
+    ``(dead_ref, old_name)`` tuple keyed by the live tensor's id,
+    then calling :func:`migrate_to_shm_and_wrap`. The factory must
+    treat the dead entry as a miss and allocate a fresh SHM segment
+    -- if it blindly reused the cached name, ``shm_create_readwrite``
+    would crash with ``EEXIST`` (and even worse, the fresh tensor
+    would be silently bound to the wrong SHM name).
+    """
+    # Standard
+    import gc
+    import weakref as _wr
+
+    # First Party
+    from lmcache.v1.platform.cpu.shm import inject_stale_cache_entry_for_test
+
+    # Build a tensor we will let die so we have a guaranteed-dead ref.
+    ghost = torch.zeros((1,), dtype=torch.float32)
+    dead_ref = _wr.ref(ghost)
+    del ghost
+    gc.collect()
+    assert dead_ref() is None
+
+    live = torch.zeros((2, 2), dtype=torch.float32)
+    stale_name = "/lmcache_test_stale_%d" % os.getpid()
+    inject_stale_cache_entry_for_test(live, dead_ref, stale_name)
+
+    w = migrate_to_shm_and_wrap(live)
+    try:
+        assert w.shm_name != stale_name
+    finally:
+        shm_unlink(w.shm_name)


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

- Test

  - Start lmcache

```
/opt/homebrew/Caskroom/miniconda/base/bin/python /Users/msy/projects/LMCache/lmcache/v1/multiprocess/http_server.py --l1-size-gb=8 --eviction-policy=LRU --no-l1-use-lazy 
[2026-05-20 22:24:32,021] LMCache INFO:  torch_dev=StubCPUDevice(device_type=cpu), torch_device_type=cpu (__init__.py:59:lmcache)
[2026-05-20 22:24:32,257] LMCache INFO: Skipping backend lmcache.xpu_ops: predicate returned False (__init__.py:91:lmcache)
[2026-05-20 22:24:32,257] LMCache INFO: Skipping backend lmcache.c_ops: predicate returned False (__init__.py:91:lmcache)
[2026-05-20 22:24:32,502] LMCache INFO: Discovered API module: cache_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,503] LMCache INFO: Discovered API module: env_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,504] LMCache INFO: Discovered API module: loglevel_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,504] LMCache INFO: Discovered API module: metrics_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,505] LMCache INFO: Discovered API module: periodic_thread_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,505] LMCache INFO: Skipping excluded API module: run_script_api (router_discovery.py:47:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,505] LMCache INFO: Discovered API module: thread_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,506] LMCache INFO: Discovered API module: common_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,506] LMCache INFO: Discovered API module: conf_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,507] LMCache INFO: Discovered API module: healthcheck_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,507] LMCache INFO: Discovered API module: quota_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,508] LMCache INFO: Discovered API module: root_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,508] LMCache INFO: Discovered API module: status_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:32,508] LMCache INFO: Discovered API module: version_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-05-20 22:24:33,441] LMCache INFO: Starting LMCache HTTP server on http://0.0.0.0:8080 (http_server.py:154:__main__)
INFO:     Started server process [78392]
INFO:     Waiting for application startup.
[2026-05-20 22:24:33,471] LMCache INFO: Starting LMCache HTTP server... (accelerator available: False) (http_server.py:59:__main__)
[2026-05-20 22:24:33,496] LMCache INFO: OTel MeterProvider initialised with Prometheus fallback (standalone metrics HTTP server disabled; /metrics must be exposed by the caller), resource={'telemetry.sdk.language': 'python', 'telemetry.sdk.name': 'opentelemetry', 'telemetry.sdk.version': '1.40.0', 'service.instance.id': 'b2fec0b9-0c58-42e1-aefc-f03bb7d4e809', 'service.name': 'unknown_service'} (otel_init.py:114:lmcache.v1.mp_observability.otel_init)
[2026-05-20 22:24:33,712] LMCache INFO: Starting L1EvictionController... (eviction_controller.py:52:lmcache.v1.distributed.storage_controllers.eviction_controller)
[2026-05-20 22:24:33,712] LMCache INFO: Starting L2EvictionController... (eviction_controller.py:228:lmcache.v1.distributed.storage_controllers.eviction_controller)
[2026-05-20 22:24:33,713] LMCache INFO: Starting StoreController... (store_controller.py:277:lmcache.v1.distributed.storage_controllers.store_controller)
[2026-05-20 22:24:33,713] LMCache INFO: Starting PrefetchController... (prefetch_controller.py:454:lmcache.v1.distributed.storage_controllers.prefetch_controller)
[2026-05-20 22:24:33,713] LMCache INFO: Using blake3 hash function (token_hasher.py:79:lmcache.v1.multiprocess.token_hasher)
INFO 05-20 22:24:35 __init__.py:207] Automatically detected platform cpu.
[2026-05-20 22:24:35,896] LMCache INFO: Computed NONE_HASH=b"~>\xff\x9e\xf7a:P4\x0e\xb1&w\xee\x03\xb8:\xc7Y\xfc\xba\x9b\xb3'\x05\xf0rH\xd5mG;" using hash function (token_hasher.py:178:lmcache.v1.multiprocess.token_hasher)
[2026-05-20 22:24:35,896] LMCache INFO: TokenHasher initialized: chunk_size=256, hash_algorithm=blake3 (token_hasher.py:67:lmcache.v1.multiprocess.token_hasher)
[2026-05-20 22:24:35,900] LMCache INFO: LMCache ZMQ cache server is running on tcp://localhost:5555 (server.py:1493:lmcache.v1.multiprocess.server)
[2026-05-20 22:24:35,900] LMCache INFO: LMCache cache server is running... (server.py:1509:lmcache.v1.multiprocess.server)
[2026-05-20 22:24:35,900] LMCache INFO: LMCache HTTP server initialized (http_server.py:102:__main__)
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
[2026-05-20 22:30:09,354] LMCache INFO: list_depth: 1, tensor_dim: 5 (utils.py:510:lmcache.v1.gpu_connector.utils)
[2026-05-20 22:30:09,354] LMCache INFO: GPU KV Cache Dimensions: [2][2, 256, 16, 4, 32] (utils.py:521:lmcache.v1.gpu_connector.utils)
[2026-05-20 22:30:09,354] LMCache INFO: CPU backend detected, using HND KV cache layout (utils.py:536:lmcache.v1.gpu_connector.utils)
[2026-05-20 22:30:09,354] LMCache INFO: vLLM KV cache layout: HND (utils.py:542:lmcache.v1.gpu_connector.utils)
[2026-05-20 22:30:09,354] LMCache INFO: GPU KV Format: NL x [2, NB, NH, BS, HS] (utils.py:413:lmcache.v1.gpu_connector.utils)
[2026-05-20 22:30:09,354] LMCache INFO: Currently used by:
  - vLLM non-MLA flash attention (HND layout) (utils.py:414:lmcache.v1.gpu_connector.utils)
[2026-05-20 22:30:09,354] LMCache INFO: Group 0 first-layer tensor: layer_idx=0 shape=(2, 256, 16, 4, 32) stride=(524288, 2048, 128, 32, 1) is_contiguous=True dtype=torch.float16 device=cpu storage_offset=0 numel=1048576 storage_nbytes=2097152 padding_per_block=0 (utils.py:1200:lmcache.v1.gpu_connector.utils)
[2026-05-20 22:30:09,355] LMCache INFO: KV layer groups: [KVLayerGroupInfo(layers=2, indices=0-1, shape_desc=(kv=2, nl=2, nb=256, bs=4, nh=16, hs=32, element_size=2, block_stride_elems=0), dtype=torch.float16, compress_ratio=1, physical_chunk_size=256)] (kv_layer_groups.py:266:lmcache.v1.kv_layer_groups)
[2026-05-20 22:30:09,356] LMCache INFO: CpuCacheContext: 2 layers, blocks=256x16, dtype=torch.float16 (shm-backed) (cache_context.py:161:lmcache.v1.platform.cpu.cache_context)
[2026-05-20 22:30:09,356] LMCache INFO: Registered KV cache for GPU ID 0 with 2 layers (server.py:312:lmcache.v1.multiprocess.server)
[2026-05-20 22:30:09,360] LMCache INFO: Stored 256 tokens in 0.003 seconds (server.py:711:lmcache.v1.multiprocess.server)
INFO:     127.0.0.1:56809 - "GET /kvcache/check?block_ids=[160,175]&block_size=16&chunk_size=16&layerwise=false HTTP/1.1" 200 OK
[2026-05-20 22:30:09,589] LMCache INFO: Prefetch request completed (L1+L2): 1/1 prefix hits (1 L1, 0 L2) in 0.6 ms (external_request_id=req-100-warm, prefetch_request_id=-1) (storage_manager.py:536:lmcache.v1.distributed.storage_manager)
[2026-05-20 22:30:09,590] LMCache INFO: Retrieved 256 tokens in 0.001 seconds (server.py:914:lmcache.v1.multiprocess.server)
INFO:     127.0.0.1:56811 - "GET /kvcache/check?block_ids=[160,175]&block_size=16&chunk_size=16&layerwise=false HTTP/1.1" 200 OK
```

  - start kvcache bench

```
(base) ~/projects/LMCache git:[serverside_shm_cp]
lmcache bench kvcache --mode cpu --start 100 --end 202 --num-tokens 256 --interval 0.2 --num-blocks 256 --block-size 16 --kvcache-shape-spec "(2,256,16,4,32):float16:2"
[2026-05-20 22:30:08,367] LMCache INFO:  torch_dev=StubCPUDevice(device_type=cpu), torch_device_type=cpu (__init__.py:59:lmcache)
[2026-05-20 22:30:08,438] LMCache INFO: Skipping backend lmcache.xpu_ops: predicate returned False (__init__.py:91:lmcache)
[2026-05-20 22:30:08,438] LMCache INFO: Skipping backend lmcache.c_ops: predicate returned False (__init__.py:91:lmcache)
Connecting to LMCache MP Server at tcp://localhost:5555 (mode=cpu) ...
Server chunk_size = 256
Resolved KV shape spec: (2,256,16,4,32):float16:2
Each request: 257 tokens (1 full chunks)
KV shape: 2 layers, 4 heads x 32, dtype=float16, blocks=256x16, kv=2
Allocated 2 CPU SHM tensors (prefix=/lmcache_kv_87912)
REGISTER_KV_CACHE: OK

=== Request seq=100 ===
  [seq 100/cold] LOOKUP: 0/1 chunks hit (1.4 ms)
  [seq 100/cold] STORE: stored (256 tokens, 3.4 ms)
  [seq 100/cold] CHECKSUM: b1f62606fe41303c (1 chunks)
  [seq 100/warm] LOOKUP: 1/1 chunks hit (1.6 ms)
  [seq 100/warm] RETRIEVE: retrieved (256 tokens, 1.4 ms)
  [seq 100/warm] CHECKSUM: b1f62606fe41303c (1 chunks)
  [seq 100] CHECKSUM MATCH OK

=== Request seq=101 ===
  [seq 101/cold] LOOKUP: 0/1 chunks hit (1.5 ms)
  [seq 101/cold] STORE: stored (256 tokens, 1.5 ms)
  [seq 101/cold] CHECKSUM: 1ad5d4ef06f2dd34 (1 chunks)
  [seq 101/warm] LOOKUP: 1/1 chunks hit (1.4 ms)
  [seq 101/warm] RETRIEVE: retrieved (256 tokens, 1.4 ms)
  [seq 101/warm] CHECKSUM: 1ad5d4ef06f2dd34 (1 chunks)
  [seq 101] CHECKSUM MATCH OK
...                                                                                    
```

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
