### PR TITLE
feat(mp): add SHM-based NonGpuContext core (server-side copy)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,8 @@ repos:
     exclude: |
       (?x)^(
         lmcache/__init__\.py|
-        lmcache/.*/gpu_connector/.*
+        lmcache/.*/gpu_connector/.*|
+        lmcache/v1/platform/cuda/.*
       )$
 - repo: https://github.com/PyCQA/isort
   rev: 6.0.1

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -18,7 +18,6 @@ from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
-    CudaIPCWrapper,
     IPCCacheEngineKey,
     KVCache,
 )
@@ -34,6 +33,7 @@ from lmcache.v1.multiprocess.transfer_context import (
     create_transfer_context,
 )
 from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
+from lmcache.v1.platform import _registry as platform_registry
 
 logger = init_logger(__name__)
 
@@ -134,7 +134,52 @@ def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
         ),
     )
     logger.info("Wrapping %d KV cache tensors for IPC", len(kv_caches))
-    return [CudaIPCWrapper(tensor) for tensor in kv_caches.values()]
+    # Per-iteration resource management: if wrapping the N-th tensor
+    # raises, ``shm_unlink`` whatever earlier iterations already
+    # registered with POSIX SHM so the named segments do not outlive
+    # the failed batch. CUDA wrappers do not own a named segment and
+    # are skipped via the duck-typed ``shm_name`` check.
+    wrappers: KVCache = []
+    try:
+        for tensor in kv_caches.values():
+            wrappers.append(_wrap_one_kv_cache(tensor))
+    except BaseException:
+        _release_partial_kv_wrappers(wrappers)
+        raise
+    return wrappers
+
+
+def _release_partial_kv_wrappers(wrappers: list[Any]) -> None:
+    """Best-effort unlink of SHM segments owned by partially built wrappers.
+
+    Used by :func:`wrap_kv_caches` to roll back a half-finished batch
+    when a later iteration raises. Only POSIX-SHM-backed wrappers carry
+    a ``shm_name`` attribute, so other wrapper kinds (e.g. CUDA-IPC)
+    are silently skipped.
+    """
+    # First Party
+    from lmcache.v1.platform.cpu.shm import shm_unlink
+
+    for w in wrappers:
+        name = getattr(w, "shm_name", None)
+        if name is None:
+            continue
+        try:
+            shm_unlink(name)
+        except Exception:  # pragma: no cover - best effort
+            logger.debug("shm_unlink failed during rollback", exc_info=True)
+
+
+def _wrap_one_kv_cache(tensor: torch.Tensor) -> Any:
+    """Dispatch by ``tensor.device.type`` via the platform registry.
+
+    Concrete factories self-register at import time (CUDA in
+    ``lmcache.v1.platform.cuda``, CPU SHM in
+    ``lmcache.v1.platform.cpu``), so this call site stays free of
+    if/elif chains and new accelerators plug in by registering a
+    sibling factory.
+    """
+    return platform_registry.get_kv_wrapper_factory(tensor.device.type)(tensor)
 
 
 def send_lmcache_request(

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -42,6 +42,7 @@ from lmcache.v1.multiprocess.native_completion import (
     submit_callback_to_stream,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
@@ -93,11 +94,19 @@ def batched_iteration(lst: list, batch_size: int) -> Generator[tuple, None, None
 
 @dataclass
 class GPUContextEntry:
-    """Registered GPU context metadata for a single worker instance.
+    """Registered cache context metadata for a single worker instance.
+
+    The ``gpu_context`` field name is kept for backwards compatibility with
+    the ``/kvcache/check`` and module status surfaces. The actual concrete
+    type is whatever :func:`create_cache_context` returned for the wrapper
+    list at registration time -- a :class:`GPUCacheContext` for CUDA-IPC
+    wrappers, a :class:`CpuCacheContext` for POSIX-SHM wrappers. Both expose
+    the same ``kv_tensors`` / ``gpu_kv_format_`` / ``num_layers`` / ...
+    duck-typed surface, so downstream consumers stay agnostic.
 
     Args:
-        gpu_context: The GPU cache context managing shape and pointers
-            to vLLM GPU KV cache tensors.
+        gpu_context: Platform cache context (GPU or CPU) managing shape
+            and pointers to the registered KV cache tensors.
         model_name: The name of the model associated with this KV cache.
         world_size: The world size associated with this KV cache.
     """
@@ -260,7 +269,7 @@ class GPUTransferModule:
             )
             return
 
-        gpu_context = GPUCacheContext(
+        gpu_context = create_cache_context(
             kv_caches,
             self._ctx.chunk_size,
             layout_hints=layout_hints or None,

--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared-memory primitives shared by SHM-based transports.
+
+Thin POSIX-SHM facade exposing the legacy
+``shm_create_readwrite`` / ``shm_map_readwrite`` / ``shm_munmap`` /
+``shm_unlink`` / ``shm_open_pool_as_mmap`` quartet, so the CPU
+KV-cache wrapper, the MP non-GPU SHM transport, and the existing
+tests keep working unchanged.
+
+We deliberately route through CPython's bundled ``_posixshmem`` C
+extension (used internally by :mod:`multiprocessing.shared_memory`)
+rather than the higher-level :class:`SharedMemory` wrapper. The
+wrapper keeps an internal ``memoryview`` over its own ``mmap``;
+when callers also export a buffer (via
+``ctypes.c_uint8.from_buffer(shm.buf)`` / ``torch.frombuffer(...)``),
+:meth:`SharedMemory.close` invoked from ``__del__`` at interpreter
+shutdown raises ``BufferError: cannot close exported pointers
+exist``. Owning the ``mmap`` ourselves and pairing every alloc with
+an explicit ``shm_munmap`` keeps shutdown silent on macOS and Linux
+alike.
+
+The previous hand-rolled libc/librt implementation tripped over
+macOS' shm_open MAC label propagation when certain native
+extensions (torch + a few others) were already loaded in the
+parent process, producing spurious ``errno=13 / EACCES`` failures
+on the child side. Routing through ``_posixshmem.shm_open`` -- the
+same underlying entry point CPython's stdlib uses -- fixes that
+and is identical on Linux.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import ctypes
+import mmap as _mmap
+import os
+import threading
+
+# Third Party
+import _posixshmem  # type: ignore[import-not-found]
+
+
+def _strip_leading_slash(name: str) -> str:
+    """Normalise a name to the bare form (no leading ``/``).
+
+    Callers historically embed the POSIX leading slash; we keep the
+    on-wire name slash-prefixed but feed the bare form to
+    ``_posixshmem.shm_open``-derived helpers that prepend it again.
+    """
+    return name[1:] if name.startswith("/") else name
+
+
+def _slashed(name: str) -> str:
+    """Inverse of :func:`_strip_leading_slash` for shm_open calls."""
+    return name if name.startswith("/") else "/" + name
+
+
+# Per-process registry mapping the public ``int`` address back to the
+# ``mmap`` object that owns the mapping, so a later ``shm_munmap`` can
+# call ``mmap.close()`` exactly once and avoid leaking pages. Owners
+# (creators) also remember the name so ``shm_unlink`` can find it
+# without a re-open round-trip.
+_REGISTRY_LOCK = threading.Lock()
+_ADDR_TO_MMAP: dict[int, _mmap.mmap] = {}
+_OWNED_NAMES: set[str] = set()
+
+
+def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap, int]:
+    """Open (or create) a POSIX SHM segment and ``mmap`` it.
+
+    Returns a ``(mmap_obj, base_addr)`` pair. The fd is always closed
+    before returning so we don't leak descriptors; the kernel keeps
+    the mapping alive as long as ``mmap_obj`` stays alive.
+    """
+    flags = os.O_RDWR | (os.O_CREAT | os.O_EXCL if create else 0)
+    fd = _posixshmem.shm_open(_slashed(name), flags, mode=0o600)
+    mm: _mmap.mmap | None = None
+    try:
+        if create:
+            os.ftruncate(fd, nbytes)
+        mm = _mmap.mmap(fd, nbytes, access=_mmap.ACCESS_WRITE)
+    except BaseException:
+        if create:
+            try:
+                _posixshmem.shm_unlink(_slashed(name))
+            except OSError:
+                pass
+        raise
+    finally:
+        os.close(fd)
+    addr = _addr_of_mmap(mm)
+    return mm, addr
+
+
+def _addr_of_mmap(mm: _mmap.mmap) -> int:
+    """Return the base address of an ``mmap`` without leaking a buffer view.
+
+    A ctypes buffer view is created just long enough to read the
+    address, then dropped before this function returns; once it is
+    out of scope the mmap has no exported pointers, so a later
+    ``mm.close()`` can complete cleanly.
+    """
+    view = (ctypes.c_uint8 * len(mm)).from_buffer(mm)
+    addr = ctypes.addressof(view)
+    del view
+    return addr
+
+
+def shm_create_readwrite(name: str, nbytes: int) -> int:
+    """Create a new shared-memory segment and return its mmap address.
+
+    Mirrors the previous ``shm_open(O_CREAT|O_EXCL) + ftruncate +
+    mmap`` sequence: collisions raise ``OSError`` (``FileExistsError``
+    is a subclass), and a failure mid-way fully tears down what was
+    allocated.
+    """
+    sm_name = _strip_leading_slash(name)
+    mm, addr = _open_and_mmap(sm_name, nbytes, create=True)
+    with _REGISTRY_LOCK:
+        _ADDR_TO_MMAP[addr] = mm
+        _OWNED_NAMES.add(sm_name)
+    return addr
+
+
+def shm_map_readwrite(name: str, nbytes: int) -> int:
+    """Open an existing shared-memory segment and return its address.
+
+    ``nbytes`` must match the segment's actual size; ``mmap`` will
+    raise on a mismatch.
+    """
+    sm_name = _strip_leading_slash(name)
+    mm, addr = _open_and_mmap(sm_name, nbytes, create=False)
+    with _REGISTRY_LOCK:
+        _ADDR_TO_MMAP[addr] = mm
+    return addr
+
+
+def shm_munmap(addr: int, nbytes: int) -> None:
+    """Best-effort release of a previously mapped segment by address.
+
+    The underlying mmap is closed exactly once; subsequent calls with
+    the same address are no-ops.
+    """
+    if not addr:
+        return
+    with _REGISTRY_LOCK:
+        mm = _ADDR_TO_MMAP.pop(addr, None)
+    if mm is None:
+        return
+    try:
+        mm.close()
+    except (BufferError, ValueError):
+        # ``BufferError`` means callers still hold an exported view
+        # (e.g. a torch tensor backed by this mmap); they will release
+        # the mapping themselves on GC. ``ValueError`` means already
+        # closed -- treat both as best-effort no-ops.
+        pass
+
+
+def shm_unlink(name: str) -> None:
+    """Best-effort segment removal.
+
+    Idempotent: a missing segment is treated as a successful
+    no-op so callers can blindly call this on shutdown.
+    """
+    sm_name = _strip_leading_slash(name)
+    with _REGISTRY_LOCK:
+        _OWNED_NAMES.discard(sm_name)
+    try:
+        _posixshmem.shm_unlink(_slashed(sm_name))
+    except FileNotFoundError:
+        pass
+    except OSError:
+        # Mirrors the historical "best effort" contract -- e.g.
+        # double-unlink on shutdown should never raise.
+        pass
+
+
+def shm_open_pool_as_mmap(name: str, nbytes: int) -> _mmap.mmap:
+    """Open an existing segment as an independent ``mmap.mmap`` object.
+
+    Convenience helper for non-GPU SHM transports that consume the
+    segment via ``torch.frombuffer(mmap_obj, ...)`` rather than a raw
+    address. The returned mmap is independent of any registry entry,
+    so the caller takes ownership and is responsible for closing it.
+    """
+    sm_name = _strip_leading_slash(name)
+    fd = _posixshmem.shm_open(_slashed(sm_name), os.O_RDWR, mode=0o600)
+    try:
+        return _mmap.mmap(fd, nbytes, access=_mmap.ACCESS_WRITE)
+    finally:
+        os.close(fd)

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -113,7 +113,15 @@ class MPCacheEngine:
 
     @property
     def gpu_contexts(self) -> dict[int, GPUCacheContext] | None:
-        """Used by ``/kvcache/check``; unwraps :class:`GPUContextEntry`."""
+        """Used by ``/kvcache/check``; unwraps :class:`GPUContextEntry`.
+
+        The map's values are whatever :func:`create_cache_context` produced at
+        registration time -- :class:`GPUCacheContext` for CUDA-IPC wrappers,
+        :class:`~lmcache.v1.platform.cpu.cache_context.CpuCacheContext` for
+        POSIX-SHM wrappers. The ``GPUCacheContext`` annotation is kept for
+        readability since both concrete classes expose the same duck-typed
+        surface used by ``/kvcache/check``.
+        """
         for module in self._modules:
             if isinstance(module, GPUTransferModule):
                 return {i: e.gpu_context for i, e in module.gpu_contexts.items()}

--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -164,7 +164,15 @@ class TokenHasher:
                     none_hash = kv_cache_utils.NONE_HASH
                     logger.info("Initialized NONE_HASH=%s from vLLM", none_hash)
                     return none_hash
-            except (ImportError, AttributeError, ValueError, RuntimeError):
+            except (
+                ImportError,
+                AttributeError,
+                ValueError,
+                RuntimeError,
+                # torch._dynamo.device_interface raises AssertionError
+                # when CudaInterface is defined on non-CUDA platforms.
+                AssertionError,
+            ):
                 pass
 
         # Fallback: compute none_hash using our hash function

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -6,6 +6,17 @@ exposes :class:`EventNotifier` -- a thin wake-up primitive used to
 signal background loops from other threads.  On Linux it is backed by
 ``os.eventfd``; on macOS / other POSIX systems it falls back to
 ``os.pipe``.  Callers never touch ``os.eventfd`` directly.
+
+Accelerator- and OS-specific implementations live in dedicated sub-
+packages so each can evolve independently:
+
+* :mod:`lmcache.v1.platform.cuda` -- CUDA-backed implementations.
+* :mod:`lmcache.v1.platform.cpu`  -- CPU-only fallbacks (POSIX SHM
+  KV-cache wrapper).
+
+Importing them here triggers their self-registration with
+:mod:`lmcache.v1.platform._registry`, so the multiprocess adapter
+can dispatch by ``tensor.device.type`` without any if/elif chain.
 """
 
 # First Party
@@ -17,3 +28,31 @@ from lmcache.v1.platform.event_notifier import consume_fd as consume_fd
 from lmcache.v1.platform.event_notifier import (
     create_event_notifier as create_event_notifier,
 )
+
+# Trigger backend self-registration with :mod:`_registry`.  The default
+# (``cpu``) backend must register first so accelerator backends can
+# transparently fall back to it.  Both imports are kept side-effect-only
+# so callers never need to know which sub-package is active.
+import lmcache.v1.platform.cpu  # noqa: F401,E402
+import lmcache.v1.platform.cuda  # noqa: F401,E402
+
+
+def __getattr__(name: str) -> object:
+    """Lazy re-export of platform cache utilities.
+
+    Deferred so that ``lmcache.c_ops`` (a compiled extension) is
+    fully available by the time the class is first used.
+    """
+    if name == "CpuCacheContext":
+        # First Party
+        from lmcache.v1.platform.cpu.cache_context import CpuCacheContext
+
+        return CpuCacheContext
+
+    if name == "create_cache_context":
+        # First Party
+        from lmcache.v1.platform.cache_context import create_cache_context
+
+        return create_cache_context
+
+    raise AttributeError(name)

--- a/lmcache/v1/platform/_registry.py
+++ b/lmcache/v1/platform/_registry.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform backend registry.
+
+Each accelerator sub-package (``platform/cuda``, ``platform/cpu``,
+future ``platform/xpu`` ...) registers a concrete factory for the
+KV-cache IPC wrapper consumed by the multiprocess adapter.
+
+The :func:`get_kv_wrapper_factory` lookup keys on
+``tensor.device.type`` so the call site in
+:mod:`lmcache.integration.vllm.vllm_multi_process_adapter` stays free
+of any if/elif chain. Adding a new accelerator therefore requires
+*zero* changes to the dispatcher; it only needs to ship its own
+sub-package and register the right callable at import time.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any, Callable, Dict
+
+# Public sentinel used by callers who want the always-available
+# fall-back regardless of the running ``torch_device_type``.
+DEFAULT_BACKEND: str = "cpu"
+
+
+# KV-cache IPC wrapper factory per device type. Concrete sub-packages
+# self-register here (CUDA -> ``CudaIPCWrapper``, CPU -> POSIX-SHM
+# wrapper) so :func:`get_kv_wrapper_factory` can dispatch by
+# ``tensor.device.type`` without any if/elif chain in the call site.
+_KV_WRAPPER_FACTORIES: Dict[str, Callable[..., Any]] = {}
+
+# Per-backend availability predicate (e.g. CUDA's ``is_available``).
+# Missing entry == always available.
+_AVAILABILITY: Dict[str, Callable[[], bool]] = {}
+
+
+def register_availability(device_type: str, predicate: Callable[[], bool]) -> None:
+    _AVAILABILITY[device_type] = predicate
+
+
+def register_kv_wrapper(device_type: str, factory: Callable[..., Any]) -> None:
+    """Register a KV-cache IPC wrapper factory for ``device_type``.
+
+    The factory takes a single ``torch.Tensor`` and returns a wrapper
+    instance ready to be sent over the multiprocess wire.
+    """
+    _KV_WRAPPER_FACTORIES[device_type] = factory
+
+
+def is_available(device_type: str) -> bool:
+    pred = _AVAILABILITY.get(device_type)
+    if pred is None:
+        return True
+    try:
+        return bool(pred())
+    except Exception:
+        return False
+
+
+def get_kv_wrapper_factory(device_type: str) -> Callable[..., Any]:
+    """Pick the KV-cache wrapper factory for ``device_type``.
+
+    A missing entry means the caller is asking for a backend that
+    nobody registered (typically because the relevant sub-package was
+    not imported), which is a programming error and deserves an
+    explicit failure.
+    """
+    factory = _KV_WRAPPER_FACTORIES.get(device_type)
+    if factory is None:
+        raise ValueError(
+            "No KV-cache wrapper factory registered for device type %r" % device_type
+        )
+    return factory
+
+
+def snapshot() -> Dict[str, Dict[str, Callable[..., Any]]]:
+    """Return a deep-copy of the registry tables.
+
+    Test suites use this to install backend overrides without leaking
+    state across tests; pair with :func:`restore` in a ``finally`` /
+    fixture teardown clause.
+    """
+    return {
+        "kv_wrapper": dict(_KV_WRAPPER_FACTORIES),
+        "availability": dict(_AVAILABILITY),
+    }
+
+
+def restore(state: Dict[str, Dict[str, Callable[..., Any]]]) -> None:
+    """Restore registry tables to a previously :func:`snapshot`-ed state."""
+    _KV_WRAPPER_FACTORIES.clear()
+    _KV_WRAPPER_FACTORIES.update(state.get("kv_wrapper", {}))
+    _AVAILABILITY.clear()
+    _AVAILABILITY.update(state.get("availability", {}))

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform-agnostic cache-context factory.
+
+The concrete implementations live in their respective sub-packages:
+
+* :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext` --
+  CUDA-backed.
+* :class:`~lmcache.v1.platform.cpu.cache_context.CpuCacheContext` --
+  CPU-only fallback (POSIX-SHM-backed KV tensors).
+
+:func:`create_cache_context` keeps the dispatch out of the call site
+in :mod:`lmcache.v1.multiprocess.server` so adding a new accelerator
+only requires shipping a new sub-package + extending the wrapper
+isinstance check below.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any, Sequence
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.platform.cpu.cache_context import CpuCacheContext
+
+
+def create_cache_context(
+    kv_caches: KVCache,
+    lmcache_logical_chunk_size: int = 256,
+    layout_hints: LayoutHints | None = None,
+    group_views: Sequence[LMCacheGroupView] = (),
+    engine_type: EngineType = EngineType.VLLM,
+) -> Any:
+    """Create the appropriate cache context.
+
+    The signature mirrors :class:`GPUCacheContext` so callers can
+    forward their kwargs verbatim and stay agnostic of the active
+    backend.
+
+    Selection is driven by the wrapper type of *kv_caches*:
+
+    * Any element is a :class:`CpuShmTensorWrapper` -> a
+      :class:`CpuCacheContext` is built and the underlying CPU
+      tensors are mapped from the client-owned POSIX shared-memory
+      segments.
+    * Otherwise (real ``CudaIPCWrapper`` instances) ->
+      :class:`GPUCacheContext` is built.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
+    from lmcache.v1.platform.cpu.shm import CpuShmTensorWrapper
+
+    if not kv_caches:
+        raise ValueError("create_cache_context requires a non-empty kv_caches list")
+
+    if any(isinstance(w, CpuShmTensorWrapper) for w in kv_caches):
+        # CpuCacheContext doesn't yet honour group_views; the CPU SHM
+        # path uses a flat per-tensor layout so the multi-group split
+        # is currently a GPU-only concept.
+        return CpuCacheContext(
+            kv_caches,
+            lmcache_logical_chunk_size,
+            layout_hints,
+            engine_type,
+        )
+    return GPUCacheContext(
+        kv_caches,
+        lmcache_logical_chunk_size,
+        layout_hints,
+        group_views,
+        engine_type,
+    )

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-specific platform primitives.
+
+Importing this package self-registers the POSIX-SHM KV-cache wrapper
+factory with :mod:`lmcache.v1.platform._registry`, so the dispatch
+in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
+pick the right wrapper based on ``tensor.device.type`` without any
+if/elif chain.
+"""
+
+# First Party
+from lmcache.v1.platform._registry import register_kv_wrapper
+
+
+def _kv_wrapper_factory(tensor):
+    """Indirect-dispatch wrapper.
+
+    Defers loading :mod:`lmcache.v1.platform.cpu.shm` (which pulls in
+    ``multiprocess.custom_types``) until first use, so importing this
+    package during ``lmcache/__init__.py``'s bootstrap does not race
+    other imports that touch ``torch_dev``.
+    """
+    # First Party
+    from lmcache.v1.platform.cpu.shm import migrate_to_shm_and_wrap
+
+    return migrate_to_shm_and_wrap(tensor)
+
+
+register_kv_wrapper("cpu", _kv_wrapper_factory)

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only cache context for platforms without CUDA GPUs.
+
+This module lives in the ``platform.cpu`` sub-package because it is
+the CPU-specific implementation of the cross-platform cache context
+-- it provides the same public API as
+:class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext` but
+keeps all tensors on CPU. Stream / Event objects are provided by
+:class:`~lmcache.v1.platform.cpu.stub_cpu_device.StubStream` so
+CPU-only hosts never import ``cupy`` or instantiate a real CUDA
+stream object.
+
+The platform-agnostic dispatcher ``create_cache_context`` lives in
+:mod:`lmcache.v1.platform.cache_context`.
+"""
+
+# Future
+from __future__ import annotations
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import (
+    LayoutHints,
+    get_group_data_ptrs,
+    normalize_kv_and_discover_format,
+)
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
+import lmcache.c_ops as lmc_ops
+
+logger = init_logger(__name__)
+
+
+class CpuCacheContext:
+    """CPU-only cache context with the same public API as
+    :class:`GPUCacheContext`.
+
+    All tensors live on CPU. CUDA streams and cupy streams are
+    replaced by :class:`StubStream` no-op objects so callers can keep
+    using ``stream.synchronize()`` / ``wait_event(...)`` etc. without
+    branching on the active backend.
+
+    KV cache tensors are reconstructed from the
+    :class:`CpuShmTensorWrapper` instances sent by the client over
+    POSIX shared memory -- the server does **not** allocate the KV
+    cache itself. This mirrors the GPU-mode CUDA-IPC flow where the
+    client owns the buffers and the server only maps them.
+    """
+
+    def __init__(
+        self,
+        kv_caches: KVCache,
+        lmcache_logical_chunk_size: int = 256,
+        layout_hints: LayoutHints | None = None,
+        engine_type: EngineType = EngineType.VLLM,
+    ) -> None:
+        if not kv_caches:
+            raise ValueError(
+                "CpuCacheContext requires a non-empty list of "
+                "CpuShmTensorWrapper; the legacy server-side "
+                "self-allocation path has been removed."
+            )
+
+        # First Party
+        from lmcache.v1.multiprocess.gpu_context import (
+            unwrap_kv_cache_tensors,
+        )
+
+        unwrapped = unwrap_kv_cache_tensors(kv_caches)
+        self.device_ = torch.device("cpu")
+        self.lmcache_logical_chunk_size = lmcache_logical_chunk_size
+        self.is_mla_ = False
+
+        # Discover layout & build KV layer groups via the same path
+        # GPUCacheContext uses, so we don't need to hand-roll any
+        # PageBufferShapeDesc here. ``layout_hints`` / ``engine_type``
+        # are forwarded so the signature matches GPUCacheContext.
+        (
+            self.gpu_kv_format_,
+            kv_caches_normalized,
+        ) = normalize_kv_and_discover_format(
+            unwrapped,
+            engine_type,
+            layout_hints=layout_hints,
+        )
+        self.kv_caches_: list[torch.Tensor] = list(kv_caches_normalized)
+        self.num_layers_ = len(self.kv_caches_)
+        # ``[2, num_blocks, block_size, num_heads, head_size]`` (NHD).
+        first = self.kv_caches_[0]
+        self.num_blocks_ = int(first.shape[1])
+        self.block_size_ = int(first.shape[2])
+        self.kv_layer_groups_manager_ = KVLayerGroupsManager(
+            self.kv_caches_,
+            gpu_kv_format=self.gpu_kv_format_,
+            num_blocks=self.num_blocks_,
+            layout_hints=layout_hints,
+            lmcache_logical_chunk_size=lmcache_logical_chunk_size,
+        )
+
+        # Per-group KV pointer tensors (CPU). Reuse the same helper
+        # GPUCacheContext relies on so the layout matches exactly.
+        self.group_kv_pointers_: list[torch.Tensor] = [
+            torch.tensor(
+                get_group_data_ptrs(
+                    self.kv_caches_,
+                    self.gpu_kv_format_,
+                    group.layer_indices,
+                ),
+                dtype=torch.long,
+            )
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+
+        # Backwards-compat aliases (a few callers still expect these).
+        self.hidden_dim_sizes_: list[int] = [
+            group.hidden_dim_size
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+        self.kv_cache_pointers_ = torch.tensor(
+            [t.data_ptr() for t in self.kv_caches_], dtype=torch.long
+        )
+
+        # Pre-allocated block IDs buffer (CPU).
+        _MAX_BLOCK_IDS = 1_000_000
+        self.block_ids_buffer_ = torch.empty(_MAX_BLOCK_IDS, dtype=torch.long)
+
+        # Temporary buffer for transfers (same layout as
+        # GPUCacheContext but on CPU).
+        self.max_batch_size = 4
+        self.tmp_chunk_group_offsets_: list[int] = [0]
+        for group_idx, group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
+            byte_size = shape.numel() * group.dtype.itemsize
+            self.tmp_chunk_group_offsets_.append(
+                self.tmp_chunk_group_offsets_[-1] + byte_size
+            )
+        self.tmp_chunk_bytes_ = self.tmp_chunk_group_offsets_[-1]
+        # Buffer lives on CPU; keep the attribute name aligned with the
+        # context to avoid GPU-prefixed naming bleeding into a CPU-only
+        # class. The public ``get_tmp_gpu_buffer_flat`` method name is
+        # preserved so ``server.py`` can duck-type across backends.
+        self.tmp_cpu_buffer_ = torch.empty(
+            self.tmp_chunk_bytes_ * self.max_batch_size,
+            dtype=torch.uint8,
+        )
+
+        # Mock streams. ``StubStream`` already implements the small
+        # subset of the API server-side code uses (``synchronize``,
+        # ``wait_event``, ``record_event`` ...), so we never import
+        # cupy or instantiate a real CUDA stream object here.
+        self.cuda_stream_: StubStream = StubStream(device="cpu")
+        self.cupy_stream_: StubStream = self.cuda_stream_
+        self.high_priority_cuda_stream_: StubStream = StubStream(
+            device="cpu", priority=0
+        )
+        self.high_priority_cupy_stream_: StubStream = self.high_priority_cuda_stream_
+
+        logger.info(
+            "CpuCacheContext: %d layers, blocks=%dx%d, dtype=%s (shm-backed)",
+            self.num_layers_,
+            self.num_blocks_,
+            self.block_size_,
+            self.kv_caches_[0].dtype,
+        )
+
+    # -- Properties (same API as GPUCacheContext) --
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Returns the dtype of the KV cache tensors."""
+        return self.kv_caches_[0].dtype
+
+    @property
+    def device(self) -> torch.device:
+        """Returns the device (always CPU)."""
+        return self.device_
+
+    @property
+    def kv_tensors(self) -> list[torch.Tensor]:
+        """Returns the list of per-layer KV cache tensors."""
+        return self.kv_caches_
+
+    @property
+    def kv_pointers(self) -> torch.Tensor:
+        """Returns a tensor of KV cache data pointers."""
+        return self.kv_cache_pointers_
+
+    @property
+    def stream(self) -> StubStream:
+        """Returns the (mock) CUDA stream."""
+        return self.cuda_stream_
+
+    @property
+    def cupy_stream(self) -> StubStream:
+        """Returns the (mock) external stream."""
+        return self.cupy_stream_
+
+    @property
+    def high_priority_stream(self) -> StubStream:
+        """Returns the (mock) high-priority CUDA stream."""
+        return self.high_priority_cuda_stream_
+
+    @property
+    def high_priority_cupy_stream(self) -> StubStream:
+        """Returns the (mock) high-priority external stream."""
+        return self.high_priority_cupy_stream_
+
+    @property
+    def block_size(self) -> int:
+        """Returns the block size (tokens per block)."""
+        return self.block_size_
+
+    @property
+    def num_layers(self) -> int:
+        """Returns the number of layers in the model."""
+        return self.num_layers_
+
+    @property
+    def num_blocks(self) -> int:
+        """Returns the number of blocks in the KV cache."""
+        return self.num_blocks_
+
+    @property
+    def is_mla(self) -> bool:
+        """Returns whether the model uses MLA."""
+        return self.is_mla_
+
+    @property
+    def hidden_dim_sizes(self) -> list[int]:
+        """Returns hidden dimension sizes per KV layer group."""
+        return self.hidden_dim_sizes_
+
+    @property
+    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
+        """Returns the KV layer groups manager."""
+        return self.kv_layer_groups_manager_
+
+    @property
+    def gpu_kv_format_name(self) -> str:
+        """Returns the GPU KV format enum name."""
+        return self.gpu_kv_format_.name
+
+    @property
+    def gpu_kv_shape(self) -> str:
+        """Returns the GPU KV cache layout description."""
+        return "NL_X_TWO_NB_BS_NH_HS"
+
+    @property
+    def attention_backend(self) -> str:
+        """Returns the attention backend name."""
+        return "cpu"
+
+    @property
+    def concrete_gpu_kv_shape(self) -> str:
+        """Returns the GPU KV shape with actual values."""
+        return "cpu-context"
+
+    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
+        """Returns the PageBufferShapeDesc for the given group."""
+        return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
+
+    def get_physical_chunk_size(self, group_idx: int) -> int:
+        """Returns the per-chunk physical slot count for the group."""
+        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
+
+    def get_group_kv_pointers(self, group_idx: int) -> torch.Tensor:
+        """Returns the KV cache pointer tensor for the given group."""
+        return self.group_kv_pointers_[group_idx]
+
+    def get_kv_buffer_shape(self, num_tokens: int, group_idx: int = 0) -> torch.Size:
+        """Returns the KV buffer shape for the given token count."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        num_layers_in_group = group.num_layers
+        hidden_dim = self.hidden_dim_sizes_[group_idx]
+        return torch.Size((2, num_layers_in_group, num_tokens, hidden_dim))
+
+    def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
+        """Returns the flat uint8 temp buffer for the given chunk."""
+        if chunk_idx >= self.max_batch_size:
+            raise ValueError(
+                "chunk_idx %d >= max_batch_size %d" % (chunk_idx, self.max_batch_size)
+            )
+        start = chunk_idx * self.tmp_chunk_bytes_
+        return self.tmp_cpu_buffer_[start : start + self.tmp_chunk_bytes_]
+
+    def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
+        """Returns a typed view of the temp buffer for one chunk."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        start = self.tmp_chunk_group_offsets_[group_idx]
+        end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        return self.tmp_cpu_buffer_[start:end].view(group.dtype).view(shape)
+
+    def get_tmp_chunk_gpu_buffer_batched(
+        self, batch_size: int, group_idx: int = 0
+    ) -> list[torch.Tensor]:
+        """Returns a list of non-overlapping temp buffer views."""
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                "batch_size %d > max_batch_size %d" % (batch_size, self.max_batch_size)
+            )
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        g_start = self.tmp_chunk_group_offsets_[group_idx]
+        g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
+        chunk = self.tmp_chunk_bytes_
+        return [
+            self.tmp_cpu_buffer_[i * chunk + g_start : i * chunk + g_end]
+            .view(group.dtype)
+            .view(shape)
+            for i in range(batch_size)
+        ]
+
+    def stage_block_ids(self, block_ids: list[int]) -> torch.Tensor:
+        """Copy block IDs into the pre-allocated buffer."""
+        if not block_ids:
+            raise ValueError("stage_block_ids requires a non-empty block_ids list")
+        n = len(block_ids)
+        capacity = self.block_ids_buffer_.shape[0]
+        if n > capacity:
+            raise ValueError(
+                "stage_block_ids: %d block IDs exceeds buffer capacity %d"
+                % (n, capacity)
+            )
+        cpu_tensor = torch.tensor(block_ids, dtype=torch.long)
+        buf = self.block_ids_buffer_[:n]
+        buf.copy_(cpu_tensor)
+        return buf
+
+    def cache_size_per_token(self) -> int:
+        """Returns cache size per token in bytes, summed across groups."""
+        total = 0
+        for group_idx, _group in enumerate(
+            self.kv_layer_groups_manager_.kv_layer_groups
+        ):
+            numels = self.get_kv_buffer_shape(1, group_idx).numel()
+            total += numels * _group.dtype.itemsize
+        return total

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only KV-cache IPC wrapper backed by POSIX shared memory.
+
+Mirrors the GPU-mode CUDA-IPC zero-copy semantics for hosts without an
+accelerator: client and LMCache mp server map the **same** physical
+pages so transfers are pointer-shuffles rather than memcpys.
+
+Self-registers a ``"cpu"`` factory with
+:mod:`lmcache.v1.platform._registry` at import time, so the
+multiprocess adapter can dispatch by ``tensor.device.type`` without
+any if/elif chain.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import ctypes
+import itertools
+import os
+import threading
+import weakref
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
+from lmcache.v1.multiprocess.posix_shm import (
+    shm_create_readwrite,
+    shm_map_readwrite,
+    shm_munmap,
+    shm_unlink,
+)
+
+logger = init_logger(__name__)
+
+# Re-export POSIX-SHM primitives so existing callers keep working.
+# The canonical home is :mod:`lmcache.v1.multiprocess.posix_shm`; new
+# code (e.g. the MP non-GPU SHM transport) should import from there.
+__all__ = [
+    "CpuShmTensorWrapper",
+    "inject_stale_cache_entry_for_test",
+    "migrate_to_shm_and_wrap",
+    "shm_create_readwrite",
+    "shm_map_readwrite",
+    "shm_munmap",
+    "shm_unlink",
+]
+
+# ---------------------------------------------------------------------------
+# Wrapper class                                                             #
+# ---------------------------------------------------------------------------
+
+
+class CpuShmTensorWrapper(CudaIPCWrapper):
+    """IPC wrapper for CPU tensors backed by POSIX shared memory.
+
+    Used by the ``lmcache bench kvcache --mode cpu`` path and the
+    vLLM CPU integration so that the client and the LMCache mp server
+    map the **same** physical pages for the KV cache, mirroring the
+    GPU-mode CUDA-IPC zero-copy semantics.
+
+    Subclassing :class:`CudaIPCWrapper` is load-bearing for the same
+    reason :class:`RawCudaIPCWrapper` does it: msgspec does not
+    support unions of custom ext-encoded types, so all wire-level
+    KV-cache wrappers must share the single ext code (1) registered
+    for ``CudaIPCWrapper``. Pickle preserves the subclass identity
+    so ``to_tensor`` dispatches correctly on both sides.
+    """
+
+    # POSIX shared-memory name (``/lmcache_...``) -- leading ``/`` is
+    # required by ``shm_open(3)`` on both Linux and macOS.
+    SHM_NAME_PREFIX = "/lmcache_kv_"
+
+    def __init__(self, tensor: torch.Tensor, shm_name: str) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import (
+            attempt_permute_to_contiguous_view,
+        )
+
+        tensor = attempt_permute_to_contiguous_view(tensor)
+        if tensor.device.type != "cpu":
+            raise ValueError(
+                "CpuShmTensorWrapper requires a CPU tensor, got %s" % tensor.device
+            )
+        if not tensor.is_contiguous():
+            raise ValueError("CpuShmTensorWrapper requires a contiguous tensor")
+
+        self.shm_name = shm_name
+        # ``numel * element_size`` is the correct logical byte size; the
+        # underlying storage may be larger when the tensor is a view.
+        self.nbytes = tensor.numel() * tensor.element_size()
+
+        # CudaIPCWrapper interface fields. ``handle`` / ``device_uuid``
+        # are unused on the CPU path but kept to satisfy the parent
+        # contract used by equality checks.
+        self.handle = None
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+        self.device_uuid = "cpu"
+
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the tensor by mapping the same SHM segment.
+
+        The returned tensor owns the mmap: a ``weakref.finalize`` hook
+        runs ``munmap`` once the tensor (and any views derived from it)
+        is garbage-collected, so the per-process virtual address space
+        does not leak across repeated ``to_tensor`` calls.
+
+        We rebuild the view through ``as_strided`` so the original
+        memory layout (stride / storage_offset / memory_format) is
+        replayed faithfully on the receiving side; reshape would
+        silently re-coalesce strides and lose, e.g., channels_last.
+        """
+        # Empty tensors carry no SHM segment (mmap with length 0 is
+        # undefined / EINVAL on POSIX); rebuild the empty view in-process.
+        if self.nbytes == 0:
+            return torch.empty(self.shape, dtype=self.dtype)
+        addr = shm_map_readwrite(self.shm_name, self.nbytes)
+        # ``torch.frombuffer`` requires a writable buffer; build one
+        # via ctypes so the resulting torch tensor shares storage
+        # with the SHM mapping (zero copy across processes).
+        buf_type = ctypes.c_uint8 * self.nbytes
+        buf = buf_type.from_address(addr)
+        flat = torch.frombuffer(buf, dtype=torch.uint8)
+        typed = flat.view(self.dtype)
+        out = torch.as_strided(typed, self.shape, self.stride, self.storage_offset)
+        # Keep ``flat`` alive for the lifetime of ``out`` so its mmap
+        # is not released while still in use, then munmap on cleanup.
+        out._lmcache_shm_buf = flat  # type: ignore[attr-defined]
+        weakref.finalize(out, shm_munmap, addr, self.nbytes)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Migrate-and-wrap factory (used by the multiprocess adapter)              #
+# ---------------------------------------------------------------------------
+
+# Per-process registry of SHM segments we have created, so the same
+# tensor object is only migrated to SHM once even if the factory is
+# called multiple times.
+#
+# Keyed by ``id(tensor)`` for cheap O(1) lookup, but each entry also
+# holds a ``weakref.ref`` to the original tensor and we *verify the
+# referent is still that exact object* before reusing the cached SHM
+# name. CPython recycles object IDs, so a fresh tensor allocated at
+# the same address as a previously migrated (now garbage-collected)
+# one would otherwise inherit a stale name -- and because
+# :func:`shm_create_readwrite` uses ``O_EXCL``, the next migration
+# would crash with ``EEXIST`` ("File exists"). The weakref-validated
+# lookup below makes that race impossible: a stale entry can only
+# point at a dead referent, which we treat as a miss.
+_CPU_SHM_NAMES: dict[int, tuple["weakref.ReferenceType[torch.Tensor]", str]] = {}
+_CPU_SHM_LOCK = threading.Lock()
+_CPU_SHM_COUNTER = itertools.count()
+
+
+def _cleanup_shm_segment(tid: int, shm_name: str, addr: int, nbytes: int) -> None:
+    """Release the mmap, unlink, and forget the cached SHM name."""
+    with _CPU_SHM_LOCK:
+        # Only drop the entry if it still points at *this* segment;
+        # a future tensor reusing ``tid`` may already have replaced it.
+        cached = _CPU_SHM_NAMES.get(tid)
+        if cached is not None and cached[1] == shm_name:
+            _CPU_SHM_NAMES.pop(tid, None)
+    shm_munmap(addr, nbytes)
+    shm_unlink(shm_name)
+
+
+def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
+    """Re-point ``tensor``'s storage at a POSIX SHM segment, then wrap.
+
+    Used as the registered ``"cpu"`` KV-wrapper factory: the LMCache mp
+    server can mmap the same physical pages on the receiving side.
+    Idempotent per tensor identity (validated via a stored weakref so
+    Python's id-recycling cannot produce a stale-name hit). The SHM
+    segment is released (``munmap`` + ``shm_unlink``) automatically
+    when the migrated tensor is garbage-collected.
+    """
+    tid = id(tensor)
+    with _CPU_SHM_LOCK:
+        cached = _CPU_SHM_NAMES.get(tid)
+        if cached is not None:
+            ref, cached_name = cached
+            if ref() is tensor:
+                return CpuShmTensorWrapper(tensor, cached_name)
+            # Stale entry from a GC'd tensor whose id has been
+            # reused; drop it and fall through to allocate fresh.
+        _CPU_SHM_NAMES.pop(tid, None)
+
+        nbytes = tensor.numel() * tensor.element_size()
+        if nbytes == 0:
+            # No SHM segment for empty tensors: ``mmap`` with length 0
+            # is undefined / EINVAL on POSIX. ``to_tensor`` rebuilds an
+            # empty view directly when ``shm_name`` is empty.
+            return CpuShmTensorWrapper(tensor, "")
+        shm_name = "%s%d_%d" % (
+            CpuShmTensorWrapper.SHM_NAME_PREFIX,
+            os.getpid(),
+            next(_CPU_SHM_COUNTER),
+        )
+        addr = shm_create_readwrite(shm_name, nbytes)
+        try:
+            buf_type = ctypes.c_uint8 * nbytes
+            buf = buf_type.from_address(addr)
+            shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
+            tensor.set_(
+                shm_storage,
+                tensor.storage_offset(),
+                tensor.shape,
+                tensor.stride(),
+            )
+        except Exception:
+            # Make sure the SHM resources don't leak if migration fails
+            # part-way (e.g. ``set_`` rejects an unusual stride).
+            shm_munmap(addr, nbytes)
+            shm_unlink(shm_name)
+            raise
+
+        _CPU_SHM_NAMES[tid] = (weakref.ref(tensor), shm_name)
+        weakref.finalize(tensor, _cleanup_shm_segment, tid, shm_name, addr, nbytes)
+        logger.info(
+            "Migrated CPU KV cache tensor (nbytes=%d) to SHM %s",
+            nbytes,
+            shm_name,
+        )
+
+    return CpuShmTensorWrapper(tensor, shm_name)
+
+
+def inject_stale_cache_entry_for_test(
+    tensor: torch.Tensor,
+    dead_ref: "weakref.ReferenceType[torch.Tensor]",
+    stale_shm_name: str,
+) -> None:
+    """Test-only hook: pre-seed the registry with a stale entry.
+
+    Lets unit tests reproduce the CPython id-reuse race -- where a
+    fresh tensor lands on the same id as a previously migrated and
+    garbage-collected one -- without the per-test global-state
+    surgery that would otherwise have to reach into the module's
+    private dict / lock.
+    """
+    with _CPU_SHM_LOCK:
+        _CPU_SHM_NAMES[id(tensor)] = (dead_ref, stale_shm_name)

--- a/lmcache/v1/platform/cpu/stub_cpu_device.py
+++ b/lmcache/v1/platform/cpu/stub_cpu_device.py
@@ -116,6 +116,25 @@ class StubStream:
         self.device = device
         self.priority = priority
         self.cuda_stream = 0
+        # Mirrors the ``ptr`` attribute exposed by ``cupy.cuda.Stream``
+        # so callers (e.g. ``mp_observability.event_bus``) that pass a
+        # raw stream pointer to native recorders accept this stub
+        # without an isinstance check.
+        self.ptr = 0
+
+    def launch_host_func(self, callback: Any, arg: Any = None) -> None:
+        """Run ``callback(arg)`` synchronously.
+
+        ``cupy.cuda.Stream.launch_host_func`` schedules the callback
+        on the GPU stream's host-side completion queue; with no real
+        stream there's nothing to wait for, so we just invoke it
+        immediately. Exceptions are swallowed to mirror the cupy
+        contract (callbacks are best-effort and must not propagate).
+        """
+        try:
+            callback(arg)
+        except Exception:  # noqa: BLE001
+            pass
 
     def synchronize(self) -> None:
         """Block the host until all kernels on this stream complete.

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA-specific platform primitives.
+
+Importing this package self-registers a CUDA KV-cache wrapper
+factory with :mod:`lmcache.v1.platform._registry`, so the dispatch
+in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
+locate it by ``tensor.device.type``.
+"""
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.platform._registry import (
+    register_availability,
+    register_kv_wrapper,
+)
+
+
+def _kv_wrapper_factory(tensor):
+    """Indirect-dispatch wrapper.
+
+    Re-imports :class:`CudaIPCWrapper` on every call so test suites
+    that swap the symbol still see their override take effect.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
+
+    return CudaIPCWrapper(tensor)
+
+
+register_availability("cuda", lambda: torch.cuda.is_available())
+register_kv_wrapper("cuda", _kv_wrapper_factory)

--- a/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
+++ b/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
@@ -67,8 +67,14 @@ def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
     ctx.chunk_size = 16
     ctx.layout_desc_registry = LayoutDescRegistry()
 
-    def fake_gpu_context(*args: object, **kwargs: object) -> _FakeGPUContext:
-        """Return a fake GPU context without touching CUDA."""
+    def fake_create_cache_context(
+        kv_caches: object,
+        lmcache_logical_chunk_size: int,
+        layout_hints: object = None,
+        group_views: object = (),
+        engine_type: object = None,
+    ) -> _FakeGPUContext:
+        """Return a fake cache context without touching CUDA or wrappers."""
         return _FakeGPUContext()
 
     def fake_layout_desc(
@@ -83,7 +89,9 @@ def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
         "DeviceHostFuncDispatcher",
         _FakeDeviceHostFuncDispatcher,
     )
-    monkeypatch.setattr(gpu_transfer_mod, "GPUCacheContext", fake_gpu_context)
+    monkeypatch.setattr(
+        gpu_transfer_mod, "create_cache_context", fake_create_cache_context
+    )
     monkeypatch.setattr(gpu_transfer_mod, "get_layout_desc", fake_layout_desc)
     monkeypatch.setattr(
         gpu_transfer_mod.torch_dev,

--- a/tests/v1/multiprocess/test_non_cuda_data_transfer.py
+++ b/tests/v1/multiprocess/test_non_cuda_data_transfer.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Protocol
 from unittest.mock import MagicMock, patch
-import mmap
 import os
 import pickle
 import sys
@@ -15,6 +14,12 @@ import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.multiprocess.posix_shm import (
+    shm_create_readwrite,
+    shm_munmap,
+    shm_open_pool_as_mmap,
+    shm_unlink,
+)
 from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.protocols.engine import (
     PrepareRetrieveResponse,
@@ -214,19 +219,30 @@ def _default_key(tokens: int = 8) -> "IPCCacheEngineKey":
     )
 
 
-def test_wrap_kv_caches_wraps_all_tensors(monkeypatch: Any) -> None:
+def test_wrap_kv_caches_wraps_all_tensors() -> None:
     """Verify wrap_kv_caches wraps all provided KV tensors."""
     # First Party
     from lmcache.integration.vllm import vllm_multi_process_adapter as adapter_mod
+    from lmcache.v1.platform import _registry as platform_registry
 
     kv_caches = _make_kv_caches()
-    monkeypatch.setattr(
-        adapter_mod,
-        "CudaIPCWrapper",
-        lambda tensor: ("wrapped", tensor),
-    )
+    # ``wrap_kv_caches`` dispatches through ``platform_registry``: each
+    # accelerator self-registers a wrapper factory keyed by
+    # ``tensor.device.type``. Override the relevant entries through the
+    # registry's documented API (snapshot + register + restore on
+    # teardown) instead of poking the adapter's private helper.
+    saved = platform_registry.snapshot()
 
-    wrapped = adapter_mod.wrap_kv_caches(kv_caches)
+    def _fake_factory(tensor: Any) -> tuple[str, Any]:
+        return ("wrapped", tensor)
+
+    try:
+        for device_type in {t.device.type for t in kv_caches.values()}:
+            platform_registry.register_kv_wrapper(device_type, _fake_factory)
+        wrapped = adapter_mod.wrap_kv_caches(kv_caches)
+    finally:
+        platform_registry.restore(saved)
+
     assert len(wrapped) == len(kv_caches)
 
 
@@ -888,22 +904,25 @@ class _CompletedFuture:
         return self._value
 
 
-def _create_shm_file(shm_name: str, size: int) -> str:
-    path = os.path.join("/dev/shm", shm_name.lstrip("/"))
-    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
-    os.ftruncate(fd, size)
-    os.close(fd)
-    return path
+def _create_shm_segment(shm_name: str, size: int) -> int:
+    """Create a POSIX SHM segment via the project facade.
+
+    Returns the owner mmap address so the test can release the segment
+    with ``shm_munmap`` + ``shm_unlink`` regardless of platform
+    (Linux/macOS), instead of hard-coding ``/dev/shm`` paths.
+    """
+    return shm_create_readwrite(shm_name, size)
 
 
 def test_non_gpu_context_shm_tensor_view_from_buffer() -> None:
     shm_name = f"lmcache_test_view_{os.getpid()}"
-    shm_path = _create_shm_file(shm_name, 4096)
+    addr = _create_shm_segment(shm_name, 4096)
     try:
-        with open(shm_path, "r+b") as f:
-            mm = mmap.mmap(f.fileno(), 4096, access=mmap.ACCESS_WRITE)
+        mm = shm_open_pool_as_mmap(shm_name, 4096)
+        try:
             src = torch.arange(8, dtype=torch.float32).reshape(2, 4)
             mm[: src.numel() * src.element_size()] = src.numpy().tobytes()
+        finally:
             mm.close()
 
         context = NonGpuContextShm(
@@ -931,13 +950,13 @@ def test_non_gpu_context_shm_tensor_view_from_buffer() -> None:
         finally:
             context.close()
     finally:
-        if os.path.exists(shm_path):
-            os.unlink(shm_path)
+        shm_munmap(addr, 4096)
+        shm_unlink(shm_name)
 
 
 def test_non_gpu_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
     shm_name = f"lmcache_test_flow_{os.getpid()}"
-    shm_path = _create_shm_file(shm_name, 4096)
+    addr = _create_shm_segment(shm_name, 4096)
     slots = [
         {
             "offset": 0,
@@ -1003,8 +1022,8 @@ def test_non_gpu_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
         assert context.commit_retrieve(key, 1)
     finally:
         context.close()
-        if os.path.exists(shm_path):
-            os.unlink(shm_path)
+        shm_munmap(addr, 4096)
+        shm_unlink(shm_name)
 
 
 def test_non_gpu_context_shm_init_raises_when_segment_missing() -> None:
@@ -1064,7 +1083,7 @@ def test_create_non_gpu_context_use_pickle_ignores_valid_shm_info() -> None:
 
 def test_non_gpu_context_shm_close_is_idempotent() -> None:
     shm_name = f"lmcache_test_close_{os.getpid()}"
-    shm_path = _create_shm_file(shm_name, 4096)
+    addr = _create_shm_segment(shm_name, 4096)
     try:
         context = NonGpuContextShm(
             metadata=NonGpuContextMetadata(
@@ -1083,5 +1102,5 @@ def test_non_gpu_context_shm_close_is_idempotent() -> None:
         context.close()
         context.close()
     finally:
-        if os.path.exists(shm_path):
-            os.unlink(shm_path)
+        shm_munmap(addr, 4096)
+        shm_unlink(shm_name)

--- a/tests/v1/multiprocess/test_posix_shm.py
+++ b/tests/v1/multiprocess/test_posix_shm.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache.v1.multiprocess.posix_shm``.
+
+Validates the POSIX-SHM primitives and the ``mmap``-based pool helper
+shared by SHM-based transports.
+"""
+
+# Standard
+import os
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.posix_shm import (
+    shm_create_readwrite,
+    shm_map_readwrite,
+    shm_munmap,
+    shm_open_pool_as_mmap,
+    shm_unlink,
+)
+
+
+def _unique_name(tag: str) -> str:
+    # macOS shm_open caps names at 31 bytes incl. leading '/'.
+    return "/lmc_pshm_%s_%d" % (tag, os.getpid())
+
+
+def test_create_map_munmap_unlink_roundtrip():
+    name = _unique_name("rt")
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        assert addr not in (0, None)
+        # Map again from a fresh address: same segment, different vaddr.
+        addr2 = shm_map_readwrite(name, 4096)
+        try:
+            assert addr2 not in (0, None)
+        finally:
+            shm_munmap(addr2, 4096)
+    finally:
+        shm_munmap(addr, 4096)
+        shm_unlink(name)
+
+
+def test_create_excl_collision():
+    name = _unique_name("excl")
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        with pytest.raises(OSError):
+            shm_create_readwrite(name, 4096)
+    finally:
+        shm_munmap(addr, 4096)
+        shm_unlink(name)
+
+
+def test_open_pool_as_mmap_zero_copy_view():
+    name = _unique_name("pool")
+    nbytes = 4096
+    addr = shm_create_readwrite(name, nbytes)
+    try:
+        mm = shm_open_pool_as_mmap(name, nbytes)
+        try:
+            mm[0:4] = b"\x01\x02\x03\x04"
+            mm2 = shm_open_pool_as_mmap(name, nbytes)
+            try:
+                assert bytes(mm2[0:4]) == b"\x01\x02\x03\x04"
+            finally:
+                mm2.close()
+        finally:
+            mm.close()
+    finally:
+        shm_munmap(addr, nbytes)
+        shm_unlink(name)
+
+
+def test_munmap_no_op_on_zero_addr():
+    # Should not crash; best-effort no-op.
+    shm_munmap(0, 4096)

--- a/tests/v1/platform/__init__.py
+++ b/tests/v1/platform/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache.v1.platform.cpu.shm``.
+
+Validates that the POSIX-SHM-backed wrapper can round-trip a CPU
+tensor in-process: the constructed wrapper's ``to_tensor()`` view
+sees writes made through the original tensor.
+"""
+
+# Standard
+import os
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.platform.cpu.shm import (
+    CpuShmTensorWrapper,
+    migrate_to_shm_and_wrap,
+    shm_create_readwrite,
+    shm_unlink,
+)
+
+
+def test_shm_create_unlink_roundtrip(tmp_path):
+    """``shm_create_readwrite`` succeeds and ``shm_unlink`` cleans up."""
+    name = "/lmcache_test_%d" % os.getpid()
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        assert addr not in (0, None)
+    finally:
+        shm_unlink(name)
+
+
+def test_migrate_to_shm_and_wrap_zero_copy_view():
+    """After migrate, writes via the original tensor are visible via wrapper."""
+    src = torch.zeros((2, 4, 4), dtype=torch.float32)
+    wrapper = migrate_to_shm_and_wrap(src)
+    try:
+        assert isinstance(wrapper, CpuShmTensorWrapper)
+        assert wrapper.shape == (2, 4, 4)
+        assert wrapper.dtype == torch.float32
+        # Mutate via the migrated source tensor; its storage is now the
+        # SHM segment, so the wrapper's reconstructed view must see it.
+        src.add_(7.0)
+        view = wrapper.to_tensor()
+        assert torch.equal(view, src)
+    finally:
+        shm_unlink(wrapper.shm_name)
+
+
+def test_migrate_handles_empty_tensor():
+    """Empty tensors must not call ``mmap`` (length 0 is EINVAL).
+
+    Regression for the case where ``nbytes == 0``: the wrapper carries
+    an empty ``shm_name`` and ``to_tensor`` rebuilds the empty view in
+    process without touching POSIX shared memory.
+    """
+    src = torch.empty((0, 4), dtype=torch.float32)
+    wrapper = migrate_to_shm_and_wrap(src)
+    assert isinstance(wrapper, CpuShmTensorWrapper)
+    assert wrapper.shm_name == ""
+    assert wrapper.nbytes == 0
+    view = wrapper.to_tensor()
+    assert view.shape == (0, 4)
+    assert view.dtype == torch.float32
+
+
+def test_migrate_is_idempotent_on_same_tensor():
+    """Re-wrapping the same tensor reuses the existing SHM segment."""
+    src = torch.zeros((3, 5), dtype=torch.float32)
+    w1 = migrate_to_shm_and_wrap(src)
+    try:
+        w2 = migrate_to_shm_and_wrap(src)
+        assert w1.shm_name == w2.shm_name
+    finally:
+        shm_unlink(w1.shm_name)
+
+
+def test_rejects_non_cpu_tensor():
+    """Construction rejects tensors that are not on CPU."""
+    if not torch.backends.mps.is_available():
+        pytest.skip("MPS not available; cannot synthesize a non-cpu tensor")
+    src = torch.zeros((2, 2), device="mps")
+    with pytest.raises(ValueError, match="CPU tensor"):
+        CpuShmTensorWrapper(src, "/lmcache_test_should_not_exist")
+
+
+def test_migrate_finalizer_unlinks_on_gc():
+    """Once the migrated tensor is GC-ed, its SHM segment is unlinked."""
+    # Standard
+    import gc
+
+    # First Party
+    from lmcache.v1.platform.cpu.shm import shm_map_readwrite
+
+    src = torch.zeros((2, 2), dtype=torch.float32)
+    w = migrate_to_shm_and_wrap(src)
+    name = w.shm_name
+    nbytes = w.nbytes
+    # Drop both references; the weakref.finalize hook should unlink.
+    del src, w
+    gc.collect()
+    with pytest.raises(OSError):
+        shm_map_readwrite(name, nbytes)
+
+
+def test_shm_create_cleans_up_on_existing_name():
+    """If ``shm_open(O_EXCL)`` fails the helper must not leave the fd open.
+
+    We exercise the failure path by creating a segment, then asking
+    ``shm_create_readwrite`` to recreate the same name -- it must
+    raise without leaking the file descriptor it briefly held.
+    """
+    name = "/lmcache_test_excl_%d" % os.getpid()
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        with pytest.raises(OSError):
+            shm_create_readwrite(name, 4096)
+    finally:
+        shm_unlink(name)
+    # And after unlink, the name is reusable again.
+    addr2 = shm_create_readwrite(name, 4096)
+    assert addr2 not in (0, None)
+    shm_unlink(name)
+    _ = addr  # silence unused-variable hint
+
+
+def test_to_tensor_view_carries_munmap_finalizer():
+    """``to_tensor`` returns a tensor that releases its mmap on GC."""
+    # Standard
+    import gc
+    import weakref
+
+    src = torch.zeros((2, 2), dtype=torch.float32)
+    w = migrate_to_shm_and_wrap(src)
+    try:
+        view = w.to_tensor()
+        # The view must keep ``flat`` alive so its mmap stays valid.
+        assert hasattr(view, "_lmcache_shm_buf")
+        ref = weakref.ref(view)
+        del view
+        gc.collect()
+        assert ref() is None
+    finally:
+        del src
+        gc.collect()
+        shm_unlink(w.shm_name)
+
+
+def test_to_tensor_replays_stride_and_storage_offset():
+    """``to_tensor`` rebuilds the view via stride+offset (not reshape)."""
+    src = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4).contiguous()
+    w = migrate_to_shm_and_wrap(src)
+    try:
+        view = w.to_tensor()
+        assert tuple(view.stride()) == w.stride
+        assert int(view.storage_offset()) == w.storage_offset
+        assert torch.equal(view, src)
+    finally:
+        del src, view
+        shm_unlink(w.shm_name)
+
+
+def test_wrap_kv_caches_unlinks_partial_batch_on_failure(monkeypatch):
+    """If wrapping the N-th tensor raises, earlier SHM names are unlinked.
+
+    Drives :func:`wrap_kv_caches` with two CPU tensors and forces the
+    second factory call to raise; the first iteration's SHM segment
+    must be ``shm_unlink``-ed so the named segment does not outlive
+    the failed batch.
+    """
+    # First Party
+    from lmcache.integration.vllm import vllm_multi_process_adapter as adapter
+    from lmcache.v1.platform.cpu.shm import shm_map_readwrite
+
+    real_wrap = adapter._wrap_one_kv_cache
+    state = {"n": 0, "first_name": None}
+
+    def flaky_wrap(tensor):
+        state["n"] += 1
+        if state["n"] == 2:
+            raise RuntimeError("simulated migration failure")
+        w = real_wrap(tensor)
+        state["first_name"] = w.shm_name
+        return w
+
+    monkeypatch.setattr(adapter, "_wrap_one_kv_cache", flaky_wrap)
+
+    t1 = torch.zeros((2, 2), dtype=torch.float32)
+    t2 = torch.zeros((2, 2), dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="simulated migration failure"):
+        adapter.wrap_kv_caches({"a": t1, "b": t2})
+
+    # The first iteration's SHM segment must no longer be openable.
+    nbytes = t1.numel() * t1.element_size()
+    with pytest.raises(OSError):
+        shm_map_readwrite(state["first_name"], nbytes)
+
+
+def test_migrate_ignores_stale_entry_from_id_reuse():
+    """A cached entry whose weakref is dead must not be reused.
+
+    Simulates CPython recycling an object id by injecting a stale
+    ``(dead_ref, old_name)`` tuple keyed by the live tensor's id,
+    then calling :func:`migrate_to_shm_and_wrap`. The factory must
+    treat the dead entry as a miss and allocate a fresh SHM segment
+    -- if it blindly reused the cached name, ``shm_create_readwrite``
+    would crash with ``EEXIST`` (and even worse, the fresh tensor
+    would be silently bound to the wrong SHM name).
+    """
+    # Standard
+    import gc
+    import weakref as _wr
+
+    # First Party
+    from lmcache.v1.platform.cpu.shm import inject_stale_cache_entry_for_test
+
+    # Build a tensor we will let die so we have a guaranteed-dead ref.
+    ghost = torch.zeros((1,), dtype=torch.float32)
+    dead_ref = _wr.ref(ghost)
+    del ghost
+    gc.collect()
+    assert dead_ref() is None
+
+    live = torch.zeros((2, 2), dtype=torch.float32)
+    stale_name = "/lmcache_test_stale_%d" % os.getpid()
+    inject_stale_cache_entry_for_test(live, dead_ref, stale_name)
+
+    w = migrate_to_shm_and_wrap(live)
+    try:
+        assert w.shm_name != stale_name
+    finally:
+        shm_unlink(w.shm_name)


### PR DESCRIPTION
Introduces a POSIX shared-memory KV transfer path so CPU-only and non-CUDA accelerator hosts can use the same single-shot REGISTER_KV_CACHE + STORE/RETRIEVE protocol that GPU CUDA-IPC uses, without forcing a worker-side gather/scatter copy.

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
