### PR TITLE
fix: Prevent Stale Prefetches and Registry Memory Leaks by Purging Unregistered KV Layouts

### DIFF
--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -453,8 +453,10 @@ class BlendModule:
                 to unregister.
         """
         if instance_id in self._cb_gpu_contexts:
+            model_name, world_size = self._cb_gpu_context_meta[instance_id]
             del self._cb_gpu_contexts[instance_id]
             del self._cb_gpu_context_meta[instance_id]
+            self._ctx.layout_desc_registry.unregister(model_name, world_size)
             logger.info("Unregistered CB KV cache for instance_id %d", instance_id)
         else:
             logger.warning(


### PR DESCRIPTION


**What this PR does / why we need it**:

Trigger Scenario:
  The CacheBlend engine is enabled ( MPServerConfig.engine_type == "blend" ), and client instances register their KV cache buffers ( CB_REGISTER_KV_CACHE ) and subsequently unregister them ( CB_UNREGISTER_KV_CACHE ).
 
  Even after all active serving instances are unregistered, their layout descriptors are permanently leaked inside the shared
  layout_desc_registry .   
Consequently,  LookupModule.lookup  can still incorrectly "find" these layout descriptors and perform redundant,  invalid prefetch operations on non-existent GPU contexts, causing performance overhead and a minor memory leak.

Root Cause:
BlendModule.cb_register_kv_cache  registers the memory layout descriptor using  self._ctx.layout_desc_registry.register(model_name,  world_size, layout_desc) .
 However,  cb_unregister_kv_cache  forgot to call  unregister , leaving the layout reference count permanently  inflated.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
