### PR TITLE
 [CB] Token-level matching + per-token slot scatter for non-block-aligned KV reuse

### DIFF
--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -376,16 +376,19 @@ class CBMatchResult:
 
 @dataclass
 class CBUnifiedLookupResult:
-    """Result of ``CB_UNIFIED_LOOKUP``: prefix lookup + non-prefix fingerprint
-    match, reconciled in one RPC.
+    """Resolved payload of ``CB_UNIFIED_LOOKUP``: prefix lookup + non-prefix
+    fingerprint match, reconciled in one RPC. The RPC returns ``None`` (not this)
+    while either leg's KV is still loading into L1; this type is sent only once
+    both are resident.
 
     Attributes:
         prefix_coverage_tokens: Contiguous prefix-cache coverage (L1+L2) in
             tokens — what the standard LOOKUP would report.
-        non_prefix_segments: Block-aligned matches outside the prefix coverage
+        non_prefix_segments: Fingerprint matches outside the prefix coverage
             (cur_st order), each carrying ``(old_st, old_ed, cur_st, cur_ed,
-            hash)``. Already sparse-prefetched, so the retrieve set equals the
-            prefetched set.
+            hash)``. Token-aligned (any offset, not block-aligned): the per-token
+            slot scatter handles them. Already resident in L1, so the retrieve
+            set equals the prefetched set.
     """
 
     prefix_coverage_tokens: int

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -83,10 +83,9 @@ class _CBUnifiedJob:
 
 
 class BlendTokenRangeMatcherV3(BlendTokenRangeMatcher):
-    """V3 matcher: full-hash collision rejection + block-aligned probe stride.
+    """V3 matcher: full-hash collision rejection + configurable probe stride.
 
-    Probes every ``probe_stride`` positions; lossless because retrieve drops
-    non-block-aligned ``cur_st`` anyway.
+    register_rope sets ``probe_stride`` to 1 for token-level matching.
     """
 
     def __init__(self, chunk_size: int = 256, probe_stride: int = 16):
