### PR TITLE
[Docs] fix: replace broken Mooncake GitHub links with docs site URLs

### DIFF
--- a/docs/source/kv_cache/storage_backends/mooncake.rst
+++ b/docs/source/kv_cache/storage_backends/mooncake.rst
@@ -22,7 +22,7 @@ Key Features
 - **RDMA optimization**: Built on Transfer Engine with support for TCP, RDMA (InfiniBand/RoCEv2/eRDMA/NVIDIA GPUDirect)
 - **Dynamic resource scaling**: Supports dynamically adding and removing nodes for elastic resource management
 
-For detailed architecture information, see the `Mooncake Architecture Guide <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/mooncake-store.md>`_.
+For detailed architecture information, see the `Mooncake Architecture Guide <https://kvcache-ai.github.io/Mooncake/design/mooncake-store.html>`_.
 
 Quick Start
 -----------
@@ -39,7 +39,7 @@ This package includes all necessary components:
 - ``mooncake_http_metadata_server``: HTTP-based metadata server used by the underlying transfer engine for connection establishment
 - Mooncake Python bindings
 
-For production deployments or custom builds, see the `Build Instructions <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md>`_.
+For production deployments or custom builds, see the `Build Instructions <https://kvcache-ai.github.io/Mooncake/getting_started/build.html>`_.
 
 Setup and Deployment
 ~~~~~~~~~~~~~~~~~~~~
@@ -241,10 +241,10 @@ Configuration
 Additional Resources
 --------------------
 
-- `Mooncake Store Architecture <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/mooncake-store.md>`_
+- `Mooncake Store Architecture <https://kvcache-ai.github.io/Mooncake/design/mooncake-store.html>`_
 - `Mooncake Store Deployment Guide <https://kvcache-ai.github.io/Mooncake/deployment/mooncake-store-deployment-guide.html>`_
 - `Mooncake Store Python API Reference <https://kvcache-ai.github.io/Mooncake/python-api-reference/mooncake-store.html>`_
-- `Transfer Engine Documentation <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/transfer-engine.md>`_
-- `Build Instructions <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md>`_
+- `Transfer Engine Documentation <https://kvcache-ai.github.io/Mooncake/design/transfer-engine/index.html>`_
+- `Build Instructions <https://kvcache-ai.github.io/Mooncake/getting_started/build.html>`_
 - `GitHub Repository <https://github.com/kvcache-ai/Mooncake>`_
-- `LMCache Integration Guide <https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/lmcache-integration.md>`_
+- `LMCache Integration Guide <https://kvcache-ai.github.io/Mooncake/getting_started/examples/lmcache-integration.html>`_


### PR DESCRIPTION
## Summary
- Fixed 4 broken Mooncake GitHub file links (returning 404) in `mooncake.rst`
- Replaced with corresponding links from `kvcache-ai.github.io/Mooncake` docs site

## Test plan
- [x] All replaced links verified accessible (HTTP 200)