### PR TITLE
[GPUKVFormat]: support vLLM CPU 2-fused KV layout

### DIFF
--- a/.buildkite/k3_tests/multiprocess/scripts/run-cpu-e2e-validation.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-cpu-e2e-validation.sh
@@ -231,8 +231,8 @@ echo "✅ Installed requirements/common.txt"
 
 echo "Installing vLLM CPU build"
 # Un-pinned from 71df063c (LMCache #3538) now that LMCache handles the
-# blocks-first fused CPU KV layout from vLLM #44393. Running against nightly
-# means a passing CPU e2e proves the new GPUKVFormat path works.
+# blocks-first fused KV layout. Running against nightly means a passing CPU
+# e2e proves the new GPUKVFormat path works.
 uv pip install vllm --extra-index-url https://wheels.vllm.ai/nightly/cpu --index-strategy first-index --torch-backend cpu
 echo "✅ vLLM CPU install completed"
 

--- a/.buildkite/k3_tests/multiprocess/scripts/run-cpu-e2e-validation.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-cpu-e2e-validation.sh
@@ -230,7 +230,10 @@ uv pip install -r requirements/common.txt
 echo "✅ Installed requirements/common.txt"
 
 echo "Installing vLLM CPU build"
-uv pip install vllm --extra-index-url https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu --index-strategy first-index --torch-backend cpu
+# Un-pinned from 71df063c (LMCache #3538) now that LMCache handles the
+# blocks-first fused CPU KV layout from vLLM #44393. Running against nightly
+# means a passing CPU e2e proves the new GPUKVFormat path works.
+uv pip install vllm --extra-index-url https://wheels.vllm.ai/nightly/cpu --index-strategy first-index --torch-backend cpu
 echo "✅ vLLM CPU install completed"
 
 echo "Installing LMCache in editable mode with NO_GPU_EXT=1"

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -103,10 +103,11 @@ enum class GPUKVFormat : int {
   NL_X_NB_NH_BS_TWO_HS = 10,
   /*
   used by:
-  - vLLM non-MLA CPU attention (blocks-first, K/V fused per vLLM #44393)
+  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
   physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
   (recovered by splitting the fused trailing [block_size, 2 * head_size]).
-  CPU-only; never reaches the CUDA transfer kernels.
+  Currently only reached via the host gather/scatter path, not the CUDA
+  transfer kernels.
   */
 };
 

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -99,6 +99,15 @@ enum class GPUKVFormat : int {
   - SGLang MHA via the MP daemon path
   physical shape per layer: [num_blocks, block_size, num_heads, head_size]
   */
+
+  NL_X_NB_NH_BS_TWO_HS = 10,
+  /*
+  used by:
+  - vLLM non-MLA CPU attention (blocks-first, K/V fused per vLLM #44393)
+  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
+  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
+  CPU-only; never reaches the CUDA transfer kernels.
+  */
 };
 
 void multi_layer_kv_transfer(

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -32,6 +32,7 @@ PYBIND11_MODULE(c_ops, m) {
       .value("NL_X_NB_TWO_NH_BS_HS", GPUKVFormat::NL_X_NB_TWO_NH_BS_HS)
       .value("NB_NL_TWO_NH_BS_HS", GPUKVFormat::NB_NL_TWO_NH_BS_HS)
       .value("TWO_X_NL_X_NB_BS_NH_HS", GPUKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
+      .value("NL_X_NB_NH_BS_TWO_HS", GPUKVFormat::NL_X_NB_NH_BS_TWO_HS)
       .export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),

--- a/csrc/sycl/pybind_sycl.cpp
+++ b/csrc/sycl/pybind_sycl.cpp
@@ -27,6 +27,7 @@ PYBIND11_MODULE(xpu_ops, m) {
       .value("NL_X_NB_TWO_NH_BS_HS", GPUKVFormat::NL_X_NB_TWO_NH_BS_HS)
       .value("NB_NL_TWO_NH_BS_HS", GPUKVFormat::NB_NL_TWO_NH_BS_HS)
       .value("TWO_X_NL_X_NB_BS_NH_HS", GPUKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
+      .value("NL_X_NB_NH_BS_TWO_HS", GPUKVFormat::NL_X_NB_NH_BS_TWO_HS)
       .export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -290,6 +290,12 @@ class GPUKVFormat(IntEnum):
     # used by: SGLang MHA via the MP daemon path
     TWO_X_NL_X_NB_BS_NH_HS = 9
 
+    # used by: vLLM non-MLA CPU attention (blocks-first, K/V fused into the
+    # trailing dim per vLLM #44393). Per-layer physical shape
+    # [num_blocks, num_heads, block_size, 2, head_size] -- the K/V "2" axis is
+    # second-to-last, recovered by splitting the fused [..., 2 * head_size].
+    NL_X_NB_NH_BS_TWO_HS = 10
+
 
 class PageBufferShapeDesc:
     """Python stand-in for the C++ ``PageBufferShapeDesc`` struct.

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -290,8 +290,8 @@ class GPUKVFormat(IntEnum):
     # used by: SGLang MHA via the MP daemon path
     TWO_X_NL_X_NB_BS_NH_HS = 9
 
-    # used by: vLLM non-MLA CPU attention (blocks-first, K/V fused into the
-    # trailing dim per vLLM #44393). Per-layer physical shape
+    # used by: vLLM non-MLA blocks-first attention with K/V fused into the
+    # trailing dim. Per-layer physical shape
     # [num_blocks, num_heads, block_size, 2, head_size] -- the K/V "2" axis is
     # second-to-last, recovered by splitting the fused [..., 2 * head_size].
     NL_X_NB_NH_BS_TWO_HS = 10

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -342,7 +342,7 @@ def get_attention_backend(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
         ),
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "TRT-LLM cross-layer (HND layout)",
         lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS: (
-            "vLLM non-MLA CPU attention (blocks-first, fused K/V)"
+            "vLLM non-MLA blocks-first, fused K/V"
         ),
     }
     return _ATTENTION_BACKENDS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
@@ -626,14 +626,14 @@ def normalize_kv_and_discover_format(
                     else:
                         detected_format = lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS
             elif tensor_dim == 4:
-                # vLLM CPU attention (post vLLM #44393): blocks-first with
-                # K/V fused into the trailing dim -> [NB, NH, BS, 2*head_size].
+                # vLLM non-MLA blocks-first attention: K/V fused into the
+                # trailing dim -> [NB, NH, BS, 2*head_size].
                 # Split the fused axis so downstream sees the canonical 5D
                 # [NB, NH, BS, 2, HS].
                 last_dim = probe.shape[3]
                 if last_dim % 2 != 0:
                     raise ValueError(
-                        "vLLM CPU KV cache trailing dim "
+                        "blocks-first fused KV cache trailing dim "
                         f"{last_dim} is not 2 * head_size"
                     )
                 kv_caches = [

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -315,6 +315,7 @@ def get_gpu_kv_shape_description(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS: "NL x [2, NB, NH, BS, HS]",
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS: "NL x [NB, 2, NH, BS, HS]",
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "[NB, NL, 2, NH, BS, HS]",
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS: "NL x [NB, NH, BS, 2, HS]",
     }
     return _SHAPE_DESCRIPTIONS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
 
@@ -340,6 +341,9 @@ def get_attention_backend(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
             "vLLM non-MLA flash infer (HND layout)"
         ),
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "TRT-LLM cross-layer (HND layout)",
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS: (
+            "vLLM non-MLA CPU attention (blocks-first, fused K/V)"
+        ),
     }
     return _ATTENTION_BACKENDS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
 
@@ -413,6 +417,12 @@ def get_concrete_gpu_kv_shape(
         nh = get_num_heads(kv_caches, fmt)
         bs = get_block_size(kv_caches, fmt)
         return f"[{nb}, {nl}, 2, {nh}, {bs}, {hs}]"
+
+    if fmt == F.NL_X_NB_NH_BS_TWO_HS:
+        nb = get_num_blocks(kv_caches, fmt)
+        nh = get_num_heads(kv_caches, fmt)
+        bs = get_block_size(kv_caches, fmt)
+        return f"{nl} x [{nb}, {nh}, {bs}, 2, {hs}]"
 
     return f"Unknown ({gpu_kv_format})"
 
@@ -615,6 +625,22 @@ def normalize_kv_and_discover_format(
                         detected_format = lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS
                     else:
                         detected_format = lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS
+            elif tensor_dim == 4:
+                # vLLM CPU attention (post vLLM #44393): blocks-first with
+                # K/V fused into the trailing dim -> [NB, NH, BS, 2*head_size].
+                # Split the fused axis so downstream sees the canonical 5D
+                # [NB, NH, BS, 2, HS].
+                last_dim = probe.shape[3]
+                if last_dim % 2 != 0:
+                    raise ValueError(
+                        "vLLM CPU KV cache trailing dim "
+                        f"{last_dim} is not 2 * head_size"
+                    )
+                kv_caches = [
+                    layer.reshape(*layer.shape[:3], 2, last_dim // 2)
+                    for layer in kv_caches
+                ]
+                detected_format = lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS
             elif tensor_dim == 3:
                 # vllm MLA
                 detected_format = lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
@@ -659,6 +685,7 @@ def get_num_layers(
         lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         return len(kv_caches)
     elif gpu_kv_format in (
@@ -692,8 +719,9 @@ def get_num_blocks(
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
-        # [num_blocks, 2, ...] — shape[0] is num_blocks
+        # [num_blocks, ...] — shape[0] is num_blocks
         return kv_caches[0].shape[0]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         return kv_caches[0].shape[0]
@@ -731,8 +759,10 @@ def get_block_size(
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
-        # NHD: [..., BS, NH, HS] — block_size at shape[2]
+        # block_size at shape[2]: NHD [..., BS, NH, HS] and the CPU fused
+        # layout [NB, NH, BS, 2, HS] both carry block_size at shape[2].
         return kv_caches[layer_idx].shape[2]
     elif gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
@@ -780,6 +810,10 @@ def get_page_buffer_size(
         # list[num_layers] of [num_blocks, 2, num_heads, block_size, head_size]
         # num_blocks=shape[0], block_size=shape[3]
         return kv_caches[0].shape[0] * kv_caches[0].shape[3]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+        # list[num_layers] of [num_blocks, num_heads, block_size, 2, head_size]
+        # num_blocks=shape[0], block_size=shape[2]
+        return kv_caches[0].shape[0] * kv_caches[0].shape[2]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size]
         return kv_caches[0].shape[0] * kv_caches[0].shape[1]
@@ -821,6 +855,9 @@ def get_num_heads(
     ):
         # HND: [..., NH, BS, HS] — num_heads at shape[2]
         return kv_caches[layer_idx].shape[2]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+        # CPU fused: [NB, NH, BS, 2, HS] — num_heads at shape[1]
+        return kv_caches[layer_idx].shape[1]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         # MLA: heads are absorbed into hidden dim, so num_heads = 1
         return 1
@@ -861,6 +898,9 @@ def get_hidden_dim_size(
     ):
         # HND: [..., NH, BS, HS] — hidden_dim = NH * HS = shape[2] * shape[4]
         return kv_caches[layer_idx].shape[2] * kv_caches[layer_idx].shape[4]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+        # CPU fused: [NB, NH, BS, 2, HS] — hidden_dim = NH * HS = shape[1] * shape[4]
+        return kv_caches[layer_idx].shape[1] * kv_caches[layer_idx].shape[4]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         return kv_caches[layer_idx].shape[2]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
@@ -895,8 +935,9 @@ def get_head_size(
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
-        # Both NHD [..., NH, HS] and HND [..., BS, HS] have head_size last
+        # All these per-layer non-MLA layouts carry head_size as the last dim
         return kv_caches[layer_idx].shape[4]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         return kv_caches[layer_idx].shape[2]
@@ -943,6 +984,10 @@ def get_tokens_per_layer(
         # k_cache = kv_caches[0][:, 0] → (NB, NH, BS, HS); tokens = NB * BS
         k_cache_shape = kv_caches[0][:, 0].shape
         return k_cache_shape[0] * k_cache_shape[2]
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+        # list[num_layers] of [num_blocks, num_heads, block_size, 2, head_size]
+        # tokens = NB * BS = shape[0] * shape[2]
+        return kv_caches[0].shape[0] * kv_caches[0].shape[2]
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size]
         return kv_caches[0].shape[0] * kv_caches[0].shape[1]
@@ -995,6 +1040,10 @@ def get_elements_per_layer(
         # [num_blocks, 2, ...] — k_cache is kv_caches[0][:, 0]
         k_cache_shape = kv_caches[0][:, 0].shape
         return k_cache_shape.numel() * 2
+    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+        # [NB, NH, BS, 2, HS] — K/V at dim 3; k_cache is kv_caches[0][:, :, :, 0]
+        k_cache_shape = kv_caches[0][:, :, :, 0].shape
+        return k_cache_shape.numel() * 2
     elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size] (MLA)
         return kv_caches[0].numel()
@@ -1022,6 +1071,7 @@ def assert_is_vllm_flash_attn_or_flash_infer(gpu_kv_format: "lmc_ops.GPUKVFormat
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     )
 
 
@@ -1033,6 +1083,7 @@ def is_hnd(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     )
 
 

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -1143,6 +1143,7 @@ def get_dtype(
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         return kv_caches[layer_idx].dtype
     elif gpu_kv_format in (

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -282,6 +282,7 @@ def gather_paged_kv_to_cpu(
     is_hnd = gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     )
 
     block_size = get_block_size(normalized, gpu_kv_format)
@@ -326,6 +327,10 @@ def gather_paged_kv_to_cpu(
                     if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
                         k_t = layer[0]
                         v_t = layer[1]
+                    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+                        # [NB, NH, BS, 2, HS] — K/V fused at dim 3
+                        k_t = layer[:, :, :, 0]
+                        v_t = layer[:, :, :, 1]
                     else:
                         k_t = layer[:, 0]
                         v_t = layer[:, 1]
@@ -419,6 +424,7 @@ def scatter_cpu_to_paged_kv(
     is_hnd = gpu_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     )
 
     # After normalization the structure is always a list of per-layer
@@ -462,6 +468,10 @@ def scatter_cpu_to_paged_kv(
                 if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
                     k_t = layer[0]
                     v_t = layer[1]
+                elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+                    # [NB, NH, BS, 2, HS] — K/V fused at dim 3
+                    k_t = layer[:, :, :, 0]
+                    v_t = layer[:, :, :, 1]
                 else:
                     k_t = layer[:, 0]
                     v_t = layer[:, 1]

--- a/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-"""vLLM CPU blocks-first, fused-K/V KV layout (GPUKVFormat.NL_X_NB_NH_BS_TWO_HS).
+"""Blocks-first, fused-K/V KV layout (GPUKVFormat.NL_X_NB_NH_BS_TWO_HS).
 
-vLLM #44393 ([Attention][CPU] Standardize kv layout to blocks first, part of
-RFC #42082) changed the CPU attention backend KV cache from the 5D K/V-major
-``[2, NB, NH, BS, HS]`` to the 4D blocks-first ``[NB, NH, BS, 2 * HS]`` with K/V
-fused into the trailing dim. Discovery splits the fused axis into the canonical
-5D ``[NB, NH, BS, 2, HS]`` and classifies it as ``NL_X_NB_NH_BS_TWO_HS``.
+A non-MLA blocks-first attention backend registers its KV cache as the 4D
+``[NB, NH, BS, 2 * HS]`` with K/V fused into the trailing dim (as opposed to
+the 5D K/V-major ``[2, NB, NH, BS, HS]``). Discovery splits the fused axis into
+the canonical 5D ``[NB, NH, BS, 2, HS]`` and classifies it as
+``NL_X_NB_NH_BS_TWO_HS``.
 
 These tests pin discovery, the format-aware accessors, and the multiprocess
-CPU gather/scatter round-trip for that layout.
+gather/scatter round-trip for that layout.
 """
 
 # Third Party
@@ -28,15 +28,15 @@ NB, NH, BS, HS, NL = 16, 4, 128, 64, 3
 HINTS = {"kv_layout": "HND"}
 
 
-def _raw_cpu_caches() -> list[torch.Tensor]:
-    """Per-layer vLLM CPU tensors as registered: [NB, NH, BS, 2 * HS]."""
+def _raw_blocks_first_caches() -> list[torch.Tensor]:
+    """Per-layer blocks-first tensors as registered: [NB, NH, BS, 2 * HS]."""
     torch.manual_seed(0)
     return [torch.randn(NB, NH, BS, 2 * HS) for _ in range(NL)]
 
 
 def test_discovery_splits_fused_axis():
     fmt, norm = U.normalize_kv_and_discover_format(
-        _raw_cpu_caches(), EngineType.VLLM, HINTS
+        _raw_blocks_first_caches(), EngineType.VLLM, HINTS
     )
     assert fmt == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS
     # 4D [NB, NH, BS, 2*HS] -> canonical 5D [NB, NH, BS, 2, HS]
@@ -51,7 +51,7 @@ def test_discovery_rejects_odd_trailing_dim():
 
 def test_accessors():
     fmt, norm = U.normalize_kv_and_discover_format(
-        _raw_cpu_caches(), EngineType.VLLM, HINTS
+        _raw_blocks_first_caches(), EngineType.VLLM, HINTS
     )
     assert U.get_num_layers(norm, fmt) == NL
     assert U.get_num_blocks(norm, fmt) == NB
@@ -64,7 +64,7 @@ def test_accessors():
     assert U.get_elements_per_layer(norm, fmt) == NB * NH * BS * HS * 2
     # get_dtype is on the register_kv_caches -> group_layers_by_identity path,
     # so it must recognize this format too.
-    assert U.get_dtype(norm, fmt) == _raw_cpu_caches()[0].dtype
+    assert U.get_dtype(norm, fmt) == _raw_blocks_first_caches()[0].dtype
     assert U.is_hnd(fmt) is True
     assert not U.is_mla(fmt)
 
@@ -72,7 +72,7 @@ def test_accessors():
 def test_mp_gather_scatter_roundtrip():
     blocks_per_chunk = 2
     block_ids = [0, 3, 5, 6]  # 2 chunks
-    raw = _raw_cpu_caches()
+    raw = _raw_blocks_first_caches()
     src = {f"layer_{i}": t for i, t in enumerate(raw)}
     ref = {k: v.clone() for k, v in src.items()}
     idx = torch.tensor(block_ids)

--- a/tests/v1/gpu_connector/test_cpu_blocks_first_kv_format.py
+++ b/tests/v1/gpu_connector/test_cpu_blocks_first_kv_format.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""vLLM CPU blocks-first, fused-K/V KV layout (GPUKVFormat.NL_X_NB_NH_BS_TWO_HS).
+
+vLLM #44393 ([Attention][CPU] Standardize kv layout to blocks first, part of
+RFC #42082) changed the CPU attention backend KV cache from the 5D K/V-major
+``[2, NB, NH, BS, HS]`` to the 4D blocks-first ``[NB, NH, BS, 2 * HS]`` with K/V
+fused into the trailing dim. Discovery splits the fused axis into the canonical
+5D ``[NB, NH, BS, 2, HS]`` and classifies it as ``NL_X_NB_NH_BS_TWO_HS``.
+
+These tests pin discovery, the format-aware accessors, and the multiprocess
+CPU gather/scatter round-trip for that layout.
+"""
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector import utils as U
+from lmcache.v1.multiprocess.transfer_context.base import (
+    gather_paged_kv_to_cpu,
+    scatter_cpu_to_paged_kv,
+)
+import lmcache.c_ops as lmc_ops
+
+NB, NH, BS, HS, NL = 16, 4, 128, 64, 3
+HINTS = {"kv_layout": "HND"}
+
+
+def _raw_cpu_caches() -> list[torch.Tensor]:
+    """Per-layer vLLM CPU tensors as registered: [NB, NH, BS, 2 * HS]."""
+    torch.manual_seed(0)
+    return [torch.randn(NB, NH, BS, 2 * HS) for _ in range(NL)]
+
+
+def test_discovery_splits_fused_axis():
+    fmt, norm = U.normalize_kv_and_discover_format(
+        _raw_cpu_caches(), EngineType.VLLM, HINTS
+    )
+    assert fmt == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS
+    # 4D [NB, NH, BS, 2*HS] -> canonical 5D [NB, NH, BS, 2, HS]
+    assert tuple(norm[0].shape) == (NB, NH, BS, 2, HS)
+
+
+def test_discovery_rejects_odd_trailing_dim():
+    bad = [torch.randn(NB, NH, BS, 2 * HS + 1) for _ in range(NL)]
+    with pytest.raises(ValueError):
+        U.normalize_kv_and_discover_format(bad, EngineType.VLLM, HINTS)
+
+
+def test_accessors():
+    fmt, norm = U.normalize_kv_and_discover_format(
+        _raw_cpu_caches(), EngineType.VLLM, HINTS
+    )
+    assert U.get_num_layers(norm, fmt) == NL
+    assert U.get_num_blocks(norm, fmt) == NB
+    assert U.get_block_size(norm, fmt) == BS
+    assert U.get_num_heads(norm, fmt) == NH
+    assert U.get_head_size(norm, fmt) == HS
+    assert U.get_hidden_dim_size(norm, fmt) == NH * HS
+    assert U.get_page_buffer_size(norm, fmt) == NB * BS
+    assert U.get_tokens_per_layer(norm, fmt) == NB * BS
+    assert U.get_elements_per_layer(norm, fmt) == NB * NH * BS * HS * 2
+    assert U.is_hnd(fmt) is True
+    assert not U.is_mla(fmt)
+
+
+def test_mp_gather_scatter_roundtrip():
+    blocks_per_chunk = 2
+    block_ids = [0, 3, 5, 6]  # 2 chunks
+    raw = _raw_cpu_caches()
+    src = {f"layer_{i}": t for i, t in enumerate(raw)}
+    ref = {k: v.clone() for k, v in src.items()}
+    idx = torch.tensor(block_ids)
+
+    chunks = gather_paged_kv_to_cpu(
+        src, block_ids, blocks_per_chunk, layout_hints=HINTS
+    )
+    # [K/V, NL, chunk_tokens, NH*HS]
+    assert tuple(chunks[0].shape) == (2, NL, blocks_per_chunk * BS, NH * HS)
+
+    # Wipe the gathered blocks, scatter back, and confirm exact recovery.
+    dst = {k: v.clone() for k, v in src.items()}
+    for k in dst:
+        dst[k][idx] = 0.0
+    scatter_cpu_to_paged_kv(
+        dst, block_ids, chunks, blocks_per_chunk, layout_hints=HINTS
+    )
+
+    for k in dst:
+        assert torch.equal(dst[k][idx], ref[k][idx])
+
+    # Untouched blocks must be left alone.
+    untouched = torch.tensor([b for b in range(NB) if b not in block_ids])
+    for k in dst:
+        assert torch.equal(dst[k][untouched], ref[k][untouched])

--- a/tests/v1/gpu_connector/test_cpu_blocks_first_kv_format.py
+++ b/tests/v1/gpu_connector/test_cpu_blocks_first_kv_format.py
@@ -62,6 +62,9 @@ def test_accessors():
     assert U.get_page_buffer_size(norm, fmt) == NB * BS
     assert U.get_tokens_per_layer(norm, fmt) == NB * BS
     assert U.get_elements_per_layer(norm, fmt) == NB * NH * BS * HS * 2
+    # get_dtype is on the register_kv_caches -> group_layers_by_identity path,
+    # so it must recognize this format too.
+    assert U.get_dtype(norm, fmt) == _raw_cpu_caches()[0].dtype
     assert U.is_hnd(fmt) is True
     assert not U.is_mla(fmt)
 

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -313,7 +313,7 @@ def generate_kv_cache_paged_list_tensors(
         elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
             shape = [num_blocks, 2, num_heads, block_size, head_size]
         elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
-            # vLLM CPU attention (post #44393): blocks-first, K/V fused
+            # blocks-first, K/V fused into the trailing dim
             shape = [num_blocks, num_heads, block_size, 2, head_size]
         else:
             raise ValueError(f"Unsupported gpu_kv_format: {gpu_kv_format}")

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -46,6 +46,7 @@ if lmc_ops is None:
         NL_X_NB_BS_HS = 2
         NL_X_TWO_NB_NH_BS_HS = 3
         NL_X_NB_TWO_NH_BS_HS = 4
+        NL_X_NB_NH_BS_TWO_HS = 5
 
     class MockCOps:
         GPUKVFormat = MockGPUKVFormat
@@ -311,6 +312,9 @@ def generate_kv_cache_paged_list_tensors(
             shape = [2, num_blocks, num_heads, block_size, head_size]
         elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
             shape = [num_blocks, 2, num_heads, block_size, head_size]
+        elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+            # vLLM CPU attention (post #44393): blocks-first, K/V fused
+            shape = [num_blocks, num_heads, block_size, 2, head_size]
         else:
             raise ValueError(f"Unsupported gpu_kv_format: {gpu_kv_format}")
 


### PR DESCRIPTION
Under RFC: https://github.com/LMCache/LMCache/issues/3560

vLLM #44393 ([Attention][CPU] Standardize kv layout to blocks first, part of RFC #42082) changed the CPU attention backend KV cache from the 5D K/V-major [2, NB, NH, BS, HS] to the 4D blocks-first [NB, NH, BS, 2 * HS]

Previous CI Hotfix (now deprecating): https://github.com/LMCache/LMCache/commit/0fae56457ea31a6f3587330dd7b06ff808fd3362

In the long term, since vllm is movign towards this direction, we will likely need to make this kind of change for other attention types.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
