### PR TITLE
fix: Prevent Lock Resource Leakage and Potential Deadlocks in L2 Lookup Benchmark

### DIFF
--- a/lmcache/cli/commands/bench/l2_adapter_bench/runner.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/runner.py
@@ -228,6 +228,10 @@ def bench_lookup(
         results = _wait_lookup_finished(adapter, task_ids, 60.0)
         t1 = time.perf_counter()
         elapsed = t1 - t0
+
+        for keys in keys_batches:
+            adapter.submit_unlock(keys)
+
         timed_out = len(results) < len(task_ids)
 
         total_found = sum(_bitmap_count(results.get(tid)) for tid in task_ids)


### PR DESCRIPTION

**What this PR does / why we need it**:

 Trigger Scenario: 
Running the lmcache bench l2 CLI command to benchmark lookup performance (e.g., using --lookup-max-hit-rate > 0) with an L2 adapter  that enforces actual locking mechanisms (like Redis, DAX, or Raw Block adapters).

Fault Manifestation: 
Locks acquired on the cached objects during the benchmark are never released. This lock leakage can cause the adapter to exhaust  its lock resources or cause subsequent operations (which attempt to lock the same keys) to block indefinitely or fail during the process lifecycle.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