@@ -162,7 +161,7 @@ class BlendTokenRangeMatcherV3(BlendTokenRangeMatcher):
     ) -> list[CBMatchResult]:
         """Probe rolling-hash array every ``probe_stride`` positions; skips
         bucket-only collisions and evicted entries. One result per unique
-        match; ``cur_st`` is the first block-aligned hit."""
+        match; ``cur_st`` is the first hit position."""
         if len(token_ids) < self.chunk_size:
             return []
 
@@ -429,20 +428,9 @@ class BlendV3Module:
         self._cb_gpu_contexts[instance_id] = gpu_context
         self._cb_gpu_context_meta[instance_id] = (entry.model_name, entry.world_size)
 
-        # Probe stride = ie block size; must divide chunk_size.
-        ie_logical_block_size = (
-            gpu_context.kv_layer_groups_manager.inference_engine_logical_block_size
-        )
-        if self._ctx.chunk_size % ie_logical_block_size == 0:
-            self._token_range_matcher._probe_stride = ie_logical_block_size
-        else:
-            logger.warning(
-                "CB matcher probe stride unchanged (%d): chunk_size %d is not "
-                "a multiple of inference_engine_logical_block_size %d.",
-                self._token_range_matcher._probe_stride,
-                self._ctx.chunk_size,
-                ie_logical_block_size,
-            )
+        # Probe every token so non-block-aligned matches are found; the
+        # per-token slot scatter writes them.
+        self._token_range_matcher._probe_stride = 1
 
         logger.info(
             "Registered CB rope state for instance %d "
@@ -667,11 +655,9 @@ class BlendV3Module:
         # enter the sparse prefetch, so they cannot leak a read lock.
         if not job.sparse_started:
             prefix_tokens = job.prefix_chunks * chunk_size
-            job.non_prefix = [
-                r
-                for r in job.matches
-                if r.cur_st >= prefix_tokens and r.cur_st % chunk_size == 0
-            ]
+            # Any offset is fine: the per-token slot scatter writes
+            # non-block-aligned matches.
+            job.non_prefix = [r for r in job.matches if r.cur_st >= prefix_tokens]
             if job.non_prefix:
                 layout_desc = self._resolve_cb_layout_desc(
                     key.model_name, key.world_size
@@ -937,7 +923,6 @@ class BlendV3Module:
                 f"chunk_size {chunk_size} must be a multiple of "
                 f"inference_engine_logical_block_size {ie_logical_block_size}"
             )
-        blocks_per_chunk = chunk_size // ie_logical_block_size
         num_groups = gpu_context.kv_layer_groups_manager.num_groups
 
         with (
@@ -982,30 +967,20 @@ class BlendV3Module:
                     if memory_objs is None:
                         return event_ipc_handle, False
 
-                    # Drop malformed matches up front.
+                    # Per-token scatter handles any cur_st; just bound the
+                    # matched range to the allocated slots.
                     pairs: list[tuple[CBMatchResult, Any]] = []
+                    num_slots = int(all_block_ids_gpu.numel()) * ie_logical_block_size
                     for r, memory_obj in zip(
                         cb_match_result, memory_objs, strict=False
                     ):
-                        if r.cur_st % ie_logical_block_size != 0:
+                        if r.cur_ed > num_slots:
                             logger.warning(
-                                "Dropping CB match cur_st=%d: not aligned to "
-                                "ie_logical_block_size=%d.",
+                                "Dropping CB match cur_st=%d cur_ed=%d: exceeds "
+                                "%d slots. Request %s.",
                                 r.cur_st,
-                                ie_logical_block_size,
-                            )
-                            continue
-                        cbs = r.cur_st // ie_logical_block_size
-                        if cbs + blocks_per_chunk > int(all_block_ids_gpu.numel()):
-                            logger.warning(
-                                "Dropping CB match cur_st=%d old_st=%d: needs "
-                                "blocks [%d:%d) but gpu_block_ids has %d. "
-                                "Request %s.",
-                                r.cur_st,
-                                r.old_st,
-                                cbs,
-                                cbs + blocks_per_chunk,
-                                int(all_block_ids_gpu.numel()),
+                                r.cur_ed,
+                                num_slots,
                                 key.request_id,
                             )
                             continue
@@ -1025,7 +1000,6 @@ class BlendV3Module:
                         for batch_start in range(0, len(run), max_batch):
                             batch = run[batch_start : batch_start + max_batch]
                             batch_len = len(batch)
-                            first_cur_st = batch[0][0].cur_st
 
                             # (a) H2D fill into per-chunk tmp slots.
                             for slot_idx, (_, memory_obj) in enumerate(batch):
@@ -1044,14 +1018,24 @@ class BlendV3Module:
                                 gpu_context, rope_state, batch_len, slots_to_rope
                             )
 
-                            # (c) One batched scatter per group.
-                            chunk_block_start = first_cur_st // ie_logical_block_size
-                            chunk_block_end = (
-                                chunk_block_start + batch_len * blocks_per_chunk
+                            # (c) Per-token slot scatter: partial vLLM blocks
+                            # shared with recomputed tokens stay disjoint.
+                            bs = ie_logical_block_size
+                            pos = torch.cat(
+                                [
+                                    torch.arange(
+                                        r.cur_st,
+                                        r.cur_ed,
+                                        device=gpu_context.device,
+                                        dtype=torch.long,
+                                    )
+                                    for (r, _) in batch
+                                ]
                             )
-                            chunk_block_ids_gpu = all_block_ids_gpu[
-                                chunk_block_start:chunk_block_end
-                            ]
+                            slot_mapping = all_block_ids_gpu[pos // bs] * bs + (
+                                pos % bs
+                            )
+                            page_buffer_size = gpu_context.num_blocks * bs
                             for group_idx in range(num_groups):
                                 tmp_buffers = (
                                     gpu_context.get_tmp_chunk_gpu_buffer_batched(
@@ -1059,23 +1043,17 @@ class BlendV3Module:
                                         group_idx=group_idx,
                                     )
                                 )
-                                group_kv_pointers = gpu_context.get_group_kv_pointers(
-                                    group_idx
-                                )
-                                group_lmcache_chunk_size = (
-                                    gpu_context.get_physical_chunk_size(group_idx)
-                                )
-
-                                lmc_ops.multi_layer_block_kv_transfer(
-                                    group_kv_pointers,
-                                    [tb.data_ptr() for tb in tmp_buffers],
-                                    chunk_block_ids_gpu,
+                                key_value = torch.cat(tmp_buffers, dim=2)
+                                lmc_ops.multi_layer_kv_transfer(
+                                    key_value,
+                                    gpu_context.get_group_kv_pointers(group_idx),
+                                    slot_mapping,
                                     gpu_context.device,
+                                    page_buffer_size,
                                     lmc_ops.TransferDirection.H2D,
-                                    gpu_context.get_shape_desc(group_idx),
-                                    group_lmcache_chunk_size,
                                     gpu_context.gpu_kv_format_,
-                                    0,  # skip_blocks_in_chunk
+                                    block_size=bs,
+                                    head_size=rope_state.head_size,
                                 )
             except Exception:
                 logger.exception("Error during retrieving prefetched results")

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Blend V3: paged-aware CacheBlend as an :class:`EngineModule`.
+"""Blend V3: paged-aware CacheBlend as an EngineModule.
 
