### PR TITLE
 [CI] Restore NO_CUDA_EXT=1 skip-all-extensions semantics

### DIFF
--- a/lmcache/cli/commands/server.py
+++ b/lmcache/cli/commands/server.py
@@ -6,6 +6,9 @@ import argparse
 
 # First Party
 from lmcache.cli.commands.base import BaseCommand
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
 
 
 class ServerCommand(BaseCommand):
@@ -53,9 +56,10 @@ class ServerCommand(BaseCommand):
             add_http_frontend_args(parser)
             add_observability_args(parser)
         except ImportError as e:
-            print(
-                f"Failed to import server dependencies: {e}. "
-                "Install the full lmcache package to use 'lmcache server'."
+            logger.warning(
+                "lmcache-cli (lightweight) detected (%s); install the full "
+                "lmcache package to use 'server' and 'bench'.",
+                e,
             )
             return
 

--- a/setup.py
+++ b/setup.py
@@ -383,20 +383,22 @@ def _collect_extensions() -> tuple[list, dict]:
 
     Notes:
         - `sdist` builds skip all extension compilation.
-        - `NO_CUDA_EXT=1` keeps pure C++ extensions and skips GPU extensions.
+        - `NO_CUDA_EXT=1` skips all extension compilation (pure-Python build,
+          used by the lmcache-cli wheel which has no torch build dependency).
         - Otherwise, pure C++ extensions are combined with one GPU backend
           extension set (CUDA, ROCm, or SYCL).
     """
     if BUILDING_SDIST:
         return source_dist_extension()
 
+    if NO_CUDA_EXT:
+        return [], {}
+
     common_cpp_flags = _get_common_cpp_flags()
     # Preserve historical SYCL compatibility: lmcache_fs was compiled without
     # _GLIBCXX_USE_CXX11_ABI in pre-refactor builds.
     fs_cpp_flags = [] if BUILD_WITH_SYCL else common_cpp_flags
     ext_modules, cmdclass = _common_cpp_extensions(common_cpp_flags, fs_cpp_flags)
-    if NO_CUDA_EXT:
-        return ext_modules, cmdclass
 
     if BUILD_WITH_SYCL:
         gpu_ext_modules, cmdclass = sycl_extension()


### PR DESCRIPTION
 ## Summary
  - `setup.py`: short-circuit `_collect_extensions()` on `NO_CUDA_EXT=1` before calling `_common_cpp_extensions()`, so the CLI wheel builds  without torch and ships zero compiled extensions.
  - `server.py`: replace the server-import `print` with a `logger.warning` that says this is the lightweight `lmcache-cli` install and the full package is needed for `server` / `bench`.

  ## Context
  #3302 redefined `NO_CUDA_EXT=1` to "skip GPU only", but pure C++ extensions still require `torch.utils.cpp_extension` at build time — which  the CLI wheel env doesn't have. Every PR opened after #3302 (incl. #3341) started failing `Build CLI Artifacts` with `ModuleNotFoundError: No module named 'torch'`. This restores the prior "skip all extensions" meaning that the CLI smoke test (`grep '\.(so|pyd)$'` → fail) requires. 
 #3302's `_common_cpp_extensions()` refactor is preserved.

  ## Follow-up
 The name `NO_CUDA_EXT` is misleading — it has always controlled *all* native extensions, not just CUDA ones. A follow-up PR will rename it to `NO_NATIVE_EXT` with a backwards-compatible alias (`NO_CUDA_EXT` keeps working, emits a deprecation warning) to reduce the chance of this regression recurring.

  ## Test plan
  - [x] CLI wheel builds with `NO_CUDA_EXT=1` in a torch-less venv; `unzip -l` shows no `.so`/`.pyd`
  - [x] `lmcache --help` and all 8 slim subcommand `--help`s pass on both `dev` and #3341 + this fix
  - [x] `NO_CUDA_EXT=1 ... --sdist` still works; full CUDA/HIP/SYCL paths byte-identical when `NO_CUDA_EXT` is unset