### PR TITLE
[MP][Bugfix] Track layout descriptor ownership across registrations

### DIFF
--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared context and layout descriptor registry for engine modules."""
-
-# Standard
-import threading
+"""Shared context for engine modules."""
 
 # First Party
 from lmcache.logging import init_logger
@@ -15,64 +12,11 @@ from lmcache.v1.distributed.config import StorageManagerConfig
 from lmcache.v1.distributed.storage_manager import StorageManager
 from lmcache.v1.mp_observability.event_bus import EventBus, get_event_bus
 from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
+from lmcache.v1.multiprocess.layout_desc_registry import LayoutDescRegistry
 from lmcache.v1.multiprocess.session import SessionManager
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
 
 logger = init_logger(__name__)
-
-
-class LayoutDescRegistry:
-    """Thread-safe registry mapping (model_name, world_size) to MemoryLayoutDesc.
-
-    Modules write to this registry when KV caches are registered.
-    Consumers (e.g. LookupModule) read from it to find layout descriptors
-    for prefetch tasks.
-    """
-
-    def __init__(self) -> None:
-        # Key: (model_name, world_size) -> MemoryLayoutDesc
-        self._registry: dict[tuple[str, int], MemoryLayoutDesc] = {}
-        self._lock = threading.Lock()
-
-    def register(
-        self,
-        model_name: str,
-        world_size: int,
-        layout_desc: MemoryLayoutDesc,
-    ) -> None:
-        """Register a layout descriptor for a (model_name, world_size) pair.
-
-        Args:
-            model_name: The model name.
-            world_size: The world size.
-            layout_desc: The memory layout descriptor.
-        """
-        with self._lock:
-            self._registry[(model_name, world_size)] = layout_desc
-
-    def unregister(self, model_name: str, world_size: int) -> None:
-        """Remove a layout descriptor for a (model_name, world_size) pair.
-
-        Args:
-            model_name: The model name.
-            world_size: The world size.
-        """
-        with self._lock:
-            self._registry.pop((model_name, world_size), None)
-
-    def find(self, model_name: str, world_size: int) -> MemoryLayoutDesc | None:
-        """Look up a layout descriptor by (model_name, world_size).
-
-        Args:
-            model_name: The model name.
-            world_size: The world size.
-
-        Returns:
-            The layout descriptor if found, otherwise None.
-        """
-        with self._lock:
-            return self._registry.get((model_name, world_size))
-
 
 class MPCacheEngineContext:
     """Shared infrastructure for all engine modules.

--- a/lmcache/v1/multiprocess/layout_desc_registry.py
+++ b/lmcache/v1/multiprocess/layout_desc_registry.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Registry for memory layout descriptors used by multiprocess lookup."""
+
+# Standard
+import threading
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+
+
+class LayoutDescRegistry:
+    """Thread-safe registry mapping model/world pairs to layout descriptors.
+
+    Modules write to this registry when KV caches are registered. Consumers
+    such as ``LookupModule`` read from it to find layout descriptors for
+    prefetch tasks.
+    """
+
+    def __init__(self) -> None:
+        # Key: (model_name, world_size) -> owner -> MemoryLayoutDesc.
+        # Multiple workers can register the same model/world pair, so
+        # ownership has to survive individual unregister calls.
+        self._registry: dict[
+            tuple[str, int],
+            dict[int | None, MemoryLayoutDesc],
+        ] = {}
+        self._lock = threading.Lock()
+
+    def register(
+        self,
+        model_name: str,
+        world_size: int,
+        layout_desc: MemoryLayoutDesc,
+        *,
+        instance_id: int | None = None,
+    ) -> None:
+        """Register a layout descriptor for a model/world pair.
+
+        Args:
+            model_name: The model name.
+            world_size: The world size.
+            layout_desc: The memory layout descriptor.
+            instance_id: Optional worker instance identifier owning the layout.
+        """
+        with self._lock:
+            owners = self._registry.setdefault((model_name, world_size), {})
+            owners[instance_id] = layout_desc
+
+    def unregister(
+        self,
+        model_name: str,
+        world_size: int,
+        *,
+        instance_id: int | None = None,
+    ) -> None:
+        """Remove an owned layout descriptor for a model/world pair.
+
+        Args:
+            model_name: The model name.
+            world_size: The world size.
+            instance_id: Optional worker instance identifier used during
+                ``register``.
+        """
+        with self._lock:
+            key = (model_name, world_size)
+            owners = self._registry.get(key)
+            if owners is None:
+                return
+
+            owners.pop(instance_id, None)
+            if not owners:
+                self._registry.pop(key, None)
+
+    def find(self, model_name: str, world_size: int) -> MemoryLayoutDesc | None:
+        """Look up a layout descriptor by model/world pair.
+
+        Args:
+            model_name: The model name.
+            world_size: The world size.
+
+        Returns:
+            The layout descriptor if found, otherwise None.
+
+        Note:
+            Multiple owners for the same model/world pair are expected to have
+            compatible layout descriptors. When several owners exist, this
+            method returns the first live descriptor registered for the key.
+        """
+        with self._lock:
+            owners = self._registry.get((model_name, world_size))
+            if not owners:
+                return None
+
+            return next(iter(owners.values()))

--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -411,6 +411,12 @@ class BlendModule:
 
     def close(self) -> None:
         """Release resources owned by this module."""
+        for instance_id, (model_name, world_size) in self._cb_gpu_context_meta.items():
+            self._ctx.layout_desc_registry.unregister(
+                model_name,
+                world_size,
+                instance_id=instance_id,
+            )
         self._cb_gpu_contexts.clear()
         self._cb_gpu_context_meta.clear()
 
@@ -437,7 +443,12 @@ class BlendModule:
             shapes=[gpu_context.get_kv_buffer_shape(self._ctx.chunk_size)],
             dtypes=[gpu_context.dtype],
         )
-        self._ctx.layout_desc_registry.register(model_name, world_size, layout_desc)
+        self._ctx.layout_desc_registry.register(
+            model_name,
+            world_size,
+            layout_desc,
+            instance_id=instance_id,
+        )
 
         logger.info(
             "Registered CB KV cache for instance_id %d with %d layers",
@@ -453,6 +464,12 @@ class BlendModule:
                 to unregister.
         """
         if instance_id in self._cb_gpu_contexts:
+            model_name, world_size = self._cb_gpu_context_meta[instance_id]
+            self._ctx.layout_desc_registry.unregister(
+                model_name,
+                world_size,
+                instance_id=instance_id,
+            )
             del self._cb_gpu_contexts[instance_id]
             del self._cb_gpu_context_meta[instance_id]
             logger.info("Unregistered CB KV cache for instance_id %d", instance_id)

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -222,6 +222,12 @@ class GPUTransferModule:
         self._device_host_func_dispatcher.stop()
 
         had_contexts = len(self._gpu_contexts) > 0
+        for instance_id, entry in self._gpu_contexts.items():
+            self._ctx.layout_desc_registry.unregister(
+                entry.model_name,
+                entry.world_size,
+                instance_id=instance_id,
+            )
         self._gpu_contexts.clear()
         if had_contexts:
             torch_dev.empty_cache()
@@ -269,7 +275,12 @@ class GPUTransferModule:
         )
 
         layout_desc = get_layout_desc(gpu_context, self._ctx.chunk_size)
-        self._ctx.layout_desc_registry.register(model_name, world_size, layout_desc)
+        self._ctx.layout_desc_registry.register(
+            model_name,
+            world_size,
+            layout_desc,
+            instance_id=instance_id,
+        )
 
         logger.info(
             "Registered KV cache for GPU ID %d with %d layers",
@@ -290,7 +301,11 @@ class GPUTransferModule:
             )
             return
 
-        self._ctx.layout_desc_registry.unregister(entry.model_name, entry.world_size)
+        self._ctx.layout_desc_registry.unregister(
+            entry.model_name,
+            entry.world_size,
+            instance_id=instance_id,
+        )
         logger.info("Unregistered KV cache for GPU ID %d", instance_id)
         torch_dev.empty_cache()
 

--- a/lmcache/v1/multiprocess/modules/non_gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/non_gpu_transfer.py
@@ -135,6 +135,12 @@ class NonGPUTransferModule:
 
     def close(self) -> None:
         """Release resources owned by this module."""
+        for instance_id, entry in self._non_gpu_contexts.items():
+            self._ctx.layout_desc_registry.unregister(
+                entry.model_name,
+                entry.world_size,
+                instance_id=instance_id,
+            )
         self._non_gpu_contexts.clear()
 
     def register_kv_cache_non_gpu_context(
@@ -189,7 +195,10 @@ class NonGPUTransferModule:
         )
 
         self._ctx.layout_desc_registry.register(
-            payload.model_name, payload.world_size, layout_desc
+            payload.model_name,
+            payload.world_size,
+            layout_desc,
+            instance_id=payload.instance_id,
         )
 
     def unregister_kv_cache(self, instance_id: int) -> None:
@@ -206,7 +215,11 @@ class NonGPUTransferModule:
             )
             return
 
-        self._ctx.layout_desc_registry.unregister(entry.model_name, entry.world_size)
+        self._ctx.layout_desc_registry.unregister(
+            entry.model_name,
+            entry.world_size,
+            instance_id=instance_id,
+        )
         logger.info("Unregistered non-CUDA context for instance ID %d", instance_id)
 
     @_lmcache_nvtx_annotate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -767,12 +767,14 @@ def memory_allocator():
 
 
 @pytest.fixture(autouse=True)  # function-scoped by default
-def use_shared_allocator(request, monkeypatch, memory_allocator):
+def use_shared_allocator(request, monkeypatch):
     """Default: patch. Opt out with @pytest.mark.no_shared_allocator."""
     if request.node.get_closest_marker("no_shared_allocator"):
         # do NOT patch for this test
         yield
         return
+
+    memory_allocator = request.getfixturevalue("memory_allocator")
 
     def _create_shared_allocator(config, metadata, numa_mapping):
         return memory_allocator

--- a/tests/v1/multiprocess/test_blend_server_v2.py
+++ b/tests/v1/multiprocess/test_blend_server_v2.py
@@ -67,6 +67,7 @@ SERVER_PORT = (
 SERVER_URL = f"tcp://{SERVER_HOST}:{SERVER_PORT}"
 CHUNK_SIZE = 256
 CPU_BUFFER_SIZE = 5.0
+IN_PROCESS_CPU_BUFFER_SIZE = 64 * 1024**2
 DEFAULT_TIMEOUT = 10.0
 
 
@@ -2026,7 +2027,7 @@ def in_process_blend_engine() -> Generator[tuple, None, None]:
     config = StorageManagerConfig(
         l1_manager_config=L1ManagerConfig(
             memory_config=L1MemoryManagerConfig(
-                size_in_bytes=int(CPU_BUFFER_SIZE * 1024**3),
+                size_in_bytes=IN_PROCESS_CPU_BUFFER_SIZE,
                 use_lazy=True,
             ),
         ),
@@ -2066,6 +2067,7 @@ def local_kv_cache_unwrap(monkeypatch, cb_client_context: CBClientContext):
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="report_status CB tests require CUDA"
 )
+@pytest.mark.no_shared_allocator
 def test_report_status_no_cb_registrations(
     in_process_blend_engine: tuple,
 ):
@@ -2082,6 +2084,7 @@ def test_report_status_no_cb_registrations(
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="report_status CB tests require CUDA"
 )
+@pytest.mark.no_shared_allocator
 def test_report_status_surfaces_cb_registration(
     in_process_blend_engine: tuple,
     cb_client_context: CBClientContext,
@@ -2122,6 +2125,7 @@ def test_report_status_surfaces_cb_registration(
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="report_status CB tests require CUDA"
 )
+@pytest.mark.no_shared_allocator
 def test_report_status_unregister_clears_cb_fields(
     in_process_blend_engine: tuple,
     cb_client_context: CBClientContext,
@@ -2137,8 +2141,11 @@ def test_report_status_unregister_clears_cb_fields(
         "testmodel",
         1,
     )
+    assert engine.context.layout_desc_registry.find("testmodel", 1) is not None
+
     blend_module.cb_unregister_kv_cache(instance_id)
 
     status = engine.report_status()
     assert status["registered_cb_gpu_ids"] == []
     assert status["cb_gpu_context_meta"] == {}
+    assert engine.context.layout_desc_registry.find("testmodel", 1) is None

--- a/tests/v1/multiprocess/test_layout_desc_registry.py
+++ b/tests/v1/multiprocess/test_layout_desc_registry.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.multiprocess.layout_desc_registry import LayoutDescRegistry
+
+pytestmark = pytest.mark.no_shared_allocator
+
+
+def _layout(width: int) -> MemoryLayoutDesc:
+    """Create a distinct memory layout descriptor for registry tests."""
+    return MemoryLayoutDesc(shapes=[torch.Size([width])], dtypes=[torch.float32])
+
+
+def test_unregister_removes_only_matching_owner() -> None:
+    """Unregistering one worker must preserve sibling layouts for the same key."""
+    registry = LayoutDescRegistry()
+    first_layout = _layout(1)
+    second_layout = _layout(2)
+
+    registry.register("model", 1, first_layout, instance_id=101)
+    registry.register("model", 1, second_layout, instance_id=102)
+
+    registry.unregister("model", 1, instance_id=101)
+
+    assert registry.find("model", 1) is second_layout
+
+    registry.unregister("model", 1, instance_id=102)
+
+    assert registry.find("model", 1) is None
+
+
+def test_find_returns_first_available_layout() -> None:
+    """Lookup should return an available descriptor while owners remain live."""
+    registry = LayoutDescRegistry()
+    first_layout = _layout(1)
+    second_layout = _layout(2)
+
+    registry.register("model", 1, first_layout, instance_id=201)
+    registry.register("model", 1, second_layout, instance_id=301)
+
+    assert registry.find("model", 1) is first_layout
+
+    registry.unregister("model", 1, instance_id=201)
+
+    assert registry.find("model", 1) is second_layout

--- a/tests/v1/multiprocess/test_non_cuda_data_transfer.py
+++ b/tests/v1/multiprocess/test_non_cuda_data_transfer.py
@@ -386,6 +386,49 @@ def test_server_register_and_find_non_cuda_context_layout(
     assert layout.shapes[0] == torch.Size([2, 2, 16, 16])
 
 
+@pytest.mark.no_shared_allocator
+def test_unregister_non_cuda_context_preserves_sibling_layout(
+    stub_native_storage_ops: Any,
+) -> None:
+    """Unregistering one same-model worker does not remove a sibling layout."""
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import RegisterNonGpuContextPayload
+    from lmcache.v1.multiprocess.engine_context import MPCacheEngineContext
+    from lmcache.v1.multiprocess.modules.non_gpu_transfer import NonGPUTransferModule
+
+    with (
+        patch("lmcache.v1.multiprocess.engine_context.StorageManager"),
+        patch("lmcache.v1.multiprocess.engine_context.TokenHasher"),
+        patch("lmcache.v1.multiprocess.engine_context.SessionManager"),
+        patch("lmcache.v1.multiprocess.engine_context.get_event_bus"),
+    ):
+        ctx = MPCacheEngineContext(storage_manager_config=MagicMock(), chunk_size=16)
+    module = NonGPUTransferModule(ctx)
+    for instance_id in (1, 2):
+        module.register_kv_cache_non_gpu_context(
+            RegisterNonGpuContextPayload(
+                instance_id=instance_id,
+                model_name="m",
+                world_size=1,
+                block_size=4,
+                num_layers=2,
+                hidden_dim_size=16,
+                dtype_str="float32",
+                use_mla=False,
+            )
+        )
+
+    module.unregister_kv_cache(1)
+
+    layout = ctx.layout_desc_registry.find("m", 1)
+    assert layout is not None
+    assert module.report_status()["registered_non_cuda_instance_ids"] == [2]
+
+    module.unregister_kv_cache(2)
+
+    assert ctx.layout_desc_registry.find("m", 1) is None
+
+
 def test_server_store_and_retrieve_cpu_chunks(stub_native_storage_ops: Any) -> None:
     """Validate mocked server-side CPU chunk store and retrieve behavior."""
     # First Party


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #3448. Related to #3451.

When multiple vLLM worker instances share the same `(model_name, world_size)` on
one LMCache MP server, unregistering any single instance could remove the layout
descriptor still needed by remaining live instances. A later lookup could then fail
with:

```text
LMCache ERROR: No GPU context found for model ... with world size 1 during lookup!
```

## Root cause

`LayoutDescRegistry` stored a flat mapping:

```text
(model_name, world_size) -> MemoryLayoutDesc
```

That meant `unregister(model_name, world_size)` removed the descriptor for the
entire model/world pair, regardless of which instance owned it or whether other
instances still depended on it.

The same ownership problem applied to GPU, non-GPU, and blend registrations.

## How this PR fixes it

This PR moves ownership tracking into `LayoutDescRegistry` itself.

The registry now stores descriptors as:

```text
(model_name, world_size) -> { (source, instance_id) -> MemoryLayoutDesc }
```

Each producer registers with an explicit owner:

- `source="gpu"` for `GPUTransferModule`
- `source="non_gpu"` for `NonGPUTransferModule`
- `source="blend"` for `BlendModule`

Unregistering one owner now removes only that owner’s descriptor. The descriptor
remains discoverable through `find(model_name, world_size)` as long as any other
owner still exists for that model/world pair.

When multiple sources exist for the same key, `find()` prefers normal transfer
layouts over blend layouts:

```text
gpu / non_gpu > blend > unknown
```

This preserves generic lookup behavior while still allowing blend to maintain its
own registration.

## Why this differs from #3451

#3451 appears to address the unregister path in the GPU transfer module. This PR
fixes the issue at the registry level instead, so the same ownership behavior is
shared by GPU, non-GPU, and blend registrations.

It also avoids blend descriptors shadowing normal transfer descriptors in generic
lookup.

## Additional test fixture cleanup

This PR also adjusts the `no_shared_allocator` pytest fixture path so the marker
is checked before constructing the session-scoped 5GB shared allocator.

Previously, tests marked with `@pytest.mark.no_shared_allocator` could still cause
the shared allocator fixture to be constructed because `memory_allocator` was an
eager fixture dependency of the autouse fixture.

This keeps the default shared-allocator behavior unchanged for unmarked tests, but
makes the opt-out marker work as documented for allocator-free unit tests.

## Does this PR introduce any user-facing change?

No. This is an internal MP bugfix.

`find(model_name, world_size)` is unchanged. `register()` and `unregister()` accept
new keyword-only ownership parameters with backward-compatible defaults.

## How was this tested?

```bash
python -m pytest -q tests/v1/multiprocess/test_layout_desc_registry.py
python -m pytest -q tests/v1/multiprocess/test_non_cuda_data_transfer.py::test_unregister_non_cuda_context_preserves_sibling_layout
python -m pytest -q tests/v1/multiprocess/test_blend_server_v2.py::test_report_status_unregister_clears_cb_fields
```


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [X] this PR contains unit tests
