### PR TITLE
feat(mp): add SHM-based NonGpuContext (server-side copy) 

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -170,3 +170,30 @@ steps:
                 volumes:
                   - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
                   - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 4Gi } }
+
+      - label: ":compression: cpu_e2e_validation (server-side copy)"
+        command: bash .buildkite/k3_tests/multiprocess/scripts/run-cpu-e2e-validation.sh
+        env:
+          LMCACHE_MP_TRANSFER_MODE: "handle"
+        timeout_in_minutes: 30
+        agents: { queue: "k8s" }
+        plugins:
+          - kubernetes:
+              podSpec:
+                containers:
+                  - name: container-0
+                    image: lmcache/ci-base:latest
+                    imagePullPolicy: Never
+                    resources:
+                      requests:
+                        cpu: "8"
+                        memory: "256Gi"
+                      limits:
+                        cpu: "8"
+                        memory: "256Gi"
+                    volumeMounts:
+                      - { name: hf-cache, mountPath: /root/.cache/huggingface }
+                      - { name: dshm, mountPath: /dev/shm }
+                volumes:
+                  - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
+                  - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 4Gi } }

--- a/.buildkite/k3_tests/multiprocess/scripts/run-cpu-e2e-validation.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-cpu-e2e-validation.sh
@@ -20,6 +20,8 @@ LMCACHE_HEALTHCHECK_TIMEOUT="${LMCACHE_HEALTHCHECK_TIMEOUT:-30}"
 VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-120}"
 # Set LMCACHE_SHM_NAME="" to use pickle transport; unset/default uses shm transport
 LMCACHE_SHM_NAME="${LMCACHE_SHM_NAME-__default__}"
+# Set LMCACHE_MP_TRANSFER_MODE=handle for server-side copy (POSIX SHM IPC)
+LMCACHE_MP_TRANSFER_MODE="${LMCACHE_MP_TRANSFER_MODE:-auto}"
 
 # Directory to collect artifacts before workspace is deleted
 ARTIFACT_DIR="/tmp/build_${BUILD_ID}_artifacts"
@@ -141,6 +143,36 @@ print(int(total))
 EOF
 }
 
