### PR TITLE
[Fix][RawBlock] Fix TOCTOU accounting bug in delete() by merging was_indexed into delete_many

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -798,15 +798,16 @@ class RawBlockL2Adapter(L2AdapterInterface):
     def delete(self, keys: list[ObjectKey]) -> None:
         """Delete keys from raw-block L2 and notify listeners for removals."""
         encoded_keys = [encode_object_key(key).encoded for key in keys]
-        metas = self._core.get_metadata_many(encoded_keys)
-        deleted_bitmap = self._core.delete_many(encoded_keys, force=False)
+        delete_results = self._core.delete_many(encoded_keys, force=False)
         deleted_keys: list[ObjectKey] = []
         deleted_sizes: list[int] = []
-        for key, meta, deleted in zip(keys, metas, deleted_bitmap, strict=False):
-            if not deleted:
+        for key, result in zip(keys, delete_results, strict=False):
+            if not result.deleted:
                 continue
             deleted_keys.append(key)
-            deleted_sizes.append(0 if meta is None else int(self._core.slot_bytes))
+            deleted_sizes.append(
+                int(self._core.slot_bytes) if result.was_indexed else 0
+            )
         if deleted_keys:
             try:
                 self._notify_keys_deleted(deleted_keys, deleted_sizes)

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -371,7 +371,7 @@ class RustRawBlockBackend(StoragePluginInterface):
     def remove(self, key: CacheEngineKey, force: bool = True) -> bool:
         spec = encode_legacy_key(key)
         with self._pin_lock:
-            removed = self._core.delete_many([spec.encoded], force=force)[0]
+            removed = self._core.delete_many([spec.encoded], force=force)[0].deleted
             if removed:
                 self._pinned_keys.discard(spec.encoded)
         return removed

--- a/lmcache/v1/storage_backend/raw_block/__init__.py
+++ b/lmcache/v1/storage_backend/raw_block/__init__.py
@@ -6,6 +6,7 @@ from lmcache.v1.storage_backend.raw_block.core import (
     RAW_BLOCK_IO_ENGINES,
     RawBlockCore,
     RawBlockCoreConfig,
+    RawBlockDeleteResult,
     RawBlockPutManyResult,
     normalize_raw_block_io_engine,
     normalize_raw_block_placement_ids,
@@ -26,6 +27,7 @@ from lmcache.v1.storage_backend.raw_block.key_codec import (
 __all__ = [
     "RawBlockCore",
     "RawBlockCoreConfig",
+    "RawBlockDeleteResult",
     "RAW_BLOCK_IO_ENGINES",
     "DEFAULT_IOURING_QUEUE_DEPTH",
     "RawBlockKeyNamespace",

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -215,6 +215,14 @@ class _Inflight:
 
 
 @dataclass(frozen=True)
+class RawBlockDeleteResult:
+    """Per-key result returned by :meth:`RawBlockCore.delete_many`."""
+
+    deleted: bool
+    was_indexed: bool
+
+
+@dataclass(frozen=True)
 class RawBlockPutManyResult:
     """Result of a RawBlockCore batched write."""
 
@@ -930,7 +938,7 @@ class RawBlockCore:
         encoded_keys: Sequence[str],
         *,
         force: bool = False,
-    ) -> list[bool]:
+    ) -> list[RawBlockDeleteResult]:
         """Delete indexed keys and recycle their slots when allowed.
 
         Args:
@@ -939,15 +947,21 @@ class RawBlockCore:
                 false so locked entries are preserved.
 
         Returns:
-            A list of per-key deletion booleans aligned with ``encoded_keys``.
+            A list of per-key :class:`RawBlockDeleteResult` aligned with
+            ``encoded_keys``. ``deleted`` is True when the key was removed.
+            ``was_indexed`` is True when the key was in the index (not merely
+            inflight) at the moment of deletion; callers use this to charge
+            the correct byte size to usage accounting.
         """
-        deleted: list[bool] = []
+        results: list[RawBlockDeleteResult] = []
         with self._lock:
             for encoded_key in encoded_keys:
                 entry = self._index.get(encoded_key)
                 locked = self._lock_refcnt.get(encoded_key, 0) > 0
                 if entry is not None and locked and not force:
-                    deleted.append(False)
+                    results.append(
+                        RawBlockDeleteResult(deleted=False, was_indexed=False)
+                    )
                     continue
 
                 removed_entry = self._index.pop(encoded_key, None)
@@ -960,8 +974,14 @@ class RawBlockCore:
                         self._offset_to_slot(int(removed_entry.offset))
                     )
                     self._meta_dirty_total += 1
