### PR TITLE
fix(token_database): return single segment when input is shorter than separator

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -467,10 +467,30 @@ class SegmentTokenDatabase(TokenDatabase):
         self.sep_len = len(self.sep_tokens)
 
     def _fast_split_by_subtensor(self, tokens: torch.Tensor) -> Iterable[torch.Tensor]:
-        """Match the `sep_tokens` with sliding windows"""
+        """Split ``tokens`` on every occurrence of ``self.sep_tokens``.
 
+        The separator is matched with sliding windows of width ``self.sep_len``.
+        The tokens between consecutive separators (and the leading/trailing
+        remainders) are yielded as the resulting segments; the separator tokens
+        themselves are dropped.
+
+        :param torch.Tensor tokens: The 1-D token id tensor to split.
+
+        :returns: A generator of token segments. When the sequence cannot
+            contain a separator -- either because the separator is empty
+            (``sep_len == 0``) or because the sequence is shorter than the
+            separator (``len(tokens) < sep_len``) -- the whole sequence is
+            yielded unchanged as a single segment.
+        """
+
+        # A sequence that is shorter than the separator (or an empty separator)
+        # cannot contain a match, so it forms a single segment. Returning here
+        # is required: ``tensor.unfold`` below raises a RuntimeError when the
+        # window is wider than the tensor, and an empty separator would make
+        # every window match vacuously.
         if self.sep_len == 0 or len(tokens) < self.sep_len:
             yield tokens
+            return
 
         # Unfold into sliding windows
         # shape: (num_tokens-sep_len+1, sep_len)

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache.v1 import token_database
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.token_database import ChunkedTokenDatabase, SegmentTokenDatabase
 
@@ -155,3 +156,87 @@ def test_process_tokens_returns_int_keys_for_bytes_hash_func() -> None:
         assert isinstance(hash_val, int), f"Expected int, got {type(hash_val)}"
         # Must fit in uint64 (msgpack range: 0 to 2**64 - 1)
         assert 0 <= hash_val <= 2**64 - 1
+
+
+class _StubTokenizer:
+    """Minimal tokenizer stand-in for SegmentTokenDatabase.
+
+    SegmentTokenDatabase derives its separator as
+    ``tokenizer.encode(blend_special_str)[1:]`` -- the leading element is
+    treated as a special start token and dropped. This stub returns a fixed
+    leading id followed by the requested separator ids so that ``sep_tokens``
+    is fully controlled without downloading a real tokenizer (the only existing
+    SegmentTokenDatabase test is skipped unless Hugging Face credentials are
+    available).
+    """
+
+    def __init__(self, sep_ids: list[int]) -> None:
+        self._encoded = [0, *sep_ids]
+
+    def encode(self, text: str) -> list[int]:
+        return list(self._encoded)
+
+
+def _make_segment_db(monkeypatch, sep_ids: list[int]) -> SegmentTokenDatabase:
+    monkeypatch.setattr(
+        token_database.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: _StubTokenizer(sep_ids),
+    )
+    cfg = LMCacheEngineConfig.from_legacy(blend_special_str="<sep>")
+    metadata = dumb_metadata_with_model_name("test_model")
+    return SegmentTokenDatabase(cfg, metadata)
+
+
+def test_segment_process_tokens_shorter_than_separator(monkeypatch) -> None:
+    """A sequence shorter than the separator must be returned as a single
+    segment.
+
+    Regression test: the splitting guard previously fell through to
+    ``tensor.unfold``, which raises ``RuntimeError`` when the window is wider
+    than the tensor, crashing on any request shorter than the separator.
+    """
+    db = _make_segment_db(monkeypatch, sep_ids=[101, 102])
+    tokens = torch.tensor([7], dtype=torch.long)
+
+    results = list(db.process_tokens(tokens=tokens, make_key=False))
+
+    assert len(results) == 1
+    start, end, _ = results[0]
+    assert (start, end) == (0, 1)
+
+
+def test_segment_process_tokens_empty_separator(monkeypatch) -> None:
+    """An empty separator must yield the whole sequence as a single segment.
+
+    Regression test: with ``sep_len == 0`` the guard previously fell through
+    and every sliding window matched vacuously, exploding the input into
+    spurious empty/single-token segments.
+    """
+    db = _make_segment_db(monkeypatch, sep_ids=[])
+    tokens = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+
+    results = list(db.process_tokens(tokens=tokens, make_key=False))
+
+    assert len(results) == 1
+    start, end, _ = results[0]
+    assert (start, end) == (0, 4)
+
+
+def test_segment_process_tokens_splits_on_separator(monkeypatch) -> None:
+    """The normal multi-segment split path is unchanged by the guard fix."""
+    db = _make_segment_db(monkeypatch, sep_ids=[101, 102])
+    sep = torch.tensor([101, 102], dtype=torch.long)
+    first = torch.tensor([1, 2, 3], dtype=torch.long)
+    second = torch.tensor([4, 5], dtype=torch.long)
+    tokens = torch.cat([first, sep, second])
+
+    results = list(db.process_tokens(tokens=tokens, make_key=False))
+
+    assert len(results) == 2
+    # First segment covers the tokens before the separator.
+    assert results[0][0] == 0
+    assert results[0][1] == len(first)
+    # Second segment starts after the dropped separator and runs to the end.
+    assert results[1][0] == len(first) + len(sep)
+    assert results[1][1] == len(tokens)


### PR DESCRIPTION
**What this PR does / why we need it**:

`SegmentTokenDatabase._fast_split_by_subtensor` guards the cases where the input cannot contain a separator — an empty separator (`sep_len == 0`) or a sequence shorter than the separator — by yielding the whole sequence as a single segment:

```python
if self.sep_len == 0 or len(tokens) < self.sep_len:
    yield tokens          # <-- missing return
# ... falls through ...
windows = tokens.unfold(0, self.sep_len, 1)
```

The guard was **missing a `return`**, so execution falls through to `tensor.unfold(0, sep_len, 1)`, which raises `RuntimeError: maximum size for tensor at dimension 0 is N but size is M` whenever the window is wider than the tensor.

Concretely:

| Input | Current behavior | Expected |
|-------|------------------|----------|
| sequence shorter than the separator (e.g. a 1-token request) | yields the chunk, then **crashes with `RuntimeError`** on the next iteration | one segment for the whole sequence |
| empty token sequence | **crashes with `RuntimeError`** | one (empty) segment |
| empty separator (`sep_len == 0`) | every sliding window matches vacuously → input **explodes into spurious single-token / empty segments** | one segment for the whole sequence |

So any blending/segment request whose token length is shorter than the configured separator crashes inside `process_tokens`. `sep_len == 0` can also occur when `blend_special_str` tokenizes to a single token (the leading token is dropped via `[1:]`).

The fix adds the missing `return` so the guard yields exactly one segment, honoring the guard's original intent. The common path (sequence longer than the separator) is untouched.

**Special notes for your reviewers**:

The only existing `SegmentTokenDatabase` test is `@pytest.mark.skipif`-gated on Hugging Face credentials (it downloads `facebook/opt-125m`), so this code path had no CI coverage. The added regression tests drive the **public** `process_tokens` interface and stub the tokenizer, so they run in CI without any network/model download. They are red on `dev` (the short-input and empty-separator cases) and green with this fix.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