+# Wait for a metric to change from its previous value
+wait_for_metric_change() {
+  local metric_name="$1"
+  local previous_value="$2"
+  local timeout_seconds="${3:-5}"
+  
+  echo "Waiting for metric '${metric_name}' to change from ${previous_value} (timeout: ${timeout_seconds}s)"
+  
+  local start_time current_time
+  start_time=$(date +%s)
+  
+  while true; do
+    current_time=$(date +%s)
+    if [ $((current_time - start_time)) -ge "${timeout_seconds}" ]; then
+      echo "Timeout: Metric '${metric_name}' did not change within ${timeout_seconds}s"
+      return 1
+    fi
+    
+    local current_value
+    current_value="$(scrape_metric "${metric_name}")"
+    
+    if [ "${current_value}" -gt "${previous_value}" ]; then
+      echo "Metric '${metric_name}' changed from ${previous_value} to ${current_value}"
+      return 0
+    fi
+    
+    sleep 1
+  done
+}
+
 # Send a completion request and print the text output
 send_completion() {
   local prompt_file="$1"
@@ -165,7 +197,9 @@ print(json.dumps({
 
 start_vllm() {
   echo "Starting vLLM server..."
-  VLLM_TARGET_DEVICE=cpu vllm serve facebook/opt-125m \
+  VLLM_TARGET_DEVICE=cpu \
+  LMCACHE_MP_TRANSFER_MODE="${LMCACHE_MP_TRANSFER_MODE}" \
+  vllm serve facebook/opt-125m \
     --port "${VLLM_PORT}" \
     --dtype bfloat16 \
     --disable-hybrid-kv-cache-manager \
@@ -273,7 +307,10 @@ LMCACHE_ARGS=(
   --eviction-policy "${LMCACHE_EVICTION_POLICY}"
   --chunk-size "${LMCACHE_CHUNK_SIZE}"
 )
-if [ "${LMCACHE_SHM_NAME}" = "__default__" ]; then
+if [ "${LMCACHE_MP_TRANSFER_MODE}" = "handle" ]; then
+  echo "Transport mode: server-side copy (handle via POSIX SHM IPC)"
+  EXPECTED_TRANSPORT="handle"
+elif [ "${LMCACHE_SHM_NAME}" = "__default__" ]; then
   echo "Transport mode: shared memory (shm)"
   EXPECTED_TRANSPORT="shm"
 else
@@ -320,7 +357,14 @@ echo "✅ E2E request validation passed"
 
 # Verify transport mode (logged after vLLM connects to LMCache server)
 echo "[Phase 2 / Step 5.5] Verifying transport mode: expecting '${EXPECTED_TRANSPORT}'"
-if [ "${EXPECTED_TRANSPORT}" = "shm" ]; then
+if [ "${EXPECTED_TRANSPORT}" = "handle" ]; then
+  if ! grep -q "CpuCacheContext" "${LMCACHE_LOG}" 2>/dev/null; then
+    echo "❌ Expected server-side copy but 'CpuCacheContext' not found in log"
+    tail -50 "${LMCACHE_LOG}"
+    false
+  fi
+  echo "✅ Transport mode confirmed: handle (server-side copy)"
+elif [ "${EXPECTED_TRANSPORT}" = "shm" ]; then
   if ! grep -q "Using shm" "${LMCACHE_LOG}" 2>/dev/null; then
     echo "❌ Expected shm transport but 'Using shm' not found in log"
     tail -50 "${LMCACHE_LOG}"

--- a/docs/design/cli/commands.md
+++ b/docs/design/cli/commands.md
@@ -194,11 +194,12 @@ Supports two run modes via ``--mode``:
 - **``gpu``** (default) -- allocates real CUDA tensors and uses CUDA IPC
   (handle transfer path).
 - **``cpu``** -- allocates POSIX-SHM-backed tensors; the server maps the same
-  physical pages for zero-copy STORE/RETRIEVE (data transfer path).
+  physical pages for zero-copy STORE/RETRIEVE (data transfer path by default).
+  To use the zero-copy SHM handle path, add ``--transfer-mode handle``.
 
 The transfer path can be overridden explicitly with ``--transfer-mode
 {auto,handle,data}``. ``auto`` keeps the historical mapping: gpu→handle,
-cpu→data. Note: ``--transfer-mode handle`` on CPU is not yet implemented.
+cpu→data.
 
 ```bash
 $ lmcache bench server \

--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -777,6 +777,32 @@ Options
      - KV cache shape spec (see below).
 
 
+CPU mode (no GPU)
+~~~~~~~~~~~~~~~~~
+
+``--mode cpu`` runs the same end-to-end path without a GPU. The server
+runs on a CPU-only host (``StubCPUDevice``); the bench tool allocates
+POSIX-SHM-backed KV tensors and exercises the full RPC path.
+
+By default ``--mode cpu`` uses the data-transfer path (``auto`` →
+``cpu→data``). To use the zero-copy SHM handle path instead, pass
+``--transfer-mode handle``:
+
+.. code-block:: bash
+
+   # Terminal 1 -- start the LMCache server (no GPU required)
+   lmcache server \
+       --host localhost --port 5555 \
+       --l1-size-gb 2 --eviction-policy LRU
+
+   # Terminal 2 -- run bench in CPU + handle mode
+   lmcache bench server \
+       --rpc-url tcp://localhost:5555 \
+       --url http://localhost:8080 \
+       --mode cpu --transfer-mode handle \
+       --start 0 --end 2
+
+
 KV cache shape spec
 ~~~~~~~~~~~~~~~~~~~
 
@@ -850,12 +876,6 @@ Exit codes
    * - ``1``
      - Fatal error (for example, CUDA unavailable in ``--mode gpu``,
        server unreachable, or a checksum mismatch).
-
-.. note::
-
-   ``--transfer-mode handle`` on CPU mode is not yet implemented and
-   will be added in a future release.
-
 
 .. _lmcache-bench-l2:
 

--- a/docs/source/mp/quickstart.rst
+++ b/docs/source/mp/quickstart.rst
@@ -180,3 +180,65 @@ Examples:
 
 The ZMQ server runs on the same default port (5555) and accepts vLLM
 connections exactly as in the local quick start.
+
+CPU-Only Quick Start
+--------------------
+
+LMCache MP mode works on hosts without a GPU. The server runs with a
+``StubCPUDevice`` and vLLM uses its CPU backend. KV tensors are shared
+between vLLM and the LMCache server via POSIX shared memory (zero-copy,
+no GPU required).
+
+**Step 1: Start the LMCache server (no GPU needed)**
+
+.. code-block:: bash
+
+    lmcache server \
+        --l1-size-gb 2 --eviction-policy LRU --port 5555
+
+Expected log output:
+
+.. code-block:: text
+
+    LMCache INFO: torch_dev=StubCPUDevice(device_type=cpu), ...
+    LMCache INFO: LMCache cache server is running...
+
+**Step 2: Start vLLM with the handle transfer mode**
+
+Pass ``lmcache.mp.mp_transfer_mode=handle`` in
+``kv_connector_extra_config`` to enable the POSIX-SHM zero-copy path.
+At startup the vLLM worker migrates each KV cache tensor to a shared
+memory segment (``/lmcache_kv_<pid>_<idx>``) so the LMCache server can
+map the same physical pages directly.
+
+.. code-block:: bash
+
+    vllm serve <model> --dtype bfloat16 \
+        --disable-hybrid-kv-cache-manager \
+        --no-enable-prefix-caching \
+        --kv-transfer-config \
+        '{"kv_connector": "LMCacheMPConnector",
+          "kv_role": "kv_both",
+          "kv_connector_module_path":
+            "lmcache.integration.vllm.lmcache_mp_connector",
+          "kv_connector_extra_config": {
+            "lmcache.mp.host": "tcp://localhost",
+            "lmcache.mp.port": 5555,
+            "lmcache.mp.mp_transfer_mode": "handle"
+          }}'
+
+Expected log output on the vLLM side:
+
+.. code-block:: text
+
+    LMCache INFO: lmcache.mp.mp_transfer_mode = handle (overridden, ...)
+    LMCache INFO: Creating transfer context (device_type=cpu, mode=handle)
+    LMCache INFO: Migrated CPU KV cache tensor (nbytes=...) to SHM /lmcache_kv_...
+
+**Step 3: Send requests** the same way as in the local quick start.
+
+.. note::
+   The default ``auto`` transfer mode routes CPU tensors to the
+   ``data`` path (worker-side gather/scatter). Use
+   ``mp_transfer_mode=handle`` explicitly to get the zero-copy SHM
+   path described above.

--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import argparse
 import itertools
-import mmap as _mmap
+import mmap
 import os
 import sys
 import time
@@ -457,7 +457,7 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
         # and size; the bench mmaps the same pool so STORE/RETRIEVE
         # can exchange tensor data via slot descriptors instead of
         # round-tripping pickle through the RPC layer.
-        server_pool: "_mmap.mmap | None" = None
+        server_pool: "mmap.mmap | None" = None
         if not use_handle and not isinstance(register_result, bool):
             shm_name = getattr(register_result, "shm_name", "")
             pool_size = getattr(register_result, "pool_size", 0)

--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -33,11 +33,11 @@ Usage examples::
 from __future__ import annotations
 
 # Standard
-from multiprocessing import shared_memory
-from multiprocessing.resource_tracker import unregister
 from typing import TYPE_CHECKING
 import argparse
 import itertools
+import mmap as _mmap
+import os
 import sys
 import time
 
@@ -53,11 +53,13 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
     _DEFAULT_SHAPE_SPEC,
     _IMPORT_ERROR,
     DTYPE_MAP,
-    _allocate_kv_cache,
+    _allocate_cpu_shm_kv_cache,
+    _allocate_gpu_kv_cache,
     _get_chunk_size,
     _process_request,
     _require_full_install,
     _send_register_kv_cache,
+    shm_open_pool_as_mmap,
 )
 
 if TYPE_CHECKING:
@@ -134,10 +136,9 @@ def register_server_parser(
         choices=["cpu", "gpu"],
         default="gpu",
         help=(
-            "Run mode (default: gpu). In cpu mode the bench drives "
-            "the data-transfer path: the server allocates a SHM pool "
-            "and the client gathers/scatters chunks via slot "
-            "descriptors. CPU handle mode is not yet supported."
+            "Run mode (default: gpu). In cpu mode the client allocates "
+            "POSIX-SHM-backed KV cache tensors and the server maps the "
+            "same physical pages."
         ),
     )
     parser.add_argument(
@@ -147,7 +148,8 @@ def register_server_parser(
         help=(
             "Transport routing for STORE/RETRIEVE (default: auto). "
             "`handle` forces the GPU-style single-shot path "
-            "(REGISTER_KV_CACHE + STORE/RETRIEVE). "
+            "(REGISTER_KV_CACHE + STORE/RETRIEVE), which on CPU mode "
+            "uses POSIX SHM to back zero-copy server-side mappings. "
             "`data` forces the worker-side gather/scatter path "
             "(REGISTER_KV_CACHE_NON_GPU_CONTEXT + PREPARE/COMMIT). "
             "`auto` keeps the historical mapping: gpu->handle, cpu->data."
@@ -265,25 +267,29 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
         sys.exit(1)
 
     # Resolve transfer mode. ``auto`` reproduces the historical
-    # behaviour: gpu -> handle path, cpu -> data path.
-    transfer_mode = args.transfer_mode
+    # behaviour: gpu -> handle path, cpu -> data path. ``handle``
+    # / ``data`` are explicit overrides; ``handle`` on CPU mode is
+    # the SHM-backed zero-copy path (server-side copy).
+    transfer_mode = getattr(args, "transfer_mode", "auto")
     if transfer_mode == "auto":
         use_handle = use_gpu
     elif transfer_mode == "handle":
         use_handle = True
     else:
         use_handle = False
+    if use_handle and not use_gpu:
+        print(
+            "  [info] --transfer-mode=handle on cpu mode: using "
+            "REGISTER_KV_CACHE + STORE/RETRIEVE over POSIX SHM"
+        )
 
     url = args.rpc_url
     print(
-        "Connecting to LMCache MP Server at %s (mode=%s, transfer=%s) ..."
-        % (url, args.mode, transfer_mode),
+        "Connecting to LMCache MP Server at %s (mode=%s) ..." % (url, args.mode),
     )
 
     ctx = zmq.Context()
     client = MessageQueueClient(url, ctx)
-    server_shm: "shared_memory.SharedMemory | None" = None
-    server_pool: "memoryview | None" = None
 
     try:
         # Query chunk size from server
@@ -303,7 +309,7 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
         )
         # Paged KV demands identical ``NB`` / ``BS`` across all groups
         # (block_id -> slot maths is shared), but ``kv_size`` / ``NH`` /
-        # ``HS`` / ``dtype`` may vary per group. ``_allocate_kv_cache(
+        # ``HS`` / ``dtype`` may vary per group. ``_allocate_gpu_kv_cache(
         # groups=...)`` honours each group's own shape; ``_process_request``
         # only needs a single ``block_size`` / ``total_blocks``.
         first = layer_groups[0]
@@ -364,6 +370,14 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
             "head_size": head_size_disp,
             "num_blocks": num_blocks,
             "block_size": block_size,
+            # Tell the server the inference-engine-side logical block
+            # size explicitly. Otherwise ``KVLayerGroupsManager`` falls
+            # back to ``shape_desc.bs``, which on the CPU/HND path can
+            # be the per-block ``num_heads`` value instead of the real
+            # ``block_size`` (HND swaps NH and BS in the tensor shape),
+            # and STORE/RETRIEVE would then expect twice as many block
+            # IDs as the bench client actually sends.
+            "inference_engine_logical_block_size": block_size,
             "dtype": dtype_str,
         }
 
@@ -390,63 +404,65 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
         )
 
         # Allocate KV tensors. GPU mode wraps real CUDA tensors
-        # via CUDA IPC; CPU mode (data transfer mode) allocates
-        # plain CPU tensors used for client-side checksum self-check.
-        # TODO(baoloongmao): CPU handle mode (zero-copy SHM IPC with
-        # the server) will be implemented in a separate PR.
+        # via CUDA IPC; CPU mode allocates POSIX-SHM-backed
+        # tensors so the server can map the same physical pages.
+        # shm_names tracks per-layer SHM segment names allocated
+        # on demand (one per layer) so we can shm_unlink on exit.
+        shm_names: list[str] = []
         if use_gpu:
             # First Party
             from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
 
-            allocated = _allocate_kv_cache(groups=layer_groups, use_gpu=True)
+            allocated = _allocate_gpu_kv_cache(groups=layer_groups)
             print(
                 "Allocated %d GPU tensors on %s" % (len(allocated), allocated[0].device)
             )
-            kv_wrappers: list = [CudaIPCWrapper(t) for t in allocated]
+            kv_wrappers = [CudaIPCWrapper(t) for t in allocated]
+            # Keep the CUDA tensors alive for the lifetime of the
+            # bench process -- storage may be reclaimed otherwise --
+            # and reuse the same list as the client-side data-mode
+            # source/sink for the round-trip self-check.
             client_kv_tensors = allocated
         else:
-            if use_handle:
-                print(
-                    "ERROR: --mode cpu --transfer-mode handle is not yet "
-                    "supported in this PR (TODO: separate PR)."
-                )
-                sys.exit(1)
-            cpu_tensors = _allocate_kv_cache(groups=layer_groups, use_gpu=False)
-            print("Allocated %d CPU tensors" % len(cpu_tensors))
-            kv_wrappers = []
+            # First Party
+            from lmcache.v1.platform.cpu.shm import CpuShmTensorWrapper
+
+            shm_prefix = CpuShmTensorWrapper.SHM_NAME_PREFIX + str(os.getpid())
+            cpu_tensors, cpu_wrappers, shm_names = _allocate_cpu_shm_kv_cache(
+                groups=layer_groups, shm_prefix=shm_prefix
+            )
+            print(
+                "Allocated %d CPU SHM tensors (prefix=%s)"
+                % (len(cpu_tensors), shm_prefix)
+            )
+            kv_wrappers = list(cpu_wrappers)
             client_kv_tensors = cpu_tensors
 
-        # Register KV cache before any store/retrieve.
-        register_ok, register_response = _send_register_kv_cache(
+        # Register KV cache before any store/retrieve. In handle mode
+        # both GPU (CUDA-IPC) and CPU (POSIX-SHM) paths share the same
+        # ``REGISTER_KV_CACHE`` protocol since ``CpuShmTensorWrapper``
+        # is a ``CudaIPCWrapper`` subclass on the wire. In data mode
+        # we fall through to the non-GPU registration protocol.
+        register_result = _send_register_kv_cache(
             client,
             layout_hints=layout_hints,
             kv_caches=kv_wrappers if use_handle else None,
             use_gpu=use_gpu,
             use_handle=use_handle,
         )
-        print("REGISTER_KV_CACHE: %s" % ("OK" if register_ok else "FAIL"))
+        print("REGISTER_KV_CACHE: %s" % ("OK" if register_result else "FAIL"))
         print()
 
         # In data mode the server reply carries the SHM pool name
-        # and size; the bench attaches to the same pool so
-        # STORE/RETRIEVE can exchange tensor data via slot
-        # descriptors. We open via :class:`SharedMemory` (matching
-        # the server-side allocator in ``transfer_context/shm.py``)
-        # and unregister from the worker's resource tracker so the
-        # segment is not unlinked when the bench exits -- the server
-        # owns its lifetime.
-        if not use_handle and register_ok and register_response is not None:
-            shm_name = register_response.shm_name
-            pool_size = register_response.pool_size
+        # and size; the bench mmaps the same pool so STORE/RETRIEVE
+        # can exchange tensor data via slot descriptors instead of
+        # round-tripping pickle through the RPC layer.
+        server_pool: "_mmap.mmap | None" = None
+        if not use_handle and not isinstance(register_result, bool):
+            shm_name = getattr(register_result, "shm_name", "")
+            pool_size = getattr(register_result, "pool_size", 0)
             if shm_name and pool_size > 0:
-                server_shm = shared_memory.SharedMemory(
-                    name=shm_name.lstrip("/"), create=False
-                )
-                try:
-                    unregister("/%s" % server_shm.name, "shared_memory")
-                except KeyError:
-                    pass
-                server_pool = server_shm.buf
+                server_pool = shm_open_pool_as_mmap(shm_name, pool_size)
 
         if args.end is not None:
             seq_iter: itertools.count | range = range(args.start, args.end)
@@ -455,9 +471,11 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
 
         http_base = args.url.rstrip("/")
 
-        # In data mode the server has no paged kv_tensors view to
-        # hash, so we self-check on the client. Handle mode keeps
-        # the legacy server-side /kvcache/check path.
+        # In data mode the server has no paged ``kv_tensors`` view to
+        # hash, so we self-check on the client: cold pass captures
+        # ground truth, warm pass zero-fills + re-hashes after
+        # RETRIEVE. Handle mode keeps the legacy server-side
+        # ``/kvcache/check`` path.
         client_tensors = None if use_handle else client_kv_tensors
 
         for seq_no in seq_iter:
@@ -527,21 +545,22 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
     except KeyboardInterrupt:
         print("\nStopping...")
     finally:
-        # Release the bench-side view of the server SHM pool first
-        # (data mode only; server_shm stays None otherwise). The
-        # ``memoryview`` returned by ``SharedMemory.buf`` must be
-        # released before ``SharedMemory.close``, otherwise CPython
-        # raises ``BufferError`` on shutdown.
-        if server_pool is not None:
+        # Release the bench-side mmap of the server SHM pool first
+        # (data mode only; ``server_pool`` stays ``None`` otherwise).
+        if "server_pool" in locals() and server_pool is not None:
             try:
-                server_pool.release()
-            except (BufferError, ValueError):
-                pass
-        if server_shm is not None:
-            try:
-                server_shm.close()
+                server_pool.close()
             except (BufferError, ValueError):
                 pass
         client.close()
         ctx.term()
+        # Best-effort SHM cleanup so segments don't linger.
+        for _name in shm_names if "shm_names" in locals() else []:
+            try:
+                # First Party
+                from lmcache.v1.platform.cpu.shm import shm_unlink
+
+                shm_unlink(_name)
+            except OSError:
+                pass
     print("Done.")

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -21,7 +21,7 @@ from typing import Any
 import ctypes
 import hashlib
 import json
-import mmap as _mmap
+import mmap
 import sys
 import time
 import urllib.error
@@ -450,7 +450,7 @@ def _make_event_handle(use_gpu: bool = True) -> bytes:
 
 
 def _build_server_slot_views(
-    server_pool: "_mmap.mmap",
+    server_pool: "mmap.mmap",
     slots: list[dict[str, Any]],
 ) -> list["torch.Tensor"]:
     """Build zero-copy tensor views over server SHM slot descriptors.
@@ -629,7 +629,7 @@ def _send_store(
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
     chunk_size: int = 0,
-    server_pool: "_mmap.mmap | None" = None,
+    server_pool: "mmap.mmap | None" = None,
 ) -> str:
     """Store KV cache blocks. Returns status string.
 
@@ -698,7 +698,7 @@ def _send_retrieve(
     use_gpu: bool = True,
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
-    server_pool: "_mmap.mmap | None" = None,
+    server_pool: "mmap.mmap | None" = None,
 ) -> str:
     """Retrieve KV cache blocks. Returns status.
 
@@ -854,7 +854,7 @@ def _process_request(
     use_gpu: bool = True,
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
-    server_pool: "_mmap.mmap | None" = None,
+    server_pool: "mmap.mmap | None" = None,
 ) -> list[str] | None:
     """Run the full lookup -> retrieve/store flow.
 

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 
 # Standard
 from typing import Any
+import ctypes
 import hashlib
 import json
+import mmap as _mmap
 import sys
 import time
 import urllib.error
@@ -58,16 +60,29 @@ try:
     )
     from lmcache.v1.multiprocess.futures import MessagingFuture
     from lmcache.v1.multiprocess.mq import MessageQueueClient
+    from lmcache.v1.multiprocess.posix_shm import shm_open_pool_as_mmap
     from lmcache.v1.multiprocess.protocols.base import RequestType
     from lmcache.v1.multiprocess.protocols.engine import (
         RegisterNonGpuContextResponse,
     )
     from lmcache.v1.multiprocess.transfer_context.shm import ShmSlotDescriptor
+    from lmcache.v1.platform.cpu.shm import (
+        CpuShmTensorWrapper,
+        shm_create_readwrite,
+    )
 except ImportError as _exc:
     _IMPORT_ERROR = _exc
     # Fallback placeholder so ``add_arguments`` can still build its
     # help text without crashing on a CLI-only install.
     DTYPE_MAP = {}  # type: ignore[assignment]
+
+    # Stubs so other modules (notably ``command.py``) can still import
+    # the SHM helpers on a slim install; ``_require_full_install`` is
+    # the gate that prevents them from ever being invoked there.
+    def shm_open_pool_as_mmap(name: str, nbytes: int) -> Any:  # type: ignore[misc]
+        raise RuntimeError(
+            "shm_open_pool_as_mmap unavailable on slim lmcache-cli install"
+        )
 
 
 def _require_full_install() -> None:
@@ -180,36 +195,18 @@ def _make_key(
 # ------------------------------------------------------------------ #
 
 
-def _alloc_tensor(
-    shape: tuple[int, ...],
-    dtype: "torch.dtype",
-    device: "torch.device | None" = None,
-) -> "torch.Tensor":
-    """Allocate a random tensor of the given shape and dtype.
-
-    ``torch.randn`` only supports floating-point dtypes; integer dtypes
-    (e.g. ``uint8`` for FP8-quantised KV) fall back to ``randint``.
-    """
-    kwargs = {} if device is None else {"device": device}
-    if dtype.is_floating_point:
-        return torch.randn(shape, dtype=dtype, **kwargs)
-    iinfo = torch.iinfo(dtype)
-    return torch.randint(iinfo.min, iinfo.max + 1, shape, dtype=dtype, **kwargs)
-
-
-def _allocate_kv_cache(
+def _allocate_gpu_kv_cache(
     num_layers: int = 32,
     num_heads: int = 8,
     head_size: int = 128,
     num_blocks: int = 1024,
     block_size: int = 16,
-    dtype: "torch.dtype | None" = None,
-    device: "str | torch.device | None" = None,
+    dtype: torch.dtype | None = None,
+    device: str | torch.device | None = None,
     kv_size: int = 2,
-    groups: "list[KVLayerGroupInfo] | None" = None,
-    use_gpu: bool = True,
-) -> "list[torch.Tensor]":
-    """Allocate paged KV cache tensors for either GPU or CPU mode.
+    groups: list[KVLayerGroupInfo] | None = None,
+) -> list[torch.Tensor]:
+    """Allocate paged GPU KV cache tensors.
 
     Each layer is a tensor of shape
     ``(kv_size, num_blocks, block_size, num_heads, head_size)``
@@ -223,39 +220,97 @@ def _allocate_kv_cache(
     (for heterogeneous multi-group specs). In that mode the flat
     ``num_heads`` / ``head_size`` / ``dtype`` / ``kv_size`` kwargs
     are ignored, and ``num_layers`` is derived from the groups.
-
-    GPU mode wraps real CUDA tensors; CPU mode (``use_gpu=False``,
-    used by ``--transfer-mode data``) allocates plain CPU tensors --
-    the server owns the SHM pool and the bench only needs these
-    tensors for client-side checksum self-check. The handle-mode
-    CPU path (true zero-copy SHM IPC with the server) will need
-    :class:`CpuShmTensorWrapper` and is left for a separate PR --
-    see ``TODO(baoloongmao)`` markers below.
     """
     # ``torch.float16`` cannot be used as a default value because the
     # module must load on ``lmcache-cli`` (no torch) installs.
     if dtype is None:
         dtype = torch.float16
     torch.random.manual_seed(42)
-    if use_gpu:
-        dev: torch.device | None = (
-            torch.device(device)
-            if device
-            else torch.device(torch_device_type, torch_dev.current_device())
-        )
-    else:
-        dev = None
+    dev = (
+        torch.device(device)
+        if device
+        else torch.device(torch_device_type, torch_dev.current_device())
+    )
+
+    def _alloc(
+        shape: tuple[int, ...],
+        a_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        if a_dtype.is_floating_point:
+            return torch.randn(shape, dtype=a_dtype, device=dev)
+        # ``torch.randn`` only supports floating-point dtypes; fall
+        # back to ``randint`` for integer dtypes (e.g. ``uint8``
+        # used by FP8 quantized KV cache layouts).
+        iinfo = torch.iinfo(a_dtype)
+        return torch.randint(iinfo.min, iinfo.max + 1, shape, dtype=a_dtype, device=dev)
 
     if groups:
         tensors: list[torch.Tensor] = []
         for g in groups:
             sd = g.shape_desc
             g_shape = (sd.kv_size, sd.nb, sd.bs, sd.nh, sd.hs)
-            tensors.extend(_alloc_tensor(g_shape, g.dtype, dev) for _ in range(sd.nl))
+            tensors.extend(_alloc(g_shape, g.dtype) for _ in range(sd.nl))
         return tensors
 
     shape = (kv_size, num_blocks, block_size, num_heads, head_size)
-    return [_alloc_tensor(shape, dtype, dev) for _ in range(num_layers)]
+    return [_alloc(shape, dtype) for _ in range(num_layers)]
+
+
+# Backward-compatible alias used by tests and older callers.
+_allocate_kv_cache = _allocate_gpu_kv_cache
+
+
+def _allocate_cpu_shm_kv_cache(
+    groups: list[KVLayerGroupInfo],
+    shm_prefix: str,
+) -> tuple[list[torch.Tensor], list[CpuShmTensorWrapper], list[str]]:
+    """Allocate paged CPU KV cache tensors backed by POSIX SHM.
+
+    For each (group, layer) we ``shm_open`` a fresh segment and
+    ``mmap`` it into the client process. The returned tensors share
+    storage with the SHM mapping, and the matching
+    :class:`CpuShmTensorWrapper` instances tell the LMCache mp
+    server how to map the very same physical pages -- i.e. true
+    zero-copy across processes (matching the GPU CUDA-IPC path).
+
+    Returns:
+        ``(tensors, wrappers, shm_names)``. ``shm_names`` is kept
+        so the caller can ``shm_unlink`` on shutdown.
+    """
+    # Fixed seed so the deterministic random fill below produces
+    # reproducible checksums across cold/warm bench iterations.
+    torch.random.manual_seed(42)
+    tensors: list[torch.Tensor] = []
+    wrappers: list[CpuShmTensorWrapper] = []
+    shm_names: list[str] = []
+    layer_idx = 0
+    for g_idx, g in enumerate(groups):
+        sd = g.shape_desc
+        g_shape = (sd.kv_size, sd.nb, sd.bs, sd.nh, sd.hs)
+        for _ in range(sd.nl):
+            n_elems = 1
+            for d in g_shape:
+                n_elems *= d
+            nbytes = n_elems * g.dtype.itemsize
+            name = "%s_%d_%d" % (shm_prefix, g_idx, layer_idx)
+            addr = shm_create_readwrite(name, nbytes)
+            buf_type = ctypes.c_uint8 * nbytes
+            buf = buf_type.from_address(addr)
+            flat = torch.frombuffer(buf, dtype=torch.uint8)
+            t = flat.view(g.dtype).reshape(g_shape)
+            # Initialise with deterministic random data so the
+            # cold/warm checksum compare in the bench loop is
+            # meaningful.
+            if g.dtype.is_floating_point:
+                t.copy_(torch.randn(g_shape, dtype=g.dtype))
+            else:
+                iinfo = torch.iinfo(g.dtype)
+                t.copy_(torch.randint(iinfo.min, iinfo.max + 1, g_shape, dtype=g.dtype))
+            tensors.append(t)
+            wrappers.append(CpuShmTensorWrapper(t, name))
+            shm_names.append(name)
+            layer_idx += 1
+    return tensors, wrappers, shm_names
 
 
 def _send_register_kv_cache(
@@ -267,27 +322,18 @@ def _send_register_kv_cache(
     kv_caches: list[CudaIPCWrapper] | None = None,
     use_gpu: bool = True,
     use_handle: bool | None = None,
-) -> "tuple[bool, RegisterNonGpuContextResponse | None]":
+) -> "bool | RegisterNonGpuContextResponse":
     """Register a KV cache context with the MP server.
 
     Dispatches to the correct protocol based on ``use_handle``:
 
-    * Handle mode: ``REGISTER_KV_CACHE`` with a ``CudaIPCWrapper``
-      list (GPU only in this PR).
+    * Handle mode: ``REGISTER_KV_CACHE`` with a wrapper list
+      (``CudaIPCWrapper`` for GPU, ``CpuShmTensorWrapper`` for CPU).
     * Data mode: ``REGISTER_KV_CACHE_NON_GPU_CONTEXT`` with a
       ``RegisterNonGpuContextPayload`` derived from ``layout_hints``.
 
-    Returns ``(success, response)`` where ``response`` is the
-    data-mode SHM pool descriptor (``None`` in handle mode or on
-    failure). Using an explicit success flag avoids relying on the
-    truthiness of a dataclass response, which is always truthy even
-    when the server returned an empty pool descriptor.
-
     ``use_handle`` defaults to ``use_gpu`` for backwards compatibility:
     GPU always goes through the handle path, CPU defaults to data.
-
-    TODO(baoloongmao): CPU handle mode (zero-copy SHM IPC with the
-    server) will be implemented in a separate PR.
     """
     if use_handle is None:
         use_handle = use_gpu
@@ -295,7 +341,7 @@ def _send_register_kv_cache(
         if not kv_caches:
             raise ValueError(
                 "kv_caches must be a non-empty list of wrappers "
-                "(CudaIPCWrapper for GPU)"
+                "(CudaIPCWrapper for GPU, CpuShmTensorWrapper for CPU)"
             )
         hints: dict = {"kv_layout": "NHD"}
         if layout_hints:
@@ -308,12 +354,12 @@ def _send_register_kv_cache(
             world_size,
             EngineType.VLLM,
             hints,
-            [],
+            [],  # group_views: empty = single non-hybrid group
         ]
         result = _call(client, RequestType.REGISTER_KV_CACHE, payloads)
-        return (result is not _TIMEOUT, None)
+        return result is not _TIMEOUT
 
-    # Data mode: use the non-GPU context registration protocol.
+    # CPU mode: use the non-GPU context registration protocol.
     # layout_hints carries num_layers, num_heads, head_size, block_size,
     # dtype.  hidden_dim_size = num_heads * head_size (NHD layout).
     hints_d: dict = layout_hints or {}
@@ -339,14 +385,13 @@ def _send_register_kv_cache(
         use_mla=False,
     )
     result = _call(client, RequestType.REGISTER_KV_CACHE_NON_GPU_CONTEXT, [payload])
-    if result is _TIMEOUT or result is None:
-        return (False, None)
+    if result is _TIMEOUT:
+        return False
     # The data-mode register reply carries the server's SHM pool name
-    # and size; the bench keeps it so STORE/RETRIEVE can mmap the same
-    # pool and exchange tensor data via slot descriptors. A non-empty
-    # ``shm_name`` is the authoritative success signal here.
-    success = bool(getattr(result, "shm_name", ""))
-    return (success, result)
+    # and size; the bench keeps it on the side so STORE / RETRIEVE
+    # can mmap the same pool and exchange tensor data without going
+    # through pickle.
+    return result
 
 
 def _send_lookup(
@@ -405,7 +450,7 @@ def _make_event_handle(use_gpu: bool = True) -> bytes:
 
 
 def _build_server_slot_views(
-    server_pool: "memoryview",
+    server_pool: "_mmap.mmap",
     slots: list[dict[str, Any]],
 ) -> list["torch.Tensor"]:
     """Build zero-copy tensor views over server SHM slot descriptors.
@@ -442,9 +487,12 @@ def _gather_paged_to_flat_chunks(
     """Gather paged client tensors into flat per-chunk CPU tensors.
 
     Output layout matches the server's expected ``commit_store``
-    payload: each chunk is ``[2, num_layers, chunk_size, hidden_dim]``,
+    payload (set up at register time by
+    ``register_kv_cache_non_gpu_context``):
+    each chunk is ``[2, num_layers, chunk_size, hidden_dim]``,
     where ``hidden_dim = NH * HS``. Assumes a homogeneous group
-    (same NH/HS/dtype across all layers).
+    (same NH/HS/dtype across all layers); heterogeneous specs
+    fall outside the bench scope.
     """
     if chunk_size % block_size != 0:
         raise ValueError(
@@ -459,10 +507,14 @@ def _gather_paged_to_flat_chunks(
         start_b = block_offset + c * blocks_per_chunk
         per_layer: list[torch.Tensor] = []
         for t in tensors:
+            # paged: (2, NB, BS, NH, HS) -> slice block range ->
+            # (2, blocks_per_chunk, BS, NH, HS) -> flatten to
+            # (2, chunk_size, NH*HS).
             sliced = t.narrow(1, start_b, blocks_per_chunk)
             kv, _, bs, nh, hs = sliced.shape
             flat = sliced.contiguous().view(kv, blocks_per_chunk * bs, nh * hs)
             per_layer.append(flat)
+        # Stack along a new layer dim -> (2, NL, chunk_size, hidden).
         chunk = torch.stack(per_layer, dim=1).contiguous()
         if chunk.shape[1] != num_layers:
             raise RuntimeError(
@@ -497,9 +549,16 @@ def _scatter_flat_chunks_to_paged(
         for layer_idx, t in enumerate(tensors):
             kv, _, bs, nh, hs = t.shape
             target = t.narrow(1, start_b, blocks_per_chunk)
+            # chunk[:, layer_idx] is (chunk_size, hidden); reshape
+            # back to (2, blocks_per_chunk, BS, NH, HS).
             flat = chunk[:, layer_idx]
             reshaped = flat.reshape(kv, blocks_per_chunk, bs, nh, hs)
             target.copy_(reshaped)
+
+
+# ------------------------------------------------------------------ #
+#  Client-side checksum / zero-fill (data-mode self-check)             #
+# ------------------------------------------------------------------ #
 
 
 def _compute_client_checksums(
@@ -511,10 +570,13 @@ def _compute_client_checksums(
 ) -> list[str]:
     """Hash a paged block range from client-side KV tensors.
 
-    For each chunk, feed every layer's bytes for that block range
-    into a single MD5 digest. Used by the data-mode self-check:
-    cold-pass digest vs warm-pass digest verifies that RETRIEVE
-    actually wrote back the data we wrote during STORE.
+    For each chunk (``chunk_size // block_size`` consecutive blocks),
+    feed every layer's bytes for that block range into a single MD5
+    digest. The returned list maps 1:1 to the chunks the bench loop
+    expects, so a cold-pass digest can be compared with a warm-pass
+    digest to verify that ``RETRIEVE`` actually wrote back the data
+    we wrote during ``STORE`` -- without relying on a server-side
+    ``/kvcache/check`` endpoint (which only exists in handle mode).
     """
     if chunk_size % block_size != 0:
         raise ValueError(
@@ -529,6 +591,11 @@ def _compute_client_checksums(
         end_b = start_b + blocks_per_chunk
         h = hashlib.md5()
         for t in tensors:
+            # Paged layout: dim 1 is the block dim for both kv-major
+            # ``(kv, NB, BS, NH, HS)`` and MLA ``(NB, BS, NH, HS)``
+            # tensors. ``contiguous().numpy().tobytes()`` survives
+            # non-contiguous slices and dtype quirks (bfloat16 has no
+            # numpy view, but uint8 reinterpret works after slice).
             view = t.narrow(1, start_b, end_b - start_b).contiguous()
             h.update(view.view(torch.uint8).numpy().tobytes())
         checksums.append(h.hexdigest())
@@ -542,8 +609,11 @@ def _zero_fill_client_blocks(
 ) -> None:
     """Zero out a paged block range across all client tensors.
 
-    Used right before a warm-pass RETRIEVE so that any non-zero
+    Used right before a warm-pass ``RETRIEVE`` so that any non-zero
     bytes observed afterwards must have been written by the server.
+    Without this, a warm checksum equal to the cold checksum could
+    still happen even if ``RETRIEVE`` was a silent no-op (the SHM
+    pages were never overwritten in the first place).
     """
     for t in tensors:
         t.narrow(1, block_offset, num_blocks).zero_()
@@ -558,20 +628,20 @@ def _send_store(
     use_gpu: bool = True,
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
-    chunk_size: int = 256,
-    server_pool: "memoryview | None" = None,
+    chunk_size: int = 0,
+    server_pool: "_mmap.mmap | None" = None,
 ) -> str:
     """Store KV cache blocks. Returns status string.
 
-    Handle mode uses the single-shot ``STORE`` RPC (GPU CUDA-IPC).
+    Handle mode uses the single-shot ``STORE`` RPC (GPU CUDA-IPC, or
+    CPU SHM with an empty event handle).
     Data mode uses the two-phase ``PREPARE_STORE`` + ``COMMIT_STORE``.
     When ``server_pool`` and ``client_tensors`` are both supplied the
     bench gathers the paged block range into flat per-chunk CPU
-    tensors and writes them into the server-owned SHM pool via the
-    slot descriptors returned by ``PREPARE_STORE``.
-
-    TODO(baoloongmao): CPU handle mode (zero-copy SHM IPC STORE path)
-    will be implemented in a separate PR.
+    tensors and writes them straight into the server-owned SHM pool
+    via the slot descriptors returned by ``PREPARE_STORE``, so the
+    follow-up ``COMMIT_STORE`` carries an empty payload and the
+    server stays on its zero-copy SHM path.
     """
     if use_handle is None:
         use_handle = use_gpu
@@ -583,22 +653,19 @@ def _send_store(
             key,
             _INSTANCE_ID,
             [block_ids] * num_engine_group_infos,
-            _make_event_handle(use_gpu),
+            _make_event_handle(),
         ]
         result = _call(client, RequestType.STORE, payloads)
         if result is _TIMEOUT:
             return "timeout"
         return "stored" if result[1] else "store_failed"
 
-    # Data mode: PREPARE_STORE -> COMMIT_STORE
+    # CPU mode: PREPARE_STORE -> COMMIT_STORE
     prep = _call(client, RequestType.PREPARE_STORE, [key, _INSTANCE_ID])
     if prep is _TIMEOUT:
         return "timeout"
-    if prep is None:
-        return "store_failed"
     if server_pool is not None and client_tensors is not None and chunk_size > 0:
-        raw_ctx = getattr(prep, "context", None)
-        ctx = raw_ctx if isinstance(raw_ctx, dict) else {}
+        ctx = prep.context if isinstance(prep.context, dict) else {}
         slots = ctx.get("slots", []) or []
         chunk_indices = ctx.get("chunk_indices", []) or []
         if slots and chunk_indices:
@@ -613,7 +680,7 @@ def _send_store(
             slot_views = _build_server_slot_views(server_pool, slots)
             for slot_view, chunk_idx in zip(slot_views, chunk_indices, strict=False):
                 if 0 <= chunk_idx < len(full_chunks):
-                    slot_view.copy_(full_chunks[chunk_idx].reshape(slot_view.shape))
+                    slot_view.copy_(full_chunks[chunk_idx].view(slot_view.shape))
     commit = _call(client, RequestType.COMMIT_STORE, [key, _INSTANCE_ID, b""])
     if commit is _TIMEOUT:
         return "timeout"
@@ -631,19 +698,19 @@ def _send_retrieve(
     use_gpu: bool = True,
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
-    server_pool: "memoryview | None" = None,
+    server_pool: "_mmap.mmap | None" = None,
 ) -> str:
     """Retrieve KV cache blocks. Returns status.
 
-    Handle mode uses the single-shot ``RETRIEVE`` RPC (GPU CUDA-IPC).
+    Handle mode uses the single-shot ``RETRIEVE`` RPC (GPU CUDA-IPC, or
+    CPU SHM with an empty event handle).
     Data mode uses the two-phase ``PREPARE_RETRIEVE`` +
     ``COMMIT_RETRIEVE``. When ``server_pool`` and ``client_tensors``
     are both supplied the bench builds zero-copy tensor views over
     the slot descriptors returned by ``PREPARE_RETRIEVE`` and
-    scatters them back into the paged client SHM.
-
-    TODO(baoloongmao): CPU handle mode (zero-copy SHM IPC RETRIEVE
-    path) will be implemented in a separate PR.
+    scatters them back into the paged client SHM, so the round-trip
+    self-check can run without ``PREPARE_RETRIEVE`` having to ship a
+    pickled copy of the chunks.
     """
     if use_handle is None:
         use_handle = use_gpu
@@ -655,7 +722,7 @@ def _send_retrieve(
             key,
             _INSTANCE_ID,
             [block_ids] * num_engine_group_infos,
-            _make_event_handle(use_gpu),
+            _make_event_handle(),
             0,  # skip_first_n_tokens
         ]
         result = _call(client, RequestType.RETRIEVE, payloads)
@@ -663,15 +730,14 @@ def _send_retrieve(
             return "timeout"
         return "retrieved" if result[1] else "retrieve_failed"
 
-    # Data mode: PREPARE_RETRIEVE -> COMMIT_RETRIEVE
+    # CPU mode: PREPARE_RETRIEVE -> COMMIT_RETRIEVE
     prep = _call(client, RequestType.PREPARE_RETRIEVE, [key, _INSTANCE_ID])
     if prep is _TIMEOUT:
         return "timeout"
-    if prep is None or not getattr(prep, "success", False):
+    if not prep.success:
         return "retrieve_failed"
     if server_pool is not None and client_tensors is not None:
-        raw_ctx = getattr(prep, "context", None)
-        ctx = raw_ctx if isinstance(raw_ctx, dict) else {}
+        ctx = prep.context if isinstance(prep.context, dict) else {}
         slots = ctx.get("slots", []) or []
         if slots:
             try:
@@ -788,7 +854,7 @@ def _process_request(
     use_gpu: bool = True,
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
-    server_pool: "memoryview | None" = None,
+    server_pool: "_mmap.mmap | None" = None,
 ) -> list[str] | None:
     """Run the full lookup -> retrieve/store flow.
 
@@ -802,7 +868,9 @@ def _process_request(
       proves the server returned the exact bytes we sent.
 
     Handle mode keeps the historical server-side
-    ``/kvcache/check`` path; client tensors are not consulted.
+    ``/kvcache/check`` path; client tensors are not consulted (in
+    handle mode the client and server share the same SHM/IPC
+    pages, so a client-side hash equals itself by construction).
     """
     token_ids = _build_token_ids(seq_no, num_tokens)
     request_id = "req-%d-%s" % (seq_no, pass_label)
@@ -963,7 +1031,8 @@ def _process_request(
     #       cold -> ground truth captured pre-STORE
     #       warm -> hash post-RETRIEVE; cold == warm proves the
     #               server returned the exact bytes we wrote.
-    #   * handle mode: query /kvcache/check on the server.
+    #   * handle mode: query /kvcache/check on the server, which
+    #     reads the shared SHM/IPC pages directly.
     checksums: list[str] | None = None
     if client_tensors is not None and num_full_tokens > 0:
         if pass_label == "cold":

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -919,9 +919,19 @@ class LMCacheMPWorkerAdapter:
             cfg = _resolve_extra_config(extra_config)
             mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
             heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
-            self._mp_transfer_mode = cfg[ExtraConfigDefault.mp_transfer_mode.name]
+            # Only treat ``mp_transfer_mode`` as an explicit override when
+            # the user actually set it in extra_config; otherwise leave it
+            # as ``None`` so ``create_transfer_context`` can still consult
+            # the ``LMCACHE_MP_TRANSFER_MODE`` env var.
+            mp_mode_key = (
+                _EXTRA_CONFIG_KEY_PREFIX + ExtraConfigDefault.mp_transfer_mode.name
+            )
+            if mp_mode_key in extra_config:
+                self._mp_transfer_mode = cfg[ExtraConfigDefault.mp_transfer_mode.name]
+            else:
+                self._mp_transfer_mode = None
         else:
-            self._mp_transfer_mode = ExtraConfigDefault.mp_transfer_mode.value
+            self._mp_transfer_mode = None
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -775,6 +775,7 @@ def _is_hnd_format(gpu_kv_format: GPUKVFormat) -> bool:
     return int(gpu_kv_format) in (
         int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS),
         int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS),
+        int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS),
     )
 
 
@@ -836,6 +837,10 @@ def _per_layer_paged_shape(
         return (2, nb, nh, bs, hs)
     if fmt == int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS):
         return (nb, 2, nh, bs, hs)
+    if fmt == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+        # vLLM CPU blocks-first fused KV: K and V interleaved at the
+        # second-to-last dim so each layer is [NB, NH, BS, 2, HS].
+        return (nb, nh, bs, 2, hs)
     if fmt == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
         return (2, nb, bs, nh, hs)
     # Covers NL_X_NB_TWO_BS_NH_HS and any future NHD variants.
@@ -1480,6 +1485,9 @@ def _transfer_per_layer_hnd(
         # Determine K/V split based on specific format
         if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
             k_t, v_t = layer[0], layer[1]
+        elif int(gpu_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+            # vLLM CPU blocks-first fused KV: [NB, NH, BS, 2, HS].
+            k_t, v_t = layer[:, :, :, 0], layer[:, :, :, 1]
         else:
             k_t, v_t = layer[:, 0], layer[:, 1]
         _nb, nh, _bs, hs = k_t.shape

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -104,12 +104,16 @@ def batched_iteration(lst: list, batch_size: int) -> Generator[tuple, None, None
 class ContextEntry:
     """Registered cache context metadata for a single worker instance.
 
-    The actual concrete type is whatever :func:`create_cache_context`
-    returned -- currently always a :class:`GPUCacheContext`.
+    The concrete type is whatever :func:`create_cache_context` returned
+    for the wrapper list at registration time -- a
+    :class:`GPUCacheContext` for CUDA-IPC wrappers, a
+    :class:`CpuCacheContext` for POSIX-SHM wrappers. Both expose
+    the same ``kv_tensors`` / ``gpu_kv_format_`` / ``num_layers`` / ...
+    duck-typed surface, so downstream consumers stay agnostic.
 
     Args:
-        cache_context: Platform cache context managing shape and pointers
-            to the registered KV cache tensors.
+        cache_context: Platform cache context (GPU or CPU) managing
+            shape and pointers to the registered KV cache tensors.
         model_name: The name of the model associated with this KV cache.
         world_size: The world size associated with this KV cache.
     """

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -113,7 +113,7 @@ class MPCacheEngine:
 
     @property
     def gpu_contexts(self) -> dict[int, GPUCacheContext] | None:
-        """Used by ``/kvcache/check``; unwraps :class:`GPUContextEntry`."""
+        """Used by ``/kvcache/check``; unwraps :class:`ContextEntry`."""
         for module in self._modules:
             if isinstance(module, GPUTransferModule):
                 return {i: e.cache_context for i, e in module.cache_contexts.items()}

--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -164,7 +164,15 @@ class TokenHasher:
                     none_hash = kv_cache_utils.NONE_HASH
                     logger.info("Initialized NONE_HASH=%s from vLLM", none_hash)
                     return none_hash
-            except (ImportError, AttributeError, ValueError, RuntimeError):
+            except (
+                ImportError,
+                AttributeError,
+                ValueError,
+                RuntimeError,
+                # torch._dynamo.device_interface raises AssertionError
+                # when CudaInterface is defined on non-CUDA platforms.
+                AssertionError,
+            ):
                 pass
 
         # Fallback: compute none_hash using our hash function

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -5,10 +5,13 @@ The concrete implementations live in their respective sub-packages:
 
 * :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext` --
   CUDA-backed.
+* :class:`~lmcache.v1.platform.cpu.cache_context.CpuCacheContext` --
+  CPU-only fallback (POSIX-SHM-backed KV tensors).
 
 :func:`create_cache_context` keeps the dispatch out of the call site
 in :mod:`lmcache.v1.multiprocess.server` so adding a new accelerator
-only requires shipping a new sub-package + extending the factory below.
+only requires shipping a new sub-package + extending the wrapper
+isinstance check below.
 """
 
 # Future
@@ -22,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform.cpu.cache_context import CpuCacheContext
 
 if TYPE_CHECKING:
     # First Party
@@ -41,6 +45,7 @@ def create_cache_context(
     forward their kwargs verbatim and stay agnostic of the active
     backend.
 
+    Selection is driven by the wrapper type of *kv_caches*:
     Currently only :class:`GPUCacheContext` is supported.  CPU and
     other accelerator backends will be added in follow-up PRs.
 
@@ -54,19 +59,24 @@ def create_cache_context(
         engine_type: Which serving engine produced the caches.
 
     Returns:
-        A concrete cache context instance (currently always
-        :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext`).
+        A concrete cache context instance.
 
     Raises:
         ValueError: If *kv_caches* is empty.
     """
     # First Party
     from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
+    from lmcache.v1.platform.cpu.shm import CpuShmTensorWrapper
 
     if not kv_caches:
         raise ValueError("create_cache_context requires a non-empty kv_caches list")
 
-    return GPUCacheContext(
+    cls: type = (
+        CpuCacheContext
+        if any(isinstance(w, CpuShmTensorWrapper) for w in kv_caches)
+        else GPUCacheContext
+    )
+    return cls(
         kv_caches,
         lmcache_logical_chunk_size,
         layout_hints,

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -31,6 +31,9 @@ from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
+    get_attention_backend,
+    get_concrete_gpu_kv_shape_from_shape_desc,
+    get_gpu_kv_shape_description,
     get_group_data_ptrs,
     get_num_blocks,
     get_num_layers,
@@ -94,7 +97,7 @@ class CpuCacheContext:
         # PageBufferShapeDesc here. ``layout_hints`` / ``engine_type``
         # are forwarded so the signature matches GPUCacheContext.
         (
-            self.gpu_kv_format_,
+            self._gpu_kv_format,
             kv_caches_normalized,
         ) = normalize_kv_and_discover_format(
             unwrapped,
@@ -102,12 +105,12 @@ class CpuCacheContext:
             layout_hints=layout_hints,
         )
         self.kv_caches_: list[torch.Tensor] = list(kv_caches_normalized)
-        self.is_mla_ = is_mla(self.gpu_kv_format_)
-        self.num_layers_ = get_num_layers(self.kv_caches_, self.gpu_kv_format_)
-        self.num_blocks_ = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
+        self.is_mla_ = is_mla(self._gpu_kv_format)
+        self.num_layers_ = get_num_layers(self.kv_caches_, self._gpu_kv_format)
+        self.num_blocks_ = get_num_blocks(self.kv_caches_, self._gpu_kv_format)
         self.kv_layer_groups_manager_ = KVLayerGroupsManager(
             self.kv_caches_,
-            gpu_kv_format=self.gpu_kv_format_,
+            gpu_kv_format=self._gpu_kv_format,
             num_blocks=self.num_blocks_,
             layout_hints=layout_hints,
             engine_group_infos=engine_group_infos,
@@ -302,24 +305,43 @@ class CpuCacheContext:
         return self.kv_layer_groups_manager_
 
     @property
-    def gpu_kv_format_name(self) -> str:
-        """Returns the GPU KV format enum name."""
-        return self.gpu_kv_format_.name
+    def gpu_kv_format_(self):
+        """Returns the GPU KV format enum (API parity with GPUCacheContext)."""
+        return self._gpu_kv_format
 
     @property
     def gpu_kv_shape(self) -> str:
-        """Returns the GPU KV cache layout description."""
-        return "NL_X_TWO_NB_BS_NH_HS"
+        """Returns the symbolic GPU KV cache layout description."""
+        return get_gpu_kv_shape_description(self._gpu_kv_format)
 
     @property
     def attention_backend(self) -> str:
         """Returns the attention backend name."""
-        return "cpu"
+        return get_attention_backend(self._gpu_kv_format)
 
     @property
     def concrete_gpu_kv_shape(self) -> str:
-        """Returns the GPU KV shape with actual values."""
-        return "cpu-context"
+        """Returns the GPU KV shape with actual numeric values."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[0]
+        return get_concrete_gpu_kv_shape_from_shape_desc(
+            group.shape_desc, self._gpu_kv_format
+        )
+
+    def calculate_num_blocks(self, num_tokens: int, kernel_group_idx: int) -> int:
+        """Calculate the number of blocks for a given number of tokens.
+
+        Mirrors :meth:`GPUCacheContext.calculate_num_blocks`.
+
+        Args:
+            num_tokens: The total number of tokens to be processed.
+            kernel_group_idx: 0-based index of the kernel group.
+
+        Returns:
+            The number of blocks.
+        """
+        return self.kv_layer_groups_manager_.calculate_num_blocks(
+            kernel_group_idx, num_tokens
+        )
 
     def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
         """Returns the PageBufferShapeDesc for the given group."""
@@ -341,6 +363,13 @@ class CpuCacheContext:
     def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
         """Returns the KV cache pointer tensor for the given group."""
         return self.group_kv_pointers_[group_idx]
+
+    def get_kernel_group_kv_pointers(self, kernel_group_idx: int) -> torch.Tensor:
+        """Returns the KV pointer tensor for the given kernel group.
+
+        Mirrors :meth:`GPUCacheContext.get_kernel_group_kv_pointers`.
+        """
+        return self.group_kv_pointers_[kernel_group_idx]
 
     def get_kernel_group_shape_dtype(
         self,
@@ -408,6 +437,69 @@ class CpuCacheContext:
             )
         start = chunk_idx * self.tmp_chunk_bytes_
         return self.tmp_cpu_buffer_[start : start + self.tmp_chunk_bytes_]
+
+    def get_temp_kernel_group_buffer(
+        self, batch_idx: int, kernel_group_idx: int
+    ) -> torch.Tensor:
+        """Returns the typed temp buffer for the given batch and kernel group.
+
+        Mirrors :meth:`GPUCacheContext.get_temp_kernel_group_buffer`.
+
+        Args:
+            batch_idx: Batch slot index (0 <= batch_idx < max_batch_size).
+            kernel_group_idx: Index of the kernel group.
+
+        Returns:
+            A typed tensor view with the correct shape and dtype.
+        """
+        if batch_idx >= self.max_batch_size:
+            raise ValueError(
+                "batch_idx %d >= max_batch_size %d" % (batch_idx, self.max_batch_size)
+            )
+        group = self.kv_layer_groups_manager_.kv_layer_groups[kernel_group_idx]
+        shape = self.get_kv_buffer_shape(
+            self.lmcache_logical_chunk_size, kernel_group_idx
+        )
+        g_start = self.tmp_chunk_group_offsets_[kernel_group_idx]
+        g_end = self.tmp_chunk_group_offsets_[kernel_group_idx + 1]
+        chunk = self.tmp_chunk_bytes_
+        return (
+            self.tmp_cpu_buffer_[
+                batch_idx * chunk + g_start : batch_idx * chunk + g_end
+            ]
+            .view(group.dtype)
+            .view(shape)
+        )
+
+    def get_temp_object_group_buffer(
+        self, batch_idx: int, object_group_idx: int
+    ) -> torch.Tensor:
+        """Returns the flat uint8 temp buffer for the given batch and object
+        group.
+
+        Mirrors :meth:`GPUCacheContext.get_temp_object_group_buffer`.
+
+        Args:
+            batch_idx: Batch slot index (0 <= batch_idx < max_batch_size).
+            object_group_idx: Index of the object group.
+
+        Returns:
+            A flat uint8 tensor view covering the object group's byte range.
+        """
+        if batch_idx >= self.max_batch_size:
+            raise ValueError(
+                "batch_idx %d >= max_batch_size %d" % (batch_idx, self.max_batch_size)
+            )
+        manager = self.kv_layer_groups_manager_
+        object_group = manager.object_groups[object_group_idx]
+        kg_indices = object_group.kernel_group_indices
+        # Object group spans from the first to the last kernel group's range.
+        g_start = self.tmp_chunk_group_offsets_[kg_indices[0]]
+        g_end = self.tmp_chunk_group_offsets_[kg_indices[-1] + 1]
+        chunk = self.tmp_chunk_bytes_
+        return self.tmp_cpu_buffer_[
+            batch_idx * chunk + g_start : batch_idx * chunk + g_end
+        ]
 
     def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
         """Returns a typed view of the temp buffer for one chunk."""
@@ -483,6 +575,58 @@ class CpuCacheContext:
             self.block_ids_buffer_[offsets[i] : offsets[i + 1]]
             for i in range(len(block_ids_per_group))
         ]
+
+    def report_status(self) -> dict:
+        """Return this context's KV cache layout metadata.
+
+        Mirrors :meth:`GPUCacheContext.report_status` so
+        ``GPUTransferModule.report_status`` can duck-type across backends.
+        """
+        manager = self.kv_layer_groups_manager_
+        kernel_groups = manager.kernel_groups
+
+        kernel_group_to_object_group: dict[int, int] = {
+            kg_idx: og_idx
+            for og_idx, og in enumerate(manager.object_groups)
+            for kg_idx in og.kernel_group_indices
+        }
+
+        gpu_kv_format = self._gpu_kv_format
+        group_reports: list[dict] = []
+        for kernel_group_idx, group in enumerate(kernel_groups):
+            group_reports.append(
+                {
+                    "kernel_group_idx": kernel_group_idx,
+                    "engine_group_idx": group.engine_group_idx,
+                    "object_group_idx": kernel_group_to_object_group.get(
+                        kernel_group_idx, 0
+                    ),
+                    "num_layers": group.num_layers,
+                    "layer_indices": list(group.layer_indices),
+                    "physical_block_size": group.shape_desc.bs,
+                    "compress_ratio": group.compress_ratio,
+                    "dtype": str(group.dtype),
+                    "gpu_kv_concrete_shape": (
+                        get_concrete_gpu_kv_shape_from_shape_desc(
+                            group.shape_desc, gpu_kv_format
+                        )
+                    ),
+                    "is_mla": is_mla(gpu_kv_format),
+                    "gpu_kv_format": gpu_kv_format.name,
+                    "gpu_kv_shape": get_gpu_kv_shape_description(gpu_kv_format),
+                    "attention_backend": get_attention_backend(gpu_kv_format),
+                }
+            )
+
+        return {
+            "num_layers": self.num_layers_,
+            "inference_engine_logical_block_size": (
+                manager.inference_engine_logical_block_size
+            ),
+            "num_blocks": self.num_blocks_,
+            "cache_size_per_token": self.cache_size_per_token(),
+            "kernel_groups": group_reports,
+        }
 
     def cache_size_per_token(self) -> int:
         """Returns cache size per *logical* token in bytes,

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -342,6 +342,40 @@ class CpuCacheContext:
         """Returns the KV cache pointer tensor for the given group."""
         return self.group_kv_pointers_[group_idx]
 
+    def get_kernel_group_shape_dtype(
+        self,
+        num_tokens: int,
+        kernel_group_idx: int,
+    ) -> tuple[torch.Size, torch.dtype]:
+        """Returns the shape and dtype for the given kernel group index and
+        number of tokens.
+
+        Mirrors :meth:`GPUCacheContext.get_kernel_group_shape_dtype` so
+        callers such as ``gpu_transfer.get_layout_desc`` can duck-type
+        across GPU and CPU backends.
+
+        Args:
+            num_tokens: Number of tokens.
+            kernel_group_idx: Index of the kernel group.
+
+        Returns:
+            A ``(shape, dtype)`` tuple for the given kernel group.
+        """
+        group = self.kv_layer_groups_manager_.kv_layer_groups[kernel_group_idx]
+        compress_ratio = group.compress_ratio
+        if num_tokens % compress_ratio != 0:
+            raise ValueError(
+                "num_tokens (%d) is not a multiple of compress_ratio (%d) "
+                "for kernel_group_idx %d"
+                % (num_tokens, compress_ratio, kernel_group_idx)
+            )
+        num_slots = num_tokens // compress_ratio
+        sd = group.shape_desc
+        shape = torch.Size(
+            (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
+        )
+        return shape, group.dtype
+
     def get_kv_buffer_shape(
         self, logical_num_tokens: int, group_idx: int = 0
     ) -> torch.Size:

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only cache context for platforms without CUDA GPUs.
+
+This module lives in the ``platform.cpu`` sub-package because it is
+the CPU-specific implementation of the cross-platform cache context
+-- it provides the same public API as
+:class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext` but
+keeps all tensors on CPU. Stream / Event objects are provided by
+:class:`~lmcache.v1.platform.cpu.stub_cpu_device.StubStream` so
+CPU-only hosts never import ``cupy`` or instantiate a real CUDA
+stream object.
+
+The platform-agnostic dispatcher ``create_cache_context`` lives in
+:mod:`lmcache.v1.platform.cache_context`.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+import array
+import os
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import (
+    LayoutHints,
+    get_group_data_ptrs,
+    get_num_blocks,
+    get_num_layers,
+    is_mla,
+    normalize_kv_and_discover_format,
+)
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
+import lmcache.c_ops as lmc_ops
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+
+logger = init_logger(__name__)
+
+
+class CpuCacheContext:
+    """CPU-only cache context with the same public API as
+    :class:`GPUCacheContext`.
+
+    All tensors live on CPU. CUDA streams and cupy streams are
+    replaced by :class:`StubStream` no-op objects so callers can keep
+    using ``stream.synchronize()`` / ``wait_event(...)`` etc. without
+    branching on the active backend.
+
+    KV cache tensors are reconstructed from the
+    :class:`CpuShmTensorWrapper` instances sent by the client over
+    POSIX shared memory -- the server does **not** allocate the KV
+    cache itself. This mirrors the GPU-mode CUDA-IPC flow where the
+    client owns the buffers and the server only maps them.
+    """
+
+    def __init__(
+        self,
+        kv_caches: KVCache,
+        lmcache_logical_chunk_size: int = 256,
+        layout_hints: LayoutHints | None = None,
+        engine_group_infos: "Sequence[EngineGroupInfo]" = (),
+        engine_type: EngineType = EngineType.VLLM,
+    ) -> None:
+        if not kv_caches:
+            raise ValueError(
+                "CpuCacheContext requires a non-empty list of "
+                "CpuShmTensorWrapper; the legacy server-side "
+                "self-allocation path has been removed."
+            )
+
+        # First Party
+        from lmcache.v1.multiprocess.gpu_context import (
+            unwrap_kv_cache_tensors,
+        )
+
+        unwrapped = unwrap_kv_cache_tensors(kv_caches)
+        self.device_ = torch.device("cpu")
+        self.lmcache_logical_chunk_size = lmcache_logical_chunk_size
+
+        # Discover layout & build KV layer groups via the same path
+        # GPUCacheContext uses, so we don't need to hand-roll any
+        # PageBufferShapeDesc here. ``layout_hints`` / ``engine_type``
+        # are forwarded so the signature matches GPUCacheContext.
+        (
+            self.gpu_kv_format_,
+            kv_caches_normalized,
+        ) = normalize_kv_and_discover_format(
+            unwrapped,
+            engine_type,
+            layout_hints=layout_hints,
+        )
+        self.kv_caches_: list[torch.Tensor] = list(kv_caches_normalized)
+        self.is_mla_ = is_mla(self.gpu_kv_format_)
+        self.num_layers_ = get_num_layers(self.kv_caches_, self.gpu_kv_format_)
+        self.num_blocks_ = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
+        self.kv_layer_groups_manager_ = KVLayerGroupsManager(
+            self.kv_caches_,
+            gpu_kv_format=self.gpu_kv_format_,
+            num_blocks=self.num_blocks_,
+            layout_hints=layout_hints,
+            engine_group_infos=engine_group_infos,
+            lmcache_logical_chunk_size=lmcache_logical_chunk_size,
+        )
+
+        # Per-group KV pointer tensors (CPU). Reuse the same helper
+        # GPUCacheContext relies on so the layout matches exactly.
+        self.group_kv_pointers_: list[torch.Tensor] = [
+            torch.tensor(
+                get_group_data_ptrs(
+                    self.kv_caches_,
+                    self.gpu_kv_format_,
+                    group.layer_indices,
+                ),
+                dtype=torch.long,
+            )
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+
+        # Backwards-compat aliases (a few callers still expect these).
+        self.hidden_dim_sizes_: list[int] = [
+            group.hidden_dim_size
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+        self.kv_cache_pointers_ = torch.tensor(
+            [t.data_ptr() for t in self.kv_caches_], dtype=torch.long
+        )
+
+        # Pre-allocated block IDs buffer (CPU).
+        _MAX_BLOCK_IDS = 1_000_000
+        self.block_ids_buffer_ = torch.empty(_MAX_BLOCK_IDS, dtype=torch.long)
+
+        # Temporary buffer for transfers (same layout as
+        # GPUCacheContext but on CPU).
+        self.max_batch_size = 4
+        self.tmp_chunk_group_offsets_: list[int] = [0]
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
+            byte_size = shape.numel() * group.dtype.itemsize
+            self.tmp_chunk_group_offsets_.append(
+                self.tmp_chunk_group_offsets_[-1] + byte_size
+            )
+        self.tmp_chunk_bytes_ = self.tmp_chunk_group_offsets_[-1]
+        # Buffer lives on CPU; keep the attribute name aligned with the
+        # context to avoid GPU-prefixed naming bleeding into a CPU-only
+        # class. The public ``get_tmp_gpu_buffer_flat`` method name is
+        # preserved so ``server.py`` can duck-type across backends.
+        self.tmp_cpu_buffer_ = torch.empty(
+            self.tmp_chunk_bytes_ * self.max_batch_size,
+            dtype=torch.uint8,
+        )
+
+        # Mock streams. ``StubStream`` already implements the small
+        # subset of the API server-side code uses (``synchronize``,
+        # ``wait_event``, ``record_event`` ...), so we never import
+        # cupy or instantiate a real CUDA stream object here.
+        self.cuda_stream_: StubStream = StubStream(device="cpu")
+        self.cupy_stream_: StubStream = self.cuda_stream_
+        self.high_priority_cuda_stream_: StubStream = StubStream(
+            device="cpu", priority=0
+        )
+        self.high_priority_cupy_stream_: StubStream = self.high_priority_cuda_stream_
+
+        # Sanity-check: warn if /dev/shm looks too small for the
+        # registered KV cache. Only meaningful on Linux where
+        # /dev/shm is the default tmpfs backing POSIX SHM.
+        self._check_shm_capacity()
+
+        logger.info(
+            "CpuCacheContext: %d layers, %d blocks, dtype=%s (shm-backed)",
+            self.num_layers_,
+            self.num_blocks_,
+            self.kv_caches_[0].dtype,
+        )
+
+    # -- Internal helpers --
+
+    _SHM_PATH = "/dev/shm"
+
+    def _check_shm_capacity(self) -> None:
+        """Warn if /dev/shm free space is smaller than the KV cache."""
+        if not os.path.isdir(self._SHM_PATH):
+            return
+        try:
+            st = os.statvfs(self._SHM_PATH)
+        except OSError:
+            return
+        free_bytes = st.f_bavail * st.f_frsize
+        kv_bytes = sum(t.numel() * t.element_size() for t in self.kv_caches_)
+        if kv_bytes > free_bytes:
+            logger.warning(
+                "Insufficient /dev/shm space for CPU KV cache: "
+                "need %d bytes but only %d bytes available. "
+                "Consider increasing the size of /dev/shm "
+                "(e.g. mount -o remount,size=<N>G /dev/shm).",
+                kv_bytes,
+                free_bytes,
+            )
+
+    # -- Properties (same API as GPUCacheContext) --
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Returns the dtype of the KV cache tensors."""
+        return self.kv_caches_[0].dtype
+
+    @property
+    def device(self) -> torch.device:
+        """Returns the device (always CPU)."""
+        return self.device_
+
+    @property
+    def kv_tensors(self) -> list[torch.Tensor]:
+        """Returns the list of per-layer KV cache tensors."""
+        return self.kv_caches_
+
+    @property
+    def kv_pointers(self) -> torch.Tensor:
+        """Returns a tensor of KV cache data pointers."""
+        return self.kv_cache_pointers_
+
+    @property
+    def stream(self) -> StubStream:
+        """Returns the (mock) CUDA stream."""
+        return self.cuda_stream_
+
+    @property
+    def cupy_stream(self) -> StubStream:
+        """Returns the (mock) external stream."""
+        return self.cupy_stream_
+
+    @property
+    def high_priority_stream(self) -> StubStream:
+        """Returns the (mock) high-priority CUDA stream."""
+        return self.high_priority_cuda_stream_
+
+    @property
+    def high_priority_cupy_stream(self) -> StubStream:
+        """Returns the (mock) high-priority external stream."""
+        return self.high_priority_cupy_stream_
+
+    @property
+    def block_size(self) -> int:
+        """Returns the block size (tokens per block)."""
+        return self.kv_layer_groups_manager_.kv_layer_groups[0].shape_desc.bs
+
+    @property
+    def num_layers(self) -> int:
+        """Returns the number of layers in the model."""
+        return self.num_layers_
+
+    @property
+    def num_blocks(self) -> int:
+        """Returns the number of blocks in the KV cache."""
+        return self.num_blocks_
+
+    @property
+    def is_mla(self) -> bool:
+        """Returns whether the model uses MLA."""
+        return self.is_mla_
+
+    @property
+    def hidden_dim_sizes(self) -> list[int]:
+        """Returns hidden dimension sizes per KV layer group."""
+        return self.hidden_dim_sizes_
+
+    @property
+    def group_physical_block_sizes(self) -> list[int]:
+        """Per-group physical slot count (``shape_desc.bs``) in group
+        order."""
+        return [
+            group.shape_desc.bs
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+
+    @property
+    def group_compress_ratios(self) -> list[int]:
+        """Per-group compression ratio in group order.
+        ``1`` for non-compressed groups.
+        """
+        return [
+            group.compress_ratio
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+
+    @property
+    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
+        """Returns the KV layer groups manager."""
+        return self.kv_layer_groups_manager_
+
+    @property
+    def gpu_kv_format_name(self) -> str:
+        """Returns the GPU KV format enum name."""
+        return self.gpu_kv_format_.name
+
+    @property
+    def gpu_kv_shape(self) -> str:
+        """Returns the GPU KV cache layout description."""
+        return "NL_X_TWO_NB_BS_NH_HS"
+
+    @property
+    def attention_backend(self) -> str:
+        """Returns the attention backend name."""
+        return "cpu"
+
+    @property
+    def concrete_gpu_kv_shape(self) -> str:
+        """Returns the GPU KV shape with actual values."""
+        return "cpu-context"
+
+    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
+        """Returns the PageBufferShapeDesc for the given group."""
+        return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
+
+    def get_physical_chunk_size(self, group_idx: int) -> int:
+        """Returns the per-chunk physical slot count for the group."""
+        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
+
+    def blocks_for_tokens(self, num_logical_tokens: int, group_idx: int) -> int:
+        """Number of blocks that span *num_logical_tokens* for a group.
+
+        Mirrors :meth:`GPUCacheContext.blocks_for_tokens`.
+        """
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        physical_slots = num_logical_tokens // group.compress_ratio
+        return physical_slots // group.shape_desc.bs
+
+    def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
+        """Returns the KV cache pointer tensor for the given group."""
+        return self.group_kv_pointers_[group_idx]
+
+    def get_kv_buffer_shape(
+        self, logical_num_tokens: int, group_idx: int = 0
+    ) -> torch.Size:
+        """Returns the KV buffer shape for the given number of
+        *logical* tokens.
+
+        Mirrors :meth:`GPUCacheContext.get_kv_buffer_shape`:
+        divides by ``compress_ratio`` and uses ``sd.kv_size`` so
+        compressed groups (MLA etc.) get the correct shape.
+        """
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        compress_ratio = group.compress_ratio
+        if logical_num_tokens % compress_ratio != 0:
+            raise ValueError(
+                "logical_num_tokens (%d) is not a multiple of "
+                "compress_ratio (%d) for group %d"
+                % (logical_num_tokens, compress_ratio, group_idx)
+            )
+        num_slots = logical_num_tokens // compress_ratio
+        sd = group.shape_desc
+        return torch.Size(
+            (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
+        )
+
+    def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
+        """Returns the flat uint8 temp buffer for the given chunk."""
+        if chunk_idx >= self.max_batch_size:
+            raise ValueError(
+                "chunk_idx %d >= max_batch_size %d" % (chunk_idx, self.max_batch_size)
+            )
+        start = chunk_idx * self.tmp_chunk_bytes_
+        return self.tmp_cpu_buffer_[start : start + self.tmp_chunk_bytes_]
+
+    def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
+        """Returns a typed view of the temp buffer for one chunk."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        start = self.tmp_chunk_group_offsets_[group_idx]
+        end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        return self.tmp_cpu_buffer_[start:end].view(group.dtype).view(shape)
+
+    def get_tmp_chunk_gpu_buffer_batched(
+        self, batch_size: int, group_idx: int = 0
+    ) -> list[torch.Tensor]:
+        """Returns a list of non-overlapping temp buffer views."""
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                "batch_size %d > max_batch_size %d" % (batch_size, self.max_batch_size)
+            )
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        g_start = self.tmp_chunk_group_offsets_[group_idx]
+        g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        chunk = self.tmp_chunk_bytes_
+        return [
+            self.tmp_cpu_buffer_[i * chunk + g_start : i * chunk + g_end]
+            .view(group.dtype)
+            .view(shape)
+            for i in range(batch_size)
+        ]
+
+    def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
+        """Copy block IDs into the pre-allocated buffer."""
+        if not block_ids:
+            raise ValueError("stage_block_ids requires a non-empty block_ids list")
+        n = len(block_ids)
+        capacity = self.block_ids_buffer_.shape[0]
+        if n > capacity:
+            raise ValueError(
+                "stage_block_ids: %d block IDs exceeds buffer capacity %d"
+                % (n, capacity)
+            )
+        cpu_tensor = torch.tensor(block_ids, dtype=torch.long)
+        buf = self.block_ids_buffer_[:n]
+        buf.copy_(cpu_tensor)
+        return buf
+
+    def copy_view_block_ids_to_gpu(
+        self, block_ids_per_group: list[list[int]]
+    ) -> list[torch.Tensor]:
+        """CPU-side counterpart to ``GPUCacheContext.copy_view_block_ids_to_gpu``.
+
+        Packs all per-group block IDs into the shared CPU buffer and
+        returns one non-overlapping view per LMCache group. The name
+        is kept for API parity; on a CPU-only host the buffer simply
+        lives on the host.
+        """
+        offsets = [0]
+        flat: array.array = array.array("l")
+        for view_block_ids in block_ids_per_group:
+            flat.extend(view_block_ids)
+            offsets.append(len(flat))
+
+        total = offsets[-1]
+        if total > self.block_ids_buffer_.shape[0]:
+            raise ValueError(
+                "block ID total %d exceeds the pre-allocated buffer "
+                "size %d" % (total, self.block_ids_buffer_.shape[0])
+            )
+        if total:
+            cpu_tensor = torch.frombuffer(flat, dtype=torch.long)
+            self.block_ids_buffer_[:total].copy_(cpu_tensor)
+
+        return [
+            self.block_ids_buffer_[offsets[i] : offsets[i + 1]]
+            for i in range(len(block_ids_per_group))
+        ]
+
+    def cache_size_per_token(self) -> int:
+        """Returns cache size per *logical* token in bytes,
+        summed across all groups.
+
+        Mirrors :meth:`GPUCacheContext.cache_size_per_token`.
+        """
+        total = 0
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            numels = self.get_kv_buffer_shape(group.compress_ratio, group_idx).numel()
+            slot_bytes = numels * group.dtype.itemsize
+            total += slot_bytes // group.compress_ratio
+        return total

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -123,10 +123,16 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
         flat = torch.frombuffer(buf, dtype=torch.uint8)
         typed = flat.view(self.dtype)
         out = torch.as_strided(typed, self.shape, self.stride, self.storage_offset)
-        # Keep ``flat`` alive for the lifetime of ``out`` so its mmap
-        # is not released while still in use, then munmap on cleanup.
-        out._lmcache_shm_buf = flat  # type: ignore[attr-defined]
-        weakref.finalize(out, shm_munmap, addr, self.nbytes)
+        # Pin the mmap to the *storage*, not the outer tensor: views
+        # (reshape / slicing) create new tensor objects that share the
+        # storage but do not inherit Python attributes, so a finalizer
+        # attached to ``out`` would munmap as soon as ``out`` is GC'd
+        # even when a view is still reading the SHM segment.
+        # ``UntypedStorage`` is shared across views, so finalizing on it
+        # only fires once every view is also dropped.
+        storage = out.untyped_storage()
+        _CPU_SHM_KEEP_ALIVE[id(storage)] = flat
+        weakref.finalize(storage, _release_shm_segment, id(storage), addr, self.nbytes)
         return out
 
 
@@ -151,6 +157,25 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
 _CPU_SHM_NAMES: dict[int, tuple["weakref.ReferenceType[torch.Tensor]", str]] = {}
 _CPU_SHM_LOCK = threading.Lock()
 _CPU_SHM_COUNTER = itertools.count()
+
+
+# Process-level registry that pins the base ``flat`` buffer of every live
+# ``to_tensor()`` mmap until its storage is finalized. Keyed by ``id(storage)``,
+# which is stable across views because PyTorch caches the storage Python
+# wrapper (so reshape / slicing returns the same ``UntypedStorage`` object).
+_CPU_SHM_KEEP_ALIVE: dict[int, torch.Tensor] = {}
+
+
+def _release_shm_segment(storage_id: int, addr: int, nbytes: int) -> None:
+    """Drop the pinned base buffer and ``munmap`` the mapping.
+
+    Invoked by ``weakref.finalize`` on the tensor's ``UntypedStorage`` once
+    every view of the mapping is gone, so views (e.g. ``reshape`` returning
+    a new tensor without ``_lmcache_shm_buf``) cannot trigger a premature
+    unmap that would turn into a use-after-free in the next read.
+    """
+    _CPU_SHM_KEEP_ALIVE.pop(storage_id, None)
+    shm_munmap(addr, nbytes)
 
 
 def _cleanup_shm_segment(tid: int, shm_name: str, addr: int, nbytes: int) -> None:

--- a/lmcache/v1/platform/cpu/stub_cpu_device.py
+++ b/lmcache/v1/platform/cpu/stub_cpu_device.py
@@ -116,6 +116,25 @@ class StubStream:
         self.device = device
         self.priority = priority
         self.cuda_stream = 0
+        # Mirrors the ``ptr`` attribute exposed by ``cupy.cuda.Stream``
+        # so callers (e.g. ``mp_observability.event_bus``) that pass a
+        # raw stream pointer to native recorders accept this stub
+        # without an isinstance check.
+        self.ptr = 0
+
+    def launch_host_func(self, callback: Any, arg: Any = None) -> None:
+        """Run ``callback(arg)`` synchronously.
+
+        ``cupy.cuda.Stream.launch_host_func`` schedules the callback
+        on the GPU stream's host-side completion queue; with no real
+        stream there's nothing to wait for, so we just invoke it
+        immediately. Exceptions are swallowed to mirror the cupy
+        contract (callbacks are best-effort and must not propagate).
+        """
+        try:
+            callback(arg)
+        except Exception:  # noqa: BLE001
+            pass
 
     def synchronize(self) -> None:
         """Block the host until all kernels on this stream complete.

--- a/lmcache/v1/platform/cpu/stub_cpu_device.py
+++ b/lmcache/v1/platform/cpu/stub_cpu_device.py
@@ -6,6 +6,11 @@ from __future__ import annotations
 from contextlib import nullcontext
 from typing import Any
 
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
 
 class StubDeviceProperties:
     """Stub for torch_dev.get_device_properties() return value."""
@@ -133,8 +138,8 @@ class StubStream:
         """
         try:
             callback(arg)
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as e:  # noqa: BLE001
+            logger.warning("launch_host_func callback raised: %s", e)
 
     def synchronize(self) -> None:
         """Block the host until all kernels on this stream complete.

--- a/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
@@ -129,9 +129,16 @@ def test_multi_layer_block_kv_transfer_roundtrip():
 
     block_ids = torch.tensor(list(range(NB)), dtype=torch.long)
 
+    # Match the C++ binding's strict signature: 1D int64 tensor of paged
+    # buffer ``data_ptr()`` values, and a list of int ``data_ptr()`` for
+    # the lmcache objects (the fallback also accepts tensors directly,
+    # but the compiled extension does not).
+    norm_ptrs = torch.tensor([t.data_ptr() for t in norm], dtype=torch.long)
+    obj_ptrs = [obj.data_ptr()]
+
     lmc_ops.multi_layer_block_kv_transfer(
-        norm,
-        [obj],
+        norm_ptrs,
+        obj_ptrs,
         block_ids,
         torch.device("cpu"),
         lmc_ops.TransferDirection.D2H,
@@ -143,9 +150,10 @@ def test_multi_layer_block_kv_transfer_roundtrip():
 
     # H2D into a fresh per-layer buffer set; round-trip must be bit-exact.
     out = [torch.zeros_like(layer) for layer in norm]
+    out_ptrs = torch.tensor([t.data_ptr() for t in out], dtype=torch.long)
     lmc_ops.multi_layer_block_kv_transfer(
-        out,
-        [obj],
+        out_ptrs,
+        obj_ptrs,
         block_ids,
         torch.device("cpu"),
         lmc_ops.TransferDirection.H2D,

--- a/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache.python_ops_fallback import set_shape_desc_dtype
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector import utils as U
 from lmcache.v1.multiprocess.transfer_context.base import (
@@ -124,7 +125,7 @@ def test_multi_layer_block_kv_transfer_roundtrip():
     sd.hs = HS
     sd.element_size = norm[0].element_size()
     sd.block_stride_elems = NH * BS * 2 * HS
-    sd.dtype = norm[0].dtype
+    set_shape_desc_dtype(sd, norm[0].dtype)
 
     block_ids = torch.tensor(list(range(NB)), dtype=torch.long)
 

--- a/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
@@ -16,7 +16,12 @@ import pytest
 import torch
 
 # First Party
-from lmcache.python_ops_fallback import set_shape_desc_dtype
+from lmcache.python_ops_fallback import (
+    multi_layer_block_kv_transfer as fallback_multi_layer_block_kv_transfer,
+)
+from lmcache.python_ops_fallback import (
+    set_shape_desc_dtype,
+)
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector import utils as U
 from lmcache.v1.multiprocess.transfer_context.base import (
@@ -136,7 +141,11 @@ def test_multi_layer_block_kv_transfer_roundtrip():
     norm_ptrs = torch.tensor([t.data_ptr() for t in norm], dtype=torch.long)
     obj_ptrs = [obj.data_ptr()]
 
-    lmc_ops.multi_layer_block_kv_transfer(
+    # Drive the python fallback directly: this regression specifically
+    # targets the CPU handle-mode path. ``lmc_ops.multi_layer_block_kv_transfer``
+    # is replaced by the CUDA C++ extension when CUDA is available, and that
+    # extension rejects ``torch.device("cpu")`` with a CUDAGuard error.
+    fallback_multi_layer_block_kv_transfer(
         norm_ptrs,
         obj_ptrs,
         block_ids,
@@ -151,7 +160,7 @@ def test_multi_layer_block_kv_transfer_roundtrip():
     # H2D into a fresh per-layer buffer set; round-trip must be bit-exact.
     out = [torch.zeros_like(layer) for layer in norm]
     out_ptrs = torch.tensor([t.data_ptr() for t in out], dtype=torch.long)
-    lmc_ops.multi_layer_block_kv_transfer(
+    fallback_multi_layer_block_kv_transfer(
         out_ptrs,
         obj_ptrs,
         block_ids,

--- a/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
@@ -98,3 +98,61 @@ def test_mp_gather_scatter_roundtrip():
     untouched = torch.tensor([b for b in range(NB) if b not in block_ids])
     for k in dst:
         assert torch.equal(dst[k][untouched], ref[k][untouched])
+
+
+def test_multi_layer_block_kv_transfer_roundtrip():
+    """Server-side copy (handle mode) D2H + H2D round-trip.
+
+    Regression for the CI ``cpu_e2e_validation (server-side copy)`` failure:
+    ``GPUTransferModule.store`` calls ``multi_layer_block_kv_transfer`` for
+    this format, so the per-layer HND fallback must recognize it and split
+    K/V at dim 3.
+    """
+    # Use canonical 5D layers so the fallback exercises the HND split path.
+    fmt, norm = U.normalize_kv_and_discover_format(
+        _raw_blocks_first_caches(), EngineType.VLLM, HINTS
+    )
+    chunk_tokens = NB * BS
+    obj = torch.zeros((2, NL, chunk_tokens, NH * HS), dtype=norm[0].dtype)
+
+    sd = lmc_ops.PageBufferShapeDesc()
+    sd.kv_size = 2
+    sd.nl = NL
+    sd.nb = NB
+    sd.bs = BS
+    sd.nh = NH
+    sd.hs = HS
+    sd.element_size = norm[0].element_size()
+    sd.block_stride_elems = NH * BS * 2 * HS
+    sd.dtype = norm[0].dtype
+
+    block_ids = torch.tensor(list(range(NB)), dtype=torch.long)
+
+    lmc_ops.multi_layer_block_kv_transfer(
+        norm,
+        [obj],
+        block_ids,
+        torch.device("cpu"),
+        lmc_ops.TransferDirection.D2H,
+        sd,
+        chunk_tokens,
+        fmt,
+        0,
+    )
+
+    # H2D into a fresh per-layer buffer set; round-trip must be bit-exact.
+    out = [torch.zeros_like(layer) for layer in norm]
+    lmc_ops.multi_layer_block_kv_transfer(
+        out,
+        [obj],
+        block_ids,
+        torch.device("cpu"),
+        lmc_ops.TransferDirection.H2D,
+        sd,
+        chunk_tokens,
+        fmt,
+        0,
+    )
+
+    for original, recovered in zip(norm, out, strict=True):
+        assert torch.equal(original, recovered)

--- a/tests/v1/multiprocess/test_non_cuda_data_transfer.py
+++ b/tests/v1/multiprocess/test_non_cuda_data_transfer.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Protocol
 from unittest.mock import MagicMock, patch
-import mmap
 import os
 import pickle
 import sys
@@ -15,6 +14,12 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.multiprocess.posix_shm import (
+    shm_create_readwrite,
+    shm_munmap,
+    shm_open_pool_as_mmap,
+    shm_unlink,
+)
 from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.protocols.engine import (
     PrepareRetrieveResponse,
@@ -277,6 +282,43 @@ def test_resolve_extra_config_overrides_mp_transfer_mode() -> None:
     assert cfg[ExtraConfigDefault.mp_transfer_mode.name] == "data"
 
 
+def test_extra_config_default_lets_env_var_select_mp_transfer_mode(
+    monkeypatch: Any,
+) -> None:
+    """When extra_config omits mp_transfer_mode, env var must still win.
+
+    The adapter detects the absence of ``lmcache.mp.mp_transfer_mode`` and
+    passes ``mode=None`` to ``create_transfer_context``, which then reads
+    the ``LMCACHE_MP_TRANSFER_MODE`` env var. Regression test for
+    buildkite k3-multiprocess CI ``cpu_e2e_validation (server-side copy)``.
+    """
+    # First Party
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        _EXTRA_CONFIG_KEY_PREFIX,
+        ExtraConfigDefault,
+    )
+    from lmcache.v1.multiprocess.transfer_context import (
+        HandleTransferContext,
+        create_transfer_context,
+    )
+    from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
+        ENV_MP_TRANSFER_MODE,
+    )
+
+    mp_mode_key = _EXTRA_CONFIG_KEY_PREFIX + ExtraConfigDefault.mp_transfer_mode.name
+    # Simulate adapter init: extra_config omits the mp_transfer_mode key.
+    extra_config: dict[str, Any] = {"lmcache.mp.mq_timeout": "1"}
+    resolved_mode = extra_config[mp_mode_key] if mp_mode_key in extra_config else None
+    assert resolved_mode is None
+
+    # With env=handle and mode=None, CPU KV must pick HandleTransferContext.
+    monkeypatch.setenv(ENV_MP_TRANSFER_MODE, "handle")
+    context = create_transfer_context(
+        {"layer_0": torch.randn(2, 2)}, mode=resolved_mode
+    )
+    assert isinstance(context, HandleTransferContext)
+
+
 def test_create_transfer_context_force_data_mode() -> None:
     """``mode='data'`` must always pick DataTransferContext, even for CUDA."""
     # First Party
@@ -290,6 +332,21 @@ def test_create_transfer_context_force_data_mode() -> None:
         {"layer_0": torch.randn(2, 2)}, mode=MPTransferMode.DATA
     )
     assert isinstance(context, DataTransferContext)
+
+
+def test_create_transfer_context_force_handle_mode_on_cpu() -> None:
+    """``mode='handle'`` on CPU works because the CPU SHM wrapper is registered."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import (
+        HandleTransferContext,
+        create_transfer_context,
+    )
+
+    # Importing the CPU sub-package self-registers its KV-wrapper factory.
+    import lmcache.v1.platform.cpu  # noqa: F401
+
+    context = create_transfer_context({"layer_0": torch.randn(2, 2)}, mode="handle")
+    assert isinstance(context, HandleTransferContext)
 
 
 def test_create_transfer_context_invalid_mode_raises() -> None:
@@ -317,6 +374,24 @@ def test_create_transfer_context_handle_mode_unsupported_device_raises(
             create_transfer_context({"layer_0": torch.randn(2, 2)}, mode="handle")
     finally:
         platform_registry.restore(snapshot)
+
+
+def test_create_transfer_context_env_var_overrides_default(
+    monkeypatch: Any,
+) -> None:
+    """``LMCACHE_MP_TRANSFER_MODE=data`` must force the data path."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import (
+        DataTransferContext,
+        create_transfer_context,
+    )
+    from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
+        ENV_MP_TRANSFER_MODE,
+    )
+
+    monkeypatch.setenv(ENV_MP_TRANSFER_MODE, "data")
+    context = create_transfer_context({"layer_0": torch.randn(2, 2)})
+    assert isinstance(context, DataTransferContext)
 
 
 @pytest.mark.parametrize(
@@ -965,22 +1040,25 @@ class _CompletedFuture:
         return self._value
 
 
-def _create_shm_file(shm_name: str, size: int) -> str:
-    path = os.path.join("/dev/shm", shm_name.lstrip("/"))
-    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
-    os.ftruncate(fd, size)
-    os.close(fd)
-    return path
+def _create_shm_segment(shm_name: str, size: int) -> int:
+    """Create a POSIX SHM segment via the project facade.
+
+    Returns the owner mmap address so the test can release the segment
+    with ``shm_munmap`` + ``shm_unlink`` regardless of platform
+    (Linux/macOS), instead of hard-coding ``/dev/shm`` paths.
+    """
+    return shm_create_readwrite(shm_name, size)
 
 
 def test_non_gpu_context_shm_tensor_view_from_buffer() -> None:
     shm_name = f"lmcache_test_view_{os.getpid()}"
-    shm_path = _create_shm_file(shm_name, 4096)
+    addr = _create_shm_segment(shm_name, 4096)
     try:
-        with open(shm_path, "r+b") as f:
-            mm = mmap.mmap(f.fileno(), 4096, access=mmap.ACCESS_WRITE)
+        mm = shm_open_pool_as_mmap(shm_name, 4096)
+        try:
             src = torch.arange(8, dtype=torch.float32).reshape(2, 4)
             mm[: src.numel() * src.element_size()] = src.numpy().tobytes()
+        finally:
             mm.close()
 
         context = NonGpuContextShm(
@@ -1008,13 +1086,13 @@ def test_non_gpu_context_shm_tensor_view_from_buffer() -> None:
         finally:
             context.close()
     finally:
-        if os.path.exists(shm_path):
-            os.unlink(shm_path)
+        shm_munmap(addr, 4096)
+        shm_unlink(shm_name)
 
 
 def test_non_gpu_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
     shm_name = f"lmcache_test_flow_{os.getpid()}"
-    shm_path = _create_shm_file(shm_name, 4096)
+    addr = _create_shm_segment(shm_name, 4096)
     slots = [
         {
             "offset": 0,
@@ -1080,8 +1158,8 @@ def test_non_gpu_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
         assert context.commit_retrieve(key, 1)
     finally:
         context.close()
-        if os.path.exists(shm_path):
-            os.unlink(shm_path)
+        shm_munmap(addr, 4096)
+        shm_unlink(shm_name)
 
 
 def test_non_gpu_context_shm_init_raises_when_segment_missing() -> None:
@@ -1141,7 +1219,7 @@ def test_create_non_gpu_context_use_pickle_ignores_valid_shm_info() -> None:
 
 def test_non_gpu_context_shm_close_is_idempotent() -> None:
     shm_name = f"lmcache_test_close_{os.getpid()}"
-    shm_path = _create_shm_file(shm_name, 4096)
+    addr = _create_shm_segment(shm_name, 4096)
     try:
         context = NonGpuContextShm(
             metadata=NonGpuContextMetadata(
@@ -1160,5 +1238,5 @@ def test_non_gpu_context_shm_close_is_idempotent() -> None:
         context.close()
         context.close()
     finally:
-        if os.path.exists(shm_path):
-            os.unlink(shm_path)
+        shm_munmap(addr, 4096)
+        shm_unlink(shm_name)

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -127,7 +127,7 @@ def test_shm_create_cleans_up_on_existing_name():
 
 
 def test_to_tensor_view_carries_munmap_finalizer():
-    """``to_tensor`` returns a tensor that releases its mmap on GC."""
+    """``to_tensor`` returns a tensor whose storage releases its mmap on GC."""
     # Standard
     import gc
     import weakref
@@ -136,12 +136,51 @@ def test_to_tensor_view_carries_munmap_finalizer():
     w = migrate_to_shm_and_wrap(src)
     try:
         view = w.to_tensor()
-        # The view must keep ``flat`` alive so its mmap stays valid.
-        assert hasattr(view, "_lmcache_shm_buf")
         ref = weakref.ref(view)
         del view
         gc.collect()
         assert ref() is None
+    finally:
+        del src
+        gc.collect()
+        shm_unlink(w.shm_name)
+
+
+def test_to_tensor_view_survives_reshape_after_original_is_gced():
+    """A reshape view must keep working after the original tensor is GC-ed.
+
+    Regression for the CI ``cpu_e2e_validation (server-side copy)`` segfault
+    where ``normalize_kv_and_discover_format`` reshapes the unwrapped 4D
+    tensor into the canonical 5D ``[NB, NH, BS, 2, HS]`` and the original
+    4D tensor goes out of scope. The reshape view shares the same storage
+    but used to be left without a lifetime hook, so the next read after GC
+    landed on an already-``munmap``-ed page and crashed the LMCache server.
+    """
+    # Standard
+    import gc
+
+    NB, NH, BS, HS = 8, 4, 16, 8
+    src = torch.zeros((NB, NH, BS, 2 * HS), dtype=torch.bfloat16)
+    w = migrate_to_shm_and_wrap(src)
+    try:
+        unwrapped = [w.to_tensor()]
+        normalized = [
+            layer.reshape(*layer.shape[:3], 2, layer.shape[3] // 2)
+            for layer in unwrapped
+        ]
+        # Drop every reference to the 4D unwrapped tensor; only the 5D
+        # reshape view keeps the storage alive now.
+        del unwrapped
+        gc.collect()
+
+        # These ops would segfault before the fix because the SHM mapping
+        # had been munmap-ed when the 4D tensor's finalizer ran.
+        idx = torch.tensor([0, 3, 5], dtype=torch.long)
+        gathered = normalized[0].index_select(0, idx)
+        assert tuple(gathered.shape) == (3, NH, BS, 2, HS)
+        # The SHM segment is freshly mmap'd zeros; just make sure the
+        # bytes are addressable end-to-end so the kernel does not fault.
+        assert gathered.float().abs().sum().item() == 0.0
     finally:
         del src
         gc.collect()


### PR DESCRIPTION
Introducing a zero-copy POSIX shared-memory path for CPU-only environments.


```console

$ 
python -m lmcache.v1.multiprocess.http_server \
    --l1-size-gb 2 \
    --eviction-policy LRU \
    --port 5555
[2026-06-03 09:17:30,647] LMCache INFO:  torch_dev=StubCPUDevice(device_type=cpu), torch_device_type=cpu (__init__.py:59:lmcache)
[2026-06-03 09:17:30,757] LMCache INFO: Skipping backend lmcache.xpu_ops: predicate returned False (__init__.py:91:lmcache)
[2026-06-03 09:17:30,757] LMCache INFO: Skipping backend lmcache.c_ops: predicate returned False (__init__.py:91:lmcache)
[2026-06-03 09:17:31,097] LMCache INFO: Discovered API module: cache_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,099] LMCache INFO: Discovered API module: env_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,099] LMCache INFO: Discovered API module: loglevel_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,099] LMCache INFO: Discovered API module: metrics_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,100] LMCache INFO: Discovered API module: periodic_thread_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,100] LMCache INFO: Discovered API module: run_script_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,101] LMCache INFO: Discovered API module: thread_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,102] LMCache INFO: Discovered API module: common_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,102] LMCache INFO: Discovered API module: conf_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,102] LMCache INFO: Discovered API module: healthcheck_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,103] LMCache INFO: Discovered API module: quota_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,103] LMCache INFO: Discovered API module: root_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,103] LMCache INFO: Discovered API module: status_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:31,104] LMCache INFO: Discovered API module: version_api (router_discovery.py:53:lmcache.v1.utils.router_discovery)
[2026-06-03 09:17:32,006] LMCache WARNING: LazyMemoryAllocator requires cudart which is not available on the current backend. Disabling l1-use-lazy. (config.py:52:lmcache.v1.distributed.config)
[2026-06-03 09:17:32,006] LMCache INFO: Starting LMCache HTTP server on http://0.0.0.0:8080 (http_server.py:149:__main__)
INFO:     Started server process [13006]
INFO:     Waiting for application startup.
[2026-06-03 09:17:32,029] LMCache INFO: Starting LMCache HTTP server... (accelerator available: False) (http_server.py:60:__main__)
[2026-06-03 09:17:32,041] LMCache INFO: OTel MeterProvider initialised with Prometheus fallback (standalone metrics HTTP server disabled; /metrics must be exposed by the caller), resource={'telemetry.sdk.language': 'python', 'telemetry.sdk.name': 'opentelemetry', 'telemetry.sdk.version': '1.40.0', 'service.instance.id': 'e5828655-d6b9-4a9c-bef9-3535383d728d', 'service.name': 'unknown_service'} (otel_init.py:114:lmcache.v1.mp_observability.otel_init)
[2026-06-03 09:17:32,042] LMCache INFO: Starting L1EvictionController... (eviction_controller.py:52:lmcache.v1.distributed.storage_controllers.eviction_controller)
[2026-06-03 09:17:32,042] LMCache INFO: Starting L2EvictionController... (eviction_controller.py:228:lmcache.v1.distributed.storage_controllers.eviction_controller)
[2026-06-03 09:17:32,042] LMCache INFO: Starting StoreController... (store_controller.py:274:lmcache.v1.distributed.storage_controllers.store_controller)
[2026-06-03 09:17:32,042] LMCache INFO: Starting PrefetchController... (prefetch_controller.py:454:lmcache.v1.distributed.storage_controllers.prefetch_controller)
[2026-06-03 09:17:32,042] LMCache INFO: Using blake3 hash function (token_hasher.py:79:lmcache.v1.multiprocess.token_hasher)
[2026-06-03 09:17:32,045] LMCache INFO: Computed NONE_HASH=b"~>\xff\x9e\xf7a:P4\x0e\xb1&w\xee\x03\xb8:\xc7Y\xfc\xba\x9b\xb3'\x05\xf0rH\xd5mG;" using hash function (token_hasher.py:180:lmcache.v1.multiprocess.token_hasher)
[2026-06-03 09:17:32,045] LMCache INFO: TokenHasher initialized: chunk_size=256, hash_algorithm=blake3 (token_hasher.py:67:lmcache.v1.multiprocess.token_hasher)
[2026-06-03 09:17:32,045] LMCache INFO: Supported transfer mode: auto (server.py:192:lmcache.v1.multiprocess.server)
[2026-06-03 09:17:32,046] LMCache INFO: LMCache ZMQ cache server is running on tcp://localhost:5555 (server.py:299:lmcache.v1.multiprocess.server)
[2026-06-03 09:17:32,046] LMCache INFO: LMCache cache server is running... (server.py:314:lmcache.v1.multiprocess.server)
[2026-06-03 09:17:32,047] LMCache INFO: LMCache HTTP server initialized (http_server.py:97:__main__)
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
[2026-06-03 09:17:49,253] LMCache INFO: list_depth: 1, tensor_dim: 5 (utils.py:566:lmcache.v1.gpu_connector.utils)
[2026-06-03 09:17:49,253] LMCache INFO: GPU KV Cache Dimensions: [32][2, 1024, 16, 8, 128] (utils.py:577:lmcache.v1.gpu_connector.utils)
[2026-06-03 09:17:49,253] LMCache INFO: CPU backend detected, using HND KV cache layout (utils.py:592:lmcache.v1.gpu_connector.utils)
[2026-06-03 09:17:49,253] LMCache INFO: vLLM KV cache layout: HND (utils.py:598:lmcache.v1.gpu_connector.utils)
[2026-06-03 09:17:49,253] LMCache INFO: GPU KV Format: NL x [2, NB, NH, BS, HS] (utils.py:428:lmcache.v1.gpu_connector.utils)
[2026-06-03 09:17:49,253] LMCache INFO: Currently used by:
  - vLLM non-MLA flash attention (HND layout) (utils.py:429:lmcache.v1.gpu_connector.utils)
