### PR TITLE
fix: resolve launch_host_func race that silently drops cache fingerprints

### DIFF
--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -755,9 +755,14 @@ class BlendModule:
                     lmcache_memcpy_async_d2h(tmp_buffer, memory_obj)
 
             event.record()
-        # Call finish_write after the copy is done
-        gpu_context.cupy_stream.launch_host_func(
-            self._ctx.storage_manager.finish_write,
+
+        # Call finish_write synchronously after GPU copy is done.
+        # Must be synchronous so the write lock is released before the
+        # store response is sent back to the client; otherwise an immediate
+        # lookup can see KEY_NOT_READABLE and spuriously evict the
+        # freshly-stored fingerprint from the matcher.
+        event.synchronize()
+        self._ctx.storage_manager.finish_write(
             list(reserved_dict.keys()),
         )
 


### PR DESCRIPTION


**What this PR does / why we need it**:

fix CI: https://buildkite.com/lmcache/k3-unit-tests/builds/1855/list?sid=019e76c8-d2a8-4cdb-a9ff-a83cd9eaa268&tab=output


 Trigger scenario
  On CacheBlend, the client completes CB_STORE_PRE_COMPUTED and calls lookup almost immediately. The server’s _cb_store_gpu_copy used to return   after recording a CUDA event while finish_write still ran later on a stream host callback, so the client could prefetch before write locks  were released.

  Failure symptoms
  Store looks successful, but lookup returns no matches. Fingerprints had matched, yet prefetch sees write-locked keys, reports zero hits, and  lookup evicts those hashes from the matcher—so later lookups keep failing even though the data may still be in L1. CI hit this as  test_cb_retrieve_v2_sub_sequence: expected one CBMatchResult, got none.

  Expected behavior
  Store success should mean the chunk is written and readable, not only that the GPU copy finished. A lookup right after store should return  the correct matches and must not treat in-flight writes as stale fingerprints.

  Root cause
  finish_write ran asynchronously after the store response, while CUDAMessagingFuture only waits on the GPU event. The client can lookup on  still write-locked keys; lookup then misclassifies that as stale data and permanently drops CB index entries.

  Fix
  In _cb_store_gpu_copy, call event.synchronize() then finish_write synchronously instead of launch_host_func, so write locks are released  before the client sees store success.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
