### PR TITLE
[CI/CD] Flexible pod specs for k3 multiprocess test (1-GPU vs 2-GPU)

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -1,12 +1,15 @@
 # Multiprocess tests — one step per test, run in parallel.
-# Each step gets its own K8s pod, launches its own servers, runs one test, cleans up.
-# All steps need 2 GPUs (LMCache+vLLM on GPU 0, baseline on GPU 1).
+# Each step gets its own K8s pod with the exact GPU count it needs.
+# Tests are grouped by GPU requirement; the 2-GPU group is listed first so
+# these heavier jobs get scheduled before 1-GPU jobs.
+#   2-GPU: LMCache+vLLM on GPU 0, baseline on GPU 1 (or TP=2 across both).
+#   1-GPU: LMCache+vLLM on GPU 0 only (no baseline server).
 
 steps:
-  - group: ":compression: Multiprocess"
+  - group: ":compression: Multiprocess (2-GPU)"
     steps:
-      - label: ":compression: lm_eval"
-        command: .buildkite/k3_tests/multiprocess/run.sh lm_eval
+      - label: ":compression: vllm_bench"
+        command: .buildkite/k3_tests/multiprocess/run.sh vllm_bench
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins:
@@ -23,13 +26,6 @@ steps:
                   - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
         artifact_paths: ["*.log"]
 
-      - label: ":compression: vllm_bench"
-        command: .buildkite/k3_tests/multiprocess/run.sh vllm_bench
-        timeout_in_minutes: 30
-        agents: { queue: "k8s" }
-        plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
-        artifact_paths: ["*.log"]
-
       - label: ":compression: long_doc_qa"
         command: .buildkite/k3_tests/multiprocess/run.sh long_doc_qa
         timeout_in_minutes: 30
@@ -44,13 +40,6 @@ steps:
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
         artifact_paths: ["*.log"]
 
-      - label: ":compression: fault_tolerance"
-        command: .buildkite/k3_tests/multiprocess/run.sh fault_tolerance
-        timeout_in_minutes: 30
-        agents: { queue: "k8s" }
-        plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
-        artifact_paths: ["*.log"]
-
       - label: ":compression: deadlock"
         command: .buildkite/k3_tests/multiprocess/run.sh deadlock
         timeout_in_minutes: 30
@@ -58,16 +47,41 @@ steps:
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
         artifact_paths: ["*.log"]
 
+  - group: ":compression: Multiprocess (1-GPU)"
+    steps:
+      - label: ":compression: lm_eval"
+        command: .buildkite/k3_tests/multiprocess/run.sh lm_eval
+        timeout_in_minutes: 30
+        agents: { queue: "k8s" }
+        plugins:
+          - kubernetes:
+              podSpec: &pod-1gpu
+                containers:
+                  - name: container-0
+                    image: lmcache/ci-base:latest
+                    imagePullPolicy: Never
+                    resources: { limits: { "nvidia.com/gpu": "1" } }
+                    volumeMounts: *vol-mounts
+                volumes: *vols
+        artifact_paths: ["*.log"]
+
+      - label: ":compression: fault_tolerance"
+        command: .buildkite/k3_tests/multiprocess/run.sh fault_tolerance
+        timeout_in_minutes: 30
+        agents: { queue: "k8s" }
+        plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
+        artifact_paths: ["*.log"]
+
       - label: ":compression: restart_recovery"
         command: .buildkite/k3_tests/multiprocess/run.sh restart_recovery
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
-        plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
+        plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
         artifact_paths: ["*.log"]
 
       - label: ":compression: cache_stats"
         command: .buildkite/k3_tests/multiprocess/run.sh cache_stats
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
-        plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
+        plugins: [{ kubernetes: { podSpec: *pod-1gpu } }]
         artifact_paths: ["*.log"]

--- a/.buildkite/k3_tests/multiprocess/scripts/launch-processes.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/launch-processes.sh
@@ -88,24 +88,30 @@ echo "$VLLM_PID" >> "$PID_FILE"
 echo "vLLM with LMCache started (PID=$VLLM_PID)"
 
 # ── 3. vLLM Baseline (without LMCache) ──────────────────────
-echo "=== Launching vLLM baseline ==="
-echo "Port: $vllm_baseline_port"
+# Only launched for tests that compare against a baseline (2-GPU pods).
+# Single-GPU tests set LAUNCH_BASELINE=false and skip this entirely.
+if [[ "${LAUNCH_BASELINE:-true}" == "true" ]]; then
+    echo "=== Launching vLLM baseline ==="
+    echo "Port: $vllm_baseline_port"
 
-CUDA_VISIBLE_DEVICES="${GPU_FOR_BASELINE}" \
-VLLM_ENABLE_V1_MULTIPROCESSING=0 \
-VLLM_SERVER_DEV_MODE=1 \
-VLLM_BATCH_INVARIANT=1 \
-PYTHONHASHSEED=0 \
-vllm serve "$MODEL" \
-    --attention-backend FLASH_ATTN \
-    --port "$vllm_baseline_port" \
-    --no-async-scheduling \
-    $GPU_MEMORY_UTIL_ARG \
-    > "/tmp/build_${BUILD_ID}_vllm_baseline.log" 2>&1 &
+    CUDA_VISIBLE_DEVICES="${GPU_FOR_BASELINE}" \
+    VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+    VLLM_SERVER_DEV_MODE=1 \
+    VLLM_BATCH_INVARIANT=1 \
+    PYTHONHASHSEED=0 \
+    vllm serve "$MODEL" \
+        --attention-backend FLASH_ATTN \
+        --port "$vllm_baseline_port" \
+        --no-async-scheduling \
+        $GPU_MEMORY_UTIL_ARG \
+        > "/tmp/build_${BUILD_ID}_vllm_baseline.log" 2>&1 &
 
-VLLM_BASELINE_PID=$!
-echo "$VLLM_BASELINE_PID" >> "$PID_FILE"
-echo "vLLM baseline started (PID=$VLLM_BASELINE_PID)"
+    VLLM_BASELINE_PID=$!
+    echo "$VLLM_BASELINE_PID" >> "$PID_FILE"
+    echo "vLLM baseline started (PID=$VLLM_BASELINE_PID)"
+else
+    echo "=== Skipping vLLM baseline (LAUNCH_BASELINE=false, 1-GPU test) ==="
+fi
 
 echo "=== All processes launched ==="
-echo "PIDs: LMCache=$LMCACHE_PID, vLLM=$VLLM_PID, Baseline=$VLLM_BASELINE_PID"
+echo "PIDs: LMCache=$LMCACHE_PID, vLLM=$VLLM_PID, Baseline=${VLLM_BASELINE_PID:-skipped}"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -45,6 +45,16 @@ echo ""
 # Tests that handle their own server lifecycle (different GPU/model config)
 SELF_CONTAINED_TESTS=" deadlock "
 
+# Tests that compare against a baseline vLLM (no LMCache) on a second GPU.
+# Only these need the baseline server (and thus a 2-GPU pod); everything
+# else runs on GPU 0 alone, so launch-processes.sh skips the baseline.
+BASELINE_TESTS=" vllm_bench long_doc_qa long_doc_qa_l2 "
+if [[ "$BASELINE_TESTS" == *" $TEST_NAME "* ]]; then
+    export LAUNCH_BASELINE=true
+else
+    export LAUNCH_BASELINE=false
+fi
+
 if [[ "$SELF_CONTAINED_TESTS" != *" $TEST_NAME "* ]]; then
     # ── Step 1: Launch native processes ──────────────────────────
     echo "============================================"

--- a/.buildkite/k3_tests/multiprocess/scripts/wait-for-servers.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/wait-for-servers.sh
@@ -59,9 +59,13 @@ if ! wait_for_vllm_server "$VLLM_PORT" "vLLM with LMCache" \
     exit 1
 fi
 
-if ! wait_for_vllm_server "$VLLM_BASELINE_PORT" "vLLM baseline (without LMCache)" \
-        "/tmp/build_${BUILD_ID}_vllm_baseline.log"; then
-    exit 1
+# The baseline server only exists for 2-GPU tests; 1-GPU tests set
+# LAUNCH_BASELINE=false in launch-processes.sh and never start it.
+if [[ "${LAUNCH_BASELINE:-true}" == "true" ]]; then
+    if ! wait_for_vllm_server "$VLLM_BASELINE_PORT" "vLLM baseline (without LMCache)" \
+            "/tmp/build_${BUILD_ID}_vllm_baseline.log"; then
+        exit 1
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
**What this PR does / why we need it**:

- Pipeline split into Multiprocess (2-GPU) and Multiprocess (1-GPU) groups using &pod-2gpu/&pod-1gpu anchors.
- 1-GPU tests (lm_eval, fault_tolerance, restart_recovery, cache_stats) now run on single-GPU pods; the baseline server launch/wait is gated behind LAUNCH_BASELINE.


**Special notes for your reviewers**:


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests