### PR TITLE
[MP] Fix GPU block exhaustion deadlock at high concurrency with chunked KV loading

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -572,6 +572,23 @@ class LMCacheConnectorV1Impl:
 
         self.force_skip_save = bool(os.environ.get("LMCACHE_FORCE_SKIP_SAVE", False))
         self._requests_priority: dict[str, int] = {}
+
+        # Chunked KV loading: cap the number of external tokens
+        # reported per scheduling step to prevent GPU block pool
+        # exhaustion at high concurrency with long contexts.
+        # Configurable via kv_connector_extra_config:
+        #   "lmcache.max_tokens_per_load": <int>
+        # Default: max_model_len // 2, capped at 128K tokens.
+        # Set 0 to disable (original behavior, all matched tokens
+        # reported at once).
+        default_cap = min(
+            vllm_config.model_config.max_model_len // 2, 131072
+        )
+        self._max_tokens_per_load: int = int(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.max_tokens_per_load", default_cap
+            )
+        )
         self._invalid_block_ids: set[int] = set()
 
     def _check_legacy_register_kv_caches(self) -> None:
@@ -1437,9 +1454,44 @@ class LMCacheConnectorV1Impl:
                 max(need_to_allocate, 0),
             )
 
+        # Chunked KV loading: cap the number of tokens reported
+        # to the scheduler to avoid exhausting the GPU block pool
+        # when many concurrent requests each need large allocations.
+        # Remaining tokens beyond the cap will be computed locally
+        # via chunked prefill rather than loaded from external cache.
+        capped_lmcache_tokens = num_external_hit_tokens
+        if (
+            self._max_tokens_per_load > 0
+            and need_to_allocate > self._max_tokens_per_load
+        ):
+            # Align cap to LMCache chunk boundaries so that the
+            # retrieve path receives chunk-aligned token ranges.
+            cap = (
+                self._max_tokens_per_load
+                // self._lmcache_chunk_size
+                * self._lmcache_chunk_size
+            )
+            need_to_allocate = cap
+            # Align capped_lmcache_tokens to chunk boundary so that
+            # session.get_hashes() receives a chunk-aligned end value.
+            capped_lmcache_tokens = (
+                (num_computed_tokens + cap)
+                // self._lmcache_chunk_size
+                * self._lmcache_chunk_size
+            )
+            logger.debug(
+                "Reqid: %s, Chunked KV loading: capped from "
+                "%d to %d external tokens "
+                "(max_tokens_per_load=%d)",
+                req_id,
+                num_external_hit_tokens - num_computed_tokens,
+                need_to_allocate,
+                self._max_tokens_per_load,
+            )
+
         self.load_specs[req_id] = LoadSpec(
             vllm_cached_tokens=num_computed_tokens,
-            lmcache_cached_tokens=num_external_hit_tokens,
+            lmcache_cached_tokens=capped_lmcache_tokens,
             can_load=False,
         )
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -578,15 +578,12 @@ class LMCacheConnectorV1Impl:
         # exhaustion at high concurrency with long contexts.
         # Configurable via kv_connector_extra_config:
         #   "lmcache.max_tokens_per_load": <int>
-        # Default: max_model_len // 2, capped at 128K tokens.
-        # Set 0 to disable (original behavior, all matched tokens
-        # reported at once).
-        default_cap = min(
-            vllm_config.model_config.max_model_len // 2, 131072
-        )
+        # Default 0 (no cap — original behavior, all matched tokens
+        # reported at once). Set to a positive value (e.g. 131072)
+        # to enable chunked loading.
         self._max_tokens_per_load: int = int(
             vllm_config.kv_transfer_config.get_from_extra_config(
-                "lmcache.max_tokens_per_load", default_cap
+                "lmcache.max_tokens_per_load", 0
             )
         )
         self._invalid_block_ids: set[int] = set()


### PR DESCRIPTION
## Problem

When using `LMCacheConnector` (v1) with high concurrency (e.g., 32+ concurrent
requests with 100K+ token contexts), `get_num_new_matched_tokens()` reports
ALL externally-cached tokens at once. The vLLM scheduler then allocates GPU
blocks for all concurrent requests simultaneously, which can exceed the total
GPU block pool capacity and cause a scheduling deadlock.

Example: 32 concurrent requests × 115K tokens × block_size=1 = 3.7M blocks
needed, but only 1.8M blocks available on 4x MI355X GPUs.

## Root Cause

The scheduler allocates GPU blocks for `num_external_computed_tokens` before
the async KV transfer, putting the request in `WAITING_FOR_REMOTE_KVS` state.
With many concurrent requests all needing large block allocations, the block
pool is exhausted and no new requests can be scheduled.

## Fix

### 1. Chunked KV loading cap (`vllm_v1_adapter.py`)

Cap the number of external tokens reported per scheduling step via
`lmcache.max_tokens_per_load` (configurable, default 131072 = 128K tokens).
When a request has more cached tokens than this limit, only the capped amount
is reported to the scheduler. The remaining tokens beyond the cap are computed
locally via chunked prefill rather than loaded from external cache.

Key properties:
- The cap is aligned to LMCache chunk boundaries (`chunk_size`)
- `LoadSpec.lmcache_cached_tokens` is adjusted to match the capped amount,
  keeping the `update_state_after_alloc` assertion consistent
- Set to `0` to disable chunking (original behavior)

### 2. Defensive alignment in `Session.get_hashes()` (`session.py`)

Replace a hard assertion (`assert end % chunk_size == 0`) with a graceful
round-down and warning log. Non-chunk-aligned end values can legitimately occur
with `block_size=1` (MLA models like DeepSeek-V3, Kimi-K2.5) during chunked
loading.

## Configuration

```json
{
  "kv_connector_extra_config": {
    "lmcache.max_tokens_per_load": 131072
  }
}
```

Set to `0` to disable chunking (original behavior, all matched tokens reported
at once).

## Testing

Validated on MI355X (4x 288GB VRAM) with Kimi-K2.5-MXFP4 (block_size=1):
- ✅ c=32 (100K+ context): 120 requests completed (was 28 → deadlock)
- ✅ c=48: No deadlock under extreme pressure (KV 98.5%)
- ✅ c=8: No overhead when block pressure is low
- ✅ TP=8: Adapts to different block pool sizes
- ✅ Short context (8K): Chunking correctly bypassed
- ✅ Correctness: Greedy decode output matches across configurations