### PR TITLE
refactor(mp): introduce create_cache_context factory

### DIFF
--- a/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-restart-recovery.sh
@@ -8,7 +8,7 @@
 #   2. Snapshot lmcache_mp_l1_write_chunks_total via /metrics.
 #   3. Kill the LMCache server, relaunch on the same port.
 #   4. Wait for the new server to be ready and for the worker to
-#      re-register (poll /status until gpu_context_meta is non-empty).
+#      re-register (poll /status until cache_context_meta is non-empty).
 #   5. Run the same bench round again.
 #   6. Snapshot the metric again.
 #   7. Assert run2 > 0 and run2 >= 0.8 * run1.
@@ -142,7 +142,7 @@ wait_for_lmcache_http() {
 }
 
 wait_for_worker_reregister() {
-    # Poll /status until gpu_context_meta has at least one entry,
+    # Poll /status until cache_context_meta has at least one entry,
     # which proves the vLLM worker re-registered with the new server.
     local deadline=$(( $(date +%s) + RECOVER_TIMEOUT ))
     while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -152,13 +152,13 @@ import json, urllib.request
 try:
     body = urllib.request.urlopen("http://localhost:${LMCACHE_HTTP_PORT}/status", timeout=5).read()
     data = json.loads(body)
-    print(len(data.get("gpu_context_meta", {})))
+    print(len(data.get("cache_context_meta", {})))
 except Exception:
     print(0)
 EOF
 )
         if [ "$count" -gt 0 ]; then
-            echo "Worker re-registered (gpu_context_meta entries: $count)"
+            echo "Worker re-registered (cache_context_meta entries: $count)"
             return 0
         fi
         sleep 2