-Plugs into the unified :class:`MPCacheEngine`; standard ``REGISTER_KV_CACHE``
-+ ``CB_REGISTER_ROPE_V3`` for setup; STORE wrapper registers fingerprints;
+Plugs into the unified MPCacheEngine; standard REGISTER_KV_CACHE +
+CB_REGISTER_ROPE_V3 for setup; STORE wrapper registers fingerprints;
 retrieve scatters into the request's paged blocks.
 """
 
@@ -39,7 +39,6 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.engine_context import MPCacheEngineContext
 from lmcache.v1.multiprocess.engine_module import HandlerSpec, ThreadPoolType
 from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
-from lmcache.v1.multiprocess.modules.blend import BlendTokenRangeMatcher
 from lmcache.v1.multiprocess.modules.gpu_transfer import GPUTransferModule
 from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.protocol import RequestType
@@ -65,7 +64,7 @@ class _CBRopeState:
 
 @dataclass
 class _CBUnifiedJob:
-    """Per-request poll state for non-blocking ``cb_unified_lookup``.
+    """Per-request poll state for non-blocking cb_unified_lookup.
 
     Stashed across polls because the underlying status/found polls are
     consume-once.
@@ -82,12 +81,34 @@ class _CBUnifiedJob:
     found_uidx: set[int] | None = None  # stashed when the sparse poll completes
 
 
-class BlendTokenRangeMatcherV3(BlendTokenRangeMatcher):
+class BlendTokenRangeMatcherV3:
     """V3 matcher: token-level probe (any offset) + full-hash collision
-    rejection."""
+    rejection. Self-contained (does not inherit a base matcher)."""
+
+    _TABLE_BITS: int = 20  # 2^20 ~ 1 M entries
+    _TABLE_SIZE: int = 1 << _TABLE_BITS
+    _BASE: np.uint64 = np.uint64(0x9E3779B97F4A7C15)  # Fibonacci-hashing const
 
     def __init__(self, chunk_size: int = 256):
