### PR TITLE
refactor: utilize multi_layer_block_kv_transfer ops for data transfer path

### DIFF
--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -1143,7 +1143,11 @@ def multi_layer_block_kv_transfer(
         gpu_kv_format=gpu_kv_format,
         dtype=kv_dtype,
     )
-    block_id_list = _to_block_id_list(block_ids)
+    n_block_ids = (
+        int(block_ids.numel())
+        if isinstance(block_ids, torch.Tensor)
+        else len(block_ids)
+    )
     blocks_per_object = lmcache_chunk_size // int(shape_desc.bs)
     block_size = int(shape_desc.bs)
 
@@ -1151,7 +1155,8 @@ def multi_layer_block_kv_transfer(
         _transfer_cross_layer(
             normalized,
             object_tensors,
-            block_id_list,
+            block_ids,
+            n_block_ids,
             blocks_per_object,
             block_size,
             gpu_kv_format,
@@ -1162,7 +1167,8 @@ def multi_layer_block_kv_transfer(
         _transfer_sglang_mha(
             normalized,
             object_tensors,
-            block_id_list,
+            block_ids,
+            n_block_ids,
             blocks_per_object,
             block_size,
             gpu_kv_format,
@@ -1173,7 +1179,8 @@ def multi_layer_block_kv_transfer(
         _transfer_per_layer_mla(
             normalized,
             object_tensors,
-            block_id_list,
+            block_ids,
+            n_block_ids,
             blocks_per_object,
             block_size,
             gpu_kv_format,
@@ -1184,7 +1191,8 @@ def multi_layer_block_kv_transfer(
         _transfer_per_layer_hnd(
             normalized,
             object_tensors,
-            block_id_list,
+            block_ids,
+            n_block_ids,
             blocks_per_object,
             block_size,
             gpu_kv_format,
@@ -1195,7 +1203,8 @@ def multi_layer_block_kv_transfer(
         _transfer_per_layer_nhd(
             normalized,
             object_tensors,
-            block_id_list,
+            block_ids,
+            n_block_ids,
             blocks_per_object,
             block_size,
             gpu_kv_format,
@@ -1234,10 +1243,28 @@ def _valid_block_range(
     return block_id_list[valid_flat_start:valid_flat_end], offset_in_object
 
 
+def _valid_block_range_indices(
+    object_idx: int,
+    n_block_ids: int,
+    blocks_per_object: int,
+    block_size: int,
+    skip_prefix_n_blocks: int,
+) -> tuple[int, int, int] | None:
+    """Return valid [start, end) range over flat block IDs and object token offset."""
+    object_flat_start = object_idx * blocks_per_object
+    valid_flat_start = max(object_flat_start, skip_prefix_n_blocks)
+    valid_flat_end = min(object_flat_start + blocks_per_object, n_block_ids)
+    if valid_flat_start >= valid_flat_end:
+        return None
+    offset_in_object = (valid_flat_start - object_flat_start) * block_size
+    return valid_flat_start, valid_flat_end, offset_in_object
+
+
 def _transfer_cross_layer(
     paged_tensor: torch.Tensor,
     object_tensors: list[torch.Tensor],
-    block_id_list: list[int],
+    block_ids: torch.Tensor | list[int],
+    n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
     gpu_kv_format: GPUKVFormat,
@@ -1261,23 +1288,24 @@ def _transfer_cross_layer(
     # H2D: pre-transfer objects to paged device
     if not is_d2h and object_tensors:
         objs_on_device = [obj.to(paged_tensor.device) for obj in object_tensors]
+    block_ids_dev = torch.as_tensor(
+        block_ids, dtype=torch.long, device=paged_tensor.device
+    )
 
     for object_idx, obj in enumerate(object_tensors):
-        valid = _valid_block_range(
+        valid = _valid_block_range_indices(
             object_idx,
-            block_id_list,
+            n_block_ids,
             blocks_per_object,
             block_size,
             skip_prefix_n_blocks,
         )
         if valid is None:
             continue
-        engine_block_ids, offset_in_object = valid
-        n_valid = len(engine_block_ids)
+        idx_start, idx_end, offset_in_object = valid
+        n_valid = idx_end - idx_start
         token_end = offset_in_object + n_valid * block_size
-        eff_idx = torch.tensor(
-            engine_block_ids, dtype=torch.long, device=paged_tensor.device
-        )
+        eff_idx = block_ids_dev[idx_start:idx_end]
 
         if is_d2h:
             selected = paged_tensor.index_select(0, eff_idx)
@@ -1317,7 +1345,8 @@ def _transfer_cross_layer(
 def _transfer_sglang_mha(
     paged_tensors: list[list[torch.Tensor]],
     object_tensors: list[torch.Tensor],
-    block_id_list: list[int],
+    block_ids: torch.Tensor | list[int],
+    n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
     gpu_kv_format: GPUKVFormat,
@@ -1336,21 +1365,22 @@ def _transfer_sglang_mha(
     # H2D: pre-transfer objects
     if not is_d2h and object_tensors:
         objs_on_device = [obj.to(target_device) for obj in object_tensors]
+    block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
 
     for object_idx, obj in enumerate(object_tensors):
-        valid = _valid_block_range(
+        valid = _valid_block_range_indices(
             object_idx,
-            block_id_list,
+            n_block_ids,
             blocks_per_object,
             block_size,
             skip_prefix_n_blocks,
         )
         if valid is None:
             continue
-        engine_block_ids, offset_in_object = valid
-        n_valid = len(engine_block_ids)
+        idx_start, idx_end, offset_in_object = valid
+        n_valid = idx_end - idx_start
         token_end = offset_in_object + n_valid * block_size
-        eff_idx = torch.tensor(engine_block_ids, dtype=torch.long, device=target_device)
+        eff_idx = block_ids_dev[idx_start:idx_end]
         if is_flat:
             # Flat token positions for all valid blocks:
             # block_id * block_size + token offset. Reused across layer/KV pairs.
@@ -1395,7 +1425,8 @@ def _transfer_sglang_mha(
 def _transfer_per_layer_mla(
     layer_tensors: list[torch.Tensor],
     object_tensors: list[torch.Tensor],
-    block_id_list: list[int],
+    block_ids: torch.Tensor | list[int],
+    n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
     gpu_kv_format: GPUKVFormat,
@@ -1403,49 +1434,57 @@ def _transfer_per_layer_mla(
     skip_prefix_n_blocks: int,
 ) -> None:
     """Handle MLA per-layer formats: [NB, BS, HS]."""
-    if not is_d2h and layer_tensors and object_tensors:
-        target_device = layer_tensors[0].device
-        objs_on_device = [obj.to(target_device) for obj in object_tensors]
+    if not layer_tensors or not object_tensors:
+        return
 
-    for layer_idx, layer in enumerate(layer_tensors):
-        is_flat = int(gpu_kv_format) == int(GPUKVFormat.NL_X_NBBS_ONE_HS)
+    is_flat = int(gpu_kv_format) == int(GPUKVFormat.NL_X_NBBS_ONE_HS)
+    target_device = layer_tensors[0].device
+    if is_flat:
+        token_offsets = torch.arange(block_size, dtype=torch.long, device=target_device)
+    block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
+
+    for object_idx, obj in enumerate(object_tensors):
+        valid = _valid_block_range_indices(
+            object_idx,
+            n_block_ids,
+            blocks_per_object,
+            block_size,
+            skip_prefix_n_blocks,
+        )
+        if valid is None:
+            continue
+        idx_start, idx_end, offset_in_object = valid
+        n_valid = idx_end - idx_start
+        token_end = offset_in_object + n_valid * block_size
+        eff_idx = block_ids_dev[idx_start:idx_end]
         if is_flat:
-            token_offsets = torch.arange(
-                block_size, dtype=torch.long, device=layer.device
-            )
-        for object_idx, obj in enumerate(object_tensors):
-            valid = _valid_block_range(
-                object_idx,
-                block_id_list,
-                blocks_per_object,
-                block_size,
-                skip_prefix_n_blocks,
-            )
-            if valid is None:
-                continue
-            engine_block_ids, offset_in_object = valid
-            n_valid = len(engine_block_ids)
-            token_end = offset_in_object + n_valid * block_size
-            eff_idx = torch.tensor(
-                engine_block_ids, dtype=torch.long, device=layer.device
-            )
-            if is_flat:
-                token_indices = (
-                    eff_idx[:, None] * block_size + token_offsets[None, :]
-                ).reshape(-1)
+            token_indices = (
+                eff_idx[:, None] * block_size + token_offsets[None, :]
+            ).reshape(-1)
 
-            if is_d2h:
+        if is_d2h:
+            hidden_size = layer_tensors[0].shape[-1]
+            chunk_gpu = torch.empty(
+                len(layer_tensors),
+                n_valid * block_size,
+                hidden_size,
+                dtype=layer_tensors[0].dtype,
+                device=target_device,
+            )
+            for layer_idx, layer in enumerate(layer_tensors):
                 if is_flat:
-                    layer_blocks = layer.index_select(0, token_indices)
+                    dst = chunk_gpu[layer_idx].view(
+                        n_valid * block_size, 1, hidden_size
+                    )
+                    torch.index_select(layer, 0, token_indices, out=dst)
                 else:
-                    layer_blocks = layer.index_select(0, eff_idx)
-                flat = layer_blocks.reshape(n_valid * block_size, layer.shape[-1])
-                obj[layer_idx, offset_in_object:token_end].copy_(
-                    flat, non_blocking=True
-                )
-            else:
-                obj_device = objs_on_device[object_idx]
-                src = obj_device[layer_idx, offset_in_object:token_end]
+                    dst = chunk_gpu[layer_idx].view(n_valid, block_size, hidden_size)
+                    torch.index_select(layer, 0, eff_idx, out=dst)
+            obj[:, offset_in_object:token_end].copy_(chunk_gpu, non_blocking=True)
+        else:
+            chunk_gpu = obj[:, offset_in_object:token_end].to(target_device)
+            for layer_idx, layer in enumerate(layer_tensors):
+                src = chunk_gpu[layer_idx]
                 hidden_size = layer.shape[-1]
                 if is_flat:
                     src_tokens = src.reshape(n_valid * block_size, 1, hidden_size)
@@ -1458,7 +1497,8 @@ def _transfer_per_layer_mla(
 def _transfer_per_layer_hnd(
     layer_tensors: list[torch.Tensor],
     object_tensors: list[torch.Tensor],
-    block_id_list: list[int],
+    block_ids: torch.Tensor | list[int],
+    n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
     gpu_kv_format: GPUKVFormat,
@@ -1466,61 +1506,82 @@ def _transfer_per_layer_hnd(
     skip_prefix_n_blocks: int,
 ) -> None:
     """Handle per-layer HND formats: heads before block tokens."""
-    if not is_d2h and layer_tensors and object_tensors:
-        target_device = layer_tensors[0].device
-        objs_on_device = [obj.to(target_device) for obj in object_tensors]
+    if not layer_tensors or not object_tensors:
+        return
 
-    for layer_idx, layer in enumerate(layer_tensors):
-        # Determine K/V split based on specific format
-        if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
-            k_t, v_t = layer[0], layer[1]
-        else:
-            k_t, v_t = layer[:, 0], layer[:, 1]
-        _nb, nh, _bs, hs = k_t.shape
+    target_device = layer_tensors[0].device
+    block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
 
-        for object_idx, obj in enumerate(object_tensors):
-            valid = _valid_block_range(
-                object_idx,
-                block_id_list,
-                blocks_per_object,
+    first_layer = layer_tensors[0]
+    if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+        first_k = first_layer[0]
+    else:
+        first_k = first_layer[:, 0]
+    _nb0, nh0, _bs0, hs0 = first_k.shape
+
+    for object_idx, obj in enumerate(object_tensors):
+        valid = _valid_block_range_indices(
+            object_idx,
+            n_block_ids,
+            blocks_per_object,
+            block_size,
+            skip_prefix_n_blocks,
+        )
+        if valid is None:
+            continue
+        idx_start, idx_end, offset_in_object = valid
+        n_valid = idx_end - idx_start
+        token_end = offset_in_object + n_valid * block_size
+        eff_idx = block_ids_dev[idx_start:idx_end]
+
+        if is_d2h:
+            chunk_gpu = torch.empty(
+                2,
+                len(layer_tensors),
+                n_valid * block_size,
+                nh0 * hs0,
+                dtype=first_k.dtype,
+                device=target_device,
+            )
+            scratch = torch.empty(
+                n_valid,
+                nh0,
                 block_size,
-                skip_prefix_n_blocks,
+                hs0,
+                dtype=first_k.dtype,
+                device=target_device,
             )
-            if valid is None:
-                continue
-            engine_block_ids, offset_in_object = valid
-            n_valid = len(engine_block_ids)
-            token_end = offset_in_object + n_valid * block_size
-            eff_idx = torch.tensor(
-                engine_block_ids, dtype=torch.long, device=layer.device
-            )
-
-            if is_d2h:
+            for layer_idx, layer in enumerate(layer_tensors):
+                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+                    k_t, v_t = layer[0], layer[1]
+                else:
+                    k_t, v_t = layer[:, 0], layer[:, 1]
+                torch.index_select(k_t, 0, eff_idx, out=scratch)
+                chunk_gpu[0, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
+                    scratch.permute(0, 2, 1, 3)
+                )
+                torch.index_select(v_t, 0, eff_idx, out=scratch)
+                chunk_gpu[1, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
+                    scratch.permute(0, 2, 1, 3)
+                )
+            obj[:, :, offset_in_object:token_end].copy_(chunk_gpu, non_blocking=True)
+        else:
+            chunk_gpu = obj[:, :, offset_in_object:token_end].to(target_device)
+            for layer_idx, layer in enumerate(layer_tensors):
+                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+                    k_t, v_t = layer[0], layer[1]
+                else:
+                    k_t, v_t = layer[:, 0], layer[:, 1]
+                _nb, nh, _bs, hs = k_t.shape
                 k_blocks = (
-                    k_t.index_select(0, eff_idx)
+                    chunk_gpu[0, layer_idx]
+                    .reshape(n_valid, block_size, nh, hs)
                     .permute(0, 2, 1, 3)
-                    .reshape(n_valid * block_size, nh * hs)
                 )
                 v_blocks = (
-                    v_t.index_select(0, eff_idx)
+                    chunk_gpu[1, layer_idx]
+                    .reshape(n_valid, block_size, nh, hs)
                     .permute(0, 2, 1, 3)
-                    .reshape(n_valid * block_size, nh * hs)
-                )
-                obj[0, layer_idx, offset_in_object:token_end].copy_(
-                    k_blocks, non_blocking=True
-                )
-                obj[1, layer_idx, offset_in_object:token_end].copy_(
-                    v_blocks, non_blocking=True
-                )
-            else:
-                obj_device = objs_on_device[object_idx]
-                k_src = obj_device[0, layer_idx, offset_in_object:token_end]
-                v_src = obj_device[1, layer_idx, offset_in_object:token_end]
-                k_blocks = k_src.reshape(n_valid, block_size, nh, hs).permute(
-                    0, 2, 1, 3
-                )
-                v_blocks = v_src.reshape(n_valid, block_size, nh, hs).permute(
-                    0, 2, 1, 3
                 )
                 k_t.index_copy_(0, eff_idx, k_blocks)
                 v_t.index_copy_(0, eff_idx, v_blocks)
@@ -1529,7 +1590,8 @@ def _transfer_per_layer_hnd(
 def _transfer_per_layer_nhd(
     layer_tensors: list[torch.Tensor],
     object_tensors: list[torch.Tensor],
-    block_id_list: list[int],
+    block_ids: torch.Tensor | list[int],
+    n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
     gpu_kv_format: GPUKVFormat,
@@ -1537,61 +1599,77 @@ def _transfer_per_layer_nhd(
     skip_prefix_n_blocks: int,
 ) -> None:
     """Handle per-layer NHD formats: block tokens before heads."""
-    if not is_d2h and layer_tensors and object_tensors:
-        target_device = layer_tensors[0].device
-        objs_on_device = [obj.to(target_device) for obj in object_tensors]
+    if not layer_tensors or not object_tensors:
+        return
 
-    for layer_idx, layer in enumerate(layer_tensors):
-        # Determine K/V split based on specific format
-        if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
-            k_t, v_t = layer[0], layer[1]
+    target_device = layer_tensors[0].device
+    block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
+
+    first_layer = layer_tensors[0]
+    if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+        first_k = first_layer[0]
+    else:
+        first_k = first_layer[:, 0]
+    _nb0, _bs0, nh0, hs0 = first_k.shape
+
+    for object_idx, obj in enumerate(object_tensors):
+        valid = _valid_block_range_indices(
+            object_idx,
+            n_block_ids,
+            blocks_per_object,
+            block_size,
+            skip_prefix_n_blocks,
+        )
+        if valid is None:
+            continue
+        idx_start, idx_end, offset_in_object = valid
+        n_valid = idx_end - idx_start
+        token_end = offset_in_object + n_valid * block_size
+        eff_idx = block_ids_dev[idx_start:idx_end]
+
+        if is_d2h:
+            chunk_gpu = torch.empty(
+                2,
+                len(layer_tensors),
+                n_valid * block_size,
+                nh0 * hs0,
+                dtype=first_k.dtype,
+                device=target_device,
+            )
+            for layer_idx, layer in enumerate(layer_tensors):
+                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+                    k_t, v_t = layer[0], layer[1]
+                else:
+                    k_t, v_t = layer[:, 0], layer[:, 1]
+                torch.index_select(
+                    k_t,
+                    0,
+                    eff_idx,
+                    out=chunk_gpu[0, layer_idx].view(n_valid, block_size, nh0, hs0),
+                )
+                torch.index_select(
+                    v_t,
+                    0,
+                    eff_idx,
+                    out=chunk_gpu[1, layer_idx].view(n_valid, block_size, nh0, hs0),
+                )
+            obj[:, :, offset_in_object:token_end].copy_(chunk_gpu, non_blocking=True)
         else:
-            k_t, v_t = layer[:, 0], layer[:, 1]
-        _nb, _bs, nh, hs = k_t.shape
-
-        for object_idx, obj in enumerate(object_tensors):
-            valid = _valid_block_range(
-                object_idx,
-                block_id_list,
-                blocks_per_object,
-                block_size,
-                skip_prefix_n_blocks,
-            )
-            if valid is None:
-                continue
-            engine_block_ids, offset_in_object = valid
-            n_valid = len(engine_block_ids)
-            token_end = offset_in_object + n_valid * block_size
-            eff_idx = torch.tensor(
-                engine_block_ids, dtype=torch.long, device=layer.device
-            )
-
-            if is_d2h:
-                k_blocks = k_t.index_select(0, eff_idx).reshape(
-                    n_valid * block_size, nh * hs
-                )
-                v_blocks = v_t.index_select(0, eff_idx).reshape(
-                    n_valid * block_size, nh * hs
-                )
-                obj[0, layer_idx, offset_in_object:token_end].copy_(
-                    k_blocks, non_blocking=True
-                )
-                obj[1, layer_idx, offset_in_object:token_end].copy_(
-                    v_blocks, non_blocking=True
-                )
-            else:
-                obj_device = objs_on_device[object_idx]
-                k_src = obj_device[0, layer_idx, offset_in_object:token_end]
-                v_src = obj_device[1, layer_idx, offset_in_object:token_end]
+            chunk_gpu = obj[:, :, offset_in_object:token_end].to(target_device)
+            for layer_idx, layer in enumerate(layer_tensors):
+                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+                    k_t, v_t = layer[0], layer[1]
+                else:
+                    k_t, v_t = layer[:, 0], layer[:, 1]
                 k_t.index_copy_(
                     0,
                     eff_idx,
-                    k_src.reshape(n_valid, block_size, nh, hs),
+                    chunk_gpu[0, layer_idx].reshape(n_valid, block_size, nh0, hs0),
                 )
                 v_t.index_copy_(
                     0,
                     eff_idx,
-                    v_src.reshape(n_valid, block_size, nh, hs),
+                    chunk_gpu[1, layer_idx].reshape(n_valid, block_size, nh0, hs0),
                 )
 
 

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -43,9 +43,73 @@ from lmcache.v1.multiprocess.native_completion import (
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
 from lmcache.v1.platform.cache_context import create_cache_context
+
+# Third Party
+import torch
+
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
+
+
+# Cache for multi_layer_block_kv_transfer parameter format preference
+# True = accepts tensors directly, False = requires pointers (data_ptr())
+_lmc_ops_accepts_tensors: bool | None = None
+
+
+def _detect_lmc_ops_param_format() -> bool:
+    """
+    Detect if multi_layer_block_kv_transfer accepts tensors directly or requires pointers.
+
+    This check is done once at startup. The c ops version requires pointers (list[int]),
+    while a Python/binding version may accept tensors directly (list[torch.Tensor]).
+
+    Returns:
+        True if tensors are accepted directly, False if pointers required
+    """
+    global _lmc_ops_accepts_tensors
+
+    if _lmc_ops_accepts_tensors is not None:
+        return _lmc_ops_accepts_tensors
+
+    # For now, default to False (requires pointers/c ops behavior)
+    # This is the safer default for c ops
+    # TODO: Add a more robust detection mechanism if needed
+    _lmc_ops_accepts_tensors = False
+
+    logger.info(
+        "multi_layer_block_kv_transfer parameter format: %s",
+        "tensors" if _lmc_ops_accepts_tensors else "pointers (c ops)"
+    )
+    return _lmc_ops_accepts_tensors
+
+
+def _convert_lmc_objects_ptrs(lmc_objects_ptrs: list) -> list:
+    """
+    Convert lmc_objects_ptrs to the appropriate format for multi_layer_block_kv_transfer.
+
+    Uses cached detection result from startup to avoid per-call detection.
+
+    Args:
+        lmc_objects_ptrs: Either list[int](pointers) or list[torch.Tensor]
+
+    Returns:
+        list[int]: List of pointer addresses (if requires pointers)
+    """
+    if not lmc_objects_ptrs:
+        return lmc_objects_ptrs
+
+    # Use cached detection result
+    accepts_tensors = _detect_lmc_ops_param_format()
+
+    if not accepts_tensors:
+        # Need to extract pointers from tensors
+        first_elem = lmc_objects_ptrs[0]
+        if isinstance(first_elem, torch.Tensor):
+            return [t.data_ptr() for t in lmc_objects_ptrs]
+
+    # Otherwise, return as-is (already pointers or accepts tensors directly)
+    return lmc_objects_ptrs
 
 
 def get_layout_desc(
@@ -466,7 +530,7 @@ class GPUTransferModule:
                         )
                         lmc_ops.multi_layer_block_kv_transfer(
                             group_kv_pointers,
-                            [tmp_buffer.data_ptr()],
+                            _convert_lmc_objects_ptrs([tmp_buffer]),
                             chunk_block_ids_gpu,
                             cache_context.device,
                             lmc_ops.TransferDirection.D2H,
@@ -669,7 +733,7 @@ class GPUTransferModule:
 
                     lmc_ops.multi_layer_block_kv_transfer(
                         group_kv_pointers,
-                        [tb.data_ptr() for tb in tmp_buffers],
+                        _convert_lmc_objects_ptrs(tmp_buffers),
                         chunk_block_ids_gpu,
                         cache_context.device,
                         lmc_ops.TransferDirection.H2D,

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -340,7 +340,12 @@ def gather_paged_kv_to_cpu(
     else:
         # Ignore any extra trailing buffers beyond what we actually gather so
         # the kernel's ``total_blocks % num_objects`` invariant still holds.
-        chunks = out[: len(iter_indices)]
+        # Return ``out`` unchanged when no trimming is needed so the in-place
+        # fill contract (result is out) is preserved.
+        if len(out) == len(iter_indices):
+            chunks = out
+        else:
+            chunks = out[: len(iter_indices)]
 
     selected_block_ids: list[int] = []
     for chunk_idx in iter_indices:

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -33,6 +33,7 @@ from lmcache.v1.multiprocess.mq import MessageQueueClient
 
 if TYPE_CHECKING:
     # First Party
+    from lmcache.v1.gpu_connector.utils import DiscoverableKVCache
     import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
@@ -249,9 +250,10 @@ def gather_paged_kv_to_cpu(
         blocks_per_chunk: Number of paged blocks in one LMCache chunk.
         layout_hints: Optional engine layout hints.
         gpu_kv_format: Optional pre-detected KV format.
-        out: Optional pre-allocated output tensors (one per entry in
-            ``chunk_indices`` when ``chunk_indices`` is given, or one per
-            chunk otherwise).
+        out: Optional pre-allocated output tensors.  If provided, length
+            must be at least ``len(chunk_indices)`` when ``chunk_indices``
+            is given, or the total number of chunks otherwise.  Any extra
+            buffers beyond the number of gathered chunks are ignored.
         chunk_indices: Optional list of chunk positions (into the full
             ``block_ids`` sequence) to gather.  When provided together with
             ``out``, only those chunks are gathered and written into
@@ -263,11 +265,19 @@ def gather_paged_kv_to_cpu(
         ``[2, num_layers, chunk_tokens, hidden_dim]`` where dimension ``0``
         stores ``(K, V)``. For MLA (multi-head latent attention) each chunk
         has shape ``[num_layers, chunk_tokens, hidden_dim]``.
+
+    Raises:
+        ValueError: If ``out`` is provided with fewer buffers than the number
+            of gathered chunks.
     """
     # First Party
     from lmcache.v1.gpu_connector.utils import (
         get_block_size,
+        get_hidden_dim_size,
+        get_num_blocks,
+        get_num_layers,
         is_mla,
+        make_page_buffer_shape_desc,
         normalize_kv_and_discover_format,
     )
     import lmcache.c_ops as lmc_ops
@@ -278,99 +288,78 @@ def gather_paged_kv_to_cpu(
     )
     if gpu_kv_format is None:
         gpu_kv_format = fmt
-    use_mla = is_mla(gpu_kv_format)
-    is_hnd = gpu_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
-    )
 
     block_size = get_block_size(normalized, gpu_kv_format)
+    num_layers = get_num_layers(normalized, gpu_kv_format)
+    hidden_dim_size = get_hidden_dim_size(normalized, gpu_kv_format)
+    num_blocks = get_num_blocks(normalized, gpu_kv_format)
     num_chunks = len(block_ids) // blocks_per_chunk
+    chunk_tokens = blocks_per_chunk * block_size
 
-    # After normalization the structure is always a list of per-layer
-    # tensors. Cast once so all downstream indexing is typed correctly.
-    layer_tensors = cast(list[torch.Tensor], normalized)
+    shape_desc = make_page_buffer_shape_desc(
+        normalized,
+        gpu_kv_format,
+        layer_idx=0,
+        num_layers_in_group=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
 
-    chunks: list[torch.Tensor] = [] if out is None else out
+    iter_indices = (
+        list(chunk_indices) if chunk_indices is not None else list(range(num_chunks))
+    )
+    # Require at least one output buffer per gathered chunk. Extra trailing
+    # buffers are ignored (see ``chunks = out[: len(iter_indices)]`` below),
+    # mirroring the scatter-side length check for consistency.
+    if out is not None and len(out) < len(iter_indices):
+        raise ValueError(
+            f"out length ({len(out)}) must be at least the number of "
+            f"gathered chunks ({len(iter_indices)})"
+        )
 
-    # When chunk_indices is given (SHM partial-reservation path), only
-    # process the specified subset.  The i-th entry in chunk_indices is the
-    # position of that chunk within the full block_ids sequence; the
-    # corresponding pre-allocated slot lives at out[i].
-    iter_indices = chunk_indices if chunk_indices is not None else range(num_chunks)
-
-    for out_idx, chunk_idx in enumerate(iter_indices):
-        chunk_block_ids = block_ids[
-            chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk
-        ]
+    if out is None:
+        use_mla = is_mla(gpu_kv_format)
         if use_mla:
-            mla_layers: list[torch.Tensor] = []
-            idx = torch.tensor(chunk_block_ids, dtype=torch.long)
-            for layer in layer_tensors:
-                layer_blocks = layer[idx]
-                mla_layers.append(
-                    layer_blocks.reshape(
-                        len(chunk_block_ids) * block_size, layer_blocks.shape[-1]
-                    )
+            chunks = [
+                torch.empty(
+                    (num_layers, chunk_tokens, hidden_dim_size),
+                    dtype=tensors[0].dtype,
+                    device=torch.device("cpu"),
                 )
-            chunk_tensor = torch.stack(mla_layers, dim=0)
-            if out is not None:
-                out[out_idx].copy_(chunk_tensor, non_blocking=True)
-            else:
-                chunks.append(chunk_tensor.cpu())
+                for _ in iter_indices
+            ]
         else:
-            k_layers: list[torch.Tensor] = []
-            v_layers: list[torch.Tensor] = []
-            for layer in layer_tensors:
-                if is_hnd:
-                    if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
-                        k_t = layer[0]
-                        v_t = layer[1]
-                    else:
-                        k_t = layer[:, 0]
-                        v_t = layer[:, 1]
-                    _num_blocks, num_heads, _block_size, head_size = k_t.shape
-                    k_blocks = k_t[torch.tensor(chunk_block_ids, dtype=torch.long)]
-                    v_blocks = v_t[torch.tensor(chunk_block_ids, dtype=torch.long)]
-                    # HND blocks are [NB, NH, BS, HS]; convert to token-major
-                    # [NB, BS, NH, HS] before flattening to [tokens, NH*HS].
-                    k_layers.append(
-                        k_blocks.permute(0, 2, 1, 3).reshape(
-                            len(chunk_block_ids) * block_size, num_heads * head_size
-                        )
-                    )
-                    v_layers.append(
-                        v_blocks.permute(0, 2, 1, 3).reshape(
-                            len(chunk_block_ids) * block_size, num_heads * head_size
-                        )
-                    )
-                else:
-                    if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
-                        k_t = layer[0]
-                        v_t = layer[1]
-                    else:
-                        k_t = layer[:, 0]
-                        v_t = layer[:, 1]
-                    _num_blocks, _block_size, num_heads, head_size = k_t.shape
-                    k_blocks = k_t[torch.tensor(chunk_block_ids, dtype=torch.long)]
-                    v_blocks = v_t[torch.tensor(chunk_block_ids, dtype=torch.long)]
-                    k_layers.append(
-                        k_blocks.reshape(
-                            len(chunk_block_ids) * block_size, num_heads * head_size
-                        )
-                    )
-                    v_layers.append(
-                        v_blocks.reshape(
-                            len(chunk_block_ids) * block_size, num_heads * head_size
-                        )
-                    )
-            k_stacked = torch.stack(k_layers, dim=0)
-            v_stacked = torch.stack(v_layers, dim=0)
-            chunk_tensor = torch.stack([k_stacked, v_stacked], dim=0)
-            if out is not None:
-                out[out_idx].copy_(chunk_tensor, non_blocking=True)
-            else:
-                chunks.append(chunk_tensor.cpu())
+            chunks = [
+                torch.empty(
+                    (2, num_layers, chunk_tokens, hidden_dim_size),
+                    dtype=tensors[0].dtype,
+                    device=torch.device("cpu"),
+                )
+                for _ in iter_indices
+            ]
+    else:
+        # Ignore any extra trailing buffers beyond what we actually gather so
+        # the kernel's ``total_blocks % num_objects`` invariant still holds.
+        chunks = out[: len(iter_indices)]
+
+    selected_block_ids: list[int] = []
+    for chunk_idx in iter_indices:
+        selected_block_ids.extend(
+            block_ids[chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk]
+        )
+
+    if selected_block_ids:
+        lmc_ops.multi_layer_block_kv_transfer(
+            cast("DiscoverableKVCache", normalized),
+            chunks,
+            selected_block_ids,
+            tensors[0].device,
+            lmc_ops.TransferDirection.D2H,
+            shape_desc,
+            chunk_tokens,
+            gpu_kv_format,
+            0,
+        )
     return chunks
 
 
@@ -387,18 +376,29 @@ def scatter_cpu_to_paged_kv(
 
     Args:
         kv_caches: Per-layer KV tensor mapping to write into.
-        block_ids: Flattened destination block IDs for all chunks.
+        block_ids: Flattened destination block IDs for all chunks.  Length
+            must be at least ``len(chunks) * blocks_per_chunk``; any extra
+            trailing block IDs are ignored.
         chunks: List of CPU chunk tensors (as returned by
             :func:`gather_paged_kv_to_cpu`).
         blocks_per_chunk: Number of paged blocks in one LMCache chunk.
-        skip_first_n_tokens: Token prefix to skip when scattering.
+        skip_first_n_tokens: Token prefix to skip when scattering.  Must be a
+            multiple of ``block_size``; non-aligned values are rounded down
+            to the nearest whole block and an error is logged (matching the
+            GPU transfer path).
         layout_hints: Optional engine layout hints.
         gpu_kv_format: Optional pre-detected KV format.
+
+    Raises:
+        ValueError: If ``block_ids`` is shorter than
+            ``len(chunks) * blocks_per_chunk``.
     """
     # First Party
     from lmcache.v1.gpu_connector.utils import (
         get_block_size,
-        is_mla,
+        get_num_blocks,
+        get_num_layers,
+        make_page_buffer_shape_desc,
         normalize_kv_and_discover_format,
     )
     import lmcache.c_ops as lmc_ops
@@ -406,90 +406,68 @@ def scatter_cpu_to_paged_kv(
     if not chunks:
         return
 
+    # Require enough block IDs to cover every chunk. Extra trailing block IDs
+    # are ignored by the per-chunk slicing below, mirroring the gather-side
+    # ``out`` length check for consistency.
+    if len(block_ids) < len(chunks) * blocks_per_chunk:
+        raise ValueError(
+            f"block_ids length ({len(block_ids)}) must be at least "
+            f"len(chunks) ({len(chunks)}) * blocks_per_chunk "
+            f"({blocks_per_chunk})"
+        )
+
     tensors = list(kv_caches.values())
     fmt, normalized = normalize_kv_and_discover_format(
         tensors, EngineType.VLLM, layout_hints=layout_hints
     )
     if gpu_kv_format is None:
         gpu_kv_format = fmt
-    use_mla = is_mla(gpu_kv_format)
 
     block_size = get_block_size(normalized, gpu_kv_format)
-    device = tensors[0].device
-    is_hnd = gpu_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+    num_layers = get_num_layers(normalized, gpu_kv_format)
+    num_blocks = get_num_blocks(normalized, gpu_kv_format)
+    chunk_tokens = blocks_per_chunk * block_size
+
+    # Block-level transfer can only skip whole blocks. A non-aligned prefix is
+    # rounded down to the nearest block (matching the GPU transfer path in
+    # gpu_transfer.py) rather than raising, so a slightly misaligned skip
+    # degrades gracefully instead of failing the whole retrieve.
+    if skip_first_n_tokens % block_size != 0:
+        logger.error(
+            "skip_first_n_tokens (%d) is not block-aligned (block_size=%d); "
+            "rounding down to %d blocks",
+            skip_first_n_tokens,
+            block_size,
+            skip_first_n_tokens // block_size,
+        )
+    skip_prefix_n_blocks = skip_first_n_tokens // block_size
+
+    shape_desc = make_page_buffer_shape_desc(
+        normalized,
+        gpu_kv_format,
+        layer_idx=0,
+        num_layers_in_group=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
     )
 
-    # After normalization the structure is always a list of per-layer
-    # tensors. Cast once so all downstream indexing is typed correctly.
-    layer_tensors = cast(list[torch.Tensor], normalized)
+    selected_block_ids: list[int] = []
+    for chunk_idx in range(len(chunks)):
+        selected_block_ids.extend(
+            block_ids[chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk]
+        )
 
-    for chunk_idx, chunk_cpu in enumerate(chunks):
-        chunk_block_ids = block_ids[
-            chunk_idx * blocks_per_chunk : (chunk_idx + 1) * blocks_per_chunk
-        ]
-        if not chunk_block_ids:
-            continue
+    if not selected_block_ids:
+        return
 
-        chunk_start_token = chunk_idx * blocks_per_chunk * block_size
-        chunk_end_token = chunk_start_token + len(chunk_block_ids) * block_size
-        effective_start = max(chunk_start_token, skip_first_n_tokens)
-        if effective_start >= chunk_end_token:
-            continue
-
-        skip_blocks_in_chunk = (effective_start - chunk_start_token) // block_size
-        effective_block_ids = chunk_block_ids[skip_blocks_in_chunk:]
-        if not effective_block_ids:
-            continue
-
-        skip_tokens = skip_blocks_in_chunk * block_size
-        chunk_device = chunk_cpu.to(device)
-
-        if use_mla:
-            eff_idx = torch.tensor(effective_block_ids, dtype=torch.long)
-            for layer_idx, layer in enumerate(layer_tensors):
-                mla_src = chunk_device[layer_idx, skip_tokens:]
-                hidden_size = layer.shape[-1]
-                mla_src_3d = mla_src.reshape(
-                    len(effective_block_ids), block_size, hidden_size
-                )
-                layer[eff_idx] = mla_src_3d
-        elif is_hnd:
-            for layer_idx, layer in enumerate(layer_tensors):
-                k_src = chunk_device[0, layer_idx, skip_tokens:]
-                v_src = chunk_device[1, layer_idx, skip_tokens:]
-                if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
-                    k_t = layer[0]
-                    v_t = layer[1]
-                else:
-                    k_t = layer[:, 0]
-                    v_t = layer[:, 1]
-                _nb, nh, _bs, hs = k_t.shape
-                k_blocks = k_src.reshape(
-                    len(effective_block_ids), block_size, nh, hs
-                ).permute(0, 2, 1, 3)
-                v_blocks = v_src.reshape(
-                    len(effective_block_ids), block_size, nh, hs
-                ).permute(0, 2, 1, 3)
-                k_t[effective_block_ids] = k_blocks
-                v_t[effective_block_ids] = v_blocks
-        else:
-            for layer_idx, layer in enumerate(layer_tensors):
-                k_src = chunk_device[0, layer_idx, skip_tokens:]
-                v_src = chunk_device[1, layer_idx, skip_tokens:]
-                if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
-                    k_t = layer[0]
-                    v_t = layer[1]
-                else:
-                    k_t = layer[:, 0]
-                    v_t = layer[:, 1]
-                _num_blocks, _block_size, num_heads, head_size = k_t.shape
-                k_src_4d = k_src.reshape(
-                    len(effective_block_ids), block_size, num_heads, head_size
-                )
-                v_src_4d = v_src.reshape(
-                    len(effective_block_ids), block_size, num_heads, head_size
-                )
-                k_t[effective_block_ids] = k_src_4d
-                v_t[effective_block_ids] = v_src_4d
+    lmc_ops.multi_layer_block_kv_transfer(
+        cast("DiscoverableKVCache", normalized),
+        chunks,
+        selected_block_ids,
+        tensors[0].device,
+        lmc_ops.TransferDirection.H2D,
+        shape_desc,
+        chunk_tokens,
+        gpu_kv_format,
+        skip_prefix_n_blocks,
+    )

--- a/tests/v1/multiprocess/test_non_cuda_data_transfer.py
+++ b/tests/v1/multiprocess/test_non_cuda_data_transfer.py
@@ -538,6 +538,9 @@ def stub_native_storage_ops() -> Any:
     module = type(sys)("lmcache.native_storage_ops")
     module.TTLLock = type("TTLLock", (), {})  # type: ignore[attr-defined]
     module.Bitmap = type("Bitmap", (), {})  # type: ignore[attr-defined]
+    module.PeriodicEventNotifier = type(  # type: ignore[attr-defined]
+        "PeriodicEventNotifier", (), {}
+    )
     with patch.dict(
         sys.modules,
         {


### PR DESCRIPTION
- Consolidate the data transfer path by utilizing the `multi_layer_block_kv_transfer` operation. 
   This update allows a single op to support both handle and data paths simultaneously, 
   streamlining the underlying transfer logic.
- Perf: optimize Python fallback block transfer for 3x speedup
   Optimize fallback block-id and D2H staging overhead
   Restructure per-layer transfer loops to iterate over objects first then layers

