### PR TITLE
Fix SGLangLayerwiseGPUConnector generator and layer indexing

### DIFF
--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -243,13 +243,13 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
             if self.layer_load_layer[i] == layer_id + 1:
                 next(self.layerwise_retrievers[i])
                 self.layer_load_layer[i] += 1
-                if self.layer_load_layer[i] == self.sgl_config.num_hidden_layers:
+                if self.layer_load_layer[i] > self.sgl_config.num_hidden_layers:
                     indices_to_remove.append(i)
 
         for i in sorted(indices_to_remove, reverse=True):
             del self.layerwise_retrievers[i]
             del self.layer_load_layer[i]
-            self.lmcache_engine.lookup_unpin(self.lookup_id_list[i])
+            self.lmcache_engine.lookup_pins.pop(self.lookup_id_list[i], None)
             del self.lookup_id_list[i]
 
         return

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -1796,6 +1796,8 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
                     token_major=True,
                 )
 
+        yield
+
         # free the buffer memory
         if self.use_gpu:
             tmp_gpu_buffer_obj.ref_count_down()

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -12,6 +12,7 @@ import torch
 # First Party
 from lmcache.v1.gpu_connector.gpu_connectors import (
     SGLangGPUConnector,
+    SGLangLayerwiseGPUConnector,
     VLLMBufferLayerwiseGPUConnector,
     VLLMPagedMemGPUConnectorV2,
     VLLMPagedMemGPUConnectorV3,
@@ -929,6 +930,124 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
         check_sglang_paged_kv_cache_equal(
             gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size
         )
+
+    allocator.close()
+
+
+@pytest.mark.parametrize("use_gpu", [True])
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="TODO: Add non-CUDA implementation to SGLangLayerwiseGPUConnector",
+)
+def test_layerwise_sglang_connector_with_gpu(use_gpu):
+    num_blocks = 100
+    block_size = 16
+    num_layers = 32
+    num_heads = 8
+    head_size = 128
+    device = "cuda"
+    dtype = torch.bfloat16
+    hidden_dim = num_heads * head_size
+
+    num_tokens = 800
+    chunk_size = 256
+
+    allocator = PinMemoryAllocator(1024 * 1024 * 1024)
+
+    gpu_kv_src = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_heads=num_heads,
+        head_size=head_size,
+        device=device,
+        dtype=dtype,
+    )
+    gpu_kv_dst = generate_sglang_kv_cache_paged_list_tensors(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_heads=num_heads,
+        head_size=head_size,
+        device=device,
+        dtype=dtype,
+    )
+
+    slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
+
+    with pytest.raises(AssertionError):
+        check_sglang_paged_kv_cache_equal(
+            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size
+        )
+
+    connector = SGLangLayerwiseGPUConnector(
+        hidden_dim,
+        num_layers,
+        use_gpu=use_gpu,
+        dtype=dtype,
+        device=device,
+    )
+
+    # from gpu to cpu
+    starts = []
+    ends = []
+    memory_objs = []
+
+    for start in range(0, num_tokens, chunk_size):
+        end = min(start + chunk_size, num_tokens)
+        shape_single_layer = connector.get_shape(end - start)
+        memory_objs_multi_layer = []
+
+        for layer_id in range(num_layers):
+            mem_obj_single_layer = allocator.allocate(
+                shape_single_layer, dtype, fmt=MemoryFormat.KV_T2D
+            )
+            memory_objs_multi_layer.append(mem_obj_single_layer)
+
+        starts.append(start)
+        ends.append(end)
+        memory_objs.append(memory_objs_multi_layer)
+
+    memory_objs = [list(row) for row in zip(*memory_objs, strict=False)]
+
+    mem_obj_generator = connector.batched_from_gpu(
+        memory_objs,
+        starts,
+        ends,
+        kvcaches=gpu_kv_src,
+        slot_mapping=slot_mapping,
+        sync=True,
+    )
+
+    for layer_id in range(num_layers + 1):
+        next(mem_obj_generator)
+
+    # from cpu to gpu
+    mem_obj_consumer = connector.batched_to_gpu(
+        starts,
+        ends,
+        kvcaches=gpu_kv_dst,
+        slot_mapping=slot_mapping,
+        sync=True,
+    )
+    next(mem_obj_consumer)
+    for layer_id in range(num_layers):
+        mem_obj_consumer.send(memory_objs[layer_id])
+    next(mem_obj_consumer)
+
+    # free all mem objs
+    for mem_obj_multi_layer in memory_objs:
+        for mem_obj in mem_obj_multi_layer:
+            mem_obj.ref_count_down()
+
+    assert allocator.memcheck()
+
+    assert connector.gpu_buffer_allocator.memcheck()
+
+    check_sglang_paged_kv_cache_equal(
+        gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size
+    )
 
     allocator.close()
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Three bugs were occurring in sequence during the SGLang layerwise KV cache load process.

### 1. Layer completion check off-by-one (sglang_adapter.py)

The condition `== num_hidden_layers` was evaluated immediately after incrementing `layer_load_layer[i]`, causing it to match before the final layer was actually processed. As a result, `layerwise_retrievers[i]` and associated resources were released prematurely. When load_kv_layerwise was called for the final layer, the retriever had already been deleted, so the KV cache load for that layer was silently skipped. Fixed by changing `==` to `>` so cleanup only happens after the final layer has been fully processed.

### 2. Missing final yield in SGLangLayerwiseGPUConnector.batched_from_gpu (gpu_connectors.py)

The generator exited without a yield after processing the last layer, causing the GPU buffer's ref_count to drop immediately before the caller could advance the generator to completion. This resulted in abnormal memory release while the buffer was still in use. Fixed by adding a yield after the last layer is processed, before the buffer cleanup.

### 3. Double unpin (sglang_adapter.py)

The bugs above caused `lookup_unpin` in `cache_engine` to be missed. When this was corrected, `lookup_unpin` was being called at the layer completion site in `sglang_adapter.py`, while `load_kv_layerwise` was already calling `unpin` — resulting in a double unpin. Removing `lookup_unpin` avoids the double unpin, but completely removing it causes a memory leak because the `lookup_id` is never popped from `LMCacheEngine.lookup_pins`, so the dictionary grows indefinitely with every layerwise retrieve request. Fixed by popping the `lookup_id` directly from `lookup_pins` without calling `batched_unpin`, which cleans up the dictionary entry while avoiding the double unpin.

### Changes

  - `lmcache/v1/gpu_connector/gpu_connectors.py`: Add missing final yield in batched_from_gpu generator before buffer cleanup
  - `lmcache/integration/sglang/sglang_adapter.py`: Fix layer completion check; replace `lookup_unpin` call with `lookup_pins.pop` to prevent memory leak without triggering double unpin.
  - `tests/v1/test_gpu_connector.py`: Add `test_layerwise_sglang_connector_with_gpu` for `SGLangLayerwiseGPUConnector`

#### Test plan
  - [ ] `pytest tests/v1/test_gpu_connector.py::test_layerwise_sglang_connector_with_gpu` passes on a CUDA-enabled machine
  - [ ] Existing test_sglang_connector_* tests unaffected

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
