### PR TITLE
MAINT: Remove unnecessary global statement in cuda_extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def hipify_wrapper() -> None:
     # Third Party
     from torch.utils.hipify.hipify_python import hipify
 
-    print("Hipifying sources ")
+    print("Hipifying sources")
 
     # Get absolute path for all source files.
     extra_files = [
@@ -221,7 +221,6 @@ def cuda_extension() -> tuple[list, dict]:
     from torch.utils import cpp_extension  # Import here
 
     print("Building CUDA extensions")
-    global ENABLE_CXX11_ABI
     if ENABLE_CXX11_ABI:
         flag_cxx_abi = "-D_GLIBCXX_USE_CXX11_ABI=1"
     else:


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

## Summary

Remove the unnecessary `global ENABLE_CXX11_ABI` statement from `cuda_extension()`.

The variable is only read within the function and is never modified, so the `global` declaration is not required.

## Changes

- Removed unused `global ENABLE_CXX11_ABI` statement.
- No functional changes.