### PR TITLE
Fix/translate workflow reuse translations

### DIFF
--- a/.github/workflows/translate_doc_zh.yml
+++ b/.github/workflows/translate_doc_zh.yml
@@ -8,7 +8,7 @@ on:
       max_entries:
         description: "Maximum entries to translate in this run"
         required: false
-        default: "10"
+        default: "50"
 
 concurrency:
     group: update-chinese-docs
@@ -60,7 +60,7 @@ jobs:
             rel="${po#docs/source/locale/zh_CN/LC_MESSAGES/}"
             if [ ! -f "docs/build/gettext/${rel%.po}.pot" ]; then
               echo "deleting $po (no matching source doc)"
-              git rm -q --ignore-unmatch "$po"
+              git rm -fq --ignore-unmatch "$po"
             fi
           done
 

--- a/.github/workflows/translate_doc_zh.yml
+++ b/.github/workflows/translate_doc_zh.yml
@@ -43,10 +43,26 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/docs.txt
 
+      - name: Reuse translations from open PR
+        run: |
+          if git fetch origin automation/update-chinese-docs 2>/dev/null; then
+            git checkout FETCH_HEAD -- docs/source/locale/zh_CN/LC_MESSAGES/ || true
+          fi
+
       - name: Update gettext catalogs
         run: |
           sphinx-build -b gettext docs/source docs/build/gettext
           sphinx-intl update -p docs/build/gettext -l zh_CN -d docs/source/locale -j 1
+
+      - name: Delete translations for renamed or removed docs
+        run: |
+          find docs/source/locale/zh_CN/LC_MESSAGES -name '*.po' | while read -r po; do
+            rel="${po#docs/source/locale/zh_CN/LC_MESSAGES/}"
+            if [ ! -f "docs/build/gettext/${rel%.po}.pot" ]; then
+              echo "deleting $po (no matching source doc)"
+              git rm -q --ignore-unmatch "$po"
+            fi
+          done
 
       - name: Translate missing Chinese entries
         env:
@@ -70,7 +86,7 @@ jobs:
           delete-branch: true
           signoff: true
           add-paths: |
-            docs/source/locale/zh_CN/LC_MESSAGES/**/*.po
+            docs/source/locale/zh_CN/LC_MESSAGES
           commit-message: "Update Chinese documentation translations"
           title: "Update Chinese documentation translations"
           body: |


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Three issues with the existing Chinese translation workflow:**
1. Re-translates from scratch every run. Workflow checks out dev (empty msgstrs), ignoring translations already in the open PR.
2. Bot's PR conflicts when dev moves. A .rst rename or delete between runs leaves a stale catalog that blocks the merge (see #3386).
3. index.rst was never translated.

**Fix:**
1. Reuse translations from open PR (new step): seeds .pos from the bot's branch before regeneration.
2. Delete translations for renamed or removed docs (new step): drops .pos whose source .rst is gone.
3. add-paths: **/*.po → LC_MESSAGES directory, so top-level catalogs land in the PR (.mo still excluded via .gitignore).

**What a manual re-trigger does after this:**
1. Checkout latest dev; seed the open PR's .pos on top.
2. sphinx-intl update reconciles entries against the regenerated .pots (new added, edited marked fuzzy, removed dropped).
3. Prune deletes .pos whose source doc is gone; translator fills new/fuzzy entries only.
4. peter-evans force-pushes the branch as latest dev + one commit — the PR auto-rebases on current dev, no conflicts.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
