### PR TITLE
  [feat] Sparse (scattered-key) prefetch for coalesced high-bandwidth L2 loads

### DIFF
--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -180,6 +180,18 @@ class PrefetchHandle:
     submit_time: float
     """Monotonic timestamp when the prefetch task was submitted."""
 
+    sparse: bool = False
+    """Sparse prefetch: every found key is loaded and read-locked (not just
+    the contiguous prefix); result is a per-key found set via
+    ``wait_prefetch_found``."""
+
+    l1_found_indices: tuple[int, ...] = ()
+    """Sparse only: original-key indices found in L1 at submit time."""
+
+    l2_orig_indices: tuple[int, ...] = ()
+    """Sparse only: original-key index of each L1-miss sent to L2; maps the
+    controller's local result bitmap back to original positions."""
+
 
 def ipc_key_to_object_keys(
     ipc_key: IPCCacheEngineKey,

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -183,7 +183,7 @@ class PrefetchHandle:
     sparse: bool = False
     """Sparse prefetch: every found key is loaded and read-locked (not just
     the contiguous prefix); result is a per-key found set via
-    ``wait_prefetch_found``."""
+    ``query_prefetch_found``."""
 
     l1_found_indices: tuple[int, ...] = ()
     """Sparse only: original-key indices found in L1 at submit time."""

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -116,6 +116,22 @@ def trim_load_plan_to_prefix(
     return trim_load_plan_to_first_n_keys(load_plan, num_keys, prefix_length)
 
 
+def trim_load_plan_with_mask(
+    load_plan: dict[int, Bitmap],
+    mask: Bitmap,
+) -> dict[int, Bitmap]:
+    """Trim the load plan to keys set in ``mask`` (sparse: keeps every masked
+    key regardless of gaps, unlike :func:`trim_load_plan_to_prefix`). Adapter
+    indices retaining no keys are dropped."""
+    trimmed_plan: dict[int, Bitmap] = {}
+    for adapter_idx, bitmap in load_plan.items():
+        new_bitmap = bitmap & mask
+        if new_bitmap.popcount() == 0:
+            continue
+        trimmed_plan[adapter_idx] = new_bitmap
+    return trimmed_plan
+
+
 def merge_bitmaps(bitmaps: Iterable[Bitmap], num_keys: int) -> Bitmap:
     """Merge multiple bitmaps with a bitwise OR."""
     if not bitmaps:
@@ -149,6 +165,10 @@ class InFlightPrefetchRequest:
     """Extra read locks per key (on top of the default 1) to acquire when
     transitioning from write-locked to read-locked.  Must match the
     ``extra_count`` used in the corresponding ``submit_prefetch_task`` call."""
+
+    sparse: bool = False
+    """Sparse: load every found key (not just the prefix), keep all
+    read-locked; result is a per-key ``Bitmap`` not a prefix-hit count."""
 
     # Lookup phase: adapter_idx -> task_id (removed as results arrive)
     pending_lookup_tasks: dict[int, L2TaskId] = field(default_factory=dict)
@@ -219,7 +239,7 @@ class PrefetchController(StorageControllerInterface):
         # In-flight request tracking (background thread only)
         self._in_flight_requests: dict[PrefetchRequestId, InFlightPrefetchRequest] = {}
         self._pending_queue: list[
-            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc, int]
+            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc, int, bool]
         ] = []
 
         # Shadow counters for status reporting (updated in background loop)
@@ -231,7 +251,7 @@ class PrefetchController(StorageControllerInterface):
         # Thread-safe submission queue (external -> background)
         self._submission_lock = threading.Lock()
         self._submission_queue: list[
-            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc, int]
+            tuple[PrefetchRequestId, list[ObjectKey], MemoryLayoutDesc, int, bool]
         ] = []
         self._next_request_id: PrefetchRequestId = 0
         self._submission_efd = create_event_notifier()
@@ -240,9 +260,10 @@ class PrefetchController(StorageControllerInterface):
         self._lookup_results_lock = threading.Lock()
         self._completed_lookups: dict[PrefetchRequestId, int] = {}
 
-        # Thread-safe prefetch results (background -> external)
-        self._prefetch_results_lock = threading.Lock()
-        self._completed_results: dict[PrefetchRequestId, int] = {}
+        # Background → external. Condition notifies wait_prefetch_result.
+        self._prefetch_results_lock = threading.Condition()
+        # int = prefix-hit count (normal); Bitmap = per-key found set (sparse).
+        self._completed_results: dict[PrefetchRequestId, int | Bitmap] = {}
 
         # Map eventfds to adapter indices for quick lookup in poll.
         # Relies on the L2AdapterInterface contract that every adapter
@@ -295,6 +316,7 @@ class PrefetchController(StorageControllerInterface):
         keys: list[ObjectKey],
         layout_desc: MemoryLayoutDesc,
         extra_count: int = 0,
+        sparse: bool = False,
     ) -> PrefetchRequestId:
         """
         Submit a prefetch request for the given keys.
@@ -307,6 +329,10 @@ class PrefetchController(StorageControllerInterface):
         the prefix are never transferred, saving I/O bandwidth and L1
         memory.  Use :meth:`query_prefetch_result` to retrieve the number
         of prefix hits once the request completes.
+
+        When ``sparse=True``, every found key is loaded and read-locked (no
+        prefix trim) and the result is a per-key :class:`Bitmap`; coalesces
+        scattered, independently-usable chunks into one L2 load.
 
         Args:
             keys: List of object keys to prefetch from L2 into L1.
@@ -324,7 +350,9 @@ class PrefetchController(StorageControllerInterface):
         with self._submission_lock:
             request_id = self._next_request_id
             self._next_request_id += 1
-            self._submission_queue.append((request_id, keys, layout_desc, extra_count))
+            self._submission_queue.append(
+                (request_id, keys, layout_desc, extra_count, sparse)
+            )
         self._submission_efd.notify()
         return request_id
 
@@ -352,7 +380,9 @@ class PrefetchController(StorageControllerInterface):
         with self._lookup_results_lock:
             return self._completed_lookups.get(request_id, None)
 
-    def query_prefetch_result(self, request_id: PrefetchRequestId) -> int | None:
+    def query_prefetch_result(
+        self, request_id: PrefetchRequestId
+    ) -> "int | Bitmap | None":
         """
         Query the result of a prefetch request.
 
@@ -377,6 +407,26 @@ class PrefetchController(StorageControllerInterface):
         if result is not None:
             with self._lookup_results_lock:
                 self._completed_lookups.pop(request_id, None)
+        return result
+
+    def wait_prefetch_result(
+        self, request_id: PrefetchRequestId, timeout: float | None = None
+    ) -> "int | Bitmap | None":
+        """Event-driven :meth:`query_prefetch_result`; blocks until ready and
+        returns the result (``int`` count or ``Bitmap``), ``None`` on timeout."""
+        with self._prefetch_results_lock:
+            if request_id in self._completed_results:
+                result = self._completed_results.pop(request_id)
+            else:
+                got = self._prefetch_results_lock.wait_for(
+                    lambda: request_id in self._completed_results,
+                    timeout=timeout,
+                )
+                if not got:
+                    return None
+                result = self._completed_results.pop(request_id)
+        with self._lookup_results_lock:
+            self._completed_lookups.pop(request_id, None)
         return result
 
     def report_status(self) -> dict:
@@ -551,9 +601,11 @@ class PrefetchController(StorageControllerInterface):
         while (
             self._pending_queue and len(self._in_flight_requests) < self._max_in_flight
         ):
-            request_id, keys, layout_desc, extra_count = self._pending_queue.pop(0)
+            request_id, keys, layout_desc, extra_count, sparse = (
+                self._pending_queue.pop(0)
+            )
             self._status_pending_count -= 1
-            self._start_lookup_phase(request_id, keys, layout_desc, extra_count)
+            self._start_lookup_phase(request_id, keys, layout_desc, extra_count, sparse)
 
     # =========================================================================
     # Lookup phase
@@ -565,10 +617,11 @@ class PrefetchController(StorageControllerInterface):
         keys: list[ObjectKey],
         layout_desc: MemoryLayoutDesc,
         extra_count: int = 0,
+        sparse: bool = False,
     ) -> None:
         """Submit lookup_and_lock to all adapters for a new request."""
         if not self._l2_adapters:
-            self._complete_request(request_id, 0)
+            self._complete_request(request_id, Bitmap(len(keys)) if sparse else 0)
             return
 
         pending_lookup_tasks: dict[int, L2TaskId] = {}
@@ -582,6 +635,7 @@ class PrefetchController(StorageControllerInterface):
             layout_desc=layout_desc,
             phase=PrefetchPhase.LOOKUP,
             extra_count=extra_count,
+            sparse=sparse,
             pending_lookup_tasks=pending_lookup_tasks,
         )
         self._in_flight_requests[request_id] = request
@@ -615,8 +669,11 @@ class PrefetchController(StorageControllerInterface):
             self._adapter_descriptors,
         )
 
-        # Step 2: trim the load plan to only prefix
-        trimmed_plan = trim_load_plan_to_prefix(load_plan, len(request.keys))
+        # Step 2: trim load plan — sparse keeps every found key, default prefix.
+        if request.sparse:
+            trimmed_plan = dict(load_plan)
+        else:
+            trimmed_plan = trim_load_plan_to_prefix(load_plan, len(request.keys))
 
         if not trimmed_plan:
             # Nothing to load after trimming to prefix. Unlock all lookup locks
@@ -688,10 +745,15 @@ class PrefetchController(StorageControllerInterface):
             if key in reserved_key_set:
                 reserved_bitmap.set(i)
 
-        prefix_length = reserved_bitmap.count_leading_ones()
-        trimmed_plan = trim_load_plan_to_first_n_keys(
-            load_plan, len(request.keys), prefix_length
-        )
+        if request.sparse:
+            # Sparse: keep every successfully-reserved key (no prefix trim).
+            lookup_hits = reserved_bitmap.popcount()
+            trimmed_plan = trim_load_plan_with_mask(load_plan, reserved_bitmap)
+        else:
+            lookup_hits = reserved_bitmap.count_leading_ones()
+            trimmed_plan = trim_load_plan_to_first_n_keys(
+                load_plan, len(request.keys), lookup_hits
+            )
         request.load_plan = trimmed_plan
 
         ## Step 6: phase 1 unlock — keys locked in lookup but not in plan
@@ -749,14 +811,14 @@ class PrefetchController(StorageControllerInterface):
             )
 
         ## Step 8: update the lookup result based on the final load plan
-        self._update_lookup_results(request.request_id, prefix_length)
+        self._update_lookup_results(request.request_id, lookup_hits)
 
         self._event_bus.publish(
             Event(
                 event_type=EventType.L2_PREFETCH_LOOKUP_COMPLETED,
                 metadata={
                     "request_id": request.request_id,
-                    "prefix_hit_count": prefix_length,
+                    "prefix_hit_count": lookup_hits,
                 },
             )
         )
@@ -922,16 +984,20 @@ class PrefetchController(StorageControllerInterface):
                 )
             )
 
-        # Partial load failures can create gaps in the prefix.
-        # Release read locks for loaded keys beyond the prefix.
-        prefix_hits = result_bitmap.count_leading_ones()
-        prefix_mask = Bitmap(num_keys, prefix_hits)
-        non_prefix_loaded_bitmap = result_bitmap & (~prefix_mask)
-        non_prefix_loaded = non_prefix_loaded_bitmap.gather(request.keys)
-        if non_prefix_loaded:
-            l1_mgr.finish_read(non_prefix_loaded, extra_count=request.extra_count)
-
-        self._complete_request(request.request_id, prefix_hits)
+        if request.sparse:
+            # Sparse: every loaded key keeps its read lock for retrieval;
+            # result is the per-key found bitmap (no prefix-based release).
+            self._complete_request(request.request_id, result_bitmap)
+        else:
+            # Partial load failures can create gaps in the prefix.
+            # Release read locks for loaded keys beyond the prefix.
+            prefix_hits = result_bitmap.count_leading_ones()
+            prefix_mask = Bitmap(num_keys, prefix_hits)
+            non_prefix_loaded_bitmap = result_bitmap & (~prefix_mask)
+            non_prefix_loaded = non_prefix_loaded_bitmap.gather(request.keys)
+            if non_prefix_loaded:
+                l1_mgr.finish_read(non_prefix_loaded, extra_count=request.extra_count)
+            self._complete_request(request.request_id, prefix_hits)
 
     # =========================================================================
     # Unlock helpers
@@ -964,11 +1030,13 @@ class PrefetchController(StorageControllerInterface):
     # =========================================================================
 
     def _complete_request(
-        self, request_id: PrefetchRequestId, prefix_hits: int
+        self, request_id: PrefetchRequestId, result: int | Bitmap
     ) -> None:
-        """Store the result and remove from in-flight tracking."""
+        """Store the result (prefix-hit ``int`` or sparse per-key ``Bitmap``)
+        and notify ``wait_prefetch_result`` waiters."""
         with self._prefetch_results_lock:
-            self._completed_results[request_id] = prefix_hits
+            self._completed_results[request_id] = result
+            self._prefetch_results_lock.notify_all()
         removed = self._in_flight_requests.pop(request_id, None)
         if removed is not None:
             self._status_in_flight_count -= 1
@@ -976,10 +1044,12 @@ class PrefetchController(StorageControllerInterface):
                 self._status_lookup_phase_count -= 1
             elif removed.phase == PrefetchPhase.PLAN_AND_LOAD:
                 self._status_load_phase_count -= 1
+        hit_count = result.popcount() if isinstance(result, Bitmap) else result
         logger.debug(
-            "Prefetch request %d completed: %d prefix hits",
+            "Prefetch request %d completed: %d hits%s",
             request_id,
-            prefix_hits,
+            hit_count,
+            " (sparse)" if isinstance(result, Bitmap) else " prefix",
         )
 
     def _cleanup_in_flight_requests(self) -> None:

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -267,13 +267,11 @@ class PrefetchController(StorageControllerInterface):
         self._lookup_results_lock = threading.Lock()
         self._completed_lookups: dict[PrefetchRequestId, int] = {}
 
-        # Background → external. Condition notifies wait_prefetch_result.
-        self._prefetch_results_lock = threading.Condition()
+        # Thread-safe prefetch results (background -> external). Consumers poll
+        # (query_prefetch_result), never block-wait, so a plain Lock suffices.
+        self._prefetch_results_lock = threading.Lock()
         # int = prefix-hit count (normal); Bitmap = per-key found set (sparse).
         self._completed_results: dict[PrefetchRequestId, int | Bitmap] = {}
-        # Callers that timed out in wait_prefetch_result; _finalize_load
-        # releases their read locks and drops the result. Guarded by the lock.
-        self._abandoned_requests: set[PrefetchRequestId] = set()
 
         # Map eventfds to adapter indices for quick lookup in poll.
         # Relies on the L2AdapterInterface contract that every adapter
@@ -417,37 +415,6 @@ class PrefetchController(StorageControllerInterface):
         if result is not None:
             with self._lookup_results_lock:
                 self._completed_lookups.pop(request_id, None)
-        return result
-
-    def wait_prefetch_result(
-        self, request_id: PrefetchRequestId, timeout: float | None = None
-    ) -> "int | Bitmap | None":
-        """Event-driven :meth:`query_prefetch_result`; blocks until ready.
-
-        Args:
-            request_id: ID from :meth:`submit_prefetch_request`.
-            timeout: Max seconds to wait; ``None`` blocks indefinitely.
-
-        Returns:
-            Result (``int`` count or per-key ``Bitmap``), or ``None`` on
-            timeout — which marks the request abandoned so the loader releases
-            its read locks at finalization (no leak). Consumed once.
-        """
-        with self._prefetch_results_lock:
-            if request_id in self._completed_results:
-                result = self._completed_results.pop(request_id)
-            else:
-                got = self._prefetch_results_lock.wait_for(
-                    lambda: request_id in self._completed_results,
-                    timeout=timeout,
-                )
-                if not got:
-                    # Abandon: _finalize_load releases locks + drops result.
-                    self._abandoned_requests.add(request_id)
-                    return None
-                result = self._completed_results.pop(request_id)
-        with self._lookup_results_lock:
-            self._completed_lookups.pop(request_id, None)
         return result
 
     def report_status(self) -> dict:
@@ -1006,12 +973,11 @@ class PrefetchController(StorageControllerInterface):
             )
 
         if request.sparse:
-            # Sparse: loaded keys keep their read lock for retrieval (per-key
-            # found bitmap, no prefix release). If abandoned (caller timed
-            # out), release them here so they don't leak.
-            abandoned = self._complete_request(request.request_id, result_bitmap)
-            if abandoned and loaded_keys:
-                l1_mgr.finish_read(loaded_keys, extra_count=request.extra_count)
+            # Sparse: every loaded key keeps its read lock for retrieval
+            # (per-key found bitmap, no prefix release). The caller polls the
+            # found set (query_prefetch_found) and defers until it lands — it
+            # never gives up mid-load, so there are no orphaned locks here.
+            self._complete_request(request.request_id, result_bitmap)
         else:
             # Partial load failures can create gaps in the prefix.
             # Release read locks for loaded keys beyond the prefix.
@@ -1055,21 +1021,11 @@ class PrefetchController(StorageControllerInterface):
 
     def _complete_request(
         self, request_id: PrefetchRequestId, result: int | Bitmap
-    ) -> bool:
-        """Store the result (prefix-hit ``int`` or sparse ``Bitmap``) and notify
-        ``wait_prefetch_result`` waiters.
-
-        Returns True if the caller already abandoned the request (timed out):
-        the result is dropped and the caller must release its read locks. The
-        abandon check + store are atomic under the lock, so a timeout racing
-        completion can't strand a lock.
-        """
+    ) -> None:
+        """Store the result (prefix-hit ``int`` or sparse ``Bitmap``) for the
+        caller to poll (query_prefetch_result / query_prefetch_found)."""
         with self._prefetch_results_lock:
-            abandoned = request_id in self._abandoned_requests
-            self._abandoned_requests.discard(request_id)
-            if not abandoned:
-                self._completed_results[request_id] = result
-                self._prefetch_results_lock.notify_all()
+            self._completed_results[request_id] = result
         removed = self._in_flight_requests.pop(request_id, None)
         if removed is not None:
             self._status_in_flight_count -= 1
@@ -1079,13 +1035,11 @@ class PrefetchController(StorageControllerInterface):
                 self._status_load_phase_count -= 1
         hit_count = result.popcount() if isinstance(result, Bitmap) else result
         logger.debug(
-            "Prefetch request %d completed: %d hits%s%s",
+            "Prefetch request %d completed: %d hits%s",
             request_id,
             hit_count,
             " (sparse)" if isinstance(result, Bitmap) else " prefix",
-            " [abandoned]" if abandoned else "",
         )
-        return abandoned
 
     def _cleanup_in_flight_requests(self) -> None:
         """Release resources for any in-flight requests during shutdown."""

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -121,8 +121,15 @@ def trim_load_plan_with_mask(
     mask: Bitmap,
 ) -> dict[int, Bitmap]:
     """Trim the load plan to keys set in ``mask`` (sparse: keeps every masked
-    key regardless of gaps, unlike :func:`trim_load_plan_to_prefix`). Adapter
-    indices retaining no keys are dropped."""
+    key regardless of gaps, unlike :func:`trim_load_plan_to_prefix`).
+
+    Args:
+        load_plan: Adapter index -> Bitmap of key indices.
+        mask: Bitmap of key indices to retain.
+
+    Returns:
+        Trimmed load plan; adapter indices retaining no keys are dropped.
+    """
     trimmed_plan: dict[int, Bitmap] = {}
     for adapter_idx, bitmap in load_plan.items():
         new_bitmap = bitmap & mask
@@ -264,6 +271,9 @@ class PrefetchController(StorageControllerInterface):
         self._prefetch_results_lock = threading.Condition()
         # int = prefix-hit count (normal); Bitmap = per-key found set (sparse).
         self._completed_results: dict[PrefetchRequestId, int | Bitmap] = {}
+        # Callers that timed out in wait_prefetch_result; _finalize_load
+        # releases their read locks and drops the result. Guarded by the lock.
+        self._abandoned_requests: set[PrefetchRequestId] = set()
 
         # Map eventfds to adapter indices for quick lookup in poll.
         # Relies on the L2AdapterInterface contract that every adapter
@@ -412,8 +422,17 @@ class PrefetchController(StorageControllerInterface):
     def wait_prefetch_result(
         self, request_id: PrefetchRequestId, timeout: float | None = None
     ) -> "int | Bitmap | None":
-        """Event-driven :meth:`query_prefetch_result`; blocks until ready and
-        returns the result (``int`` count or ``Bitmap``), ``None`` on timeout."""
+        """Event-driven :meth:`query_prefetch_result`; blocks until ready.
+
+        Args:
+            request_id: ID from :meth:`submit_prefetch_request`.
+            timeout: Max seconds to wait; ``None`` blocks indefinitely.
+
+        Returns:
+            Result (``int`` count or per-key ``Bitmap``), or ``None`` on
+            timeout — which marks the request abandoned so the loader releases
+            its read locks at finalization (no leak). Consumed once.
+        """
         with self._prefetch_results_lock:
             if request_id in self._completed_results:
                 result = self._completed_results.pop(request_id)
@@ -423,6 +442,8 @@ class PrefetchController(StorageControllerInterface):
                     timeout=timeout,
                 )
                 if not got:
+                    # Abandon: _finalize_load releases locks + drops result.
+                    self._abandoned_requests.add(request_id)
                     return None
                 result = self._completed_results.pop(request_id)
         with self._lookup_results_lock:
@@ -985,9 +1006,12 @@ class PrefetchController(StorageControllerInterface):
             )
 
         if request.sparse:
-            # Sparse: every loaded key keeps its read lock for retrieval;
-            # result is the per-key found bitmap (no prefix-based release).
-            self._complete_request(request.request_id, result_bitmap)
+            # Sparse: loaded keys keep their read lock for retrieval (per-key
+            # found bitmap, no prefix release). If abandoned (caller timed
+            # out), release them here so they don't leak.
+            abandoned = self._complete_request(request.request_id, result_bitmap)
+            if abandoned and loaded_keys:
+                l1_mgr.finish_read(loaded_keys, extra_count=request.extra_count)
         else:
             # Partial load failures can create gaps in the prefix.
             # Release read locks for loaded keys beyond the prefix.
@@ -1031,12 +1055,21 @@ class PrefetchController(StorageControllerInterface):
 
     def _complete_request(
         self, request_id: PrefetchRequestId, result: int | Bitmap
-    ) -> None:
-        """Store the result (prefix-hit ``int`` or sparse per-key ``Bitmap``)
-        and notify ``wait_prefetch_result`` waiters."""
+    ) -> bool:
+        """Store the result (prefix-hit ``int`` or sparse ``Bitmap``) and notify
+        ``wait_prefetch_result`` waiters.
+
+        Returns True if the caller already abandoned the request (timed out):
+        the result is dropped and the caller must release its read locks. The
+        abandon check + store are atomic under the lock, so a timeout racing
+        completion can't strand a lock.
+        """
         with self._prefetch_results_lock:
-            self._completed_results[request_id] = result
-            self._prefetch_results_lock.notify_all()
+            abandoned = request_id in self._abandoned_requests
+            self._abandoned_requests.discard(request_id)
+            if not abandoned:
+                self._completed_results[request_id] = result
+                self._prefetch_results_lock.notify_all()
         removed = self._in_flight_requests.pop(request_id, None)
         if removed is not None:
             self._status_in_flight_count -= 1
@@ -1046,11 +1079,13 @@ class PrefetchController(StorageControllerInterface):
                 self._status_load_phase_count -= 1
         hit_count = result.popcount() if isinstance(result, Bitmap) else result
         logger.debug(
-            "Prefetch request %d completed: %d hits%s",
+            "Prefetch request %d completed: %d hits%s%s",
             request_id,
             hit_count,
             " (sparse)" if isinstance(result, Bitmap) else " prefix",
+            " [abandoned]" if abandoned else "",
         )
+        return abandoned
 
     def _cleanup_in_flight_requests(self) -> None:
         """Release resources for any in-flight requests during shutdown."""

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -406,7 +406,7 @@ class StorageManager:
             external_request_id: Request ID from the caller
                 for end-to-end log tracing.
             sparse: If True, retain every found key (L1+L2), not just the
-                contiguous prefix; results via :meth:`wait_prefetch_found`.
+                contiguous prefix; results via :meth:`query_prefetch_found`.
                 Coalesces scattered chunks into one L2 load.
             covered_keys: Sparse only. Keys already served elsewhere (e.g. the
                 parent prefix): excluded from the L2 load and found set, and
