### PR TITLE
[MP]: run_script_api support mp mode http endpoint

### DIFF
--- a/lmcache/v1/internal_api_server/common/run_script_api.py
+++ b/lmcache/v1/internal_api_server/common/run_script_api.py
@@ -22,7 +22,7 @@ def _get_allowed_imports(request: Request) -> List[str]:
     if adapter is not None:
         return getattr(adapter.config, "script_allowed_imports", None) or []
     configs = getattr(request.app.state, "configs", None)
-    if configs is not None:
+    if isinstance(configs, dict):
         mp_cfg = configs.get("mp")
         return getattr(mp_cfg, "script_allowed_imports", None) or []
     return []

--- a/lmcache/v1/internal_api_server/common/run_script_api.py
+++ b/lmcache/v1/internal_api_server/common/run_script_api.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import Any
+from typing import Any, List
 import importlib
 
 # Third Party
@@ -16,6 +16,18 @@ logger = init_logger(__name__)
 router = APIRouter()
 
 
+def _get_allowed_imports(request: Request) -> List[str]:
+    """Extract script_allowed_imports from either inProcess or mp mode."""
+    adapter = getattr(request.app.state, "lmcache_adapter", None)
+    if adapter is not None:
+        return getattr(adapter.config, "script_allowed_imports", None) or []
+    configs = getattr(request.app.state, "configs", None)
+    if configs is not None:
+        mp_cfg = configs.get("mp")
+        return getattr(mp_cfg, "script_allowed_imports", None) or []
+    return []
+
+
 @router.post("/run_script")
 async def run_script(request: Request):
     form_data = await request.form()
@@ -27,9 +39,7 @@ async def run_script(request: Request):
     script_content = await script_file.read()
 
     try:
-        # Get allowed imports from config
-        config = request.app.state.lmcache_adapter.config
-        allowed_imports = config.script_allowed_imports or []
+        allowed_imports = _get_allowed_imports(request)
 
         # Pre-import allowed modules
         allowed_modules = {}

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -47,6 +47,9 @@ class MPServerConfig:
     )
     """Runtime plugin configuration (locations + extra config)."""
 
+    script_allowed_imports: list[str] = field(default_factory=list)
+    """Modules that /run_script endpoint is allowed to import."""
+
 
 @dataclass
 class RuntimePluginConfig:
@@ -167,6 +170,14 @@ def add_mp_server_args(
         'Example: \'{"plugin.frontend.heartbeat_url": '
         '"http://localhost:5000/heartbeat"}\'',
     )
+    mp_group.add_argument(
+        "--script-allowed-imports",
+        type=str,
+        nargs="*",
+        default=[],
+        help="Python modules that the /run_script endpoint is allowed to "
+        "import. Example: --script-allowed-imports numpy pandas",
+    )
     return parser
 
 
@@ -202,6 +213,7 @@ def parse_args_to_mp_server_config(
             locations=(args.runtime_plugin_locations or []),
             extra_config=plugin_extra,
         ),
+        script_allowed_imports=args.script_allowed_imports or [],
     )
 
 

--- a/lmcache/v1/multiprocess/http_apis/common_api.py
+++ b/lmcache/v1/multiprocess/http_apis/common_api.py
@@ -33,7 +33,7 @@ router = APIRouter()
 
 # Modules that depend on vLLM-specific ``app.state`` attributes and
 # therefore cannot run on the multiprocess HTTP server.
-_MP_INCOMPATIBLE_MODULES = frozenset({"run_script_api"})
+_MP_INCOMPATIBLE_MODULES: frozenset = frozenset()
 
 _common_path = Path(internal_api_server.__file__).parent / "common"
 _common_package = f"{internal_api_server.__name__}.common"

--- a/lmcache/v1/multiprocess/http_apis/common_api.py
+++ b/lmcache/v1/multiprocess/http_apis/common_api.py
@@ -33,7 +33,7 @@ router = APIRouter()
 
 # Modules that depend on vLLM-specific ``app.state`` attributes and
 # therefore cannot run on the multiprocess HTTP server.
-_MP_INCOMPATIBLE_MODULES: frozenset = frozenset()
+_MP_INCOMPATIBLE_MODULES: frozenset[str] = frozenset()
 
 _common_path = Path(internal_api_server.__file__).parent / "common"
 _common_package = f"{internal_api_server.__name__}.common"

--- a/tests/v1/multiprocess/http_apis/test_common_api.py
+++ b/tests/v1/multiprocess/http_apis/test_common_api.py
@@ -5,14 +5,26 @@ Tests for common_api.py — the aggregation layer that pulls in
 vLLM-specific modules.
 
 Covers:
-- ``run_script_api`` is NOT registered on the mp HTTP server.
+- ``run_script_api`` IS now registered on the mp HTTP server.
 - Other common endpoints (env, loglevel, metrics, …) ARE present.