-        super().__init__(chunk_size)
+        """Initialize the V3 matcher.
+
+        Args:
+            chunk_size (int): Tokens per non-overlapping fingerprint chunk.
+        """
+        self.chunk_size = chunk_size
+        # poly_chunk_hash -> compact_chunk_id; -1 = empty
+        self._table_id = np.full(self._TABLE_SIZE, -1, dtype=np.int64)
+        self._mask = np.uint64(self._TABLE_SIZE - 1)
+        # compact_chunk_id -> caller token_hash (full bytes); None once evicted
+        self._chunk_token_hash: list[bytes | None] = []
+        # token_hash -> start position in its registered sequence
+        self._token_hash_to_start: dict[bytes, int] = {}
+        # compact_chunk_id -> table slot (reverse lookup for eviction)
+        self._compact_id_to_slot = np.full(self._TABLE_SIZE, -1, dtype=np.int64)
+        # token_hash -> compact_chunk_id (for eviction lookup)
+        self._token_hash_to_compact_id: dict[bytes, int] = {}
+        self._lock = threading.Lock()
+        # V3 addition: compact_chunk_id -> full poly hash, for collision reject.
         self._chunk_poly_hash: list[int] = []
 
     def on_new_token_hashes(
@@ -97,9 +118,23 @@ class BlendTokenRangeMatcherV3(BlendTokenRangeMatcher):
         start_chunk_idx: int = 0,
         position_offset: int = 0,
     ) -> None:
-        """Index non-overlapping chunks; ``start_chunk_idx=1`` skips pos-0
-        (handled by the standard prefix lookup); ``position_offset`` is
-        added to recorded positions for tail-slices."""
+        """Index a stored sequence's non-overlapping chunks into the matcher.
+
+        Records each new chunk's poly hash + start position so a later
+        match_sub_sequence can find it. Thread-safe (holds the matcher lock).
+
+        Args:
+            token_ids (list[int]): The stored sequence's token IDs.
+            token_hashes (list[bytes]): Per-chunk content hashes (one per
+                chunk), used as the dedup/eviction key.
+            start_chunk_idx (int): First chunk to index; 1 skips chunk 0 (the
+                standard prefix lookup owns it).
+            position_offset (int): Added to each recorded start position (for
+                indexing a tail-slice of a larger sequence).
+
+        Returns:
+            None.
+        """
         arr = np.array(token_ids, dtype=np.uint64)
         chunk_hashes = chunk_hash_windows_numba(arr, self.chunk_size, self._BASE)
         n = int(chunk_hashes.shape[0])
@@ -156,9 +191,20 @@ class BlendTokenRangeMatcherV3(BlendTokenRangeMatcher):
         self,
         token_ids: list[int],
     ) -> list[CBMatchResult]:
-        """Find every registered chunk reused in ``token_ids``. One result per
-        unique chunk; ``cur_st`` is its first query position. Verifies the full
-        poly hash to reject direct-address bucket collisions."""
+        """Find every registered chunk reused anywhere in a query sequence.
+
+        Vectorized direct-address probe over all token positions, then a small
+        verify loop over the surviving hits (a full poly-hash check rejects
+        bucket collisions; evicted/unknown chunks are skipped). Thread-safe.
+
+        Args:
+            token_ids (list[int]): The query sequence's token IDs.
+
+        Returns:
+            list[CBMatchResult]: One result per unique reused chunk (cur_st
+            = its first query position, old_st = its stored position).
+            Empty if the query is shorter than one chunk or nothing matched.
+        """
         if len(token_ids) < self.chunk_size:
             return []
 
@@ -363,8 +409,8 @@ class BlendV3Module:
         head_size: int,
         is_neox_style: bool,
     ) -> None:
