### PR TITLE
docs: daily drift check — multi-process mode (2026-06-02)

### DIFF
--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -82,6 +82,11 @@ compatibility with the vLLM-embedded API server.
      - ``/clear-cache``
      - Force-clear all KV data in L1 (CPU) memory.
    * - GET
+     - ``/kvcache/check``
+     - Compute MD5 checksums over the GPU KV cache for a set of block IDs.
+       Intended for diagnostics and round-trip integrity checks from
+       ``lmcache bench server``.
+   * - GET
      - ``/quota``
      - List every registered ``cache_salt`` quota with live usage.
    * - PUT
@@ -298,6 +303,76 @@ The request body is ignored.
 .. code-block:: bash
 
     curl -s -X POST http://localhost:8080/clear-cache
+
+``GET /kvcache/check``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Compute MD5 checksums over the GPU KV cache, grouped ``chunk_size`` blocks
+per hashed chunk. MP mode addresses KV storage by block IDs natively (the
+same units used by ``STORE`` / ``RETRIEVE``), so the endpoint is fully
+block-centric: ``block_ids`` enumerates the target blocks and
+``chunk_size`` counts blocks per chunk. Intended for diagnostics and
+round-trip integrity checks from ``lmcache bench server`` — not for the
+inference data path.
+
+**Query parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Name
+     - Required
+     - Description
+   * - ``block_ids``
+     - yes
+     - GPU block IDs in mixed format, e.g. ``"0,[2,5],8"``.
+   * - ``chunk_size``
+     - yes
+     - Positive integer — number of blocks per hashed chunk.
+   * - ``instance_id``
+     - no (default ``0``)
+     - Registered GPU context ID on the engine.
+   * - ``layerwise``
+     - no (default ``false``)
+     - If ``true``, return per-layer checksums keyed by ``"layer_<idx>"``;
+       otherwise a single aggregated digest per chunk over all layers.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "status": "success",
+      "chunk_size": 2,
+      "num_chunks": 2,
+      "chunk_checksums": ["<md5>", "<md5>"],
+      "layerwise": false,
+      "block_id_ranges": "0,[2,5],8"
+    }
+
+When ``layerwise=true``, ``chunk_checksums`` is a dict keyed by
+``"layer_<idx>"`` whose values are per-layer lists.
+
+**HTTP status codes:**
+
+- ``200``: success.
+- ``400``: ``block_ids`` missing/malformed, or ``chunk_size`` missing or
+  non-positive.
+- ``404``: ``instance_id`` not registered, or the registered KV tensors
+  are empty.
+- ``501``: engine has no ``gpu_contexts``, or the GPU KV format is not
+  supported by this endpoint (page-buffer-fused and cross-layer layouts
+  are declined until a real need appears).
+- ``503``: engine not yet initialized on ``app.state``.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s "http://localhost:8080/kvcache/check?block_ids=0,1,2,3&chunk_size=2"
+
+    curl -s "http://localhost:8080/kvcache/check?block_ids=0,1,2,3&chunk_size=2&layerwise=true"
 
 .. _mp-http-quota-api:
 


### PR DESCRIPTION
## Summary

Auto-generated daily drift check against the multi-process mode user-facing docs. Today's MP-related commits (CUDA IPC-event retention #3245, `lmcache_frontend` move #3216, the docker-example doc fix #3481, and a handful of unrelated bugfixes) did not introduce new drift — but the sweep across `docs/source/mp/` surfaced one pre-existing miss that prior drift-checks did not pick up.

**`docs/source/mp/` (user-facing):**

- `http_api.rst` — the auto-discovered route `GET /kvcache/check` (added in [#3411](https://github.com/LMCache/LMCache/pull/3411), refined in [#3437](https://github.com/LMCache/LMCache/pull/3437)) is missing from both the endpoints summary table and the per-endpoint reference section, even though `docs/source/cli/server.rst` already advertises "checksum APIs" and `lmcache bench server` calls this endpoint for its round-trip integrity check.

**`docs/design/`:** no new drift this cycle attributable to today's commits.

## Evidence

| Stale doc | Current code |
|-----------|--------------|
| `docs/source/mp/http_api.rst` endpoint table (no `GET /kvcache/check` row) and missing dedicated section | [`lmcache/v1/multiprocess/http_apis/cache_api.py:63-181`](https://github.com/LMCache/LMCache/blob/b0d1e1e74e89da1d0c9764475c5e6b35a4989af1/lmcache/v1/multiprocess/http_apis/cache_api.py#L63-L181) — `@router.get("/kvcache/check")` with query params `block_ids`, `chunk_size`, `instance_id`, `layerwise` and the full 200 / 400 / 404 / 501 / 503 contract |
| `docs/source/cli/server.rst:8` advertises "checksum APIs" served by `lmcache server` | The MP `/kvcache/check` endpoint is the implementation behind that promise — `lmcache bench server` consumes it via its `--url http://host:port` HTTP client |

## Proposed fix

Already applied in this PR's diff. Doc-only — no code changes:

- `docs/source/mp/http_api.rst`: add a `GET /kvcache/check` row to the endpoint summary table and a full reference section covering query parameters, success payload, and HTTP status codes.

## Overlap with prior open drift PRs

This PR is **independent** of the still-open prior-day drift PRs and touches no overlapping doc text:

- [#3484](https://github.com/LMCache/LMCache/pull/3484) (2026-06-01): `--supported-transfer-mode` row in `configuration.rst` and the `--shm-name` clarification in `deployment.rst`.
- [#3467](https://github.com/LMCache/LMCache/pull/3467) (2026-05-30): blend_server_v2 removal across `index.rst` / `architecture.rst` and an updated request-event-span design doc.
- [#3454](https://github.com/LMCache/LMCache/pull/3454) (2026-05-29): `--script-allowed-imports` and `POST /run_script` rows, plus the `_MP_INCOMPATIBLE_MODULES` wording fix — none of which touch the `GET /kvcache/check` row this PR adds.
- [#3435](https://github.com/LMCache/LMCache/pull/3435), [#3417](https://github.com/LMCache/LMCache/pull/3417), [#3329](https://github.com/LMCache/LMCache/pull/3329), [#3273](https://github.com/LMCache/LMCache/pull/3273): unrelated areas (CLI design doc, configuration vLLM connector keys, design-doc L2 throughput).

## Notes

- Auto-generated by the daily LMCache docs drift-check routine. **Human review required before merge.**
- Marked as **draft**; please do not merge without an editorial pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvhPJinY4hpenSG7Dh7ZcY)_