### PR TITLE
refactor: add set_shape_desc_dtype helper to avoid scattered try/except

### DIFF
--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -318,6 +318,7 @@ class PageBufferShapeDesc:
         "hs",
         "element_size",
         "block_stride_elems",
+        "dtype",
     )
 
     def __init__(self) -> None:
@@ -331,6 +332,23 @@ class PageBufferShapeDesc:
         # 0 means "unset — fall back to tight stride"; any downstream
         # consumer that needs exact addressing must check this.
         self.block_stride_elems: int = 0
+        self.dtype: torch.dtype | None = None
+
+
+def set_shape_desc_dtype(shape_desc, dtype: torch.dtype) -> None:
+    """Best-effort ``shape_desc.dtype = dtype``.
+
+    The pure-Python ``PageBufferShapeDesc`` exposes a ``dtype`` slot so
+    the CPU fallback kernel can disambiguate float16 vs bfloat16 (both
+    have ``element_size == 2``). The pybind C++ struct in
+    ``csrc/pybind.cpp`` has no such field; assignment raises
+    ``AttributeError`` and is silently swallowed here so call sites
+    don't need to branch on the active backend.
+    """
+    try:
+        shape_desc.dtype = dtype
+    except AttributeError:
+        pass
 
 
 # Cuda path goes through func cudaHostAlloc, which is

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -7,7 +7,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from enum import IntEnum
 from multiprocessing import shared_memory
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 import ctypes
 import ctypes.util
 import os
@@ -335,7 +335,7 @@ class PageBufferShapeDesc:
         self.dtype: torch.dtype | None = None
 
 
-def set_shape_desc_dtype(shape_desc, dtype: torch.dtype) -> None:
+def set_shape_desc_dtype(shape_desc: Any, dtype: torch.dtype) -> None:
     """Best-effort ``shape_desc.dtype = dtype``.
 
     The pure-Python ``PageBufferShapeDesc`` exposes a ``dtype`` slot so
@@ -344,6 +344,11 @@ def set_shape_desc_dtype(shape_desc, dtype: torch.dtype) -> None:
     ``csrc/pybind.cpp`` has no such field; assignment raises
     ``AttributeError`` and is silently swallowed here so call sites
     don't need to branch on the active backend.
+
+    Args:
+        shape_desc: A ``PageBufferShapeDesc`` instance (either the
+            pure-Python fallback or the C++ pybind struct).
+        dtype: The torch dtype to assign.
     """
     try:
         shape_desc.dtype = dtype

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -2058,6 +2058,7 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         shape_desc.nh = self.num_kv_heads
         shape_desc.hs = self.head_dim
         shape_desc.element_size = normalized.element_size()
+        lmc_ops.set_shape_desc_dtype(shape_desc, self.dtype)
         self.shape_desc = shape_desc
 
         self.paged_buffer_ptrs = torch.tensor(

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -8,6 +8,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.python_ops_fallback import set_shape_desc_dtype
 from lmcache.utils import EngineType, _lmcache_nvtx_annotate
 from lmcache.v1.compute.blend.utils import LMCBlenderBuilder
 from lmcache.v1.gpu_connector.utils import (
@@ -2058,7 +2059,7 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         shape_desc.nh = self.num_kv_heads
         shape_desc.hs = self.head_dim
         shape_desc.element_size = normalized.element_size()
-        lmc_ops.set_shape_desc_dtype(shape_desc, self.dtype)
+        set_shape_desc_dtype(shape_desc, self.dtype)
         self.shape_desc = shape_desc
 
         self.paged_buffer_ptrs = torch.tensor(

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -22,6 +22,7 @@ import torch
 # First Party
 from lmcache import torch_device_type
 from lmcache.logging import init_logger
+from lmcache.python_ops_fallback import set_shape_desc_dtype
 from lmcache.utils import EngineType
 from lmcache.v1.config import LMCacheEngineConfig
 
@@ -1369,7 +1370,7 @@ def make_page_buffer_shape_desc(
     # The C++ PageBufferShapeDesc has no ``dtype`` field, but the
     # pure-Python CPU fallback (``python_ops_fallback``) does -- and
     # needs it to disambiguate float16 vs bfloat16. Set best-effort.
-    lmc_ops.set_shape_desc_dtype(desc, dtype)
+    set_shape_desc_dtype(desc, dtype)
 
     resolved_stride = int(block_stride_elems) if block_stride_elems else 0
     desc.block_stride_elems = resolved_stride

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -1364,7 +1364,12 @@ def make_page_buffer_shape_desc(
         else get_num_heads(kv_caches, gpu_kv_format, layer_idx)
     )
     desc.hs = get_head_size(kv_caches, gpu_kv_format, layer_idx)
-    desc.element_size = get_dtype(kv_caches, gpu_kv_format, layer_idx).itemsize
+    dtype = get_dtype(kv_caches, gpu_kv_format, layer_idx)
+    desc.element_size = dtype.itemsize
+    # The C++ PageBufferShapeDesc has no ``dtype`` field, but the
+    # pure-Python CPU fallback (``python_ops_fallback``) does -- and
+    # needs it to disambiguate float16 vs bfloat16. Set best-effort.
+    lmc_ops.set_shape_desc_dtype(desc, dtype)
 
     resolved_stride = int(block_stride_elems) if block_stride_elems else 0
     desc.block_stride_elems = resolved_stride

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -548,6 +548,7 @@ def parse_kvcache_shape_spec(
         shape_desc.nh = nh
         shape_desc.hs = hs
         shape_desc.element_size = dtype.itemsize
+        lmc_ops.set_shape_desc_dtype(shape_desc, dtype)
 
         indices = list(range(layer_offset, layer_offset + layer_count))
         groups.append(

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -13,6 +13,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.python_ops_fallback import set_shape_desc_dtype
 import lmcache.c_ops as lmc_ops
 
 if TYPE_CHECKING:
@@ -548,7 +549,7 @@ def parse_kvcache_shape_spec(
         shape_desc.nh = nh
         shape_desc.hs = hs
         shape_desc.element_size = dtype.itemsize
-        lmc_ops.set_shape_desc_dtype(shape_desc, dtype)
+        set_shape_desc_dtype(shape_desc, dtype)
 
         indices = list(range(layer_offset, layer_offset + layer_count))
         groups.append(


### PR DESCRIPTION
## What

Extract the repeated `try/except AttributeError` pattern around `shape_desc.dtype = ...` into a single helper `set_shape_desc_dtype()` in `python_ops_fallback.py`.

Also add a `dtype` slot to the pure-Python `PageBufferShapeDesc` fallback class.

## Why

The C++ `PageBufferShapeDesc` struct (bound via pybind11) has no `dtype` field, so assigning `shape_desc.dtype = dtype` raises `AttributeError` at runtime when the compiled extension is active. Three call sites worked around this independently with identical `try/except AttributeError: pass` blocks -- which is noisy and easy to forget when adding new call sites.

The pure-Python fallback (`PageBufferShapeDesc` in `python_ops_fallback.py`) *does* need the `dtype` field because `element_size` alone cannot distinguish `float16` from `bfloat16` (both are 2 bytes), and the CPU fallback kernel uses `dtype` to pick the right code path.
