### PR TITLE
fix(v1): reconnect LMCServerConnector on broken connection (fixes #3565)

### DIFF
--- a/lmcache/v1/storage_backend/connector/lm_connector.py
+++ b/lmcache/v1/storage_backend/connector/lm_connector.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import List, Optional, no_type_check
+from typing import Awaitable, Callable, List, Optional, TypeVar, no_type_check
 import asyncio
+import errno
+import random
 import socket
 
 # Third Party
@@ -21,6 +23,27 @@ from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
+
+_T = TypeVar("_T")
+
+# Total attempts (1 initial + retries) for a single RPC before giving up.
+_MAX_RPC_ATTEMPTS = 3
+# Exponential backoff base / cap between reconnect attempts.
+_RECONNECT_BACKOFF_BASE_S = 0.1
+_RECONNECT_BACKOFF_MAX_S = 2.0
+# ``OSError.errno`` values that indicate the connection is dead and a
+# reconnect should be attempted.
+_RETRYABLE_ERRNOS = frozenset(
+    {
+        errno.EPIPE,
+        errno.ECONNRESET,
+        errno.ECONNREFUSED,
+        errno.ECONNABORTED,
+        errno.ENOTCONN,
+        errno.ESHUTDOWN,
+        errno.EBADF,
+    }
+)
 
 
 # TODO: performance optimization for this class, consider using C/C++/Rust
@@ -44,14 +67,112 @@ class LMCServerConnector(RemoteConnector):
         # initialize base class, which includes some common attributes
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
-        self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.client_socket.connect((host, port))
+        # Keep host/port so the socket can be re-established if the remote
+        # lmcache-server restarts (see ``_reconnect``).
+        self.host = host
+        self.port = port
+        self._closed = False
+
+        self.client_socket = self._open_socket()
         # loop.sock_recv_into(sock, buf)
 
         self.loop = loop
         self.local_cpu_backend = local_cpu_backend
 
         self.async_socket_lock = asyncio.Lock()
+
+    def _open_socket(self) -> socket.socket:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((self.host, self.port))
+        return sock
+
+    def _reconnect(self) -> None:
+        """Tear down the dead socket and open a fresh connection.
+
+        The caller must hold ``async_socket_lock``, so only one coroutine
+        actually reconnects (single-flight); concurrent RPCs wait on the lock
+        and then reuse the freshly opened socket.
+        """
+        if self._closed:
+            return
+        try:
+            self.client_socket.close()
+        except OSError:
+            pass
+        self.client_socket = self._open_socket()
+
+    @staticmethod
+    def _is_retryable(exc: OSError) -> bool:
+        """A connection-level error worth reconnecting + retrying for."""
+        return isinstance(exc, ConnectionError) or exc.errno in _RETRYABLE_ERRNOS
+
+    async def _run_with_reconnect(
+        self, op_name: str, op: Callable[[], Awaitable[_T]]
+    ) -> _T:
+        """Run a full send+recv RPC with reconnect-on-failure.
+
+        ``op`` performs one complete RPC against ``self.client_socket`` and is
+        re-driven from the start on each attempt (it reads
+        ``self.client_socket`` afresh, so it picks up a reconnected socket). On
+        a connection-level ``OSError`` — from either the RPC itself or the
+        reconnect's ``connect()`` (e.g. ``ECONNREFUSED`` while the server pod
+        is still coming back up) — the socket is reconnected and the RPC
+        retried, up to ``_MAX_RPC_ATTEMPTS`` times with jittered exponential
+        backoff. Non-connection errors propagate immediately. The caller must
+        hold ``async_socket_lock``.
+        """
+        last_exc: Optional[OSError] = None
+        for attempt in range(_MAX_RPC_ATTEMPTS):
+            try:
+                # Reconnect (with backoff) before every retry. Keeping the
+                # reconnect inside the try means a failed ``connect()`` while
+                # the server is still down is itself retried within the budget
+                # instead of aborting the whole RPC.
+                if attempt > 0:
+                    backoff = min(
+                        _RECONNECT_BACKOFF_BASE_S * (2 ** (attempt - 1)),
+                        _RECONNECT_BACKOFF_MAX_S,
+                    )
+                    await asyncio.sleep(
+                        backoff + random.uniform(0, _RECONNECT_BACKOFF_BASE_S)
+                    )
+                    self._reconnect()
+                return await op()
+            except OSError as exc:
+                if not self._is_retryable(exc):
+                    raise
+                last_exc = exc
+                logger.warning(
+                    "lmserver connection error on %s (attempt %d/%d): %s; "
+                    "will reconnect to %s:%d and retry",
+                    op_name,
+                    attempt + 1,
+                    _MAX_RPC_ATTEMPTS,
+                    exc,
+                    self.host,
+                    self.port,
+                )
+        assert last_exc is not None
+        raise last_exc
+
+    def _recv_exact(self, n: int) -> bytes:
+        """Receive exactly ``n`` bytes from the socket.
+
+        Raises ``ConnectionResetError`` if the peer closes the connection
+        before ``n`` bytes arrive (a restarted server surfaces as an empty or
+        short read), so the RPC layer treats it as a connection failure and
+        reconnects + retries rather than feeding a truncated buffer to
+        ``deserialize`` (which would raise a non-retryable ``struct.error``).
+        """
+        chunks: List[bytes] = []
+        received = 0
+        while received < n:
+            chunk = self.client_socket.recv(n - received)
+            if not chunk:
+                raise ConnectionResetError("lmserver closed the connection during recv")
+            chunks.append(chunk)
+            received += len(chunk)
+        return b"".join(chunks)
 
     # TODO(Jiayi): This should be an async function
     def receive_all(self, meta: ServerMetaMessage) -> Optional[MemoryObj]:
@@ -75,7 +196,12 @@ class LMCServerConnector(RemoteConnector):
         while received < n:
             num_bytes = self.client_socket.recv_into(view[received:], n - received)
             if num_bytes == 0:
-                return None
+                # Peer closed mid-body (e.g. server restart). Surface as a
+                # connection error so the whole GET RPC reconnects + retries
+                # instead of being silently reported as a cache miss.
+                raise ConnectionResetError(
+                    "lmserver closed the connection during body recv"
+                )
             received += num_bytes
 
         return memory_obj
@@ -83,7 +209,7 @@ class LMCServerConnector(RemoteConnector):
     async def exists(self, key: CacheEngineKey) -> bool:
         # logger.debug("Call to exists()!")
 
-        async with self.async_socket_lock:
+        async def op() -> bool:
             self.client_socket.sendall(
                 ClientMetaMessage(
                     ClientCommand.EXIST,
@@ -95,9 +221,13 @@ class LMCServerConnector(RemoteConnector):
                 ).serialize()
             )
 
-            response = self.client_socket.recv(ServerMetaMessage.packlength())
+            response = self._recv_exact(ServerMetaMessage.packlength())
+            return (
+                ServerMetaMessage.deserialize(response).code == ServerReturnCode.SUCCESS
+            )
 
-        return ServerMetaMessage.deserialize(response).code == ServerReturnCode.SUCCESS
+        async with self.async_socket_lock:
+            return await self._run_with_reconnect("exists", op)
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
         future = asyncio.run_coroutine_threadsafe(self.exists(key), self.loop)
@@ -120,7 +250,7 @@ class LMCServerConnector(RemoteConnector):
         kv_dtype = memory_obj.get_dtype()
         memory_format = memory_obj.get_memory_format()
 
-        async with self.async_socket_lock:
+        async def op() -> None:
             await self.loop.sock_sendall(
                 self.client_socket,
                 ClientMetaMessage(
@@ -135,14 +265,21 @@ class LMCServerConnector(RemoteConnector):
 
             await self.loop.sock_sendall(self.client_socket, kv_bytes)
 
+        async with self.async_socket_lock:
+            await self._run_with_reconnect("put", op)
+
     # TODO(Jiayi): This should be an async function
     @_lmcache_nvtx_annotate
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         # NOTE(Jiayi): Not using any await in the following as
         # we don't want to yield control to other tasks which could
         # sacrifice the performance loading to trade the performance of
-        # saving
-        async with self.async_socket_lock:
+        # saving.
+        # The send, meta recv, and body recv are kept under a single lock hold
+        # so the whole RPC can be reconnected + retried atomically (the
+        # original code released the lock between meta and body, which both
+        # opened an interleave window and made a clean retry impossible).
+        async def op() -> Optional[MemoryObj]:
             self.client_socket.sendall(
                 ClientMetaMessage(
                     ClientCommand.GET,
@@ -154,16 +291,16 @@ class LMCServerConnector(RemoteConnector):
                 ).serialize()
             )
 
-            data = self.client_socket.recv(ServerMetaMessage.packlength())
+            data = self._recv_exact(ServerMetaMessage.packlength())
 
-        meta = ServerMetaMessage.deserialize(data)
-        if meta.code != ServerReturnCode.SUCCESS:
-            return None
+            meta = ServerMetaMessage.deserialize(data)
+            if meta.code != ServerReturnCode.SUCCESS:
+                return None
+
+            return self.receive_all(meta)
 
         async with self.async_socket_lock:
-            memory_obj = self.receive_all(meta)
-
-        return memory_obj
+            return await self._run_with_reconnect("get", op)
 
     # TODO
     @no_type_check
@@ -172,5 +309,6 @@ class LMCServerConnector(RemoteConnector):
 
     async def close(self):
         async with self.async_socket_lock:
+            self._closed = True
             self.client_socket.close()
         logger.info("Closed the lmserver connection")

--- a/tests/v1/storage_backend/test_lm_connector_reconnect.py
+++ b/tests/v1/storage_backend/test_lm_connector_reconnect.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only tests for LMCServerConnector reconnect-on-EPIPE behavior.
+
+Regression for https://github.com/LMCache/LMCache/issues/3565: the connector
+opened its TCP socket once in ``__init__`` and never reconnected, so after the
+remote lmcache-server restarted every PUT failed silently with
+``[Errno 32] Broken pipe``. These tests drive the write/read paths against a
+fake socket that fails once (simulating the dead FD) and assert the connector
+transparently reconnects and retries.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+import asyncio
+import errno
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.storage_backend.connector import lm_connector
+from lmcache.v1.storage_backend.connector.lm_connector import LMCServerConnector
+
+
+class _FakeSocket:
+    """A socket whose send path fails with a chosen errno for the first
+    ``fail_times`` calls, then succeeds; tracks whether it was closed.
+
+    ``connect_fail`` makes ``connect()`` raise once (to simulate the server
+    pod not yet being back up during a reconnect). ``recv_data`` lets a test
+    drive the read path (``b""`` simulates a peer that closed the connection).
+    """
+
+    def __init__(
+        self,
+        fail_times: int = 0,
+        fail_errno: int = errno.EPIPE,
+        connect_fail: bool = False,
+        recv_data: bytes = b"",
+    ):
+        self._fail_times = fail_times
+        self._fail_errno = fail_errno
+        self._connect_fail = connect_fail
+        self._recv_data = recv_data
+        self.closed = False
+        self.sent: list[bytes] = []
+
+    def connect(self, addr: tuple) -> None:
+        if self._connect_fail:
+            self._connect_fail = False
+            raise ConnectionRefusedError(errno.ECONNREFUSED, "Connection refused")
+
+    def sendall(self, data: bytes) -> None:
+        if self._fail_times > 0:
+            self._fail_times -= 1
+            raise OSError(self._fail_errno, "Broken pipe")
+        self.sent.append(bytes(data))
+
+    def recv(self, n: int) -> bytes:
+        chunk, self._recv_data = self._recv_data[:n], self._recv_data[n:]
+        return chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_connector(sockets: list) -> tuple:
+    """Build an LMCServerConnector whose socket factory yields ``sockets`` in
+    order (first for __init__, the rest for reconnects)."""
+    it = iter(sockets)
+
+    def fake_socket(*args, **kwargs):
+        return next(it)
+
+    backend = MagicMock()
+    backend.config = MagicMock()
+    backend.metadata = MagicMock()
+
+    loop = asyncio.new_event_loop()
+
+    # ``loop.sock_sendall`` is what put() uses; delegate to the fake socket's
+    # sendall so a dead FD raises the same OSError the kernel would.
+    async def sock_sendall(sock, data):
+        sock.sendall(data)
+
+    with patch.object(lm_connector.socket, "socket", side_effect=fake_socket):
+        with patch.object(lm_connector.RemoteConnector, "__init__", return_value=None):
+            conn = LMCServerConnector.__new__(LMCServerConnector)
+            conn.host = "127.0.0.1"
+            conn.port = 12345
+            conn._closed = False
+            conn.client_socket = conn._open_socket()
+            conn.loop = loop
+            conn.local_cpu_backend = backend
+            conn.async_socket_lock = asyncio.Lock()
+    loop.sock_sendall = sock_sendall  # type: ignore[method-assign]
+    return conn, loop
+
+
+async def _instant_sleep(_seconds: float) -> None:
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep():
+    """Make the retry backoff instant so tests stay fast."""
+    with patch.object(lm_connector.asyncio, "sleep", side_effect=_instant_sleep):
+        yield
+
+
+def test_put_reconnects_after_broken_pipe():
+    """A PUT that hits EPIPE on a stale socket must reconnect and succeed."""
+    dead = _FakeSocket(fail_times=1)  # first sendall raises EPIPE
+    fresh = _FakeSocket(fail_times=0)
+    conn, loop = _make_connector([dead, fresh])
+
+    obj = MagicMock()
+    obj.byte_array = b"payload"
+    obj.get_shape.return_value = (0, 0, 0, 0)
+    obj.get_dtype.return_value = "float16"
+    obj.get_memory_format.return_value = 1
+
+    key = MagicMock()
+    key.to_string.return_value = "k"
+    with patch(
+        "lmcache.v1.storage_backend.connector.lm_connector.ClientMetaMessage"
+    ) as mm:
+        mm.return_value.serialize.return_value = b"meta"
+        loop.run_until_complete(conn.put(key, obj))
+
+    assert dead.closed, "stale socket should be closed on reconnect"
+    assert fresh.sent, "fresh socket should have received the retried PUT"
+    loop.close()
+
+
+def test_put_gives_up_after_max_attempts():
+    """If every reconnect also fails, the error eventually propagates rather
+    than looping forever."""
+    socks = [_FakeSocket(fail_times=1) for _ in range(5)]
+    conn, loop = _make_connector(socks)
+
+    obj = MagicMock()
+    obj.byte_array = b"payload"
+    obj.get_shape.return_value = (0, 0, 0, 0)
+    obj.get_dtype.return_value = "float16"
+    obj.get_memory_format.return_value = 1
+    key = MagicMock()
+
+    with patch(
+        "lmcache.v1.storage_backend.connector.lm_connector.ClientMetaMessage"
+    ) as mm:
+        mm.return_value.serialize.return_value = b"meta"
+        with pytest.raises(OSError):
+            loop.run_until_complete(conn.put(key, obj))
+    loop.close()
+
+
+def test_non_retryable_error_propagates_without_reconnect():
+    """A non-connection OSError (e.g. EACCES) must not trigger a reconnect."""
+    sock = _FakeSocket(fail_times=1, fail_errno=errno.EACCES)
+    conn, loop = _make_connector([sock])  # only one socket: no reconnect allowed
+
+    obj = MagicMock()
+    obj.byte_array = b"payload"
+    obj.get_shape.return_value = (0, 0, 0, 0)
+    obj.get_dtype.return_value = "float16"
+    obj.get_memory_format.return_value = 1
+    key = MagicMock()
+
+    with patch(
+        "lmcache.v1.storage_backend.connector.lm_connector.ClientMetaMessage"
+    ) as mm:
+        mm.return_value.serialize.return_value = b"meta"
+        with pytest.raises(OSError) as exc_info:
+            loop.run_until_complete(conn.put(key, obj))
+    assert exc_info.value.errno == errno.EACCES
+    assert not sock.closed, "non-retryable error must not reconnect"
+    loop.close()
+
+
+def test_close_prevents_reconnect():
+    """After close(), a reconnect attempt is a no-op (don't resurrect)."""
+    sock = _FakeSocket()
+    conn, loop = _make_connector([sock])
+    loop.run_until_complete(conn.close())
+    assert conn._closed
+    conn._reconnect()  # must not open a new socket
+    assert conn.client_socket is sock
+    loop.close()
+
+
+def test_put_retries_when_reconnect_initially_refused():
+    """The K8s window: the stale FD breaks, then the first reconnect's
+    connect() is refused because the server pod is still coming up, and a
+    later attempt finally succeeds. The connect() failure must be retried
+    within the budget, not abort the whole RPC."""
+    dead = _FakeSocket(fail_times=1)  # send raises EPIPE
+    refused = _FakeSocket(connect_fail=True)  # reconnect connect() refused once
+    fresh = _FakeSocket()  # final reconnect succeeds
+    conn, loop = _make_connector([dead, refused, fresh])
+
+    obj = MagicMock()
+    obj.byte_array = b"payload"
+    obj.get_shape.return_value = (0, 0, 0, 0)
+    obj.get_dtype.return_value = "float16"
+    obj.get_memory_format.return_value = 1
+    key = MagicMock()
+
+    with patch(
+        "lmcache.v1.storage_backend.connector.lm_connector.ClientMetaMessage"
+    ) as mm:
+        mm.return_value.serialize.return_value = b"meta"
+        loop.run_until_complete(conn.put(key, obj))
+
+    assert fresh.sent, "PUT should succeed after a refused reconnect then a good one"
+    loop.close()
+
+
+def test_recv_exact_raises_on_peer_close():
+    """`_recv_exact` must raise a (retryable) ConnectionResetError when the
+    peer closes the connection, so a restarted server doesn't feed a truncated
+    header into deserialize()."""
+    sock = _FakeSocket(recv_data=b"")  # peer closed: recv returns b""
+    conn, loop = _make_connector([sock])
+    with pytest.raises(ConnectionResetError):
+        conn._recv_exact(8)
+    # And the error is classified retryable, so the RPC layer would reconnect.
+    assert conn._is_retryable(ConnectionResetError())
+    loop.close()


### PR DESCRIPTION
## Summary

Fixes #3565. `LMCServerConnector` opens its TCP socket once in `__init__` and never reconnects. After the remote `lmcache-server` restarts (pod replace, OOM, image roll, node maintenance), the client-held FD is dead but every subsequent `put()` / `get()` / `exists()` reuses it and fails silently with `[Errno 32] Broken pipe`. As @EdHasNoLife reports, T2 stays dead until the **engine** pod itself restarts — an operator-invisible regression whose only signal is the per-PUT log line.

## Fix

Transparent, single-flight reconnect:

- Store `host`/`port` (previously discarded) so the socket can be reopened.
- `_run_with_reconnect()` wraps each RPC: on a connection-level `OSError` (EPIPE/ECONNRESET/ECONNREFUSED/... or any `ConnectionError`) it reconnects and retries the whole send+recv, up to 3 attempts with jittered exponential backoff; non-connection errors propagate immediately. The reconnect runs **inside** the retry's `try`, so a `connect()` refused while the server pod is still coming back up is itself retried within the budget instead of aborting the RPC (the ~10 s "pod not Ready yet" window in the repro).
- Reconnect happens under the existing `async_socket_lock`, so only one coroutine reopens the socket (single-flight); concurrent RPCs wait on the lock and reuse the new socket.
- `_recv_exact()` reads the response header fully and raises a retryable `ConnectionResetError` on an empty/short read (a restarted peer otherwise fed a truncated buffer into `deserialize()` → a non-retryable `struct.error`).
- `receive_all()` raises `ConnectionResetError` on a mid-body EOF instead of returning `None`, so a transport drop during a GET body retries the whole RPC rather than being reported as a cache miss.
- `get()` now runs send + recv-meta + recv-body under a single lock hold so the whole RPC can be retried atomically (it previously released the lock between meta and body).
- `close()` marks the connector closed so a late RPC does not resurrect it.

## Test Plan

New CPU-only `tests/v1/storage_backend/test_lm_connector_reconnect.py` (fake socket, no server):

- reconnect after EPIPE then succeed
- retry across a **refused** reconnect (the server-still-restarting window) then succeed
- give up after the attempt budget (no infinite loop)
- non-retryable `OSError` (e.g. `EACCES`) propagates without reconnect
- `_recv_exact` raises a retryable error on peer close
- `close()` prevents reconnect

```
pre-commit run --files lmcache/v1/storage_backend/connector/lm_connector.py tests/v1/storage_backend/test_lm_connector_reconnect.py
# isort / ruff / ruff-format / codespell / mypy / SPDX -> all Passed
```