### PR TITLE
feat(mp): add mp_transfer_mode config option

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -438,9 +438,15 @@ On the vLLM side, specify the LMCache server host and port via the
 ``LMCacheMPConnector`` reads the following keys from
 ``kv_connector_extra_config``:
 
+Connector ``extra_config`` Keys
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All connector-level options are passed through
+``kv_connector_extra_config`` and use the ``lmcache.mp.`` prefix.
+
 .. list-table::
    :header-rows: 1
-   :widths: 35 20 45
+   :widths: 30 15 55
 
    * - Key
      - Default
@@ -461,6 +467,12 @@ On the vLLM side, specify the LMCache server host and port via the
      - ``10.0``
      - Interval (seconds) between periodic heartbeat pings sent from the
        connector to the server.
+   * - ``lmcache.mp.mp_transfer_mode``
+     - ``auto``
+     - Routing mode for the worker -> server transfer context. One of
+       ``auto`` (CUDA -> handle, others -> data), ``handle`` (force IPC /
+       SHM zero-copy), or ``data`` (force worker-side gather/scatter copy).
+       Overrides the ``LMCACHE_MP_TRANSFER_MODE`` env var when set.
 
 Environment Variables
 ---------------------

--- a/lmcache/integration/vllm/lmcache_mp_connector_0180.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0180.py
@@ -146,6 +146,7 @@ def create_worker_adapter(
         vllm_config.parallel_config.rank,
         vllm_config,
     )
+    extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
     return LMCacheMPWorkerAdapter(
         server_url,
         zmq_context,
@@ -155,6 +156,7 @@ def create_worker_adapter(
         vllm_config.cache_config.block_size,
         mq_timeout=mq_timeout,
         heartbeat_interval=heartbeat_interval,
+        extra_config=extra_config,
     )
 
 
@@ -450,6 +452,11 @@ class LMCacheMPConnector(KVConnectorBase_V1):
     - lmcache.mp.mq_timeout: timeout (seconds) for message queue requests.
     - lmcache.mp.heartbeat_interval: interval (seconds) between server
       heartbeat pings.
+    - lmcache.mp.mp_transfer_mode: routing mode for the worker -> server
+      transfer context. One of ``auto`` (default; CUDA -> handle, others
+      -> data), ``handle`` (force IPC / SHM zero-copy), ``data`` (force
+      worker-side gather/scatter copy). Overrides the
+      ``LMCACHE_MP_TRANSFER_MODE`` env var when set.
     """
 
     def __init__(

--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -171,6 +171,7 @@ def create_worker_adapter(
         parallel_strategy=parallel_strategy,
         mq_timeout=mq_timeout,
         heartbeat_interval=heartbeat_interval,
+        extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
     )
 
 
@@ -472,6 +473,11 @@ class LMCacheMPConnector(KVConnectorBase_V1):
     - lmcache.mp.mq_timeout: timeout (seconds) for message queue requests.
     - lmcache.mp.heartbeat_interval: interval (seconds) between server
       heartbeat pings.
+    - lmcache.mp.mp_transfer_mode: routing mode for the worker -> server
+      transfer context. One of ``auto`` (default; CUDA -> handle, others
+      -> data), ``handle`` (force IPC / SHM zero-copy), ``data`` (force
+      worker-side gather/scatter copy). Overrides the
+      ``LMCACHE_MP_TRANSFER_MODE`` env var when set.
     """
 
     def __init__(

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -18,7 +18,6 @@ from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
-    CudaIPCWrapper,
     IPCCacheEngineKey,
     KVCache,
 )
@@ -34,6 +33,7 @@ from lmcache.v1.multiprocess.transfer_context import (
     create_transfer_context,
 )
 from lmcache.v1.periodic_thread import PeriodicThread, ThreadLevel, ThreadRunSummary
+from lmcache.v1.platform import _registry as platform_registry
 
 logger = init_logger(__name__)
 
@@ -52,6 +52,13 @@ class ExtraConfigDefault(enum.Enum):
     # Interval (seconds) between periodic heartbeat pings
     # to the server.
     heartbeat_interval = 10.0
+    # Routing mode for ``create_transfer_context``: ``auto`` keeps the
+    # historical CUDA -> handle / others -> data dispatch; ``handle``
+    # forces the IPC / SHM zero-copy path; ``data`` forces the
+    # worker-side gather/scatter copy path. Mirrors the
+    # ``LMCACHE_MP_TRANSFER_MODE`` env var; this extra_config key wins
+    # when both are set.
+    mp_transfer_mode = "auto"
 
 
 # Backward-compatible aliases for the legacy `lmcache_mp_connector_0180`
@@ -134,7 +141,52 @@ def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
         ),
     )
     logger.info("Wrapping %d KV cache tensors for IPC", len(kv_caches))
-    return [CudaIPCWrapper(tensor) for tensor in kv_caches.values()]
+    # Per-iteration resource management: if wrapping the N-th tensor
+    # raises, ``shm_unlink`` whatever earlier iterations already
+    # registered with POSIX SHM so the named segments do not outlive
+    # the failed batch. CUDA wrappers do not own a named segment and
+    # are skipped via the duck-typed ``shm_name`` check.
+    wrappers: KVCache = []
+    try:
+        for tensor in kv_caches.values():
+            wrappers.append(_wrap_one_kv_cache(tensor))
+    except BaseException:
+        _release_partial_kv_wrappers(wrappers)
+        raise
+    return wrappers
+
+
+def _release_partial_kv_wrappers(wrappers: list[Any]) -> None:
+    """Best-effort unlink of SHM segments owned by partially built wrappers.
+
+    Used by :func:`wrap_kv_caches` to roll back a half-finished batch
+    when a later iteration raises. Only POSIX-SHM-backed wrappers carry
+    a ``shm_name`` attribute, so other wrapper kinds (e.g. CUDA-IPC)
+    are silently skipped.
+    """
+    # First Party
+    from lmcache.v1.platform.cpu.shm import shm_unlink
+
+    for w in wrappers:
+        name = getattr(w, "shm_name", None)
+        if name is None:
+            continue
+        try:
+            shm_unlink(name)
+        except Exception:  # pragma: no cover - best effort
+            logger.debug("shm_unlink failed during rollback", exc_info=True)
+
+
+def _wrap_one_kv_cache(tensor: torch.Tensor) -> Any:
+    """Dispatch by ``tensor.device.type`` via the platform registry.
+
+    Concrete factories self-register at import time (CUDA in
+    ``lmcache.v1.platform.cuda``, CPU SHM in
+    ``lmcache.v1.platform.cpu``), so this call site stays free of
+    if/elif chains and new accelerators plug in by registering a
+    sibling factory.
+    """
+    return platform_registry.get_kv_wrapper_factory(tensor.device.type)(tensor)
 
 
 def send_lmcache_request(
@@ -845,6 +897,9 @@ class LMCacheMPWorkerAdapter:
             cfg = _resolve_extra_config(extra_config)
             mq_timeout = cfg[ExtraConfigDefault.mq_timeout.name]
             heartbeat_interval = cfg[ExtraConfigDefault.heartbeat_interval.name]
+            self._mp_transfer_mode = cfg[ExtraConfigDefault.mp_transfer_mode.name]
+        else:
+            self._mp_transfer_mode = ExtraConfigDefault.mp_transfer_mode.value
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 
@@ -1005,7 +1060,9 @@ class LMCacheMPWorkerAdapter:
                 mq_timeout.
         """
         self.kv_caches = kv_caches
-        self.transfer_ctx = create_transfer_context(kv_caches)
+        self.transfer_ctx = create_transfer_context(
+            kv_caches, mode=self._mp_transfer_mode
+        )
         layout_hints = vllm_layout_hints()
         layout_hints["inference_engine_logical_block_size"] = (
             self.vllm_logical_block_size

--- a/lmcache/v1/multiprocess/transfer_context/__init__.py
+++ b/lmcache/v1/multiprocess/transfer_context/__init__.py
@@ -20,6 +20,7 @@ from .shm import NonGpuContextShm, ShmSlotDescriptor
 from .worker_transfer import (
     DataTransferContext,
     HandleTransferContext,
+    MPTransferMode,
     TransferContext,
     create_transfer_context,
 )
@@ -27,6 +28,7 @@ from .worker_transfer import (
 __all__ = [
     "DataTransferContext",
     "HandleTransferContext",
+    "MPTransferMode",
     "NonGpuContext",
     "NonGpuContextMetadata",
     "NonGpuContextPickle",

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -4,7 +4,9 @@
 # Standard
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from enum import Enum
 from typing import Any, Callable, Protocol
+import os
 
 # Third Party
 import torch
@@ -28,8 +30,62 @@ from lmcache.v1.multiprocess.transfer_context.base import (
     gather_paged_kv_to_cpu,
     scatter_cpu_to_paged_kv,
 )
+from lmcache.v1.platform import _registry as platform_registry
 
 logger = init_logger(__name__)
+
+# Environment variable that lets the user override the default routing
+# performed by :func:`create_transfer_context`. Accepted values match the
+# string values of :class:`MPTransferMode` (``auto`` / ``handle`` /
+# ``data``); ``auto`` reproduces the historical device-type-based dispatch.
+ENV_MP_TRANSFER_MODE = "LMCACHE_MP_TRANSFER_MODE"
+
+
+class MPTransferMode(str, Enum):
+    """Routing mode used by :func:`create_transfer_context`.
+
+    * ``AUTO``: dispatch by ``tensor.device.type`` (CUDA -> handle, others
+      -> data). Preserves the historical behaviour.
+    * ``HANDLE``: force :class:`HandleTransferContext` (IPC / SHM zero-copy
+      path). Requires a registered KV-wrapper factory for the device.
+    * ``DATA``: force :class:`DataTransferContext` (worker-side gather /
+      scatter copy path).
+    """
+
+    AUTO = "auto"
+    HANDLE = "handle"
+    DATA = "data"
+
+
+def _resolve_mode(mode: "str | MPTransferMode | None") -> MPTransferMode:
+    """Coerce ``mode`` into :class:`MPTransferMode`, falling back to env."""
+    raw = (
+        mode
+        if mode is not None
+        else os.environ.get(ENV_MP_TRANSFER_MODE, MPTransferMode.AUTO.value)
+    )
+    if isinstance(raw, MPTransferMode):
+        return raw
+    try:
+        return MPTransferMode(str(raw).lower())
+    except ValueError as exc:
+        valid = ", ".join(m.value for m in MPTransferMode)
+        raise ValueError(
+            "Invalid MP transfer mode %r (valid: %s)" % (raw, valid)
+        ) from exc
+
+
+def _build_handle_context(device_type: str) -> "TransferContext":
+    """Build a :class:`HandleTransferContext` after capability check."""
+    try:
+        platform_registry.get_kv_wrapper_factory(device_type)
+    except ValueError as exc:
+        raise ValueError(
+            "MP transfer mode 'handle' is not supported for device type "
+            "%r: no KV-cache wrapper factory is registered. "
+            "Use mode 'data' or 'auto' instead." % device_type
+        ) from exc
+    return HandleTransferContext()
 
 
 class IPCEvent(Protocol):
@@ -432,21 +488,29 @@ class DataTransferContext(TransferContext):
 
 def create_transfer_context(
     kv_caches: dict[str, torch.Tensor],
+    mode: "str | MPTransferMode | None" = None,
     **_kwargs: Any,
 ) -> TransferContext:
     """Create a transfer context from KV cache device type.
 
-    The device check is intentionally centralized here.
+    The device check is intentionally centralized here. Routing can be
+    overridden via the ``mode`` argument or the ``LMCACHE_MP_TRANSFER_MODE``
+    environment variable; see :class:`MPTransferMode` for accepted values.
 
     Args:
         kv_caches: Worker KV cache tensors keyed by layer name.
+        mode: Optional routing override. When ``None`` the value of
+            ``LMCACHE_MP_TRANSFER_MODE`` is consulted, defaulting to
+            :attr:`MPTransferMode.AUTO`.
         **kwargs: Unused placeholder for forward-compatible factory extension.
 
     Returns:
         A concrete :class:`TransferContext` implementation.
 
     Raises:
-        ValueError: If ``kv_caches`` is empty or has mixed device types.
+        ValueError: If ``kv_caches`` is empty, has mixed device types, the
+            requested mode string is unknown, or the requested mode is not
+            supported for the worker device.
     """
     if not kv_caches:
         raise ValueError("kv_caches is empty")
@@ -456,7 +520,17 @@ def create_transfer_context(
             f"All KV cache tensors must share one device type, got {device_types}"
         )
     device_type = next(iter(device_types))
-    logger.info("Creating transfer context (device_type=%s)", device_type)
+    resolved_mode = _resolve_mode(mode)
+    logger.info(
+        "Creating transfer context (device_type=%s, mode=%s)",
+        device_type,
+        resolved_mode.value,
+    )
+    if resolved_mode is MPTransferMode.HANDLE:
+        return _build_handle_context(device_type)
+    if resolved_mode is MPTransferMode.DATA:
+        return DataTransferContext()
+    # AUTO: preserve the historical device-type-based dispatch.
     if device_type == "cuda":
         return HandleTransferContext()
     return DataTransferContext()

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -6,6 +6,16 @@ exposes :class:`EventNotifier` -- a thin wake-up primitive used to
 signal background loops from other threads.  On Linux it is backed by
 ``os.eventfd``; on macOS / other POSIX systems it falls back to
 ``os.pipe``.  Callers never touch ``os.eventfd`` directly.
+
+Accelerator- and OS-specific implementations live in dedicated sub-
+packages so each can evolve independently:
+
+* :mod:`lmcache.v1.platform.cuda` -- CUDA-backed implementations.
+* :mod:`lmcache.v1.platform.cpu`  -- CPU-only fallbacks.
+
+Importing them here triggers their self-registration with
+:mod:`lmcache.v1.platform._registry`, so the multiprocess adapter
+can dispatch by ``tensor.device.type`` without any if/elif chain.
 """
 
 # First Party
@@ -17,3 +27,7 @@ from lmcache.v1.platform.event_notifier import consume_fd as consume_fd
 from lmcache.v1.platform.event_notifier import (
     create_event_notifier as create_event_notifier,
 )
+
+# Trigger backend self-registration with :mod:`_registry`.
+import lmcache.v1.platform.cpu  # noqa: F401,E402
+import lmcache.v1.platform.cuda  # noqa: F401,E402

--- a/lmcache/v1/platform/_registry.py
+++ b/lmcache/v1/platform/_registry.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform backend registry.
+
+Each accelerator sub-package (``platform/cuda``, ``platform/cpu``,
+future ``platform/xpu`` ...) registers a concrete factory for the
+KV-cache IPC wrapper consumed by the multiprocess adapter.
+
+The :func:`get_kv_wrapper_factory` lookup keys on
+``tensor.device.type`` so the call site in
+:mod:`lmcache.integration.vllm.vllm_multi_process_adapter` stays free
+of any if/elif chain. Adding a new accelerator therefore requires
+*zero* changes to the dispatcher; it only needs to ship its own
+sub-package and register the right callable at import time.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any, Callable, Dict
+
+# Public sentinel used by callers who want the always-available
+# fall-back regardless of the running ``torch_device_type``.
+DEFAULT_BACKEND: str = "cpu"
+
+
+# KV-cache IPC wrapper factory per device type. Concrete sub-packages
+# self-register here (CUDA -> ``CudaIPCWrapper``, CPU -> POSIX-SHM
+# wrapper) so :func:`get_kv_wrapper_factory` can dispatch by
+# ``tensor.device.type`` without any if/elif chain in the call site.
+_KV_WRAPPER_FACTORIES: Dict[str, Callable[..., Any]] = {}
+
+# Per-backend availability predicate (e.g. CUDA's ``is_available``).
+# Missing entry == always available.
+_AVAILABILITY: Dict[str, Callable[[], bool]] = {}
+
+
+def register_availability(device_type: str, predicate: Callable[[], bool]) -> None:
+    _AVAILABILITY[device_type] = predicate
+
+
+def register_kv_wrapper(device_type: str, factory: Callable[..., Any]) -> None:
+    """Register a KV-cache IPC wrapper factory for ``device_type``.
+
+    The factory takes a single ``torch.Tensor`` and returns a wrapper
+    instance ready to be sent over the multiprocess wire.
+    """
+    _KV_WRAPPER_FACTORIES[device_type] = factory
+
+
+def is_available(device_type: str) -> bool:
+    pred = _AVAILABILITY.get(device_type)
+    if pred is None:
+        return True
+    try:
+        return bool(pred())
+    except Exception:
+        return False
+
+
+def get_kv_wrapper_factory(device_type: str) -> Callable[..., Any]:
+    """Pick the KV-cache wrapper factory for ``device_type``.
+
+    A missing entry means the caller is asking for a backend that
+    nobody registered (typically because the relevant sub-package was
+    not imported), which is a programming error and deserves an
+    explicit failure.
+    """
+    factory = _KV_WRAPPER_FACTORIES.get(device_type)
+    if factory is None:
+        raise ValueError(
+            "No KV-cache wrapper factory registered for device type %r" % device_type
+        )
+    return factory
+
+
+def snapshot() -> Dict[str, Dict[str, Callable[..., Any]]]:
+    """Return a deep-copy of the registry tables.
+
+    Test suites use this to install backend overrides without leaking
+    state across tests; pair with :func:`restore` in a ``finally`` /
+    fixture teardown clause.
+    """
+    return {
+        "kv_wrapper": dict(_KV_WRAPPER_FACTORIES),
+        "availability": dict(_AVAILABILITY),
+    }
+
+
+def restore(state: Dict[str, Dict[str, Callable[..., Any]]]) -> None:
+    """Restore registry tables to a previously :func:`snapshot`-ed state."""
+    _KV_WRAPPER_FACTORIES.clear()
+    _KV_WRAPPER_FACTORIES.update(state.get("kv_wrapper", {}))
+    _AVAILABILITY.clear()
+    _AVAILABILITY.update(state.get("availability", {}))

--- a/lmcache/v1/platform/_registry.py
+++ b/lmcache/v1/platform/_registry.py
@@ -36,19 +36,37 @@ _AVAILABILITY: Dict[str, Callable[[], bool]] = {}
 
 
 def register_availability(device_type: str, predicate: Callable[[], bool]) -> None:
+    """Register an availability predicate for a device type.
+
+    Args:
+        device_type: The device type string (e.g., ``"cuda"``).
+        predicate: A zero-argument callable returning ``True`` when the
+            device is available.
+    """
     _AVAILABILITY[device_type] = predicate
 
 
 def register_kv_wrapper(device_type: str, factory: Callable[..., Any]) -> None:
     """Register a KV-cache IPC wrapper factory for ``device_type``.
 
-    The factory takes a single ``torch.Tensor`` and returns a wrapper
-    instance ready to be sent over the multiprocess wire.
+    Args:
+        device_type: The device type string (e.g., ``"cuda"``).
+        factory: A callable that takes a single ``torch.Tensor`` and
+            returns a wrapper instance ready for the multiprocess wire.
     """
     _KV_WRAPPER_FACTORIES[device_type] = factory
 
 
 def is_available(device_type: str) -> bool:
+    """Check whether a device type is available.
+
+    Args:
+        device_type: The device type string (e.g., ``"cuda"``).
+
+    Returns:
+        ``True`` if the device is available or no predicate is registered,
+        ``False`` otherwise.
+    """
     pred = _AVAILABILITY.get(device_type)
     if pred is None:
         return True
@@ -65,6 +83,15 @@ def get_kv_wrapper_factory(device_type: str) -> Callable[..., Any]:
     nobody registered (typically because the relevant sub-package was
     not imported), which is a programming error and deserves an
     explicit failure.
+
+    Args:
+        device_type: The device type string (e.g., ``"cuda"``).
+
+    Returns:
+        The registered KV-cache wrapper factory for the device type.
+
+    Raises:
+        ValueError: If no factory is registered for the device type.
     """
     factory = _KV_WRAPPER_FACTORIES.get(device_type)
     if factory is None:
@@ -80,6 +107,10 @@ def snapshot() -> Dict[str, Dict[str, Callable[..., Any]]]:
     Test suites use this to install backend overrides without leaking
     state across tests; pair with :func:`restore` in a ``finally`` /
     fixture teardown clause.
+
+    Returns:
+        A dict with keys ``"kv_wrapper"`` and ``"availability"``, each
+        mapping device-type strings to their registered callables.
     """
     return {
         "kv_wrapper": dict(_KV_WRAPPER_FACTORIES),
@@ -88,7 +119,11 @@ def snapshot() -> Dict[str, Dict[str, Callable[..., Any]]]:
 
 
 def restore(state: Dict[str, Dict[str, Callable[..., Any]]]) -> None:
-    """Restore registry tables to a previously :func:`snapshot`-ed state."""
+    """Restore registry tables to a previously :func:`snapshot`-ed state.
+
+    Args:
+        state: A snapshot dict as returned by :func:`snapshot`.
+    """
     _KV_WRAPPER_FACTORIES.clear()
     _KV_WRAPPER_FACTORIES.update(state.get("kv_wrapper", {}))
     _AVAILABILITY.clear()

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-specific platform primitives.
+
+This package will register a CPU KV-cache wrapper factory with
+:mod:`lmcache.v1.platform._registry` once the POSIX-SHM backend
+is available.
+"""

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -7,15 +7,20 @@ in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
 locate it by ``tensor.device.type``.
 """
 
+# Standard
+from typing import Any
+
+# Third Party
+import torch
+
 # First Party
-from lmcache import torch_dev
 from lmcache.v1.platform._registry import (
     register_availability,
     register_kv_wrapper,
 )
 
 
-def _kv_wrapper_factory(tensor):
+def _kv_wrapper_factory(tensor: torch.Tensor) -> Any:
     """Indirect-dispatch wrapper.
 
     Re-imports :class:`CudaIPCWrapper` on every call so test suites
@@ -27,5 +32,13 @@ def _kv_wrapper_factory(tensor):
     return CudaIPCWrapper(tensor)
 
 
-register_availability("cuda", lambda: torch_dev.is_available())
+def _cuda_is_available() -> bool:
+    """Lazy availability check to avoid circular import at module load."""
+    # First Party
+    from lmcache import torch_dev
+
+    return torch_dev.is_available()
+
+
+register_availability("cuda", _cuda_is_available)
 register_kv_wrapper("cuda", _kv_wrapper_factory)

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA-specific platform primitives.
+
+Importing this package self-registers a CUDA KV-cache wrapper
+factory with :mod:`lmcache.v1.platform._registry`, so the dispatch
+in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
+locate it by ``tensor.device.type``.
+"""
+
+# First Party
+from lmcache import torch_dev
+from lmcache.v1.platform._registry import (
+    register_availability,
+    register_kv_wrapper,
+)
+
+
+def _kv_wrapper_factory(tensor):
+    """Indirect-dispatch wrapper.
+
+    Re-imports :class:`CudaIPCWrapper` on every call so test suites
+    that swap the symbol still see their override take effect.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
+
+    return CudaIPCWrapper(tensor)
+
+
+register_availability("cuda", lambda: torch_dev.is_available())
+register_kv_wrapper("cuda", _kv_wrapper_factory)

--- a/tests/v1/multiprocess/test_non_cuda_data_transfer.py
+++ b/tests/v1/multiprocess/test_non_cuda_data_transfer.py
@@ -214,19 +214,30 @@ def _default_key(tokens: int = 8) -> "IPCCacheEngineKey":
     )
 
 
-def test_wrap_kv_caches_wraps_all_tensors(monkeypatch: Any) -> None:
+def test_wrap_kv_caches_wraps_all_tensors() -> None:
     """Verify wrap_kv_caches wraps all provided KV tensors."""
     # First Party
     from lmcache.integration.vllm import vllm_multi_process_adapter as adapter_mod
+    from lmcache.v1.platform import _registry as platform_registry
 
     kv_caches = _make_kv_caches()
-    monkeypatch.setattr(
-        adapter_mod,
-        "CudaIPCWrapper",
-        lambda tensor: ("wrapped", tensor),
-    )
+    # ``wrap_kv_caches`` dispatches through ``platform_registry``: each
+    # accelerator self-registers a wrapper factory keyed by
+    # ``tensor.device.type``. Override the relevant entries through the
+    # registry's documented API (snapshot + register + restore on
+    # teardown) instead of poking the adapter's private helper.
+    saved = platform_registry.snapshot()
 
-    wrapped = adapter_mod.wrap_kv_caches(kv_caches)
+    def _fake_factory(tensor: Any) -> tuple[str, Any]:
+        return ("wrapped", tensor)
+
+    try:
+        for device_type in {t.device.type for t in kv_caches.values()}:
+            platform_registry.register_kv_wrapper(device_type, _fake_factory)
+        wrapped = adapter_mod.wrap_kv_caches(kv_caches)
+    finally:
+        platform_registry.restore(saved)
+
     assert len(wrapped) == len(kv_caches)
 
 
@@ -240,6 +251,72 @@ def test_create_transfer_context_uses_non_cuda_context_on_cpu() -> None:
 
     context = create_transfer_context({"layer_0": torch.randn(2, 2)})
     assert isinstance(context, DataTransferContext)
+
+
+def test_resolve_extra_config_default_mp_transfer_mode_is_auto() -> None:
+    """Without override the resolved mp_transfer_mode must be ``auto``."""
+    # First Party
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        ExtraConfigDefault,
+        _resolve_extra_config,
+    )
+
+    cfg = _resolve_extra_config(None)
+    assert cfg[ExtraConfigDefault.mp_transfer_mode.name] == "auto"
+
+
+def test_resolve_extra_config_overrides_mp_transfer_mode() -> None:
+    """``lmcache.mp.mp_transfer_mode`` override flows through unchanged."""
+    # First Party
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        ExtraConfigDefault,
+        _resolve_extra_config,
+    )
+
+    cfg = _resolve_extra_config({"lmcache.mp.mp_transfer_mode": "data"})
+    assert cfg[ExtraConfigDefault.mp_transfer_mode.name] == "data"
+
+
+def test_create_transfer_context_force_data_mode() -> None:
+    """``mode='data'`` must always pick DataTransferContext, even for CUDA."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import (
+        DataTransferContext,
+        MPTransferMode,
+        create_transfer_context,
+    )
+
+    context = create_transfer_context(
+        {"layer_0": torch.randn(2, 2)}, mode=MPTransferMode.DATA
+    )
+    assert isinstance(context, DataTransferContext)
+
+
+def test_create_transfer_context_invalid_mode_raises() -> None:
+    """Unknown mode strings must raise a clear ValueError."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import create_transfer_context
+
+    with pytest.raises(ValueError, match="Invalid MP transfer mode"):
+        create_transfer_context({"layer_0": torch.randn(2, 2)}, mode="bogus")
+
+
+def test_create_transfer_context_handle_mode_unsupported_device_raises(
+    monkeypatch: Any,
+) -> None:
+    """``mode='handle'`` must raise when no wrapper factory exists for device."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import create_transfer_context
+    from lmcache.v1.platform import _registry as platform_registry
+
+    snapshot = platform_registry.snapshot()
+    try:
+        # Drop every registered factory so 'cpu' can never be resolved.
+        platform_registry.restore({"kv_wrapper": {}, "availability": {}})
+        with pytest.raises(ValueError, match="not supported for device type"):
+            create_transfer_context({"layer_0": torch.randn(2, 2)}, mode="handle")
+    finally:
+        platform_registry.restore(snapshot)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add `lmcache.mp.mp_transfer_mode` extra_config key to let users override the worker->server transfer path (`auto`/`handle`/`data`).

Extracted from #3352, only the transfer-mode routing part.