### PR TITLE
[Docs] Combined PR from recent doc drift scannings

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/overall.md
+++ b/docs/design/v1/distributed/l2_adapters/overall.md
@@ -65,13 +65,21 @@ silently misroute events.
 
 ```
 submit_store_task(keys, objects) -> L2TaskId
-pop_completed_store_tasks() -> dict[L2TaskId, bool]
+pop_completed_store_tasks() -> dict[L2TaskId, L2StoreResult]
 ```
 
 - **Caller provides buffers:** The `objects` list contains `MemoryObj` references
   managed by the caller (StoreController holds L1 read locks on them).
 - **Coarse-grained errors:** A store task either fully succeeds or fully fails.
-  The bool in the completion dict is `True` for success, `False` for failure.
+  The completion dict maps each task id to an `L2StoreResult`
+  (`lmcache.v1.distributed.internal_api.L2StoreResult`) that encodes both
+  the success flag and the bytes actually transferred. Use
+  `result.is_successful()` to check the outcome and
+  `result.bytes_transferred()` to read the real byte count written to L2
+  (always `0` on failure). Adapters that fast-path duplicate keys (e.g.
+  skip the write when the key already exists in the backend) should
+  report the real, non-skipped byte count here so the L2 throughput
+  histogram reflects actual work — not submitted-but-skipped bytes.
 - **Pop semantics:** `pop_completed_store_tasks()` drains all completed tasks.
   Each task appears exactly once.
 
@@ -172,8 +180,8 @@ _process_new_keys(keys)
   │
   ▼ (later, for each adapter whose store_efd signaled)
 _drain_l2_store_completions(signaled_adapters)
-  │  adapter.pop_completed_store_tasks() → deposit success/failure
-  │  on each InFlightStoreTask.l2_store_result
+  │  adapter.pop_completed_store_tasks() → deposit L2StoreResult
+  │  (success flag + bytes_transferred) on each InFlightStoreTask
   │
   ▼
 _advance_request(task_key, task)  [state transition]

--- a/docs/design/v1/distributed/l2_adapters/serde_wrapper.md
+++ b/docs/design/v1/distributed/l2_adapters/serde_wrapper.md
@@ -51,7 +51,9 @@ consumed by the wrapper's internal thread.
    │                 │      signal wrapper.store_efd               
    └────────┬────────┘                                             
             │                                                      
-            │ (8) pop_completed_store_tasks() → {wrapped_id: True} 
+            │ (8) pop_completed_store_tasks() →                   
+            │     {wrapped_id: L2StoreResult(success=True,         
+            │                                bytes_transferred=N)}
             ▼                                                      
           caller                                                   
 ```
@@ -121,13 +123,13 @@ sequenceDiagram
 
     Inner-->>Thread: store_efd fires
     Thread->>Inner: pop_completed_store_tasks()
-    Inner-->>Thread: {inner_id: True}
+    Inner-->>Thread: {inner_id: L2StoreResult(ok=True, bytes=N)}
     Thread->>L1: finish_read(temp_keys)   %% auto-deletes temps
-    Thread->>W: _finalize_store(wrapped_id, True)
+    Thread->>W: _finalize_store(wrapped_id, inner_result)
     W-->>Controller: store_efd fires
 
     Controller->>W: pop_completed_store_tasks()
-    W-->>Controller: {wrapped_id: True}
+    W-->>Controller: {wrapped_id: L2StoreResult(ok=True, bytes=N)}
 ```
 
 ## Load Path
@@ -234,17 +236,18 @@ If **any** key's temp allocation fails or `submit_serialize` /
 `submit_deserialize` / `inner.submit_*` raises, the **whole wrapped
 task fails**:
 
-- Store task: `pop_completed_store_tasks()` returns `{wrapped_id: False}`.
+- Store task: `pop_completed_store_tasks()` returns
+  `{wrapped_id: L2StoreResult(success=False, bytes_transferred=0)}`.
 - Load task: `query_load_result(wrapped_id)` returns an all-zeros
   `Bitmap(len(keys))`.
 
 This preserves the **coarse-grained success semantic** of
