### PR TITLE
[MP][DSV4] Make the LMCache server block-only (connector-side SWA-suffix trim)

### DIFF
--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -362,7 +362,7 @@ def _send_retrieve(
         _INSTANCE_ID,
         [block_ids] * num_group_views,
         _make_event_handle(),
-        0,  # skip_first_n_tokens
+        [],  # skip_blocks_per_group
     ]
     result = _call(client, RequestType.RETRIEVE, payloads)
     if result is _TIMEOUT:

--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -414,7 +414,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
                         self._instance_id,
                         [spec.block_ids],
                         event.ipc_handle(),
-                        0,  # skip_first_n_tokens
+                        [],  # skip_blocks_per_group
                     ],
                 ).result(timeout=self._mq_timeout)
             except Exception as e:

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -98,3 +98,75 @@ def create_group_views_from_vllm(
             per_layer_group_idx,
         )
     ]
+
+
+def spec_int_attr(spec: Any, attr: str) -> int:
+    """Read an integer ``attr`` off a vLLM KVCacheGroupSpec spec.
+
+    Falls back to the first inner spec for ``UniformTypeKVCacheSpecs`` wrappers.
+    Returns ``0`` when the attribute is absent or ``None``.
+    """
+    value = getattr(spec, attr, None)
+    if value is None:
+        inner_specs = getattr(spec, "kv_cache_specs", None)
+        if inner_specs:
+            first_inner = next(iter(inner_specs.values()))
+            value = getattr(first_inner, attr, None)
+    return int(value or 0)
+
+
+def storage_blocks_per_chunk(
+    sliding_window: int,
+    logical_block_size: int,
+    chunk_tokens: int,
+) -> int:
+    """Blocks per chunk a group actually stores/retrieves (SWA-suffix-aware).
+
+    Returns the full chunk for full-attention groups (``sliding_window <= 0``),
+    or ``ceil(sliding_window / logical_block_size)`` capped at the full chunk
+    for sliding-window groups. Shared by the connector's scheduler-side trim
+    and its worker-side register hint so the two cannot drift.
+    """
+    full_bpc = chunk_tokens // logical_block_size
+    if sliding_window <= 0:
+        return full_bpc
+    suffix = (sliding_window + logical_block_size - 1) // logical_block_size
+    return min(suffix, full_bpc)
+
+
+def per_layer_storage_blocks_per_chunk_from_vllm(
+    kv_cache_config: Any,
+    kv_caches: Mapping[str, Any],
+    chunk_tokens: int,
+) -> list[int] | None:
+    """Per-registered-layer stored-blocks-per-chunk derived from vLLM metadata.
+
+    Combines each group's ``block_size`` and ``sliding_window`` via
+    :func:`storage_blocks_per_chunk` and maps the result onto every layer in
+    that group. Returns ``None`` when no group reports a positive block size.
+    """
+    vllm_groups = (
+        getattr(kv_cache_config, "kv_cache_groups", ()) or ()
+        if kv_cache_config is not None
+        else ()
+    )
+    if not vllm_groups:
+        return None
+
+    layer_to_idx = {name: idx for idx, name in enumerate(kv_caches.keys())}
+    per_layer = [0] * len(layer_to_idx)
+    any_block_size = False
+    for group in vllm_groups:
+        spec = getattr(group, "kv_cache_spec", None)
+        logical_bs = spec_int_attr(spec, "block_size")
+        if logical_bs <= 0:
+            continue
+        any_block_size = True
+        window = spec_int_attr(spec, "sliding_window")
+        bpc = storage_blocks_per_chunk(window, logical_bs, chunk_tokens)
+        for name in group.layer_names:
+            idx = layer_to_idx.get(name)
+            if idx is not None:
+                per_layer[idx] = bpc
+
+    return per_layer if any_block_size else None

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -38,6 +38,9 @@ import zmq
 from lmcache import torch_dev
 from lmcache.integration.vllm.kv_cache_groups import (
     create_group_views_from_vllm,
+    per_layer_storage_blocks_per_chunk_from_vllm,
+    spec_int_attr,
+    storage_blocks_per_chunk,
 )
 from lmcache.integration.vllm.utils import mla_enabled, vllm_layout_hints
 from lmcache.utils import init_logger as lmcache_init_logger
@@ -314,34 +317,90 @@ class LMCacheMPRequestMetadata:
     cache_salt: str = ""
 
     @staticmethod
