### PR TITLE
feat: add POSIX SHM infra for CPU KV-cache IPC

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -165,7 +165,7 @@ def _release_partial_kv_wrappers(wrappers: list[Any]) -> None:
     are silently skipped.
     """
     # First Party
-    from lmcache.v1.platform.cpu.shm import shm_unlink
+    from lmcache.v1.multiprocess.posix_shm import shm_unlink
 
     for w in wrappers:
         name = getattr(w, "shm_name", None)

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -149,7 +149,7 @@ def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
     wrappers: KVCache = []
     try:
         for tensor in kv_caches.values():
-            wrappers.append(_wrap_one_kv_cache(tensor))
+            wrappers.append(wrap_one_kv_cache(tensor))
     except BaseException:
         _release_partial_kv_wrappers(wrappers)
         raise
@@ -177,7 +177,7 @@ def _release_partial_kv_wrappers(wrappers: list[Any]) -> None:
             logger.debug("shm_unlink failed during rollback", exc_info=True)
 
 
-def _wrap_one_kv_cache(tensor: torch.Tensor) -> Any:
+def wrap_one_kv_cache(tensor: torch.Tensor) -> Any:
     """Dispatch by ``tensor.device.type`` via the platform registry.
 
     Concrete factories self-register at import time (CUDA in

--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -99,12 +99,14 @@ def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap,
 def _addr_of_mmap(mm: _mmap.mmap) -> int:
     """Return the base address of an ``mmap`` without leaking a buffer view.
 
-    A ctypes buffer view is created just long enough to read the
-    address, then dropped before this function returns; once it is
+    A single-byte ctypes view is created just long enough to read the
+    base address, then dropped before this function returns; once it is
     out of scope the mmap has no exported pointers, so a later
-    ``mm.close()`` can complete cleanly.
+    ``mm.close()`` can complete cleanly.  A 1-byte view is sufficient
+    -- ``ctypes.addressof`` returns the start of the buffer regardless
+    of its declared length.
     """
-    view = (ctypes.c_uint8 * len(mm)).from_buffer(mm)
+    view = (ctypes.c_uint8 * 1).from_buffer(mm)
     addr = ctypes.addressof(view)
     del view
     return addr
@@ -159,7 +161,7 @@ def shm_map_readwrite(name: str, nbytes: int) -> int:
     return addr
 
 
-def shm_munmap(addr: int, nbytes: int) -> None:
+def shm_munmap(addr: int, nbytes: int = 0) -> None:
     """Best-effort release of a previously mapped segment by address.
 
     The underlying mmap is closed exactly once; subsequent calls with
@@ -167,8 +169,8 @@ def shm_munmap(addr: int, nbytes: int) -> None:
 
     Args:
         addr: The virtual address of the mapped segment.
-        nbytes: Kept for API compatibility; not used internally since
-            ``mmap.close()`` does not require the size.
+        nbytes: Unused; kept for API compatibility so callers that
+            already pass the size do not need to be updated.
     """
     if not addr:
         return
@@ -209,9 +211,17 @@ def shm_unlink(name: str) -> None:
 
 
 def _atexit_cleanup() -> None:
-    """Unlink any SHM segments still owned by this process at exit."""
+    """Unlink and munmap any SHM segments still owned by this process."""
     with _REGISTRY_LOCK:
         names = list(_OWNED_NAMES)
+        mmaps = list(_ADDR_TO_MMAP.values())
+        _ADDR_TO_MMAP.clear()
+        _OWNED_NAMES.clear()
+    for mm in mmaps:
+        try:
+            mm.close()
+        except (BufferError, OSError):
+            pass
     for n in names:
         try:
             _posixshmem.shm_unlink(_slashed(n))

--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -32,6 +32,7 @@ and is identical on Linux.
 from __future__ import annotations
 
 # Standard
+import atexit
 import ctypes
 import mmap as _mmap
 import os
@@ -80,7 +81,10 @@ def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap,
         if create:
             os.ftruncate(fd, nbytes)
         mm = _mmap.mmap(fd, nbytes, access=_mmap.ACCESS_WRITE)
+        addr = _addr_of_mmap(mm)
     except BaseException:
+        if mm is not None:
+            mm.close()
         if create:
             try:
                 _posixshmem.shm_unlink(_slashed(name))
@@ -89,7 +93,6 @@ def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap,
         raise
     finally:
         os.close(fd)
-    addr = _addr_of_mmap(mm)
     return mm, addr
 
 
@@ -114,6 +117,16 @@ def shm_create_readwrite(name: str, nbytes: int) -> int:
     mmap`` sequence: collisions raise ``OSError`` (``FileExistsError``
     is a subclass), and a failure mid-way fully tears down what was
     allocated.
+
+    Args:
+        name: The name of the shared-memory segment.
+        nbytes: The size of the segment in bytes.
+
+    Returns:
+        The virtual address of the mapped segment.
+
+    Raises:
+        OSError: If the segment already exists or creation fails.
     """
     sm_name = _strip_leading_slash(name)
     mm, addr = _open_and_mmap(sm_name, nbytes, create=True)
@@ -128,6 +141,16 @@ def shm_map_readwrite(name: str, nbytes: int) -> int:
 
     ``nbytes`` must match the segment's actual size; ``mmap`` will
     raise on a mismatch.
+
+    Args:
+        name: The name of the shared-memory segment.
+        nbytes: The size of the segment in bytes.
+
+    Returns:
+        The virtual address of the mapped segment.
+
+    Raises:
+        OSError: If the segment cannot be opened or mapped.
     """
     sm_name = _strip_leading_slash(name)
     mm, addr = _open_and_mmap(sm_name, nbytes, create=False)
@@ -141,6 +164,11 @@ def shm_munmap(addr: int, nbytes: int) -> None:
 
     The underlying mmap is closed exactly once; subsequent calls with
     the same address are no-ops.
+
+    Args:
+        addr: The virtual address of the mapped segment.
+        nbytes: Kept for API compatibility; not used internally since
+            ``mmap.close()`` does not require the size.
     """
     if not addr:
         return
@@ -163,6 +191,9 @@ def shm_unlink(name: str) -> None:
 
     Idempotent: a missing segment is treated as a successful
     no-op so callers can blindly call this on shutdown.
+
+    Args:
+        name: The name of the shared-memory segment to unlink.
     """
     sm_name = _strip_leading_slash(name)
     with _REGISTRY_LOCK:
@@ -177,6 +208,20 @@ def shm_unlink(name: str) -> None:
         pass
 
 
+def _atexit_cleanup() -> None:
+    """Unlink any SHM segments still owned by this process at exit."""
+    with _REGISTRY_LOCK:
+        names = list(_OWNED_NAMES)
+    for n in names:
+        try:
+            _posixshmem.shm_unlink(_slashed(n))
+        except OSError:
+            pass
+
+
+atexit.register(_atexit_cleanup)
+
+
 def shm_open_pool_as_mmap(name: str, nbytes: int) -> _mmap.mmap:
     """Open an existing segment as an independent ``mmap.mmap`` object.
 
@@ -184,6 +229,16 @@ def shm_open_pool_as_mmap(name: str, nbytes: int) -> _mmap.mmap:
     segment via ``torch.frombuffer(mmap_obj, ...)`` rather than a raw
     address. The returned mmap is independent of any registry entry,
     so the caller takes ownership and is responsible for closing it.
+
+    Args:
+        name: The name of the shared-memory segment.
+        nbytes: The size of the segment in bytes.
+
+    Returns:
+        An independent ``mmap.mmap`` object backed by the segment.
+
+    Raises:
+        OSError: If the segment cannot be opened or mapped.
     """
     sm_name = _strip_leading_slash(name)
     fd = _posixshmem.shm_open(_slashed(sm_name), os.O_RDWR, mode=0o600)

--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -34,12 +34,15 @@ from __future__ import annotations
 # Standard
 import atexit
 import ctypes
+import logging
 import mmap as _mmap
 import os
 import threading
 
 # Third Party
 import _posixshmem  # type: ignore[import-not-found]
+
+logger = logging.getLogger(__name__)
 
 
 def _strip_leading_slash(name: str) -> str:
@@ -89,7 +92,11 @@ def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap,
             try:
                 _posixshmem.shm_unlink(_slashed(name))
             except OSError:
-                pass
+                logger.warning(
+                    "shm_unlink failed during cleanup of %s",
+                    name,
+                    exc_info=True,
+                )
         raise
     finally:
         os.close(fd)
@@ -180,12 +187,16 @@ def shm_munmap(addr: int, nbytes: int = 0) -> None:
         return
     try:
         mm.close()
-    except (BufferError, ValueError):
+    except (BufferError, ValueError) as exc:
         # ``BufferError`` means callers still hold an exported view
         # (e.g. a torch tensor backed by this mmap); they will release
         # the mapping themselves on GC. ``ValueError`` means already
         # closed -- treat both as best-effort no-ops.
-        pass
+        logger.warning(
+            "shm_munmap: mmap.close() skipped for addr=%#x: %s",
+            addr,
+            exc,
+        )
 
 
 def shm_unlink(name: str) -> None:
@@ -203,11 +214,15 @@ def shm_unlink(name: str) -> None:
     try:
         _posixshmem.shm_unlink(_slashed(sm_name))
     except FileNotFoundError:
-        pass
+        logger.debug("shm_unlink: segment %s already removed", sm_name)
     except OSError:
         # Mirrors the historical "best effort" contract -- e.g.
         # double-unlink on shutdown should never raise.
-        pass
+        logger.warning(
+            "shm_unlink: failed to unlink %s",
+            sm_name,
+            exc_info=True,
+        )
 
 
 def _atexit_cleanup() -> None:
@@ -220,13 +235,13 @@ def _atexit_cleanup() -> None:
     for mm in mmaps:
         try:
             mm.close()
-        except (BufferError, OSError):
-            pass
+        except (BufferError, OSError) as exc:
+            logger.warning("atexit: mmap.close() failed: %s", exc)
     for n in names:
         try:
             _posixshmem.shm_unlink(_slashed(n))
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.warning("atexit: shm_unlink(%s) failed: %s", n, exc)
 
 
 atexit.register(_atexit_cleanup)

--- a/lmcache/v1/multiprocess/posix_shm.py
+++ b/lmcache/v1/multiprocess/posix_shm.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared-memory primitives shared by SHM-based transports.
+
+Thin POSIX-SHM facade exposing the legacy
+``shm_create_readwrite`` / ``shm_map_readwrite`` / ``shm_munmap`` /
+``shm_unlink`` / ``shm_open_pool_as_mmap`` quartet, so the CPU
+KV-cache wrapper, the MP non-GPU SHM transport, and the existing
+tests keep working unchanged.
+
+We deliberately route through CPython's bundled ``_posixshmem`` C
+extension (used internally by :mod:`multiprocessing.shared_memory`)
+rather than the higher-level :class:`SharedMemory` wrapper. The
+wrapper keeps an internal ``memoryview`` over its own ``mmap``;
+when callers also export a buffer (via
+``ctypes.c_uint8.from_buffer(shm.buf)`` / ``torch.frombuffer(...)``),
+:meth:`SharedMemory.close` invoked from ``__del__`` at interpreter
+shutdown raises ``BufferError: cannot close exported pointers
+exist``. Owning the ``mmap`` ourselves and pairing every alloc with
+an explicit ``shm_munmap`` keeps shutdown silent on macOS and Linux
+alike.
+
+The previous hand-rolled libc/librt implementation tripped over
+macOS' shm_open MAC label propagation when certain native
+extensions (torch + a few others) were already loaded in the
+parent process, producing spurious ``errno=13 / EACCES`` failures
+on the child side. Routing through ``_posixshmem.shm_open`` -- the
+same underlying entry point CPython's stdlib uses -- fixes that
+and is identical on Linux.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import ctypes
+import mmap as _mmap
+import os
+import threading
+
+# Third Party
+import _posixshmem  # type: ignore[import-not-found]
+
+
+def _strip_leading_slash(name: str) -> str:
+    """Normalise a name to the bare form (no leading ``/``).
+
+    Callers historically embed the POSIX leading slash; we keep the
+    on-wire name slash-prefixed but feed the bare form to
+    ``_posixshmem.shm_open``-derived helpers that prepend it again.
+    """
+    return name[1:] if name.startswith("/") else name
+
+
+def _slashed(name: str) -> str:
+    """Inverse of :func:`_strip_leading_slash` for shm_open calls."""
+    return name if name.startswith("/") else "/" + name
+
+
+# Per-process registry mapping the public ``int`` address back to the
+# ``mmap`` object that owns the mapping, so a later ``shm_munmap`` can
+# call ``mmap.close()`` exactly once and avoid leaking pages. Owners
+# (creators) also remember the name so ``shm_unlink`` can find it
+# without a re-open round-trip.
+_REGISTRY_LOCK = threading.Lock()
+_ADDR_TO_MMAP: dict[int, _mmap.mmap] = {}
+_OWNED_NAMES: set[str] = set()
+
+
+def _open_and_mmap(name: str, nbytes: int, *, create: bool) -> tuple[_mmap.mmap, int]:
+    """Open (or create) a POSIX SHM segment and ``mmap`` it.
+
+    Returns a ``(mmap_obj, base_addr)`` pair. The fd is always closed
+    before returning so we don't leak descriptors; the kernel keeps
+    the mapping alive as long as ``mmap_obj`` stays alive.
+    """
+    flags = os.O_RDWR | (os.O_CREAT | os.O_EXCL if create else 0)
+    fd = _posixshmem.shm_open(_slashed(name), flags, mode=0o600)
+    mm: _mmap.mmap | None = None
+    try:
+        if create:
+            os.ftruncate(fd, nbytes)
+        mm = _mmap.mmap(fd, nbytes, access=_mmap.ACCESS_WRITE)
+    except BaseException:
+        if create:
+            try:
+                _posixshmem.shm_unlink(_slashed(name))
+            except OSError:
+                pass
+        raise
+    finally:
+        os.close(fd)
+    addr = _addr_of_mmap(mm)
+    return mm, addr
+
+
+def _addr_of_mmap(mm: _mmap.mmap) -> int:
+    """Return the base address of an ``mmap`` without leaking a buffer view.
+
+    A ctypes buffer view is created just long enough to read the
+    address, then dropped before this function returns; once it is
+    out of scope the mmap has no exported pointers, so a later
+    ``mm.close()`` can complete cleanly.
+    """
+    view = (ctypes.c_uint8 * len(mm)).from_buffer(mm)
+    addr = ctypes.addressof(view)
+    del view
+    return addr
+
+
+def shm_create_readwrite(name: str, nbytes: int) -> int:
+    """Create a new shared-memory segment and return its mmap address.
+
+    Mirrors the previous ``shm_open(O_CREAT|O_EXCL) + ftruncate +
+    mmap`` sequence: collisions raise ``OSError`` (``FileExistsError``
+    is a subclass), and a failure mid-way fully tears down what was
+    allocated.
+    """
+    sm_name = _strip_leading_slash(name)
+    mm, addr = _open_and_mmap(sm_name, nbytes, create=True)
+    with _REGISTRY_LOCK:
+        _ADDR_TO_MMAP[addr] = mm
+        _OWNED_NAMES.add(sm_name)
+    return addr
+
+
+def shm_map_readwrite(name: str, nbytes: int) -> int:
+    """Open an existing shared-memory segment and return its address.
+
+    ``nbytes`` must match the segment's actual size; ``mmap`` will
+    raise on a mismatch.
+    """
+    sm_name = _strip_leading_slash(name)
+    mm, addr = _open_and_mmap(sm_name, nbytes, create=False)
+    with _REGISTRY_LOCK:
+        _ADDR_TO_MMAP[addr] = mm
+    return addr
+
+
+def shm_munmap(addr: int, nbytes: int) -> None:
+    """Best-effort release of a previously mapped segment by address.
+
+    The underlying mmap is closed exactly once; subsequent calls with
+    the same address are no-ops.
+    """
+    if not addr:
+        return
+    with _REGISTRY_LOCK:
+        mm = _ADDR_TO_MMAP.pop(addr, None)
+    if mm is None:
+        return
+    try:
+        mm.close()
+    except (BufferError, ValueError):
+        # ``BufferError`` means callers still hold an exported view
+        # (e.g. a torch tensor backed by this mmap); they will release
+        # the mapping themselves on GC. ``ValueError`` means already
+        # closed -- treat both as best-effort no-ops.
+        pass
+
+
+def shm_unlink(name: str) -> None:
+    """Best-effort segment removal.
+
+    Idempotent: a missing segment is treated as a successful
+    no-op so callers can blindly call this on shutdown.
+    """
+    sm_name = _strip_leading_slash(name)
+    with _REGISTRY_LOCK:
+        _OWNED_NAMES.discard(sm_name)
+    try:
+        _posixshmem.shm_unlink(_slashed(sm_name))
+    except FileNotFoundError:
+        pass
+    except OSError:
+        # Mirrors the historical "best effort" contract -- e.g.
+        # double-unlink on shutdown should never raise.
+        pass
+
+
+def shm_open_pool_as_mmap(name: str, nbytes: int) -> _mmap.mmap:
+    """Open an existing segment as an independent ``mmap.mmap`` object.
+
+    Convenience helper for non-GPU SHM transports that consume the
+    segment via ``torch.frombuffer(mmap_obj, ...)`` rather than a raw
+    address. The returned mmap is independent of any registry entry,
+    so the caller takes ownership and is responsible for closing it.
+    """
+    sm_name = _strip_leading_slash(name)
+    fd = _posixshmem.shm_open(_slashed(sm_name), os.O_RDWR, mode=0o600)
+    try:
+        return _mmap.mmap(fd, nbytes, access=_mmap.ACCESS_WRITE)
+    finally:
+        os.close(fd)

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -1,7 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 """CPU-specific platform primitives.
 
-This package will register a CPU KV-cache wrapper factory with
-:mod:`lmcache.v1.platform._registry` once the POSIX-SHM backend
-is available.
+Importing this package self-registers the POSIX-SHM KV-cache wrapper
+factory with :mod:`lmcache.v1.platform._registry`, so the dispatch
+in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
+pick the right wrapper based on ``tensor.device.type`` without any
+if/elif chain.
 """
+
+# First Party
+from lmcache.v1.platform._registry import register_kv_wrapper
+
+
+def _kv_wrapper_factory(tensor):
+    """Indirect-dispatch wrapper.
+
+    Defers loading :mod:`lmcache.v1.platform.cpu.shm` (which pulls in
+    ``multiprocess.custom_types``) until first use, so importing this
+    package during ``lmcache/__init__.py``'s bootstrap does not race
+    other imports that touch ``torch_dev``.
+    """
+    # First Party
+    from lmcache.v1.platform.cpu.shm import migrate_to_shm_and_wrap
+
+    return migrate_to_shm_and_wrap(tensor)
+
+
+register_kv_wrapper("cpu", _kv_wrapper_factory)

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -8,11 +8,17 @@ pick the right wrapper based on ``tensor.device.type`` without any
 if/elif chain.
 """
 
+# Standard
+from typing import Any
+
+# Third Party
+import torch
+
 # First Party
 from lmcache.v1.platform._registry import register_kv_wrapper
 
 
-def _kv_wrapper_factory(tensor):
+def _kv_wrapper_factory(tensor: torch.Tensor) -> Any:
     """Indirect-dispatch wrapper.
 
     Defers loading :mod:`lmcache.v1.platform.cpu.shm` (which pulls in

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only KV-cache IPC wrapper backed by POSIX shared memory.
+
+Mirrors the GPU-mode CUDA-IPC zero-copy semantics for hosts without an
+accelerator: client and LMCache mp server map the **same** physical
+pages so transfers are pointer-shuffles rather than memcpys.
+
+Self-registers a ``"cpu"`` factory with
+:mod:`lmcache.v1.platform._registry` at import time, so the
+multiprocess adapter can dispatch by ``tensor.device.type`` without
+any if/elif chain.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import ctypes
+import itertools
+import os
+import threading
+import weakref
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
+from lmcache.v1.multiprocess.posix_shm import (
+    shm_create_readwrite,
+    shm_map_readwrite,
+    shm_munmap,
+    shm_unlink,
+)
+
+logger = init_logger(__name__)
+
+# Re-export POSIX-SHM primitives so existing callers keep working.
+# The canonical home is :mod:`lmcache.v1.multiprocess.posix_shm`; new
+# code (e.g. the MP non-GPU SHM transport) should import from there.
+__all__ = [
+    "CpuShmTensorWrapper",
+    "inject_stale_cache_entry_for_test",
+    "migrate_to_shm_and_wrap",
+    "shm_create_readwrite",
+    "shm_map_readwrite",
+    "shm_munmap",
+    "shm_unlink",
+]
+
+# ---------------------------------------------------------------------------
+# Wrapper class                                                             #
+# ---------------------------------------------------------------------------
+
+
+class CpuShmTensorWrapper(CudaIPCWrapper):
+    """IPC wrapper for CPU tensors backed by POSIX shared memory.
+
+    Used by the ``lmcache bench kvcache --mode cpu`` path and the
+    vLLM CPU integration so that the client and the LMCache mp server
+    map the **same** physical pages for the KV cache, mirroring the
+    GPU-mode CUDA-IPC zero-copy semantics.
+
+    Subclassing :class:`CudaIPCWrapper` is load-bearing for the same
+    reason :class:`RawCudaIPCWrapper` does it: msgspec does not
+    support unions of custom ext-encoded types, so all wire-level
+    KV-cache wrappers must share the single ext code (1) registered
+    for ``CudaIPCWrapper``. Pickle preserves the subclass identity
+    so ``to_tensor`` dispatches correctly on both sides.
+    """
+
+    # POSIX shared-memory name (``/lmcache_...``) -- leading ``/`` is
+    # required by ``shm_open(3)`` on both Linux and macOS.
+    SHM_NAME_PREFIX = "/lmcache_kv_"
+
+    def __init__(self, tensor: torch.Tensor, shm_name: str) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import (
+            attempt_permute_to_contiguous_view,
+        )
+
+        tensor = attempt_permute_to_contiguous_view(tensor)
+        if tensor.device.type != "cpu":
+            raise ValueError(
+                "CpuShmTensorWrapper requires a CPU tensor, got %s" % tensor.device
+            )
+        if not tensor.is_contiguous():
+            raise ValueError("CpuShmTensorWrapper requires a contiguous tensor")
+
+        self.shm_name = shm_name
+        # ``numel * element_size`` is the correct logical byte size; the
+        # underlying storage may be larger when the tensor is a view.
+        self.nbytes = tensor.numel() * tensor.element_size()
+
+        # CudaIPCWrapper interface fields. ``handle`` / ``device_uuid``
+        # are unused on the CPU path but kept to satisfy the parent
+        # contract used by equality checks.
+        self.handle = None
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+        self.device_uuid = "cpu"
+
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the tensor by mapping the same SHM segment.
+
+        The returned tensor owns the mmap: a ``weakref.finalize`` hook
+        runs ``munmap`` once the tensor (and any views derived from it)
+        is garbage-collected, so the per-process virtual address space
+        does not leak across repeated ``to_tensor`` calls.
+
+        We rebuild the view through ``as_strided`` so the original
+        memory layout (stride / storage_offset / memory_format) is
+        replayed faithfully on the receiving side; reshape would
+        silently re-coalesce strides and lose, e.g., channels_last.
+        """
+        # Empty tensors carry no SHM segment (mmap with length 0 is
+        # undefined / EINVAL on POSIX); rebuild the empty view in-process.
+        if self.nbytes == 0:
+            return torch.empty(self.shape, dtype=self.dtype)
+        addr = shm_map_readwrite(self.shm_name, self.nbytes)
+        # ``torch.frombuffer`` requires a writable buffer; build one
+        # via ctypes so the resulting torch tensor shares storage
+        # with the SHM mapping (zero copy across processes).
+        buf_type = ctypes.c_uint8 * self.nbytes
+        buf = buf_type.from_address(addr)
+        flat = torch.frombuffer(buf, dtype=torch.uint8)
+        typed = flat.view(self.dtype)
+        out = torch.as_strided(typed, self.shape, self.stride, self.storage_offset)
+        # Keep ``flat`` alive for the lifetime of ``out`` so its mmap
+        # is not released while still in use, then munmap on cleanup.
+        out._lmcache_shm_buf = flat  # type: ignore[attr-defined]
+        weakref.finalize(out, shm_munmap, addr, self.nbytes)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Migrate-and-wrap factory (used by the multiprocess adapter)              #
+# ---------------------------------------------------------------------------
+
+# Per-process registry of SHM segments we have created, so the same
+# tensor object is only migrated to SHM once even if the factory is
+# called multiple times.
+#
+# Keyed by ``id(tensor)`` for cheap O(1) lookup, but each entry also
+# holds a ``weakref.ref`` to the original tensor and we *verify the
+# referent is still that exact object* before reusing the cached SHM
+# name. CPython recycles object IDs, so a fresh tensor allocated at
+# the same address as a previously migrated (now garbage-collected)
+# one would otherwise inherit a stale name -- and because
+# :func:`shm_create_readwrite` uses ``O_EXCL``, the next migration
+# would crash with ``EEXIST`` ("File exists"). The weakref-validated
+# lookup below makes that race impossible: a stale entry can only
+# point at a dead referent, which we treat as a miss.
+_CPU_SHM_NAMES: dict[int, tuple["weakref.ReferenceType[torch.Tensor]", str]] = {}
+_CPU_SHM_LOCK = threading.Lock()
+_CPU_SHM_COUNTER = itertools.count()
+
+
+def _cleanup_shm_segment(tid: int, shm_name: str, addr: int, nbytes: int) -> None:
+    """Release the mmap, unlink, and forget the cached SHM name."""
+    with _CPU_SHM_LOCK:
+        # Only drop the entry if it still points at *this* segment;
+        # a future tensor reusing ``tid`` may already have replaced it.
+        cached = _CPU_SHM_NAMES.get(tid)
+        if cached is not None and cached[1] == shm_name:
+            _CPU_SHM_NAMES.pop(tid, None)
+    shm_munmap(addr, nbytes)
+    shm_unlink(shm_name)
+
+
+def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
+    """Re-point ``tensor``'s storage at a POSIX SHM segment, then wrap.
+
+    Used as the registered ``"cpu"`` KV-wrapper factory: the LMCache mp
+    server can mmap the same physical pages on the receiving side.
+    Idempotent per tensor identity (validated via a stored weakref so
+    Python's id-recycling cannot produce a stale-name hit). The SHM
+    segment is released (``munmap`` + ``shm_unlink``) automatically
+    when the migrated tensor is garbage-collected.
+    """
+    tid = id(tensor)
+    with _CPU_SHM_LOCK:
+        cached = _CPU_SHM_NAMES.get(tid)
+        if cached is not None:
+            ref, cached_name = cached
+            if ref() is tensor:
+                return CpuShmTensorWrapper(tensor, cached_name)
+            # Stale entry from a GC'd tensor whose id has been
+            # reused; drop it and fall through to allocate fresh.
+        _CPU_SHM_NAMES.pop(tid, None)
+
+        nbytes = tensor.numel() * tensor.element_size()
+        if nbytes == 0:
+            # No SHM segment for empty tensors: ``mmap`` with length 0
+            # is undefined / EINVAL on POSIX. ``to_tensor`` rebuilds an
+            # empty view directly when ``shm_name`` is empty.
+            return CpuShmTensorWrapper(tensor, "")
+        shm_name = "%s%d_%d" % (
+            CpuShmTensorWrapper.SHM_NAME_PREFIX,
+            os.getpid(),
+            next(_CPU_SHM_COUNTER),
+        )
+        addr = shm_create_readwrite(shm_name, nbytes)
+        try:
+            buf_type = ctypes.c_uint8 * nbytes
+            buf = buf_type.from_address(addr)
+            shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
+            tensor.set_(
+                shm_storage,
+                tensor.storage_offset(),
+                tensor.shape,
+                tensor.stride(),
+            )
+        except Exception:
+            # Make sure the SHM resources don't leak if migration fails
+            # part-way (e.g. ``set_`` rejects an unusual stride).
+            shm_munmap(addr, nbytes)
+            shm_unlink(shm_name)
+            raise
+
+        _CPU_SHM_NAMES[tid] = (weakref.ref(tensor), shm_name)
+        weakref.finalize(tensor, _cleanup_shm_segment, tid, shm_name, addr, nbytes)
+        logger.info(
+            "Migrated CPU KV cache tensor (nbytes=%d) to SHM %s",
+            nbytes,
+            shm_name,
+        )
+
+    return CpuShmTensorWrapper(tensor, shm_name)
+
+
+def inject_stale_cache_entry_for_test(
+    tensor: torch.Tensor,
+    dead_ref: "weakref.ReferenceType[torch.Tensor]",
+    stale_shm_name: str,
+) -> None:
+    """Test-only hook: pre-seed the registry with a stale entry.
+
+    Lets unit tests reproduce the CPython id-reuse race -- where a
+    fresh tensor lands on the same id as a previously migrated and
+    garbage-collected one -- without the per-test global-state
+    surgery that would otherwise have to reach into the module's
+    private dict / lock.
+    """
+    with _CPU_SHM_LOCK:
+        _CPU_SHM_NAMES[id(tensor)] = (dead_ref, stale_shm_name)

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -181,7 +181,25 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
     segment is released (``munmap`` + ``shm_unlink``) automatically
     when the migrated tensor is garbage-collected.
     """
+    # Validate and normalise the tensor *before* touching the registry
+    # or mutating storage, so a bad input never leaves things half-done.
+    # First Party
+    from lmcache.v1.gpu_connector.utils import (
+        attempt_permute_to_contiguous_view,
+    )
+
+    tensor = attempt_permute_to_contiguous_view(tensor)
+    if tensor.device.type != "cpu":
+        raise ValueError(
+            "migrate_to_shm_and_wrap requires a CPU tensor, got %s" % tensor.device
+        )
+    if not tensor.is_contiguous():
+        raise ValueError("migrate_to_shm_and_wrap requires a contiguous tensor")
+
     tid = id(tensor)
+
+    # Fast path: check the registry under the lock, return early if the
+    # tensor has already been migrated.
     with _CPU_SHM_LOCK:
         cached = _CPU_SHM_NAMES.get(tid)
         if cached is not None:
@@ -192,43 +210,46 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
             # reused; drop it and fall through to allocate fresh.
         _CPU_SHM_NAMES.pop(tid, None)
 
-        nbytes = tensor.numel() * tensor.element_size()
-        if nbytes == 0:
-            # No SHM segment for empty tensors: ``mmap`` with length 0
-            # is undefined / EINVAL on POSIX. ``to_tensor`` rebuilds an
-            # empty view directly when ``shm_name`` is empty.
-            return CpuShmTensorWrapper(tensor, "")
-        shm_name = "%s%d_%d" % (
-            CpuShmTensorWrapper.SHM_NAME_PREFIX,
-            os.getpid(),
-            next(_CPU_SHM_COUNTER),
-        )
-        addr = shm_create_readwrite(shm_name, nbytes)
-        try:
-            buf_type = ctypes.c_uint8 * nbytes
-            buf = buf_type.from_address(addr)
-            shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
-            tensor.set_(
-                shm_storage,
-                tensor.storage_offset(),
-                tensor.shape,
-                tensor.stride(),
-            )
-        except Exception:
-            # Make sure the SHM resources don't leak if migration fails
-            # part-way (e.g. ``set_`` rejects an unusual stride).
-            shm_munmap(addr, nbytes)
-            shm_unlink(shm_name)
-            raise
+    nbytes = tensor.numel() * tensor.element_size()
+    if nbytes == 0:
+        # No SHM segment for empty tensors: ``mmap`` with length 0
+        # is undefined / EINVAL on POSIX. ``to_tensor`` rebuilds an
+        # empty view directly when ``shm_name`` is empty.
+        return CpuShmTensorWrapper(tensor, "")
 
+    shm_name = "%s%d_%d" % (
+        CpuShmTensorWrapper.SHM_NAME_PREFIX,
+        os.getpid(),
+        next(_CPU_SHM_COUNTER),
+    )
+    # Perform the heavy work (syscall + tensor mutation) outside the lock
+    # to keep the critical section small.
+    addr = shm_create_readwrite(shm_name, nbytes)
+    try:
+        buf_type = ctypes.c_uint8 * nbytes
+        buf = buf_type.from_address(addr)
+        shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
+        tensor.set_(
+            shm_storage,
+            tensor.storage_offset(),
+            tensor.shape,
+            tensor.stride(),
+        )
+    except Exception:
+        # Make sure the SHM resources don't leak if migration fails
+        # part-way (e.g. ``set_`` rejects an unusual stride).
+        shm_munmap(addr, nbytes)
+        shm_unlink(shm_name)
+        raise
+
+    with _CPU_SHM_LOCK:
         _CPU_SHM_NAMES[tid] = (weakref.ref(tensor), shm_name)
-        weakref.finalize(tensor, _cleanup_shm_segment, tid, shm_name, addr, nbytes)
-        logger.info(
-            "Migrated CPU KV cache tensor (nbytes=%d) to SHM %s",
-            nbytes,
-            shm_name,
-        )
-
+    weakref.finalize(tensor, _cleanup_shm_segment, tid, shm_name, addr, nbytes)
+    logger.info(
+        "Migrated CPU KV cache tensor (nbytes=%d) to SHM %s",
+        nbytes,
+        shm_name,
+    )
     return CpuShmTensorWrapper(tensor, shm_name)
 
 

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -75,12 +75,6 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
     SHM_NAME_PREFIX = "/lmcache_kv_"
 
     def __init__(self, tensor: torch.Tensor, shm_name: str) -> None:
-        # First Party
-        from lmcache.v1.gpu_connector.utils import (
-            attempt_permute_to_contiguous_view,
-        )
-
-        tensor = attempt_permute_to_contiguous_view(tensor)
         if tensor.device.type != "cpu":
             raise ValueError(
                 "CpuShmTensorWrapper requires a CPU tensor, got %s" % tensor.device
@@ -181,13 +175,11 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
     segment is released (``munmap`` + ``shm_unlink``) automatically
     when the migrated tensor is garbage-collected.
     """
+    # First Party
+    from lmcache.v1.gpu_connector.utils import attempt_permute_to_contiguous_view
+
     # Validate and normalise the tensor *before* touching the registry
     # or mutating storage, so a bad input never leaves things half-done.
-    # First Party
-    from lmcache.v1.gpu_connector.utils import (
-        attempt_permute_to_contiguous_view,
-    )
-
     tensor = attempt_permute_to_contiguous_view(tensor)
     if tensor.device.type != "cpu":
         raise ValueError(

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -203,6 +203,11 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
         _CPU_SHM_NAMES.pop(tid, None)
 
     nbytes = tensor.numel() * tensor.element_size()
+    assert tensor.storage_offset() == 0, (
+        "migrate_to_shm_and_wrap: SHM segment is sized to "
+        "numel*elem_size; a nonzero storage_offset would cause "
+        "OOB access. Got offset=%d" % tensor.storage_offset()
+    )
     if nbytes == 0:
         # No SHM segment for empty tensors: ``mmap`` with length 0
         # is undefined / EINVAL on POSIX. ``to_tensor`` rebuilds an

--- a/tests/v1/multiprocess/test_posix_shm.py
+++ b/tests/v1/multiprocess/test_posix_shm.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache.v1.multiprocess.posix_shm``.
+
+Validates the POSIX-SHM primitives and the ``mmap``-based pool helper
+shared by SHM-based transports.
+"""
+
+# Standard
+import os
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.posix_shm import (
+    shm_create_readwrite,
+    shm_map_readwrite,
+    shm_munmap,
+    shm_open_pool_as_mmap,
+    shm_unlink,
+)
+
+
+def _unique_name(tag: str) -> str:
+    # macOS shm_open caps names at 31 bytes incl. leading '/'.
+    return "/lmc_pshm_%s_%d" % (tag, os.getpid())
+
+
+def test_create_map_munmap_unlink_roundtrip():
+    name = _unique_name("rt")
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        assert addr not in (0, None)
+        # Map again from a fresh address: same segment, different vaddr.
+        addr2 = shm_map_readwrite(name, 4096)
+        try:
+            assert addr2 not in (0, None)
+        finally:
+            shm_munmap(addr2, 4096)
+    finally:
+        shm_munmap(addr, 4096)
+        shm_unlink(name)
+
+
+def test_create_excl_collision():
+    name = _unique_name("excl")
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        with pytest.raises(OSError):
+            shm_create_readwrite(name, 4096)
+    finally:
+        shm_munmap(addr, 4096)
+        shm_unlink(name)
+
+
+def test_open_pool_as_mmap_zero_copy_view():
+    name = _unique_name("pool")
+    nbytes = 4096
+    addr = shm_create_readwrite(name, nbytes)
+    try:
+        mm = shm_open_pool_as_mmap(name, nbytes)
+        try:
+            mm[0:4] = b"\x01\x02\x03\x04"
+            mm2 = shm_open_pool_as_mmap(name, nbytes)
+            try:
+                assert bytes(mm2[0:4]) == b"\x01\x02\x03\x04"
+            finally:
+                mm2.close()
+        finally:
+            mm.close()
+    finally:
+        shm_munmap(addr, nbytes)
+        shm_unlink(name)
+
+
+def test_munmap_no_op_on_zero_addr():
+    # Should not crash; best-effort no-op.
+    shm_munmap(0, 4096)

--- a/tests/v1/platform/__init__.py
+++ b/tests/v1/platform/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache.v1.platform.cpu.shm``.
+
+Validates that the POSIX-SHM-backed wrapper can round-trip a CPU
+tensor in-process: the constructed wrapper's ``to_tensor()`` view
+sees writes made through the original tensor.
+"""
+
+# Standard
+import os
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.platform.cpu.shm import (
+    CpuShmTensorWrapper,
+    migrate_to_shm_and_wrap,
+    shm_create_readwrite,
+    shm_unlink,
+)
+
+
+def test_shm_create_unlink_roundtrip(tmp_path):
+    """``shm_create_readwrite`` succeeds and ``shm_unlink`` cleans up."""
+    name = "/lmcache_test_%d" % os.getpid()
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        assert addr not in (0, None)
+    finally:
+        shm_unlink(name)
+
+
+def test_migrate_to_shm_and_wrap_zero_copy_view():
+    """After migrate, writes via the original tensor are visible via wrapper."""
+    src = torch.zeros((2, 4, 4), dtype=torch.float32)
+    wrapper = migrate_to_shm_and_wrap(src)
+    try:
+        assert isinstance(wrapper, CpuShmTensorWrapper)
+        assert wrapper.shape == (2, 4, 4)
+        assert wrapper.dtype == torch.float32
+        # Mutate via the migrated source tensor; its storage is now the
+        # SHM segment, so the wrapper's reconstructed view must see it.
+        src.add_(7.0)
+        view = wrapper.to_tensor()
+        assert torch.equal(view, src)
+    finally:
+        shm_unlink(wrapper.shm_name)
+
+
+def test_migrate_handles_empty_tensor():
+    """Empty tensors must not call ``mmap`` (length 0 is EINVAL).
+
+    Regression for the case where ``nbytes == 0``: the wrapper carries
+    an empty ``shm_name`` and ``to_tensor`` rebuilds the empty view in
+    process without touching POSIX shared memory.
+    """
+    src = torch.empty((0, 4), dtype=torch.float32)
+    wrapper = migrate_to_shm_and_wrap(src)
+    assert isinstance(wrapper, CpuShmTensorWrapper)
+    assert wrapper.shm_name == ""
+    assert wrapper.nbytes == 0
+    view = wrapper.to_tensor()
+    assert view.shape == (0, 4)
+    assert view.dtype == torch.float32
+
+
+def test_migrate_is_idempotent_on_same_tensor():
+    """Re-wrapping the same tensor reuses the existing SHM segment."""
+    src = torch.zeros((3, 5), dtype=torch.float32)
+    w1 = migrate_to_shm_and_wrap(src)
+    try:
+        w2 = migrate_to_shm_and_wrap(src)
+        assert w1.shm_name == w2.shm_name
+    finally:
+        shm_unlink(w1.shm_name)
+
+
+def test_rejects_non_cpu_tensor():
+    """Construction rejects tensors that are not on CPU."""
+    if not torch.backends.mps.is_available():
+        pytest.skip("MPS not available; cannot synthesize a non-cpu tensor")
+    src = torch.zeros((2, 2), device="mps")
+    with pytest.raises(ValueError, match="CPU tensor"):
+        CpuShmTensorWrapper(src, "/lmcache_test_should_not_exist")
+
+
+def test_migrate_finalizer_unlinks_on_gc():
+    """Once the migrated tensor is GC-ed, its SHM segment is unlinked."""
+    # Standard
+    import gc
+
+    # First Party
+    from lmcache.v1.platform.cpu.shm import shm_map_readwrite
+
+    src = torch.zeros((2, 2), dtype=torch.float32)
+    w = migrate_to_shm_and_wrap(src)
+    name = w.shm_name
+    nbytes = w.nbytes
+    # Drop both references; the weakref.finalize hook should unlink.
+    del src, w
+    gc.collect()
+    with pytest.raises(OSError):
+        shm_map_readwrite(name, nbytes)
+
+
+def test_shm_create_cleans_up_on_existing_name():
+    """If ``shm_open(O_EXCL)`` fails the helper must not leave the fd open.
+
+    We exercise the failure path by creating a segment, then asking
+    ``shm_create_readwrite`` to recreate the same name -- it must
+    raise without leaking the file descriptor it briefly held.
+    """
+    name = "/lmcache_test_excl_%d" % os.getpid()
+    addr = shm_create_readwrite(name, 4096)
+    try:
+        with pytest.raises(OSError):
+            shm_create_readwrite(name, 4096)
+    finally:
+        shm_unlink(name)
+    # And after unlink, the name is reusable again.
+    addr2 = shm_create_readwrite(name, 4096)
+    assert addr2 not in (0, None)
+    shm_unlink(name)
+    _ = addr  # silence unused-variable hint
+
+
+def test_to_tensor_view_carries_munmap_finalizer():
+    """``to_tensor`` returns a tensor that releases its mmap on GC."""
+    # Standard
+    import gc
+    import weakref
+
+    src = torch.zeros((2, 2), dtype=torch.float32)
+    w = migrate_to_shm_and_wrap(src)
+    try:
+        view = w.to_tensor()
+        # The view must keep ``flat`` alive so its mmap stays valid.
+        assert hasattr(view, "_lmcache_shm_buf")
+        ref = weakref.ref(view)
+        del view
+        gc.collect()
+        assert ref() is None
+    finally:
+        del src
+        gc.collect()
+        shm_unlink(w.shm_name)
+
+
+def test_to_tensor_replays_stride_and_storage_offset():
+    """``to_tensor`` rebuilds the view via stride+offset (not reshape)."""
+    src = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4).contiguous()
+    w = migrate_to_shm_and_wrap(src)
+    try:
+        view = w.to_tensor()
+        assert tuple(view.stride()) == w.stride
+        assert int(view.storage_offset()) == w.storage_offset
+        assert torch.equal(view, src)
+    finally:
+        del src, view
+        shm_unlink(w.shm_name)
+
+
+def test_wrap_kv_caches_unlinks_partial_batch_on_failure(monkeypatch):
+    """If wrapping the N-th tensor raises, earlier SHM names are unlinked.
+
+    Drives :func:`wrap_kv_caches` with two CPU tensors and forces the
+    second factory call to raise; the first iteration's SHM segment
+    must be ``shm_unlink``-ed so the named segment does not outlive
+    the failed batch.
+    """
+    # First Party
+    from lmcache.integration.vllm import vllm_multi_process_adapter as adapter
+    from lmcache.v1.platform.cpu.shm import shm_map_readwrite
+
+    real_wrap = adapter._wrap_one_kv_cache
+    state = {"n": 0, "first_name": None}
+
+    def flaky_wrap(tensor):
+        state["n"] += 1
+        if state["n"] == 2:
+            raise RuntimeError("simulated migration failure")
+        w = real_wrap(tensor)
+        state["first_name"] = w.shm_name
+        return w
+
+    monkeypatch.setattr(adapter, "_wrap_one_kv_cache", flaky_wrap)
+
+    t1 = torch.zeros((2, 2), dtype=torch.float32)
+    t2 = torch.zeros((2, 2), dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="simulated migration failure"):
+        adapter.wrap_kv_caches({"a": t1, "b": t2})
+
+    # The first iteration's SHM segment must no longer be openable.
+    nbytes = t1.numel() * t1.element_size()
+    with pytest.raises(OSError):
+        shm_map_readwrite(state["first_name"], nbytes)
+
+
+def test_migrate_ignores_stale_entry_from_id_reuse():
+    """A cached entry whose weakref is dead must not be reused.
+
+    Simulates CPython recycling an object id by injecting a stale
+    ``(dead_ref, old_name)`` tuple keyed by the live tensor's id,
+    then calling :func:`migrate_to_shm_and_wrap`. The factory must
+    treat the dead entry as a miss and allocate a fresh SHM segment
+    -- if it blindly reused the cached name, ``shm_create_readwrite``
+    would crash with ``EEXIST`` (and even worse, the fresh tensor
+    would be silently bound to the wrong SHM name).
+    """
+    # Standard
+    import gc
+    import weakref as _wr
+
+    # First Party
+    from lmcache.v1.platform.cpu.shm import inject_stale_cache_entry_for_test
+
+    # Build a tensor we will let die so we have a guaranteed-dead ref.
+    ghost = torch.zeros((1,), dtype=torch.float32)
+    dead_ref = _wr.ref(ghost)
+    del ghost
+    gc.collect()
+    assert dead_ref() is None
+
+    live = torch.zeros((2, 2), dtype=torch.float32)
+    stale_name = "/lmcache_test_stale_%d" % os.getpid()
+    inject_stale_cache_entry_for_test(live, dead_ref, stale_name)
+
+    w = migrate_to_shm_and_wrap(live)
+    try:
+        assert w.shm_name != stale_name
+    finally:
+        shm_unlink(w.shm_name)

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -14,15 +14,15 @@ import pytest
 import torch
 
 # First Party
+from lmcache.v1.multiprocess.posix_shm import shm_unlink
 from lmcache.v1.platform.cpu.shm import (
     CpuShmTensorWrapper,
     migrate_to_shm_and_wrap,
     shm_create_readwrite,
-    shm_unlink,
 )
 
 
-def test_shm_create_unlink_roundtrip(tmp_path):
+def test_shm_create_unlink_roundtrip():
     """``shm_create_readwrite`` succeeds and ``shm_unlink`` cleans up."""
     name = "/lmcache_test_%d" % os.getpid()
     addr = shm_create_readwrite(name, 4096)
@@ -174,7 +174,7 @@ def test_wrap_kv_caches_unlinks_partial_batch_on_failure(monkeypatch):
     from lmcache.integration.vllm import vllm_multi_process_adapter as adapter
     from lmcache.v1.platform.cpu.shm import shm_map_readwrite
 
-    real_wrap = adapter._wrap_one_kv_cache
+    real_wrap = adapter.wrap_one_kv_cache
     state = {"n": 0, "first_name": None}
 
     def flaky_wrap(tensor):
@@ -185,7 +185,7 @@ def test_wrap_kv_caches_unlinks_partial_batch_on_failure(monkeypatch):
         state["first_name"] = w.shm_name
         return w
 
-    monkeypatch.setattr(adapter, "_wrap_one_kv_cache", flaky_wrap)
+    monkeypatch.setattr(adapter, "wrap_one_kv_cache", flaky_wrap)
 
     t1 = torch.zeros((2, 2), dtype=torch.float32)
     t2 = torch.zeros((2, 2), dtype=torch.float32)


### PR DESCRIPTION
## Summary

Add the POSIX shared-memory infrastructure that underpins the CPU KV-cache IPC path.


This is extracted from #3352 as a standalone, self-contained piece.