### PR TITLE
Release MemoryObj ref when async disk write fails

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -539,7 +539,17 @@ class LocalDiskBackend(StorageBackendInterface):
         self.stats_monitor.update_local_storage_usage(self.usage)
 
         # TODO(Jiayi): need to add ref count in disk memory object
-        self.write_file(buffer, path)
+        try:
+            self.write_file(buffer, path)
+        except Exception:
+            # On write failure, roll back the usage accounting and release the
+            # ref taken in `submit_put_task` so the MemoryObj is not leaked, and
+            # drop the task without inserting a key with no backing file.
+            self.usage -= size
+            self.stats_monitor.update_local_storage_usage(self.usage)
+            memory_obj.ref_count_down()
+            self.disk_worker.remove_put_task(key)
+            raise
 
         # ref count down here because there's a ref_count_up in
         # `submit_put_task` above.

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -169,6 +169,23 @@ class TestLocalDiskBackend:
         assert str(local_disk_backend) == "LocalDiskBackend"
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
+    def test_async_save_releases_ref_on_write_failure(self, local_disk_backend):
+        """A failed disk write must release the MemoryObj ref and not insert a key."""
+        backend = local_disk_backend
+        key = create_test_key(1)
+        memory_obj = MagicMock(spec=MemoryObj)
+        memory_obj.byte_array = bytearray(64)
+        usage_before = backend.usage
+
+        with patch.object(backend, "write_file", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                backend.async_save_bytes_to_disk(key, memory_obj)
+
+        memory_obj.ref_count_down.assert_called_once()
+        assert key not in backend.dict
+        assert backend.usage == usage_before
+        backend.local_cpu_backend.memory_allocator.close()
+
     def test_key_to_path(self, local_disk_backend):
         """Test key to path conversion."""
         key = create_test_key(1)


### PR DESCRIPTION
### Problem

`LocalDiskBackend.async_save_bytes_to_disk` does `memory_obj.ref_count_up()`'s counterpart `ref_count_down()` (balancing the `ref_count_up` taken in `submit_put_task`) **after** `write_file`:

```python
self.usage += size
self.stats_monitor.update_local_storage_usage(self.usage)
self.write_file(buffer, path)          # <-- if this raises...
...
memory_obj.ref_count_down()            # <-- ...this is never reached -> ref leak
self.insert_key(...)
self.disk_worker.remove_put_task(key)
```

If `write_file` raises (disk full, I/O error, O_DIRECT failure, …), the function exits before `ref_count_down()`, so the `MemoryObj` ref taken in `submit_put_task` is **leaked** (it can never be freed/reused). The `usage` accounting is also left inflated and the put task stays pending.

### Fix

Wrap `write_file` so that on failure we roll back `usage`, release the ref, drop the put task, and re-raise — without inserting a key that has no backing file on disk. The success path is unchanged.

### Testing

Added `test_async_save_releases_ref_on_write_failure` (patches `write_file` to raise and asserts `ref_count_down` is called once, no key is inserted, and `usage` is restored). Runs on CPU:

```
tests/v1/storage_backend/test_local_disk_backend.py::TestLocalDiskBackend::test_async_save_releases_ref_on_write_failure PASSED
```

`ruff` clean.
