### PR TITLE
[good-first-issue] core: convert f-string log calls in cache_engine.py to %-format (#3424)

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -2017,7 +2017,7 @@ class LMCacheEngineBuilder:
         raises: ValueError if the instance already exists with a different
             configuration.
         """
-        logger.info(f"Creating LMCacheEngine instance {instance_id}")
+        logger.info("Creating LMCacheEngine instance %s", instance_id)
         if instance_id not in cls._instances:
             numa_mapping = NUMADetector.get_numa_mapping(config)
             logger.info(f"NUMA mapping for instance {instance_id}: {numa_mapping}")
@@ -2063,7 +2063,7 @@ class LMCacheEngineBuilder:
     def destroy(cls, instance_id: str) -> None:
         """Close and delete the LMCacheEngine instance by the instance ID"""
         # TODO: unit test for this
-        logger.info(f"Destroying LMCacheEngine instance: {instance_id}")
+        logger.info("Destroying LMCacheEngine instance: %s", instance_id)
 
         if instance_id in cls._instances:
             stat_logger = cls._stat_loggers[instance_id]
@@ -2099,6 +2099,6 @@ class LMCacheEngineBuilder:
             except Exception as e:
                 logger.error(f"Error destroying stats monitor: {e}")
 
-            logger.info(f"LMCacheEngine instance {instance_id} destroyed")
+            logger.info("LMCacheEngine instance %s destroyed", instance_id)
         else:
             logger.warning(f"Instance {instance_id} not found for destruction")


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #3424
Refs #3372

Converts three `LMCacheEngine` instance-lifecycle log calls in `lmcache/v1/cache_engine.py` from f-string formatting to %-format (lazy evaluation per Python logging docs / ruff G004). No behavior change. 

**Special notes for your reviewers**:
- This is my first PR to LMCache 🙇 please be gentle and thanks @maobaolong  for guiding.
- Ran `pre-commit run --files lmcache/v1/cache_engine.py` locally — all green.
    - Why i did that - Logging-format-only change: %s and f-string render identical output, same call path — and it didn't involved any behaviour changes.
- Skipped pytest: logging-format-only change, identical runtime behavior.