[2026-06-03 09:17:49,253] LMCache INFO: Group 0 first-layer tensor: layer_idx=0 shape=(2, 1024, 16, 8, 128) stride=(16777216, 16384, 1024, 128, 1) is_contiguous=True dtype=torch.float16 device=cpu storage_offset=0 numel=33554432 storage_nbytes=67108864 padding_per_block=0 (utils.py:1302:lmcache.v1.gpu_connector.utils)
[2026-06-03 09:17:49,253] LMCache INFO: KV layer groups: [KVLayerGroupInfo(layers=32, indices=0-31, shape_desc=(kv=2, nl=32, nb=1024, bs=8, nh=16, hs=128, element_size=2, block_stride_elems=0), dtype=torch.float16, compress_ratio=1, physical_chunk_size=256)] (kv_layer_groups.py:266:lmcache.v1.kv_layer_groups)
[2026-06-03 09:17:49,254] LMCache INFO: CpuCacheContext: 32 layers, blocks=1024x16, dtype=torch.float16 (shm-backed) (cache_context.py:165:lmcache.v1.platform.cpu.cache_context)
[2026-06-03 09:17:49,254] LMCache INFO: Registered KV cache for GPU ID 0 with 32 layers (gpu_transfer.py:283:lmcache.v1.multiprocess.modules.gpu_transfer)
[2026-06-03 09:17:49,337] LMCache INFO: Stored 512 tokens in 0.082 seconds (gpu_transfer.py:477:lmcache.v1.multiprocess.modules.gpu_transfer)
INFO:     127.0.0.1:63068 - "GET /kvcache/check?block_ids=[0,31]&block_size=16&chunk_size=16&layerwise=false HTTP/1.1" 200 OK
[2026-06-03 09:17:50,074] LMCache INFO: Prefetch request completed (L1+L2): 2/2 prefix hits (2 L1, 0 L2) in 0.8 ms (external_request_id=req-0-warm, prefetch_request_id=-1) (storage_manager.py:549:lmcache.v1.distributed.storage_manager)
[2026-06-03 09:17:50,164] LMCache INFO: Retrieved 512 tokens in 0.089 seconds (gpu_transfer.py:678:lmcache.v1.multiprocess.modules.gpu_transfer)
INFO:     127.0.0.1:63070 - "GET /kvcache/check?block_ids=[0,31]&block_size=16&chunk_size=16&layerwise=false HTTP/1.1" 200 OK
[2026-06-03 09:17:50,951] LMCache INFO: Stored 512 tokens in 0.053 seconds (gpu_transfer.py:477:lmcache.v1.multiprocess.modules.gpu_transfer)
INFO:     127.0.0.1:63072 - "GET /kvcache/check?block_ids=[32,63]&block_size=16&chunk_size=16&layerwise=false HTTP/1.1" 200 OK
[2026-06-03 09:17:51,709] LMCache INFO: Prefetch request completed (L1+L2): 2/2 prefix hits (2 L1, 0 L2) in 0.4 ms (external_request_id=req-1-warm, prefetch_request_id=-1) (storage_manager.py:549:lmcache.v1.distributed.storage_manager)
[2026-06-03 09:17:51,806] LMCache INFO: Retrieved 512 tokens in 0.096 seconds (gpu_transfer.py:678:lmcache.v1.multiprocess.modules.gpu_transfer)
INFO:     127.0.0.1:63080 - "GET /kvcache/check?block_ids=[32,63]&block_size=16&chunk_size=16&layerwise=false HTTP/1.1" 200 OK
[2026-06-03 09:17:52,691] LMCache INFO: Stored 512 tokens in 0.163 seconds (gpu_transfer.py:477:lmcache.v1.multiprocess.modules.gpu_transfer)
INFO:     127.0.0.1:63082 - "GET /kvcache/check?block_ids=[64,95]&block_size=16&chunk_size=16&layerwise=false HTTP/1.1" 200 OK
[2026-06-03 09:17:53,610] LMCache INFO: Prefetch request completed (L1+L2): 2/2 prefix hits (2 L1, 0 L2) in 0.4 ms (external_request_id=req-2-warm, prefetch_request_id=-1) (storage_manager.py:549:lmcache.v1.distributed.storage_manager)
[2026-06-03 09:17:53,666] LMCache INFO: Retrieved 512 tokens in 0.055 seconds (gpu_transfer.py:678:lmcache.v1.multiprocess.modules.gpu_transfer)
INFO:     127.0.0.1:63084 - "GET /kvcache/check?block_ids=[64,95]&block_size=16&chunk_size=16&layerwise=false HTTP/1.1" 200 OK


