### PR TITLE
fix(docker): install CLI requirements in standalone image so `lmcache server` boots (fixes #3353)

### DIFF
--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -37,9 +37,15 @@ WORKDIR /workspace
 
 # Install small non-torch runtime dependencies; torch is installed in lmcache-build
 # against the exact CUDA version so the compiled C extensions match at runtime.
+# The CLI requirements (e.g. ``openai`` for the bench client) are also installed
+# here so ``lmcache`` subcommand discovery in ``lmcache.cli.commands`` -- which
+# eagerly imports every command module -- does not crash with
+# ``ModuleNotFoundError: No module named 'openai'`` when the standalone image
+# boots ``lmcache server``. See LMCache#3353.
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=requirements/cli.txt,target=/tmp/cli.txt \
     . /opt/venv/bin/activate && \
-    uv pip install ray nvidia-ml-py
+    uv pip install ray nvidia-ml-py -r /tmp/cli.txt
 
 # CUDA arch list used by torch
 ARG torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX'


### PR DESCRIPTION
## Summary

`lmcache/standalone` (v0.4.5, latest, nightly) crashes on `lmcache server` with `ModuleNotFoundError: No module named 'openai'`, as reported in #3353. Fix: install `requirements/cli.txt` in the standalone image's base stage so `lmcache` subcommand discovery does not crash.

## Root cause (`#3353` deep-dive)

1. `setup.py` builds `install_requires` from `requirements/common.txt` + `requirements/cuda{12,13}_core.txt`. **`requirements/cli.txt` is not in `install_requires`** — `openai` lives there (used by the `bench` engine client at `lmcache/cli/commands/bench/engine_bench/request_sender.py:11`).
2. `lmcache server` is the `lmcache.cli.main:main` entry point. Its first statement, `from lmcache.cli.commands import ALL_COMMANDS`, triggers `lmcache/cli/commands/__init__.py:_discover_commands()`, which uses `discover_subclasses(...)` to **eagerly `importlib.import_module`** every submodule under `cli/commands/`.
3. That includes `bench/__init__.py`, whose top-level imports chain into `engine_bench/request_sender.py` → `from openai import AsyncOpenAI`. On the standalone image (no `openai`), this raises `ModuleNotFoundError`, propagates out of `_discover_commands()`, and aborts CLI startup.
4. `cli/commands/__init__.py:18-30` deliberately re-raises import errors (the docstring says: *"Import errors are intentionally re-raised: a broken CLI command module should fail loudly rather than silently disappear from the CLI."*). So the discovery side cannot be softened on slim installs — the install side has to be fixed.

The other Docker images don't hit this:

| Image | Why it survives |
|---|---|
| `Dockerfile` (main) | installs `vllm[runai,tensorizer,flashinfer]`; vLLM's deps include `openai` |
| `Dockerfile.rocm` | installs `vllm[runai,tensorizer]`; same |
| `Dockerfile.lightweight` | `FROM vllm/vllm-openai:latest` (already has openai) |
| `Dockerfile.rocm-lightweight` | `FROM vllm/vllm-openai-rocm:latest` (already has openai) |
| **`Dockerfile.standalone`** | **vLLM-free → no transitive openai → crash** |

## Fix

```dockerfile
RUN --mount=type=cache,target=/root/.cache/uv \
    --mount=type=bind,source=requirements/cli.txt,target=/tmp/cli.txt \
    . /opt/venv/bin/activate && \
    uv pip install ray nvidia-ml-py && \
    uv pip install -r /tmp/cli.txt
```

`--mount=type=bind` keeps `cli.txt` out of the image layer (matching the `build.txt` style the lmcache-build stage already uses).

## Fixes

- #3353

## Out of scope (intentional)

The deeper architectural question — whether `cli.txt` should land in `install_requires`, or in an `extras_require["cli"]` block consumed by `lmcache[cli]`, or whether the fail-loudly contract in `cli/commands/__init__.py` should be relaxed — is a maintainer call. Any of those would also fix users who hit this crash via `pip install lmcache` outside of Docker. I left those alone here to keep the review surface tight and unblock the broken standalone images today; happy to follow up on whichever direction maintainers prefer.

## Test plan

I cannot run `docker build` against `nvcr.io/nvidia/cuda-dl-base` from this dev box (mac, no NVIDIA Container Runtime; the upstream nvcr image is also gated). Relying on LMCache CI's standalone build job to confirm the resolved dependency tree includes `openai` and that `lmcache server --help` no longer crashes inside the image.

For local verification of the trace independently of Docker:

```
$ python3 -c "from lmcache.cli.commands import ALL_COMMANDS"  # in a venv without openai
Traceback (most recent call last):
  ...
  File ".../lmcache/cli/commands/bench/engine_bench/request_sender.py", line 11, in <module>
    from openai import AsyncOpenAI
ModuleNotFoundError: No module named 'openai'
```

`pip install -r requirements/cli.txt` in the same venv removes the crash.
