### PR TITLE
docs: add docstrings to public helpers in lmcache/utils.py

### DIFF
--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -691,6 +691,7 @@ def thread_safe(func):
     Returns:
         A wrapper that serializes calls to ``func`` using the shared lock.
     """
+
     def wrapper(*args, **kwargs):
         with _shared_observability_lock:
             result = func(*args, **kwargs)

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -285,6 +285,13 @@ except ImportError:
 
 
 def get_version():
+    """Return a human-readable version string.
+
+    Returns:
+        ``"<version>-<commit-id>"``, with ``"NA"`` substituted when the
+        package version or commit id is not available (e.g. when running
+        from a source checkout without a tag).
+    """
     version_display = VERSION if VERSION else "NA"
     commit_id_display = COMMIT_ID if COMMIT_ID else "NA"
     return f"{version_display}-{commit_id_display}"
@@ -676,6 +683,14 @@ _shared_observability_lock = threading.Lock()
 
 
 def thread_safe(func):
+    """Wrap a callable with the shared observability lock.
+
+    Args:
+        func: Callable to execute while holding the lock.
+
+    Returns:
+        A wrapper that serializes calls to ``func`` using the shared lock.
+    """
     def wrapper(*args, **kwargs):
         with _shared_observability_lock:
             result = func(*args, **kwargs)
@@ -686,12 +701,22 @@ def thread_safe(func):
 
 #### Thread/asyncio-related utilities ####
 def handle_thread_exception(args):
+    """Handle an uncaught exception reported by ``threading``.
+
+    Args:
+        args: Thread exception information provided by ``threading``.
+    """
     logger.error(
         f"Thread {args.thread.name} crashed: {args.exc_type.__name__}: {args.exc_value}"
     )
 
 
 def start_loop_in_thread_with_exceptions(loop: asyncio.AbstractEventLoop):
+    """Run an event loop forever with an exception handler.
+
+    Args:
+        loop: Event loop to bind to the current thread and run.
+    """
     # The loop must be set in the *same* thread where it runs.
     asyncio.set_event_loop(loop)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a short docstring to the public functions in lmcache/utils.py that don't have one. Public = the name does not start with _.

Fixes #3378 

**Special notes for your reviewers**:

The two unimplemented functions, `mock_up_broadcast_fn` and `mock_up_broadcast_object_fn`, have not yet been commented out.



**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