$ lmcache bench server --rpc-url tcp://localhost:5555 \
    --mode cpu --transfer-mode handle \
    --num-tokens 512 --start 0 --end 3
[2026-06-03 09:17:39,582] LMCache INFO:  torch_dev=StubCPUDevice(device_type=cpu), torch_device_type=cpu (__init__.py:59:lmcache)
[2026-06-03 09:17:39,657] LMCache INFO: Skipping backend lmcache.xpu_ops: predicate returned False (__init__.py:91:lmcache)
[2026-06-03 09:17:39,657] LMCache INFO: Skipping backend lmcache.c_ops: predicate returned False (__init__.py:91:lmcache)
  [info] --transfer-mode=handle on cpu mode: using REGISTER_KV_CACHE + STORE/RETRIEVE over POSIX SHM
Connecting to LMCache MP Server at tcp://localhost:5555 (mode=cpu) ...
Server chunk_size = 256
Resolved KV shape spec: (2,1024,16,8,128):float16:32
Each request: 513 tokens (2 full chunks)
KV shape: 32 layers, 8 heads x 128, dtype=float16, blocks=1024x16, kv=2
Allocated 32 CPU SHM tensors (prefix=/lmcache_kv_13299)
REGISTER_KV_CACHE: OK

=== Request seq=0 ===
  [seq 0/cold] LOOKUP: 0/2 chunks hit (1.1 ms)
  [seq 0/cold] STORE: stored (512 tokens, 83.1 ms)
  [seq 0/cold] CHECKSUM: 142dbc52e32f9574 (2 chunks)
  [seq 0/warm] LOOKUP: 2/2 chunks hit (2.0 ms)
  [seq 0/warm] RETRIEVE: retrieved (512 tokens, 90.1 ms)
  [seq 0/warm] CHECKSUM: 142dbc52e32f9574 (2 chunks)
  [seq 0] CHECKSUM MATCH OK

=== Request seq=1 ===
  [seq 1/cold] LOOKUP: 0/2 chunks hit (1.4 ms)
  [seq 1/cold] STORE: stored (512 tokens, 53.6 ms)
  [seq 1/cold] CHECKSUM: 55d5c26724c1f6be (2 chunks)
  [seq 1/warm] LOOKUP: 2/2 chunks hit (1.2 ms)
  [seq 1/warm] RETRIEVE: retrieved (512 tokens, 97.2 ms)
  [seq 1/warm] CHECKSUM: 55d5c26724c1f6be (2 chunks)
  [seq 1] CHECKSUM MATCH OK

=== Request seq=2 ===
  [seq 2/cold] LOOKUP: 0/2 chunks hit (1.2 ms)
  [seq 2/cold] STORE: stored (512 tokens, 163.6 ms)
  [seq 2/cold] CHECKSUM: 307f6ad70555d9e8 (2 chunks)
  [seq 2/warm] LOOKUP: 2/2 chunks hit (1.2 ms)
  [seq 2/warm] RETRIEVE: retrieved (512 tokens, 55.4 ms)
  [seq 2/warm] CHECKSUM: 307f6ad70555d9e8 (2 chunks)
  [seq 2] CHECKSUM MATCH OK

Done.

```
