### PR TITLE
[Hotfix][CI] fix raw-block L2 store result assertions

### DIFF
--- a/tests/v1/multiprocess/test_raw_block_l2_adapter.py
+++ b/tests/v1/multiprocess/test_raw_block_l2_adapter.py
@@ -66,7 +66,9 @@ def test_raw_block_l2_adapter_store_lookup_load_roundtrip(tmp_path):
 
         store_task_id = adapter.submit_store_task([key], [make_memory_obj(payload)])
         assert wait_for_event_fd(adapter.get_store_event_fd())
-        assert adapter.pop_completed_store_tasks()[store_task_id] is True
+        store_result = adapter.pop_completed_store_tasks()[store_task_id]
+        assert store_result.is_successful()
+        assert store_result.bytes_transferred() == RAW_BLOCK_CI_SLOT_BYTES
 
         lookup_task_id = adapter.submit_lookup_and_lock_task([key, missing_key])
         assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
@@ -98,7 +100,9 @@ def test_raw_block_l2_adapter_delete_makes_key_miss(tmp_path):
 
         store_task_id = adapter.submit_store_task([key], [make_memory_obj(payload)])
         assert wait_for_event_fd(adapter.get_store_event_fd())
-        assert adapter.pop_completed_store_tasks()[store_task_id] is True
+        store_result = adapter.pop_completed_store_tasks()[store_task_id]
+        assert store_result.is_successful()
+        assert store_result.bytes_transferred() == RAW_BLOCK_CI_SLOT_BYTES
 
         adapter.delete([key])
 


### PR DESCRIPTION
Fix the raw-block MP tempfile tests introduced by #3203 to assert the `L2StoreResult` contract instead of comparing the int subclass directly to `True`.

The adapter returns transferred bytes on success, so the CI failure was:

```text
assert 65536 is True
```

This updates both store assertions to use:

- `store_result.is_successful()`
- `store_result.bytes_transferred() == RAW_BLOCK_CI_SLOT_BYTES`

Local verification:

```text
python -m maturin build --release --manifest-path rust/raw_block/Cargo.toml --out .pytest-tmp/raw-block-dist
uv pip install --python .venv/bin/python .pytest-tmp/raw-block-dist/*.whl
python -m pytest -q --basetemp=.pytest-tmp/raw-block tests/v1/storage_backend/test_raw_block_device.py tests/v1/storage_backend/test_raw_block_core.py tests/v1/multiprocess/test_raw_block_l2_adapter.py
# 9 passed, 1 skipped
```