### PR TITLE
[fix] bench close event loop

### DIFF
--- a/lmcache/cli/commands/bench/engine_bench/command.py
+++ b/lmcache/cli/commands/bench/engine_bench/command.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 # Standard
 from typing import TYPE_CHECKING
 import argparse
-import asyncio
 import os
 import sys
 
@@ -577,7 +576,6 @@ def run_engine_bench(command: "BaseCommand", args: argparse.Namespace) -> None:
         workload.run()
     finally:
         progress_monitor.stop()
-        asyncio.run(request_sender.close())
 
     # 7. Final metrics
     final = stats_collector.get_final_stats()

--- a/lmcache/cli/commands/bench/engine_bench/workloads/base.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/base.py
@@ -72,11 +72,21 @@ class BaseWorkload(ABC):
     # ------------------------------------------------------------------
 
     def run(self) -> None:
-        """Run the full workload: warmup, then the benchmark loop.
+        """Run warmup + benchmark, closing the HTTP client in the same loop.
 
-        Blocks until the workload is complete.
+        Blocks until the workload is complete. The ``RequestSender``'s
+        httpx transports are bound to this loop, so they must be closed
+        before ``asyncio.run`` destroys it — otherwise a later close
+        from a fresh loop raises ``RuntimeError: Event loop is closed``.
         """
-        asyncio.run(self._run_async())
+
+        async def _run_and_close() -> None:
+            try:
+                await self._run_async()
+            finally:
+                await self._request_sender.close()
+
+        asyncio.run(_run_and_close())
 
     async def _run_async(self) -> None:
         """Internal async implementation of the run loop."""

--- a/lmcache/cli/commands/bench/engine_bench/workloads/long_doc_permutator.py
+++ b/lmcache/cli/commands/bench/engine_bench/workloads/long_doc_permutator.py
@@ -278,26 +278,6 @@ class LongDocPermutatorWorkload(BaseWorkload):
             len(self._request_list),
         )
 
-    def run(self) -> None:
-        """Run warmup + benchmark, closing the HTTP client in the same loop.
-
-        Overrides ``BaseWorkload.run()`` to ensure the ``RequestSender``'s
-        async HTTP client is closed before the event loop shuts down.
-        ``asyncio.run()`` closes the loop on exit, which orphans any open
-        httpx connections; closing the client here — inside the same
-        ``asyncio.run()`` — tears them down cleanly so the caller's
-        subsequent ``asyncio.run(request_sender.close())`` finds nothing
-        to close and completes without error.
-        """
-
-        async def _run_and_close() -> None:
-            try:
-                await self._run_async()
-            finally:
-                await self._request_sender.close()
-
-        asyncio.run(_run_and_close())
-
     def log_config(self) -> None:
         """Log key workload config before the benchmark starts."""
         c = self._config

--- a/tests/cli/commands/bench/engine_bench/workloads/test_base_workload.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_base_workload.py
@@ -2,7 +2,7 @@
 """Tests for the BaseWorkload abstract class."""
 
 # Standard
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 import queue
 
 # First Party
@@ -46,6 +46,7 @@ def _make_mock_result(request_id: str = "req_0") -> RequestResult:
 
 def _make_stub(**kwargs) -> StubWorkload:
     sender = MagicMock()
+    sender.close = AsyncMock()
     collector = MagicMock()
     monitor = MagicMock()
     return StubWorkload(sender, collector, monitor, **kwargs)
@@ -137,6 +138,7 @@ class TestBaseWorkloadRunLoop:
                 self.request_finished(_make_mock_result("warmup_0"), "warmup_text")
 
         sender = MagicMock()
+        sender.close = AsyncMock()
         collector = MagicMock()
         monitor = MagicMock()
         w = WarmupEnqueuer(sender, collector, monitor)

--- a/tests/cli/commands/bench/engine_bench/workloads/test_long_doc_qa.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_long_doc_qa.py
@@ -158,6 +158,7 @@ def _make_mock_sender() -> MagicMock:
     sender = MagicMock()
     sender.send_request = AsyncMock(return_value=_make_mock_result())
     sender.send_warmup_request = AsyncMock(return_value=_make_mock_result())
+    sender.close = AsyncMock(return_value=None)
     return sender
 
 

--- a/tests/cli/commands/bench/engine_bench/workloads/test_multi_round_chat.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_multi_round_chat.py
@@ -256,6 +256,7 @@ def _make_mock_sender() -> MagicMock:
     sender = MagicMock()
     sender.send_request = AsyncMock(return_value=_make_mock_result())
     sender.send_warmup_request = AsyncMock(return_value=_make_mock_result())
+    sender.close = AsyncMock(return_value=None)
     return sender
 
 

--- a/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_prefix_suffix_tuner.py
@@ -229,6 +229,7 @@ def _make_mock_sender() -> MagicMock:
     sender = MagicMock()
     sender.send_request = AsyncMock(return_value=_make_mock_result())
     sender.send_warmup_request = AsyncMock(return_value=_make_mock_result())
+    sender.close = AsyncMock(return_value=None)
     return sender
 
 

--- a/tests/cli/commands/bench/engine_bench/workloads/test_random_prefill.py
+++ b/tests/cli/commands/bench/engine_bench/workloads/test_random_prefill.py
@@ -99,6 +99,7 @@ def _make_mock_sender() -> MagicMock:
     sender = MagicMock()
     sender.send_request = AsyncMock(return_value=_make_mock_result())
     sender.send_warmup_request = AsyncMock(return_value=_make_mock_result())
+    sender.close = AsyncMock(return_value=None)
     return sender
 
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Anything that opens loop-bound I/O, `RequestSender._client._client` (the `httpx.AsyncClient` inside `AsyncOpenAI`), the `_SelectorSocketTransport` instances inside its `_pool`, the `workload._pending_tasks` (set of `asyncio.Task`), `workload._semaphore` (`asyncio.Semaphore`), must be closed inside the same event loop it was opened in.

If you let the loop die while the object still exists, the object becomes an orphan pointing at a dead loop, and any later operation that touches it will hit `RuntimeError: Event loop is closed`.

Concretely:

1. We run `asyncio.run(self._run_async())` in `run(self)` in `base.py`. We create BaseEventLoop A in `self._loop = events.new_event_loop()` in `_lazy_init` in `runners.py`. Then we reach `transport = self._make_socket_transport(sock, protocol, waiter)` in `base_events.py`. And it will call `self._loop = loop` in `_FlowControlMixin` in `transports.py`, which binds the BaseEventLoop A to `_SelectorSocketTransport`. A.close is called when this asyncio finishes, setting `A._closed = True`.

2. We run `asyncio.run(request_sender.close())` in `command.py`, that same `_SelectorSocketTransport` that lives inside `self._request_sender` still calls `A.call_soon(self._call_connection_lost, None)` at `selector_events.py:875`. `call_soon` internally runs `A._check_closed()`, which sees `A._closed == True` and raises `RuntimeError('Event loop is closed')`.

Why it's environment-dependent: before reaching the bad `transport.close()`, anyio checks `if not self._transport.is_closing()`. If the server closes the keep-alive socket before A dies, asyncio processes the FIN, marks the transport as closing, and step 2's check skips the crash. On CI the server doesn't close in time, so the check passes and the crash fires.

Concrete log: https://buildkite.com/organizations/lmcache/pipelines/k3-sglang-test/builds/327/jobs/019e6fd7-37e7-464e-96ee-a17fb656720a/artifacts/019e6fdd-7b62-4512-8e88-c454c8e98ef3.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
