### PR TITLE
[CI][Hotfix] fix the pytest lazy import issue caused by vLLM torch dynamo compilation

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,6 +19,9 @@ opentelemetry-exporter-prometheus >= 0.50b0, <= 0.61b0
 prometheus_client >= 0.18.0, <= 0.24.1
 psutil
 py-cpuinfo
+# cupy.testing._random unconditionally imports pytest at module level;
+# torch._dynamo triggers this via inspect.getmodule() during compilation.
+pytest
 pyyaml
 pyzmq >= 25.0.0
 redis


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `pytest` to `requirements/common.txt` as a runtime dependency.

**Problem**
- vLLM engine crashes during model compilation with `ModuleNotFoundError: No module named 'pytest'`
- This blocks all CI integration tests that start a vLLM server

**Root cause**
- `cupy.testing._random` unconditionally does `import pytest` at module level
- `cupy.testing` is registered as a lazy module in `sys.modules`
- During model compilation, `torch._dynamo` calls `inspect.getmodule()`, which triggers `hasattr(module, '__file__')` on all modules
- This attribute access realizes the lazy `cupy.testing` module, triggering the `pytest` import
- `pytest` is not installed in the production Docker image → crash

**Fix**
- Add `pytest` to `requirements/common.txt` so it is always available at runtime
- This is a workaround for a CuPy bug (`cupy.testing` should not unconditionally import `pytest`)

**Special notes for your reviewers**:

- One-line change in `requirements/common.txt`
- `pytest` was previously only in `requirements/test.txt`; now it is also a runtime dependency

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests