### PR TITLE
cleanup: simplify redundant conditions in RawBlockCore

### DIFF
--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -669,7 +669,6 @@ class RawBlockCore:
         deleted: list[bool] = []
         with self._lock:
             for encoded_key in encoded_keys:
-                existed = encoded_key in self._index or encoded_key in self._inflight
                 entry = self._index.get(encoded_key)
                 locked = self._lock_refcnt.get(encoded_key, 0) > 0
                 if entry is not None and locked and not force:
@@ -686,9 +685,7 @@ class RawBlockCore:
                         self._offset_to_slot(int(removed_entry.offset))
                     )
                     self._meta_dirty_total += 1
-                deleted.append(
-                    existed and (removed_entry is not None or inflight is not None)
-                )
+                deleted.append(removed_entry is not None or inflight is not None)
         return deleted
 
     def usage(self) -> tuple[float, float]:
@@ -1224,7 +1221,7 @@ class RawBlockCore:
         if rel % self.slot_bytes != 0:
             return False
         slot = rel // self.slot_bytes
-        if slot < 0 or slot >= self._max_slots:
+        if slot >= self._max_slots:
             return False
         return 0 < size <= (self.slot_bytes - self.header_bytes)
 
@@ -1234,7 +1231,8 @@ class RawBlockCore:
             return False
         if int(data.get("version", 0)) != 1:
             return False
-        if data.get("device_path") and data.get("device_path") != self.device_path:
+        checkpoint_device_path = data.get("device_path")
+        if checkpoint_device_path and checkpoint_device_path != self.device_path:
             logger.warning("Device metadata device_path mismatch; ignoring metadata")
             return False
         if int(data.get("slot_bytes", self.slot_bytes)) != self.slot_bytes:


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

  **What this PR does / why we need it**:

  Pure refactor cleanups in `raw_block/core.py`:
  - `delete_many`: drop `existed` (equivalent to `removed_entry is not None or inflight is not None` under
  `_lock`).
  - `_is_valid_checkpoint_entry`: drop unreachable `slot < 0` (`rel >= 0` guaranteed by the earlier offset
  check).
  - `_apply_loaded_state`: cache `data.get("device_path")` instead of calling it twice.

  No behavior change. Existing raw-block tests pass; 

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [ ] this PR contains unit tests