### PR TITLE
fix: register EventBus health metrics via subscriber

### DIFF
--- a/lmcache/v1/mp_observability/event_bus.py
+++ b/lmcache/v1/mp_observability/event_bus.py
@@ -17,7 +17,6 @@ import time
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.mp_observability.event import Event, EventType
-from lmcache.v1.mp_observability.otel_init import register_gauge
 
 try:
     # Third Party
@@ -118,27 +117,6 @@ class EventBus:
         self._discard_count: int = 0
         self._last_discard_warning: float = 0.0
         self._subscriber_exception_counts: dict[str, int] = {}
-
-        self._register_self_gauges()
-
-    def _register_self_gauges(self) -> None:
-        """Register the two self-monitoring gauges via ``register_gauge``."""
-        register_gauge(
-            "lmcache.event_bus",
-            "lmcache_mp.event_bus.queue_depth",
-            "Events currently queued in the EventBus.",
-            self.queue_depth,
-        )
-        register_gauge(
-            "lmcache.event_bus",
-            "lmcache_mp.event_bus.drain_lag_seconds",
-            (
-                "Seconds since the oldest queued event was published; 0.0 "
-                "when empty.  Rising values mean the drain thread is "
-                "falling behind."
-            ),
-            self.oldest_event_lag_seconds,
-        )
 
     # -- Public API --------------------------------------------------------
 

--- a/lmcache/v1/mp_observability/subscribers/metrics/event_bus.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/event_bus.py
@@ -4,6 +4,8 @@
 
 Surfaces two metrics describing the EventBus's own health (per #3108):
 
+- ``lmcache_mp.event_bus.queue_depth`` (observable gauge)
+- ``lmcache_mp.event_bus.drain_lag_seconds`` (observable gauge)
 - ``lmcache_mp.event_bus.dropped_events_total`` (observable counter)
 - ``lmcache_mp.event_bus.subscriber_exceptions`` (observable counter,
   attr ``subscriber_name``)
@@ -35,6 +37,24 @@ class EventBusSelfMetricsSubscriber(EventSubscriber):
     def __init__(self, bus: EventBus) -> None:
         meter = metrics.get_meter("lmcache.event_bus")
 
+        meter.create_observable_gauge(
+            "lmcache_mp.event_bus.queue_depth",
+            callbacks=[lambda _o: [metrics.Observation(bus.queue_depth())]],
+            description="Events currently queued in the EventBus.",
+        )
+        meter.create_observable_gauge(
+            "lmcache_mp.event_bus.drain_lag_seconds",
+            callbacks=[
+                lambda _o: [
+                    metrics.Observation(bus.oldest_event_lag_seconds()),
+                ]
+            ],
+            description=(
+                "Seconds since the oldest queued event was published; 0.0 "
+                "when empty. Rising values mean the drain thread is "
+                "falling behind."
+            ),
+        )
         meter.create_observable_counter(
             "lmcache_mp.event_bus.dropped_events_total",
             callbacks=[lambda _o: [metrics.Observation(bus.dropped_events_count())]],

--- a/tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py
@@ -71,16 +71,16 @@ class TestRegistration:
 
     def test_drain_lag_gauge_reports_oldest_queued_event_age(self):
         bus = EventBus(EventBusConfig(enabled=True))
-        event = Event(event_type=EventType.L1_READ_FINISHED, session_id="s1")
-        event.timestamp = time.time() - 2.0
-        bus._queue.append(event)
+        with patch("time.time", return_value=100.0):
+            bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s1"))
 
         mock_metrics, meter = _make_mock_metrics()
         with patch(_PATCH_TARGET, mock_metrics):
             EventBusSelfMetricsSubscriber(bus)
             cb = _gauge_callbacks(meter)["lmcache_mp.event_bus.drain_lag_seconds"]
-            [(lag, attrs)] = cb(None)
-            assert lag >= 2.0
+            with patch("time.time", return_value=102.0):
+                [(lag, attrs)] = cb(None)
+            assert lag == 2.0
             assert attrs is None
 
     def test_dropped_counter_callback_reflects_drops(self):

--- a/tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py
+++ b/tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py
@@ -36,16 +36,52 @@ def _counter_callbacks(meter: MagicMock) -> dict:
     }
 
 
+def _gauge_callbacks(meter: MagicMock) -> dict:
+    return {
+        c.args[0]: c.kwargs["callbacks"][0]
+        for c in meter.create_observable_gauge.call_args_list
+    }
+
+
 class TestRegistration:
-    def test_registers_two_counters(self):
+    def test_registers_health_gauges_and_counters(self):
         bus = EventBus(EventBusConfig(enabled=True))
         mock_metrics, meter = _make_mock_metrics()
         with patch(_PATCH_TARGET, mock_metrics):
             EventBusSelfMetricsSubscriber(bus)
