### PR TITLE
fix(examples): skip empty-choices frames in disagg proxy chat streaming (fixes #3475)

### DIFF
--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -471,6 +471,54 @@ def pick_up_clients(request: Request) -> tuple[ClientInfo, ClientInfo, ClientInf
     return round_robin_pick_clients()
 
 
+def completion_chunk_to_chat_chunk(completion_data: dict) -> Optional[dict]:
+    """Convert one ``/v1/completions`` stream chunk to ``chat.completion.chunk`` form.
+
+    The decoder's streaming response can include chunks with an empty
+    ``choices`` list -- for example the trailing usage/metadata frame emitted
+    when ``stream_options.include_usage`` is set. The previous inline code
+    indexed ``choices[0]`` unconditionally, so those frames raised
+    ``IndexError`` and aborted the whole proxied stream (LMCache#3475).
+
+    Such empty-``choices`` frames are dropped (return ``None``) rather than
+    converted: this proxy already surfaces the prefill token both by
+    appending it to the decoder prompt and by emitting it to the client as
+    completion content, so the decoder subrequest's ``usage`` is miscounted
+    for the original client request -- forwarding it would propagate wrong
+    token accounting. Dropping the frame also matches the pre-existing
+    behavior, where the converted chat chunk never carried ``usage``.
+
+    Args:
+        completion_data: A decoded ``text_completion`` stream chunk. Expected
+            keys: ``id`` / ``created`` / ``model`` and a ``choices`` list
+            (possibly empty); each choice carries ``text`` plus optional
+            ``logprobs`` / ``finish_reason``.
+
+    Returns:
+        A ``chat.completion.chunk``-shaped dict ready to be re-serialized,
+        or ``None`` when the source chunk has no choices and the caller
+        should skip it.
+    """
+    choices = completion_data.get("choices") or []
+    if not choices:
+        return None
+    first_choice = choices[0]
+    return {
+        "id": completion_data["id"],
+        "object": "chat.completion.chunk",
+        "created": completion_data["created"],
+        "model": completion_data["model"],
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": first_choice["text"]},
+                "logprobs": first_choice.get("logprobs"),
+                "finish_reason": first_choice.get("finish_reason"),
+            }
+        ],
+    }
+
+
 @app.post("/v1/completions")
 async def handle_completions(request: Request):
     global counter, stats_calculator
@@ -714,28 +762,14 @@ async def handle_chat_completions(request: Request):
                         json_str = chunk_str[6:].strip()  # Remove 'data: ' prefix
                         if json_str:
                             completion_data = json.loads(json_str)
