### PR TITLE
[Feat]Add Valkey L2 adapter (standalone + cluster) for MP mode

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/valkey.md
+++ b/docs/design/v1/distributed/l2_adapters/valkey.md
@@ -61,8 +61,8 @@ is what unlocks batch-level parallelism.
 - `lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py` —
   registers adapter type `valkey`. Defines `ValkeyL2AdapterConfig`,
   `ValkeyL2Adapter`, the `_BatchState` helper, and the factory.
-- `_parse_startup_nodes` — accepts node specs as `"host:port"`,
-  comma-separated strings, list-of-pairs, or list-of-dicts.
+- `_parse_startup_nodes` — parses the seed list from a single
+  comma-separated `"host:port[,host:port...]"` string.
 - Reuses `_object_key_to_string` from `native_connector_l2_adapter.py`
   to compute the standard wire key (model, kv_rank, chunk hash,
   optional `cache_salt`).
@@ -339,7 +339,7 @@ JSON schema (CLI `--l2-adapter`):
 ```json
 {
   "type": "valkey",
-  "startup_nodes": [["host1", 6379], ["host2", 6379]],
+  "startup_nodes": "host1:6379,host2:6379",
   "cluster_mode": true,
   "username": "...",
   "password": "...",

--- a/docs/design/v1/distributed/l2_adapters/valkey.md
+++ b/docs/design/v1/distributed/l2_adapters/valkey.md
@@ -44,47 +44,26 @@ is what unlocks batch-level parallelism.
 - `valkey-glide-sync >= 2.3.0` — the **sync** GLIDE client package
   (provides the `glide_sync` module), the first stable release with both
   zero-copy SET (`#5492`) and buffer GET (`#5493`). It bundles
-  `glide_shared` and `glide_sync`; the plain `valkey-glide` package ships
-  only the **async** client (under `glide`) and is **not** sufficient —
-  async glide cannot do zero-copy (see *Why glide sync*).
-- The import is **lazy** (inside the worker pool), so LMCache
-  installations that don't use this adapter never need it installed. A
-  missing dependency yields:
+  `glide_shared` and `glide_sync`. 
+  
+  It's lazy imported, won't get used unless triggered 
+  , if host is missing dependency, following error will be raised
+
+  If valkey is installed but version is outdated, 
+  valkey adaptor will fall back to use copying through a `bytes` 
 
   ```
   Valkey support requires the glide_sync module.
   Install: pip install 'valkey-glide-sync>=2.3.0'
   ```
 
-## Components
-
-- `lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py` —
-  registers adapter type `valkey`. Defines `ValkeyL2AdapterConfig`,
-  `ValkeyL2Adapter`, the `_BatchState` helper, and the factory.
-- `_parse_startup_nodes` — parses the seed list from a single
-  comma-separated `"host:port[,host:port...]"` string.
-- Reuses `_object_key_to_string` from `native_connector_l2_adapter.py`
-  to compute the standard wire key (model, kv_rank, chunk hash,
-  optional `cache_salt`).
-
 ## Wire key layout
 
-A key written to Valkey has the form:
+key be written to Valkey has the form:
 
 ```
 [<key_prefix>@]<model_name>@<kv_rank_hex>@<chunk_hash_hex>[@<cache_salt>]
 ```
-
-- `key_prefix` is the deployment-level namespace (config field) and is
-  only present when non-empty. It must not contain `@`.
-- The standard 3-field shape (no trailing salt) is bit-identical to
-  the wire format used by all other native-connector adapters when
-  `cache_salt=""`, so a Valkey instance shared with other LMCache
-  backends does not see schema drift.
-
-This gives both deployment-level isolation (via `key_prefix`) and
-per-tenant isolation (via `cache_salt`) without adapter-specific
-parsing.
 
 ## Threading model
 
@@ -109,10 +88,10 @@ ValkeyL2Adapter │ submit one Future per key to ThreadPoolExecutor│
         └──────────────────────────────────────────────┘
 ```
 
-### Per-batch state (`_BatchState`)
+### Per-batch state (`_SubmitTaskBatchState`)
 
-Each `submit_*_task` allocates a `_BatchState` shared by N per-key
-futures:
+Each `submit_*_task` allocates a `_SubmitTaskBatchState` shared by N
+per-key futures:
 
 | Field         | Purpose                                                       |
 |---------------|---------------------------------------------------------------|
@@ -122,25 +101,6 @@ futures:
 | `keys`        | Original keys (for listener notifies + per-salt accounting).  |
 | `sizes`       | Bytes per key (store batches only — others leave empty).      |
 
-The last-finisher pattern avoids a separate demux thread and keeps the
-fast path entirely on worker threads.
-
-### Why per-key futures (not per-batch)
-
-A single `Future` for the whole batch would either (a) serialize all N
-keys on one worker — wasting `num_workers - 1` threads — or (b) require
-the worker to internally split work, duplicating ThreadPool logic. One
-future per key lets the executor distribute load naturally. Per-key
-callback overhead is negligible compared to the wire round-trip.
-
-## Capability detection
-
-After the first worker constructs its glide client, the adapter probes
-`inspect.signature(client.get).parameters` once and caches whether the
-`buffer=` parameter is supported. Older glide releases (<2.3.0) lack
-buffer GET — in that case the adapter falls back to copying through a
-`bytes` intermediate and still validates size, so correctness is
-preserved at the cost of performance.
 
 ## Size validation on load
 
@@ -159,22 +119,15 @@ the adapter.
 
 ## Partial-failure accounting
 
-`L2StoreResult` is **binary** by contract: `success=False` forces
-`bytes_transferred()` to `0`. A partial batch failure is therefore
-reported as a task failure (`is_successful() == False`). This is the
-**safe** choice — the store controller drops the task's keys from L1
-only when the task reports success (`select_l1_deletions`), so reporting
-success on a partial failure would evict the un-stored key from L1 and
-lose it entirely.
+A store task is reported as failed if **any** key in it fails to write.
+This is the safe choice: the store controller only drops a task's keys
+from L1 when the task succeeds, so reporting success on a partial failure
+would evict the un-stored keys from L1 and lose them.
 
-The *meaningful* byte accounting flows through
-`_notify_keys_stored`, which is fired with **only** the keys that
-actually wrote. The base class folds those into per-`cache_salt` and
-aggregate totals, so `get_usage()` stays accurate even under partial
-failure. This is more precise than `NativeConnectorL2Adapter` today
-(whose `do_batch_set` raises on the first failure and treats the whole
-batch as failed) because each key has its own Python `Future` and is
-accounted independently.
+Byte accounting is finer-grained. `_notify_keys_stored` is fired with
+**only** the keys that actually wrote, and the base class folds those
+into per-`cache_salt` and aggregate totals — so `get_usage()` stays
+accurate even when the task as a whole is marked failed.
 
 ## Cluster vs standalone
 
@@ -183,9 +136,28 @@ accounted independently.
 | standalone   | `GlideClient`          | honored       | first only (warned if >1) |
 | cluster      | `GlideClusterClient`   | ignored (warned) | full list — seeds for discovery |
 
-Cluster discovery, MOVED/ASK redirect handling, and topology refresh
-are entirely the responsibility of `GlideClusterClient`. The adapter
-delegates and does not parse RESP redirects itself.
+### Slot routing & redirects (handled by glide)
+
+Each key belongs to one of 16384 slots (`CRC16(key) % 16384`), and each
+slot is owned by one primary. The client caches a slot→node map and
+sends each request straight to the owning node. That map can go stale
+(after a reshard or a failover), so the request lands on the wrong node
+and the server replies with a **redirect** — the cluster's self-healing
+mechanism, not an error:
+
+- **MOVED** — the slot's owner has **permanently changed** (reshard
+  finished, or a replica was promoted). The client retries on the new
+  node and updates its cached map.
+- **ASK** — the slot is **mid-migration** and *this specific key* has
+  already moved to the target while the slot still officially belongs to
+  the source. The client sends `ASKING` + the command to the target for
+  this one request and does **not** update its map (the migration isn't
+  done).
+
+All of this — initial discovery (`CLUSTER SHARDS`), MOVED/ASK handling,
+`ASKING`, and topology refresh — is owned by `GlideClusterClient`. The
+adapter never parses redirects: a `client.get`/`set` call returns only
+the final, post-redirect result.
 
 ### Cluster routing & load balancing
 
@@ -219,18 +191,22 @@ Known imbalance sources / tuning levers:
   (via a `{cache_salt}` hashtag) is intentionally **not** done; it would
   aid pipelining but risk hot shards. Uniform spread is preferred.
 
-`report_status()`' `current_size_bytes` is LMCache's **aggregate logical**
-byte count, not per-node physical memory. In cluster mode this aggregate
-can mask a hot shard (one node full while others are nearly empty). For
-true per-node physical usage, query each node's `INFO memory` directly or
-use Valkey's own monitoring.
+`report_status()` exposes two different views of usage:
+
+- `current_size_bytes` — LMCache's **aggregate logical** byte count. In
+  cluster mode this aggregate can mask a hot shard (one node full while
+  others are nearly empty).
+- `node_memory` (cluster mode only) — the server's **real per-node
+  physical** memory, collected by routing `INFO memory` to all nodes
+  (`used_memory` / `maxmemory` per node). Use this to spot shard
+  imbalance. It is best-effort: an empty dict means the `INFO` query
+  failed and never blocks status reporting.
 
 **Resharding** (adding/removing nodes) is transparent to the adapter:
 glide handles `MOVED`/`ASK` redirects and topology refresh, and seed
 nodes need not be updated. A graceful reshard migrates keys and keeps the
 cache warm; dropping a node without migrating its slots loses those keys,
-which simply surface as cache misses (recomputed, never stale) — though
-LMCache's byte accounting may drift afterward (see *Two eviction layers*).
+which simply surface as cache misses and LMCache's byte accounting may drift afterward
 
 ## Authentication and TLS
 
@@ -354,20 +330,6 @@ JSON schema (CLI `--l2-adapter`):
 
 Shortcut for a single node: `{"host": "host1", "port": 6379, ...}`.
 
-All settings (including credentials) come from the config object; there
-are no environment-variable fallbacks.
-
-## Capability summary
-
-| Capability                           | Where implemented                                    |
-|--------------------------------------|------------------------------------------------------|
-| Cluster discovery + multiple seeds   | `GlideClusterClient` (glide handles `CLUSTER SHARDS`)|
-| Authentication                       | `ServerCredentials` from config                      |
-| Deployment key prefix                | `key_prefix` field, joined by `@`                    |
-| `cache_salt` integration             | Inherited from `_object_key_to_string`                |
-| Validate size on load                | `_do_get_into` rejects size mismatch                 |
-| Partial-failure accounting           | Per-key `Future` + accurate per-salt usage           |
-
 ## Non-goals
 
 - **Custom MOVED/ASK parsing**: delegated to glide.
@@ -384,10 +346,5 @@ are no environment-variable fallbacks.
 ## Testing
 
 - `tests/v1/distributed/test_valkey_l2_adapter.py` — unit tests
-  against an in-process fake `glide_sync` module. Covers config
-  validation, the L2AdapterInterface contract, partial-failure
-  bytes_transferred, size-mismatch handling, key prefix and cache_salt
-  isolation, and the fallback path when buffer GET is unavailable.
-- An integration test against a real Valkey-Cluster container can be
-  added as a follow-up (gated on `valkey-glide-sync` install and a
-  reachable cluster).
+  against an in-process fake `glide_sync` module. 
+- `tests/v1/distributed/test_valkey_l2_adapter_integration.py` - integration tests running with real local valkey instance

--- a/docs/design/v1/distributed/l2_adapters/valkey.md
+++ b/docs/design/v1/distributed/l2_adapters/valkey.md
@@ -1,0 +1,393 @@
+# Valkey L2 Adapter Design
+
+This document describes the built-in `valkey` L2 adapter for LMCache
+multiprocess mode. The adapter stores KV cache chunks in a Valkey (or
+Redis) instance, supporting both standalone and Valkey-Cluster
+topologies. It uses the official `valkey-glide` Python sync client.
+
+## Goals
+
+- Provide a first-class Valkey-Cluster backend for LMCache MP mode.
+- Preserve **zero-copy** SET and GET for multi-megabyte KV chunks.
+- Reuse the existing wire-key format so `cache_salt`-based per-tenant
+  isolation works without adapter-specific code.
+- Stay within the standard `L2AdapterInterface` contract — submit,
+  event-fd, query-result, no controller changes.
+
+## Why glide sync (not async)
+
+`glide-async` cannot do zero-copy for either SET or GET. The async
+client serializes commands as Protobuf messages across an in-process
+Rust-runtime boundary, which forces a `bytes` copy of every value.
+glide upstream documents this explicitly: *"zero-copy is sync-only"*
+(see [valkey-glide#5492][pr-5492] and [#5493][pr-5493]).
+
+KV cache chunks are multi-megabyte (∼10 MB per chunk for a 70B model
+with TP=8) and every request touches hundreds of chunks. Paying a copy
+on every transfer would dominate the wire time. Sync glide is the only
+configuration that preserves zero-copy via CFFI (`ffi.from_buffer`), so
+this adapter standardizes on it.
+
+A sync API blocks the calling Python thread per call, so the adapter
+runs a `ThreadPoolExecutor` of independent worker threads to drive
+concurrent in-flight requests. Each worker holds its own glide client
+via `threading.local()` — glide's internal multiplexing makes one
+client capable of high concurrency, but the sync Python API only lets a
+single thread submit one command at a time, so N threads × N clients
+is what unlocks batch-level parallelism.
+
+[pr-5492]: https://github.com/valkey-io/valkey-glide/pull/5492
+[pr-5493]: https://github.com/valkey-io/valkey-glide/pull/5493
+
+## Dependencies
+
+- `valkey-glide-sync >= 2.3.0` — the **sync** GLIDE client package
+  (provides the `glide_sync` module), the first stable release with both
+  zero-copy SET (`#5492`) and buffer GET (`#5493`). It bundles
+  `glide_shared` and `glide_sync`; the plain `valkey-glide` package ships
+  only the **async** client (under `glide`) and is **not** sufficient —
+  async glide cannot do zero-copy (see *Why glide sync*).
+- The import is **lazy** (inside the worker pool), so LMCache
+  installations that don't use this adapter never need it installed. A
+  missing dependency yields:
+
+  ```
+  Valkey support requires the glide_sync module.
+  Install: pip install 'valkey-glide-sync>=2.3.0'
+  ```
+
+## Components
+
+- `lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py` —
+  registers adapter type `valkey`. Defines `ValkeyL2AdapterConfig`,
+  `ValkeyL2Adapter`, the `_BatchState` helper, and the factory.
+- `_parse_startup_nodes` — accepts node specs as `"host:port"`,
+  comma-separated strings, list-of-pairs, or list-of-dicts.
+- Reuses `_object_key_to_string` from `native_connector_l2_adapter.py`
+  to compute the standard wire key (model, kv_rank, chunk hash,
+  optional `cache_salt`).
+
+## Wire key layout
+
+A key written to Valkey has the form:
+
+```
+[<key_prefix>@]<model_name>@<kv_rank_hex>@<chunk_hash_hex>[@<cache_salt>]
+```
+
+- `key_prefix` is the deployment-level namespace (config field) and is
+  only present when non-empty. It must not contain `@`.
+- The standard 3-field shape (no trailing salt) is bit-identical to
+  the wire format used by all other native-connector adapters when
+  `cache_salt=""`, so a Valkey instance shared with other LMCache
+  backends does not see schema drift.
+
+This gives both deployment-level isolation (via `key_prefix`) and
+per-tenant isolation (via `cache_salt`) without adapter-specific
+parsing.
+
+## Threading model
+
+```
+                ┌──────────────── L2 controller ─────────────────┐
+                │ submit_store_task / lookup / load              │
+                │   ▼                                             │
+ValkeyL2Adapter │ submit one Future per key to ThreadPoolExecutor│
+                │   │                                             │
+                └───┼─────────────────────────────────────────────┘
+                    │
+        ┌───────────┴──────── worker pool ─────────────┐
+        │ N threads, each with thread-local            │
+        │ GlideClient / GlideClusterClient             │
+        │                                              │
+        │ ┌────────── Future.add_done_callback ──────┐ │
+        │ │  Atomically decrement batch.remaining,   │ │
+        │ │  record per-key ok/fail.                 │ │
+        │ │  Last finisher publishes the result and  │ │
+        │ │  signals the matching event fd.          │ │
+        │ └──────────────────────────────────────────┘ │
+        └──────────────────────────────────────────────┘
+```
+
+### Per-batch state (`_BatchState`)
+
+Each `submit_*_task` allocates a `_BatchState` shared by N per-key
+futures:
+
+| Field         | Purpose                                                       |
+|---------------|---------------------------------------------------------------|
+| `task_id`     | Public id returned to the caller.                             |
+| `remaining`   | Decremented under `lock`; zero ⇒ this is the finishing callback.|
+| `per_key_ok`  | Indexed by submit-order; written by each callback.            |
+| `keys`        | Original keys (for listener notifies + per-salt accounting).  |
+| `sizes`       | Bytes per key (store batches only — others leave empty).      |
+
+The last-finisher pattern avoids a separate demux thread and keeps the
+fast path entirely on worker threads.
+
+### Why per-key futures (not per-batch)
+
+A single `Future` for the whole batch would either (a) serialize all N
+keys on one worker — wasting `num_workers - 1` threads — or (b) require
+the worker to internally split work, duplicating ThreadPool logic. One
+future per key lets the executor distribute load naturally. Per-key
+callback overhead is negligible compared to the wire round-trip.
+
+## Capability detection
+
+After the first worker constructs its glide client, the adapter probes
+`inspect.signature(client.get).parameters` once and caches whether the
+`buffer=` parameter is supported. Older glide releases (<2.3.0) lack
+buffer GET — in that case the adapter falls back to copying through a
+`bytes` intermediate and still validates size, so correctness is
+preserved at the cost of performance.
+
+## Size validation on load
+
+`_do_get_into` returns `False` (cache miss) whenever the GET result is
+inconsistent with the expected buffer size:
+
+1. **Buffer-GET path** — glide returns the number of bytes written;
+   if `bytes_written != len(buf)`, the stored value is stale or
+   truncated and treated as a miss.
+2. **Fallback path** — `len(data) != len(buf)` yields the same miss
+   semantics.
+
+In both cases the load bitmap reports a `0` bit for that key, and the
+chunk is recomputed by the engine — no stale data ever flows out of
+the adapter.
+
+## Partial-failure accounting
+
+`L2StoreResult` is **binary** by contract: `success=False` forces
+`bytes_transferred()` to `0`. A partial batch failure is therefore
+reported as a task failure (`is_successful() == False`). This is the
+**safe** choice — the store controller drops the task's keys from L1
+only when the task reports success (`select_l1_deletions`), so reporting
+success on a partial failure would evict the un-stored key from L1 and
+lose it entirely.
+
+The *meaningful* byte accounting flows through
+`_notify_keys_stored`, which is fired with **only** the keys that
+actually wrote. The base class folds those into per-`cache_salt` and
+aggregate totals, so `get_usage()` stays accurate even under partial
+failure. This is more precise than `NativeConnectorL2Adapter` today
+(whose `do_batch_set` raises on the first failure and treats the whole
+batch as failed) because each key has its own Python `Future` and is
+accounted independently.
+
+## Cluster vs standalone
+
+| Mode         | glide class            | `database_id` | startup nodes used |
+|--------------|------------------------|---------------|---------------------|
+| standalone   | `GlideClient`          | honored       | first only (warned if >1) |
+| cluster      | `GlideClusterClient`   | ignored (warned) | full list — seeds for discovery |
+
+Cluster discovery, MOVED/ASK redirect handling, and topology refresh
+are entirely the responsibility of `GlideClusterClient`. The adapter
+delegates and does not parse RESP redirects itself.
+
+### Cluster routing & load balancing
+
+The adapter performs **no explicit load balancing** — distribution
+happens at two independent layers:
+
+1. **Across nodes** — glide hashes each key to one of 16384 slots
+   (`CRC16(key) % 16384`) and routes to the slot's owning primary. Our
+   wire key embeds a uniform content hash (`chunk_hash`) and contains
+   **no hashtag** (`{...}`), so keys spread evenly across slots and
+   therefore across nodes with no extra work.
+2. **Across worker threads** — a batch fans out one future per key onto
+   the `ValkeyWorkerPool`'s `num_workers` threads, each holding a full
+   cluster client. A large batch thus parallelizes over both threads and
+   nodes simultaneously; keys landing on different nodes is normal and
+   handled transparently by glide.
+
+Known imbalance sources / tuning levers:
+
+- **Reads hit primaries only.** Replica reads are **not enabled**
+  (no read-from-replica preference is set), so replicas provide
+  redundancy but do not share read load. Read-heavy workloads put all
+  GET traffic on primaries.
+- **Hot keys.** A single very popular chunk (e.g. a shared system
+  prompt) maps to one slot → one node, creating a read hotspot that
+  uniform hashing cannot spread. Replica reads would help here.
+- **Pool size vs node count.** Concurrency is capped at `num_workers`
+  (default 8). On a large cluster, the thread pool — not the cluster —
+  can become the bottleneck; raise `num_workers` to saturate more nodes.
+- **No hashtag routing.** Co-locating a `cache_salt`'s keys on one node
+  (via a `{cache_salt}` hashtag) is intentionally **not** done; it would
+  aid pipelining but risk hot shards. Uniform spread is preferred.
+
+`report_status()`' `current_size_bytes` is LMCache's **aggregate logical**
+byte count, not per-node physical memory. In cluster mode this aggregate
+can mask a hot shard (one node full while others are nearly empty). For
+true per-node physical usage, query each node's `INFO memory` directly or
+use Valkey's own monitoring.
+
+**Resharding** (adding/removing nodes) is transparent to the adapter:
+glide handles `MOVED`/`ASK` redirects and topology refresh, and seed
+nodes need not be updated. A graceful reshard migrates keys and keeps the
+cache warm; dropping a node without migrating its slots loses those keys,
+which simply surface as cache misses (recomputed, never stale) — though
+LMCache's byte accounting may drift afterward (see *Two eviction layers*).
+
+## Authentication and TLS
+
+`ServerCredentials(username, password)` is passed to glide when either
+field is non-empty. `tls_enable=True` sets glide's `use_tls`. Credentials
+come from the config only; the resolved values never appear in
+`report_status()` output or logs.
+
+### TLS scope and limitations
+
+`tls_enable` is an on/off switch (glide's `use_tls`) with no certificate
+options. It works only when the server's certificate is verifiable
+against the client's existing OS trust store — i.e. publicly-signed
+certs (ElastiCache Serverless, Let's Encrypt).
+
+Custom-certificate setups are a planned follow-up (exposing glide's
+`TlsAdvancedConfiguration`):
+
+| Deployment | `tls_enable` alone |
+|------------|--------------------|
+| Public-CA cert (ElastiCache Serverless) | ✅ works |
+| Self-signed cert | ⏳ to be supported |
+| Private / internal CA | ⏳ to be supported |
+| Mutual TLS (mTLS) | ⏳ to be supported |
+
+## Capacity and eviction
+
+- `max_capacity_gb > 0` enables aggregate (global) eviction signals
+  via `get_usage().usage_fraction`. Set this when LMCache should track
+  total bytes used and trigger eviction at a watermark.
+- Per-`cache_salt` quotas operate regardless of `max_capacity_gb` —
+  the base class tracks per-salt totals from `_notify_keys_stored` /
+  `_notify_keys_deleted` for any quota policy.
+
+`delete(keys)` is synchronous: it submits one DEL per key to the pool,
+waits for each completion (up to `request_timeout`), and fires
+`_notify_keys_deleted` with the per-key sizes captured at store time
+(via `_key_sizes`). Keys whose DEL returned `0` (already absent) are
+silently skipped.
+
+### Two eviction layers — configure only one
+
+There are **two independent eviction mechanisms** and they can conflict:
+
+1. **LMCache** (this controller) — tracks bytes via `get_usage()` and
+   issues `delete()` calls. It understands LRU ordering, prefix-chain
+   ordering, per-`cache_salt` quotas, and locked keys.
+2. **The Valkey server** — its own `maxmemory` + `maxmemory-policy`
+   evicts keys when server memory fills, **without notifying LMCache**.
+
+Pick exactly one as the authority. **The recommended setup is
+LMCache-driven: leave Valkey server-side eviction off (`maxmemory 0` /
+`noeviction`) and let LMCache evict via `max_capacity_gb > 0`.** LMCache's
+policy is strictly smarter than the server's — it honors prefix-chain
+ordering, per-`cache_salt` quotas, and read-locked keys, none of which a
+plain `allkeys-lru` understands.
+
+| Setup | Valkey config | LMCache config |
+|-------|---------------|----------------|
+| **LMCache-driven** (recommended) | `maxmemory 0` (or large) + `noeviction` | `max_capacity_gb > 0` |
+| **Server-driven** (only if LMCache eviction is intentionally disabled) | `maxmemory <N>` + `allkeys-lru` | `max_capacity_gb = 0` |
+
+> **Note** — this guidance is specific to the MP-mode `valkey` L2
+> adapter. The non-MP `ValkeyConnector` has no eviction layer of its own
+> and *must* rely on Valkey server-side eviction, so the recommendation
+> there is the opposite.
+
+Running both (a server `maxmemory` cap *and* `max_capacity_gb > 0`) lets
+the server silently drop keys that LMCache still counts, so LMCache's
+byte accounting and LRU order drift from reality. This is a
+**performance / accounting** issue, not a correctness one: a server-side
+drop surfaces as a lookup/load miss (handled by the size-validation and
+per-key miss paths above), so no stale data is ever returned — but the
+LMCache-side LRU bookkeeping will hold ghost keys.
+
+This adapter does not set a TTL on SET, so keys never expire on the
+server by time; lifetime is governed entirely by whichever eviction
+authority is configured above.
+
+## Lock semantics
+
+Locking is **client-side**: glide / Valkey have no notion of LMCache's
+eviction-pinning concept. The adapter maintains a per-key refcount in
+`_locked_keys`; a successful `lookup` increments it, `submit_unlock`
+decrements it, and refcounts at zero are removed. The adapter never
+prevents eviction on the server side — pinning is enforced only at the
+L2 controller layer above this adapter.
+
+## Error model
+
+| Failure                              | Per-key bit | Logged          | Notes                                |
+|--------------------------------------|-------------|-----------------|--------------------------------------|
+| Single SET raises                    | `False`     | `WARNING`       | Other keys in batch unaffected.      |
+| Single GET raises / times out        | `False`     | `WARNING`       | Cache miss; chunk recomputed.        |
+| GET size mismatch                    | `False`     | `DEBUG`         | Stale/truncated value rejected.      |
+| Single EXISTS raises                 | `False`     | `WARNING`       | Looks like a miss.                   |
+| Single DEL raises                    | (skipped)   | `WARNING`       | Listener not notified for that key.  |
+| Cluster MOVED/ASK                    | (handled by glide) | —        | Transparent to the adapter.          |
+| Connection drop                      | (handled by glide) | —        | Glide reconnects; calls retry.       |
+| Missing `valkey-glide-sync`       | construction fails | (raises) | Clear actionable error.              |
+
+## Configuration
+
+JSON schema (CLI `--l2-adapter`):
+
+```json
+{
+  "type": "valkey",
+  "startup_nodes": [["host1", 6379], ["host2", 6379]],
+  "cluster_mode": true,
+  "username": "...",
+  "password": "...",
+  "key_prefix": "prod",
+  "num_workers": 8,
+  "tls_enable": true,
+  "request_timeout": 5.0,
+  "connection_timeout": 10.0,
+  "max_capacity_gb": 0
+}
+```
+
+Shortcut for a single node: `{"host": "host1", "port": 6379, ...}`.
+
+All settings (including credentials) come from the config object; there
+are no environment-variable fallbacks.
+
+## Capability summary
+
+| Capability                           | Where implemented                                    |
+|--------------------------------------|------------------------------------------------------|
+| Cluster discovery + multiple seeds   | `GlideClusterClient` (glide handles `CLUSTER SHARDS`)|
+| Authentication                       | `ServerCredentials` from config                      |
+| Deployment key prefix                | `key_prefix` field, joined by `@`                    |
+| `cache_salt` integration             | Inherited from `_object_key_to_string`                |
+| Validate size on load                | `_do_get_into` rejects size mismatch                 |
+| Partial-failure accounting           | Per-key `Future` + accurate per-salt usage           |
+
+## Non-goals
+
+- **Custom MOVED/ASK parsing**: delegated to glide.
+- **Custom slot map**: delegated to glide.
+- **C++ extension**: glide's Rust runtime already runs FFI-released
+  GIL; a hand-rolled C++ connector would duplicate glide.
+- **Async-glide path**: cannot do zero-copy (see *Why glide sync*).
+- **EXISTS-time size check**: RESP `EXISTS` doesn't return size; the
+  subsequent GET enforces it instead.
+- **Advanced TLS** (self-signed / private CA / mTLS): only the basic
+  `use_tls` flag is wired now — to be supported (see *TLS scope and
+  limitations*).
+
+## Testing
+
+- `tests/v1/distributed/test_valkey_l2_adapter.py` — unit tests
+  against an in-process fake `glide_sync` module. Covers config
+  validation, the L2AdapterInterface contract, partial-failure
+  bytes_transferred, size-mismatch handling, key prefix and cache_salt
+  isolation, and the fallback path when buffer GET is unavailable.
+- An integration test against a real Valkey-Cluster container can be
+  added as a follow-up (gated on `valkey-glide-sync` install and a
+  reachable cluster).

--- a/docs/design/v1/distributed/l2_adapters/valkey.md
+++ b/docs/design/v1/distributed/l2_adapters/valkey.md
@@ -234,10 +234,10 @@ Custom-certificate setups are a planned follow-up (exposing glide's
 
 ## Capacity and eviction
 
-- `max_capacity_gb > 0` enables the **LMCache-driven** eviction signal
-  (`get_usage().usage_fraction`). This is **not** the default — server-driven
-  is recommended (`max_capacity_gb = 0`); see "Two eviction layers" below.
-  LMCache-driven eviction additionally requires an `"eviction"` config block
+- `max_capacity_gb > 0` enables the **LMCache built-in** eviction signal
+  (`get_usage().usage_fraction`); `0` (default) defers to the other
+  options — see "Eviction options" below.
+  LMCache built-in eviction additionally requires an `"eviction"` config block
   (`eviction_policy` / `trigger_watermark` / `eviction_ratio`); without it
   `eviction_config` is `None`, the eviction controller is not wired for this
   adapter, and `max_capacity_gb` has no effect.
@@ -251,64 +251,48 @@ waits for each completion (up to `request_timeout`), and fires
 (via `_key_sizes`). Keys whose DEL returned `0` (already absent) are
 silently skipped.
 
-### Two eviction layers — configure only one
+### Eviction options
 
-There are **two independent eviction mechanisms** and they can conflict:
+Eviction comes from two sides: the **LMCache side** (LMCache decides and
+issues the deletes, tracking bytes itself) and the **server side** (the
+Valkey server reclaims on its own; LMCache is not notified). Pick **one
+side as the authority** — running both drifts LMCache's byte accounting and
+LRU (surfaces as lookup/load misses, never stale data, but ghost keys
+linger).
 
-1. **LMCache** (this controller) — tracks bytes via `get_usage()` and
-   issues `delete()` calls. It understands LRU ordering, prefix-chain
-   ordering, per-`cache_salt` quotas, and locked keys.
-2. **The Valkey server** — its own `maxmemory` + `maxmemory-policy`
-   evicts keys when server memory fills, **without notifying LMCache**.
+**A. LMCache side** — LMCache tracks usage and calls the adapter's
+`delete()` (the adapter never self-evicts; it only executes the deletes it
+is handed). Two forms:
 
-Pick exactly one as the authority. **Server-driven is the recommended
-default**: set `maxmemory <N>` + `allkeys-lfu` on the server and leave
-LMCache eviction off (`max_capacity_gb = 0`, the default). The server
-bounds real memory regardless of how many processes write, leftover data,
-or restarts (see the limitation note below). **LMCache-driven** is a
-special case for a single writer that owns the cluster: it enables
-LMCache's smarter policy — prefix-chain ordering, per-`cache_salt` quotas,
-and read-locked keys, none of which a plain `allkeys-*` understands — but
-only its per-process accounting is trustworthy in that case.
+1. **Built-in** (`max_capacity_gb > 0` + an `eviction` block) — an
+   in-process pass tracks usage (global `usage_fraction`, or per-`cache_salt`
+   quota) and deletes past `trigger_watermark`. Its byte counter is
+   per-process and resets on restart, so it is trustworthy only for a single
+   writer that privately owns the cluster.
+2. **Coordinator-managed** (opt-in) — when `LMCACHE_COORDINATOR_URL` points
+   at a running MP coordinator, instances register with it and it enforces
+   per-`cache_salt` quotas across the whole fleet (aggregate usage a single
+   instance can't see). Use it when several LMCache instances share one
+   cluster; unset (default) → no coordinator.
 
-| Setup | Valkey config | LMCache config | Use when |
-|-------|---------------|----------------|----------|
-| **Server-driven** (recommended) | `maxmemory <N>` + `allkeys-lfu` | `max_capacity_gb = 0` | default; required for shared cluster or any process that restarts |
-| **LMCache-driven** | `maxmemory 0` + `noeviction` | `max_capacity_gb > 0` | single writer owns the cluster, no leftover data, no restart dependency |
+**B. Server side** — set `maxmemory` + a `maxmemory-policy` on the Valkey
+server (config file / `CONFIG SET` / managed parameter group; LMCache does
+not set it). LMCache does not track these evictions. Pick the policy by
+deployment:
 
-> **Note** — this guidance is specific to the MP-mode `valkey` L2
-> adapter. The non-MP `ValkeyConnector` has no eviction layer of its own
-> and likewise relies on Valkey server-side eviction.
+- **Dedicated cluster** → `allkeys-lfu`: evicts *any* key under memory
+  pressure, so it never wedges at `maxmemory`. No TTL needed.
+- **Shared cluster** → set `ttl_seconds` + `volatile-lfu`: `volatile-*`
+  policies evict only keys that carry a TTL — i.e. only LMCache's own keys —
+  so the server never evicts data other processes wrote. (A TTL also lets
+  keys expire by time on its own, independent of memory pressure.)
 
-Running both (a server `maxmemory` cap *and* `max_capacity_gb > 0`) lets
-the server silently drop keys that LMCache still counts, so LMCache's
-byte accounting and LRU order drift from reality. This is a
-**performance / accounting** issue, not a correctness one: a server-side
-drop surfaces as a lookup/load miss (handled by the size-validation and
-per-key miss paths above), so no stale data is ever returned — but the
-LMCache-side LRU bookkeeping will hold ghost keys.
+> The `ttl_seconds` + `max_capacity_gb > 0` combination mixes the two sides
+> (the server side's TTL with the LMCache side's built-in) and logs a warning.
 
-This adapter does not set a TTL on SET, so keys never expire on the
-server by time; lifetime is governed entirely by whichever eviction
-authority is configured above.
-
-> **Known limitation.** LMCache-driven eviction relies on
-> `get_usage().total_bytes_used`, which is a **per-process logical
-> counter**: it counts only the bytes *this* process wrote and resets to
-> zero on restart. It therefore does **not** reflect the server's real
-> memory and is unreliable when:
-> - **multiple LMCache processes share one cluster** — per-process
->   `max_capacity_gb` budgets do not compose and can overshoot the cluster;
-> - **the cluster holds leftover data** (another writer, app, or a prior
->   run — keys persist since no TTL is set) — it is uncounted;
-> - **the process restarts on top of existing data** — both the byte
->   counter and the eviction LRU start empty, so pre-existing keys are
->   never evicted by LMCache.
->
-> In all three cases prefer **server-driven** eviction (`maxmemory` +
-> `allkeys-lfu`, `max_capacity_gb = 0`): the server bounds real memory
-> regardless of writer or restart, and `allkeys-*` is required because
-> this adapter sets no TTL (`volatile-*` would evict nothing and OOM).
+> **Note** — the LMCache side is MP-mode specific. The non-MP
+> `ValkeyConnector` has no eviction of its own and relies entirely on the
+> server side (same TTL via `valkey_enable_ttl` / `valkey_ttl_sec`).
 
 ## Lock semantics
 

--- a/docs/design/v1/distributed/l2_adapters/valkey.md
+++ b/docs/design/v1/distributed/l2_adapters/valkey.md
@@ -8,7 +8,7 @@ topologies. It uses the official `valkey-glide` Python sync client.
 ## Goals
 
 - Provide a first-class Valkey-Cluster backend for LMCache MP mode.
-- Preserve **zero-copy** SET and GET for multi-megabyte KV chunks.
+- Preserve **copy-reduced** SET and GET for multi-megabyte KV chunks.
 - Reuse the existing wire-key format so `cache_salt`-based per-tenant
   isolation works without adapter-specific code.
 - Stay within the standard `L2AdapterInterface` contract — submit,
@@ -16,17 +16,22 @@ topologies. It uses the official `valkey-glide` Python sync client.
 
 ## Why glide sync (not async)
 
-`glide-async` cannot do zero-copy for either SET or GET. The async
-client serializes commands as Protobuf messages across an in-process
-Rust-runtime boundary, which forces a `bytes` copy of every value.
-glide upstream documents this explicitly: *"zero-copy is sync-only"*
-(see [valkey-glide#5492][pr-5492] and [#5493][pr-5493]).
+`glide-async` adds an unavoidable per-value copy on both SET and GET.
+The async client serializes commands as Protobuf messages across an
+in-process Rust-runtime boundary, which forces a `bytes` copy of every
+value. glide upstream documents this explicitly: *"zero-copy is
+sync-only"* (see [valkey-glide#5492][pr-5492] and [#5493][pr-5493]).
 
 KV cache chunks are multi-megabyte (∼10 MB per chunk for a 70B model
-with TP=8) and every request touches hundreds of chunks. Paying a copy
-on every transfer would dominate the wire time. Sync glide is the only
-configuration that preserves zero-copy via CFFI (`ffi.from_buffer`), so
+with TP=8) and every request touches hundreds of chunks. Paying an
+extra copy on every transfer would dominate the wire time. Sync glide is
+the only configuration that avoids it, via CFFI (`ffi.from_buffer`), so
 this adapter standardizes on it.
+
+**"Zero-copy" is glide's term, not a literal claim.** Both paths are
+*copy-reduced*, not copy-free: on GET the value is still materialized
+inside glide-core before it is copied into the caller's buffer, and on
+SET the payload still lands in the command buffer.
 
 A sync API blocks the calling Python thread per call, so the adapter
 runs a `ThreadPoolExecutor` of independent worker threads to drive
@@ -43,7 +48,7 @@ is what unlocks batch-level parallelism.
 
 - `valkey-glide-sync >= 2.3.0` — the **sync** GLIDE client package
   (provides the `glide_sync` module), the first stable release with both
-  zero-copy SET (`#5492`) and buffer GET (`#5493`). It bundles
+  copy-reduced SET (`#5492`) and buffer GET (`#5493`). It bundles
   `glide_shared` and `glide_sync`. 
   
   It's lazy imported, won't get used unless triggered 
@@ -336,15 +341,13 @@ JSON schema (CLI `--l2-adapter`):
 }
 ```
 
-Shortcut for a single node: `{"host": "host1", "port": 6379, ...}`.
-
 ## Non-goals
 
 - **Custom MOVED/ASK parsing**: delegated to glide.
 - **Custom slot map**: delegated to glide.
 - **C++ extension**: glide's Rust runtime already runs FFI-released
   GIL; a hand-rolled C++ connector would duplicate glide.
-- **Async-glide path**: cannot do zero-copy (see *Why glide sync*).
+- **Async-glide path**: adds a per-value copy (see *Why glide sync*).
 - **EXISTS-time size check**: RESP `EXISTS` doesn't return size; the
   subsequent GET enforces it instead.
 - **Advanced TLS** (self-signed / private CA / mTLS): only the basic

--- a/docs/design/v1/distributed/l2_adapters/valkey.md
+++ b/docs/design/v1/distributed/l2_adapters/valkey.md
@@ -206,7 +206,7 @@ Known imbalance sources / tuning levers:
 glide handles `MOVED`/`ASK` redirects and topology refresh, and seed
 nodes need not be updated. A graceful reshard migrates keys and keeps the
 cache warm; dropping a node without migrating its slots loses those keys,
-which simply surface as cache misses and LMCache's byte accounting may drift afterward
+which simply surface as cache misses and LMCache's byte accounting may drift afterward.
 
 ## Authentication and TLS
 
@@ -234,9 +234,13 @@ Custom-certificate setups are a planned follow-up (exposing glide's
 
 ## Capacity and eviction
 
-- `max_capacity_gb > 0` enables aggregate (global) eviction signals
-  via `get_usage().usage_fraction`. Set this when LMCache should track
-  total bytes used and trigger eviction at a watermark.
+- `max_capacity_gb > 0` enables the **LMCache-driven** eviction signal
+  (`get_usage().usage_fraction`). This is **not** the default — server-driven
+  is recommended (`max_capacity_gb = 0`); see "Two eviction layers" below.
+  LMCache-driven eviction additionally requires an `"eviction"` config block
+  (`eviction_policy` / `trigger_watermark` / `eviction_ratio`); without it
+  `eviction_config` is `None`, the eviction controller is not wired for this
+  adapter, and `max_capacity_gb` has no effect.
 - Per-`cache_salt` quotas operate regardless of `max_capacity_gb` —
   the base class tracks per-salt totals from `_notify_keys_stored` /
   `_notify_keys_deleted` for any quota policy.
@@ -257,22 +261,24 @@ There are **two independent eviction mechanisms** and they can conflict:
 2. **The Valkey server** — its own `maxmemory` + `maxmemory-policy`
    evicts keys when server memory fills, **without notifying LMCache**.
 
-Pick exactly one as the authority. **The recommended setup is
-LMCache-driven: leave Valkey server-side eviction off (`maxmemory 0` /
-`noeviction`) and let LMCache evict via `max_capacity_gb > 0`.** LMCache's
-policy is strictly smarter than the server's — it honors prefix-chain
-ordering, per-`cache_salt` quotas, and read-locked keys, none of which a
-plain `allkeys-lru` understands.
+Pick exactly one as the authority. **Server-driven is the recommended
+default**: set `maxmemory <N>` + `allkeys-lfu` on the server and leave
+LMCache eviction off (`max_capacity_gb = 0`, the default). The server
+bounds real memory regardless of how many processes write, leftover data,
+or restarts (see the limitation note below). **LMCache-driven** is a
+special case for a single writer that owns the cluster: it enables
+LMCache's smarter policy — prefix-chain ordering, per-`cache_salt` quotas,
+and read-locked keys, none of which a plain `allkeys-*` understands — but
+only its per-process accounting is trustworthy in that case.
 
-| Setup | Valkey config | LMCache config |
-|-------|---------------|----------------|
-| **LMCache-driven** (recommended) | `maxmemory 0` (or large) + `noeviction` | `max_capacity_gb > 0` |
-| **Server-driven** (only if LMCache eviction is intentionally disabled) | `maxmemory <N>` + `allkeys-lru` | `max_capacity_gb = 0` |
+| Setup | Valkey config | LMCache config | Use when |
+|-------|---------------|----------------|----------|
+| **Server-driven** (recommended) | `maxmemory <N>` + `allkeys-lfu` | `max_capacity_gb = 0` | default; required for shared cluster or any process that restarts |
+| **LMCache-driven** | `maxmemory 0` + `noeviction` | `max_capacity_gb > 0` | single writer owns the cluster, no leftover data, no restart dependency |
 
 > **Note** — this guidance is specific to the MP-mode `valkey` L2
 > adapter. The non-MP `ValkeyConnector` has no eviction layer of its own
-> and *must* rely on Valkey server-side eviction, so the recommendation
-> there is the opposite.
+> and likewise relies on Valkey server-side eviction.
 
 Running both (a server `maxmemory` cap *and* `max_capacity_gb > 0`) lets
 the server silently drop keys that LMCache still counts, so LMCache's
@@ -285,6 +291,24 @@ LMCache-side LRU bookkeeping will hold ghost keys.
 This adapter does not set a TTL on SET, so keys never expire on the
 server by time; lifetime is governed entirely by whichever eviction
 authority is configured above.
+
+> **Known limitation.** LMCache-driven eviction relies on
+> `get_usage().total_bytes_used`, which is a **per-process logical
+> counter**: it counts only the bytes *this* process wrote and resets to
+> zero on restart. It therefore does **not** reflect the server's real
+> memory and is unreliable when:
+> - **multiple LMCache processes share one cluster** — per-process
+>   `max_capacity_gb` budgets do not compose and can overshoot the cluster;
+> - **the cluster holds leftover data** (another writer, app, or a prior
+>   run — keys persist since no TTL is set) — it is uncounted;
+> - **the process restarts on top of existing data** — both the byte
+>   counter and the eviction LRU start empty, so pre-existing keys are
+>   never evicted by LMCache.
+>
+> In all three cases prefer **server-driven** eviction (`maxmemory` +
+> `allkeys-lfu`, `max_capacity_gb = 0`): the server bounds real memory
+> regardless of writer or restart, and `allkeys-*` is required because
+> this adapter sets no TTL (`volatile-*` would evict nothing and OOM).
 
 ## Lock semantics
 

--- a/examples/kv_cache_reuse/remote_backends/valkey/README.md
+++ b/examples/kv_cache_reuse/remote_backends/valkey/README.md
@@ -1,0 +1,79 @@
+## LMCache can use [Valkey](https://valkey.io/) as an L2 backend (MP mode).
+
+Offloads KV cache to a Valkey standalone or cluster via the `valkey` L2
+adapter (zero-copy through the `valkey-glide-sync` client). In MP mode
+vLLM talks to a separate LMCache server over ZMQ, which stores to Valkey.
+For the non-MP `valkey://` connector instead, see
+[`VALKEY_CONNECTOR_BENCHMARKING.md`](VALKEY_CONNECTOR_BENCHMARKING.md).
+
+Requires a GPU and `pip install 'valkey-glide-sync>=2.3.0'`.
+
+## Step 1: Start a local Valkey
+
+For this example we run Valkey **locally on this machine** (alongside
+vLLM). In production, point `startup_nodes` at your managed/remote Valkey
+instead and skip this step.
+
+```bash
+# Local standalone
+valkey-server --port 6390 --save "" --appendonly no --daemonize yes
+
+# Or a local 6-node cluster (3 primaries + 3 replicas, all on localhost)
+for p in 7000 7001 7002 7003 7004 7005; do
+  valkey-server --port $p --cluster-enabled yes --cluster-config-file nodes-$p.conf \
+    --save "" --appendonly no --daemonize yes
+done
+valkey-cli --cluster create 127.0.0.1:{7000,7001,7002,7003,7004,7005} \
+  --cluster-replicas 1 --cluster-yes
+```
+
+## Step 2: Start the LMCache MP server
+
+```bash
+# Standalone (use the cluster line below for a cluster)
+lmcache server --l1-size-gb 4 --eviction-policy LRU --chunk-size 16 --port 6555 \
+  --l2-adapter '{"type":"valkey","startup_nodes":"localhost:6390","num_workers":8}'
+
+# Cluster
+#   --l2-adapter '{"type":"valkey","cluster_mode":true,"startup_nodes":"127.0.0.1:7000,127.0.0.1:7001","num_workers":8}'
+```
+
+`--l2-adapter` is a JSON object with `type:"valkey"`, a
+`"host:port[,host:port]"` `startup_nodes` string, and optional
+`cluster_mode`, `username`/`password`, `key_prefix`, `tls_enable`,
+`num_workers`, `max_capacity_gb`. Run `lmcache server --help` for the full
+field reference.
+
+## Step 3: Start vLLM with the MP connector
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+  --kv-transfer-config '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.host":"tcp://localhost","lmcache.mp.port":6555}}' \
+  --no-enable-prefix-caching --load-format dummy --port 8000
+```
+
+## Step 4: Send requests
+
+Send the same prompt twice — the first stores KV cache to Valkey, the
+second retrieves it:
+
+```bash
+curl -X POST http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "prompt": "'"$(printf 'Elaborate the significance of KV cache in language models. %.0s' {1..1000})"'",
+    "max_tokens": 10
+  }'
+```
+
+## Confirming the offload worked
+
+Watch vLLM's periodic engine logs for **`External prefix cache hit
+rate`** — the fraction of prefix KV served from LMCache's L2 (Valkey). It
+is `0.0%` on the first request and rises on repeats.
+
+Confirm data physically landed in Valkey:
+
+```bash
+valkey-cli -p 6390 dbsize       # standalone
+valkey-cli -c -p 7000 dbsize    # cluster
+```

--- a/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
@@ -16,19 +16,6 @@ Concurrency model:
     per-key callbacks atomically decrement the batch's ``remaining``
     counter and the last finisher publishes the result and signals the
     matching event fd.
-
-Capabilities:
-    1. Cluster discovery — delegated to ``GlideClusterClient``.
-    2. Authentication — ``username``/``password`` via glide credentials.
-    3. Deployment key prefix — ``key_prefix`` joined with the standard
-       ``_object_key_to_string`` wire format.
-    4. ``cache_salt`` isolation — already part of the wire key produced
-       by ``_object_key_to_string``.
-    5. Size validation on load — buffer GET return value is compared
-       against the expected buffer length; size mismatch → cache miss.
-    6. Partial-failure accounting — per-key ``Future`` outcomes are
-       aggregated so per-salt byte accounting reflects only the keys
-       that actually wrote.
 """
 
 # Future
@@ -367,7 +354,7 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
 
 
 @dataclass
-class _BatchState:
+class _SubmitTaskBatchState:
     """Shared per-batch state used by per-key future callbacks.
 
     A batch holds one ``Future`` per key; each completion callback
@@ -389,11 +376,6 @@ class _BatchState:
     lock: threading.Lock = field(default_factory=threading.Lock)
 
 
-# ---------------------------------------------------------------------------
-# Adapter
-# ---------------------------------------------------------------------------
-
-
 class ValkeyL2Adapter(L2AdapterInterface):
     """
     L2 adapter that stores KV-cache chunks in Valkey (or Redis) via the
@@ -404,21 +386,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
     """
 
     def __init__(self, config: ValkeyL2AdapterConfig) -> None:
-        """Initialize the adapter and warm up worker clients.
-
-        The shared ``ValkeyWorkerPool`` builds (and warms up) one glide
-        client per worker thread, so connection / auth / missing-dependency
-        errors surface immediately here rather than on the first
-        ``submit_*_task`` call.
-
-        Args:
-            config: A fully validated ``ValkeyL2AdapterConfig``.
-
-        Raises:
-            RuntimeError: If ``valkey-glide`` is not installed.
-            Exception: Any connection / authentication error raised by
-                glide during warmup is propagated.
-        """
+        """Initialize the adapter and warm up worker clients."""
         super().__init__(max_capacity_bytes=int(config.max_capacity_gb * (1024**3)))
         self._config: ValkeyL2AdapterConfig = config
 
@@ -497,16 +465,6 @@ class ValkeyL2Adapter(L2AdapterInterface):
         ``bytes_transferred`` reflects only the keys that actually
         wrote (partial failures are accounted correctly).
 
-        Args:
-            keys: Keys to store. ``cache_salt`` is already encoded into
-                the wire key by ``_object_key_to_string``.
-            objects: Memory objects whose ``byte_array`` provides the
-                value bytes. Must be parallel to ``keys``.
-
-        Returns:
-            The assigned task id; result is retrievable once the store
-            event fd fires.
-
         Raises:
             ValueError: If ``keys`` and ``objects`` differ in length.
         """
@@ -528,7 +486,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
         wire_keys = [self._wire_key(k) for k in keys]
         sizes = [obj.get_size() for obj in objects]
 
-        batch = _BatchState(
+        batch = _SubmitTaskBatchState(
             task_id=task_id,
             remaining=len(keys),
             per_key_ok=[False] * len(keys),
@@ -544,7 +502,9 @@ class ValkeyL2Adapter(L2AdapterInterface):
 
         return task_id
 
-    def _on_store_done(self, batch: _BatchState, idx: int, fut: Future) -> None:
+    def _on_store_done(
+        self, batch: _SubmitTaskBatchState, idx: int, fut: Future
+    ) -> None:
         """Per-key callback for a store batch; finalizes when last done.
 
         Runs in the worker thread that completed ``fut``. A cancelled or
@@ -576,7 +536,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
         if done:
             self._finalize_store(batch)
 
-    def _finalize_store(self, batch: _BatchState) -> None:
+    def _finalize_store(self, batch: _SubmitTaskBatchState) -> None:
         """Publish the final ``L2StoreResult`` for ``batch``.
 
         Accounting (``_notify_keys_stored``) is fired outside
@@ -613,10 +573,6 @@ class ValkeyL2Adapter(L2AdapterInterface):
             self._completed_stores = {}
         return completed
 
-    # ---------------------------------------------------------------
-    # Lookup and Lock Interface
-    # ---------------------------------------------------------------
-
     def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
         """Submit a non-blocking batch EXISTS to Valkey.
 
@@ -640,7 +596,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
             return task_id
 
         wire_keys = [self._wire_key(k) for k in keys]
-        batch = _BatchState(
+        batch = _SubmitTaskBatchState(
             task_id=task_id,
             remaining=len(keys),
             per_key_ok=[False] * len(keys),
@@ -651,7 +607,9 @@ class ValkeyL2Adapter(L2AdapterInterface):
             fut.add_done_callback(functools.partial(self._on_lookup_done, batch, i))
         return task_id
 
-    def _on_lookup_done(self, batch: _BatchState, idx: int, fut: Future) -> None:
+    def _on_lookup_done(
+        self, batch: _SubmitTaskBatchState, idx: int, fut: Future
+    ) -> None:
         """Per-key callback for a lookup batch."""
         exists = False
         if fut.cancelled():
@@ -686,7 +644,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
         if done:
             self._finalize_lookup(batch)
 
-    def _finalize_lookup(self, batch: _BatchState) -> None:
+    def _finalize_lookup(self, batch: _SubmitTaskBatchState) -> None:
         """Publish lookup bitmap and apply lock-refcount increments."""
         bitmap = Bitmap(len(batch.keys))
         accessed: list[ObjectKey] = []
@@ -719,10 +677,6 @@ class ValkeyL2Adapter(L2AdapterInterface):
                 else:
                     self._locked_keys[key] = count - 1
 
-    # ---------------------------------------------------------------
-    # Load Interface
-    # ---------------------------------------------------------------
-
     def submit_load_task(
         self,
         keys: list[ObjectKey],
@@ -733,17 +687,6 @@ class ValkeyL2Adapter(L2AdapterInterface):
         Uses glide's buffer GET (zero-copy) when available; otherwise
         falls back to copying through a ``bytes`` intermediate. In both
         paths a size mismatch is treated as a cache miss.
-
-        Args:
-            keys: Keys to load.
-            objects: Destination buffers; ``objects[i].byte_array`` must
-                be a writeable memoryview of the expected chunk size.
-
-        Returns:
-            The assigned task id.
-
-        Raises:
-            ValueError: If ``keys`` and ``objects`` differ in length.
         """
         if len(keys) != len(objects):
             raise ValueError(
@@ -765,7 +708,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
         # treats any GET whose byte count differs as a cache miss (stale
         # or truncated value).
         expected_sizes = [obj.get_size() for obj in objects]
-        batch = _BatchState(
+        batch = _SubmitTaskBatchState(
             task_id=task_id,
             remaining=len(keys),
             per_key_ok=[False] * len(keys),
@@ -777,7 +720,9 @@ class ValkeyL2Adapter(L2AdapterInterface):
             fut.add_done_callback(functools.partial(self._on_load_done, batch, i))
         return task_id
 
-    def _on_load_done(self, batch: _BatchState, idx: int, fut: Future) -> None:
+    def _on_load_done(
+        self, batch: _SubmitTaskBatchState, idx: int, fut: Future
+    ) -> None:
         """Per-key callback for a load batch.
 
         The pool returns the number of bytes available for the key (or
@@ -828,7 +773,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
         if done:
             self._finalize_load(batch)
 
-    def _finalize_load(self, batch: _BatchState) -> None:
+    def _finalize_load(self, batch: _SubmitTaskBatchState) -> None:
         """Publish the load result bitmap and notify access listeners."""
         bitmap = Bitmap(len(batch.keys))
         accessed: list[ObjectKey] = []
@@ -896,19 +841,8 @@ class ValkeyL2Adapter(L2AdapterInterface):
     # class maintains totals from ``_notify_keys_stored`` /
     # ``_notify_keys_deleted`` so no override is needed.
 
-    # ---------------------------------------------------------------
-    # Status Interface
-    # ---------------------------------------------------------------
-
     def report_status(self) -> dict[str, Any]:
-        """Return a JSON-serializable health/status snapshot.
-
-        Returns:
-            Dict with ``is_healthy`` (alive worker pool and not closed),
-            ``type`` (``"valkey"``), current byte usage / declared
-            capacity (``usage_fraction == -1`` when uncapped), and
-            adapter configuration that is safe to log (no credentials).
-        """
+        """Return a JSON-serializable health/status snapshot."""
         usage = self.get_usage()
         status: dict[str, Any] = {
             "is_healthy": not self._closed,
@@ -933,15 +867,8 @@ class ValkeyL2Adapter(L2AdapterInterface):
             status["node_memory"] = self._pool.node_memory_usage()
         return status
 
-    # ---------------------------------------------------------------
-    # Cleanup
-    # ---------------------------------------------------------------
-
     def close(self) -> None:
-        """Close the worker pool (and its glide clients) and event fds.
-
-        Idempotent — subsequent calls are no-ops.
-        """
+        """Close the worker pool (and its glide clients) and event fds."""
         if self._closed:
             return
         self._closed = True
@@ -950,10 +877,6 @@ class ValkeyL2Adapter(L2AdapterInterface):
         self._lookup_efd.close()
         self._load_efd.close()
         logger.info("ValkeyL2Adapter closed")
-
-    # ---------------------------------------------------------------
-    # Internal helpers
-    # ---------------------------------------------------------------
 
     def _new_task_id(self) -> L2TaskId:
         """Allocate the next task id. Caller must hold ``self._lock``."""

--- a/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 # First Party
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
-from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
@@ -573,7 +573,11 @@ class ValkeyL2Adapter(L2AdapterInterface):
             self._completed_stores = {}
         return completed
 
-    def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
+    def submit_lookup_and_lock_task(
+        self,
+        keys: list[ObjectKey],
+        layout_desc: MemoryLayoutDesc,
+    ) -> L2TaskId:
         """Submit a non-blocking batch EXISTS to Valkey.
 
         On completion the bitmap has bit ``i`` set iff key ``i`` was
@@ -582,6 +586,8 @@ class ValkeyL2Adapter(L2AdapterInterface):
 
         Args:
             keys: Keys to look up and lock.
+            layout_desc: The memory layout of the objects. Advisory hint,
+                not used by the Valkey adapter.
 
         Returns:
             The assigned task id.

--- a/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
@@ -281,11 +281,9 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
     def from_dict(cls, d: dict) -> "ValkeyL2AdapterConfig":
         """Build a config instance from a JSON-derived dict.
 
-        Accepts ``startup_nodes`` in several forms (see
-        ``_parse_startup_nodes``), or a single ``host``/``port`` pair as
-        a shortcut for one-node configs. Environment variables provide
-        defaults for nodes / username / password when those fields are
-        absent.
+        Requires ``startup_nodes`` as a ``"host:port[,host:port...]"``
+        string (see ``_parse_startup_nodes``); every other field is
+        optional and falls back to its default.
 
         Args:
             d: Parsed JSON dict (must include ``type``: ``"valkey"``).
@@ -444,6 +442,8 @@ class ValkeyL2Adapter(L2AdapterInterface):
         self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
 
         # Stored sizes, so delete can report accurate per-key byte deltas.
+        # NOTE: grows unbounded under server-side eviction (delete is never
+        # called); shared across remote adapters, best fixed in the base class.
         self._key_sizes: dict[ObjectKey, int] = {}
 
         self._next_task_id: L2TaskId = 0
@@ -609,6 +609,13 @@ class ValkeyL2Adapter(L2AdapterInterface):
     def pop_completed_store_tasks(
         self,
     ) -> dict[L2TaskId, L2StoreResult]:
+        """Drain and return all completed store-task results.
+
+        Returns:
+            A mapping of ``L2TaskId`` to its ``L2StoreResult`` for every
+            store task finished since the last call. The internal buffer is
+            cleared, so each result is returned exactly once.
+        """
         with self._lock:
             completed = self._completed_stores
             self._completed_stores = {}
@@ -707,6 +714,16 @@ class ValkeyL2Adapter(L2AdapterInterface):
         self._lookup_efd.notify()
 
     def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Bitmap | None:
+        """Non-blockingly pop the result of a lookup-and-lock task.
+
+        Args:
+            task_id: Id of a previously submitted lookup-and-lock task.
+
+        Returns:
+            A ``Bitmap`` whose bits mark per-key success (key found and
+            locked), or ``None`` if the task has not completed yet or its
+            result was already retrieved (returns non-``None`` only once).
+        """
         with self._lock:
             return self._completed_lookups.pop(task_id, None)
 
@@ -835,6 +852,16 @@ class ValkeyL2Adapter(L2AdapterInterface):
         self._load_efd.notify()
 
     def query_load_result(self, task_id: L2TaskId) -> Bitmap | None:
+        """Non-blockingly pop the result of a load task.
+
+        Args:
+            task_id: Id of a previously submitted load task.
+
+        Returns:
+            A ``Bitmap`` whose bits mark per-key load success, or ``None``
+            if the task has not completed yet or its result was already
+            retrieved (returns non-``None`` only once).
+        """
         with self._lock:
             return self._completed_loads.pop(task_id, None)
 

--- a/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
@@ -5,9 +5,9 @@ Valkey L2 adapter backed by the official ``valkey-glide`` sync client.
 Supports both standalone (``GlideClient``) and Valkey Cluster
 (``GlideClusterClient``) topologies via the ``cluster_mode`` field. The
 sync glide client is used (rather than async) because it is the only
-glide API that supports zero-copy SET (``bytearray``/``memoryview`` args)
-and buffer GET — async glide cannot avoid an intermediate ``bytes``
-allocation due to its Protobuf-based IPC layer.
+glide API that supports copy-reduced SET (``bytearray``/``memoryview``
+args) and buffer GET — async glide adds an unavoidable intermediate
+``bytes`` allocation on top of that, due to its Protobuf-based IPC layer.
 
 Concurrency model:
     The glide clients and worker threads live in the shared
@@ -413,6 +413,32 @@ class _SubmitTaskBatchState:
     sizes: list[int] = field(default_factory=list)
     lock: threading.Lock = field(default_factory=threading.Lock)
 
+    def settle_unlaunched(self, launched: int) -> bool:
+        """Account for keys that never got a future, after a launch error.
+
+        Called when the per-key dispatch loop raised at index ``launched``:
+        keys ``[launched, len(keys))`` will never run a completion callback,
+        so their ``remaining`` share must be dropped here or the batch would
+        never finalize. They keep their initial ``per_key_ok`` of ``False``.
+
+        Takes ``lock`` and re-checks ``remaining``, so it races safely with
+        the callbacks of the keys that did launch.
+
+        Args:
+            launched: Number of keys whose future was successfully
+                submitted (i.e. the index at which dispatch raised).
+
+        Returns:
+            ``True`` if this call drove ``remaining`` to zero and the caller
+            must therefore finalize the batch.
+        """
+        unlaunched = len(self.keys) - launched
+        if unlaunched <= 0:
+            return False
+        with self.lock:
+            self.remaining -= unlaunched
+            return self.remaining == 0
+
 
 class ValkeyL2Adapter(L2AdapterInterface):
     """
@@ -449,7 +475,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
         self._next_task_id: L2TaskId = 0
         self._lock: threading.Lock = threading.Lock()
 
-        # Shared glide client pool — owns clients, thread pool, zero-copy
+        # Shared glide client pool — owns clients, thread pool, copy-reduced
         # primitives, capability probing, and reliable shutdown.
         self._pool: ValkeyWorkerPool = ValkeyWorkerPool(
             addresses=config.startup_nodes,
@@ -506,6 +532,9 @@ class ValkeyL2Adapter(L2AdapterInterface):
         ``bytes_transferred`` reflects only the keys that actually
         wrote (partial failures are accounted correctly).
 
+        If the adapter is closed, or the pool rejects a dispatch, the
+        task completes immediately as a failure rather than hanging.
+
         Raises:
             ValueError: If ``keys`` and ``objects`` differ in length.
         """
@@ -517,6 +546,15 @@ class ValkeyL2Adapter(L2AdapterInterface):
 
         with self._lock:
             task_id = self._new_task_id()
+
+        if self._closed:
+            logger.warning(
+                "submit_store_task on a closed ValkeyL2Adapter; failing task"
+            )
+            with self._lock:
+                self._completed_stores[task_id] = L2StoreResult(False, 0)
+            self._store_efd.notify()
+            return task_id
 
         if not keys:
             with self._lock:
@@ -535,11 +573,24 @@ class ValkeyL2Adapter(L2AdapterInterface):
             sizes=sizes,
         )
 
-        for i in range(len(keys)):
-            fut = self._pool.submit_set(wire_keys[i], objects[i].byte_array)
-            # partial binds this key's batch+index; the future is passed
-            # last by add_done_callback.
-            fut.add_done_callback(functools.partial(self._on_store_done, batch, i))
+        launched = 0
+        try:
+            for i in range(len(keys)):
+                fut = self._pool.submit_set(wire_keys[i], objects[i].byte_array)
+                # partial binds this key's batch+index; the future is passed
+                # last by add_done_callback.
+                fut.add_done_callback(functools.partial(self._on_store_done, batch, i))
+                launched = i + 1
+        except Exception as e:
+            logger.error(
+                "Valkey SET dispatch failed after %d/%d keys (task_id=%d): %s",
+                launched,
+                len(keys),
+                task_id,
+                e,
+            )
+            if batch.settle_unlaunched(launched):
+                self._finalize_store(batch)
 
         return task_id
 
@@ -583,24 +634,27 @@ class ValkeyL2Adapter(L2AdapterInterface):
         Accounting (``_notify_keys_stored``) is fired outside
         ``self._lock`` so a slow listener cannot stall the next submit.
         """
-        bytes_transferred = sum(
-            sz for sz, ok in zip(batch.sizes, batch.per_key_ok, strict=True) if ok
-        )
         all_ok = all(batch.per_key_ok)
 
         stored_keys: list[ObjectKey] = []
         stored_sizes: list[int] = []
-        for k, sz, ok in zip(batch.keys, batch.sizes, batch.per_key_ok, strict=True):
-            if ok:
-                stored_keys.append(k)
-                stored_sizes.append(sz)
-
+        bytes_transferred = 0
         with self._lock:
+            for k, sz, ok in zip(
+                batch.keys, batch.sizes, batch.per_key_ok, strict=True
+            ):
+                if not ok:
+                    continue
+                stored_keys.append(k)
+                if k in self._key_sizes:
+                    stored_sizes.append(0)
+                else:
+                    self._key_sizes[k] = sz
+                    stored_sizes.append(sz)
+                    bytes_transferred += sz
             self._completed_stores[batch.task_id] = L2StoreResult(
                 all_ok, bytes_transferred
             )
-            for k, sz in zip(stored_keys, stored_sizes, strict=True):
-                self._key_sizes[k] = sz
 
         if stored_keys:
             self._notify_keys_stored(stored_keys, stored_sizes)
@@ -632,6 +686,10 @@ class ValkeyL2Adapter(L2AdapterInterface):
         present, and the lock refcount for each present key is
         incremented so subsequent ``submit_unlock`` calls balance.
 
+        If the adapter is closed, or the pool rejects a dispatch, the
+        task completes immediately as an all-miss bitmap rather than
+        hanging.
+
         Args:
             keys: Keys to look up and lock.
             layout_desc: The memory layout of the objects. Advisory hint,
@@ -642,6 +700,16 @@ class ValkeyL2Adapter(L2AdapterInterface):
         """
         with self._lock:
             task_id = self._new_task_id()
+
+        if self._closed:
+            logger.warning(
+                "submit_lookup_and_lock_task on a closed ValkeyL2Adapter; "
+                "reporting all keys as missing"
+            )
+            with self._lock:
+                self._completed_lookups[task_id] = Bitmap(len(keys))
+            self._lookup_efd.notify()
+            return task_id
 
         if not keys:
             with self._lock:
@@ -656,9 +724,22 @@ class ValkeyL2Adapter(L2AdapterInterface):
             per_key_ok=[False] * len(keys),
             keys=list(keys),
         )
-        for i in range(len(keys)):
-            fut = self._pool.submit_exists(wire_keys[i])
-            fut.add_done_callback(functools.partial(self._on_lookup_done, batch, i))
+        launched = 0
+        try:
+            for i in range(len(keys)):
+                fut = self._pool.submit_exists(wire_keys[i])
+                fut.add_done_callback(functools.partial(self._on_lookup_done, batch, i))
+                launched = i + 1
+        except Exception as e:
+            logger.error(
+                "Valkey EXISTS dispatch failed after %d/%d keys (task_id=%d): %s",
+                launched,
+                len(keys),
+                task_id,
+                e,
+            )
+            if batch.settle_unlaunched(launched):
+                self._finalize_lookup(batch)
         return task_id
 
     def _on_lookup_done(
@@ -748,9 +829,16 @@ class ValkeyL2Adapter(L2AdapterInterface):
     ) -> L2TaskId:
         """Submit a non-blocking batch GET into ``objects`` buffers.
 
-        Uses glide's buffer GET (zero-copy) when available; otherwise
+        Uses glide's buffer GET (copy-reduced) when available; otherwise
         falls back to copying through a ``bytes`` intermediate. In both
         paths a size mismatch is treated as a cache miss.
+
+        If the adapter is closed, or the pool rejects a dispatch, the
+        task completes immediately as an all-miss bitmap rather than
+        hanging.
+
+        Raises:
+            ValueError: If ``keys`` and ``objects`` differ in length.
         """
         if len(keys) != len(objects):
             raise ValueError(
@@ -760,6 +848,16 @@ class ValkeyL2Adapter(L2AdapterInterface):
 
         with self._lock:
             task_id = self._new_task_id()
+
+        if self._closed:
+            logger.warning(
+                "submit_load_task on a closed ValkeyL2Adapter; "
+                "reporting all keys as missing"
+            )
+            with self._lock:
+                self._completed_loads[task_id] = Bitmap(len(keys))
+            self._load_efd.notify()
+            return task_id
 
         if not keys:
             with self._lock:
@@ -779,9 +877,22 @@ class ValkeyL2Adapter(L2AdapterInterface):
             keys=list(keys),
             sizes=expected_sizes,
         )
-        for i in range(len(keys)):
-            fut = self._pool.submit_get_into(wire_keys[i], objects[i].byte_array)
-            fut.add_done_callback(functools.partial(self._on_load_done, batch, i))
+        launched = 0
+        try:
+            for i in range(len(keys)):
+                fut = self._pool.submit_get_into(wire_keys[i], objects[i].byte_array)
+                fut.add_done_callback(functools.partial(self._on_load_done, batch, i))
+                launched = i + 1
+        except Exception as e:
+            logger.error(
+                "Valkey GET dispatch failed after %d/%d keys (task_id=%d): %s",
+                launched,
+                len(keys),
+                task_id,
+                e,
+            )
+            if batch.settle_unlaunched(launched):
+                self._finalize_load(batch)
         return task_id
 
     def _on_load_done(
@@ -878,9 +989,13 @@ class ValkeyL2Adapter(L2AdapterInterface):
         ``request_timeout`` is hit. Only keys whose DEL actually removed a
         value (glide returns ``1``) are reported via
         ``_notify_keys_deleted`` with their original stored size from
-        ``_key_sizes``.
+        ``_key_sizes``. A closed adapter deletes nothing.
         """
         if not keys:
+            return
+
+        if self._closed:
+            logger.warning("delete on a closed ValkeyL2Adapter; ignoring")
             return
 
         # Skip keys currently pinned by a read; same convention as the
@@ -942,7 +1057,12 @@ class ValkeyL2Adapter(L2AdapterInterface):
         return status
 
     def close(self) -> None:
-        """Close the worker pool (and its glide clients) and event fds."""
+        """Close the worker pool (and its glide clients) and event fds.
+
+        Idempotent so a double-close never submits to a shut-down
+        executor. ``close`` is a lifecycle call from a single owner, not
+        contended with ``submit_*`` — no lock is needed.
+        """
         if self._closed:
             return
         self._closed = True

--- a/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
@@ -148,14 +148,18 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
         cluster mode.
       * ``request_timeout`` / ``connection_timeout``: Glide timeouts in
         seconds.
-      * ``max_capacity_gb``: Declared capacity for aggregate eviction.
-        ``0`` (default) disables aggregate-usage-based eviction; per
-        ``cache_salt`` quota policies still operate. Recommended: let
-        LMCache own eviction (set this ``> 0``) and disable Valkey
-        server-side eviction (``maxmemory 0`` / ``noeviction``). Enabling
-        both lets the server silently drop keys LMCache still counts,
-        drifting its byte accounting and LRU order (see the design doc's
-        "Two eviction layers" section).
+      * ``max_capacity_gb``: Declared capacity for LMCache-driven
+        eviction. ``0`` (default) disables it and defers to server-side
+        eviction (recommended); per ``cache_salt`` quota policies still
+        operate. ``> 0`` (plus an ``eviction`` block) makes LMCache own
+        eviction — trustworthy only for a single writer that privately
+        owns the cluster. Do not combine ``> 0`` with any server-side
+        eviction or TTL, which drifts LMCache's byte accounting (see the
+        design doc's eviction section).
+      * ``ttl_seconds``: Opt-in per-key TTL in seconds; ``None`` (default)
+        writes keys with no expiry. Enables server-side time-based expiry
+        (required by ``volatile-*`` policies). Do not combine with
+        ``max_capacity_gb > 0``.
     """
 
     def __init__(
@@ -171,6 +175,7 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
         request_timeout: float = DEFAULT_REQUEST_TIMEOUT_SECS,
         connection_timeout: float = DEFAULT_CONNECTION_TIMEOUT_SECS,
         max_capacity_gb: float = 0.0,
+        ttl_seconds: Optional[int] = None,
     ) -> None:
         """Initialize a ValkeyL2AdapterConfig with validated fields.
 
@@ -189,11 +194,18 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
             connection_timeout: Initial connection timeout in seconds.
             max_capacity_gb: Aggregate capacity in GB for eviction; ``0``
                 disables global eviction.
+            ttl_seconds: Opt-in per-key TTL in seconds; must be a positive
+                integer when set. ``None`` (default) writes keys with no
+                expiry. Enables server-side time-based expiry (required by
+                ``volatile-*`` policies). Do not combine with
+                ``max_capacity_gb > 0`` (logs a warning; see the design
+                doc's eviction section).
 
         Raises:
             ValueError: If any validation fails (empty
                 ``startup_nodes``, non-positive ``num_workers``,
-                negative capacity, ``@`` in ``key_prefix``, etc.).
+                negative capacity, non-positive ``ttl_seconds``, ``@`` in
+                ``key_prefix``, etc.).
         """
         super().__init__()
         if not startup_nodes:
@@ -237,6 +249,20 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
             raise ValueError("request_timeout must be > 0")
         if connection_timeout <= 0:
             raise ValueError("connection_timeout must be > 0")
+        if ttl_seconds is not None:
+            # bool is an int subclass, so reject it (True would be 1 second).
+            if isinstance(ttl_seconds, bool) or not isinstance(ttl_seconds, int):
+                raise ValueError("ttl_seconds must be a positive integer or None")
+            if ttl_seconds <= 0:
+                raise ValueError("ttl_seconds must be a positive integer or None")
+            if max_capacity_gb > 0:
+                # Server-side expiry is not reported to LMCache, so its byte
+                # accounting / LRU drift (see the eviction section in docs).
+                logger.warning(
+                    "Valkey: ttl_seconds set with max_capacity_gb > 0; "
+                    "server-side expiry drifts LMCache eviction accounting. "
+                    "Prefer max_capacity_gb=0 when using a TTL."
+                )
 
         self.startup_nodes: list[tuple[str, int]] = startup_nodes
         self.cluster_mode: bool = cluster_mode
@@ -249,6 +275,7 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
         self.request_timeout: float = request_timeout
         self.connection_timeout: float = connection_timeout
         self.max_capacity_gb: float = max_capacity_gb
+        self.ttl_seconds: Optional[int] = ttl_seconds
 
     @classmethod
     def from_dict(cls, d: dict) -> "ValkeyL2AdapterConfig":
@@ -299,6 +326,14 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
             raise ValueError("max_capacity_gb must be a number")
         max_capacity_gb = float(max_capacity_raw)
 
+        ttl_raw = d.get("ttl_seconds")
+        if ttl_raw is None:
+            ttl_seconds = None
+        elif isinstance(ttl_raw, bool) or not isinstance(ttl_raw, int):
+            raise ValueError("ttl_seconds must be a positive integer or omitted")
+        else:
+            ttl_seconds = ttl_raw
+
         return cls(
             startup_nodes=startup_nodes,
             cluster_mode=cluster_mode,
@@ -311,6 +346,7 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
             request_timeout=request_timeout,
             connection_timeout=connection_timeout,
             max_capacity_gb=max_capacity_gb,
+            ttl_seconds=ttl_seconds,
         )
 
     @classmethod
@@ -344,7 +380,11 @@ class ValkeyL2AdapterConfig(L2AdapterConfigBase):
             "- max_capacity_gb (float, default 0): aggregate capacity "
             "for eviction; 0 disables global eviction. Recommended: set "
             "this > 0 and disable Valkey server-side eviction "
-            "(maxmemory 0 / noeviction) so only LMCache evicts."
+            "(maxmemory 0 / noeviction) so only LMCache evicts.\n"
+            "- ttl_seconds (int, optional): opt-in per-key TTL in seconds; "
+            "omit (default) for no expiry. Enables server-side time-based "
+            "expiry (required by volatile-* policies). Do not combine with "
+            "max_capacity_gb > 0."
         )
 
 
@@ -421,6 +461,7 @@ class ValkeyL2Adapter(L2AdapterInterface):
             tls_enable=config.tls_enable,
             cluster_mode=config.cluster_mode,
             database_id=config.database_id,
+            ttl_seconds=config.ttl_seconds,
         )
 
         self._closed: bool = False

--- a/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
@@ -1,0 +1,977 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Valkey L2 adapter backed by the official ``valkey-glide`` sync client.
+
+Supports both standalone (``GlideClient``) and Valkey Cluster
+(``GlideClusterClient``) topologies via the ``cluster_mode`` field. The
+sync glide client is used (rather than async) because it is the only
+glide API that supports zero-copy SET (``bytearray``/``memoryview`` args)
+and buffer GET — async glide cannot avoid an intermediate ``bytes``
+allocation due to its Protobuf-based IPC layer.
+
+Concurrency model:
+    The glide clients and worker threads live in the shared
+    ``ValkeyWorkerPool`` (also used by the non-MP ``ValkeyConnector``). A
+    batch ``submit_*_task`` fans out one per-key future per key; the
+    per-key callbacks atomically decrement the batch's ``remaining``
+    counter and the last finisher publishes the result and signals the
+    matching event fd.
+
+Capabilities:
+    1. Cluster discovery — delegated to ``GlideClusterClient``.
+    2. Authentication — ``username``/``password`` via glide credentials.
+    3. Deployment key prefix — ``key_prefix`` joined with the standard
+       ``_object_key_to_string`` wire format.
+    4. ``cache_salt`` isolation — already part of the wire key produced
+       by ``_object_key_to_string``.
+    5. Size validation on load — buffer GET return value is compared
+       against the expected buffer length; size mismatch → cache miss.
+    6. Partial-failure accounting — per-key ``Future`` outcomes are
+       aggregated so per-salt byte accounting reflects only the keys
+       that actually wrote.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections import defaultdict
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+import functools
+import threading
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
+from lmcache.v1.distributed.l2_adapters.base import (
+    L2AdapterInterface,
+    L2TaskId,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
+    register_l2_adapter_factory,
+)
+from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
+    _object_key_to_string,
+)
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
+from lmcache.v1.storage_backend.valkey.worker_pool import ValkeyWorkerPool
+
+logger = init_logger(__name__)
+
+#: Default per-request timeout (seconds).
+DEFAULT_REQUEST_TIMEOUT_SECS: float = 5.0
+#: Default initial-connection timeout (seconds).
+DEFAULT_CONNECTION_TIMEOUT_SECS: float = 10.0
+
+# Separator used to join ``key_prefix`` and the standard wire key. Mirrors
+# the ``@`` separator inside ``_object_key_to_string`` so an empty prefix
+# is bit-identical to the unprefixed wire format.
+_KEY_SEP = "@"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_startup_nodes(raw: object) -> list[tuple[str, int]]:
+    """Parse a comma-separated ``"host:port"`` startup-nodes string.
+
+    Example: ``"host1:6379,host2:6379"``. In standalone mode only the
+    first entry is used; in cluster mode glide discovers the rest from
+    any reachable seed.
+
+    Args:
+        raw: A non-empty ``"host:port[,host:port...]"`` string.
+
+    Returns:
+        A list of ``(host, port)`` tuples; never empty.
+
+    Raises:
+        ValueError: If ``raw`` is not a string, is empty, or any entry
+            is malformed (missing ``:`` or non-integer port).
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(
+            "startup_nodes is required and must be a non-empty "
+            "'host:port[,host:port...]' string"
+        )
+
+    nodes: list[tuple[str, int]] = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        host, sep, port_str = chunk.rpartition(":")
+        if not sep or not host:
+            raise ValueError(f"startup_nodes entry must be 'host:port', got {chunk!r}")
+        try:
+            port = int(port_str)
+        except ValueError as e:
+            raise ValueError(
+                f"startup_nodes entry has non-integer port: {chunk!r}"
+            ) from e
+        if port <= 0:
+            raise ValueError(f"startup_nodes port must be > 0, got {chunk!r}")
+        nodes.append((host, port))
+
+    if not nodes:
+        raise ValueError("startup_nodes parsed to an empty list")
+    return nodes
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class ValkeyL2AdapterConfig(L2AdapterConfigBase):
+    """
+    Config for the Valkey L2 adapter.
+
+    Fields:
+      * ``startup_nodes``: List of ``(host, port)`` tuples (the JSON
+        config supplies this as a ``"host:port,host:port"`` string). In
+        standalone mode only the first is used (a warning is logged for
+        the rest). In cluster mode, glide auto-discovers the full
+        topology from any reachable seed node.
+      * ``cluster_mode``: When ``True``, build a ``GlideClusterClient``;
+        otherwise a standalone ``GlideClient``.
+      * ``username`` / ``password``: Optional auth credentials.
+      * ``key_prefix``: Deployment-level key namespace; joined with the
+        standard wire key via ``@``. Must not contain ``@``.
+      * ``num_workers``: Size of the internal worker thread pool. Each
+        worker holds an independent glide client.
+      * ``tls_enable``: Enable TLS (required for managed Valkey services
+        like ElastiCache Serverless).
+      * ``database_id``: Standalone-only logical database id; ignored in
+        cluster mode.
+      * ``request_timeout`` / ``connection_timeout``: Glide timeouts in
+        seconds.
+      * ``max_capacity_gb``: Declared capacity for aggregate eviction.
+        ``0`` (default) disables aggregate-usage-based eviction; per
+        ``cache_salt`` quota policies still operate. Recommended: let
+        LMCache own eviction (set this ``> 0``) and disable Valkey
+        server-side eviction (``maxmemory 0`` / ``noeviction``). Enabling
+        both lets the server silently drop keys LMCache still counts,
+        drifting its byte accounting and LRU order (see the design doc's
+        "Two eviction layers" section).
+    """
+
+    def __init__(
+        self,
+        startup_nodes: list[tuple[str, int]],
+        cluster_mode: bool = False,
+        username: str = "",
+        password: str = "",
+        key_prefix: str = "",
+        num_workers: int = 8,
+        tls_enable: bool = False,
+        database_id: Optional[int] = None,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT_SECS,
+        connection_timeout: float = DEFAULT_CONNECTION_TIMEOUT_SECS,
+        max_capacity_gb: float = 0.0,
+    ) -> None:
+        """Initialize a ValkeyL2AdapterConfig with validated fields.
+
+        Args:
+            startup_nodes: Non-empty list of ``(host, port)`` pairs.
+            cluster_mode: ``True`` to use ``GlideClusterClient``.
+            username: Optional auth username.
+            password: Optional auth password.
+            key_prefix: Optional namespace prefix; must not contain
+                ``@``.
+            num_workers: Worker thread count; must be > 0.
+            tls_enable: Whether to use TLS.
+            database_id: Standalone DB id; ignored when
+                ``cluster_mode=True``.
+            request_timeout: Per-request timeout in seconds.
+            connection_timeout: Initial connection timeout in seconds.
+            max_capacity_gb: Aggregate capacity in GB for eviction; ``0``
+                disables global eviction.
+
+        Raises:
+            ValueError: If any validation fails (empty
+                ``startup_nodes``, non-positive ``num_workers``,
+                negative capacity, ``@`` in ``key_prefix``, etc.).
+        """
+        super().__init__()
+        if not startup_nodes:
+            raise ValueError("startup_nodes must contain at least one (host, port)")
+        for node in startup_nodes:
+            if not (
+                isinstance(node, tuple)
+                and len(node) == 2
+                and isinstance(node[0], str)
+                and node[0]
+                and isinstance(node[1], int)
+                and not isinstance(node[1], bool)
+                and node[1] > 0
+            ):
+                raise ValueError(f"invalid startup_nodes entry: {node!r}")
+        if isinstance(num_workers, bool) or not isinstance(num_workers, int):
+            raise ValueError("num_workers must be an integer")
+        if num_workers <= 0:
+            raise ValueError("num_workers must be > 0")
+        if _KEY_SEP in key_prefix:
+            raise ValueError(
+                f"key_prefix must not contain {_KEY_SEP!r}: {key_prefix!r}"
+            )
+        if not cluster_mode and len(startup_nodes) > 1:
+            logger.warning(
+                "Valkey: cluster_mode=False but %d startup_nodes provided; "
+                "only the first (%s:%d) will be used",
+                len(startup_nodes),
+                startup_nodes[0][0],
+                startup_nodes[0][1],
+            )
+        if cluster_mode and database_id is not None:
+            logger.warning(
+                "Valkey: database_id=%d is ignored in cluster_mode",
+                database_id,
+            )
+            database_id = None
+        if max_capacity_gb < 0:
+            raise ValueError("max_capacity_gb must be >= 0")
+        if request_timeout <= 0:
+            raise ValueError("request_timeout must be > 0")
+        if connection_timeout <= 0:
+            raise ValueError("connection_timeout must be > 0")
+
+        self.startup_nodes: list[tuple[str, int]] = startup_nodes
+        self.cluster_mode: bool = cluster_mode
+        self.username: str = username
+        self.password: str = password
+        self.key_prefix: str = key_prefix
+        self.num_workers: int = num_workers
+        self.tls_enable: bool = tls_enable
+        self.database_id: Optional[int] = database_id
+        self.request_timeout: float = request_timeout
+        self.connection_timeout: float = connection_timeout
+        self.max_capacity_gb: float = max_capacity_gb
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ValkeyL2AdapterConfig":
+        """Build a config instance from a JSON-derived dict.
+
+        Accepts ``startup_nodes`` in several forms (see
+        ``_parse_startup_nodes``), or a single ``host``/``port`` pair as
+        a shortcut for one-node configs. Environment variables provide
+        defaults for nodes / username / password when those fields are
+        absent.
+
+        Args:
+            d: Parsed JSON dict (must include ``type``: ``"valkey"``).
+
+        Returns:
+            A validated ``ValkeyL2AdapterConfig`` instance.
+
+        Raises:
+            ValueError: If required keys are missing or values are
+                invalid.
+        """
+        startup_nodes = _parse_startup_nodes(d.get("startup_nodes"))
+
+        cluster_mode = bool(d.get("cluster_mode", False))
+        username = str(d.get("username", ""))
+        password = str(d.get("password", ""))
+        key_prefix = str(d.get("key_prefix", ""))
+
+        num_workers_raw = d.get("num_workers", 8)
+        if isinstance(num_workers_raw, bool) or not isinstance(num_workers_raw, int):
+            raise ValueError("num_workers must be an integer")
+        num_workers = num_workers_raw
+
+        tls_enable = bool(d.get("tls_enable", False))
+
+        database_id_raw = d.get("database_id")
+        database_id = int(database_id_raw) if database_id_raw is not None else None
+
+        request_timeout = float(d.get("request_timeout", DEFAULT_REQUEST_TIMEOUT_SECS))
+        connection_timeout = float(
+            d.get("connection_timeout", DEFAULT_CONNECTION_TIMEOUT_SECS)
+        )
+
+        max_capacity_raw = d.get("max_capacity_gb", 0)
+        if not isinstance(max_capacity_raw, (int, float)) or isinstance(
+            max_capacity_raw, bool
+        ):
+            raise ValueError("max_capacity_gb must be a number")
+        max_capacity_gb = float(max_capacity_raw)
+
+        return cls(
+            startup_nodes=startup_nodes,
+            cluster_mode=cluster_mode,
+            username=username,
+            password=password,
+            key_prefix=key_prefix,
+            num_workers=num_workers,
+            tls_enable=tls_enable,
+            database_id=database_id,
+            request_timeout=request_timeout,
+            connection_timeout=connection_timeout,
+            max_capacity_gb=max_capacity_gb,
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        """Return human-readable help describing the JSON config fields.
+
+        Returns:
+            A multi-line string used by the CLI to document the
+            adapter's config schema.
+        """
+        return (
+            "Valkey L2 adapter config fields:\n"
+            "- startup_nodes (required): 'host:port' string, comma-"
+            "separated for multiple seeds, e.g. 'h1:6379,h2:6379'. In "
+            "standalone mode only the first entry is used.\n"
+            "- cluster_mode (bool, default false): use "
+            "GlideClusterClient when true.\n"
+            "- username (str, default empty): auth username.\n"
+            "- password (str, default empty): auth password.\n"
+            "- key_prefix (str, default empty): deployment namespace "
+            "joined with each key by '@'. Must not contain '@'.\n"
+            "- num_workers (int, default 8): worker thread count "
+            "(> 0).\n"
+            "- tls_enable (bool, default false): enable TLS.\n"
+            "- database_id (int, optional): standalone-only logical DB; "
+            "ignored when cluster_mode=true.\n"
+            "- request_timeout (float, default 5.0): per-request "
+            "timeout (seconds).\n"
+            "- connection_timeout (float, default 10.0): initial "
+            "connection timeout (seconds).\n"
+            "- max_capacity_gb (float, default 0): aggregate capacity "
+            "for eviction; 0 disables global eviction. Recommended: set "
+            "this > 0 and disable Valkey server-side eviction "
+            "(maxmemory 0 / noeviction) so only LMCache evicts."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal batch state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _BatchState:
+    """Shared per-batch state used by per-key future callbacks.
+
+    A batch holds one ``Future`` per key; each completion callback
+    atomically updates ``per_key_ok[idx]`` and decrements ``remaining``
+    under ``lock``. The last finisher (whose decrement drives
+    ``remaining`` to zero) is responsible for publishing the result and
+    signalling the event fd.
+
+    ``sizes`` is only populated for store batches — load/lookup/delete
+    batches leave it as an empty list because byte accounting is not
+    needed in those paths.
+    """
+
+    task_id: L2TaskId
+    remaining: int
+    per_key_ok: list[bool]
+    keys: list[ObjectKey]
+    sizes: list[int] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class ValkeyL2Adapter(L2AdapterInterface):
+    """
+    L2 adapter that stores KV-cache chunks in Valkey (or Redis) via the
+    glide sync client.
+
+    See the module docstring for the design rationale and the list of
+    capabilities this adapter provides.
+    """
+
+    def __init__(self, config: ValkeyL2AdapterConfig) -> None:
+        """Initialize the adapter and warm up worker clients.
+
+        The shared ``ValkeyWorkerPool`` builds (and warms up) one glide
+        client per worker thread, so connection / auth / missing-dependency
+        errors surface immediately here rather than on the first
+        ``submit_*_task`` call.
+
+        Args:
+            config: A fully validated ``ValkeyL2AdapterConfig``.
+
+        Raises:
+            RuntimeError: If ``valkey-glide`` is not installed.
+            Exception: Any connection / authentication error raised by
+                glide during warmup is propagated.
+        """
+        super().__init__(max_capacity_bytes=int(config.max_capacity_gb * (1024**3)))
+        self._config: ValkeyL2AdapterConfig = config
+
+        # Three distinct event fds (interface requirement).
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
+
+        # Result queues — popped (and cleared) by the L2 controller.
+        self._completed_stores: dict[L2TaskId, L2StoreResult] = {}
+        self._completed_lookups: dict[L2TaskId, Bitmap] = {}
+        self._completed_loads: dict[L2TaskId, Bitmap] = {}
+
+        # Client-side lock refcounts (in-flight lookups pin keys).
+        self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
+
+        # Stored sizes, so delete can report accurate per-key byte deltas.
+        self._key_sizes: dict[ObjectKey, int] = {}
+
+        self._next_task_id: L2TaskId = 0
+        self._lock: threading.Lock = threading.Lock()
+
+        # Shared glide client pool — owns clients, thread pool, zero-copy
+        # primitives, capability probing, and reliable shutdown.
+        self._pool: ValkeyWorkerPool = ValkeyWorkerPool(
+            addresses=config.startup_nodes,
+            num_workers=config.num_workers,
+            username=config.username,
+            password=config.password,
+            request_timeout=config.request_timeout,
+            connection_timeout=config.connection_timeout,
+            tls_enable=config.tls_enable,
+            cluster_mode=config.cluster_mode,
+            database_id=config.database_id,
+        )
+
+        self._closed: bool = False
+        logger.info(
+            "ValkeyL2Adapter ready: workers=%d cluster_mode=%s nodes=%s "
+            "tls=%s buffer_get=%s key_prefix=%r",
+            config.num_workers,
+            config.cluster_mode,
+            list(config.startup_nodes),
+            config.tls_enable,
+            self._pool.has_buffer_get,
+            config.key_prefix,
+        )
+
+    # ---------------------------------------------------------------
+    # Event Fd Interface
+    # ---------------------------------------------------------------
+
+    def get_store_event_fd(self) -> int:
+        return self._store_efd.fileno()
+
+    def get_lookup_and_lock_event_fd(self) -> int:
+        return self._lookup_efd.fileno()
+
+    def get_load_event_fd(self) -> int:
+        return self._load_efd.fileno()
+
+    # ---------------------------------------------------------------
+    # Store Interface
+    # ---------------------------------------------------------------
+
+    def submit_store_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        """Submit a non-blocking batch SET to Valkey.
+
+        Each key is dispatched as an independent ``Future`` to the
+        worker pool. When the final per-key future completes, the
+        adapter publishes an ``L2StoreResult`` whose
+        ``bytes_transferred`` reflects only the keys that actually
+        wrote (partial failures are accounted correctly).
+
+        Args:
+            keys: Keys to store. ``cache_salt`` is already encoded into
+                the wire key by ``_object_key_to_string``.
+            objects: Memory objects whose ``byte_array`` provides the
+                value bytes. Must be parallel to ``keys``.
+
+        Returns:
+            The assigned task id; result is retrievable once the store
+            event fd fires.
+
+        Raises:
+            ValueError: If ``keys`` and ``objects`` differ in length.
+        """
+        if len(keys) != len(objects):
+            raise ValueError(
+                "submit_store_task: keys and objects length mismatch "
+                f"({len(keys)} vs {len(objects)})"
+            )
+
+        with self._lock:
+            task_id = self._new_task_id()
+
+        if not keys:
+            with self._lock:
+                self._completed_stores[task_id] = L2StoreResult(True, 0)
+            self._store_efd.notify()
+            return task_id
+
+        wire_keys = [self._wire_key(k) for k in keys]
+        sizes = [obj.get_size() for obj in objects]
+
+        batch = _BatchState(
+            task_id=task_id,
+            remaining=len(keys),
+            per_key_ok=[False] * len(keys),
+            keys=list(keys),
+            sizes=sizes,
+        )
+
+        for i in range(len(keys)):
+            fut = self._pool.submit_set(wire_keys[i], objects[i].byte_array)
+            # partial binds this key's batch+index; the future is passed
+            # last by add_done_callback.
+            fut.add_done_callback(functools.partial(self._on_store_done, batch, i))
+
+        return task_id
+
+    def _on_store_done(self, batch: _BatchState, idx: int, fut: Future) -> None:
+        """Per-key callback for a store batch; finalizes when last done.
+
+        Runs in the worker thread that completed ``fut``. Exceptions
+        from glide are logged and recorded as per-key failure; the
+        callback never re-raises.
+        """
+        exc = fut.exception()
+        ok = exc is None
+        if not ok:
+            logger.warning(
+                "Valkey SET failed (batch task_id=%d, key idx=%d): %s",
+                batch.task_id,
+                idx,
+                exc,
+            )
+        with batch.lock:
+            batch.per_key_ok[idx] = ok
+            batch.remaining -= 1
+            done = batch.remaining == 0
+        if done:
+            self._finalize_store(batch)
+
+    def _finalize_store(self, batch: _BatchState) -> None:
+        """Publish the final ``L2StoreResult`` for ``batch``.
+
+        Accounting (``_notify_keys_stored``) is fired outside
+        ``self._lock`` so a slow listener cannot stall the next submit.
+        """
+        bytes_transferred = sum(
+            sz for sz, ok in zip(batch.sizes, batch.per_key_ok, strict=True) if ok
+        )
+        all_ok = all(batch.per_key_ok)
+
+        stored_keys: list[ObjectKey] = []
+        stored_sizes: list[int] = []
+        for k, sz, ok in zip(batch.keys, batch.sizes, batch.per_key_ok, strict=True):
+            if ok:
+                stored_keys.append(k)
+                stored_sizes.append(sz)
+
+        with self._lock:
+            self._completed_stores[batch.task_id] = L2StoreResult(
+                all_ok, bytes_transferred
+            )
+            for k, sz in zip(stored_keys, stored_sizes, strict=True):
+                self._key_sizes[k] = sz
+
+        if stored_keys:
+            self._notify_keys_stored(stored_keys, stored_sizes)
+        self._store_efd.notify()
+
+    def pop_completed_store_tasks(
+        self,
+    ) -> dict[L2TaskId, L2StoreResult]:
+        with self._lock:
+            completed = self._completed_stores
+            self._completed_stores = {}
+        return completed
+
+    # ---------------------------------------------------------------
+    # Lookup and Lock Interface
+    # ---------------------------------------------------------------
+
+    def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
+        """Submit a non-blocking batch EXISTS to Valkey.
+
+        On completion the bitmap has bit ``i`` set iff key ``i`` was
+        present, and the lock refcount for each present key is
+        incremented so subsequent ``submit_unlock`` calls balance.
+
+        Args:
+            keys: Keys to look up and lock.
+
+        Returns:
+            The assigned task id.
+        """
+        with self._lock:
+            task_id = self._new_task_id()
+
+        if not keys:
+            with self._lock:
+                self._completed_lookups[task_id] = Bitmap(0)
+            self._lookup_efd.notify()
+            return task_id
+
+        wire_keys = [self._wire_key(k) for k in keys]
+        batch = _BatchState(
+            task_id=task_id,
+            remaining=len(keys),
+            per_key_ok=[False] * len(keys),
+            keys=list(keys),
+        )
+        for i in range(len(keys)):
+            fut = self._pool.submit_exists(wire_keys[i])
+            fut.add_done_callback(functools.partial(self._on_lookup_done, batch, i))
+        return task_id
+
+    def _on_lookup_done(self, batch: _BatchState, idx: int, fut: Future) -> None:
+        """Per-key callback for a lookup batch."""
+        exc = fut.exception()
+        exists = False
+        if exc is None:
+            try:
+                exists = bool(fut.result())
+            except Exception as e:  # defensive — result() shouldn't raise here
+                logger.warning(
+                    "Valkey EXISTS unexpected error (batch=%d, idx=%d): %s",
+                    batch.task_id,
+                    idx,
+                    e,
+                )
+        else:
+            logger.warning(
+                "Valkey EXISTS failed (batch=%d, idx=%d): %s",
+                batch.task_id,
+                idx,
+                exc,
+            )
+        with batch.lock:
+            batch.per_key_ok[idx] = exists
+            batch.remaining -= 1
+            done = batch.remaining == 0
+        if done:
+            self._finalize_lookup(batch)
+
+    def _finalize_lookup(self, batch: _BatchState) -> None:
+        """Publish lookup bitmap and apply lock-refcount increments."""
+        bitmap = Bitmap(len(batch.keys))
+        accessed: list[ObjectKey] = []
+        with self._lock:
+            for i, (k, ok) in enumerate(zip(batch.keys, batch.per_key_ok, strict=True)):
+                if ok:
+                    bitmap.set(i)
+                    self._locked_keys[k] += 1
+                    accessed.append(k)
+            self._completed_lookups[batch.task_id] = bitmap
+        if accessed:
+            self._notify_keys_accessed(accessed)
+        self._lookup_efd.notify()
+
+    def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Bitmap | None:
+        with self._lock:
+            return self._completed_lookups.pop(task_id, None)
+
+    def submit_unlock(self, keys: list[ObjectKey]) -> None:
+        """Decrement the lock refcount for ``keys``.
+
+        Missing keys are silently ignored — the L2 controller does not
+        rely on unlock symmetry beyond refcount semantics.
+        """
+        with self._lock:
+            for key in keys:
+                count = self._locked_keys.get(key, 0)
+                if count <= 1:
+                    self._locked_keys.pop(key, None)
+                else:
+                    self._locked_keys[key] = count - 1
+
+    # ---------------------------------------------------------------
+    # Load Interface
+    # ---------------------------------------------------------------
+
+    def submit_load_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        """Submit a non-blocking batch GET into ``objects`` buffers.
+
+        Uses glide's buffer GET (zero-copy) when available; otherwise
+        falls back to copying through a ``bytes`` intermediate. In both
+        paths a size mismatch is treated as a cache miss.
+
+        Args:
+            keys: Keys to load.
+            objects: Destination buffers; ``objects[i].byte_array`` must
+                be a writeable memoryview of the expected chunk size.
+
+        Returns:
+            The assigned task id.
+
+        Raises:
+            ValueError: If ``keys`` and ``objects`` differ in length.
+        """
+        if len(keys) != len(objects):
+            raise ValueError(
+                "submit_load_task: keys and objects length mismatch "
+                f"({len(keys)} vs {len(objects)})"
+            )
+
+        with self._lock:
+            task_id = self._new_task_id()
+
+        if not keys:
+            with self._lock:
+                self._completed_loads[task_id] = Bitmap(0)
+            self._load_efd.notify()
+            return task_id
+
+        wire_keys = [self._wire_key(k) for k in keys]
+        # ``sizes[i]`` is the expected chunk length; the load callback
+        # treats any GET whose byte count differs as a cache miss (stale
+        # or truncated value).
+        expected_sizes = [obj.get_size() for obj in objects]
+        batch = _BatchState(
+            task_id=task_id,
+            remaining=len(keys),
+            per_key_ok=[False] * len(keys),
+            keys=list(keys),
+            sizes=expected_sizes,
+        )
+        for i in range(len(keys)):
+            fut = self._pool.submit_get_into(wire_keys[i], objects[i].byte_array)
+            fut.add_done_callback(functools.partial(self._on_load_done, batch, i))
+        return task_id
+
+    def _on_load_done(self, batch: _BatchState, idx: int, fut: Future) -> None:
+        """Per-key callback for a load batch.
+
+        The pool returns the number of bytes available for the key (or
+        ``GET_MISS``). A hit requires the byte count to match the
+        expected chunk size, so a stale or truncated value is rejected
+        as a cache miss.
+        """
+        exc = fut.exception()
+        loaded = False
+        if exc is None:
+            try:
+                nbytes = int(fut.result())
+                loaded = nbytes == batch.sizes[idx]
+                if nbytes >= 0 and not loaded:
+                    logger.debug(
+                        "Valkey GET size mismatch (batch=%d, idx=%d): "
+                        "got %d bytes, expected %d",
+                        batch.task_id,
+                        idx,
+                        nbytes,
+                        batch.sizes[idx],
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Valkey GET unexpected error (batch=%d, idx=%d): %s",
+                    batch.task_id,
+                    idx,
+                    e,
+                )
+        else:
+            logger.warning(
+                "Valkey GET failed (batch=%d, idx=%d): %s",
+                batch.task_id,
+                idx,
+                exc,
+            )
+        with batch.lock:
+            batch.per_key_ok[idx] = loaded
+            batch.remaining -= 1
+            done = batch.remaining == 0
+        if done:
+            self._finalize_load(batch)
+
+    def _finalize_load(self, batch: _BatchState) -> None:
+        """Publish the load result bitmap and notify access listeners."""
+        bitmap = Bitmap(len(batch.keys))
+        accessed: list[ObjectKey] = []
+        for i, ok in enumerate(batch.per_key_ok):
+            if ok:
+                bitmap.set(i)
+                accessed.append(batch.keys[i])
+        with self._lock:
+            self._completed_loads[batch.task_id] = bitmap
+        if accessed:
+            self._notify_keys_accessed(accessed)
+        self._load_efd.notify()
+
+    def query_load_result(self, task_id: L2TaskId) -> Bitmap | None:
+        with self._lock:
+            return self._completed_loads.pop(task_id, None)
+
+    # ---------------------------------------------------------------
+    # Eviction Interface
+    # ---------------------------------------------------------------
+
+    def delete(self, keys: list[ObjectKey]) -> None:
+        """Synchronously delete a batch of keys from Valkey.
+
+        Locked keys (pinned by an in-flight lookup/load) are skipped —
+        deleting a value mid-read would corrupt the load. The remaining
+        keys are deleted; blocks until each per-key future completes or
+        ``request_timeout`` is hit. Only keys whose DEL actually removed a
+        value (glide returns ``1``) are reported via
+        ``_notify_keys_deleted`` with their original stored size from
+        ``_key_sizes``.
+        """
+        if not keys:
+            return
+
+        # Skip keys currently pinned by a read; same convention as the
+        # other L2 adapters (e.g. S3).
+        with self._lock:
+            deletable = [k for k in keys if self._locked_keys.get(k, 0) == 0]
+        if not deletable:
+            return
+
+        wire_keys = [self._wire_key(k) for k in deletable]
+        futures = [self._pool.submit_delete(wk) for wk in wire_keys]
+
+        deleted_keys: list[ObjectKey] = []
+        deleted_sizes: list[int] = []
+        for i, fut in enumerate(futures):
+            try:
+                deleted = bool(fut.result(timeout=self._config.request_timeout))
+            except Exception as e:
+                logger.warning("Valkey DEL failed for key idx %d: %s", i, e)
+                continue
+            if not deleted:
+                continue
+            deleted_keys.append(deletable[i])
+            with self._lock:
+                size = self._key_sizes.pop(deletable[i], 0)
+            deleted_sizes.append(size)
+
+        if deleted_keys:
+            self._notify_keys_deleted(deleted_keys, deleted_sizes)
+
+    # ``get_usage()`` is inherited from ``L2AdapterInterface``; the base
+    # class maintains totals from ``_notify_keys_stored`` /
+    # ``_notify_keys_deleted`` so no override is needed.
+
+    # ---------------------------------------------------------------
+    # Status Interface
+    # ---------------------------------------------------------------
+
+    def report_status(self) -> dict[str, Any]:
+        """Return a JSON-serializable health/status snapshot.
+
+        Returns:
+            Dict with ``is_healthy`` (alive worker pool and not closed),
+            ``type`` (``"valkey"``), current byte usage / declared
+            capacity (``usage_fraction == -1`` when uncapped), and
+            adapter configuration that is safe to log (no credentials).
+        """
+        usage = self.get_usage()
+        status: dict[str, Any] = {
+            "is_healthy": not self._closed,
+            "type": "valkey",
+            "cluster_mode": self._config.cluster_mode,
+            "num_workers": self._config.num_workers,
+            "startup_nodes": [
+                {"host": h, "port": p} for h, p in self._config.startup_nodes
+            ],
+            "key_prefix": self._config.key_prefix,
+            "tls_enable": self._config.tls_enable,
+            "has_buffer_get": self._pool.has_buffer_get,
+            "current_size_bytes": usage.total_bytes_used,
+            "max_capacity_bytes": usage.total_capacity_bytes,
+            "usage_fraction": usage.usage_fraction,
+        }
+        # In cluster mode also expose the server's real per-node memory
+        # (``current_size_bytes`` above is LMCache's aggregate logical
+        # count and cannot reveal a hot shard). Best-effort: an empty
+        # dict means the INFO query failed or returned nothing.
+        if self._config.cluster_mode:
+            status["node_memory"] = self._pool.node_memory_usage()
+        return status
+
+    # ---------------------------------------------------------------
+    # Cleanup
+    # ---------------------------------------------------------------
+
+    def close(self) -> None:
+        """Close the worker pool (and its glide clients) and event fds.
+
+        Idempotent — subsequent calls are no-ops.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._pool.close()
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
+        logger.info("ValkeyL2Adapter closed")
+
+    # ---------------------------------------------------------------
+    # Internal helpers
+    # ---------------------------------------------------------------
+
+    def _new_task_id(self) -> L2TaskId:
+        """Allocate the next task id. Caller must hold ``self._lock``."""
+        tid = self._next_task_id
+        self._next_task_id += 1
+        return tid
+
+    def _wire_key(self, key: ObjectKey) -> str:
+        """Compute the on-wire string for ``key``.
+
+        Layout: ``<key_prefix>@<_object_key_to_string(key)>`` when a
+        prefix is configured, otherwise just the standard wire format
+        (which already encodes ``cache_salt``).
+        """
+        base = _object_key_to_string(key)
+        prefix = self._config.key_prefix
+        return f"{prefix}{_KEY_SEP}{base}" if prefix else base
+
+
+# ---------------------------------------------------------------------------
+# Factory + registration
+# ---------------------------------------------------------------------------
+
+
+def _create_valkey_l2_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+) -> L2AdapterInterface:
+    """Factory entry-point registered under type name ``"valkey"``.
+
+    ``l1_memory_desc`` is accepted for protocol parity with other
+    adapters but is unused — Valkey stores raw bytes and has no need to
+    co-register an L1 buffer with the backend.
+    """
+    if not isinstance(config, ValkeyL2AdapterConfig):
+        raise TypeError(
+            "_create_valkey_l2_adapter expected ValkeyL2AdapterConfig, "
+            f"got {type(config).__name__}"
+        )
+    return ValkeyL2Adapter(config)
+
+
+register_l2_adapter_type("valkey", ValkeyL2AdapterConfig)
+register_l2_adapter_factory("valkey", _create_valkey_l2_adapter)

--- a/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py
@@ -547,19 +547,28 @@ class ValkeyL2Adapter(L2AdapterInterface):
     def _on_store_done(self, batch: _BatchState, idx: int, fut: Future) -> None:
         """Per-key callback for a store batch; finalizes when last done.
 
-        Runs in the worker thread that completed ``fut``. Exceptions
-        from glide are logged and recorded as per-key failure; the
-        callback never re-raises.
+        Runs in the worker thread that completed ``fut``. A cancelled or
+        failed future is recorded as a per-key failure; the callback
+        never re-raises (so it always decrements the batch counter and
+        the batch can never hang).
         """
-        exc = fut.exception()
-        ok = exc is None
-        if not ok:
+        if fut.cancelled():
+            ok = False
             logger.warning(
-                "Valkey SET failed (batch task_id=%d, key idx=%d): %s",
+                "Valkey SET cancelled (batch task_id=%d, key idx=%d)",
                 batch.task_id,
                 idx,
-                exc,
             )
+        else:
+            exc = fut.exception()
+            ok = exc is None
+            if not ok:
+                logger.warning(
+                    "Valkey SET failed (batch task_id=%d, key idx=%d): %s",
+                    batch.task_id,
+                    idx,
+                    exc,
+                )
         with batch.lock:
             batch.per_key_ok[idx] = ok
             batch.remaining -= 1
@@ -644,25 +653,32 @@ class ValkeyL2Adapter(L2AdapterInterface):
 
     def _on_lookup_done(self, batch: _BatchState, idx: int, fut: Future) -> None:
         """Per-key callback for a lookup batch."""
-        exc = fut.exception()
         exists = False
-        if exc is None:
-            try:
-                exists = bool(fut.result())
-            except Exception as e:  # defensive — result() shouldn't raise here
-                logger.warning(
-                    "Valkey EXISTS unexpected error (batch=%d, idx=%d): %s",
-                    batch.task_id,
-                    idx,
-                    e,
-                )
-        else:
+        if fut.cancelled():
             logger.warning(
-                "Valkey EXISTS failed (batch=%d, idx=%d): %s",
+                "Valkey EXISTS cancelled (batch=%d, idx=%d)",
                 batch.task_id,
                 idx,
-                exc,
             )
+        else:
+            exc = fut.exception()
+            if exc is None:
+                try:
+                    exists = bool(fut.result())
+                except Exception as e:  # defensive — result() shouldn't raise here
+                    logger.warning(
+                        "Valkey EXISTS unexpected error (batch=%d, idx=%d): %s",
+                        batch.task_id,
+                        idx,
+                        e,
+                    )
+            else:
+                logger.warning(
+                    "Valkey EXISTS failed (batch=%d, idx=%d): %s",
+                    batch.task_id,
+                    idx,
+                    exc,
+                )
         with batch.lock:
             batch.per_key_ok[idx] = exists
             batch.remaining -= 1
@@ -769,35 +785,42 @@ class ValkeyL2Adapter(L2AdapterInterface):
         expected chunk size, so a stale or truncated value is rejected
         as a cache miss.
         """
-        exc = fut.exception()
         loaded = False
-        if exc is None:
-            try:
-                nbytes = int(fut.result())
-                loaded = nbytes == batch.sizes[idx]
-                if nbytes >= 0 and not loaded:
-                    logger.debug(
-                        "Valkey GET size mismatch (batch=%d, idx=%d): "
-                        "got %d bytes, expected %d",
-                        batch.task_id,
-                        idx,
-                        nbytes,
-                        batch.sizes[idx],
-                    )
-            except Exception as e:
-                logger.warning(
-                    "Valkey GET unexpected error (batch=%d, idx=%d): %s",
-                    batch.task_id,
-                    idx,
-                    e,
-                )
-        else:
+        if fut.cancelled():
             logger.warning(
-                "Valkey GET failed (batch=%d, idx=%d): %s",
+                "Valkey GET cancelled (batch=%d, idx=%d)",
                 batch.task_id,
                 idx,
-                exc,
             )
+        else:
+            exc = fut.exception()
+            if exc is None:
+                try:
+                    nbytes = int(fut.result())
+                    loaded = nbytes == batch.sizes[idx]
+                    if nbytes >= 0 and not loaded:
+                        logger.debug(
+                            "Valkey GET size mismatch (batch=%d, idx=%d): "
+                            "got %d bytes, expected %d",
+                            batch.task_id,
+                            idx,
+                            nbytes,
+                            batch.sizes[idx],
+                        )
+                except Exception as e:
+                    logger.warning(
+                        "Valkey GET unexpected error (batch=%d, idx=%d): %s",
+                        batch.task_id,
+                        idx,
+                        e,
+                    )
+            else:
+                logger.warning(
+                    "Valkey GET failed (batch=%d, idx=%d): %s",
+                    batch.task_id,
+                    idx,
+                    exc,
+                )
         with batch.lock:
             batch.per_key_ok[idx] = loaded
             batch.remaining -= 1

--- a/lmcache/v1/storage_backend/connector/valkey_connector.py
+++ b/lmcache/v1/storage_backend/connector/valkey_connector.py
@@ -9,10 +9,10 @@ is shared with ``sync_valkey_connector.SyncValkeyConnector`` (which
 registers on the ``valkey-sync://`` scheme as a backward-compat alias).
 
 Design choices:
-- N worker threads, each with its own GLIDE sync client
-  (``GlideClient`` in standalone mode, ``GlideClusterClient`` in cluster mode)
-  via ``threading.local()``, enabling true parallel I/O when the GIL is
-  released during FFI calls.
+- The glide client lifecycle and worker thread pool live in the shared
+  :class:`~lmcache.v1.storage_backend.valkey.worker_pool.ValkeyWorkerPool`,
+  which is also used by the MP-mode ``ValkeyL2Adapter`` so both paths
+  share one implementation of zero-copy GET/SET/EXISTS/DELETE.
 - Direct ``memoryview`` access to pinned CPU memory — no shared-memory
   arena or cross-process copies needed since threads share the parent's
   address space.
@@ -27,16 +27,14 @@ Migration notes from the old ValkeyConnector:
 - Cluster mode (``valkey_mode: "cluster"``) uses ``GlideClusterClient`` which
   auto-discovers cluster topology from a single seed node.
 
-Requires ``valkey-glide`` with PRs #5492 (zero-copy SET) and #5493 (buffer GET).
+Requires the ``valkey-glide-sync`` package (``>= 2.3.0``) for the
+``glide_sync`` module; the plain ``valkey-glide`` package is async-only.
 """
 
 # Standard
-from concurrent.futures import Future, ThreadPoolExecutor
 from enum import IntEnum, auto
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 import asyncio
-import inspect
-import threading
 
 # First Party
 from lmcache.logging import init_logger
@@ -45,19 +43,19 @@ from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.job_executor.pq_executor import AsyncPQExecutor
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
-
-if TYPE_CHECKING:
-    # Third Party
-    import glide_sync  # type: ignore[import-untyped]
+from lmcache.v1.storage_backend.valkey.worker_pool import (
+    DEFAULT_CONNECTION_TIMEOUT_SECS,
+    DEFAULT_REQUEST_TIMEOUT_SECS,
+    GET_MISS,
+    ValkeyWorkerPool,
+)
 
 logger = init_logger(__name__)
 
-#: Default request timeout (seconds).
-DEFAULT_REQUEST_TIMEOUT_SECS: float = 5.0
-#: Default connection timeout (seconds).
-DEFAULT_CONNECTION_TIMEOUT_SECS: float = 10.0
 #: Default key TTL (seconds) used when the TTL feature flag is enabled but no
-#: explicit ``valkey_ttl_sec`` is configured (24 hours).
+#: explicit ``valkey_ttl_sec`` is configured (24 hours). The request/connection
+#: timeout defaults are re-exported from ``worker_pool`` (imported above) so
+#: ``valkey_adapter`` can import all three from this module.
 DEFAULT_TTL_SECS: int = 86400
 
 
@@ -72,282 +70,6 @@ class Priorities(IntEnum):
     PREFETCH = auto()
     GET = auto()
     PUT = auto()
-
-
-class _ThreadWorkerPool:
-    """Manages a pool of threads, each with its own GLIDE sync client.
-
-    Each thread gets an independent GLIDE sync client
-    (``GlideClient`` or ``GlideClusterClient``) via
-    ``threading.local()``, enabling true parallel I/O when the GIL is
-    released during FFI calls.
-
-    Args:
-        host: Valkey server hostname.
-        port: Valkey server port.
-        num_workers: Number of worker threads.
-        username: Valkey authentication username.
-        password: Valkey authentication password.
-        request_timeout: Timeout in seconds for GLIDE requests and
-            Future.result() calls.
-        connection_timeout: Timeout in seconds for initial GLIDE client
-            connections and thread pool warmup.
-        tls_enable: Whether to use TLS for Valkey connections.
-        cluster_mode: If True, use GlideClusterClient; else GlideClient.
-        database_id: Database ID for standalone mode (ignored in cluster).
-        ttl_seconds: If set, every key is written with this expiry (in
-            seconds) so Valkey/Redis ``volatile-*`` eviction policies can
-            reclaim L2 cache keys under memory pressure. ``None`` (default)
-            disables TTL — keys are persisted without expiry.
-    """
-
-    def __init__(
-        self,
-        host: str,
-        port: int,
-        num_workers: int,
-        username: str,
-        password: str,
-        request_timeout: float = DEFAULT_REQUEST_TIMEOUT_SECS,
-        connection_timeout: float = DEFAULT_CONNECTION_TIMEOUT_SECS,
-        tls_enable: bool = False,
-        cluster_mode: bool = False,
-        database_id: Optional[int] = None,
-        ttl_seconds: Optional[int] = None,
-    ):
-        self.num_workers = num_workers
-        self._host = host
-        self._port = port
-        self._username = username
-        self._password = password
-        self._request_timeout = request_timeout
-        self._request_timeout_ms = int(request_timeout * 1000)
-        self._connection_timeout_ms = int(connection_timeout * 1000)
-        self._tls_enable = tls_enable
-        self._cluster_mode = cluster_mode
-        self._database_id = database_id
-        self._ttl_seconds = ttl_seconds
-        self._expiry_obj = None  # lazily built ExpirySet (see _do_set)
-        self._local = threading.local()
-        self._has_buffer_get: Optional[bool] = None
-
-        self._executor = ThreadPoolExecutor(
-            max_workers=num_workers,
-            thread_name_prefix="valkey",
-        )
-        # Warm up: create a client on each thread
-        futs = [self._executor.submit(self._get_client) for _ in range(num_workers)]
-        for f in futs:
-            f.result(timeout=connection_timeout)
-        mode_str = "cluster" if cluster_mode else "standalone"
-        logger.info(
-            "Valkey thread pool: %d threads, mode=%s, per-thread clients, "
-            "buffer_get=%s, ttl_seconds=%s",
-            num_workers,
-            mode_str,
-            self._has_buffer_get,
-            ttl_seconds,
-        )
-
-    def _get_client(self):  # type: ignore[no-untyped-def]
-        """Get or create the per-thread GLIDE sync client.
-
-        Creates a ``GlideClusterClient`` (cluster mode) or ``GlideClient``
-        (standalone mode) depending on the ``cluster_mode`` flag.
-        """
-        # Third Party
-        import glide_sync  # type: ignore[import-untyped]
-
-        client = getattr(self._local, "client", None)
-        if client is not None:
-            return client
-
-        credentials = None
-        if self._username or self._password:
-            credentials = glide_sync.ServerCredentials(self._username, self._password)
-
-        address = glide_sync.NodeAddress(self._host, self._port)
-
-        if self._cluster_mode:
-            advanced = glide_sync.AdvancedGlideClusterClientConfiguration(
-                connection_timeout=self._connection_timeout_ms,
-            )
-            config_kwargs: dict = {
-                "addresses": [address],
-                "request_timeout": self._request_timeout_ms,
-                "use_tls": self._tls_enable,
-                "advanced_config": advanced,
-            }
-            if credentials is not None:
-                config_kwargs["credentials"] = credentials
-            config = glide_sync.GlideClusterClientConfiguration(**config_kwargs)
-            client = glide_sync.GlideClusterClient.create(config)
-        else:
-            # Standalone mode — supports database_id and advanced config
-            advanced = glide_sync.AdvancedGlideClientConfiguration(
-                connection_timeout=self._connection_timeout_ms,
-            )
-            config_kwargs = {
-                "addresses": [address],
-                "request_timeout": self._request_timeout_ms,
-                "use_tls": self._tls_enable,
-                "advanced_config": advanced,
-            }
-            if credentials is not None:
-                config_kwargs["credentials"] = credentials
-            if self._database_id is not None:
-                config_kwargs["database_id"] = self._database_id
-            config = glide_sync.GlideClientConfiguration(**config_kwargs)
-            client = glide_sync.GlideClient.create(config)
-
-        self._local.client = client
-
-        if self._has_buffer_get is None:
-            self._has_buffer_get = "buffer" in inspect.signature(client.get).parameters
-
-        return client
-
-    @property
-    def has_buffer_get(self) -> bool:
-        """Whether the GLIDE client supports buffer GET."""
-        if self._has_buffer_get is None:
-            self._executor.submit(self._get_client).result(
-                timeout=self._connection_timeout_ms / 1000
-            )
-        return bool(self._has_buffer_get)
-
-    def _build_expiry(self) -> "glide_sync.ExpirySet":
-        """Lazily build (and cache) the GLIDE ``ExpirySet`` for SET calls.
-
-        Built lazily so ``glide_sync`` is only imported on worker threads
-        (matching ``_get_client``). The resulting ``ExpirySet`` is an
-        immutable value object, so it is safe to share across threads; a
-        benign race during lazy init just rebuilds an equivalent object.
-        """
-        exp = self._expiry_obj
-        if exp is None:
-            if self._ttl_seconds is None:
-                raise ValueError("ttl_seconds must be set to build an ExpirySet")
-            # Third Party
-            import glide_sync  # type: ignore[import-untyped]
-
-            exp = glide_sync.ExpirySet(glide_sync.ExpiryType.SEC, self._ttl_seconds)
-            self._expiry_obj = exp
-        return exp
-
-    def _do_set(self, key_str: str, data: bytes) -> None:
-        """SET a key (runs on a worker thread).
-
-        When a TTL is configured (``ttl_seconds`` is not None), the key is
-        written with an expiry so that Valkey/Redis ``volatile-*`` eviction
-        policies can reclaim it once the node reaches ``maxmemory``. Without
-        a TTL the key is persisted indefinitely (legacy behavior).
-        """
-        expiry = self._build_expiry() if self._ttl_seconds is not None else None
-        self._get_client().set(key_str.encode(), data, expiry=expiry)
-
-    def _get_scratch(self, size: int) -> bytearray:
-        """Per-thread reusable staging buffer for buffer-GET (issue #6215).
-
-        GLIDE writes into this thread-private bytearray (not slab memory),
-        then we copy into the destination under the GIL.  Eliminates the
-        dangling-slot race without pinning or touching ref_count/pin_count.
-        The buffer is grown on demand and reused across GETs on the same
-        worker thread, so there is no per-call allocation.
-        """
-        buf = getattr(self._local, "scratch", None)
-        if buf is None or len(buf) < size:
-            buf = bytearray(size)
-            self._local.scratch = buf
-        return buf
-
-    def _do_get_into(self, key_str: str, buf: memoryview) -> bool:
-        """GET a key into a buffer (runs on a worker thread).
-
-        Safety (issue #6215): GLIDE's native buffer-GET writes with the GIL
-        released, so it must never write directly into ``buf`` when ``buf``
-        aliases slab-allocator memory that another thread could recycle
-        mid-write.  We stage into a thread-private scratch buffer and copy
-        into ``buf`` under the GIL.
-        """
-        client = self._get_client()
-        if self._has_buffer_get:
-            size = buf.nbytes
-            scratch = self._get_scratch(size)
-            scratch_view = memoryview(scratch)[:size]
-            result = client.get(key_str.encode(), buffer=scratch_view)
-            if result is None:
-                return False
-            n = int(result)
-            if n != size:
-                # Fixed-size KV chunks must round-trip exactly. A short read
-                # signals a size mismatch / corrupt or stale-format entry;
-                # treat it as a miss rather than leaving stale tail bytes in
-                # buf[n:] and reporting success.
-                logger.warning(
-                    "Valkey GET size mismatch for key %s: read %d bytes, "
-                    "expected %d; treating as miss.",
-                    key_str,
-                    n,
-                    size,
-                )
-                return False
-            buf[:n] = scratch_view[:n]
-            return True
-        else:
-            data = client.get(key_str.encode())
-            if data is None:
-                return False
-            if len(data) != buf.nbytes:
-                logger.warning(
-                    "Valkey GET size mismatch for key %s: read %d bytes, "
-                    "expected %d; treating as miss.",
-                    key_str,
-                    len(data),
-                    buf.nbytes,
-                )
-                return False
-            buf[: len(data)] = data
-            return True
-
-    def _do_exists(self, key_str: str) -> bool:
-        """Check if a key exists (runs on a worker thread)."""
-        return bool(self._get_client().exists([key_str.encode()]))
-
-    def submit_set(self, key_str: str, data: bytes) -> Future:
-        """Submit a SET operation."""
-        return self._executor.submit(self._do_set, key_str, data)
-
-    def submit_get_into(self, key_str: str, buf: memoryview) -> Future:
-        """Submit a GET-into-buffer operation."""
-        return self._executor.submit(self._do_get_into, key_str, buf)
-
-    def submit_exists(self, key_str: str) -> Future:
-        """Submit an EXISTS check."""
-        return self._executor.submit(self._do_exists, key_str)
-
-    def _close_client(self) -> None:
-        """Close the per-thread GLIDE client (runs on a worker thread)."""
-        client = getattr(self._local, "client", None)
-        if client is not None:
-            try:
-                client.close()
-            except Exception as exc:
-                logger.debug("Error closing per-thread GLIDE client: %s", exc)
-            self._local.client = None
-
-    def close(self) -> None:
-        """Shut down all per-thread GLIDE clients and the thread pool."""
-        close_futs = [
-            self._executor.submit(self._close_client) for _ in range(self.num_workers)
-        ]
-        for f in close_futs:
-            try:
-                f.result(timeout=self._request_timeout)
-            except Exception as exc:
-                logger.debug("Error during client close: %s", exc)
-        self._executor.shutdown(wait=True, cancel_futures=False)
-        logger.info("Valkey thread pool closed")
 
 
 class ValkeyConnector(RemoteConnector):
@@ -407,12 +129,11 @@ class ValkeyConnector(RemoteConnector):
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
-        self._pool = _ThreadWorkerPool(
-            host,
-            port,
-            num_workers,
-            username,
-            password,
+        self._pool = ValkeyWorkerPool(
+            addresses=[(host, port)],
+            num_workers=num_workers,
+            username=username,
+            password=password,
             request_timeout=request_timeout,
             connection_timeout=connection_timeout,
             tls_enable=tls_enable,
@@ -451,21 +172,17 @@ class ValkeyConnector(RemoteConnector):
             logger.warning("Failed to allocate memory during remote receive")
             return None
 
-        dst = memory_obj.byte_array
-        if not isinstance(dst, memoryview):
-            dst = memoryview(dst)
-        if dst.format != "B":
-            dst = dst.cast("B")
-
+        # The pool casts the buffer to a byte view internally, so pass
+        # ``byte_array`` straight through.
         try:
-            found = await asyncio.wrap_future(
-                self._pool.submit_get_into(key.to_string(), dst)
+            nbytes = await asyncio.wrap_future(
+                self._pool.submit_get_into(key.to_string(), memory_obj.byte_array)
             )
         except Exception:
             memory_obj.ref_count_down()
             raise
 
-        if not found:
+        if nbytes <= GET_MISS:
             memory_obj.ref_count_down()
             return None
         return memory_obj
@@ -568,12 +285,8 @@ class ValkeyConnector(RemoteConnector):
                 continue
 
             memory_objs.append(mobj)
-            dst = mobj.byte_array
-            if not isinstance(dst, memoryview):
-                dst = memoryview(dst)
-            if dst.format != "B":
-                dst = dst.cast("B")
-            dst_bufs.append(dst)
+            # The pool casts the buffer to a byte view internally.
+            dst_bufs.append(mobj.byte_array)
 
         # Submit GET futures for allocated slots; track which indices have
         # real futures vs None (allocation failed).
@@ -593,8 +306,8 @@ class ValkeyConnector(RemoteConnector):
 
         try:
             results = await asyncio.gather(*live_futures)
-            for idx, found in zip(live_indices, results, strict=True):
-                if not found:
+            for idx, nbytes in zip(live_indices, results, strict=True):
+                if nbytes <= GET_MISS:
                     memory_objs[idx].ref_count_down()  # type: ignore[union-attr]
                     memory_objs[idx] = None
         except Exception:

--- a/lmcache/v1/storage_backend/valkey/__init__.py
+++ b/lmcache/v1/storage_backend/valkey/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared Valkey building blocks used by both the non-MP connector and the
+MP-mode L2 adapter.
+
+The single reusable core is :class:`ValkeyWorkerPool`, which owns the
+``valkey-glide`` sync clients, the worker thread pool, and the zero-copy
+GET/SET/EXISTS/DELETE primitives. Mirrors the DAX layout
+(``storage_backend/dax/core.py`` shared by the non-MP backend and the MP
+adapter).
+"""
+
+# First Party
+from lmcache.v1.storage_backend.valkey.worker_pool import ValkeyWorkerPool
+
+__all__ = ["ValkeyWorkerPool"]

--- a/lmcache/v1/storage_backend/valkey/worker_pool.py
+++ b/lmcache/v1/storage_backend/valkey/worker_pool.py
@@ -342,9 +342,11 @@ class ValkeyWorkerPool:
     def _do_get_into(self, key_str: str, buf: Any) -> int:
         """GET a key directly into ``buf``.
 
-        The caller owns the size policy: this returns the number of
-        payload bytes for the key (which the caller compares against the
-        expected length), or :data:`GET_MISS` when the key is absent.
+        Fixed-size KV chunks must round-trip exactly, so the read size is
+        validated against the destination buffer length here — the single
+        place shared by both the connector and the L2 adapter. A short,
+        truncated, or oversized value is rejected as a miss rather than
+        leaving a partially-filled buffer with stale tail bytes.
 
         ``buf`` is cast to an unsigned-byte (``"B"``) memoryview if it
         isn't already, because glide's buffer protocol rejects
@@ -357,32 +359,41 @@ class ValkeyWorkerPool:
         and copy into ``dst`` under the GIL.
 
         Returns:
-            Number of bytes available for the key (``>= 0``), or
-            :data:`GET_MISS` (``-1``) if the key does not exist.
+            The number of payload bytes copied, which always equals the
+            buffer length on a hit, or :data:`GET_MISS` (``-1``) if the
+            key is absent or its stored size does not match the buffer.
         """
         client = self._get_client()
         dst = buf if isinstance(buf, memoryview) else memoryview(buf)
         if dst.format != "B":
             dst = dst.cast("B")
+        size = len(dst)
         if self.has_buffer_get:
-            size = len(dst)
             scratch_view = memoryview(self._get_scratch(size))[:size]
             result = client.get(key_str.encode(), buffer=scratch_view)
             if result is None:
                 return GET_MISS
             # glide buffer GET returns the number of bytes written.
             n = int(result) if isinstance(result, int) else size
-            # Only copy what fits; the caller treats a size mismatch as a
-            # miss and will not use the buffer, but we must not overflow it.
-            dst[: min(n, size)] = scratch_view[: min(n, size)]
-            return n
-        data = client.get(key_str.encode())
-        if data is None:
+            source: Any = scratch_view
+        else:
+            data = client.get(key_str.encode())
+            if data is None:
+                return GET_MISS
+            n = len(data)
+            source = data
+
+        if n != size:
+            logger.warning(
+                "Valkey GET size mismatch for key %s: read %d bytes, "
+                "expected %d; treating as miss.",
+                key_str,
+                n,
+                size,
+            )
             return GET_MISS
-        n = len(data)
-        # Only copy what fits; the caller treats a size mismatch as a miss
-        # and will not use the buffer, but we must not overflow it.
-        dst[: min(n, len(dst))] = data[: min(n, len(dst))]
+        # Sizes match: copy the full payload into the destination.
+        dst[:] = source[:size]
         return n
 
     def _do_exists(self, key_str: str) -> bool:

--- a/lmcache/v1/storage_backend/valkey/worker_pool.py
+++ b/lmcache/v1/storage_backend/valkey/worker_pool.py
@@ -324,6 +324,21 @@ class ValkeyWorkerPool:
         else:
             self._get_client().set(key_str.encode(), data)
 
+    def _get_scratch(self, size: int) -> bytearray:
+        """Per-thread reusable staging buffer for buffer-GET (issue #6215).
+
+        glide writes into this thread-private bytearray (not slab memory),
+        then we copy into the destination under the GIL. Eliminates the
+        dangling-slot race without pinning or touching ref_count/pin_count.
+        The buffer is grown on demand and reused across GETs on the same
+        worker thread, so there is no per-call allocation.
+        """
+        buf = getattr(self._local, "scratch", None)
+        if buf is None or len(buf) < size:
+            buf = bytearray(size)
+            self._local.scratch = buf
+        return buf
+
     def _do_get_into(self, key_str: str, buf: Any) -> int:
         """GET a key directly into ``buf``.
 
@@ -335,6 +350,12 @@ class ValkeyWorkerPool:
         isn't already, because glide's buffer protocol rejects
         non-byte-format views (e.g. a float-typed tensor view).
 
+        Safety (issue #6215): glide's native buffer-GET writes with the
+        GIL released, so it must never write directly into ``dst`` when
+        ``dst`` aliases slab-allocator memory that another thread could
+        recycle mid-write. We stage into a thread-private scratch buffer
+        and copy into ``dst`` under the GIL.
+
         Returns:
             Number of bytes available for the key (``>= 0``), or
             :data:`GET_MISS` (``-1``) if the key does not exist.
@@ -344,11 +365,17 @@ class ValkeyWorkerPool:
         if dst.format != "B":
             dst = dst.cast("B")
         if self.has_buffer_get:
-            result = client.get(key_str.encode(), buffer=dst)
+            size = len(dst)
+            scratch_view = memoryview(self._get_scratch(size))[:size]
+            result = client.get(key_str.encode(), buffer=scratch_view)
             if result is None:
                 return GET_MISS
             # glide buffer GET returns the number of bytes written.
-            return int(result) if isinstance(result, int) else len(dst)
+            n = int(result) if isinstance(result, int) else size
+            # Only copy what fits; the caller treats a size mismatch as a
+            # miss and will not use the buffer, but we must not overflow it.
+            dst[: min(n, size)] = scratch_view[: min(n, size)]
+            return n
         data = client.get(key_str.encode())
         if data is None:
             return GET_MISS

--- a/lmcache/v1/storage_backend/valkey/worker_pool.py
+++ b/lmcache/v1/storage_backend/valkey/worker_pool.py
@@ -1,0 +1,485 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared Valkey worker pool built on the ``valkey-glide`` sync client.
+
+A pool of ``num_workers`` threads, each holding its own glide client via
+``threading.local()``. The sync glide client is used (rather than async)
+because it is the only glide API that supports **zero-copy** SET
+(``bytearray``/``memoryview`` args) and buffer GET — async glide cannot
+avoid an intermediate ``bytes`` allocation due to its Protobuf-based IPC
+layer. A sync call blocks its calling thread, so concurrency comes from
+running N worker threads each with an independent client.
+
+Both the non-MP ``ValkeyConnector`` (``RemoteConnector``) and the MP-mode
+``ValkeyL2Adapter`` (``L2AdapterInterface``) build on this single class,
+so the glide client lifecycle, capability probing, buffer-format
+handling, and reliable shutdown live in exactly one place.
+
+Requires the ``valkey-glide-sync`` package (``>= 2.3.0``), which provides
+the ``glide_sync`` module with zero-copy SET and buffer GET. Note the
+plain ``valkey-glide`` package ships only the *async* client and is not
+sufficient. The dependency is imported lazily so installations that don't
+use Valkey never need it.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Optional
+import inspect
+import threading
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+#: Default per-request timeout (seconds).
+DEFAULT_REQUEST_TIMEOUT_SECS: float = 5.0
+#: Default initial-connection timeout (seconds).
+DEFAULT_CONNECTION_TIMEOUT_SECS: float = 10.0
+
+#: Sentinel returned by ``_do_get_into`` when the key is absent.
+GET_MISS: int = -1
+
+
+def _to_str(value: Any) -> str:
+    """Decode ``bytes`` to ``str`` (utf-8, replacing bad bytes); pass
+    through anything already string-like."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return str(value)
+
+
+def _parse_memory_info(text: str) -> dict[str, int]:
+    """Extract ``used_memory`` / ``maxmemory`` from an ``INFO memory`` body.
+
+    Args:
+        text: The raw ``INFO memory`` section text from one node.
+
+    Returns:
+        ``{"used_memory": int, "maxmemory": int}``. Missing or
+        unparseable fields default to ``0``.
+    """
+    used = 0
+    maxm = 0
+    for line in text.splitlines():
+        if line.startswith("used_memory:"):
+            try:
+                used = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif line.startswith("maxmemory:"):
+            try:
+                maxm = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+    return {"used_memory": used, "maxmemory": maxm}
+
+
+class ValkeyWorkerPool:
+    """A thread pool of per-thread glide sync clients.
+
+    Each worker thread lazily constructs and caches its own
+    ``GlideClient`` (standalone) or ``GlideClusterClient`` (cluster) via
+    ``threading.local()``. Operations are submitted as ``Future`` objects
+    and run on whichever worker thread the executor picks; because each
+    thread has its own client, this yields true parallel I/O while the
+    GIL is released across the glide FFI boundary.
+
+    The pool speaks only ``str`` keys and byte buffers — it has no
+    knowledge of ``ObjectKey`` / ``CacheEngineKey`` or any LMCache type,
+    so it can be shared by both the connector and the L2 adapter.
+
+    Args:
+        addresses: One or more ``(host, port)`` seed nodes. In standalone
+            mode only the first is used; in cluster mode glide
+            auto-discovers the full topology from any reachable seed.
+        num_workers: Number of worker threads (and clients); must be > 0.
+        username: Optional auth username.
+        password: Optional auth password.
+        request_timeout: Per-request timeout in seconds.
+        connection_timeout: Initial connection timeout in seconds.
+        tls_enable: Whether to use TLS.
+        cluster_mode: ``True`` to build ``GlideClusterClient``.
+        database_id: Standalone-only logical DB id; ignored in cluster
+            mode.
+        ttl_seconds: If set, every key is written with this expiry (in
+            seconds) so Valkey/Redis ``volatile-*`` eviction policies can
+            reclaim cache keys under memory pressure. ``None`` (default)
+            disables TTL — keys are persisted without expiry.
+
+    Raises:
+        ValueError: If ``addresses`` is empty or ``num_workers <= 0``.
+        RuntimeError: If ``valkey-glide`` is not installed (raised during
+            warmup).
+    """
+
+    def __init__(
+        self,
+        addresses: list[tuple[str, int]],
+        num_workers: int,
+        username: str = "",
+        password: str = "",
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT_SECS,
+        connection_timeout: float = DEFAULT_CONNECTION_TIMEOUT_SECS,
+        tls_enable: bool = False,
+        cluster_mode: bool = False,
+        database_id: Optional[int] = None,
+        ttl_seconds: Optional[int] = None,
+    ) -> None:
+        if not addresses:
+            raise ValueError("addresses must contain at least one (host, port)")
+        if num_workers <= 0:
+            raise ValueError("num_workers must be > 0")
+
+        self.num_workers: int = num_workers
+        self._addresses: list[tuple[str, int]] = list(addresses)
+        self._username: str = username
+        self._password: str = password
+        self._request_timeout: float = request_timeout
+        self._request_timeout_ms: int = int(request_timeout * 1000)
+        self._connection_timeout: float = connection_timeout
+        self._connection_timeout_ms: int = int(connection_timeout * 1000)
+        self._tls_enable: bool = tls_enable
+        self._cluster_mode: bool = cluster_mode
+        self._database_id: Optional[int] = database_id
+        self._ttl_seconds: Optional[int] = ttl_seconds
+        # Lazily built ExpirySet (see _build_expiry); glide_sync is only
+        # imported on worker threads, so this stays None until the first SET.
+        self._expiry_obj: Any = None
+
+        self._local: threading.local = threading.local()
+        self._has_buffer_get: Optional[bool] = None
+        self._capability_lock: threading.Lock = threading.Lock()
+
+        self._executor: ThreadPoolExecutor = ThreadPoolExecutor(
+            max_workers=num_workers,
+            thread_name_prefix="valkey",
+        )
+        # Warm up: force each worker to build its client up-front so any
+        # connection / auth / missing-dependency error fails fast here
+        # rather than on the first real operation.
+        warmup = [self._executor.submit(self._get_client) for _ in range(num_workers)]
+        for f in warmup:
+            f.result(timeout=connection_timeout)
+
+        logger.info(
+            "ValkeyWorkerPool: %d threads, mode=%s, nodes=%s, tls=%s, "
+            "buffer_get=%s, ttl_seconds=%s",
+            num_workers,
+            "cluster" if cluster_mode else "standalone",
+            self._addresses,
+            tls_enable,
+            self._has_buffer_get,
+            ttl_seconds,
+        )
+
+    # ------------------------------------------------------------------
+    # Client lifecycle
+    # ------------------------------------------------------------------
+
+    def _get_client(self) -> Any:
+        """Return the calling thread's glide client, creating it lazily.
+
+        ``glide_sync`` is imported here (not at module load) so that
+        LMCache installations that don't use Valkey never need the
+        dependency.
+
+        Returns:
+            A ``GlideClient`` or ``GlideClusterClient`` instance.
+
+        Raises:
+            RuntimeError: If ``valkey-glide`` is not installed.
+        """
+        client = getattr(self._local, "client", None)
+        if client is not None:
+            return client
+
+        try:
+            # Third Party
+            import glide_sync  # type: ignore[import-untyped]
+        except ImportError as e:
+            raise RuntimeError(
+                "Valkey support requires the glide_sync module. "
+                "Install: pip install 'valkey-glide-sync>=2.3.0' "
+                "(note: the plain 'valkey-glide' package is async-only)"
+            ) from e
+
+        credentials = None
+        if self._username or self._password:
+            credentials = glide_sync.ServerCredentials(self._username, self._password)
+
+        addresses = [
+            glide_sync.NodeAddress(host, port) for host, port in self._addresses
+        ]
+
+        if self._cluster_mode:
+            advanced = glide_sync.AdvancedGlideClusterClientConfiguration(
+                connection_timeout=self._connection_timeout_ms,
+            )
+            cfg_kwargs: dict = {
+                "addresses": addresses,
+                "request_timeout": self._request_timeout_ms,
+                "use_tls": self._tls_enable,
+                "advanced_config": advanced,
+            }
+            if credentials is not None:
+                cfg_kwargs["credentials"] = credentials
+            config = glide_sync.GlideClusterClientConfiguration(**cfg_kwargs)
+            client = glide_sync.GlideClusterClient.create(config)
+        else:
+            # Standalone mode — only the first seed is meaningful; it also
+            # supports database_id selection.
+            advanced = glide_sync.AdvancedGlideClientConfiguration(
+                connection_timeout=self._connection_timeout_ms,
+            )
+            cfg_kwargs = {
+                "addresses": addresses[:1],
+                "request_timeout": self._request_timeout_ms,
+                "use_tls": self._tls_enable,
+                "advanced_config": advanced,
+            }
+            if credentials is not None:
+                cfg_kwargs["credentials"] = credentials
+            if self._database_id is not None:
+                cfg_kwargs["database_id"] = self._database_id
+            config = glide_sync.GlideClientConfiguration(**cfg_kwargs)
+            client = glide_sync.GlideClient.create(config)
+
+        self._local.client = client
+
+        # Probe buffer-GET capability once. Concurrent warmup threads race
+        # here, so guard the one-time write with a lock.
+        with self._capability_lock:
+            if self._has_buffer_get is None:
+                self._has_buffer_get = (
+                    "buffer" in inspect.signature(client.get).parameters
+                )
+
+        return client
+
+    @property
+    def has_buffer_get(self) -> bool:
+        """Whether the glide client supports zero-copy buffer GET.
+
+        Returns:
+            ``True`` if ``client.get`` accepts a ``buffer=`` argument
+            (glide >= 2.3.0). Forces creation of a client on a worker
+            thread if the capability has not been probed yet.
+        """
+        if self._has_buffer_get is None:
+            self._executor.submit(self._get_client).result(
+                timeout=self._connection_timeout
+            )
+        return bool(self._has_buffer_get)
+
+    # ------------------------------------------------------------------
+    # Worker-side primitives (run on a worker thread)
+    # ------------------------------------------------------------------
+
+    def _build_expiry(self) -> Any:
+        """Lazily build (and cache) the glide ``ExpirySet`` for SET calls.
+
+        Built lazily so ``glide_sync`` is only imported on worker threads
+        (matching :meth:`_get_client`). The resulting ``ExpirySet`` is an
+        immutable value object, so it is safe to share across threads; a
+        benign race during lazy init just rebuilds an equivalent object.
+
+        Returns:
+            A ``glide_sync.ExpirySet`` configured with ``ttl_seconds``.
+
+        Raises:
+            ValueError: If ``ttl_seconds`` was not configured.
+        """
+        exp = self._expiry_obj
+        if exp is None:
+            if self._ttl_seconds is None:
+                raise ValueError("ttl_seconds must be set to build an ExpirySet")
+            # Third Party
+            import glide_sync  # type: ignore[import-untyped]
+
+            exp = glide_sync.ExpirySet(glide_sync.ExpiryType.SEC, self._ttl_seconds)
+            self._expiry_obj = exp
+        return exp
+
+    def _do_set(self, key_str: str, data: Any) -> None:
+        """SET a key. ``data`` is a memoryview / bytes / bytearray.
+
+        With glide >= 2.3.0 and a memoryview/bytearray, this is a
+        zero-copy write. When ``ttl_seconds`` is configured, the key is
+        written with an expiry so Valkey/Redis ``volatile-*`` eviction
+        policies can reclaim it under memory pressure; otherwise the key
+        is persisted indefinitely.
+        """
+        if self._ttl_seconds is not None:
+            self._get_client().set(key_str.encode(), data, expiry=self._build_expiry())
+        else:
+            self._get_client().set(key_str.encode(), data)
+
+    def _do_get_into(self, key_str: str, buf: Any) -> int:
+        """GET a key directly into ``buf``.
+
+        The caller owns the size policy: this returns the number of
+        payload bytes for the key (which the caller compares against the
+        expected length), or :data:`GET_MISS` when the key is absent.
+
+        ``buf`` is cast to an unsigned-byte (``"B"``) memoryview if it
+        isn't already, because glide's buffer protocol rejects
+        non-byte-format views (e.g. a float-typed tensor view).
+
+        Returns:
+            Number of bytes available for the key (``>= 0``), or
+            :data:`GET_MISS` (``-1``) if the key does not exist.
+        """
+        client = self._get_client()
+        dst = buf if isinstance(buf, memoryview) else memoryview(buf)
+        if dst.format != "B":
+            dst = dst.cast("B")
+        if self.has_buffer_get:
+            result = client.get(key_str.encode(), buffer=dst)
+            if result is None:
+                return GET_MISS
+            # glide buffer GET returns the number of bytes written.
+            return int(result) if isinstance(result, int) else len(dst)
+        data = client.get(key_str.encode())
+        if data is None:
+            return GET_MISS
+        n = len(data)
+        # Only copy what fits; the caller treats a size mismatch as a miss
+        # and will not use the buffer, but we must not overflow it.
+        dst[: min(n, len(dst))] = data[: min(n, len(dst))]
+        return n
+
+    def _do_exists(self, key_str: str) -> bool:
+        """Return whether ``key_str`` exists."""
+        return bool(self._get_client().exists([key_str.encode()]))
+
+    def _do_delete(self, key_str: str) -> bool:
+        """Delete ``key_str``; return ``True`` iff a value was removed."""
+        return int(self._get_client().delete([key_str.encode()])) > 0
+
+    # ------------------------------------------------------------------
+    # Submit API (returns Futures)
+    # ------------------------------------------------------------------
+
+    def submit_set(self, key_str: str, data: Any) -> Future:
+        """Submit a SET; the future resolves to ``None`` on success."""
+        return self._executor.submit(self._do_set, key_str, data)
+
+    def submit_get_into(self, key_str: str, buf: Any) -> Future:
+        """Submit a GET-into-buffer; future resolves to bytes-or-``-1``.
+
+        See :meth:`_do_get_into` for the return-value contract.
+        """
+        return self._executor.submit(self._do_get_into, key_str, buf)
+
+    def submit_exists(self, key_str: str) -> Future:
+        """Submit an EXISTS; the future resolves to ``bool``."""
+        return self._executor.submit(self._do_exists, key_str)
+
+    def submit_delete(self, key_str: str) -> Future:
+        """Submit a DEL; the future resolves to ``bool`` (removed?)."""
+        return self._executor.submit(self._do_delete, key_str)
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    def node_memory_usage(self) -> dict[str, dict[str, int]]:
+        """Return physical memory usage per Valkey node.
+
+        Runs ``INFO memory`` routed to all cluster nodes and parses each
+        node's ``used_memory`` / ``maxmemory``. This is the **server's
+        real per-node memory**, distinct from LMCache's aggregate logical
+        byte accounting — useful for spotting a hot shard in cluster mode.
+
+        Returns:
+            A dict mapping ``"host:port"`` to
+            ``{"used_memory": int, "maxmemory": int}``. ``maxmemory`` is
+            ``0`` when the node has no cap configured. Returns an empty
+            dict in standalone mode, or if the query fails (the call is
+            best-effort so a slow / unreachable node never breaks status
+            reporting).
+        """
+        if not self._cluster_mode:
+            return {}
+        try:
+            return self._executor.submit(self._do_node_memory).result(
+                timeout=self._request_timeout
+            )
+        except Exception as e:
+            logger.debug("node_memory_usage query failed: %s", e)
+            return {}
+
+    def _do_node_memory(self) -> dict[str, dict[str, int]]:
+        """Worker-side ``INFO memory`` fan-out to all nodes."""
+        # Third Party
+        from glide_shared.commands.core_options import (  # type: ignore[import-untyped]
+            InfoSection,
+        )
+        from glide_shared.routes import AllNodes  # type: ignore[import-untyped]
+
+        client = self._get_client()
+        raw = client.info([InfoSection.MEMORY], AllNodes())
+
+        out: dict[str, dict[str, int]] = {}
+        if isinstance(raw, dict):
+            # Multi-node route: address -> INFO bytes.
+            for node, text in raw.items():
+                out[_to_str(node)] = _parse_memory_info(_to_str(text))
+        else:
+            # Single-response fallback (not expected with AllNodes).
+            out["<aggregate>"] = _parse_memory_info(_to_str(raw))
+        return out
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    def _close_local_client(self, barrier: threading.Barrier) -> None:
+        """Close the calling thread's client after all workers gather.
+
+        The barrier guarantees every worker thread is simultaneously
+        executing one close task before any proceeds, so each of the N
+        tasks lands on a distinct thread and closes that thread's own
+        client exactly once. Without it, a fast thread could grab
+        multiple close tasks (no-ops after the first) while another
+        thread's client is never closed.
+        """
+        try:
+            barrier.wait(timeout=self._request_timeout)
+        except threading.BrokenBarrierError:
+            # Fall through to best-effort close of whatever this thread owns.
+            logger.debug("ValkeyWorkerPool close barrier broke; best-effort close")
+        client = getattr(self._local, "client", None)
+        if client is None:
+            return
+        try:
+            client.close()
+        except Exception as exc:
+            logger.debug("Error closing per-thread glide client: %s", exc)
+        self._local.client = None
+
+    def close(self) -> None:
+        """Close every per-thread glide client and stop the worker pool.
+
+        Each client is closed on its owning thread (matching glide's
+        per-thread client model) with 1:1 coverage guaranteed by a
+        barrier. Safe to call once; the executor must not receive new
+        submissions afterward.
+        """
+        barrier = threading.Barrier(self.num_workers)
+        close_futs = [
+            self._executor.submit(self._close_local_client, barrier)
+            for _ in range(self.num_workers)
+        ]
+        for f in close_futs:
+            try:
+                f.result(timeout=self._connection_timeout)
+            except Exception as exc:
+                logger.debug("Error during ValkeyWorkerPool close: %s", exc)
+        self._executor.shutdown(wait=True, cancel_futures=False)
+        logger.info("ValkeyWorkerPool closed")

--- a/lmcache/v1/storage_backend/valkey/worker_pool.py
+++ b/lmcache/v1/storage_backend/valkey/worker_pool.py
@@ -61,7 +61,7 @@ def _parse_memory_info(text: str) -> dict[str, int]:
 
     Returns:
         ``{"used_memory": int, "maxmemory": int}``. Missing or
-        unparseable fields default to ``0``.
+        unparsable fields default to ``0``.
     """
     used = 0
     maxm = 0
@@ -154,6 +154,7 @@ class ValkeyWorkerPool:
         self._local: threading.local = threading.local()
         self._has_buffer_get: Optional[bool] = None
         self._capability_lock: threading.Lock = threading.Lock()
+        self._closed: bool = False
 
         self._executor: ThreadPoolExecutor = ThreadPoolExecutor(
             max_workers=num_workers,
@@ -451,9 +452,14 @@ class ValkeyWorkerPool:
         """
         try:
             barrier.wait(timeout=self._request_timeout)
-        except threading.BrokenBarrierError:
-            # Fall through to best-effort close of whatever this thread owns.
-            logger.debug("ValkeyWorkerPool close barrier broke; best-effort close")
+        except Exception as exc:
+            # BrokenBarrierError, TimeoutError (3.12+), etc. — fall through
+            # to a best-effort close of whatever this thread owns so a
+            # broken barrier never skips client cleanup.
+            logger.debug(
+                "ValkeyWorkerPool close barrier did not gather (%s); best-effort close",
+                exc,
+            )
         client = getattr(self._local, "client", None)
         if client is None:
             return
@@ -468,9 +474,11 @@ class ValkeyWorkerPool:
 
         Each client is closed on its owning thread (matching glide's
         per-thread client model) with 1:1 coverage guaranteed by a
-        barrier. Safe to call once; the executor must not receive new
-        submissions afterward.
+        barrier. Idempotent — repeated calls are no-ops.
         """
+        if self._closed:
+            return
+        self._closed = True
         barrier = threading.Barrier(self.num_workers)
         close_futs = [
             self._executor.submit(self._close_local_client, barrier)

--- a/lmcache/v1/storage_backend/valkey/worker_pool.py
+++ b/lmcache/v1/storage_backend/valkey/worker_pool.py
@@ -479,7 +479,7 @@ class ValkeyWorkerPool:
             best-effort so a slow / unreachable node never breaks status
             reporting).
         """
-        if not self._cluster_mode:
+        if not self._cluster_mode or self._closed:
             return {}
         try:
             return self._executor.submit(self._do_node_memory).result(

--- a/lmcache/v1/storage_backend/valkey/worker_pool.py
+++ b/lmcache/v1/storage_backend/valkey/worker_pool.py
@@ -4,11 +4,12 @@ Shared Valkey worker pool built on the ``valkey-glide`` sync client.
 
 A pool of ``num_workers`` threads, each holding its own glide client via
 ``threading.local()``. The sync glide client is used (rather than async)
-because it is the only glide API that supports **zero-copy** SET
-(``bytearray``/``memoryview`` args) and buffer GET — async glide cannot
-avoid an intermediate ``bytes`` allocation due to its Protobuf-based IPC
-layer. A sync call blocks its calling thread, so concurrency comes from
-running N worker threads each with an independent client.
+because it is the only glide API that supports **copy-reduced** SET
+(``bytearray``/``memoryview`` args) and buffer GET — async glide adds an
+unavoidable intermediate ``bytes`` allocation on top of that, due to its
+Protobuf-based IPC layer. A sync call blocks its calling thread, so
+concurrency comes from running N worker threads each with an independent
+client.
 
 Both the non-MP ``ValkeyConnector`` (``RemoteConnector``) and the MP-mode
 ``ValkeyL2Adapter`` (``L2AdapterInterface``) build on this single class,
@@ -16,7 +17,7 @@ so the glide client lifecycle, capability probing, buffer-format
 handling, and reliable shutdown live in exactly one place.
 
 Requires the ``valkey-glide-sync`` package (``>= 2.3.0``), which provides
-the ``glide_sync`` module with zero-copy SET and buffer GET. Note the
+the ``glide_sync`` module with copy-reduced SET and buffer GET. Note the
 plain ``valkey-glide`` package ships only the *async* client and is not
 sufficient. The dependency is imported lazily so installations that don't
 use Valkey never need it.
@@ -43,6 +44,12 @@ DEFAULT_CONNECTION_TIMEOUT_SECS: float = 10.0
 
 #: Sentinel returned by ``_do_get_into`` when the key is absent.
 GET_MISS: int = -1
+
+#: Upper bound on how long ``close()`` waits for all workers to gather at
+#: the shutdown barrier. Workers idle at close time gather in microseconds;
+#: this only caps the wait when a worker is stuck in a slow glide call, so
+#: close falls through to its best-effort path promptly
+CLOSE_BARRIER_TIMEOUT_SECS: float = 1.0
 
 
 def _to_str(value: Any) -> str:
@@ -268,7 +275,7 @@ class ValkeyWorkerPool:
 
     @property
     def has_buffer_get(self) -> bool:
-        """Whether the glide client supports zero-copy buffer GET.
+        """Whether the glide client supports copy-reduced buffer GET.
 
         Returns:
             ``True`` if ``client.get`` accepts a ``buffer=`` argument
@@ -314,7 +321,7 @@ class ValkeyWorkerPool:
         """SET a key. ``data`` is a memoryview / bytes / bytearray.
 
         With glide >= 2.3.0 and a memoryview/bytearray, this is a
-        zero-copy write. When ``ttl_seconds`` is configured, the key is
+        copy-reduced write. When ``ttl_seconds`` is configured, the key is
         written with an expiry so Valkey/Redis ``volatile-*`` eviction
         policies can reclaim it under memory pressure; otherwise the key
         is persisted indefinitely.
@@ -373,8 +380,33 @@ class ValkeyWorkerPool:
             result = client.get(key_str.encode(), buffer=scratch_view)
             if result is None:
                 return GET_MISS
-            # glide buffer GET returns the number of bytes written.
-            n = int(result) if isinstance(result, int) else size
+            # glide buffer GET returns the number of bytes written. Real
+            # glide sync (>= 2.3.0) reports this as an ASCII byte string
+            # (e.g. ``b'4096'``); the fake used in unit tests may report
+            # a plain ``int``. Anything else means we cannot trust the
+            # byte count, so treat it as a miss rather than assume a
+            # full-size read and defeat the size check below.
+            if isinstance(result, (bytes, bytearray, memoryview)):
+                try:
+                    n = int(bytes(result))
+                except ValueError:
+                    logger.warning(
+                        "Valkey buffer GET for key %s returned "
+                        "non-numeric byte string %r; treating as miss.",
+                        key_str,
+                        bytes(result)[:32],
+                    )
+                    return GET_MISS
+            elif isinstance(result, int) and not isinstance(result, bool):
+                n = result
+            else:
+                logger.warning(
+                    "Valkey buffer GET for key %s returned unexpected type %s; "
+                    "treating as miss.",
+                    key_str,
+                    type(result).__name__,
+                )
+                return GET_MISS
             source: Any = scratch_view
         else:
             data = client.get(key_str.encode())
@@ -491,9 +523,13 @@ class ValkeyWorkerPool:
         client exactly once. Without it, a fast thread could grab
         multiple close tasks (no-ops after the first) while another
         thread's client is never closed.
+
+        The wait is capped at :data:`CLOSE_BARRIER_TIMEOUT_SECS`: if a
+        worker is stuck in a slow glide call the barrier can never gather,
+        and a longer wait would only delay the best-effort close below.
         """
         try:
-            barrier.wait(timeout=self._request_timeout)
+            barrier.wait(timeout=CLOSE_BARRIER_TIMEOUT_SECS)
         except Exception as exc:
             # BrokenBarrierError, TimeoutError (3.12+), etc. — fall through
             # to a best-effort close of whatever this thread owns so a

--- a/lmcache/v1/storage_backend/valkey/worker_pool.py
+++ b/lmcache/v1/storage_backend/valkey/worker_pool.py
@@ -151,6 +151,10 @@ class ValkeyWorkerPool:
         # imported on worker threads, so this stays None until the first SET.
         self._expiry_obj: Any = None
 
+        # Per-thread glide client holder. The object itself is shared by
+        # the pool, but ``self._local.client`` resolves to a separate
+        # value per worker thread — so each thread builds and reuses its
+        # own client (glide clients are not shared across threads).
         self._local: threading.local = threading.local()
         self._has_buffer_get: Optional[bool] = None
         self._capability_lock: threading.Lock = threading.Lock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,6 +175,14 @@ class MockSyncGlideClient:
     def exists(self, keys: list[bytes]) -> int:
         return sum(1 for k in keys if k in self._store)
 
+    def delete(self, keys: list[bytes]) -> int:
+        removed = 0
+        for k in keys:
+            if k in self._store:
+                del self._store[k]
+                removed += 1
+        return removed
+
     @classmethod
     def reset_store(cls) -> None:
         cls._store.clear()

--- a/tests/v1/distributed/conftest.py
+++ b/tests/v1/distributed/conftest.py
@@ -89,3 +89,50 @@ if find_spec("lmcache.native_storage_ops") is None:
     fallback_module_any.Bitmap = Bitmap
     fallback_module_any.TTLLock = TTLLock
     sys.modules["lmcache.native_storage_ops"] = fallback_module
+
+
+# ---------------------------------------------------------------------------
+# CLI options for live-server integration tests (e.g. the Valkey adapter).
+#
+# These let integration tests point at a real Valkey/Redis without
+# environment variables, e.g.::
+#
+#   pytest test_valkey_l2_adapter_integration.py \
+#       --valkey-cluster --valkey-nodes=127.0.0.1:7000,127.0.0.1:7001
+#
+#   pytest test_valkey_l2_adapter_integration.py \
+#       --valkey-host=localhost --valkey-port=6390
+#
+# Defaults point at localhost so a bare run connects to a locally-running
+# server; the test still self-skips when nothing is reachable.
+# ---------------------------------------------------------------------------
+
+
+def pytest_addoption(parser: Any) -> None:
+    """Register Valkey integration-test connection options."""
+    group = parser.getgroup("valkey-integration")
+    group.addoption(
+        "--valkey-cluster",
+        action="store_true",
+        default=False,
+        help="Run Valkey integration tests in cluster mode against --valkey-nodes.",
+    )
+    group.addoption(
+        "--valkey-nodes",
+        action="store",
+        default="127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002",
+        help="Comma-separated host:port cluster seed nodes (cluster mode).",
+    )
+    group.addoption(
+        "--valkey-host",
+        action="store",
+        default="localhost",
+        help="Valkey host (standalone mode).",
+    )
+    group.addoption(
+        "--valkey-port",
+        action="store",
+        type=int,
+        default=6379,
+        help="Valkey port (standalone mode).",
+    )

--- a/tests/v1/distributed/test_valkey_l2_adapter.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter.py
@@ -184,7 +184,10 @@ _install_fake_glide()
 
 # First Party
 # First Party  (imported after fake glide is installed)
-from lmcache.v1.distributed.api import ObjectKey  # noqa: E402
+from lmcache.v1.distributed.api import (  # noqa: E402
+    MemoryLayoutDesc,
+    ObjectKey,
+)
 from lmcache.v1.distributed.internal_api import L2AdapterListener  # noqa: E402
 from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (  # noqa: E402
     ValkeyL2Adapter,
@@ -197,6 +200,8 @@ from lmcache.v1.memory_management import (  # noqa: E402
     TensorMemoryObj,
 )
 from lmcache.v1.platform import consume_fd  # noqa: E402
+
+_EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -534,13 +539,15 @@ class TestLookupAndLock:
         objs = [create_memory_obj(size=8) for _ in keys]
         _wait_for_store(adapter, adapter.submit_store_task(keys, objs))
 
-        task = adapter.submit_lookup_and_lock_task(keys)
+        task = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
         bm = _wait_for_lookup(adapter, task)
         assert all(bm.test(i) for i in range(3))
 
     def test_lookup_miss(self, adapter):
         keys = [create_object_key(99)]
-        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task(keys))
+        bm = _wait_for_lookup(
+            adapter, adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
+        )
         assert not bm.test(0)
 
     def test_unlock_balances_lookup(self, adapter):
@@ -549,17 +556,15 @@ class TestLookupAndLock:
         _wait_for_store(adapter, adapter.submit_store_task(keys, objs))
         # Two successful lookups → refcount == 2 per key.
         for _ in range(2):
-            _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task(keys))
+            _wait_for_lookup(
+                adapter, adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
+            )
         # Two unlocks should bring it back to zero — no internal state
         # to assert publicly, just verify no exception and that we can
         # delete the keys afterward.
         adapter.submit_unlock(keys)
         adapter.submit_unlock(keys)
         adapter.delete(keys)
-
-    def test_empty_lookup_batch(self, adapter):
-        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([]))
-        assert bm is not None
 
 
 class TestLoad:
@@ -612,7 +617,9 @@ class TestDelete:
         # Listener observed the deletions.
         assert any(set(batch) == set(keys) for batch in listener.deleted)
         # Subsequent lookup should miss.
-        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task(keys))
+        bm = _wait_for_lookup(
+            adapter, adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
+        )
         assert not any(bm.test(i) for i in range(len(keys)))
 
     def test_delete_unknown_keys_is_noop(self, adapter):
@@ -627,7 +634,9 @@ class TestDelete:
         )
 
         # Lookup bumps the lock refcount.
-        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([key]))
+        bm = _wait_for_lookup(
+            adapter, adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
+        )
         assert bm.test(0)
 
         adapter.delete([key])
@@ -645,7 +654,9 @@ class TestDelete:
             adapter, adapter.submit_store_task([key], [create_memory_obj(4)])
         )
         for _ in range(2):
-            _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([key]))
+            _wait_for_lookup(
+                adapter, adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
+            )
 
         adapter.submit_unlock([key])  # refcount 1, still pinned
         adapter.delete([key])
@@ -665,7 +676,9 @@ class TestKeyNamespacing:
             obj = create_memory_obj(size=4)
             _wait_for_store(a1, a1.submit_store_task([k], [obj]))
             # a2 sees no value for the same logical key.
-            bm = _wait_for_lookup(a2, a2.submit_lookup_and_lock_task([k]))
+            bm = _wait_for_lookup(
+                a2, a2.submit_lookup_and_lock_task([k], _EMPTY_LAYOUT)
+            )
             assert not bm.test(0)
         finally:
             a1.close()
@@ -678,5 +691,7 @@ class TestKeyNamespacing:
         k_b = create_object_key(1, cache_salt="user-B")
         obj = create_memory_obj(size=4)
         _wait_for_store(adapter, adapter.submit_store_task([k_a], [obj]))
-        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([k_b]))
+        bm = _wait_for_lookup(
+            adapter, adapter.submit_lookup_and_lock_task([k_b], _EMPTY_LAYOUT)
+        )
         assert not bm.test(0)

--- a/tests/v1/distributed/test_valkey_l2_adapter.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter.py
@@ -212,7 +212,7 @@ class _RecordingListener(L2AdapterListener):
         self.deleted: list[list[ObjectKey]] = []
         self.lock = threading.Lock()
 
-    def on_l2_keys_stored(self, keys: list[ObjectKey]) -> None:
+    def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
         with self.lock:
             self.stored.append(list(keys))
 

--- a/tests/v1/distributed/test_valkey_l2_adapter.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter.py
@@ -1,0 +1,897 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for ValkeyL2Adapter.
+
+These tests exercise the L2AdapterInterface contract against an
+in-process fake of ``glide_sync`` so neither ``valkey-glide`` nor a real
+Valkey server is required.  Behavior verified:
+
+* Event fds are distinct and signaled on completion.
+* Partial-failure accounting reflects only the keys that wrote.
+* Size-mismatched GET responses are treated as cache misses.
+* ``cache_salt`` and ``key_prefix`` are both encoded into the wire key.
+* ``submit_unlock`` decrements lock refcounts and matches ``lookup``.
+* ``delete`` reports per-key sizes recorded at store time.
+* Config validation rejects bad inputs.
+"""
+
+# Standard
+from typing import Any, Optional
+import select
+import sys
+import threading
+import types
+
+# Third Party
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# In-process fake `glide_sync`
+# ---------------------------------------------------------------------------
+#
+# The worker pool imports ``glide_sync`` lazily when it creates a client.
+# We install a fake module in ``sys.modules`` *before* the adapter is
+# imported so that lazy import resolves to our fake.  All workers share
+# the same backing dict so multi-thread behavior matches a real
+# centralized server.
+
+
+_STORE_LOCK = threading.Lock()
+_STORE: dict[bytes, bytes] = {}
+# Maps "set" / "get" / "exists" / "delete" -> Exception instance to raise
+# on the *next* call for any key, OR a callable
+# (key: bytes) -> Optional[Exception] for per-key faults.
+_FAULTS: dict[str, object] = {}
+# When set, ``set`` writes only the first ``_TRUNCATE_BYTES`` bytes of
+# the value — used to simulate stale/incompatible entries.
+_TRUNCATE_BYTES: Optional[int] = None
+
+
+def _reset_fake_state() -> None:
+    """Reset the fake glide backing state between tests."""
+    global _TRUNCATE_BYTES
+    with _STORE_LOCK:
+        _STORE.clear()
+    _FAULTS.clear()
+    _TRUNCATE_BYTES = None
+
+
+def _maybe_fault(op: str, key: bytes) -> None:
+    """Raise the configured fault (if any) for ``op``."""
+    fault = _FAULTS.get(op)
+    if fault is None:
+        return
+    if callable(fault):
+        result = fault(key)
+        if result is not None:
+            raise result
+    elif isinstance(fault, BaseException):
+        raise fault
+
+
+class _FakeGlideClient:
+    """Minimal in-process stand-in for ``glide_sync.GlideClient``."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    @classmethod
+    def create(cls, config: object) -> "_FakeGlideClient":
+        inst = cls()
+        inst.config = config  # type: ignore[attr-defined]
+        return inst
+
+    def set(self, key: bytes, value) -> None:
+        _maybe_fault("set", bytes(key))
+        v = bytes(value)
+        if _TRUNCATE_BYTES is not None:
+            v = v[:_TRUNCATE_BYTES]
+        with _STORE_LOCK:
+            _STORE[bytes(key)] = v
+
+    def get(self, key: bytes, buffer=None):
+        _maybe_fault("get", bytes(key))
+        with _STORE_LOCK:
+            v = _STORE.get(bytes(key))
+        if v is None:
+            return None
+        if buffer is None:
+            return v
+        n = min(len(v), len(buffer))
+        buffer[:n] = v[:n]
+        return n  # buffer GET returns bytes-written
+
+    def exists(self, keys) -> int:
+        for k in keys:
+            _maybe_fault("exists", bytes(k))
+        with _STORE_LOCK:
+            return sum(1 for k in keys if bytes(k) in _STORE)
+
+    def delete(self, keys) -> int:
+        for k in keys:
+            _maybe_fault("delete", bytes(k))
+        n = 0
+        with _STORE_LOCK:
+            for k in keys:
+                kb = bytes(k)
+                if kb in _STORE:
+                    del _STORE[kb]
+                    n += 1
+        return n
+
+    def close(self) -> None:
+        self.closed = True
+
+
+# Per-node INFO memory the fake cluster client reports (node addr -> bytes).
+_NODE_INFO: dict[str, bytes] = {}
+
+
+class _FakeGlideClusterClient(_FakeGlideClient):
+    """Cluster client behaves identically against the shared fake, plus a
+    stubbed ``info()`` that returns ``_NODE_INFO`` for AllNodes routing."""
+
+    def info(self, sections=None, route=None):
+        # AllNodes route → dict of node addr -> INFO bytes.
+        return dict(_NODE_INFO)
+
+
+def _install_fake_glide() -> types.ModuleType:
+    """Install the fake glide_sync module in ``sys.modules``."""
+    fake = types.ModuleType("glide_sync")
+
+    def _record(name):
+        def _ctor(**kw):
+            return (name, kw)
+
+        return _ctor
+
+    fake.ServerCredentials = lambda u, p: ("creds", u, p)  # type: ignore[attr-defined]
+    fake.NodeAddress = lambda h, p: ("addr", h, p)  # type: ignore[attr-defined]
+    fake.AdvancedGlideClientConfiguration = _record("adv_std")  # type: ignore[attr-defined]
+    fake.AdvancedGlideClusterClientConfiguration = _record(  # type: ignore[attr-defined]
+        "adv_cluster"
+    )
+    fake.GlideClientConfiguration = _record("cfg_std")  # type: ignore[attr-defined]
+    fake.GlideClusterClientConfiguration = _record("cfg_cluster")  # type: ignore[attr-defined]
+    fake.GlideClient = _FakeGlideClient  # type: ignore[attr-defined]
+    fake.GlideClusterClient = _FakeGlideClusterClient  # type: ignore[attr-defined]
+    sys.modules["glide_sync"] = fake
+
+    # Stub the glide_shared modules that `_do_node_memory` lazily imports
+    # for per-node INFO routing.
+    routes_mod = types.ModuleType("glide_shared.routes")
+    routes_mod.AllNodes = lambda: ("route", "all_nodes")  # type: ignore[attr-defined]
+    core_opts_mod = types.ModuleType("glide_shared.commands.core_options")
+
+    class _InfoSection:
+        MEMORY = "memory"
+
+    core_opts_mod.InfoSection = _InfoSection  # type: ignore[attr-defined]
+    shared_pkg = types.ModuleType("glide_shared")
+    commands_pkg = types.ModuleType("glide_shared.commands")
+    sys.modules["glide_shared"] = shared_pkg
+    sys.modules["glide_shared.commands"] = commands_pkg
+    sys.modules["glide_shared.commands.core_options"] = core_opts_mod
+    sys.modules["glide_shared.routes"] = routes_mod
+    return fake
+
+
+# Install before the adapter module is imported below.
+_install_fake_glide()
+
+
+# First Party
+# First Party  (imported after fake glide is installed)
+from lmcache.v1.distributed.api import ObjectKey  # noqa: E402
+from lmcache.v1.distributed.internal_api import L2AdapterListener  # noqa: E402
+from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (  # noqa: E402
+    ValkeyL2Adapter,
+    ValkeyL2AdapterConfig,
+    _parse_startup_nodes,
+)
+from lmcache.v1.memory_management import (  # noqa: E402
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingListener(L2AdapterListener):
+    """Captures listener events for inspection in tests."""
+
+    def __init__(self) -> None:
+        self.stored: list[list[ObjectKey]] = []
+        self.accessed: list[list[ObjectKey]] = []
+        self.deleted: list[list[ObjectKey]] = []
+        self.lock = threading.Lock()
+
+    def on_l2_keys_stored(self, keys: list[ObjectKey]) -> None:
+        with self.lock:
+            self.stored.append(list(keys))
+
+    def on_l2_keys_accessed(self, keys: list[ObjectKey]) -> None:
+        with self.lock:
+            self.accessed.append(list(keys))
+
+    def on_l2_keys_deleted(self, keys: list[ObjectKey]) -> None:
+        with self.lock:
+            self.deleted.append(list(keys))
+
+
+def create_object_key(
+    chunk_id: int,
+    model_name: str = "test_model",
+    cache_salt: str = "",
+) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name=model_name,
+        kv_rank=0,
+        cache_salt=cache_salt,
+    )
+
+
+def create_memory_obj(size: int = 64, fill_value: float = 1.0) -> TensorMemoryObj:
+    raw = torch.empty(size, dtype=torch.float32)
+    raw.fill_(fill_value)
+    meta = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=size * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw, meta, parent_allocator=None)
+
+
+def _in_store(adapter: ValkeyL2Adapter, key: ObjectKey) -> bool:
+    """Whether ``key`` currently exists in the fake Valkey store."""
+    return adapter._wire_key(key).encode() in _STORE  # noqa: SLF001
+
+
+def wait_for_event_fd(fd: int, timeout: float = 5.0) -> bool:
+    poll = select.poll()
+    poll.register(fd, select.POLLIN)
+    if not poll.poll(timeout * 1000):
+        return False
+    try:
+        consume_fd(fd)
+    except BlockingIOError:
+        pass
+    return True
+
+
+def _wait_for_store(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0):
+    """Poll the store event fd until ``task_id`` shows up; return its result."""
+    fd = adapter.get_store_event_fd()
+    deadline = timeout
+    poll = select.poll()
+    poll.register(fd, select.POLLIN)
+    # Drain may report extra completions; loop until task_id appears.
+    while deadline > 0:
+        events = poll.poll(deadline * 1000)
+        if not events:
+            break
+        try:
+            consume_fd(fd)
+        except BlockingIOError:
+            pass
+        completed = adapter.pop_completed_store_tasks()
+        if task_id in completed:
+            return completed[task_id]
+        # Re-stash any other task results (shouldn't normally happen
+        # in single-batch tests).
+        for tid, r in completed.items():
+            # Best-effort: re-insert into adapter's completed dict by
+            # popping again is not possible — but tests submit one
+            # task at a time, so this branch is defensive only.
+            pass
+        deadline -= 0.05
+    raise AssertionError(f"store task {task_id} did not complete in {timeout}s")
+
+
+def _wait_for_lookup(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0):
+    fd = adapter.get_lookup_and_lock_event_fd()
+    poll = select.poll()
+    poll.register(fd, select.POLLIN)
+    while timeout > 0:
+        events = poll.poll(timeout * 1000)
+        if not events:
+            break
+        try:
+            consume_fd(fd)
+        except BlockingIOError:
+            pass
+        bm = adapter.query_lookup_and_lock_result(task_id)
+        if bm is not None:
+            return bm
+        timeout -= 0.05
+    raise AssertionError(f"lookup task {task_id} did not complete")
+
+
+def _wait_for_load(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0):
+    fd = adapter.get_load_event_fd()
+    poll = select.poll()
+    poll.register(fd, select.POLLIN)
+    while timeout > 0:
+        events = poll.poll(timeout * 1000)
+        if not events:
+            break
+        try:
+            consume_fd(fd)
+        except BlockingIOError:
+            pass
+        bm = adapter.query_load_result(task_id)
+        if bm is not None:
+            return bm
+        timeout -= 0.05
+    raise AssertionError(f"load task {task_id} did not complete")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    _reset_fake_state()
+    yield
+    _reset_fake_state()
+
+
+def _make_config(**overrides: Any) -> ValkeyL2AdapterConfig:
+    base: dict[str, Any] = {
+        "startup_nodes": [("localhost", 6379)],
+        "num_workers": 2,
+        "connection_timeout": 2.0,
+        "request_timeout": 2.0,
+    }
+    base.update(overrides)
+    return ValkeyL2AdapterConfig(**base)
+
+
+@pytest.fixture
+def adapter():
+    a = ValkeyL2Adapter(_make_config())
+    yield a
+    a.close()
+
+
+@pytest.fixture
+def cluster_adapter():
+    a = ValkeyL2Adapter(_make_config(cluster_mode=True))
+    yield a
+    a.close()
+
+
+# ===========================================================================
+# Config validation
+# ===========================================================================
+
+
+class TestConfigValidation:
+    def test_empty_startup_nodes_rejected(self):
+        with pytest.raises(ValueError, match="startup_nodes"):
+            ValkeyL2AdapterConfig(startup_nodes=[])
+
+    def test_bad_port_rejected(self):
+        with pytest.raises(ValueError):
+            ValkeyL2AdapterConfig(startup_nodes=[("h", 0)])
+
+    def test_negative_capacity_rejected(self):
+        with pytest.raises(ValueError, match="max_capacity_gb"):
+            ValkeyL2AdapterConfig(startup_nodes=[("h", 1)], max_capacity_gb=-1)
+
+    def test_zero_workers_rejected(self):
+        with pytest.raises(ValueError, match="num_workers"):
+            ValkeyL2AdapterConfig(startup_nodes=[("h", 1)], num_workers=0)
+
+    def test_at_sign_in_prefix_rejected(self):
+        with pytest.raises(ValueError, match="key_prefix"):
+            ValkeyL2AdapterConfig(startup_nodes=[("h", 1)], key_prefix="bad@prefix")
+
+    def test_cluster_mode_warns_on_database_id(self, caplog):
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ValkeyL2AdapterConfig(
+                startup_nodes=[("h", 1)],
+                cluster_mode=True,
+                database_id=3,
+            )
+        assert cfg.database_id is None
+
+    def test_standalone_warns_on_multiple_nodes(self, caplog):
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            ValkeyL2AdapterConfig(
+                startup_nodes=[("h1", 1), ("h2", 2)],
+                cluster_mode=False,
+            )
+
+
+class TestParseStartupNodes:
+    def test_single(self):
+        assert _parse_startup_nodes("host:6379") == [("host", 6379)]
+
+    def test_comma_separated(self):
+        nodes = _parse_startup_nodes("a:1,b:2,c:3")
+        assert nodes == [("a", 1), ("b", 2), ("c", 3)]
+
+    def test_missing_colon(self):
+        with pytest.raises(ValueError, match="host:port"):
+            _parse_startup_nodes("nocolon")
+
+    def test_non_integer_port(self):
+        with pytest.raises(ValueError, match="non-integer port"):
+            _parse_startup_nodes("host:abc")
+
+    def test_empty_or_non_string_rejected(self):
+        for bad in ("", "   ", None, [("a", 1)]):
+            with pytest.raises(ValueError):
+                _parse_startup_nodes(bad)
+
+
+class TestFromDict:
+    def test_basic(self):
+        cfg = ValkeyL2AdapterConfig.from_dict(
+            {
+                "type": "valkey",
+                "startup_nodes": "a:1,b:2",
+                "cluster_mode": True,
+                "username": "u",
+                "password": "p",
+                "key_prefix": "deploy1",
+                "num_workers": 4,
+                "tls_enable": True,
+                "max_capacity_gb": 2.5,
+            }
+        )
+        assert cfg.startup_nodes == [("a", 1), ("b", 2)]
+        assert cfg.cluster_mode is True
+        assert cfg.key_prefix == "deploy1"
+        assert cfg.num_workers == 4
+        assert cfg.tls_enable is True
+        assert cfg.max_capacity_gb == 2.5
+
+
+# ===========================================================================
+# Event fd interface
+# ===========================================================================
+
+
+class TestEventFds:
+    def test_fds_are_distinct(self, adapter):
+        a = adapter.get_store_event_fd()
+        b = adapter.get_lookup_and_lock_event_fd()
+        c = adapter.get_load_event_fd()
+        assert a != b and b != c and a != c
+        assert all(fd >= 0 for fd in (a, b, c))
+
+
+# ===========================================================================
+# Store
+# ===========================================================================
+
+
+class TestStore:
+    def test_single_key_round_trip(self, adapter):
+        k = create_object_key(1)
+        o = create_memory_obj(size=16, fill_value=0.5)
+        task = adapter.submit_store_task([k], [o])
+        result = _wait_for_store(adapter, task)
+        assert result.is_successful()
+        assert result.bytes_transferred() == o.get_size()
+
+    def test_empty_batch_completes_immediately(self, adapter):
+        task = adapter.submit_store_task([], [])
+        result = _wait_for_store(adapter, task)
+        assert result.is_successful()
+        assert result.bytes_transferred() == 0
+
+    def test_partial_failure_accounting(self, adapter):
+        """Issue #3342 req 6: a partial batch failure must (a) report the
+        task as NOT successful — so the store controller keeps the
+        un-stored keys in L1 rather than dropping them — and (b) account
+        only the keys that actually wrote in per-salt / aggregate usage.
+
+        ``L2StoreResult`` is binary by contract (``success=False`` ⇒
+        ``bytes_transferred()==0``), so the meaningful byte accounting is
+        verified via ``get_usage()`` and the stored-listener, not via the
+        coarse task result.
+        """
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
+        keys = [create_object_key(i) for i in range(3)]
+        objs = [create_memory_obj(size=16) for _ in range(3)]
+
+        # Make the SET for key index 1's wire key fail.
+        target_wire = adapter._wire_key(keys[1]).encode()  # noqa: SLF001
+
+        def faulty(k: bytes):
+            if k == target_wire:
+                return RuntimeError("simulated SET failure")
+            return None
+
+        _FAULTS["set"] = faulty
+
+        task = adapter.submit_store_task(keys, objs)
+        result = _wait_for_store(adapter, task)
+
+        # Task-level: a partial failure is a task failure.
+        assert not result.is_successful()
+        assert result.bytes_transferred() == 0
+
+        # Real accounting: only the 2 successful keys are counted.
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == 2 * objs[0].get_size()
+        # ...and the failed key is not in the stored-listener notifications.
+        stored_flat = {k for batch in listener.stored for k in batch}
+        assert keys[0] in stored_flat
+        assert keys[2] in stored_flat
+        assert keys[1] not in stored_flat
+
+    def test_length_mismatch_raises(self, adapter):
+        with pytest.raises(ValueError, match="length mismatch"):
+            adapter.submit_store_task([create_object_key(0)], [])
+
+    def test_store_fires_listener(self, adapter):
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
+        keys = [create_object_key(i) for i in range(2)]
+        objs = [create_memory_obj(size=8) for _ in keys]
+        task = adapter.submit_store_task(keys, objs)
+        _wait_for_store(adapter, task)
+        # ``_notify_keys_stored`` should have fired with these keys.
+        assert any(set(batch) == set(keys) for batch in listener.stored)
+
+
+# ===========================================================================
+# Lookup + lock
+# ===========================================================================
+
+
+class TestLookupAndLock:
+    def test_lookup_after_store(self, adapter):
+        keys = [create_object_key(i) for i in range(3)]
+        objs = [create_memory_obj(size=8) for _ in keys]
+        _wait_for_store(adapter, adapter.submit_store_task(keys, objs))
+
+        task = adapter.submit_lookup_and_lock_task(keys)
+        bm = _wait_for_lookup(adapter, task)
+        assert all(bm.test(i) for i in range(3))
+
+    def test_lookup_miss(self, adapter):
+        keys = [create_object_key(99)]
+        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task(keys))
+        assert not bm.test(0)
+
+    def test_unlock_balances_lookup(self, adapter):
+        keys = [create_object_key(i) for i in range(2)]
+        objs = [create_memory_obj(size=4) for _ in keys]
+        _wait_for_store(adapter, adapter.submit_store_task(keys, objs))
+        # Two successful lookups → refcount == 2 per key.
+        for _ in range(2):
+            _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task(keys))
+        # Two unlocks should bring it back to zero — no internal state
+        # to assert publicly, just verify no exception and that we can
+        # delete the keys afterward.
+        adapter.submit_unlock(keys)
+        adapter.submit_unlock(keys)
+        adapter.delete(keys)
+
+    def test_empty_lookup_batch(self, adapter):
+        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([]))
+        assert bm is not None
+
+
+# ===========================================================================
+# Load
+# ===========================================================================
+
+
+class TestLoad:
+    def test_load_after_store_returns_hit(self, adapter):
+        k = create_object_key(1)
+        src = create_memory_obj(size=8, fill_value=0.25)
+        _wait_for_store(adapter, adapter.submit_store_task([k], [src]))
+
+        dst = create_memory_obj(size=8, fill_value=0.0)
+        bm = _wait_for_load(adapter, adapter.submit_load_task([k], [dst]))
+        assert bm.test(0)
+        # Loaded buffer matches the source data.
+        assert torch.allclose(dst.tensor, src.tensor)
+
+    def test_load_miss_returns_zero_bit(self, adapter):
+        dst = create_memory_obj(size=8)
+        bm = _wait_for_load(
+            adapter, adapter.submit_load_task([create_object_key(42)], [dst])
+        )
+        assert not bm.test(0)
+
+    def test_size_mismatch_treated_as_miss(self, adapter):
+        """Issue #3342 req 5: stale/wrong-size GET = cache miss."""
+        global _TRUNCATE_BYTES
+        k = create_object_key(1)
+        obj = create_memory_obj(size=16)  # 64 bytes (16 * float32)
+
+        # Simulate a stale entry of the wrong length on the server.
+        _TRUNCATE_BYTES = 8  # store only 8 bytes
+        _wait_for_store(adapter, adapter.submit_store_task([k], [obj]))
+        _TRUNCATE_BYTES = None
+
+        dst = create_memory_obj(size=16)
+        bm = _wait_for_load(adapter, adapter.submit_load_task([k], [dst]))
+        assert not bm.test(0), "size-mismatched value must be reported as miss"
+
+    def test_length_mismatch_raises(self, adapter):
+        with pytest.raises(ValueError, match="length mismatch"):
+            adapter.submit_load_task([create_object_key(0)], [])
+
+
+# ===========================================================================
+# Delete + accounting
+# ===========================================================================
+
+
+class TestDelete:
+    def test_delete_after_store(self, adapter):
+        listener = _RecordingListener()
+        adapter.register_listener(listener)
+        keys = [create_object_key(i) for i in range(2)]
+        objs = [create_memory_obj(size=8) for _ in keys]
+        _wait_for_store(adapter, adapter.submit_store_task(keys, objs))
+
+        adapter.delete(keys)
+        # Listener observed the deletions.
+        assert any(set(batch) == set(keys) for batch in listener.deleted)
+        # Subsequent lookup should miss.
+        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task(keys))
+        assert not any(bm.test(i) for i in range(len(keys)))
+
+    def test_delete_unknown_keys_is_noop(self, adapter):
+        # Should not raise even though the keys were never stored.
+        adapter.delete([create_object_key(999)])
+
+    def test_lock_blocks_delete(self, adapter):
+        """A key pinned by an in-flight lookup must not be deleted."""
+        key = create_object_key(1)
+        _wait_for_store(
+            adapter, adapter.submit_store_task([key], [create_memory_obj(4)])
+        )
+
+        # Lookup bumps the lock refcount.
+        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([key]))
+        assert bm.test(0)
+
+        adapter.delete([key])
+        assert _in_store(adapter, key), "locked key must survive delete"
+
+        # After unlock the key is deletable again.
+        adapter.submit_unlock([key])
+        adapter.delete([key])
+        assert not _in_store(adapter, key)
+
+    def test_refcount_blocks_until_fully_unlocked(self, adapter):
+        """Two lookups → refcount 2 → needs two unlocks before delete."""
+        key = create_object_key(1)
+        _wait_for_store(
+            adapter, adapter.submit_store_task([key], [create_memory_obj(4)])
+        )
+        for _ in range(2):
+            _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([key]))
+
+        adapter.submit_unlock([key])  # refcount 1, still pinned
+        adapter.delete([key])
+        assert _in_store(adapter, key)
+
+        adapter.submit_unlock([key])  # refcount 0
+        adapter.delete([key])
+        assert not _in_store(adapter, key)
+
+
+# ===========================================================================
+# Key prefix + cache_salt isolation
+# ===========================================================================
+
+
+class TestKeyNamespacing:
+    def test_different_prefixes_do_not_collide(self):
+        a1 = ValkeyL2Adapter(_make_config(key_prefix="dep-A"))
+        a2 = ValkeyL2Adapter(_make_config(key_prefix="dep-B"))
+        try:
+            k = create_object_key(7)
+            obj = create_memory_obj(size=4)
+            _wait_for_store(a1, a1.submit_store_task([k], [obj]))
+            # a2 sees no value for the same logical key.
+            bm = _wait_for_lookup(a2, a2.submit_lookup_and_lock_task([k]))
+            assert not bm.test(0)
+        finally:
+            a1.close()
+            a2.close()
+
+    def test_cache_salt_isolation(self, adapter):
+        # cache_salt is part of the wire key produced by
+        # _object_key_to_string, so different salts must miss.
+        k_a = create_object_key(1, cache_salt="user-A")
+        k_b = create_object_key(1, cache_salt="user-B")
+        obj = create_memory_obj(size=4)
+        _wait_for_store(adapter, adapter.submit_store_task([k_a], [obj]))
+        bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([k_b]))
+        assert not bm.test(0)
+
+
+# ===========================================================================
+# Status + close
+# ===========================================================================
+
+
+class TestStatusAndClose:
+    def test_report_status_minimum_keys(self, adapter):
+        st = adapter.report_status()
+        assert st["is_healthy"] is True
+        assert st["type"] == "valkey"
+        assert "num_workers" in st
+        # Usage is exposed.
+        assert "current_size_bytes" in st
+        assert "max_capacity_bytes" in st
+        assert "usage_fraction" in st
+        # Sensitive fields must not leak.
+        assert "password" not in st
+        assert "username" not in st
+
+    def test_report_status_tracks_stored_bytes(self, adapter):
+        keys = [create_object_key(i) for i in range(3)]
+        objs = [create_memory_obj(size=16) for _ in keys]
+        _wait_for_store(adapter, adapter.submit_store_task(keys, objs))
+        st = adapter.report_status()
+        assert st["current_size_bytes"] == 3 * objs[0].get_size()
+
+    def test_close_is_idempotent(self):
+        a = ValkeyL2Adapter(_make_config())
+        a.close()
+        a.close()  # must not raise
+        assert a.report_status()["is_healthy"] is False
+
+
+# ===========================================================================
+# Buffer GET capability detection
+# ===========================================================================
+
+
+class TestBufferGetCapability:
+    def test_buffer_get_detected(self, adapter):
+        # Our fake's get() signature has `buffer=`, so it must be True.
+        assert adapter.report_status()["has_buffer_get"] is True
+
+    def test_fallback_when_no_buffer_param(self):
+        """Adapter must fall back gracefully if glide lacks buffer=."""
+
+        # Build a fake client class whose `get` has no `buffer` param.
+        class _NoBufferGet(_FakeGlideClient):
+            def get(self, key):  # type: ignore[override]
+                return _FakeGlideClient.get(self, key, buffer=None)
+
+        fake_mod = sys.modules["glide_sync"]
+        original = fake_mod.GlideClient
+        fake_mod.GlideClient = _NoBufferGet  # type: ignore[attr-defined]
+        try:
+            adapter = ValkeyL2Adapter(_make_config())
+            try:
+                assert adapter.report_status()["has_buffer_get"] is False
+                k = create_object_key(1)
+                src = create_memory_obj(size=4, fill_value=0.5)
+                _wait_for_store(adapter, adapter.submit_store_task([k], [src]))
+                dst = create_memory_obj(size=4, fill_value=0.0)
+                bm = _wait_for_load(adapter, adapter.submit_load_task([k], [dst]))
+                assert bm.test(0)
+                assert torch.allclose(dst.tensor, src.tensor)
+            finally:
+                adapter.close()
+        finally:
+            fake_mod.GlideClient = original  # type: ignore[attr-defined]
+
+
+# ===========================================================================
+# Missing dependency
+# ===========================================================================
+
+
+class TestMissingGlide:
+    def test_missing_glide_raises_actionable_error(self, monkeypatch):
+        # Hide the fake module so the lazy import fails.
+        monkeypatch.setitem(sys.modules, "glide_sync", None)
+        with pytest.raises(RuntimeError, match="valkey-glide"):
+            ValkeyL2Adapter(_make_config())
+
+
+# ===========================================================================
+# get_usage
+# ===========================================================================
+
+
+class TestGetUsage:
+    def test_disabled_returns_minus_one(self):
+        a = ValkeyL2Adapter(_make_config(max_capacity_gb=0))
+        try:
+            usage = a.get_usage()
+            assert usage.usage_fraction == -1.0
+            assert usage.total_bytes_used == 0
+            assert usage.total_capacity_bytes == 0
+        finally:
+            a.close()
+
+    def test_grows_on_store_and_shrinks_on_delete(self):
+        a = ValkeyL2Adapter(_make_config(max_capacity_gb=0.001))  # 1 MB
+        try:
+            keys = [create_object_key(i) for i in range(4)]
+            objs = [create_memory_obj(size=16) for _ in range(4)]  # 64 bytes each
+            _wait_for_store(a, a.submit_store_task(keys, objs))
+
+            total = 4 * objs[0].get_size()
+            capacity = int(0.001 * 1024**3)
+            usage = a.get_usage()
+            assert usage.total_bytes_used == total
+            assert usage.total_capacity_bytes == capacity
+            assert usage.usage_fraction == pytest.approx(total / capacity)
+
+            a.delete(keys)
+            assert a.get_usage().total_bytes_used == 0
+        finally:
+            a.close()
+
+    def test_per_cache_salt_accounting(self):
+        a = ValkeyL2Adapter(_make_config(max_capacity_gb=0.001))
+        try:
+            k_a = create_object_key(1, cache_salt="user-A")
+            k_b = create_object_key(2, cache_salt="user-B")
+            obj = create_memory_obj(size=16)
+            _wait_for_store(
+                a, a.submit_store_task([k_a, k_b], [obj, create_memory_obj(16)])
+            )
+            by_salt = a.get_usage().bytes_by_cache_salt
+            assert by_salt["user-A"] == obj.get_size()
+            assert by_salt["user-B"] == obj.get_size()
+        finally:
+            a.close()
+
+
+# ===========================================================================
+# Factory registration
+# ===========================================================================
+
+
+class TestFactoryRegistration:
+    def test_create_via_factory(self):
+        # First Party
+        from lmcache.v1.distributed.l2_adapters import create_l2_adapter
+
+        cfg = ValkeyL2AdapterConfig.from_dict(
+            {"type": "valkey", "startup_nodes": "localhost:6379", "num_workers": 1}
+        )
+        adapter = create_l2_adapter(cfg)
+        try:
+            assert isinstance(adapter, ValkeyL2Adapter)
+            assert adapter.report_status()["type"] == "valkey"
+        finally:
+            adapter.close()
+
+    def test_registered_in_type_registry(self):
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.config import (
+            get_registered_l2_adapter_types,
+        )
+
+        assert "valkey" in get_registered_l2_adapter_types()

--- a/tests/v1/distributed/test_valkey_l2_adapter.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 import select
 import sys
 import threading
+import time
 import types
 
 # Third Party
@@ -22,11 +23,16 @@ import torch
 # In-process fake `glide_sync`
 # ---------------------------------------------------------------------------
 #
-# The worker pool imports ``glide_sync`` lazily when it creates a client.
-# We install a fake module in ``sys.modules`` *before* the adapter is
-# imported so that lazy import resolves to our fake.  All workers share
-# the same backing dict so multi-thread behavior matches a real
-# centralized server.
+# The worker pool imports ``glide_sync`` lazily when it creates a client,
+# so the fake only has to be in ``sys.modules`` while a test is running --
+# importing the adapter module does not pull glide in.  The ``_fake_glide``
+# autouse fixture below installs it per test and removes it afterwards.
+# Installing it at import time instead would leave the fake in
+# ``sys.modules`` for the rest of the session, and
+# ``test_valkey_l2_adapter_integration.py`` (collected after this file)
+# would then "connect" to the in-process fake and pass without ever
+# touching a real server.  All workers share the same backing dict so
+# multi-thread behavior matches a real centralized server.
 
 
 class MockValkeyServer:
@@ -137,8 +143,13 @@ class _FakeGlideClusterClient(_FakeGlideClient):
         return dict(_SERVER.node_info)
 
 
-def _install_fake_glide() -> types.ModuleType:
-    """Install the fake glide_sync module in ``sys.modules``."""
+def _build_fake_glide_modules() -> dict[str, types.ModuleType]:
+    """Build the fake ``glide_sync`` / ``glide_shared`` module objects.
+
+    Returns:
+        A mapping of module name to module object, ready to be spliced
+        into ``sys.modules`` for the duration of a test.
+    """
     fake = types.ModuleType("glide_sync")
 
     def _record(name):
@@ -157,7 +168,6 @@ def _install_fake_glide() -> types.ModuleType:
     fake.GlideClusterClientConfiguration = _record("cfg_cluster")  # type: ignore[attr-defined]
     fake.GlideClient = _FakeGlideClient  # type: ignore[attr-defined]
     fake.GlideClusterClient = _FakeGlideClusterClient  # type: ignore[attr-defined]
-    sys.modules["glide_sync"] = fake
 
     # Stub the glide_shared modules that `_do_node_memory` lazily imports
     # for per-node INFO routing.
@@ -169,21 +179,16 @@ def _install_fake_glide() -> types.ModuleType:
         MEMORY = "memory"
 
     core_opts_mod.InfoSection = _InfoSection  # type: ignore[attr-defined]
-    shared_pkg = types.ModuleType("glide_shared")
-    commands_pkg = types.ModuleType("glide_shared.commands")
-    sys.modules["glide_shared"] = shared_pkg
-    sys.modules["glide_shared.commands"] = commands_pkg
-    sys.modules["glide_shared.commands.core_options"] = core_opts_mod
-    sys.modules["glide_shared.routes"] = routes_mod
-    return fake
-
-
-# Install before the adapter module is imported below.
-_install_fake_glide()
+    return {
+        "glide_sync": fake,
+        "glide_shared": types.ModuleType("glide_shared"),
+        "glide_shared.commands": types.ModuleType("glide_shared.commands"),
+        "glide_shared.commands.core_options": core_opts_mod,
+        "glide_shared.routes": routes_mod,
+    }
 
 
 # First Party
-# First Party  (imported after fake glide is installed)
 from lmcache.v1.distributed.api import (  # noqa: E402
     MemoryLayoutDesc,
     ObjectKey,
@@ -277,13 +282,14 @@ def wait_for_event_fd(fd: int, timeout: float = 5.0) -> bool:
 def _wait_for_store(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0):
     """Poll the store event fd until ``task_id`` shows up; return its result."""
     fd = adapter.get_store_event_fd()
-    deadline = timeout
     poll = select.poll()
     poll.register(fd, select.POLLIN)
-    # Drain may report extra completions; loop until task_id appears.
-    while deadline > 0:
-        events = poll.poll(deadline * 1000)
-        if not events:
+    # Drain may report extra completions; loop until task_id appears, but
+    # never past the wall-clock deadline the caller asked for.
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not poll.poll(remaining * 1000):
             break
         try:
             consume_fd(fd)
@@ -292,8 +298,6 @@ def _wait_for_store(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0
         completed = adapter.pop_completed_store_tasks()
         if task_id in completed:
             return completed[task_id]
-        # Tests submit one store task at a time, so keep polling for ours.
-        deadline -= 0.05
     raise AssertionError(f"store task {task_id} did not complete in {timeout}s")
 
 
@@ -301,9 +305,10 @@ def _wait_for_lookup(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.
     fd = adapter.get_lookup_and_lock_event_fd()
     poll = select.poll()
     poll.register(fd, select.POLLIN)
-    while timeout > 0:
-        events = poll.poll(timeout * 1000)
-        if not events:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not poll.poll(remaining * 1000):
             break
         try:
             consume_fd(fd)
@@ -312,17 +317,17 @@ def _wait_for_lookup(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.
         bm = adapter.query_lookup_and_lock_result(task_id)
         if bm is not None:
             return bm
-        timeout -= 0.05
-    raise AssertionError(f"lookup task {task_id} did not complete")
+    raise AssertionError(f"lookup task {task_id} did not complete in {timeout}s")
 
 
 def _wait_for_load(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0):
     fd = adapter.get_load_event_fd()
     poll = select.poll()
     poll.register(fd, select.POLLIN)
-    while timeout > 0:
-        events = poll.poll(timeout * 1000)
-        if not events:
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not poll.poll(remaining * 1000):
             break
         try:
             consume_fd(fd)
@@ -331,13 +336,25 @@ def _wait_for_load(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0)
         bm = adapter.query_load_result(task_id)
         if bm is not None:
             return bm
-        timeout -= 0.05
-    raise AssertionError(f"load task {task_id} did not complete")
+    raise AssertionError(f"load task {task_id} did not complete in {timeout}s")
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_glide(monkeypatch):
+    """Make the worker pool's lazy ``import glide_sync`` resolve to the fake.
+
+    Scoped to a single test: ``monkeypatch.setitem`` restores (or removes)
+    each ``sys.modules`` entry on teardown, so the fake never survives into
+    the real-server integration tests in this session.
+    """
+    for name, module in _build_fake_glide_modules().items():
+        monkeypatch.setitem(sys.modules, name, module)
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/v1/distributed/test_valkey_l2_adapter.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter.py
@@ -4,15 +4,7 @@ Unit tests for ValkeyL2Adapter.
 
 These tests exercise the L2AdapterInterface contract against an
 in-process fake of ``glide_sync`` so neither ``valkey-glide`` nor a real
-Valkey server is required.  Behavior verified:
-
-* Event fds are distinct and signaled on completion.
-* Partial-failure accounting reflects only the keys that wrote.
-* Size-mismatched GET responses are treated as cache misses.
-* ``cache_salt`` and ``key_prefix`` are both encoded into the wire key.
-* ``submit_unlock`` decrements lock refcounts and matches ``lookup``.
-* ``delete`` reports per-key sizes recorded at store time.
-* Config validation rejects bad inputs.
+Valkey server is required.
 """
 
 # Standard
@@ -37,37 +29,48 @@ import torch
 # centralized server.
 
 
-_STORE_LOCK = threading.Lock()
-_STORE: dict[bytes, bytes] = {}
-# Maps "set" / "get" / "exists" / "delete" -> Exception instance to raise
-# on the *next* call for any key, OR a callable
-# (key: bytes) -> Optional[Exception] for per-key faults.
-_FAULTS: dict[str, object] = {}
-# When set, ``set`` writes only the first ``_TRUNCATE_BYTES`` bytes of
-# the value — used to simulate stale/incompatible entries.
-_TRUNCATE_BYTES: Optional[int] = None
+class MockValkeyServer:
+    """Shared backing state for the fake glide clients — a single
+    in-process stand-in for a Valkey server.
+
+    """
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.store: dict[bytes, bytes] = {}
+        # operation ("set"/"get"/"exists"/"delete") -> an Exception to
+        # raise on the next call, or a callable
+        # (key: bytes) -> Optional[Exception] for per-key faults.
+        self.faults: dict[str, object] = {}
+        # When set, ``set`` writes only the first ``truncate_bytes`` bytes
+        # of the value — simulates a stale / incompatible entry.
+        self.truncate_bytes: Optional[int] = None
+        # Per-node INFO memory the cluster client's ``info()`` returns
+        # (node addr -> INFO bytes).
+        self.node_info: dict[str, bytes] = {}
+
+    def reset(self) -> None:
+        with self.lock:
+            self.store.clear()
+        self.faults.clear()
+        self.truncate_bytes = None
+        self.node_info.clear()
+
+    def maybe_fault(self, operation: str, key: bytes) -> None:
+        """Raise the fault configured for ``operation`` (one of
+        ``"set"`` / ``"get"`` / ``"exists"`` / ``"delete"``), if any."""
+        fault = self.faults.get(operation)
+        if fault is None:
+            return
+        if callable(fault):
+            result = fault(key)
+            if result is not None:
+                raise result
+        elif isinstance(fault, BaseException):
+            raise fault
 
 
-def _reset_fake_state() -> None:
-    """Reset the fake glide backing state between tests."""
-    global _TRUNCATE_BYTES
-    with _STORE_LOCK:
-        _STORE.clear()
-    _FAULTS.clear()
-    _TRUNCATE_BYTES = None
-
-
-def _maybe_fault(op: str, key: bytes) -> None:
-    """Raise the configured fault (if any) for ``op``."""
-    fault = _FAULTS.get(op)
-    if fault is None:
-        return
-    if callable(fault):
-        result = fault(key)
-        if result is not None:
-            raise result
-    elif isinstance(fault, BaseException):
-        raise fault
+_SERVER = MockValkeyServer()
 
 
 class _FakeGlideClient:
@@ -83,17 +86,17 @@ class _FakeGlideClient:
         return inst
 
     def set(self, key: bytes, value) -> None:
-        _maybe_fault("set", bytes(key))
+        _SERVER.maybe_fault("set", bytes(key))
         v = bytes(value)
-        if _TRUNCATE_BYTES is not None:
-            v = v[:_TRUNCATE_BYTES]
-        with _STORE_LOCK:
-            _STORE[bytes(key)] = v
+        if _SERVER.truncate_bytes is not None:
+            v = v[: _SERVER.truncate_bytes]
+        with _SERVER.lock:
+            _SERVER.store[bytes(key)] = v
 
     def get(self, key: bytes, buffer=None):
-        _maybe_fault("get", bytes(key))
-        with _STORE_LOCK:
-            v = _STORE.get(bytes(key))
+        _SERVER.maybe_fault("get", bytes(key))
+        with _SERVER.lock:
+            v = _SERVER.store.get(bytes(key))
         if v is None:
             return None
         if buffer is None:
@@ -104,19 +107,19 @@ class _FakeGlideClient:
 
     def exists(self, keys) -> int:
         for k in keys:
-            _maybe_fault("exists", bytes(k))
-        with _STORE_LOCK:
-            return sum(1 for k in keys if bytes(k) in _STORE)
+            _SERVER.maybe_fault("exists", bytes(k))
+        with _SERVER.lock:
+            return sum(1 for k in keys if bytes(k) in _SERVER.store)
 
     def delete(self, keys) -> int:
         for k in keys:
-            _maybe_fault("delete", bytes(k))
+            _SERVER.maybe_fault("delete", bytes(k))
         n = 0
-        with _STORE_LOCK:
+        with _SERVER.lock:
             for k in keys:
                 kb = bytes(k)
-                if kb in _STORE:
-                    del _STORE[kb]
+                if kb in _SERVER.store:
+                    del _SERVER.store[kb]
                     n += 1
         return n
 
@@ -124,17 +127,14 @@ class _FakeGlideClient:
         self.closed = True
 
 
-# Per-node INFO memory the fake cluster client reports (node addr -> bytes).
-_NODE_INFO: dict[str, bytes] = {}
-
-
 class _FakeGlideClusterClient(_FakeGlideClient):
     """Cluster client behaves identically against the shared fake, plus a
-    stubbed ``info()`` that returns ``_NODE_INFO`` for AllNodes routing."""
+    stubbed ``info()`` that returns ``_SERVER.node_info`` for AllNodes
+    routing."""
 
     def info(self, sections=None, route=None):
         # AllNodes route → dict of node addr -> INFO bytes.
-        return dict(_NODE_INFO)
+        return dict(_SERVER.node_info)
 
 
 def _install_fake_glide() -> types.ModuleType:
@@ -254,7 +254,7 @@ def create_memory_obj(size: int = 64, fill_value: float = 1.0) -> TensorMemoryOb
 
 def _in_store(adapter: ValkeyL2Adapter, key: ObjectKey) -> bool:
     """Whether ``key`` currently exists in the fake Valkey store."""
-    return adapter._wire_key(key).encode() in _STORE  # noqa: SLF001
+    return adapter._wire_key(key).encode() in _SERVER.store  # noqa: SLF001
 
 
 def wait_for_event_fd(fd: int, timeout: float = 5.0) -> bool:
@@ -287,13 +287,7 @@ def _wait_for_store(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0
         completed = adapter.pop_completed_store_tasks()
         if task_id in completed:
             return completed[task_id]
-        # Re-stash any other task results (shouldn't normally happen
-        # in single-batch tests).
-        for tid, r in completed.items():
-            # Best-effort: re-insert into adapter's completed dict by
-            # popping again is not possible — but tests submit one
-            # task at a time, so this branch is defensive only.
-            pass
+        # Tests submit one store task at a time, so keep polling for ours.
         deadline -= 0.05
     raise AssertionError(f"store task {task_id} did not complete in {timeout}s")
 
@@ -343,9 +337,9 @@ def _wait_for_load(adapter: ValkeyL2Adapter, task_id: int, timeout: float = 5.0)
 
 @pytest.fixture(autouse=True)
 def _reset_state():
-    _reset_fake_state()
+    _SERVER.reset()
     yield
-    _reset_fake_state()
+    _SERVER.reset()
 
 
 def _make_config(**overrides: Any) -> ValkeyL2AdapterConfig:
@@ -467,25 +461,6 @@ class TestFromDict:
         assert cfg.max_capacity_gb == 2.5
 
 
-# ===========================================================================
-# Event fd interface
-# ===========================================================================
-
-
-class TestEventFds:
-    def test_fds_are_distinct(self, adapter):
-        a = adapter.get_store_event_fd()
-        b = adapter.get_lookup_and_lock_event_fd()
-        c = adapter.get_load_event_fd()
-        assert a != b and b != c and a != c
-        assert all(fd >= 0 for fd in (a, b, c))
-
-
-# ===========================================================================
-# Store
-# ===========================================================================
-
-
 class TestStore:
     def test_single_key_round_trip(self, adapter):
         k = create_object_key(1)
@@ -502,15 +477,10 @@ class TestStore:
         assert result.bytes_transferred() == 0
 
     def test_partial_failure_accounting(self, adapter):
-        """Issue #3342 req 6: a partial batch failure must (a) report the
-        task as NOT successful — so the store controller keeps the
-        un-stored keys in L1 rather than dropping them — and (b) account
-        only the keys that actually wrote in per-salt / aggregate usage.
-
-        ``L2StoreResult`` is binary by contract (``success=False`` ⇒
-        ``bytes_transferred()==0``), so the meaningful byte accounting is
-        verified via ``get_usage()`` and the stored-listener, not via the
-        coarse task result.
+        """
+        partial batch failure must report the
+        task as NOT successful and  account
+        only the keys that actually wrote in per-salt
         """
         listener = _RecordingListener()
         adapter.register_listener(listener)
@@ -525,7 +495,7 @@ class TestStore:
                 return RuntimeError("simulated SET failure")
             return None
 
-        _FAULTS["set"] = faulty
+        _SERVER.faults["set"] = faulty
 
         task = adapter.submit_store_task(keys, objs)
         result = _wait_for_store(adapter, task)
@@ -537,7 +507,7 @@ class TestStore:
         # Real accounting: only the 2 successful keys are counted.
         usage = adapter.get_usage()
         assert usage.total_bytes_used == 2 * objs[0].get_size()
-        # ...and the failed key is not in the stored-listener notifications.
+        # verify the failed key is not in the stored-listener notifications.
         stored_flat = {k for batch in listener.stored for k in batch}
         assert keys[0] in stored_flat
         assert keys[2] in stored_flat
@@ -556,11 +526,6 @@ class TestStore:
         _wait_for_store(adapter, task)
         # ``_notify_keys_stored`` should have fired with these keys.
         assert any(set(batch) == set(keys) for batch in listener.stored)
-
-
-# ===========================================================================
-# Lookup + lock
-# ===========================================================================
 
 
 class TestLookupAndLock:
@@ -597,11 +562,6 @@ class TestLookupAndLock:
         assert bm is not None
 
 
-# ===========================================================================
-# Load
-# ===========================================================================
-
-
 class TestLoad:
     def test_load_after_store_returns_hit(self, adapter):
         k = create_object_key(1)
@@ -622,15 +582,14 @@ class TestLoad:
         assert not bm.test(0)
 
     def test_size_mismatch_treated_as_miss(self, adapter):
-        """Issue #3342 req 5: stale/wrong-size GET = cache miss."""
-        global _TRUNCATE_BYTES
+        """A stale/wrong-size GET must be reported as a cache miss."""
         k = create_object_key(1)
         obj = create_memory_obj(size=16)  # 64 bytes (16 * float32)
 
         # Simulate a stale entry of the wrong length on the server.
-        _TRUNCATE_BYTES = 8  # store only 8 bytes
+        _SERVER.truncate_bytes = 8  # store only 8 bytes
         _wait_for_store(adapter, adapter.submit_store_task([k], [obj]))
-        _TRUNCATE_BYTES = None
+        _SERVER.truncate_bytes = None
 
         dst = create_memory_obj(size=16)
         bm = _wait_for_load(adapter, adapter.submit_load_task([k], [dst]))
@@ -639,11 +598,6 @@ class TestLoad:
     def test_length_mismatch_raises(self, adapter):
         with pytest.raises(ValueError, match="length mismatch"):
             adapter.submit_load_task([create_object_key(0)], [])
-
-
-# ===========================================================================
-# Delete + accounting
-# ===========================================================================
 
 
 class TestDelete:
@@ -702,11 +656,6 @@ class TestDelete:
         assert not _in_store(adapter, key)
 
 
-# ===========================================================================
-# Key prefix + cache_salt isolation
-# ===========================================================================
-
-
 class TestKeyNamespacing:
     def test_different_prefixes_do_not_collide(self):
         a1 = ValkeyL2Adapter(_make_config(key_prefix="dep-A"))
@@ -731,167 +680,3 @@ class TestKeyNamespacing:
         _wait_for_store(adapter, adapter.submit_store_task([k_a], [obj]))
         bm = _wait_for_lookup(adapter, adapter.submit_lookup_and_lock_task([k_b]))
         assert not bm.test(0)
-
-
-# ===========================================================================
-# Status + close
-# ===========================================================================
-
-
-class TestStatusAndClose:
-    def test_report_status_minimum_keys(self, adapter):
-        st = adapter.report_status()
-        assert st["is_healthy"] is True
-        assert st["type"] == "valkey"
-        assert "num_workers" in st
-        # Usage is exposed.
-        assert "current_size_bytes" in st
-        assert "max_capacity_bytes" in st
-        assert "usage_fraction" in st
-        # Sensitive fields must not leak.
-        assert "password" not in st
-        assert "username" not in st
-
-    def test_report_status_tracks_stored_bytes(self, adapter):
-        keys = [create_object_key(i) for i in range(3)]
-        objs = [create_memory_obj(size=16) for _ in keys]
-        _wait_for_store(adapter, adapter.submit_store_task(keys, objs))
-        st = adapter.report_status()
-        assert st["current_size_bytes"] == 3 * objs[0].get_size()
-
-    def test_close_is_idempotent(self):
-        a = ValkeyL2Adapter(_make_config())
-        a.close()
-        a.close()  # must not raise
-        assert a.report_status()["is_healthy"] is False
-
-
-# ===========================================================================
-# Buffer GET capability detection
-# ===========================================================================
-
-
-class TestBufferGetCapability:
-    def test_buffer_get_detected(self, adapter):
-        # Our fake's get() signature has `buffer=`, so it must be True.
-        assert adapter.report_status()["has_buffer_get"] is True
-
-    def test_fallback_when_no_buffer_param(self):
-        """Adapter must fall back gracefully if glide lacks buffer=."""
-
-        # Build a fake client class whose `get` has no `buffer` param.
-        class _NoBufferGet(_FakeGlideClient):
-            def get(self, key):  # type: ignore[override]
-                return _FakeGlideClient.get(self, key, buffer=None)
-
-        fake_mod = sys.modules["glide_sync"]
-        original = fake_mod.GlideClient
-        fake_mod.GlideClient = _NoBufferGet  # type: ignore[attr-defined]
-        try:
-            adapter = ValkeyL2Adapter(_make_config())
-            try:
-                assert adapter.report_status()["has_buffer_get"] is False
-                k = create_object_key(1)
-                src = create_memory_obj(size=4, fill_value=0.5)
-                _wait_for_store(adapter, adapter.submit_store_task([k], [src]))
-                dst = create_memory_obj(size=4, fill_value=0.0)
-                bm = _wait_for_load(adapter, adapter.submit_load_task([k], [dst]))
-                assert bm.test(0)
-                assert torch.allclose(dst.tensor, src.tensor)
-            finally:
-                adapter.close()
-        finally:
-            fake_mod.GlideClient = original  # type: ignore[attr-defined]
-
-
-# ===========================================================================
-# Missing dependency
-# ===========================================================================
-
-
-class TestMissingGlide:
-    def test_missing_glide_raises_actionable_error(self, monkeypatch):
-        # Hide the fake module so the lazy import fails.
-        monkeypatch.setitem(sys.modules, "glide_sync", None)
-        with pytest.raises(RuntimeError, match="valkey-glide"):
-            ValkeyL2Adapter(_make_config())
-
-
-# ===========================================================================
-# get_usage
-# ===========================================================================
-
-
-class TestGetUsage:
-    def test_disabled_returns_minus_one(self):
-        a = ValkeyL2Adapter(_make_config(max_capacity_gb=0))
-        try:
-            usage = a.get_usage()
-            assert usage.usage_fraction == -1.0
-            assert usage.total_bytes_used == 0
-            assert usage.total_capacity_bytes == 0
-        finally:
-            a.close()
-
-    def test_grows_on_store_and_shrinks_on_delete(self):
-        a = ValkeyL2Adapter(_make_config(max_capacity_gb=0.001))  # 1 MB
-        try:
-            keys = [create_object_key(i) for i in range(4)]
-            objs = [create_memory_obj(size=16) for _ in range(4)]  # 64 bytes each
-            _wait_for_store(a, a.submit_store_task(keys, objs))
-
-            total = 4 * objs[0].get_size()
-            capacity = int(0.001 * 1024**3)
-            usage = a.get_usage()
-            assert usage.total_bytes_used == total
-            assert usage.total_capacity_bytes == capacity
-            assert usage.usage_fraction == pytest.approx(total / capacity)
-
-            a.delete(keys)
-            assert a.get_usage().total_bytes_used == 0
-        finally:
-            a.close()
-
-    def test_per_cache_salt_accounting(self):
-        a = ValkeyL2Adapter(_make_config(max_capacity_gb=0.001))
-        try:
-            k_a = create_object_key(1, cache_salt="user-A")
-            k_b = create_object_key(2, cache_salt="user-B")
-            obj = create_memory_obj(size=16)
-            _wait_for_store(
-                a, a.submit_store_task([k_a, k_b], [obj, create_memory_obj(16)])
-            )
-            by_salt = a.get_usage().bytes_by_cache_salt
-            assert by_salt["user-A"] == obj.get_size()
-            assert by_salt["user-B"] == obj.get_size()
-        finally:
-            a.close()
-
-
-# ===========================================================================
-# Factory registration
-# ===========================================================================
-
-
-class TestFactoryRegistration:
-    def test_create_via_factory(self):
-        # First Party
-        from lmcache.v1.distributed.l2_adapters import create_l2_adapter
-
-        cfg = ValkeyL2AdapterConfig.from_dict(
-            {"type": "valkey", "startup_nodes": "localhost:6379", "num_workers": 1}
-        )
-        adapter = create_l2_adapter(cfg)
-        try:
-            assert isinstance(adapter, ValkeyL2Adapter)
-            assert adapter.report_status()["type"] == "valkey"
-        finally:
-            adapter.close()
-
-    def test_registered_in_type_registry(self):
-        # First Party
-        from lmcache.v1.distributed.l2_adapters.config import (
-            get_registered_l2_adapter_types,
-        )
-
-        assert "valkey" in get_registered_l2_adapter_types()

--- a/tests/v1/distributed/test_valkey_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter_integration.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Integration test for the Valkey L2 adapter in MP mode.
+
+Talks to a **real** Valkey (or Redis) deployment via the ``glide_sync``
+client (from the ``valkey-glide-sync`` package). Skipped unless that
+package is importable and a server is reachable at the configured target.
+
+Scope: this suite intentionally covers **only what a real server can
+verify and the mock cannot** — real glide wire serialization (byte-exact
+round-trips), real cluster slot routing across nodes, and real per-node
+``INFO memory``. Pure adapter logic (bitmap assembly, lock refcounting,
+``cache_salt`` wire keys, byte accounting, partial-failure handling,
+size-mismatch-as-miss, config validation) is exhaustively covered by the
+mock-based unit tests in ``test_valkey_l2_adapter.py`` and is **not**
+duplicated here.
+
+Target selection via pytest CLI options (see ``conftest.py``):
+
+  * ``--valkey-cluster`` + ``--valkey-nodes=h:p,h:p`` — **cluster** mode.
+  * ``--valkey-host`` / ``--valkey-port`` — **standalone** mode
+    (defaults ``localhost:6379``).
+
+Examples::
+
+    pytest <thisfile> --valkey-host=localhost --valkey-port=6390 -v
+    pytest <thisfile> --valkey-cluster \\
+        --valkey-nodes=127.0.0.1:7000,127.0.0.1:7001 -v
+"""
+
+# Standard
+import select
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd
+
+
+def create_object_key(
+    chunk_id: int,
+    model_name: str = "test_model",
+    cache_salt: str = "",
+) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name=model_name,
+        kv_rank=0,
+        cache_salt=cache_salt,
+    )
+
+
+def create_memory_obj(size: int = 256, fill_value: float = 1.0) -> TensorMemoryObj:
+    raw_data = torch.empty(size, dtype=torch.float32)
+    raw_data.fill_(fill_value)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=size * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+def wait_for_event_fd(event_fd: int, timeout: float = 10.0) -> bool:
+    poll = select.poll()
+    poll.register(event_fd, select.POLLIN)
+    events = poll.poll(timeout * 1000)
+    if events:
+        try:
+            consume_fd(event_fd)
+        except BlockingIOError:
+            pass
+        return True
+    return False
+
+
+def _build_config(cluster_mode: bool, startup_nodes: str, **extra):
+    """Build a ValkeyL2AdapterConfig for the resolved target."""
+    # First Party
+    from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (
+        ValkeyL2AdapterConfig,
+    )
+
+    spec = {
+        "type": "valkey",
+        "startup_nodes": startup_nodes,
+        "cluster_mode": cluster_mode,
+    }
+    spec.update(extra)
+    return ValkeyL2AdapterConfig.from_dict(spec)
+
+
+def _probe_reachable(cluster_mode: bool, startup_nodes: str) -> bool:
+    """Whether a real Valkey responds at the target.
+
+    Builds a throwaway adapter and runs a tiny lookup; any exception
+    (no glide_sync, connection refused, auth error) means "not
+    reachable".
+    """
+    try:
+        # Third Party
+        import glide_sync  # noqa: F401
+    except ImportError:
+        return False
+    # First Party
+    from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (
+        ValkeyL2Adapter,
+    )
+
+    try:
+        adapter = ValkeyL2Adapter(
+            _build_config(
+                cluster_mode,
+                startup_nodes,
+                num_workers=1,
+                connection_timeout=3.0,
+                request_timeout=3.0,
+            )
+        )
+    except Exception:
+        return False
+    try:
+        tid = adapter.submit_lookup_and_lock_task([create_object_key(0)])
+        wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout=3.0)
+        adapter.query_lookup_and_lock_result(tid)
+        return True
+    except Exception:
+        return False
+    finally:
+        adapter.close()
+
+
+@pytest.fixture(scope="session")
+def valkey_target(request) -> tuple[bool, str]:
+    """Resolve ``(cluster_mode, startup_nodes)`` from CLI options."""
+    if request.config.getoption("--valkey-cluster"):
+        return True, request.config.getoption("--valkey-nodes")
+    host = request.config.getoption("--valkey-host")
+    port = request.config.getoption("--valkey-port")
+    return False, f"{host}:{port}"
+
+
+@pytest.fixture(scope="session")
+def valkey_reachable(valkey_target) -> bool:
+    """Probe the target once per session."""
+    return _probe_reachable(*valkey_target)
+
+
+# ---------------------------------------------------------------------------
+# Tests — real-server-only behaviors
+# ---------------------------------------------------------------------------
+
+
+class TestValkeyL2AdapterIntegration:
+    """E2E tests that exercise the real glide↔Valkey wire path.
+
+    Logic-level behavior is covered by the mock unit tests; here we only
+    assert the things that require a live server.
+    """
+
+    @pytest.fixture
+    def adapter(self, valkey_target, valkey_reachable):
+        if not valkey_reachable:
+            cluster_mode, nodes = valkey_target
+            pytest.skip(
+                f"Valkey not reachable (cluster={cluster_mode}, nodes={nodes}) "
+                "or valkey-glide-sync not installed"
+            )
+        # First Party
+        from lmcache.v1.distributed.l2_adapters import create_l2_adapter
+
+        cluster_mode, startup_nodes = valkey_target
+        # A unique key_prefix isolates this run's keys in a (possibly
+        # shared) Valkey and lets the fixture clean up only its own keys.
+        adapter = create_l2_adapter(
+            _build_config(
+                cluster_mode,
+                startup_nodes,
+                num_workers=4,
+                key_prefix="itest",
+                max_capacity_gb=1.0,
+            )
+        )
+        self._stored: list[ObjectKey] = []
+        yield adapter
+        if self._stored:
+            adapter.delete(self._stored)
+        adapter.close()
+
+    def _store(self, adapter, keys, objs):
+        self._stored.extend(keys)
+        tid = adapter.submit_store_task(keys, objs)
+        assert wait_for_event_fd(adapter.get_store_event_fd())
+        return adapter.pop_completed_store_tasks()[tid]
+
+    def _lookup(self, adapter, keys):
+        tid = adapter.submit_lookup_and_lock_task(keys)
+        assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+        return adapter.query_lookup_and_lock_result(tid)
+
+    def _load(self, adapter, keys, objs):
+        tid = adapter.submit_load_task(keys, objs)
+        assert wait_for_event_fd(adapter.get_load_event_fd())
+        return adapter.query_load_result(tid)
+
+    def test_roundtrip_is_byte_exact(self, adapter):
+        """Real glide SET → GET must round-trip the payload bit-for-bit.
+
+        This is the core thing the mock cannot prove: that the bytes
+        actually survive real wire serialization and buffer GET.
+        """
+        key = create_object_key(1)
+        src = create_memory_obj(size=512, fill_value=3.14159)
+        dst = create_memory_obj(size=512, fill_value=0.0)
+
+        assert self._store(adapter, [key], [src]).is_successful()
+
+        assert self._lookup(adapter, [key]).test(0) is True
+        adapter.submit_unlock([key])
+
+        assert self._load(adapter, [key], [dst]).test(0) is True
+        assert torch.equal(dst.tensor, src.tensor)
+
+    def test_batch_roundtrip_spreads_across_nodes(self, adapter):
+        """Many keys round-trip with byte-exact data.
+
+        In cluster mode these keys hash to different slots / nodes, so
+        this exercises real cross-node routing and concurrent connections
+        — neither of which the single-process mock can represent.
+        """
+        n = 32
+        keys = [create_object_key(i) for i in range(n)]
+        src = [create_memory_obj(size=128, fill_value=float(i + 1)) for i in range(n)]
+        dst = [create_memory_obj(size=128, fill_value=0.0) for _ in range(n)]
+
+        assert self._store(adapter, keys, src).is_successful()
+
+        bm = self._lookup(adapter, keys)
+        assert all(bm.test(i) for i in range(n))
+        adapter.submit_unlock(keys)
+
+        bm = self._load(adapter, keys, dst)
+        for i in range(n):
+            assert bm.test(i) is True
+            assert torch.equal(dst[i].tensor, src[i].tensor), f"mismatch at {i}"
+
+    def test_delete_actually_removes_on_server(self, adapter):
+        """A real DEL makes the key disappear from the live server."""
+        key = create_object_key(1)
+        self._store(adapter, [key], [create_memory_obj()])
+        assert self._lookup(adapter, [key]).test(0) is True
+        adapter.submit_unlock([key])
+
+        adapter.delete([key])
+        assert self._lookup(adapter, [key]).test(0) is False
+
+    def test_cluster_reports_real_per_node_memory(self, adapter, valkey_target):
+        """``report_status`` runs real ``INFO memory`` routed to all nodes.
+
+        Entirely real-server-only: the mock has no notion of nodes.
+        Skipped in standalone mode (per-node memory is cluster-only).
+        """
+        cluster_mode, _ = valkey_target
+        if not cluster_mode:
+            pytest.skip("per-node memory is cluster-only")
+        # Store something so at least one node has non-zero usage.
+        keys = [create_object_key(i) for i in range(8)]
+        self._store(adapter, keys, [create_memory_obj(size=256) for _ in keys])
+
+        node_mem = adapter.report_status().get("node_memory", {})
+        assert node_mem, "cluster report_status must include node_memory"
+        for addr, mem in node_mem.items():
+            assert "used_memory" in mem and isinstance(mem["used_memory"], int)
+            assert "maxmemory" in mem and isinstance(mem["maxmemory"], int)

--- a/tests/v1/distributed/test_valkey_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter_integration.py
@@ -100,11 +100,18 @@ def _probe_reachable(cluster_mode: bool, startup_nodes: str) -> bool:
     Builds a throwaway adapter and runs a tiny lookup; any exception
     (no glide_sync, connection refused, auth error) means "not
     reachable".
+
+    A ``glide_sync`` without an import spec is a hand-built stand-in (the
+    unit tests install one), not the installed package. Treat it as
+    unreachable so these tests skip rather than passing vacuously against
+    an in-process fake.
     """
     try:
         # Third Party
-        import glide_sync  # noqa: F401
+        import glide_sync
     except ImportError:
+        return False
+    if getattr(glide_sync, "__spec__", None) is None:
         return False
     # First Party
     from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (

--- a/tests/v1/distributed/test_valkey_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter_integration.py
@@ -6,15 +6,6 @@ Talks to a **real** Valkey (or Redis) deployment via the ``glide_sync``
 client (from the ``valkey-glide-sync`` package). Skipped unless that
 package is importable and a server is reachable at the configured target.
 
-Scope: this suite intentionally covers **only what a real server can
-verify and the mock cannot** — real glide wire serialization (byte-exact
-round-trips), real cluster slot routing across nodes, and real per-node
-``INFO memory``. Pure adapter logic (bitmap assembly, lock refcounting,
-``cache_salt`` wire keys, byte accounting, partial-failure handling,
-size-mismatch-as-miss, config validation) is exhaustively covered by the
-mock-based unit tests in ``test_valkey_l2_adapter.py`` and is **not**
-duplicated here.
-
 Target selection via pytest CLI options (see ``conftest.py``):
 
   * ``--valkey-cluster`` + ``--valkey-nodes=h:p,h:p`` — **cluster** mode.
@@ -157,17 +148,8 @@ def valkey_reachable(valkey_target) -> bool:
     return _probe_reachable(*valkey_target)
 
 
-# ---------------------------------------------------------------------------
-# Tests — real-server-only behaviors
-# ---------------------------------------------------------------------------
-
-
 class TestValkeyL2AdapterIntegration:
-    """E2E tests that exercise the real glide↔Valkey wire path.
-
-    Logic-level behavior is covered by the mock unit tests; here we only
-    assert the things that require a live server.
-    """
+    """E2E tests that exercise the real glide↔Valkey wire path."""
 
     @pytest.fixture
     def adapter(self, valkey_target, valkey_reachable):

--- a/tests/v1/distributed/test_valkey_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter_integration.py
@@ -20,6 +20,7 @@ Examples::
 """
 
 # Standard
+from typing import Any
 import select
 
 # Third Party
@@ -28,6 +29,10 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (
+    ValkeyL2Adapter,
+    ValkeyL2AdapterConfig,
+)
 from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObjMetadata,
@@ -78,13 +83,10 @@ def wait_for_event_fd(event_fd: int, timeout: float = 10.0) -> bool:
     return False
 
 
-def _build_config(cluster_mode: bool, startup_nodes: str, **extra):
+def _build_config(
+    cluster_mode: bool, startup_nodes: str, **extra: Any
+) -> ValkeyL2AdapterConfig:
     """Build a ValkeyL2AdapterConfig for the resolved target."""
-    # First Party
-    from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (
-        ValkeyL2AdapterConfig,
-    )
-
     spec = {
         "type": "valkey",
         "startup_nodes": startup_nodes,
@@ -113,10 +115,6 @@ def _probe_reachable(cluster_mode: bool, startup_nodes: str) -> bool:
         return False
     if getattr(glide_sync, "__spec__", None) is None:
         return False
-    # First Party
-    from lmcache.v1.distributed.l2_adapters.valkey_l2_adapter import (
-        ValkeyL2Adapter,
-    )
 
     try:
         adapter = ValkeyL2Adapter(

--- a/tests/v1/distributed/test_valkey_l2_adapter_integration.py
+++ b/tests/v1/distributed/test_valkey_l2_adapter_integration.py
@@ -27,13 +27,15 @@ import pytest
 import torch
 
 # First Party
-from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObjMetadata,
     TensorMemoryObj,
 )
 from lmcache.v1.platform import consume_fd
+
+_EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
 
 
 def create_object_key(
@@ -122,7 +124,7 @@ def _probe_reachable(cluster_mode: bool, startup_nodes: str) -> bool:
     except Exception:
         return False
     try:
-        tid = adapter.submit_lookup_and_lock_task([create_object_key(0)])
+        tid = adapter.submit_lookup_and_lock_task([create_object_key(0)], _EMPTY_LAYOUT)
         wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout=3.0)
         adapter.query_lookup_and_lock_result(tid)
         return True
@@ -187,7 +189,7 @@ class TestValkeyL2AdapterIntegration:
         return adapter.pop_completed_store_tasks()[tid]
 
     def _lookup(self, adapter, keys):
-        tid = adapter.submit_lookup_and_lock_task(keys)
+        tid = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
         assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
         return adapter.query_lookup_and_lock_result(tid)
 

--- a/tests/v1/storage_backend/test_valkey_connector.py
+++ b/tests/v1/storage_backend/test_valkey_connector.py
@@ -28,6 +28,7 @@ from lmcache.v1.memory_management import PinMemoryAllocator
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.connector import CreateConnector
+from lmcache.v1.storage_backend.valkey.worker_pool import GET_MISS, ValkeyWorkerPool
 
 # Local
 from ...conftest import MockSyncGlideClient
@@ -1199,3 +1200,72 @@ def test_valkey_save_chunk_meta_string_coercion(
             )
     finally:
         close_asyncio_loop(async_loop, async_thread)
+
+
+class _FakeGlideClient:
+    """Minimal glide-client stand-in for ``ValkeyWorkerPool._do_get_into``.
+
+    ``payload`` of ``None`` models an absent key. The buffer-GET path writes
+    what fits into the caller-provided buffer and returns the byte count,
+    mirroring glide's native buffer protocol.
+    """
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def get(self, key, buffer=None):
+        if self._payload is None:
+            return None
+        if buffer is not None:
+            n = min(len(self._payload), len(buffer))
+            buffer[:n] = self._payload[:n]
+            return n
+        return self._payload
+
+
+def _fake_pool(payload, has_buffer_get):
+    """Build a ``SimpleNamespace`` usable as ``self`` for the unbound
+    ``ValkeyWorkerPool._do_get_into`` (no real client / server needed)."""
+    # Standard
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        _get_client=lambda: _FakeGlideClient(payload),
+        has_buffer_get=has_buffer_get,
+        _get_scratch=lambda size: bytearray(size),
+    )
+
+
+@pytest.mark.parametrize("has_buffer_get", [True, False])
+def test_worker_pool_get_into_exact_read_is_hit(has_buffer_get):
+    """An exact-size read returns the byte count and fills the buffer."""
+    expected = 8
+    buf = memoryview(bytearray(expected))
+    pool = _fake_pool(b"\xbb" * expected, has_buffer_get=has_buffer_get)
+    assert ValkeyWorkerPool._do_get_into(pool, "k", buf) == expected
+    assert bytes(buf) == b"\xbb" * expected
+
+
+@pytest.mark.parametrize("has_buffer_get", [True, False])
+def test_worker_pool_get_into_absent_is_miss(has_buffer_get):
+    """An absent key returns GET_MISS."""
+    buf = memoryview(bytearray(8))
+    pool = _fake_pool(None, has_buffer_get=has_buffer_get)
+    assert ValkeyWorkerPool._do_get_into(pool, "k", buf) == GET_MISS
+
+
+@pytest.mark.parametrize("has_buffer_get", [True, False])
+def test_worker_pool_get_into_short_read_is_miss(has_buffer_get):
+    """A short read (fewer bytes than the buffer) is rejected as a miss so
+    stale tail bytes are never surfaced to the caller."""
+    buf = memoryview(bytearray(8))
+    pool = _fake_pool(b"\xaa" * 4, has_buffer_get=has_buffer_get)
+    assert ValkeyWorkerPool._do_get_into(pool, "k", buf) == GET_MISS
+
+
+def test_worker_pool_get_into_oversized_read_is_miss():
+    """An oversized read (more bytes than the buffer) is rejected as a miss
+    (non-buffer path; the buffer path is bounded by the buffer length)."""
+    buf = memoryview(bytearray(8))
+    pool = _fake_pool(b"\xcc" * 12, has_buffer_get=False)
+    assert ValkeyWorkerPool._do_get_into(pool, "k", buf) == GET_MISS

--- a/tests/v1/storage_backend/test_valkey_connector.py
+++ b/tests/v1/storage_backend/test_valkey_connector.py
@@ -29,13 +29,6 @@ from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.connector import CreateConnector
 
-# Captured at import time (before the autouse mock_thread_worker_pool fixture
-# patches valkey_connector._ThreadWorkerPool) so tests can exercise the real
-# worker-pool methods directly.
-from lmcache.v1.storage_backend.connector.valkey_connector import (  # noqa: E402
-    _ThreadWorkerPool as _RealThreadWorkerPool,
-)
-
 # Local
 from ...conftest import MockSyncGlideClient
 from ..utils import (
@@ -47,7 +40,7 @@ from ..utils import (
 
 
 class MockThreadWorkerPool:
-    """In-memory mock of _ThreadWorkerPool that uses MockSyncGlideClient.
+    """In-memory mock of ValkeyWorkerPool that uses MockSyncGlideClient.
 
     Runs all operations in-process so tests don't need glide_sync or a
     real Valkey server.  Captures constructor kwargs so tests can verify
@@ -56,12 +49,6 @@ class MockThreadWorkerPool:
 
     # Class-level record of the last __init__ kwargs for config assertions.
     last_init_kwargs: dict = {}
-
-    #: When True, ``_do_get_into`` mirrors the real buffer-GET branch: it stages
-    #: into a scratch buffer and relies on the client returning an int byte
-    #: count (``n = int(result)``), exercising the same control flow as the real
-    #: ``_ThreadWorkerPool``. Default False uses the simpler legacy GET branch.
-    simulate_buffer_get: bool = False
 
     def __init__(self, *args, **kwargs):
         MockThreadWorkerPool.last_init_kwargs = {
@@ -82,33 +69,27 @@ class MockThreadWorkerPool:
         expiry = ("EX", self._ttl_seconds) if self._ttl_seconds is not None else None
         self._client.set(key_str.encode(), bytes(data), expiry=expiry)
 
-    def _do_get_into(self, key_str: str, buf: memoryview) -> bool:
+    def _do_get_into(self, key_str: str, buf: memoryview) -> int:
         """GET a key into a buffer.
 
-        Mirrors the real ``_ThreadWorkerPool._do_get_into``: when
-        ``simulate_buffer_get`` is set, take the buffer-GET branch (stage into
-        a scratch buffer, rely on an int byte count); otherwise use the legacy
-        GET branch that returns the full bytes.
+        Mirrors ``ValkeyWorkerPool._do_get_into``: returns the number of
+        payload bytes for the key, or ``-1`` (GET_MISS) when absent.
         """
-        flat = buf.cast("B") if buf.format != "B" else buf
-        if type(self).simulate_buffer_get:
-            size = flat.nbytes
-            scratch = memoryview(bytearray(size))
-            result = self._client.get(key_str.encode(), buffer=scratch)
-            if result is None:
-                return False
-            n = int(result)
-            flat[:n] = scratch[:n]
-            return True
         data = self._client.get(key_str.encode())
         if data is None:
-            return False
-        flat[: len(data)] = data
-        return True
+            return -1
+        flat = buf.cast("B") if buf.format != "B" else buf
+        n = len(data)
+        flat[: min(n, len(flat))] = data[: min(n, len(flat))]
+        return n
 
     def _do_exists(self, key_str: str) -> bool:
         """Check if a key exists."""
         return bool(self._client.exists([key_str.encode()]))
+
+    def _do_delete(self, key_str: str) -> bool:
+        """Delete a key; return True iff a value was removed."""
+        return int(self._client.delete([key_str.encode()])) > 0
 
     def submit_set(self, key_str: str, data: bytes) -> Future:
         """Submit a SET operation."""
@@ -121,6 +102,15 @@ class MockThreadWorkerPool:
     def submit_exists(self, key_str: str) -> Future:
         """Submit an EXISTS check."""
         return self._executor.submit(self._do_exists, key_str)
+
+    def submit_delete(self, key_str: str) -> Future:
+        """Submit a DELETE operation."""
+        return self._executor.submit(self._do_delete, key_str)
+
+    @property
+    def has_buffer_get(self) -> bool:
+        """Mock always exposes buffer GET."""
+        return True
 
     def close(self) -> None:
         """Shut down the thread pool."""
@@ -176,13 +166,12 @@ def _create_test_memory_obj(local_backend, seed=42):
 
 @pytest.fixture(autouse=True)
 def mock_thread_worker_pool():
-    """Replace _ThreadWorkerPool with in-memory mock so tests never need
+    """Replace ValkeyWorkerPool with in-memory mock so tests never need
     glide_sync or a real Valkey server."""
     MockSyncGlideClient.reset_store()
     MockThreadWorkerPool.last_init_kwargs = {}
-    MockThreadWorkerPool.simulate_buffer_get = False
     with patch(
-        "lmcache.v1.storage_backend.connector.valkey_connector._ThreadWorkerPool",
+        "lmcache.v1.storage_backend.connector.valkey_connector.ValkeyWorkerPool",
         MockThreadWorkerPool,
     ):
         yield
@@ -774,10 +763,10 @@ def test_valkey_standalone_mode_config(local_backend, autorelease_v1):
         )
 
         init_info = MockThreadWorkerPool.last_init_kwargs
-        # Positional args: host, port, num_workers, username, password
-        assert init_info["args"][0] == "standalone.local"
-        assert init_info["args"][1] == 6379
-        assert init_info["args"][2] == 2
+        # ValkeyWorkerPool is constructed with keyword args:
+        # addresses=[(host, port)], num_workers=..., etc.
+        assert init_info["kwargs"]["addresses"] == [("standalone.local", 6379)]
+        assert init_info["kwargs"]["num_workers"] == 2
         assert init_info["kwargs"].get("cluster_mode") is False
         assert init_info["kwargs"].get("database_id") == 3
 
@@ -808,8 +797,7 @@ def test_valkey_cluster_mode_config(local_backend, autorelease_v1):
         )
 
         init_info = MockThreadWorkerPool.last_init_kwargs
-        assert init_info["args"][0] == "cluster.local"
-        assert init_info["args"][1] == 7000
+        assert init_info["kwargs"]["addresses"] == [("cluster.local", 7000)]
         assert init_info["kwargs"].get("cluster_mode") is True
         # database_id should be None (ignored in cluster mode)
         assert init_info["kwargs"].get("database_id") is None
@@ -1209,97 +1197,5 @@ def test_valkey_save_chunk_meta_string_coercion(
                     config,
                 )
             )
-    finally:
-        close_asyncio_loop(async_loop, async_thread)
-
-
-def test_valkey_do_get_into_rejects_short_read():
-    """_do_get_into must not silently accept a short read: fixed-size chunks
-    require an exact round-trip, so a partial fill is treated as a miss
-    (returns False) instead of leaving stale tail bytes in the buffer."""
-    # Standard
-    from types import SimpleNamespace
-
-    class _FakeClient:
-        def __init__(self, payload: bytes):
-            self._payload = payload
-
-        def get(self, key, buffer=None):
-            if buffer is not None:
-                n = len(self._payload)
-                buffer[:n] = self._payload
-                return n
-            return self._payload
-
-    def _make_self(payload, has_buffer_get):
-        return SimpleNamespace(
-            _get_client=lambda: _FakeClient(payload),
-            _has_buffer_get=has_buffer_get,
-            _get_scratch=lambda size: bytearray(size),
-        )
-
-    expected = 8
-
-    # Short read (buffer-get path) → treated as miss
-    buf = memoryview(bytearray(expected))
-    fake = _make_self(b"\xaa" * 4, has_buffer_get=True)
-    assert _RealThreadWorkerPool._do_get_into(fake, "k", buf) is False
-
-    # Short read (non-buffer path) → treated as miss
-    buf = memoryview(bytearray(expected))
-    fake = _make_self(b"\xaa" * 4, has_buffer_get=False)
-    assert _RealThreadWorkerPool._do_get_into(fake, "k", buf) is False
-
-    # Exact read (buffer-get path) → hit, buffer fully populated
-    buf = memoryview(bytearray(expected))
-    fake = _make_self(b"\xbb" * expected, has_buffer_get=True)
-    assert _RealThreadWorkerPool._do_get_into(fake, "k", buf) is True
-    assert bytes(buf) == b"\xbb" * expected
-
-    # Exact read (non-buffer path) → hit, buffer fully populated
-    buf = memoryview(bytearray(expected))
-    fake = _make_self(b"\xcc" * expected, has_buffer_get=False)
-    assert _RealThreadWorkerPool._do_get_into(fake, "k", buf) is True
-    assert bytes(buf) == b"\xcc" * expected
-
-
-@pytest.mark.parametrize("simulate_buffer_get", [False, True])
-def test_valkey_get_round_trip_both_get_modes(
-    valkey_url, local_backend, valkey_config, autorelease_v1, simulate_buffer_get
-):
-    """get/batched_get must round-trip correctly on both worker-pool GET paths:
-    the legacy GET (returns full bytes) and the buffer-GET branch (returns an
-    int byte count). This closes the gap where the mock only exercised the
-    non-buffer branch, leaving the connector's buffer-GET handling untested."""
-    MockThreadWorkerPool.simulate_buffer_get = simulate_buffer_get
-    async_loop, async_thread = init_asyncio_loop()
-
-    try:
-        connector = autorelease_v1(
-            CreateConnector(valkey_url, async_loop, local_backend, valkey_config)
-        )
-
-        # Single get round-trip
-        key = dumb_cache_engine_key()
-        mem = _create_test_memory_obj(local_backend, seed=7)
-        asyncio.run_coroutine_threadsafe(connector.put(key, mem), async_loop).result()
-        retrieved = asyncio.run_coroutine_threadsafe(
-            connector.get(key), async_loop
-        ).result()
-        assert retrieved is not None
-        check_mem_obj_equal([retrieved], [mem])
-
-        # Batched get round-trip
-        keys = [dumb_cache_engine_key(i) for i in range(3)]
-        mems = [_create_test_memory_obj(local_backend, seed=100 + i) for i in range(3)]
-        asyncio.run_coroutine_threadsafe(
-            connector.batched_put(keys, mems), async_loop
-        ).result()
-        retrieved_batch = asyncio.run_coroutine_threadsafe(
-            connector.batched_get(keys), async_loop
-        ).result()
-        assert all(r is not None for r in retrieved_batch)
-        check_mem_obj_equal(retrieved_batch, mems)
-
     finally:
         close_asyncio_loop(async_loop, async_thread)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add valkey L2 adapter for issue https://github.com/LMCache/LMCache/issues/3342

**Special notes for your reviewers**:
 
  Follows the convention in current valkey connector and s3 adapter

  1. Build based on glide — use the official valkey-glide client so LMCache carries no protocol/cluster
  code of its own to maintain.
  2. Sync, not async — async glide forces a bytes copy through its Protobuf IPC; only the sync client
  (CFFI) keeps SET/GET zero-copy for multi-MB KV chunks. This dictates the thread-pool concurrency
  model.
  3. Extract a shared ValkeyWorkerPool, originally used in ValkeyConnector, now used in the adapter as
  well (mirrors the DAX core pattern).
  4. Within the adapter, each batch fans out one future per key, and the last to finish publishes the
  result and signals the event fd (_BatchState) — giving non-blocking submit, per-key concurrency, and
  accurate partial-failure accounting.
  5. Glide owns the cluster — slot routing / MOVED-ASK / topology / resharding are glide's
  responsibility; the adapter only adds what glide lacks: key_prefix, size-on-load validation (stale →
  miss), and delete-skips-locked-keys.
  6. Eviction — Valkey has its own eviction policy, but it is disabled and unused by default; only
  LMCache's eviction is used. This is explained in detail in the doc.

The current resp adapter still remains for single-host setups that don't want the valkey-glide-sync 
  
I have already run unit tests and end to end tests for this feature before submitting it. 

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