--- a/lmcache/cli/commands/bench/engine_bench/config.py
+++ b/lmcache/cli/commands/bench/engine_bench/config.py
@@ -125,7 +125,7 @@ def _find_model_meta(
     """Find the GPU metadata entry matching *model_name*.
 
     Args:
-        gpu_meta: The ``gpu_context_meta`` dict from ``/status``.
+        gpu_meta: The ``cache_context_meta`` dict from ``/status``.
         model_name: Model name to match.
 
     Returns:
@@ -171,10 +171,10 @@ def resolve_tokens_per_gb(lmcache_url: str, model_name: str) -> int:
     """
     data = _fetch_lmcache_status(lmcache_url)
 
-    gpu_meta = data.get("gpu_context_meta", {})
+    gpu_meta = data.get("cache_context_meta", {})
     if not gpu_meta:
         # CB-only deployments (engine_type="blend") populate
-        # cb_gpu_context_meta instead of gpu_context_meta.
+        # cb_gpu_context_meta instead of cache_context_meta.
         gpu_meta = data.get("cb_gpu_context_meta", {})
     if not gpu_meta:
         raise RuntimeError(

--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -172,7 +172,7 @@ class KVCacheDescriber:
 
     def add_models(self) -> None:
         """Per-model KV cache layout sections."""
-        gpu_meta = self.data.get("gpu_context_meta", {})
+        gpu_meta = self.data.get("cache_context_meta", {})
         if not gpu_meta:
             # CB-only deployments populate cb_gpu_context_meta instead.
             gpu_meta = self.data.get("cb_gpu_context_meta", {})

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -386,16 +386,16 @@ class BlendV3Module:
         head_size: int,
         is_neox_style: bool,
     ) -> None:
-        """Bolt rope state onto an already-registered ``gpu_contexts`` entry;
+        """Bolt rope state onto an already-registered ``cache_contexts`` entry;
         idempotent. ``REGISTER_KV_CACHE`` must precede this."""
-        gpu_contexts = self._gpu_transfer.gpu_contexts
-        if instance_id not in gpu_contexts:
+        cache_contexts = self._gpu_transfer.cache_contexts
+        if instance_id not in cache_contexts:
             raise ValueError(
                 f"Instance {instance_id} has no paged KV cache registered; "
                 "send REGISTER_KV_CACHE before CB_REGISTER_ROPE_V3."
             )
-        entry = gpu_contexts[instance_id]
-        gpu_context = entry.gpu_context
+        entry = cache_contexts[instance_id]
+        gpu_context = entry.cache_context
 
         cos_sin_cache = cos_sin_cache_ipc.to_tensor()
         # YaRN/longrope bake an mscale m into the rope cache (cos²+sin²=m²≠1).
@@ -461,7 +461,7 @@ class BlendV3Module:
         self._cb_rope_state.pop(instance_id, None)
         self._cb_gpu_contexts.pop(instance_id, None)
         self._cb_gpu_context_meta.pop(instance_id, None)
-        if instance_id not in self._gpu_transfer.gpu_contexts:
+        if instance_id not in self._gpu_transfer.cache_contexts:
             logger.warning(
                 "cb_unregister_rope: instance %d not registered", instance_id
             )
@@ -768,8 +768,8 @@ class BlendV3Module:
             job = (tokens_in_range, chunk_hashes, start_chunk_idx, key.start)
             with self._pending_fp_lock:
                 self._pending_fp_hashes.update(chunk_hashes[start_chunk_idx:])
-            entry = self._gpu_transfer.gpu_contexts.get(instance_id)
-            gpu_ctx = entry.gpu_context if entry is not None else None
+            entry = self._gpu_transfer.cache_contexts.get(instance_id)
+            gpu_ctx = entry.cache_context if entry is not None else None
             if gpu_ctx is not None and gpu_ctx.cupy_stream is not None:
                 gpu_ctx.cupy_stream.launch_host_func(
                     self._fingerprint_queue.put_nowait, job
@@ -871,8 +871,8 @@ class BlendV3Module:
         """Scatter EVERY matched chunk into paged KV (prefix-hit + shifted);
         K-only re-RoPE on the shifted subset. Drops misaligned matches;
         MLA layouts unsupported."""
-        gpu_contexts = self._gpu_transfer.gpu_contexts
-        if instance_id not in gpu_contexts:
+        cache_contexts = self._gpu_transfer.cache_contexts
+        if instance_id not in cache_contexts:
             raise ValueError(
                 f"Instance {instance_id} not registered for paged KV cache"
             )
@@ -881,7 +881,7 @@ class BlendV3Module:
                 f"Instance {instance_id} has no CB rope state; "
                 "send CB_REGISTER_ROPE_V3 before CB_RETRIEVE_PRE_COMPUTED_V3."
             )
-        gpu_context = gpu_contexts[instance_id].gpu_context
+        gpu_context = cache_contexts[instance_id].cache_context
         rope_state = self._cb_rope_state[instance_id]
         chunk_size = self._ctx.chunk_size
 

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -48,25 +48,27 @@ import lmcache.c_ops as lmc_ops
 logger = init_logger(__name__)
 
 
-def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayoutDesc:
+def get_layout_desc(
+    cache_context: GPUCacheContext, num_tokens: int
+) -> MemoryLayoutDesc:
     """Get the memory layout description for a given GPU context and number of tokens.
 
     Supports multiple KV layer groups with different shapes and dtypes.
 
     Args:
-        gpu_context: The GPU cache context containing the KV cache information.
+        cache_context: The GPU cache context containing the KV cache information.
         num_tokens: The number of tokens to determine the layout for.
 
     Returns:
         MemoryLayoutDesc: The memory layout description containing shapes and dtypes.
     """
-    num_groups = gpu_context.kv_layer_groups_manager.num_groups
+    num_groups = cache_context.kv_layer_groups_manager.num_groups
     shapes = [
-        gpu_context.get_kv_buffer_shape(num_tokens, group_idx)
+        cache_context.get_kv_buffer_shape(num_tokens, group_idx)
         for group_idx in range(num_groups)
     ]
     dtypes = [
-        gpu_context.kv_layer_groups_manager.kv_layer_groups[group_idx].dtype
+        cache_context.kv_layer_groups_manager.kv_layer_groups[group_idx].dtype
         for group_idx in range(num_groups)
     ]
     return MemoryLayoutDesc(shapes=shapes, dtypes=dtypes)
@@ -100,13 +102,13 @@ class ContextEntry:
     returned -- currently always a :class:`GPUCacheContext`.
 
     Args:
-        gpu_context: Platform cache context managing shape and pointers
+        cache_context: Platform cache context managing shape and pointers
             to the registered KV cache tensors.
         model_name: The name of the model associated with this KV cache.
         world_size: The world size associated with this KV cache.
     """
 
-    gpu_context: GPUCacheContext
+    cache_context: GPUCacheContext
     model_name: str
     world_size: int
 
@@ -123,7 +125,7 @@ class GPUTransferModule:
 
     def __init__(self, ctx: MPCacheEngineContext) -> None:
         self._ctx = ctx
-        self._gpu_contexts: dict[int, ContextEntry] = {}
+        self._cache_contexts: dict[int, ContextEntry] = {}
 
         # Route finish_write / finish_read_prefetched through a C++ host
         # callback so the driver thread doesn't acquire the GIL.
@@ -146,9 +148,9 @@ class GPUTransferModule:
         return self._ctx
 
     @property
-    def gpu_contexts(self) -> dict[int, ContextEntry]:
+    def cache_contexts(self) -> dict[int, ContextEntry]:
         """Per-instance GPU context registry."""
-        return self._gpu_contexts
+        return self._cache_contexts
 
     def get_handlers(self) -> list[HandlerSpec]:
         """Return handler specs for all request types this module serves.
@@ -188,12 +190,12 @@ class GPUTransferModule:
             per-instance KV cache layout metadata.
         """
         registered_gpu_ids: list[int] = []
-        gpu_context_meta: dict[str, dict] = {}
+        cache_context_meta: dict[str, dict] = {}
 
-        for instance_id, entry in self._gpu_contexts.items():
+        for instance_id, entry in self._cache_contexts.items():
             registered_gpu_ids.append(instance_id)
-            ctx = entry.gpu_context
-            gpu_context_meta[str(instance_id)] = {
+            ctx = entry.cache_context
+            cache_context_meta[str(instance_id)] = {
                 "model_name": entry.model_name,
                 "world_size": entry.world_size,
                 "kv_cache_layout": {
@@ -217,7 +219,7 @@ class GPUTransferModule:
 
         return {
             "registered_gpu_ids": registered_gpu_ids,
-            "gpu_context_meta": gpu_context_meta,
+            "cache_context_meta": cache_context_meta,
         }
 
     def close(self) -> None:
@@ -226,8 +228,8 @@ class GPUTransferModule:
         # in-flight completions reach a live storage manager.
         self._device_host_func_dispatcher.stop()
 
-        had_contexts = len(self._gpu_contexts) > 0
-        self._gpu_contexts.clear()
+        had_contexts = len(self._cache_contexts) > 0
+        self._cache_contexts.clear()
         if had_contexts:
             torch_dev.empty_cache()
 
@@ -256,7 +258,7 @@ class GPUTransferModule:
             group_views: Engine-neutral KV cache group metadata
                 (already msgspec-decoded by the message queue).
         """
-        if instance_id in self._gpu_contexts:
+        if instance_id in self._cache_contexts:
             logger.warning(
                 "Instance %s's KV cache is already registered, "
                 "skipping the new registration",
@@ -264,26 +266,26 @@ class GPUTransferModule:
             )
             return
 
-        gpu_context = create_cache_context(
+        cache_context = create_cache_context(
             kv_caches,
             self._ctx.chunk_size,
             layout_hints=layout_hints or None,
             group_views=group_views,
             engine_type=engine_type,
         )
-        self._gpu_contexts[instance_id] = ContextEntry(
-            gpu_context=gpu_context,
+        self._cache_contexts[instance_id] = ContextEntry(
+            cache_context=cache_context,
             model_name=model_name,
             world_size=world_size,
         )
 
-        layout_desc = get_layout_desc(gpu_context, self._ctx.chunk_size)
+        layout_desc = get_layout_desc(cache_context, self._ctx.chunk_size)
         self._ctx.layout_desc_registry.register(model_name, world_size, layout_desc)
 
         logger.info(
             "Registered KV cache for GPU ID %d with %d layers",
             instance_id,
-            gpu_context.num_layers,
+            cache_context.num_layers,
         )
 
     def unregister_kv_cache(self, instance_id: int) -> None:
@@ -292,7 +294,7 @@ class GPUTransferModule:
         Args:
             instance_id: The GPU instance ID (such as PID).
         """
-        entry = self._gpu_contexts.pop(instance_id, None)
+        entry = self._cache_contexts.pop(instance_id, None)
         if entry is None:
             logger.warning(
                 "No registered GPU context found for instance ID %d", instance_id
@@ -343,28 +345,28 @@ class GPUTransferModule:
         st = time.perf_counter()
         obj_keys = self._ctx.resolve_obj_keys(key)
 
-        entry = self._gpu_contexts.get(instance_id)
+        entry = self._cache_contexts.get(instance_id)
         if entry is None:
             raise ValueError(f"No GPU context registered for instance ID {instance_id}")
-        gpu_context = entry.gpu_context
+        cache_context = entry.cache_context
         model_name = entry.model_name
 
         # NOTE: different engine groups may have different block sizes, so
         # ``blocks_per_chunk[i]`` is the number of blocks in one chunk for
         # group ``i``.
         blocks_per_chunk = [
-            gpu_context.blocks_for_tokens(self._ctx.chunk_size, group_idx)
-            for group_idx in range(gpu_context.kv_layer_groups_manager.num_groups)
+            cache_context.blocks_for_tokens(self._ctx.chunk_size, group_idx)
+            for group_idx in range(cache_context.kv_layer_groups_manager.num_groups)
         ]
 
         with (
-            torch_dev.device(gpu_context.device),
-            torch_dev.stream(gpu_context.stream),
+            torch_dev.device(cache_context.device),
+            torch_dev.stream(cache_context.stream),
         ):
             check_interprocess_event_support()
             event = torch_dev.Event(interprocess=True)
 
-            block_ids_per_group_gpu = gpu_context.copy_view_block_ids_to_gpu(
+            block_ids_per_group_gpu = cache_context.copy_view_block_ids_to_gpu(
                 gpu_block_ids
             )
 
@@ -398,9 +400,9 @@ class GPUTransferModule:
                     "Multiprocess IPC requires CUDA."
                 )
             vllm_event = torch_dev.Event.from_ipc_handle(
-                gpu_context.device, event_ipc_handle
+                cache_context.device, event_ipc_handle
             )
-            vllm_event.wait(stream=gpu_context.stream)
+            vllm_event.wait(stream=cache_context.stream)
 
             # CPU-synchronous sentinel: a GPU store is about to be enqueued.
             # Must be published via publish() (not publish_on_stream) so the
@@ -409,17 +411,17 @@ class GPUTransferModule:
                 Event(
                     event_type=EventType.MP_STORE_SUBMITTED,
                     session_id=key.request_id,
-                    metadata={"device": str(gpu_context.device)},
+                    metadata={"device": str(cache_context.device)},
                 )
             )
 
             self._ctx.event_bus.publish_on_stream(
-                gpu_context.cupy_stream,
+                cache_context.cupy_stream,
                 Event(
                     event_type=EventType.MP_STORE_START,
                     session_id=key.request_id,
                     metadata={
-                        "device": str(gpu_context.device),
+                        "device": str(cache_context.device),
                         "engine_id": instance_id,
                         "model_name": model_name,
                     },
@@ -429,7 +431,7 @@ class GPUTransferModule:
             reserved_dict: dict[ObjectKey, MemoryObj] = {}
             store_succeeded = False
             try:
-                layout_desc = get_layout_desc(gpu_context, self._ctx.chunk_size)
+                layout_desc = get_layout_desc(cache_context, self._ctx.chunk_size)
                 reserved_dict = self._ctx.storage_manager.reserve_write(
                     obj_keys, layout_desc, "new"
                 )
@@ -438,7 +440,7 @@ class GPUTransferModule:
                 # skipped (not in reserved_dict), making block_ids
                 # non-contiguous. Batching would require torch.cat to
                 # reassemble block_ids, negating the benefit.
-                num_groups = gpu_context.kv_layer_groups_manager.num_groups
+                num_groups = cache_context.kv_layer_groups_manager.num_groups
                 for idx, obj_key in enumerate(obj_keys):
                     if obj_key in reserved_dict:
                         memory_obj = reserved_dict[obj_key]
@@ -452,28 +454,30 @@ class GPUTransferModule:
                         chunk_block_ids_gpu = block_ids_per_group_gpu[group_idx][
                             idx * bpc : (idx + 1) * bpc
                         ]
-                        tmp_buffer = gpu_context.get_tmp_chunk_gpu_buffer(group_idx)
-                        group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
+                        tmp_buffer = cache_context.get_tmp_chunk_gpu_buffer(group_idx)
+                        group_kv_pointers = cache_context.get_group_kv_pointers(
+                            group_idx
+                        )
                         # Kernel contract: ``group_lmcache_chunk_size`` here is the
                         # number of *physical* slots per chunk for this group
                         # (= logical chunk_size // compress_ratio).
-                        group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                            group_idx
+                        group_lmcache_chunk_size = (
+                            cache_context.get_physical_chunk_size(group_idx)
                         )
                         lmc_ops.multi_layer_block_kv_transfer(
                             group_kv_pointers,
                             [tmp_buffer.data_ptr()],
                             chunk_block_ids_gpu,
-                            gpu_context.device,
+                            cache_context.device,
                             lmc_ops.TransferDirection.D2H,
-                            gpu_context.get_shape_desc(group_idx),
+                            cache_context.get_shape_desc(group_idx),
                             group_lmcache_chunk_size,
-                            gpu_context.gpu_kv_format_,
+                            cache_context.gpu_kv_format_,
                             0,
                         )
                     # Store is not batched, so we always use chunk_idx=0 (single slot)
                     lmcache_memcpy_async_d2h(
-                        gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=0), memory_obj
+                        cache_context.get_tmp_gpu_buffer_flat(chunk_idx=0), memory_obj
                     )
                 store_succeeded = True
             except Exception:
@@ -486,7 +490,7 @@ class GPUTransferModule:
                 stored_count = len(reserved_dict) if store_succeeded else 0
                 if stored_count:
                     submit_callback_to_stream(
-                        gpu_context.cupy_stream,
+                        cache_context.cupy_stream,
                         "finish_write",
                         list(reserved_dict.keys()),
                     )
@@ -498,13 +502,13 @@ class GPUTransferModule:
                     else 0
                 )
                 self._ctx.event_bus.publish_on_stream(
-                    gpu_context.cupy_stream,
+                    cache_context.cupy_stream,
                     Event(
                         event_type=EventType.MP_STORE_END,
                         session_id=key.request_id,
                         metadata={
                             "stored_count": stored_count,
-                            "device": str(gpu_context.device),
+                            "device": str(cache_context.device),
                             "engine_id": instance_id,
                             "model_name": model_name,
                             "total_bytes": total_bytes,
@@ -555,10 +559,10 @@ class GPUTransferModule:
         st = time.perf_counter()
         obj_keys = self._ctx.resolve_obj_keys(key)
 
-        entry = self._gpu_contexts.get(instance_id)
+        entry = self._cache_contexts.get(instance_id)
         if entry is None:
             raise ValueError(f"No GPU context registered for instance ID {instance_id}")
-        gpu_context = entry.gpu_context
+        cache_context = entry.cache_context
         model_name = entry.model_name
 
         # CPU-synchronous sentinel: a GPU retrieve is about to be enqueued.
@@ -568,17 +572,17 @@ class GPUTransferModule:
             Event(
                 event_type=EventType.MP_RETRIEVE_SUBMITTED,
                 session_id=key.request_id,
-                metadata={"device": str(gpu_context.device)},
+                metadata={"device": str(cache_context.device)},
             )
         )
 
         self._ctx.event_bus.publish_on_stream(
-            gpu_context.cupy_stream,
+            cache_context.cupy_stream,
             Event(
                 event_type=EventType.MP_RETRIEVE_START,
                 session_id=key.request_id,
                 metadata={
-                    "device": str(gpu_context.device),
+                    "device": str(cache_context.device),
                     "engine_id": instance_id,
                     "model_name": model_name,
                 },
@@ -590,12 +594,12 @@ class GPUTransferModule:
         # ``skip_blocks_in_chunk`` argument expects regardless
         # of per-group compression.
         ie_logical_block_size = (
-            gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
+            cache_context.kv_layer_groups_manager.inference_engine_logical_block_size
         )
 
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
-            _BATCH_SIZE = gpu_context.max_batch_size
-            groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
+            _BATCH_SIZE = cache_context.max_batch_size
+            groups = cache_context.kv_layer_groups_manager.kv_layer_groups
             for batch_idx, memory_obj_batch in enumerate(
                 batched_iteration(memory_objs, batch_size=_BATCH_SIZE)
             ):
@@ -632,10 +636,12 @@ class GPUTransferModule:
                 for chunk_idx, memory_obj in enumerate(memory_obj_batch):
                     lmcache_memcpy_async_h2d(
                         memory_obj,
-                        gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=chunk_idx),
+                        cache_context.get_tmp_gpu_buffer_flat(chunk_idx=chunk_idx),
                     )
                 for group_idx, group in enumerate(groups):
-                    bpc = gpu_context.blocks_for_tokens(self._ctx.chunk_size, group_idx)
+                    bpc = cache_context.blocks_for_tokens(
+                        self._ctx.chunk_size, group_idx
+                    )
                     chunk_block_ids_gpu = block_ids_per_group_gpu[group_idx][
                         start_chunk_id * bpc : end_chunk_id * bpc
                     ]
@@ -650,14 +656,14 @@ class GPUTransferModule:
                             f"expected={batch_len * bpc} "
                             f"got={chunk_block_ids_gpu.shape[0]}"
                         )
-                    group_skip_blocks = gpu_context.blocks_for_tokens(
+                    group_skip_blocks = cache_context.blocks_for_tokens(
                         skip_tokens_in_chunk, group_idx
                     )
-                    tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
+                    tmp_buffers = cache_context.get_tmp_chunk_gpu_buffer_batched(
                         batch_len, group_idx
                     )
-                    group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                    group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
+                    group_kv_pointers = cache_context.get_group_kv_pointers(group_idx)
+                    group_lmcache_chunk_size = cache_context.get_physical_chunk_size(
                         group_idx
                     )
 
@@ -665,20 +671,20 @@ class GPUTransferModule:
                         group_kv_pointers,
                         [tb.data_ptr() for tb in tmp_buffers],
                         chunk_block_ids_gpu,
-                        gpu_context.device,
+                        cache_context.device,
                         lmc_ops.TransferDirection.H2D,
-                        gpu_context.get_shape_desc(group_idx),
+                        cache_context.get_shape_desc(group_idx),
                         group_lmcache_chunk_size,
-                        gpu_context.gpu_kv_format_,
+                        cache_context.gpu_kv_format_,
                         group_skip_blocks,
                     )
 
         with (
-            torch_dev.device(gpu_context.device),
-            torch_dev.stream(gpu_context.stream),
+            torch_dev.device(cache_context.device),
+            torch_dev.stream(cache_context.stream),
         ):
             # Copy all block_ids to GPU once before the loop
-            block_ids_per_group_gpu = gpu_context.copy_view_block_ids_to_gpu(
+            block_ids_per_group_gpu = cache_context.copy_view_block_ids_to_gpu(
                 gpu_block_ids
             )
 
@@ -708,18 +714,18 @@ class GPUTransferModule:
                 event.record()
                 if retrieve_succeeded:
                     submit_callback_to_stream(
-                        gpu_context.cupy_stream,
+                        cache_context.cupy_stream,
                         "finish_read_prefetched",
                         prefetched_keys,
                     )
                 self._ctx.event_bus.publish_on_stream(
-                    gpu_context.cupy_stream,
+                    cache_context.cupy_stream,
                     Event(
                         event_type=EventType.MP_RETRIEVE_END,
                         session_id=key.request_id,
                         metadata={
                             "retrieved_count": len(prefetched_keys),
-                            "device": str(gpu_context.device),
+                            "device": str(cache_context.device),
                             "engine_id": instance_id,
                             "model_name": model_name,
                             "cache_salt": key.cache_salt,

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -93,10 +93,9 @@ def batched_iteration(lst: list, batch_size: int) -> Generator[tuple, None, None
 
 
 @dataclass
-class GPUContextEntry:
+class ContextEntry:
     """Registered cache context metadata for a single worker instance.
 
-    The ``gpu_context`` field name is kept for backwards compatibility.
     The actual concrete type is whatever :func:`create_cache_context`
     returned -- currently always a :class:`GPUCacheContext`.
 
@@ -124,7 +123,7 @@ class GPUTransferModule:
 
     def __init__(self, ctx: MPCacheEngineContext) -> None:
         self._ctx = ctx
-        self._gpu_contexts: dict[int, GPUContextEntry] = {}
+        self._gpu_contexts: dict[int, ContextEntry] = {}
 
         # Route finish_write / finish_read_prefetched through a C++ host
         # callback so the driver thread doesn't acquire the GIL.
@@ -147,7 +146,7 @@ class GPUTransferModule:
         return self._ctx
 
     @property
-    def gpu_contexts(self) -> dict[int, GPUContextEntry]:
+    def gpu_contexts(self) -> dict[int, ContextEntry]:
         """Per-instance GPU context registry."""
         return self._gpu_contexts
 
@@ -272,7 +271,7 @@ class GPUTransferModule:
             group_views=group_views,
             engine_type=engine_type,
         )
-        self._gpu_contexts[instance_id] = GPUContextEntry(
+        self._gpu_contexts[instance_id] = ContextEntry(
             gpu_context=gpu_context,
             model_name=model_name,
             world_size=world_size,

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -42,6 +42,7 @@ from lmcache.v1.multiprocess.native_completion import (
     submit_callback_to_stream,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
@@ -93,11 +94,15 @@ def batched_iteration(lst: list, batch_size: int) -> Generator[tuple, None, None
 
 @dataclass
 class GPUContextEntry:
-    """Registered GPU context metadata for a single worker instance.
+    """Registered cache context metadata for a single worker instance.
+
+    The ``gpu_context`` field name is kept for backwards compatibility.
+    The actual concrete type is whatever :func:`create_cache_context`
+    returned -- currently always a :class:`GPUCacheContext`.
 
     Args:
-        gpu_context: The GPU cache context managing shape and pointers
-            to vLLM GPU KV cache tensors.
+        gpu_context: Platform cache context managing shape and pointers
+            to the registered KV cache tensors.
         model_name: The name of the model associated with this KV cache.
         world_size: The world size associated with this KV cache.
     """
@@ -260,7 +265,7 @@ class GPUTransferModule:
             )
             return
 
-        gpu_context = GPUCacheContext(
+        gpu_context = create_cache_context(
             kv_caches,
             self._ctx.chunk_size,
             layout_hints=layout_hints or None,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -116,7 +116,7 @@ class MPCacheEngine:
         """Used by ``/kvcache/check``; unwraps :class:`GPUContextEntry`."""
         for module in self._modules:
             if isinstance(module, GPUTransferModule):
-                return {i: e.gpu_context for i, e in module.gpu_contexts.items()}
+                return {i: e.cache_context for i, e in module.cache_contexts.items()}
         return None
 
     def clear(self) -> None:

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -43,6 +43,22 @@ def create_cache_context(
 
     Currently only :class:`GPUCacheContext` is supported.  CPU and
     other accelerator backends will be added in follow-up PRs.
+
+    Args:
+        kv_caches: KV cache tensor wrappers from the serving engine.
+            Must be non-empty.
+        lmcache_logical_chunk_size: Number of tokens per LMCache chunk.
+        layout_hints: Optional hints for GPU KV format detection.
+            Forwarded verbatim to the concrete context constructor.
+        group_views: Engine-neutral KV cache group metadata.
+        engine_type: Which serving engine produced the caches.
+
+    Returns:
+        A concrete cache context instance (currently always
+        :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext`).
+
+    Raises:
+        ValueError: If *kv_caches* is empty.
     """
     # First Party
     from lmcache.v1.multiprocess.gpu_context import GPUCacheContext

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform-agnostic cache-context factory.
+
+The concrete implementations live in their respective sub-packages:
+
+* :class:`~lmcache.v1.multiprocess.gpu_context.GPUCacheContext` --
+  CUDA-backed.
+
+:func:`create_cache_context` keeps the dispatch out of the call site
+in :mod:`lmcache.v1.multiprocess.server` so adding a new accelerator
+only requires shipping a new sub-package + extending the factory below.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import LayoutHints
+from lmcache.v1.multiprocess.custom_types import KVCache
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+
+
+def create_cache_context(
+    kv_caches: KVCache,
+    lmcache_logical_chunk_size: int = 256,
+    layout_hints: LayoutHints | None = None,
+    group_views: "Sequence[LMCacheGroupView]" = (),
+    engine_type: EngineType = EngineType.VLLM,
+) -> Any:
+    """Create the appropriate cache context.
+
+    The signature mirrors :class:`GPUCacheContext` so callers can
+    forward their kwargs verbatim and stay agnostic of the active
+    backend.
+
+    Currently only :class:`GPUCacheContext` is supported.  CPU and
+    other accelerator backends will be added in follow-up PRs.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
+
+    if not kv_caches:
+        raise ValueError("create_cache_context requires a non-empty kv_caches list")
+
+    return GPUCacheContext(
+        kv_caches,
+        lmcache_logical_chunk_size,
+        layout_hints,
+        group_views,
+        engine_type,
+    )

--- a/tests/cli/commands/bench/engine_bench/test_config.py
+++ b/tests/cli/commands/bench/engine_bench/test_config.py
@@ -236,7 +236,7 @@ class TestResolveTokensPerGb:
         model_name: str = "Qwen/Qwen3-14B",
     ) -> dict:
         return {
-            "gpu_context_meta": {
+            "cache_context_meta": {
                 "gpu_0": {
                     "model_name": model_name,
                     "world_size": world_size,
@@ -288,7 +288,7 @@ class TestResolveTokensPerGb:
         "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",
     )
     def test_no_gpu_meta_raises(self, mock_fetch) -> None:
-        mock_fetch.return_value = {"gpu_context_meta": {}}
+        mock_fetch.return_value = {"cache_context_meta": {}}
         with pytest.raises(RuntimeError, match="No model info"):
             resolve_tokens_per_gb(
                 "http://localhost:8080",
@@ -311,7 +311,9 @@ class TestResolveTokensPerGb:
     )
     def test_no_cache_size_raises(self, mock_fetch) -> None:
         data = self._status_response()
-        del data["gpu_context_meta"]["gpu_0"]["kv_cache_layout"]["cache_size_per_token"]
+        del data["cache_context_meta"]["gpu_0"]["kv_cache_layout"][
+            "cache_size_per_token"
+        ]
         mock_fetch.return_value = data
         with pytest.raises(RuntimeError, match="cache_size_per_token"):
             resolve_tokens_per_gb(
@@ -324,7 +326,7 @@ class TestResolveTokensPerGb:
     )
     def test_no_layout_raises(self, mock_fetch) -> None:
         data = self._status_response()
-        del data["gpu_context_meta"]["gpu_0"]["kv_cache_layout"]
+        del data["cache_context_meta"]["gpu_0"]["kv_cache_layout"]
         mock_fetch.return_value = data
         with pytest.raises(RuntimeError, match="kv_cache_layout"):
             resolve_tokens_per_gb(

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -29,7 +29,7 @@ SAMPLE_STATUS = {
     "chunk_size": 256,
     "hash_algorithm": "sha256",
     "registered_gpu_ids": [0],
-    "gpu_context_meta": {
+    "cache_context_meta": {
         "0": {
             "model_name": "llama",
             "world_size": 1,

--- a/tests/v1/multiprocess/test_engine_passthroughs.py
+++ b/tests/v1/multiprocess/test_engine_passthroughs.py
@@ -28,9 +28,9 @@ def test_storage_manager_returns_context_storage_manager() -> None:
 def test_gpu_contexts_unwraps_entries_from_gpu_transfer_module() -> None:
     gpu0, gpu1 = MagicMock(name="gpu_ctx_0"), MagicMock(name="gpu_ctx_1")
     gpu_transfer = MagicMock(spec=GPUTransferModule)
-    gpu_transfer.gpu_contexts = {
-        0: ContextEntry(gpu_context=gpu0, model_name="m", world_size=1),
-        7: ContextEntry(gpu_context=gpu1, model_name="m", world_size=1),
+    gpu_transfer.cache_contexts = {
+        0: ContextEntry(cache_context=gpu0, model_name="m", world_size=1),
+        7: ContextEntry(cache_context=gpu1, model_name="m", world_size=1),
     }
 
     engine = MPCacheEngine(MagicMock(), modules=[MagicMock(), gpu_transfer])

--- a/tests/v1/multiprocess/test_engine_passthroughs.py
+++ b/tests/v1/multiprocess/test_engine_passthroughs.py
@@ -9,7 +9,7 @@ import pytest
 
 # First Party
 from lmcache.v1.multiprocess.modules.gpu_transfer import (
-    GPUContextEntry,
+    ContextEntry,
     GPUTransferModule,
 )
 from lmcache.v1.multiprocess.modules.management import ManagementModule
@@ -29,8 +29,8 @@ def test_gpu_contexts_unwraps_entries_from_gpu_transfer_module() -> None:
     gpu0, gpu1 = MagicMock(name="gpu_ctx_0"), MagicMock(name="gpu_ctx_1")
     gpu_transfer = MagicMock(spec=GPUTransferModule)
     gpu_transfer.gpu_contexts = {
-        0: GPUContextEntry(gpu_context=gpu0, model_name="m", world_size=1),
-        7: GPUContextEntry(gpu_context=gpu1, model_name="m", world_size=1),
+        0: ContextEntry(gpu_context=gpu0, model_name="m", world_size=1),
+        7: ContextEntry(gpu_context=gpu1, model_name="m", world_size=1),
     }
 
     engine = MPCacheEngine(MagicMock(), modules=[MagicMock(), gpu_transfer])

--- a/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
+++ b/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
@@ -38,6 +38,7 @@ def stub_native_storage_ops() -> Any:
     module_any = cast(Any, module)
     module_any.TTLLock = type("TTLLock", (), {})
     module_any.Bitmap = type("Bitmap", (), {})
+    module_any.PeriodicEventNotifier = type("PeriodicEventNotifier", (), {})
     with patch.dict(
         sys.modules,
         {
@@ -67,8 +68,14 @@ def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
     ctx.chunk_size = 16
     ctx.layout_desc_registry = LayoutDescRegistry()
 
-    def fake_gpu_context(*args: object, **kwargs: object) -> _FakeGPUContext:
-        """Return a fake GPU context without touching CUDA."""
+    def fake_create_cache_context(
+        kv_caches: object,
+        lmcache_logical_chunk_size: int,
+        layout_hints: object = None,
+        group_views: object = (),
+        engine_type: object = None,
+    ) -> _FakeGPUContext:
+        """Return a fake cache context without touching CUDA or wrappers."""
         return _FakeGPUContext()
 
     def fake_layout_desc(
@@ -83,7 +90,9 @@ def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
         "DeviceHostFuncDispatcher",
         _FakeDeviceHostFuncDispatcher,
     )
-    monkeypatch.setattr(gpu_transfer_mod, "GPUCacheContext", fake_gpu_context)
+    monkeypatch.setattr(
+        gpu_transfer_mod, "create_cache_context", fake_create_cache_context
+    )
     monkeypatch.setattr(gpu_transfer_mod, "get_layout_desc", fake_layout_desc)
     monkeypatch.setattr(
         gpu_transfer_mod.torch_dev,


### PR DESCRIPTION
This is a piece of https://github.com/LMCache/LMCache/pull/3352 to avoid the size of #3352 become too big.

So, I extract a platform-agnostic `create_cache_context` factory into `lmcache/v1/platform/cache_context.py`.

`gpu_transfer.py` now calls the factory instead of instantiating `GPUCacheContext` directly, keeping the call site decoupled from the concrete backend.

CPU and other accelerator backends will be wired in follow-up PRs.

Changes:
- Add `lmcache/v1/platform/cache_context.py` with `create_cache_context`
- Update `gpu_transfer.py` to use the factory
- Update test to monkeypatch `create_cache_context` instead of `GPUCacheContext`