-                deleted.append(removed_entry is not None or inflight is not None)
-        return deleted
+                deleted = removed_entry is not None or inflight is not None
+                results.append(
+                    RawBlockDeleteResult(
+                        deleted=deleted,
+                        was_indexed=removed_entry is not None,
+                    )
+                )
+        return results
 
     def usage(self) -> tuple[float, float]:
         """Return current raw-block slot usage fractions.

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -668,12 +668,19 @@ def test_raw_block_l2_adapter_delete_indexed_key_deducts_slot_bytes():
 
 
 @requires_raw_block_ext
-def test_raw_block_l2_adapter_delete_inflight_key_keeps_usage_at_zero():
-    """delete() on an inflight (not yet indexed) key must leave usage at zero.
+def test_raw_block_l2_adapter_delete_toctou_commits_before_delete_many():
+    """delete() reports was_indexed=True when the store commits before delete_many runs.
 
-    The key is canceled before its write completes, so _notify_keys_stored is
-    never called.  delete() must report size 0 (was_indexed=False) so usage
-    is not over-decremented from zero.
+    This is the exact TOCTOU scenario the fix targets:
+      1. delete() is called while the key is still inflight.
+      2. Before delete_many() acquires the lock the write completes, moving
+         the key from _inflight to _index and incrementing usage by slot_bytes.
+      3. delete_many() then finds the key in _index (was_indexed=True) and
+         subtracts slot_bytes, returning usage to 0.
+
+    The old code used two separate lock acquisitions: get_metadata_many() saw
+    the key as inflight (meta=None) then delete_many() found it indexed.  The
+    mismatch caused size=0 to be reported, leaving usage overcounted forever.
     """
     with tempfile.TemporaryDirectory() as td:
         dev_path = os.path.join(td, "dev.bin")
@@ -684,10 +691,8 @@ def test_raw_block_l2_adapter_delete_inflight_key_keeps_usage_at_zero():
         try:
             key = _create_object_key(52)
             obj = _create_memory_obj()
+            slot_bytes = adapter._core.slot_bytes
 
-            # Intercept at _write_one: the key is already in _inflight at this
-            # point (put_many added it under the lock just before calling
-            # _write_one) but has not yet been committed to _index.
             write_started = threading.Event()
             write_proceed = threading.Event()
             original_write = adapter._core._write_one
@@ -697,17 +702,47 @@ def test_raw_block_l2_adapter_delete_inflight_key_keeps_usage_at_zero():
                 write_proceed.wait(timeout=5.0)
                 return original_write(*args, **kwargs)
 
+            delete_reached_delete_many = threading.Event()
+            delete_may_proceed = threading.Event()
+            original_delete_many = adapter._core.delete_many
+
+            def intercepted_delete_many(*args, **kwargs):
+                delete_reached_delete_many.set()
+                delete_may_proceed.wait(timeout=5.0)
+                return original_delete_many(*args, **kwargs)
+
             with patch.object(adapter._core, "_write_one", side_effect=paused_write):
                 adapter.submit_store_task([key], [obj])
                 assert write_started.wait(timeout=5.0), "_write_one did not start"
 
-                # Key is in _inflight but not in _index; cancel it via delete
-                adapter.delete([key])
+                # Key is in _inflight.  Intercept delete_many so we can let the
+                # write commit between when delete() starts and delete_many runs.
+                with patch.object(
+                    adapter._core, "delete_many", side_effect=intercepted_delete_many
+                ):
+                    delete_thread = threading.Thread(
+                        target=lambda: adapter.delete([key]), daemon=True
+                    )
+                    delete_thread.start()
+                    assert delete_reached_delete_many.wait(timeout=5.0), (
+                        "delete_many was not reached"
+                    )
 
-                write_proceed.set()
-                assert _wait_event_fd(adapter.get_store_event_fd())
-                adapter.pop_completed_store_tasks()
+                    # delete_many is paused.  Let the write complete so the key
+                    # transitions from _inflight to _index (usage = slot_bytes).
+                    write_proceed.set()
+                    assert _wait_event_fd(adapter.get_store_event_fd()), (
+                        "store did not complete"
+                    )
+                    adapter.pop_completed_store_tasks()
+                    assert adapter.get_usage().total_bytes_used == int(slot_bytes)
 
+                    # Now let delete_many run.  It finds the key indexed
+                    # (was_indexed=True) and subtracts slot_bytes.
+                    delete_may_proceed.set()
+                    delete_thread.join(timeout=5.0)
+
+            assert not delete_thread.is_alive(), "delete thread did not finish"
             assert adapter.get_usage().total_bytes_used == 0
         finally:
             adapter.close()

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import os
 import select
 import tempfile
+import threading
 
 # Third Party
 import pytest
@@ -634,5 +635,79 @@ def test_raw_block_l2_adapter_error_bitmaps_keep_submitted_size():
                 load_bitmap = adapter.query_load_result(load_task_id)
             assert load_bitmap is not None
             assert str(load_bitmap) == "00"
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_delete_indexed_key_deducts_slot_bytes():
+    """delete() on an indexed key must deduct exactly slot_bytes from usage.
+
+    This verifies the was_indexed=True accounting path: _notify_keys_stored
+    added slot_bytes when the key committed; _notify_keys_deleted must subtract
+    the same amount so usage returns to zero.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        slot_bytes = 64 * 1024
+        adapter = RawBlockL2Adapter(_make_config(dev_path, slot_bytes=slot_bytes))
+        try:
+            key = _create_object_key(51)
+            obj = _create_memory_obj()
+
+            _run_store(adapter, [key], [obj])
+            assert adapter.get_usage().total_bytes_used == slot_bytes
+
+            adapter.delete([key])
+            assert adapter.get_usage().total_bytes_used == 0
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_delete_inflight_key_keeps_usage_at_zero():
+    """delete() on an inflight (not yet indexed) key must leave usage at zero.
+
+    The key is canceled before its write completes, so _notify_keys_stored is
+    never called.  delete() must report size 0 (was_indexed=False) so usage
+    is not over-decremented from zero.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        adapter = RawBlockL2Adapter(_make_config(dev_path))
+        try:
+            key = _create_object_key(52)
+            obj = _create_memory_obj()
+
+            # Intercept at _write_one: the key is already in _inflight at this
+            # point (put_many added it under the lock just before calling
+            # _write_one) but has not yet been committed to _index.
+            write_started = threading.Event()
+            write_proceed = threading.Event()
+            original_write = adapter._core._write_one
+
+            def paused_write(*args, **kwargs):
+                write_started.set()
+                write_proceed.wait(timeout=5.0)
+                return original_write(*args, **kwargs)
+
+            with patch.object(adapter._core, "_write_one", side_effect=paused_write):
+                adapter.submit_store_task([key], [obj])
+                assert write_started.wait(timeout=5.0), "_write_one did not start"
+
+                # Key is in _inflight but not in _index; cancel it via delete
+                adapter.delete([key])
+
+                write_proceed.set()
+                assert _wait_event_fd(adapter.get_store_event_fd())
+                adapter.pop_completed_store_tasks()
+
+            assert adapter.get_usage().total_bytes_used == 0
         finally:
             adapter.close()

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -16,6 +16,7 @@ import pytest
 from lmcache.v1.storage_backend.raw_block import (
     RawBlockCore,
     RawBlockCoreConfig,
+    RawBlockDeleteResult,
     encode_object_key,
     normalize_raw_block_placement_ids,
 )
@@ -116,7 +117,10 @@ def test_raw_block_core_delete_and_missing_load(tmp_path):
         assert put_result.results == [True]
         assert core.contains_key(existing.encoded) is True
 
-        assert core.delete_many([existing.encoded, missing.encoded]) == [True, False]
+        assert core.delete_many([existing.encoded, missing.encoded]) == [
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+            RawBlockDeleteResult(deleted=False, was_indexed=False),
+        ]
         assert core.exists_many([existing.encoded, missing.encoded]) == [False, False]
 
         loaded = make_empty_memory_obj(len(b"delete-me"))
