### PR TITLE
[Bugfix][Test] Fix disk_lock leak on CPU staging allocation failure 

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -447,20 +447,29 @@ class LocalDiskBackend(StorageBackendInterface):
 
         logger.debug(f"lookup_id: {lookup_id}; Prefetching {len(keys)} keys from disk.")
         for key in keys:
-            self.disk_lock.acquire()
-            assert key in self.dict, f"Key {key} not found in disk cache after pinning"
+            # Hold disk_lock only for shared disk metadata.
+            with self.disk_lock:
+                assert key in self.dict, (
+                    f"Key {key} not found in disk cache after pinning"
+                )
 
-            path = self.dict[key].path
-            dtype = self.dict[key].dtype
-            shape = self.dict[key].shape
-            fmt = self.dict[key].fmt
+                disk_meta = self.dict[key]
+                path = disk_meta.path
+                dtype = disk_meta.dtype
+                shape = disk_meta.shape
+                fmt = disk_meta.fmt
 
-            assert dtype is not None
-            assert shape is not None
+                assert dtype is not None
+                assert shape is not None
+
+                # Pin before releasing the lock to prevent eviction during staging.
+                disk_meta.pin()
 
             # busy_loop=False prevents spinning on the event loop thread;
             # if staging memory is exhausted the caller will get a logged
             # error rather than a silent deadlock.
+            #
+            # Allocate outside disk_lock to avoid blocking metadata access.
             memory_obj = self.local_cpu_backend.allocate(
                 shape,
                 dtype,
@@ -469,6 +478,12 @@ class LocalDiskBackend(StorageBackendInterface):
             )
 
             if memory_obj is None:
+                # Allocation failed; undo the disk pin taken above.
+                with self.disk_lock:
+                    # Check for stale metadata.
+                    if key in self.dict:
+                        self.dict[key].unpin()
+
                 logger.error(
                     "Memory allocation failed during async disk load for key %s. "
                     "CPU staging pool may be exhausted (unpin() not called after "
@@ -477,13 +492,21 @@ class LocalDiskBackend(StorageBackendInterface):
                 )
                 return mem_objs
 
-            self.dict[key].pin()
+            with self.disk_lock:
+                # Check for stale metadata.
+                if key in self.dict:
+                    # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
+                    # Update cache recency
+                    self.cache_policy.update_on_hit(key, self.dict)
+                else:
+                    logger.warning(
+                        "Key %s disappeared from disk cache after pinning. "
+                        "Skipping async disk load.",
+                        key,
+                    )
+                    memory_obj.ref_count_down()
+                    continue
 
-            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
-            # Update cache recency
-            self.cache_policy.update_on_hit(key, self.dict)
-
-            self.disk_lock.release()
             logger.debug(f"Prefetching {key} from disk.")
             memory_obj.pin()
             mem_objs.append(memory_obj)

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -466,3 +466,59 @@ class TestGetBlockingCachePolicyUpdate:
         assert result is None
         mock_update.assert_not_called()
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class TestBatchedGetNonBlockingAllocationFailure:
+    """Regression tests for disk_lock cleanup in disk prefetch path."""
+
+    def _inject_key(
+        self,
+        backend: LocalDiskBackend,
+        key: CacheEngineKey,
+        shape: torch.Size,
+        dtype: torch.dtype,
+    ) -> None:
+        """Insert a fake disk-cache metadata entry without writing a file."""
+        meta = DiskCacheMetadata(
+            path="/nonexistent/path.pt",
+            size=0,
+            shape=shape,
+            dtype=dtype,
+            cached_positions=None,
+            fmt=MemoryFormat.KV_2LTD,
+            pin_count=0,
+        )
+        with backend.disk_lock:
+            backend.dict[key] = meta
+            backend.cache_policy.update_on_put(key)
+
+    @pytest.mark.asyncio
+    async def test_batched_get_releases_disk_lock_on_cpu_alloc_failure(
+        self,
+        local_disk_backend: LocalDiskBackend,
+    ) -> None:
+        """batched_get_non_blocking must not leak disk_lock when CPU alloc fails."""
+        key = create_test_key(201)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        self._inject_key(local_disk_backend, key, shape, torch.bfloat16)
+
+        with patch.object(
+            local_disk_backend.local_cpu_backend,
+            "allocate",
+            return_value=None,
+        ):
+            result = await local_disk_backend.batched_get_non_blocking(
+                lookup_id="req-lock-leak",
+                keys=[key],
+            )
+
+        assert result == []
+
+        acquired = local_disk_backend.disk_lock.acquire(timeout=0.1)
+        try:
+            assert acquired, "disk_lock was leaked when CPU staging allocation failed"
+        finally:
+            if acquired:
+                local_disk_backend.disk_lock.release()
+
+        local_disk_backend.local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
## What this PR does / why we need it

Fixes a `disk_lock` leak in `LocalDiskBackend.batched_get_non_blocking()` when CPU staging allocation fails.

Previously, the disk prefetch path held `disk_lock` while calling `local_cpu_backend.allocate()`. If allocation returned `None`, the function returned early without releasing `disk_lock`, causing later disk-cache metadata operations to block.

## Fix

* Scope `disk_lock` only around shared disk-cache metadata access.
* Pin the disk metadata entry before releasing `disk_lock` so it cannot be evicted during CPU staging allocation.
* Move CPU staging allocation outside `disk_lock`.
* On allocation failure, reacquire `disk_lock`, unpin the disk metadata entry, log the failure, and return partial results.
* Use `with self.disk_lock:` instead of manual `acquire()` / `release()` to make early-return paths safe.

## Test

Added a regression test for the CPU allocation failure path in `batched_get_non_blocking()`.

The test:

* Injects fake disk-cache metadata.
* Mocks `local_cpu_backend.allocate()` to return `None`.
* Verifies `batched_get_non_blocking()` returns `[]`.
* Verifies `disk_lock` can still be acquired afterward, proving the lock was not leaked.

Ran:

```bash
pytest -xvs tests/v1/storage_backend/test_local_disk_backend.py::TestBatchedGetNonBlockingAllocationFailure::test_batched_get_releases_disk_lock_on_cpu_alloc_failure

pytest -xvs tests/v1/storage_backend/test_local_disk_backend.py