### PR TITLE
ci: add macOS vLLM CPU e2e test

### DIFF
--- a/.github/scripts/macos_vllm_e2e_test.sh
+++ b/.github/scripts/macos_vllm_e2e_test.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # macOS vLLM CPU end-to-end smoke test for lmcache multiprocess server.
-# Installs vLLM CPU build, starts LMCache server + vLLM, and sends a
-# completion request to verify the full stack works on macOS.
+# Assumes vLLM CPU build and facebook/opt-125m are already installed/
+# downloaded by the CI workflow steps before this script is invoked.
 #
 # Key differences from the Linux CPU e2e validation:
 #   - No /dev/shm on macOS -> use pickle transport (LMCACHE_SHM_NAME="")
@@ -106,33 +106,16 @@ trap on_error ERR
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
-# Phase 1: Install vLLM CPU build
+# Phase 1: Validate installs
 # ---------------------------------------------------------------------------
 
 echo ""
-echo "=== Phase 1: Install vLLM CPU build ==="
-
-echo "==> Installing numpy<2 for scipy/vLLM compatibility"
-pip install "numpy<2"
-echo "    numpy<2 installed"
-
-echo "==> Installing vLLM CPU build"
-pip install vllm \
-    --extra-index-url \
-    https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu
-echo "    vLLM CPU install completed"
+echo "=== Phase 1: Validate installs ==="
 
 echo "==> Validating imports"
 python3 -c "import lmcache; import vllm; print('imports OK')"
 python3 -c "import vllm; print('vllm:', vllm.__version__)"
 python3 -c "import lmcache; print('lmcache:', lmcache.__version__)"
-
-echo "==> Downloading facebook/opt-125m (cache-aware)"
-python3 -c "
-from huggingface_hub import snapshot_download
-snapshot_download('facebook/opt-125m')
-print('model ready')
-"
 
 echo "=== Phase 1 passed ==="
 