+    def _group_ratio(
+        engine_group_idx: int,
+        logical_block_sizes: "list[int]",
+        vllm_block_size: int,
+    ) -> int:
+        """GCD-grain blocks per one own-grain block for this group.
+
+        ``logical_block_size_g // vllm_block_size`` (vllm_block_size is the
+        GCD under HMA). Used to convert between GCD-grain bookkeeping and
+        per-group block-ID grain. Returns 1 for non-hybrid / V3.2.
+        """
+        if engine_group_idx < len(logical_block_sizes):
+            logical_bs = logical_block_sizes[engine_group_idx]
+            if logical_bs and vllm_block_size:
+                return max(1, logical_bs // vllm_block_size)
+        return 1
+
+    @staticmethod
+    def _group_geometry(
+        engine_group_idx: int,
+        logical_block_sizes: "list[int]",
+        sliding_windows: "list[int]",
+        vllm_block_size: int,
+        blocks_in_chunk: int,
+    ) -> "tuple[int, int, int]":
+        """Return ``(ratio, full_bpc, suffix_bpc)`` for a group.
+
+        ``ratio`` is the GCD-to-own-grain factor; ``full_bpc`` is the full
+        chunk block count in own grain; ``suffix_bpc`` is the trimmed count
+        after applying the SWA window (equals ``full_bpc`` for full attention).
+        """
+        ratio = LMCacheMPRequestMetadata._group_ratio(
+            engine_group_idx, logical_block_sizes, vllm_block_size
+        )
+        full_bpc = blocks_in_chunk // ratio
+        logical_bs = ratio * vllm_block_size
+        window = (
+            sliding_windows[engine_group_idx]
+            if engine_group_idx < len(sliding_windows)
+            else 0
+        )
+        suffix_bpc = storage_blocks_per_chunk(
+            window, logical_bs, blocks_in_chunk * vllm_block_size
+        )
+        return ratio, full_bpc, suffix_bpc
+
+    @staticmethod
     def _slice_block_ids(
         tracker: LMCacheMPRequestTracker,
         num_engine_groups: int,
         start: int,
         end: int,
+        logical_block_sizes: "list[int]",
+        sliding_windows: "list[int]",
+        vllm_block_size: int,
+        blocks_in_chunk: int,
     ) -> list[list[int]]:
-        """Slice every engine group's block IDs for the block range.
+        """Slice every engine group's block IDs for ``[start, end)`` (GCD grain),
+        trimming each chunk to its trailing SWA-suffix window.
 
-        Args:
-            tracker: Request tracker holding the per-engine-group block IDs.
-            num_engine_groups: Number of engine KV cache groups; the result
-                has one inner list per group, in engine-group order.
-            start: Start **block** index (inclusive), not a token index.
-            end: End **block** index (exclusive), not a token index.
-
-        Returns:
-            One ``list[int]`` of block IDs per engine group, each sliced to
-            ``[start, end)``.
-
-        Notes:
-            Minimal HMA support assumes all groups share vLLM's scheduler
-            block size. DeepSeek-V4's per-group logical/physical block-size
-            mapping is intentionally left for a follow-up.
+        Returns one ``list[int]`` per engine group, in engine-group order.
         """
-        return [
-            tracker.allocated_block_ids.get(engine_group_idx, [])[start:end]
-            for engine_group_idx in range(num_engine_groups)
-        ]
+        num_chunks = (end - start) // blocks_in_chunk if blocks_in_chunk else 0
+        sliced: list[list[int]] = []
+        for engine_group_idx in range(num_engine_groups):
+            ratio, full_bpc, suffix_bpc = LMCacheMPRequestMetadata._group_geometry(
+                engine_group_idx,
+                logical_block_sizes,
+                sliding_windows,
+                vllm_block_size,
+                blocks_in_chunk,
+            )
+            group_block_ids = tracker.allocated_block_ids.get(engine_group_idx, [])
+            own = group_block_ids[start // ratio : end // ratio]
+            if suffix_bpc < full_bpc and num_chunks > 0:
+                # Keep only the trailing ``suffix_bpc`` blocks of each chunk.
+                trimmed: list[int] = []
+                for c in range(num_chunks):
+                    base = c * full_bpc
+                    trimmed.extend(own[base + full_bpc - suffix_bpc : base + full_bpc])
+                sliced.append(trimmed)
+            else:
+                sliced.append(own)
+        return sliced
 
     @staticmethod
     def GetStoreMetadata(
@@ -349,16 +408,24 @@ class LMCacheMPRequestMetadata:
         blocks_in_chunk: int,
         vllm_block_size: int,
         num_engine_groups: int,
+        logical_block_sizes: "list[int]",
+        sliding_windows: "list[int]",
     ) -> "LMCacheMPRequestMetadata | None":
         """
         Generate the store metadata for the current request tracker.
 
         Args:
             tracker: The request tracker to generate the metadata from.
-            blocks_in_chunk: the number of blocks in a LMCache data chunk
-            vllm_block_size: the block size used in vLLM
+            blocks_in_chunk: the number of GCD-grain blocks in a LMCache chunk.
+            vllm_block_size: ``cache_config.block_size`` (GCD under hybrid).
             num_engine_groups: number of engine KV cache groups; the op's
                 block IDs carry one inner list per group, in engine order.
+            logical_block_sizes: per-engine-group logical (scheduler) block
+                size, used to reconcile per-group allocation counts (own grain)
+                against the GCD-grain bookkeeping. Scheduler-side only.
+            sliding_windows: per-engine-group sliding window in logical tokens
+                (``0`` = full attention), used to trim each chunk's block IDs to
+                its trailing window before sending. Scheduler-side only.
         """
         # Store the blocks that has block hashes
         # NOTE: the invariant here is that `num_stored_blocks` should
@@ -386,9 +453,18 @@ class LMCacheMPRequestMetadata:
             tracker.num_vllm_hit_blocks, tracker.num_lmcache_hit_blocks
         )
         allocated_lengths = tracker.num_allocated_blocks()
+        # Each group's allocation is counted at the group's own logical grain;
+        # scale every group up to GCD grain (multiply by ratio_g) before taking
+        # the cross-group min, so groups with different logical block sizes are
+        # compared on the same axis. (Pre-fix this took the raw min, which a
+        # coarse-grained group like V4 full-attn bs=256 dominated, wedging the
+        # store gate to 0 chunks.)
         allocated_blocks = (
             min(
                 allocated_lengths.get(engine_group_idx, 0)
+                * LMCacheMPRequestMetadata._group_ratio(
+                    engine_group_idx, logical_block_sizes, vllm_block_size
+                )
                 for engine_group_idx in range(num_engine_groups)
             )
             if num_engine_groups > 0
@@ -406,7 +482,9 @@ class LMCacheMPRequestMetadata:
             start = tracker.num_stored_blocks
             end = start + num_chunks * blocks_in_chunk
             block_ids = LMCacheMPRequestMetadata._slice_block_ids(
-                tracker, num_engine_groups, start, end
+                tracker, num_engine_groups, start, end,
+                logical_block_sizes, sliding_windows,
+                vllm_block_size, blocks_in_chunk,
             )
             start_token_idx = start * vllm_block_size
             end_token_idx = end * vllm_block_size
@@ -437,16 +515,25 @@ class LMCacheMPRequestMetadata:
         blocks_in_chunk: int,
         vllm_block_size: int,
         num_engine_groups: int,
+        logical_block_sizes: "list[int]",
+        sliding_windows: "list[int]",
     ) -> "LMCacheMPRequestMetadata | None":
         """
         Generate the retrieve metadata for the current request tracker.
 
         Args:
             tracker: The request tracker to generate the metadata from.
-            blocks_in_chunk: the number of blocks in a LMCache data chunk
-            vllm_block_size: the block size used in vLLM
+            blocks_in_chunk: the number of GCD-grain blocks in a LMCache chunk.
+            vllm_block_size: ``cache_config.block_size`` (GCD under hybrid).
             num_engine_groups: number of engine KV cache groups; the op's
                 block IDs carry one inner list per group, in engine order.
+            logical_block_sizes: per-engine-group logical (scheduler) block
+                size, used to slice each group's block IDs at its own grain.
+                Scheduler-side only.
+            sliding_windows: per-engine-group sliding window in logical tokens
+                (``0`` = full attention), used to trim each chunk to its trailing
+                window and to convert the APC skip to per-group stored-block
+                units. Scheduler-side only.
         """
         if not tracker.is_ready_for_retrieving():
             return None
@@ -468,26 +555,41 @@ class LMCacheMPRequestMetadata:
         )
         if end > start:
             block_ids = LMCacheMPRequestMetadata._slice_block_ids(
-                tracker, num_engine_groups, start, end
+                tracker, num_engine_groups, start, end,
+                logical_block_sizes, sliding_windows,
+                vllm_block_size, blocks_in_chunk,
             )
             start_token_idx = start * vllm_block_size
             end_token_idx = end * vllm_block_size
             token_ids = list(tracker.all_token_ids)
 
-            # Compute how many tokens at the start of the retrieve range
-            # overlap with APC-shared blocks. The server must skip writing
-            # to these positions to avoid a cross-stream data race: the
-            # retrieve writes on the LMCache CUDA stream while concurrent
-            # requests may read these APC-shared blocks on the vLLM stream.
             apc_overlap_blocks = tracker.num_vllm_hit_blocks - start
-            skip_first_n_tokens = apc_overlap_blocks * vllm_block_size
+            apc_overlap_tokens = apc_overlap_blocks * vllm_block_size
+
+            # Per-group skip in stored-block units: token overlap -> own-grain
+            # blocks, minus the leading blocks already dropped by SWA trimming.
+            skip_blocks_per_group: list[int] = []
+            for engine_group_idx in range(num_engine_groups):
+                ratio, full_bpc, suffix_bpc = (
+                    LMCacheMPRequestMetadata._group_geometry(
+                        engine_group_idx,
+                        logical_block_sizes,
+                        sliding_windows,
+                        vllm_block_size,
+                        blocks_in_chunk,
+                    )
+                )
+                logical_bs = ratio * vllm_block_size
+                skip_blocks_full = apc_overlap_tokens // logical_bs
+                suffix_offset = full_bpc - suffix_bpc
+                skip_blocks_per_group.append(max(0, skip_blocks_full - suffix_offset))
 
             op = LoadStoreOp(
                 token_ids=token_ids,
                 block_ids=block_ids,
                 start=start_token_idx,
                 end=end_token_idx,
-                skip_first_n_tokens=skip_first_n_tokens,
+                skip_blocks_per_group=skip_blocks_per_group,
             )
 
             ret = LMCacheMPRequestMetadata(
@@ -588,6 +690,17 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self._num_engine_groups = len(vllm_groups) or 1
 
+        # Per-engine-group logical block size and sliding window, scheduler-side
+        # only (never sent to server). Empty for non-hybrid / V3.2 -> ratio 1.
+        self._engine_group_logical_block_sizes: list[int] = [
+            spec_int_attr(getattr(group, "kv_cache_spec", None), "block_size")
+            for group in vllm_groups
+        ]
+        self._engine_group_sliding_windows: list[int] = [
+            spec_int_attr(getattr(group, "kv_cache_spec", None), "sliding_window")
+            for group in vllm_groups
+        ]
+
     @property
     def role(self) -> KVConnectorRole:
         return self._role
@@ -624,7 +737,20 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             kv_caches,
             layout_hints=vllm_layout_hints(),
         )
-        self.worker_adapter.register_kv_caches(kv_caches, group_views=group_views)
+        chunk_tokens = (
+            self.worker_adapter.blocks_in_chunk
+            * self.worker_adapter.vllm_logical_block_size
+        )
+        per_layer_storage_blocks_per_chunk = (
+            per_layer_storage_blocks_per_chunk_from_vllm(
+                kv_cache_config, kv_caches, chunk_tokens
+            )
+        )
+        self.worker_adapter.register_kv_caches(
+            kv_caches,
+            group_views=group_views,
+            per_layer_storage_blocks_per_chunk=per_layer_storage_blocks_per_chunk,
+        )
         return
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
@@ -1120,6 +1246,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 blocks_per_chunk,
                 vllm_block_size=self.vllm_block_size,
                 num_engine_groups=self._num_engine_groups,
+                logical_block_sizes=self._engine_group_logical_block_sizes,
+                sliding_windows=self._engine_group_sliding_windows,
             )
             if r_metadata is not None:
                 metadata.add_request_metadata(r_metadata)
@@ -1143,6 +1271,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 blocks_per_chunk,
                 self.vllm_block_size,
                 self._num_engine_groups,
+                self._engine_group_logical_block_sizes,
+                self._engine_group_sliding_windows,
             )
             if r_meta is not None:
                 metadata.add_request_metadata(r_meta)
@@ -1173,6 +1303,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 blocks_per_chunk,
                 self.vllm_block_size,
                 self._num_engine_groups,
+                self._engine_group_logical_block_sizes,
+                self._engine_group_sliding_windows,
             )
 
             if r_meta is not None:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, NoReturn, Protocol
 import enum
 import os
@@ -25,6 +25,7 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.group_view import (
     LMCacheGroupView,
     expand_block_ids_to_views,
+    expand_per_group_values_to_views,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
@@ -417,9 +418,9 @@ class LoadStoreOp:
     end: int = 0
     """End token index"""
 
-    skip_first_n_tokens: int = 0
-    """Number of tokens to skip writing at the beginning of the retrieve
-    range. Used to avoid overwriting APC-shared GPU blocks during retrieve."""
+    skip_blocks_per_group: list[int] = field(default_factory=list)
+    """Per-engine-group leading blocks to skip on retrieve (stored-block units,
+    parallel to ``block_ids``). Empty for store ops / no APC overlap."""
 
     @property
     def flat_block_ids(self) -> list[int]:
@@ -854,6 +855,7 @@ class LMCacheMPWorkerAdapter:
         # Registered kv caches from vLLM
         self.kv_caches: dict[str, torch.Tensor] = {}
         self.group_views: list[LMCacheGroupView] = []
+        self.per_layer_storage_blocks_per_chunk: list[int] | None = None
 
         # Transport context for transfer operations.
         self.transfer_ctx: TransferContext | None = None
@@ -968,26 +970,36 @@ class LMCacheMPWorkerAdapter:
         self,
         kv_caches: dict[str, torch.Tensor],
         group_views: Sequence[LMCacheGroupView] = (),
+        per_layer_storage_blocks_per_chunk: list[int] | None = None,
     ) -> None:
-        """
-        Register the kv caches with LMCache server.
+        """Register the KV caches with the LMCache server.
 
         Args:
-            kv_caches: A dict of kv caches to register. The keys are the
-                layer names and the values are the corresponding tensors.
+            kv_caches: Layer-name → tensor mapping.
             group_views: LMCache-owned engine KV cache group metadata.
+            per_layer_storage_blocks_per_chunk: Per-layer block count the
+                connector sends per chunk (trimmed for SWA groups). Forwarded
+                to the server as ``layout_hints``. ``None`` for non-hybrid.
 
         Raises:
-            ConnectionError: if the server does not respond within
-                mq_timeout.
+            ConnectionError: if the server does not respond within mq_timeout.
         """
         logger.info("Registering kv caches")
         self.kv_caches = kv_caches
         self.group_views = list(group_views)
+        self.per_layer_storage_blocks_per_chunk = per_layer_storage_blocks_per_chunk
         self._send_register_kv_caches_request(kv_caches)
 
     def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
         return expand_block_ids_to_views(self.group_views, op.block_ids)
+
+    def _skip_blocks_per_group(self, op: LoadStoreOp) -> list[int]:
+        """Re-index the op's per-engine-group retrieve skip to LMCache-group
+        order (parallel to ``_block_ids_per_group``). Empty skip (store ops /
+        no APC overlap) expands to all-zero."""
+        return expand_per_group_values_to_views(
+            self.group_views, op.skip_blocks_per_group
+        )
 
     def _send_register_kv_caches_request(
         self, kv_caches: dict[str, torch.Tensor]
@@ -1010,6 +1022,13 @@ class LMCacheMPWorkerAdapter:
         layout_hints["inference_engine_logical_block_size"] = (
             self.vllm_logical_block_size
         )
+        per_layer_storage_blocks_per_chunk = getattr(
+            self, "per_layer_storage_blocks_per_chunk", None
+        )
+        if per_layer_storage_blocks_per_chunk is not None:
+            layout_hints["per_layer_storage_blocks_per_chunk"] = (
+                per_layer_storage_blocks_per_chunk
+            )
         try:
             self.transfer_ctx.register(
                 self.instance_id,
@@ -1174,7 +1193,7 @@ class LMCacheMPWorkerAdapter:
             self._block_ids_per_group(op),
             event,
             self.blocks_in_chunk,
-            skip_first_n_tokens=op.skip_first_n_tokens,
+            skip_blocks_per_group=self._skip_blocks_per_group(op),
         )
         self.retrieve_futures[request_id] = (future, op.flat_block_ids)
         self.retrieve_events[request_id] = event

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -77,15 +77,8 @@ class LayoutHints(TypedDict, total=False):
             depth-1 → depth-2 un-flatten + 3-D → 4-D reshape.
         head_dim: Per-head dimension. Used by TRT-LLM (same).
         inference_engine_logical_block_size: Inference-engine-side block
-            size (logical tokens per engine block; for vLLM this is
-            ``cache_config.block_size``). Carried inside
-            ``LayoutHints`` (instead of as a standalone
-            ``REGISTER_KV_CACHE`` argument) so that engines without a
-            logical block-size concept can simply omit it. The server
-            uses it to derive per-group compression ratios when some
-            KV layer groups compress multiple logical tokens into a
-            single physical slot
-            (``shape_desc.bs < inference_engine_logical_block_size``).
+            size (logical tokens per engine block). Carried inside
+            ``LayoutHints`` so engines without this concept can omit it.
     """
 
     kv_layout: Literal["NHD", "HND"]
@@ -93,6 +86,10 @@ class LayoutHints(TypedDict, total=False):
     tokens_per_block: int
     head_dim: int
     inference_engine_logical_block_size: int
+    per_layer_storage_blocks_per_chunk: list[int]
+    """Per-registered-layer blocks-per-chunk the connector actually sends:
+    full chunk for full-attention groups, trailing-window count for SWA groups.
+    Used by the server for buffer sizing, kernel chunk-size, and underflow check."""
 
 
 def attempt_permute_to_contiguous_view(

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -140,24 +140,12 @@ class KVLayerGroupInfo:
     """Torch dtype of the KV cache tensors for this group. Used for
     kernel template instantiation; see class docstring for why we keep
     this alongside ``shape_desc.element_size``."""
-    compress_ratio: int = 1
-    """Logical-tokens-per-physical-slot for this group. ``1`` for
-    non-compressed groups (one logical token per physical slot);
-    greater than ``1`` for compressed groups where each physical slot
-    packs ``compress_ratio`` logical tokens (e.g. DeepSeek V4
-    compressor / indexer caches). Derived from
-    ``inference_engine_logical_block_size`` carried in ``layout_hints``
-    at :class:`KVLayerGroupsManager` construction time."""
-    physical_chunk_size: int = 0
-    """Number of *physical* slots in one LMCache chunk for this group
-    (= ``lmcache_logical_chunk_size // compress_ratio``). This is what
-    the block-level transfer kernel must be told, not the logical
-    ``lmcache_logical_chunk_size`` which counts vLLM tokens. ``0``
-    means the field has not been populated yet; ``GPUCacheContext``
-    fills it in after construction once ``lmcache_logical_chunk_size``
-    is known."""
     engine_group_idx: int = 0
     """Engine group index (paged-block address space). 0 for non-hybrid."""
+    storage_blocks_per_chunk: int = 0
+    """Blocks per chunk to transfer for this group (from ``per_layer_storage_blocks_per_chunk``
+    layout hint). Full chunk for full-attention; trailing-window count for SWA.
+    ``storage_slots_per_chunk = storage_blocks_per_chunk * shape_desc.bs``."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -173,15 +161,24 @@ class KVLayerGroupInfo:
             f"element_size={sd.element_size}, "
             f"block_stride_elems={sd.block_stride_elems}), "
             f"dtype={self.dtype}, "
-            f"compress_ratio={self.compress_ratio}, "
-            f"physical_chunk_size={self.physical_chunk_size}, "
-            f"engine_group_idx={self.engine_group_idx})"
+            f"engine_group_idx={self.engine_group_idx}, "
+            f"storage_blocks_per_chunk={self.storage_blocks_per_chunk})"
         )
 
     @property
     def num_layers(self) -> int:
         """Number of layers in this group."""
         return len(self.layer_indices)
+
+    @property
+    def storage_slots_per_chunk(self) -> int:
+        """Physical slots transferred per chunk for this group.
+
+        ``storage_blocks_per_chunk * shape_desc.bs`` — the value the
+        block-level transfer kernel must be told as its ``lmcache_chunk_size``
+        (the kernel checks ``num_blocks_per_object * bs == lmcache_chunk_size``).
+        """
+        return self.storage_blocks_per_chunk * self.shape_desc.bs
 
     @property
     def hidden_dim_size(self) -> int:
@@ -239,23 +236,14 @@ class KVLayerGroupsManager:
                 ``shape_desc.nb``. Each group's ``shape_desc.bs`` is
                 discovered per-layer via :func:`get_block_size`, so
                 compressed and non-compressed groups can coexist.
-            layout_hints: Engine-provided hints. The manager only reads
-                ``inference_engine_logical_block_size`` (logical tokens
-                per inference-engine block) from it to derive each
-                group's ``compress_ratio`` and ``physical_chunk_size``.
-                ``None`` means every group is treated as non-compressed
-                (``compress_ratio == 1``).
-            group_views: LMCache-owned engine KV cache group
-                metadata. When present, it is used to keep layers from
-                different engine block-ID spaces in separate LMCache
-                transfer groups.
-            lmcache_logical_chunk_size: Logical tokens per LMCache chunk
-                (one logical token = one inference-engine token).
-                Together with ``compress_ratio`` it determines each
-                group's ``physical_chunk_size =
-                lmcache_logical_chunk_size // compress_ratio``, the
-                number of *physical* slots per chunk fed to the
-                block-level transfer kernel.
+            layout_hints: Engine-provided hints. Reads
+                ``per_layer_storage_blocks_per_chunk`` to set each group's
+                transfer block count. ``None`` defaults every group to the
+                full chunk.
+            group_views: LMCache-owned engine KV cache group metadata.
+                Keeps layers from different block-ID spaces in separate groups.
+            lmcache_logical_chunk_size: Logical tokens per LMCache chunk.
+                Used as fallback when no per-layer hint is provided.
         """
         # Import here to break a circular import via
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
@@ -267,14 +255,8 @@ class KVLayerGroupsManager:
         )
         from lmcache.v1.multiprocess.group_view import get_engine_group_indices
 
-        # Pull the inference-engine logical block size out of
-        # ``layout_hints`` once; ``None`` means no compression info
-        # available and every group is treated as non-compressed below.
-        # The attribute is finalised after the group-building loop
-        # below, where ``None`` is replaced by the first group's
-        # physical ``bs`` so the public ``int`` contract holds.
-        self.inference_engine_logical_block_size_: "int | None" = (
-            layout_hints.get("inference_engine_logical_block_size")
+        per_layer_storage_blocks_per_chunk: "Sequence[int] | None" = (
+            layout_hints.get("per_layer_storage_blocks_per_chunk")
             if layout_hints
             else None
         )
@@ -312,77 +294,25 @@ class KVLayerGroupsManager:
                 block_stride_elems=block_stride_elems,
             )
 
-            compress_ratio, physical_chunk_size = self._derive_compression_metadata(
-                group_idx=group_idx,
-                bs=bs,
-                ie_logical_block_size=self.inference_engine_logical_block_size_,
-                lmcache_logical_chunk_size=lmcache_logical_chunk_size,
-            )
+            # storage_bpc: prefer hint (SWA-trimmed); fall back to full chunk.
+            full_bpc = lmcache_logical_chunk_size // bs
+            storage_bpc = full_bpc
+            if per_layer_storage_blocks_per_chunk is not None:
+                hinted = int(per_layer_storage_blocks_per_chunk[indices[0]])
+                if hinted > 0:
+                    storage_bpc = min(hinted, full_bpc)
 
             self.kv_layer_groups.append(
                 KVLayerGroupInfo(
                     layer_indices=indices,
                     shape_desc=shape_desc,
                     dtype=dt,
-                    compress_ratio=compress_ratio,
-                    physical_chunk_size=physical_chunk_size,
                     engine_group_idx=engine_group_idx,
+                    storage_blocks_per_chunk=storage_bpc,
                 )
             )
-
-        self.inference_engine_logical_block_size_ = (
-            self.inference_engine_logical_block_size_
-            or self.kv_layer_groups[0].shape_desc.bs
-        )
 
         logger.info("KV layer groups: %s", self.kv_layer_groups)
-
-    @staticmethod
-    def _derive_compression_metadata(
-        group_idx: int,
-        bs: int,
-        ie_logical_block_size: "int | None",
-        lmcache_logical_chunk_size: int,
-    ) -> tuple[int, int]:
-        """Resolve ``(compress_ratio, physical_chunk_size)`` for one group.
-
-        ``compress_ratio`` falls back to ``1`` when
-        ``ie_logical_block_size`` is absent (no compression info
-        available); otherwise it equals
-        ``ie_logical_block_size // bs`` and the divisibility invariants
-        are enforced loudly. ``physical_chunk_size`` is then
-        ``lmcache_logical_chunk_size // compress_ratio``, the per-chunk
-        physical slot count fed to the block-level transfer kernel.
-        """
-        if ie_logical_block_size is None:
-            compress_ratio = 1
-        else:
-            if ie_logical_block_size % bs != 0:
-                raise ValueError(
-                    f"inference engine logical block size "
-                    f"{ie_logical_block_size} must be a multiple of "
-                    f"group {group_idx} physical slot count {bs}"
-                )
-            compress_ratio = ie_logical_block_size // bs
-        if lmcache_logical_chunk_size % compress_ratio != 0:
-            raise ValueError(
-                f"lmcache_logical_chunk_size {lmcache_logical_chunk_size} "
-                f"must be a multiple of compress_ratio {compress_ratio} "
-                f"(group {group_idx})"
-            )
-        physical_chunk_size = lmcache_logical_chunk_size // compress_ratio
-        if compress_ratio != 1:
-            logger.info(
-                "group %d: compressed "
-                "(inference_engine_logical_block_size=%d -> "
-                "slots=%d, compress_ratio=%d, physical_chunk_size=%d)",
-                group_idx,
-                ie_logical_block_size,
-                bs,
-                compress_ratio,
-                physical_chunk_size,
-            )
-        return compress_ratio, physical_chunk_size
 
     @property
     def num_groups(self) -> int:
@@ -391,20 +321,6 @@ class KVLayerGroupsManager:
         Zero if ``kv_caches`` had no layers at construction time.
         """
         return len(self.kv_layer_groups)
-
-    @property
-    def inference_engine_logical_block_size(self):
-        """Inference-engine-side logical block size.
-
-        Taken from ``layout_hints`` at construction time, or falls back
-        to the first group's physical ``bs`` when no hint is provided
-        (non-vLLM engines, or vLLM without mixed-compression KV groups),
-        in which case every group is treated as non-compressed.
-        """
-        return (
-            self.inference_engine_logical_block_size_
-            or self.kv_layer_groups[0].shape_desc.bs
-        )
 
     def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
         """Return the :class:`PageBufferShapeDesc` for *group_idx*.
@@ -418,25 +334,6 @@ class KVLayerGroupsManager:
             IndexError: If *group_idx* is out of range.
         """
         return self.kv_layer_groups[group_idx].shape_desc
-
-    def get_physical_chunk_size(self, group_idx: int) -> int:
-        """Return the per-chunk *physical* slot count for *group_idx*.
-
-        Equivalent to
-        ``self.kv_layer_groups[group_idx].physical_chunk_size``.
-        For non-compressed groups this equals
-        ``lmcache_logical_chunk_size``; for compressed groups it equals
-        ``lmcache_logical_chunk_size // compress_ratio`` and is what the
-        block-level transfer kernel must be told (the logical chunk size
-        in *vLLM tokens* is not what the kernel addresses).
-
-        Args:
-            group_idx: 0-based group index.
-
-        Raises:
-            IndexError: If *group_idx* is out of range.
-        """
-        return self.kv_layer_groups[group_idx].physical_chunk_size
 
 
 # ------------------------------------------------------------------ #

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -132,10 +132,7 @@ class GPUCacheContext:
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            # ``get_kv_buffer_shape`` takes *logical* tokens; for
-            # compressed groups it folds ``compress_ratio`` logical
-            # tokens into one physical slot internally.
-            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
+            shape = self.get_storage_kv_buffer_shape(group_idx)
             byte_size = shape.numel() * group.dtype.itemsize
             self.tmp_chunk_group_offsets_.append(
                 self.tmp_chunk_group_offsets_[-1] + byte_size
@@ -205,25 +202,9 @@ class GPUCacheContext:
 
     @property
     def group_physical_block_sizes(self) -> list[int]:
-        """Per-group physical slot count (``shape_desc.bs``) in group
-        order. For non-compressed groups this equals
-        ``inference_engine_logical_block_size``; for compressed groups
-        it equals
-        ``inference_engine_logical_block_size // compress_ratio``.
-        """
+        """Per-group physical slot count (``shape_desc.bs``) in group order."""
         return [
             group.shape_desc.bs
-            for group in self.kv_layer_groups_manager_.kv_layer_groups
-        ]
-
-    @property
-    def group_compress_ratios(self) -> list[int]:
-        """Per-group compression ratio
-        (= ``inference_engine_logical_block_size // shape_desc.bs``)
-        in group order. ``1`` for non-compressed groups.
-        """
-        return [
-            group.compress_ratio
             for group in self.kv_layer_groups_manager_.kv_layer_groups
         ]
 
@@ -259,15 +240,6 @@ class GPUCacheContext:
     def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
         """Returns the PageBufferShapeDesc for the given KV layer group."""
         return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
-
-    def get_physical_chunk_size(self, group_idx: int) -> int:
-        """Returns the per-chunk physical slot count for the given group.
-
-        Equal to ``lmcache_logical_chunk_size // compress_ratio``; for
-        non-compressed groups this is just ``lmcache_logical_chunk_size``.
-        This is the value the block-level transfer kernel must be told.
-        """
-        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
 
     @property
     def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
@@ -320,16 +292,16 @@ class GPUCacheContext:
     def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
         """
         Returns a view of the temporary GPU buffer for the given group,
-        sized for a single chunk. The chunk holds
-        ``lmcache_logical_chunk_size`` logical tokens which, for a
-        compressed group, correspond to ``group.physical_chunk_size``
-        physical slots.
+        sized for a single chunk's *stored* payload
+        (``group.storage_slots_per_chunk`` physical slots). For a full-attention
+        group this is the whole chunk; for a sliding-window group it is only the
+        trailing-window portion the connector sends.
 
         Args:
             group_idx: Index of the KV layer group (default 0).
         """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        shape = self.get_storage_kv_buffer_shape(group_idx)
         start = self.tmp_chunk_group_offsets_[group_idx]
         end = self.tmp_chunk_group_offsets_[group_idx + 1]
         return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
@@ -340,7 +312,8 @@ class GPUCacheContext:
         """
         Returns a list of ``batch_size`` non-overlapping views into the
         pre-allocated temporary GPU buffer for the given group, each
-        sized for ``lmcache_logical_chunk_size`` tokens.
+        sized for one chunk's *stored* payload (SWA-suffix-aware; see
+        :meth:`get_tmp_chunk_gpu_buffer`).
 
         Args:
             batch_size: Number of concurrent requests (must be <= max_batch_size).
@@ -351,7 +324,7 @@ class GPUCacheContext:
                 f"batch_size {batch_size} exceeds max_batch_size {self.max_batch_size}"
             )
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        shape = self.get_storage_kv_buffer_shape(group_idx)
         g_start = self.tmp_chunk_group_offsets_[group_idx]
         g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
         chunk = self.tmp_chunk_bytes_
@@ -393,61 +366,44 @@ class GPUCacheContext:
         ]
 
     def get_kv_buffer_shape(
-        self, logical_num_tokens: int, group_idx: int = 0
+        self, num_slots: int, group_idx: int = 0
     ) -> torch.Size:
-        """
-        Returns the shape of the KV buffer for the given number of
-        *logical* tokens.
-
-        For a compressed group (``compress_ratio > 1``) every
-        ``compress_ratio`` logical tokens are packed into a single
-        physical slot, so the returned shape's token dimension is
-        ``num_tokens // compress_ratio``. Callers therefore always
-        pass logical-token counts and never need to know per-group
-        compression ratios.
+        """Returns the KV buffer shape for the given number of physical slots.
 
         Args:
-            logical_num_tokens: Number of *logical* tokens. Must be a multiple
-                of the group's ``compress_ratio``.
+            num_slots: Number of physical KV slots.
             group_idx: Index of the KV layer group (default 0).
         """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        compress_ratio = group.compress_ratio
-        if logical_num_tokens % compress_ratio != 0:
-            raise ValueError(
-                f"logical_num_tokens ({logical_num_tokens}) is not a multiple of "
-                f"compress_ratio ({compress_ratio}) for group {group_idx}"
-            )
-        num_slots = logical_num_tokens // compress_ratio
         sd = group.shape_desc
         return torch.Size(
             (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
         )
 
-    def cache_size_per_token(self) -> int:
-        """
-        Returns the cache size per *logical* token (in bytes), summed
-        across all groups. For a compressed group, one physical slot
-        stores ``compress_ratio`` logical tokens, so the per-logical-token
-        contribution is ``physical_slot_bytes // compress_ratio``.
+    def get_storage_kv_buffer_shape(self, group_idx: int = 0) -> torch.Size:
+        """KV buffer shape for one chunk's stored payload (``storage_slots_per_chunk`` slots)."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        sd = group.shape_desc
+        return torch.Size(
+            (
+                sd.kv_size,
+                group.num_layers,
+                group.storage_slots_per_chunk,
+                group.hidden_dim_size,
+            )
+        )
 
-        Reporting-only metric (surfaced via the ``/api/status`` HTTP
-        endpoint and the ``lmcache describe`` CLI); sub-byte truncation
-        from integer division is acceptable.
+    def cache_size_per_token(self) -> int:
+        """Cache bytes per token, summed across all groups.
+
+        Reporting-only metric (``/api/status``, ``lmcache describe``).
         """
         total = 0
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            # ``get_kv_buffer_shape`` now takes *logical* tokens, so
-            # query ``compress_ratio`` logical tokens (= 1 physical
-            # slot) and then divide the resulting bytes back by
-            # ``compress_ratio`` to recover the per-logical-token
-            # contribution. Equivalent to the old
-            # ``physical_slot_bytes // compress_ratio`` formulation.
-            numels = self.get_kv_buffer_shape(group.compress_ratio, group_idx).numel()
-            slot_bytes = numels * group.dtype.itemsize
-            total += slot_bytes // group.compress_ratio
+            slot_bytes = self.get_kv_buffer_shape(1, group_idx).numel() * group.dtype.itemsize
+            total += slot_bytes
         return total
 
 

--- a/lmcache/v1/multiprocess/group_view.py
+++ b/lmcache/v1/multiprocess/group_view.py
@@ -118,6 +118,24 @@ def expand_block_ids_to_views(
     ]
 
 
+def expand_per_group_values_to_views(
+    groups: Sequence[LMCacheGroupView],
+    engine_side_values: Sequence[int],
+    default: int = 0,
+) -> list[int]:
+    """Re-index a per-engine-group int list to one value per LMCache group.
+
+    Symmetric with :func:`expand_block_ids_to_views`. Each LMCache group
+    takes the value of its source engine group; missing entries use *default*.
+    """
+    return [
+        engine_side_values[engine_group_id]
+        if engine_group_id < len(engine_side_values)
+        else default
+        for engine_group_id in _engine_group_id_per_view(groups)
+    ]
+
+
 def get_engine_group_indices(
     groups: Sequence[LMCacheGroupView],
     num_registered_layers: int,

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -47,21 +47,11 @@ import lmcache.c_ops as lmc_ops
 logger = init_logger(__name__)
 
 
-def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayoutDesc:
-    """Get the memory layout description for a given GPU context and number of tokens.
-
-    Supports multiple KV layer groups with different shapes and dtypes.
-
-    Args:
-        gpu_context: The GPU cache context containing the KV cache information.
-        num_tokens: The number of tokens to determine the layout for.
-
-    Returns:
-        MemoryLayoutDesc: The memory layout description containing shapes and dtypes.
-    """
+def get_layout_desc(gpu_context: GPUCacheContext) -> MemoryLayoutDesc:
+    """Memory layout description for all KV layer groups in a GPU context."""
     num_groups = gpu_context.kv_layer_groups_manager.num_groups
     shapes = [
-        gpu_context.get_kv_buffer_shape(num_tokens, group_idx)
+        gpu_context.get_storage_kv_buffer_shape(group_idx)
         for group_idx in range(num_groups)
     ]
     dtypes = [
@@ -194,11 +184,7 @@ class GPUTransferModule:
                 "world_size": entry.world_size,
                 "kv_cache_layout": {
                     "num_layers": ctx.num_layers,
-                    "inference_engine_logical_block_size": (
-                        ctx.kv_layer_groups_manager.inference_engine_logical_block_size
-                    ),
                     "group_physical_block_sizes": ctx.group_physical_block_sizes,
-                    "group_compress_ratios": ctx.group_compress_ratios,
                     "hidden_dim_sizes": str(ctx.hidden_dim_sizes),
                     "dtype": str(ctx.dtype),
                     "is_mla": ctx.is_mla,
@@ -273,7 +259,7 @@ class GPUTransferModule:
             world_size=world_size,
         )
 
-        layout_desc = get_layout_desc(gpu_context, self._ctx.chunk_size)
+        layout_desc = get_layout_desc(gpu_context)
         self._ctx.layout_desc_registry.register(model_name, world_size, layout_desc)
 
         logger.info(
@@ -345,16 +331,11 @@ class GPUTransferModule:
         gpu_context = entry.gpu_context
         model_name = entry.model_name
 
-        # ``blocks_per_chunk`` is counted in inference-engine-side
-        # blocks (each block addresses
-        # ``inference_engine_logical_block_size`` *logical* tokens).
-        # For compressed groups the per-group physical slot count
-        # differs, but the block-id indexing is shared with the engine
-        # and therefore uses the engine logical block size here.
-        blocks_per_chunk = (
-            self._ctx.chunk_size
-            // gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
-        )
+        groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
+        num_groups = len(groups)
+        blocks_per_chunk_per_group = [
+            group.storage_blocks_per_chunk for group in groups
+        ]
 
         with (
             torch_dev.device(gpu_context.device),
@@ -372,18 +353,22 @@ class GPUTransferModule:
             # drive the transfer kernel to read out-of-bounds GPU memory, so skip
             # the whole store and commit nothing rather than caching a partial or
             # garbage entry. A later request can store it once the block IDs are
-            # complete.
-            required_blocks = len(obj_keys) * blocks_per_chunk
+            # complete. Each group has its own per-chunk block count under HMA.
+            num_chunks_requested = len(obj_keys)
             if any(
-                group_block_ids.shape[0] < required_blocks
-                for group_block_ids in block_ids_per_group_gpu
+                group_block_ids.shape[0]
+                < num_chunks_requested * blocks_per_chunk_per_group[group_idx]
+                for group_idx, group_block_ids in enumerate(block_ids_per_group_gpu)
             ):
                 logger.warning(
-                    "STORE block ID underflow for request_id=%s: need %d block "
+                    "STORE block ID underflow for request_id=%s: need %s block "
                     "IDs per group for %d chunks; skipping the store.",
                     key.request_id,
-                    required_blocks,
-                    len(obj_keys),
+                    [
+                        num_chunks_requested * bpc
+                        for bpc in blocks_per_chunk_per_group
+                    ],
+                    num_chunks_requested,
                 )
                 event.record()
                 return event.ipc_handle(), False
@@ -426,7 +411,7 @@ class GPUTransferModule:
             reserved_dict: dict[ObjectKey, MemoryObj] = {}
             store_succeeded = False
             try:
-                layout_desc = get_layout_desc(gpu_context, self._ctx.chunk_size)
+                layout_desc = get_layout_desc(gpu_context)
                 reserved_dict = self._ctx.storage_manager.reserve_write(
                     obj_keys, layout_desc, "new"
                 )
@@ -435,27 +420,22 @@ class GPUTransferModule:
                 # skipped (not in reserved_dict), making block_ids
                 # non-contiguous. Batching would require torch.cat to
                 # reassemble block_ids, negating the benefit.
-                num_groups = gpu_context.kv_layer_groups_manager.num_groups
                 for idx, obj_key in enumerate(obj_keys):
                     if obj_key in reserved_dict:
                         memory_obj = reserved_dict[obj_key]
                     else:
                         continue
 
-                    # Copy from GPU paged buffer to tmp buffer, then to CPU — per
-                    # group. Each group uses its own block-id list (HMA).
+                    # D2H per group; block IDs are already pre-trimmed by the connector.
                     for group_idx in range(num_groups):
+                        group = groups[group_idx]
+                        bpc = blocks_per_chunk_per_group[group_idx]
                         chunk_block_ids_gpu = block_ids_per_group_gpu[group_idx][
-                            idx * blocks_per_chunk : (idx + 1) * blocks_per_chunk
+                            idx * bpc : (idx + 1) * bpc
                         ]
                         tmp_buffer = gpu_context.get_tmp_chunk_gpu_buffer(group_idx)
                         group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                        # Kernel contract: ``group_lmcache_chunk_size`` here is the
-                        # number of *physical* slots per chunk for this group
-                        # (= logical chunk_size // compress_ratio).
-                        group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                            group_idx
-                        )
+                        group_lmcache_chunk_size = group.storage_slots_per_chunk
                         lmc_ops.multi_layer_block_kv_transfer(
                             group_kv_pointers,
                             [tmp_buffer.data_ptr()],
@@ -524,30 +504,25 @@ class GPUTransferModule:
         instance_id: int,
         gpu_block_ids: list[list[int]],
         event_ipc_handle: bytes,
-        skip_first_n_tokens: int = 0,
+        skip_blocks_per_group: list[int] = [],
     ) -> tuple[bytes, bool]:
         """Retrieve the CPU KV cache and put into GPU blocks.
 
         Args:
-            key: The IPC key for the KV cache blocks.
-                Must have worker_id != None (worker retrieve operation).
-            instance_id: The GPU instance ID (such as PID).
-            gpu_block_ids: GPU block IDs to retrieve into, indexed by LMCache
-                KV group index.
-            event_ipc_handle: The IPC handle of the event to wait on.
-            skip_first_n_tokens: Number of tokens to skip writing at
-                the start of the retrieve range. This avoids overwriting
-                APC-shared GPU blocks that may be read concurrently by other
-                requests.
+            key: IPC key for the KV cache blocks (worker_id must be set).
+            instance_id: GPU instance ID (PID).
+            gpu_block_ids: Block IDs to retrieve into, per LMCache KV group.
+            event_ipc_handle: CUDA event IPC handle for synchronization.
+            skip_blocks_per_group: Leading stored-blocks to skip per group
+                (APC-overlap guard). Empty -> no skip.
 
         Returns:
-            A tuple where the first element is the IPC handle of the event
-            that signals the completion of the retrieve operation, and the
-            second element indicates whether the key was successfully retrieved.
+            ``(event_ipc_handle, success)``.
 
         Raises:
-            ValueError: If no GPU context is registered for the given instance ID.
+            ValueError: If no GPU context is registered for *instance_id*.
         """
+        skip_blocks_per_group = skip_blocks_per_group or []
         st = time.perf_counter()
         obj_keys = self._ctx.resolve_obj_keys(key)
 
@@ -581,49 +556,19 @@ class GPUTransferModule:
             ),
         )
 
-        # ``skip_*_in_chunk`` is expressed in engine-block units
-        # (logical tokens), which is what the kernel's
-        # ``skip_blocks_in_chunk`` argument expects regardless
-        # of per-group compression.
-        ie_logical_block_size = (
-            gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
-        )
-        blocks_per_chunk = self._ctx.chunk_size // ie_logical_block_size
+        # Per-group blocks-per-chunk = the count the connector sends per chunk
+        # (already SWA-trimmed); the server moves exactly these blocks.
+        groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
+        blocks_per_chunk_per_group = [
+            group.storage_blocks_per_chunk for group in groups
+        ]
 
         def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
             _BATCH_SIZE = gpu_context.max_batch_size
-            groups = gpu_context.kv_layer_groups_manager.kv_layer_groups
             for batch_idx, memory_obj_batch in enumerate(
                 batched_iteration(memory_objs, batch_size=_BATCH_SIZE)
             ):
                 batch_len = len(memory_obj_batch)
-                chunk_start = batch_idx * self._ctx.chunk_size * _BATCH_SIZE
-                chunk_end = chunk_start + self._ctx.chunk_size * batch_len
-
-                effective_start = max(chunk_start, skip_first_n_tokens)
-                if effective_start >= chunk_end:
-                    # Entire batch is within APC range, skip it
-                    continue
-
-                skip_tokens_in_chunk = max(
-                    0,
-                    min(
-                        effective_start - chunk_start,
-                        self._ctx.chunk_size * batch_len - 1,
-                    ),
-                )
-                if skip_tokens_in_chunk % ie_logical_block_size != 0:
-                    logger.error(
-                        "skip_first_n_tokens (%d) is not aligned to "
-                        "inference_engine_logical_block_size (%d), "
-                        "rounding down from %d tokens to %d blocks",
-                        skip_first_n_tokens,
-                        ie_logical_block_size,
-                        skip_tokens_in_chunk,
-                        skip_tokens_in_chunk // ie_logical_block_size,
-                    )
-                skip_blocks_in_chunk = skip_tokens_in_chunk // ie_logical_block_size
-
                 start_chunk_id = batch_idx * _BATCH_SIZE
                 end_chunk_id = start_chunk_id + batch_len
                 # Copy from CPU to GPU tmp buffers, then scatter to paged KV — per group
@@ -634,6 +579,7 @@ class GPUTransferModule:
                         gpu_context.get_tmp_gpu_buffer_flat(chunk_idx=chunk_idx),
                     )
                 for group_idx, group in enumerate(groups):
+                    blocks_per_chunk = blocks_per_chunk_per_group[group_idx]
                     chunk_block_ids_gpu = block_ids_per_group_gpu[group_idx][
                         start_chunk_id * blocks_per_chunk : end_chunk_id
                         * blocks_per_chunk
@@ -649,13 +595,20 @@ class GPUTransferModule:
                             f"expected={batch_len * blocks_per_chunk} "
                             f"got={chunk_block_ids_gpu.shape[0]}"
                         )
+                    # APC skip: pre-computed by connector, applies to batch 0 only.
+                    skip_blocks_in_chunk = (
+                        skip_blocks_per_group[group_idx]
+                        if batch_idx == 0 and group_idx < len(skip_blocks_per_group)
+                        else 0
+                    )
                     tmp_buffers = gpu_context.get_tmp_chunk_gpu_buffer_batched(
                         batch_len, group_idx
                     )
                     group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                    group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                        group_idx
-                    )
+                    # Physical slots transferred per chunk for this group
+                    # (= bpc * shape_desc.bs); satisfies the kernel's
+                    # ``num_blocks_per_object * bs == lmcache_chunk_size`` check.
+                    group_lmcache_chunk_size = group.storage_slots_per_chunk
 
                     lmc_ops.multi_layer_block_kv_transfer(
                         group_kv_pointers,

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -135,17 +135,12 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
             handler_type=HandlerType.BLOCKING,
         ),
         # Retrieve KV cache blocks
-        # Payload:
-        #   - key: KeyType - Cache key to retrieve
-        #   - instance_id: int - Unique identifier for the vLLM instance
-        #   - gpu_block_ids: list[list[int]] - GPU block IDs to store
-        #     retrieved data, indexed by LMCache KV group index.
-        #   - event_ipc_handle: bytes - CUDA event IPC handle for synchronization
-        #   - skip_first_n_tokens: int - Number of tokens to skip writing at the
-        #     start of the retrieve range (to avoid overwriting APC-shared blocks)
+        # Payload: key, instance_id, gpu_block_ids, event_ipc_handle,
+        #   skip_blocks_per_group: list[int] - per-group leading blocks to skip
+        #   (APC overlap guard, stored-block units).
         # Returns: tuple[bytes, bool] - (CUDA event handle, success flag)
         "RETRIEVE": ProtocolDefinition(
-            payload_classes=[KeyType, int, list[list[int]], bytes, int],
+            payload_classes=[KeyType, int, list[list[int]], bytes, list[int]],
             response_class=tuple[bytes, bool],
             handler_type=HandlerType.BLOCKING,
         ),

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -131,23 +131,13 @@ class TransferContext(ABC):
         block_ids: list[list[int]],
         event: IPCEvent,
         blocks_in_chunk: int,
-        skip_first_n_tokens: int = 0,
+        skip_blocks_per_group: list[int] | None = None,
     ) -> MessagingFuture:
         """Submit a retrieve request and return a completion future.
 
         Args:
-            request_id: External request identifier.
-            key: LMCache key object for the retrieve range.
-            instance_id: Worker process instance identifier.
-            kv_caches: Worker KV cache tensors keyed by layer name.
-            block_ids: vLLM block IDs to retrieve into, indexed by LMCache KV
-                group id.
-            event: Synchronization event object.
-            blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
-            skip_first_n_tokens: Number of initial tokens to skip when writing.
-
-        Returns:
-            A future compatible with adapter-side ``query()``/``result()`` flow.
+            skip_blocks_per_group: Per-group leading blocks to skip (APC guard,
+                stored-block units). ``None`` / empty -> no skip.
 
         Raises:
             RuntimeError: If register() was not called first.
@@ -228,7 +218,7 @@ class HandleTransferContext(TransferContext):
         block_ids: list[list[int]],
         event: IPCEvent,
         _blocks_in_chunk: int,
-        skip_first_n_tokens: int = 0,
+        skip_blocks_per_group: list[int] | None = None,
     ) -> MessagingFuture:
         if self._mq_client is None or self._send_request is None:
             raise RuntimeError(
@@ -238,7 +228,13 @@ class HandleTransferContext(TransferContext):
         return self._send_request(
             self._mq_client,
             RequestType.RETRIEVE,
-            [key, instance_id, block_ids, event.ipc_handle(), skip_first_n_tokens],
+            [
+                key,
+                instance_id,
+                block_ids,
+                event.ipc_handle(),
+                list(skip_blocks_per_group or []),
+            ],
         ).to_cuda_future()
 
     def close(self) -> None:
@@ -391,7 +387,7 @@ class DataTransferContext(TransferContext):
         block_ids: list[list[int]],
         _event: IPCEvent,
         blocks_in_chunk: int,
-        skip_first_n_tokens: int = 0,
+        skip_blocks_per_group: list[int] | None = None,
     ) -> MessagingFuture:
         if self._non_gpu_context is None:
             raise RuntimeError(
@@ -402,13 +398,18 @@ class DataTransferContext(TransferContext):
         src_buffers = self._non_gpu_context.prepare_retrieve(key, instance_id)
         ok = src_buffers is not None
         if src_buffers is not None:
+            # Single-group non-GPU path: convert group-0 block skip to tokens.
+            skip_blocks = (
+                skip_blocks_per_group[0] if skip_blocks_per_group else 0
+            )
+            block_size = self._non_gpu_context.metadata.block_size
             try:
                 scatter_cpu_to_paged_kv(
                     kv_caches,
                     _single_group_block_ids(block_ids),
                     src_buffers,
                     blocks_in_chunk,
-                    skip_first_n_tokens=skip_first_n_tokens,
+                    skip_first_n_tokens=skip_blocks * block_size,
                     layout_hints=self._layout_hints,
                     gpu_kv_format=self._gpu_kv_format,
                 )

--- a/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
+++ b/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
@@ -73,7 +73,6 @@ def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
 
     def fake_layout_desc(
         gpu_context: _FakeGPUContext,
-        num_tokens: int,
     ) -> MemoryLayoutDesc:
         """Return the shared layout descriptor used by both registrations."""
         return layout_desc

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -176,6 +176,113 @@ class TestKVLayerGroupsManager:
         assert sd1.hs == 64
 
 
+class TestKVLayerGroupInfoFields:
+    """KVLayerGroupInfo has exactly the expected fields and no compression artifacts."""
+
+    def _make_manager(self, *, bs, hint=None, chunk=1024):
+        tensors = [torch.randn(1, 32, bs, 1, 128, dtype=torch.float16)]
+        layout_hints: LayoutHints = {}
+        if hint is not None:
+            layout_hints["per_layer_storage_blocks_per_chunk"] = hint
+        return KVLayerGroupsManager(
+            tensors,
+            gpu_kv_format=_nhd_format(),
+            num_blocks=32,
+            layout_hints=layout_hints or None,
+            lmcache_logical_chunk_size=chunk,
+        )
+
+    def test_no_compress_ratio_field(self):
+        """compress_ratio and physical_chunk_size no longer exist on KVLayerGroupInfo."""
+        g = self._make_manager(bs=64).kv_layer_groups[0]
+        assert not hasattr(g, "compress_ratio")
+        assert not hasattr(g, "physical_chunk_size")
+        assert not hasattr(g, "logical_block_size")
+        assert not hasattr(g, "full_blocks_per_chunk")
+
+    def test_storage_blocks_per_chunk_defaults_to_full(self):
+        """No hint -> storage_blocks_per_chunk = chunk_size // bs."""
+        g = self._make_manager(bs=64).kv_layer_groups[0]
+        assert g.storage_blocks_per_chunk == 1024 // 64  # 16
+
+    def test_storage_blocks_per_chunk_from_hint(self):
+        g = self._make_manager(bs=64, hint=[2]).kv_layer_groups[0]
+        assert g.storage_blocks_per_chunk == 2
+
+    def test_storage_slots_per_chunk(self):
+        g = self._make_manager(bs=64, hint=[2]).kv_layer_groups[0]
+        assert g.storage_slots_per_chunk == 2 * 64
+
+
+class TestStorageBlocksPerChunkHint:
+    """``storage_blocks_per_chunk`` populated from the per-layer hint.
+
+    This is the single per-group block count the server uses on the transfer
+    path; the connector pre-trims SWA groups so the server stays window-blind.
+    """
+
+    def _manager(self, *, bs, hint=None, chunk=1024):
+        tensors = [torch.randn(1, 32, bs, 1, 128, dtype=torch.float16)]
+        layout_hints: LayoutHints = {}
+        if hint is not None:
+            layout_hints["per_layer_storage_blocks_per_chunk"] = hint
+        return KVLayerGroupsManager(
+            tensors,
+            gpu_kv_format=_nhd_format(),
+            num_blocks=32,
+            layout_hints=layout_hints or None,
+            lmcache_logical_chunk_size=chunk,
+        )
+
+    def test_hint_sets_storage_blocks(self):
+        # bs=64, full chunk = 1024/64 = 16; hint trims to 2 (SWA suffix).
+        g = self._manager(bs=64, hint=[2]).kv_layer_groups[0]
+        assert g.storage_blocks_per_chunk == 2
+        assert g.storage_slots_per_chunk == 2 * 64  # bpc * bs
+
+    def test_absent_hint_defaults_to_full_chunk(self):
+        g = self._manager(bs=64, hint=None).kv_layer_groups[0]
+        assert g.storage_blocks_per_chunk == 16  # 1024 // 64
+
+    def test_zero_hint_defaults_to_full_chunk(self):
+        g = self._manager(bs=64, hint=[0]).kv_layer_groups[0]
+        assert g.storage_blocks_per_chunk == 16
+
+    def test_hint_capped_at_full_chunk(self):
+        # A hint larger than the full chunk is clamped (defensive).
+        g = self._manager(bs=64, hint=[999]).kv_layer_groups[0]
+        assert g.storage_blocks_per_chunk == 16
+
+    def test_state_group_large_shrink(self):
+        # bs=4, full chunk = 1024/4 = 256; hint trims to 2.
+        g = self._manager(bs=4, hint=[2]).kv_layer_groups[0]
+        assert g.storage_blocks_per_chunk == 2
+        assert g.storage_slots_per_chunk == 8  # 2 * 4
+
+    def test_kernel_chunk_size_invariant(self):
+        """storage_slots_per_chunk must equal storage_blocks_per_chunk * bs.
+
+        The kernel asserts num_blocks_per_object * bs == lmcache_chunk_size; we
+        pass storage_blocks_per_chunk block IDs and storage_slots_per_chunk as
+        lmcache_chunk_size, so this identity is what keeps it valid.
+        """
+        for bs, hint in [
+            (64, [4]),
+            (64, [2]),
+            (4, [2]),
+            (8, [2]),
+        ]:
+            g = self._manager(bs=bs, hint=hint).kv_layer_groups[0]
+            assert g.storage_slots_per_chunk == g.storage_blocks_per_chunk * g.shape_desc.bs
+
+
+def _nhd_format():
+    # First Party
+    import lmcache.c_ops as lmc_ops
+
+    return lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+
 class TestParseKvcacheShapeSpec:
     """Test cases for parse_kvcache_shape_spec function."""
 

--- a/tests/v1/test_mp_connector_slicing.py
+++ b/tests/v1/test_mp_connector_slicing.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the connector-side per-group block-ID slicing + SWA-suffix
+trimming + per-group APC-skip computation (scheduler-side, no server / GPU).
+
+These cover the load-bearing arithmetic that moved out of the server in the
+"hide vLLM info from LMCache" refactor: the connector now pre-trims SWA groups
+to their trailing window and emits a per-group skip-block count, so the server
+stays window- and logical-size-agnostic.
+"""
+
+# Standard
+from types import SimpleNamespace
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_connector import LMCacheMPRequestMetadata
+
+
+def _tracker(allocated_block_ids):
+    """Minimal tracker stand-in: only ``allocated_block_ids`` is read by the
+    geometry / slicing static methods under test."""
+    return SimpleNamespace(allocated_block_ids=dict(allocated_block_ids))
+
+
+# ----------------------------------------------------------------------------
+# _group_ratio / _group_geometry
+# ----------------------------------------------------------------------------
+
+
+def test_group_ratio_gcd_grain():
+    # logical 256 over GCD block size 4 -> ratio 64
+    assert LMCacheMPRequestMetadata._group_ratio(0, [256, 64], 4) == 64
+    assert LMCacheMPRequestMetadata._group_ratio(1, [256, 64], 4) == 16
+
+
+def test_group_ratio_defaults_to_one():
+    # No per-group logical sizes (non-hybrid) -> ratio 1 everywhere.
+    assert LMCacheMPRequestMetadata._group_ratio(0, [], 16) == 1
+    # Out-of-range index -> 1.
+    assert LMCacheMPRequestMetadata._group_ratio(5, [256], 4) == 1
+
+
+def test_group_geometry_full_attention():
+    # logical 256, GCD 4, blocks_in_chunk 256 (chunk 1024 tokens / 4):
+    # ratio 64, full_bpc 4, no window -> suffix == full.
+    ratio, full_bpc, suffix_bpc = LMCacheMPRequestMetadata._group_geometry(
+        0, [256], [0], 4, 256
+    )
+    assert (ratio, full_bpc, suffix_bpc) == (64, 4, 4)
+
+
+def test_group_geometry_swa_suffix():
+    # logical 64 (ratio 16), full_bpc = 256/16 = 16, window 128 -> ceil(128/64)=2.
+    ratio, full_bpc, suffix_bpc = LMCacheMPRequestMetadata._group_geometry(
+        0, [64], [128], 4, 256
+    )
+    assert (ratio, full_bpc, suffix_bpc) == (16, 16, 2)
+
+
+# ----------------------------------------------------------------------------
+# _slice_block_ids: own-grain slice + SWA-suffix trimming
+# ----------------------------------------------------------------------------
+
+
+def test_slice_full_attention_no_trim():
+    # Single group, ratio 1, full chunk. GCD range [0, 8) over 2 chunks of 4.
+    tracker = _tracker({0: list(range(100, 120))})
+    sliced = LMCacheMPRequestMetadata._slice_block_ids(
+        tracker,
+        num_engine_groups=1,
+        start=0,
+        end=8,
+        logical_block_sizes=[],  # non-hybrid -> ratio 1
+        sliding_windows=[],
+        vllm_block_size=16,
+        blocks_in_chunk=4,
+    )
+    # Whole [0,8) range, untrimmed.
+    assert sliced == [list(range(100, 108))]
+
+
+def test_slice_swa_keeps_trailing_window_per_chunk():
+    # One SWA group: logical 64, GCD 4 -> ratio 16, full_bpc = 16 per chunk,
+    # window 128 -> suffix 2. Two chunks. GCD range [0, 2*64) = [0,128).
+    # In own grain: [0//16, 128//16) = [0, 8) -> 8 own-grain blocks = 2 chunks
+    # of full_bpc 4? No: blocks_in_chunk is GCD-grain (64), full_bpc=64/16=4.
+    # Use blocks_in_chunk=64 (chunk 1024 tokens / 16 GCD blocks... keep simple):
+    # logical 64, vllm_bs 4 -> ratio 16; blocks_in_chunk 64 -> full_bpc 4,
+    # window 64 -> ceil(64/64)=1 suffix.
+    own = list(range(200, 240))  # 40 own-grain block ids available
+    tracker = _tracker({0: own})
+    sliced = LMCacheMPRequestMetadata._slice_block_ids(
+        tracker,
+        num_engine_groups=1,
+        start=0,
+        end=128,  # 2 chunks of blocks_in_chunk=64
+        logical_block_sizes=[64],
+        sliding_windows=[64],  # window == one logical block -> suffix 1
+        vllm_block_size=4,
+        blocks_in_chunk=64,
+    )
+    # own slice = own[0:8] (128//16=8), full_bpc=4, suffix=1:
+    # chunk0 own[0:4] -> keep last 1 = own[3]; chunk1 own[4:8] -> own[7].
+    assert sliced == [[own[3], own[7]]]
+
+
+def test_slice_mixed_groups_trim_only_swa():
+    # Group 0: full attention (logical 256, ratio 64, full_bpc=4, no window).
+    # Group 1: SWA (logical 64, ratio 16, full_bpc=16, window 128 -> suffix 2).
+    # One chunk: blocks_in_chunk = 256 GCD blocks, range [0, 256).
+    g0 = list(range(1000, 1004))  # group0 own grain: 256//64 = 4 ids
+    g1 = list(range(2000, 2016))  # group1 own grain: 256//16 = 16 ids
+    tracker = _tracker({0: g0, 1: g1})
+    sliced = LMCacheMPRequestMetadata._slice_block_ids(
+        tracker,
+        num_engine_groups=2,
+        start=0,
+        end=256,
+        logical_block_sizes=[256, 64],
+        sliding_windows=[0, 128],
+        vllm_block_size=4,
+        blocks_in_chunk=256,
+    )
+    # group0: full 4 ids untrimmed; group1: keep trailing 2 of 16.
+    assert sliced[0] == g0
+    assert sliced[1] == g1[14:16]
+
+
+# ----------------------------------------------------------------------------
+# GetRetrieveMetadata: per-group skip_blocks_per_group
+# ----------------------------------------------------------------------------
+
+
+def _retrieve_tracker(*, allocated, block_hashes_len, vllm_hit, lmcache_hit, tokens):
+    return SimpleNamespace(
+        request_id="r0",
+        cache_salt="",
+        all_token_ids=list(range(tokens)),
+        block_hashes=list(range(block_hashes_len)),
+        allocated_block_ids=dict(allocated),
+        num_stored_blocks=0,
+        num_vllm_hit_blocks=vllm_hit,
+        num_lmcache_hit_blocks=lmcache_hit,
+        is_ready_for_retrieving=lambda: True,
+    )
+
+
+def test_retrieve_skip_blocks_per_group_swa():
+    # blocks_in_chunk = 256 (GCD). vllm hit 0, lmcache hit 256 -> retrieve 1 chunk.
+    # Group 0 full (logical 256), group 1 SWA (logical 64, window 128).
+    # With vllm_hit=0 -> apc overlap 0 -> skip all zero.
+    tracker = _retrieve_tracker(
+        allocated={0: list(range(4)), 1: list(range(16))},
+        block_hashes_len=256,
+        vllm_hit=0,
+        lmcache_hit=256,
+        tokens=256 * 4,
+    )
+    meta = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+        tracker,
+        blocks_in_chunk=256,
+        vllm_block_size=4,
+        num_engine_groups=2,
+        logical_block_sizes=[256, 64],
+        sliding_windows=[0, 128],
+    )
+    assert meta is not None
+    assert meta.op.skip_blocks_per_group == [0, 0]
+
+
+def test_retrieve_skip_absorbed_by_swa_trim():
+    # vllm_hit within the first chunk produces an APC overlap; the SWA group's
+    # dropped leading blocks should absorb it (skip clamps to 0), while a full
+    # group still carries the block skip.
+    # blocks_in_chunk=256 GCD; start floors num_vllm_hit to chunk -> 0.
+    # vllm_hit=64 (GCD blocks) within chunk 0, lmcache_hit=256.
+    tracker = _retrieve_tracker(
+        allocated={0: list(range(4)), 1: list(range(16))},
+        block_hashes_len=256,
+        vllm_hit=64,
+        lmcache_hit=256,
+        tokens=256 * 4,
+    )
+    meta = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+        tracker,
+        blocks_in_chunk=256,
+        vllm_block_size=4,
+        num_engine_groups=2,
+        logical_block_sizes=[256, 64],
+        sliding_windows=[0, 128],
+    )
+    assert meta is not None
+    # apc_overlap_blocks (GCD) = 64; tokens = 64*4 = 256.
+    # group0 full: logical 256 -> skip 256//256 = 1 block, suffix_offset 0 -> 1.
+    # group1 SWA: logical 64 -> skip 256//64 = 4 blocks; full_bpc 16, suffix 2
+    #   -> suffix_offset 14; 4 - 14 < 0 -> clamped to 0.
+    assert meta.op.skip_blocks_per_group == [1, 0]

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -8,6 +8,8 @@ import torch
 # First Party
 from lmcache.integration.vllm.kv_cache_groups import (
     create_group_views_from_vllm,
+    per_layer_storage_blocks_per_chunk_from_vllm,
+    storage_blocks_per_chunk,
 )
 from lmcache.v1.multiprocess.group_view import (
     expand_block_ids_to_views,
@@ -19,7 +21,6 @@ from lmcache.v1.multiprocess.group_view import (
 @dataclass
 class MockKVCacheGroup:
     layer_names: list[str]
-
 
 @dataclass
 class MockKVCacheConfig:
@@ -79,3 +80,83 @@ def test_conversion_splits_by_lmcache_layer_identity():
         [20],
         [10],
     ]
+
+
+# ----------------------------------------------------------------------------
+# per_layer_* hint derivation (logical block size + sliding window)
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class MockSpec:
+    """A vLLM ``KVCacheGroupSpec.kv_cache_spec`` stand-in."""
+
+    block_size: int = 0
+    sliding_window: int | None = None
+
+
+@dataclass
+class MockUniformSpec:
+    """A ``UniformTypeKVCacheSpecs`` stand-in: block size/window on inner specs."""
+
+    kv_cache_specs: dict
+
+
+@dataclass
+class MockGroupWithSpec:
+    layer_names: list[str]
+    kv_cache_spec: object
+
+
+@dataclass
+class MockConfigWithSpecs:
+    kv_cache_groups: list
+
+
+def test_storage_blocks_per_chunk_helper():
+    """Shared SWA-suffix formula: full chunk vs trailing window, capped."""
+    # full attention -> full chunk (1024 / 64 = 16)
+    assert storage_blocks_per_chunk(0, 64, 1024) == 16
+    # window 128, logical 64 -> ceil(128/64) = 2
+    assert storage_blocks_per_chunk(128, 64, 1024) == 2
+    # window 8, logical 4 -> ceil(8/4) = 2
+    assert storage_blocks_per_chunk(8, 4, 1024) == 2
+    # window larger than a chunk -> capped at full chunk
+    assert storage_blocks_per_chunk(4096, 64, 1024) == 16
+    # compressed MLA-like: logical 256 -> 1024/256 = 4
+    assert storage_blocks_per_chunk(0, 256, 1024) == 4
+
+
+def test_per_layer_storage_blocks_maps_per_group():
+    """Each layer gets its group's stored block count (full or SWA suffix)."""
+    config = MockConfigWithSpecs(
+        kv_cache_groups=[
+            # full attention, logical 256 -> full chunk 1024/256 = 4
+            MockGroupWithSpec(["layer.0"], MockSpec(block_size=256, sliding_window=0)),
+            # SWA, logical 64, window 128 -> ceil(128/64) = 2
+            MockGroupWithSpec(["layer.1"], MockSpec(block_size=64, sliding_window=128)),
+        ]
+    )
+    caches = {"layer.0": None, "layer.1": None}
+    result = per_layer_storage_blocks_per_chunk_from_vllm(config, caches, 1024)
+    assert result == [4, 2]
+
+
+def test_per_layer_storage_blocks_uniform_inner_spec_fallback():
+    """Block size / window read from inner specs for a UniformTypeKVCacheSpecs."""
+    uniform = MockUniformSpec(
+        kv_cache_specs={"layer.0": MockSpec(block_size=4, sliding_window=8)}
+    )
+    config = MockConfigWithSpecs(
+        kv_cache_groups=[MockGroupWithSpec(["layer.0", "layer.1"], uniform)]
+    )
+    caches = {"layer.0": None, "layer.1": None}
+    result = per_layer_storage_blocks_per_chunk_from_vllm(config, caches, 1024)
+    # logical 4, window 8 -> ceil(8/4) = 2 for both layers
+    assert result == [2, 2]
+
+
+def test_per_layer_storage_blocks_none_without_groups():
+    """No engine groups -> None (server treats every group as full chunk)."""
+    assert per_layer_storage_blocks_per_chunk_from_vllm(None, {}, 1024) is None
+

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -215,13 +215,16 @@ def test_submit_retrieve_request_tracks_returned_future(fake_adapter, monkeypatc
         block_ids=[[0]],
         start=0,
         end=4,
-        skip_first_n_tokens=1,
+        skip_blocks_per_group=[1],
     )
 
     adapter.submit_retrieve_request("req-1", op, event=MagicMock())
 
     assert transfer_ctx.submit_retrieve.called
-    assert transfer_ctx.submit_retrieve.call_args.kwargs == {"skip_first_n_tokens": 1}
+    # Single (no group_views) -> skip expands to one value per LMCache group.
+    assert transfer_ctx.submit_retrieve.call_args.kwargs == {
+        "skip_blocks_per_group": [1]
+    }
     assert transfer_ctx.submit_retrieve.call_args.args[4] == [[0]]
     assert adapter.retrieve_futures["req-1"] == (fake_future, [0])
 


### PR DESCRIPTION
> **Status: Ready for review.** Validated end-to-end on DeepSeek-V4-Flash (see Validation below). Supersedes #3548, #3261, and #3564 — all closed in favor of this branch.

## What & why

DeepSeek-V4's hybrid KV cache manager exposes several KV groups with **different logical block sizes** (256 for the full-attention MLA group, 64/4/8 for the SWA / compressor-state groups) while `cache_config.block_size` collapses to their GCD. Two problems followed from teaching the LMCache server about that vLLM-side geometry:

1. The server derived each group's `compress_ratio` / `physical_chunk_size` from a single (GCD-collapsed) scalar, so SWA / state groups silently stored only a fraction of each chunk.
2. To do SWA-suffix-only offload, the server had to understand sliding windows, convert token offsets to per-group blocks, and reshape/gather the trailing window on the hot path — error-prone (the "shape-invalid" landmine) and a layering violation: a KV **store** shouldn't need to model the engine's paging semantics.

This PR makes the server **block-only**. It receives, per group:
- already-**trimmed** block IDs (SWA groups carry only their trailing-window blocks), and
- one block count (`storage_blocks_per_chunk`) plus a per-group block skip.

It never reasons about sliding windows, logical block sizes, compress ratios, or token offsets on the transfer path. All of that now lives in the connector (scheduler side), in plain Python.

## Commit 1 — per-group logical block size + SWA-suffix offload (was #3548)

Fixes the correctness bug by plumbing per-group logical block sizes so the server derives each group's geometry correctly, and adds SWA-suffix-only offload (store/retrieve only the trailing window of each sliding-window group). Validated live on `DeepSeek-V4-Flash` tp=4: L1 dropped ~17× (667 MB → 38.7 MB) with cold≈warm semantically identical.

## Commit 2 — make the server block-only (this refactor)

**Connector (scheduler side):**
- `_slice_block_ids` trims each chunk to its trailing SWA window before sending.
- The retrieve APC skip is emitted as `skip_blocks_per_group` (per engine group, in each group's stored-block units) instead of a scalar token count — the connector folds in the token→block conversion and the suffix-offset adjustment, so the server applies it verbatim.
- A shared `storage_blocks_per_chunk` helper is the single source of the suffix formula for both the scheduler trim and the worker register hint (drift guard).

**Wire / hints:**
- New `per_layer_storage_blocks_per_chunk` layout hint — the one per-group block count the server uses for buffer sizing, kernel chunk-size, and the underflow check.
- `per_layer_sliding_window` removed from the wire.
- `per_layer_inference_engine_logical_block_size` kept, but now consumed **only** by the `cache_size_per_token` reporting metric, not the hot path.
- RETRIEVE op/protocol field `skip_first_n_tokens: int` → `skip_blocks_per_group: list[int]`.

**Server:**
- `KVLayerGroupInfo` collapses `blocks_per_chunk` and `storage_blocks_per_chunk` into one stored field (the distinction was an artifact of server-side trimming).
- Deletes the SWA machinery: `sliding_window`, `num_suffix_blocks_per_chunk`, `chunk_suffix_offset_blocks`, the retrieve-loop `view/reshape` suffix gather, and the token→block skip conversion with its alignment warning. Buffer/layout shapes derive directly from `storage_slots_per_chunk` physical slots.

The non-GPU CPU/SHM scatter path and the legacy single-group connectors convert the group-0 block skip back to a token prefix at the boundary, leaving the token-based scatter helper unchanged.

## Validation

**Live end-to-end** — `DeepSeek-V4-Flash` tp=4, fp8, block_size=256, chunk_size=1024, LMCache 256 GiB L1 (SHM), `--no-enable-prefix-caching`:

| 2026-06-05 (block-only path, first run) | 2026-06-06 (re-verified) |
|---|---|
| `l1_memory_usage_bytes` **58 MB** (vs 667 MB full-chunk) | store gate not wedged; L1 grows `0→19→77→97 MB` across chunks |
| `lookup_hit / requested` **3072 / 5120 = 60%** | warm lookup hits the full stored prefix (2048 / 2048 newly hit) |
| vLLM external prefix cache hit **32.2%** | **30.4%** |
| Cold ≈ warm ✅ semantically identical | ✅ semantically identical |
| No kernel errors | No `blocks_per_object * block_size == lmcache_chunk_size` crash |

The reduced L1 reflects SWA-suffix trimming working: only trailing-window blocks of each SWA/state chunk are stored.

**Unit tests** — 102 V4-relevant tests green (`tests/v1/test_kv_layer_groups_manager.py`, `test_kv_cache_groups.py`, `test_vllm_kv_cache_groups.py`, `test_mp_connector_slicing.py`, `test_vllm_mp_adapter.py`, `test_mp_mem_kernels.py`). New `tests/v1/test_mp_connector_slicing.py` covers the connector geometry / per-chunk trim / per-group skip arithmetic (it already caught a real `NameError` that would have crashed every hybrid store/retrieve). The `kv_layer_groups_manager` and `vllm_kv_cache_groups` suites are reworked around the storage-blocks hint.

## Not yet exercised
- Broader failure-mode coverage (APC-on, concurrency / multi-request, V3.2 regression).
- L2 (NIXL / FS) path on V4 HMA.

## Note on direction
This intentionally adds one server hint (`per_layer_storage_blocks_per_chunk`) while **removing** all server-side SWA / logical hot-path logic — a net-simpler server and a cleaner layering boundary (the store no longer models vLLM paging). Flagging the wire-protocol change (`skip` field; register hint) for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
