### PR TITLE
[Doc][ROCm] Document gfx950 (MI350X/MI355X) in install example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ lmcache/experimental/tests
 /csrc/*.hip
 /csrc/*_hip.cuh
 /csrc/*_hip.cpp
+/csrc/*_hip.h
 
 # SYCL build artifacts
 /build_sycl/

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -140,7 +140,11 @@ Install LMCache
                             uv pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.0
 
                             # Build LMCache. BUILD_WITH_HIP=1 makes setup.py pick cupy-rocm-7-0 automatically.
-                            PYTORCH_ROCM_ARCH="gfx942" \
+                            # PYTORCH_ROCM_ARCH selects the target GPU(s):
+                            #   gfx942  -> MI300X / MI325X
+                            #   gfx950  -> MI350X / MI355X
+                            # Comma-separate to build a fat binary for multiple archs.
+                            PYTORCH_ROCM_ARCH="gfx942,gfx950" \
                             TORCH_DONT_CHECK_COMPILER_ABI=1 \
                             CXX=hipcc \
                             BUILD_WITH_HIP=1 \


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents and unblocks a clean source install of LMCache on AMD Instinct MI350X / MI355X (gfx950).

The ROCm build path in `setup.py` (`BUILD_WITH_HIP=1`, hipify pipeline) and the Dockerfiles (`Dockerfile.rocm`, `Dockerfile.rocm-lightweight`) already supported `gfx950` — but the source-install example in `docs/source/getting_started/installation.rst` only listed `gfx942`, so a user following the docs on an MI350X / MI355X host would build a wheel that won't run on their GPU.

This PR:

1. Updates the install example to `PYTORCH_ROCM_ARCH="gfx942,gfx950"` and adds an inline comment mapping arch → Instinct family:
   - `gfx942` → MI300X / MI325X
   - `gfx950` → MI350X / MI355X
2. Adds `/csrc/*_hip.h` to `.gitignore`. The hipify step generates `completion_recorder_hip.h` and `event_recorder_hip.h` headers that weren't covered by the existing `*_hip.{cuh,cpp}` ignore rules, leaving the working tree dirty after a HIP build.

No code, build-system, or test changes were required — the existing `csrc/` sources hipify and compile cleanly for gfx950.

**Special notes for your reviewers**:

Validated locally on an 8x MI355X host (gfx950, ROCm 7.1.1, torch 2.10.0+rocm7.1):

| Check | Result |
|---|---|
| `BUILD_WITH_HIP=1 PYTORCH_ROCM_ARCH=gfx950 CXX=hipcc python setup.py build_ext --inplace` | ✅ |
| Imports: `lmcache.c_ops`, `lmcache.native_storage_ops`, `lmcache.lmcache_redis`, `lmcache.lmcache_fs` | ✅ |
| `tests/v1/test_mem_kernels.py` | ✅ 56 / 56 |
| `tests/v1/test_mp_mem_kernels.py`, `test_c_ops_fallback_parity.py`, `test_gpu_connector.py` | ✅ 85 passed, 3 skipped |
| Full `tests/v1/` suite (excluding `test_xpu_connector.py`, `test_pos_kernels.py` [needs vLLM], `multiprocess/` [needs IPC env]) | ✅ **2635 passed, 120 skipped, 0 failed** |
| End-to-end `LMCacheEngine` paged store → retrieve round-trip on GPU (`test_paged_same_retrieve_store`) | ✅ |

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests (no behavior change; existing GPU tests exercise the HIP code path)
