### PR TITLE
fix: correct spelling 'mignt' -> 'might' in cache policy comments

### DIFF
--- a/lmcache/v1/storage_backend/cache_policy/fifo.py
+++ b/lmcache/v1/storage_backend/cache_policy/fifo.py
@@ -41,7 +41,7 @@ class FIFOCachePolicy(BaseCachePolicy[KeyType, dict[KeyType, Any]]):
         pass
 
     # NOTE(Jiayi): We do best effort to get eviction candidates so the number
-    # of returned keys mignt be smaller than num_candidates.
+    # of returned keys might be smaller than num_candidates.
     def get_evict_candidates(
         self,
         cache_dict: dict[KeyType, Any],

--- a/lmcache/v1/storage_backend/cache_policy/lfu.py
+++ b/lmcache/v1/storage_backend/cache_policy/lfu.py
@@ -76,7 +76,7 @@ class LFUCachePolicy(BaseCachePolicy[KeyType, dict[KeyType, Any]]):
             self.freq_to_keys.pop(freq)
 
     # NOTE(Jiayi): We do best effort to get eviction candidates so the number
-    # of returned keys mignt be smaller than num_candidates.
+    # of returned keys might be smaller than num_candidates.
     def get_evict_candidates(
         self,
         cache_dict: dict[KeyType, Any],

--- a/lmcache/v1/storage_backend/cache_policy/lru.py
+++ b/lmcache/v1/storage_backend/cache_policy/lru.py
@@ -64,7 +64,7 @@ class LRUCachePolicy(BaseCachePolicy[KeyType, OrderedDict[KeyType, Any]]):
         pass
 
     # NOTE(Jiayi): We do best effort to get eviction candidates so the number
-    # of returned keys mignt be smaller than num_candidates.
+    # of returned keys might be smaller than num_candidates.
     def get_evict_candidates(
         self,
         cache_dict: OrderedDict[KeyType, Any],

--- a/lmcache/v1/storage_backend/cache_policy/mru.py
+++ b/lmcache/v1/storage_backend/cache_policy/mru.py
@@ -43,7 +43,7 @@ class MRUCachePolicy(BaseCachePolicy[KeyType, OrderedDict[KeyType, Any]]):
         pass
 
     # NOTE(Jiayi): We do best effort to get eviction candidates so the number
-    # of returned keys mignt be smaller than num_candidates.
+    # of returned keys might be smaller than num_candidates.
     def get_evict_candidates(
         self,
         cache_dict: OrderedDict[KeyType, Any],


### PR DESCRIPTION
## Description
Fixes typo in comments in 4 cache policy files:
- `lmcache/v1/storage_backend/cache_policy/lru.py`
- `lmcache/v1/storage_backend/cache_policy/lfu.py`
- `lmcache/v1/storage_backend/cache_policy/fifo.py`
- `lmcache/v1/storage_backend/cache_policy/mru.py`

`mignt` → `might`

This is a comment-only change, no code logic modified.

## DCO
This PR fixes the DCO issue from #3418 by using the correct author email with Signed-off-by.
