### PR TITLE
[CI][Build] CPU-only build (NO_GPU_EXT=1) + CI

### DIFF
--- a/.github/workflows/build_cpu_artifacts.yml
+++ b/.github/workflows/build_cpu_artifacts.yml
@@ -1,0 +1,122 @@
+name: Build CPU Artifacts
+
+# Build LMCache with NO_GPU_EXT=1 (common C++ extensions only).
+# Gates the CPU-only build path against regression.
+
+on:
+    workflow_call:
+    pull_request:
+        branches:
+            - dev
+            - "release-**"
+        paths:
+            - 'setup.py'
+            - 'pyproject.toml'
+            - 'csrc/**'
+            - 'requirements/common.txt'
+            - 'requirements/build.txt'
+            - 'lmcache/__init__.py'
+            - '.github/workflows/build_cpu_artifacts.yml'
+
+env:
+    LC_ALL: en_US.UTF-8
+
+defaults:
+    run:
+        shell: bash
+
+# Cancel stale runs per ref.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    build-cpu-artifacts:
+        name: Build CPU artifacts
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+              with:
+                disable-sudo-and-containers: false
+                egress-policy: audit
+
+            - name: Checkout code
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              with:
+                fetch-depth: 0
+
+            - name: Remove non-release tags
+              run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+$' | xargs -r git tag -d
+
+            - name: Setup Python 3.13
+              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              with:
+                python-version: "3.13"
+
+            - name: Install build tooling and CPU torch
+              run: |
+                python -m pip install --upgrade pip
+                pip install --index-url https://download.pytorch.org/whl/cpu torch
+                # Pre-install build deps for --no-isolation below.
+                pip install -r requirements/build.txt
+                pip install build
+
+            - name: Clean up release artifacts
+              run: |
+                rm -rf dist/
+
+            - name: Build CPU-only wheel (common C++ extensions, no GPU backend)
+              # --skip-dependency-check: the pre-installed CPU torch may not
+              # match pyproject.toml's exact build-system pin, but is ABI-
+              # compatible for compiling CppExtensions.
+              run: |
+                NO_GPU_EXT=1 python -m build --wheel --no-isolation \
+                  --skip-dependency-check
+
+            - name: Verify CPU wheel contents
+              run: |
+                set -e
+                # Required: common C++ extensions.
+                for mod in native_storage_ops lmcache_redis lmcache_fs; do
+                  if ! unzip -l dist/lmcache-*.whl | grep -qE "lmcache/${mod}\..*\.so"; then
+                    echo "::error::missing common C++ extension: ${mod}"
+                    exit 1
+                  fi
+                done
+                # Forbidden: GPU extensions.
+                for mod in c_ops xpu_ops; do
+                  if unzip -l dist/lmcache-*.whl | grep -qE "lmcache/${mod}\..*\.so"; then
+                    echo "::error::unexpected GPU extension in CPU wheel: ${mod}"
+                    exit 1
+                  fi
+                done
+
+            - name: Smoke-test CPU wheel
+              # Run from $RUNNER_TEMP so Python resolves `lmcache` from the
+              # installed wheel, not the checkout on CWD.
+              working-directory: ${{ runner.temp }}
+              run: |
+                set -e
+                pip install ${{ github.workspace }}/dist/lmcache-*.whl
+                python -c "
+                import lmcache
+                assert lmcache.torch_device_type == 'cpu', lmcache.torch_device_type
+                "
+                python -c "import lmcache.native_storage_ops"
+                python -c "import lmcache.lmcache_redis"
+                python -c "import lmcache.lmcache_fs"
+                # c_ops resolves to the python_ops_fallback shim on CPU.
+                python -c "
+                import sys, lmcache, lmcache.c_ops
+                assert sys.modules['lmcache.c_ops'].__name__ == 'lmcache.python_ops_fallback'
+                "
+
+            - name: Upload CPU release artifacts to GHA
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                name: release-cpu-artifacts
+                path: dist/

--- a/.github/workflows/pr_full_build.yml
+++ b/.github/workflows/pr_full_build.yml
@@ -38,6 +38,11 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'full')
         uses: ./.github/workflows/build_cli_artifacts.yml
 
+    build-cpu:
+        name: Build CPU
+        if: contains(github.event.pull_request.labels.*.name, 'full')
+        uses: ./.github/workflows/build_cpu_artifacts.yml
+
     build-cu129:
         name: Build cu129
         if: contains(github.event.pull_request.labels.*.name, 'full')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ pip install -e . --no-build-isolation
 # Source-only (no native extensions)
 NO_NATIVE_EXT=1 pip install -e .
 
