### PR TITLE
Fixes #3490: in async-prefetch, skip GPU-resident chunks to avoid redundant prefetch

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1386,6 +1386,7 @@ class LMCacheConnectorV1Impl:
                 token_ids,
                 lookup_id=req_id,
                 request_configs=request_configs,
+                num_computed_tokens=num_computed_tokens,
             )
 
         if num_external_hit_tokens is None:

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -48,6 +48,7 @@ class LMCacheStats:
     interval_lookup_hits: int
     interval_vllm_hit_tokens: int
     interval_prompt_tokens: int
+    interval_async_prefetch_skipped_tokens: int
 
     interval_num_slow_retrieval_by_time: int
     interval_num_slow_retrieval_by_speed: int
@@ -261,6 +262,7 @@ class LMCStatsMonitor:
         self.interval_lookup_hits = 0  # total hit tokens lookup
         self.interval_vllm_hit_tokens = 0  # total hit tokens in vllm
         self.interval_prompt_tokens = 0  # total prompt tokens
+        self.interval_async_prefetch_skipped_tokens = 0
         self.interval_lookup_0_hit_requests = 0
 
         self.interval_num_slow_retrieval_by_time = 0
@@ -591,6 +593,10 @@ class LMCStatsMonitor:
     def update_interval_prompt_tokens(self, delta: int):
         self.interval_prompt_tokens += delta
 
+    @thread_safe
+    def update_interval_async_prefetch_skipped_tokens(self, delta: int):
+        self.interval_async_prefetch_skipped_tokens += delta
+
     def _clear(self):
         """
         Clear all the distribution stats
@@ -606,6 +612,7 @@ class LMCStatsMonitor:
         self.interval_lookup_hits = 0
         self.interval_vllm_hit_tokens = 0
         self.interval_prompt_tokens = 0
+        self.interval_async_prefetch_skipped_tokens = 0
 
         self.interval_num_slow_retrieval_by_time = 0
         self.interval_num_slow_retrieval_by_speed = 0
@@ -822,6 +829,7 @@ class LMCStatsMonitor:
             interval_request_cache_lifespan=request_lifespan,
             interval_prompt_tokens=self.interval_prompt_tokens,
             interval_lookup_0_hit_requests=self.interval_lookup_0_hit_requests,
+            interval_async_prefetch_skipped_tokens=self.interval_async_prefetch_skipped_tokens,
         )
         self._clear()
         return ret
@@ -985,6 +993,13 @@ class PrometheusLogger:
         self.counter_num_vllm_hit_tokens = self._create_counter(
             name="lmcache:num_vllm_hit_tokens",
             documentation="Number of hit tokens in vllm",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_async_prefetch_skipped_tokens = self._create_counter(
+            name="lmcache:num_async_prefetch_skipped_tokens",
+            documentation="Number of tokens skipped during async prefetch "
+            "because they were already resident in GPU memory",
             labelnames=labelnames,
         )
 
@@ -1711,6 +1726,10 @@ class PrometheusLogger:
         self._log_counter(self.counter_num_prompt_tokens, stats.interval_prompt_tokens)
         self._log_counter(
             self.counter_num_vllm_hit_tokens, stats.interval_vllm_hit_tokens
+        )
+        self._log_counter(
+            self.counter_num_async_prefetch_skipped_tokens,
+            stats.interval_async_prefetch_skipped_tokens,
         )
 
         self._log_counter(

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -594,7 +594,12 @@ class LMCStatsMonitor:
         self.interval_prompt_tokens += delta
 
     @thread_safe
-    def update_interval_async_prefetch_skipped_tokens(self, delta: int):
+    def update_interval_async_prefetch_skipped_tokens(self, delta: int) -> None:
+        """Increment the count of async-prefetch tokens skipped this interval.
+
+        Args:
+            delta: Number of tokens to add to the skipped-token counter.
+        """
         self.interval_async_prefetch_skipped_tokens += delta
 
     def _clear(self):

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1307,6 +1307,7 @@ class LMCacheEngine:
         search_range: Optional[List[str]] = None,
         pin: bool = False,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> None:
         """
         An async version of lookup + prefetch.
@@ -1330,6 +1331,7 @@ class LMCacheEngine:
         # storage backend hot_cache lookups match the same key type.
         keys_per_chunk = self.num_layers if self.use_layerwise else 1
 
+        num_skip_tokens = 0
         # TODO(Jiayi): make token database able to return list.
         for start, end, key in self.token_database.process_tokens(
             tokens=tokens,
@@ -1338,11 +1340,17 @@ class LMCacheEngine:
             request_configs=request_configs,
         ):
             assert isinstance(key, CacheEngineKey)
+            if end <= num_computed_tokens:
+                # This chunk is already resident in GPU memory; skip loading it
+                # from storage but track how many tokens we are skipping so the
+                # scheduler response still reflects the full prefix coverage.
+                num_skip_tokens = end
+                continue
             if self.use_layerwise:
                 keys.extend(key.split_layers(self.num_layers))
             else:
                 keys.append(key)
-            cum_chunk_lengths.append(end)
+            cum_chunk_lengths.append(end - num_skip_tokens)
 
         asyncio.run_coroutine_threadsafe(
             self.storage_manager.async_lookup_and_prefetch(
@@ -1352,6 +1360,7 @@ class LMCacheEngine:
                 search_range,
                 pin,
                 keys_per_chunk=keys_per_chunk,
+                num_skip_tokens=num_skip_tokens,
             ),
             self.storage_manager.loop,
         )

--- a/lmcache/v1/lookup_client/abstract_client.py
+++ b/lmcache/v1/lookup_client/abstract_client.py
@@ -30,6 +30,7 @@ class LookupClientInterface(metaclass=abc.ABCMeta):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         """
         Perform lookup for the given token IDs.

--- a/lmcache/v1/lookup_client/async_lookup_message.py
+++ b/lmcache/v1/lookup_client/async_lookup_message.py
@@ -20,11 +20,13 @@ class LookupRequestMsg(AsyncLookupMsg):
     hashes: list[int]
     offsets: list[int]
     request_configs: Optional[Dict[str, str]] = None
+    num_computed_tokens: int = 0
 
     def describe(self) -> str:
         return (
             f"Async lookup request for lookup_id={self.lookup_id} "
-            f"with {len(self.hashes)} hashes"
+            f"with {len(self.hashes)} hashes "
+            f"num_computed_tokens={self.num_computed_tokens}"
         )
 
 

--- a/lmcache/v1/lookup_client/chunk_statistics_lookup_client.py
+++ b/lmcache/v1/lookup_client/chunk_statistics_lookup_client.py
@@ -123,12 +123,14 @@ class ChunkStatisticsLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         start_time = time.time()
         result = self.actual_lookup_client.lookup(
             token_ids,
             lookup_id,
             request_configs,
+            num_computed_tokens,
         )
         lookup_elapsed = time.time() - start_time
         with self.lock:

--- a/lmcache/v1/lookup_client/hit_limit_lookup_client.py
+++ b/lmcache/v1/lookup_client/hit_limit_lookup_client.py
@@ -42,12 +42,14 @@ class HitLimitLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         # get real hit tokens
         result = self.actual_lookup_client.lookup(
             token_ids,
             lookup_id,
             request_configs,
+            num_computed_tokens,
         )
         if result is not None:
             total_tokens_length = len(token_ids)

--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -195,6 +195,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         hashes: list[int] = []
         offsets = []
@@ -210,6 +211,7 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
             hashes=hashes,
             offsets=offsets,
             request_configs=request_configs,
+            num_computed_tokens=num_computed_tokens,
         )
 
         # Serialize message using msgspec
@@ -372,6 +374,7 @@ class LMCacheAsyncLookupServer:
                         offsets=msg.offsets,
                         pin=True,
                         request_configs=msg.request_configs,
+                        num_computed_tokens=msg.num_computed_tokens,
                     )
 
                 elif isinstance(msg, LookupCleanupMsg):

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -88,6 +88,7 @@ class LMCacheLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         request_configs_str = ""
         if request_configs is not None and len(request_configs) != 0:

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -54,6 +54,7 @@ class LMCacheBypassLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         try:
             if not self.enable_blending:

--- a/lmcache/v1/lookup_client/mooncake_lookup_client.py
+++ b/lmcache/v1/lookup_client/mooncake_lookup_client.py
@@ -63,6 +63,7 @@ class MooncakeLookupClient(LookupClientInterface):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: Optional[str] = None,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         # process token_ids to cacheengine keys
         keys = []

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -25,7 +25,7 @@ import torch
 # First Party
 from lmcache import torch_dev, torch_device_type
 from lmcache.logging import init_logger
-from lmcache.observability import PrometheusLogger
+from lmcache.observability import LMCStatsMonitor, PrometheusLogger
 from lmcache.utils import (
     CacheEngineKey,
     _lmcache_nvtx_annotate,
@@ -558,6 +558,7 @@ class StorageManager:
         cum_chunk_lengths_total: list[int],
         tier_expected_chunks: list[int],
         keys_per_chunk: int = 1,
+        num_skip_tokens: int = 0,
     ) -> None:
         """
         Callback function when all prefetch tasks
@@ -641,10 +642,11 @@ class StorageManager:
                         mem_obj.ref_count_down()
                 break
 
-        retrieved_length = cum_chunk_lengths_total[total_retrieved_chunks]
+        retrieved_length = cum_chunk_lengths_total[total_retrieved_chunks] + num_skip_tokens
         logger.info(
             f"Responding to scheduler for lookup id {lookup_id}"
-            f" with retrieved length {retrieved_length}"
+            f" with retrieved length {retrieved_length} "
+            f"including num_skip_tokens {num_skip_tokens}"
         )
         self.async_lookup_server.send_response_to_scheduler(lookup_id, retrieved_length)
 
@@ -656,6 +658,7 @@ class StorageManager:
         search_range: Optional[list[str]] = None,
         pin: bool = False,
         keys_per_chunk: int = 1,
+        num_skip_tokens: int = 0,
     ) -> None:
         """
         Perform asynchronous lookup and prefetching across all storage backends.
@@ -708,6 +711,16 @@ class StorageManager:
             raise ValueError(
                 f"len(keys)={len(keys)} is not a multiple of "
                 f"keys_per_chunk={keys_per_chunk}"
+            )
+        if num_skip_tokens > 0:
+            logger.info(
+                "Async prefetch: skipping %d already-GPU-resident tokens "
+                "for lookup_id=%s",
+                num_skip_tokens,
+                lookup_id,
+            )
+            LMCStatsMonitor.GetOrCreate().update_interval_async_prefetch_skipped_tokens(
+                num_skip_tokens
             )
         num_total_chunks = len(keys) // keys_per_chunk
         num_total_hit_chunks = 0
@@ -786,7 +799,9 @@ class StorageManager:
         # If no chunks were hit across all backends, respond immediately and return.
         if num_total_hit_chunks == 0:
             if self.async_lookup_server is not None:
-                self.async_lookup_server.send_response_to_scheduler(lookup_id, 0)
+                self.async_lookup_server.send_response_to_scheduler(
+                    lookup_id, num_skip_tokens
+                )
             return
 
         # gather_with_keys() here make a pair of (key, memory_obj) for each chunk
@@ -822,6 +837,7 @@ class StorageManager:
                 cum_chunk_lengths_total,
                 tier_expected_chunks,
                 keys_per_chunk=keys_per_chunk,
+                num_skip_tokens=num_skip_tokens,
             )
         )
 

--- a/tests/v1/lookup_client/test_chunk_statistics_lookup_client.py
+++ b/tests/v1/lookup_client/test_chunk_statistics_lookup_client.py
@@ -43,6 +43,7 @@ class MockLookupClient(BaseMockClient):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         self.lookup_calls.append((token_ids, lookup_id, request_configs))
         return len(token_ids) // 2
@@ -54,6 +55,7 @@ class FastMissLookupClient(BaseMockClient):
         token_ids: Union[torch.Tensor, list[int]],
         lookup_id: str,
         request_configs: Optional[dict] = None,
+        num_computed_tokens: int = 0,
     ) -> Optional[int]:
         time.sleep(0.008)
         return 0


### PR DESCRIPTION
### Summary

  1. Passes num_computed_tokens from the vLLM scheduler through the full lookup-client stack into LMCacheEngine and StorageManager
  2. Chunks whose token range falls entirely within [0, num_computed_tokens) are skipped in async prefetch; the skip count is added back to retrieved_length so the scheduler response still reflects full prefix coverage
  3. Adds Prometheus counter lmcache:num_async_prefetch_skipped_tokens and an INFO log line to make the skip observable

### Local validation for the bug fix

  1. Validation was done using a local vLLM + LMCache setup with multiple prompts sharing a long prefix. When chunks were already resident in vLLM's APC, LMCache correctly skipped retrieving those from CPU storage.

  2. Test validation confirmed by the log line:
      ```
      Async prefetch: skipping 768 already-GPU-resident tokens for lookup_id=...
      need to load: 0
      ```
  3. If maintainers think so, then I can include the unit test in the PR and merge that too
   
### To validate the fix
  1. Navigate to the directory which contains the github clone with the fix 
  2. NO_NATIVE_EXT=1 pip install -e .
  3. Setup the lmcache yaml to enable async prefetch (enable_async_loading: true)
  5. export PROMETHEUS_MULTIPROC_DIR=/tmp/shared_prometheus
  6. LMCACHE_CONFIG_FILE=<your-lmcache-config.yaml> vllm serve <model> --enable-prefix-caching --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
  7. Run prompts which share a prefix
  8. Check for lmcache:num_async_prefetch_skipped_tokens in Prometheus or for the log line in the output of vllm to confirm that the fix is working.