### PR TITLE
[MP][DSV4] Replace compress_ratio with per_layer_storage_blocks_per_chunk

### DIFF
--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 # Standard
+import math
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,85 @@ if TYPE_CHECKING:
 
 # First Party
 from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+
+
+def spec_int_attr(spec: Any, attr: str) -> int:
+    """Read an integer attribute from a vLLM KV cache spec.
+
+    For ``UniformTypeKVCacheSpec``, the attribute lives on the inner ``kv_type``
+    spec; for all others it lives directly on *spec*.
+
+    Args:
+        spec: A vLLM ``KVCacheSpec`` (or ``None``).
+        attr: Attribute name to read.
+
+    Returns:
+        Integer value, or ``0`` when *spec* is ``None`` or the attribute is absent.
+    """
+    if spec is None:
+        return 0
+    inner = getattr(spec, "kv_type", None)
+    src = inner if inner is not None else spec
+    return int(getattr(src, attr, 0) or 0)
+
+
+def storage_blocks_per_chunk(
+    sliding_window: int,
+    logical_block_size: int,
+    chunk_tokens: int,
+) -> int:
+    """Blocks per LMCache chunk for a KV group.
+
+    Full-attention groups (``sliding_window == 0``) return the full chunk block
+    count. SWA groups return only the trailing blocks that fall inside the
+    window, capped at the full count.
+
+    Args:
+        sliding_window: Sliding-window size in tokens (0 = full attention).
+        logical_block_size: Inference-engine-side logical block size in tokens.
+        chunk_tokens: LMCache logical chunk size in tokens.
+
+    Returns:
+        Number of blocks per chunk to store/retrieve for this group.
+    """
+    full_bpc = chunk_tokens // logical_block_size
+    if sliding_window == 0:
+        return full_bpc
+    suffix_bpc = math.ceil(sliding_window / logical_block_size)
+    return min(suffix_bpc, full_bpc)
+
+
+def engine_group_sbpc_from_vllm(
+    kv_cache_config: Any,
+    chunk_tokens: int,
+) -> "dict[int, int]":
+    """Compute per-engine-group ``storage_blocks_per_chunk`` from vLLM config.
+
+    Reads ``block_size`` and ``sliding_window`` from each engine group's
+    ``kv_cache_spec`` and delegates to :func:`storage_blocks_per_chunk`.
+
+    Args:
+        kv_cache_config: vLLM ``KVCacheConfig`` (or ``None``).
+        chunk_tokens: LMCache logical chunk size in tokens. ``0`` or missing
+            config yields an empty mapping.
+
+    Returns:
+        Mapping from engine group id to blocks-per-chunk for that group.
+        Empty dict when *kv_cache_config* has no groups or *chunk_tokens* is 0.
+    """
+    if not chunk_tokens or kv_cache_config is None:
+        return {}
+    vllm_groups = getattr(kv_cache_config, "kv_cache_groups", ()) or ()
+    result: dict[int, int] = {}
+    for engine_group_id, group in enumerate(vllm_groups):
+        spec = getattr(group, "kv_cache_spec", None)
+        logical_bs = spec_int_attr(spec, "block_size")
+        sliding_win = spec_int_attr(spec, "sliding_window")
+        if logical_bs > 0:
+            result[engine_group_id] = storage_blocks_per_chunk(
+                sliding_win, logical_bs, chunk_tokens
+            )
+    return result
 
 
 def create_group_views_from_vllm(
@@ -30,6 +110,11 @@ def create_group_views_from_vllm(
     splits the layers by physical transfer identity using the real tensors (via
     the shared :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`).
     vLLM-specific field access is intentionally confined to this function.
+
+    For per-group geometry hints (e.g. ``storage_blocks_per_chunk``) use
+    :func:`engine_group_sbpc_from_vllm` and embed the result in
+    :class:`~lmcache.v1.gpu_connector.utils.LayoutHints` under
+    ``per_engine_group_storage_blocks_per_chunk`` before passing to the server.
 
     Args:
         kv_cache_config: vLLM ``KVCacheConfig`` describing the engine KV cache

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -38,6 +38,7 @@ import zmq
 from lmcache import torch_dev
 from lmcache.integration.vllm.kv_cache_groups import (
     create_group_views_from_vllm,
+    engine_group_sbpc_from_vllm,
 )
 from lmcache.integration.vllm.utils import mla_enabled, vllm_layout_hints
 from lmcache.utils import init_logger as lmcache_init_logger
@@ -619,10 +620,15 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         logger.info("Registering kv caches!")
         kv_cache_config = getattr(self, "_kv_cache_config", None)
+        chunk_tokens = self.worker_adapter.blocks_in_chunk * self.vllm_block_size
+        layout_hints = vllm_layout_hints()
+        sbpc = engine_group_sbpc_from_vllm(kv_cache_config, chunk_tokens)
+        if sbpc:
+            layout_hints["per_engine_group_storage_blocks_per_chunk"] = sbpc
         group_views = create_group_views_from_vllm(
             kv_cache_config,
             kv_caches,
-            layout_hints=vllm_layout_hints(),
+            layout_hints=layout_hints,
         )
         self.worker_adapter.register_kv_caches(kv_caches, group_views=group_views)
         return

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -86,6 +86,13 @@ class LayoutHints(TypedDict, total=False):
             KV layer groups compress multiple logical tokens into a
             single physical slot
             (``shape_desc.bs < inference_engine_logical_block_size``).
+        per_engine_group_storage_blocks_per_chunk: Per-engine-group
+            physical block count to transfer per LMCache chunk, keyed
+            by engine group id (0-based). When present, the server
+            uses the value directly instead of deriving it from the
+            logical chunk size and block size. Groups absent from the
+            mapping fall back to the default
+            (``lmcache_logical_chunk_size // shape_desc.bs``).
     """
 
     kv_layout: Literal["NHD", "HND"]
@@ -93,6 +100,7 @@ class LayoutHints(TypedDict, total=False):
     tokens_per_block: int
     head_dim: int
     inference_engine_logical_block_size: int
+    per_engine_group_storage_blocks_per_chunk: dict[int, int]
 
 
 def attempt_permute_to_contiguous_view(

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -140,24 +140,12 @@ class KVLayerGroupInfo:
     """Torch dtype of the KV cache tensors for this group. Used for
     kernel template instantiation; see class docstring for why we keep
     this alongside ``shape_desc.element_size``."""
-    compress_ratio: int = 1
-    """Logical-tokens-per-physical-slot for this group. ``1`` for
-    non-compressed groups (one logical token per physical slot);
-    greater than ``1`` for compressed groups where each physical slot
-    packs ``compress_ratio`` logical tokens (e.g. DeepSeek V4
-    compressor / indexer caches). Derived from
-    ``inference_engine_logical_block_size`` carried in ``layout_hints``
-    at :class:`KVLayerGroupsManager` construction time."""
-    physical_chunk_size: int = 0
-    """Number of *physical* slots in one LMCache chunk for this group
-    (= ``lmcache_logical_chunk_size // compress_ratio``). This is what
-    the block-level transfer kernel must be told, not the logical
-    ``lmcache_logical_chunk_size`` which counts vLLM tokens. ``0``
-    means the field has not been populated yet; ``GPUCacheContext``
-    fills it in after construction once ``lmcache_logical_chunk_size``
-    is known."""
     engine_group_idx: int = 0
     """Engine group index (paged-block address space). 0 for non-hybrid."""
+    storage_blocks_per_chunk: int = 0
+    """Blocks per chunk to transfer for this group (from
+    ``per_layer_storage_blocks_per_chunk`` layout hint).
+    ``storage_slots_per_chunk = storage_blocks_per_chunk * shape_desc.bs``."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -173,15 +161,19 @@ class KVLayerGroupInfo:
             f"element_size={sd.element_size}, "
             f"block_stride_elems={sd.block_stride_elems}), "
             f"dtype={self.dtype}, "
-            f"compress_ratio={self.compress_ratio}, "
-            f"physical_chunk_size={self.physical_chunk_size}, "
-            f"engine_group_idx={self.engine_group_idx})"
+            f"engine_group_idx={self.engine_group_idx}, "
+            f"storage_blocks_per_chunk={self.storage_blocks_per_chunk})"
         )
 
     @property
     def num_layers(self) -> int:
         """Number of layers in this group."""
         return len(self.layer_indices)
+
+    @property
+    def storage_slots_per_chunk(self) -> int:
+        """Physical slots transferred per chunk: ``storage_blocks_per_chunk * shape_desc.bs``."""
+        return self.storage_blocks_per_chunk * self.shape_desc.bs
 
     @property
     def hidden_dim_size(self) -> int:
@@ -239,23 +231,14 @@ class KVLayerGroupsManager:
                 ``shape_desc.nb``. Each group's ``shape_desc.bs`` is
                 discovered per-layer via :func:`get_block_size`, so
                 compressed and non-compressed groups can coexist.
-            layout_hints: Engine-provided hints. The manager only reads
-                ``inference_engine_logical_block_size`` (logical tokens
-                per inference-engine block) from it to derive each
-                group's ``compress_ratio`` and ``physical_chunk_size``.
-                ``None`` means every group is treated as non-compressed
-                (``compress_ratio == 1``).
-            group_views: LMCache-owned engine KV cache group
-                metadata. When present, it is used to keep layers from
-                different engine block-ID spaces in separate LMCache
-                transfer groups.
-            lmcache_logical_chunk_size: Logical tokens per LMCache chunk
-                (one logical token = one inference-engine token).
-                Together with ``compress_ratio`` it determines each
-                group's ``physical_chunk_size =
-                lmcache_logical_chunk_size // compress_ratio``, the
-                number of *physical* slots per chunk fed to the
-                block-level transfer kernel.
+            layout_hints: Engine-provided hints. Reads
+                ``per_layer_storage_blocks_per_chunk`` to set each group's
+                transfer block count. ``None`` defaults every group to the
+                full chunk.
+            group_views: LMCache-owned engine KV cache group metadata.
+                Keeps layers from different block-ID spaces in separate groups.
+            lmcache_logical_chunk_size: Logical tokens per LMCache chunk.
+                Used as fallback when no per-layer hint is provided.
         """
         # Import here to break a circular import via
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
@@ -287,6 +270,15 @@ class KVLayerGroupsManager:
 
         per_layer_engine_group_idx = get_engine_group_indices(group_views, num_layers)
 
+        # Build an engine_group_idx -> storage_blocks_per_chunk map from
+        # layout_hints. Non-zero values were set by the connector; zero (or
+        # absent) means "use default" (full chunk).
+        hint_sbpc: dict[int, int] = (
+            layout_hints.get("per_engine_group_storage_blocks_per_chunk") or {}
+            if layout_hints
+            else {}
+        )
+
         groups_by_identity = group_layers_by_identity(
             kv_caches, gpu_kv_format, num_layers, per_layer_engine_group_idx
         )
@@ -312,21 +304,18 @@ class KVLayerGroupsManager:
                 block_stride_elems=block_stride_elems,
             )
 
-            compress_ratio, physical_chunk_size = self._derive_compression_metadata(
-                group_idx=group_idx,
-                bs=bs,
-                ie_logical_block_size=self.inference_engine_logical_block_size_,
-                lmcache_logical_chunk_size=lmcache_logical_chunk_size,
-            )
+            # storage_bpc: prefer hint keyed by engine group; fall back to full chunk.
+            full_bpc = lmcache_logical_chunk_size // bs
+            hinted = hint_sbpc.get(engine_group_idx, 0)
+            storage_bpc = min(hinted, full_bpc) if hinted > 0 else full_bpc
 
             self.kv_layer_groups.append(
                 KVLayerGroupInfo(
                     layer_indices=indices,
                     shape_desc=shape_desc,
                     dtype=dt,
-                    compress_ratio=compress_ratio,
-                    physical_chunk_size=physical_chunk_size,
                     engine_group_idx=engine_group_idx,
+                    storage_blocks_per_chunk=storage_bpc,
                 )
             )
 
@@ -336,53 +325,6 @@ class KVLayerGroupsManager:
         )
 
         logger.info("KV layer groups: %s", self.kv_layer_groups)
-
-    @staticmethod
-    def _derive_compression_metadata(
-        group_idx: int,
-        bs: int,
-        ie_logical_block_size: "int | None",
-        lmcache_logical_chunk_size: int,
-    ) -> tuple[int, int]:
-        """Resolve ``(compress_ratio, physical_chunk_size)`` for one group.
-
-        ``compress_ratio`` falls back to ``1`` when
-        ``ie_logical_block_size`` is absent (no compression info
-        available); otherwise it equals
-        ``ie_logical_block_size // bs`` and the divisibility invariants
-        are enforced loudly. ``physical_chunk_size`` is then
-        ``lmcache_logical_chunk_size // compress_ratio``, the per-chunk
-        physical slot count fed to the block-level transfer kernel.
-        """
-        if ie_logical_block_size is None:
-            compress_ratio = 1
-        else:
-            if ie_logical_block_size % bs != 0:
-                raise ValueError(
-                    f"inference engine logical block size "
-                    f"{ie_logical_block_size} must be a multiple of "
-                    f"group {group_idx} physical slot count {bs}"
-                )
-            compress_ratio = ie_logical_block_size // bs
-        if lmcache_logical_chunk_size % compress_ratio != 0:
-            raise ValueError(
-                f"lmcache_logical_chunk_size {lmcache_logical_chunk_size} "
-                f"must be a multiple of compress_ratio {compress_ratio} "
-                f"(group {group_idx})"
-            )
-        physical_chunk_size = lmcache_logical_chunk_size // compress_ratio
-        if compress_ratio != 1:
-            logger.info(
-                "group %d: compressed "
-                "(inference_engine_logical_block_size=%d -> "
-                "slots=%d, compress_ratio=%d, physical_chunk_size=%d)",
-                group_idx,
-                ie_logical_block_size,
-                bs,
-                compress_ratio,
-                physical_chunk_size,
-            )
-        return compress_ratio, physical_chunk_size
 
     @property
     def num_groups(self) -> int:
@@ -418,25 +360,6 @@ class KVLayerGroupsManager:
             IndexError: If *group_idx* is out of range.
         """
         return self.kv_layer_groups[group_idx].shape_desc
-
-    def get_physical_chunk_size(self, group_idx: int) -> int:
-        """Return the per-chunk *physical* slot count for *group_idx*.
-
-        Equivalent to
-        ``self.kv_layer_groups[group_idx].physical_chunk_size``.
-        For non-compressed groups this equals
-        ``lmcache_logical_chunk_size``; for compressed groups it equals
-        ``lmcache_logical_chunk_size // compress_ratio`` and is what the
-        block-level transfer kernel must be told (the logical chunk size
-        in *vLLM tokens* is not what the kernel addresses).
-
-        Args:
-            group_idx: 0-based group index.
-
-        Raises:
-            IndexError: If *group_idx* is out of range.
-        """
-        return self.kv_layer_groups[group_idx].physical_chunk_size
 
 
 # ------------------------------------------------------------------ #

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -132,10 +132,7 @@ class GPUCacheContext:
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            # ``get_kv_buffer_shape`` takes *logical* tokens; for
-            # compressed groups it folds ``compress_ratio`` logical
-            # tokens into one physical slot internally.
-            shape = self.get_kv_buffer_shape(lmcache_logical_chunk_size, group_idx)
+            shape = self.get_storage_kv_buffer_shape(group_idx)
             byte_size = shape.numel() * group.dtype.itemsize
             self.tmp_chunk_group_offsets_.append(
                 self.tmp_chunk_group_offsets_[-1] + byte_size
@@ -217,17 +214,6 @@ class GPUCacheContext:
         ]
 
     @property
-    def group_compress_ratios(self) -> list[int]:
-        """Per-group compression ratio
-        (= ``inference_engine_logical_block_size // shape_desc.bs``)
-        in group order. ``1`` for non-compressed groups.
-        """
-        return [
-            group.compress_ratio
-            for group in self.kv_layer_groups_manager_.kv_layer_groups
-        ]
-
-    @property
     def num_layers(self) -> int:
         """
         Returns the number of layers in the model
@@ -260,14 +246,22 @@ class GPUCacheContext:
         """Returns the PageBufferShapeDesc for the given KV layer group."""
         return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
 
-    def get_physical_chunk_size(self, group_idx: int) -> int:
-        """Returns the per-chunk physical slot count for the given group.
+    def get_storage_kv_buffer_shape(self, group_idx: int = 0) -> torch.Size:
+        """Shape of one chunk's transfer buffer for *group_idx*.
 
-        Equal to ``lmcache_logical_chunk_size // compress_ratio``; for
-        non-compressed groups this is just ``lmcache_logical_chunk_size``.
-        This is the value the block-level transfer kernel must be told.
+        Uses ``storage_slots_per_chunk`` directly; no ``compress_ratio`` needed.
+
+        Args:
+            group_idx: Index of the KV layer group (default 0).
+
+        Returns:
+            ``(kv_size, num_layers, storage_slots_per_chunk, hidden_dim_size)``
         """
-        return self.kv_layer_groups_manager_.get_physical_chunk_size(group_idx)
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        sd = group.shape_desc
+        return torch.Size(
+            (sd.kv_size, group.num_layers, group.storage_slots_per_chunk, group.hidden_dim_size)
+        )
 
     @property
     def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
@@ -318,18 +312,13 @@ class GPUCacheContext:
         return self.tmp_gpu_buffer_[start : start + self.tmp_chunk_bytes_]
 
     def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
-        """
-        Returns a view of the temporary GPU buffer for the given group,
-        sized for a single chunk. The chunk holds
-        ``lmcache_logical_chunk_size`` logical tokens which, for a
-        compressed group, correspond to ``group.physical_chunk_size``
-        physical slots.
+        """Return a view of the tmp GPU buffer for one chunk of *group_idx*.
 
         Args:
             group_idx: Index of the KV layer group (default 0).
         """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        shape = self.get_storage_kv_buffer_shape(group_idx)
         start = self.tmp_chunk_group_offsets_[group_idx]
         end = self.tmp_chunk_group_offsets_[group_idx + 1]
         return self.tmp_gpu_buffer_[start:end].view(group.dtype).view(shape)
@@ -337,10 +326,7 @@ class GPUCacheContext:
     def get_tmp_chunk_gpu_buffer_batched(
         self, batch_size: int, group_idx: int = 0
     ) -> list[torch.Tensor]:
-        """
-        Returns a list of ``batch_size`` non-overlapping views into the
-        pre-allocated temporary GPU buffer for the given group, each
-        sized for ``lmcache_logical_chunk_size`` tokens.
+        """Return *batch_size* non-overlapping views into the tmp GPU buffer.
 
         Args:
             batch_size: Number of concurrent requests (must be <= max_batch_size).
@@ -351,7 +337,7 @@ class GPUCacheContext:
                 f"batch_size {batch_size} exceeds max_batch_size {self.max_batch_size}"
             )
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        shape = self.get_kv_buffer_shape(self.lmcache_logical_chunk_size, group_idx)
+        shape = self.get_storage_kv_buffer_shape(group_idx)
         g_start = self.tmp_chunk_group_offsets_[group_idx]
         g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
         chunk = self.tmp_chunk_bytes_
@@ -395,59 +381,41 @@ class GPUCacheContext:
     def get_kv_buffer_shape(
         self, logical_num_tokens: int, group_idx: int = 0
     ) -> torch.Size:
-        """
-        Returns the shape of the KV buffer for the given number of
-        *logical* tokens.
-
-        For a compressed group (``compress_ratio > 1``) every
-        ``compress_ratio`` logical tokens are packed into a single
-        physical slot, so the returned shape's token dimension is
-        ``num_tokens // compress_ratio``. Callers therefore always
-        pass logical-token counts and never need to know per-group
-        compression ratios.
+        """Shape of a KV buffer for *logical_num_tokens* of group *group_idx*.
 
         Args:
-            logical_num_tokens: Number of *logical* tokens. Must be a multiple
-                of the group's ``compress_ratio``.
+            logical_num_tokens: Number of logical tokens (must be a multiple
+                of ``shape_desc.bs``).
             group_idx: Index of the KV layer group (default 0).
+
+        Returns:
+            ``(kv_size, num_layers, num_slots, hidden_dim_size)``
         """
         group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        compress_ratio = group.compress_ratio
-        if logical_num_tokens % compress_ratio != 0:
+        bs = group.shape_desc.bs
+        if logical_num_tokens % bs != 0:
             raise ValueError(
                 f"logical_num_tokens ({logical_num_tokens}) is not a multiple of "
-                f"compress_ratio ({compress_ratio}) for group {group_idx}"
+                f"block_size ({bs}) for group {group_idx}"
             )
-        num_slots = logical_num_tokens // compress_ratio
+        num_slots = logical_num_tokens // bs
         sd = group.shape_desc
         return torch.Size(
             (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
         )
 
     def cache_size_per_token(self) -> int:
-        """
-        Returns the cache size per *logical* token (in bytes), summed
-        across all groups. For a compressed group, one physical slot
-        stores ``compress_ratio`` logical tokens, so the per-logical-token
-        contribution is ``physical_slot_bytes // compress_ratio``.
+        """Cache bytes per logical token, summed across all groups.
 
-        Reporting-only metric (surfaced via the ``/api/status`` HTTP
-        endpoint and the ``lmcache describe`` CLI); sub-byte truncation
-        from integer division is acceptable.
+        Reporting-only metric; sub-byte truncation from integer division is
+        acceptable.
         """
         total = 0
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
         ):
-            # ``get_kv_buffer_shape`` now takes *logical* tokens, so
-            # query ``compress_ratio`` logical tokens (= 1 physical
-            # slot) and then divide the resulting bytes back by
-            # ``compress_ratio`` to recover the per-logical-token
-            # contribution. Equivalent to the old
-            # ``physical_slot_bytes // compress_ratio`` formulation.
-            numels = self.get_kv_buffer_shape(group.compress_ratio, group_idx).numel()
-            slot_bytes = numels * group.dtype.itemsize
-            total += slot_bytes // group.compress_ratio
+            numels = self.get_kv_buffer_shape(group.shape_desc.bs, group_idx).numel()
+            total += numels * group.dtype.itemsize
         return total
 
 

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -48,20 +48,18 @@ logger = init_logger(__name__)
 
 
 def get_layout_desc(gpu_context: GPUCacheContext, num_tokens: int) -> MemoryLayoutDesc:
-    """Get the memory layout description for a given GPU context and number of tokens.
-
-    Supports multiple KV layer groups with different shapes and dtypes.
+    """Get the memory layout description for a GPU context.
 
     Args:
-        gpu_context: The GPU cache context containing the KV cache information.
-        num_tokens: The number of tokens to determine the layout for.
+        gpu_context: The GPU cache context.
+        num_tokens: Unused; kept for call-site compatibility.
 
     Returns:
-        MemoryLayoutDesc: The memory layout description containing shapes and dtypes.
+        MemoryLayoutDesc with per-group storage shapes and dtypes.
     """
     num_groups = gpu_context.kv_layer_groups_manager.num_groups
     shapes = [
-        gpu_context.get_kv_buffer_shape(num_tokens, group_idx)
+        gpu_context.get_storage_kv_buffer_shape(group_idx)
         for group_idx in range(num_groups)
     ]
     dtypes = [
@@ -198,7 +196,6 @@ class GPUTransferModule:
                         ctx.kv_layer_groups_manager.inference_engine_logical_block_size
                     ),
                     "group_physical_block_sizes": ctx.group_physical_block_sizes,
-                    "group_compress_ratios": ctx.group_compress_ratios,
                     "hidden_dim_sizes": str(ctx.hidden_dim_sizes),
                     "dtype": str(ctx.dtype),
                     "is_mla": ctx.is_mla,
@@ -345,12 +342,8 @@ class GPUTransferModule:
         gpu_context = entry.gpu_context
         model_name = entry.model_name
 
-        # ``blocks_per_chunk`` is counted in inference-engine-side
-        # blocks (each block addresses
-        # ``inference_engine_logical_block_size`` *logical* tokens).
-        # For compressed groups the per-group physical slot count
-        # differs, but the block-id indexing is shared with the engine
-        # and therefore uses the engine logical block size here.
+        # blocks_per_chunk: engine-side blocks per LMCache chunk, used to
+        # index into the per-group block ID list.
         blocks_per_chunk = (
             self._ctx.chunk_size
             // gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
@@ -450,12 +443,7 @@ class GPUTransferModule:
                         ]
                         tmp_buffer = gpu_context.get_tmp_chunk_gpu_buffer(group_idx)
                         group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                        # Kernel contract: ``group_lmcache_chunk_size`` here is the
-                        # number of *physical* slots per chunk for this group
-                        # (= logical chunk_size // compress_ratio).
-                        group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                            group_idx
-                        )
+                        group = gpu_context.kv_layer_groups_manager.kv_layer_groups[group_idx]
                         lmc_ops.multi_layer_block_kv_transfer(
                             group_kv_pointers,
                             [tmp_buffer.data_ptr()],
@@ -463,7 +451,7 @@ class GPUTransferModule:
                             gpu_context.device,
                             lmc_ops.TransferDirection.D2H,
                             gpu_context.get_shape_desc(group_idx),
-                            group_lmcache_chunk_size,
+                            group.storage_slots_per_chunk,
                             gpu_context.gpu_kv_format_,
                             0,
                         )
@@ -653,9 +641,7 @@ class GPUTransferModule:
                         batch_len, group_idx
                     )
                     group_kv_pointers = gpu_context.get_group_kv_pointers(group_idx)
-                    group_lmcache_chunk_size = gpu_context.get_physical_chunk_size(
-                        group_idx
-                    )
+                    group = gpu_context.kv_layer_groups_manager.kv_layer_groups[group_idx]
 
                     lmc_ops.multi_layer_block_kv_transfer(
                         group_kv_pointers,
@@ -664,7 +650,7 @@ class GPUTransferModule:
                         gpu_context.device,
                         lmc_ops.TransferDirection.H2D,
                         gpu_context.get_shape_desc(group_idx),
-                        group_lmcache_chunk_size,
+                        group.storage_slots_per_chunk,
                         gpu_context.gpu_kv_format_,
                         skip_blocks_in_chunk,
                     )


### PR DESCRIPTION
**What this PR does / why we need it**:

The existing `compress_ratio` / `physical_chunk_size` derivation in
`KVLayerGroupsManager` infers how many physical slots a KV group has per
LMCache chunk from `inference_engine_logical_block_size`. This works for
the current two-tier (compressed / non-compressed) split but does not
generalise to per-group storage budgets (e.g. SWA-only suffix storage
coming in a follow-up PR).

This PR replaces that indirect derivation with a direct
`storage_blocks_per_chunk` field on `KVLayerGroupInfo`, populated at
registration time from a new `per_layer_storage_blocks_per_chunk` layout
hint. The server becomes a "pure block mover": it only needs to know how
many blocks to transfer per group per chunk, and nothing about logical
block sizes or compression ratios.

Changes:
- `KVLayerGroupInfo`: drops `compress_ratio` / `physical_chunk_size` /
  `_derive_compression_metadata`; adds `storage_blocks_per_chunk` +
  `storage_slots_per_chunk`.
- `gpu_context`: new `get_storage_kv_buffer_shape()` replaces
  `get_physical_chunk_size()`; tmp-buffer sizing unified through it.
- `gpu_transfer`: store and retrieve kernels read
  `group.storage_slots_per_chunk` directly.
- `kv_cache_groups.py`: new helpers `spec_int_attr`,
  `storage_blocks_per_chunk`, `per_layer_storage_blocks_per_chunk_from_vllm`
  compute the per-layer hint from vLLM group specs at registration time.
- `vllm_multi_process_adapter`: ships the hint in
  `layout_hints["per_layer_storage_blocks_per_chunk"]`.

For non-hybrid (non-V4) models the hint is absent and every group falls
back to `lmcache_logical_chunk_size // bs`, preserving existing behaviour.

**Special notes for your reviewers**:

`group_compress_ratios` is kept as a backward-compatible stub (returns
all 1s) to avoid breaking any external callers that read the status dict.
It can be removed in a later cleanup PR.

A follow-up PR will use this hint mechanism to implement SWA-suffix-only
storage for DeepSeek-V4's sliding-window groups (connector pre-slices the
block ID list and ships a smaller `storage_blocks_per_chunk` for those
groups).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests