### PR TITLE
[MP][Bugfix] Keep shared layout descriptors until final unregister (#3448)

### DIFF
--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -2,6 +2,7 @@
 """Shared context and layout descriptor registry for engine modules."""
 
 # Standard
+from dataclasses import dataclass
 import threading
 
 # First Party
@@ -21,17 +22,27 @@ from lmcache.v1.multiprocess.token_hasher import TokenHasher
 logger = init_logger(__name__)
 
 
+@dataclass
+class _LayoutDescEntry:
+    """Stored layout descriptor and its active registration count."""
+
+    layout_desc: MemoryLayoutDesc
+    ref_count: int
+
+
 class LayoutDescRegistry:
     """Thread-safe registry mapping (model_name, world_size) to MemoryLayoutDesc.
 
     Modules write to this registry when KV caches are registered.
     Consumers (e.g. LookupModule) read from it to find layout descriptors
-    for prefetch tasks.
+    for prefetch tasks. Multiple worker instances can share the same
+    ``(model_name, world_size)`` entry, so the registry keeps the descriptor
+    until the last matching registration is unregistered.
     """
 
     def __init__(self) -> None:
-        # Key: (model_name, world_size) -> MemoryLayoutDesc
-        self._registry: dict[tuple[str, int], MemoryLayoutDesc] = {}
+        # Key: (model_name, world_size) -> layout descriptor entry
+        self._registry: dict[tuple[str, int], _LayoutDescEntry] = {}
         self._lock = threading.Lock()
 
     def register(
@@ -42,23 +53,48 @@ class LayoutDescRegistry:
     ) -> None:
         """Register a layout descriptor for a (model_name, world_size) pair.
 
+        Re-registering the same pair increments the active registration
+        count. The latest descriptor is retained for lookups.
+
         Args:
             model_name: The model name.
             world_size: The world size.
             layout_desc: The memory layout descriptor.
         """
+        key = (model_name, world_size)
         with self._lock:
-            self._registry[(model_name, world_size)] = layout_desc
+            entry = self._registry.get(key)
+            if entry is None:
+                self._registry[key] = _LayoutDescEntry(
+                    layout_desc=layout_desc,
+                    ref_count=1,
+                )
+                return
+
+            entry.layout_desc = layout_desc
+            entry.ref_count += 1
 
     def unregister(self, model_name: str, world_size: int) -> None:
-        """Remove a layout descriptor for a (model_name, world_size) pair.
+        """Unregister one layout descriptor registration for a pair.
+
+        The descriptor is removed only when the last active registration for
+        the pair is unregistered.
 
         Args:
             model_name: The model name.
             world_size: The world size.
         """
+        key = (model_name, world_size)
         with self._lock:
-            self._registry.pop((model_name, world_size), None)
+            entry = self._registry.get(key)
+            if entry is None:
+                return
+
+            if entry.ref_count <= 1:
+                self._registry.pop(key)
+                return
+
+            entry.ref_count -= 1
 
     def find(self, model_name: str, world_size: int) -> MemoryLayoutDesc | None:
         """Look up a layout descriptor by (model_name, world_size).
@@ -71,7 +107,10 @@ class LayoutDescRegistry:
             The layout descriptor if found, otherwise None.
         """
         with self._lock:
-            return self._registry.get((model_name, world_size))
+            entry = self._registry.get((model_name, world_size))
+            if entry is None:
+                return None
+            return entry.layout_desc
 
 
 class MPCacheEngineContext:

--- a/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
+++ b/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for GPU transfer layout registration lifetime."""
+
+# Standard
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+import sys
+import types
+
+# Third Party
+import pytest
+import torch
+
+
+class _FakeGPUContext:
+    """Small stand-in for GPUCacheContext used by registration tests."""
+
+    num_layers: int = 2
+
+
+class _FakeDeviceHostFuncDispatcher:
+    """No-op dispatcher to avoid starting native completion threads."""
+
+    def register(self, kind: str, handler: object, payload_type: object) -> None:
+        """Record no native callback registration."""
+
+    def start(self) -> None:
+        """Start no background thread."""
+
+    def stop(self) -> None:
+        """Stop no background thread."""
+
+
+@pytest.fixture
+def stub_native_storage_ops() -> Any:
+    """Stub native modules so MP server imports work in source-only test runs."""
+    module = types.ModuleType("lmcache.native_storage_ops")
+    module_any = cast(Any, module)
+    module_any.TTLLock = type("TTLLock", (), {})
+    module_any.Bitmap = type("Bitmap", (), {})
+    with patch.dict(
+        sys.modules,
+        {
+            "lmcache.native_storage_ops": module,
+            "cupy": MagicMock(),
+        },
+    ):
+        yield
+
+
+def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_native_storage_ops: Any,
+) -> None:
+    """Unregistering one shared GPU instance must not remove the shared layout."""
+    # First Party
+    from lmcache.utils import EngineType
+    from lmcache.v1.distributed.api import MemoryLayoutDesc
+    from lmcache.v1.multiprocess.engine_context import LayoutDescRegistry
+    from lmcache.v1.multiprocess.modules import gpu_transfer as gpu_transfer_mod
+
+    layout_desc = MemoryLayoutDesc(
+        shapes=[torch.Size([2, 16, 32])],
+        dtypes=[torch.float32],
+    )
+    ctx = MagicMock()
+    ctx.chunk_size = 16
+    ctx.layout_desc_registry = LayoutDescRegistry()
+
+    def fake_gpu_context(*args: object, **kwargs: object) -> _FakeGPUContext:
+        """Return a fake GPU context without touching CUDA."""
+        return _FakeGPUContext()
+
+    def fake_layout_desc(
+        gpu_context: _FakeGPUContext,
+        num_tokens: int,
+    ) -> MemoryLayoutDesc:
+        """Return the shared layout descriptor used by both registrations."""
+        return layout_desc
+
+    monkeypatch.setattr(
+        gpu_transfer_mod,
+        "DeviceHostFuncDispatcher",
+        _FakeDeviceHostFuncDispatcher,
+    )
+    monkeypatch.setattr(gpu_transfer_mod, "GPUCacheContext", fake_gpu_context)
+    monkeypatch.setattr(gpu_transfer_mod, "get_layout_desc", fake_layout_desc)
+    monkeypatch.setattr(
+        gpu_transfer_mod.torch_dev,
+        "empty_cache",
+        lambda: None,
+        raising=False,
+    )
+
+    module = gpu_transfer_mod.GPUTransferModule(ctx)
+    module.register_kv_cache(1, [], "shared-model", 1, EngineType.VLLM, {})
+    module.register_kv_cache(2, [], "shared-model", 1, EngineType.VLLM, {})
+    assert ctx.layout_desc_registry.find("shared-model", 1) is layout_desc
+
+    module.unregister_kv_cache(1)
+
+    assert ctx.layout_desc_registry.find("shared-model", 1) is layout_desc
+
+    module.unregister_kv_cache(2)
+    assert ctx.layout_desc_registry.find("shared-model", 1) is None


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #3448.

When multiple MP worker instances register the same `(model_name, world_size)`, they share one layout descriptor entry in `LayoutDescRegistry`. Previously, unregistering any one instance removed that shared entry immediately, so remaining live instances could fail lookup with "No GPU context found".

This PR tracks the number of active registrations per `(model_name, world_size)` and only removes the layout descriptor when the final matching registration is unregistered.

**Special notes for your reviewers**:

The regression test uses mocked GPU context construction, so it exercises the MP GPU registration/unregistration path without requiring CUDA.

Verified with:
- `pytest -q tests/v1/multiprocess/test_gpu_transfer_layout_registry.py`
- Manual MP integration test with one LMCache server and two vLLM instances sharing the same model/world size. After stopping one instance, requests to the remaining instance continued normally and the original lookup error did not reappear.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests