### PR TITLE
refactor: move encoder/decoder helpers to end of custom_types.py

### DIFF
--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -346,6 +346,34 @@ class CustomizedSerdeConfig:
     code: int
 
 
+@dataclass
+class BlockAllocationRecord:
+    """A single per-request GPU block allocation delta from vLLM."""
+
+    req_id: str
+    new_block_ids: list[int]
+    new_token_ids: list[int]
+
+
+@dataclass
+class CBMatchResult:
+    """Result of a sub-sequence match from BlendTokenRangeMatcher.
+
+    Attributes:
+        old_st: Start position in the originally registered (stored) sequence.
+        old_ed: End position in the originally registered (stored) sequence.
+        cur_st: Start position in the query sequence where the match was found.
+        cur_ed: End position in the query sequence where the match was found.
+        hash: Token hash bytes (from registration) used as the storage key.
+    """
+
+    old_st: int
+    old_ed: int
+    cur_st: int
+    cur_ed: int
+    hash: bytes
+
+
 _CUSTOMERIZED_SERIALIZERS = {
     CudaIPCWrapper: CustomizedSerdeConfig(
         serializer=CudaIPCWrapper.Serialize,
@@ -375,31 +403,3 @@ def get_customized_decoder(type: Any) -> msgspec.msgpack.Decoder:
         raise TypeError(f"Unsupported ext code for deserialization: {code}")
 
     return msgspec.msgpack.Decoder(ext_hook=ext_hook, type=type)
-
-
-@dataclass
-class BlockAllocationRecord:
-    """A single per-request GPU block allocation delta from vLLM."""
-
-    req_id: str
-    new_block_ids: list[int]
-    new_token_ids: list[int]
-
-
-@dataclass
-class CBMatchResult:
-    """Result of a sub-sequence match from BlendTokenRangeMatcher.
-
-    Attributes:
-        old_st: Start position in the originally registered (stored) sequence.
-        old_ed: End position in the originally registered (stored) sequence.
-        cur_st: Start position in the query sequence where the match was found.
-        cur_ed: End position in the query sequence where the match was found.
-        hash: Token hash bytes (from registration) used as the storage key.
-    """
-
-    old_st: int
-    old_ed: int
-    cur_st: int
-    cur_ed: int
-    hash: bytes


### PR DESCRIPTION
## Summary

Closes #3459

Moves `_CUSTOMERIZED_SERIALIZERS`, `get_customized_encoder`, and `get_customized_decoder` from their current position (mid-file, interrupting the type/dataclass grouping) to the end of `lmcache/v1/multiprocess/custom_types.py`, after `CBMatchResult`.

**Changes:**
- Pure code movement — no logic, signatures, or docstrings modified
- Registry dict placed immediately before the two functions that depend on it
- Two blank lines maintained between all top-level definitions (PEP 8)

## Test plan
- [x] `python -c "import ast; ast.parse(open('lmcache/v1/multiprocess/custom_types.py').read())"` — parses clean
- [x] AST walk confirms `CBMatchResult` (line 359) appears before `_CUSTOMERIZED_SERIALIZERS` (line 377)
- [x] `codespell --toml pyproject.toml` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)