+            assert set(_gauge_callbacks(meter)) == {
+                "lmcache_mp.event_bus.queue_depth",
+                "lmcache_mp.event_bus.drain_lag_seconds",
+            }
             assert set(_counter_callbacks(meter)) == {
                 "lmcache_mp.event_bus.dropped_events_total",
                 "lmcache_mp.event_bus.subscriber_exceptions",
             }
+
+    def test_queue_depth_gauge_callback_reflects_bus(self):
+        bus = EventBus(EventBusConfig(enabled=True))
+        bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s1"))
+        bus.publish(Event(event_type=EventType.L1_READ_FINISHED, session_id="s2"))
+
+        mock_metrics, meter = _make_mock_metrics()
+        with patch(_PATCH_TARGET, mock_metrics):
+            EventBusSelfMetricsSubscriber(bus)
+            cb = _gauge_callbacks(meter)["lmcache_mp.event_bus.queue_depth"]
+            assert cb(None) == [(2, None)]
+
+    def test_drain_lag_gauge_reports_oldest_queued_event_age(self):
+        bus = EventBus(EventBusConfig(enabled=True))
+        event = Event(event_type=EventType.L1_READ_FINISHED, session_id="s1")
+        event.timestamp = time.time() - 2.0
+        bus._queue.append(event)
+
+        mock_metrics, meter = _make_mock_metrics()
+        with patch(_PATCH_TARGET, mock_metrics):
+            EventBusSelfMetricsSubscriber(bus)
+            cb = _gauge_callbacks(meter)["lmcache_mp.event_bus.drain_lag_seconds"]
+            [(lag, attrs)] = cb(None)
+            assert lag >= 2.0
+            assert attrs is None
 
     def test_dropped_counter_callback_reflects_drops(self):
         bus = EventBus(EventBusConfig(enabled=True, max_queue_size=2))

--- a/tests/v1/mp_observability/test_event_bus.py
+++ b/tests/v1/mp_observability/test_event_bus.py
@@ -3,7 +3,7 @@
 """Tests for EventBus, EventSubscriber, and singleton management."""
 
 # Standard
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import time
 
 # Third Party
@@ -511,29 +511,3 @@ class TestBlockAllocationEvent:
         bus.stop()
 
         assert len(sub.events) == 0
-
-
-_REGISTER_GAUGE = "lmcache.v1.mp_observability.event_bus.register_gauge"
-
-
-class TestSelfMonitoringGauges:
-    def test_init_registers_both_gauges(self):
-        with patch(_REGISTER_GAUGE) as mock_register:
-            EventBus(EventBusConfig(enabled=True))
-            names = [c.args[1] for c in mock_register.call_args_list]
-            assert set(names) == {
-                "lmcache_mp.event_bus.queue_depth",
-                "lmcache_mp.event_bus.drain_lag_seconds",
-            }
-
-    def test_queue_depth_callback_reflects_bus(self):
-        captured: dict[str, object] = {}
-
-        def _capture(_meter, name, _desc, func):
-            captured[name] = func
-
-        with patch(_REGISTER_GAUGE, side_effect=_capture):
-            bus = EventBus(EventBusConfig(enabled=True))
-            bus.publish(_make_event(session_id="s1"))
-            bus.publish(_make_event(session_id="s2"))
-            assert captured["lmcache_mp.event_bus.queue_depth"]() == 2


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #3108. The EventBus self-health docs and `setup_mp_observability()` wiring say queue depth, drain lag, dropped events, and subscriber exceptions are owned by `EventBusSelfMetricsSubscriber`. Two of those metrics (`queue_depth` and `drain_lag_seconds`) were still registered directly from `EventBus.__init__`, so constructing any EventBus, including disabled/test buses, could create OTel instruments even when metrics subscribers were not enabled.

This moves the queue-depth and drain-lag observable gauges into `EventBusSelfMetricsSubscriber`, keeping all four EventBus health metrics behind the metrics subscriber path. The `EventBus` still exposes the same public accessors (`queue_depth()` and `oldest_event_lag_seconds()`), so dashboard/query semantics are unchanged.

**Special notes for your reviewers**:

I read `CONTRIBUTING.md` and used a signed-off commit. This contribution was prepared with Codex assistance; I reviewed the diff and ran the checks below locally.

Checks run:
- `PYTHONPATH=. .venv/bin/python -m py_compile lmcache/v1/mp_observability/event_bus.py lmcache/v1/mp_observability/subscribers/metrics/event_bus.py tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py tests/v1/mp_observability/test_event_bus.py`
- `.venv/bin/python -m ruff check lmcache/v1/mp_observability/event_bus.py lmcache/v1/mp_observability/subscribers/metrics/event_bus.py tests/v1/mp_observability/subscribers/metrics/test_event_bus_self_metrics.py tests/v1/mp_observability/test_event_bus.py`
- Direct subscriber smoke check exercising the new gauge callbacks against a mocked OTel meter.

I also tried the focused pytest files, but the local macOS environment cannot load `lmcache.c_ops` from the repository test `conftest.py` without building native extensions.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests