### PR TITLE
cleanup: move serializer registry + encoder/decoder helpers to end of custom_types.py

### DIFF
--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -346,6 +346,34 @@ class CustomizedSerdeConfig:
     code: int
 
 
+@dataclass
+class BlockAllocationRecord:
+    """A single per-request GPU block allocation delta from vLLM."""
+
+    req_id: str
+    new_block_ids: list[int]
+    new_token_ids: list[int]
+
+
+@dataclass
+class CBMatchResult:
+    """Result of a sub-sequence match from BlendTokenRangeMatcher.
+
+    Attributes:
+        old_st: Start position in the originally registered (stored) sequence.
+        old_ed: End position in the originally registered (stored) sequence.
+        cur_st: Start position in the query sequence where the match was found.
+        cur_ed: End position in the query sequence where the match was found.
+        hash: Token hash bytes (from registration) used as the storage key.
+    """
+
+    old_st: int
+    old_ed: int
+    cur_st: int
+    cur_ed: int
+    hash: bytes
+
+
 _CUSTOMERIZED_SERIALIZERS = {
     CudaIPCWrapper: CustomizedSerdeConfig(
         serializer=CudaIPCWrapper.Serialize,
@@ -375,31 +403,3 @@ def get_customized_decoder(type: Any) -> msgspec.msgpack.Decoder:
         raise TypeError(f"Unsupported ext code for deserialization: {code}")
 
     return msgspec.msgpack.Decoder(ext_hook=ext_hook, type=type)
-
-
-@dataclass
-class BlockAllocationRecord:
-    """A single per-request GPU block allocation delta from vLLM."""
-
-    req_id: str
-    new_block_ids: list[int]
-    new_token_ids: list[int]
-
-
-@dataclass
-class CBMatchResult:
-    """Result of a sub-sequence match from BlendTokenRangeMatcher.
-
-    Attributes:
-        old_st: Start position in the originally registered (stored) sequence.
-        old_ed: End position in the originally registered (stored) sequence.
-        cur_st: Start position in the query sequence where the match was found.
-        cur_ed: End position in the query sequence where the match was found.
-        hash: Token hash bytes (from registration) used as the storage key.
-    """
-
-    old_st: int
-    old_ed: int
-    cur_st: int
-    cur_ed: int
-    hash: bytes


### PR DESCRIPTION
Refs #3372
Closes #3459

## Summary

Move the serializer registry and public encoder/decoder helpers to the end of `lmcache/v1/multiprocess/custom_types.py`, after `CBMatchResult`, to keep the dataclass/type definitions
 grouped together.

This is a pure code-movement change only:
- `_CUSTOMERIZED_SERIALIZERS`
- `get_customized_encoder`
- `get_customized_decoder`

No logic, signatures, docstrings, or dict contents were changed.

## Verification

Ran locally in a Python 3.12 environment:

- `pre-commit run --all-files`
- `python -c "import lmcache.v1.multiprocess.custom_types"`
- callable check for `get_customized_encoder` / `get_customized_decoder`
- AST order check confirming the registry and helpers now appear after `CBMatchResult` in the required order