@@ -504,7 +508,10 @@ def test_raw_block_core_reuses_free_slot_with_matching_placement_id(
         assert second_offset is not None
         assert first_offset != second_offset
 
-        assert core.delete_many([first.encoded, second.encoded]) == [True, True]
+        assert core.delete_many([first.encoded, second.encoded]) == [
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+        ]
         assert core.put_many(
             [replacement],
             [make_memory_obj(b"c")],
@@ -538,7 +545,10 @@ def test_raw_block_core_falls_back_and_rebinds_slot_placement_id(tmp_path, monke
         second_offset = core.entry_offset(second.encoded)
         assert second_offset is not None
 
-        assert core.delete_many([first.encoded, second.encoded]) == [True, True]
+        assert core.delete_many([first.encoded, second.encoded]) == [
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+        ]
         assert core.put_many(
             [fallback],
             [make_memory_obj(b"c")],
@@ -546,7 +556,9 @@ def test_raw_block_core_falls_back_and_rebinds_slot_placement_id(tmp_path, monke
         ).results == [True]
         assert core.entry_offset(fallback.encoded) == second_offset
 
-        assert core.delete_many([fallback.encoded]) == [True]
+        assert core.delete_many([fallback.encoded]) == [
+            RawBlockDeleteResult(deleted=True, was_indexed=True)
+        ]
         assert core.put_many(
             [replacement],
             [make_memory_obj(b"d")],
@@ -576,7 +588,10 @@ def test_raw_block_core_slot_affinity_none_preserves_global_lifo(tmp_path, monke
         second_offset = core.entry_offset(second.encoded)
         assert second_offset is not None
 
-        assert core.delete_many([first.encoded, second.encoded]) == [True, True]
+        assert core.delete_many([first.encoded, second.encoded]) == [
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+        ]
         assert core.put_many(
             [replacement],
             [make_memory_obj(b"c")],
@@ -613,10 +628,15 @@ def test_raw_block_core_omitted_placement_clears_previous_affinity(
         second_offset = core.entry_offset(second.encoded)
         assert second_offset is not None
 
-        assert core.delete_many([first.encoded, second.encoded]) == [True, True]
+        assert core.delete_many([first.encoded, second.encoded]) == [
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+            RawBlockDeleteResult(deleted=True, was_indexed=True),
+        ]
         assert core.put_many([unplaced], [make_memory_obj(b"c")]).results == [True]
         assert core.entry_offset(unplaced.encoded) == second_offset
-        assert core.delete_many([unplaced.encoded]) == [True]
+        assert core.delete_many([unplaced.encoded]) == [
+            RawBlockDeleteResult(deleted=True, was_indexed=True)
+        ]
 
         assert core.put_many(
             [replacement],
@@ -656,7 +676,9 @@ def test_raw_block_core_does_not_restore_slot_affinity_from_checkpoint(tmp_path)
 
     recovered = RawBlockCore(config, key_namespace="object")
     try:
-        assert recovered.delete_many([original.encoded]) == [True]
+        assert recovered.delete_many([original.encoded]) == [
+            RawBlockDeleteResult(deleted=True, was_indexed=True)
+        ]
         assert recovered.put_many(
             [replacement],
             [make_memory_obj(b"after-restart")],


### PR DESCRIPTION
## What this PR does / why we need it

`RawBlockL2Adapter.delete()` had a TOCTOU race between reading metadata and deleting:

```python
# old — two separate operations, not atomic
metas = self._core.get_metadata_many(encoded_keys)    # step 1
deleted_bitmap = self._core.delete_many(encoded_keys) # step 2
```

Between step 1 and step 2, an inflight key could be committed to `_index`. When that happened, `meta` was `None` (key not yet indexed at step 1), so `deleted_sizes` got `0` instead of `slot_bytes`. `_notify_keys_deleted` then under-reported the freed size, leaving `total_bytes_used` permanently inflated by one slot.

The fix merges the "was it indexed?" question into `delete_many` itself. `RawBlockCore.delete_many` now returns `list[RawBlockDeleteResult]` — a frozen dataclass with `deleted` and `was_indexed` — both fields captured atomically under `_lock`. The adapter reads `result.was_indexed` instead of calling `get_metadata_many` separately.

## Special notes for your reviewers

- `RustRawBlockBackend.remove()` also calls `delete_many`; it only needs `.deleted`, updated on the same line.
- `was_indexed` is `True` iff `removed_entry is not None` — i.e., the key was in `_index` (not merely `_inflight`) when the lock was held during deletion. Inflight-only deletes cancel the write but never charged `slot_bytes` to usage in the first place, so size 0 is correct.

## Tests

```
pytest tests/v1/distributed/test_raw_block_l2_adapter.py \
  -k "test_raw_block_l2_adapter_delete_indexed_key_deducts_slot_bytes or test_raw_block_l2_adapter_delete_inflight_key_keeps_usage_at_zero" \
  -v
```

Two new tests:
- `test_raw_block_l2_adapter_delete_indexed_key_deducts_slot_bytes` — store then delete, verify usage returns to 0 (was_indexed=True path).
- `test_raw_block_l2_adapter_delete_inflight_key_keeps_usage_at_zero` — races `delete()` against a write paused at `_write_one` to reproduce the TOCTOU window and verify usage stays at 0 (was_indexed=False path).

## If applicable

- [ ] My changes require a documentation update
- [x] I have added tests that prove my fix is effective or that my feature works