### PR TITLE
[Feat] raw_block: compress checkpoint payload to fit more entries and cut write amplification

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -96,10 +96,20 @@ Rules:
 - periodic checkpointing
 - optional checkpoint load on startup
 - optional verification on load
+- optional checkpoint payload compression (`meta_checkpoint_compression`)
 - recovery by loading the latest durable checkpoint and rebuilding the in-memory
   index
 
-The on-device format is intentionally unchanged by the MP adapter work.
+The checkpoint payload may optionally be compressed with zlib. When enabled, the
+on-device payload is framed with a leading magic tag (`b"LMCZ1\x00"`) so recovery
+auto-detects the codec without changing the metadata header struct or
+`meta_version`. An uncompressed payload is JSON and always starts with `{`, which
+never collides with the tag, so checkpoints written without compression (or by
+older versions) still load. The CRC and the container-capacity check operate on
+the stored (compressed) bytes, so torn-write detection is preserved and more
+entries fit per metadata container while fewer bytes are written each cycle.
+
+The on-device slot/header format is otherwise unchanged by the MP adapter work.
 
 Recovered keys are exposed to the shared L2 eviction policy on adapter startup,
 so reclaimed slots come from global L2 eviction or explicit `delete()` calls.
@@ -124,6 +134,7 @@ The MP adapter is configured through `--l2-adapter` JSON:
   "meta_enable_periodic": true,
   "load_checkpoint_on_init": true,
   "meta_verify_on_load": true,
+  "meta_checkpoint_compression": "zlib",
   "num_store_workers": 2,
   "num_lookup_workers": 1,
   "num_load_workers": 4
@@ -140,6 +151,9 @@ Important validation rules:
   of loading the latest on-device metadata checkpoint
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
+- `meta_checkpoint_compression` must be `"none"` or `"zlib"` (default `"zlib"`).
+  A compressed checkpoint cannot be read by a version that predates this knob;
+  set `"none"` before downgrading.
 
 ## Relationship to Non-MP Mode
 

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -23,6 +23,13 @@ caller-provided load buffers during prefetch.
 - ``meta_checkpoint_interval_sec`` / ``meta_idle_quiet_ms`` /
   ``meta_enable_periodic`` / ``meta_verify_on_load``: Checkpoint and recovery
   controls carried over from the legacy raw-block backend.
