### PR TITLE
NIXL: DOCA_MEMOS storage backend (NVIDIA CMX)

### DIFF
--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -48,7 +48,7 @@ Key settings:
 
 - ``nixl_path``: directory under which the storage files will be saved (e.g. /mnt/nixl/). Needed for NIXL backends that store to file.
 
-- ``nixl_buffer_device``: dictates where the memory managed by NIXL should be on. "cpu" or "cuda" is supported for "GDS", "GDS_MT", and "OBJ" backends - for "POSIX", "HF3FS" & "AZURE_BLOB", must be "cpu".
+- ``nixl_buffer_device``: dictates where the memory managed by NIXL should be on. "cpu" or "cuda" is supported for "GDS", "GDS_MT", and "OBJ" backends - for "POSIX", "HF3FS", "AZURE_BLOB" & "DOCA_MEMOS", must be "cpu".
 
 - ``nixl_backend``: configuration of which nixl backend to use for storage.
 
@@ -56,7 +56,7 @@ Key settings:
 
 .. note::
 
-    Supported backends are: ["GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ", "AZURE_BLOB"].
+    Supported backends are: ["GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ", "AZURE_BLOB", "DOCA_MEMOS"].
 
     Backend specific params should be provided via ``extra_config.nixl_backend_params``. Please refer to NIXL documentation for specifics.
 
@@ -144,6 +144,10 @@ round-robin order based on its ``local_worker_id`` (the worker ID within its hos
     When ``nixl_endpoint_list`` is set, any ``endpoint_override`` value in
     ``nixl_backend_params`` is ignored (a warning is logged).
 
+    ``nixl_endpoint_list`` is only honored for the OBJ backend; it is ignored
+    for all other backends (including DOCA_MEMOS, AZURE_BLOB, and the file
+    backends).
+
 Dynamic Mode
 ~~~~~~~~~~~~~
 
@@ -154,7 +158,7 @@ In order to use dynamic mode, extra_config.nixl_pool_size should be set to 0.
 Restrictions
 ^^^^^^^^^^^^
 
-- Dynamic mode is currently only supported for nixl OBJ and AZURE_BLOB backends.
+- Dynamic mode is supported for object backends ("OBJ", "AZURE_BLOB", "DOCA_MEMOS") and file backends ("POSIX", "GDS", "GDS_MT", "HF3FS").
 - save_unfull_chunk must be set to False.
 
 Example ``lmcache-config.yaml`` for OBJ backend with dynamic mode:
@@ -205,3 +209,24 @@ Example ``lmcache-config.yaml`` for AZURE_BLOB backend with dynamic mode:
     nixl_backend_params:
       account_url: https://<your_azure_storage_account_name>.blob.core.windows.net
       container_name: <your_container_name>
+
+DOCA_MEMOS Backend (NVIDIA CMX)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``DOCA_MEMOS`` stores KV cache on NVIDIA CMX (Context Memory Storage), a
+BlueField-4 context-memory tier accessed through NIXL. It is an object-style
+backend (like ``OBJ``), supported in both static (``nixl_pool_size`` > 0) and
+dynamic (``nixl_pool_size`` = 0) mode. ``nixl_buffer_device`` must be ``cpu``.
+``nixl_endpoint_list`` is not supported for DOCA_MEMOS.
+
+.. code-block:: yaml
+
+    chunk_size: 256
+    nixl_buffer_size: 1073741824 # 1GB
+    nixl_buffer_device: cpu
+    extra_config:
+      enable_nixl_storage: true
+      nixl_backend: DOCA_MEMOS
+      nixl_pool_size: 64
+      nixl_backend_params:
+        # refer to NIXL DOCA_MEMOS plugin docs for connection params

--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -219,6 +219,12 @@ backend (like ``OBJ``), supported in both static (``nixl_pool_size`` > 0) and
 dynamic (``nixl_pool_size`` = 0) mode. ``nixl_buffer_device`` must be ``cpu``.
 ``nixl_endpoint_list`` is not supported for DOCA_MEMOS.
 
+Object names are 128-bit lowercase-hex strings: the NIXL DOCA_MEMOS plugin
+passes object names as strings and hex-decodes them on the device side, so
+each name is exactly 32 hex characters. In dynamic mode this name is a
+truncated SHA-256 of the cache key, so names are opaque (they carry no
+model/chunk debug information) and uniqueness is probabilistic at 128 bits.
+
 .. code-block:: yaml
 
     chunk_size: 256

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -99,7 +99,7 @@ class NixlStorageConfig:
         device = device.split(":", 1)[0]
         if backend in ("GDS", "GDS_MT", "OBJ"):
             return device == "cpu" or device == "cuda"
-        elif backend in ("POSIX", "HF3FS", "AZURE_BLOB"):
+        elif backend in ("POSIX", "HF3FS", "AZURE_BLOB", "DOCA_MEMOS"):
             return device == "cpu"
         else:
             return False
@@ -573,7 +573,7 @@ class NixlDynamicStorageAgent(NixlStorageAgent):
             allocator, device, backend, backend_params, enable_prog_thread, sync_mode
         )
 
-        if backend in ("OBJ", "AZURE_BLOB"):
+        if backend in ("OBJ", "AZURE_BLOB", "DOCA_MEMOS"):
             self.mem_type = "OBJ"
         else:
             self.mem_type = "FILE"
@@ -891,7 +891,7 @@ class NixlStaticStorageBackend(NixlStorageBackend):
     def createPool(backend: str, size: int, path: str, use_direct_io: bool):
         if backend in ("GDS", "GDS_MT", "POSIX", "HF3FS"):
             return NixlFilePool(size, path, use_direct_io)
-        elif backend in ("OBJ", "AZURE_BLOB"):
+        elif backend in ("OBJ", "AZURE_BLOB", "DOCA_MEMOS"):
             return NixlObjectPool(size)
         else:
             raise ValueError(f"Unsupported NIXL backend: {backend}")

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, List, Optional, Sequence, Set, Tuple, Union, cast
 from urllib.parse import quote as url_quote
 import asyncio
+import hashlib
 import os
 import threading
 import time
@@ -76,6 +77,10 @@ DEFAULT_FILE_CREATE_MODE = 0o644
 
 # Max concurrency for parallel S3 HEAD requests in batched_contains().
 _CONTAINS_BATCH_SIZE = 16
+
+# Max static b128 pool size: the slot index occupies 8 hex chars (32 bits) of
+# the 32-hex-char (128-bit) name, so the index must be <= 0xffffffff.
+B128_MAX_POOL_SIZE = 0x100000000  # 2**32
 
 
 @dataclass
@@ -281,12 +286,38 @@ class NixlFilePool(NixlDescPool):
 
 
 class NixlObjectPool(NixlDescPool):
-    def __init__(self, size: int):
+    def __init__(self, size: int, b128: bool = False) -> None:
+        """Create a pool of ``size`` NIXL object slot names.
+
+        Args:
+            size: Number of object slots to pre-generate.
+            b128: If True, generate 128-bit hex slot names (32 hex chars) for
+                the DOCA_MEMOS backend instead of the default ``obj_{i}_{uuid}``
+                names.
+
+        Raises:
+            ValueError: If ``b128`` is True and ``size`` exceeds
+                ``B128_MAX_POOL_SIZE`` (the slot index would no longer fit in
+                8 hex chars).
+        """
+        if b128 and size > B128_MAX_POOL_SIZE:
+            raise ValueError(
+                "b128 object pool supports at most 2**32 slots "
+                f"(got {size}); the slot index must fit in 8 hex chars"
+            )
         super().__init__(size)
         self.keys: List[str] = []
 
         for i in reversed(range(size)):
-            key = f"obj_{i}_{uuid.uuid4().hex[0:4]}"
+            if b128:
+                # DOCA_MEMOS requires slot names that fit in 128 bits and are
+                # hex-decodable (the NIXL plugin hex-decodes the name on the
+                # other side). 8 hex chars (32 bits) encode the slot index for
+                # in-pool uniqueness; 24 hex chars (96 bits) of randomness avoid
+                # collisions across LMCache instances on the shared backend.
+                key = f"{i:08x}{uuid.uuid4().hex[:24]}"
+            else:
+                key = f"obj_{i}_{uuid.uuid4().hex[0:4]}"
             self.keys.append(key)
 
     def close(self):
@@ -892,7 +923,7 @@ class NixlStaticStorageBackend(NixlStorageBackend):
         if backend in ("GDS", "GDS_MT", "POSIX", "HF3FS"):
             return NixlFilePool(size, path, use_direct_io)
         elif backend in ("OBJ", "AZURE_BLOB", "DOCA_MEMOS"):
-            return NixlObjectPool(size)
+            return NixlObjectPool(size, b128=(backend == "DOCA_MEMOS"))
         else:
             raise ValueError(f"Unsupported NIXL backend: {backend}")
 
@@ -1166,7 +1197,7 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
         metadata: LMCacheMetadata,
         loop: asyncio.AbstractEventLoop,
         cache_policy: Optional[PresenceCache] = None,
-    ):
+    ) -> None:
         super().__init__(nixl_config, config, metadata, loop)
 
         self.async_mode = nixl_config.enable_async_put
@@ -1181,6 +1212,9 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
                     "use_direct_io is True, but O_DIRECT is not available on "
                     "this system. Falling back to buffered I/O."
                 )
+        # DOCA_MEMOS needs object names that fit into 128 bits; other OBJ
+        # backends use URL-safe names. See _format_object_key.
+        self._use_b128_object_keys = nixl_config.backend == "DOCA_MEMOS"
         # Presence cache to reduce remote contains checks
         self.hit_counter = 0
         self.total_counter = 0
@@ -1281,9 +1315,27 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
         )
 
     def _format_object_key(self, key: CacheEngineKey) -> str:
+        """Format the NIXL object name for ``key`` per the configured backend."""
+        if self._use_b128_object_keys:
+            return self._format_object_key_b128(key)
+        return self._format_object_key_url_safe(key)
+
+    def _format_object_key_b128(self, key: CacheEngineKey) -> str:
         """
-        Generate object key name based on CacheEngineKey information.
-        Similar to s3_connector._format_safe_path()
+        Generate a 128-bit object key for the DOCA_MEMOS backend.
+
+        Returns a 32-char hex string (sha256 truncated to 128 bits). Hex encoding
+        is required because the key is passed via NIXL metadata as a string; the
+        NIXL plugin hex-decodes it on the other side.
+        """
+        return hashlib.sha256(key.to_string().encode("utf-8")).hexdigest()[:32]
+
+    def _format_object_key_url_safe(self, key: CacheEngineKey) -> str:
+        """
+        Generate a URL-safe object key for non-DOCA_MEMOS backends.
+
+        Replaces slashes and @ signs with underscores, then percent-encodes
+        the result for safe use as an object storage key.
         """
         key_str = key.to_string()
         # Replace slashes with underscores to make it safe for object storage/FS

--- a/tests/v1/test_nixl_doca_memos.py
+++ b/tests/v1/test_nixl_doca_memos.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DOCA_MEMOS backend config validation."""
+
+# Third Party
+import pytest
+
+pytest.importorskip("nixl")
+
+# First Party
+from lmcache.v1.storage_backend.nixl_storage_backend import NixlStorageConfig
+
+
+class TestValidateNixlBackend:
+    """NixlStorageConfig.validate_nixl_backend — the config-acceptance path."""
+
+    def test_doca_memos_cpu_is_valid(self) -> None:
+        assert NixlStorageConfig.validate_nixl_backend("DOCA_MEMOS", "cpu") is True
+
+    def test_doca_memos_cuda_is_rejected(self) -> None:
+        assert NixlStorageConfig.validate_nixl_backend("DOCA_MEMOS", "cuda") is False
+
+    def test_doca_memos_cuda_with_index_is_rejected(self) -> None:
+        # device strings may carry an index suffix (e.g. "cuda:0")
+        assert NixlStorageConfig.validate_nixl_backend("DOCA_MEMOS", "cuda:0") is False

--- a/tests/v1/test_nixl_doca_memos.py
+++ b/tests/v1/test_nixl_doca_memos.py
@@ -1,13 +1,140 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for DOCA_MEMOS backend config validation."""
+"""Tests for the DOCA_MEMOS NIXL storage backend.
+
+Covers backend/device validation, the 128-bit-hex object-key format
+(``_format_object_key_b128``) and the URL-safe regression guard, static
+object-pool slot names and the ``createPool`` routing, and the dynamic
+backend's formatter dispatch.
+
+All tests run without NIXL hardware: the formatters do not touch instance
+state, so the real unbound methods are invoked directly with a
+``Mock(spec=...)`` standing in for ``self``.
+"""
+
+# Standard
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+import hashlib
+import re
+import uuid
 
 # Third Party
 import pytest
+import torch
 
 pytest.importorskip("nixl")
 
 # First Party
-from lmcache.v1.storage_backend.nixl_storage_backend import NixlStorageConfig
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.storage_backend.nixl_storage_backend import (
+    B128_MAX_POOL_SIZE,
+    NixlDynamicStorageBackend,
+    NixlObjectPool,
+    NixlStaticStorageBackend,
+    NixlStorageConfig,
+)
+import lmcache.v1.storage_backend.nixl_storage_backend as nsb
+
+_HEX_128 = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _make_key(
+    model_name: str = "org/test_model", chunk_hash: int = 0
+) -> CacheEngineKey:
+    """A CacheEngineKey whose to_string() contains both '/' and '@'."""
+    return CacheEngineKey(
+        model_name=model_name,
+        world_size=1,
+        worker_id=0,
+        chunk_hash=chunk_hash,
+        dtype=torch.bfloat16,
+    )
+
+
+class TestFormatObjectKeyB128:
+    """``_format_object_key_b128`` -> 32-char hex (sha256 truncated to 128 bits)."""
+
+    @staticmethod
+    def _fmt(key: CacheEngineKey) -> str:
+        backend = Mock(spec=NixlDynamicStorageBackend)
+        return NixlDynamicStorageBackend._format_object_key_b128(backend, key)
+
+    def test_returns_32_char_lowercase_hex(self) -> None:
+        out = self._fmt(_make_key())
+        assert _HEX_128.match(out), f"not 128-bit hex: {out!r}"
+
+    def test_matches_documented_algorithm(self) -> None:
+        key = _make_key()
+        expected = hashlib.sha256(key.to_string().encode("utf-8")).hexdigest()[:32]
+        assert self._fmt(key) == expected
+
+    def test_deterministic_for_same_key(self) -> None:
+        key = _make_key(chunk_hash=42)
+        assert self._fmt(key) == self._fmt(_make_key(chunk_hash=42))
+
+    def test_distinct_keys_differ(self) -> None:
+        assert self._fmt(_make_key(chunk_hash=1)) != self._fmt(_make_key(chunk_hash=2))
+
+
+class TestFormatObjectKeyUrlSafe:
+    """Regression guard for the legacy URL-safe formatter (non-DOCA backends)."""
+
+    @staticmethod
+    def _fmt(key: CacheEngineKey) -> str:
+        backend = Mock(spec=NixlDynamicStorageBackend)
+        return NixlDynamicStorageBackend._format_object_key_url_safe(backend, key)
+
+    def test_no_raw_slash_or_at(self) -> None:
+        out = self._fmt(_make_key())
+        assert "/" not in out and "@" not in out
+
+    def test_matches_legacy_transform(self) -> None:
+        # Standard
+        from urllib.parse import quote
+
+        key = _make_key()
+        flat = key.to_string().replace("/", "_").replace("@", "_")
+        assert self._fmt(key) == quote(flat, safe="")
+
+
+class TestNixlObjectPoolKeys:
+    """Static object-pool slot names per backend."""
+
+    def test_b128_keys_are_128bit_hex(self) -> None:
+        pool = NixlObjectPool(64, b128=True)
+        assert len(pool.keys) == 64
+        assert all(_HEX_128.match(k) for k in pool.keys)
+
+    def test_b128_keys_are_unique(self) -> None:
+        pool = NixlObjectPool(256, b128=True)
+        assert len(set(pool.keys)) == len(pool.keys)
+
+    def test_b128_first_8_hex_encode_slot_index(self) -> None:
+        size = 16
+        pool = NixlObjectPool(size, b128=True)
+        # Keys are generated for i in reversed(range(size)); the leading
+        # 8 hex chars must recover every slot index exactly once.
+        indices = sorted(int(k[:8], 16) for k in pool.keys)
+        assert indices == list(range(size))
+
+    def test_default_keys_use_obj_prefix(self) -> None:
+        pool = NixlObjectPool(8)
+        assert all(k.startswith("obj_") for k in pool.keys)
+
+    def test_b128_rejects_pool_size_above_max(self) -> None:
+        with pytest.raises(ValueError, match="at most"):
+            NixlObjectPool(B128_MAX_POOL_SIZE + 1, b128=True)
+
+    def test_b128_max_pool_size_is_2_32(self) -> None:
+        # The guard accepts up to 2**32 slots because the largest valid slot
+        # index (B128_MAX_POOL_SIZE - 1 == 0xffffffff) still formats to exactly
+        # 8 hex chars, keeping the full slot name at 32 hex chars (128 bits).
+        # Constructing a 2**32-slot pool is infeasible in a test, so this
+        # asserts the boundary invariant directly rather than the constructor.
+        assert B128_MAX_POOL_SIZE == 2**32
+        max_index = B128_MAX_POOL_SIZE - 1
+        key = f"{max_index:08x}{uuid.uuid4().hex[:24]}"
+        assert len(key) == 32 and _HEX_128.match(key)
 
 
 class TestValidateNixlBackend:
