### PR TITLE
[CI/CD] Tighten the threshold requirement for k3 multiprocess test

### DIFF
--- a/.buildkite/k3_tests/multiprocess/scripts/run-long-doc-qa-l2.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-long-doc-qa-l2.sh
@@ -43,9 +43,12 @@ L2_MAX_SIZE_GB="${L2_MAX_SIZE_GB:-80}"
 L2_BANDWIDTH_GB="${L2_BANDWIDTH_GB:-4}"
 
 # L2 performance thresholds
-MIN_L2_SPEEDUP="${MIN_L2_SPEEDUP:-1.0}"
-MIN_L2_TTFT_SPEEDUP="${MIN_L2_TTFT_SPEEDUP:-1.0}"
-MAX_WARMUP_OVERHEAD="${MAX_WARMUP_OVERHEAD:-2.0}"
+# Recent CI runs show ~1.51-1.67x query speedup, ~1.77-2.02x TTFT speedup,
+# and ~0.87-0.99x warmup overhead. Tighten from the previous pass-anything
+# thresholds (1.0x/1.0x/2.0x) while leaving headroom for variance.
+MIN_L2_SPEEDUP="${MIN_L2_SPEEDUP:-1.3}"
+MIN_L2_TTFT_SPEEDUP="${MIN_L2_TTFT_SPEEDUP:-1.5}"
+MAX_WARMUP_OVERHEAD="${MAX_WARMUP_OVERHEAD:-1.2}"
 
 L2_RESULTS_DIR="$RESULTS_DIR/long_doc_qa_l2"
 PID_FILE="/tmp/lmcache_mp_pids_${BUILD_ID}"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-long-doc-qa.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-long-doc-qa.sh
@@ -27,9 +27,11 @@ SHUFFLE_SEED="${SHUFFLE_SEED:-0}"
 MAX_INFLIGHT_REQUESTS="${MAX_INFLIGHT_REQUESTS:-5}"
 
 # Relative performance thresholds (compared against baseline run in same job)
-# Allow at most 10% slower than baseline for both metrics
-MAX_TTFT_SLOWDOWN_PCT="${MAX_TTFT_SLOWDOWN_PCT:-10}"
-MAX_ROUND_TIME_SLOWDOWN_PCT="${MAX_ROUND_TIME_SLOWDOWN_PCT:-10}"
+# Negative values mean LMCache must be *faster* than baseline by at least that %.
+# Recent CI runs show ~77-84% TTFT improvement and ~27-40% round-time improvement,
+# so requiring 60% and 15% respectively leaves comfortable headroom.
+MAX_TTFT_SLOWDOWN_PCT="${MAX_TTFT_SLOWDOWN_PCT:--60}"
+MAX_ROUND_TIME_SLOWDOWN_PCT="${MAX_ROUND_TIME_SLOWDOWN_PCT:--15}"
 
 # Output directory
 LONG_DOC_QA_DIR="$RESULTS_DIR/long_doc_qa"
@@ -43,9 +45,9 @@ echo "Number of documents: $NUM_DOCUMENTS"
 echo "Output length: $OUTPUT_LEN"
 echo "Results dir: $LONG_DOC_QA_DIR"
 echo ""
-echo "Performance thresholds (relative to baseline):"
-echo "  Max TTFT slowdown: ${MAX_TTFT_SLOWDOWN_PCT}%"
-echo "  Max query round time slowdown: ${MAX_ROUND_TIME_SLOWDOWN_PCT}%"
+echo "Performance thresholds (relative to baseline, negative = must be faster):"
+echo "  Max TTFT slowdown: ${MAX_TTFT_SLOWDOWN_PCT}% (LMCache must be >= $(echo "$MAX_TTFT_SLOWDOWN_PCT" | tr -d '-')% faster)"
+echo "  Max round time slowdown: ${MAX_ROUND_TIME_SLOWDOWN_PCT}% (LMCache must be >= $(echo "$MAX_ROUND_TIME_SLOWDOWN_PCT" | tr -d '-')% faster)"
 echo ""
 
 mkdir -p "$LONG_DOC_QA_DIR"
@@ -196,12 +198,16 @@ def check_metric(name, lmcache_val, baseline_val, max_slowdown_pct):
         print(f"{name}: unable to compare (lmcache={lmcache_val}, baseline={baseline_val}) -- FAIL")
         return False
     pct = ((lmc - base) / base) * 100
+    label = f"{abs(pct):.1f}% faster" if pct < 0 else f"{pct:.1f}% slower"
+    if max_slowdown_pct < 0:
+        threshold_label = f"need >= {abs(max_slowdown_pct):.0f}% faster"
+    else:
+        threshold_label = f"max {max_slowdown_pct}% slower"
     if pct <= max_slowdown_pct:
-        label = f"{abs(pct):.1f}% faster" if pct < 0 else f"{pct:.1f}% slower"
-        print(f"{name}: {lmc:.4f}s vs baseline {base:.4f}s ({label}, max {max_slowdown_pct}% slower) -- PASS")
+        print(f"{name}: {lmc:.4f}s vs baseline {base:.4f}s ({label}, {threshold_label}) -- PASS")
         return True
     else:
-        print(f"{name}: {lmc:.4f}s vs baseline {base:.4f}s ({pct:.1f}% slower, max {max_slowdown_pct}% slower) -- FAIL")
+        print(f"{name}: {lmc:.4f}s vs baseline {base:.4f}s ({label}, {threshold_label}) -- FAIL")
         return False
 
 failed = False


### PR DESCRIPTION
**What this PR does / why we need it**:

Tightens the performance thresholds for `long_doc_qa` and `long_doc_qa_l2` in the k3 multiprocess CI pipeline. The previous thresholds were too loose to catch real regressions:

- `long_doc_qa`: only required LMCache to be no more than 10% *slower* than baseline, while recent CI consistently shows 77-84% TTFT improvement and 27-40% round-time improvement. Now requires ≥60% TTFT improvement and ≥15% round-time improvement.
- `long_doc_qa_l2`: required just ≥1.0x speedup and ≤2.0x warmup overhead — effectively pass-anything. Recent CI shows 1.51-1.67x query speedup, 1.77-2.02x TTFT speedup, and 0.87-0.99x warmup overhead. Now requires ≥1.3x query speedup, ≥1.5x TTFT speedup, and ≤1.2x warmup overhead.

All thresholds remain overridable via environment variables.

| Test | Metric | Old threshold | New threshold | Observed range |
|------|--------|--------------|---------------|----------------|
| `long_doc_qa` | TTFT | max 10% slower | must be ≥60% faster | 77-84% faster |
| `long_doc_qa` | Round time | max 10% slower | must be ≥15% faster | 27-40% faster |
| `long_doc_qa_l2` | Query speedup | ≥1.0x | ≥1.3x | 1.51-1.67x |
| `long_doc_qa_l2` | TTFT speedup | ≥1.0x | ≥1.5x | 1.77-2.02x |
| `long_doc_qa_l2` | Warmup overhead | ≤2.0x | ≤1.2x | 0.87-0.99x |

**Special notes for your reviewers**:

Based on data from 4 recent passing builds (#2190, #2178, #2175, #2173). The new thresholds leave 17%+ margin from worst observed values to avoid flaky failures.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests