### PR TITLE
[Misc] align MP server id with OTel service.instance.id

### DIFF
--- a/lmcache/v1/mp_observability/README.md
+++ b/lmcache/v1/mp_observability/README.md
@@ -58,7 +58,10 @@ CLI, pass the flags below; when embedding programmatically, construct an
 | `--event-bus-queue-size N` | `10000` | Maximum number of events in the EventBus queue before tail-drop. |
 | `--otlp-endpoint URL` | *(none)* | OTLP gRPC endpoint (e.g. `http://localhost:4317`). When set, metrics and traces are pushed to an OTel collector. When unset, metrics fall back to Prometheus pull mode. |
 | `--prometheus-port PORT` | `9090` | Port for the Prometheus `/metrics` endpoint. Only used when `--otlp-endpoint` is not set. |
-| `--service-instance-id ID` | *unset* (default random UUID v4) | Identifier for this MP server instance.  Attached as the OTel Resource attribute `service.instance.id` on every metric and span.  When the flag is not passed, defaults to a random UUID v4 minted at startup.  Pass `--service-instance-id=""` to force an explicit empty value. |
+
+The OTel Resource attribute `service.instance.id` is not set here. It is
+projected from the MP server's `--instance-id` (see the MP server config), so
+metrics, traces, and coordinator membership all key on the same id.
 
 ### `ObservabilityConfig` fields
 
@@ -71,7 +74,7 @@ CLI, pass the flags below; when embedding programmatically, construct an
 | `tracing_enabled` | `bool` | `False` | Register tracing subscribers (OTel spans). |
 | `otlp_endpoint` | `str \| None` | `None` | OTLP gRPC endpoint. When set, metrics and traces are pushed. When `None`, metrics use Prometheus pull fallback. |
 | `prometheus_port` | `int` | `9090` | Port for the Prometheus `/metrics` endpoint (pull fallback only). |
-| `service_instance_id` | `str \| None` | `None` (default random UUID v4) | Identifier for this MP server instance; attached as the OTel Resource attribute `service.instance.id` on every metric and span.  `None` defaults to a random UUID v4 at `init_observability` time.  An explicit `""` is preserved. |
+| `service_instance_id` | `str \| None` | `None` | OTel Resource attribute `service.instance.id`, attached to every metric and span. No CLI flag: `run_cache_server` projects the MP server's `--instance-id` onto it. `None` (standalone callers only) falls back to a random UUID v4 at `init_observability` time; an explicit value is preserved. |
 
 ### Metrics export modes
 

--- a/lmcache/v1/mp_observability/README.md
+++ b/lmcache/v1/mp_observability/README.md
@@ -59,10 +59,6 @@ CLI, pass the flags below; when embedding programmatically, construct an
 | `--otlp-endpoint URL` | *(none)* | OTLP gRPC endpoint (e.g. `http://localhost:4317`). When set, metrics and traces are pushed to an OTel collector. When unset, metrics fall back to Prometheus pull mode. |
 | `--prometheus-port PORT` | `9090` | Port for the Prometheus `/metrics` endpoint. Only used when `--otlp-endpoint` is not set. |
 
-The OTel Resource attribute `service.instance.id` is not set here. It is
-projected from the MP server's `--instance-id` (see the MP server config), so
-metrics, traces, and coordinator membership all key on the same id.
-
 ### `ObservabilityConfig` fields
 
 | Field | Type | Default | Description |

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -74,17 +74,16 @@ class ObservabilityConfig:
     minted and logged at INFO."""
 
     service_instance_id: str | None = None
-    """Identifier for this MP server instance.  Attached as the OTel
-    Resource attribute ``service.instance.id`` on every metric and span.
-    One MP server has exactly one instance id.
+    """OTel ``service.instance.id`` resource attribute, attached to every
+    metric and span. There is no CLI flag for it: the operator-facing id is
+    ``--instance-id`` (``MPServerConfig.instance_id``), which ``run_cache_server``
+    projects onto this attribute so telemetry and coordinator membership share
+    one id.
 
-    ``None`` (the default, also the state when the CLI flag is not
-    passed) means "not set explicitly": on the full MP server
-    ``run_cache_server`` fills it from the generated
-    ``MPServerConfig.instance_id`` so OTel and coordinator membership match;
-    standalone callers (e.g. the trace CLI driver) fall back to a random
-    UUID v4 at ``init_observability`` time. An explicit value (including an
-    empty string) is preserved verbatim."""
+    ``None`` (the default) means "not set": standalone callers that build an
+    ``ObservabilityConfig`` directly (e.g. the trace CLI driver) fall back to a
+    random UUID v4 at ``init_observability`` time. An explicit value is
+    preserved verbatim."""
 
 
 DEFAULT_OBSERVABILITY_CONFIG = ObservabilityConfig(enabled=False)
@@ -163,18 +162,6 @@ def add_observability_args(
         help=(
             "Fraction of chunks/blocks to track for lifecycle histograms "
             "(0, 1.0]. Counters always count all events. Default is 0.01 (1%%)."
-        ),
-    )
-    group.add_argument(
-        "--service-instance-id",
-        type=str,
-        default=None,
-        help=(
-            "Identifier for this MP server instance. Attached as the OTel "
-            "Resource attribute 'service.instance.id' on every metric and "
-            "span. When the flag is not passed, defaults to a random "
-            "UUID v4 minted at startup. Pass --service-instance-id='' to "
-            "force an empty attribute value."
         ),
     )
 
@@ -265,7 +252,6 @@ def parse_args_to_observability_config(
         ),
         trace_level=args.trace_level,
         trace_output=args.trace_output,
-        service_instance_id=args.service_instance_id,
     )
 
     if config.tracing_enabled and config.otlp_endpoint is None:

--- a/lmcache/v1/mp_observability/config.py
+++ b/lmcache/v1/mp_observability/config.py
@@ -79,9 +79,12 @@ class ObservabilityConfig:
     One MP server has exactly one instance id.
 
     ``None`` (the default, also the state when the CLI flag is not
-    passed) falls back to a random UUID v4 at ``init_observability``
-    time.  An explicit empty string is preserved verbatim so operators
-    who want the attribute to report ``""`` can ask for it."""
+    passed) means "not set explicitly": on the full MP server
+    ``run_cache_server`` fills it from the generated
+    ``MPServerConfig.instance_id`` so OTel and coordinator membership match;
+    standalone callers (e.g. the trace CLI driver) fall back to a random
+    UUID v4 at ``init_observability`` time. An explicit value (including an
+    empty string) is preserved verbatim."""
 
 
 DEFAULT_OBSERVABILITY_CONFIG = ObservabilityConfig(enabled=False)

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -61,6 +61,11 @@ class MPServerConfig:
     script_allowed_imports: list[str] = field(default_factory=list)
     """Modules that /run_script endpoint is allowed to import."""
 
+    instance_id: str = ""
+    """Internal identity of this MP server, used as the coordinator
+    membership key. Not operator-settable: ``run_cache_server`` generates a
+    random UUID at startup."""
+
 
 @dataclass
 class RuntimePluginConfig:

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -10,6 +10,7 @@ import argparse
 import json
 import math
 import os
+import uuid
 
 
 @dataclass
@@ -61,10 +62,12 @@ class MPServerConfig:
     script_allowed_imports: list[str] = field(default_factory=list)
     """Modules that /run_script endpoint is allowed to import."""
 
-    instance_id: str = ""
-    """Internal identity of this MP server, used as the coordinator
-    membership key. Not operator-settable: ``run_cache_server`` generates a
-    random UUID at startup."""
+    instance_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    """Stable identity of this MP server, the single source of truth for who
+    this server is. Used as the coordinator membership key and projected onto
+    the OTel ``service.instance.id`` resource attribute (see
+    ``run_cache_server``) so metrics, traces, and coordinator state all key on
+    the same id. Set via ``--instance-id``; defaults to a random UUID v4."""
 
 
 @dataclass
@@ -137,6 +140,15 @@ def add_mp_server_args(
     """
     mp_group = parser.add_argument_group(
         "MP Server", "Configuration for the ZMQ multiprocess cache server"
+    )
+    mp_group.add_argument(
+        "--instance-id",
+        type=str,
+        default=None,
+        help="Stable identity of this MP server. Used as the coordinator "
+        "membership key and as the OTel 'service.instance.id' resource "
+        "attribute on every metric and span. Defaults to a random UUID v4 "
+        "minted at startup.",
     )
     mp_group.add_argument(
         "--host",
@@ -261,6 +273,7 @@ def parse_args_to_mp_server_config(
     except json.JSONDecodeError as exc:
         raise ValueError("--runtime-plugin-config is not valid JSON: %s" % exc) from exc
     return MPServerConfig(
+        instance_id=args.instance_id or str(uuid.uuid4()),
         host=args.host,
         port=args.port,
         chunk_size=args.chunk_size,

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -107,7 +107,6 @@ async def lifespan(app: FastAPI):
     # the keep_registered task registers, heartbeats, and deregisters on
     # shutdown. Best-effort: failures are logged and retried, never fatal.
     http_config = _configs.get("http")
-    obs_config = _configs.get("observability")
     coordinator_config = _configs.get("coordinator")
     coordinator_client = None
     coordinator_registration_task = None
@@ -117,16 +116,14 @@ async def lifespan(app: FastAPI):
         and http_config is not None
     ):
         coordinator_client = httpx.AsyncClient(timeout=10.0)
-        # Reuse this server's telemetry identity (OTel service.instance.id) so
-        # coordinator membership lines up with metrics/traces. Empty lets the
-        # coordinator assign one.
-        service_instance_id = getattr(obs_config, "service_instance_id", None)
+        # Canonical id resolved by run_cache_server above; shared with
+        # the OTel service.instance.id so membership matches metrics/traces.
         coordinator_registration_task = asyncio.create_task(
             keep_registered(
                 coordinator_client,
                 coordinator_config.url,
                 http_port=http_config.http_port,
-                instance_id=service_instance_id or "",
+                instance_id=mp_config.instance_id,
                 advertise_ip=coordinator_config.advertise_ip,
                 heartbeat_interval=coordinator_config.heartbeat_interval,
             )

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -6,6 +6,7 @@ import argparse
 import shutil
 import sys
 import time
+import uuid
 
 # Third Party
 import zmq
@@ -235,6 +236,13 @@ def run_cache_server(
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine).
         If return_engine is False: None (blocks until interrupted).
     """
+    # Generate this server's identity once at startup. It keys the coordinator
+    # membership and, unless observability set its service.instance.id
+    # explicitly, also tags OTel metrics/traces.
+    mp_config.instance_id = str(uuid.uuid4())
+    if obs_config.service_instance_id is None:
+        obs_config.service_instance_id = mp_config.instance_id
+
     event_bus = init_observability(
         obs_config, start_prometheus_http_server=start_prometheus_http_server
     )

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -6,7 +6,6 @@ import argparse
 import shutil
 import sys
 import time
-import uuid
 
 # Third Party
 import zmq
@@ -236,10 +235,10 @@ def run_cache_server(
         If return_engine is True: tuple of (MessageQueueServer, MPCacheEngine).
         If return_engine is False: None (blocks until interrupted).
     """
-    # Generate this server's identity once at startup. It keys the coordinator
-    # membership and, unless observability set its service.instance.id
-    # explicitly, also tags OTel metrics/traces.
-    mp_config.instance_id = str(uuid.uuid4())
+    # mp_config.instance_id is this server's single source of identity (set via
+    # --instance-id, else a random UUID v4). Project it onto the OTel
+    # service.instance.id unless observability set that attribute explicitly, so
+    # metrics/traces and coordinator membership all key on the same id.
     if obs_config.service_instance_id is None:
         obs_config.service_instance_id = mp_config.instance_id
 

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -8,6 +8,7 @@ pure config layer (no native extensions), so it runs without a CUDA build.
 
 # Standard
 import argparse
+import uuid
 
 # Third Party
 import pytest
@@ -15,8 +16,11 @@ import pytest
 # First Party
 from lmcache.v1.multiprocess.config import (
     CoordinatorConfig,
+    MPServerConfig,
     add_coordinator_args,
+    add_mp_server_args,
     parse_args_to_coordinator_config,
+    parse_args_to_mp_server_config,
 )
 
 _COORD_ENV = (
@@ -96,3 +100,30 @@ def test_garbage_env_heartbeat_rejected(monkeypatch):
     monkeypatch.setenv("LMCACHE_COORDINATOR_HEARTBEAT_INTERVAL", "abc")
     with pytest.raises(ValueError, match="not a number"):
         _parse([])
+
+
+def _parse_mp(argv: list[str]) -> MPServerConfig:
+    parser = argparse.ArgumentParser()
+    add_mp_server_args(parser)
+    return parse_args_to_mp_server_config(parser.parse_args(argv))
+
+
+def test_instance_id_defaults_to_uuid4():
+    # No --instance-id flag => a random UUID v4 is minted.
+    config = _parse_mp([])
+    assert uuid.UUID(config.instance_id).version == 4
+
+
+def test_instance_id_flag_is_preserved():
+    config = _parse_mp(["--instance-id", "mp-server-7"])
+    assert config.instance_id == "mp-server-7"
+
+
+def test_instance_id_defaults_are_distinct():
+    # Each parse without the flag gets its own id (no shared default).
+    assert _parse_mp([]).instance_id != _parse_mp([]).instance_id
+
+
+def test_instance_id_dataclass_default_is_distinct():
+    # Direct construction (no CLI) also mints a fresh id per instance.
+    assert MPServerConfig().instance_id != MPServerConfig().instance_id


### PR DESCRIPTION
**What this PR does / why we need it**:

The MP server's coordinator membership id and its OTel `service.instance.id` could diverge. `init_observability` minted a UUID into a local variable that was never written back to the config, so the coordinator registration read a still-`None` id, sent empty, and the coordinator assigned a *different* UUID. Metrics/traces and coordinator state then keyed on different ids and couldn't be correlated.

Now `run_cache_server` generates one identity at startup (`MPServerConfig.instance_id`), uses it as the coordinator membership key, and projects it onto `service.instance.id` unless observability set that value explicitly. The id is internal-only (no operator flag).

**Special notes for your reviewers**:

Single source of truth is `MPServerConfig.instance_id`. The standalone trace CLI path (no MP server) still falls back to its own UUID in `init_observability`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests