### PR TITLE
[Fix][Example]: Drop EngineArgs+asdict to fix vLLM 0.20+ pydantic error

### DIFF
--- a/examples/kv_cache_reuse/local_backends/offload.py
+++ b/examples/kv_cache_reuse/local_backends/offload.py
@@ -58,21 +58,15 @@ def build_llm_with_lmcache(lmcache_connector: str, model: str, vllm_version: str
     # field, and vLLM >= 0.20 / pydantic v2 rejects None for
     # CompilationConfig fields like cudagraph_capture_sizes (list) and
     # pass_config.fuse_minimax_qk_norm (bool). See issue #3438.
+    llm_kwargs = {
+        "model": model,
+        "kv_transfer_config": ktc,
+        "max_model_len": 8000,
+        "gpu_memory_utilization": 0.8,
+    }
     if vllm_version == "v0":
-        llm = LLM(
-            model=model,
-            kv_transfer_config=ktc,
-            max_model_len=8000,
-            gpu_memory_utilization=0.8,
-            enable_chunked_prefill=True,  # Only in v0
-        )
-    else:
-        llm = LLM(
-            model=model,
-            kv_transfer_config=ktc,
-            max_model_len=8000,
-            gpu_memory_utilization=0.8,
-        )
+        llm_kwargs["enable_chunked_prefill"] = True  # Only in v0
+    llm = LLM(**llm_kwargs)
     try:
         yield llm
     finally:
@@ -128,7 +122,7 @@ def main():
         model = "mistralai/Mistral-7B-Instruct-v0.2"
     else:
         lmcache_connector = "LMCacheConnectorV1"
-        model = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+        model = "mistralai/Mistral-7B-Instruct-v0.2"
 
     setup_environment_variables(args.version, args.use_disk)
 

--- a/examples/kv_cache_reuse/local_backends/offload.py
+++ b/examples/kv_cache_reuse/local_backends/offload.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from dataclasses import asdict
 import argparse
 import contextlib
 import os
@@ -9,7 +8,6 @@ import time
 # Third Party
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
-from vllm.engine.arg_utils import EngineArgs
 
 # First Party
 from lmcache.integration.vllm.utils import ENGINE_NAME
@@ -54,8 +52,14 @@ def build_llm_with_lmcache(lmcache_connector: str, model: str, vllm_version: str
     # Set GPU memory utilization to 0.8 for an A40 GPU with 40GB
     # memory. Reduce the value if your GPU has less memory.
     # Note: LMCache supports chunked prefill (see vLLM#14505, LMCache#392).
+    #
+    # Pass kwargs directly to LLM() instead of routing through
+    # EngineArgs + asdict(). asdict() emits None for every unset EngineArgs
+    # field, and vLLM >= 0.20 / pydantic v2 rejects None for
+    # CompilationConfig fields like cudagraph_capture_sizes (list) and
+    # pass_config.fuse_minimax_qk_norm (bool). See issue #3438.
     if vllm_version == "v0":
-        llm_args = EngineArgs(
+        llm = LLM(
             model=model,
             kv_transfer_config=ktc,
             max_model_len=8000,
@@ -63,14 +67,12 @@ def build_llm_with_lmcache(lmcache_connector: str, model: str, vllm_version: str
             enable_chunked_prefill=True,  # Only in v0
         )
     else:
-        llm_args = EngineArgs(
+        llm = LLM(
             model=model,
             kv_transfer_config=ktc,
             max_model_len=8000,
             gpu_memory_utilization=0.8,
         )
-
-    llm = LLM(**asdict(llm_args))
     try:
         yield llm
     finally:
@@ -104,7 +106,10 @@ def parse_args():
         "--version",
         choices=["v0", "v1"],
         default="v1",
-        help="Specify vLLM version (default: v1)",
+        help=(
+            "Specify vLLM version (default: v1). "
+            "v0 requires vLLM <= 0.10.x; vLLM 0.11.0+ removed the V0 engine."
+        ),
     )
     parser.add_argument(
         "-d",


### PR DESCRIPTION
**What this PR does / why we need it**:
for issue: https://github.com/LMCache/LMCache/issues/3438
to make `offload.py` example run with latest vllm

I ran it on an instance, confirmed working. 

Also add a comment in the code explaining that V0 is supported only up to vLLM 0.10.x, as per https://github.com/vllm-project/vllm/issues/18571

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
