### PR TITLE
[MP][Feat] add coordinator CLI and mp server registration

### DIFF
--- a/docs/design/cli/commands.md
+++ b/docs/design/cli/commands.md
@@ -13,6 +13,7 @@ LMCache functionality.
 ```
 lmcache
 ├── server                          # Launch LMCache server (ZMQ + HTTP)
+├── coordinator                     # Launch the mp coordinator (HTTP)
 ├── describe {kvcache,engine}       # Rich status view of a running endpoint
 ├── ping     {kvcache,engine}       # Pure liveness check (OK/FAIL)
 ├── query    {kvcache,engine}       # Single-shot query with metrics
@@ -52,6 +53,25 @@ lmcache server \
 Server args are composed from existing helpers: `add_mp_server_args()`,
 `add_storage_manager_args()`, `add_prometheus_args()`, `add_telemetry_args()`,
 `add_http_frontend_args()`.
+
+### `lmcache coordinator`
+
+Replaces `python3 -m lmcache.v1.mp_coordinator`. Runs the mp coordinator's
+FastAPI/HTTP app in the foreground (Ctrl-C to stop). The coordinator tracks mp
+server instances in a registry and evicts those whose heartbeats lapse.
+
+```bash
+lmcache coordinator \
+    --host 0.0.0.0 --port 9300 \
+    --instance-timeout 30 \
+    --health-check-interval 10
+```
+
+Config resolves from `MPCoordinatorConfig.from_env()` (the
+`LMCACHE_MP_COORDINATOR_*` environment variables); any CLI flag that is supplied
+overrides the corresponding field. Each flag defaults to unset so env-only
+deployments keep working. See
+[../v1/mp_coordinator/README.md](../v1/mp_coordinator/README.md).
 
 ### `lmcache describe`
 
@@ -289,6 +309,7 @@ lmcache/cli/
 │   ├── base.py          # BaseCommand ABC
 │   ├── mock.py          # lmcache mock  (example/test command)
 │   ├── server.py        # lmcache server
+│   ├── coordinator.py   # lmcache coordinator
 │   ├── describe.py      # lmcache describe {kvcache,engine}
 │   ├── ping.py          # lmcache ping {kvcache,engine}
 │   ├── query.py         # lmcache query {kvcache,engine}

--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -135,12 +135,17 @@ liveness.
 ## Running
 
 ```
