### PR TITLE
docs: daily drift check — multi-process mode (2026-05-29)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -63,6 +63,11 @@ Source: ``lmcache/v1/multiprocess/config.py``
      - JSON string of extra key-value config forwarded to runtime
        plugins via ``LMCACHE_RUNTIME_PLUGIN_EXTRA_CONFIG``. Example:
        ``'{"plugin.frontend.heartbeat_url": "http://localhost:5000/heartbeat"}'``.
+   * - ``--script-allowed-imports``
+     - ``[]``
+     - Space-separated list of Python module names that scripts posted
+       to the HTTP ``/run_script`` endpoint are allowed to import.
+       Example: ``--script-allowed-imports numpy pandas``.
 
 Lookup Hash Logging
 -------------------

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -16,10 +16,11 @@ A subset of routes defined under
 ``lmcache/v1/internal_api_server/common/`` is also exposed on this HTTP
 server. The module
 ``lmcache/v1/multiprocess/http_apis/common_api.py`` aggregates those
-routers (skipping modules listed in ``_MP_INCOMPATIBLE_MODULES``, such as
-``run_script_api``) and forwards them to the auto-discovery pipeline.
-Adding a new compatible module under ``internal_api_server/common``
-therefore requires no wiring changes on the MP side.
+routers (skipping any module listed in ``_MP_INCOMPATIBLE_MODULES``,
+which is currently empty) and forwards them to the auto-discovery
+pipeline. Adding a new compatible module under
+``internal_api_server/common`` therefore requires no wiring changes on
+the MP side.
 
 .. contents::
    :local:
@@ -131,6 +132,10 @@ compatibility with the vLLM-embedded API server.
    * - GET
      - ``/periodic-threads-health``
      - Quick health check for critical/high-level periodic threads.
+   * - POST
+     - ``/run_script``
+     - Execute an uploaded Python script in a restricted sandbox. Only
+       modules listed in ``--script-allowed-imports`` can be imported.
 
 ``GET /``
 ~~~~~~~~~
@@ -706,9 +711,9 @@ registration list to edit.
 If the route is generic enough to be shared with the vLLM-embedded API
 server, add it under ``lmcache/v1/internal_api_server/common/`` instead.
 It will be picked up on the MP side via ``common_api.py`` unless its
-module name is listed in ``_MP_INCOMPATIBLE_MODULES`` there (used for
-modules that require vLLM-specific ``app.state`` attributes, e.g.
-``run_script_api``).
+module name is listed in ``_MP_INCOMPATIBLE_MODULES`` there (reserved
+for modules that require vLLM-specific ``app.state`` attributes; the
+list is currently empty).
 
 When adding a new endpoint, please also add a matching section to this
 page documenting the endpoint's purpose, request/response schema, and


### PR DESCRIPTION
## Summary

Auto-generated daily drift check against the multi-process mode user-facing docs. Two stale claims found, both introduced by [#3398](https://github.com/LMCache/LMCache/pull/3398) (`[MP]: run_script_api support mp mode http endpoint`, merged 2026-05-28):

**`docs/source/mp/` (user-facing):**

- `http_api.rst` — intro paragraph and the "Adding New Endpoints" section both stated that `_MP_INCOMPATIBLE_MODULES` skips `run_script_api`. The set is now empty in code, and `/run_script` is available on the MP HTTP server.
- `http_api.rst` — endpoint table was missing the new `POST /run_script` route.
- `configuration.rst` — new CLI argument `--script-allowed-imports` (on `MPServerConfig`) was not documented in the MP Server arguments table.

**`docs/design/`:** no drift found this round.

## Evidence

| Stale doc | Current code |
|-----------|--------------|
| `docs/source/mp/http_api.rst:19-20` — "skipping modules listed in `_MP_INCOMPATIBLE_MODULES`, such as `run_script_api`" | [`lmcache/v1/multiprocess/http_apis/common_api.py:36`](https://github.com/LMCache/LMCache/blob/a7528a8d4e8b54e8dd642eba36f4f2fc4df7719f/lmcache/v1/multiprocess/http_apis/common_api.py#L36) — `_MP_INCOMPATIBLE_MODULES: frozenset[str] = frozenset()` |
| `docs/source/mp/http_api.rst:709-711` — "unless its module name is listed in `_MP_INCOMPATIBLE_MODULES` there … e.g. `run_script_api`" | same line as above |
| `docs/source/mp/http_api.rst` endpoint table — missing `POST /run_script` | [`lmcache/v1/internal_api_server/common/run_script_api.py:31`](https://github.com/LMCache/LMCache/blob/a7528a8d4e8b54e8dd642eba36f4f2fc4df7719f/lmcache/v1/internal_api_server/common/run_script_api.py#L31) defines `@router.post("/run_script")`, now reachable on MP |
| `docs/source/mp/configuration.rst` MP Server table — no row for `--script-allowed-imports` | [`lmcache/v1/multiprocess/config.py:54`](https://github.com/LMCache/LMCache/blob/a7528a8d4e8b54e8dd642eba36f4f2fc4df7719f/lmcache/v1/multiprocess/config.py#L54) — `script_allowed_imports: list[str] = field(default_factory=list)`; CLI flag registered in [`add_mp_server_args`](https://github.com/LMCache/LMCache/blob/a7528a8d4e8b54e8dd642eba36f4f2fc4df7719f/lmcache/v1/multiprocess/config.py#L185) (lines 185–192) |

## Proposed fix

Already applied in this PR's diff. Doc-only — no code changes:

- `docs/source/mp/http_api.rst`: rewrite both `_MP_INCOMPATIBLE_MODULES` references to note the set is currently empty; add a `POST /run_script` row to the endpoint table with a one-line description.
- `docs/source/mp/configuration.rst`: add an `--script-allowed-imports` row to the MP Server arguments table (default `[]`, with usage example).

## Other PRs considered (no drift)

Inspected for drift; no stale doc claims found:

- #3437 — [MP][Bugfix] Restore MPCacheEngine HTTP-layer passthroughs (the restored `storage_manager`/`clear()`/`gpu_contexts` passthroughs are already covered by the `/quota/*`, `/clear-cache`, and `/kvcache/check` docs).
- #3402 — [LMCache MP Connector] Report cache hit stats in KVTransferParams (`cached_token_stats` is a new field; no existing doc claims contradict it. Not flagged here to keep the PR scoped to clear drift — could be a candidate for a future "document the connector's KVTransferParams surface" PR).
- #3365 — [Integration] LMCache MP mode warn log while cannot reach lmcache server (no doc claim was contradicted).

## Notes

- Auto-generated by the daily LMCache docs drift-check routine. **Human review required before merge.**
- Marked as **draft**; please do not merge without an editorial pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCfLrbeByScHBo9rj5G4ij)_