### PR TITLE
[Feature] Add native PeriodicEventNotifier C++ singleton

### DIFF
--- a/csrc/storage_manager/periodic_event_notifier.cpp
+++ b/csrc/storage_manager/periodic_event_notifier.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "periodic_event_notifier.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <algorithm>
+
+namespace lmcache {
+namespace storage_manager {
+
+std::mutex PeriodicEventNotifier::create_mutex_;
+std::unique_ptr<PeriodicEventNotifier> PeriodicEventNotifier::instance_;
+
+PeriodicEventNotifier::PeriodicEventNotifier(int interval_ms, bool use_eventfd)
+    : interval_ms_(std::max(1, interval_ms)), use_eventfd_(use_eventfd) {
+  thread_ = std::thread(&PeriodicEventNotifier::thread_func, this);
+}
+
+PeriodicEventNotifier::~PeriodicEventNotifier() {
+  stop_.store(true, std::memory_order_release);
+  cv_.notify_all();
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+void PeriodicEventNotifier::create(int interval_ms, bool use_eventfd) {
+  std::lock_guard<std::mutex> lock(create_mutex_);
+  if (instance_) {
+    return;
+  }
+  instance_.reset(new PeriodicEventNotifier(interval_ms, use_eventfd));
+}
+
+PeriodicEventNotifier* PeriodicEventNotifier::get() { return instance_.get(); }
+
+void PeriodicEventNotifier::shutdown() {
+  std::lock_guard<std::mutex> lock(create_mutex_);
+  if (!instance_) {
+    return;
+  }
+  instance_->stop_.store(true, std::memory_order_release);
+  instance_->cv_.notify_all();
+  if (instance_->thread_.joinable()) {
+    instance_->thread_.join();
+  }
+  instance_.reset();
+}
+
+void PeriodicEventNotifier::register_fd(int fd) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    fds_.insert(fd);
+  }
+  cv_.notify_one();
+}
+
+void PeriodicEventNotifier::unregister_fd(int fd) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  fds_.erase(fd);
+}
+
+void PeriodicEventNotifier::set_interval_ms(int interval_ms) {
+  interval_ms_.store(std::max(1, interval_ms), std::memory_order_release);
+  cv_.notify_one();
+}
+
+void PeriodicEventNotifier::signal_fd(int fd) {
+  if (use_eventfd_) {
+    uint64_t one = 1;
+    for (;;) {
+      ssize_t w = ::write(fd, &one, sizeof(one));
+      if (w == static_cast<ssize_t>(sizeof(one))) return;
+      if (w < 0) {
+        if (errno == EINTR) continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+        return;
+      }
+    }
+  } else {
+    uint8_t one = 1;
+    for (;;) {
+      ssize_t w = ::write(fd, &one, sizeof(one));
+      if (w == 1) return;
+      if (w < 0) {
+        if (errno == EINTR) continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+        return;
+      }
+    }
+  }
+}
+
+void PeriodicEventNotifier::thread_func() {
+  while (true) {
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      cv_.wait(lock, [this] {
+        return stop_.load(std::memory_order_acquire) || !fds_.empty();
+      });
+      if (stop_.load(std::memory_order_acquire)) {
+        return;
+      }
+    }
+
+    while (!stop_.load(std::memory_order_acquire)) {
+      std::vector<int> snapshot;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (fds_.empty()) {
+          break;
+        }
+        snapshot.assign(fds_.begin(), fds_.end());
+      }
+
+      for (int fd : snapshot) {
+        signal_fd(fd);
+      }
+
+      {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait_for(lock,
+                     std::chrono::milliseconds(
+                         interval_ms_.load(std::memory_order_acquire)),
+                     [this] { return stop_.load(std::memory_order_acquire); });
+      }
+    }
+  }
+}
+
+}  // namespace storage_manager
+}  // namespace lmcache

