### PR TITLE
[Feat][RawBlock] Add BLKDISCARD startup support

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -142,6 +142,22 @@ The on-device format is intentionally unchanged by the MP adapter work.
 Recovered keys are exposed to the shared L2 eviction policy on adapter startup,
 so reclaimed slots come from global L2 eviction or explicit `delete()` calls.
 
+## Startup Discard
+
+Raw block deployments sometimes intentionally start with an empty in-memory
+index instead of loading an on-device checkpoint. In that mode, bytes from a
+previous run may still exist on the device even though LMCache will not index or
+load them. `BLKDISCARD` is the Linux block-device discard/TRIM operation used to
+tell the storage stack that a byte range is no longer in use. On SSDs and NVMe
+devices, this can let the device drop old physical mappings and prepare the
+range for fresh writes.
+
+`blkdiscard_on_init=true` performs that discard over the configured raw-block
+range during startup. It is a cleanup hint, not a durable overwrite guarantee:
+device support and read-after-discard behavior are driver dependent. For that
+reason, failures are logged as warnings and startup continues with the empty
+index.
+
 ## Configuration
 
 The MP adapter is configured through `--l2-adapter` JSON:
@@ -182,10 +198,10 @@ Important validation rules:
 - `per_tp_device_paths` is rejected in MP mode
 - `load_checkpoint_on_init=false` starts with an empty in-memory index instead
   of loading the latest on-device metadata checkpoint
-- `blkdiscard_on_init=true` issues a `BLKDISCARD` ioctl to trim the full
-  device range on startup; requires `load_checkpoint_on_init=false` (combining
-  the two raises `ValueError`). The discard is split automatically using the
-  kernel `discard_max_bytes` limit when available.
+- `blkdiscard_on_init=true` issues a `BLKDISCARD` ioctl to discard/TRIM the
+  full device range on startup; requires `load_checkpoint_on_init=false`
+  (combining the two raises `ValueError`). The discard is split automatically
+  using the kernel `discard_max_bytes` limit when available.
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
 - with `use_odirect=true`, raw-block I/O rejects offsets and total I/O lengths

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -161,6 +161,7 @@ The MP adapter is configured through `--l2-adapter` JSON:
   "meta_checkpoint_interval_sec": 60,
   "meta_enable_periodic": true,
   "load_checkpoint_on_init": true,
+  "blkdiscard_on_init": false,
   "meta_verify_on_load": true,
   "num_store_workers": 2,
   "num_lookup_workers": 1,
@@ -181,6 +182,9 @@ Important validation rules:
 - `per_tp_device_paths` is rejected in MP mode
 - `load_checkpoint_on_init=false` starts with an empty in-memory index instead
   of loading the latest on-device metadata checkpoint
+- `blkdiscard_on_init=true` issues a `BLKDISCARD` ioctl to zero/trim the full
+  device range on startup; requires `load_checkpoint_on_init=false` (combining
+  the two raises `ValueError`)
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
 - with `use_odirect=true`, raw-block I/O rejects offsets and total I/O lengths

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -182,9 +182,10 @@ Important validation rules:
 - `per_tp_device_paths` is rejected in MP mode
 - `load_checkpoint_on_init=false` starts with an empty in-memory index instead
   of loading the latest on-device metadata checkpoint
-- `blkdiscard_on_init=true` issues a `BLKDISCARD` ioctl to zero/trim the full
+- `blkdiscard_on_init=true` issues a `BLKDISCARD` ioctl to trim the full
   device range on startup; requires `load_checkpoint_on_init=false` (combining
-  the two raises `ValueError`)
+  the two raises `ValueError`). The discard is split automatically using the
+  kernel `discard_max_bytes` limit when available.
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
 - with `use_odirect=true`, raw-block I/O rejects offsets and total I/O lengths

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -27,6 +27,9 @@ caller-provided load buffers during prefetch.
 - ``load_checkpoint_on_init``: Load an existing on-device metadata checkpoint
   during startup (default ``true``). Set to ``false`` to start with an empty
   in-memory index instead.
