### PR TITLE
[WIP][MP][DSV4] Per-group logical block size + SWA-suffix-only offload

### DIFF
--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -98,3 +98,104 @@ def create_group_views_from_vllm(
             per_layer_group_idx,
         )
     ]
+
+
+def spec_int_attr(spec: Any, attr: str) -> int:
+    """Read an integer ``attr`` off a vLLM ``KVCacheGroupSpec.kv_cache_spec``.
+
+    The value may live directly on the spec, or — for a
+    ``UniformTypeKVCacheSpecs`` wrapper that bundles several inner specs — on
+    its inner specs (all of which share one value), in which case the first
+    inner spec is read. Returns ``0`` when neither carries the attribute (or it
+    is ``None``), so callers treat ``0`` uniformly as "absent".
+    """
+    value = getattr(spec, attr, None)
+    if value is None:
+        inner_specs = getattr(spec, "kv_cache_specs", None)
+        if inner_specs:
+            first_inner = next(iter(inner_specs.values()))
+            value = getattr(first_inner, attr, None)
+    return int(value or 0)
+
+
+def _per_layer_spec_attr_from_vllm(
+    kv_cache_config: Any,
+    kv_caches: Mapping[str, Any],
+    attr: str,
+) -> list[int] | None:
+    """Map an integer ``KVCacheGroupSpec.kv_cache_spec`` attribute onto layers.
+
+    Reads ``attr`` off each engine group's spec (see :func:`spec_int_attr`) and
+    assigns it to every registered layer in that group, indexed by registration
+    order.
+
+    Args:
+        kv_cache_config: vLLM ``KVCacheConfig``. ``None`` or one without
+            ``kv_cache_groups`` yields ``None``.
+        kv_caches: Registered KV tensors keyed by layer name, in registration
+            order, providing the layer-name -> index mapping.
+        attr: The integer spec attribute to read (e.g. ``"block_size"`` or
+            ``"sliding_window"``).
+
+    Returns:
+        A list of length ``len(kv_caches)`` giving each layer's value, or
+        ``None`` when no group reports a positive value (callers then omit the
+        hint and the server keeps its legacy/scalar fallback).
+    """
+    vllm_groups = (
+        getattr(kv_cache_config, "kv_cache_groups", ()) or ()
+        if kv_cache_config is not None
+        else ()
+    )
+    if not vllm_groups:
+        return None
+
+    layer_to_idx = {name: idx for idx, name in enumerate(kv_caches.keys())}
+    per_layer = [0] * len(layer_to_idx)
+    any_positive = False
+    for group in vllm_groups:
+        value = spec_int_attr(getattr(group, "kv_cache_spec", None), attr)
+        if value > 0:
+            any_positive = True
+        for name in group.layer_names:
+            idx = layer_to_idx.get(name)
+            if idx is not None:
+                per_layer[idx] = value
+
+    return per_layer if any_positive else None
+
+
+def per_layer_sliding_window_from_vllm(
+    kv_cache_config: Any,
+    kv_caches: Mapping[str, Any],
+) -> list[int] | None:
+    """Build the per-registered-layer sliding-window list from vLLM metadata.
+
+    Reads ``sliding_window`` off each engine group's spec and maps it onto every
+    registered layer in that group. Enables the SWA-suffix-only optimization:
+    layers in a sliding-window group only need their trailing window
+    stored/retrieved. Layers whose group has no window get ``0``; an all-full-
+    attention model yields ``None`` (no SWA metadata to send).
+    """
+    return _per_layer_spec_attr_from_vllm(
+        kv_cache_config, kv_caches, "sliding_window"
+    )
+
+
+def per_layer_inference_engine_logical_block_size_from_vllm(
+    kv_cache_config: Any,
+    kv_caches: Mapping[str, Any],
+) -> list[int] | None:
+    """Build the per-registered-layer logical block size list from vLLM metadata.
+
+    Reads ``block_size`` off each engine group's spec and maps it onto every
+    registered layer in that group. Under the hybrid KV cache manager these
+    differ across groups (e.g. DeepSeek-V4: 256 for the full-attention MLA
+    group, 64/4/8 for the SWA / compressor-state groups) while
+    ``cache_config.block_size`` collapses to their GCD; the server uses this
+    list to derive each LMCache group's ``compress_ratio`` /
+    ``physical_chunk_size`` per group. ``None`` when no group reports a block
+    size (server falls back to the scalar ``inference_engine_logical_block_size``
+    for every group).
+    """
+    return _per_layer_spec_attr_from_vllm(kv_cache_config, kv_caches, "block_size")

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -38,6 +38,9 @@ import zmq
 from lmcache import torch_dev
 from lmcache.integration.vllm.kv_cache_groups import (
     create_group_views_from_vllm,
+    per_layer_inference_engine_logical_block_size_from_vllm,
+    per_layer_sliding_window_from_vllm,
+    spec_int_attr,
 )
 from lmcache.integration.vllm.utils import mla_enabled, vllm_layout_hints
 from lmcache.utils import init_logger as lmcache_init_logger
@@ -314,34 +317,73 @@ class LMCacheMPRequestMetadata:
     cache_salt: str = ""
 
     @staticmethod
+    def _group_ratio(
+        engine_group_idx: int,
+        logical_block_sizes: "list[int]",
+        vllm_block_size: int,
+    ) -> int:
+        """GCD-grain blocks per one of this group's logical blocks.
+
+        ``ratio_g = logical_block_size_g // vllm_block_size`` where
+        ``vllm_block_size`` is ``cache_config.block_size`` — which the hybrid
+        KV cache manager sets to ``gcd(group_block_sizes)``. So every group's
+        logical block size is an exact multiple of it and ``ratio_g >= 1``.
+
+        The store/retrieve bookkeeping (``num_stored_blocks``, hit counts,
+        ``computed_blocks``) is all in GCD-grain blocks, while each group's
+        ``allocated_block_ids`` are at the group's own logical grain. ``ratio_g``
+        converts between the two:
+
+        * own-grain count -> GCD grain: ``count * ratio_g``
+        * GCD-grain index -> own-grain index: ``index // ratio_g``
+
+        Returns ``1`` when no per-group logical sizes are known (non-hybrid /
+        V3.2), preserving the legacy single-grain behavior.
+        """
+        if engine_group_idx < len(logical_block_sizes):
+            logical_bs = logical_block_sizes[engine_group_idx]
+            if logical_bs and vllm_block_size:
+                return max(1, logical_bs // vllm_block_size)
+        return 1
+
+    @staticmethod
     def _slice_block_ids(
         tracker: LMCacheMPRequestTracker,
         num_engine_groups: int,
         start: int,
         end: int,
+        logical_block_sizes: "list[int]",
+        vllm_block_size: int,
     ) -> list[list[int]]:
-        """Slice every engine group's block IDs for the block range.
+        """Slice every engine group's block IDs for a GCD-grain block range.
 
         Args:
             tracker: Request tracker holding the per-engine-group block IDs.
             num_engine_groups: Number of engine KV cache groups; the result
                 has one inner list per group, in engine-group order.
-            start: Start **block** index (inclusive), not a token index.
-            end: End **block** index (exclusive), not a token index.
+            start: Start block index (inclusive), in GCD-grain block units.
+            end: End block index (exclusive), in GCD-grain block units.
+            logical_block_sizes: Per-engine-group logical block size (scheduler
+                grain). Used to convert the GCD-grain ``[start, end)`` range to
+                each group's own block-ID grain.
+            vllm_block_size: ``cache_config.block_size`` (GCD under hybrid).
 
         Returns:
-            One ``list[int]`` of block IDs per engine group, each sliced to
-            ``[start, end)``.
-
-        Notes:
-            Minimal HMA support assumes all groups share vLLM's scheduler
-            block size. DeepSeek-V4's per-group logical/physical block-size
-            mapping is intentionally left for a follow-up.
+            One ``list[int]`` of block IDs per engine group. Each group's slice
+            is taken at the group's own logical grain:
+            ``[start // ratio_g, end // ratio_g)``. ``start``/``end`` are exact
+            multiples of every ``ratio_g`` (the store/retrieve ranges are
+            chunk-aligned and ``chunk_size`` is a multiple of every group's
+            logical block size), so no block is split.
         """
-        return [
-            tracker.allocated_block_ids.get(engine_group_idx, [])[start:end]
-            for engine_group_idx in range(num_engine_groups)
-        ]
+        sliced: list[list[int]] = []
+        for engine_group_idx in range(num_engine_groups):
+            ratio = LMCacheMPRequestMetadata._group_ratio(
+                engine_group_idx, logical_block_sizes, vllm_block_size
+            )
+            group_block_ids = tracker.allocated_block_ids.get(engine_group_idx, [])
+            sliced.append(group_block_ids[start // ratio : end // ratio])
+        return sliced
 
     @staticmethod
     def GetStoreMetadata(
@@ -349,16 +391,20 @@ class LMCacheMPRequestMetadata:
         blocks_in_chunk: int,
         vllm_block_size: int,
         num_engine_groups: int,
+        logical_block_sizes: "list[int]",
     ) -> "LMCacheMPRequestMetadata | None":
         """
         Generate the store metadata for the current request tracker.
 
         Args:
             tracker: The request tracker to generate the metadata from.
-            blocks_in_chunk: the number of blocks in a LMCache data chunk
-            vllm_block_size: the block size used in vLLM
+            blocks_in_chunk: the number of GCD-grain blocks in a LMCache chunk.
+            vllm_block_size: ``cache_config.block_size`` (GCD under hybrid).
             num_engine_groups: number of engine KV cache groups; the op's
                 block IDs carry one inner list per group, in engine order.
+            logical_block_sizes: per-engine-group logical (scheduler) block
+                size, used to reconcile per-group allocation counts (own grain)
+                against the GCD-grain bookkeeping. Scheduler-side only.
         """
         # Store the blocks that has block hashes
         # NOTE: the invariant here is that `num_stored_blocks` should
@@ -386,9 +432,18 @@ class LMCacheMPRequestMetadata:
             tracker.num_vllm_hit_blocks, tracker.num_lmcache_hit_blocks
         )
         allocated_lengths = tracker.num_allocated_blocks()
+        # Each group's allocation is counted at the group's own logical grain;
+        # scale every group up to GCD grain (multiply by ratio_g) before taking
+        # the cross-group min, so groups with different logical block sizes are
+        # compared on the same axis. (Pre-fix this took the raw min, which a
+        # coarse-grained group like V4 full-attn bs=256 dominated, wedging the
+        # store gate to 0 chunks.)
         allocated_blocks = (
             min(
                 allocated_lengths.get(engine_group_idx, 0)
+                * LMCacheMPRequestMetadata._group_ratio(
+                    engine_group_idx, logical_block_sizes, vllm_block_size
+                )
                 for engine_group_idx in range(num_engine_groups)
             )
             if num_engine_groups > 0
@@ -406,7 +461,8 @@ class LMCacheMPRequestMetadata:
             start = tracker.num_stored_blocks
             end = start + num_chunks * blocks_in_chunk
             block_ids = LMCacheMPRequestMetadata._slice_block_ids(
-                tracker, num_engine_groups, start, end
+                tracker, num_engine_groups, start, end,
+                logical_block_sizes, vllm_block_size,
             )
             start_token_idx = start * vllm_block_size
             end_token_idx = end * vllm_block_size
@@ -437,16 +493,20 @@ class LMCacheMPRequestMetadata:
         blocks_in_chunk: int,
         vllm_block_size: int,
         num_engine_groups: int,
+        logical_block_sizes: "list[int]",
     ) -> "LMCacheMPRequestMetadata | None":
         """
         Generate the retrieve metadata for the current request tracker.
 
         Args:
             tracker: The request tracker to generate the metadata from.
-            blocks_in_chunk: the number of blocks in a LMCache data chunk
-            vllm_block_size: the block size used in vLLM
+            blocks_in_chunk: the number of GCD-grain blocks in a LMCache chunk.
+            vllm_block_size: ``cache_config.block_size`` (GCD under hybrid).
             num_engine_groups: number of engine KV cache groups; the op's
                 block IDs carry one inner list per group, in engine order.
+            logical_block_sizes: per-engine-group logical (scheduler) block
+                size, used to slice each group's block IDs at its own grain.
+                Scheduler-side only.
         """
         if not tracker.is_ready_for_retrieving():
             return None
@@ -468,7 +528,8 @@ class LMCacheMPRequestMetadata:
         )
         if end > start:
             block_ids = LMCacheMPRequestMetadata._slice_block_ids(
-                tracker, num_engine_groups, start, end
+                tracker, num_engine_groups, start, end,
+                logical_block_sizes, vllm_block_size,
             )
             start_token_idx = start * vllm_block_size
             end_token_idx = end * vllm_block_size
@@ -588,9 +649,44 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self._num_engine_groups = len(vllm_groups) or 1
 
+        # Per-engine-group *logical* block size (vLLM scheduler block grain,
+        # i.e. ``KVCacheSpec.block_size``), indexed by engine group id. Under
+        # the hybrid KV cache manager these differ across groups (e.g. V4:
+        # 256 for full-attn, 64/4/8 for the SWA / state groups) while
+        # ``cache_config.block_size`` collapses to their GCD. The store /
+        # retrieve block-ID slicing runs in GCD-grain block units, so it must
+        # know each group's logical block size to reconcile the per-group
+        # allocation counts (kept at each group's own grain) against the
+        # GCD-grain bookkeeping. Kept entirely scheduler-side; never sent to
+        # the LMCache server. Empty -> every group uses vllm_block_size
+        # (non-hybrid / V3.2: ratio 1, legacy behavior preserved).
+        self._engine_group_logical_block_sizes: list[int] = (
+            self._read_engine_group_logical_block_sizes(vllm_groups)
+        )
+
     @property
     def role(self) -> KVConnectorRole:
         return self._role
+
+    @staticmethod
+    def _read_engine_group_logical_block_sizes(vllm_groups) -> list[int]:
+        """Read each engine KV cache group's logical (scheduler) block size.
+
+        The logical block size is ``KVCacheGroupSpec.kv_cache_spec.block_size``
+        — the grain at which vLLM hands out that group's block IDs. For a
+        ``UniformTypeKVCacheSpecs`` wrapper the value lives on its inner specs
+        (all of which share one block size), so fall back to the first inner
+        spec when the outer one does not carry it.
+
+        Returns:
+            One logical block size per engine group, in engine-group order.
+            Empty when ``vllm_groups`` is empty (non-hybrid / V3.2): callers
+            then fall back to ``vllm_block_size`` for every group (ratio 1).
+        """
+        return [
+            spec_int_attr(getattr(group, "kv_cache_spec", None), "block_size")
+            for group in vllm_groups
+        ]
 
     # ==============================
     # Worker-side methods
@@ -624,7 +720,31 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             kv_caches,
             layout_hints=vllm_layout_hints(),
         )
-        self.worker_adapter.register_kv_caches(kv_caches, group_views=group_views)
+        # Per-layer sliding windows enable the SWA-suffix-only optimization on
+        # the server. ``None`` when no group is sliding-window (full attention
+        # everywhere), in which case the server keeps the legacy full-chunk path.
+        per_layer_sliding_window = per_layer_sliding_window_from_vllm(
+            kv_cache_config, kv_caches
+        )
+        # Per-layer logical block sizes let the server derive each LMCache
+        # group's compress_ratio / physical_chunk_size correctly per group
+        # (under HMA the engine groups have different logical block sizes while
+        # cache_config.block_size collapses to their GCD). ``None`` for
+        # non-hybrid engines -> server falls back to the scalar
+        # inference_engine_logical_block_size for every group.
+        per_layer_logical_block_size = (
+            per_layer_inference_engine_logical_block_size_from_vllm(
+                kv_cache_config, kv_caches
+            )
+        )
+        self.worker_adapter.register_kv_caches(
+            kv_caches,
+            group_views=group_views,
+            per_layer_sliding_window=per_layer_sliding_window,
+            per_layer_inference_engine_logical_block_size=(
+                per_layer_logical_block_size
+            ),
+        )
         return
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
@@ -1120,6 +1240,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 blocks_per_chunk,
                 vllm_block_size=self.vllm_block_size,
                 num_engine_groups=self._num_engine_groups,
+                logical_block_sizes=self._engine_group_logical_block_sizes,
             )
             if r_metadata is not None:
                 metadata.add_request_metadata(r_metadata)
@@ -1143,6 +1264,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 blocks_per_chunk,
                 self.vllm_block_size,
                 self._num_engine_groups,
+                self._engine_group_logical_block_sizes,
             )
             if r_meta is not None:
                 metadata.add_request_metadata(r_meta)
@@ -1173,6 +1295,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 blocks_per_chunk,
                 self.vllm_block_size,
                 self._num_engine_groups,
+                self._engine_group_logical_block_sizes,
             )
 
             if r_meta is not None:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -854,6 +854,7 @@ class LMCacheMPWorkerAdapter:
         # Registered kv caches from vLLM
         self.kv_caches: dict[str, torch.Tensor] = {}
         self.group_views: list[LMCacheGroupView] = []
+        self.per_layer_sliding_window: list[int] | None = None
 
         # Transport context for transfer operations.
         self.transfer_ctx: TransferContext | None = None
@@ -968,6 +969,8 @@ class LMCacheMPWorkerAdapter:
         self,
         kv_caches: dict[str, torch.Tensor],
         group_views: Sequence[LMCacheGroupView] = (),
+        per_layer_sliding_window: list[int] | None = None,
+        per_layer_inference_engine_logical_block_size: list[int] | None = None,
     ) -> None:
         """
         Register the kv caches with LMCache server.
@@ -976,6 +979,16 @@ class LMCacheMPWorkerAdapter:
             kv_caches: A dict of kv caches to register. The keys are the
                 layer names and the values are the corresponding tensors.
             group_views: LMCache-owned engine KV cache group metadata.
+            per_layer_sliding_window: Per-registered-layer sliding-window
+                size in logical tokens (``0`` = full attention), or ``None``
+                when no group is sliding-window. Forwarded to the server in
+                ``layout_hints`` to drive the SWA-suffix-only optimization.
+            per_layer_inference_engine_logical_block_size: Per-registered-layer
+                logical block size (logical tokens per engine block), or
+                ``None`` for engines without per-group logical block sizes.
+                Forwarded to the server in ``layout_hints`` so it derives each
+                group's compress_ratio / physical_chunk_size per group instead
+                of from the single (GCD-collapsed) scalar.
 
         Raises:
             ConnectionError: if the server does not respond within
@@ -984,6 +997,10 @@ class LMCacheMPWorkerAdapter:
         logger.info("Registering kv caches")
         self.kv_caches = kv_caches
         self.group_views = list(group_views)
+        self.per_layer_sliding_window = per_layer_sliding_window
+        self.per_layer_inference_engine_logical_block_size = (
+            per_layer_inference_engine_logical_block_size
+        )
         self._send_register_kv_caches_request(kv_caches)
 
     def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
@@ -1010,6 +1027,16 @@ class LMCacheMPWorkerAdapter:
         layout_hints["inference_engine_logical_block_size"] = (
             self.vllm_logical_block_size
         )
+        per_layer_sliding_window = getattr(self, "per_layer_sliding_window", None)
+        if per_layer_sliding_window is not None:
+            layout_hints["per_layer_sliding_window"] = per_layer_sliding_window
+        per_layer_logical_block_size = getattr(
+            self, "per_layer_inference_engine_logical_block_size", None
+        )
+        if per_layer_logical_block_size is not None:
+            layout_hints["per_layer_inference_engine_logical_block_size"] = (
+                per_layer_logical_block_size
+            )
         try:
             self.transfer_ctx.register(
                 self.instance_id,

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -93,6 +93,31 @@ class LayoutHints(TypedDict, total=False):
     tokens_per_block: int
     head_dim: int
     inference_engine_logical_block_size: int
+    per_layer_inference_engine_logical_block_size: list[int]
+    """Per-registered-layer inference-engine logical block size (logical
+    tokens per engine block), indexed by registration order. Under a hybrid
+    KV cache manager the engine's groups have *different* logical block sizes
+    (e.g. DeepSeek-V4: 256 for the full-attention MLA group, 64/4/8 for the
+    SWA / compressor-state groups), while the single scalar
+    ``inference_engine_logical_block_size`` collapses to their GCD on the
+    worker. The server uses this per-layer list to derive each LMCache
+    group's ``compress_ratio`` / ``physical_chunk_size`` (and thus its
+    per-chunk block count) correctly per group instead of from one global
+    value. All layers in one LMCache group share a value (the group is keyed
+    by engine group id). Omit this key (or pass it empty) for engines without
+    per-group logical block sizes; the server then falls back to the scalar
+    ``inference_engine_logical_block_size`` for every group (legacy behavior,
+    e.g. DeepSeek-V3.2 / non-hybrid)."""
+    per_layer_sliding_window: list[int]
+    """Per-registered-layer sliding-window size in logical tokens, indexed
+    by registration order. ``0`` (or omission of this key) means full
+    attention. A positive value enables the SWA-suffix-only optimization
+    for that layer's group: store/retrieve only the trailing
+    ``ceil(sliding_window / inference_engine_logical_block_size)`` blocks
+    of every chunk, since earlier blocks fall outside the attention window
+    and are never read. All layers within one LMCache group share a window
+    (the group is keyed by engine group id, and vLLM places SWA and
+    full-attention layers in separate engine groups)."""
 
 
 def attempt_permute_to_contiguous_view(

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -158,6 +158,16 @@ class KVLayerGroupInfo:
     is known."""
     engine_group_idx: int = 0
     """Engine group index (paged-block address space). 0 for non-hybrid."""
+    sliding_window: int = 0
+    """Sliding-window size in logical tokens for this group, or ``0`` for
+    full attention. When positive, the SWA-suffix-only optimization applies:
+    only the trailing ``ceil(sliding_window / logical_block_size)`` blocks of
+    every chunk are stored and retrieved, because earlier blocks fall outside
+    the attention window and are never read back. Derived from
+    ``per_layer_sliding_window`` carried in ``layout_hints`` at
+    :class:`KVLayerGroupsManager` construction time; all layers in the group
+    share one window because the group is keyed by engine group id and vLLM
+    places SWA and full-attention layers in distinct engine groups."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -175,13 +185,105 @@ class KVLayerGroupInfo:
             f"dtype={self.dtype}, "
             f"compress_ratio={self.compress_ratio}, "
             f"physical_chunk_size={self.physical_chunk_size}, "
-            f"engine_group_idx={self.engine_group_idx})"
+            f"engine_group_idx={self.engine_group_idx}, "
+            f"sliding_window={self.sliding_window})"
         )
 
     @property
     def num_layers(self) -> int:
         """Number of layers in this group."""
         return len(self.layer_indices)
+
+    @property
+    def logical_block_size(self) -> int:
+        """Inference-engine logical block size for this group.
+
+        ``shape_desc.bs * compress_ratio`` — the number of *logical* (engine)
+        tokens that one inference-engine block addresses for this group. Equal
+        to the physical slot count when ``compress_ratio == 1``; larger for
+        compressed groups (each physical slot packs ``compress_ratio`` logical
+        tokens). This is the grain at which the engine hands out this group's
+        block IDs, so it drives how many block IDs make up one LMCache chunk.
+        """
+        return self.shape_desc.bs * self.compress_ratio
+
+    @property
+    def blocks_per_chunk(self) -> int:
+        """Number of inference-engine blocks in one LMCache chunk for this group.
+
+        ``physical_chunk_size // shape_desc.bs`` — equivalently
+        ``lmcache_logical_chunk_size // logical_block_size``. This is the number
+        of block IDs the store/retrieve loops consume per chunk for this group.
+        Under the hybrid KV cache manager it differs across groups (e.g. V4
+        chunk_size=1024: 4 for the logical-256 MLA group, 16 for the logical-64
+        SWA groups, 256 for the logical-4 state groups).
+        """
+        return self.physical_chunk_size // self.shape_desc.bs
+
+    @property
+    def num_suffix_blocks_per_chunk(self) -> int | None:
+        """Trailing blocks per chunk to keep under SWA-suffix-only, or
+        ``None`` for full attention (store/retrieve the whole chunk).
+
+        ``ceil(sliding_window / logical_block_size)`` — the minimum number
+        of trailing inference-engine blocks that can cover a window of
+        ``sliding_window`` logical tokens. Capped at
+        :attr:`blocks_per_chunk` so a window larger than one chunk degrades
+        gracefully to the full chunk.
+        """
+        if self.sliding_window <= 0:
+            return None
+        suffix = (
+            self.sliding_window + self.logical_block_size - 1
+        ) // self.logical_block_size
+        return min(suffix, self.blocks_per_chunk)
+
+    @property
+    def storage_blocks_per_chunk(self) -> int:
+        """Engine blocks actually transferred per chunk (SWA-suffix-aware).
+
+        For a sliding-window group this is :attr:`num_suffix_blocks_per_chunk`
+        (only the trailing window of each chunk is stored/retrieved); for a
+        full-attention group it is the full :attr:`blocks_per_chunk`. This is
+        the single source of truth for how many block IDs are sliced per chunk
+        and — together with ``shape_desc.bs`` — for sizing the staging buffer,
+        the ``MemoryObj`` layout, and the kernel's ``lmcache_chunk_size`` arg,
+        which must all agree (see the SWA-suffix shape landmine)."""
+        suffix = self.num_suffix_blocks_per_chunk
+        return suffix if suffix is not None else self.blocks_per_chunk
+
+    @property
+    def storage_slots_per_chunk(self) -> int:
+        """Physical slots transferred per chunk for this group.
+
+        ``storage_blocks_per_chunk * shape_desc.bs`` — the value the
+        block-level transfer kernel must be told as its ``lmcache_chunk_size``
+        (the kernel checks ``num_blocks_per_object * bs == lmcache_chunk_size``).
+        Equals :attr:`physical_chunk_size` for full-attention groups; smaller
+        for SWA-suffix groups."""
+        return self.storage_blocks_per_chunk * self.shape_desc.bs
+
+    @property
+    def storage_tokens_per_chunk(self) -> int:
+        """Logical tokens transferred per chunk for this group.
+
+        ``storage_blocks_per_chunk * logical_block_size``. Used to size the
+        per-group staging buffer view and the ``MemoryObj`` layout (which are
+        expressed in logical tokens and fold ``compress_ratio`` logical tokens
+        per physical slot). Equals ``lmcache_logical_chunk_size`` for
+        full-attention groups; smaller for SWA-suffix groups."""
+        return self.storage_blocks_per_chunk * self.logical_block_size
+
+    @property
+    def chunk_suffix_offset_blocks(self) -> int:
+        """Leading engine blocks dropped per chunk under SWA-suffix.
+
+        ``blocks_per_chunk - storage_blocks_per_chunk`` — the number of leading
+        blocks of each chunk that are *not* transferred (they fall outside the
+        attention window). ``0`` for full-attention groups. The store/retrieve
+        loops slice each chunk starting at this offset to keep only the trailing
+        window."""
+        return self.blocks_per_chunk - self.storage_blocks_per_chunk
 
     @property
     def hidden_dim_size(self) -> int:
@@ -278,6 +380,25 @@ class KVLayerGroupsManager:
             if layout_hints
             else None
         )
+        # Per-registered-layer sliding-window sizes (logical tokens), or
+        # ``None`` when the engine reports no SWA metadata. Each group reads
+        # its window from its first layer's entry below; layers in one group
+        # always share a window (the group is keyed by engine group id).
+        per_layer_sliding_window: "Sequence[int] | None" = (
+            layout_hints.get("per_layer_sliding_window") if layout_hints else None
+        )
+        # Per-registered-layer inference-engine logical block size, or ``None``
+        # when the engine reports no per-group sizes. Under the hybrid KV cache
+        # manager the engine's groups have different logical block sizes (e.g.
+        # V4: 256 for full attention, 64/4/8 for SWA / state groups) while the
+        # scalar ``inference_engine_logical_block_size`` collapses to their GCD.
+        # Each group reads its size from its first layer's entry below; a
+        # ``0`` entry (or no list) falls back to the scalar for that group.
+        per_layer_logical_block_size: "Sequence[int] | None" = (
+            layout_hints.get("per_layer_inference_engine_logical_block_size")
+            if layout_hints
+            else None
+        )
         self.kv_layer_groups: list[KVLayerGroupInfo] = []
 
         num_layers = get_num_layers(kv_caches, gpu_kv_format)
@@ -312,11 +433,30 @@ class KVLayerGroupsManager:
                 block_stride_elems=block_stride_elems,
             )
 
+            # Resolve this group's inference-engine logical block size. Prefer
+            # the per-layer hint (correct per group under HMA); fall back to
+            # the single scalar when the per-layer entry is absent or 0 (legacy
+            # / non-hybrid engines). All layers in a group share one value.
+            group_ie_logical_block_size = self.inference_engine_logical_block_size_
+            if per_layer_logical_block_size is not None:
+                first_layer_logical_bs = int(per_layer_logical_block_size[indices[0]])
+                if first_layer_logical_bs > 0:
+                    group_ie_logical_block_size = first_layer_logical_bs
+
             compress_ratio, physical_chunk_size = self._derive_compression_metadata(
                 group_idx=group_idx,
                 bs=bs,
-                ie_logical_block_size=self.inference_engine_logical_block_size_,
+                ie_logical_block_size=group_ie_logical_block_size,
                 lmcache_logical_chunk_size=lmcache_logical_chunk_size,
+            )
+
+            # All layers in a group share one window (group keyed by engine
+            # group id; vLLM separates SWA from full-attention layers). Read
+            # it from the first layer; ``0`` (or no hint) means full attention.
+            sliding_window = (
+                int(per_layer_sliding_window[indices[0]])
+                if per_layer_sliding_window is not None
+                else 0
             )
 
             self.kv_layer_groups.append(
@@ -327,6 +467,7 @@ class KVLayerGroupsManager:
                     compress_ratio=compress_ratio,
                     physical_chunk_size=physical_chunk_size,
                     engine_group_idx=engine_group_idx,
+                    sliding_window=sliding_window,
                 )
             )
 

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -132,10 +132,14 @@ class GPUCacheContext:
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            # ``get_kv_buffer_shape`` takes *logical* tokens; for
-            # compressed groups it folds ``compress_ratio`` logical
-            # tokens into one physical slot internally.
-            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
+            # ``get_storage_kv_buffer_shape`` takes the *stored* logical tokens
+            # for this group (SWA-suffix-aware: a sliding-window group stores
+            # only the trailing window of each chunk, not the full chunk). For
+            # compressed groups it folds ``compress_ratio`` logical tokens into
+            # one physical slot internally. Sizing the slot from the same
+            # truncated per-group count is what keeps the buffer, the MemoryObj
+            # layout, and the kernel chunk-size arg in agreement.
+            shape = self.get_storage_kv_buffer_shape(group_idx)
             byte_size = shape.numel() * group.dtype.itemsize
             self.tmp_chunk_group_offsets_.append(
                 self.tmp_chunk_group_offsets_[-1] + byte_size
@@ -320,16 +324,17 @@ class GPUCacheContext:
     def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
         """
         Returns a view of the temporary GPU buffer for the given group,
-        sized for a single chunk. The chunk holds
-        ``lmcache_logical_chunk_size`` logical tokens which, for a
-        compressed group, correspond to ``group.physical_chunk_size``
-        physical slots.
+        sized for a single chunk's *stored* payload. For a full-attention
+        group this is ``lmcache_logical_chunk_size`` logical tokens (=
+        ``group.physical_chunk_size`` physical slots); for an SWA-suffix
+        group it is only the trailing-window portion
+        (``group.storage_tokens_per_chunk`` logical tokens).
 
         Args:
             group_idx: Index of the KV layer group (default 0).
         """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        shape = self.get_storage_kv_buffer_shape(group_idx)
         start = self.tmp_chunk_group_offsets_[group_idx]
         end = self.tmp_chunk_group_offsets_[group_idx + 1]
         return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
@@ -340,7 +345,8 @@ class GPUCacheContext:
         """
         Returns a list of ``batch_size`` non-overlapping views into the
         pre-allocated temporary GPU buffer for the given group, each
-        sized for ``lmcache_logical_chunk_size`` tokens.
+        sized for one chunk's *stored* payload (SWA-suffix-aware; see
+        :meth:`get_tmp_chunk_gpu_buffer`).
 
         Args:
             batch_size: Number of concurrent requests (must be <= max_batch_size).
@@ -351,7 +357,7 @@ class GPUCacheContext:
                 f"batch_size {batch_size} exceeds max_batch_size {self.max_batch_size}"
             )
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        shape = self.get_storage_kv_buffer_shape(group_idx)
         g_start = self.tmp_chunk_group_offsets_[group_idx]
         g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
         chunk = self.tmp_chunk_bytes_
@@ -423,6 +429,22 @@ class GPUCacheContext:
         return torch.Size(
             (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
         )
+
+    def get_storage_kv_buffer_shape(self, group_idx: int = 0) -> torch.Size:
+        """Returns the KV buffer shape for one chunk's *stored* payload.
+
+        SWA-suffix-aware: a sliding-window group stores only the trailing
+        window of each chunk (``group.storage_tokens_per_chunk`` logical
+        tokens), a full-attention group stores the whole chunk
+        (``lmcache_logical_chunk_size`` logical tokens). This is the single
+        shape that the staging buffer slot, the per-group buffer views, and the
+        ``MemoryObj`` layout (via ``get_layout_desc``) must all share, so a
+        mismatch cannot arise between them.
+        """
+        tokens = self.kv_layer_groups_manager_.kv_layer_groups[
+            group_idx
+        ].storage_tokens_per_chunk
+        return self.get_kv_buffer_shape(tokens, group_idx)
 
     def cache_size_per_token(self) -> int:
         """

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -47,21 +47,25 @@ import lmcache.c_ops as lmc_ops
 logger = init_logger(__name__)
 
 
-def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayoutDesc:
-    """Get the memory layout description for a given GPU context and number of tokens.
+def get_layout_desc(gpu_context: GPUCacheContext) -> MemoryLayoutDesc:
+    """Get the memory layout description for a given GPU context.
 
-    Supports multiple KV layer groups with different shapes and dtypes.
+    Supports multiple KV layer groups with different shapes and dtypes. Each
+    group's shape is its *stored* payload shape (SWA-suffix-aware): a
+    sliding-window group's ``MemoryObj`` holds only the trailing window of each
+    chunk, a full-attention group holds the whole chunk. Both the staging
+    buffer and the kernel chunk-size arg derive from the same per-group stored
+    count, so the buffer, the layout, and the kernel cannot disagree.
 
     Args:
         gpu_context: The GPU cache context containing the KV cache information.
-        num_tokens: The number of tokens to determine the layout for.
 
     Returns:
         MemoryLayoutDesc: The memory layout description containing shapes and dtypes.
     """
     num_groups = gpu_context.kv_layer_groups_manager.num_groups
     shapes = [
-        gpu_context.get_kv_buffer_shape(num_tokens, group_idx)
+        gpu_context.get_storage_kv_buffer_shape(group_idx)
         for group_idx in range(num_groups)
     ]
     dtypes = [
@@ -273,7 +277,7 @@ class GPUTransferModule:
             world_size=world_size,
         )
 
-        layout_desc = get_layout_desc(gpu_context, self._ctx.chunk_size)
+        layout_desc = get_layout_desc(gpu_context)
         self._ctx.layout_desc_registry.register(model_name, world_size, layout_desc)
 
         logger.info(
@@ -345,16 +349,14 @@ class GPUTransferModule:
         gpu_context = entry.gpu_context
         model_name = entry.model_name
 
-        # ``blocks_per_chunk`` is counted in inference-engine-side
-        # blocks (each block addresses
-        # ``inference_engine_logical_block_size`` *logical* tokens).
-        # For compressed groups the per-group physical slot count
-        # differs, but the block-id indexing is shared with the engine
-        # and therefore uses the engine logical block size here.
-        blocks_per_chunk = (
-            self._ctx.chunk_size
-            // gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
-        )
+        # ``blocks_per_chunk`` is counted in inference-engine-side blocks (each
+        # block addresses one engine logical block). Under the hybrid KV cache
+        # manager each LMCache group has its own logical block size, so the
+        # per-chunk block count differs per group — read it per group
+        # (``group.blocks_per_chunk`` = ``physical_chunk_size // shape_desc.bs``).
+        groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
+        num_groups = len(groups)
+        blocks_per_chunk_per_group = [group.blocks_per_chunk for group in groups]
 
         with (
             torch_dev.device(gpu_context.device),
@@ -372,18 +374,22 @@ class GPUTransferModule:
             # drive the transfer kernel to read out-of-bounds GPU memory, so skip
             # the whole store and commit nothing rather than caching a partial or
             # garbage entry. A later request can store it once the block IDs are
-            # complete.
-            required_blocks = len(obj_keys) * blocks_per_chunk
+            # complete. Each group has its own per-chunk block count under HMA.
+            num_chunks_requested = len(obj_keys)
             if any(
-                group_block_ids.shape[0] < required_blocks
-                for group_block_ids in block_ids_per_group_gpu
+                group_block_ids.shape[0]
+                < num_chunks_requested * blocks_per_chunk_per_group[group_idx]
+                for group_idx, group_block_ids in enumerate(block_ids_per_group_gpu)
             ):
                 logger.warning(
-                    "STORE block ID underflow for request_id=%s: need %d block "
+                    "STORE block ID underflow for request_id=%s: need %s block "
                     "IDs per group for %d chunks; skipping the store.",
                     key.request_id,
-                    required_blocks,
-                    len(obj_keys),
+                    [
+                        num_chunks_requested * bpc
+                        for bpc in blocks_per_chunk_per_group
+                    ],
+                    num_chunks_requested,
                 )
                 event.record()
                 return event.ipc_handle(), False
@@ -426,7 +432,7 @@ class GPUTransferModule:
             reserved_dict: dict[ObjectKey, MemoryObj] = {}
             store_succeeded = False
             try:
-                layout_desc = get_layout_desc(gpu_context, self._ctx.chunk_size)
+                layout_desc = get_layout_desc(gpu_context)
                 reserved_dict = self._ctx.storage_manager.reserve_write(
                     obj_keys, layout_desc, "new"
                 )
@@ -435,7 +441,6 @@ class GPUTransferModule:
                 # skipped (not in reserved_dict), making block_ids
                 # non-contiguous. Batching would require torch.cat to
                 # reassemble block_ids, negating the benefit.
-                num_groups = gpu_context.kv_layer_groups_manager.num_groups
                 for idx, obj_key in enumerate(obj_keys):
                     if obj_key in reserved_dict:
                         memory_obj = reserved_dict[obj_key]
@@ -443,19 +448,28 @@ class GPUTransferModule:
                         continue
 
                     # Copy from GPU paged buffer to tmp buffer, then to CPU — per
-                    # group. Each group uses its own block-id list (HMA).
+                    # group. Each group uses its own block-id list (HMA), its own
+                    # per-chunk block count, and (for SWA groups) stores only the
+                    # trailing window of each chunk.
                     for group_idx in range(num_groups):
+                        group = groups[group_idx]
+                        bpc = blocks_per_chunk_per_group[group_idx]
+                        # SWA-suffix: keep only the trailing
+                        # ``storage_blocks_per_chunk`` blocks of this chunk;
+                        # ``chunk_suffix_offset_blocks`` is 0 for full-attention
+                        # groups (store the whole chunk).
+                        chunk_start = idx * bpc + group.chunk_suffix_offset_blocks
                         chunk_block_ids_gpu = block_ids_per_group_gpu[group_idx][
-                            idx * blocks_per_chunk : (idx + 1) * blocks_per_chunk
+                            chunk_start : chunk_start + group.storage_blocks_per_chunk
                         ]
                         tmp_buffer = gpu_context.get_tmp_chunk_gpu_buffer(group_idx)
                         group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                        # Kernel contract: ``group_lmcache_chunk_size`` here is the
-                        # number of *physical* slots per chunk for this group
-                        # (= logical chunk_size // compress_ratio).
-                        group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                            group_idx
-                        )
+                        # Kernel contract: ``group_lmcache_chunk_size`` is the
+                        # number of *physical* slots actually transferred for
+                        # this group's chunk (SWA-suffix-aware), so the kernel's
+                        # ``num_blocks_per_object * bs == lmcache_chunk_size``
+                        # check holds.
+                        group_lmcache_chunk_size = group.storage_slots_per_chunk
                         lmc_ops.multi_layer_block_kv_transfer(
                             group_kv_pointers,
                             [tmp_buffer.data_ptr()],
@@ -581,18 +595,18 @@ class GPUTransferModule:
             ),
         )
 
-        # ``skip_*_in_chunk`` is expressed in engine-block units
-        # (logical tokens), which is what the kernel's
-        # ``skip_blocks_in_chunk`` argument expects regardless
-        # of per-group compression.
-        ie_logical_block_size = (
-            gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
-        )
-        blocks_per_chunk = self._ctx.chunk_size // ie_logical_block_size
+        # Under the hybrid KV cache manager each LMCache group has its own
+        # logical block size, so the per-chunk block count and the
+        # skip-block count differ per group. ``skip_first_n_tokens`` is in
+        # logical tokens (engine grain); convert it to a per-group block count
+        # inside the loop using that group's logical block size.
+        groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
+        blocks_per_chunk_per_group = [
+            group.blocks_per_chunk for group in groups
+        ]
 
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
             _BATCH_SIZE = gpu_context.max_batch_size
-            groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
             for batch_idx, memory_obj_batch in enumerate(
                 batched_iteration(memory_objs, batch_size=_BATCH_SIZE)
             ):
@@ -612,17 +626,6 @@ class GPUTransferModule:
                         self._ctx.chunk_size * batch_len - 1,
                     ),
                 )
-                if skip_tokens_in_chunk % ie_logical_block_size != 0:
-                    logger.error(
-                        "skip_first_n_tokens (%d) is not aligned to "
-                        "inference_engine_logical_block_size (%d), "
-                        "rounding down from %d tokens to %d blocks",
-                        skip_first_n_tokens,
-                        ie_logical_block_size,
-                        skip_tokens_in_chunk,
-                        skip_tokens_in_chunk // ie_logical_block_size,
-                    )
-                skip_blocks_in_chunk = skip_tokens_in_chunk // ie_logical_block_size
 
                 start_chunk_id = batch_idx * _BATCH_SIZE
                 end_chunk_id = start_chunk_id + batch_len
@@ -634,11 +637,30 @@ class GPUTransferModule:
                         gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=chunk_idx),
                     )
                 for group_idx, group in enumerate(groups):
-                    chunk_block_ids_gpu = block_ids_per_group_gpu[group_idx][
+                    blocks_per_chunk = blocks_per_chunk_per_group[group_idx]
+                    group_logical_bs = group.logical_block_size
+                    # ``skip_blocks_in_chunk`` is in this group's engine blocks.
+                    if skip_tokens_in_chunk % group_logical_bs != 0:
+                        logger.error(
+                            "skip_first_n_tokens (%d) is not aligned to group %d "
+                            "logical block size (%d); rounding down %d tokens to "
+                            "%d blocks",
+                            skip_first_n_tokens,
+                            group_idx,
+                            group_logical_bs,
+                            skip_tokens_in_chunk,
+                            skip_tokens_in_chunk // group_logical_bs,
+                        )
+                    skip_blocks_in_chunk = skip_tokens_in_chunk // group_logical_bs
+                    # The connector sends full-grain block IDs (all
+                    # ``blocks_per_chunk`` per chunk); validate that, then keep
+                    # only the trailing window of each chunk for SWA-suffix
+                    # groups below (offset is 0 for full attention).
+                    full_slice = block_ids_per_group_gpu[group_idx][
                         start_chunk_id * blocks_per_chunk : end_chunk_id
                         * blocks_per_chunk
                     ]
-                    if chunk_block_ids_gpu.shape[0] != batch_len * blocks_per_chunk:
+                    if full_slice.shape[0] != batch_len * blocks_per_chunk:
                         # Fail closed: a short block-id slice would make the
                         # transfer kernel write out-of-bounds GPU memory.
                         raise ValueError(
@@ -647,15 +669,40 @@ class GPUTransferModule:
                             f"engine_group_idx={group.engine_group_idx} "
                             f"batch={batch_idx} "
                             f"expected={batch_len * blocks_per_chunk} "
-                            f"got={chunk_block_ids_gpu.shape[0]}"
+                            f"got={full_slice.shape[0]}"
                         )
+                    # SWA-suffix: keep only the trailing window of each chunk;
+                    # ``chunk_suffix_offset_blocks`` is 0 for full-attention
+                    # groups (retrieve the whole chunk).
+                    suffix_offset = group.chunk_suffix_offset_blocks
+                    if suffix_offset:
+                        # Gather the trailing window of each chunk: reshape to
+                        # (chunks, full_bpc), drop the leading ``suffix_offset``
+                        # blocks, flatten back to chunk-major order. ``reshape``
+                        # after the column slice yields a contiguous int64 tensor
+                        # (required by the kernel).
+                        chunk_block_ids_gpu = (
+                            full_slice.view(batch_len, blocks_per_chunk)[
+                                :, suffix_offset:
+                            ]
+                            .reshape(-1)
+                            .contiguous()
+                        )
+                        # The leading blocks we dropped already absorb the APC
+                        # skip; only any remaining skip applies to stored blocks.
+                        skip_blocks_in_chunk = max(
+                            0, skip_blocks_in_chunk - suffix_offset
+                        )
+                    else:
+                        chunk_block_ids_gpu = full_slice
                     tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
                         batch_len, group_idx
                     )
                     group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                    group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                        group_idx
-                    )
+                    # Physical slots actually transferred per chunk for this
+                    # group (SWA-suffix-aware); satisfies the kernel's
+                    # ``num_blocks_per_object * bs == lmcache_chunk_size`` check.
+                    group_lmcache_chunk_size = group.storage_slots_per_chunk
 
                     lmc_ops.multi_layer_block_kv_transfer(
                         group_kv_pointers,

--- a/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
+++ b/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
@@ -73,7 +73,6 @@ def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
 
     def fake_layout_desc(
         gpu_context: _FakeGPUContext,
-        num_tokens: int,
     ) -> MemoryLayoutDesc:
         """Return the shared layout descriptor used by both registrations."""
         return layout_desc

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -176,6 +176,284 @@ class TestKVLayerGroupsManager:
         assert sd1.hs == 64
 
 
+class TestPerGroupCompressionMetadata:
+    """Per-group compress_ratio / physical_chunk_size derivation.
+
+    Exercises the hybrid-KV-cache-manager case where the engine's groups have
+    *different* logical block sizes, carried per layer via
+    ``LayoutHints["per_layer_inference_engine_logical_block_size"]``.
+    """
+
+    def _v4_like_tensors(self) -> list[torch.Tensor]:
+        """Two engine groups with different physical block sizes.
+
+        - layers 0,1: physical bs=64 (V4 SWA-like: logical 64 -> ratio 1)
+        - layer  2:   physical bs=4  (V4 state-like: logical 4 -> ratio 1)
+
+        The shapes also differ in ``hs`` so each engine group becomes its own
+        identity even before the engine-group split.
+        """
+        return [
+            torch.randn(1, 32, 64, 1, 128, dtype=torch.float16),  # bs=64
+            torch.randn(1, 32, 64, 1, 128, dtype=torch.float16),  # bs=64
+            torch.randn(1, 32, 4, 1, 512, dtype=torch.float16),  # bs=4
+        ]
+
+    def test_per_group_logical_block_size_drives_ratio(self):
+        """Each group's compress_ratio uses its own logical block size."""
+        tensors = self._v4_like_tensors()
+        # logical block sizes: groups [0,1] = 64, group [2] = 4
+        layout_hints: LayoutHints = {
+            "inference_engine_logical_block_size": 4,  # GCD scalar (wrong per group)
+            "per_layer_inference_engine_logical_block_size": [64, 64, 4],
+        }
+        manager = KVLayerGroupsManager(
+            tensors,
+            gpu_kv_format=_nhd_format(),
+            num_blocks=32,
+            layout_hints=layout_hints,
+            group_views=[
+                LMCacheGroupView(0, (0, 1)),
+                LMCacheGroupView(1, (2,)),
+            ],
+            lmcache_logical_chunk_size=1024,
+        )
+        by_engine = {g.engine_group_idx: g for g in manager.kv_layer_groups}
+        swa = by_engine[0]
+        state = by_engine[1]
+        # SWA group: physical bs 64, logical 64 -> ratio 1, full chunk 1024 slots
+        assert swa.compress_ratio == 1
+        assert swa.logical_block_size == 64
+        assert swa.physical_chunk_size == 1024
+        assert swa.blocks_per_chunk == 16  # 1024 / 64
+        # State group: physical bs 4, logical 4 -> ratio 1, 256 blocks/chunk
+        assert state.compress_ratio == 1
+        assert state.logical_block_size == 4
+        assert state.physical_chunk_size == 1024
+        assert state.blocks_per_chunk == 256  # 1024 / 4
+
+    def test_compressed_group_ratio_gt_one(self):
+        """logical block size larger than physical bs -> compress_ratio > 1."""
+        tensors = [torch.randn(1, 32, 64, 1, 128, dtype=torch.float16)]
+        layout_hints: LayoutHints = {
+            "per_layer_inference_engine_logical_block_size": [256],
+        }
+        manager = KVLayerGroupsManager(
+            tensors,
+            gpu_kv_format=_nhd_format(),
+            num_blocks=32,
+            layout_hints=layout_hints,
+            lmcache_logical_chunk_size=1024,
+        )
+        g = manager.kv_layer_groups[0]
+        assert g.compress_ratio == 4  # 256 / 64
+        assert g.logical_block_size == 256
+        assert g.physical_chunk_size == 256  # 1024 / 4
+        assert g.blocks_per_chunk == 4  # 256 / 64
+
+    def test_scalar_fallback_when_no_per_layer_hint(self):
+        """Absent per-layer hint -> scalar inference_engine_logical_block_size."""
+        tensors = [torch.randn(1, 32, 64, 1, 128, dtype=torch.float16)]
+        layout_hints: LayoutHints = {
+            "inference_engine_logical_block_size": 256,
+        }
+        manager = KVLayerGroupsManager(
+            tensors,
+            gpu_kv_format=_nhd_format(),
+            num_blocks=32,
+            layout_hints=layout_hints,
+            lmcache_logical_chunk_size=1024,
+        )
+        g = manager.kv_layer_groups[0]
+        assert g.compress_ratio == 4  # 256 / 64 (from the scalar)
+
+    def test_zero_per_layer_entry_falls_back_to_scalar(self):
+        """A 0 entry in the per-layer list defers to the scalar for that group."""
+        tensors = [torch.randn(1, 32, 64, 1, 128, dtype=torch.float16)]
+        layout_hints: LayoutHints = {
+            "inference_engine_logical_block_size": 256,
+            "per_layer_inference_engine_logical_block_size": [0],
+        }
+        manager = KVLayerGroupsManager(
+            tensors,
+            gpu_kv_format=_nhd_format(),
+            num_blocks=32,
+            layout_hints=layout_hints,
+            lmcache_logical_chunk_size=1024,
+        )
+        g = manager.kv_layer_groups[0]
+        assert g.compress_ratio == 4  # falls back to scalar 256
+
+    def test_no_hint_at_all_treats_as_uncompressed(self):
+        """No layout hints -> compress_ratio 1 (physical == logical)."""
+        tensors = [torch.randn(1, 32, 64, 1, 128, dtype=torch.float16)]
+        manager = KVLayerGroupsManager(
+            tensors,
+            gpu_kv_format=_nhd_format(),
+            num_blocks=32,
+            layout_hints=None,
+            lmcache_logical_chunk_size=1024,
+        )
+        g = manager.kv_layer_groups[0]
+        assert g.compress_ratio == 1
+        assert g.logical_block_size == 64
+        assert g.blocks_per_chunk == 16
+
+
+class TestNumSuffixBlocksPerChunk:
+    """``num_suffix_blocks_per_chunk`` / SWA-suffix helper math."""
+
+    def _group(
+        self,
+        *,
+        bs: int,
+        compress_ratio: int,
+        physical_chunk_size: int,
+        sliding_window: int,
+    ) -> KVLayerGroupInfo:
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        sd = lmc_ops.PageBufferShapeDesc()
+        sd.kv_size = 1
+        sd.nl = 1
+        sd.nb = 32
+        sd.bs = bs
+        sd.nh = 1
+        sd.hs = 128
+        sd.element_size = 2
+        return KVLayerGroupInfo(
+            layer_indices=[0],
+            shape_desc=sd,
+            dtype=torch.float16,
+            compress_ratio=compress_ratio,
+            physical_chunk_size=physical_chunk_size,
+            sliding_window=sliding_window,
+        )
+
+    def test_full_attention_returns_none(self):
+        g = self._group(
+            bs=64, compress_ratio=4, physical_chunk_size=256, sliding_window=0
+        )
+        assert g.num_suffix_blocks_per_chunk is None
+
+    def test_swa_ceil(self):
+        # logical bs = 64*1 = 64, window 128 -> ceil(128/64) = 2
+        g = self._group(
+            bs=64, compress_ratio=1, physical_chunk_size=1024, sliding_window=128
+        )
+        assert g.logical_block_size == 64
+        assert g.blocks_per_chunk == 16
+        assert g.num_suffix_blocks_per_chunk == 2
+
+    def test_swa_ceil_rounds_up(self):
+        # logical bs 4, window 8 -> ceil(8/4) = 2
+        g = self._group(
+            bs=4, compress_ratio=1, physical_chunk_size=1024, sliding_window=8
+        )
+        assert g.blocks_per_chunk == 256
+        assert g.num_suffix_blocks_per_chunk == 2
+
+    def test_window_larger_than_chunk_capped(self):
+        # logical bs 64, window 4096 -> ceil = 64, but capped at blocks_per_chunk 16
+        g = self._group(
+            bs=64, compress_ratio=1, physical_chunk_size=1024, sliding_window=4096
+        )
+        assert g.num_suffix_blocks_per_chunk == 16
+
+
+class TestStoragePerChunkHelpers:
+    """SWA-suffix storage helpers that the transfer loops + buffers share."""
+
+    def _group(
+        self,
+        *,
+        bs: int,
+        compress_ratio: int,
+        physical_chunk_size: int,
+        sliding_window: int,
+    ) -> KVLayerGroupInfo:
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        sd = lmc_ops.PageBufferShapeDesc()
+        sd.kv_size = 1
+        sd.nl = 1
+        sd.nb = 32
+        sd.bs = bs
+        sd.nh = 1
+        sd.hs = 128
+        sd.element_size = 2
+        return KVLayerGroupInfo(
+            layer_indices=[0],
+            shape_desc=sd,
+            dtype=torch.float16,
+            compress_ratio=compress_ratio,
+            physical_chunk_size=physical_chunk_size,
+            sliding_window=sliding_window,
+        )
+
+    def test_full_attention_stores_whole_chunk(self):
+        # MLA full-attn: physical bs 64, logical 256, chunk 256 slots, 4 blk/chunk
+        g = self._group(
+            bs=64, compress_ratio=4, physical_chunk_size=256, sliding_window=0
+        )
+        assert g.storage_blocks_per_chunk == g.blocks_per_chunk == 4
+        assert g.storage_slots_per_chunk == g.physical_chunk_size == 256
+        assert g.storage_tokens_per_chunk == 1024  # 4 blocks * logical 256
+        assert g.chunk_suffix_offset_blocks == 0
+
+    def test_swa_stores_only_trailing_window(self):
+        # SWA: physical bs 64, logical 64, window 128, chunk 1024 slots, 16 blk/chunk
+        g = self._group(
+            bs=64, compress_ratio=1, physical_chunk_size=1024, sliding_window=128
+        )
+        assert g.blocks_per_chunk == 16
+        assert g.storage_blocks_per_chunk == 2  # ceil(128/64)
+        assert g.storage_slots_per_chunk == 2 * 64  # 128 physical slots
+        assert g.storage_tokens_per_chunk == 2 * 64  # logical_bs == bs here
+        assert g.chunk_suffix_offset_blocks == 14  # 16 - 2
+
+    def test_state_group_large_shrink(self):
+        # C4A state: physical bs 4, logical 4, window 8, 256 blk/chunk
+        g = self._group(
+            bs=4, compress_ratio=1, physical_chunk_size=1024, sliding_window=8
+        )
+        assert g.blocks_per_chunk == 256
+        assert g.storage_blocks_per_chunk == 2  # ceil(8/4)
+        assert g.storage_slots_per_chunk == 8
+        assert g.chunk_suffix_offset_blocks == 254  # 256 - 2
+
+    def test_kernel_chunk_size_invariant(self):
+        """storage_slots_per_chunk must equal storage_blocks_per_chunk * bs.
+
+        The kernel asserts num_blocks_per_object * bs == lmcache_chunk_size; we
+        pass storage_blocks_per_chunk block IDs and storage_slots_per_chunk as
+        lmcache_chunk_size, so this identity is what keeps it valid.
+        """
+        for g in [
+            self._group(bs=64, compress_ratio=4, physical_chunk_size=256,
+                        sliding_window=0),
+            self._group(bs=64, compress_ratio=1, physical_chunk_size=1024,
+                        sliding_window=128),
+            self._group(bs=4, compress_ratio=1, physical_chunk_size=1024,
+                        sliding_window=8),
+            self._group(bs=8, compress_ratio=1, physical_chunk_size=1024,
+                        sliding_window=128),
+        ]:
+            assert (
+                g.storage_slots_per_chunk
+                == g.storage_blocks_per_chunk * g.shape_desc.bs
+            )
+
+
+def _nhd_format():
+    # First Party
+    import lmcache.c_ops as lmc_ops
+
+    return lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+
 class TestParseKvcacheShapeSpec:
     """Test cases for parse_kvcache_shape_spec function."""
 

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -8,6 +8,8 @@ import torch
 # First Party
 from lmcache.integration.vllm.kv_cache_groups import (
     create_group_views_from_vllm,
+    per_layer_inference_engine_logical_block_size_from_vllm,
+    per_layer_sliding_window_from_vllm,
 )
 from lmcache.v1.multiprocess.group_view import (
     expand_block_ids_to_views,
@@ -19,7 +21,6 @@ from lmcache.v1.multiprocess.group_view import (
 @dataclass
 class MockKVCacheGroup:
     layer_names: list[str]
-
 
 @dataclass
 class MockKVCacheConfig:
@@ -79,3 +80,88 @@ def test_conversion_splits_by_lmcache_layer_identity():
         [20],
         [10],
     ]
+
+
+# ----------------------------------------------------------------------------
+# per_layer_* hint derivation (logical block size + sliding window)
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class MockSpec:
+    """A vLLM ``KVCacheGroupSpec.kv_cache_spec`` stand-in."""
+
+    block_size: int = 0
+    sliding_window: int | None = None
+
+
+@dataclass
+class MockUniformSpec:
+    """A ``UniformTypeKVCacheSpecs`` stand-in: block size/window on inner specs."""
+
+    kv_cache_specs: dict
+
+
+@dataclass
+class MockGroupWithSpec:
+    layer_names: list[str]
+    kv_cache_spec: object
+
+
+@dataclass
+class MockConfigWithSpecs:
+    kv_cache_groups: list
+
+
+def test_per_layer_logical_block_size_maps_per_group():
+    """Each layer gets its engine group's block_size, in registration order."""
+    config = MockConfigWithSpecs(
+        kv_cache_groups=[
+            MockGroupWithSpec(["layer.0", "layer.2"], MockSpec(block_size=256)),
+            MockGroupWithSpec(["layer.1", "layer.3"], MockSpec(block_size=64)),
+        ]
+    )
+    caches = {f"layer.{i}": None for i in range(4)}
+    result = per_layer_inference_engine_logical_block_size_from_vllm(config, caches)
+    # registration order is layer.0,1,2,3 -> [256, 64, 256, 64]
+    assert result == [256, 64, 256, 64]
+
+
+def test_per_layer_logical_block_size_uniform_inner_spec_fallback():
+    """Block size read from inner specs for a UniformTypeKVCacheSpecs wrapper."""
+    uniform = MockUniformSpec(kv_cache_specs={"layer.0": MockSpec(block_size=4)})
+    config = MockConfigWithSpecs(
+        kv_cache_groups=[MockGroupWithSpec(["layer.0", "layer.1"], uniform)]
+    )
+    caches = {"layer.0": None, "layer.1": None}
+    result = per_layer_inference_engine_logical_block_size_from_vllm(config, caches)
+    assert result == [4, 4]
+
+
+def test_per_layer_logical_block_size_none_without_groups():
+    """No engine groups -> None (server falls back to the scalar)."""
+    assert per_layer_inference_engine_logical_block_size_from_vllm(None, {}) is None
+
+
+def test_per_layer_sliding_window_maps_per_group():
+    config = MockConfigWithSpecs(
+        kv_cache_groups=[
+            MockGroupWithSpec(["layer.0"], MockSpec(block_size=256, sliding_window=0)),
+            MockGroupWithSpec(
+                ["layer.1"], MockSpec(block_size=64, sliding_window=128)
+            ),
+        ]
+    )
+    caches = {"layer.0": None, "layer.1": None}
+    result = per_layer_sliding_window_from_vllm(config, caches)
+    assert result == [0, 128]
+
+
+def test_per_layer_sliding_window_none_when_all_full_attention():
+    """All groups full attention -> None (server keeps legacy full-chunk path)."""
+    config = MockConfigWithSpecs(
+        kv_cache_groups=[
+            MockGroupWithSpec(["layer.0"], MockSpec(block_size=256, sliding_window=0)),
+        ]
+    )
+    assert per_layer_sliding_window_from_vllm(config, {"layer.0": None}) is None


### PR DESCRIPTION
> **Status: Work in Progress (draft).** Functional and validated end-to-end on
> DeepSeek-V4-Flash, but opened as a draft for early feedback on the approach
> while broader failure-mode coverage (APC-on, concurrency, V3.2 regression) is
> still being added. There is no "Work in Progress" label on this repo, so WIP
> is signalled via the draft status and the `[WIP]` title prefix.
>
> Supersedes the approach in #3261 (which predates the #3419 HMA redesign).
> This is a fresh PR rebuilt on top of #3419; #3261 is left open for now.

## Summary

Builds on the #3419 hybrid memory allocator (HMA) framework to make the
LMCache MP connector correct **and** efficient for DeepSeek-V4's hybrid KV
cache. It implements the two V4 items #3419 explicitly left as Non-Goals:

1. **DeepSeek-V4 logical→physical block translation** (per-group logical block
   size) — a correctness fix.
2. **Sliding-window load-plan trimming** (SWA-suffix-only offload) — an
   efficiency optimization.

No C++/CUDA changes: `block_stride_elems` and the padded-stride kernel walk
already landed upstream (#3171 / #3419).

## Problem

Under the hybrid KV cache manager, vLLM's engine groups have **different
logical block sizes** (V4-Flash: 256 for the full-attention MLA group, 64/4/8
for the SWA / compressor-state groups), while `cache_config.block_size`
collapses to their GCD. The server derived every group's `compress_ratio` /
`physical_chunk_size` from a single global
`inference_engine_logical_block_size`, and the store/retrieve loops used one
uniform `blocks_per_chunk`.

That is only correct for the group whose logical block size happens to equal
the assumed value (the MLA group). For the SWA / state groups the kernel
sliced too few block IDs per chunk and transferred only the **leading
fraction** of each chunk, leaving the rest untransferred. It went unnoticed
because the full-attention MLA group — which dominates output quality — was
the one group sized correctly.

## Changes

### Per-group logical block size (correctness)

- `LayoutHints` gains `per_layer_inference_engine_logical_block_size`; a new
  `per_layer_inference_engine_logical_block_size_from_vllm` helper reads each
  `KVCacheGroupSpec.block_size` (with `UniformTypeKVCacheSpecs` inner-spec
  fallback), and the worker forwards it at registration.
- **Geometry only** — no block IDs are exposed to the server, and the hint is
  omitted for non-hybrid engines, so V3.2 / other engines keep the legacy
  scalar path unchanged (keeps #3419's minimal-server design).
- `KVLayerGroupsManager` derives `compress_ratio` / `physical_chunk_size` per
  group; the store/retrieve loops use per-group `blocks_per_chunk` for slicing,
  underflow checks, and the per-group skip-block computation.

### SWA-suffix-only offload (efficiency)

- For a sliding-window group the attention mask never reads tokens older than
  the window, so only the trailing `ceil(window / logical_block_size)` blocks
  of each chunk are attended on reload. Store/retrieve now move just that
  suffix for SWA groups (full chunks for full-attention groups). Default-on.
- A single source of truth (`storage_blocks_per_chunk` /
  `storage_slots_per_chunk` / `storage_tokens_per_chunk` /
  `chunk_suffix_offset_blocks`) drives the block-ID slice, the kernel
  `lmcache_chunk_size` arg, the tmp GPU buffer slot, the per-group buffer
  views, and the `MemoryObj` layout, so they cannot disagree. The connector
  keeps sending full-grain block IDs; the server selects the trailing window.

## Validation

DeepSeek-V4-Flash, tp=4, fp8, `--block-size 256`,
`--no-disable-hybrid-kv-cache-manager`, LMCache 256 GiB L1, APC off:

- Per-group geometry corrected: SWA/state groups `compress_ratio/physical_chunk`
  `4 / 256` → `1 / 1024`.
- Store/retrieve succeed with no shape error; ~37–42% external prefix cache
  hit rate; cold vs warm semantically identical.
- L1 usage **667 MB** (full chunks) → **38.7 MB** (suffix-only), ~17× shrink.
- `tests/v1` (`kv_layer_groups_manager`, `vllm_kv_cache_groups`,
  `vllm_mp_adapter`, `mp_mem_kernels`, `gpu_connector`): **123 passed, 2
  skipped**.

## Remaining before un-drafting

- Broader failure-mode coverage: APC-on, partial hits, concurrency /
  multi-request, V3.2 regression run.
- L2 (NIXL / FS) path on V4 HMA is not exercised here (L1 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