--- a/.github/scripts/macos_vllm_e2e_test.sh
+++ b/.github/scripts/macos_vllm_e2e_test.sh
@@ -51,7 +51,7 @@ wait_for_endpoint() {
     local label="$4"
     local response
 
-    for _ in $(seq 1 "${timeout}"); do
+    for ((i=1; i<=timeout; i++)); do
         if response="$(curl -fsS "${url}" 2>/dev/null)"; then
             if [ -z "${expected}" ] || \
                echo "${response}" | grep -q "${expected}"; then
@@ -73,22 +73,29 @@ print_logs() {
 
 cleanup() {
     set +e
-    if [ -n "${VLLM_PID}" ] && kill -0 "${VLLM_PID}" 2>/dev/null; then
-        echo "==> Stopping vLLM (PID=${VLLM_PID})"
-        kill "${VLLM_PID}" 2>/dev/null || true
-        wait "${VLLM_PID}" 2>/dev/null || true
-    fi
-    if [ -n "${LMCACHE_PID}" ] && kill -0 "${LMCACHE_PID}" 2>/dev/null; then
-        echo "==> Stopping LMCache (PID=${LMCACHE_PID})"
-        kill "${LMCACHE_PID}" 2>/dev/null || true
-        wait "${LMCACHE_PID}" 2>/dev/null || true
-    fi
+    for pid in "${VLLM_PID}" "${LMCACHE_PID}"; do
+        if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+            echo "==> Stopping process PID=${pid} gracefully..."
+            kill "${pid}" 2>/dev/null || true
+            for ((i=1; i<=5; i++)); do
+                if ! kill -0 "${pid}" 2>/dev/null; then
+                    break
+                fi
+                sleep 1
+            done
+            if kill -0 "${pid}" 2>/dev/null; then
+                echo "==> Force killing process PID=${pid}..."
+                kill -9 "${pid}" 2>/dev/null || true
+            fi
+            wait "${pid}" 2>/dev/null || true
+        fi
+    done
     set -e
 }
 
 on_error() {
     local exit_code=$?
-    trap - ERR
+    trap - ERR EXIT
     echo "!! macOS vLLM CPU e2e test FAILED (exit code: ${exit_code})"
     print_logs
     cleanup

--- a/.github/scripts/macos_vllm_e2e_test.sh
+++ b/.github/scripts/macos_vllm_e2e_test.sh
@@ -112,8 +112,7 @@ echo "    numpy<2 installed"
 echo "==> Installing vLLM CPU build"
 pip install vllm \
     --extra-index-url \
-    https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu \
-    --index-strategy first-index
+    https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu
 echo "    vLLM CPU install completed"
 
 echo "==> Validating imports"

--- a/.github/scripts/macos_vllm_e2e_test.sh
+++ b/.github/scripts/macos_vllm_e2e_test.sh
@@ -106,15 +106,13 @@ echo ""
 echo "=== Phase 1: Install vLLM CPU build ==="
 
 echo "==> Installing numpy<2 for scipy/vLLM compatibility"
-uv pip install "numpy<2"
+pip install "numpy<2"
 echo "    numpy<2 installed"
 
 echo "==> Installing vLLM CPU build"
-uv pip install vllm \
+pip install vllm \
     --extra-index-url \
-    https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu \
-    --index-strategy first-index \
-    --torch-backend cpu
+    https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu
 echo "    vLLM CPU install completed"
 
 echo "==> Validating imports"

--- a/.github/scripts/macos_vllm_e2e_test.sh
+++ b/.github/scripts/macos_vllm_e2e_test.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# macOS vLLM CPU end-to-end smoke test for lmcache multiprocess server.
+# Installs vLLM CPU build, starts LMCache server + vLLM, and sends a
+# completion request to verify the full stack works on macOS.
+#
+# Key differences from the Linux CPU e2e validation:
+#   - No /dev/shm on macOS -> use pickle transport (LMCACHE_SHM_NAME="")
+#   - No apt-get / libnuma1 install step
+#   - Phase 3 (cache-hit metrics) is skipped to keep CI time reasonable
+#
+# Environment variables (all optional, defaults shown):
+#   LMCACHE_HTTP_PORT   HTTP port for LMCache server  (default: 8080)
+#   VLLM_PORT           HTTP port for vLLM server     (default: 8000)
+#   LMCACHE_L1_SIZE_GB  LMCache L1 cache size in GB   (default: 2)
+#   VLLM_READY_TIMEOUT  Seconds to wait for vLLM      (default: 300)
+#   LMCACHE_HEALTHCHECK_TIMEOUT  Seconds to wait for LMCache (default: 60)
+
+set -euo pipefail
+
+echo "==> macOS vLLM CPU e2e test"
+echo "    Python: $(python3 --version 2>&1 || true)"
+echo "    uname:  $(uname -a)"
+sw_vers 2>/dev/null || true
+
+LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+LMCACHE_L1_SIZE_GB="${LMCACHE_L1_SIZE_GB:-2}"
+LMCACHE_EVICTION_POLICY="${LMCACHE_EVICTION_POLICY:-LRU}"
+LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-128}"
+LMCACHE_HEALTHCHECK_TIMEOUT="${LMCACHE_HEALTHCHECK_TIMEOUT:-60}"
+VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-300}"
+
+LMCACHE_LOG="${LMCACHE_LOG_FILE:-/tmp/macos_e2e_lmcache.log}"
+VLLM_LOG="/tmp/macos_e2e_vllm.log"
+LMCACHE_PID=""
+VLLM_PID=""
+
+# macOS has no /dev/shm -> always use pickle transport
+LMCACHE_SHM_NAME=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+wait_for_endpoint() {
+    local url="$1"
+    local timeout="$2"
+    local expected="$3"
+    local label="$4"
+    local response
+
+    for _ in $(seq 1 "${timeout}"); do
+        if response="$(curl -fsS "${url}" 2>/dev/null)"; then
+            if [ -z "${expected}" ] || \
+               echo "${response}" | grep -q "${expected}"; then
+                return 0
+            fi
+        fi
+        sleep 1
+    done
+    echo "!! ${label} did not become ready within ${timeout}s"
+    return 1
+}
+
+print_logs() {
+    echo "=== LMCache log (${LMCACHE_LOG}) ==="
+    tail -n 100 "${LMCACHE_LOG}" 2>/dev/null || echo "(not found)"
+    echo "=== vLLM log (${VLLM_LOG}) ==="
+    tail -n 100 "${VLLM_LOG}" 2>/dev/null || echo "(not found)"
+}
+
+cleanup() {
+    set +e
+    if [ -n "${VLLM_PID}" ] && kill -0 "${VLLM_PID}" 2>/dev/null; then
+        echo "==> Stopping vLLM (PID=${VLLM_PID})"
+        kill "${VLLM_PID}" 2>/dev/null || true
+        wait "${VLLM_PID}" 2>/dev/null || true
+    fi
+    if [ -n "${LMCACHE_PID}" ] && kill -0 "${LMCACHE_PID}" 2>/dev/null; then
+        echo "==> Stopping LMCache (PID=${LMCACHE_PID})"
+        kill "${LMCACHE_PID}" 2>/dev/null || true
+        wait "${LMCACHE_PID}" 2>/dev/null || true
+    fi
+    set -e
+}
+
+on_error() {
+    local exit_code=$?
+    trap - ERR
+    echo "!! macOS vLLM CPU e2e test FAILED (exit code: ${exit_code})"
+    print_logs
+    cleanup
+    exit "${exit_code}"
+}
+
+trap on_error ERR
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Phase 1: Install vLLM CPU build
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Phase 1: Install vLLM CPU build ==="
+
+echo "==> Installing numpy<2 for scipy/vLLM compatibility"
+pip install "numpy<2"
+echo "    numpy<2 installed"
+
+echo "==> Installing vLLM CPU build"
+pip install vllm \
+    --extra-index-url \
+    https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu \
+    --index-strategy first-index \
+    --torch-backend cpu
+echo "    vLLM CPU install completed"
+
+echo "==> Validating imports"
+python3 -c "import lmcache; import vllm; print('imports OK')"
+python3 -c "import vllm; print('vllm:', vllm.__version__)"
+python3 -c "import lmcache; print('lmcache:', lmcache.__version__)"
+
+echo "==> Downloading facebook/opt-125m (cache-aware)"
+python3 -c "
+from huggingface_hub import snapshot_download
+snapshot_download('facebook/opt-125m')
+print('model ready')
+"
+
+echo "=== Phase 1 passed ==="
+
+# ---------------------------------------------------------------------------
+# Phase 2: Start LMCache server
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Phase 2: Start LMCache server ==="
+echo "    Transport mode: pickle (macOS has no /dev/shm)"
+echo "    LMCache log: ${LMCACHE_LOG}"
+
+lmcache server \
+    --l1-size-gb "${LMCACHE_L1_SIZE_GB}" \
+    --eviction-policy "${LMCACHE_EVICTION_POLICY}" \
+    --chunk-size "${LMCACHE_CHUNK_SIZE}" \
+    --shm-name "${LMCACHE_SHM_NAME}" \
+    >"${LMCACHE_LOG}" 2>&1 &
+LMCACHE_PID=$!
+echo "==> LMCache server started (PID=${LMCACHE_PID})"
+
+sleep 2
+if ! kill -0 "${LMCACHE_PID}" 2>/dev/null; then
+    echo "!! LMCache server exited immediately"
+    print_logs
+    exit 1
+fi
+
+echo "==> Waiting for LMCache healthcheck (timeout: ${LMCACHE_HEALTHCHECK_TIMEOUT}s)"
+if ! wait_for_endpoint \
+    "http://localhost:${LMCACHE_HTTP_PORT}/healthcheck" \
+    "${LMCACHE_HEALTHCHECK_TIMEOUT}" \
+    "" \
+    "LMCache server"; then
+    print_logs
+    exit 1
+fi
+echo "    LMCache server is healthy"
+
+# ---------------------------------------------------------------------------
+# Phase 3: Start vLLM CPU server
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Phase 3: Start vLLM CPU server ==="
+echo "    vLLM log: ${VLLM_LOG}"
+
+VLLM_TARGET_DEVICE=cpu vllm serve facebook/opt-125m \
+    --port "${VLLM_PORT}" \
+    --dtype bfloat16 \
+    --disable-hybrid-kv-cache-manager \
+    --no-enable-prefix-caching \
+    --gpu-memory-utilization 0.3 \
+    --kv-transfer-config \
+    '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both"}' \
+    >"${VLLM_LOG}" 2>&1 &
+VLLM_PID=$!
+echo "==> vLLM server started (PID=${VLLM_PID})"
+
+sleep 2
+if ! kill -0 "${VLLM_PID}" 2>/dev/null; then
+    echo "!! vLLM server exited immediately"
+    print_logs
+    exit 1
+fi
+
+echo "==> Waiting for vLLM readiness (timeout: ${VLLM_READY_TIMEOUT}s)"
+if ! wait_for_endpoint \
+    "http://localhost:${VLLM_PORT}/v1/models" \
+    "${VLLM_READY_TIMEOUT}" \
+    "facebook/opt-125m" \
+    "vLLM server"; then
+    print_logs
+    exit 1
+fi
+echo "    vLLM server is ready"
+
+# ---------------------------------------------------------------------------
+# Phase 4: E2E completion request
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Phase 4: E2E completion request ==="
+
+COMPLETION_RESPONSE="$(curl -fsS \
+    "http://localhost:${VLLM_PORT}/v1/completions" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"facebook/opt-125m","prompt":"Hello","max_tokens":5}')"
+echo "    Response: ${COMPLETION_RESPONSE}"
+
+if ! echo "${COMPLETION_RESPONSE}" | grep -q '"choices"'; then
+    echo "!! E2E response missing 'choices' field"
+    exit 1
+fi
+if ! echo "${COMPLETION_RESPONSE}" | grep -q "facebook/opt-125m"; then
+    echo "!! E2E response missing expected model name"
+    exit 1
+fi
+echo "    E2E request validation passed"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=========================================="
+echo "==> macOS vLLM CPU e2e test passed"
+echo "=========================================="

--- a/.github/scripts/macos_vllm_e2e_test.sh
+++ b/.github/scripts/macos_vllm_e2e_test.sh
@@ -106,11 +106,11 @@ echo ""
 echo "=== Phase 1: Install vLLM CPU build ==="
 
 echo "==> Installing numpy<2 for scipy/vLLM compatibility"
-pip install "numpy<2"
+uv pip install "numpy<2"
 echo "    numpy<2 installed"
 
 echo "==> Installing vLLM CPU build"
-pip install vllm \
+uv pip install vllm \
     --extra-index-url \
     https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu \
     --index-strategy first-index \

--- a/.github/scripts/macos_vllm_e2e_test.sh
+++ b/.github/scripts/macos_vllm_e2e_test.sh
@@ -112,7 +112,8 @@ echo "    numpy<2 installed"
 echo "==> Installing vLLM CPU build"
 pip install vllm \
     --extra-index-url \
-    https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu
+    https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu \
+    --index-strategy first-index
 echo "    vLLM CPU install completed"
 
 echo "==> Validating imports"

--- a/.github/scripts/macos_vllm_e2e_test.sh
+++ b/.github/scripts/macos_vllm_e2e_test.sh
@@ -139,6 +139,7 @@ echo "    Transport mode: pickle (macOS has no /dev/shm)"
 echo "    LMCache log: ${LMCACHE_LOG}"
 
 lmcache server \
+    --http-port "${LMCACHE_HTTP_PORT}" \
     --l1-size-gb "${LMCACHE_L1_SIZE_GB}" \
     --eviction-policy "${LMCACHE_EVICTION_POLICY}" \
     --chunk-size "${LMCACHE_CHUNK_SIZE}" \

--- a/.github/workflows/macos_compat.yml
+++ b/.github/workflows/macos_compat.yml
@@ -187,6 +187,18 @@ jobs:
           path: ~/.cache/huggingface
           key: hf-opt-125m-v1
 
+      # Separate cache for vLLM CPU wheel (large, keyed by commit hash).
+      # Must be declared before the install step so the cache is restored
+      # before pip runs.
+      - name: Cache vLLM pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: >-
+            vllm-cpu-macos-py3.12-71df063c
+          restore-keys: |
+            vllm-cpu-macos-py3.12-
+
       - name: Install lmcache (CPU-only, no vLLM)
         env:
           NO_GPU_EXT: "1"
@@ -198,6 +210,21 @@ jobs:
           python -m pip install -r requirements/common.txt
           python -m pip install -r requirements/cli.txt
           python -m pip install -e . --no-deps --no-build-isolation
+
+      - name: Install vLLM CPU build
+        run: |
+          pip install "numpy<2"
+          pip install vllm \
+            --extra-index-url \
+            https://wheels.vllm.ai/71df063c494c111ab60f6a33c54aafe7b9ae1d02/cpu
+
+      - name: Download facebook/opt-125m
+        run: |
+          python3 -c "
+          from huggingface_hub import snapshot_download
+          snapshot_download('facebook/opt-125m')
+          print('model ready')
+          "
 
       - name: Run macOS vLLM CPU e2e test
         env:

--- a/.github/workflows/macos_compat.yml
+++ b/.github/workflows/macos_compat.yml
@@ -179,6 +179,13 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
             requirements/*.txt
+            .github/workflows/macos_compat.yml
+
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-opt-125m-v1
 
       - name: Install lmcache (CPU-only, no vLLM)
         env:

--- a/.github/workflows/macos_compat.yml
+++ b/.github/workflows/macos_compat.yml
@@ -1,13 +1,17 @@
 name: macOS Compat
 
-# Smoke test that verifies the lmcache multiprocess server can be
-# installed and launched on macOS (GPU backend skipped via NO_GPU_EXT=1;
-# common C++ extensions — native_storage_ops / lmcache_redis /
-# lmcache_fs — are still built so the cross-platform PipeNotifier
-# fallback in csrc/storage_backends/event_notifier.h is exercised),
-# and that both the HTTP endpoint and the `lmcache` CLI are usable.
-# This is a "best-effort basic compatibility" check — it does not
-# cover GPU / CUDA / vLLM code paths.
+# Two-job macOS compatibility suite:
+#
+# 1. macos-smoke  — fast sanity check: installs lmcache (NO_GPU_EXT=1,
+#    no vLLM), verifies common C++ extensions load, and confirms the
+#    LMCache HTTP server starts and answers /healthcheck.
+#
+# 2. macos-vllm-e2e  — full CPU e2e: installs vLLM CPU build on top of
+#    lmcache, starts LMCache server (pickle transport, macOS has no
+#    /dev/shm), starts vLLM with LMCacheMPConnector, and sends a
+#    completion request to verify the whole stack works end-to-end.
+#    Mirrors .buildkite/k3_tests/multiprocess/scripts/
+#    run-cpu-e2e-validation.sh but adapted for macOS.
 
 on:
   workflow_call:
@@ -66,6 +70,7 @@ jobs:
               - 'requirements/**.txt'
               - '.github/workflows/macos_compat.yml'
               - '.github/scripts/macos_smoke_test.sh'
+              - '.github/scripts/macos_vllm_e2e_test.sh'
               - '!operator/**'
 
   macos-smoke:
@@ -144,4 +149,69 @@ jobs:
         with:
           name: lmcache-server-log-${{ matrix.platform }}-py${{ matrix.python }}
           path: ${{ env.LMCACHE_LOG_FILE }}
+          if-no-files-found: ignore
+
+  macos-vllm-e2e:
+    needs: changes
+    if: needs.changes.outputs.lmcache == 'true'
+    name: "macOS vLLM CPU e2e: py3.12"
+    # macos-latest is Apple Silicon (arm64); vLLM CPU wheels support arm64.
+    runs-on: macos-latest
+    # vLLM CPU install + model download + server startup can be slow.
+    timeout-minutes: 60
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements/*.txt
+
+      - name: Install lmcache (CPU-only, no vLLM)
+        env:
+          NO_GPU_EXT: "1"
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0.dev0"
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/build.txt
+          python -m pip install torch
+          python -m pip install -r requirements/common.txt
+          python -m pip install -r requirements/cli.txt
+          python -m pip install -e . --no-deps --no-build-isolation
+
+      - name: Run macOS vLLM CPU e2e test
+        env:
+          LMCACHE_HTTP_PORT: "18080"
+          VLLM_PORT: "18000"
+          LMCACHE_LOG_FILE: "/tmp/macos_e2e_lmcache.log"
+          # macOS has no /dev/shm -> pickle transport
+          LMCACHE_SHM_NAME: ""
+          # GitHub macOS runners are slower; give vLLM more time to start.
+          VLLM_READY_TIMEOUT: "300"
+          LMCACHE_HEALTHCHECK_TIMEOUT: "60"
+        run: |
+          chmod +x .github/scripts/macos_vllm_e2e_test.sh
+          .github/scripts/macos_vllm_e2e_test.sh
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-vllm-e2e-logs
+          path: |
+            /tmp/macos_e2e_lmcache.log
+            /tmp/macos_e2e_vllm.log
           if-no-files-found: ignore


### PR DESCRIPTION
Add a new `macos-vllm-e2e` job to the macOS Compat workflow.

- Installs vLLM CPU build on macOS (arm64)
- Starts LMCache server with pickle transport (no /dev/shm on macOS)
- Starts vLLM with LMCacheMPConnector
- Sends a completion request to verify the full stack end-to-end

Mirrors `.buildkite/k3_tests/multiprocess/scripts/run-cpu-e2e-validation.sh` but adapted for macOS.