### PR TITLE
docs: daily drift check — multi-process mode (2026-05-28)

### DIFF
--- a/docs/design/cli/commands.md
+++ b/docs/design/cli/commands.md
@@ -161,33 +161,40 @@ Checksum:                                OK
 
 ### `lmcache bench`
 
-**`bench kvcache`** -- exercises store/retrieve/lookup over ZMQ. Includes a
-correctness check: each retrieved KV cache chunk is checksummed against the original
-stored data to verify integrity under load.
+**`bench server`** -- end-to-end sanity test for a running LMCache MP cache
+server (ZMQ + HTTP). For each sequence in ``[--start, --end)`` the tool runs a
+cold pass (``LOOKUP`` miss → ``STORE``) and a warm pass (``LOOKUP`` hit →
+``RETRIEVE``), then cross-checks per-chunk checksums against the server's HTTP
+API. Exercises the full RPC path
+(``REGISTER_KV_CACHE → GET_CHUNK_SIZE → LOOKUP → QUERY_PREFETCH_STATUS →
+RETRIEVE → STORE → END_SESSION``).
 
 ```bash
-$ lmcache bench kvcache --url localhost:5555 --duration 30
+$ lmcache bench server \
+    --rpc-url tcp://localhost:5555 \
+    --url http://localhost:8080 \
+    --start 0 --end 2
 
-========= Bench KV Cache Result (30s) =========
---------------Operations (ops/s)----------------
-Store:                                   41.3
-Retrieve:                                127.3
-Lookup:                                  281.7
------------------Hit Rate-----------------------
-L1:                                      92.3%
-L2:                                      67.8%
----------------Bandwidth (GB/s)-----------------
-L1 read:                                 12.4
-L1 write:                                8.7
-L2 read:                                 2.1
-L2 write:                                1.4
---------------Correctness-----------------------
-Checksums:                               5060/5060 OK
-================================================
+Connecting to LMCache MP Server at tcp://localhost:5555 (mode=gpu) ...
+Server chunk_size = 256
+Resolved KV shape spec: (2,1024,16,8,128):float16:32
+[seq=0] LOOKUP cold:  0/2 chunks hit (1.82 ms)
+[seq=0] STORE:        2 chunks stored (1.74 ms)
+[seq=0] LOOKUP warm:  2/2 chunks hit (1.31 ms)
+[seq=0] RETRIEVE:     2 chunks retrieved (1.48 ms)
+[seq=0] CHECKSUM MATCH OK
+[seq=1] ...
 ```
 
-Use `--verify-only` to run the correctness check without reporting throughput
-(useful in CI), or `--no-verify` to skip checksums for pure throughput measurement.
+With ``--end`` unset, the loop runs forever; stop with ``Ctrl-C``. The KV
+tensor layout is controlled by ``--kvcache-shape-spec`` (see
+``lmcache/v1/kv_layer_groups.py``); see :doc:`bench_server` in the user guide
+for the full flag list.
+
+**`bench l2`** -- store / lookup / load throughput benchmark against an
+``L2AdapterInterface`` implementation (no MP server required). Implemented at
+``lmcache/cli/commands/bench/l2_adapter_bench/``; see the
+``docs/source/cli/bench_l2.rst`` user guide for full options.
 
 **`bench engine`** -- **superset of `vllm bench serve`**. Same CLI args, same output
 format, plus an extra LMCache KV cache metrics section:


### PR DESCRIPTION
## Summary

Auto-generated by the daily docs drift-check routine focused on
**multi-process mode**. One new piece of `docs/design/` drift was
introduced between the previous drift sweep window (2026-05-27,
[PR #3417](https://github.com/LMCache/LMCache/pull/3417), based on `dev`
HEAD [`dca25488`](https://github.com/LMCache/LMCache/commit/dca25488b44a7eec685f425cc0c042aab384b429))
and today's `dev` HEAD
([`9071961`](https://github.com/LMCache/LMCache/commit/9071961a5bfc8043654da2497d53a34365526e2c)).

**Human review is required before merge — do not merge as-is.**

The new daily PR is filed separately rather than rebased onto #3417
because that PR is already under review with a different set of items
(BlendModule refactor / `--transfer-mode`); the bench-CLI drift below is
independent.

### `docs/source/` drift

None new today.

### `docs/design/` drift

#### `docs/design/cli/commands.md` — stale `bench kvcache` section

[PR #3411](https://github.com/LMCache/LMCache/pull/3411)
("[refactor]Refactor bench kvcache cli", commit
[`d6b1a08`](https://github.com/LMCache/LMCache/commit/d6b1a08389a33070df0a8686f0642f0293eee283))
merged on 2026-05-28 and **renamed** `lmcache bench kvcache` to
`lmcache bench server`, with a new sibling target `lmcache bench l2`.
The user-facing rst was moved (`bench_kvcache.rst` →
[`bench_server.rst`](https://github.com/LMCache/LMCache/blob/9071961a5bfc8043654da2497d53a34365526e2c/docs/source/cli/bench_server.rst)),
and the top-of-file command tree and source-tree diagram in
`commands.md` were updated by that PR
([diff for commands.md](https://github.com/LMCache/LMCache/commit/d6b1a08389a33070df0a8686f0642f0293eee283#diff-26830d80ae6c5e36feb35e6f10ce9f15f8a0e15ef79be4f88d39e7ec84cad086)) —
but the detailed `### lmcache bench` section in the same file was
**not** touched. It still:

- titles the first subsection
  [`**bench kvcache**`](https://github.com/LMCache/LMCache/blob/9071961a5bfc8043654da2497d53a34365526e2c/docs/design/cli/commands.md#L164),
- invokes
  [`lmcache bench kvcache --url localhost:5555 --duration 30`](https://github.com/LMCache/LMCache/blob/9071961a5bfc8043654da2497d53a34365526e2c/docs/design/cli/commands.md#L169) —
  the `bench kvcache` subcommand no longer exists, and the new
  `bench server` does **not** accept `--url localhost:5555` (it uses
  `--rpc-url tcp://...` for the ZMQ endpoint and `--url http://...` for
  the HTTP checksum endpoint) or `--duration` at all,
- shows a throughput-style sample output
  ([lines 171-186](https://github.com/LMCache/LMCache/blob/9071961a5bfc8043654da2497d53a34365526e2c/docs/design/cli/commands.md#L171-L186))
  with "Operations (ops/s) / Hit Rate / Bandwidth / Correctness"
  sections — the actual `bench server` output is a per-sequence
  `LOOKUP cold / STORE / LOOKUP warm / RETRIEVE / CHECKSUM MATCH` log
  (see
  [`docs/source/cli/bench_server.rst#L155-L162`](https://github.com/LMCache/LMCache/blob/9071961a5bfc8043654da2497d53a34365526e2c/docs/source/cli/bench_server.rst#L155-L162)
  on the user-facing side),
- and documents
  [`--verify-only` and `--no-verify`](https://github.com/LMCache/LMCache/blob/9071961a5bfc8043654da2497d53a34365526e2c/docs/design/cli/commands.md#L189-L190) —
  neither flag is registered by `register_server_parser` in
  [`lmcache/cli/commands/bench/server_bench/command.py`](https://github.com/LMCache/LMCache/blob/9071961a5bfc8043654da2497d53a34365526e2c/lmcache/cli/commands/bench/server_bench/command.py).
  The new flag surface is `--rpc-url / --url / --mode / --num-tokens /
  --num-blocks / --block-size / --start / --end / --interval /
  --kvcache-shape-spec` (see
  [`bench_server.rst` options table](https://github.com/LMCache/LMCache/blob/9071961a5bfc8043654da2497d53a34365526e2c/docs/source/cli/bench_server.rst#L69-L109)).

The same section also never mentioned `bench l2` even though the new
top-of-file tree already lists `bench {engine,server,l2}`.

The user-facing rst pages (`docs/source/cli/bench_server.rst`,
`docs/source/cli/bench_l2.rst`, `docs/source/cli/index.rst`) were updated
by PR #3411 and are not stale.

## Proposed fix (applied in this PR — one commit)

A single doc-only commit
([`a966796`](https://github.com/ApostaC/LMCache/commit/a9667966278e1b611db380c1f3858b747990ff2c)),
DCO-signed and authored by ApostaC:

- **`docs/design/cli/commands.md`** — rewrite the `### lmcache bench`
  section:
  - rename the first sub-bullet from `bench kvcache` to `bench server`,
  - replace the throughput-style description and sample output with the
    real cold-pass / warm-pass / checksum-match flow (wording follows
    `docs/source/cli/bench_server.rst` and the module docstring of
    `lmcache/cli/commands/bench/server_bench/command.py` verbatim — no
    behavior change is implied),
  - update the example invocation to use the actual flag surface
    (`--rpc-url`, `--url`, `--start`, `--end`),
  - drop the stale `--verify-only` / `--no-verify` paragraph,
  - add a short `bench l2` paragraph that points at the user guide so
    the section enumerates the same three targets (`{engine,server,l2}`)
    as the command tree above.

No code files are touched.

## Audit-clean (no drift) commits in today's window

The other commits between
[`dca25488`](https://github.com/LMCache/LMCache/commit/dca25488b44a7eec685f425cc0c042aab384b429)
(2026-05-27) and
[`9071961`](https://github.com/LMCache/LMCache/commit/9071961a5bfc8043654da2497d53a34365526e2c)
(today) were audited and introduced no additional MP doc drift:

- **PR #3402** ([LMCache MP Connector] Report cache hit stats in
  `KVTransferParams`, commit
  [`3e0e3ff`](https://github.com/LMCache/LMCache/commit/3e0e3ff08f94a95d57bc1939ca8db04dac0e0ad9))
  — renames the return-params key
  `num_lmcache_extra_cached_tokens` → `cached_token_stats` (now a dict
  with `num_vllm_cached_tokens` / `num_lmcache_cached_tokens` /
  `num_lmcache_extra_cached_tokens` fields). Verified that **neither**
  the old nor the new key appears anywhere under `docs/source/mp/` or
  `docs/design/` (`grep -rn "num_lmcache_extra_cached_tokens\|cached_token_stats" docs/`
  returns zero hits), so no doc surface is stale on this front.
- **PR #3424/#3426** (f-string → %-format in `cache_engine.py`,
  [`9071961`](https://github.com/LMCache/LMCache/commit/9071961a5bfc8043654da2497d53a34365526e2c)) — pure logging refactor.
- **PR #3425** (typo `mignt` → `might`,
  [`49823dc`](https://github.com/LMCache/LMCache/commit/49823dc)) — comment-only.
- **PR #3348** (sync torch 2.11.0 with vLLM,
  [`29bbd55`](https://github.com/LMCache/LMCache/commit/29bbd55)) — build only.
- **PR #3250** (move `pytest.ini` to project root,
  [`67a72cc`](https://github.com/LMCache/LMCache/commit/67a72cc)) — CI only.
- **PR #3370** (nixl meta-package on CUDA 13,
  [`39e3beb`](https://github.com/LMCache/LMCache/commit/39e3beb)) — `requirements/cuda13_core.txt` only.
- **PR #3416** (avoid vLLM import in blake3 hasher,
  [`713b1a5`](https://github.com/LMCache/LMCache/commit/713b1a5)) — startup refactor.
- **PR #3415** (CI raw-block L2 assertions,
  [`acf3c7f`](https://github.com/LMCache/LMCache/commit/acf3c7f)) — test only.
- **PR #3395** (ROCm gfx950 install doc,
  [`262759a`](https://github.com/LMCache/LMCache/commit/262759a)) — doc-only addition.
- **PR #3408** (Qwen3 in kv cache calculator,
  [`b3a7275`](https://github.com/LMCache/LMCache/commit/b3a7275)) — calculator data file only.
- **PR #3401** (combined doc-drift fixes,
  [`f41931c`](https://github.com/LMCache/LMCache/commit/f41931c)) — already merged; no new drift it introduces.
- **PR #3399** (drift-check 2026-05-26,
  [`4ded4ab`](https://github.com/LMCache/LMCache/commit/4ded4ab)) — already merged.
- **PR #3405** (tighten k3 MP test threshold,
  [`61aa202`](https://github.com/LMCache/LMCache/commit/61aa202)) — CI tuning.

## Note on the still-open prior drift PRs

- [PR #3417](https://github.com/LMCache/LMCache/pull/3417) (2026-05-27)
  remains the right home for the `MPCacheEngine.report_status` /
  `engine_type` doc note and the `--transfer-mode` / `BlendModule`
  items; **not re-filed here** per the routine's dedup rule.
- [PR #3329](https://github.com/LMCache/LMCache/pull/3329) (2026-05-19)
  remains the right home for the `lmcache.mp.mq_timeout` /
  `lmcache.mp.heartbeat_interval` doc items.
- [PR #3273](https://github.com/LMCache/LMCache/pull/3273) (2026-05-13/14)
  remains the right home for the `bytes_transferred` /
  `pop_completed_store_task_bytes` / `block_stride_elems` doc items.

## Generated by

Auto-generated by the daily docs drift-check routine focused on
multi-process mode. Branch: `ApostaC:docs/drift-check-2026-05-28`.
**Human review is still required before merge; please leave this PR in
draft until reviewed.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01SomQQdTkGuHFev2mAtDZwD)_