### PR TITLE
cleanup: move serializer registry + encoder/decoder helpers to end of custom_types.py

### DIFF
--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -346,6 +346,34 @@ class CustomizedSerdeConfig:
     code: int
 
 
+@dataclass
+class BlockAllocationRecord:
+    """A single per-request GPU block allocation delta from vLLM."""
+
+    req_id: str
+    new_block_ids: list[int]
+    new_token_ids: list[int]
+
+
+@dataclass
+class CBMatchResult:
+    """Result of a sub-sequence match from BlendTokenRangeMatcher.
+
+    Attributes:
+        old_st: Start position in the originally registered (stored) sequence.
+        old_ed: End position in the originally registered (stored) sequence.
+        cur_st: Start position in the query sequence where the match was found.
+        cur_ed: End position in the query sequence where the match was found.
+        hash: Token hash bytes (from registration) used as the storage key.
+    """
+
+    old_st: int
+    old_ed: int
+    cur_st: int
+    cur_ed: int
+    hash: bytes
+
+
 _CUSTOMERIZED_SERIALIZERS = {
     CudaIPCWrapper: CustomizedSerdeConfig(
         serializer=CudaIPCWrapper.Serialize,
@@ -375,31 +403,3 @@ def get_customized_decoder(type: Any) -> msgspec.msgpack.Decoder:
         raise TypeError(f"Unsupported ext code for deserialization: {code}")
 
     return msgspec.msgpack.Decoder(ext_hook=ext_hook, type=type)
-
-
-@dataclass
-class BlockAllocationRecord:
-    """A single per-request GPU block allocation delta from vLLM."""
-
-    req_id: str
-    new_block_ids: list[int]
-    new_token_ids: list[int]
-
-
-@dataclass
-class CBMatchResult:
-    """Result of a sub-sequence match from BlendTokenRangeMatcher.
-
-    Attributes:
-        old_st: Start position in the originally registered (stored) sequence.
-        old_ed: End position in the originally registered (stored) sequence.
-        cur_st: Start position in the query sequence where the match was found.
-        cur_ed: End position in the query sequence where the match was found.
-        hash: Token hash bytes (from registration) used as the storage key.
-    """
-
-    old_st: int
-    old_ed: int
-    cur_st: int
-    cur_ed: int
-    hash: bytes


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `_CUSTOMERIZED_SERIALIZERS`, `get_customized_encoder`, and `get_customized_decoder` to the end of `lmcache/v1/multiprocess/custom_types.py`, after `CBMatchResult`, so the dataclass/type definitions stay grouped together and the public serializer helpers are easier to find.

This is a pure code movement change; the registry contents, function bodies, signatures, and docstrings are unchanged.

Closes #3459
Refs #3372

**Special notes for your reviewers**:

Validation run locally:

- `python - <<'PY' ...` AST order check from the issue
- `python -c "import lmcache.v1.multiprocess.custom_types"`
- callable import check for `get_customized_encoder` / `get_customized_decoder`
- `uvx ruff format --check lmcache/v1/multiprocess/custom_types.py`
- `uvx ruff check lmcache/v1/multiprocess/custom_types.py`
- `pre-commit run --files lmcache/v1/multiprocess/custom_types.py`

Note: the import checks emitted a local torch/NumPy compatibility warning in my environment before succeeding; the command exit code was 0.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
