### PR TITLE
fix: handle concurrent None-tensor allocations gracefully in GPU connector

### DIFF
--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -282,7 +282,9 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        assert memory_obj.tensor is not None
+        if memory_obj.tensor is None:
+            logger.debug("LMCache Warning: memory_obj.tensor is None. Skipping.")
+            return
 
         self.initialize_kvcaches_ptr(**kwargs)
 
@@ -348,7 +350,9 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        assert memory_obj.tensor is not None
+        if memory_obj.tensor is None:
+            logger.debug("LMCache Warning: memory_obj.tensor is None. Skipping.")
+            return
 
         self.initialize_kvcaches_ptr(**kwargs)
         assert self.kvcaches is not None, (
@@ -531,7 +535,9 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
 
     @_lmcache_nvtx_annotate
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
-        assert memory_obj.raw_tensor is not None
+        if memory_obj.raw_tensor is None:
+            logger.debug("LMCache Warning: memory_obj.raw_tensor is None. Skipping.")
+            return
         assert "slot_mapping" in kwargs
         if self.use_mla:
             assert memory_obj.metadata.fmt == MemoryFormat.KV_MLA_FMT
@@ -1519,7 +1525,9 @@ class SGLangGPUConnector(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        assert memory_obj.tensor is not None
+        if memory_obj.tensor is None:
+            logger.debug("LMCache Warning: memory_obj.tensor is None. Skipping.")
+            return
 
         if self.use_mla:
             if memory_obj.metadata.fmt != MemoryFormat.KV_MLA_FMT:
@@ -1575,7 +1583,9 @@ class SGLangGPUConnector(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        assert memory_obj.tensor is not None
+        if memory_obj.tensor is None:
+            logger.debug("LMCache Warning: memory_obj.tensor is None. Skipping.")
+            return
 
         if "kvcaches" not in kwargs:
             raise ValueError("'kvcaches' should be provided in kwargs.")

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -282,7 +282,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        if memory_obj.tensor is None:
+        tensor = memory_obj.tensor
+        if tensor is None:
             logger.debug("LMCache Warning: memory_obj.tensor is None. Skipping.")
             return
 
@@ -319,7 +320,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
         lmc_ops.multi_layer_kv_transfer(
-            memory_obj.tensor,
+            tensor,
             kv_cache_pointers,
             slot_mapping[start:end],
             self.device,
@@ -350,7 +351,8 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        if memory_obj.tensor is None:
+        tensor = memory_obj.tensor
+        if tensor is None:
             logger.debug("LMCache Warning: memory_obj.tensor is None. Skipping.")
             return
 
@@ -369,7 +371,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         with torch.cuda.stream(self.store_stream):
             if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
                 lmc_ops.multi_layer_kv_transfer(
-                    memory_obj.tensor,
+                    tensor,
                     kv_cache_pointers,
                     slot_mapping[start:end],
                     self.kvcaches[0].device,
@@ -394,9 +396,9 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     block_size=self.block_size,
                     head_size=self.head_size,
                 )
-                memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
+                tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.tensor.is_cuda:
+        if not tensor.is_cuda:
             # Force a synchronize if the target buffer is NOT CUDA device
             # NOTE: for better performance, we may not want to sync for every
             # memory object
@@ -535,7 +537,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
 
     @_lmcache_nvtx_annotate
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
-        if memory_obj.raw_tensor is None:
+        raw_tensor = memory_obj.raw_tensor
+        if raw_tensor is None:
             logger.debug("LMCache Warning: memory_obj.raw_tensor is None. Skipping.")
             return
         assert "slot_mapping" in kwargs
@@ -551,6 +554,15 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self._initialize_kv_cache_pointers()
         assert self.group_kv_cache_pointers_on_gpu is not None
 
+        # Resolve all group tensors up-front
+        num_groups = len(self.group_kv_cache_pointers_on_gpu)
+        group_tensors = []
+        for idx in range(num_groups):
+            t = memory_obj.get_tensor(idx)
+            if t is None:
+                raise AssertionError(f"Group tensor {idx} is None")
+            group_tensors.append(t)
+
         # avoid read/write stream race condition for shared block
         # this will only be potentially non-zero for the first
         # block lmcache is transferring back
@@ -558,8 +570,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
         for i, kv_cache_pointer in enumerate(self.group_kv_cache_pointers_on_gpu):
-            memory_obj_tensor = memory_obj.get_tensor(i)
-            assert memory_obj_tensor is not None
+            memory_obj_tensor = group_tensors[i]
             lmc_ops.multi_layer_kv_transfer(
                 memory_obj_tensor,
                 kv_cache_pointer,
@@ -575,7 +586,8 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
 
     @_lmcache_nvtx_annotate
     def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
-        assert memory_obj.raw_tensor is not None
+        raw_tensor = memory_obj.raw_tensor
+        assert raw_tensor is not None
         assert "slot_mapping" in kwargs
 
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
@@ -584,13 +596,21 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         assert self.kvcaches[0].device == self.device
         self._initialize_kv_cache_pointers()
         assert self.group_kv_cache_pointers_on_gpu is not None
+
+        # Resolve all group tensors up-front
+        num_groups = len(self.group_kv_cache_pointers_on_gpu)
+        group_tensors = []
+        for idx in range(num_groups):
+            t = memory_obj.get_tensor(idx)
+            assert t is not None
+            group_tensors.append(t)
+
         with torch.cuda.stream(self.store_stream):
             if not self.use_gpu or end - start != self.chunk_size:
                 for i, kv_cache_pointer in enumerate(
                     self.group_kv_cache_pointers_on_gpu
                 ):
-                    memory_obj_tensor = memory_obj.get_tensor(i)
-                    assert memory_obj_tensor is not None
+                    memory_obj_tensor = group_tensors[i]
                     lmc_ops.multi_layer_kv_transfer(
                         memory_obj_tensor,
                         kv_cache_pointer,
@@ -620,11 +640,10 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                         block_size=self.block_size,
                         head_size=self.head_size,
                     )
-                    memory_obj_tensor = memory_obj.get_tensor(i)
-                    assert memory_obj_tensor is not None
+                    memory_obj_tensor = group_tensors[i]
                     memory_obj_tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.raw_tensor.is_cuda:
+        if not raw_tensor.is_cuda:
             # Force a synchronize if the target buffer is NOT CUDA device
             # NOTE: for better performance, we may not want to sync for every
             # memory object
@@ -913,13 +932,15 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     ):
                         assert memory_obj.metadata.fmt == MemoryFormat.KV_2TD
                         assert load_gpu_buffer_obj.tensor is not None
+                        tensor = memory_obj.tensor
+                        assert tensor is not None
                         load_gpu_buffer_obj.tensor[0][
                             start - buf_offset : end - buf_offset
-                        ].copy_(memory_obj.tensor[0], non_blocking=True)
+                        ].copy_(tensor[0], non_blocking=True)
 
                         load_gpu_buffer_obj.tensor[1][
                             start - buf_offset : end - buf_offset
-                        ].copy_(memory_obj.tensor[1], non_blocking=True)
+                        ].copy_(tensor[1], non_blocking=True)
 
                         if self.cache_positions and layer_id == 0:
                             old_positions_full[
@@ -1038,12 +1059,13 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     old_positions_chunks,
                     strict=False,
                 ):
-                    assert memory_obj.tensor is not None
-                    memory_obj.tensor[0].copy_(
+                    tensor = memory_obj.tensor
+                    assert tensor is not None
+                    tensor[0].copy_(
                         tmp_gpu_buffer_obj.tensor[0][buf_start:buf_end],
                         non_blocking=True,
                     )
-                    memory_obj.tensor[1].copy_(
+                    tensor[1].copy_(
                         tmp_gpu_buffer_obj.tensor[1][buf_start:buf_end],
                         non_blocking=True,
                     )
@@ -1271,13 +1293,15 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                             f"Expected memory format {MemoryFormat.KV_T2D}, "
                             f"got {memory_obj.metadata.fmt}"
                         )
+                    tensor = memory_obj.tensor
+                    assert tensor is not None
                     if self.use_gpu:
                         tmp_gpu_buffer_obj.tensor[start - offset : end - offset].copy_(
-                            memory_obj.tensor, non_blocking=True
+                            tensor, non_blocking=True
                         )
                     else:
                         lmc_ops.single_layer_kv_transfer(
-                            memory_obj.tensor,
+                            tensor,
                             self.kvcaches[layer_id],
                             slot_mapping_full,
                             lmc_ops.TransferDirection.H2D,
@@ -1397,15 +1421,16 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                 for start, end, memory_obj in zip(
                     starts, ends, memory_objs_layer, strict=False
                 ):
-                    assert memory_obj.tensor is not None
+                    tensor = memory_obj.tensor
+                    assert tensor is not None
                     if self.use_gpu:
-                        memory_obj.tensor.copy_(
+                        tensor.copy_(
                             tmp_gpu_buffer_obj.tensor[start - offset : end - offset],
                             non_blocking=True,
                         )
                     else:
                         lmc_ops.single_layer_kv_transfer(
-                            memory_obj.tensor,
+                            tensor,
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
                             lmc_ops.TransferDirection.D2H,
@@ -1525,7 +1550,8 @@ class SGLangGPUConnector(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        if memory_obj.tensor is None:
+        tensor = memory_obj.tensor
+        if tensor is None:
             logger.debug("LMCache Warning: memory_obj.tensor is None. Skipping.")
             return
 
@@ -1555,7 +1581,7 @@ class SGLangGPUConnector(GPUConnectorInterface):
 
         kv_cache_pointers = self._initialize_pointers(kvcaches)
         lmc_ops.multi_layer_kv_transfer_unilateral(
-            memory_obj.tensor,
+            tensor,
             kv_cache_pointers,
             slot_mapping[start - offset : end - offset],
             get_device(kvcaches),
@@ -1583,7 +1609,8 @@ class SGLangGPUConnector(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        if memory_obj.tensor is None:
+        tensor = memory_obj.tensor
+        if tensor is None:
             logger.debug("LMCache Warning: memory_obj.tensor is None. Skipping.")
             return
 
@@ -1600,7 +1627,7 @@ class SGLangGPUConnector(GPUConnectorInterface):
 
         if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
             lmc_ops.multi_layer_kv_transfer_unilateral(
-                memory_obj.tensor,
+                tensor,
                 kv_cache_pointers,
                 slot_mapping[start:end],
                 get_device(kvcaches),
@@ -1621,9 +1648,9 @@ class SGLangGPUConnector(GPUConnectorInterface):
                 lmc_ops.TransferDirection.D2H,
                 self.engine_kv_format,
             )
-            memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
+            tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.tensor.is_cuda:
+        if not tensor.is_cuda:
             # Force a synchronize if the target buffer is NOT CUDA device
             # NOTE: for better performance, we may not want to sync for every
             # memory object
@@ -1791,13 +1818,15 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
                 starts, ends, memory_objs_layer, strict=False
             ):
                 assert memory_obj.metadata.fmt == MemoryFormat.KV_T2D
+                tensor = memory_obj.tensor
+                assert tensor is not None
                 if self.use_gpu:
                     tmp_gpu_buffer_obj.tensor[start - offset : end - offset].copy_(
-                        memory_obj.tensor, non_blocking=True
+                        tensor, non_blocking=True
                     )
                 else:
                     lmc_ops.single_layer_kv_transfer_sgl(
-                        memory_obj.tensor,
+                        tensor,
                         self.kvcaches[0][layer_id],
                         self.kvcaches[1][layer_id],
                         slot_mapping[start:end],
@@ -1912,17 +1941,18 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
             for start, end, memory_obj in zip(
                 starts, ends, memory_objs_layer, strict=False
             ):
-                assert memory_obj.tensor is not None
+                tensor = memory_obj.tensor
+                assert tensor is not None
                 if self.use_gpu:
-                    chunk_len = memory_obj.tensor.shape[0]
-                    memory_obj.tensor.copy_(
+                    chunk_len = tensor.shape[0]
+                    tensor.copy_(
                         tmp_gpu_buffer_obj.tensor[start_idx : start_idx + chunk_len],
                         non_blocking=True,
                     )
                     start_idx += chunk_len
                 else:
                     lmc_ops.single_layer_kv_transfer_sgl(
-                        memory_obj.tensor,
+                        tensor,
                         self.kvcaches[0][layer_id],
                         self.kvcaches[1][layer_id],
                         slot_mapping[start:end],
@@ -2130,10 +2160,13 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         if self.kv_cache_tensor is None:
             raise RuntimeError("register_kv_caches must be called before to_gpu")
         chunk_blocks = self._get_chunk_block_ids(kwargs.get("block_ids", []), start)
-        if chunk_blocks is None or memory_obj.tensor is None:
+        if chunk_blocks is None:
+            return
+        tensor = memory_obj.tensor
+        if tensor is None:
             return
         self._transfer(
-            memory_obj.tensor.data_ptr(),
+            tensor.data_ptr(),
             chunk_blocks,
             lmc_ops.TransferDirection.H2D,
             self.load_stream,
@@ -2143,10 +2176,13 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         if self.kv_cache_tensor is None:
             raise RuntimeError("register_kv_caches must be called before from_gpu")
         chunk_blocks = self._get_chunk_block_ids(kwargs.get("block_ids", []), start)
-        if chunk_blocks is None or memory_obj.tensor is None:
+        if chunk_blocks is None:
+            return
+        tensor = memory_obj.tensor
+        if tensor is None:
             return
         self._transfer(
-            memory_obj.tensor.data_ptr(),
+            tensor.data_ptr(),
             chunk_blocks,
             lmc_ops.TransferDirection.D2H,
             self.store_stream,
@@ -2160,22 +2196,25 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         direction: "lmc_ops.TransferDirection",
         stream: torch.cuda.Stream,
     ) -> None:
-        valid: List[Tuple[MemoryObj, List[int]]] = []
+        valid: List[Tuple[torch.Tensor, List[int]]] = []
         for memory_obj, start in zip(memory_objs, starts, strict=False):
-            if isinstance(memory_obj, list) or memory_obj.tensor is None:
+            if isinstance(memory_obj, list):
+                continue
+            tensor = memory_obj.tensor
+            if tensor is None:
                 continue
             chunk_blocks = self._get_chunk_block_ids(block_ids, start)
             if chunk_blocks is not None:
-                valid.append((memory_obj, chunk_blocks))
+                valid.append((tensor, chunk_blocks))
 
         with torch.cuda.stream(stream):
             for i in range(0, len(valid), self._batch_size):
                 batch = valid[i : i + self._batch_size]
                 all_block_ids: List[int] = []
                 ptrs: List[int] = []
-                for mo, blocks in batch:
+                for tensor, blocks in batch:
                     all_block_ids.extend(blocks)
-                    ptrs.append(mo.tensor.data_ptr())  # type: ignore[union-attr]
+                    ptrs.append(tensor.data_ptr())
                 block_ids_gpu = self._stage_block_ids(all_block_ids)
                 lmc_ops.multi_layer_block_kv_transfer(
                     self.paged_buffer_ptrs,

--- a/lmcache/v1/gpu_connector/hpu_connector.py
+++ b/lmcache/v1/gpu_connector/hpu_connector.py
@@ -97,7 +97,8 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        assert memory_obj.tensor is not None
+        tensor = memory_obj.tensor
+        assert tensor is not None
 
         self.initialize_kvcaches_ptr(**kwargs)
 
@@ -120,7 +121,7 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
         htorch.core.mark_step()
 
         if self.use_mla:
-            tmp = memory_obj.tensor[0].to(slot_mapping.device)
+            tmp = tensor[0].to(slot_mapping.device)
             total_blocks = self.num_blocks * self.block_size
             for i, kvcache in enumerate(self.kvcaches):
                 kvcache.view(total_blocks, self.head_size).index_copy_(
@@ -128,8 +129,8 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
                 )
                 htorch.core.mark_step()
         else:
-            tmp_k = memory_obj.tensor[0].to(slot_mapping.device)
-            tmp_v = memory_obj.tensor[1].to(slot_mapping.device)
+            tmp_k = tensor[0].to(slot_mapping.device)
+            tmp_v = tensor[1].to(slot_mapping.device)
             total_blocks = self.num_blocks * self.block_size
             d = self.num_heads * self.head_size
             for i, (kcache, vcache) in enumerate(self.kvcaches):
@@ -158,7 +159,8 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        assert memory_obj.tensor is not None
+        tensor = memory_obj.tensor
+        assert tensor is not None
 
         self.initialize_kvcaches_ptr(**kwargs)
         assert self.kvcaches is not None, (
@@ -199,7 +201,7 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
                 ]
             )
             tmp = torch.stack([tmp_k, tmp_v])
-        memory_obj.tensor.copy_(tmp, non_blocking=True)
+        tensor.copy_(tmp, non_blocking=True)
 
         htorch.core.mark_step()
         torch.hpu.synchronize()

--- a/lmcache/v1/gpu_connector/musa_connectors.py
+++ b/lmcache/v1/gpu_connector/musa_connectors.py
@@ -123,7 +123,8 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
             ValueError: If slot_mapping is missing from kwargs.
             AssertionError: If memory_obj has no tensor.
         """
-        assert memory_obj.tensor is not None
+        tensor = memory_obj.tensor
+        assert tensor is not None
 
         self.initialize_kvcaches_ptr(**kwargs)
         assert self.kvcaches is not None
@@ -160,15 +161,15 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
         )
 
         if self.use_mla:
-            tmp = memory_obj.tensor[0].to(self.device, non_blocking=True)
+            tmp = tensor[0].to(self.device, non_blocking=True)
             total_blocks = self.num_blocks * self.block_size
             for i, kvcache in enumerate(self.kvcaches):
                 kvcache.view(total_blocks, self.head_size).index_copy_(
                     0, slices, tmp[i, skip_prefix_n_tokens:]
                 )
         else:
-            tmp_k = memory_obj.tensor[0].to(self.device, non_blocking=True)
-            tmp_v = memory_obj.tensor[1].to(self.device, non_blocking=True)
+            tmp_k = tensor[0].to(self.device, non_blocking=True)
+            tmp_v = tensor[1].to(self.device, non_blocking=True)
             total_blocks = self.num_blocks * self.block_size
             d = self.num_heads * self.head_size
             for i, (kcache, vcache) in enumerate(self.kvcaches):
@@ -197,7 +198,8 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
             ValueError: If slot_mapping is missing from kwargs.
             AssertionError: If memory_obj has no tensor.
         """
-        assert memory_obj.tensor is not None
+        tensor = memory_obj.tensor
+        assert tensor is not None
 
         self.initialize_kvcaches_ptr(**kwargs)
         assert self.kvcaches is not None
@@ -258,9 +260,9 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
                 ]
             )
             tmp = torch.stack([tmp_k, tmp_v])
-        memory_obj.tensor.copy_(tmp, non_blocking=True)
+        tensor.copy_(tmp, non_blocking=True)
 
-        if memory_obj.tensor.device.type != "musa":
+        if tensor.device.type != "musa":
             torch.musa.synchronize()  # type: ignore[attr-defined]
 
         if self.use_mla:

--- a/lmcache/v1/gpu_connector/musa_connectors.py
+++ b/lmcache/v1/gpu_connector/musa_connectors.py
@@ -144,7 +144,7 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
             return
         if try_native_to_gpu(
             use_mla=self.use_mla,
-            memory_tensor=memory_obj.tensor,
+            memory_tensor=tensor,
             kvcaches=self.kvcaches,
             slot_mapping=slot_mapping,
             start=start,
@@ -217,7 +217,7 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
             return
         if try_native_from_gpu(
             use_mla=self.use_mla,
-            memory_tensor=memory_obj.tensor,
+            memory_tensor=tensor,
             kvcaches=self.kvcaches,
             slot_mapping=slot_mapping,
             start=start,
@@ -226,7 +226,7 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
             num_heads=self.num_heads,
             head_size=self.head_size,
         ):
-            if memory_obj.tensor.device.type != "musa" and hasattr(torch, "musa"):
+            if tensor.device.type != "musa" and hasattr(torch, "musa"):
                 torch.musa.synchronize()  # type: ignore[attr-defined]
             if self.use_mla:
                 memory_obj.metadata.fmt = MemoryFormat.KV_MLA_FMT

--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -156,7 +156,8 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        assert memory_obj.tensor is not None
+        tensor = memory_obj.tensor
+        assert tensor is not None
 
         self.initialize_kvcaches_ptr(**kwargs)
 
@@ -191,7 +192,7 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
         lmc_ops.multi_layer_kv_transfer(
-            memory_obj.tensor,
+            tensor,
             kv_cache_pointers,
             slot_mapping[start:end],
             self.device,
@@ -221,7 +222,8 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
         :raises AssertionError: If the memory object does not have a tensor.
         :raises ValueError: If 'slot_mapping' is not provided in kwargs.
         """
-        assert memory_obj.tensor is not None
+        tensor = memory_obj.tensor
+        assert tensor is not None
 
         self.initialize_kvcaches_ptr(**kwargs)
         assert self.kvcaches is not None, (
@@ -238,7 +240,7 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
         with torch.xpu.stream(self.store_stream):
             if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
                 lmc_ops.multi_layer_kv_transfer(
-                    memory_obj.tensor,
+                    tensor,
                     kv_cache_pointers,
                     slot_mapping[start:end],
                     self.kvcaches[0].device,
@@ -261,9 +263,9 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
                     self.engine_kv_format,
                     self.block_size,
                 )
-                memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
+                tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.tensor.is_xpu:
+        if not tensor.is_xpu:
             # Force a synchronize if the target buffer is NOT XPU device
             # NOTE: for better performance, we may not want to sync for every
             # memory object
@@ -367,7 +369,8 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
 
     @_lmcache_nvtx_annotate
     def to_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
-        assert memory_obj.raw_tensor is not None
+        raw_tensor = memory_obj.raw_tensor
+        assert raw_tensor is not None
         assert "slot_mapping" in kwargs
         if self.use_mla:
             assert memory_obj.metadata.fmt == MemoryFormat.KV_MLA_FMT
@@ -381,6 +384,15 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
         self._initialize_kv_cache_pointers()
         assert self.group_kv_cache_pointers_on_gpu is not None
 
+        # Resolve all group tensors up-front
+        num_groups = len(self.group_kv_cache_pointers_on_gpu)
+        group_tensors = []
+        for idx in range(num_groups):
+            t = memory_obj.get_tensor(idx)
+            if t is None:
+                raise AssertionError(f"Group tensor {idx} is None")
+            group_tensors.append(t)
+
         # avoid read/write stream race condition for shared block
         # this will only be potentially non-zero for the first
         # block lmcache is transferring back
@@ -388,8 +400,7 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
         for i, kv_cache_pointer in enumerate(self.group_kv_cache_pointers_on_gpu):
-            memory_obj_tensor = memory_obj.get_tensor(i)
-            assert memory_obj_tensor is not None
+            memory_obj_tensor = group_tensors[i]
             lmc_ops.multi_layer_kv_transfer(
                 memory_obj_tensor,
                 kv_cache_pointer,
@@ -404,7 +415,8 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
 
     @_lmcache_nvtx_annotate
     def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):
-        assert memory_obj.raw_tensor is not None
+        raw_tensor = memory_obj.raw_tensor
+        assert raw_tensor is not None
         assert "slot_mapping" in kwargs
 
         slot_mapping: torch.Tensor = kwargs["slot_mapping"]
@@ -413,13 +425,21 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
         assert self.kvcaches[0].device == self.device
         self._initialize_kv_cache_pointers()
         assert self.group_kv_cache_pointers_on_gpu is not None
+
+        # Resolve all group tensors up-front
+        num_groups = len(self.group_kv_cache_pointers_on_gpu)
+        group_tensors = []
+        for idx in range(num_groups):
+            t = memory_obj.get_tensor(idx)
+            assert t is not None
+            group_tensors.append(t)
+
         with torch.xpu.stream(self.store_stream):
             if not self.use_gpu or end - start != self.chunk_size:
                 for i, kv_cache_pointer in enumerate(
                     self.group_kv_cache_pointers_on_gpu
                 ):
-                    memory_obj_tensor = memory_obj.get_tensor(i)
-                    assert memory_obj_tensor is not None
+                    memory_obj_tensor = group_tensors[i]
                     lmc_ops.multi_layer_kv_transfer(
                         memory_obj_tensor,
                         kv_cache_pointer,
@@ -447,11 +467,10 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
                         self.engine_kv_format,
                         self.block_size,
                     )
-                    memory_obj_tensor = memory_obj.get_tensor(i)
-                    assert memory_obj_tensor is not None
+                    memory_obj_tensor = group_tensors[i]
                     memory_obj_tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
-        if not memory_obj.raw_tensor.is_xpu:
+        if not raw_tensor.is_xpu:
             # Force a synchronize if the target buffer is NOT XPU device
             # NOTE: for better performance, we may not want to sync for every
             # memory object
@@ -726,13 +745,15 @@ class VLLMBufferLayerwiseXPUConnector(GPUConnectorInterface):
                     ):
                         assert memory_obj.metadata.fmt == MemoryFormat.KV_2TD
                         assert load_gpu_buffer_obj.tensor is not None
+                        tensor = memory_obj.tensor
+                        assert tensor is not None
                         load_gpu_buffer_obj.tensor[0][
                             start - buf_offset : end - buf_offset
-                        ].copy_(memory_obj.tensor[0], non_blocking=True)
+                        ].copy_(tensor[0], non_blocking=True)
 
                         load_gpu_buffer_obj.tensor[1][
                             start - buf_offset : end - buf_offset
-                        ].copy_(memory_obj.tensor[1], non_blocking=True)
+                        ].copy_(tensor[1], non_blocking=True)
 
                         if self.cache_positions and layer_id == 0:
                             old_positions_full[
@@ -851,12 +872,13 @@ class VLLMBufferLayerwiseXPUConnector(GPUConnectorInterface):
                     old_positions_chunks,
                     strict=False,
                 ):
-                    assert memory_obj.tensor is not None
-                    memory_obj.tensor[0].copy_(
+                    tensor = memory_obj.tensor
+                    assert tensor is not None
+                    tensor[0].copy_(
                         tmp_gpu_buffer_obj.tensor[0][buf_start:buf_end],
                         non_blocking=True,
                     )
-                    memory_obj.tensor[1].copy_(
+                    tensor[1].copy_(
                         tmp_gpu_buffer_obj.tensor[1][buf_start:buf_end],
                         non_blocking=True,
                     )
@@ -1071,13 +1093,15 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                             f"Expected memory format {MemoryFormat.KV_T2D}, "
                             f"got {memory_obj.metadata.fmt}"
                         )
+                    tensor = memory_obj.tensor
+                    assert tensor is not None
                     if self.use_gpu:
                         tmp_gpu_buffer_obj.tensor[start - offset : end - offset].copy_(
-                            memory_obj.tensor, non_blocking=True
+                            tensor, non_blocking=True
                         )
                     else:
                         lmc_ops.single_layer_kv_transfer(
-                            memory_obj.tensor,
+                            tensor,
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
                             lmc_ops.TransferDirection.H2D,
@@ -1195,15 +1219,16 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                 for start, end, memory_obj in zip(
                     starts, ends, memory_objs_layer, strict=False
                 ):
-                    assert memory_obj.tensor is not None
+                    tensor = memory_obj.tensor
+                    assert tensor is not None
                     if self.use_gpu:
-                        memory_obj.tensor.copy_(
+                        tensor.copy_(
                             tmp_gpu_buffer_obj.tensor[start - offset : end - offset],
                             non_blocking=True,
                         )
                     else:
                         lmc_ops.single_layer_kv_transfer(
-                            memory_obj.tensor,
+                            tensor,
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
                             lmc_ops.TransferDirection.D2H,

--- a/tests/v1/storage_backend/test_raw_block_uring_cmd.py
+++ b/tests/v1/storage_backend/test_raw_block_uring_cmd.py
@@ -308,7 +308,7 @@ def test_uring_cmd_explicit_transfer_limit_must_be_block_aligned():
     with pytest.raises(
         ValueError,
         match=r"max_data_transfer_size \(5000\) must be a multiple of "
-        "block_align \(4096\)",
+        r"block_align \(4096\)",
     ):
         _build_transfer_limit_backend(
             TEST_DEVICES["char_device"], max_data_transfer_size=5000

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -984,7 +984,7 @@ def test_vllm_paged_connector_active_concurrency_race():
         device=device,
         block_size=block_size,
         num_layers=num_layers,
-        gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        engine_kv_format=lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
     )
 
     allocator = PinMemoryAllocator(10 * 1024 * 1024)

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -957,3 +957,91 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
         engine_kv_formats=[engine_kv_format] * len(kv_list),
     )
     return metadata
+
+
+def test_vllm_paged_connector_active_concurrency_race():
+    """
+    Actively races a Loader thread (calling to_gpu) and an Eviction thread
+    (invalidating memory_obj.valid to False) to demonstrate the concurrency crash
+    and verify the graceful recovery.
+    """
+    # Standard
+    import time
+
+    num_blocks = 10
+    block_size = 16
+    num_layers = 4
+    num_heads = 8
+    head_size = 64
+    device = "cuda"
+    dtype = torch.float16
+    start, end = 0, 32
+
+    slot_mapping = torch.arange(32, dtype=torch.long, device=device)
+    gpu_kv_dst = generate_kv_cache_paged_list_tensors(
+        num_blocks=num_blocks,
+        device=device,
+        block_size=block_size,
+        gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+    )
+
+    allocator = PinMemoryAllocator(10 * 1024 * 1024)
+    hidden_dim = num_heads * head_size
+    connector = VLLMPagedMemGPUConnectorV2(
+        hidden_dim_size=hidden_dim,
+        num_layers=num_layers,
+        use_gpu=True,
+        chunk_size=256,
+        dtype=dtype,
+        device=device,
+    )
+
+    shape = connector.get_shape(end - start)
+    memory_obj = allocator.allocate(shape, dtype)
+
+    stop_event = threading.Event()
+    exceptions = []
+
+    # --- THREAD 1: The Loader ---
+    def loader_worker():
+        while not stop_event.is_set():
+            try:
+                connector.to_gpu(
+                    memory_obj,
+                    start,
+                    end,
+                    kvcaches=gpu_kv_dst,
+                    slot_mapping=slot_mapping,
+                    offset=0,
+                )
+            except Exception as e:
+                exceptions.append(e)
+                stop_event.set()
+                break
+            time.sleep(0.0001)
+
+    # --- THREAD 2: The Evictor ---
+    def evictor_worker():
+        while not stop_event.is_set():
+            memory_obj.valid = False
+            time.sleep(0.0005)
+            memory_obj.valid = True
+            time.sleep(0.0005)
+
+    t1 = threading.Thread(target=loader_worker)
+    t2 = threading.Thread(target=evictor_worker)
+
+    t1.start()
+    t2.start()
+
+    time.sleep(0.5)
+    stop_event.set()
+
+    t1.join()
+    t2.join()
+
+    allocator.free(memory_obj)
+    allocator.close()
+
+    if exceptions:
+        raise exceptions[0]

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -983,6 +983,7 @@ def test_vllm_paged_connector_active_concurrency_race():
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
+        num_layers=num_layers,
         gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
     )
 

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -959,6 +959,7 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
     return metadata
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA GPU not available")
 def test_vllm_paged_connector_active_concurrency_race():
     """
     Actively races a Loader thread (calling to_gpu) and an Eviction thread
@@ -975,9 +976,9 @@ def test_vllm_paged_connector_active_concurrency_race():
     head_size = 64
     device = "cuda"
     dtype = torch.float16
-    start, end = 0, 32
+    start, end = 0, 4
 
-    slot_mapping = torch.arange(32, dtype=torch.long, device=device)
+    slot_mapping = torch.arange(4, dtype=torch.long, device=device)
     gpu_kv_dst = generate_kv_cache_paged_list_tensors(
         num_blocks=num_blocks,
         device=device,


### PR DESCRIPTION
**Why we need it**:

Under high concurrent serving workloads, LMCache storage tiers trigger transient GPU tensor memory-mapping allocation races during rapid background cache evictions or prefetch transfers. This was discovers during a locust load test.

This can set `memory_obj.tensor = None` right before the PyTorch CUDA driver executes `to_gpu` on the inference thread. Because `gpu_connectors.py` carries an `assert` check, this transient race triggers a process-fatal `AssertionError` crash, terminating the completions container under load.

**What this PR does**:

This PR 

- Add None check to prevent AssertionError crashes under concurrent prefetch races

- Include active thread race test `test_vllm_paged_connector_active_concurrency_race` to verify stability

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains unit tests
