### PR TITLE
docs: daily drift check — multi-process mode (2026-05-21)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -139,6 +139,10 @@ Source: ``lmcache/v1/distributed/config.py``
      - Enable or disable lazy allocation for L1 memory.
        Pass ``--l1-use-lazy`` to enable (default) or
        ``--no-l1-use-lazy`` to explicitly disable.
+       Lazy allocation relies on ``cudart`` host-pinned memory, so on
+       non-CUDA backends (where ``lmcache.torch_dev`` exposes no
+       ``cudart`` attribute) it is automatically downgraded to eager
+       allocation with a logged warning, regardless of the flag value.
    * - ``--l1-init-size-gb``
      - ``20``
      - Initial allocation size (GB) when using lazy allocation.


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine.
**Human review is required before merge — do not merge as-is.**

One new piece of `docs/source/` drift was introduced between the
previous drift sweep window
([2026-05-19 — PR #3329](https://github.com/LMCache/LMCache/pull/3329)
based on `dev` HEAD
[`f9ce8cb`](https://github.com/LMCache/LMCache/commit/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a))
and today's `dev` HEAD
([`d9f3438`](https://github.com/LMCache/LMCache/commit/d9f3438b067ae36fd08671fb3e058d55ffd07634)).
It is user-facing — the MP `Configuration Reference` description of
`--l1-use-lazy` no longer matches the post-init behavior that
silently downgrades the flag on non-CUDA backends.

Today's PR is filed as a separate draft (not appended to #3273 or
#3329) because the item is **independent** of the items already under
review on those branches: neither open PR touches the *L1 Memory
Manager* configuration table, and rebasing them would require
force-pushing reviewed commits. The dedup rule asks us to merge only
when the *same* items are still open, which is not the case here.

---

### `docs/source/` drift

#### `docs/source/mp/configuration.rst` — `--l1-use-lazy` default omits the non-CUDA auto-disable caveat

[PR #3259](https://github.com/LMCache/LMCache/pull/3259)
("feat(mp): Non-GPU Context by pickle", commit
[`259c0b3`](https://github.com/LMCache/LMCache/commit/259c0b39873b7ad1d5b10992d47ccf19801b00f1))
merged on 2026-05-21. As part of the broader CPU-context refactor,
it added a `__post_init__` guard to
[`L1MemoryManagerConfig`](https://github.com/LMCache/LMCache/blob/d9f3438b067ae36fd08671fb3e058d55ffd07634/lmcache/v1/distributed/config.py#L42-L52)
that auto-disables `use_lazy` whenever `lmcache.torch_dev` does not
expose a `cudart` attribute:

```python
# LazyMemoryAllocator requires cudart (CUDA host-pinned memory).
# Auto-disable on non-CUDA backends to avoid a RuntimeError.
if self.use_lazy and not hasattr(torch_dev, "cudart"):
    logger.warning(
        "LazyMemoryAllocator requires cudart which is not available "
        "on the current backend. Disabling l1-use-lazy."
    )
    self.use_lazy = False
```

So although the argparse default in
[`add_l1_memory_manager_args` (`config.py:L149-L154`)](https://github.com/LMCache/LMCache/blob/d9f3438b067ae36fd08671fb3e058d55ffd07634/lmcache/v1/distributed/config.py#L149-L154)
remains `default=True`, the **effective** default on non-CUDA
backends is now `False` with a warning logged. Users running the
multi-process server on a non-CUDA backend (XPU, HPU, ROCm without
cudart, etc.) will silently get eager L1 allocation regardless of
what they pass on the command line.

The stale doc location:

- [`docs/source/mp/configuration.rst` lines 137-141 on `dev`](https://github.com/LMCache/LMCache/blob/d9f3438b067ae36fd08671fb3e058d55ffd07634/docs/source/mp/configuration.rst#L137-L141)
  — the *L1 Memory Manager* `list-table` row for `--l1-use-lazy`
  shows the default as plain `True` and the description never names
  the non-CUDA auto-disable.

A `grep -rn "cudart\|non-CUDA" docs/source/mp/configuration.rst` on
[`d9f3438`](https://github.com/LMCache/LMCache/commit/d9f3438b067ae36fd08671fb3e058d55ffd07634)
returns zero hits, confirming the caveat is entirely undocumented
on this page.

The `docs/source/mp/quickstart.rst`, `deployment.rst`, and
`tracing_and_debugging.rst` examples are not stale — they all use
CUDA backends, where `--l1-use-lazy` still behaves exactly as
written.

#### `docs/design/` drift

None new today. The MP design doc added by PR #3259 —
[`docs/design/v1/multiprocess/non_gpu_context_design.md`](https://github.com/LMCache/LMCache/blob/d9f3438b067ae36fd08671fb3e058d55ffd07634/docs/design/v1/multiprocess/non_gpu_context_design.md)
— is brand-new and matches the merged code.

---

## Proposed fix (applied in this PR — one commit)

A single doc-only commit
([`e285329`](https://github.com/ApostaC/LMCache/commit/e285329)),
DCO-signed and authored by ApostaC:

- **`docs/source/mp/configuration.rst`** — extend the description
  cell of the `--l1-use-lazy` row in the *L1 Memory Manager* table to
  name the `cudart` requirement and explain that non-CUDA backends
  auto-downgrade to eager allocation with a logged warning,
  regardless of the flag value. Wording follows the `__post_init__`
  guard and the warning string verbatim; no behavior change is
  implied.

No code files are touched.

## Audit-clean (no drift) commits in today's window

The following `dev` commits between
[`f9ce8cb`](https://github.com/LMCache/LMCache/commit/f9ce8cbe105bccfae81c82cdb5b32d57c7aba63a)
(2026-05-19) and
[`d9f3438`](https://github.com/LMCache/LMCache/commit/d9f3438b067ae36fd08671fb3e058d55ffd07634)
(2026-05-21) were audited and introduced no additional MP doc drift:

- **PR #3290** (`[MP][Observability] Refactor metric names and units`)
  — bulk metric rename. The same PR already rewrote
  `docs/source/mp/observability.rst` and
  `docs/design/v1/mp_observability/METRICS.md` to use the new names.
  Spot-checked the union of `lmcache_mp.*` references between
  `docs/source/mp/observability.rst` and
  `lmcache/v1/mp_observability/subscribers/metrics/` on `dev`
  HEAD — both `num_inflight_l2_loads` *and* the new
  `num_inflight_l2_stores` gauge are documented at
  [`observability.rst:L543-L552`](https://github.com/LMCache/LMCache/blob/d9f3438b067ae36fd08671fb3e058d55ffd07634/docs/source/mp/observability.rst#L543-L552).
- **PR #3338** (`[optimize] rename non_cuda_equivalents to python_ops_fallback`)
  — design doc update was bundled into the same PR
  ([`docs/design/ARCHITECTURE_MULTI_HARDWARE.md`](https://github.com/LMCache/LMCache/blob/d9f3438b067ae36fd08671fb3e058d55ffd07634/docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L72)
  references `python_ops_fb` / `python_ops_fallback.py`).
- **PR #3243** (`[MP][bench] add l2 adapter benchmark cli`) — the
  PR added the new
  [`docs/source/cli/bench_l2.rst`](https://github.com/LMCache/LMCache/blob/d9f3438b067ae36fd08671fb3e058d55ffd07634/docs/source/cli/bench_l2.rst)
  page and wired it into `docs/source/cli/index.rst` in the same
  commit. No MP doc references the bench tool.
- **PR #3354** (`[CI] Rename NO_CUDA_EXT → NO_NATIVE_EXT (keep legacy alias)`)
  — a `grep -rn "NO_CUDA_EXT\|NO_NATIVE_EXT\|NO_GPU_EXT" docs/` on
  [`d9f3438`](https://github.com/LMCache/LMCache/commit/d9f3438b067ae36fd08671fb3e058d55ffd07634)
  returns zero hits; the env-var name is not used in the doc tree at
  all, only in `AGENTS.md`, which the same PR already updated.
- **PR #3357** (`[CI][Build] CPU-only build (NO_GPU_EXT=1) + CI`) —
  CI workflow + `setup.py` only. The new `NO_GPU_EXT` env var is
  also not referenced in `docs/`.
- **PR #3349** (`[CI] Restore NO_CUDA_EXT=1 skip-all-extensions semantics`),
  **PR #3314** (`[CI] fix incorrect version tagging`),
  **PR #3302** (`Unconditionally compile common c++ extensions in setup.py`),
  **PR #3237** (`Refactor: abstract discover_subclasses util method`),
  **PR #3334** (`Fix the translation icon`), **PR #3324**, **PR #3316**
  (CODEOWNERS chores), and the Chinese-translation refresh PRs
  (**#3335**, **#3310**) — none touch user-facing MP behavior.
- **PR #3355** (`fix(docker): install CLI requirements`) — only
  modifies `docker/Dockerfile.standalone`. No user docs claim a
  specific dependency set for the standalone image.
- **PR #3309** (the previous drift-check PR for 2026-05-18) — already
  merged; nothing further to audit.

## Generated by

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Branch: `ApostaC:docs/drift-check-2026-05-21`.
Human review is still required before merge; please leave this PR in
draft until reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_018W8ijVh4Bk2QVLtMCSHgVG)_