--- a/csrc/storage_manager/periodic_event_notifier.h
+++ b/csrc/storage_manager/periodic_event_notifier.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <unistd.h>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+namespace lmcache {
+namespace storage_manager {
+
+class PeriodicEventNotifier {
+ public:
+  static void create(int interval_ms, bool use_eventfd);
+  static PeriodicEventNotifier* get();
+  static void shutdown();
+
+  void register_fd(int fd);
+  void unregister_fd(int fd);
+  void set_interval_ms(int interval_ms);
+
+  ~PeriodicEventNotifier();
+
+  PeriodicEventNotifier(const PeriodicEventNotifier&) = delete;
+  PeriodicEventNotifier& operator=(const PeriodicEventNotifier&) = delete;
+
+ private:
+  PeriodicEventNotifier(int interval_ms, bool use_eventfd);
+
+  void thread_func();
+  void signal_fd(int fd);
+
+  static std::mutex create_mutex_;
+  static std::unique_ptr<PeriodicEventNotifier> instance_;
+
+  std::thread thread_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::atomic<bool> stop_{false};
+
+  std::atomic<int> interval_ms_;
+  bool use_eventfd_;
+
+  std::unordered_set<int> fds_;
+};
+
+}  // namespace storage_manager
+}  // namespace lmcache

--- a/csrc/storage_manager/pybind.cpp
+++ b/csrc/storage_manager/pybind.cpp
@@ -4,11 +4,13 @@
 #include <pybind11/stl.h>
 #include "ttl_lock.h"
 #include "bitmap.h"
+#include "periodic_event_notifier.h"
 #include "utils.h"
 
 namespace py = pybind11;
 
 using lmcache::storage_manager::Bitmap;
+using lmcache::storage_manager::PeriodicEventNotifier;
 using lmcache::storage_manager::TTLLock;
 using lmcache::utils::ParallelPatternMatcher;
 using lmcache::utils::RangePatternMatcher;
@@ -91,4 +93,24 @@ PYBIND11_MODULE(native_storage_ops, m) {
            "pattern and end_pos is the exclusive index after the end pattern. "
            "When multiple end patterns exist after a start pattern, matches "
            "the first one (minimal range).");
+
+  py::class_<PeriodicEventNotifier>(m, "PeriodicEventNotifier")
+      .def_static("create", &PeriodicEventNotifier::create,
+                  py::call_guard<py::gil_scoped_release>(),
+                  py::arg("interval_ms"), py::arg("use_eventfd"),
+                  "Create the singleton PeriodicEventNotifier. "
+                  "Idempotent -- second call is a no-op.")
+      .def_static("get", &PeriodicEventNotifier::get,
+                  py::return_value_policy::reference,
+                  "Get the singleton instance, or None if not created.")
+      .def_static("shutdown", &PeriodicEventNotifier::shutdown,
+                  py::call_guard<py::gil_scoped_release>(),
+                  "Shut down the singleton. Idempotent.")
+      .def("register_fd", &PeriodicEventNotifier::register_fd, py::arg("fd"),
+           "Register a file descriptor for periodic signaling.")
+      .def("unregister_fd", &PeriodicEventNotifier::unregister_fd,
+           py::arg("fd"), "Unregister a file descriptor.")
+      .def("set_interval_ms", &PeriodicEventNotifier::set_interval_ms,
+           py::arg("interval_ms"),
+           "Change the notification interval in milliseconds.");
 }