+# CPU-only (common C++ extensions, no GPU backend)
+NO_GPU_EXT=1 pip install -e . --no-build-isolation
+
 # HIP/ROCm build
 BUILD_WITH_HIP=1 pip install -e .
 ```

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ if os.environ.get("NO_CUDA_EXT", "0") == "1":
         "warning: NO_CUDA_EXT is deprecated; use NO_NATIVE_EXT=1 instead.",
         file=sys.stderr,
     )
+# Common C++ extensions only; skip CUDA / ROCm / SYCL.
+NO_GPU_EXT = os.environ.get("NO_GPU_EXT", "0") == "1"
 
 # New environment variable to choose between CUDA, HIP, and SYCL
 BUILD_WITH_HIP = os.environ.get("BUILD_WITH_HIP", "0") == "1"
@@ -393,11 +395,10 @@ def _collect_extensions() -> tuple[list, dict]:
             - dict: cmdclass containing BuildExtension when extensions are built.
 
     Notes:
-        - `sdist` builds skip all extension compilation.
-        - `NO_NATIVE_EXT=1` skips all extension compilation (pure-Python build,
-          used by the lmcache-cli wheel which has no torch build dependency).
-        - Otherwise, pure C++ extensions are combined with one GPU backend
-          extension set (CUDA, ROCm, or SYCL).
+        - `sdist`: no extensions.
+        - `NO_NATIVE_EXT=1`: no extensions (pure-Python lmcache-cli wheel).
+        - `NO_GPU_EXT=1`: common C++ extensions only.
+        - Default: common C++ extensions + one GPU backend (CUDA/ROCm/SYCL).
     """
     if BUILDING_SDIST:
         return source_dist_extension()
@@ -410,6 +411,9 @@ def _collect_extensions() -> tuple[list, dict]:
     # _GLIBCXX_USE_CXX11_ABI in pre-refactor builds.
     fs_cpp_flags = [] if BUILD_WITH_SYCL else common_cpp_flags
     ext_modules, cmdclass = _common_cpp_extensions(common_cpp_flags, fs_cpp_flags)
+
+    if NO_GPU_EXT:
+        return ext_modules, cmdclass
 
     if BUILD_WITH_SYCL:
         gpu_ext_modules, cmdclass = sycl_extension()
@@ -425,21 +429,23 @@ if __name__ == "__main__":
     ext_modules, cmdclass = _collect_extensions()
 
     install_requires = _read_requirements(ROOT_DIR / "requirements" / "common.txt")
-    if BUILD_WITH_HIP:
-        core_file = "rocm_core.txt"
-    elif BUILD_WITH_SYCL:
-        core_file = "xpu_core.txt"
-    else:
-        # CUDA major selects between cu12 and cu13 vendor pins (cupy, nixl).
-        # Defaults to cu13 (the PyPI build); cu12.9 wheel builds set
-        # LMCACHE_CUDA_MAJOR=12 to pull cu12 wheels of those deps.
-        cuda_major = os.environ.get("LMCACHE_CUDA_MAJOR", "13")
-        if cuda_major not in ("12", "13"):
-            raise ValueError(
-                f"LMCACHE_CUDA_MAJOR must be '12' or '13', got '{cuda_major}'"
-            )
-        core_file = f"cuda{cuda_major}_core.txt"
-    install_requires += _read_requirements(ROOT_DIR / "requirements" / core_file)
+    # NO_GPU_EXT skips GPU-vendor deps (cupy / nixl).
+    if not NO_GPU_EXT:
+        if BUILD_WITH_HIP:
+            core_file = "rocm_core.txt"
+        elif BUILD_WITH_SYCL:
+            core_file = "xpu_core.txt"
+        else:
+            # CUDA major selects between cu12 and cu13 vendor pins (cupy, nixl).
+            # Defaults to cu13 (the PyPI build); cu12.9 wheel builds set
+            # LMCACHE_CUDA_MAJOR=12 to pull cu12 wheels of those deps.
+            cuda_major = os.environ.get("LMCACHE_CUDA_MAJOR", "13")
+            if cuda_major not in ("12", "13"):
+                raise ValueError(
+                    f"LMCACHE_CUDA_MAJOR must be '12' or '13', got '{cuda_major}'"
+                )
+            core_file = f"cuda{cuda_major}_core.txt"
+        install_requires += _read_requirements(ROOT_DIR / "requirements" / core_file)
 
     setup(
         packages=find_packages(


### PR DESCRIPTION
 
  **What this PR does / why we need it**:

 1. `NO_GPU_EXT=1` in `setup.py`: builds the common C++ exts only, skips CUDA/ROCm/SYCL. drops cupy/nixl from `install_requires` in this mode. for the "CPU vLLM + LMCache" path (#3302's original motivation).
  2. new `build_cpu_artifacts.yml` CI: runs on every PR touching build inputs, builds with `NO_GPU_EXT=1`, asserts common C++ `.so` present + GPU `.so`
  absent, smoke-tests the install. also wired into `pr_full_build.yml`.
 3. `AGENTS.md` updated.

  **Special notes for your reviewers**:

  for the gate to actually enforce, a maintainer needs to add `Build CPU artifacts` to required branch-protection checks. verified locally e2e (Py  + CPU torch).

  **If applicable**:

  - [x] user facing changes - docs added (AGENTS.md)
  - [x] tests (CI workflow gates the build path)