@@ -506,7 +506,7 @@ class StorageManager:
     ) -> PrefetchHandle:
         """Sparse prefetch: keep read locks on every found L1 key (not just the
         prefix) and send all L1-misses to L2 as one sparse request; found keys
-        reported via :meth:`wait_prefetch_found`. ``covered_keys`` (served by the
+        reported via :meth:`query_prefetch_found`. ``covered_keys`` (served by the
         parent prefix) are excluded and any probe lock on them released, so the
         locked set equals what the caller retrieves."""
         # L1-present keys kept read-locked, except parent-covered (released below).
@@ -568,26 +568,25 @@ class StorageManager:
             l2_orig_indices=tuple(l2_orig_indices),
         )
 
-    def wait_prefetch_found(
+    def query_prefetch_found(
         self,
         handle: PrefetchHandle,
-        timeout: float | None = None,
     ) -> set[int] | None:
-        """Event-driven result of a sparse prefetch (``sparse=True`` in
-        :meth:`submit_prefetch_task`).
+        """Non-blocking sparse counterpart of :meth:`query_prefetch_status`.
 
-        Args:
-            handle: The sparse :class:`PrefetchHandle` from submit.
-            timeout: Max seconds to wait; ``None`` blocks indefinitely.
+        Polls the per-key found set without blocking: returns the set of
+        ORIGINAL key indices found and read-locked in L1 (directly or via L2
+        promotion), or ``None`` if the sparse prefetch is still in progress.
+        For sparse handles only.
 
-        Returns:
-            Set of original key indices found and read-locked in L1 (directly
-            or via L2), or ``None`` on timeout (which releases the locks).
+        Note: the underlying ``query_prefetch_result`` is consume-once, so the
+        caller must stash the first non-``None`` result and not re-poll after
+        it arrives.
         """
         found: set[int] = set(handle.l1_found_indices)
         if handle.prefetch_request_id != -1:
-            l2_res = self._prefetch_controller.wait_prefetch_result(
-                handle.prefetch_request_id, timeout=timeout
+            l2_res = self._prefetch_controller.query_prefetch_result(
+                handle.prefetch_request_id
             )
             if l2_res is None:
                 return None

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -573,8 +573,17 @@ class StorageManager:
         handle: PrefetchHandle,
         timeout: float | None = None,
     ) -> set[int] | None:
-        """Sparse-prefetch result: the set of original key indices found and
-        read-locked in L1 (directly or via L2), or ``None`` on timeout."""
+        """Event-driven result of a sparse prefetch (``sparse=True`` in
+        :meth:`submit_prefetch_task`).
+
+        Args:
+            handle: The sparse :class:`PrefetchHandle` from submit.
+            timeout: Max seconds to wait; ``None`` blocks indefinitely.
+
+        Returns:
+            Set of original key indices found and read-locked in L1 (directly
+            or via L2), or ``None`` on timeout (which releases the locks).
+        """
         found: set[int] = set(handle.l1_found_indices)
         if handle.prefetch_request_id != -1:
             l2_res = self._prefetch_controller.wait_prefetch_result(

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -10,6 +10,7 @@ import time
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
@@ -391,6 +392,8 @@ class StorageManager:
         layout_desc: MemoryLayoutDesc,
         extra_count: int = 0,
         external_request_id: str = "",
+        sparse: bool = False,
+        covered_keys: set[ObjectKey] | None = None,
     ) -> PrefetchHandle:
         """Prefetch objects into L1 asynchronously.
 
@@ -402,6 +405,13 @@ class StorageManager:
                 key.  Total locks = 1 + extra_count.
             external_request_id: Request ID from the caller
                 for end-to-end log tracing.
+            sparse: If True, retain every found key (L1+L2), not just the
+                contiguous prefix; results via :meth:`wait_prefetch_found`.
+                Coalesces scattered chunks into one L2 load.
+            covered_keys: Sparse only. Keys already served elsewhere (e.g. the
+                parent prefix): excluded from the L2 load and found set, and
+                any probe read-lock on them is released — so the locked set
+                equals what the caller retrieves (no leak).
 
         Returns:
             PrefetchHandle to track the task.
@@ -410,6 +420,15 @@ class StorageManager:
         # objects are already in L1, and adding read locks to them.
 
         l1_read_result = self._l1_manager.reserve_read(keys, extra_count=extra_count)
+        if sparse:
+            return self._finish_submit_prefetch_sparse(
+                keys,
+                l1_read_result,
+                layout_desc,
+                extra_count,
+                external_request_id,
+                covered_keys or frozenset(),
+            )
         hit_count = 0
         for key in keys:
             entry = l1_read_result.get(key, None)
@@ -476,6 +495,102 @@ class StorageManager:
             submit_time=submit_time,
         )
 
+    def _finish_submit_prefetch_sparse(
+        self,
+        keys: list[ObjectKey],
+        l1_read_result: dict,
+        layout_desc: MemoryLayoutDesc,
+        extra_count: int,
+        external_request_id: str,
+        covered_keys: "frozenset[ObjectKey] | set[ObjectKey]",
+    ) -> PrefetchHandle:
+        """Sparse prefetch: keep read locks on every found L1 key (not just the
+        prefix) and send all L1-misses to L2 as one sparse request; found keys
+        reported via :meth:`wait_prefetch_found`. ``covered_keys`` (served by the
+        parent prefix) are excluded and any probe lock on them released, so the
+        locked set equals what the caller retrieves."""
+        # L1-present keys kept read-locked, except parent-covered (released below).
+        l1_found_indices = [
+            i
+            for i, key in enumerate(keys)
+            if key not in covered_keys
+            and (ent := l1_read_result.get(key)) is not None
+            and ent[0] == L1Error.SUCCESS
+            and ent[1] is not None
+        ]
+        l1_found_set = {keys[i] for i in l1_found_indices}
+
+        # Release probe read-locks we won't retain (covered + stray), else leak.
+        stray_keys = [
+            key
+            for key, ent in l1_read_result.items()
+            if ent is not None and ent[1] is not None and key not in l1_found_set
+        ]
+        if stray_keys:
+            self._l1_manager.finish_read(stray_keys, extra_count=extra_count)
+
+        # L1 misses (minus covered) → L2 sparse; keep each one's original index.
+        found_set = set(l1_found_indices)
+        l2_orig_indices = [
+            i
+            for i in range(len(keys))
+            if i not in found_set and keys[i] not in covered_keys
+        ]
+        remaining_keys = [keys[i] for i in l2_orig_indices]
+
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.SM_READ_PREFETCHED,
+                metadata={
+                    "succeeded_keys": [keys[i] for i in l1_found_indices],
+                    "failed_keys": remaining_keys,
+                },
+            )
+        )
+
+        prefetch_request_id = -1
+        if remaining_keys and self._l2_adapters:
+            prefetch_request_id = self._prefetch_controller.submit_prefetch_request(
+                remaining_keys,
+                layout_desc,
+                extra_count=extra_count,
+                sparse=True,
+            )
+
+        return PrefetchHandle(
+            prefetch_request_id=prefetch_request_id,
+            external_request_id=external_request_id,
+            l1_prefix_hit_count=len(l1_found_indices),
+            total_requested_keys=len(keys),
+            submit_time=time.monotonic(),
+            sparse=True,
+            l1_found_indices=tuple(l1_found_indices),
+            l2_orig_indices=tuple(l2_orig_indices),
+        )
+
+    def wait_prefetch_found(
+        self,
+        handle: PrefetchHandle,
+        timeout: float | None = None,
+    ) -> set[int] | None:
+        """Sparse-prefetch result: the set of original key indices found and
+        read-locked in L1 (directly or via L2), or ``None`` on timeout."""
+        found: set[int] = set(handle.l1_found_indices)
+        if handle.prefetch_request_id != -1:
+            l2_res = self._prefetch_controller.wait_prefetch_result(
+                handle.prefetch_request_id, timeout=timeout
+            )
+            if l2_res is None:
+                return None
+            if isinstance(l2_res, Bitmap):
+                for local_idx in l2_res.get_indices_list():
+                    found.add(handle.l2_orig_indices[local_idx])
+            else:
+                # Defensive: a prefix-count int (non-sparse controller path).
+                for local_idx in range(int(l2_res)):
+                    found.add(handle.l2_orig_indices[local_idx])
+        return found
+
     def query_prefetch_lookup_hits(
         self,
         handle: PrefetchHandle,
@@ -540,7 +655,8 @@ class StorageManager:
 
             if l2_r is None:
                 return None
-            l2_result = l2_r  # Just to make linter happy
+            # Non-sparse handle => int; tolerate a Bitmap defensively.
+            l2_result = l2_r.popcount() if isinstance(l2_r, Bitmap) else l2_r
 
         total_hits = handle.l1_prefix_hit_count + l2_result
         elapsed_ms = (time.monotonic() - handle.submit_time) * 1000

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -171,6 +171,22 @@ def wait_for_prefetch_status(
     return None
 
 
+def wait_for_prefetch_found(
+    sm: StorageManager,
+    handle,
+    timeout: float = 10.0,
+    poll_interval: float = 0.05,
+) -> set[int] | None:
+    """Poll the non-blocking sparse query_prefetch_found until it lands."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        found = sm.query_prefetch_found(handle)
+        if found is not None:
+            return found
+        time.sleep(poll_interval)
+    return None
+
+
 # =============================================================================
 # Tests
 # =============================================================================
@@ -801,7 +817,7 @@ class TestStorageManagerSparsePrefetch:
         sm.finish_write(list(ret.keys()))
 
         handle = sm.submit_prefetch_task(all_keys, basic_layout, sparse=True)
-        found = sm.wait_prefetch_found(handle, timeout=10.0)
+        found = wait_for_prefetch_found(sm, handle, timeout=10.0)
 
         # Sparse: all four found indices, NOT just the prefix {0, 1}.
         assert found == {0, 1, 3, 4}
@@ -839,7 +855,7 @@ class TestStorageManagerSparsePrefetch:
         assert used == 0
 
         handle = sm.submit_prefetch_task(all_keys, basic_layout, sparse=True)
-        found = sm.wait_prefetch_found(handle, timeout=10.0)
+        found = wait_for_prefetch_found(sm, handle, timeout=10.0)
 
         # Sparse from L2: all found {0,1,3,4}, NOT the contiguous prefix {0,1}.
         assert found == {0, 1, 3, 4}
@@ -861,7 +877,7 @@ class TestStorageManagerSparsePrefetch:
         handle = sm.submit_prefetch_task(
             all_keys, basic_layout, sparse=True, covered_keys=covered
         )
-        found = sm.wait_prefetch_found(handle, timeout=10.0)
+        found = wait_for_prefetch_found(sm, handle, timeout=10.0)
 
         # Covered indices 2, 3 excluded; only the complement is found.
         assert found == {0, 1, 4}
@@ -877,40 +893,4 @@ class TestStorageManagerSparsePrefetch:
         assert len(freed) == len(covered_keys_list)
 
         sm.finish_read_prefetched(complement)
-        sm.close()
-
-    def test_sparse_abandoned_timeout_releases_locks(
-        self, l2_storage_manager_config, basic_layout
-    ):
-        """A ``wait_prefetch_found`` timeout must not leak L1 read locks: the
-        background load still completes, but the abandoned request releases the
-        loaded keys' locks (L1 usage returns to 0 instead of staying pinned)."""
-        sm = StorageManager(l2_storage_manager_config)
-        keys = [make_object_key(i) for i in range(4)]
-        wret = sm.reserve_write(keys, basic_layout, mode="new")
-        sm.finish_write(list(wret.keys()))
-        adapter = sm._l2_adapters[0]
-        assert wait_for_condition(
-            lambda: all(adapter.debug_has_key(k) for k in keys),  # type: ignore
-            timeout=10.0,
-        )
-        time.sleep(0.05)
-        sm.clear()  # evict from L1; L2 retains, so the prefetch must hit L2
-        assert sm._l1_manager.get_memory_usage()[0] == 0
-
-        handle = sm.submit_prefetch_task(keys, basic_layout, sparse=True)
-        assert handle.prefetch_request_id != -1  # all keys went to the L2 load
-        # Zero-timeout: the async load can't finish this fast -> None + abandoned.
-        assert sm.wait_prefetch_found(handle, timeout=0.0) is None
-
-        # Wait for the load to finalize, then assert no leak below.
-        pc = sm._prefetch_controller
-        assert wait_for_condition(
-            lambda: handle.prefetch_request_id not in pc._in_flight_requests,
-            timeout=10.0,
-        )
-        time.sleep(0.05)  # let _finalize_load's finish_read settle
-        # No leak: locks released -> L1 usage 0 (would stay >0 pinned if leaked).
-        assert sm._l1_manager.get_memory_usage()[0] == 0
-
         sm.close()

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -777,3 +777,104 @@ class TestFailureEventProduction:
             assert keys[1] in meta["keys"]
         finally:
             sm.close()
+
+
+# =============================================================================
+# Sparse prefetch + reconcile-before-prefetch (covered_keys) tests
+# =============================================================================
+
+
+class TestStorageManagerSparsePrefetch:
+    """Sparse prefetch (retain every found key, not just the prefix) +
+    ``covered_keys`` reconcile-before-prefetch."""
+
+    def test_sparse_keeps_all_found_not_just_prefix(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """Sparse L1 prefetch retains + read-locks every found key, including
+        those past a gap (unlike the contiguous-prefix default)."""
+        sm = StorageManager(basic_storage_manager_config)
+        all_keys = [make_object_key(i) for i in range(5)]
+        # Write {0,1,3,4}; key 2 is the gap.
+        existing = [all_keys[i] for i in (0, 1, 3, 4)]
+        ret = sm.reserve_write(existing, basic_layout, mode="new")
+        sm.finish_write(list(ret.keys()))
+
+        handle = sm.submit_prefetch_task(all_keys, basic_layout, sparse=True)
+        found = sm.wait_prefetch_found(handle, timeout=10.0)
+
+        # Sparse: all four found indices, NOT just the prefix {0, 1}.
+        assert found == {0, 1, 3, 4}
+
+        # Every found key is read-locked (none write-reservable).
+        locked = sm.reserve_write(existing, basic_layout, mode="update")
+        assert len(locked) == 0
+
+        # Releasing the full found set frees them.
+        sm.finish_read_prefetched(existing)
+        freed = sm.reserve_write(existing, basic_layout, mode="update")
+        assert len(freed) == len(existing)
+
+        sm.close()
+
+    def test_sparse_from_l2_loads_all_found(
+        self, l2_storage_manager_config, basic_layout
+    ):
+        """Sparse prefetch from L2 loads every found key (controller skips the
+        prefix-only trim), not just the prefix before a gap."""
+        sm = StorageManager(l2_storage_manager_config)
+        all_keys = [make_object_key(i) for i in range(5)]
+        # L2 has {0,1,3,4}; gap at 2.
+        existing = [all_keys[i] for i in (0, 1, 3, 4)]
+        wret = sm.reserve_write(existing, basic_layout, mode="new")
+        sm.finish_write(list(wret.keys()))
+        adapter = sm._l2_adapters[0]
+        assert wait_for_condition(
+            lambda: all(adapter.debug_has_key(k) for k in existing),  # type: ignore
+            timeout=10.0,
+        )
+        time.sleep(0.05)
+        sm.clear()
+        used, _ = sm._l1_manager.get_memory_usage()
+        assert used == 0
+
+        handle = sm.submit_prefetch_task(all_keys, basic_layout, sparse=True)
+        found = sm.wait_prefetch_found(handle, timeout=10.0)
+
+        # Sparse from L2: all found {0,1,3,4}, NOT the contiguous prefix {0,1}.
+        assert found == {0, 1, 3, 4}
+
+        sm.finish_read_prefetched(existing)
+        sm.close()
+
+    def test_sparse_covered_keys_excluded_and_released(
+        self, basic_storage_manager_config, basic_layout
+    ):
+        """``covered_keys`` are excluded from the found set and any probe
+        read-lock on them released — so they never leak a read lock."""
+        sm = StorageManager(basic_storage_manager_config)
+        all_keys = [make_object_key(i) for i in range(5)]
+        ret = sm.reserve_write(all_keys, basic_layout, mode="new")
+        sm.finish_write(list(ret.keys()))
+
+        covered = {all_keys[2], all_keys[3]}
+        handle = sm.submit_prefetch_task(
+            all_keys, basic_layout, sparse=True, covered_keys=covered
+        )
+        found = sm.wait_prefetch_found(handle, timeout=10.0)
+
+        # Covered indices 2, 3 excluded; only the complement is found.
+        assert found == {0, 1, 4}
+
+        # Non-covered found keys remain read-locked.
+        complement = [all_keys[i] for i in (0, 1, 4)]
+        assert len(sm.reserve_write(complement, basic_layout, mode="update")) == 0
+
+        # Covered keys are write-reservable again -> their probe lock was
+        # released (no leak), even though they were never retrieved.
+        covered_keys_list = [all_keys[2], all_keys[3]]
+        freed = sm.reserve_write(covered_keys_list, basic_layout, mode="update")
+        assert len(freed) == len(covered_keys_list)
+
+        sm.finish_read_prefetched(complement)
+        sm.close()

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -878,3 +878,39 @@ class TestStorageManagerSparsePrefetch:
 
         sm.finish_read_prefetched(complement)
         sm.close()
+
+    def test_sparse_abandoned_timeout_releases_locks(
+        self, l2_storage_manager_config, basic_layout
+    ):
+        """A ``wait_prefetch_found`` timeout must not leak L1 read locks: the
+        background load still completes, but the abandoned request releases the
+        loaded keys' locks (L1 usage returns to 0 instead of staying pinned)."""
+        sm = StorageManager(l2_storage_manager_config)
+        keys = [make_object_key(i) for i in range(4)]
+        wret = sm.reserve_write(keys, basic_layout, mode="new")
+        sm.finish_write(list(wret.keys()))
+        adapter = sm._l2_adapters[0]
+        assert wait_for_condition(
+            lambda: all(adapter.debug_has_key(k) for k in keys),  # type: ignore
+            timeout=10.0,
+        )
+        time.sleep(0.05)
+        sm.clear()  # evict from L1; L2 retains, so the prefetch must hit L2
+        assert sm._l1_manager.get_memory_usage()[0] == 0
+
+        handle = sm.submit_prefetch_task(keys, basic_layout, sparse=True)
+        assert handle.prefetch_request_id != -1  # all keys went to the L2 load
+        # Zero-timeout: the async load can't finish this fast -> None + abandoned.
+        assert sm.wait_prefetch_found(handle, timeout=0.0) is None
+
+        # Wait for the load to finalize, then assert no leak below.
+        pc = sm._prefetch_controller
+        assert wait_for_condition(
+            lambda: handle.prefetch_request_id not in pc._in_flight_requests,
+            timeout=10.0,
+        )
+        time.sleep(0.05)  # let _finalize_load's finish_read settle
+        # No leak: locks released -> L1 usage 0 (would stay >0 pinned if leaked).
+        assert sm._l1_manager.get_memory_usage()[0] == 0
+
+        sm.close()

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
 from lmcache.v1.distributed.error import L1Error
@@ -88,7 +89,7 @@ def wait_for_prefetch_result(
     req_id: int,
     timeout: float = 5.0,
     poll_interval: float = 0.05,
-) -> int | None:
+) -> int | Bitmap | None:
     """Poll query_prefetch_result until it returns a non-None value."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:


### PR DESCRIPTION
  Description:
  **What this PR does / why we need it**:

  Adds a `sparse=True` mode to `StorageManager.submit_prefetch_task` /
  `PrefetchController.submit_prefetch_request` that loads **every** individually
  found key (not just the contiguous prefix), keeps each read-locked, and reports
  results as a per-key found set via `wait_prefetch_found` instead of a
  prefix-hit count.

  Loading a set of scattered, independently-usable keys currently needs one
  prefetch request per contiguous run. Fragmenting a scattered read into many
  small, under-parallelized L2 tasks wastes bandwidth; coalescing into a single
  sparse request recovers it (**2–4.5× effective L2 prefetch bandwidth** on
  `fs_native` in our benchmarks).

  **Special notes for your reviewers**:

  - **The non-sparse prefix path is behaviorally unchanged.** Every sparse
    behavior is gated behind `if sparse:`. The only edits to shared code are: a
    variable rename (`prefix_length` → `lookup_hits`, identical value on the
    prefix branch), a return-type widening (`int` → `int | Bitmap`), and
    upgrading `_prefetch_results_lock` from `Lock` to `Condition` (adds the
    event-driven `wait_prefetch_result`; `notify_all` is inert for polling
    callers).
  - `covered_keys` (sparse-only) excludes keys already satisfied by another path
    and releases any read-lock the L1 probe took on them
    (reconcile-before-prefetch), keeping the locked set equal to what the caller
    retrieves — so covered chunks can't leak a read lock.
  

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added  *(internal storage API; no
  user-facing change)*
  - [x] this PR contains unit tests  *(`TestStorageManagerSparsePrefetch`: keeps-all-found,
  loads-from-L2, covered_keys excluded+released)*