-                            chat_completion_data = {
-                                "id": completion_data["id"],
-                                "object": "chat.completion.chunk",
-                                "created": completion_data["created"],
-                                "model": completion_data["model"],
-                                "choices": [
-                                    {
-                                        "index": 0,
-                                        "delta": {
-                                            "content": completion_data["choices"][0][
-                                                "text"
-                                            ]
-                                        },
-                                        "logprobs": completion_data["choices"][0].get(
-                                            "logprobs"
-                                        ),
-                                        "finish_reason": completion_data["choices"][
-                                            0
-                                        ].get("finish_reason"),
-                                    }
-                                ],
-                            }
+                            chat_completion_data = completion_chunk_to_chat_chunk(
+                                completion_data
+                            )
+                            # Empty-choices frames (e.g. the trailing usage
+                            # frame) convert to None and are skipped — see
+                            # completion_chunk_to_chat_chunk (LMCache#3475).
+                            if chat_completion_data is None:
+                                continue
                             converted_chunk = (
                                 "data: "
                                 + json.dumps(

--- a/tests/disagg/test_disagg_proxy_chunk_conversion.py
+++ b/tests/disagg/test_disagg_proxy_chunk_conversion.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the disagg-proxy completion→chat stream chunk conversion.
+
+Regression coverage for LMCache#3475: the example PD-disaggregation proxy
+crashed with ``IndexError`` when the decoder streamed a chunk carrying an
+empty ``choices`` list (e.g. the trailing usage/metadata frame emitted when
+``stream_options.include_usage`` is set). The conversion helper now returns
+``None`` for those frames (the caller skips them) instead of indexing
+``choices[0]``. Empty-choices frames are dropped rather than forwarded
+because this PD proxy miscounts the decoder subrequest's ``usage`` (the
+prefill token is both appended to the decoder prompt and emitted to the
+client as content), matching the pre-existing behavior where the converted
+chat chunk never carried ``usage``.
+
+The proxy lives under ``examples/`` and is a runnable script (guarded by
+``if __name__ == "__main__"``), so the test inserts its directory on
+``sys.path`` and imports the module to exercise the pure helper directly --
+no server, sockets, or GPU required.
+"""
+
+# Standard
+from pathlib import Path
+import sys
+
+# Third Party
+import pytest
+
+# Make the example script importable (it is not a package).
+_PROXY_DIR = Path(__file__).resolve().parents[2] / "examples" / "disagg_prefill"
+sys.path.insert(0, str(_PROXY_DIR))
+
+# Third Party
+from disagg_proxy_server import (  # noqa: E402
+    completion_chunk_to_chat_chunk,
+)
+
+
+def _base_completion_chunk(choices: list, usage=None) -> dict:
+    """Build a minimal ``text_completion`` stream chunk for tests."""
+    chunk = {
+        "id": "cmpl-abc",
+        "object": "text_completion",
+        "created": 1234567890,
+        "model": "Qwen3-8B",
+        "choices": choices,
+    }
+    if usage is not None:
+        chunk["usage"] = usage
+    return chunk
+
+
+def test_single_choice_is_converted_to_chat_delta() -> None:
+    """A normal token chunk maps ``choices[0].text`` to ``delta.content``."""
+    src = _base_completion_chunk(
+        [
+            {
+                "index": 0,
+                "text": "hello",
+                "logprobs": {"tokens": ["hello"]},
+                "finish_reason": None,
+            }
+        ]
+    )
+
+    out = completion_chunk_to_chat_chunk(src)
+
+    assert out["object"] == "chat.completion.chunk"
+    assert out["id"] == "cmpl-abc"
+    assert out["created"] == 1234567890
+    assert out["model"] == "Qwen3-8B"
+    assert len(out["choices"]) == 1
+    choice = out["choices"][0]
+    assert choice["index"] == 0
+    assert choice["delta"] == {"content": "hello"}
+    assert choice["logprobs"] == {"tokens": ["hello"]}
+    assert choice["finish_reason"] is None
+
+
+def test_empty_choices_returns_none_instead_of_raising() -> None:
+    """The #3475 crash case: a chunk with ``choices: []`` must not raise.
+
+    Before the fix, ``choices[0]`` raised ``IndexError`` and aborted the
+    whole streamed response. The helper now returns ``None`` so the caller
+    skips the frame.
+    """
+    src = _base_completion_chunk([])
+
+    assert completion_chunk_to_chat_chunk(src) is None
+
+
+def test_empty_choices_with_usage_is_still_dropped() -> None:
+    """The trailing usage/metadata frame (empty choices + usage) is dropped.
+
+    Forwarding it would propagate the decoder subrequest's ``usage``, which
+    is miscounted for the client request in this PD proxy. Returning
+    ``None`` matches the pre-existing behavior of never emitting ``usage``.
+    """
+    usage = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    src = _base_completion_chunk([], usage=usage)
+
+    assert completion_chunk_to_chat_chunk(src) is None
+
+
+def test_missing_choices_key_returns_none() -> None:
+    """A chunk lacking the ``choices`` key entirely returns ``None``.
+
+    ``.get("choices") or []`` guards both the empty-list and missing-key
+    shapes, so neither raises.
+    """
+    src = {
+        "id": "cmpl-abc",
+        "object": "text_completion",
+        "created": 1234567890,
+        "model": "Qwen3-8B",
+    }
+
+    assert completion_chunk_to_chat_chunk(src) is None
+
+
+def test_usage_is_never_forwarded_on_token_chunks() -> None:
+    """A token chunk that carries ``usage`` still converts without ``usage``.
+
+    The proxy intentionally never surfaces the decoder subrequest's usage
+    (it is miscounted for the client request), so even a non-empty chunk
+    that happens to include ``usage`` drops it on conversion.
+    """
+    src = _base_completion_chunk(
+        [{"index": 0, "text": "x", "finish_reason": None}],
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+
+    out = completion_chunk_to_chat_chunk(src)
+
+    assert out is not None
+    assert "usage" not in out
+
+
+def test_first_choice_used_when_multiple_present() -> None:
+    """Only the first choice is mapped (the proxy is single-choice)."""
+    src = _base_completion_chunk(
+        [
+            {"index": 0, "text": "first", "finish_reason": None},
+            {"index": 1, "text": "second", "finish_reason": None},
+        ]
+    )
+
+    out = completion_chunk_to_chat_chunk(src)
+
+    assert len(out["choices"]) == 1
+    assert out["choices"][0]["delta"] == {"content": "first"}
+
+
+def test_missing_logprobs_and_finish_reason_default_to_none() -> None:
+    """Optional per-choice fields fall back to ``None`` via ``.get``."""
+    src = _base_completion_chunk([{"index": 0, "text": "x"}])
+
+    out = completion_chunk_to_chat_chunk(src)
+
+    choice = out["choices"][0]
+    assert choice["logprobs"] is None
+    assert choice["finish_reason"] is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

The PD-disaggregation example proxy crashes when serving `/v1/chat/completions` with streaming enabled.

`examples/disagg_prefill/disagg_proxy_server.py` converts each decoder `/v1/completions` stream chunk into `chat.completion.chunk` form by indexing `completion_data["choices"][0]` unconditionally. The decoder can stream a valid chunk with `choices: []` — e.g. the trailing usage/metadata frame emitted when `stream_options.include_usage` is set — so the index raised `IndexError: list index out of range` and aborted the whole ASGI streaming response even though the decoder request returned HTTP 200.

Fixes #3475.

## Fix

Extract the conversion into a module-level helper `completion_chunk_to_chat_chunk(completion_data)` that returns `None` for empty-`choices` frames; the streaming loop skips those frames.

**Empty-`choices` frames are dropped rather than forwarded on purpose.** This proxy surfaces the prefill token twice for the original client request — it appends the prefill token to the decoder prompt *and* separately emits it to the client as completion content — so the decoder subrequest's `usage` is miscounted for the client. Forwarding it would propagate wrong token accounting, and dropping the frame matches the pre-existing behavior where the converted chat chunk never carried `usage`.

## Scope note

The two other `prefill_output["choices"][0]` accesses in this file are left unchanged: they read the **prefill response**, which is forced non-streaming (`stream_options` removed before the prefill request), so those indexes are never exposed to an empty-`choices` streaming frame.

## Test plan

`tests/disagg/test_disagg_proxy_chunk_conversion.py` (7 cases, CPU-only, imports the helper from the example script via `sys.path`):

- single choice → chat delta with `content`/`logprobs`/`finish_reason`
- empty `choices` → `None` (the #3475 crash case, no raise)
- empty `choices` + `usage` → `None` (dropped, not forwarded)
- missing `choices` key → `None`
- `usage` never forwarded even on a token chunk that carries it
- multiple choices → first only (proxy is single-choice)
- missing `logprobs`/`finish_reason` → `None` defaults

```
$ pytest tests/disagg/test_disagg_proxy_chunk_conversion.py -q
7 passed

$ pre-commit run --files examples/disagg_prefill/disagg_proxy_server.py \
    tests/disagg/test_disagg_proxy_chunk_conversion.py
ruff / ruff-format / isort / mypy / codespell / spdx ... Passed
```

AI assistance was used in drafting this fix and tests; the human contributor reviewed every line and ran the test plan locally.
