### PR TITLE
[Bugfix] batched_nixl_desc_exists never hits on FILE (dynamic NIXL)

### DIFF
--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -710,20 +710,40 @@ class NixlDynamicStorageAgent(NixlStorageAgent):
             return False
 
     def batched_nixl_desc_exists(
-        self, reg_list: List[tuple[int, int, int, str]]
+        self, reg_list: List[tuple[int, int, int, str]], path: Optional[str] = None
     ) -> int:
-        """Check if multiple descriptors exist via a single ``query_memory`` call.
+        """Check if multiple descriptors exist from the start of ``reg_list``.
 
         :param reg_list: List of tuples ``(0, 0, 0, meta_info)`` where
             *meta_info* is the formatted object-key string.
+        :param path: Directory for FILE backends (required for FILE; ignored
+            for OBJ). FILE existence is resolved on the filesystem, since NIXL
+            ``query_memory`` only answers for object stores.
         :return: Number of consecutive descriptors that exist from the
             start of the list.
-        :raises: No exceptions are raised. Errors from the underlying
-            ``query_memory`` call are caught internally and logged as
-            warnings; the method returns ``0`` in that case.
+        :raises ValueError: If ``path`` is ``None`` for a FILE backend.
+        :raises: Errors from the underlying ``query_memory`` call (OBJ
+            backends) are caught internally and logged as warnings; the
+            method returns ``0`` in that case.
         """
         if not reg_list:
             return 0
+
+        # FILE backends are not resolvable via NIXL ``query_memory`` (it only
+        # answers for object stores), so reuse the single-key
+        # ``nixl_desc_exists`` -- which already handles FILE via os.path.exists.
+        # Without this, FILE/POSIX dynamic backends always return 0 here, so
+        # every batched lookup misses and the cache is never reused.
+        if self.mem_type == "FILE":
+            if path is None:
+                raise ValueError("path must be provided for FILE backends")
+            consecutive_count = 0
+            for _, _, _, meta_info in reg_list:
+                if self.nixl_desc_exists(meta_info, path):
+                    consecutive_count += 1
+                else:
+                    break
+            return consecutive_count
 
         try:
             resp = self.nixl_agent.query_memory(
@@ -1979,7 +1999,7 @@ class NixlDynamicStorageBackend(NixlStorageBackend):
         reg_list = [(0, 0, 0, self._format_object_key(key)) for key in remaining_keys]
 
         # Use the agent's batched_nixl_desc_exists method
-        consecutive_hits = self.agent.batched_nixl_desc_exists(reg_list)
+        consecutive_hits = self.agent.batched_nixl_desc_exists(reg_list, self.path)
 
         # Update cache for the hits and return total count
         for i in range(consecutive_hits):

--- a/tests/v1/test_nixl_batched_contains.py
+++ b/tests/v1/test_nixl_batched_contains.py
@@ -61,6 +61,10 @@ def _mock_backend(**overrides) -> Mock:
         side_effect=lambda key: f"formatted_{key.chunk_hash}"
     )
     backend.agent.batched_nixl_desc_exists = Mock(return_value=0)
+    # batched_contains() reads self.path to pass it to the agent; the value
+    # is unused here (the agent is mocked), but Mock(spec=...) raises on the
+    # unset instance attribute without it.
+    backend.path = None
     for k, v in overrides.items():
         setattr(backend, k, v)
     return backend
@@ -113,6 +117,51 @@ class TestBatchedNixlDescExists:
         agent = self._make_agent()
         agent.nixl_agent.query_memory.side_effect = RuntimeError("boom")
         assert self._call(agent, [(0, 0, 0, "k1")]) == 0
+
+    # -- FILE backend: resolves via os.path.exists, not query_memory --------
+
+    @staticmethod
+    def _make_file_agent() -> Mock:
+        agent = Mock(spec=NixlDynamicStorageAgent)
+        agent.nixl_agent = Mock()
+        agent.backend = "POSIX"
+        agent.mem_type = "FILE"
+        return agent
+
+    def test_file_all_exist(self) -> None:
+        agent = self._make_file_agent()
+        agent.nixl_desc_exists.return_value = True
+        reg_list = [(0, 0, 0, "k1"), (0, 0, 0, "k2"), (0, 0, 0, "k3")]
+        assert (
+            NixlDynamicStorageAgent.batched_nixl_desc_exists(agent, reg_list, "/dir")
+            == 3
+        )
+        # FILE must not use query_memory (it only answers for object stores)
+        agent.nixl_agent.query_memory.assert_not_called()
+        agent.nixl_desc_exists.assert_any_call("k1", "/dir")
+
+    def test_file_consecutive_then_miss(self) -> None:
+        agent = self._make_file_agent()
+        agent.nixl_desc_exists.side_effect = [True, True, False, True]
+        reg_list = [(0, 0, 0, f"k{i}") for i in range(4)]
+        assert (
+            NixlDynamicStorageAgent.batched_nixl_desc_exists(agent, reg_list, "/dir")
+            == 2
+        )
+
+    def test_file_first_missing(self) -> None:
+        agent = self._make_file_agent()
+        agent.nixl_desc_exists.side_effect = [False, True]
+        reg_list = [(0, 0, 0, "k1"), (0, 0, 0, "k2")]
+        assert (
+            NixlDynamicStorageAgent.batched_nixl_desc_exists(agent, reg_list, "/dir")
+            == 0
+        )
+
+    def test_file_requires_path(self) -> None:
+        agent = self._make_file_agent()
+        with pytest.raises(ValueError, match="path must be provided"):
+            NixlDynamicStorageAgent.batched_nixl_desc_exists(agent, [(0, 0, 0, "k1")])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The dynamic NIXL backend's batched contains calls batched_nixl_desc_exists, which only calls nixl_agent.query_memory. query_memory resolves object stores (OBJ), not POSIX files, so on a FILE backend (POSIX) it returns all-not-found -> 0 hits on every lookup. Stores succeed (files land on disk) but every request reports 'LMCache hit tokens: 0' and recomputes + re-stores, so the cache is never reused.

Add a FILE branch that delegates to nixl_desc_exists and pass the directory from the caller. The new path parameter defaults to None, so OBJ callers and the query_memory fast-path are unchanged.

Verified on a dynamic POSIX backend (nixl_pool_size: 0), APC+async off: external prefix cache hit rate 0.0% -> 99.6%, KV streamed back from storage (~56-59 GB/s) instead of recomputed on every request.

**BEFORE (bug present) — every lookup misses, nothing read back:**

```
LMCache INFO: Reqid: ...8fe76f38, Total tokens 118087, Inference Engine computed tokens: 0, LMCache hit tokens: 0, need to load: 0
LMCache INFO: Reqid: ...85b8bf6c, Total tokens 118087, Inference Engine computed tokens: 16, LMCache hit tokens: 0, need to load: 0
APIServer INFO loggers.py:259 Engine 000: ... External prefix cache hit rate: 0.0%
LMCache INFO: Reqid: ...bdb4c02f, Total tokens 118177, Inference Engine computed tokens: 118032, LMCache hit tokens: 0, need to load: 0
APIServer INFO loggers.py:259 Engine 000: ... Prefix cache hit rate: 13.6%, External prefix cache hit rate: 0.0%
```
(`External prefix cache hit rate` stays `0.0%` across the whole run; zero `Retrieved ... tokens` lines — full recompute every request.)

**AFTER (fixed) — lookups hit, KV streamed back from storage:**

```
LMCache INFO: Reqid: ...8167c1f0, Total tokens 118087, Inference Engine computed tokens: 0, LMCache hit tokens: 117760, need to load: 117760
LMCache INFO: [req_id=...8167c1f0] Retrieved 117760 out of 117760 required tokens (from 117760 total tokens). size: 17.9688 gb, cost 393.9024 ms, throughput: 45.6173 GB/s
LMCache INFO: Reqid: ...9adbe35f, Total tokens 118087, Inference Engine computed tokens: 16, LMCache hit tokens: 117760, need to load: 117744
LMCache INFO: [req_id=...8853a724] Retrieved 113664 out of 113664 required tokens (from 117760 total tokens). size: 17.3438 gb, cost 308.4387 ms, throughput: 56.2308 GB/s
LMCache INFO: [req_id=...9fe7d7b1] Retrieved 114688 out of 114688 required tokens (from 117760 total tokens). size: 17.5000 gb, cost 293.9446 ms, throughput: 59.5350 GB/s
APIServer INFO loggers.py:259 Engine 000: ... Prefix cache hit rate: 1.2%, External prefix cache hit rate: 99.6%
```
(First request after a fresh store logs `hit tokens: 0` — that's the cold store — then every reuse hits.)


