### PR TITLE
[Bugfix] Fix L2 bench L1 alignment for raw-block O_DIRECT

### DIFF
--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -1165,10 +1165,9 @@ round against the byte pattern that ``store`` wrote (see
    [Verify] Checking store -> load data integrity for last measured round...
    [Verify] OK
 
-Verification is **off** by default because the stricter byte pattern
-also forces every key to allocate its own ``data_size`` buffer
-(otherwise the runner is free to reuse a single shared buffer across
-keys to keep the memory footprint small).
+Verification is **off** by default so the benchmark can focus on L2
+adapter throughput unless byte-for-byte store/load validation is
+explicitly requested.
 
 
 Exit codes

--- a/lmcache/cli/commands/bench/l2_adapter_bench/command.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/command.py
@@ -168,12 +168,10 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
         args: Parsed CLI arguments from the ``bench l2`` subparser.
     """
     # Lazy imports: keep CLI loadable without torch / native deps.
-    # Third Party
-    import torch
-
     # First Party
     from lmcache.cli.commands.bench.l2_adapter_bench.data import (
         create_l1_memory_desc,
+        make_aligned_l1_buffer,
         make_memory_objects,
         make_object_keys,
         verify_round_trip,
@@ -191,6 +189,7 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
     kb = 1024
     mb = 1024 * 1024
     data_size = args.data_size_kb * kb
+    l1_align_bytes = 4096
     in_flight = args.in_flight
     num_keys = args.num_keys
     rounds = args.rounds
@@ -241,8 +240,14 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
 
     # Backing L1 memory buffer for adapters that need an L1 desc.
     # Sized for one in-flight wave of store + load buffers.
-    l1_buffer = torch.empty(2 * keys_per_round * data_size, dtype=torch.uint8)
-    l1_memory_desc = create_l1_memory_desc(l1_buffer)
+    l1_buffer = make_aligned_l1_buffer(
+        2 * keys_per_round * data_size,
+        align_bytes=l1_align_bytes,
+    )
+    l1_memory_desc = create_l1_memory_desc(
+        l1_buffer,
+        align_bytes=l1_align_bytes,
+    )
 
     log("\n[Init] Creating adapter...")
     try:

--- a/lmcache/cli/commands/bench/l2_adapter_bench/command.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/command.py
@@ -125,9 +125,8 @@ def register_l2_parser(
             "never stored. Default: 0.0."
         ),
     )
-    # Round-trip verification is OFF by default (cheaper memory
-    # footprint: see make_memory_objects' share_buffer layout).
-    # Use --no-skip-verify to enable verification.
+    # Round-trip verification is OFF by default. Use --no-skip-verify
+    # to compare store and load buffers after the measured rounds.
     parser.add_argument(
         "--skip-verify",
         action=argparse.BooleanOptionalAction,
@@ -238,10 +237,15 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
     # Use the first adapter config for benchmarking
     adapter_cfg = l2_cfg.adapters[0]
 
-    # Backing L1 memory buffer for adapters that need an L1 desc.
-    # Sized for one in-flight wave of store + load buffers.
+    # Backing L1 memory buffer for adapters that need an L1 desc. The buffer
+    # is eagerly reserved for one in-flight store wave and one in-flight load
+    # wave; store/load MemoryObj views are created lazily below.
+    l1_slot_size = ((data_size + l1_align_bytes - 1) // l1_align_bytes) * (
+        l1_align_bytes
+    )
+    l1_direction_bytes = keys_per_round * l1_slot_size
     l1_buffer = make_aligned_l1_buffer(
-        2 * keys_per_round * data_size,
+        2 * l1_direction_bytes,
         align_bytes=l1_align_bytes,
     )
     l1_memory_desc = create_l1_memory_desc(
@@ -282,20 +286,29 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
             for i in range(in_flight)
         ]
 
-    def _build_round_objs() -> list[list]:
+    def _build_round_objs(start_offset: int) -> list[list]:
         """Allocate per-submit object batches for one round.
 
-        Every key in every batch gets its OWN ``data_size`` tensor,
+        Every key in every batch gets its OWN L1-backed tensor view,
         pre-filled with a distinguishing byte pattern. This keeps
         ``verify_round_trip`` meaningful (it can detect cross-key
         corruption after a store -> load cycle) and keeps the
         memory layout consistent regardless of whether verify is
         actually run.
 
-        Per-round (per direction) memory:
-        ``in_flight * num_keys * data_size`` bytes.
+        Per direction, the returned views cover:
+        ``in_flight * num_keys * l1_slot_size`` bytes.
         """
-        return [make_memory_objects(num_keys, data_size) for _ in range(in_flight)]
+        return [
+            make_memory_objects(
+                num_keys,
+                data_size,
+                l1_buffer,
+                start_offset + i * num_keys * l1_slot_size,
+                align_bytes=l1_align_bytes,
+            )
+            for i in range(in_flight)
+        ]
 
     # Lookup hit/miss split per round.
     per_round_hit = int(keys_per_round * max_hit_rate)
@@ -327,29 +340,28 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
 
     # Per-direction object batches for store / load.
     #
-    # Allocation strategy:
-    # * Lazy: only allocate when the corresponding direction is
-    #   actually exercised. With ``--only store`` we never touch
-    #   load buffers (and vice versa), saving
-    #   ``in_flight * num_keys * data_size`` bytes of host memory.
-    # * Cross-round reuse: once allocated, the same batches are
-    #   fed into every round; only the keys change per round. The
-    #   L2 adapter does not care about object identity across
-    #   rounds, and re-allocating these buffers each round would
-    #   just be wasted work.
+    # Object-view construction strategy:
+    # * Direction-lazy: only create MemoryObj wrappers/views when the
+    #   corresponding operation runs. The backing L1 buffer was already
+    #   reserved above, so this saves wrapper construction and buffer
+    #   initialization work, not the reserved L1 capacity.
+    # * Cross-round reuse: once created, the same batches are fed into every
+    #   round; only the keys change per round. The L2 adapter does not care
+    #   about object identity across rounds, and rebuilding the views each
+    #   round would just be wasted work.
     store_obj_batches: list[list] | None = None
     load_obj_batches: list[list] | None = None
 
     def _store_objs(_r: int) -> list[list]:
         nonlocal store_obj_batches
         if store_obj_batches is None:
-            store_obj_batches = _build_round_objs()
+            store_obj_batches = _build_round_objs(0)
         return store_obj_batches
 
     def _load_objs(_r: int) -> list[list]:
         nonlocal load_obj_batches
         if load_obj_batches is None:
-            load_obj_batches = _build_round_objs()
+            load_obj_batches = _build_round_objs(l1_direction_bytes)
         return load_obj_batches
 
     results: list = []
@@ -424,7 +436,7 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
             # the last measured round, and load buffers now hold what
             # the adapter returned. Compare against the byte pattern
             # written by store (i & 0xFF, where i is position within
-            # the batch — see make_memory_objects).
+            # the batch; see make_memory_objects).
             log(
                 "[Verify] Checking store -> load data integrity for last "
                 "measured round..."

--- a/lmcache/cli/commands/bench/l2_adapter_bench/data.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/data.py
@@ -95,28 +95,58 @@ def make_object_keys(
 def make_memory_objects(
     num_keys: int,
     data_size: int,
+    l1_buffer: torch.Tensor,
+    start_offset: int,
+    align_bytes: int = _DEFAULT_L1_ALIGN_BYTES,
 ) -> list[MemoryObj]:
-    """Create *num_keys* ``TensorMemoryObj`` instances of *data_size* bytes.
+    """Create ``TensorMemoryObj`` instances backed by an L1 buffer.
 
-    Each returned object owns an independent ``data_size``-byte tensor
-    pre-filled with a distinguishing byte pattern (key index mod 256)
-    so that ``verify_round_trip`` can detect cross-key corruption after
-    a store -> load cycle.
+    Args:
+        num_keys: Number of memory objects to create.
+        data_size: Logical data size per object in bytes.
+        l1_buffer: Flat CPU tensor representing the benchmark's synthetic L1
+            memory pool.
+        start_offset: Byte offset into ``l1_buffer`` where allocation begins.
+        align_bytes: Byte alignment for object starts and physical sizes.
 
-    Per-call memory: ``num_keys * data_size``.
+    Returns:
+        ``num_keys`` memory objects whose tensors are views into ``l1_buffer``.
+
+    Raises:
+        ValueError: If arguments are invalid or the requested objects do not fit
+            inside ``l1_buffer``.
     """
-    # Independent buffers with distinguishing fill patterns for verify.
+    if num_keys < 0:
+        raise ValueError("num_keys must be >= 0")
+    if data_size < 0:
+        raise ValueError("data_size must be >= 0")
+    if start_offset < 0:
+        raise ValueError("start_offset must be >= 0")
+    _validate_align_bytes(align_bytes)
+    if start_offset % align_bytes != 0:
+        raise ValueError("start_offset must be aligned to align_bytes")
+
+    flat_buffer = l1_buffer.view(-1)
+    slot_size = _round_up(data_size, align_bytes)
+    end_offset = start_offset + num_keys * slot_size
+    if end_offset > flat_buffer.numel() * flat_buffer.element_size():
+        raise ValueError("requested memory objects exceed l1_buffer capacity")
+
     objects: list[MemoryObj] = []
     for i in range(num_keys):
-        raw_tensor = torch.empty(data_size, dtype=torch.uint8)
-        raw_tensor.fill_(i & 0xFF)
+        offset = start_offset + i * slot_size
+        raw_tensor = flat_buffer[offset : offset + slot_size]
+        raw_tensor.zero_()
+        raw_tensor[:data_size].fill_(i & 0xFF)
         metadata = MemoryObjMetadata(
             shape=torch.Size([data_size]),
             dtype=torch.uint8,
-            address=raw_tensor.data_ptr(),
-            phy_size=data_size * raw_tensor.element_size(),
+            address=offset,
+            phy_size=slot_size,
             fmt=MemoryFormat.KV_2LTD,
             ref_count=1,
+            shapes=[torch.Size([data_size])],
+            dtypes=[torch.uint8],
         )
         objects.append(
             TensorMemoryObj(

--- a/lmcache/cli/commands/bench/l2_adapter_bench/data.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/data.py
@@ -22,6 +22,46 @@ from lmcache.v1.memory_management import (
 from lmcache.v1.platform import consume_fd
 
 _KB = 1024
+_DEFAULT_L1_ALIGN_BYTES = 4096
+
+
+def _round_up(value: int, align_bytes: int) -> int:
+    return (value + align_bytes - 1) & ~(align_bytes - 1)
+
+
+def _validate_align_bytes(align_bytes: int) -> None:
+    if align_bytes <= 0 or align_bytes & (align_bytes - 1) != 0:
+        raise ValueError("align_bytes must be a positive power of two")
+
+
+def make_aligned_l1_buffer(
+    size: int,
+    align_bytes: int = _DEFAULT_L1_ALIGN_BYTES,
+) -> torch.Tensor:
+    """Create a CPU uint8 tensor whose data pointer satisfies *align_bytes*.
+
+    Args:
+        size: Requested logical capacity in bytes.
+        align_bytes: Required byte alignment for the returned tensor.
+
+    Returns:
+        A contiguous ``torch.uint8`` CPU tensor with capacity rounded up to
+        ``align_bytes`` and a data pointer aligned to ``align_bytes``.
+
+    Raises:
+        ValueError: If ``size`` is negative or ``align_bytes`` is not a
+            positive power of two.
+    """
+    if size < 0:
+        raise ValueError("size must be >= 0")
+    _validate_align_bytes(align_bytes)
+    if size == 0:
+        return torch.empty(0, dtype=torch.uint8)
+
+    aligned_size = _round_up(size, align_bytes)
+    base_buffer = torch.empty(aligned_size + align_bytes, dtype=torch.uint8)
+    offset = (-base_buffer.data_ptr()) % align_bytes
+    return base_buffer[offset : offset + aligned_size]
 
 
 def make_object_keys(
@@ -88,13 +128,28 @@ def make_memory_objects(
     return objects
 
 
-def create_l1_memory_desc(buffer: torch.Tensor) -> L1MemoryDesc:
-    """Create an L1 memory descriptor for a contiguous test buffer."""
+def create_l1_memory_desc(
+    buffer: torch.Tensor,
+    align_bytes: int = _DEFAULT_L1_ALIGN_BYTES,
+) -> L1MemoryDesc:
+    """Create an L1 memory descriptor for a contiguous test buffer.
+
+    Args:
+        buffer: Contiguous tensor backing the benchmark's synthetic L1 memory.
+        align_bytes: Byte alignment advertised to L2 adapters.
+
+    Returns:
+        An ``L1MemoryDesc`` describing the supplied buffer.
+
+    Raises:
+        ValueError: If ``align_bytes`` is not a positive power of two.
+    """
+    _validate_align_bytes(align_bytes)
     flat_buffer = buffer.view(-1)
     return L1MemoryDesc(
         ptr=flat_buffer.data_ptr(),
         size=flat_buffer.numel() * flat_buffer.element_size(),
-        align_bytes=flat_buffer.element_size(),
+        align_bytes=align_bytes,
     )
 
 

--- a/tests/cli/commands/bench/test_l2_adapter_bench_data.py
+++ b/tests/cli/commands/bench/test_l2_adapter_bench_data.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for L2 adapter benchmark memory object construction."""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import argparse
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.cli.commands.bench.l2_adapter_bench.command import run_l2_adapter_bench
+from lmcache.cli.commands.bench.l2_adapter_bench.data import (
+    create_l1_memory_desc,
+    make_aligned_l1_buffer,
+    make_memory_objects,
+)
+from lmcache.cli.commands.bench.l2_adapter_bench.result import BenchResult
+from lmcache.v1.memory_management import MemoryFormat
+
+
+def test_make_memory_objects_allocates_views_from_l1_buffer() -> None:
+    align_bytes = 64
+    data_size = 100
+    slot_size = 128
+    start_offset = 64
+    l1_buffer = make_aligned_l1_buffer(
+        start_offset + 3 * slot_size,
+        align_bytes=align_bytes,
+    )
+    l1_desc = create_l1_memory_desc(l1_buffer, align_bytes=align_bytes)
+
+    objects = make_memory_objects(
+        3,
+        data_size,
+        l1_buffer,
+        start_offset,
+        align_bytes=align_bytes,
+    )
+
+    assert len(objects) == 3
+    for i, obj in enumerate(objects):
+        offset = start_offset + i * slot_size
+        assert obj.metadata.address == offset
+        assert obj.metadata.phy_size == slot_size
+        assert obj.metadata.shape == torch.Size([data_size])
+        assert obj.metadata.dtype is torch.uint8
+        assert obj.metadata.fmt is MemoryFormat.KV_2LTD
+        assert obj.raw_data.data_ptr() == l1_desc.ptr + offset
+        assert l1_desc.ptr <= obj.raw_data.data_ptr() < l1_desc.ptr + l1_desc.size
+        assert obj.raw_data.numel() == slot_size
+        assert torch.all(obj.raw_data[:data_size] == (i & 0xFF))
+        assert torch.all(obj.raw_data[data_size:] == 0)
+
+
+def test_make_memory_objects_rejects_out_of_range_allocation() -> None:
+    l1_buffer = make_aligned_l1_buffer(128, align_bytes=64)
+
+    with pytest.raises(ValueError, match="exceed l1_buffer"):
+        make_memory_objects(
+            3,
+            64,
+            l1_buffer,
+            0,
+            align_bytes=64,
+        )
+
+
+def test_run_l2_adapter_bench_passes_l1_backed_objects_to_runners() -> None:
+    fake_adapter = MagicMock()
+    captured_desc = None
+    captured_batches = []
+
+    def fake_create_l2_adapter(_adapter_cfg, l1_memory_desc=None):
+        nonlocal captured_desc
+        captured_desc = l1_memory_desc
+        return fake_adapter
+
+    def fake_bench_store(
+        _adapter,
+        in_flight,
+        num_keys,
+        data_size,
+        rounds,
+        keys_for_round,
+        objs_for_round,
+        log,
+    ):
+        del keys_for_round, log
+        captured_batches.extend(objs_for_round(0))
+        return BenchResult(
+            operation="Store",
+            in_flight=in_flight,
+            num_keys=num_keys,
+            data_size_bytes=data_size,
+            round_durations=[0.1] * rounds,
+            success_counts=[in_flight * num_keys] * rounds,
+        )
+
+    def fake_bench_lookup(
+        _adapter,
+        in_flight,
+        num_keys,
+        rounds,
+        keys_for_round,
+        log,
+        expected_max_hit_rate=0.0,
+        expected_hit_count=0,
+    ):
+        del keys_for_round, log
+        return BenchResult(
+            operation="Lookup",
+            in_flight=in_flight,
+            num_keys=num_keys,
+            data_size_bytes=0,
+            round_durations=[0.1] * rounds,
+            success_counts=[0] * rounds,
+            expected_max_hit_rate=expected_max_hit_rate,
+            expected_hit_count=expected_hit_count,
+        )
+
+    def fake_bench_load(
+        _adapter,
+        in_flight,
+        num_keys,
+        data_size,
+        rounds,
+        keys_for_round,
+        objs_for_round,
+        log,
+    ):
+        del keys_for_round, log
+        captured_batches.extend(objs_for_round(0))
+        return BenchResult(
+            operation="Load",
+            in_flight=in_flight,
+            num_keys=num_keys,
+            data_size_bytes=data_size,
+            round_durations=[0.1] * rounds,
+            success_counts=[in_flight * num_keys] * rounds,
+        )
+
+    command = MagicMock()
+    metrics = MagicMock()
+    metrics.add_section.return_value = MagicMock()
+    command.create_metrics.return_value = metrics
+    args = argparse.Namespace(
+        l2_adapter=['{"type":"mock","max_size_gb":1,"mock_bandwidth_gb":10}'],
+        num_keys=2,
+        in_flight=2,
+        data_size_kb=1,
+        rounds=1,
+        warmup_rounds=0,
+        lookup_max_hit_rate=0.0,
+        skip_verify=True,
+        only=None,
+        quiet=True,
+        format=None,
+        output=None,
+    )
+
+    with (
+        patch(
+            "lmcache.v1.distributed.l2_adapters.config."
+            "parse_args_to_l2_adapters_config",
+            return_value=SimpleNamespace(adapters=[object()]),
+        ),
+        patch(
+            "lmcache.v1.distributed.l2_adapters.create_l2_adapter",
+            side_effect=fake_create_l2_adapter,
+        ),
+        patch(
+            "lmcache.cli.commands.bench.l2_adapter_bench.runner.bench_store",
+            side_effect=fake_bench_store,
+        ),
+        patch(
+            "lmcache.cli.commands.bench.l2_adapter_bench.runner.bench_lookup",
+            side_effect=fake_bench_lookup,
+        ),
+        patch(
+            "lmcache.cli.commands.bench.l2_adapter_bench.runner.bench_load",
+            side_effect=fake_bench_load,
+        ),
+    ):
+        run_l2_adapter_bench(command, args)
+
+    assert captured_desc is not None
+    assert len(captured_batches) == 4
+    for batch in captured_batches:
+        for obj in batch:
+            assert obj.raw_data.data_ptr() == captured_desc.ptr + obj.metadata.address
+            assert obj.metadata.phy_size == 4096
+            assert 0 <= obj.metadata.address < captured_desc.size
+            assert obj.metadata.address % captured_desc.align_bytes == 0
+            assert obj.raw_data.data_ptr() < captured_desc.ptr + captured_desc.size
+    fake_adapter.close.assert_called_once_with()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the `lmcache bench l2` data path so the benchmark uses an explicit L1 backing buffer with aligned per-object views instead of treating each object as an independent host allocation.

The main changes are:

- allocate a single aligned L1 buffer for one in-flight store wave and one in-flight load wave
- build `TensorMemoryObj` views from that buffer with aligned offsets and physical sizes so O_DIRECT-backed raw-block adapters receive valid L1 layout information
- advertise the intended L1 alignment through `L1MemoryDesc` instead of the tensor element size
- keep store/load verification semantics the same while clarifying that verification is optional and focused on byte-for-byte validation
- add unit coverage for aligned buffer creation, bounds checking, and the CLI bench runner wiring

Why this is needed:

The previous benchmark object construction could produce L1 metadata that did not match the buffer layout expected by raw-block O_DIRECT paths. That made the benchmark less representative and could trip alignment-sensitive adapters. Reusing a single aligned L1 buffer makes the benchmark data model match the adapter contract more closely.

**Special notes for your reviewers**:

- This PR is scoped to the CLI L2 adapter benchmark path and its tests/docs.
- The new `make_memory_objects(...)` contract now expects an L1 buffer and starting offset, and records object addresses relative to that L1 region.
- The benchmark still creates store/load object batches lazily, but the L1 capacity is reserved up front for both directions.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests