### PR TITLE
[Bugfix] Avoid vLLM import during blake3 token hasher startup

### DIFF
--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -154,17 +154,18 @@ class TokenHasher:
 
         Adapted from TokenDatabase.__init__ (token_database.py:64-82).
         """
-        try:
-            # Third Party
-            from vllm.v1.core import kv_cache_utils
+        if self.hash_algorithm_name != "blake3":
+            try:
+                # Third Party
+                from vllm.v1.core import kv_cache_utils
 
-            if hasattr(kv_cache_utils, "init_none_hash"):
-                kv_cache_utils.init_none_hash(self.hash_func)
-                none_hash = kv_cache_utils.NONE_HASH
-                logger.info("Initialized NONE_HASH=%s from vLLM", none_hash)
-                return none_hash
-        except (ImportError, AttributeError, ValueError):
-            pass
+                if hasattr(kv_cache_utils, "init_none_hash"):
+                    kv_cache_utils.init_none_hash(self.hash_func)
+                    none_hash = kv_cache_utils.NONE_HASH
+                    logger.info("Initialized NONE_HASH=%s from vLLM", none_hash)
+                    return none_hash
+            except (ImportError, AttributeError, ValueError, RuntimeError):
+                pass
 
         # Fallback: compute none_hash using our hash function
         none_hash = self.hash_func((0, (0,), None))

--- a/tests/v1/multiprocess/test_token_hasher.py
+++ b/tests/v1/multiprocess/test_token_hasher.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for TokenHasher."""
 
+# Standard
+import builtins
+
 # Third Party
 import numpy as np
 import pytest
@@ -26,6 +29,39 @@ class TestTokenHasher:
         hasher = TokenHasher(chunk_size=256, hash_algorithm="blake3")
         assert hasher.chunk_size == 256
         assert hasher.none_hash is not None
+
+    def test_init_blake3_does_not_import_vllm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        real_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name == "vllm" or name.startswith("vllm."):
+                raise AssertionError("blake3 TokenHasher should not import vLLM")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+        hasher = TokenHasher(chunk_size=256, hash_algorithm="blake3")
+
+        assert hasher.none_hash is not None
+
+    def test_init_none_hash_vllm_runtime_error_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        real_import = builtins.__import__
+
+        def failing_vllm_import(name, *args, **kwargs):
+            if name == "vllm.v1.core":
+                raise RuntimeError("already a kernel registered")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", failing_vllm_import)
+        hasher = TokenHasher.__new__(TokenHasher)
+        hasher.hash_algorithm_name = "sha256_cbor"
+        hasher.hash_func = lambda _: b"fallback"
+
+        assert hasher._init_none_hash() == b"fallback"
 
     def test_hash_tokens_returns_bytes(self, hasher: TokenHasher) -> None:
         h = hasher.hash_tokens([1, 2, 3, 4])


### PR DESCRIPTION
Fixes #3414.

This PR prevents the multiprocess `TokenHasher` default `blake3` path from importing `vllm.v1.core` during LMCache server startup. 
That avoids the Torch 2.11 double kernel registration crash triggered through vLLM import side effects.

It also makes optional vLLM `NONE_HASH` initialization fall back safely if that import path raises `RuntimeError`.

  **Special notes for your reviewers**:
  Tested with:

  ```bash
  LMCACHE_LOG_LEVEL=CRITICAL python3 -m pytest --confcutdir=tests/v1/multiprocess tests/v1/multiprocess/test_token_hasher.py
  python3 -m ruff check lmcache/v1/multiprocess/token_hasher.py tests/v1/multiprocess/test_token_hasher.py
```
  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