+- ``meta_checkpoint_compression``: Checkpoint payload codec, ``"none"`` or
+  ``"zlib"`` (default ``"zlib"``). Compression shrinks the checkpoint so more
+  entries fit per metadata container and fewer bytes are written each cycle;
+  it runs on the background checkpoint thread and does not affect the KV data
+  path. Recovery auto-detects the codec, so uncompressed checkpoints still
+  load. A compressed checkpoint cannot be read by a version predating this
+  knob; set ``"none"`` before downgrading.
 - ``load_checkpoint_on_init``: Load an existing on-device metadata checkpoint
   during startup (default ``true``). Set to ``false`` to start with an empty
   in-memory index instead.

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -38,12 +38,15 @@ from lmcache.v1.distributed.l2_adapters.factory import (
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.platform import EventNotifier, create_event_notifier
 from lmcache.v1.storage_backend.raw_block import (
+    DEFAULT_CHECKPOINT_COMPRESSION,
     DEFAULT_IOURING_QUEUE_DEPTH,
+    RawBlockCheckpointCompression,
     RawBlockCore,
     RawBlockCoreConfig,
     decode_object_key,
     encode_object_key,
     normalize_raw_block_io_engine,
+    validate_checkpoint_compression,
     validate_raw_block_io_options,
 )
 
@@ -88,6 +91,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH,
         use_uring_cmd: bool = False,
         max_data_transfer_size: int = 0,
+        meta_checkpoint_compression: RawBlockCheckpointCompression = (
+            DEFAULT_CHECKPOINT_COMPRESSION
+        ),
         num_store_workers: int = 2,
         num_lookup_workers: int = 1,
         num_load_workers: int = 4,
@@ -114,6 +120,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             iouring_queue_depth: Queue depth for the Rust io_uring engine.
             use_uring_cmd: Whether to use NVMe io_uring_cmd passthrough.
             max_data_transfer_size: Max data transfer size for a single request.
+            meta_checkpoint_compression: Checkpoint payload codec, ``"none"`` or
+                ``"zlib"``.
             num_store_workers: Number of store worker threads.
             num_lookup_workers: Number of lookup worker threads.
             num_load_workers: Number of load worker threads.
@@ -136,6 +144,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         self.enable_zero_copy = bool(enable_zero_copy)
         self.io_engine = normalize_raw_block_io_engine(io_engine)
         self.iouring_queue_depth = int(iouring_queue_depth)
+        self.meta_checkpoint_compression = validate_checkpoint_compression(
+            str(meta_checkpoint_compression)
+        )
         validate_raw_block_io_options(
             iouring_queue_depth=self.iouring_queue_depth,
         )
@@ -227,6 +238,11 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             iouring_queue_depth=iouring_queue_depth,
             use_uring_cmd=use_uring_cmd,
             max_data_transfer_size=max_data_transfer_size,
+            meta_checkpoint_compression=validate_checkpoint_compression(
+                str(
+                    d.get("meta_checkpoint_compression", DEFAULT_CHECKPOINT_COMPRESSION)
+                )
+            ),
             num_store_workers=worker_counts["num_store_workers"],
             num_lookup_workers=worker_counts["num_lookup_workers"],
             num_load_workers=worker_counts["num_load_workers"],
@@ -268,6 +284,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "- max_data_transfer_size (int): for a single I/O request "
             "(0: (default) auto detect limit splitting, > 0: explicit split, "
             "< 0: auto detect limit splitting)\n"
+            "- meta_checkpoint_compression (str): checkpoint payload codec, "
+            f"none or zlib (default {DEFAULT_CHECKPOINT_COMPRESSION})\n"
             "- num_store_workers (int): store worker threads (default 2)\n"
             "- num_lookup_workers (int): lookup worker threads (default 1)\n"
             "- num_load_workers (int): load worker threads (default 4)"
@@ -295,6 +313,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             iouring_queue_depth=self.iouring_queue_depth,
             use_uring_cmd=self.use_uring_cmd,
             max_data_transfer_size=self.max_data_transfer_size,
+            meta_checkpoint_compression=self.meta_checkpoint_compression,
         )
 
 

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -20,6 +20,7 @@ from lmcache.v1.storage_backend.abstract_backend import (
     StoragePluginInterface,
 )
 from lmcache.v1.storage_backend.raw_block import (
+    DEFAULT_CHECKPOINT_COMPRESSION,
     DEFAULT_IOURING_QUEUE_DEPTH,
     RawBlockCore,
     RawBlockCoreConfig,
@@ -28,6 +29,7 @@ from lmcache.v1.storage_backend.raw_block import (
     encode_legacy_key,
     normalize_raw_block_io_engine,
     round_up,
+    validate_checkpoint_compression,
     validate_raw_block_io_options,
 )
 
@@ -314,6 +316,14 @@ class RustRawBlockBackend(StoragePluginInterface):
             io_engine=io_engine,
             iouring_queue_depth=iouring_queue_depth,
             use_uring_cmd=use_uring_cmd,
+            meta_checkpoint_compression=validate_checkpoint_compression(
+                str(
+                    extra.get(
+                        "rust_raw_block.meta_checkpoint_compression",
+                        DEFAULT_CHECKPOINT_COMPRESSION,
+                    )
+                )
+            ),
         )
 
     def _warn_if_loaded_metadata_looks_cross_rank(self) -> None:

--- a/lmcache/v1/storage_backend/raw_block/__init__.py
+++ b/lmcache/v1/storage_backend/raw_block/__init__.py
@@ -2,13 +2,16 @@
 
 # First Party
 from lmcache.v1.storage_backend.raw_block.core import (
+    DEFAULT_CHECKPOINT_COMPRESSION,
     DEFAULT_IOURING_QUEUE_DEPTH,
     RAW_BLOCK_IO_ENGINES,
+    RawBlockCheckpointCompression,
     RawBlockCore,
     RawBlockCoreConfig,
     RawBlockPutManyResult,
     normalize_raw_block_io_engine,
     round_up,
+    validate_checkpoint_compression,
     validate_raw_block_io_options,
 )
 from lmcache.v1.storage_backend.raw_block.key_codec import (
@@ -25,8 +28,10 @@ from lmcache.v1.storage_backend.raw_block.key_codec import (
 __all__ = [
     "RawBlockCore",
     "RawBlockCoreConfig",
+    "RawBlockCheckpointCompression",
     "RAW_BLOCK_IO_ENGINES",
     "DEFAULT_IOURING_QUEUE_DEPTH",
+    "DEFAULT_CHECKPOINT_COMPRESSION",
     "RawBlockKeyNamespace",
     "RawBlockKeySpec",
     "RawBlockPutManyResult",
@@ -38,5 +43,6 @@ __all__ = [
     "normalize_raw_block_io_engine",
     "round_up",
     "slot_identity_from_encoded_key",
+    "validate_checkpoint_compression",
     "validate_raw_block_io_options",
 ]

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 # Standard
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Literal, Optional, cast
 import ctypes
 import json
 import os
@@ -43,6 +43,22 @@ _DEFAULT_META_VERSION = 1
 _META_HEADER_STRUCT = struct.Struct("<8sIQQI")
 RAW_BLOCK_IO_ENGINES = frozenset({"posix", "io_uring"})
 DEFAULT_IOURING_QUEUE_DEPTH = 256
+
+# Checkpoint payload compression.
+#
+# The on-device checkpoint payload is optionally framed with a leading magic
+# tag so recovery can auto-detect the codec without changing the metadata header
+# struct or bumping ``meta_version``. An uncompressed payload is JSON and always
+# starts with ``{`` (0x7B), which never collides with the magic tag, so
+# checkpoints written by older versions (no tag) still load unchanged.
+RawBlockCheckpointCompression = Literal["none", "zlib"]
+RAW_BLOCK_CHECKPOINT_COMPRESSIONS = frozenset({"none", "zlib"})
+DEFAULT_CHECKPOINT_COMPRESSION: RawBlockCheckpointCompression = "zlib"
+_CHECKPOINT_COMPRESS_MAGIC = b"LMCZ1\x00"
+# Level 1 captures nearly all of the achievable ratio for this payload (repeated
+# key prefixes and JSON structure); the bulk of the bytes are random chunk-hash
+# hex that does not compress. Higher levels roughly double the CPU for ~7% more.
+_CHECKPOINT_COMPRESS_LEVEL = 1
 
 
 def round_up(x: int, align: int) -> int:
@@ -126,6 +142,24 @@ def _read_sysfs_int(path: str) -> Optional[int]:
         return None
 
 
+def validate_checkpoint_compression(value: str) -> RawBlockCheckpointCompression:
+    """Validate and narrow a checkpoint payload compression codec name.
+
+    Args:
+        value: Codec name from configuration.
+
+    Returns:
+        The validated codec name (``"none"`` or ``"zlib"``).
+
+    Raises:
+        ValueError: If ``value`` is not a supported codec.
+    """
+    if value not in RAW_BLOCK_CHECKPOINT_COMPRESSIONS:
+        allowed = ", ".join(sorted(RAW_BLOCK_CHECKPOINT_COMPRESSIONS))
+        raise ValueError(f"meta_checkpoint_compression must be one of: {allowed}")
+    return cast(RawBlockCheckpointCompression, value)
+
+
 @dataclass(frozen=True)
 class RawBlockCoreConfig:
     """Configuration for RawBlockCore device layout, I/O, and checkpoints."""
@@ -149,6 +183,9 @@ class RawBlockCoreConfig:
     io_engine: str = "posix"
     iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH
     use_uring_cmd: bool = False
+    meta_checkpoint_compression: RawBlockCheckpointCompression = (
+        DEFAULT_CHECKPOINT_COMPRESSION
+    )
 
 
 @dataclass
@@ -228,6 +265,9 @@ class RawBlockCore:
                 "character devices when use_uring_cmd=true"
             )
             self.use_odirect = False
+        self.meta_checkpoint_compression = validate_checkpoint_compression(
+            str(config.meta_checkpoint_compression)
+        )
         self.key_namespace = key_namespace
 
         if not self.device_path:
@@ -933,6 +973,7 @@ class RawBlockCore:
                 "io_engine": self.io_engine,
                 "iouring_queue_depth": self.iouring_queue_depth,
                 "use_uring_cmd": self.use_uring_cmd,
+                "meta_checkpoint_compression": self.meta_checkpoint_compression,
             }
 
     def close(self) -> None:
@@ -1624,6 +1665,41 @@ class RawBlockCore:
             return None
         return TORCH_DTYPE_TO_STR_DTYPE.get(dtype, str(dtype))
 
+    def _encode_checkpoint_payload(self, raw: bytes) -> bytes:
+        """Frame a serialized checkpoint payload for on-device storage.
+
+        Args:
+            raw: UTF-8 JSON checkpoint bytes produced by ``_snapshot_state``.
+
+        Returns:
+            The bytes to store on the device. When compression is enabled the
+            result is ``_CHECKPOINT_COMPRESS_MAGIC`` followed by the
+            zlib-compressed payload; otherwise ``raw`` is returned unchanged.
+        """
+        if self.meta_checkpoint_compression == "zlib":
+            return _CHECKPOINT_COMPRESS_MAGIC + zlib.compress(
+                raw, _CHECKPOINT_COMPRESS_LEVEL
+            )
+        return raw
+
+    def _decode_checkpoint_payload(self, payload: bytes) -> bytes:
+        """Decode an on-device checkpoint payload back to JSON bytes.
+
+        Args:
+            payload: CRC-validated bytes read from a checkpoint container.
+
+        Returns:
+            The original UTF-8 JSON checkpoint bytes. A payload carrying the
+            compression magic tag is decompressed; an untagged payload (written
+            by older versions or with compression disabled) is returned as-is.
+
+        Raises:
+            zlib.error: If a tagged payload cannot be decompressed.
+        """
+        if payload.startswith(_CHECKPOINT_COMPRESS_MAGIC):
+            return zlib.decompress(payload[len(_CHECKPOINT_COMPRESS_MAGIC) :])
+        return payload
+
     def _write_checkpoint(self, payload: bytes, dirty_total_snapshot: int) -> bool:
         """Write one checkpoint copy and advance persisted metadata counters."""
         payload_cap = self._meta_payload_capacity()
@@ -1680,9 +1756,10 @@ class RawBlockCore:
             return False
 
         snapshot, dirty_total_snapshot = self._snapshot_state()
-        payload = json.dumps(snapshot, separators=(",", ":"), ensure_ascii=True).encode(
-            "utf-8"
-        )
+        raw_payload = json.dumps(
+            snapshot, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+        payload = self._encode_checkpoint_payload(raw_payload)
         return self._write_checkpoint(payload, dirty_total_snapshot)
 
     def _is_valid_checkpoint_entry(self, offset: int, size: int) -> bool:
@@ -1929,7 +2006,7 @@ class RawBlockCore:
             logger.warning("RawBlockCore: checkpoint header had no payload")
             return
         try:
-            data = json.loads(payload.decode("utf-8"))
+            data = json.loads(self._decode_checkpoint_payload(payload).decode("utf-8"))
         except Exception:
             logger.warning("RawBlockCore: failed to decode metadata payload")
             return

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -627,3 +627,26 @@ def test_raw_block_l2_adapter_error_bitmaps_keep_submitted_size():
             assert str(load_bitmap) == "00"
         finally:
             adapter.close()
+
+
+def test_raw_block_l2_adapter_config_default_compression():
+    config = RawBlockL2AdapterConfig.from_dict(_config_dict())
+
+    assert config.meta_checkpoint_compression == "zlib"
+    assert config.to_core_config().meta_checkpoint_compression == "zlib"
+
+
+def test_raw_block_l2_adapter_config_explicit_compression_passthrough():
+    config = RawBlockL2AdapterConfig.from_dict(
+        _config_dict(meta_checkpoint_compression="none")
+    )
+
+    assert config.meta_checkpoint_compression == "none"
+    assert config.to_core_config().meta_checkpoint_compression == "none"
+
+
+def test_raw_block_l2_adapter_config_rejects_invalid_compression():
+    with pytest.raises(ValueError, match="meta_checkpoint_compression"):
+        RawBlockL2AdapterConfig.from_dict(
+            _config_dict(meta_checkpoint_compression="gzip")
+        )

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 # Standard
 from concurrent.futures import Future
+from typing import cast
 from unittest.mock import MagicMock, patch
 import asyncio
 import os
@@ -36,10 +37,14 @@ from lmcache.v1.storage_backend.plugins.rust_raw_block_backend import (
     RustRawBlockBackend,
 )
 from lmcache.v1.storage_backend.raw_block import (
+    DEFAULT_CHECKPOINT_COMPRESSION,
+    RawBlockCheckpointCompression,
     RawBlockCore,
     RawBlockCoreConfig,
     RawBlockKeySpec,
+    slot_identity_from_encoded_key,
 )
+from lmcache.v1.storage_backend.raw_block.core import _CHECKPOINT_COMPRESS_MAGIC
 
 
 def _has_ext() -> bool:
@@ -84,26 +89,39 @@ def _install_fake_raw_block_device(monkeypatch, *, size_bytes: int = 64 * 1024):
     )
 
 
-def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
+def _make_raw_block_core(
+    *,
+    use_odirect: bool = False,
+    device_path: str = "/tmp/raw-block-boundary-test",
+    capacity_bytes: int = 64 * 1024,
+    meta_total_bytes: int = 16 * 1024,
+    load_checkpoint_on_init: bool = True,
+    meta_checkpoint_compression: str = DEFAULT_CHECKPOINT_COMPRESSION,
+) -> RawBlockCore:
     return RawBlockCore(
         RawBlockCoreConfig(
-            device_path="/tmp/raw-block-boundary-test",
-            capacity_bytes=64 * 1024,
+            device_path=device_path,
+            capacity_bytes=capacity_bytes,
             block_align=4096,
             header_bytes=4096,
             slot_bytes=8192,
             use_odirect=use_odirect,
             enable_zero_copy=True,
-            meta_total_bytes=16 * 1024,
+            meta_total_bytes=meta_total_bytes,
             meta_magic=b"LMCIDX01",
             meta_version=1,
             meta_checkpoint_interval_sec=60,
             meta_idle_quiet_ms=100,
             meta_enable_periodic=False,
-            load_checkpoint_on_init=True,
+            load_checkpoint_on_init=load_checkpoint_on_init,
             meta_verify_on_load=True,
             io_engine="posix",
             iouring_queue_depth=256,
+            # cast: the helper intentionally accepts arbitrary strings so the
+            # invalid-codec test can exercise RawBlockCore's runtime validation.
+            meta_checkpoint_compression=cast(
+                RawBlockCheckpointCompression, meta_checkpoint_compression
+            ),
         ),
         key_namespace="object",
     )
@@ -2270,3 +2288,223 @@ def test_rust_raw_block_backend_batched_get_with_uring(
 
         finally:
             backend.close()
+
+
+# --------------------------------------------------------------------------- #
+# Checkpoint payload compression (meta_checkpoint_compression)
+# --------------------------------------------------------------------------- #
+
+
+class _SharedFakeRawBlockDevice(_FakeRawBlockDevice):
+    """Fake raw device whose bytes persist across cores opening the same path.
+
+    Behaves exactly like ``_FakeRawBlockDevice`` except the backing buffer is
+    keyed by path in a class-level store, so a core reopening the same device
+    sees what a previous core wrote (needed for checkpoint recovery tests).
+    """
+
+    _STORES: dict[str, bytearray] = {}
+
+    def __init__(self, path: str, *, size_bytes: int, **kwargs):
+        del kwargs
+        self._data = self._STORES.setdefault(path, bytearray(size_bytes))
+
+
+def _install_shared_fake_device(monkeypatch, *, size_bytes: int) -> None:
+    _SharedFakeRawBlockDevice._STORES.clear()
+
+    def create(path: str, **kwargs):
+        return _SharedFakeRawBlockDevice(path, size_bytes=size_bytes, **kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "lmcache_rust_raw_block_io",
+        types.SimpleNamespace(RawBlockDevice=create),
+    )
+
+
+def _object_spec(encoded: str) -> RawBlockKeySpec:
+    return RawBlockKeySpec(
+        encoded=encoded,
+        slot_identity=slot_identity_from_encoded_key(encoded, "object"),
+    )
+
+
+def _object_keys(count: int) -> list[str]:
+    base = "meta-llama%2FLlama-3.1-8B-Instruct"
+    return [f"{base}@{i:#010x}@{i:064x}" for i in range(count)]
+
+
+def test_raw_block_core_compression_roundtrip(monkeypatch):
+    _install_shared_fake_device(monkeypatch, size_bytes=512 * 1024)
+    path = "/tmp/raw-block-compress-roundtrip"
+    payload_size = 4096
+    keys = _object_keys(3)
+
+    core1 = _make_raw_block_core(
+        device_path=path,
+        meta_checkpoint_compression="zlib",
+        capacity_bytes=512 * 1024,
+        meta_total_bytes=64 * 1024,
+    )
+    try:
+        result = core1.put_many(
+            [_object_spec(k) for k in keys],
+            [_make_byte_obj(payload_size) for _ in keys],
+        )
+        assert result.results == [True, True, True]
+        core1.checkpoint_now()
+    finally:
+        core1.close()
+
+    core2 = _make_raw_block_core(
+        device_path=path,
+        meta_checkpoint_compression="zlib",
+        capacity_bytes=512 * 1024,
+        meta_total_bytes=64 * 1024,
+    )
+    try:
+        assert core2.indexed_key_count() == 3
+        assert core2.exists_many(keys) == [True, True, True]
+        metas = core2.get_metadata_many(keys)
+        assert all(m is not None and m.size == payload_size for m in metas)
+    finally:
+        core2.close()
+
+
+def test_raw_block_core_loads_uncompressed_checkpoint(monkeypatch):
+    """A zlib-enabled core recovers a checkpoint written without compression."""
+    _install_shared_fake_device(monkeypatch, size_bytes=512 * 1024)
+    path = "/tmp/raw-block-compress-backcompat"
+    keys = _object_keys(2)
+
+    core1 = _make_raw_block_core(
+        device_path=path,
+        meta_checkpoint_compression="none",
+        capacity_bytes=512 * 1024,
+        meta_total_bytes=64 * 1024,
+    )
+    try:
+        core1.put_many(
+            [_object_spec(k) for k in keys],
+            [_make_byte_obj(4096) for _ in keys],
+        )
+        core1.checkpoint_now()
+    finally:
+        core1.close()
+
+    core2 = _make_raw_block_core(
+        device_path=path,
+        meta_checkpoint_compression="zlib",
+        capacity_bytes=512 * 1024,
+        meta_total_bytes=64 * 1024,
+    )
+    try:
+        assert core2.exists_many(keys) == [True, True]
+    finally:
+        core2.close()
+
+
+def test_raw_block_core_compression_fits_more_entries(monkeypatch):
+    """Compression keeps a checkpoint that would overflow the container raw."""
+    size = 4 * 1024 * 1024
+    meta_total = 16 * 1024  # container 8KiB, payload capacity ~4KiB
+    keys = _object_keys(25)
+
+    # Without compression the JSON exceeds the container -> checkpoint skipped.
+    _install_shared_fake_device(monkeypatch, size_bytes=size)
+    path_none = "/tmp/raw-block-compress-oversize-none"
+    core_none = _make_raw_block_core(
+        device_path=path_none,
+        meta_checkpoint_compression="none",
+        capacity_bytes=size,
+        meta_total_bytes=meta_total,
+    )
+    try:
+        core_none.put_many(
+            [_object_spec(k) for k in keys],
+            [_make_byte_obj(64) for _ in keys],
+        )
+        core_none.checkpoint_now()
+    finally:
+        core_none.close()
+    reopened_none = _make_raw_block_core(
+        device_path=path_none,
+        meta_checkpoint_compression="none",
+        capacity_bytes=size,
+        meta_total_bytes=meta_total,
+    )
+    try:
+        assert reopened_none.indexed_key_count() == 0  # oversize -> nothing persisted
+    finally:
+        reopened_none.close()
+
+    # With zlib the same index compresses under the cap and is recovered.
+    _install_shared_fake_device(monkeypatch, size_bytes=size)
+    path_zlib = "/tmp/raw-block-compress-oversize-zlib"
+    core_zlib = _make_raw_block_core(
+        device_path=path_zlib,
+        meta_checkpoint_compression="zlib",
+        capacity_bytes=size,
+        meta_total_bytes=meta_total,
+    )
+    try:
+        core_zlib.put_many(
+            [_object_spec(k) for k in keys],
+            [_make_byte_obj(64) for _ in keys],
+        )
+        core_zlib.checkpoint_now()
+    finally:
+        core_zlib.close()
+    reopened_zlib = _make_raw_block_core(
+        device_path=path_zlib,
+        meta_checkpoint_compression="zlib",
+        capacity_bytes=size,
+        meta_total_bytes=meta_total,
+    )
+    try:
+        assert reopened_zlib.indexed_key_count() == len(keys)
+    finally:
+        reopened_zlib.close()
+
+
+def test_raw_block_core_rejects_invalid_compression(monkeypatch):
+    _install_shared_fake_device(monkeypatch, size_bytes=64 * 1024)
+    with pytest.raises(ValueError, match="meta_checkpoint_compression"):
+        _make_raw_block_core(
+            device_path="/tmp/raw-block-compress-invalid",
+            meta_checkpoint_compression="gzip",
+            capacity_bytes=64 * 1024,
+            meta_total_bytes=16 * 1024,
+        )
+
+
+def test_raw_block_core_decode_rejects_corrupt_compressed_payload(monkeypatch):
+    """A CRC-valid but undecompressable payload loads gracefully as empty."""
+    _install_shared_fake_device(monkeypatch, size_bytes=64 * 1024)
+    path = "/tmp/raw-block-compress-corrupt"
+    core1 = _make_raw_block_core(
+        device_path=path,
+        meta_checkpoint_compression="zlib",
+        capacity_bytes=64 * 1024,
+        meta_total_bytes=16 * 1024,
+        load_checkpoint_on_init=False,
+    )
+    try:
+        # _write_checkpoint is the only way to plant a payload that passes CRC
+        # (computed over the stored bytes) yet has a tagged body that cannot be
+        # inflated; there is no public API for injecting a corrupt checkpoint.
+        core1._write_checkpoint(_CHECKPOINT_COMPRESS_MAGIC + b"garbage", 1)
+    finally:
+        core1.close()
+
+    core2 = _make_raw_block_core(
+        device_path=path,
+        meta_checkpoint_compression="zlib",
+        capacity_bytes=64 * 1024,
+        meta_total_bytes=16 * 1024,
+    )
+    try:
+        assert core2.indexed_key_count() == 0
+    finally:
+        core2.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

The raw_block metadata checkpoint is a single full-index JSON snapshot, rewritten in full every cycle and mirrored across two fixed-size containers. Its size is dominated by repetition — the per-entry key prefix (`model@kv_rank`) and the JSON structural keys (`"offset"`, `"size"`, `"shape"`, ...) repeat for every entry. This causes two problems:

1. **Write amplification** — the whole snapshot is re-serialized and re-written every checkpoint, even for a small delta.
2. **Silent durability cliff** — once the JSON exceeds the container capacity, the checkpoint is skipped with only a warning, losing durability that cycle.

This PR optionally compresses the checkpoint payload with zlib. The on-device payload is framed with a leading magic tag (`b"LMCZ1\x00"`); recovery auto-detects the codec from the tag, so:

- the metadata header struct and `meta_version` are **unchanged**;
- an uncompressed payload is JSON and always starts with `{` (0x7B), which never collides with the tag, so **checkpoints written without compression (or by older versions) still load**;
- the CRC and the container-capacity check operate on the **stored (compressed)** bytes, so torn-write detection is preserved and more entries fit per container.

Controlled by `meta_checkpoint_compression` (`"none"` | `"zlib"`, default `"zlib"`), plumbed through the non-MP plugin (`rust_raw_block.meta_checkpoint_compression`) and the MP adapter config, and surfaced in `report_status`. zlib level 1 is used deliberately (see reviewer notes).

Compression runs on the **background checkpoint thread** and decompression runs once **at startup**, so the KV data path (put/get payload I/O) is unaffected.

**Measurements** (real raw-block device, object keys with random sha256 hashes):

_N = 20,000 entries:_

| mode | checkpoint payload | checkpoint write | recovery | recovered |
|------|-------------------:|-----------------:|---------:|----------:|
| none | 4332 KB            | 25.3 ms          | 200.5 ms | 20000     |
| zlib | 952 KB (**4.6x**)  | 38.8 ms          | 217.8 ms | 20000     |

- Recovery is dominated by `meta_verify_on_load` slot-header validation (O(N) reads); decompression is a small fraction of it (~18 ms).
- _Capacity_ (fixed ~28 KiB container payload): `none` persists ~100 entries, `zlib` persists ~550 (**~5.5x** more durable entries in the same container).
- _Cumulative write_ (10 checkpoints, index 2k→20k): `none` 23.3 MiB vs `zlib` 5.1 MiB written to the metadata region.

The ratio is bounded by the entropy floor — most bytes are random hash hex, which is incompressible; the gain comes from the repeated prefixes/structure.

**Special notes for your reviewers**:

- **Magic-prefix framing vs alternatives**: a header `flags` field would require changing `_META_HEADER_STRUCT` (and the hand-built test headers); bumping `meta_version` would collide with its config-knob / layout-mismatch semantics. The payload magic tag avoids both and gives automatic backward-compatible reads.
- **Level 1, not the zlib default (6)**: the payload is mostly incompressible random hash hex, so the repeated prefixes/JSON structure are already captured at level 1. Level 6 yields only ~7% smaller output for roughly double the compress CPU — a poor trade for a background, large-payload task.
- **Validation helper**: `validate_checkpoint_compression()` validates and narrows the codec to `Literal["none","zlib"]`, mirroring `normalize_raw_block_io_engine`. Invalid values are rejected eagerly in `from_dict`/`__init__`, not lazily.
- **Forward compatibility**: a compressed checkpoint cannot be read by a version predating this knob; operators set `meta_checkpoint_compression="none"` before downgrading. Documented in the design doc + user docs. The magic tag is versioned (`LMCZ1`) so future codecs can be added without breaking compatibility.
- **Test private access**: the new core tests touch a few private methods (`_select_latest_checkpoint`, `_write_checkpoint`, `_decode_checkpoint_payload`) to assert on-device byte framing and the CRC-valid-but-undecompressable path, for which there is no public surface. This matches existing patterns in that test module.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
