### PR TITLE
[good-first-issue] examples/agents: Fix 4 bugs in prefix_analysis.py

### DIFF
--- a/examples/agents/prefix_analysis.py
+++ b/examples/agents/prefix_analysis.py
@@ -17,6 +17,9 @@ import torch
 DEFAULT_TOKENIZER = "meta-llama/Llama-3.1-8B"
 DEFAULT_TOKENS_PER_GB = 8200  # Default for Llama-3.1; More details here: https://docs.lmcache.ai/getting_started/kv_cache_calculator.html
 DEFAULT_POOL_SIZES_GB: List[Union[int, float, str]] = [
+    0.1,
+    0.2,
+    0.4,
     1,
     2,
     4,
@@ -124,9 +127,23 @@ class LRUTokenPool:
     ) -> None:
         """
         Add a request to the pool, evicting LRU entries if necessary.
+        When a single request exceeds the pool capacity, tokens are trimmed
+        to capacity (keeping the head) to maintain the pool invariant that
+        current_tokens <= max_tokens.
         """
+        # For unlimited pools (max_tokens == inf), skip trimming since
+        # there is no capacity limit. Otherwise convert to int for slicing.
+        if self.max_tokens == float("inf"):
+            tokens_to_store = tokens
+        else:
+            capacity = int(self.max_tokens)
+            tokens_to_store = tokens[:capacity] if len(tokens) > capacity else tokens
+
         # Evict until we have space
-        while self.current_tokens + len(tokens) > self.max_tokens and self.requests:
+        while (
+            self.current_tokens + len(tokens_to_store) > self.max_tokens
+            and self.requests
+        ):
             old_id, old_tokens = self.requests.popitem(last=False)
             self.current_tokens -= len(old_tokens)
 
@@ -135,8 +152,19 @@ class LRUTokenPool:
                 token_tensor[old_id, :] = 0
 
         # Add new request
-        self.requests[request_id] = tokens
-        self.current_tokens += len(tokens)
+        self.requests[request_id] = tokens_to_store
+        self.current_tokens += len(tokens_to_store)
+
+        # Zero out excess tokens in tensor after trimming so substring
+        # matching does not count hits against tokens never actually stored.
+        if (
+            token_tensor is not None
+            and self.max_tokens != float("inf")
+            and len(tokens) > int(self.max_tokens)
+        ):
+            token_tensor[request_id, int(self.max_tokens) :] = 0
+
+
 
 
 def load_and_tokenize_inputs(
@@ -252,7 +280,7 @@ def analyze_hit_rates_across_pool_sizes(
             token_desc = ""
         else:
             size_tokens = int(size_gb * tokens_per_gb)
-            x_labels.append(str(int(size_gb)))
+            x_labels.append(str(size_gb))
             pool_desc = f"{size_gb}GB"
             token_desc = f" ({size_tokens:,} tokens)"
 


### PR DESCRIPTION
## Summary

Fix 4 bugs in `examples/agents/prefix_analysis.py` that cause the hit rate analysis to report incorrect numbers, especially for small pool sizes.

### Bug 1 - LRU pool capacity overflow (most critical)
When a single request exceeds the pool's token capacity, `current_tokens` grows beyond `max_tokens`, breaking the pool invariant. Fixed by trimming tokens to `capacity` before inserting - keeping the head, since prefix matching compares from index 0.

### Bug 2 - Ghost tokens in substring matching
After trimming `tokens`, the corresponding `token_tensor` row still held the full untrimmed sequence. This caused CacheBlend / substring hit rate to count hits against tokens that were never actually stored. Fixed by zeroing out the excess: `token_tensor[request_id, capacity:] = 0`.

### Bug 3 - X-axis labels show 0 instead of decimal values
`str(int(0.1))` evaluates to "0". Fixed with `str(size_gb)` to preserve decimal labels for small pool sizes.

### Bug 4 - Missing fine-grained pool sizes
The default pool size list started at 1 GB, making small-cache scenarios invisible in plots. Added 0.1, 0.2, 0.4 GB entries - which also makes Bugs 1 and 2 more impactful to fix, since small pools trigger trimming more frequently.

## Note
Bug 1 was originally caught by @yamazakihirofumi in PR #1918, which was stale-closed before merging. Crediting them in this commit.

## Related Issue
Fixes #1826 (addresses bugs identified in the issue thread by @ianliuy and @yamazakihirofumi)

## Tested
- Verified the 4 bugs logically by code inspection
- Pool sizes now correctly include 0.1, 0.2, 0.4 GB
- `add_request` now correctly trims and zeros excess tokens
- X-axis labels now show decimal values for small pool sizes

## Risk
- Low risk: changes only affect the example analysis script, not core library
- The trimming logic in `add_request` is defensive and should not affect normal (large pool) operation

## Notes for Maintainers
This PR is submitted as part of the Onboarding 2026 good first issues initiative (#3372). Happy to make any adjustments based on review feedback.