### PR TITLE
feat: Support dynamic plugin registration for Redis to enable custom lookup priorities 

### DIFF
--- a/docs/source/kv_cache/storage_backends/redis.rst
+++ b/docs/source/kv_cache/storage_backends/redis.rst
@@ -49,6 +49,21 @@ Example ``config.yaml``:
     # How to serialize and deserialize KV cache on remote transmission
     remote_serde: "naive" # "naive" (default) or "cachegen"
 
+Dynamic Plugin Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+    # 256 Tokens per KV Chunk
+    chunk_size: 256
+    local_cpu: true
+
+    remote_storage_plugins:
+      - "redis"
+
+    extra_config:
+      remote_storage_plugin.redis.redis_url: "redis://your-redis-host:6379"
+
 Remote Storage Explanation:
 ----------------------------
 

--- a/lmcache/v1/storage_backend/connector/redis_adapter.py
+++ b/lmcache/v1/storage_backend/connector/redis_adapter.py
@@ -80,15 +80,25 @@ class RedisConnectorAdapter(ConnectorAdapter):
         super().__init__("redis://")
 
     def can_parse(self, url: str) -> bool:
-        return url.startswith((self.schema, "rediss://", "unix://"))
+        return url.startswith((self.schema, "rediss://", "unix://", "plugin://redis"))
 
     def create_connector(self, context: ConnectorContext) -> RemoteConnector:
         # Local
         from .redis_connector import RedisConnector
 
-        logger.info(f"Creating Redis connector for URL: {context.url}")
+        url = context.url
+        if url.startswith("plugin://redis"):
+            extra_config = {}
+            remote_url = None
+            if context.config is not None:
+                extra_config = context.config.extra_config if context.config.extra_config is not None else {}
+                remote_url = context.config.remote_url
+            cfg_redis_url = extra_config.get("remote_storage_plugin.redis.redis_url") or extra_config.get("redis_url")
+            url = cfg_redis_url or remote_url or "redis://localhost:6379"
+
+        logger.info(f"Creating Redis connector for URL: {url}")
         return RedisConnector(
-            url=context.url,
+            url=url,
             loop=context.loop,
             local_cpu_backend=context.local_cpu_backend,
         )

--- a/lmcache/v1/storage_backend/connector/redis_adapter.py
+++ b/lmcache/v1/storage_backend/connector/redis_adapter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 import os
 
 # First Party
@@ -88,12 +88,18 @@ class RedisConnectorAdapter(ConnectorAdapter):
 
         url = context.url
         if url.startswith("plugin://redis"):
-            extra_config = {}
+            extra_config: Dict[str, Any] = {}
             remote_url = None
             if context.config is not None:
-                extra_config = context.config.extra_config if context.config.extra_config is not None else {}
+                extra_config = (
+                    context.config.extra_config
+                    if context.config.extra_config is not None
+                    else {}
+                )
                 remote_url = context.config.remote_url
-            cfg_redis_url = extra_config.get("remote_storage_plugin.redis.redis_url") or extra_config.get("redis_url")
+            cfg_redis_url = extra_config.get(
+                "remote_storage_plugin.redis.redis_url"
+            ) or extra_config.get("redis_url")
             url = cfg_redis_url or remote_url or "redis://localhost:6379"
 
         logger.info(f"Creating Redis connector for URL: {url}")

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from pathlib import Path
+from unittest.mock import patch
 import asyncio
 import tempfile
 
@@ -177,6 +178,7 @@ def test_fs_connector(autorelease_v1, full_chunk, save_chunk_meta, use_mla):
         "redis://:password@localhost:6379/1",
         "rediss://user:password@localhost:6380?ssl_cert_reqs=CERT_REQUIRED",
         "unix:///tmp/redis.sock",
+        "plugin://redis",
     ],
 )
 def test_redis_connector(url, autorelease_v1):
@@ -418,3 +420,35 @@ def _create_local_cpu_backend(memory_allocator, use_mla, config=None):
     return LocalCPUBackend(
         config=config, metadata=metadata, memory_allocator=memory_allocator
     )