@@ -22,3 +149,63 @@ class TestValidateNixlBackend:
     def test_doca_memos_cuda_with_index_is_rejected(self) -> None:
         # device strings may carry an index suffix (e.g. "cuda:0")
         assert NixlStorageConfig.validate_nixl_backend("DOCA_MEMOS", "cuda:0") is False
+
+
+class TestCreatePool:
+    """NixlStaticStorageBackend.createPool — the static configured path."""
+
+    def test_doca_memos_creates_b128_object_pool(self) -> None:
+        pool = NixlStaticStorageBackend.createPool(
+            "DOCA_MEMOS", size=8, path="/tmp/unused", use_direct_io=False
+        )
+        assert isinstance(pool, NixlObjectPool)
+        # b128 slot names are 32-char lowercase hex (no "obj_" prefix).
+        assert all(_HEX_128.match(k) for k in pool.keys)
+        assert not any(k.startswith("obj_") for k in pool.keys)
+
+    def test_obj_creates_non_b128_object_pool(self) -> None:
+        pool = NixlStaticStorageBackend.createPool(
+            "OBJ", size=8, path="/tmp/unused", use_direct_io=False
+        )
+        assert isinstance(pool, NixlObjectPool)
+        assert all(k.startswith("obj_") for k in pool.keys)
+
+
+class TestDynamicFormatterDispatch:
+    """A dynamic backend must route _format_object_key to b128 for DOCA_MEMOS."""
+
+    @staticmethod
+    def _make_dynamic_backend(backend_name: str) -> nsb.NixlDynamicStorageBackend:
+        cfg = MagicMock()
+        cfg.backend = backend_name
+        cfg.use_direct_io = False
+        cfg.enable_async_put = False
+        cfg.enable_presence_cache = False
+        cfg.path = "/tmp/nixl-unused"
+
+        def fake_super_init(self: Any, *args: Any, **kwargs: Any) -> None:
+            # super().__init__ normally allocates the NIXL buffer/allocator;
+            # the agent constructor reads self.memory_allocator.
+            self.memory_allocator = MagicMock()
+
+        with (
+            patch.object(nsb.NixlStorageBackend, "__init__", fake_super_init),
+            # Skip init_chunk_meta so the mock metadata is never dereferenced.
+            patch.object(nsb.NixlDynamicStorageBackend, "init_chunk_meta"),
+            patch.object(nsb, "NixlDynamicStorageAgent", return_value=MagicMock()),
+        ):
+            return nsb.NixlDynamicStorageBackend(
+                cfg, MagicMock(), MagicMock(), MagicMock()
+            )
+
+    def test_doca_memos_uses_b128(self) -> None:
+        backend = self._make_dynamic_backend("DOCA_MEMOS")
+        key = _make_key()
+        assert backend._format_object_key(key) == backend._format_object_key_b128(key)
+
+    def test_obj_uses_url_safe(self) -> None:
+        backend = self._make_dynamic_backend("OBJ")
+        key = _make_key()
+        assert backend._format_object_key(key) == backend._format_object_key_url_safe(
+            key
+        )


### PR DESCRIPTION
### Add NIXL `DOCA_MEMOS` storage backend (NVIDIA CMX KV-cache tier)

Adds **`DOCA_MEMOS`**, a NIXL storage backend that offloads KV cache to **NVIDIA CMX** — a
BlueField-4 context-memory tier purpose-built for KV cache. CMX is an optimized object store, so
from LMCache's side it behaves like the existing `OBJ` backend, with one constraint: object names
must fit in 128 bits.

Two commits, along that one difference:

1. **Treat `DOCA_MEMOS` as an object-style backend.** It's structurally an object store, so the
   existing `OBJ` code paths already do the work — LMCache just needs to recognize the backend and
   route it through them. Includes the user-facing docs for the new backend.

2. **Conform object names to the 128-bit key limit.** The NIXL plugin requires hex-decodable,
   128-bit object names, which LMCache's default `OBJ` key formats don't satisfy — so this makes
   DOCA_MEMOS keys 128-bit hex on both the dynamic and static paths.

Existing backends are unaffected (the new behavior is gated on `DOCA_MEMOS`). Exercising it
end-to-end needs a NIXL build with the DOCA_MEMOS plugin; the included unit tests cover the
validation and key-format logic without hardware.