--- a/lmcache/native_storage_ops.pyi
+++ b/lmcache/native_storage_ops.pyi
@@ -179,6 +179,60 @@ class ParallelPatternMatcher:
         """
         ...
 
+class PeriodicEventNotifier:
+    """Singleton that periodically signals registered file descriptors.
+
+    A background thread writes to every registered fd at a configurable
+    interval.  The thread sleeps when no fds are registered and wakes
+    automatically when the first fd is added.
+    """
+
+    @staticmethod
+    def create(interval_ms: int, use_eventfd: bool) -> None:
+        """Create the singleton. Idempotent -- second call is a no-op.
+
+        Args:
+            interval_ms: Notification interval in milliseconds.
+            use_eventfd: True to write as eventfd (8-byte uint64),
+                False to write as pipe (1-byte).
+        """
+        ...
+
+    @staticmethod
+    def get() -> PeriodicEventNotifier | None:
+        """Return the singleton instance, or None if not created."""
+        ...
+
+    @staticmethod
+    def shutdown() -> None:
+        """Shut down the singleton and join its thread. Idempotent."""
+        ...
+
+    def register_fd(self, fd: int) -> None:
+        """Register a file descriptor for periodic signaling.
+
+        Args:
+            fd: The file descriptor to signal. For eventfd, pass the
+                eventfd itself. For pipes, pass the write end.
+        """
+        ...
+
+    def unregister_fd(self, fd: int) -> None:
+        """Unregister a file descriptor. No-op if not registered.
+
+        Args:
+            fd: The file descriptor to stop signaling.
+        """
+        ...
+
+    def set_interval_ms(self, interval_ms: int) -> None:
+        """Change the notification interval. Clamped to >= 1ms.
+
+        Args:
+            interval_ms: New interval in milliseconds.
+        """
+        ...
+
 class RangePatternMatcher:
     """
     Range pattern matcher for integer vectors.

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -110,6 +110,9 @@ class StorageManagerConfig:
     prefetch_max_in_flight: int = 8
     """ Maximum number of concurrent prefetch requests. """
 
+    periodic_notifier_interval_ms: int = 5
+    """ Interval (ms) for the periodic event notifier heartbeat. """
+
 
 def add_storage_manager_args(
     parser: argparse.ArgumentParser,
@@ -251,6 +254,12 @@ def add_storage_manager_args(
         default=8,
         help="Maximum number of concurrent prefetch requests. Default is 8.",
     )
+    policy_group.add_argument(
+        "--periodic-notifier-interval-ms",
+        type=int,
+        default=5,
+        help="Interval in ms for the periodic event notifier heartbeat. Default is 5.",
+    )
 
     # Adapter config
     add_l2_adapters_args(parser)
@@ -315,6 +324,7 @@ def parse_args_to_config(
         store_policy=args.l2_store_policy,
         prefetch_policy=args.l2_prefetch_policy,
         prefetch_max_in_flight=args.l2_prefetch_max_in_flight,
+        periodic_notifier_interval_ms=args.periodic_notifier_interval_ms,
     )
 
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -10,6 +10,7 @@ import time
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.native_storage_ops import PeriodicEventNotifier
 from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
@@ -46,6 +47,7 @@ from lmcache.v1.mp_observability.trace.decorator import (
     is_tracing_enabled,
     publish_call_event,
 )
+from lmcache.v1.platform import HAS_EVENTFD
 
 logger = init_logger(__name__)
 
@@ -77,6 +79,11 @@ class StorageManager:
                     l1_manager=self._l1_manager,
                 )
             self._l2_adapters.append(adapter)
+
+        PeriodicEventNotifier.create(
+            interval_ms=config.periodic_notifier_interval_ms,
+            use_eventfd=HAS_EVENTFD,
+        )
 
         # Per-cache_salt quota registry. Shared across the L2 eviction
         # controller (reads quotas each cycle) and the HTTP quota
@@ -646,6 +653,8 @@ class StorageManager:
         self._store_controller.stop()
         self._eviction_controller.stop()
         self._l2_eviction_controller.stop()
+
+        PeriodicEventNotifier.shutdown()
 
         for adapter in self._l2_adapters:
             adapter.close()