+- ``blkdiscard_on_init``: Issue a ``BLKDISCARD`` ioctl to zero/trim the full
+  device range on startup (default ``false``). Requires
+  ``load_checkpoint_on_init=false``; combining the two raises an error.
 - ``enable_zero_copy``: Try aligned direct-buffer I/O when possible.
 - ``io_engine``: Rust raw-block I/O engine. Valid values are ``"posix"``
   (default synchronous ``pread``/``pwrite`` path), ``"io_uring"`` (direct Rust

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -27,8 +27,11 @@ caller-provided load buffers during prefetch.
 - ``load_checkpoint_on_init``: Load an existing on-device metadata checkpoint
   during startup (default ``true``). Set to ``false`` to start with an empty
   in-memory index instead.
-- ``blkdiscard_on_init``: Issue a ``BLKDISCARD`` ioctl to zero/trim the full
-  device range on startup (default ``false``). Requires
+- ``blkdiscard_on_init``: Issue a Linux ``BLKDISCARD`` ioctl to discard/TRIM
+  the full device range on startup (default ``false``). This is useful when
+  starting with an empty in-memory index because it tells the storage device
+  that bytes left by a previous run are no longer in use. It is a best-effort
+  storage hint rather than a secure erase or guaranteed zero-fill. Requires
   ``load_checkpoint_on_init=false``; combining the two raises an error. The
   discard is split automatically using the kernel ``discard_max_bytes`` limit
   when available.

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -29,7 +29,9 @@ caller-provided load buffers during prefetch.
   in-memory index instead.
 - ``blkdiscard_on_init``: Issue a ``BLKDISCARD`` ioctl to zero/trim the full
   device range on startup (default ``false``). Requires
-  ``load_checkpoint_on_init=false``; combining the two raises an error.
+  ``load_checkpoint_on_init=false``; combining the two raises an error. The
+  discard is split automatically using the kernel ``discard_max_bytes`` limit
+  when available.
 - ``enable_zero_copy``: Try aligned direct-buffer I/O when possible.
 - ``io_engine``: Rust raw-block I/O engine. Valid values are ``"posix"``
   (default synchronous ``pread``/``pwrite`` path), ``"io_uring"`` (direct Rust

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -228,8 +228,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         meta_checkpoint_interval_sec: int = 60,
         meta_idle_quiet_ms: int = 100,
         meta_enable_periodic: bool = True,
-        load_checkpoint_on_init: bool = True,
         meta_verify_on_load: bool = True,
+        load_checkpoint_on_init: bool = True,
+        blkdiscard_on_init: bool = False,
         enable_zero_copy: bool = True,
         io_engine: str = "posix",
         iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH,
@@ -259,8 +260,11 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_checkpoint_interval_sec: Periodic checkpoint interval.
             meta_idle_quiet_ms: Quiet period before periodic checkpoints.
             meta_enable_periodic: Whether to run the checkpoint thread.
-            load_checkpoint_on_init: Whether to load existing checkpoint metadata.
             meta_verify_on_load: Whether recovery verifies slot headers.
+            load_checkpoint_on_init: Whether to load existing checkpoint metadata.
+            blkdiscard_on_init: Issue a BLKDISCARD ioctl to zero/trim the full
+                device range on startup.  Only valid when
+                ``load_checkpoint_on_init=False``.
             enable_zero_copy: Whether to use aligned direct-buffer I/O.
             io_engine: Raw-block I/O engine: ``"posix"`` or ``"io_uring"``.
             iouring_queue_depth: Queue depth for the Rust io_uring engine.
@@ -300,8 +304,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         self.meta_checkpoint_interval_sec = int(meta_checkpoint_interval_sec)
         self.meta_idle_quiet_ms = int(meta_idle_quiet_ms)
         self.meta_enable_periodic = bool(meta_enable_periodic)
-        self.load_checkpoint_on_init = bool(load_checkpoint_on_init)
         self.meta_verify_on_load = bool(meta_verify_on_load)
+        self.load_checkpoint_on_init = bool(load_checkpoint_on_init)
+        self.blkdiscard_on_init = bool(blkdiscard_on_init)
         self.enable_zero_copy = bool(enable_zero_copy)
         self.io_engine = normalize_raw_block_io_engine(io_engine)
         self.iouring_queue_depth = int(iouring_queue_depth)
@@ -446,8 +451,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_checkpoint_interval_sec=int(d.get("meta_checkpoint_interval_sec", 60)),
             meta_idle_quiet_ms=int(d.get("meta_idle_quiet_ms", 100)),
             meta_enable_periodic=bool(d.get("meta_enable_periodic", True)),
-            load_checkpoint_on_init=bool(d.get("load_checkpoint_on_init", True)),
             meta_verify_on_load=bool(d.get("meta_verify_on_load", True)),
+            load_checkpoint_on_init=bool(d.get("load_checkpoint_on_init", True)),
+            blkdiscard_on_init=bool(d.get("blkdiscard_on_init", False)),
             enable_zero_copy=bool(d.get("enable_zero_copy", True)),
             io_engine=io_engine,
             iouring_queue_depth=iouring_queue_depth,
@@ -486,10 +492,13 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "- meta_idle_quiet_ms (int): quiet period before checkpoint (default 100)\n"
             "- meta_enable_periodic (bool): enable periodic checkpointing "
             "(default true)\n"
-            "- load_checkpoint_on_init (bool): load existing metadata checkpoint "
-            "on startup (default true)\n"
             "- meta_verify_on_load (bool): validate slot headers on recovery "
             "(default true)\n"
+            "- load_checkpoint_on_init (bool): load existing metadata checkpoint "
+            "on startup (default true)\n"
+            "- blkdiscard_on_init (bool): issue BLKDISCARD to zero/trim the full "
+            "device on startup; requires load_checkpoint_on_init=false "
+            "(default false)\n"
             "- enable_zero_copy (bool): use aligned direct buffers when possible "
             "(default true)\n"
             "- io_engine (str): posix or io_uring (default posix)\n"
@@ -535,8 +544,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_checkpoint_interval_sec=self.meta_checkpoint_interval_sec,
             meta_idle_quiet_ms=self.meta_idle_quiet_ms,
             meta_enable_periodic=self.meta_enable_periodic,
-            load_checkpoint_on_init=self.load_checkpoint_on_init,
             meta_verify_on_load=self.meta_verify_on_load,
+            load_checkpoint_on_init=self.load_checkpoint_on_init,
+            blkdiscard_on_init=self.blkdiscard_on_init,
             io_engine=self.io_engine,
             iouring_queue_depth=self.iouring_queue_depth,
             use_uring_cmd=self.use_uring_cmd,

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -309,11 +309,14 @@ class RustRawBlockBackend(StoragePluginInterface):
             meta_enable_periodic=bool(
                 extra.get("rust_raw_block.meta_enable_periodic", True)
             ),
+            meta_verify_on_load=bool(
+                extra.get("rust_raw_block.meta_verify_on_load", True)
+            ),
             load_checkpoint_on_init=bool(
                 extra.get("rust_raw_block.load_checkpoint_on_init", True)
             ),
-            meta_verify_on_load=bool(
-                extra.get("rust_raw_block.meta_verify_on_load", True)
+            blkdiscard_on_init=bool(
+                extra.get("rust_raw_block.blkdiscard_on_init", False)
             ),
             max_data_transfer_size=max_data_transfer_size,
             io_engine=io_engine,

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -193,6 +193,7 @@ class RawBlockCoreConfig:
     meta_verify_on_load: bool
     max_data_transfer_size: int = 0
     load_checkpoint_on_init: bool = True
+    blkdiscard_on_init: bool = False
     io_engine: str = "posix"
     iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH
     use_uring_cmd: bool = False
@@ -266,8 +267,9 @@ class RawBlockCore:
         self.meta_checkpoint_interval_sec = int(config.meta_checkpoint_interval_sec)
         self.meta_idle_quiet_ms = int(config.meta_idle_quiet_ms)
         self.meta_enable_periodic = bool(config.meta_enable_periodic)
-        self.load_checkpoint_on_init = bool(config.load_checkpoint_on_init)
         self.meta_verify_on_load = bool(config.meta_verify_on_load)
+        self.load_checkpoint_on_init = bool(config.load_checkpoint_on_init)
+        self.blkdiscard_on_init = bool(config.blkdiscard_on_init)
         self.io_engine = normalize_raw_block_io_engine(config.io_engine)
         self.iouring_queue_depth = int(config.iouring_queue_depth)
         self.use_uring_cmd = bool(config.use_uring_cmd)
@@ -349,6 +351,10 @@ class RawBlockCore:
             self.max_data_transfer_size = self._resolve_max_data_transfer_size(
                 config.max_data_transfer_size
             )
+        if self.blkdiscard_on_init and self.load_checkpoint_on_init:
+            raise ValueError(
+                "blkdiscard_on_init requires load_checkpoint_on_init=False"
+            )
 
         try:
             self.meta_magic_text = self.meta_magic.decode("ascii")
@@ -396,6 +402,8 @@ class RawBlockCore:
                 self._load_checkpoint_from_device()
             else:
                 logger.info("RawBlockCore: skipping on-device metadata checkpoint load")
+                if self.blkdiscard_on_init:
+                    self._discard_full_device()
 
             if self.meta_enable_periodic:
                 self._meta_thread = threading.Thread(
@@ -1151,6 +1159,32 @@ class RawBlockCore:
         ptr = ctypes.addressof((ctypes.c_byte * 1).from_buffer(backing))
         offset = (-ptr) % self.block_align
         return memoryview(backing)[offset : offset + length]
+
+    def _discard_full_device(self) -> None:
+        """Issue BLKDISCARD via the Rust binding to discard the full device range.
+
+        This is a best-effort operation. When the underlying device does not
+        support TRIM/discard (e.g. a regular file or a driver that lacks
+        BLKDISCARD), the Rust binding raises ``OSError``; those errors are
+        logged as warnings and execution continues normally.
+        """
+        length = self._effective_capacity_bytes
+        if length <= 0:
+            return
+        try:
+            self._rawdev().discard(0, length)
+            logger.info(
+                "RawBlockCore: BLKDISCARD discarded %d bytes on %s",
+                length,
+                self.device_path,
+            )
+        except OSError as e:
+            logger.warning(
+                "RawBlockCore: BLKDISCARD failed on %s (%s); "
+                "device may not support TRIM or is not a block device",
+                self.device_path,
+                e,
+            )
 
     def _build_direct_odirect_view(
         self,

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -1180,8 +1180,10 @@ class RawBlockCore:
             )
         except OSError as e:
             logger.warning(
-                "RawBlockCore: BLKDISCARD failed on %s (%s); "
-                "device may not support TRIM or is not a block device",
+                "RawBlockCore: BLKDISCARD request for %d bytes on %s failed "
+                "before completion (%s); device may not support TRIM/discard, "
+                "is not a block device, or rejected one discard chunk",
+                length,
                 self.device_path,
                 e,
             )

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -3272,6 +3272,44 @@ impl RawBlockDevice {
         Ok(())
     }
 
+    /// Issue a BLKDISCARD ioctl to zero/trim a byte range on the block device.
+    ///
+    /// Raises ``OSError`` on any failure, including:
+    /// - ``EOPNOTSUPP`` / ``ENOTTY``: device or driver does not support BLKDISCARD.
+    /// - ``EOPNOTSUPP``: called on a non-Linux platform.
+    ///
+    /// Args:
+    ///     offset: Byte offset of the range to discard (must be sector-aligned).
+    ///     length: Number of bytes to discard (must be sector-aligned).
+    #[pyo3(signature = (offset, length))]
+    fn discard(&self, offset: u64, length: u64) -> PyResult<()> {
+        if self.closed.load(Ordering::Relaxed) {
+            return Err(PyRuntimeError::new_err("device is closed"));
+        }
+        if length == 0 {
+            return Ok(());
+        }
+        // BLKDISCARD = _IO(0x12, 119) from <linux/fs.h>
+        #[cfg(target_os = "linux")]
+        {
+            let range: [u64; 2] = [offset, length];
+            // SAFETY: ioctl expects a pointer to a [u64; 2] range argument for BLKDISCARD.
+            let rc = unsafe { libc::ioctl(self.fd, 0x1277_u64, range.as_ptr()) };
+            if rc != 0 {
+                return Err(os_err("BLKDISCARD ioctl failed"));
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (offset, length);
+            return Err(PyOSError::new_err((
+                libc::EOPNOTSUPP,
+                "BLKDISCARD is not supported on this platform",
+            )));
+        }
+        Ok(())
+    }
+
     /// Internal function to perform the cleanup operation.
     fn do_close(&mut self) -> Result<(), PyErr> {
         if self.use_iouring {

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -20,10 +20,8 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::fs;
 use std::io;
 use std::os::unix::io::RawFd;
-use std::path::{Path, PathBuf};
 use std::slice;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
@@ -665,13 +663,20 @@ struct NvmeCmdData {
     dspec: u16,     // Directive Specific
 }
 
-fn read_positive_u64(path: &Path) -> Option<u64> {
+#[cfg(target_os = "linux")]
+fn read_positive_u64(path: &std::path::Path) -> Option<u64> {
+    use std::fs;
+
     let text = fs::read_to_string(path).ok()?;
     let value = text.trim().parse::<u64>().ok()?;
     (value > 0).then_some(value)
 }
 
+#[cfg(target_os = "linux")]
 fn detect_blkdiscard_max_bytes(path: &str) -> Option<u64> {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
     let real_path = fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path));
     let block_name = real_path.file_name()?.to_str()?;
     let mut sysfs_path = fs::canonicalize(Path::new("/sys/class/block").join(block_name)).ok()?;

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -20,8 +20,10 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use std::collections::HashMap;
 use std::ffi::CString;
+use std::fs;
 use std::io;
 use std::os::unix::io::RawFd;
+use std::path::{Path, PathBuf};
 use std::slice;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
@@ -177,6 +179,8 @@ const NVME_IOCTL_ID: libc::c_ulong = 0x4e40;
 // Linux ioctl for block device size in bytes.
 // Defined in <linux/fs.h>: BLKGETSIZE64 _IOR(0x12,114,size_t)
 const BLKGETSIZE64: libc::c_ulong = 0x8008_1272; // ioctl op to query block size
+const BLKDISCARD: libc::c_ulong = 0x1277; // _IO(0x12,119)
+const DEFAULT_BLKDISCARD_CHUNK_BYTES: u64 = 1 << 30;
 
 // Buffer protocol flags (from CPython C-API).
 const PYBUF_WRITABLE: i32 = 0x0001; // buffer must be writable
@@ -661,6 +665,29 @@ struct NvmeCmdData {
     dspec: u16,     // Directive Specific
 }
 
+fn read_positive_u64(path: &Path) -> Option<u64> {
+    let text = fs::read_to_string(path).ok()?;
+    let value = text.trim().parse::<u64>().ok()?;
+    (value > 0).then_some(value)
+}
+
+fn detect_blkdiscard_max_bytes(path: &str) -> Option<u64> {
+    let real_path = fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path));
+    let block_name = real_path.file_name()?.to_str()?;
+    let mut sysfs_path = fs::canonicalize(Path::new("/sys/class/block").join(block_name)).ok()?;
+    let sys_root = Path::new("/sys");
+
+    while sysfs_path.starts_with(sys_root) {
+        if let Some(value) = read_positive_u64(&sysfs_path.join("queue/discard_max_bytes")) {
+            return Some(value);
+        }
+        if !sysfs_path.pop() {
+            break;
+        }
+    }
+    None
+}
+
 /// Aligned buffer for O_DIRECT I/O.
 /// Allocated with posix_memalign so the pointer satisfies alignment requirements.
 /// Automatically freed on drop.
@@ -1022,6 +1049,7 @@ impl Default for IoSubmission {
 /// Higher-level policies (slotting, manifests, etc.) live in Python.
 #[pyclass]
 struct RawBlockDevice {
+    path: String,        // original device path, used for sysfs discard limits
     fd: RawFd,           // raw file descriptor
     size: u64,           // cached device size in bytes
     closed: AtomicBool,  // avoid double-close
@@ -1944,6 +1972,7 @@ impl RawBlockDevice {
         let fd = fd_guard.disarm();
 
         Ok(Self {
+            path,
             fd,
             size,
             closed: AtomicBool::new(false),
@@ -3274,13 +3303,17 @@ impl RawBlockDevice {
 
     /// Issue a BLKDISCARD ioctl to zero/trim a byte range on the block device.
     ///
+    /// The request is split internally using the kernel's discard_max_bytes
+    /// limit when available. This avoids driver rejections for very large
+    /// discard ranges while keeping the Python API simple.
+    ///
     /// Raises ``OSError`` on any failure, including:
     /// - ``EOPNOTSUPP`` / ``ENOTTY``: device or driver does not support BLKDISCARD.
     /// - ``EOPNOTSUPP``: called on a non-Linux platform.
     ///
     /// Args:
-    ///     offset: Byte offset of the range to discard (must be sector-aligned).
-    ///     length: Number of bytes to discard (must be sector-aligned).
+    ///     offset: Byte offset of the range to discard.
+    ///     length: Number of bytes to discard.
     #[pyo3(signature = (offset, length))]
     fn discard(&self, offset: u64, length: u64) -> PyResult<()> {
         if self.closed.load(Ordering::Relaxed) {
@@ -3292,11 +3325,30 @@ impl RawBlockDevice {
         // BLKDISCARD = _IO(0x12, 119) from <linux/fs.h>
         #[cfg(target_os = "linux")]
         {
-            let range: [u64; 2] = [offset, length];
-            // SAFETY: ioctl expects a pointer to a [u64; 2] range argument for BLKDISCARD.
-            let rc = unsafe { libc::ioctl(self.fd, 0x1277_u64, range.as_ptr()) };
-            if rc != 0 {
-                return Err(os_err("BLKDISCARD ioctl failed"));
+            let total_len = length;
+            let chunk_bytes =
+                detect_blkdiscard_max_bytes(&self.path).unwrap_or(DEFAULT_BLKDISCARD_CHUNK_BYTES);
+
+            let mut discarded = 0_u64;
+            while discarded < total_len {
+                let chunk_len = chunk_bytes.min(total_len - discarded);
+                let chunk_offset = offset
+                    .checked_add(discarded)
+                    .ok_or_else(|| PyValueError::new_err("offset overflow"))?;
+                let range: [u64; 2] = [chunk_offset, chunk_len];
+                // SAFETY: ioctl expects a pointer to a [u64; 2] range argument
+                // for BLKDISCARD and does not retain it after the call returns.
+                let rc = unsafe { libc::ioctl(self.fd, BLKDISCARD, range.as_ptr()) };
+                if rc != 0 {
+                    return Err(PyOSError::new_err((
+                        errno(),
+                        format!(
+                            "BLKDISCARD ioctl failed at offset={} length={}",
+                            chunk_offset, chunk_len
+                        ),
+                    )));
+                }
+                discarded += chunk_len;
             }
         }
         #[cfg(not(target_os = "linux"))]

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -641,6 +641,7 @@ def test_raw_block_l2_adapter_error_bitmaps_keep_submitted_size():
             adapter.close()
 
 
+@requires_raw_block_ext
 def test_raw_block_l2_adapter_blkdiscard_on_init_calls_discard(monkeypatch):
     """Adapter forwards blkdiscard_on_init to RawBlockCore discard setup."""
     discard_calls: list[tuple[int, int]] = []

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -26,6 +26,7 @@ from lmcache.v1.memory_management import (
     MemoryObjMetadata,
     TensorMemoryObj,
 )
+from lmcache.v1.storage_backend.raw_block import RawBlockCore
 
 _EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
 
@@ -639,25 +640,10 @@ def test_raw_block_l2_adapter_error_bitmaps_keep_submitted_size():
         finally:
             adapter.close()
 
-def test_raw_block_l2_adapter_config_discard_from_dict():
-    config = RawBlockL2AdapterConfig.from_dict(
-        _config_dict(load_checkpoint_on_init=False, blkdiscard_on_init=True)
-    )
-    assert config.blkdiscard_on_init is True
-
-
-def test_raw_block_l2_adapter_config_to_core_config_propagates_discard():
-    adapter_cfg = RawBlockL2AdapterConfig.from_dict(
-        _config_dict(load_checkpoint_on_init=False, blkdiscard_on_init=True)
-    )
-    core_cfg = adapter_cfg.to_core_config()
-    assert core_cfg.blkdiscard_on_init is True
-
 
 def test_raw_block_l2_adapter_blkdiscard_on_init_calls_discard(monkeypatch):
-    """Adapter forwards blkdiscard_on_init to RawBlockCore which calls device.discard."""
+    """Adapter forwards blkdiscard_on_init to RawBlockCore discard setup."""
     discard_calls: list[tuple[int, int]] = []
-    original_discard = RawBlockCore._discard_full_device
 
     def tracking_discard(self):
         # Record the call, then invoke the real method to exercise the full path.
@@ -671,7 +657,11 @@ def test_raw_block_l2_adapter_blkdiscard_on_init_calls_discard(monkeypatch):
         with open(dev_path, "wb") as f:
             f.truncate(8 * 1024 * 1024)
 
-        cfg = _make_config(dev_path, load_checkpoint_on_init=False, blkdiscard_on_init=True)
+        cfg = _make_config(
+            dev_path,
+            load_checkpoint_on_init=False,
+            blkdiscard_on_init=True,
+        )
         adapter = RawBlockL2Adapter(cfg)
         try:
             assert len(discard_calls) == 1
@@ -683,14 +673,19 @@ def test_raw_block_l2_adapter_blkdiscard_on_init_calls_discard(monkeypatch):
 
 
 def test_raw_block_l2_adapter_discard_rejected_with_load_checkpoint():
-    """Adapter raises ValueError when blkdiscard_on_init is combined with checkpoint load."""
+    """Adapter rejects blkdiscard_on_init with checkpoint loading."""
     with tempfile.TemporaryDirectory() as td:
         dev_path = os.path.join(td, "dev.bin")
         with open(dev_path, "wb") as f:
             f.truncate(8 * 1024 * 1024)
 
-        cfg = _make_config(dev_path, load_checkpoint_on_init=True, blkdiscard_on_init=True)
+        cfg = _make_config(
+            dev_path,
+            load_checkpoint_on_init=True,
+            blkdiscard_on_init=True,
+        )
         with pytest.raises(
-            ValueError, match="blkdiscard_on_init requires load_checkpoint_on_init=False"
+            ValueError,
+            match="blkdiscard_on_init requires load_checkpoint_on_init=False",
         ):
             RawBlockL2Adapter(cfg)

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -646,8 +646,8 @@ def test_raw_block_l2_adapter_blkdiscard_on_init_calls_discard(monkeypatch):
     discard_calls: list[tuple[int, int]] = []
 
     def tracking_discard(self):
-        # Record the call, then invoke the real method to exercise the full path.
-        # We intercept at the core level so we don't need the Rust extension.
+        # Record the call and bypass the real method to avoid requiring the
+        # Rust extension.
         discard_calls.append((0, self._effective_capacity_bytes))
 
     monkeypatch.setattr(RawBlockCore, "_discard_full_device", tracking_discard)

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -138,6 +138,7 @@ def _make_config(
     capacity_bytes: int = 0,
     io_engine: str = "posix",
     use_uring_cmd: bool = False,
+    **kwargs,
 ) -> RawBlockL2AdapterConfig:
     return RawBlockL2AdapterConfig(
         device_path=device_path,
@@ -153,6 +154,7 @@ def _make_config(
         num_store_workers=2,
         num_lookup_workers=1,
         num_load_workers=2,
+        **kwargs,
     )
 
 
@@ -636,3 +638,59 @@ def test_raw_block_l2_adapter_error_bitmaps_keep_submitted_size():
             assert str(load_bitmap) == "00"
         finally:
             adapter.close()
+
+def test_raw_block_l2_adapter_config_discard_from_dict():
+    config = RawBlockL2AdapterConfig.from_dict(
+        _config_dict(load_checkpoint_on_init=False, blkdiscard_on_init=True)
+    )
+    assert config.blkdiscard_on_init is True
+
+
+def test_raw_block_l2_adapter_config_to_core_config_propagates_discard():
+    adapter_cfg = RawBlockL2AdapterConfig.from_dict(
+        _config_dict(load_checkpoint_on_init=False, blkdiscard_on_init=True)
+    )
+    core_cfg = adapter_cfg.to_core_config()
+    assert core_cfg.blkdiscard_on_init is True
+
+
+def test_raw_block_l2_adapter_blkdiscard_on_init_calls_discard(monkeypatch):
+    """Adapter forwards blkdiscard_on_init to RawBlockCore which calls device.discard."""
+    discard_calls: list[tuple[int, int]] = []
+    original_discard = RawBlockCore._discard_full_device
+
+    def tracking_discard(self):
+        # Record the call, then invoke the real method to exercise the full path.
+        # We intercept at the core level so we don't need the Rust extension.
+        discard_calls.append((0, self._effective_capacity_bytes))
+
+    monkeypatch.setattr(RawBlockCore, "_discard_full_device", tracking_discard)
+
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        cfg = _make_config(dev_path, load_checkpoint_on_init=False, blkdiscard_on_init=True)
+        adapter = RawBlockL2Adapter(cfg)
+        try:
+            assert len(discard_calls) == 1
+            offset, length = discard_calls[0]
+            assert offset == 0
+            assert length > 0
+        finally:
+            adapter.close()
+
+
+def test_raw_block_l2_adapter_discard_rejected_with_load_checkpoint():
+    """Adapter raises ValueError when blkdiscard_on_init is combined with checkpoint load."""
+    with tempfile.TemporaryDirectory() as td:
+        dev_path = os.path.join(td, "dev.bin")
+        with open(dev_path, "wb") as f:
+            f.truncate(8 * 1024 * 1024)
+
+        cfg = _make_config(dev_path, load_checkpoint_on_init=True, blkdiscard_on_init=True)
+        with pytest.raises(
+            ValueError, match="blkdiscard_on_init requires load_checkpoint_on_init=False"
+        ):
+            RawBlockL2Adapter(cfg)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds BLKDISCARD support for raw-block storage initialization.

This PR:
- adds `RawBlockDevice.discard(offset, length)` in the Rust raw-block binding
- splits long BLKDISCARD requests in Rust using the kernel `discard_max_bytes` limit when available
- adds `blkdiscard_on_init` to `RawBlockCore`, `RustRawBlockBackend`, and `RawBlockL2AdapterConfig`
- issues BLKDISCARD over the raw-block device during startup when configured
- rejects `blkdiscard_on_init=true` with `load_checkpoint_on_init=true`
- documents the new option in user-facing and design docs
- adds unit coverage for discard invocation, and invalid config rejection

This helps deployments start from a clean raw-block device while using an empty in-memory index.

**Special notes for your reviewers**:

`BLKDISCARD` is Linux-specific and device-dependent. If the underlying device does not support discard/TRIM, is not a block device, or rejects one discard chunk, the operation logs a warning and startup continues.
`blkdiscard_on_init` requires `load_checkpoint_on_init=false` because discarding the device is incompatible with loading existing on-device metadata.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests