### PR TITLE
[Docs][operator] Fix CRD spec docs and policy enum gaps

### DIFF
--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -265,7 +265,8 @@ Eviction
      - Description
    * - ``eviction.policy``
      - ``LRU``
-     - Only ``LRU`` is supported.
+     - ``LRU`` or ``noop``.  Use ``noop`` with ``l2Backend.storePolicy: skip_l1``
+       for buffer-only mode.
    * - ``eviction.triggerWatermark``
      - ``0.8``
      - Usage ratio (0.0--1.0] to trigger eviction.
@@ -480,7 +481,7 @@ The operator validates the CR spec at apply time:
    * - ``l1.sizeGB``
      - Required, must be > 0.
    * - ``eviction.policy``
-     - Must be ``LRU`` (if set).
+     - Must be ``LRU`` or ``noop`` (if set).
    * - ``eviction.triggerWatermark``
      - Must be in (0.0, 1.0].
    * - ``eviction.evictionRatio``

--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -238,6 +238,9 @@ Server
    * - ``server.hashAlgorithm``
      - ``blake3``
      - ``builtin``, ``sha256_cbor``, or ``blake3``.
+   * - ``server.httpPort``
+     - ``8080``
+     - HTTP frontend port for health checks and cache admin (1024--65535).
 
 L1 Cache
 ~~~~~~~~
@@ -310,10 +313,25 @@ L2 Storage
    * - Field
      - Default
      - Description
-   * - ``l2Backends``
+   * - ``l2Backend``
      - --
      - List of L2 backends (``type`` + ``config``).
        See :doc:`l2_storage/index`.
+
+GPU Vendor
+~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 20 45
+
+   * - Field
+     - Default
+     - Description
+   * - ``gpuVendor``
+     - ``nvidia``
+     - GPU vendor: ``nvidia`` (uses the ``nvidia`` RuntimeClass) or ``amd``
+       (runs on the default runtime with ``privileged: true``).
 
 Scheduling
 ~~~~~~~~~~
@@ -399,6 +417,8 @@ via the CRD):
   Service can route to it.
 - **NVIDIA_VISIBLE_DEVICES=all** -- Ensures GPU access for IPC-based memory
   transfers.
+- **NVIDIA_DRIVER_CAPABILITIES=all** -- Exposes all driver capabilities
+  (compute, utility, etc.) to the container.
 - **TCP socket probes** -- Startup (5s initial, 30 failures), liveness (10s),
   and readiness (5s) probes on the server port.
 

--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -107,10 +107,10 @@ type L1BackendSpec struct {
 
 // EvictionSpec defines the cache eviction configuration.
 type EvictionSpec struct {
-	// policy is the eviction policy. Currently only LRU is supported.
+	// policy is the eviction policy. LRU or noop.
 	// +optional
 	// +kubebuilder:default="LRU"
-	// +kubebuilder:validation:Enum=LRU
+	// +kubebuilder:validation:Enum=LRU;noop
 	Policy *string `json:"policy,omitempty"`
 
 	// triggerWatermark is the cache usage ratio that triggers eviction.
@@ -185,7 +185,7 @@ type L2BackendSpec struct {
 	// cache misses. "default" picks the first adapter that has the key.
 	// +optional
 	// +kubebuilder:default="default"
-	// +kubebuilder:validation:Enum=default
+	// +kubebuilder:validation:Enum=default;retain
 	PrefetchPolicy *string `json:"prefetchPolicy,omitempty"`
 
 	// prefetchMaxInFlight limits the number of concurrent prefetch

--- a/operator/internal/controller/lmcacheengine_controller.go
+++ b/operator/internal/controller/lmcacheengine_controller.go
@@ -87,31 +87,31 @@ func (r *LMCacheEngineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	// 6. Reconcile lookup Service (node-local discovery for vLLM)
+	// 7. Reconcile lookup Service (node-local discovery for vLLM)
 	if err := r.reconcileLookupService(ctx, engine); err != nil {
 		log.Error(err, "Failed to reconcile lookup Service")
 		return ctrl.Result{}, err
 	}
 
-	// 7. Reconcile metrics Service
+	// 8. Reconcile metrics Service
 	if err := r.reconcileMetricsService(ctx, engine); err != nil {
 		log.Error(err, "Failed to reconcile metrics Service")
 		return ctrl.Result{}, err
 	}
 
-	// 8. Reconcile ConfigMap
+	// 9. Reconcile ConfigMap
 	if err := r.reconcileConnectionConfigMap(ctx, engine); err != nil {
 		log.Error(err, "Failed to reconcile ConfigMap")
 		return ctrl.Result{}, err
 	}
 
-	// 9. Reconcile ServiceMonitor
+	// 10. Reconcile ServiceMonitor
 	if err := r.reconcileServiceMonitor(ctx, engine); err != nil {
 		log.Error(err, "Failed to reconcile ServiceMonitor")
 		return ctrl.Result{}, err
 	}
 
-	// 10. Update status
+	// 11. Update status
 	if err := r.updateStatus(ctx, engine); err != nil {
 		log.Error(err, "Failed to update status")
 		return ctrl.Result{}, err


### PR DESCRIPTION
## What this PR does / why we need it

Cross-checked `docs/source/mp/operator.rst` and the operator CRD types against the actual Go and Python server code, and fixed three categories of issues:

**CRD enum gaps** (`lmcacheengine_types.go`):
- `eviction.policy`: added `noop` — the server supports it and the existing docs already recommend it for buffer-only mode (`storePolicy: skip_l1`), but the CRD rejected it at admission time
- `prefetchPolicy`: added `retain` — the server registers both `default` and `retain`, but the operator only allowed `default`

**Missing fields in the CRD spec reference** (`operator.rst`):
- `server.httpPort` (default `8080`) was not documented at all
- `gpuVendor` (`nvidia` / `amd`) was missing entirely from the spec reference
- `NVIDIA_DRIVER_CAPABILITIES=all` was absent from the auto-injected pod settings list
- `l2Backends` → `l2Backend` (field name was wrong; the CRD uses the singular form)

**Comment fix** (`lmcacheengine_controller.go`):
- Duplicate step numbers in reconcile comments

## Special notes for your reviewers

- `IsolatedLRU` eviction policy was intentionally **not** added to the CRD enum — it was merged 1 month ago, requires `cache_salt` to be passed or raises `ValueError`, and is designed to pair with the quota API rather than be used as a standalone option. Users can reach it via `extraArgs` if needed.
- No behaviour changes — the enum additions unlock values the server already accepts; the doc changes are documentation-only.

## If applicable

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests