### PR TITLE
docs: daily drift check — multi-process mode (2026-05-30)

### DIFF
--- a/docs/design/observability/request-event-span.md
+++ b/docs/design/observability/request-event-span.md
@@ -84,7 +84,7 @@ The same three attributes appear on the `"cb.request"` root span and are set
 when `CB_LOOKUP_END` is processed by `BlendTracingSubscriber`.
 
 `CB_LOOKUP_END` carries `hit_tokens` and `requested_tokens` in its metadata,
-computed at the emit site in `blend_server_v2.py`:
+computed at the emit site in `lmcache/v1/multiprocess/modules/blend.py`:
 
 | Field | Value |
 |-------|-------|
@@ -270,7 +270,7 @@ root "request"  [═════════════════════
 | `lmcache/v1/mp_observability/subscribers/tracing/mp_server.py` | Root span logic: `_pending_store_count`, `_pending_retrieve_count`, `_deferred_session_end_ts`; handlers `_on_request_start`, `_on_store_submitted`, `_on_retrieve_submitted`, `_on_session_end`; helpers `_get_or_create_request_span`, `_close_request_span` |
 | `lmcache/v1/mp_observability/subscribers/tracing/span_registry.py` | `SpanRegistry`: shared dict of open spans keyed by `(session_id, span_name)` for cross-subscriber parent lookup |
 | `tests/v1/mp_observability/subscribers/tracing/test_mp_server.py` | Tests for all scenarios including retrieve deferral |
-| `lmcache/v1/multiprocess/blend_server_v2.py` | Prefix probe in `cb_lookup_pre_computed`; lazy registration; `has_chunk` on `BlendTokenRangeMatcher`; `prefix_hits` in `CB_LOOKUP_END` metadata |
+| `lmcache/v1/multiprocess/modules/blend.py` | Prefix probe in `cb_lookup_pre_computed`; lazy registration; `has_chunk` on `BlendTokenRangeMatcher`; `prefix_hits` in `CB_LOOKUP_END` metadata |
 | `lmcache/v1/mp_observability/subscribers/tracing/cb_server.py` | Stamp `prefix_hits` on `"cb.request"` root span from `CB_LOOKUP_END` |
 | `tests/v1/multiprocess/test_blend_server_v2.py` | `has_chunk` unit tests |
 | `tests/v1/mp_observability/subscribers/tracing/test_cb_server.py` | `prefix_hits` attribute tests |

--- a/docs/source/mp/architecture.rst
+++ b/docs/source/mp/architecture.rst
@@ -42,18 +42,29 @@ High-Level Architecture
 Server Variants
 ---------------
 
-All three server entry points share the same ``MPCacheEngine`` and
-``StorageManager`` core.
+All server entry points share the same ``MPCacheEngine`` and
+``StorageManager`` core. ``MPCacheEngine`` is now a thin compositor:
+it holds an ``MPCacheEngineContext`` and a list of ``EngineModule``
+instances assembled by ``build_engine_modules()`` (in ``server.py``)
+based on ``--engine-type`` and ``--transfer-mode``.
 
-**``server.py``** -- The default ZMQ-only server.  Creates an ``MPCacheEngine``
-and a ``MessageQueueServer``, registers handlers for all core
-``RequestType`` values, and blocks in a keep-alive loop.
+**``server.py``** -- The default ZMQ-only server.  Creates an
+``MPCacheEngine``, assembles the engine modules
+(``LookupModule`` + ``ManagementModule`` + either
+``GPUTransferModule`` or ``NonGPUTransferModule`` depending on
+``--transfer-mode``, plus ``BlendModule`` when
+``--engine-type blend``), starts a ``MessageQueueServer``, registers
+handlers for every ``RequestType`` exposed by the loaded modules, and
+blocks in a keep-alive loop.
 
-**``blend_server_v2.py``** -- Extends ``MPCacheEngine`` with ``BlendEngineV2``,
-which adds CacheBlend operations (``CB_REGISTER_KV_CACHE``,
+**``modules/blend.py``** -- Defines ``BlendModule`` and ``BlendEngineV2``,
+which add CacheBlend operations (``CB_REGISTER_KV_CACHE``,
 ``CB_LOOKUP_PRE_COMPUTED``, ``CB_STORE_PRE_COMPUTED``,
-``CB_RETRIEVE_PRE_COMPUTED``, ``CB_STORE_FINAL``).  Enables non-prefix KV
-cache reuse across document paragraphs.
+``CB_RETRIEVE_PRE_COMPUTED``, ``CB_STORE_FINAL`` and their V2
+variants). Enables non-prefix KV cache reuse across document
+paragraphs. Selected by passing ``--engine-type blend`` to
+``lmcache server``; ``BlendModule`` requires ``--transfer-mode gpu``
+and will refuse to load otherwise.
 
 **``http_server.py``** -- Wraps ``run_cache_server()`` (from ``server.py``)
 inside a FastAPI application.  Endpoints are contributed by modules under
@@ -181,8 +192,11 @@ Each config module exposes a composable triple:
       # which internally calls add_l2_adapters_args(parser)
     add_observability_args(parser)    # from mp_observability/config.py
 
-Both ``blend_server_v2.py`` and ``http_server.py`` reuse this pattern, adding
-``add_http_frontend_args()`` for the HTTP variant.
+``http_server.py`` reuses this pattern, adding
+``add_http_frontend_args()`` for the HTTP variant. CacheBlend is no
+longer a separate entry point — it is opted into at runtime by passing
+``--engine-type blend`` to ``server.py`` (or ``lmcache server``), which
+appends ``BlendModule`` to the engine module list.
 
 Distributed Storage
 -------------------
@@ -403,11 +417,21 @@ Key Source Files
    * - File
      - Purpose
    * - ``lmcache/v1/multiprocess/server.py``
-     - MPCacheEngine + ZMQ server entry point
+     - MPCacheEngine compositor + ZMQ server entry point;
+       ``build_engine_modules()`` assembles modules per
+       ``--engine-type`` / ``--transfer-mode``.
    * - ``lmcache/v1/multiprocess/config.py``
      - MPServerConfig, HTTPFrontendConfig
-   * - ``lmcache/v1/multiprocess/blend_server_v2.py``
-     - BlendEngineV2 (extends MPCacheEngine)
+   * - ``lmcache/v1/multiprocess/engine_context.py``
+     - MPCacheEngineContext (shared state passed to every EngineModule)
+   * - ``lmcache/v1/multiprocess/engine_module.py``
+     - ``EngineModule`` base class (per-module handler registration)
+   * - ``lmcache/v1/multiprocess/modules/``
+     - Engine module implementations: ``lookup.py`` (``LookupModule``),
+       ``management.py`` (``ManagementModule``), ``gpu_transfer.py``
+       (``GPUTransferModule``), ``non_gpu_transfer.py``
+       (``NonGPUTransferModule``), and ``blend.py``
+       (``BlendModule`` / ``BlendEngineV2``).
    * - ``lmcache/v1/multiprocess/http_server.py``
      - FastAPI wrapper with health check and many other useful APIs
    * - ``lmcache/v1/multiprocess/http_api_registry.py``

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -52,6 +52,14 @@ Source: ``lmcache/v1/multiprocess/config.py``
        ``default`` uses MPCacheEngine; ``blend`` uses BlendEngineV2
        for cross-request KV reuse.
        Choices: ``default``, ``blend``.
+   * - ``--transfer-mode``
+     - ``gpu``
+     - KV transfer transport. ``gpu`` uses GPU-based CUDA IPC for the
+       STORE/RETRIEVE fast path (default, required when
+       ``--engine-type blend`` is used). ``non_gpu`` switches to the
+       PREPARE/COMMIT shared-memory path used by non-CUDA backends
+       (loads ``NonGPUTransferModule`` instead of ``GPUTransferModule``).
+       Choices: ``gpu``, ``non_gpu``.
    * - ``--runtime-plugin-locations``
      - ``[]``
      - Zero or more paths to runtime plugin scripts or directories to

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -32,7 +32,7 @@ Prerequisites
 Server Variants
 ---------------
 
-LMCache ships three server entry points:
+LMCache ships two server entry points:
 
 .. list-table::
    :header-rows: 1
@@ -46,10 +46,15 @@ LMCache ships three server entry points:
        :doc:`http_api`). Use ``--engine-type blend`` to enable BlendEngineV2
        for cross-request KV reuse.
    * - ``python3 -m lmcache.v1.multiprocess.server``
-     - (Legacy) ZMQ-only server using MPCacheEngine (no HTTP endpoints).
+     - (Legacy) ZMQ-only server with no HTTP endpoints; same
+       ``--engine-type`` / ``--transfer-mode`` flags as ``lmcache server``.
        Prefer ``lmcache server``.
-   * - ``python3 -m lmcache.v1.multiprocess.blend_server_v2``
-     - (Legacy) CacheBlend-enabled server. Prefer ``lmcache server --engine-type blend``.
+
+.. note::
+   The standalone ``blend_server_v2`` entry point has been retired;
+   CacheBlend is now selected at runtime via ``--engine-type blend`` on
+   the entries above (which loads ``BlendModule`` from
+   ``lmcache/v1/multiprocess/modules/blend.py``).
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Summary

Auto-generated daily drift check against the multi-process mode docs.
Two pieces of drift introduced by [#3391](https://github.com/LMCache/LMCache/pull/3391)
(the MPCacheEngine refactor, merged 2026-05-26) were missed by previous drift
scans and are still present on `dev` (currently at
[7eb57ad](https://github.com/LMCache/LMCache/commit/7eb57ad)).

**`docs/source/mp/` (user-facing):**

- `configuration.rst` — the MP Server arguments table is missing the new
  `--transfer-mode` CLI flag (default `gpu`, choices `gpu` / `non_gpu`).
- `index.rst` — the **Server Variants** table still lists
  `python3 -m lmcache.v1.multiprocess.blend_server_v2` as a legacy entry
  point. That module has been removed; the command now fails with
  `ModuleNotFoundError`.
- `architecture.rst` — three locations describe `blend_server_v2.py` as a
  current source file / entry point: the **Server Variants** subsection,
  the **Config System** subsection ("Both `blend_server_v2.py` and
  `http_server.py` reuse this pattern…"), and the **Key Source Files**
  table row.

**`docs/design/`:**

- `observability/request-event-span.md` — both the `CB_LOOKUP_END`
  emit-site reference and the "Source files touched" table point to
  the removed `blend_server_v2.py`.

## Evidence

| Stale doc | Current code |
|-----------|--------------|
| `docs/source/mp/configuration.rst:49-54` — MP Server table ends at `--engine-type` with no row for `--transfer-mode` | [`lmcache/v1/multiprocess/config.py:159-167`](https://github.com/LMCache/LMCache/blob/7eb57adb04f7f37c1e7c81f56b9e4b8a4eda4a8b/lmcache/v1/multiprocess/config.py#L159-L167) registers `--transfer-mode` with `choices=["gpu", "non_gpu"]`, `default="gpu"`; consumed at [`server.py:170-180`](https://github.com/LMCache/LMCache/blob/7eb57adb04f7f37c1e7c81f56b9e4b8a4eda4a8b/lmcache/v1/multiprocess/server.py#L170-L180) to pick `GPUTransferModule` vs `NonGPUTransferModule`, with an explicit `--engine-type blend` ⇒ `transfer_mode=='gpu'` precondition. |
| `docs/source/mp/index.rst:51` — lists `python3 -m lmcache.v1.multiprocess.blend_server_v2` as a (Legacy) entry point | The module no longer exists: `find lmcache -name 'blend_server_v2*'` returns nothing. [#3391 diff](https://github.com/LMCache/LMCache/commit/bda3af18db83a9e1a2da9d8ed8ee7ca064b890ef) shows `{blend_server_v2.py => modules/blend.py}` (rename). Running the documented command today raises `ModuleNotFoundError: No module named 'lmcache.v1.multiprocess.blend_server_v2'`. |
| `docs/source/mp/architecture.rst:52-56` — "**``blend_server_v2.py``** -- Extends ``MPCacheEngine`` with ``BlendEngineV2``…" | [`lmcache/v1/multiprocess/modules/blend.py`](https://github.com/LMCache/LMCache/blob/7eb57adb04f7f37c1e7c81f56b9e4b8a4eda4a8b/lmcache/v1/multiprocess/modules/blend.py) is the current home of `BlendModule`/`BlendEngineV2`; it is appended to the engine module list by [`server.py:182-184`](https://github.com/LMCache/LMCache/blob/7eb57adb04f7f37c1e7c81f56b9e4b8a4eda4a8b/lmcache/v1/multiprocess/server.py#L182-L184) only when `--engine-type blend`. |
| `docs/source/mp/architecture.rst:184-185` — "Both ``blend_server_v2.py`` and ``http_server.py`` reuse this pattern" | Same as above — `blend_server_v2.py` is no longer a separate entry point reusing `add_mp_server_args`. |
| `docs/source/mp/architecture.rst:409-410` — Key Source Files row `lmcache/v1/multiprocess/blend_server_v2.py` → `BlendEngineV2 (extends MPCacheEngine)` | File moved to `lmcache/v1/multiprocess/modules/blend.py` (and the surrounding refactor added `engine_context.py`, `engine_module.py`, and the `modules/` package). |
| `docs/design/observability/request-event-span.md:87` — "computed at the emit site in `blend_server_v2.py`" | `cb_lookup_pre_computed` and the `CB_LOOKUP_END` emit live in `lmcache/v1/multiprocess/modules/blend.py`. |
| `docs/design/observability/request-event-span.md:273` — source-files-touched row `lmcache/v1/multiprocess/blend_server_v2.py` | Same — file path is the new one. |

## Proposed fix

Already applied in this PR's diff. Doc-only — no code changes:

- `docs/source/mp/configuration.rst`: add a `--transfer-mode` row to the
  MP Server arguments table, with the choices, default, and the
  blend-requires-gpu precondition.
- `docs/source/mp/index.rst`: drop the dead `blend_server_v2` row from
  the Server Variants table (it now ships **two** entry points, not
  three), add a short note that CacheBlend is opted into at runtime via
  `--engine-type blend` (which loads `BlendModule` from
  `modules/blend.py`), and mention `--transfer-mode` on the remaining
  legacy `server.py` entry-point row.
- `docs/source/mp/architecture.rst`: rewrite the Server Variants
  subsection to describe `MPCacheEngine` as a compositor of
  `EngineModule` instances and replace the `blend_server_v2.py` bullet
  with a `modules/blend.py` bullet; fix the Config System paragraph
  that mentioned `blend_server_v2.py`; update the Key Source Files
  table (drop `blend_server_v2.py`; add `engine_context.py`,
  `engine_module.py`, and a row for the `modules/` package).
- `docs/design/observability/request-event-span.md`: fix the two stale
  file path references to point at `lmcache/v1/multiprocess/modules/blend.py`.

## Overlap with prior open drift PRs

This PR is **independent** of the still-open [#3454](https://github.com/LMCache/LMCache/pull/3454)
("docs: daily drift check — multi-process mode (2026-05-29)"), which
addresses the `_MP_INCOMPATIBLE_MODULES` claims, the missing
`POST /run_script` entry, and the missing `--script-allowed-imports` CLI
flag introduced by [#3398](https://github.com/LMCache/LMCache/pull/3398).
No file or table row is touched by both PRs.

## Notes

- Auto-generated by the daily LMCache docs drift-check routine.
  **Human review required before merge.**
- Marked as **draft**; please do not merge without an editorial pass.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01USwcGWCDzgUnUTXaVjCUGw)_