-python -m lmcache.v1.mp_coordinator
+lmcache coordinator [--host HOST] [--port PORT] \
+    [--instance-timeout SECS] [--health-check-interval SECS]
 ```
+
+(or, equivalently, `python -m lmcache.v1.mp_coordinator`).
 
 Configured via `LMCACHE_MP_COORDINATOR_*` environment variables — see
 `MPCoordinatorConfig` in `config.py` (`HOST`, `PORT`, `INSTANCE_TIMEOUT`,
-`HEALTH_CHECK_INTERVAL`).
+`HEALTH_CHECK_INTERVAL`). The `lmcache coordinator` CLI flags override the
+matching env-derived field; unset flags fall back to the env vars and then the
+config defaults.
 
 An mp server joins via the `registrar.py` helpers — no dedicated client object,
 mirroring how the coordinator just calls mp endpoints. The mp server's FastAPI

--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -1,0 +1,56 @@
+lmcache coordinator
+===================
+
+The ``lmcache coordinator`` command launches the LMCache MP **coordinator**, a
+standalone HTTP service that tracks the MP server instances in a deployment. MP
+servers register with it and send periodic heartbeats; the coordinator evicts
+any instance whose heartbeat lapses past ``--instance-timeout``.
+
+It replaces ``python -m lmcache.v1.mp_coordinator``. The process runs in the
+foreground; stop it with ``Ctrl-C``.
+
+.. code-block:: bash
+
+   lmcache coordinator [options]
+
+Quick start
+-----------
+
+.. code-block:: bash
+
+   lmcache coordinator \
+       --host 0.0.0.0 --port 9300 \
+       --instance-timeout 30 \
+       --health-check-interval 10
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Flag
+     - Description
+   * - ``--host HOST``
+     - Bind address for the coordinator's HTTP server (default: ``0.0.0.0``).
+   * - ``--port PORT``
+     - HTTP port (default: ``9300``).
+   * - ``--instance-timeout SECS``
+     - Seconds without a heartbeat after which an instance is evicted
+       (default: ``30``).
+   * - ``--health-check-interval SECS``
+     - Seconds between eviction sweeps; ``0`` disables the loop
+       (default: ``10``).
+
+Configuration
+-------------
+
+Every flag is optional. Unset flags fall back to the
+``LMCACHE_MP_COORDINATOR_*`` environment variables (``HOST``, ``PORT``,
+``INSTANCE_TIMEOUT``, ``HEALTH_CHECK_INTERVAL``), and then to the built-in
+defaults. A supplied flag always overrides the matching env-derived value, so
+env-only deployments keep working unchanged.
+
+See :doc:`/mp/coordinator` for the coordinator's architecture, registration
+protocol, and HTTP API.

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -51,6 +51,8 @@ Available Commands
      - Description
    * - :doc:`server`
      - Launch the LMCache MP server (ZMQ + HTTP). Requires the full install.
+   * - :doc:`coordinator`
+     - Launch the LMCache MP coordinator (HTTP instance registry).
    * - :doc:`describe`
      - Show detailed status of a running LMCache service.
    * - :doc:`ping`
@@ -92,6 +94,7 @@ See :doc:`/developer_guide/cli` for details.
    :maxdepth: 1
 
    server
+   coordinator
    describe
    ping
    query

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -13,7 +13,7 @@ The coordinator is a FastAPI service. Start it with:
 
 .. code-block:: bash
 
-    python3 -m lmcache.v1.mp_coordinator
+    lmcache coordinator
 
 Expected log output:
 
@@ -21,9 +21,11 @@ Expected log output:
 
     LMCache INFO: MP coordinator listening on http://0.0.0.0:9300
 
-.. note::
-   A first-class ``lmcache`` CLI subcommand is planned; for now the coordinator
-   runs as the module above and is configured via environment variables.
+The CLI accepts ``--host``, ``--port``, ``--instance-timeout``, and
+``--health-check-interval``; any flag overrides the matching environment
+variable below. See :doc:`/cli/coordinator` for details. Equivalently, the
+coordinator can still be launched as a module with
+``python3 -m lmcache.v1.mp_coordinator``.
 
 Configuration
 -------------

--- a/lmcache/cli/commands/coordinator.py
+++ b/lmcache/cli/commands/coordinator.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache coordinator`` — launch the LMCache mp coordinator (HTTP).
+
+The coordinator tracks mp server instances via a registry and evicts those
+whose heartbeats lapse. Configuration falls back to ``LMCACHE_MP_COORDINATOR_*``
+environment variables; CLI flags override them.
+"""
+
+# Standard
+import argparse
+
+# First Party
+from lmcache.cli.commands.base import BaseCommand
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+
+class CoordinatorCommand(BaseCommand):
+    """CLI command that launches the LMCache mp coordinator (HTTP)."""
+
+    def name(self) -> str:
+        """Return the subcommand name.
+
+        Returns:
+            The string ``"coordinator"``.
+        """
+        return "coordinator"
+
+    def help(self) -> str:
+        """Return short help text.
+
+        Returns:
+            Help string shown by ``lmcache -h``.
+        """
+        return "Launch the LMCache mp coordinator (HTTP)."
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        """Add coordinator-specific arguments to the parser.
+
+        Each flag defaults to ``None`` so that unset flags fall back to the
+        ``LMCACHE_MP_COORDINATOR_*`` environment variables (and then the
+        config defaults) in :meth:`execute`.
+
+        Args:
+            parser: The ``ArgumentParser`` for this subcommand.
+        """
+        parser.add_argument(
+            "--host",
+            type=str,
+            default=None,
+            help="Host the coordinator's HTTP server binds to (default: 0.0.0.0).",
+        )
+        parser.add_argument(
+            "--port",
+            type=int,
+            default=None,
+            help="Port the coordinator's HTTP server binds to (default: 9300).",
+        )
+        parser.add_argument(
+            "--instance-timeout",
+            type=float,
+            default=None,
+            help=(
+                "Seconds without a heartbeat after which an instance is evicted "
+                "(default: 30)."
+            ),
+        )
+        parser.add_argument(
+            "--health-check-interval",
+            type=float,
+            default=None,
+            help=(
+                "Seconds between health-check sweeps; 0 disables the loop "
+                "(default: 10)."
+            ),
+        )
+
+    def execute(self, args: argparse.Namespace) -> None:
+        """Build the coordinator config and serve the app with uvicorn.
+
+        Resolves config from the environment, then overrides any field whose
+        corresponding CLI flag was supplied.
+
+        Args:
+            args: Parsed CLI arguments.
+
+        Raises:
+            SystemExit: When coordinator dependencies are not installed.
+        """
+        # Standard
+        import dataclasses
+        import sys
+
+        try:
+            # Third Party
+            import uvicorn
+
+            # First Party
+            from lmcache.v1.mp_coordinator.app import create_app
+            from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+        except ImportError:
+            print(
+                "The 'lmcache coordinator' command requires the full lmcache "
+                "installation.\nInstall with: pip install lmcache",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        config = MPCoordinatorConfig.from_env()
+
+        overrides = {
+            field: value
+            for field, value in (
+                ("host", args.host),
+                ("port", args.port),
+                ("instance_timeout", args.instance_timeout),
+                ("health_check_interval", args.health_check_interval),
+            )
+            if value is not None
+        }
+        if overrides:
+            config = dataclasses.replace(config, **overrides)
+
+        app = create_app(config)
+        uvicorn.run(app, host=config.host, port=config.port, log_level="info")


### PR DESCRIPTION
**What this PR does / why we need it**:

Wires MP servers and the mp coordinator together and makes the coordinator launchable from the CLI:

- New `lmcache coordinator` subcommand launches the mp coordinator HTTP server. Config resolves from `LMCACHE_MP_COORDINATOR_*` env vars; CLI flags (`--host`, `--port`, `--instance-timeout`, `--health-check-interval`) override.
- New `mp_coordinator/registrar.py` gives MP servers a best-effort registration loop: register, heartbeat on a timer, deregister on shutdown. Transient failures are logged and retried; a `404` triggers re-registration. A down coordinator never takes the MP server down.
- MP server HTTP frontend gains coordinator config (`lmcache server` flags + env fallback) and launches the registration loop in its FastAPI lifespan.

**Special notes for your reviewers**:

Registration is intentionally plain HTTP via the MP server's existing `httpx.AsyncClient` — no dedicated client object, mirroring how the coordinator calls mp endpoints directly.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests