### PR TITLE
docs: daily drift check — multi-process mode (2026-05-22)

### DIFF
--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -348,19 +348,25 @@ point-in-time state snapshots that do not correspond to discrete events.
 
 ## L1 / L2 State Metrics
 
-Live state of the L1 memory pool and the in-flight L2 store / prefetch-load
-queues.  These metrics are useful for capacity planning, sizing L1, and
-spotting backpressure on individual L2 adapters.
+Live state of the L1 memory pool, the per-adapter L2 byte usage, and the
+in-flight L2 store / prefetch-load queues.  These metrics are useful for
+capacity planning, sizing L1, watching L2 fullness, and spotting
+backpressure on individual L2 adapters.
 
-All four metrics are OTel `ObservableGauge` instruments registered via the
+All five metrics are OTel `ObservableGauge` instruments registered via the
 shared `register_gauge` helper.  At scrape time, OTel invokes the
-registered callback, which iterates the controller's live in-flight state
-and returns one observation per adapter that currently has work.
-Adapters with no in-flight work emit no datapoint for that scrape.
+registered callback, which iterates the controller's live state and
+returns one observation per adapter (for `l2_usage_bytes`, one per
+configured adapter; for the in-flight gauges, only adapters with work).
+Adapters with no in-flight work emit no datapoint for the three
+in-flight gauges.
 
-The three in-flight metrics carry two attributes that disambiguate
-adapters even when more than one is registered with the same backend type
-— same shape as the existing `lmcache_mp.l2_store_completed` counter:
+`lmcache_mp.l2_usage_bytes` carries a single `l2_name` attribute — the
+adapter's registered type name (e.g. `"fs"`, `"mock"`,
+`"nixl_store"`).  The three in-flight metrics carry two attributes
+that disambiguate adapters even when more than one is registered with
+the same backend type — same shape as the existing
+`lmcache_mp.l2_store_completed` counter:
 
 - `l2_name` — the registered adapter type (e.g. `"fs"`, `"mock"`,
   `"nixl_store"`).
@@ -371,6 +377,7 @@ adapters even when more than one is registered with the same backend type
 | OTel metric name | Prometheus name | Type | Source of truth | Calculation |
 |---|---|---|---|---|
 | `lmcache_mp.l1_memory_usage_bytes` | `lmcache_mp_l1_memory_usage_bytes` | ObservableGauge | `L1Manager.get_memory_usage()` | Bytes currently held in L1 at scrape time |
+| `lmcache_mp.l2_usage_bytes` | `lmcache_mp_l2_usage_bytes` | ObservableGauge (attr: `l2_name`) | `StorageManager.get_l2_usages()` (calls `L2AdapterInterface.get_usage().total_bytes_used`) | Per-adapter bytes currently held in L2 at scrape time; one observation per configured adapter.  Adapters whose `get_usage()` raises are skipped silently. |
 | `lmcache_mp.num_inflight_l2_stores` | `lmcache_mp_num_inflight_l2_stores` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `StoreController.get_inflight_count_by_adapter()` | Snapshot of in-flight L2 store tasks grouped by adapter |
 | `lmcache_mp.num_inflight_l2_loads` | `lmcache_mp_num_inflight_l2_loads` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `PrefetchController.get_inflight_load_state_by_adapter()` | Per-adapter count from the same snapshot |
 | `lmcache_mp.inflight_load_memory_usage_bytes` | `lmcache_mp_inflight_load_memory_usage_bytes` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `PrefetchController.get_inflight_load_state_by_adapter()` | Per-adapter reserved bytes from the same snapshot |
@@ -378,6 +385,12 @@ adapters even when more than one is registered with the same backend type
 **What `l1_memory_usage_bytes` answers:** How full is the L1 cache? Helps
 size L1 against working set and detect leaks (steadily climbing without
 plateauing).
+
+**What `l2_usage_bytes` answers:** How full is each L2 backend? Lets
+operators query how much each L2 tier currently holds, decide whether
+an adapter needs eviction or purge, and spot per-backend asymmetries
+when more than one L2 is configured.  Parallel to `l1_memory_usage_bytes`
+on the L2 tier.
 
 **What `num_inflight_l2_stores` answers:** Are L2 stores piling up on a
 particular adapter? Sustained non-zero values indicate the adapter cannot

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -540,6 +540,15 @@ Adapters with no in-flight work emit no datapoint for that scrape.
        the callback never raises during a scrape. Compare against the
        eviction watermark (default ``0.8``) to read whether the
        eviction loop is below or above its trigger threshold.
+   * - ``lmcache_mp.l2_usage_bytes``
+     - ObservableGauge (attr: ``l2_name``)
+     - Bytes currently held in each L2 adapter, tagged by ``l2_name``
+       (one observation per adapter).  Sampled at scrape time from
+       ``L2AdapterInterface.get_usage().total_bytes_used``.  Parallel to
+       ``l1_memory_usage_bytes`` on the L2 tier — use it to see how full
+       each backend is and whether eviction or purge is keeping up.
+       Adapters whose ``get_usage()`` raises are skipped silently rather
+       than poisoning the gauge.
    * - ``lmcache_mp.num_inflight_l2_stores``
      - ObservableGauge (attrs: ``l2_name``, ``adapter_index``)
      - L2 store tasks currently executing, per adapter.  Sustained


### PR DESCRIPTION
## Summary

Auto-generated by the daily multi-process docs drift-check routine.
**Human review is required before merge — do not merge as-is.**

One new piece of `docs/source/` drift (with a parallel `docs/design/`
counterpart) was introduced between the previous drift sweep window
([2026-05-21 — PR #3361](https://github.com/LMCache/LMCache/pull/3361)
based on `dev` HEAD
[`d9f3438`](https://github.com/LMCache/LMCache/commit/d9f3438b067ae36fd08671fb3e058d55ffd07634))
and today's `dev` HEAD
([`4168b09`](https://github.com/LMCache/LMCache/commit/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989)).
It is user-facing — the MP *Observable Gauges* reference does not
list the new `lmcache_mp.l2_usage_bytes` gauge that was added on
2026-05-22.

Today's PR is filed as a separate draft (not appended to #3273,
#3329, or #3361) because the item is **independent** of the items
already under review on those branches: none of the open drift-check
PRs touch the *Observable Gauges* list-table in
`docs/source/mp/observability.rst` or the *L1 / L2 State Metrics*
section in `docs/design/v1/mp_observability/METRICS.md`, and rebasing
them would require force-pushing reviewed commits. The dedup rule
asks us to merge only when the *same* items are still open, which is
not the case here.

---

### `docs/source/` drift

#### `docs/source/mp/observability.rst` — *Observable Gauges* table missing `lmcache_mp.l2_usage_bytes`

[PR #3320](https://github.com/LMCache/LMCache/pull/3320)
(*[Observability]: Add L2 Usage to SM*, commit
[`3300d0d`](https://github.com/LMCache/LMCache/commit/3300d0d9a3411c3b79f0190ab360408d1394c20c))
merged on 2026-05-22. It registers a new observable gauge in
`StorageManager.__init__`:

```python
# lmcache/v1/distributed/storage_manager.py (dev HEAD 4168b09)
# L2 usage gauge — one observation per adapter, tagged by
# ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
register_gauge(
    "lmcache.l2",
    "lmcache_mp.l2_usage_bytes",
    (
        "Bytes currently held in each L2 adapter, tagged by "
        "``l2_name`` (one observation per adapter)."
    ),
    self.get_l2_usages,
)
```

— see
[`storage_manager.py#L143-L153`](https://github.com/LMCache/LMCache/blob/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989/lmcache/v1/distributed/storage_manager.py#L143-L153).
The callback,
[`get_l2_usages` (`storage_manager.py#L429-L455`)](https://github.com/LMCache/LMCache/blob/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989/lmcache/v1/distributed/storage_manager.py#L429-L455),
returns one `(int(total_bytes_used), {"l2_name": <type_name>})`
observation per configured L2 adapter, calling
`L2AdapterInterface.get_usage()` per adapter and silently skipping
any adapter whose `get_usage()` raises.

The stale doc locations:

- [`docs/source/mp/observability.rst` *Observable Gauges* section,
  lines 519-560 on `dev`](https://github.com/LMCache/LMCache/blob/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989/docs/source/mp/observability.rst#L519-L560)
  — enumerates `lmcache_mp.active_prefetch_jobs`,
  `l1_memory_usage_bytes`, `l1_usage_ratio`, `num_inflight_l2_stores`,
  `num_inflight_l2_loads`, and `inflight_load_memory_usage_bytes`,
  but not the new `l2_usage_bytes`.
- A `grep -rn "l2_usage_bytes" docs/source/` on
  [`4168b09`](https://github.com/LMCache/LMCache/commit/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989)
  returns zero hits, confirming the metric is entirely undocumented
  on this page.

The `docs/source/mp/quickstart.rst`, `deployment.rst`,
`tracing_and_debugging.rst`, and `l2_storage.rst` pages are not stale
— none of them enumerate Observable Gauges, so the omission is
isolated to `observability.rst`.

#### `docs/design/` drift

##### `docs/design/v1/mp_observability/METRICS.md` — *L1 / L2 State Metrics* table missing `lmcache_mp.l2_usage_bytes`

The matching design-doc catalogue at
[`docs/design/v1/mp_observability/METRICS.md` *L1 / L2 State Metrics*,
lines 349-376 on `dev`](https://github.com/LMCache/LMCache/blob/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989/docs/design/v1/mp_observability/METRICS.md#L349-L376)
likewise lists only the four pre-existing gauges
(`l1_memory_usage_bytes`, `num_inflight_l2_stores`,
`num_inflight_l2_loads`, `inflight_load_memory_usage_bytes`) and
declares "All four metrics are OTel `ObservableGauge` instruments…".
A `grep -rn "l2_usage_bytes" docs/design/` on
[`4168b09`](https://github.com/LMCache/LMCache/commit/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989)
returns zero hits.

---

## Proposed fix (applied in this PR — one commit)

A single doc-only commit
([`a687192`](https://github.com/ApostaC/LMCache/commit/a6871922dfa539ea8b3a34e14ca63e49d9f9a2a9)),
DCO-signed and authored by ApostaC:

- **`docs/source/mp/observability.rst`** — add an `lmcache_mp.l2_usage_bytes`
  row to the *Observable Gauges* `list-table`, between `l1_usage_ratio`
  and `num_inflight_l2_stores`.  Description text follows the
  `register_gauge(...)` description string and `get_l2_usages`
  docstring verbatim, and explicitly names the `L2AdapterInterface.get_usage().total_bytes_used`
  source.
- **`docs/design/v1/mp_observability/METRICS.md`** — add a row to
  the *L1 / L2 State Metrics* table, update the section intro from
  "All four" to "All five" and call out the new gauge's `l2_name`
  attribute alongside the in-flight gauges' two-attribute shape,
  and add a "What `l2_usage_bytes` answers" paragraph below the
  existing per-metric answers.

No code files are touched.  No behavior change is implied — wording
follows the merged code verbatim.

## Audit-clean (no drift) commits in today's window

The following `dev` commits between
[`d9f3438`](https://github.com/LMCache/LMCache/commit/d9f3438b067ae36fd08671fb3e058d55ffd07634)
(2026-05-21) and
[`4168b09`](https://github.com/LMCache/LMCache/commit/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989)
(2026-05-22) were audited and introduced no additional MP doc drift:

- **PR #3148** (`Add macos ci check`) — adds a macOS smoke-test CI
  workflow, swaps it to `NO_GPU_EXT=1` to align with
  `build_cpu_artifacts.yml`, and introduces a C++ `event_notifier.h`
  abstraction with a `PipeNotifier` fallback for platforms without
  `eventfd`. `grep -rn "NO_GPU_EXT\|NO_NATIVE_EXT\|NO_CUDA_EXT\|EventFdNotifier\|PipeNotifier\|event_notifier\|macos" docs/source/mp/ docs/design/v1/mp_observability/` on
  [`4168b09`](https://github.com/LMCache/LMCache/commit/4168b0991cd1c5eeef36efda6c7dc4c91f7b8989)
  returns zero hits — these strings are not referenced in MP user
  docs or in the MP observability design tree. No MP doc claims a
  specific platform-support matrix that would now be stale.
- **PR #3366** (`Hotfix: remove macos-13 from ci workflow as resource
  insufficient`) — `.github/workflows/macos_compat.yml` only.  Pure CI
  infra change; no MP doc enumerates CI runner versions.
- **PR #3361** (the previous drift-check PR for 2026-05-21) — still
  open and orthogonal to today's item (it touches the *L1 Memory
  Manager* configuration table in `configuration.rst`); nothing
  further to audit.

## Generated by

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Branch: `ApostaC:docs/drift-check-2026-05-22`.
Human review is still required before merge; please leave this PR in
draft until reviewed.

---
_Generated by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01SappMVpKnofEajmKsCR1zy)_