-        """Bolt rope state onto an already-registered ``cache_contexts`` entry;
-        idempotent. ``REGISTER_KV_CACHE`` must precede this."""
+        """Bolt rope state onto an already-registered cache_contexts entry;
+        idempotent. REGISTER_KV_CACHE must precede this."""
         cache_contexts = self._gpu_transfer.cache_contexts
         if instance_id not in cache_contexts:
             raise ValueError(
@@ -454,7 +500,7 @@ class BlendV3Module:
     def _match_fingerprints(self, key: IPCCacheEngineKey) -> list[CBMatchResult]:
         """Drain pending registrations, fingerprint-match sub-sequences, then
         leftmost-greedy dedup over overlapping ranges. Returns matches sorted
-        by ``cur_st`` (empty if none)."""
+        by cur_st (empty if none)."""
         self._drain_fingerprints_sync()
         matches = self._token_range_matcher.match_sub_sequence(list(key.token_ids))
         if not matches:
@@ -487,8 +533,8 @@ class BlendV3Module:
         layout_desc: "MemoryLayoutDesc",
         matches: list[CBMatchResult],
     ) -> "tuple[PrefetchHandle, dict[bytes, list], list[int]]":
-        """Coalesce all ``matches`` into one sparse prefetch and submit it
-        (non-blocking). The caller polls ``query_prefetch_status(handle)`` then
+        """Coalesce all matches into one sparse prefetch and submit it
+        (non-blocking). The caller polls query_prefetch_status(handle) then
         calls :meth:`_sparse_classify` with the found set."""
         world_size = key.world_size
         per_hash_obj_keys: dict[bytes, list] = {}
@@ -585,7 +631,7 @@ class BlendV3Module:
         """Non-blocking single-RPC CB lookup (submit-once, poll-on-recall).
 
         First call submits the prefix lookup + fingerprint match; later calls
-        poll both legs, returning ``None`` until the prefix and the sparse
+        poll both legs, returning None until the prefix and the sparse
         complement are both resident in L1 (so a worker thread never blocks on
         the L2->L1 loads). The prefix job's L1 read locks persist for the
         retrieve.
@@ -744,7 +790,7 @@ class BlendV3Module:
         return result
 
     def _drain_fingerprint_queue(self) -> None:
-        """Best-effort background drainer for ``_fingerprint_queue``."""
+        """Best-effort background drainer for _fingerprint_queue."""
         while not self._fingerprint_stop.is_set():
             try:
                 job = self._fingerprint_queue.get(timeout=0.1)
@@ -774,7 +820,7 @@ class BlendV3Module:
         slots_to_rope: list[tuple[int, int, int]],
     ) -> None:
         """Re-RoPE tmp-pool slots in-place (K-only, per group); list of
-        ``(slot_idx, old_st, cur_st)``."""
+        (slot_idx, old_st, cur_st)."""
         if not slots_to_rope:
             return
         num_groups = gpu_context.kv_layer_groups_manager.num_groups
@@ -849,7 +895,14 @@ class BlendV3Module:
         with self._lookup_obj_keys_lock:
             cached = self._lookup_obj_keys_cache.pop(key.request_id, None)
         if cached is not None and all(r.hash in cached for r in cb_match_result):
-            all_obj_keys = [k for r in cb_match_result for k in cached[r.hash]]
+            # The lookup cached all-ranks obj keys (world_size per hash). This
+            # retrieve is per-worker, so select THIS rank's key -> M objects, not
+            # M*world_size (else the zip below silently truncates and mispairs
+            # ranks at TP>1). Mirrors the non-cached path's per-worker resolve.
+            if key.worker_id is not None and key.world_size > 1:
+                all_obj_keys = [cached[r.hash][key.worker_id] for r in cb_match_result]
+            else:
+                all_obj_keys = [k for r in cb_match_result for k in cached[r.hash]]
         else:
             all_obj_keys = ipc_key_to_object_keys(
                 key, [r.hash for r in cb_match_result]
@@ -943,9 +996,7 @@ class BlendV3Module:
                     # matched range to the allocated slots.
                     pairs: list[tuple[CBMatchResult, Any]] = []
                     num_slots = int(all_block_ids_gpu.numel()) * ie_logical_block_size
-                    for r, memory_obj in zip(
-                        cb_match_result, memory_objs, strict=False
-                    ):
+                    for r, memory_obj in zip(cb_match_result, memory_objs, strict=True):
                         if r.cur_ed > num_slots:
                             logger.warning(
                                 "Dropping CB match cur_st=%d cur_ed=%d: exceeds "

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -83,15 +83,12 @@ class _CBUnifiedJob:
 
 
 class BlendTokenRangeMatcherV3(BlendTokenRangeMatcher):
-    """V3 matcher: full-hash collision rejection + configurable probe stride.
+    """V3 matcher: token-level probe (any offset) + full-hash collision
+    rejection."""
 
-    register_rope sets ``probe_stride`` to 1 for token-level matching.
-    """
-
-    def __init__(self, chunk_size: int = 256, probe_stride: int = 16):
+    def __init__(self, chunk_size: int = 256):
         super().__init__(chunk_size)
         self._chunk_poly_hash: list[int] = []
-        self._probe_stride: int = probe_stride
 
     def on_new_token_hashes(
         self,
@@ -159,74 +156,55 @@ class BlendTokenRangeMatcherV3(BlendTokenRangeMatcher):
         self,
         token_ids: list[int],
     ) -> list[CBMatchResult]:
-        """Probe rolling-hash array every ``probe_stride`` positions; skips
-        bucket-only collisions and evicted entries. One result per unique
-        match; ``cur_st`` is the first hit position."""
+        """Find every registered chunk reused in ``token_ids``. One result per
+        unique chunk; ``cur_st`` is its first query position. Verifies the full
+        poly hash to reject direct-address bucket collisions."""
         if len(token_ids) < self.chunk_size:
             return []
 
         arr = np.array(token_ids, dtype=np.uint64)
         rolling = rolling_hash_windows_numba(arr, self.chunk_size, self._BASE)
-        n_positions = int(rolling.shape[0])
 
         with self._lock:
             if not self._chunk_token_hash:
-                logger.info(
-                    "[match_probe] empty fingerprint table; n_tok=%d", len(token_ids)
-                )
                 return []
 
-            mask = int(self._mask)
-            stride = self._probe_stride
+            # Vectorized direct-address probe over all positions. The table is
+            # sparse (TABLE_SIZE >> registered chunks), so only true matches and
+            # a few bucket collisions reach the Python verify loop below.
+            cids_at_pos = self._table_id[rolling & self._mask]
+            hit_positions = np.nonzero(cids_at_pos >= 0)[0]
+
             seen_cids: set[int] = set()
             results: list[CBMatchResult] = []
-            n_probes = 0
-            n_table_hit = 0
-            n_collision = 0
-            n_evicted = 0
-            n_no_old_st = 0
-            for q_pos in range(0, n_positions, stride):
-                n_probes += 1
-                r = int(rolling[q_pos])
-                cid = int(self._table_id[r & mask])
-                if cid < 0 or cid in seen_cids:
+            for pos in hit_positions:
+                pos = int(pos)
+                cid = int(cids_at_pos[pos])
+                if cid in seen_cids:
                     continue
-                n_table_hit += 1
-                if r != self._chunk_poly_hash[cid]:
-                    n_collision += 1
-                    continue
+                if int(rolling[pos]) != self._chunk_poly_hash[cid]:
+                    continue  # bucket-only collision
                 th = self._chunk_token_hash[cid]
                 if th is None:
-                    n_evicted += 1
-                    continue
+                    continue  # evicted
                 old_st = self._token_hash_to_start.get(th)
                 if old_st is None:
-                    n_no_old_st += 1
                     continue
                 seen_cids.add(cid)
                 results.append(
                     CBMatchResult(
                         old_st=old_st,
                         old_ed=old_st + self.chunk_size,
-                        cur_st=q_pos,
-                        cur_ed=q_pos + self.chunk_size,
+                        cur_st=pos,
+                        cur_ed=pos + self.chunk_size,
                         hash=th,
                     )
                 )
             logger.info(
-                "[match_probe] n_tok=%d stride=%d n_probes=%d "
-                "table_hit=%d collisions=%d evicted=%d no_old_st=%d "
-                "→ matches=%d (sample old_st=%s cur_st=%s)",
+                "[match_probe] n_tok=%d table_hits=%d matches=%d",
                 len(token_ids),
-                stride,
-                n_probes,
-                n_table_hit,
-                n_collision,
-                n_evicted,
-                n_no_old_st,
+                len(hit_positions),
                 len(results),
-                [r.old_st for r in results[:3]],
-                [r.cur_st for r in results[:3]],
             )
             return results
 
@@ -428,20 +406,14 @@ class BlendV3Module:
         self._cb_gpu_contexts[instance_id] = gpu_context
         self._cb_gpu_context_meta[instance_id] = (entry.model_name, entry.world_size)
 
-        # Probe every token so non-block-aligned matches are found; the
-        # per-token slot scatter writes them.
-        self._token_range_matcher._probe_stride = 1
-
         logger.info(
             "Registered CB rope state for instance %d "
-            "(cos_sin_cache shape=%s dtype=%s, head_size=%d, is_neox=%s, "
-            "matcher_probe_stride=%d)",
+            "(cos_sin_cache shape=%s dtype=%s, head_size=%d, is_neox=%s)",
             instance_id,
             tuple(cos_sin_cache.shape),
             cos_sin_cache.dtype,
             head_size,
             is_neox_style,
-            self._token_range_matcher._probe_stride,
         )
 
     def cb_unregister_rope(self, instance_id: int) -> None:

--- a/lmcache/v1/multiprocess/protocols/blend_v3.py
+++ b/lmcache/v1/multiprocess/protocols/blend_v3.py
@@ -1,16 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Blend V3 protocol — paged-aware CB pipeline.
-
-RPCs:
-* ``CB_REGISTER_ROPE_V3`` / ``CB_UNREGISTER_ROPE_V3`` — share / release the rope
-  cos/sin cache onto a context already registered via ``REGISTER_KV_CACHE``.
-* ``CB_RETRIEVE_PRE_COMPUTED_V3`` — scatter all matched chunks (prefix- and
-  non-prefix-hit) into paged KV by per-token block ID; re-RoPE only the shifted
-  (``old_st != cur_st``) subset.
-* ``CB_UNIFIED_LOOKUP`` — the sole live lookup path: one RPC runs prefix +
-  non-prefix match, reconcile, one sparse-coalesced prefetch, and per-TP-rank
-  classify. ``(IPCCacheEngineKey, tp_size)`` → ``CBUnifiedLookupResult``.
-"""
+"""Blend V3 protocol definitions."""
 
 # First Party
 from lmcache.v1.multiprocess.custom_types import (


### PR DESCRIPTION
## Description
blend V3 matched fingerprints at vLLM-block stride and scattered reused KV with the whole-block kernel, so it could only reuse chunks landing on a block boundary. Real-world workloads share content at arbitrary token offsets (partial vLLM blocks), which couldn't be blended — collapsing the hit rate. This makes both matching and scatter token-granular.

## Changes
- **Match at token stride** (`probe_stride = 1`) to find non-block-aligned matches.
- **Per-token slot scatter for non-prefix chunks** (`multi_layer_kv_transfer`) instead of the whole-block kernel: writes partial vLLM blocks, so matched and recomputed tokens sharing a block don't conflict — no trim/seam handling. Removes the block-aligned drop checks and dead whole-block scatter path.
- **Vectorized matcher probe**: token stride made the old per-position Python loop O(tokens); replace with a numpy direct-address gather + small poly-verify loop over surviving hits (restores the base class vectorization the V3 override dropped). Drops the obsolete `probe_stride`.