-`L2AdapterInterface` — store is task-level, load is per-key via
-bitmap. The alternative ("drop the failed keys, succeed with the
-rest") would silently violate the caller's assumption that every key
-it passed either succeeded (task-level True) or failed (task-level
-False). Keeping the policy coarse is what lets the controllers stay
-untouched.
+`L2AdapterInterface` — store is task-level (the `L2StoreResult.is_successful()`
+flag), load is per-key via bitmap. The alternative ("drop the failed keys,
+succeed with the rest") would silently violate the caller's assumption
+that every key it passed either succeeded (task-level) or failed
+(task-level). Keeping the policy coarse is what lets the controllers
+stay untouched.
 
 Partial load failures inside the inner adapter (some keys in the
 inner bitmap succeed, some fail) are faithfully preserved: only keys

--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -116,7 +116,7 @@ helper.
 | Helper | Returns | Notes |
 |---|---|---|
 | `get_group_data_ptrs(kv, fmt, layer_indices)` | `list[int]` | Pointer array in **kernel-expected order**: `[base]` for cross-layer (`layer_indices` ignored), `[K_0…K_N, V_0…V_N]` for SGLang MHA, per-layer flat elsewhere. Matches the dispatch in `csrc/mp_mem_kernels.cu:161-169`. The pointer-array shape is a property of the format — callers never ask "does this format have per-layer pointers?". |
-| `make_page_buffer_shape_desc(kv, fmt, layer_idx, num_layers_in_group, num_blocks, block_size)` | `PageBufferShapeDesc` | The kernel-facing shape struct. |
+| `make_page_buffer_shape_desc(kv, fmt, layer_idx, num_layers_in_group, num_blocks, block_size, block_stride_elems)` | `PageBufferShapeDesc` | The kernel-facing shape struct. ``block_stride_elems`` carries the per-block dim-0 element stride; pass the value returned by `resolve_block_stride_and_log_layout` so groups with different physical block sizes (e.g. a compressed DeepSeek V4 indexer group alongside dense layers) share a single GPU pool. |
 
 ### Contiguity
 
@@ -151,12 +151,17 @@ helper.
 ## Consumers
 
 - **`lmcache/v1/kv_layer_groups.py::KVLayerGroupsManager.__init__`** —
-  partitions layers by the 4-tuple `(kv_size, num_heads, head_size,
-  dtype)` using `is_mla`, `get_num_heads`, `get_head_size`, and
-  `get_dtype` with each layer's index. Builds a `PageBufferShapeDesc`
-  per group via `make_page_buffer_shape_desc`. The real constructor is
-  the only way in — no test-only shortcuts, no cached topology fields;
-  the manager exposes only `kv_layer_groups`, `num_groups`, and
+  partitions layers by the 5-tuple `(kv_size, num_heads, head_size,
+  block_size, dtype)` using `is_mla`, `get_num_heads`, `get_head_size`,
+  `get_block_size`, and `get_dtype` with each layer's index. Including
+  `block_size` in the identity lets compressed groups (e.g. a DeepSeek
+  V4 indexer with a smaller physical slot count) sit alongside
+  non-compressed groups under a single `GPUCacheContext`. Builds a
+  `PageBufferShapeDesc` per group via `make_page_buffer_shape_desc`,
+  passing the `block_stride_elems` resolved by
+  `resolve_block_stride_and_log_layout`. The real constructor is the
+  only way in — no test-only shortcuts, no cached topology fields; the
+  manager exposes only `kv_layer_groups`, `num_groups`, and
   `get_shape_desc`.
 - **`lmcache/v1/multiprocess/gpu_context.py::GPUCacheContext`** —
   constructs the manager directly at init, delegates

--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -280,10 +280,21 @@ registered adapter type (e.g. `"fs"`, `"nixl_store"`, `"mooncake_store"`)
 — enabling per-adapter-type slicing in Prometheus (e.g.
 `lmcache_mp_l2_store_throughput_gbs{l2_name="nixl_store"}`).
 
+**Store-path fast-path accounting.** Some adapters skip the write when
+a key is already present in the backend, collapsing
+`(completed_ts - submitted_ts)` to near-zero while the submitted
+`total_bytes` count stays unchanged. To avoid inflated throughput
+samples, the `L2StoreResult` returned by `pop_completed_store_tasks()`
+carries `bytes_transferred()` covering only the bytes actually written.
+The `L2_STORE_COMPLETED` event propagates this value, and the store
+throughput subscriber records `bytes_transferred / dt`; when
+`bytes_transferred <= 0` (every key fast-pathed) the sample is dropped
+entirely. The load path continues to use the submitted `total_bytes`.
+
 | OTel metric name | Prometheus name | Type | Source event | Calculation |
 |---|---|---|---|---|
-| `lmcache_mp.l2_store_throughput` | `lmcache_mp_l2_store_throughput_GBs` | Histogram | `L2_STORE_SUBMITTED` → `L2_STORE_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per task |
-| `lmcache_mp.l2_load_throughput` | `lmcache_mp_l2_load_throughput_GBs` | Histogram | `L2_LOAD_TASK_SUBMITTED` → `L2_LOAD_TASK_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per (request, adapter) pair |
+| `lmcache_mp.l2_store_throughput` | `lmcache_mp_l2_store_throughput_GBs` | Histogram | `L2_STORE_SUBMITTED` → `L2_STORE_COMPLETED` | `bytes_transferred / (completed_ts - submitted_ts) / 1e9` per task. `bytes_transferred` is read from the `L2_STORE_COMPLETED` event (populated from the `L2StoreResult` returned by `pop_completed_store_tasks()`); samples where `bytes_transferred <= 0` (e.g. duplicate-key fast paths that skip the write) are dropped, so the histogram reflects real work, not submitted-but-skipped bytes. |
+| `lmcache_mp.l2_load_throughput` | `lmcache_mp_l2_load_throughput_GBs` | Histogram | `L2_LOAD_TASK_SUBMITTED` → `L2_LOAD_TASK_COMPLETED` | `total_bytes / (completed_ts - submitted_ts) / 1e9` per (request, adapter) pair. The load path still uses submitted `total_bytes`; per-task real-bytes accounting only applies to the store path. |
 
 **What it answers:** What end-to-end throughput is each L2 adapter
 delivering? Which backends are keeping up with demand, and which are
@@ -348,19 +359,25 @@ point-in-time state snapshots that do not correspond to discrete events.
 
 ## L1 / L2 State Metrics
 
-Live state of the L1 memory pool and the in-flight L2 store / prefetch-load
-queues.  These metrics are useful for capacity planning, sizing L1, and
-spotting backpressure on individual L2 adapters.
+Live state of the L1 memory pool, the per-adapter L2 byte usage, and the
+in-flight L2 store / prefetch-load queues.  These metrics are useful for
+capacity planning, sizing L1, watching L2 fullness, and spotting
+backpressure on individual L2 adapters.
 
-All four metrics are OTel `ObservableGauge` instruments registered via the
+All five metrics are OTel `ObservableGauge` instruments registered via the
 shared `register_gauge` helper.  At scrape time, OTel invokes the
-registered callback, which iterates the controller's live in-flight state
-and returns one observation per adapter that currently has work.
-Adapters with no in-flight work emit no datapoint for that scrape.
+registered callback, which iterates the controller's live state and
+returns one observation per adapter (for `l2_usage_bytes`, one per
+configured adapter; for the in-flight gauges, only adapters with work).
+Adapters with no in-flight work emit no datapoint for the three
+in-flight gauges.
 
-The three in-flight metrics carry two attributes that disambiguate
-adapters even when more than one is registered with the same backend type
-— same shape as the existing `lmcache_mp.l2_store_completed` counter:
+`lmcache_mp.l2_usage_bytes` carries a single `l2_name` attribute — the
+adapter's registered type name (e.g. `"fs"`, `"mock"`,
+`"nixl_store"`).  The three in-flight metrics carry two attributes
+that disambiguate adapters even when more than one is registered with
+the same backend type — same shape as the existing
+`lmcache_mp.l2_store_completed` counter:
 
 - `l2_name` — the registered adapter type (e.g. `"fs"`, `"mock"`,
   `"nixl_store"`).
@@ -371,6 +388,7 @@ adapters even when more than one is registered with the same backend type
 | OTel metric name | Prometheus name | Type | Source of truth | Calculation |
 |---|---|---|---|---|
 | `lmcache_mp.l1_memory_usage_bytes` | `lmcache_mp_l1_memory_usage_bytes` | ObservableGauge | `L1Manager.get_memory_usage()` | Bytes currently held in L1 at scrape time |
+| `lmcache_mp.l2_usage_bytes` | `lmcache_mp_l2_usage_bytes` | ObservableGauge (attr: `l2_name`) | `StorageManager.get_l2_usages()` (calls `L2AdapterInterface.get_usage().total_bytes_used`) | Per-adapter bytes currently held in L2 at scrape time; one observation per configured adapter.  Adapters whose `get_usage()` raises are skipped silently. |
 | `lmcache_mp.num_inflight_l2_stores` | `lmcache_mp_num_inflight_l2_stores` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `StoreController.get_inflight_count_by_adapter()` | Snapshot of in-flight L2 store tasks grouped by adapter |
 | `lmcache_mp.num_inflight_l2_loads` | `lmcache_mp_num_inflight_l2_loads` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `PrefetchController.get_inflight_load_state_by_adapter()` | Per-adapter count from the same snapshot |
 | `lmcache_mp.inflight_load_memory_usage_bytes` | `lmcache_mp_inflight_load_memory_usage_bytes` | ObservableGauge (attrs: `l2_name`, `adapter_index`) | `PrefetchController.get_inflight_load_state_by_adapter()` | Per-adapter reserved bytes from the same snapshot |
@@ -378,6 +396,12 @@ adapters even when more than one is registered with the same backend type
 **What `l1_memory_usage_bytes` answers:** How full is the L1 cache? Helps
 size L1 against working set and detect leaks (steadily climbing without
 plateauing).
+
+**What `l2_usage_bytes` answers:** How full is each L2 backend? Lets
+operators query how much each L2 tier currently holds, decide whether
+an adapter needs eviction or purge, and spot per-backend asymmetries
+when more than one L2 is configured.  Parallel to `l1_memory_usage_bytes`
+on the L2 tier.
 
 **What `num_inflight_l2_stores` answers:** Are L2 stores piling up on a
 particular adapter? Sustained non-zero values indicate the adapter cannot

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -412,6 +412,33 @@ On the vLLM side, specify the LMCache server host and port via the
         --kv-transfer-config \
         '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "127.0.0.1", "lmcache.mp.port": 6000}}'
 
+``LMCacheMPConnector`` reads the following keys from
+``kv_connector_extra_config``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 20 45
+
+   * - Key
+     - Default
+     - Description
+   * - ``lmcache.mp.host``
+     - ``tcp://localhost``
+     - Host (with ZMQ transport prefix) of the LMCache MP server.
+   * - ``lmcache.mp.port``
+     - ``5555``
+     - Port of the LMCache MP server. Must match the server's ``--port``.
+   * - ``lmcache.mp.mq_timeout``
+     - ``300.0``
+     - Timeout (seconds) for blocking message-queue requests, including
+       the initial chunk-size query and KV cache
+       registration/unregistration. If the server does not respond within
+       this window, the connector raises ``ConnectionError`` on startup.
+   * - ``lmcache.mp.heartbeat_interval``
+     - ``10.0``
+     - Interval (seconds) between periodic heartbeat pings sent from the
+       connector to the server.
+
 Environment Variables
 ---------------------
 

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -463,6 +463,18 @@ attribute — the registered adapter type (e.g. ``"fs"``, ``"nixl_store"``,
 ``"mooncake_store"``) — enabling per-backend slicing in Prometheus (e.g.
 ``lmcache_mp_l2_store_throughput_GB_per_second{l2_name="nixl_store"}``).
 
+.. note::
+   **Store-path fast-path accounting.** Some adapters skip the write
+   when a key is already present in the backend.  That fast-path
+   collapses ``(completed_ts - submitted_ts)`` to near-zero while the
+   submitted ``total_bytes`` stays unchanged, which would inflate the
+   store throughput samples.  The ``L2StoreResult`` returned by
+   ``pop_completed_store_tasks()`` carries the bytes actually written
+   via ``bytes_transferred()``, and the throughput subscriber uses that
+   value instead of the submitted bytes.  Tasks where every key was
+   fast-pathed report ``0`` bytes and the corresponding samples are
+   dropped (no useful throughput data) rather than recorded as a spike.
+
 .. list-table::
    :header-rows: 1
    :widths: 40 15 45
@@ -472,7 +484,9 @@ attribute — the registered adapter type (e.g. ``"fs"``, ``"nixl_store"``,
      - Description
    * - ``lmcache_mp.l2_store_throughput``
      - Histogram
-     - L1→L2 store throughput in GB/s per request.
+     - L1→L2 store throughput in GB/s per task.  Uses adapter-reported
+       transferred bytes when available; otherwise the submitted
+       ``total_bytes``.  Tasks with zero transferred bytes are dropped.
    * - ``lmcache_mp.l2_load_throughput``
      - Histogram
      - L2→L1 load throughput in GB/s per (request, adapter) pair.
@@ -540,6 +554,18 @@ Adapters with no in-flight work emit no datapoint for that scrape.
        the callback never raises during a scrape. Compare against the
        eviction watermark (default ``0.8``) to read whether the
        eviction loop is below or above its trigger threshold.
+   * - ``lmcache_mp.l2_usage_bytes``
+     - ObservableGauge (attr: ``l2_name``)
+     - Bytes currently held in each L2 adapter, sampled at scrape time
+       from ``adapter.get_usage()``.  One observation per configured
+       adapter, tagged by ``l2_name`` (the adapter type, e.g. ``"fs"``,
+       ``"nixl_store"``, ``"mooncake_store"``).  Parallel to
+       ``l1_memory_usage_bytes`` for the L2 tier — use it to see how
+       much each L2 backend currently holds.  Adapters whose
+       ``get_usage()`` raises are skipped silently rather than poisoning
+       the observation, so a missing datapoint for one ``l2_name`` can
+       mean either "not configured" or "adapter errored on this
+       scrape" — cross-check with the L2 store/load counters.
    * - ``lmcache_mp.num_inflight_l2_stores``
      - ObservableGauge (attrs: ``l2_name``, ``adapter_index``)
      - L2 store tasks currently executing, per adapter.  Sustained

--- a/docs/source/mp/observability.rst
+++ b/docs/source/mp/observability.rst
@@ -463,18 +463,6 @@ attribute — the registered adapter type (e.g. ``"fs"``, ``"nixl_store"``,
 ``"mooncake_store"``) — enabling per-backend slicing in Prometheus (e.g.
 ``lmcache_mp_l2_store_throughput_GB_per_second{l2_name="nixl_store"}``).
 
-.. note::
-   **Store-path fast-path accounting.** Some adapters skip the write
-   when a key is already present in the backend.  That fast-path
-   collapses ``(completed_ts - submitted_ts)`` to near-zero while the
-   submitted ``total_bytes`` stays unchanged, which would inflate the
-   store throughput samples.  The ``L2StoreResult`` returned by
-   ``pop_completed_store_tasks()`` carries the bytes actually written
-   via ``bytes_transferred()``, and the throughput subscriber uses that
-   value instead of the submitted bytes.  Tasks where every key was
-   fast-pathed report ``0`` bytes and the corresponding samples are
-   dropped (no useful throughput data) rather than recorded as a spike.
-
 .. list-table::
    :header-rows: 1
    :widths: 40 15 45
@@ -484,9 +472,7 @@ attribute — the registered adapter type (e.g. ``"fs"``, ``"nixl_store"``,
      - Description
    * - ``lmcache_mp.l2_store_throughput``
      - Histogram
-     - L1→L2 store throughput in GB/s per task.  Uses adapter-reported
-       transferred bytes when available; otherwise the submitted
-       ``total_bytes``.  Tasks with zero transferred bytes are dropped.
+     - L1→L2 store throughput in GB/s per request.
    * - ``lmcache_mp.l2_load_throughput``
      - Histogram
      - L2→L1 load throughput in GB/s per (request, adapter) pair.


### PR DESCRIPTION
**What this PR does / why we need it**:

Consolidates the doc-only fixes from five open daily drift-check PRs
into a single branch, resolving overlaps and updating stale references.

Source PRs (all doc-only, all still open):
- #3273 — 2026-05-13 + 2026-05-14: `layout-invariant.md` 5-tuple / `block_stride_elems`, `METRICS.md` fast-path accounting, `observability.rst` note
- #3329 — 2026-05-19: `configuration.rst` extra-config keys (`mq_timeout`, `heartbeat_interval`)
- #3369 — 2026-05-22: `METRICS.md` + `observability.rst` `l2_usage_bytes` gauge
- #3377 — 2026-05-23: `observability.rst` `l2_usage_bytes` gauge (more detailed variant)
- #3399 — 2026-05-26: `overall.md` + `serde_wrapper.md` + `METRICS.md` `L2StoreResult` migration

**Overlap resolution:**
- **#3399 supersedes #3273** on `overall.md` and the `METRICS.md` throughput table: #3273 added the since-removed `pop_completed_store_task_bytes()` hook; #3399 uses the current `L2StoreResult` API.
- **#3377 supersedes #3369** on the `observability.rst` `l2_usage_bytes` row (more detailed description, same data).
- **#3273's `EVENTS.md` change skipped** — `bytes_transferred` is already present on `dev` (landed with PR #3363).
- **#3273's fast-path paragraph** reworded to reference `L2StoreResult.bytes_transferred()` instead of the removed method.

**Special notes for your reviewers**:

Once this PR is merged, the five source PRs (#3273, #3329, #3369, #3377, #3399) can be closed.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests