### PR TITLE
[good-first-issue] core: convert loglevel_api f-strings to %-format (#3429)

### DIFF
--- a/lmcache/v1/internal_api_server/common/loglevel_api.py
+++ b/lmcache/v1/internal_api_server/common/loglevel_api.py
@@ -26,13 +26,13 @@ async def get_or_set_log_level(
         result = "=== Loggers and Levels ===\n"
         for name, logger_obj in loggers.items():
             if isinstance(logger_obj, logging.Logger):
-                result += f"{name}: {logging.getLevelName(logger_obj.level)}\n"
+                result += "%s: %s\n" % (name, logging.getLevelName(logger_obj.level))
         return PlainTextResponse(content=result, media_type="text/plain")
     elif logger_name and not level:
         # Get the level of the specified logger
         target_logger = logging.getLogger(logger_name)
         return PlainTextResponse(
-            content=f"{logger_name}: {logging.getLevelName(target_logger.level)}",
+            content="%s: %s" % (logger_name, logging.getLevelName(target_logger.level)),
             media_type="text/plain",
         )
     elif logger_name and level:
@@ -45,13 +45,13 @@ async def get_or_set_log_level(
             for handler in target_logger.handlers:
                 handler.setLevel(level_value)
             return PlainTextResponse(
-                content=f"Set {logger_name} level to {level.upper()} "
-                "(including all handlers)",
+                content="Set %s level to %s (including all handlers)"
+                % (logger_name, level.upper()),
                 media_type="text/plain",
             )
         except AttributeError:
             return PlainTextResponse(
-                content=f"Invalid log level: {level}",
+                content="Invalid log level: %s" % level,
                 media_type="text/plain",
                 status_code=400,
             )


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #3429
Refs #3372

Converts f-string formatting to `%`-format in
`lmcache/v1/internal_api_server/common/loglevel_api.py`. All f-strings
that build log-level response messages (returned via `PlainTextResponse`
or accumulated into the listing string) were rewritten to use `%`-style
formatting. No behavior change — purely a formatting-style cleanup.

**Special notes for your reviewers**:
- This is my first PR to LMCache 🙇 please be gentle. Thank you @maobaolong  for this opportunity
- I ran `pre-commit run --all-files` locally — all green.
- No new tests added — change is purely cosmetic (string formatting style)
  and existing behavior is unchanged.
- Note: I converted all the f-strings in this file that produce log-level
  response messages (passed to `PlainTextResponse`) to `%`-format. Happy to
  expand scope to actual `logger.*` calls in nearby files
  (`run_script_api.py`, `vllm/cache_api.py`, `api_server.py`) if you'd like
  those cleaned up too.