+- /run_script works in mp mode (no lmcache_adapter on app.state).
+- /run_script works in inProcess mode (lmcache_adapter on app.state).
 """
+
+# Standard
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Optional
 
 # Third Party
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 # First Party
+from lmcache.v1.internal_api_server.common.run_script_api import (
+    router as run_script_router,
+)
+from lmcache.v1.multiprocess.config import MPServerConfig
 from lmcache.v1.multiprocess.http_api_registry import HTTPAPIRegistry
 
 
@@ -24,11 +36,11 @@ def _app_with_all_apis() -> FastAPI:
 
 
 class TestCommonApiAggregation:
-    def test_run_script_endpoint_excluded(self):
-        """/run_script must NOT be registered on the mp server."""
+    def test_run_script_endpoint_present(self):
+        """/run_script must be registered on the mp server."""
         app = _app_with_all_apis()
         paths = {r.path for r in app.routes if hasattr(r, "path")}
-        assert "/run_script" not in paths
+        assert "/run_script" in paths
 
     def test_common_env_endpoint_present(self):
         """/env from env_api should be registered."""
@@ -47,3 +59,98 @@ class TestCommonApiAggregation:
         app = _app_with_all_apis()
         paths = {r.path for r in app.routes if hasattr(r, "path")}
         assert "/conf" in paths
+
+
+@dataclass
+class _FakeAdapterConfig:
+    script_allowed_imports: Optional[list] = None
+
+
+class _FakeAdapter:
+    def __init__(self, allowed=None):
+        self.config = _FakeAdapterConfig(script_allowed_imports=allowed)
+
+
+def _make_run_script_app(state_kwargs: dict) -> FastAPI:
+    app = FastAPI()
+    app.include_router(run_script_router)
+    for k, v in state_kwargs.items():
+        setattr(app.state, k, v)
+    return app
+
+
+class TestRunScriptMpMode:
+    """Tests for /run_script in mp mode (no lmcache_adapter)."""
+
+    def test_mp_mode_basic_script(self):
+        """Script executes and returns result in mp mode."""
+        app = _make_run_script_app({"configs": {"mp": MPServerConfig()}})
+        client = TestClient(app)
+        script = b"result = 1 + 2"
+        resp = client.post(
+            "/run_script",
+            files={"script": ("test.py", BytesIO(script), "text/plain")},
+        )
+        assert resp.status_code == 200
+        assert resp.text == "3"
+
+    def test_mp_mode_no_script_file(self):
+        """Missing script file returns 400."""
+        app = _make_run_script_app({"configs": {"mp": MPServerConfig()}})
+        client = TestClient(app)
+        resp = client.post("/run_script", data={})
+        assert resp.status_code == 400
+
+    def test_mp_mode_allowed_imports(self):
+        """script_allowed_imports in MPServerConfig is respected."""
+        cfg = MPServerConfig(script_allowed_imports=["math"])
+        app = _make_run_script_app({"configs": {"mp": cfg}})
+        client = TestClient(app)
+        script = b"math = __import__('math'); result = math.floor(3.9)"
+        resp = client.post(
+            "/run_script",
+            files={"script": ("test.py", BytesIO(script), "text/plain")},
+        )
+        assert resp.status_code == 200
+        assert resp.text == "3"
+
+    def test_mp_mode_no_state(self):
+        """No app.state set — allowed_imports falls back to empty list."""
+        app = FastAPI()
+        app.include_router(run_script_router)
+        client = TestClient(app)
+        script = b"result = 'ok'"
+        resp = client.post(
+            "/run_script",
+            files={"script": ("test.py", BytesIO(script), "text/plain")},
+        )
+        assert resp.status_code == 200
+        assert resp.text == "ok"
+
+
+class TestRunScriptInProcessMode:
+    """Tests for /run_script in inProcess mode (lmcache_adapter present)."""
+
+    def test_inprocess_mode_basic_script(self):
+        """Script executes and returns result in inProcess mode."""
+        app = _make_run_script_app({"lmcache_adapter": _FakeAdapter()})
+        client = TestClient(app)
+        script = b"result = 'hello'"
+        resp = client.post(
+            "/run_script",
+            files={"script": ("test.py", BytesIO(script), "text/plain")},
+        )
+        assert resp.status_code == 200
+        assert resp.text == "hello"
+
+    def test_inprocess_mode_default_result(self):
+        """Script with no result variable returns default message."""
+        app = _make_run_script_app({"lmcache_adapter": _FakeAdapter()})
+        client = TestClient(app)
+        script = b"x = 1"
+        resp = client.post(
+            "/run_script",
+            files={"script": ("test.py", BytesIO(script), "text/plain")},
+        )
+        assert resp.status_code == 200
+        assert resp.text == "Script executed successfully"


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Enable `run_script` endpoint on the multiprocess HTTP server

**Special notes for your reviewers**:

How to test:

```python
python -m lmcache.v1.multiprocess.http_server \
  --http-port 8080 \
  --l1-size-gb 1 \
  --eviction-policy LRU \
  --script-allowed-imports math



# 1. healthcheck
curl http://localhost:8080/healthcheck
# → {"status": "healthy"}

# 2. basic script
echo "result = 1 + 2" > /tmp/test.py
curl -X POST http://localhost:8080/run_script -F "script=@/tmp/test.py"
# → 3

# 3. Allow import math in --script-allowed-imports
echo "import math; result = math.floor(3.9)" > /tmp/test2.py
curl -X POST http://localhost:8080/run_script -F "script=@/tmp/test2.py"
# → 3

# 4. Blocked import os as it is not in the blacklist
echo "import os; result = os.getcwd()" > /tmp/test3.py
curl -X POST http://localhost:8080/run_script -F "script=@/tmp/test3.py"
# → Error executing script: Import of 'os' is not allowed

```

Further more, this is an advance case, which can get and set the value of internal variable of `LMCache Server process`

```
# Example script: update L1Manager write_ttl_seconds at runtime.
#
# Usage:
#   curl -X POST http://localhost:8080/run_script \
#        -F "script=@examples/set_write_ttl.py"
#
# Access path (mp mode):
#   app.state.engine          -> MPCacheEngine
#     .context                -> MPCacheEngineContext
#       .storage_manager      -> StorageManager
#         .l1_manager         -> L1Manager
#           .write_ttl_seconds  (float, read/write property)

NEW_TTL = 120.0

engine = app.state.engine
l1 = engine.context.storage_manager.l1_manager

old_ttl = l1.write_ttl_seconds
l1.write_ttl_seconds = NEW_TTL

result = (
    "write_ttl_seconds: " + str(old_ttl) + " -> " + str(l1.write_ttl_seconds)
)

```


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
