### PR TITLE
[CI] Rename NO_CUDA_EXT → NO_NATIVE_EXT (keep legacy alias)

### DIFF
--- a/.github/workflows/build_cli_artifacts.yml
+++ b/.github/workflows/build_cli_artifacts.yml
@@ -63,10 +63,10 @@ jobs:
               run: |
                 rm -rf dist/
 
-            - name: Build lmcache-cli wheel (pure Python, no CUDA)
+            - name: Build lmcache-cli wheel (pure Python, no native extensions)
               run: |
                 cp pyproject_cli.toml pyproject.toml
-                NO_CUDA_EXT=1 python -m build --wheel
+                NO_NATIVE_EXT=1 python -m build --wheel
 
             - name: Smoke-test CLI wheel (no torch)
               run: |

--- a/.github/workflows/build_main_artifacts.yml
+++ b/.github/workflows/build_main_artifacts.yml
@@ -55,9 +55,9 @@ jobs:
               run: |
                 rm -rf dist/
 
-            - name: Build source distribution (no CUDA)
+            - name: Build source distribution (no native extensions)
               run: |
-                NO_CUDA_EXT=1 python -m build --sdist
+                NO_NATIVE_EXT=1 python -m build --sdist
 
             - name: Build CUDA wheels with cibuildwheel
               # Configuration is set in pyproject.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ uv pip install -e . --no-build-isolation
 # Standard install with CUDA extensions (requires torch pre-installed)
 pip install -e . --no-build-isolation
 
-# Source-only (no CUDA extensions)
-NO_CUDA_EXT=1 pip install -e .
+# Source-only (no native extensions)
+NO_NATIVE_EXT=1 pip install -e .
 
 # HIP/ROCm build
 BUILD_WITH_HIP=1 pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,18 @@ HIPIFY_OUT_DIR = os.path.join(ROOT_DIR, "csrc_hip/")
 # python -m build --sdist
 # will run python setup.py sdist --dist-dir dist
 BUILDING_SDIST = "sdist" in sys.argv
-NO_CUDA_EXT = os.environ.get("NO_CUDA_EXT", "0") == "1"
+# `NO_NATIVE_EXT=1` skips compilation of all native extensions (pure-Python
+# build). `NO_CUDA_EXT=1` is the legacy name kept for backwards compatibility;
+# it has always controlled all native extensions, not just CUDA ones.
+NO_NATIVE_EXT = (
+    os.environ.get("NO_NATIVE_EXT", "0") == "1"
+    or os.environ.get("NO_CUDA_EXT", "0") == "1"
+)
+if os.environ.get("NO_CUDA_EXT", "0") == "1":
+    print(
+        "warning: NO_CUDA_EXT is deprecated; use NO_NATIVE_EXT=1 instead.",
+        file=sys.stderr,
+    )
 
 # New environment variable to choose between CUDA, HIP, and SYCL
 BUILD_WITH_HIP = os.environ.get("BUILD_WITH_HIP", "0") == "1"
@@ -383,7 +394,7 @@ def _collect_extensions() -> tuple[list, dict]:
 
     Notes:
         - `sdist` builds skip all extension compilation.
-        - `NO_CUDA_EXT=1` skips all extension compilation (pure-Python build,
+        - `NO_NATIVE_EXT=1` skips all extension compilation (pure-Python build,
           used by the lmcache-cli wheel which has no torch build dependency).
         - Otherwise, pure C++ extensions are combined with one GPU backend
           extension set (CUDA, ROCm, or SYCL).
@@ -391,7 +402,7 @@ def _collect_extensions() -> tuple[list, dict]:
     if BUILDING_SDIST:
         return source_dist_extension()
 
-    if NO_CUDA_EXT:
+    if NO_NATIVE_EXT:
         return [], {}
 
     common_cpp_flags = _get_common_cpp_flags()


### PR DESCRIPTION

  ## Summary
  - Rename the build-time env var `NO_CUDA_EXT` → `NO_NATIVE_EXT` to match its actual behavior: it skips *all*
  native extensions (C++ and GPU), not just CUDA.
  - `NO_CUDA_EXT=1` is kept as a deprecated alias — it still works and prints a stderr deprecation warning
  pointing users to `NO_NATIVE_EXT`.
  - Updates CI workflows (`build_cli_artifacts.yml`, `build_main_artifacts.yml`) and `AGENTS.md` install docs to
  the new name.

  ## Context
  Follow-up to #3349, which restored the "skip all extensions" semantics. With that landed, the `NO_CUDA_EXT` name
   is actively misleading, so this PR renames it while preserving backwards compatibility for anyone with the old
  var in their scripts.