### PR TITLE
docs: daily drift check — multi-process mode (2026-06-01)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -63,9 +63,19 @@ Source: ``lmcache/v1/multiprocess/config.py``
      - JSON string of extra key-value config forwarded to runtime
        plugins via ``LMCACHE_RUNTIME_PLUGIN_EXTRA_CONFIG``. Example:
        ``'{"plugin.frontend.heartbeat_url": "http://localhost:5000/heartbeat"}'``.
+   * - ``--supported-transfer-mode``
+     - ``auto``
+     - Which worker → server transfer paths the server loads.
+       ``gpu`` enables only GPU-based IPC transfer (STORE/RETRIEVE);
+       ``non_gpu`` enables only the non-GPU (PREPARE/COMMIT) transfer
+       path; ``auto`` (default) loads both so workers of either device
+       type can connect without manual configuration.
+       Choices: ``gpu``, ``non_gpu``, ``auto``.
    * - ``--shm-name``
      - *(not set)*
-     - SHM segment name for non-GPU KV transfer.
+     - SHM segment name for non-GPU KV transfer (only used when the
+       non-GPU path is loaded, i.e. ``--supported-transfer-mode`` is
+       ``auto`` or ``non_gpu``).
        Not set (default): auto-allocate a shared-memory pool.
        ``""`` (empty string): disable SHM and force the pickle transfer
        path.  Any other value: use that exact name for the SHM pool

--- a/docs/source/mp/deployment.rst
+++ b/docs/source/mp/deployment.rst
@@ -219,12 +219,27 @@ A larger L1 cache means fewer L2 round-trips.
 Use ``LMCACHE_LOG_LEVEL=DEBUG`` during initial setup to verify L2 store/load
 activity.  Switch to ``INFO`` (default) for production to reduce log volume.
 
-Non-GPU Transfer Mode (``--shm-name``)
---------------------------------------
+Non-GPU Transfer Mode (``--supported-transfer-mode``, ``--shm-name``)
+---------------------------------------------------------------------
 
-By default, LMCache creates a shared-memory (SHM) pool for non-GPU KV
-transfers between the server and vLLM workers.  The ``--shm-name`` option
-lets you control this behavior:
+LMCache supports two worker → server transfer paths: a **GPU** path
+(CUDA IPC, used for STORE/RETRIEVE) and a **non-GPU** path
+(PREPARE/COMMIT, used by CPU-only or non-CUDA accelerator workers).
+The server picks which paths to load via ``--supported-transfer-mode``:
+
+- ``auto`` *(default)* -- load both paths.  Workers of either device
+  type can connect without manual configuration; the server has no
+  upfront knowledge of the connecting worker's device.
+- ``gpu`` -- load only the GPU IPC path.  Use when every worker is a
+  CUDA device and you want to skip allocating the non-GPU resources
+  (SHM pool, pickle codec).
+- ``non_gpu`` -- load only the non-GPU path.  Use when serving CPU-only
+  or non-CUDA accelerator workers.
+
+When the non-GPU path is loaded (``auto`` or ``non_gpu``), LMCache by
+default creates a shared-memory (SHM) pool for non-GPU KV transfers
+between the server and vLLM workers.  The ``--shm-name`` option lets
+you control this behavior:
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
## Summary

Auto-generated daily drift check against the multi-process mode user-facing docs. One round of drift found, introduced today by [#3359](https://github.com/LMCache/LMCache/pull/3359) (`feat(mp): SHM-based data transfer path for GPUs/CPU/Accelerators`, merged 2026-06-01 at commit [cb5343d](https://github.com/LMCache/LMCache/commit/cb5343d1b2effb25d6cabcf898947def1c20088f)).

**`docs/source/mp/` (user-facing):**

- `configuration.rst` — the MP Server arguments table is missing the new `--supported-transfer-mode` CLI flag. PR #3359 renamed the previously-internal `--transfer-mode` flag to `--supported-transfer-mode`, added an `auto` choice, and changed the default from `gpu` to `auto` (loads both transfer paths). The PR self-updated `--shm-name` into the table but did not add the rename/default-change for the transfer-mode flag itself.
- `deployment.rst` — the "Non-GPU Transfer Mode" section header and intro discuss only `--shm-name` and don't mention the top-level `--supported-transfer-mode` toggle that gates whether the non-GPU path is loaded at all.

**`docs/design/`:** no new drift attributable to #3359; the design doc `docs/design/v1/multiprocess/non_gpu_context_design.md` was updated as part of #3359 and is current.

## Evidence

| Stale doc | Current code |
|-----------|--------------|
| `docs/source/mp/configuration.rst` MP Server table — no row for `--supported-transfer-mode` (table ends at `--runtime-plugin-config`, then jumps to `--shm-name`) | [`lmcache/v1/multiprocess/config.py:45-48`](https://github.com/LMCache/LMCache/blob/5b2d4aee6ffc7a22fa4f95a886d667afe815fd72/lmcache/v1/multiprocess/config.py#L45-L48) — `supported_transfer_mode: str = "auto"`; CLI flag registered at [`config.py:164-173`](https://github.com/LMCache/LMCache/blob/5b2d4aee6ffc7a22fa4f95a886d667afe815fd72/lmcache/v1/multiprocess/config.py#L164-L173) with `choices=["gpu", "non_gpu", "auto"]`, `default="auto"`; consumed in `parse_args_to_mp_server_config` at [`config.py:239`](https://github.com/LMCache/LMCache/blob/5b2d4aee6ffc7a22fa4f95a886d667afe815fd72/lmcache/v1/multiprocess/config.py#L239). |
| `docs/source/mp/deployment.rst:222` — section heading `Non-GPU Transfer Mode (``--shm-name``)` and intro mention only `--shm-name` | Same code reference — `--supported-transfer-mode` is the top-level toggle for whether the non-GPU path is even loaded; `--shm-name` only takes effect when the non-GPU path is loaded (i.e. `--supported-transfer-mode` is `auto` or `non_gpu`). |

## Proposed fix

Already applied in this PR's diff. Doc-only — no code changes:

- `docs/source/mp/configuration.rst`: add a `--supported-transfer-mode` row to the MP Server arguments table (default `auto`, choices `gpu`/`non_gpu`/`auto`, with a short description of each mode) and clarify that `--shm-name` only applies when the non-GPU path is loaded.
- `docs/source/mp/deployment.rst`: rename the "Non-GPU Transfer Mode" section to include `--supported-transfer-mode` alongside `--shm-name`, and expand the intro into a short bullet list that explains the three transfer-mode values before falling through to the existing `--shm-name` table.

## Overlap with prior open drift PRs

This PR is **independent** of the still-open prior-day drift PRs and touches no overlapping doc text:

- [#3467](https://github.com/LMCache/LMCache/pull/3467) (2026-05-30): addresses the `blend_server_v2.py` rename / removal under `MPCacheEngine` refactor (touches `docs/source/mp/index.rst`, `architecture.rst`, and `docs/design/observability/request-event-span.md`). **Heads-up:** the version of #3467's `configuration.rst` edit on its branch adds a row for the old `--transfer-mode` name with default `gpu`; that's no longer the flag's name or default after #3359 landed, so #3467 will need a small rebase / refresh before merge — flagged here for the reviewer rather than fixed in this PR.
- [#3454](https://github.com/LMCache/LMCache/pull/3454) (2026-05-29): adds `--script-allowed-imports` and the `POST /run_script` row to `http_api.rst` / `configuration.rst`. No overlapping rows.

## Notes

- Auto-generated by the daily LMCache docs drift-check routine. **Human review required before merge.**
- Marked as **draft**; please do not merge without an editorial pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGBqvgt1BhAfEbSfHtVbLg)_