+
+
+@patch("lmcache.v1.storage_backend.connector.redis_connector.RedisConnector")
+def test_redis_plugin_custom_url(mock_redis_connector, autorelease_v1) -> None:
+    """Verify that RedisConnectorAdapter successfully extracts custom Redis URL from extra_config
+    when loaded dynamically as a plugin.
+    """
+    async_loop, async_thread = init_asyncio_loop()
+    memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+    local_cpu_backend = _create_local_cpu_backend(memory_allocator, False)
+
+    # Define custom Redis URL inside extra_config
+    custom_url = "redis://my-custom-redis-host:6379"
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "remote_storage_plugin.redis.redis_url": custom_url
+        }
+    )
+    
+    # Create connector using dynamic plugin schema URL
+    autorelease_v1(
+        CreateConnector("plugin://redis", async_loop, local_cpu_backend, config)
+    )
+    
+    mock_redis_connector.assert_called_once_with(
+        url=custom_url,
+        loop=async_loop,
+        local_cpu_backend=local_cpu_backend,
+    )
+    
+    close_asyncio_loop(async_loop, async_thread)
+    local_cpu_backend.close()

--- a/tests/v1/test_connector.py
+++ b/tests/v1/test_connector.py
@@ -424,8 +424,8 @@ def _create_local_cpu_backend(memory_allocator, use_mla, config=None):
 
 @patch("lmcache.v1.storage_backend.connector.redis_connector.RedisConnector")
 def test_redis_plugin_custom_url(mock_redis_connector, autorelease_v1) -> None:
-    """Verify that RedisConnectorAdapter successfully extracts custom Redis URL from extra_config
-    when loaded dynamically as a plugin.
+    """Verify that RedisConnectorAdapter extracts custom Redis URL
+    from extra_config when loaded dynamically as a plugin.
     """
     async_loop, async_thread = init_asyncio_loop()
     memory_allocator = PinMemoryAllocator(1024 * 1024 * 1024)
@@ -434,21 +434,19 @@ def test_redis_plugin_custom_url(mock_redis_connector, autorelease_v1) -> None:
     # Define custom Redis URL inside extra_config
     custom_url = "redis://my-custom-redis-host:6379"
     config = LMCacheEngineConfig.from_defaults(
-        extra_config={
-            "remote_storage_plugin.redis.redis_url": custom_url
-        }
+        extra_config={"remote_storage_plugin.redis.redis_url": custom_url}
     )
-    
+
     # Create connector using dynamic plugin schema URL
     autorelease_v1(
         CreateConnector("plugin://redis", async_loop, local_cpu_backend, config)
     )
-    
+
     mock_redis_connector.assert_called_once_with(
         url=custom_url,
         loop=async_loop,
         local_cpu_backend=local_cpu_backend,
     )
-    
+
     close_asyncio_loop(async_loop, async_thread)
     local_cpu_backend.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #3350
Fixes #3337

Allow registering Redis as a dynamic plugin allowed us to explicitly list it first:

```
    remote_storage_plugins:
      - "redis"      # 1st in OrderedDict (RAM)
      - "bigtable"   # 2nd in OrderedDict (SSD Disk)
```

Changes to `redis_adapter.py`

* Update `can_parse` to accept the dynamic plugin schema prefix `plugin://redis`.
* Updates `create_connector` to dynamically extract connection strings from the `ConfigMap`'s  `extra_config` namespace (supporting both flat  `redis_url` and instance-prefixed  `remote_storage_plugin.redis.redis_url` keys), falling back to global `remote_url` or `localhost`.
* Includes safety checks to handle `config=None` cases, avoiding `AttributeError` crashes under unit tests.

**Special notes for your reviewers**:

During development of the Bigtable connector, we discovered that Bigtable SSD was never queried at all while  using `remote_url` parameter to configure Redis.

In LMCache, remote storage backends are queried sequentially (rather than in parallel) inside an awaited asynchronous loop during prefetch and lookup routines (inside [storage_manager.py](https://github.com/LMCache/LMCache/blob/dev/lmcache/v1/storage_backend/storage_manager.py#L693-L735)

[CreateStorageBackends](https://github.com/LMCache/LMCache/blob/dev/lmcache/v1/storage_backend/__init__.py#L111-L316) always loads `remote_url` [see](https://github.com/LMCache/LMCache/blob/dev/lmcache/v1/storage_backend/__init__.py#L268-L282) after any dynamic plugins [see](https://github.com/LMCache/LMCache/blob/dev/lmcache/v1/storage_backend/__init__.py#L239-L265).

Enabling Redis to be used as a dynamic plugin allowed us to explicitly list it first.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
