### PR TITLE
Add Qwen3 Coder 480B model to calculator

### DIFF
--- a/docs/source/_static/modelconfig.json
+++ b/docs/source/_static/modelconfig.json
@@ -147,6 +147,13 @@
         "num_key_value_heads": 8,
         "head_dim": 128
     },
+    "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+        "hidden_size": 6144,
+        "num_attention_heads": 96,
+        "num_hidden_layers": 62,
+        "num_key_value_heads": 8,
+        "head_dim": 128
+    },
     "meta-llama/Llama-3.1-405B": {
         "hidden_size": 16384,
         "num_attention_heads": 128,

--- a/examples/kv_cache_calculator/modelconfig.json
+++ b/examples/kv_cache_calculator/modelconfig.json
@@ -156,6 +156,7 @@
         "num_key_value_heads": 4,
         "head_dim": 128
     },
+<<<<<<< HEAD
     "tencent/Hunyuan-0.5B-Instruct": {
         "hidden_size": 1024,
         "num_attention_heads": 16,
@@ -197,5 +198,12 @@
         "num_hidden_layers": 64,
         "num_key_value_heads": 8,
         "cla_share_factor": 2
+    },
+    "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+        "hidden_size": 6144,
+        "num_attention_heads": 96,
+        "num_hidden_layers": 62,
+        "num_key_value_heads": 8,
+        "head_dim": 128
     }
 }


### PR DESCRIPTION
Add configuration for `Qwen/Qwen3-Coder-480B-A35B-Instruct` to both the KV cache calculator example and the static docs configurations.