### PR TITLE
[MP] Update the L2 adapter interface to force measuring the real transferred bytes

### DIFF
--- a/docs/design/v1/mp_observability/EVENTS.md
+++ b/docs/design/v1/mp_observability/EVENTS.md
@@ -71,7 +71,7 @@ Producers:
 | EventType | Metadata keys | Types |
 |---|---|---|
 | `L2_STORE_SUBMITTED` | `adapter_index`, `task_id`, `l2_name`, `key_count`, `total_bytes` | `int`, `int`, `str`, `int`, `int` |
-| `L2_STORE_COMPLETED` | `adapter_index`, `task_id`, `l2_name`, `succeeded_count`, `failed_count` | `int`, `int`, `str`, `int`, `int` |
+| `L2_STORE_COMPLETED` | `adapter_index`, `task_id`, `l2_name`, `bytes_transferred`, `succeeded_count`, `failed_count` | `int`, `int`, `str`, `int`, `int`, `int` |
 
 ---
 

--- a/examples/lmc_external_l2_adapter/src/lmc_external_l2_adapter/adapter.py
+++ b/examples/lmc_external_l2_adapter/src/lmc_external_l2_adapter/adapter.py
@@ -22,6 +22,7 @@ import torch  # noqa: F401  # must precede native_storage_ops
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
     L2TaskId,
@@ -128,7 +129,7 @@ class InMemoryL2Adapter(L2AdapterInterface):
         self._locked: dict[ObjectKey, int] = defaultdict(int)
 
         self._next_id: L2TaskId = 0
-        self._done_store: dict[L2TaskId, bool] = {}
+        self._done_store: dict[L2TaskId, L2StoreResult] = {}
         self._done_lookup: dict[L2TaskId, Bitmap] = {}
         self._done_load: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()
@@ -171,7 +172,7 @@ class InMemoryL2Adapter(L2AdapterInterface):
 
     def pop_completed_store_tasks(
         self,
-    ) -> dict[L2TaskId, bool]:
+    ) -> dict[L2TaskId, L2StoreResult]:
         with self._lock:
             done = self._done_store
             self._done_store = {}
@@ -300,7 +301,7 @@ class InMemoryL2Adapter(L2AdapterInterface):
             await asyncio.sleep(delay)
 
         with self._lock:
-            self._done_store[tid] = ok
+            self._done_store[tid] = L2StoreResult(ok, total)
         self._store_efd.notify()
 
     def _do_lookup(

--- a/examples/lmc_external_l2_adapter/tests/test_plugin.py
+++ b/examples/lmc_external_l2_adapter/tests/test_plugin.py
@@ -289,7 +289,8 @@ class TestPluginRoundTrip:
         tid = adapter.submit_store_task([key], [obj])
         assert _wait_event_fd(store_fd)
         done = adapter.pop_completed_store_tasks()
-        assert done.get(tid) is True
+        assert done.get(tid) is not None
+        assert done[tid].is_successful()
 
         ltid = adapter.submit_lookup_and_lock_task([key])
         assert _wait_event_fd(lookup_fd)
@@ -311,7 +312,8 @@ class TestPluginRoundTrip:
         tid = adapter.submit_store_task([key], [obj])
         assert _wait_event_fd(store_fd)
         done = adapter.pop_completed_store_tasks()
-        assert done.get(tid) is True
+        assert done.get(tid) is not None
+        assert done[tid].is_successful()
 
         dst = torch.zeros_like(src)
         load_obj = _make_tensor_obj(dst)
@@ -334,7 +336,8 @@ class TestPluginRoundTrip:
         tid = adapter.submit_store_task(keys, objs)
         assert _wait_event_fd(store_fd)
         done = adapter.pop_completed_store_tasks()
-        assert done.get(tid) is True
+        assert done.get(tid) is not None
+        assert done[tid].is_successful()
 
         ltid = adapter.submit_lookup_and_lock_task(keys)
         assert _wait_event_fd(lookup_fd)
@@ -387,13 +390,15 @@ class TestPluginRoundTrip:
             tid = adapter.submit_store_task([k], [_create_obj(OBJ_SIZE)])
             assert _wait_event_fd(store_fd)
             done = adapter.pop_completed_store_tasks()
-            assert done.get(tid) is True
+            assert done.get(tid) is not None
+            assert done[tid].is_successful()
 
         # Store k3 -- should evict k1
         tid = adapter.submit_store_task([k3], [_create_obj(OBJ_SIZE)])
         assert _wait_event_fd(store_fd)
         done = adapter.pop_completed_store_tasks()
-        assert done.get(tid) is True
+        assert done.get(tid) is not None
+        assert done[tid].is_successful()
 
         # Lookup all three
         ltid = adapter.submit_lookup_and_lock_task([k1, k2, k3])

--- a/lmcache/cli/commands/bench/l2_adapter_bench/runner.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/runner.py
@@ -21,6 +21,7 @@ import time
 # First Party
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.memory_management import MemoryObj
 
 # Local
@@ -46,10 +47,10 @@ def _bitmap_count(bitmap: Bitmap | None) -> int:
 
 def _wait_store_finished(
     adapter, task_ids: list[int], timeout: float
-) -> dict[int, bool]:
+) -> dict[int, L2StoreResult]:
     """Wait for all store tasks to finish.
 
-    Returns the accumulated ``{task_id: success}`` dict.
+    Returns the accumulated ``{task_id: L2StoreResult}`` dict.
     ``pop_completed_store_tasks`` consumes the adapter's completion
     dict, so we must accumulate the results here for the caller to
     use. On timeout, returns whatever was harvested so far (possibly
@@ -58,7 +59,7 @@ def _wait_store_finished(
     """
     unfinished = len(task_ids)
     efd = adapter.get_store_event_fd()
-    completed: dict[int, bool] = {}
+    completed: dict[int, L2StoreResult] = {}
     while unfinished > 0:
         if not wait_eventfd(efd, timeout=timeout):
             return completed
@@ -168,7 +169,7 @@ def bench_store(
         success_keys = sum(
             len(keys_batches[i])
             for i, tid in enumerate(task_ids)
-            if completed.get(tid, False)
+            if completed.get(tid, L2StoreResult(False, 0)).is_successful()
         )
 
         if timed_out:

--- a/lmcache/v1/check/check_mode_test_l2_adapter.py
+++ b/lmcache/v1/check/check_mode_test_l2_adapter.py
@@ -18,7 +18,7 @@ from lmcache.v1.check.utils import (
     print_performance_results,
 )
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2StoreResult
 from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 from lmcache.v1.distributed.l2_adapters.config import (
     parse_args_to_l2_adapters_config,
@@ -108,7 +108,7 @@ def _run_store_phase(adapter, keys, objects):
         return None, False
     completed = adapter.pop_completed_store_tasks()
     elapsed_ms = (time.perf_counter() - start) * 1000
-    ok = completed.get(task_id, False)
+    ok = completed.get(task_id, L2StoreResult(False, 0)).is_successful()
     return elapsed_ms, ok
 
 

--- a/lmcache/v1/distributed/internal_api.py
+++ b/lmcache/v1/distributed/internal_api.py
@@ -170,6 +170,36 @@ class EvictionAction:
     """The key of the object to be evicted"""
 
 
+class L2StoreResult(int):
+    """Immutable result of a completed L2 store task.
+
+    Encodes both the success flag and bytes transferred in the int
+    value: ``>= 0`` means success (value = bytes transferred);
+    ``-1`` means failure.
+
+    Args:
+        success: Whether the store task succeeded.
+        bytes_transferred: Bytes actually written to L2. Must be >= 0.
+
+    Raises:
+        ValueError: If ``bytes_transferred`` is negative.
+    """
+
+    def __new__(cls, success: bool, bytes_transferred: int) -> "L2StoreResult":
+        if bytes_transferred < 0:
+            raise ValueError(f"bytes_transferred must be >= 0, got {bytes_transferred}")
+        return super().__new__(cls, bytes_transferred if success else -1)
+
+    def is_successful(self) -> bool:
+        """Return ``True`` when the store task succeeded."""
+        return int(self) >= 0
+
+    def bytes_transferred(self) -> int:
+        """Return the number of bytes actually written, or 0 on failure."""
+        value = int(self)
+        return value if value >= 0 else 0
+
+
 @dataclass(frozen=True)
 class QuotaEntry:
     """Snapshot of a single quota registration."""

--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
 from lmcache.v1.memory_management import MemoryObj
 
 logger = init_logger(__name__)
@@ -219,38 +219,17 @@ class L2AdapterInterface(ABC):
         pass
 
     @abstractmethod
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
-        """
-        Pop all the completed store tasks with a flag indicating
-        whether the task is successful or not.
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
+        """Pop all completed store tasks.
 
         Returns:
-            dict[L2TaskId, bool]: a dictionary mapping the task id to a boolean flag
-            indicating whether the task is successful or not. True means
-            successful, and False means failed.
+            dict[L2TaskId, L2StoreResult]: a dictionary mapping the task
+            id to an ``L2StoreResult`` that encodes both the success flag
+            and the bytes actually transferred. Use
+            ``result.is_successful()`` and ``result.bytes_transferred()``
+            to inspect the outcome.
         """
         pass
-
-    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
-        """Report bytes actually transferred per completed store task.
-
-        Optional. Default returns ``{}``, which leaves the L2 throughput
-        subscriber to fall back on submitted-bytes accounting.
-
-        Adapters that fast-path duplicate keys (e.g. skip the write when
-        the key already exists in the backend) SHOULD override this so
-        the throughput histogram reflects real work, not skipped no-ops.
-        A task with all keys fast-pathed reports ``0`` here, which the
-        subscriber treats as "no useful sample" and skips.
-
-        Returns:
-            dict[L2TaskId, int]: task id -> bytes actually written. Keys
-            present here MUST also appear in the next
-            ``pop_completed_store_tasks`` call (they share the same
-            per-task completion record), and the returned dict should be
-            cleared on read, mirroring ``pop_completed_store_tasks``.
-        """
-        return {}
 
     #####################
     # Lookup and Lock Interface

--- a/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/dax_l2_adapter.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     AdapterUsage,
     L2AdapterInterface,
@@ -175,7 +176,7 @@ class DaxL2Adapter(L2AdapterInterface):
         self._load_executor: Optional[ThreadPoolExecutor] = None
 
         self._next_task_id: L2TaskId = 0
-        self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
 
@@ -265,11 +266,11 @@ class DaxL2Adapter(L2AdapterInterface):
         )
         return task_id
 
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
         """Drain completed store task results.
 
         Returns:
-            Mapping from task id to task-level success. Each task appears at
+            Mapping from task id to store result. Each task appears at
             most once; subsequent calls do not return already drained tasks.
         """
         with self._lock:
@@ -512,8 +513,11 @@ class DaxL2Adapter(L2AdapterInterface):
                 if ok:
                     stored_keys.append(key)
         finally:
+            bytes_transferred = self._config.slot_bytes * len(stored_keys)
             with self._lock:
-                self._completed_store_tasks[task_id] = all(per_key_results)
+                self._completed_store_tasks[task_id] = L2StoreResult(
+                    all(per_key_results), bytes_transferred
+                )
                 self._inflight_store_tasks -= 1
 
             if stored_keys:

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -30,6 +30,7 @@ import aiofiles.os
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
     L2TaskId,
@@ -286,12 +287,7 @@ class FSL2Adapter(L2AdapterInterface):
 
         # Task bookkeeping
         self._next_task_id: L2TaskId = 0
-        self._completed_store_tasks: dict[L2TaskId, bool] = {}
-        # Bytes actually written per completed store task.  Excludes
-        # duplicate-key fast-paths (see ``_execute_store``).  Reported to
-        # the L2 throughput subscriber via ``pop_completed_store_task_bytes``
-        # so the histogram reflects real disk I/O, not skipped no-ops.
-        self._completed_store_task_bytes: dict[L2TaskId, int] = {}
+        self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()
@@ -344,17 +340,18 @@ class FSL2Adapter(L2AdapterInterface):
 
     def pop_completed_store_tasks(
         self,
-    ) -> dict[L2TaskId, bool]:
+    ) -> dict[L2TaskId, L2StoreResult]:
+        """Pop all completed store tasks.
+
+        Returns:
+            dict[L2TaskId, L2StoreResult]: a dictionary mapping the task
+            id to an ``L2StoreResult`` that encodes both the success flag
+            and the bytes actually transferred.
+        """
         with self._lock:
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
         return completed
-
-    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
-        with self._lock:
-            completed_bytes = self._completed_store_task_bytes
-            self._completed_store_task_bytes = {}
-        return completed_bytes
 
     # ------------------------------------------------------------------
     # Lookup and Lock Interface
@@ -640,8 +637,7 @@ class FSL2Adapter(L2AdapterInterface):
             success = False
 
         with self._lock:
-            self._completed_store_tasks[task_id] = success
-            self._completed_store_task_bytes[task_id] = bytes_written
+            self._completed_store_tasks[task_id] = L2StoreResult(success, bytes_written)
         self._store_efd.notify()
 
     # ---- lookup ---------------------------------------------------------

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdapterConfigBase,
@@ -124,8 +125,7 @@ class MockL2Adapter(L2AdapterInterface):
 
         # Task ID management
         self._next_task_id: L2TaskId = 0
-        self._completed_store_tasks: dict[L2TaskId, bool] = {}
-        self._completed_store_task_bytes: dict[L2TaskId, int] = {}
+        self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()  # lock for all shared state
@@ -182,26 +182,18 @@ class MockL2Adapter(L2AdapterInterface):
 
         return task_id
 
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
         """
-        Pop all the completed store tasks with a flag indicating
-        whether the task is successful or not.
+        Pop all the completed store tasks with their results.
 
         Returns:
-            dict[L2TaskId, bool]: a dictionary mapping the task id to a boolean flag
-            indicating whether the task is successful or not. True means
-            successful, and False means failed.
+            dict[L2TaskId, L2StoreResult]: a dictionary mapping the task id to
+            an L2StoreResult encoding success/failure and bytes transferred.
         """
         with self._lock:
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
         return completed
-
-    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
-        with self._lock:
-            completed_bytes = self._completed_store_task_bytes
-            self._completed_store_task_bytes = {}
-        return completed_bytes
 
     def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
         with self._lock:
@@ -440,12 +432,11 @@ class MockL2Adapter(L2AdapterInterface):
         # Schedule completion coroutine on the event loop
         await asyncio.sleep(delay_seconds)
         with self._lock:
-            self._completed_store_tasks[task_id] = success
             # ``total_bytes`` counts only objects actually written into
             # ``self._memory_objects`` — duplicates and capacity-skipped
             # keys are excluded.  Reporting this lets the L2 throughput
             # subscriber distinguish real I/O from fast-pathed no-ops.
-            self._completed_store_task_bytes[task_id] = total_bytes
+            self._completed_store_tasks[task_id] = L2StoreResult(success, total_bytes)
 
         if stored_keys:
             self._notify_keys_stored(stored_keys, stored_sizes)

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -30,6 +30,7 @@ import threading
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
     L2TaskId,
@@ -133,7 +134,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         ] = {}
 
         # Completed results (same pattern as MockL2Adapter)
-        self._completed_stores: dict[L2TaskId, bool] = {}
+        self._completed_stores: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookups: dict[L2TaskId, Bitmap] = {}
         self._completed_loads: dict[L2TaskId, Bitmap] = {}
 
@@ -215,7 +216,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
     def pop_completed_store_tasks(
         self,
-    ) -> dict[L2TaskId, bool]:
+    ) -> dict[L2TaskId, L2StoreResult]:
         with self._lock:
             completed = self._completed_stores
             self._completed_stores = {}
@@ -451,8 +452,8 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                     ) = entry
 
                     if op_type == self._OP_STORE:
-                        self._completed_stores[task_id] = ok
                         store_info = self._pending_store_sizes.pop(fid, None)
+                        task_bytes = 0
                         if ok and store_info is not None:
                             store_keys, sizes = store_info
                             for key, size in zip(store_keys, sizes, strict=True):
@@ -467,9 +468,11 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                     self._key_sizes[key] = size
                                     keys_stored.append(key)
                                     sizes_stored.append(size)
+                                    task_bytes += size
                                 else:
                                     keys_stored.append(key)
                                     sizes_stored.append(0)
+                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
                         self._store_efd.notify()
 
                     elif op_type == self._OP_LOOKUP:

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
@@ -41,7 +41,7 @@ from nixl._api import (
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdapterConfigBase,
@@ -358,7 +358,7 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
 
         # Task ID management
         self._next_task_id: L2TaskId = 0
-        self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()
@@ -408,7 +408,7 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         )
         return task_id
 
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
         with self._lock:
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
@@ -649,8 +649,11 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         if stored_keys:
             self._notify_keys_stored(stored_keys, stored_sizes)
 
+        bytes_transferred = sum(stored_sizes)
         with self._lock:
-            self._completed_store_tasks[task_id] = success
+            self._completed_store_tasks[task_id] = L2StoreResult(
+                success, bytes_transferred
+            )
         self._signal_store_event()
 
     def _execute_lookup_in_the_loop(

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -24,7 +24,7 @@ from nixl._api import (
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
 from lmcache.v1.distributed.l2_adapters.config import (
     L2AdapterConfigBase,
@@ -457,13 +457,7 @@ class NixlStoreL2Adapter(L2AdapterInterface):
 
         # Task ID management
         self._next_task_id: L2TaskId = 0
-        self._completed_store_tasks: dict[L2TaskId, bool] = {}
-        # Bytes actually transferred per completed store task.  Excludes
-        # keys that were fast-pathed (already present in
-        # ``_memory_objects``) and any pool-exhaustion fallouts.  Surfaces
-        # to the L2 throughput subscriber so its histogram reflects real
-        # NIXL transfers, not skipped no-ops.
-        self._completed_store_task_bytes: dict[L2TaskId, int] = {}
+        self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()  # lock for all shared state
@@ -517,26 +511,18 @@ class NixlStoreL2Adapter(L2AdapterInterface):
 
         return task_id
 
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
-        """
-        Pop all the completed store tasks with a flag indicating
-        whether the task is successful or not.
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
+        """Pop all completed store tasks.
 
         Returns:
-            dict[L2TaskId, bool]: a dictionary mapping the task id to a boolean flag
-            indicating whether the task is successful or not. True means
-            successful, and False means failed.
+            dict[L2TaskId, L2StoreResult]: a dictionary mapping the task
+            id to an ``L2StoreResult`` that encodes both the success flag
+            and the bytes actually transferred.
         """
         with self._lock:
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
         return completed
-
-    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
-        with self._lock:
-            completed_bytes = self._completed_store_task_bytes
-            self._completed_store_task_bytes = {}
-        return completed_bytes
 
     #####################
     # Lookup and Lock Interface
@@ -777,8 +763,7 @@ class NixlStoreL2Adapter(L2AdapterInterface):
             if not mem_indices_flat:
                 # Nothing to store (all keys already existed or pool empty)
                 with self._lock:
-                    self._completed_store_tasks[task_id] = True
-                    self._completed_store_task_bytes[task_id] = 0
+                    self._completed_store_tasks[task_id] = L2StoreResult(True, 0)
                 self._signal_store_event()
                 return
 
@@ -812,8 +797,9 @@ class NixlStoreL2Adapter(L2AdapterInterface):
             self.nixl_agent.pool.batched_free(storage_indices_flat)
 
         with self._lock:
-            self._completed_store_tasks[task_id] = success
-            self._completed_store_task_bytes[task_id] = bytes_transferred
+            self._completed_store_tasks[task_id] = L2StoreResult(
+                success, bytes_transferred
+            )
 
         self._signal_store_event()
 

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
     L2TaskId,
@@ -351,7 +352,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
         self._lock = threading.Lock()
         self._next_task_id: L2TaskId = 0
 
-        self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
 
@@ -414,7 +415,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
         future.add_done_callback(partial(self._finish_store_task, task_id))
         return task_id
 
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
         """Drain and return completed store task results."""
         with self._lock:
             completed = self._completed_store_tasks
@@ -657,13 +658,17 @@ class RawBlockL2Adapter(L2AdapterInterface):
         success = False
         stored_keys: list[ObjectKey] = []
         stored_sizes: list[int] = []
+        bytes_transferred = 0
         try:
             success, stored_keys, stored_sizes = future.result()
+            bytes_transferred = sum(stored_sizes)
         except Exception as e:
             logger.error("RawBlockL2Adapter store task %d failed: %s", task_id, e)
         with self._lock:
             self._store_inflight_tasks -= 1
-            self._completed_store_tasks[task_id] = success
+            self._completed_store_tasks[task_id] = L2StoreResult(
+                success, bytes_transferred
+            )
             event_fd = self._store_efd
         if stored_keys:
             try:

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -34,6 +34,7 @@ from awscrt.io import ClientTlsContext, TlsConnectionOptions, TlsContextOptions
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
     L2TaskId,
@@ -391,7 +392,7 @@ class S3L2Adapter(L2AdapterInterface):
         self._load_efd = create_event_notifier()
 
         self._next_task_id: L2TaskId = 0
-        self._completed_store_tasks: dict[L2TaskId, bool] = {}
+        self._completed_store_tasks: dict[L2TaskId, L2StoreResult] = {}
         self._completed_lookup_tasks: dict[L2TaskId, Bitmap] = {}
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
 
@@ -462,7 +463,7 @@ class S3L2Adapter(L2AdapterInterface):
             task_id = self._next_task_id
             self._next_task_id += 1
             if self._connection_disabled:
-                self._completed_store_tasks[task_id] = False
+                self._completed_store_tasks[task_id] = L2StoreResult(False, 0)
                 disabled = True
             else:
                 disabled = False
@@ -477,7 +478,7 @@ class S3L2Adapter(L2AdapterInterface):
         )
         return task_id
 
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
         with self._lock:
             completed = self._completed_store_tasks
             self._completed_store_tasks = {}
@@ -876,8 +877,11 @@ class S3L2Adapter(L2AdapterInterface):
 
         self._record_connection_outcome(last_error if not success else None)
 
+        bytes_transferred = sum(newly_stored_sizes)
         with self._lock:
-            self._completed_store_tasks[task_id] = success
+            self._completed_store_tasks[task_id] = L2StoreResult(
+                success, bytes_transferred
+            )
 
         if newly_stored_keys:
             self._notify_keys_stored(newly_stored_keys, newly_stored_sizes)

--- a/lmcache/v1/distributed/l2_adapters/serde_wrapper.py
+++ b/lmcache/v1/distributed/l2_adapters/serde_wrapper.py
@@ -40,7 +40,7 @@ from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.error import L1Error
-from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.base import (
     AdapterUsage,
@@ -131,11 +131,7 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
         self._serde_to_load: dict[SerdeTaskId, L2TaskId] = {}
 
         # User-visible completion queues (drained by controller polls).
-        self._completed_store: dict[L2TaskId, bool] = {}
-        # Bytes actually transferred per completed store task, forwarded
-        # from the inner adapter so wrapped fast-path adapters still
-        # expose accurate throughput data.
-        self._completed_store_bytes: dict[L2TaskId, int] = {}
+        self._completed_store: dict[L2TaskId, L2StoreResult] = {}
         self._completed_load: dict[L2TaskId, Bitmap] = {}
 
         self._stop_flag = threading.Event()
@@ -217,16 +213,10 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
             return wrapped_id
         return wrapped_id
 
-    def pop_completed_store_tasks(self) -> dict[L2TaskId, bool]:
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
         with self._lock:
             result = self._completed_store
             self._completed_store = {}
-        return result
-
-    def pop_completed_store_task_bytes(self) -> dict[L2TaskId, int]:
-        with self._lock:
-            result = self._completed_store_bytes
-            self._completed_store_bytes = {}
         return result
 
     # ------------------------------------------------------------------
@@ -467,8 +457,7 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
         """Drain inner store completions; release temp read locks (auto-
         delete) and finalize the wrapped tasks."""
         completed = self._inner.pop_completed_store_tasks()
-        inner_bytes = self._inner.pop_completed_store_task_bytes()
-        for inner_id, success in completed.items():
+        for inner_id, result in completed.items():
             with self._lock:
                 wrapped_id = self._inner_to_store.pop(inner_id, None)
                 state = (
@@ -484,7 +473,9 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
                 continue
             if state is not None:
                 self._l1_manager.finish_read(state.temp_keys)
-            self._finalize_store(wrapped_id, success, inner_bytes.get(inner_id))
+            self._finalize_store(
+                wrapped_id, result.is_successful(), result.bytes_transferred()
+            )
 
     def _drain_inner_load(self) -> None:
         """Drain inner load completions; on per-key success submit
@@ -622,18 +613,13 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
         self,
         wrapped_id: L2TaskId,
         success: bool,
-        bytes_transferred: int | None = None,
+        bytes_transferred: int = 0,
     ) -> None:
         with self._lock:
             self._store_tasks.pop(wrapped_id, None)
-            self._completed_store[wrapped_id] = success
-            # Only record bytes when the inner adapter reported them.
-            # Absence in the dict signals "unknown" to the controller,
-            # which then falls back to submitted-bytes accounting.  A 0
-            # here means "transferred nothing" -- the subscriber drops
-            # those samples.
-            if bytes_transferred is not None:
-                self._completed_store_bytes[wrapped_id] = bytes_transferred
+            self._completed_store[wrapped_id] = L2StoreResult(
+                success, bytes_transferred
+            )
         try:
             self._store_efd.notify()
         except OSError:

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -182,11 +182,8 @@ class InFlightStoreTask:
     l2_store_result: bool | None = None
     """L2 outcome (True=success, False=failure, None=still in flight)."""
 
-    l2_bytes_transferred: int | None = None
-    """Bytes actually transferred by the adapter for this task.  ``None``
-    means the adapter does not track per-task transfer bytes (default
-    behavior for non fast-path adapters); consumers fall back to the
-    submitted-bytes count from the SUBMITTED event."""
+    l2_bytes_transferred: int = 0
+    """Bytes actually transferred by the adapter for this task."""
 
 
 # Main class
@@ -528,8 +525,7 @@ class StoreController(StorageControllerInterface):
         for adapter_index in signaled_adapters:
             adapter = self._l2_adapters[adapter_index]
             completed = adapter.pop_completed_store_tasks()
-            bytes_map = adapter.pop_completed_store_task_bytes()
-            for task_id, success in completed.items():
+            for task_id, result in completed.items():
                 task = self._in_flight_tasks.get((adapter_index, task_id))
                 if task is None:
                     logger.warning(
@@ -538,9 +534,8 @@ class StoreController(StorageControllerInterface):
                         adapter_index,
                     )
                     continue
-                task.l2_store_result = success
-                if task_id in bytes_map:
-                    task.l2_bytes_transferred = bytes_map[task_id]
+                task.l2_store_result = result.is_successful()
+                task.l2_bytes_transferred = result.bytes_transferred()
 
     def _advance_request(
         self,
@@ -570,20 +565,12 @@ class StoreController(StorageControllerInterface):
         self._status_in_flight_count -= 1
 
         l2_name = self._adapter_descriptors[adapter_index].type_name
-        # Adapters that fast-path duplicate keys report ``bytes_transferred``
-        # so the L2 throughput subscriber can use real-work bytes for the
-        # histogram instead of submitted bytes (which inflates dt-based
-        # throughput when the adapter skipped the write).  Adapters that
-        # don't report bytes leave this at ``None`` -- the field is then
-        # omitted from the event so consumers fall back to the submitted
-        # bytes carried on the SUBMITTED event.
         completion_meta: dict[str, object] = {
             "adapter_index": adapter_index,
             "task_id": task_id,
             "l2_name": l2_name,
+            "bytes_transferred": task.l2_bytes_transferred,
         }
-        if task.l2_bytes_transferred is not None:
-            completion_meta["bytes_transferred"] = task.l2_bytes_transferred
         if success:
             self._event_bus.publish(
                 Event(

--- a/lmcache/v1/mp_observability/subscribers/metrics/l2_throughput.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/l2_throughput.py
@@ -21,17 +21,6 @@ Implementation:
   - ``(end_ts - start_ts)`` spans submit -> complete and therefore
     includes adapter queue, network, and disk time — not just transfer.
     The histogram is "bytes / end-to-end latency", not raw transfer rate.
-
-Fast-path adapters:
-  Some adapters (``mock``, ``fs``, ``nixl_store``) skip writes for keys
-  that are already present, which makes ``dt`` collapse to near-zero and
-  inflates store throughput (the controller asked to store N bytes but
-  the adapter actually transferred 0).  When ``L2_STORE_COMPLETED``
-  carries ``bytes_transferred``, the store path uses it instead of the
-  submitted bytes; if ``bytes_transferred == 0`` the sample is dropped
-  (no work, no useful throughput data).  When the field is absent
-  (adapter doesn't track it), behavior matches the load path -- submitted
-  bytes / dt.
 """
 
 # Future
@@ -101,16 +90,16 @@ class L2ThroughputSubscriber(EventSubscriber):
         key = self._store_key(event)
         if key is None:
             return
-        # If the adapter reports per-task transfer bytes, prefer that
-        # over submitted bytes.  ``None`` means "adapter doesn't track" ->
-        # fall back to submitted-bytes accounting (the load-path code).
+
+        # ``bytes_transferred`` is always present in L2_STORE_COMPLETED
+        # events (populated from L2StoreResult).
         bytes_transferred = event.metadata.get("bytes_transferred")
         self._record(
             event=event,
             correlation_key=key,
             pending=self._pending_store,
             hist=self._store_hist,
-            override_bytes=bytes_transferred,
+            real_bytes_transferred=bytes_transferred,
         )
 
     # -- Load path (L2->L1) ------------------------------------------------
@@ -166,18 +155,27 @@ class L2ThroughputSubscriber(EventSubscriber):
         correlation_key: tuple[int, int],
         pending: dict[tuple[int, int], tuple[float, int]],
         hist: Any,
-        override_bytes: int | None = None,
+        real_bytes_transferred: int | None = None,
     ) -> None:
+        """
+        Record a throughput sample.
+
+        Args:
+            event: The COMPLETED event, used for timestamp and metadata.
+            correlation_key: The key to look up the matching SUBMITTED event.
+            pending: The dict mapping correlation keys to (t_start, total_bytes).
+            hist: The OTel histogram to record into.
+            real_bytes_transferred: If set, use this instead of the submitted
+                totay_bytes, When it's 0, drop the sample.
+        """
         pending_entry = pending.pop(correlation_key, None)
         if pending_entry is None:
             return  # no matching SUBMITTED event;
         t_start, total_bytes = pending_entry
 
-        # ``override_bytes`` carries the adapter-reported transfer bytes
-        # for fast-path-aware adapters.  ``None`` -> use submitted bytes
-        # (current behavior).  ``0`` -> adapter fast-pathed everything,
-        # there is no real throughput to record -- drop the sample.
-        effective_bytes = total_bytes if override_bytes is None else override_bytes
+        effective_bytes = (
+            total_bytes if real_bytes_transferred is None else real_bytes_transferred
+        )
         if effective_bytes <= 0:
             return
 

--- a/tests/v1/distributed/test_dax_l2_adapter.py
+++ b/tests/v1/distributed/test_dax_l2_adapter.py
@@ -134,7 +134,7 @@ def store_and_wait(adapter: DaxL2Adapter, key: ObjectKey, obj: MemoryObj) -> Non
     task_id = adapter.submit_store_task([key], [obj])
     assert wait_for_event_fd(adapter.get_store_event_fd())
     completed = adapter.pop_completed_store_tasks()
-    assert completed == {task_id: True}
+    assert completed[task_id].is_successful()
 
 
 def bitmap_to_bools(bitmap: Bitmap, size: int) -> list[bool]:
@@ -170,7 +170,8 @@ def test_dax_adapter_store_lookup_load_and_one_shot_results(tmp_path):
 
         store_task = adapter.submit_store_task([key0, key2], [obj0, obj2])
         assert wait_for_event_fd(adapter.get_store_event_fd())
-        assert adapter.pop_completed_store_tasks() == {store_task: True}
+        completed = adapter.pop_completed_store_tasks()
+        assert completed[store_task].is_successful()
         assert adapter.pop_completed_store_tasks() == {}
         assert listener.stored == [[key0, key2]]
 
@@ -294,7 +295,8 @@ def test_dax_adapter_full_arena_does_not_evict_internally(tmp_path):
 
         task_id = adapter.submit_store_task([key2], [obj2])
         assert wait_for_event_fd(adapter.get_store_event_fd())
-        assert adapter.pop_completed_store_tasks() == {task_id: False}
+        completed = adapter.pop_completed_store_tasks()
+        assert not completed[task_id].is_successful()
         assert listener.stored == [[key0], [key1]]
         assert adapter.get_usage().usage_fraction == pytest.approx(1.0)
 

--- a/tests/v1/distributed/test_l2_adapter_base.py
+++ b/tests/v1/distributed/test_l2_adapter_base.py
@@ -15,10 +15,11 @@ import pytest
 
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
-from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     AdapterUsage,
     L2AdapterInterface,
+    L2TaskId,
 )
 
 
@@ -47,7 +48,7 @@ class _StubAdapter(L2AdapterInterface):
     def submit_store_task(self, keys, objects):
         return 0
 
-    def pop_completed_store_tasks(self):
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
         return {}
 
     def submit_lookup_and_lock_task(self, keys):

--- a/tests/v1/distributed/test_mock_l2_adapter.py
+++ b/tests/v1/distributed/test_mock_l2_adapter.py
@@ -202,7 +202,7 @@ class TestStoreInterface:
         completed = adapter.pop_completed_store_tasks()
 
         assert task_id in completed
-        assert completed[task_id] is True  # Should be successful
+        assert completed[task_id].is_successful()  # Should be successful
 
     def test_pop_completed_store_tasks_clears_completed(self, adapter):
         """pop_completed_store_tasks should clear the completed tasks."""
@@ -244,7 +244,7 @@ class TestStoreInterface:
         # All tasks should be completed
         for task_id in task_ids:
             assert task_id in completed
-            assert completed[task_id] is True
+            assert completed[task_id].is_successful()
 
     def test_store_batch_of_objects(self, adapter):
         """A single store task can store multiple key-object pairs."""
@@ -258,7 +258,7 @@ class TestStoreInterface:
 
         completed = adapter.pop_completed_store_tasks()
         assert task_id in completed
-        assert completed[task_id] is True
+        assert completed[task_id].is_successful()
 
 
 # =============================================================================
@@ -516,7 +516,7 @@ class TestEndToEndWorkflow:
         store_task_id = adapter.submit_store_task([key], [store_obj])
         assert wait_for_event_fd(store_fd, timeout=5.0)
         completed = adapter.pop_completed_store_tasks()
-        assert completed[store_task_id] is True
+        assert completed[store_task_id].is_successful()
 
         # Step 2: Lookup and lock
         lookup_task_id = adapter.submit_lookup_and_lock_task([key])
@@ -556,7 +556,7 @@ class TestEndToEndWorkflow:
         store_task_id = adapter.submit_store_task(keys, store_objs)
         assert wait_for_event_fd(store_fd, timeout=5.0)
         completed = adapter.pop_completed_store_tasks()
-        assert completed[store_task_id] is True
+        assert completed[store_task_id].is_successful()
 
         # Lookup all
         lookup_task_id = adapter.submit_lookup_and_lock_task(keys)

--- a/tests/v1/distributed/test_mooncake_store_l2_adapter.py
+++ b/tests/v1/distributed/test_mooncake_store_l2_adapter.py
@@ -657,7 +657,7 @@ class TestMooncakeStoreIntegration:
         store_tid = self.adapter.submit_store_task(keys, objs)
         assert wait_for_event_fd(store_fd)
         completed = self.adapter.pop_completed_store_tasks()
-        assert completed[store_tid] is True
+        assert completed[store_tid].is_successful()
 
         # Lookup all — should find everything
         lookup_tid = self.adapter.submit_lookup_and_lock_task(keys)
@@ -695,7 +695,7 @@ class TestMooncakeStoreIntegration:
         # Store
         store_tid = self.adapter.submit_store_task([key], [store_obj])
         assert wait_for_event_fd(store_fd)
-        assert self.adapter.pop_completed_store_tasks()[store_tid] is True
+        assert self.adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         # Lookup
         lookup_tid = self.adapter.submit_lookup_and_lock_task([key])
@@ -733,7 +733,7 @@ class TestMooncakeStoreIntegration:
         # Store all
         store_tid = self.adapter.submit_store_task(keys, store_objs)
         assert wait_for_event_fd(store_fd)
-        assert self.adapter.pop_completed_store_tasks()[store_tid] is True
+        assert self.adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         # Lookup all
         lookup_tid = self.adapter.submit_lookup_and_lock_task(keys)
@@ -798,7 +798,7 @@ class TestMooncakeStoreIntegration:
         # Store
         store_tid = self.adapter.submit_store_task([key], [store_obj])
         assert wait_for_event_fd(store_fd)
-        assert self.adapter.pop_completed_store_tasks()[store_tid] is True
+        assert self.adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         # Confirm stored
         lookup_tid = self.adapter.submit_lookup_and_lock_task([key])
@@ -840,7 +840,7 @@ class TestMooncakeStoreIntegration:
         # Store the first 3
         store_tid = self.adapter.submit_store_task(stored_keys, stored_objs)
         assert wait_for_event_fd(store_fd)
-        assert self.adapter.pop_completed_store_tasks()[store_tid] is True
+        assert self.adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         # Confirm they exist
         lookup_tid = self.adapter.submit_lookup_and_lock_task(stored_keys)
@@ -874,7 +874,7 @@ class TestMooncakeStoreIntegration:
         # Store
         store_tid = self.adapter.submit_store_task([key], [store_obj])
         assert wait_for_event_fd(store_fd)
-        assert self.adapter.pop_completed_store_tasks()[store_tid] is True
+        assert self.adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         usage_after_store = self.adapter.get_usage().total_bytes_used
         assert usage_after_store > usage_before, "Usage should increase after store"
@@ -967,7 +967,7 @@ class TestMooncakeStoreIntegration:
 
             store_tid = adapter.submit_store_task([key], [store_obj])
             assert wait_for_event_fd(adapter.get_store_event_fd())
-            assert adapter.pop_completed_store_tasks()[store_tid] is True
+            assert adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
             lookup_tid = adapter.submit_lookup_and_lock_task([key])
             assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -432,7 +432,7 @@ class TestStoreInterface:
 
         completed = adapter.pop_completed_store_tasks()
         assert task_id in completed
-        assert completed[task_id] is True
+        assert completed[task_id].is_successful()
 
     def test_pop_clears_completed_tasks(self, adapter):
         key = create_object_key(1)
@@ -465,7 +465,7 @@ class TestStoreInterface:
             completed.update(adapter.pop_completed_store_tasks())
 
         for tid in task_ids:
-            assert completed[tid] is True
+            assert completed[tid].is_successful()
 
     def test_batch_store(self, adapter):
         keys = [create_object_key(i) for i in range(3)]
@@ -476,7 +476,7 @@ class TestStoreInterface:
         assert wait_for_event_fd(store_fd, timeout=5.0)
 
         completed = adapter.pop_completed_store_tasks()
-        assert completed[task_id] is True
+        assert completed[task_id].is_successful()
 
 
 # =============================================================================
@@ -670,7 +670,7 @@ class TestEndToEndWorkflow:
         # Store
         store_tid = adapter.submit_store_task([key], [store_obj])
         assert wait_for_event_fd(store_fd, timeout=5.0)
-        assert adapter.pop_completed_store_tasks()[store_tid] is True
+        assert adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         # Lookup
         lookup_tid = adapter.submit_lookup_and_lock_task([key])
@@ -703,7 +703,7 @@ class TestEndToEndWorkflow:
         # Store all
         store_tid = adapter.submit_store_task(keys, store_objs)
         assert wait_for_event_fd(store_fd, timeout=5.0)
-        assert adapter.pop_completed_store_tasks()[store_tid] is True
+        assert adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         # Lookup all
         lookup_tid = adapter.submit_lookup_and_lock_task(keys)

--- a/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
@@ -255,7 +255,7 @@ class TestStoreInterface:
 
         completed = adpt.pop_completed_store_tasks()
         assert task_id in completed
-        assert completed[task_id] is True
+        assert completed[task_id].is_successful()
 
     def test_store_creates_file_on_disk(self, adapter):
         adpt, buf, tmp_dir = adapter
@@ -407,7 +407,7 @@ class TestEndToEnd:
         store_task = adpt.submit_store_task([key], [store_obj])
         wait_for_event_fd(adpt.get_store_event_fd())
         completed = adpt.pop_completed_store_tasks()
-        assert completed[store_task] is True
+        assert completed[store_task].is_successful()
 
         # Lookup
         lookup_task = adpt.submit_lookup_and_lock_task([key])

--- a/tests/v1/distributed/test_nixl_store_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_l2_adapter.py
@@ -253,7 +253,7 @@ class TestStoreInterface:
         completed = adpt.pop_completed_store_tasks()
 
         assert task_id in completed
-        assert completed[task_id] is True
+        assert completed[task_id].is_successful()
 
     def test_pop_completed_store_tasks_clears_completed(self, adapter):
         """pop_completed_store_tasks should clear the completed tasks."""
@@ -298,7 +298,7 @@ class TestStoreInterface:
 
         for task_id in task_ids:
             assert task_id in completed
-            assert completed[task_id] is True
+            assert completed[task_id].is_successful()
 
     def test_store_batch_of_objects(self, adapter):
         """A single store task can store multiple key-object pairs."""
@@ -315,7 +315,7 @@ class TestStoreInterface:
 
         completed = adpt.pop_completed_store_tasks()
         assert task_id in completed
-        assert completed[task_id] is True
+        assert completed[task_id].is_successful()
 
 
 # =============================================================================
@@ -589,7 +589,7 @@ class TestEndToEndWorkflow:
         store_task_id = adpt.submit_store_task([key], [store_obj])
         assert wait_for_event_fd(store_fd, timeout=5.0)
         completed = adpt.pop_completed_store_tasks()
-        assert completed[store_task_id] is True
+        assert completed[store_task_id].is_successful()
 
         # Step 2: Lookup and lock
         lookup_task_id = adpt.submit_lookup_and_lock_task([key])
@@ -627,7 +627,7 @@ class TestEndToEndWorkflow:
         store_task_id = adpt.submit_store_task([key], [store_obj])
         assert wait_for_event_fd(store_fd, timeout=5.0)
         completed = adpt.pop_completed_store_tasks()
-        assert completed[store_task_id] is True
+        assert completed[store_task_id].is_successful()
 
         # Lookup
         lookup_task_id = adpt.submit_lookup_and_lock_task([key])
@@ -668,7 +668,7 @@ class TestEndToEndWorkflow:
         store_task_id = adpt.submit_store_task(keys, store_objs)
         assert wait_for_event_fd(store_fd, timeout=5.0)
         completed = adpt.pop_completed_store_tasks()
-        assert completed[store_task_id] is True
+        assert completed[store_task_id].is_successful()
 
         # Lookup all
         lookup_task_id = adpt.submit_lookup_and_lock_task(keys)

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -203,7 +203,7 @@ def _run_store(adapter: RawBlockL2Adapter, keys, objects) -> bool:
     assert _wait_event_fd(adapter.get_store_event_fd())
     completed = adapter.pop_completed_store_tasks()
     assert task_id in completed
-    return completed[task_id]
+    return completed[task_id].is_successful()
 
 
 def _run_lookup(adapter: RawBlockL2Adapter, keys):
@@ -400,7 +400,7 @@ def test_raw_block_l2_adapter_listener_errors_do_not_block_eventfds():
 
             store_task_id = adapter.submit_store_task([key], [obj])
             assert _wait_event_fd(adapter.get_store_event_fd())
-            assert adapter.pop_completed_store_tasks()[store_task_id] is True
+            assert adapter.pop_completed_store_tasks()[store_task_id].is_successful()
 
             load_buffer = _create_memory_obj(fill_value=0.0)
             load_task_id = adapter.submit_load_task([key], [load_buffer])

--- a/tests/v1/distributed/test_resp_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_resp_l2_adapter_integration.py
@@ -148,7 +148,7 @@ class TestRESPL2AdapterIntegration:
         store_tid = self.adapter.submit_store_task(keys, objs)
         assert wait_for_event_fd(store_fd)
         completed = self.adapter.pop_completed_store_tasks()
-        assert completed[store_tid] is True
+        assert completed[store_tid].is_successful()
 
         # Lookup all — should find everything
         lookup_tid = self.adapter.submit_lookup_and_lock_task(keys)
@@ -186,7 +186,7 @@ class TestRESPL2AdapterIntegration:
         # Store
         store_tid = self.adapter.submit_store_task([key], [store_obj])
         assert wait_for_event_fd(store_fd)
-        assert self.adapter.pop_completed_store_tasks()[store_tid] is True
+        assert self.adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         # Lookup
         lookup_tid = self.adapter.submit_lookup_and_lock_task([key])
@@ -224,7 +224,7 @@ class TestRESPL2AdapterIntegration:
         # Store all
         store_tid = self.adapter.submit_store_task(keys, store_objs)
         assert wait_for_event_fd(store_fd)
-        assert self.adapter.pop_completed_store_tasks()[store_tid] is True
+        assert self.adapter.pop_completed_store_tasks()[store_tid].is_successful()
 
         # Lookup all
         lookup_tid = self.adapter.submit_lookup_and_lock_task(keys)

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -380,7 +380,7 @@ class TestStoreLookupLoad:
         tid = adapter.submit_store_task([key], [obj])
         assert wait_for_event_fd(adapter.get_store_event_fd())
         completed = adapter.pop_completed_store_tasks()
-        assert completed == {tid: True}
+        assert completed[tid].is_successful()
 
         # Lookup
         tid = adapter.submit_lookup_and_lock_task([key])
@@ -564,7 +564,7 @@ class TestCircuitBreaker:
         )
         wait_for_event_fd(adapter.get_store_event_fd(), timeout=2.0)
         completed = adapter.pop_completed_store_tasks()
-        assert completed[disabled_tid] is False
+        assert not completed[disabled_tid].is_successful()
         assert _BACKEND.counts()["put"] == put_before  # never reached the backend
 
         # Lookup and load also short-circuit to all-zero bitmaps.


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Introduces `L2StoreResult(int)` — an immutable result type
  a. `>= 0` means success with that many bytes transferred, 
  b. `-1` means failure.
2. Removes the `pop_completed_store_task_bytes()` interface.
3. `pop_completed_store_tasks()` now returns `dict[L2TaskId, L2StoreResult]` instead of `dict[L2TaskId, bool]`. All the related code is updated.


2 and 3 effectively force every L2 adapter to report actual bytes transferred, which avoids the potential for wrong metrics being reported.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests