### PR TITLE
  [MP][Bugfix] Restore MPCacheEngine HTTP-layer passthroughs

### DIFF
--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -407,7 +407,7 @@ def _query_checksum(
         else:
             parts.append(str(item))
     block_ids = ",".join(parts)
-    # The MP /api/kvcache/check endpoint is block-native: its
+    # The MP /kvcache/check endpoint is block-native: its
     # chunk_size counts blocks per chunk, while our caller passes
     # in the server-side token-level chunk_size. Convert here.
     if chunk_size % block_size != 0:
@@ -418,7 +418,7 @@ def _query_checksum(
         return None
     chunk_size_blocks = chunk_size // block_size
     url = (
-        "%s/api/kvcache/check?block_ids=%s&block_size=%d&chunk_size=%d&layerwise=false"
+        "%s/kvcache/check?block_ids=%s&block_size=%d&chunk_size=%d&layerwise=false"
     ) % (
         http_base,
         block_ids,

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -23,7 +23,7 @@ router = APIRouter()
 
 
 # Per-format axis of the ``num_blocks`` dimension inside a per-layer KV tensor.
-# The MP /api/kvcache/check endpoint gathers KV data by block IDs along this
+# The MP /kvcache/check endpoint gathers KV data by block IDs along this
 # axis, which preserves the block_size dimension verbatim so chunking is a
 # clean slice on a known axis.
 #

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -140,6 +140,11 @@ class GPUTransferModule:
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
 
+    @property
+    def gpu_contexts(self) -> dict[int, GPUContextEntry]:
+        """Per-instance GPU context registry."""
+        return self._gpu_contexts
+
     def get_handlers(self) -> list[HandlerSpec]:
         """Return handler specs for all request types this module serves.
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -16,6 +16,7 @@ from lmcache.v1.distributed.config import (
     add_storage_manager_args,
     parse_args_to_config,
 )
+from lmcache.v1.distributed.storage_manager import StorageManager
 from lmcache.v1.mp_observability.config import (
     ObservabilityConfig,
     add_observability_args,
@@ -34,6 +35,7 @@ from lmcache.v1.multiprocess.engine_module import (
     HandlerSpec,
     ThreadPoolType,
 )
+from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
 from lmcache.v1.multiprocess.modules.gpu_transfer import GPUTransferModule
 from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.modules.management import ManagementModule
@@ -99,6 +101,29 @@ class MPCacheEngine:
             module.close()
         self._context.storage_manager.close()
         logger.info("MPCacheEngine closed")
+
+    # HTTP-layer passthroughs lost in the engine refactor.
+
+    @property
+    def storage_manager(self) -> StorageManager:
+        """Used by ``/quota/*``."""
+        return self._context.storage_manager
+
+    @property
+    def gpu_contexts(self) -> dict[int, GPUCacheContext] | None:
+        """Used by ``/kvcache/check``; unwraps :class:`GPUContextEntry`."""
+        for module in self._modules:
+            if isinstance(module, GPUTransferModule):
+                return {i: e.gpu_context for i, e in module.gpu_contexts.items()}
+        return None
+
+    def clear(self) -> None:
+        """Used by ``/clear-cache``; delegates to :class:`ManagementModule`."""
+        for module in self._modules:
+            if isinstance(module, ManagementModule):
+                module.clear()
+                return
+        raise RuntimeError("MPCacheEngine.clear: no ManagementModule registered")
 
 
 def add_handler_helper(

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -240,7 +240,7 @@ class _ChecksumHandler(BaseHTTPRequestHandler):
     """Tiny HTTP handler that returns fake checksums."""
 
     def do_GET(self):
-        if "/api/kvcache/check" in self.path:
+        if "/kvcache/check" in self.path:
             body = json.dumps(
                 {
                     "status": "success",

--- a/tests/v1/multiprocess/test_engine_passthroughs.py
+++ b/tests/v1/multiprocess/test_engine_passthroughs.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: HTTP-layer passthroughs dropped by the engine refactor."""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.modules.gpu_transfer import (
+    GPUContextEntry,
+    GPUTransferModule,
+)
+from lmcache.v1.multiprocess.modules.management import ManagementModule
+from lmcache.v1.multiprocess.server import MPCacheEngine
+
+
+def test_storage_manager_returns_context_storage_manager():
+    sm = MagicMock(name="storage_manager")
+    ctx = MagicMock()
+    ctx.storage_manager = sm
+
+    engine = MPCacheEngine(ctx, modules=[])
+    assert engine.storage_manager is sm
+
+
+def test_gpu_contexts_unwraps_entries_from_gpu_transfer_module():
+    gpu0, gpu1 = MagicMock(name="gpu_ctx_0"), MagicMock(name="gpu_ctx_1")
+    gpu_transfer = MagicMock(spec=GPUTransferModule)
+    gpu_transfer.gpu_contexts = {
+        0: GPUContextEntry(gpu_context=gpu0, model_name="m", world_size=1),
+        7: GPUContextEntry(gpu_context=gpu1, model_name="m", world_size=1),
+    }
+
+    engine = MPCacheEngine(MagicMock(), modules=[MagicMock(), gpu_transfer])
+    # Values must be unwrapped GPUCacheContexts.
+    assert engine.gpu_contexts == {0: gpu0, 7: gpu1}
+
+
+def test_gpu_contexts_returns_none_in_non_gpu_mode():
+    engine = MPCacheEngine(MagicMock(), modules=[MagicMock()])
+    assert engine.gpu_contexts is None
+
+
+def test_clear_delegates_to_management_module():
+    mgmt = MagicMock(spec=ManagementModule)
+    engine = MPCacheEngine(MagicMock(), modules=[MagicMock(), mgmt])
+    engine.clear()
+    mgmt.clear.assert_called_once_with()
+
+
+def test_clear_raises_without_management_module():
+    engine = MPCacheEngine(MagicMock(), modules=[])
+    with pytest.raises(RuntimeError, match="no ManagementModule"):
+        engine.clear()

--- a/tests/v1/multiprocess/test_engine_passthroughs.py
+++ b/tests/v1/multiprocess/test_engine_passthroughs.py
@@ -16,7 +16,7 @@ from lmcache.v1.multiprocess.modules.management import ManagementModule
 from lmcache.v1.multiprocess.server import MPCacheEngine
 
 
-def test_storage_manager_returns_context_storage_manager():
+def test_storage_manager_returns_context_storage_manager() -> None:
     sm = MagicMock(name="storage_manager")
     ctx = MagicMock()
     ctx.storage_manager = sm
@@ -25,7 +25,7 @@ def test_storage_manager_returns_context_storage_manager():
     assert engine.storage_manager is sm
 
 
-def test_gpu_contexts_unwraps_entries_from_gpu_transfer_module():
+def test_gpu_contexts_unwraps_entries_from_gpu_transfer_module() -> None:
     gpu0, gpu1 = MagicMock(name="gpu_ctx_0"), MagicMock(name="gpu_ctx_1")
     gpu_transfer = MagicMock(spec=GPUTransferModule)
     gpu_transfer.gpu_contexts = {
@@ -38,19 +38,19 @@ def test_gpu_contexts_unwraps_entries_from_gpu_transfer_module():
     assert engine.gpu_contexts == {0: gpu0, 7: gpu1}
 
 
-def test_gpu_contexts_returns_none_in_non_gpu_mode():
+def test_gpu_contexts_returns_none_in_non_gpu_mode() -> None:
     engine = MPCacheEngine(MagicMock(), modules=[MagicMock()])
     assert engine.gpu_contexts is None
 
 
-def test_clear_delegates_to_management_module():
+def test_clear_delegates_to_management_module() -> None:
     mgmt = MagicMock(spec=ManagementModule)
     engine = MPCacheEngine(MagicMock(), modules=[MagicMock(), mgmt])
     engine.clear()
     mgmt.clear.assert_called_once_with()
 
 
-def test_clear_raises_without_management_module():
+def test_clear_raises_without_management_module() -> None:
     engine = MPCacheEngine(MagicMock(), modules=[])
     with pytest.raises(RuntimeError, match="no ManagementModule"):
         engine.clear()


### PR DESCRIPTION
  

  Description:

  ## Summary

  PR #3391 split the monolithic `MPCacheEngine` into a compositor + per-module handlers, but dropped three engine attributes that `http_apis/` reads directly (bypassing ZMQ). All three are silently broken on `upstream/dev`:

  | HTTP endpoint | Reads | Symptom on `dev` |
  |---|---|---|
  | `POST /clear-cache` (+ `lmcache kvcache clear` CLI) | `engine.clear()` | HTTP 500 `AttributeError` |
  | `GET /quota/*` | `engine.storage_manager` | HTTP 500 `AttributeError` |
  | `GET /kvcache/check` (+ `lmcache bench server` CLI) | `engine.gpu_contexts` | HTTP 501 silent "not supported" |

  This restores all three on `MPCacheEngine` as thin passthroughs:

  - `storage_manager` → `self._context.storage_manager`
  - `gpu_contexts` → finds `GPUTransferModule` and unwraps `GPUContextEntry → GPUCacheContext` so the pre-refactor contract holds
  - `clear()` → delegates to `ManagementModule.clear` (which owns the lock)

  Also fixes a stale `/api/` URL prefix in `lmcache bench server`'s checksum helper (path was renamed in an earlier PR; helper + its test were missed).

  ## Test plan

  - [x] New `tests/v1/multiprocess/test_engine_passthroughs.py` — 5 regression  tests covering each passthrough + the missing-module guards.
  - [x] Existing `tests/cli/commands/bench/test_server_bench.py` updated to match the corrected URL; all 23 tests pass.
  - [x] Live verification: started an HTTP server off this branch, hit each codes (200 / 200 / 404-without-instance) instead of 500 / 500 / 501.