--- a/lmcache/v1/platform/event_notifier.py
+++ b/lmcache/v1/platform/event_notifier.py
@@ -70,6 +70,14 @@ class EventNotifier(ABC):
         """
 
     @abstractmethod
+    def notify_fileno(self) -> int:
+        """Return the fd to write to for signaling.
+
+        For eventfd this is the same as ``fileno()``.  For pipes
+        this is the *write* end (``fileno()`` returns the read end).
+        """
+
+    @abstractmethod
     def close(self) -> None:
         """Release underlying OS resources.  Idempotent."""
 
@@ -110,6 +118,9 @@ if HAS_EVENTFD:
         def notify(self) -> None:
             os.eventfd_write(self._efd, 1)
 
+        def notify_fileno(self) -> int:
+            return self._efd
+
         def consume(self) -> None:
             try:
                 os.eventfd_read(self._efd)
@@ -138,6 +149,9 @@ else:
             raise RuntimeError("unreachable")
 
         def notify(self) -> None:  # pragma: no cover
+            raise RuntimeError("unreachable")
+
+        def notify_fileno(self) -> int:  # pragma: no cover
             raise RuntimeError("unreachable")
 
         def consume(self) -> None:  # pragma: no cover
@@ -181,6 +195,9 @@ class PipeNotifier(EventNotifier):
             os.write(self._write_fd, b"\x01")
         except BlockingIOError:
             pass  # pipe buffer full - signal already pending
+
+    def notify_fileno(self) -> int:
+        return self._write_fd
 
     def consume(self) -> None:
         while True:

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,7 @@ def _common_cpp_extensions(
 
     storage_manager_sources = [
         "csrc/storage_manager/bitmap.cpp",
+        "csrc/storage_manager/periodic_event_notifier.cpp",
         "csrc/storage_manager/pybind.cpp",
         "csrc/storage_manager/ttl_lock.cpp",
         "csrc/storage_manager/utils.cpp",

--- a/tests/v1/native_storage_ops/test_periodic_event_notifier.py
+++ b/tests/v1/native_storage_ops/test_periodic_event_notifier.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+import os
+import select
+import time
+
+# Third Party
+import pytest
+
+pytest.importorskip(
+    "lmcache.native_storage_ops",
+    reason="native_storage_ops extension not built",
+)
+
+# First Party
+from lmcache.native_storage_ops import PeriodicEventNotifier
+from lmcache.v1.platform import HAS_EVENTFD
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    PeriodicEventNotifier.shutdown()
+
+
+def _make_notifier_fd():
+    """Create a test fd suitable for the periodic notifier to write to.
+
+    Returns (poll_fd, write_fd, close_func) where poll_fd is for
+    select.poll() and write_fd is what gets registered with the notifier.
+    For eventfd they are the same; for pipes they differ.
+    """
+    if HAS_EVENTFD:
+        fd = os.eventfd(0, os.EFD_NONBLOCK | os.EFD_CLOEXEC)
+        return fd, fd, lambda: os.close(fd)
+    else:
+        r, w = os.pipe()
+        os.set_blocking(r, False)
+        os.set_blocking(w, False)
+
+        def close_both():
+            os.close(r)
+            os.close(w)
+
+        return r, w, close_both
+
+
+def _consume_fd(fd):
+    if HAS_EVENTFD:
+        try:
+            os.eventfd_read(fd)
+        except BlockingIOError:
+            pass
+    else:
+        while True:
+            try:
+                if not os.read(fd, 4096):
+                    return
+            except BlockingIOError:
+                return
+
+
+def _poll_fd(fd, timeout_ms=500):
+    poller = select.poll()
+    poller.register(fd, select.POLLIN)
+    return bool(poller.poll(timeout_ms))
+
+
+class TestLifecycle:
+    def test_get_before_create_returns_none(self):
+        assert PeriodicEventNotifier.get() is None
+
+    def test_create_and_get(self):
+        PeriodicEventNotifier.create(interval_ms=50, use_eventfd=HAS_EVENTFD)
+        assert PeriodicEventNotifier.get() is not None
+
+    def test_shutdown_clears_instance(self):
+        PeriodicEventNotifier.create(interval_ms=50, use_eventfd=HAS_EVENTFD)
+        PeriodicEventNotifier.shutdown()
+        assert PeriodicEventNotifier.get() is None
+
+    def test_double_create_idempotent(self):
+        PeriodicEventNotifier.create(interval_ms=50, use_eventfd=HAS_EVENTFD)
+        PeriodicEventNotifier.create(interval_ms=100, use_eventfd=HAS_EVENTFD)
+        assert PeriodicEventNotifier.get() is not None
+
+    def test_double_shutdown_idempotent(self):
+        PeriodicEventNotifier.create(interval_ms=50, use_eventfd=HAS_EVENTFD)
+        PeriodicEventNotifier.shutdown()
+        PeriodicEventNotifier.shutdown()
+
+    def test_shutdown_before_create(self):
+        PeriodicEventNotifier.shutdown()
+
+
+class TestSignaling:
+    def test_register_fd_triggers_signals(self):
+        PeriodicEventNotifier.create(interval_ms=10, use_eventfd=HAS_EVENTFD)
+        poll_fd, write_fd, close_fn = _make_notifier_fd()
+        try:
+            notifier = PeriodicEventNotifier.get()
+            notifier.register_fd(write_fd)
+            assert _poll_fd(poll_fd, timeout_ms=1000)
+            _consume_fd(poll_fd)
+        finally:
+            notifier.unregister_fd(write_fd)
+            close_fn()
+
+    def test_multiple_fds_all_signaled(self):
+        PeriodicEventNotifier.create(interval_ms=10, use_eventfd=HAS_EVENTFD)
+        fds = [_make_notifier_fd() for _ in range(3)]
+        try:
+            notifier = PeriodicEventNotifier.get()
+            for _, write_fd, _ in fds:
+                notifier.register_fd(write_fd)
+            time.sleep(0.05)
+            for poll_fd, _, _ in fds:
+                assert _poll_fd(poll_fd, timeout_ms=500)
+                _consume_fd(poll_fd)
+        finally:
+            for _, write_fd, close_fn in fds:
+                notifier.unregister_fd(write_fd)
+                close_fn()
+
+    def test_unregister_stops_signals(self):
+        PeriodicEventNotifier.create(interval_ms=10, use_eventfd=HAS_EVENTFD)
+        poll_fd, write_fd, close_fn = _make_notifier_fd()
+        try:
+            notifier = PeriodicEventNotifier.get()
+            notifier.register_fd(write_fd)
+            assert _poll_fd(poll_fd, timeout_ms=1000)
+            _consume_fd(poll_fd)
+
+            notifier.unregister_fd(write_fd)
+            time.sleep(0.05)
+            _consume_fd(poll_fd)
+            assert not _poll_fd(poll_fd, timeout_ms=100)
+        finally:
+            close_fn()
+
+
+class TestDormancy:
+    def test_dormancy_and_wake(self):
+        PeriodicEventNotifier.create(interval_ms=10, use_eventfd=HAS_EVENTFD)
+        poll_fd, write_fd, close_fn = _make_notifier_fd()
+        try:
+            notifier = PeriodicEventNotifier.get()
+
+            notifier.register_fd(write_fd)
+            assert _poll_fd(poll_fd, timeout_ms=1000)
+            _consume_fd(poll_fd)
+
+            notifier.unregister_fd(write_fd)
+            time.sleep(0.05)
+            _consume_fd(poll_fd)
+            assert not _poll_fd(poll_fd, timeout_ms=100)
+
+            notifier.register_fd(write_fd)
+            assert _poll_fd(poll_fd, timeout_ms=1000)
+            _consume_fd(poll_fd)
+        finally:
+            notifier.unregister_fd(write_fd)
+            close_fn()
+
+
+class TestInterval:
+    def test_set_interval_ms(self):
+        PeriodicEventNotifier.create(interval_ms=10, use_eventfd=HAS_EVENTFD)
+        poll_fd, write_fd, close_fn = _make_notifier_fd()
+        try:
+            notifier = PeriodicEventNotifier.get()
+            notifier.register_fd(write_fd)
+
+            # Drain initial burst and wait for steady state.
+            time.sleep(0.05)
+            _consume_fd(poll_fd)
+
+            # Count signals at 10ms interval over 200ms → expect ~20.
+            count_fast = 0
+            deadline = time.monotonic() + 0.2
+            while time.monotonic() < deadline:
+                if _poll_fd(poll_fd, timeout_ms=50):
+                    _consume_fd(poll_fd)
+                    count_fast += 1
+
+            notifier.set_interval_ms(200)
+            time.sleep(0.25)
+            _consume_fd(poll_fd)
+
+            # Count signals at 200ms interval over 1s → expect ~5.
+            count_slow = 0
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline:
+                if _poll_fd(poll_fd, timeout_ms=250):
+                    _consume_fd(poll_fd)
+                    count_slow += 1
+
+            assert count_fast > count_slow
+        finally:
+            notifier.unregister_fd(write_fd)
+            close_fn()
+
+
+class TestEdgeCases:
+    def test_register_same_fd_twice(self):
+        PeriodicEventNotifier.create(interval_ms=10, use_eventfd=HAS_EVENTFD)
+        poll_fd, write_fd, close_fn = _make_notifier_fd()
+        try:
+            notifier = PeriodicEventNotifier.get()
+            notifier.register_fd(write_fd)
+            notifier.register_fd(write_fd)
+            assert _poll_fd(poll_fd, timeout_ms=1000)
+            _consume_fd(poll_fd)
+        finally:
+            notifier.unregister_fd(write_fd)
+            close_fn()
+
+    def test_unregister_nonexistent_fd(self):
+        PeriodicEventNotifier.create(interval_ms=10, use_eventfd=HAS_EVENTFD)
+        notifier = PeriodicEventNotifier.get()
+        notifier.unregister_fd(999)
+
+    def test_closed_fd_does_not_crash(self):
+        PeriodicEventNotifier.create(interval_ms=10, use_eventfd=HAS_EVENTFD)
+        poll_fd, write_fd, close_fn = _make_notifier_fd()
+        notifier = PeriodicEventNotifier.get()
+        notifier.register_fd(write_fd)
+        close_fn()
+        time.sleep(0.05)
+        notifier.unregister_fd(write_fd)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a C++ singleton (`PeriodicEventNotifier`) that runs a single background thread to periodically signal registered file descriptors. This provides a "heartbeat" mechanism for L2 adapters that lack native async completion callbacks — the periodic notifier writes to their event fds so that controllers' `select.poll()` loops wake up and check for completed tasks.

**Changes:**

- **New C++ module** (`csrc/storage_manager/periodic_event_notifier.{h,cpp}`): Thread-safe singleton with a two-phase background thread (dormant when no fds registered, active periodic loop otherwise). Platform-aware fd signaling (eventfd 8-byte write vs pipe 1-byte write).
- **Pybind11 bindings** added to `pybind.cpp` — exposes `create()`, `get()`, `shutdown()`, `register_fd()`, `unregister_fd()`, `set_interval_ms()` to Python via `lmcache.native_storage_ops`.
- **Type stub** (`native_storage_ops.pyi`) updated with `PeriodicEventNotifier` class.
- **`EventNotifier.notify_fileno()`** added to `lmcache/v1/platform/event_notifier.py` — returns the write-capable fd (same as `fileno()` for eventfd, write end for pipes). This is needed because `fileno()` returns the read end for `PipeNotifier`.
- **Config**: `periodic_notifier_interval_ms` field added to `StorageManagerConfig` (default 5ms) with argparse wiring.
- **StorageManager integration**: `PeriodicEventNotifier.create()` in `__init__`, `.shutdown()` in `close()` (after controllers stop, before adapters close).

**Special notes for your reviewers**:

- The background thread uses `cv_.wait()` (dormant) / `cv_.wait_for()` (active) so it never spins and responds immediately to shutdown or interval changes.
- `signal_fd()` mirrors the write semantics from `csrc/storage_backends/event_notifier.h` — handles EINTR retry, silently skips EAGAIN (signal already pending) and EBADF (fd closed in a race).
- GIL is released during `create()` (spawns thread) and `shutdown()` (joins thread) via `py::call_guard<py::gil_scoped_release>()`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

14 tests in `tests/v1/native_storage_ops/test_periodic_event_notifier.py` covering lifecycle, signaling, dormancy/wake transitions, interval changes, and edge cases (double-create, closed fd, etc.).