### PR TITLE
[Chore][CI] Force vLLM Model Runner V1 in the PD comprehensive test

### DIFF
--- a/.buildkite/configs/pd.yaml
+++ b/.buildkite/configs/pd.yaml
@@ -11,6 +11,11 @@ feature:
 
 docker-prefiller:
   env:
+    # Force vLLM Model Runner V1: MRV2 (enabled by default for Llama/Mistral
+    # dense models in vLLM nightly, see vllm-project/vllm#43458) is incompatible
+    # with KV cache connectors and hangs the PD path. Remove once MRV2 supports
+    # connectors / auto-falls back to MRV1.
+    - "VLLM_USE_V2_MODEL_RUNNER=0"
     - "LMCACHE_LOCAL_CPU=False"
     - "LMCACHE_MAX_LOCAL_CPU_SIZE=5"
     - "LMCACHE_ENABLE_PD=True"
@@ -27,6 +32,11 @@ docker-prefiller:
 
 docker-decoder:
   env:
+    # Force vLLM Model Runner V1: MRV2 (enabled by default for Llama/Mistral
+    # dense models in vLLM nightly, see vllm-project/vllm#43458) is incompatible
+    # with KV cache connectors and hangs the PD path. Remove once MRV2 supports
+    # connectors / auto-falls back to MRV1.
+    - "VLLM_USE_V2_MODEL_RUNNER=0"
     - "LMCACHE_LOCAL_CPU=False"
     - "LMCACHE_MAX_LOCAL_CPU_SIZE=0"
     - "LMCACHE_ENABLE_PD=True"


### PR DESCRIPTION
The PD comprehensive test (k3-comprehensive-test) started timing out on 2026-06-02 when the floating vLLM nightly bumped from 0.22.1rc1.dev91 to .dev95. That delta includes vllm-project/vllm#43458, which enables Model Runner V2 (MRV2) by default for Llama/Mistral dense models -- including meta-llama/Llama-3.2-1B-Instruct, the model used by pd.yaml.

MRV2 is incompatible with KV cache connectors, so the prefiller/decoder (both driven through LMCacheConnectorV1) hang on the first request and the job is killed by the 30-minute timeout. The vLLM servers start fine; only the disaggregated request path hangs.

Pin the PD prefiller and decoder to MRV1 via VLLM_USE_V2_MODEL_RUNNER=0 until MRV2 supports KV connectors / reliably falls back to MRV1.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
