### PR TITLE
[Feat][Coordinator] Global CacheBlend fingerprint directory on the MP coordinator

### DIFF
--- a/docs/design/v1/mp_coordinator/blend_lookup.md
+++ b/docs/design/v1/mp_coordinator/blend_lookup.md
@@ -1,0 +1,213 @@
+# Global CacheBlend Lookup (Coordinator Fingerprint Directory)
+
+A coordinator-level capability that lets a CacheBlend lookup on one mp-server
+find and reuse chunk KV cached anywhere in the fleet, fetched from a shared,
+content-addressed L2. Blend servers **publish fingerprints on STORE** and
+**query on LOOKUP**; the coordinator holds the fleet-wide directory and runs the
+match. It is **opt-in** (enabled only when a coordinator URL is configured) and
+**additive** (the existing local matcher fast path is unchanged).
+
+Code: `lmcache/v1/mp_coordinator/blend_directory.py`,
+`lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py`,
+`lmcache/v1/multiprocess/modules/blend_coordinator.py`.
+
+## Why
+
+CacheBlend lookup today is **local to one mp-server**: the matcher
+(`BlendTokenRangeMatcherV3`, `lmcache/v1/multiprocess/modules/blend_v3.py`)
+indexes only chunks that server stored, so a request routed to a different
+replica recomputes KV a peer already holds. As replicas scale, cache sharding
+works against reuse. The coordinator directory federates fingerprints so any
+server can discover and reuse content cached fleet-wide.
+
+## This PR: the original matching algorithm, globalized
+
+The coordinator reuses the **exact matching algorithm** the local matcher
+already uses — non-overlapping chunk fingerprints + a strided rolling-hash probe
+— lifted to a fleet table. Nothing about the match semantics changes; only its
+*scope* (one server → the fleet) and its *transport* (in-process → HTTP).
+
+**The coordinator does all hashing.** Servers send **raw tokens** plus the
+storage mapping only they know; the coordinator chunks, hashes, and matches. This
+keeps the whole matching algorithm in one place, so future evolution (see below)
+is a coordinator-only change — no server hashing change, no fleet redeploy, no
+cross-server hash-base consistency to maintain.
+
+```
+STORE (blend server, worker-0)
+  per stored range: tokens[start:end] + object_keys (per chunk) + old_st_base
+        ── POST /blend/fingerprints ──▶ coordinator.register():
+                                          chunk tokens, hash each → (poly→object_key,old_st)
+
+LOOKUP (blend server, cb_unified_lookup)
+  local match (unchanged, additive)
+  request tokens
+        ── POST /blend/match ──▶ coordinator.match():
+                                   roll hash over tokens, probe every probe_stride
+        ◀── matches: [(object_key, old_st, cur_st)] ──
+  → global_segments → sparse prefetch from shared L2 → retrieve + re-RoPE
+```
+
+The coordinator owns `chunk_size` (`blend_chunk_size`, fleet config, must equal
+the servers' LMCache chunk size) and the polynomial base; servers carry neither.
+**Trust note:** the coordinator now sees raw tokens (content), not just opaque
+hashes — acceptable when it is trusted fleet infra; revisit if not.
+
+### What is matched, and the granularity knob
+
+- **Match window = `chunk_size`** (the LMCache chunk, 256, a fleet config). A
+  stored chunk's content is one polynomial hash (`chunk_hash_windows_numba`);
+  a match is "this request window equals a stored chunk."
+- **Probe stride** = how many positions the coordinator skips between probes
+  (`rolling_hash_windows_numba` is computed over every position; the table is
+  probed every `probe_stride`). It is a **coordinator-side config**
+  (`blend_probe_stride`, default `1`), **not** sent by servers and **not** tied
+  to any vLLM block size.
+
+Why not the vLLM block size: with **partial-fill** KV transfer a matched chunk is
+reusable at **any** `cur_st` (the server scatters it token-wise, filling ragged
+pages), so there is no block-alignment constraint to honor. The default
+`probe_stride=1` therefore probes every offset for full recall; raise it only to
+trade recall for coordinator CPU. (vLLM block sizes are per-machine and
+dynamically computed — another reason not to bake one into the match.) `stride`
+controls probe density; `chunk_size` is the reuse unit.
+
+### Identity and scope
+
+The table is keyed by `(model_scope, poly_hash)`:
+
+- **`poly_hash`** — the content-only 64-bit polynomial chunk hash
+  (`chunk_hash_windows_numba` with the fleet-constant base `POLY_BASE`), computed
+  **by the coordinator** from the published tokens.
+- **`model_scope`** = `f"{model_name}@{cache_salt}"`. CacheBlend reuse is
+  same-model only (K is model-specific), and `cache_salt` is explicit cache
+  isolation — both are part of `ObjectKey` (`distributed/api.py`). Content from a
+  different scope lands under a different key and is never matched.
+
+**TP rank is not in the key.** KV is stored per rank, but the directory matches
+content (rank-agnostic); the querying server expands a matched `object_key` into
+its `world_size` per-rank `ObjectKey`s at retrieve (`ipc_key_to_object_keys`),
+exactly as the local path does. So one fingerprint serves all ranks.
+
+The 64-bit poly-hash carries the same collision behavior as the local matcher
+(which also matches on the 64-bit poly); acceptable within a model scope, and a
+collision only causes a wasted prefetch (caught downstream), never wrong KV.
+
+## Coordinator directory (`blend_directory.py`)
+
+`GlobalBlendMatcher` (thread-safe, single lock, mirroring `InstanceRegistry`):
+
+```
+_index   : dict[(model_scope, poly_hash:int) -> ChunkLoc(object_key, old_st)]
+_by_key  : dict[object_key -> list[(model_scope, poly_hash)]]   # for eviction
+```
+
+- `register(ranges)` — for each `StoreRange(model_scope, tokens, object_keys,
+  old_st_base)`, chunk the tokens, hash each chunk, and insert
+  `(model_scope, poly_hash) → (object_key, old_st)`; idempotent (first-writer
+  wins per key).
+- `remove(object_keys)` — drop all entries for an evicted chunk (reverse map).
+- `match(model_scope, tokens)` — roll a chunk-window hash over the request
+  tokens, probe every `probe_stride` positions against the scope's table; dedup
+  by `object_key`; return `[(object_key, old_st, cur_st)]`. Mirrors
+  `BlendTokenRangeMatcherV3.match_sub_sequence`, minus the local direct-address
+  table (a real dict gives exact 64-bit match, no separate collision step).
+
+It is **ephemeral**: rebuilt from publishes after a restart; a stale instance
+leaving the fleet does not drop fingerprints (shared-L2 object keys stay valid).
+
+## Blend-server comms (`blend_coordinator.py`)
+
+Blend handlers run in sync thread pools with no asyncio loop, so the client owns
+a synchronous `httpx.Client` plus a daemon, mirroring the module's existing
+`_fingerprint_queue` worker:
+
+- **STORE**: `enqueue_register` → best-effort, fire-and-forget `POST
+  /blend/fingerprints` (register). Eviction, when wired, is the distinct
+  `enqueue_evict` → `DELETE /blend/fingerprints`.
+- **LOOKUP**: `submit_match` (once per request) + `poll_match` — the same
+  non-blocking submit/poll pattern the prefix and sparse legs already use;
+  `cb_unified_lookup` polls until the match resolves and merges it. The single
+  wall-clock bound is the client HTTP `request_timeout` (default 50 ms): a slow
+  or down coordinator returns/​times-out into an empty result, so the lookup
+  proceeds local-only without stalling. No separate poll-count budget.
+
+Opt-in via `LMCACHE_COORDINATOR_URL`; absent → the module receives `None` and
+every publish/query path is skipped (behavior unchanged).
+
+## Lookup flow in `cb_unified_lookup`
+
+The coordinator leg is additive around the existing prefix + sparse legs:
+
+1. First call: submit the local fingerprint match (unchanged) **and** the
+   coordinator match (request tokens).
+2. Local legs complete once (classify side effects run once).
+3. Poll the coordinator (defer until resolved, bounded by the HTTP
+   `request_timeout`); when ready, flatten matches into
+   `global_segments` on `CBUnifiedLookupResult`.
+
+`CBUnifiedLookupResult.global_segments` is chunk-granular
+(`object_key, old_st, old_ed, cur_st, cur_ed`), parallel to the local
+`non_prefix_segments` but pointing at shared-L2 storage keys. The partial-KV
+transfer / retrieve path consumes it (and reconciles any overlap with the local
+segments — not merged here).
+
+## Eviction & staleness
+
+Lazy. On local eviction the server may publish a `remove`, but the directory
+tolerates stale entries: a match to an evicted object key simply misses at sparse
+prefetch → the server recomputes. Never wrong KV. (Eager per-chunk eviction
+publish is optional and not required for correctness.)
+
+## Failure modes
+
+| event | effect | handling |
+| --- | --- | --- |
+| coordinator down | no global leg | HTTP times out → empty result → local-only |
+| poly-hash collision | wasted prefetch | confirmed-miss → recompute |
+| stale entry (evicted) | wasted prefetch | miss → recompute; lazy remove |
+| publish dropped | a chunk unindexed globally | recomputed on a peer until re-published |
+
+## Future evolution (not in this PR)
+
+The original algorithm reuses content only at **chunk granularity** and only when
+the content is chunk-phase aligned (store-side non-overlapping chunks). Two
+refinements raise reuse, gated by the partial-KV-transfer work:
+
+- **Block-level** — match at the inference block size `G` (`block_content_hashes`
+  + minimizer-sparse anchor index + seed-and-extend), so reuse is `G`-grained and
+  partial chunks are reusable. Still `G`-phase-sensitive.
+- **Token-level** — rolling k-mer **minimizer seeds** + **token-level extend**,
+  giving arbitrary-offset reuse and ragged partial-page tails. Requires dense
+  per-token hash arrays at the coordinator.
+
+### Role of the minimizer (for the refinements)
+
+The minimizer picks ~1 anchor per window `W` by **content** (local-min hash). It
+**decouples** three things: match completeness (a run `≥ W` shares an anchor),
+index cost (`÷W`), and offset (content-defined selection is offset-free). It
+sparsifies the *seed index* only; the dense per-position arrays needed to
+*extend* stay dense. With it, you keep a fine match granularity *and* a small
+index; without it you must coarsen granularity to shrink the index.
+
+### Complexity (n=request tokens, m=stored tokens, C=chunk, G=block, W=window)
+
+| | original (this PR) | block-level | token-level |
+| --- | --- | --- | --- |
+| store | O(m) hash + O(m/C) insert | O(m) + O(m/(G·W)) | O(m) + O(m/W) |
+| lookup | O(n) roll + O(n/stride) probe | O(n) + O(n/(G·W)) + O(hit/G) | O(n) + O(n/W) + O(hit) |
+| coordinator hash mem | O(m/C) | O(m/G) | O(m) |
+| match unit | C (256) | G | 1 token |
+| offset | store chunk-phase bound | G-phase bound | arbitrary |
+
+All lookups are O(n + hit) asymptotically; the differences are constants,
+coordinator memory (`m/C : m/G : m` ≈ `1 : 16 : 256` at C=256,G=16), and
+capability (granularity + offset). This PR takes the cheapest, simplest point;
+the refinements trade coordinator memory for finer, offset-robust reuse.
+
+## Scope
+
+Additive: no change to local prefix/blend lookup, retrieve/re-RoPE/scatter, or
+the coordinator backbone. Composes via the documented extension seam — a new
+`http_apis` router reading `app.state`, plus the opt-in blend client — with no
+edits to membership or the health loop.

--- a/docs/design/v1/mp_coordinator/blend_lookup.md
+++ b/docs/design/v1/mp_coordinator/blend_lookup.md
@@ -140,17 +140,22 @@ every publish/query path is skipped (behavior unchanged).
 The coordinator leg is additive around the existing prefix + sparse legs:
 
 1. First call: submit the local fingerprint match (unchanged) **and** the
-   coordinator match (request tokens).
+   coordinator match (request tokens). A per-lookup wall-clock deadline is armed
+   (`match_budget_s`, from `LMCACHE_COORDINATOR_BLEND_TIMEOUT`).
 2. Local legs complete once (classify side effects run once).
-3. Poll the coordinator (defer until resolved, bounded by the HTTP
-   `request_timeout`); when ready, flatten matches into
-   `global_segments` on `CBUnifiedLookupResult`.
+3. Poll the coordinator: defer while pending, but give up at the deadline and
+   proceed local-only. The deadline (not just the per-request HTTP timeout)
+   bounds total wait, since the coordinator daemon services match queries
+   serially and a query can sit queued behind others. When ready, the matches
+   become `global_segments` on `CBUnifiedLookupResult`.
 
-`CBUnifiedLookupResult.global_segments` is chunk-granular
-(`object_key, old_st, old_ed, cur_st, cur_ed`), parallel to the local
-`non_prefix_segments` but pointing at shared-L2 storage keys. The partial-KV
-transfer / retrieve path consumes it (and reconciles any overlap with the local
-segments — not merged here).
+`CBUnifiedLookupResult.global_segments` is `list[CBMatchResult]`, the same shape
+as the local `non_prefix_segments`: each `hash` is the chunk's content hash
+(the coordinator's `object_key` hex), which `ipc_key_to_object_keys` expands to
+per-rank shared-L2 keys at retrieve. The consumer merges these into the single
+`cb_match_result` list it sends to `CB_RETRIEVE_PRE_COMPUTED_V3` (reconciling any
+overlap with the local segments — not merged here), so the existing retrieve /
+re-RoPE path fetches and scatters them with no protocol change.
 
 ## Eviction & staleness
 

--- a/docs/design/v1/mp_coordinator/blend_lookup.md
+++ b/docs/design/v1/mp_coordinator/blend_lookup.md
@@ -40,12 +40,13 @@ STORE (blend server, worker-0)
                                           chunk tokens, hash each → (poly→object_key,old_st)
 
 LOOKUP (blend server, cb_unified_lookup)
-  local match (unchanged, additive)
+  coordinator present? fleet match only (local matcher skipped); else local only
   request tokens
         ── POST /blend/match ──▶ coordinator.match():
                                    roll hash over tokens, probe every probe_stride
         ◀── matches: [(object_key, old_st, cur_st)] ──
-  → global_segments → sparse prefetch from shared L2 → retrieve + re-RoPE
+  → non-prefix set (drop prefix-covered, leftmost-greedy overlap dedup)
+  → one sparse prefetch from shared L2 → retrieve + re-RoPE
 ```
 
 The coordinator owns `chunk_size` (`blend_chunk_size`, fleet config, must equal
@@ -137,25 +138,34 @@ every publish/query path is skipped (behavior unchanged).
 
 ## Lookup flow in `cb_unified_lookup`
 
-The coordinator leg is additive around the existing prefix + sparse legs:
+Local and coordinator matching are **mutually exclusive**, chosen by coordinator
+presence: with a coordinator configured the fleet directory (a superset of the
+local table) is the *only* match source and the local matcher is skipped
+entirely; with none, matching is purely local as before. There is no merge.
 
-1. First call: submit the local fingerprint match (unchanged) **and** the
-   coordinator match (request tokens). A per-lookup wall-clock deadline is armed
+With a coordinator:
+
+1. First call: skip the local fingerprint match; submit only the coordinator
+   match (request tokens). A per-lookup wall-clock deadline is armed
    (`match_budget_s`, from `LMCACHE_COORDINATOR_BLEND_TIMEOUT`).
-2. Local legs complete once (classify side effects run once).
-3. Poll the coordinator: defer while pending, but give up at the deadline and
-   proceed local-only. The deadline (not just the per-request HTTP timeout)
-   bounds total wait, since the coordinator daemon services match queries
-   serially and a query can sit queued behind others. When ready, the matches
-   become `global_segments` on `CBUnifiedLookupResult`.
+2. After the prefix resolves, poll the coordinator **before** the sparse
+   prefetch: defer while pending, give up at the deadline (then no fleet matches
+   that lookup). The deadline (not just the per-request HTTP timeout) bounds
+   total wait, since the coordinator daemon services match queries serially.
+3. Keep matches outside the prefix coverage and apply **leftmost-greedy overlap
+   dedup** — the coordinator dedups only by `object_key`, so its matches can
+   still overlap, and two matches over the same request range can't both scatter.
+4. Submit **one** sparse prefetch over that set, classify, retrieve.
 
-`CBUnifiedLookupResult.global_segments` is `list[CBMatchResult]`, the same shape
-as the local `non_prefix_segments`: each `hash` is the chunk's content hash
-(the coordinator's `object_key` hex), which `ipc_key_to_object_keys` expands to
-per-rank shared-L2 keys at retrieve. The consumer merges these into the single
-`cb_match_result` list it sends to `CB_RETRIEVE_PRE_COMPUTED_V3` (reconciling any
-overlap with the local segments — not merged here), so the existing retrieve /
-re-RoPE path fetches and scatters them with no protocol change.
+Without a coordinator, step 1 instead runs the local matcher and steps 3–4 use
+its matches (already non-overlapping, so the dedup is a no-op).
+
+Fleet matches are `CBMatchResult` (each `hash` is the chunk content hash — the
+coordinator's `object_key` hex — which `ipc_key_to_object_keys` expands to
+per-rank shared-L2 keys), so they ride the **identical** sparse prefetch +
+classify + retrieve + re-RoPE path as local matches and surface in
+`CBUnifiedLookupResult.non_prefix_segments`. There is no separate
+`global_segments` field and no protocol change.
 
 ## Eviction & staleness
 

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -29,6 +29,7 @@ from fastapi import FastAPI
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.quota_manager import QuotaManager
+from lmcache.v1.mp_coordinator.blend_directory import GlobalBlendMatcher
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 from lmcache.v1.mp_coordinator.l2.eviction_manager import (
     L2EvictionManager,
@@ -67,7 +68,8 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     Returns:
         A configured FastAPI application. ``app.state`` carries the shared
         collaborators (``config``, ``registry``, ``quota_manager``,
-        ``usage_manager``); all ``http_apis`` routers are registered.
+        ``usage_manager``, ``blend_directory``); all ``http_apis`` routers are
+        registered.
     """
     registry = InstanceRegistry()
     quota_manager = QuotaManager()
@@ -77,6 +79,9 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         usage_manager=usage_manager,
         eviction_ratio=config.eviction_ratio,
         trigger_watermark=config.trigger_watermark,
+    )
+    blend_directory = GlobalBlendMatcher(
+        chunk_size=config.blend_chunk_size, probe_stride=config.blend_probe_stride
     )
 
     async def _health_loop() -> None:
@@ -119,6 +124,7 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     app.state.quota_manager = quota_manager
     app.state.usage_manager = usage_manager
     app.state.eviction_manager = eviction_manager
+    app.state.blend_directory = blend_directory
 
     apis_path = Path(__file__).parent / "http_apis"
     package = f"{__package__}.http_apis"

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -79,6 +79,7 @@ class BlendCoordinatorClient:
         *,
         request_fn: _RequestFn | None = None,
         request_timeout: float = 2.0,
+        match_budget_s: float = 2.0,
     ) -> None:
         """Create the client and start its daemon.
 
@@ -89,7 +90,12 @@ class BlendCoordinatorClient:
                 json_dict`` used instead of the built-in HTTP client (for
                 testing). Must raise on transport failure.
             request_timeout: Per-request HTTP timeout in seconds.
+            match_budget_s: Per-lookup wall-clock budget the blend module uses to
+                bound the optional global leg. Unlike ``request_timeout`` (one
+                round-trip), this bounds total time including queue wait behind
+                other match queries, since the daemon services them serially.
         """
+        self.match_budget_s = match_budget_s
         self._client = None
         if request_fn is None:
             # Third Party
@@ -191,10 +197,12 @@ class BlendCoordinatorClient:
 
         Reads ``LMCACHE_COORDINATOR_URL`` (required to enable) and
         ``LMCACHE_COORDINATOR_BLEND_TIMEOUT`` (default 0.05s). This timeout is the
-        single wall-clock budget on the optional global leg: the lookup polls
-        until the match resolves (matches, or ``[]`` if the HTTP call times out),
-        so it bounds how long the critical path waits before proceeding
-        local-only. Keep it small.
+        wall-clock budget on the optional global leg: the blend module polls
+        until the match resolves (matches, or ``[]`` on failure) but gives up
+        once the budget elapses, so it bounds how long the critical path waits
+        -- including time queued behind other match queries -- before proceeding
+        local-only. It is used both as the per-request HTTP timeout and as the
+        module's per-lookup deadline. Keep it small.
 
         Returns:
             A started client, or ``None`` when no coordinator URL is configured
@@ -205,7 +213,7 @@ class BlendCoordinatorClient:
             return None
         timeout = float(os.getenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "0.05"))
         logger.info("Blend coordinator client enabled -> %s", url)
-        return cls(url, request_timeout=timeout)
+        return cls(url, request_timeout=timeout, match_budget_s=timeout)
 
     # -- daemon ------------------------------------------------------------
 

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Blend mp-server side client for the coordinator fingerprint directory.
+
+The blend module runs in sync thread pools with no asyncio loop, so this client
+owns a synchronous ``httpx.Client`` plus a background daemon, mirroring the
+module's existing ``_fingerprint_queue`` worker. STORE publishes are best-effort
+and fire-and-forget; LOOKUP match queries follow the same non-blocking
+submit-once / poll-on-recall pattern the blend lookup already uses for its prefix
+and sparse legs (the handler never blocks a worker thread on the round-trip).
+
+It is **opt-in**: with no coordinator URL configured the blend module receives
+``None`` and every publish/query path is skipped, so behavior is unchanged.
+"""
+
+# Standard
+from collections.abc import Callable
+from dataclasses import dataclass
+from queue import Empty, Queue
+import os
+import threading
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+# poll_match sentinel: query submitted, round-trip not finished yet.
+PENDING = object()
+
+# (method, path, json_body) -> json_dict
+_RequestFn = Callable[[str, str, dict], dict]
+
+
+@dataclass
+class RemoteMatch:
+    """One chunk matched in the fleet directory (see directory.GlobalMatch).
+
+    Attributes:
+        object_key: Shared-L2 storage key of the matched chunk.
+        old_st: Token position in the stored sequence (re-RoPE source).
+        cur_st: Token position in the request (re-RoPE target).
+    """
+
+    object_key: str
+    old_st: int
+    cur_st: int
+
+
+@dataclass
+class _PublishItem:
+    """A queued best-effort write: an HTTP ``method``/``path``/``payload``."""
+
+    method: str
+    path: str
+    payload: dict
+
+
+@dataclass
+class _MatchItem:
+    """A queued match query for request ``rid``."""
+
+    rid: str
+    model_scope: str
+    tokens: list[int]
+
+
+class BlendCoordinatorClient:
+    """Background bridge from the blend module to the coordinator directory.
+
+    Thread-safe. Publishes and match queries are enqueued by blend handler
+    threads and serviced by one daemon thread; match results are stored in a dict
+    the handler polls. Match queries are prioritized over publishes so lookup
+    latency is not held up by best-effort store traffic.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "",
+        *,
+        request_fn: _RequestFn | None = None,
+        request_timeout: float = 2.0,
+    ) -> None:
+        """Create the client and start its daemon.
+
+        Args:
+            base_url: Coordinator base URL (e.g. ``http://coordinator:9300``).
+                Ignored when ``request_fn`` is supplied.
+            request_fn: Optional injected ``(method, path, json_body) ->
+                json_dict`` used instead of the built-in HTTP client (for
+                testing). Must raise on transport failure.
+            request_timeout: Per-request HTTP timeout in seconds.
+        """
+        self._client = None
+        if request_fn is None:
+            # Third Party
+            import httpx
+
+            client = httpx.Client(timeout=request_timeout)
+            base = base_url.rstrip("/")
+
+            def _http_request(method: str, path: str, payload: dict) -> dict:
+                resp = client.request(method, f"{base}{path}", json=payload)
+                resp.raise_for_status()
+                return resp.json()
+
+            self._client = client
+            self._request: _RequestFn = _http_request
+        else:
+            self._request = request_fn
+
+        self._publish_q: "Queue[_PublishItem]" = Queue()
+        self._match_q: "Queue[_MatchItem]" = Queue()
+        self._results: dict[str, object] = {}
+        self._results_lock = threading.Lock()
+        self._stop = threading.Event()
+        self._worker = threading.Thread(
+            target=self._run, name="cb-coordinator-client", daemon=True
+        )
+        self._worker.start()
+
+    def enqueue_register(self, ranges: list[dict]) -> None:
+        """Queue a best-effort register of stored ranges.
+
+        Args:
+            ranges: Wire-form ``StoreRange`` dicts to register.
+        """
+        if not ranges:
+            return
+        self._publish_q.put(
+            _PublishItem("POST", "/blend/fingerprints", {"ranges": ranges})
+        )
+
+    def enqueue_evict(self, object_keys: list[str]) -> None:
+        """Queue a best-effort eviction of fingerprints by storage key.
+
+        Args:
+            object_keys: ``object_key`` values to evict.
+        """
+        if not object_keys:
+            return
+        self._publish_q.put(
+            _PublishItem("DELETE", "/blend/fingerprints", {"object_keys": object_keys})
+        )
+
+    def submit_match(self, rid: str, model_scope: str, tokens: list[int]) -> None:
+        """Submit a match query for a request once (idempotent per ``rid``).
+
+        Args:
+            rid: Request id, the poll key.
+            model_scope: Scope to match within.
+            tokens: The request tokens (the coordinator hashes and probes them).
+        """
+        with self._results_lock:
+            if rid in self._results:
+                return
+            self._results[rid] = PENDING
+        self._match_q.put(_MatchItem(rid=rid, model_scope=model_scope, tokens=tokens))
+
+    def poll_match(self, rid: str) -> object:
+        """Return the match state for a request.
+
+        Args:
+            rid: Request id used in :meth:`submit_match`.
+
+        Returns:
+            :data:`PENDING` while in flight, a ``list[RemoteMatch]`` when ready,
+            or ``None`` if never submitted (or already consumed).
+        """
+        with self._results_lock:
+            return self._results.get(rid)
+
+    def take_match(self, rid: str) -> None:
+        """Drop a request's stored match state once consumed.
+
+        Args:
+            rid: Request id to clear.
+        """
+        with self._results_lock:
+            self._results.pop(rid, None)
+
+    def close(self) -> None:
+        """Stop the daemon and close the HTTP client."""
+        self._stop.set()
+        self._worker.join(timeout=2.0)
+        if self._client is not None:
+            self._client.close()
+
+    @classmethod
+    def maybe_from_env(cls) -> "BlendCoordinatorClient | None":
+        """Build a client from ``LMCACHE_COORDINATOR_*`` env vars if configured.
+
+        Reads ``LMCACHE_COORDINATOR_URL`` (required to enable) and
+        ``LMCACHE_COORDINATOR_BLEND_TIMEOUT`` (default 0.05s). This timeout is the
+        single wall-clock budget on the optional global leg: the lookup polls
+        until the match resolves (matches, or ``[]`` if the HTTP call times out),
+        so it bounds how long the critical path waits before proceeding
+        local-only. Keep it small.
+
+        Returns:
+            A started client, or ``None`` when no coordinator URL is configured
+            (the blend module then runs purely local).
+        """
+        url = os.getenv("LMCACHE_COORDINATOR_URL", "").strip()
+        if not url:
+            return None
+        timeout = float(os.getenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "0.05"))
+        logger.info("Blend coordinator client enabled -> %s", url)
+        return cls(url, request_timeout=timeout)
+
+    # -- daemon ------------------------------------------------------------
+
+    def _run(self) -> None:
+        """Service match queries (priority) then publishes until stopped."""
+        while not self._stop.is_set():
+            try:
+                self._handle_match(self._match_q.get(timeout=0.05))
+                continue
+            except Empty:
+                pass
+            try:
+                self._handle_publish(self._publish_q.get_nowait())
+            except Empty:
+                pass
+
+    def _handle_match(self, item: _MatchItem) -> None:
+        """POST a match query and store the parsed matches (miss on error)."""
+        matches: list[RemoteMatch] = []
+        try:
+            body = self._request(
+                "POST",
+                "/blend/match",
+                {
+                    "model_scope": item.model_scope,
+                    "tokens": item.tokens,
+                },
+            )
+            matches = [
+                RemoteMatch(
+                    object_key=m["object_key"],
+                    old_st=int(m["old_st"]),
+                    cur_st=int(m["cur_st"]),
+                )
+                for m in body.get("matches", [])
+            ]
+        except Exception:
+            # Best-effort: a failed query degrades to local-only (empty result).
+            logger.warning("Blend coordinator match failed for %s", item.rid)
+        with self._results_lock:
+            # Only fill if still awaited (not taken/cleared meanwhile).
+            if self._results.get(item.rid) is PENDING:
+                self._results[item.rid] = matches
+
+    def _handle_publish(self, item: _PublishItem) -> None:
+        """Send a best-effort register/evict; failures are logged and dropped."""
+        try:
+            self._request(item.method, item.path, item.payload)
+        except Exception:
+            logger.warning("Blend coordinator %s %s failed", item.method, item.path)

--- a/lmcache/v1/mp_coordinator/blend_directory.py
+++ b/lmcache/v1/mp_coordinator/blend_directory.py
@@ -148,31 +148,36 @@ class GlobalBlendMatcher:
             Number of chunk fingerprints newly inserted (excludes idempotent
             skips).
         """
+        # Hash every range outside the lock; keep only well-formed ranges.
+        prepared: list[tuple[str, np.ndarray, list[str], int]] = []
+        for rng in ranges:
+            arr = np.array(rng.tokens, dtype=np.uint64)
+            polys = chunk_hash_windows_numba(arr, self._chunk_size, POLY_BASE)
+            n_chunks = int(polys.shape[0])
+            if n_chunks != len(rng.object_keys):
+                logger.error(
+                    "blend register: %d chunks from %d tokens (chunk_size=%d) "
+                    "but %d object_keys for scope %s; skipping range "
+                    "(publisher/chunk_size mismatch)",
+                    n_chunks,
+                    len(rng.tokens),
+                    self._chunk_size,
+                    len(rng.object_keys),
+                    rng.model_scope,
+                )
+                continue
+            prepared.append((rng.model_scope, polys, rng.object_keys, rng.old_st_base))
+
         inserted = 0
         with self._lock:
-            for rng in ranges:
-                arr = np.array(rng.tokens, dtype=np.uint64)
-                polys = chunk_hash_windows_numba(arr, self._chunk_size, POLY_BASE)
-                n_chunks = int(polys.shape[0])
-                if n_chunks != len(rng.object_keys):
-                    logger.error(
-                        "blend register: %d chunks from %d tokens (chunk_size=%d) "
-                        "but %d object_keys for scope %s; skipping range "
-                        "(publisher/chunk_size mismatch)",
-                        n_chunks,
-                        len(rng.tokens),
-                        self._chunk_size,
-                        len(rng.object_keys),
-                        rng.model_scope,
-                    )
-                    continue
-                for i in range(n_chunks):
-                    key = (rng.model_scope, int(polys[i]))
+            for model_scope, polys, object_keys, old_st_base in prepared:
+                for i in range(len(object_keys)):
+                    key = (model_scope, int(polys[i]))
                     if key in self._index:
                         continue
-                    object_key = rng.object_keys[i]
+                    object_key = object_keys[i]
                     self._index[key] = _ChunkLoc(
-                        object_key, rng.old_st_base + i * self._chunk_size
+                        object_key, old_st_base + i * self._chunk_size
                     )
                     self._by_key.setdefault(object_key, []).append(key)
                     inserted += 1

--- a/lmcache/v1/mp_coordinator/blend_directory.py
+++ b/lmcache/v1/mp_coordinator/blend_directory.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fleet-wide CacheBlend fingerprint directory held by the MP coordinator.
+
+Blend mp-servers publish stored token ranges on STORE and query with the request
+tokens on LOOKUP; the coordinator does **all hashing and matching**, so the whole
+matching algorithm lives here and can evolve without touching or redeploying
+servers. Servers send raw tokens plus the storage mapping they alone know
+(``object_key`` per chunk, base token position).
+
+The algorithm matches the local matcher (`BlendTokenRangeMatcherV3`): a table of
+non-overlapping chunk polynomial hashes, probed by a strided rolling-hash scan of
+the request.
+
+- **Match unit = chunk_size** (fleet config). Each stored chunk is one poly hash.
+- **Probe stride** (the querying server's inference block size) controls which
+  request offsets can seed a match; sent per query, so servers with different
+  (per-machine, dynamic) block sizes interoperate.
+- **Scope** = ``f"{model_name}@{cache_salt}"``; cross-scope content never matches.
+- **TP rank** is resolved at retrieve (``ipc_key_to_object_keys``), not here.
+
+``object_key`` is the chunk's shared-L2 storage key (``th``), which is
+prefix-bound and computed by the storing server -- the coordinator cannot derive
+it, so it is supplied with each published range.
+
+Thread-safe (single lock, mirroring ``InstanceRegistry``) and ephemeral. A stale
+entry (chunk evicted from L2 but not yet removed here) only causes a wasted
+prefetch downstream, then recompute -- never wrong KV.
+
+See ``docs/design/v1/mp_coordinator/blend_lookup.md``.
+"""
+
+# Standard
+from dataclasses import dataclass
+import threading
+
+# Third Party
+import numpy as np
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.multiprocess.token_hasher import (
+    chunk_hash_windows_numba,
+    rolling_hash_windows_numba,
+)
+
+logger = init_logger(__name__)
+
+# Fleet-constant polynomial base for blend fingerprints. The coordinator owns
+# the hashing, so this lives here: the same base hashes published chunks
+# (``chunk_hash_windows_numba``) and probes requests (``rolling_hash_windows_numba``)
+# so the two align. Constant across a coordinator's lifetime.
+POLY_BASE = np.uint64(0x9E3779B97F4A7C15)
+
+
+@dataclass
+class StoreRange:
+    """One stored token range published by a blend server.
+
+    Attributes:
+        model_scope: Reuse-compatibility scope, ``f"{model_name}@{cache_salt}"``.
+        tokens: The stored tokens (``token_ids[start:end]``). The coordinator
+            chunks these at ``chunk_size`` and hashes each chunk.
+        object_keys: Shared-L2 storage key (hex of the ObjectKey chunk hash) per
+            chunk, in order; chunk ``i`` maps to ``object_keys[i]``.
+        old_st_base: Token position of the range's first token in the stored
+            sequence; chunk ``i`` starts at ``old_st_base + i * chunk_size``.
+    """
+
+    model_scope: str
+    tokens: list[int]
+    object_keys: list[str]
+    old_st_base: int
+
+
+@dataclass
+class _ChunkLoc:
+    """Where a registered chunk lives (anchor index value)."""
+
+    object_key: str
+    old_st: int
+
+
+@dataclass
+class GlobalMatch:
+    """One matched chunk returned to a querying server.
+
+    Attributes:
+        object_key: Shared-L2 storage key of the matched chunk.
+        old_st: Token position of the chunk in the stored sequence (re-RoPE).
+        cur_st: Token position in the request where the match was found.
+    """
+
+    object_key: str
+    old_st: int
+    cur_st: int
+
+
+class GlobalBlendMatcher:
+    """Thread-safe fleet-wide chunk fingerprint directory.
+
+    Hashes published token ranges into a poly-hash table and matches request
+    tokens by a strided rolling-hash probe. All public methods take the internal
+    lock, so the directory stays consistent under concurrent
+    publish/query/evict.
+    """
+
+    def __init__(self, chunk_size: int = 256, probe_stride: int = 1) -> None:
+        """Initialize an empty directory.
+
+        Args:
+            chunk_size: Tokens per chunk (the LMCache chunk size; fleet config).
+                The match unit; must be the same value the storing servers use.
+            probe_stride: Positions between match probes. With partial-fill reuse
+                any offset is usable, so the default ``1`` (probe every offset)
+                gives full recall; raise only to trade recall for coordinator CPU.
+
+        Raises:
+            ValueError: If ``chunk_size`` or ``probe_stride`` is not positive.
+        """
+        if chunk_size < 1:
+            raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
+        if probe_stride < 1:
+            raise ValueError(f"probe_stride must be >= 1, got {probe_stride}")
+        self._chunk_size = chunk_size
+        self._probe_stride = probe_stride
+        self._lock = threading.Lock()
+        self._index: dict[tuple[str, int], _ChunkLoc] = {}
+        # Reverse map for eviction: object_key -> its (scope, poly_hash) keys.
+        self._by_key: dict[str, list[tuple[str, int]]] = {}
+
+    def register(self, ranges: list[StoreRange]) -> int:
+        """Hash and insert published token ranges (idempotent per chunk).
+
+        The coordinator chunks each range's tokens, hashes each chunk, and maps
+        the poly hash to its storage key and position. Re-publishing a
+        ``(model_scope, poly_hash)`` already present is a no-op.
+
+        A range whose chunk count (``len(tokens) // chunk_size``) does not equal
+        its ``object_keys`` count is **skipped** with an error log: the two are
+        1:1 by construction, so a mismatch signals a publisher bug or a
+        chunk-size disagreement, and registering the aligned prefix would map
+        chunks to the wrong storage keys (a shift) -- worse than dropping it.
+
+        Args:
+            ranges: Stored token ranges to register.
+
+        Returns:
+            Number of chunk fingerprints newly inserted (excludes idempotent
+            skips).
+        """
+        inserted = 0
+        with self._lock:
+            for rng in ranges:
+                arr = np.array(rng.tokens, dtype=np.uint64)
+                polys = chunk_hash_windows_numba(arr, self._chunk_size, POLY_BASE)
+                n_chunks = int(polys.shape[0])
+                if n_chunks != len(rng.object_keys):
+                    logger.error(
+                        "blend register: %d chunks from %d tokens (chunk_size=%d) "
+                        "but %d object_keys for scope %s; skipping range "
+                        "(publisher/chunk_size mismatch)",
+                        n_chunks,
+                        len(rng.tokens),
+                        self._chunk_size,
+                        len(rng.object_keys),
+                        rng.model_scope,
+                    )
+                    continue
+                for i in range(n_chunks):
+                    key = (rng.model_scope, int(polys[i]))
+                    if key in self._index:
+                        continue
+                    object_key = rng.object_keys[i]
+                    self._index[key] = _ChunkLoc(
+                        object_key, rng.old_st_base + i * self._chunk_size
+                    )
+                    self._by_key.setdefault(object_key, []).append(key)
+                    inserted += 1
+        return inserted
+
+    def remove(self, object_keys: list[str]) -> int:
+        """Evict all fingerprints for the given storage keys.
+
+        Args:
+            object_keys: Storage keys of chunks to evict.
+
+        Returns:
+            Number of fingerprint entries removed.
+        """
+        removed = 0
+        with self._lock:
+            for object_key in object_keys:
+                for key in self._by_key.pop(object_key, []):
+                    if self._index.pop(key, None) is not None:
+                        removed += 1
+        return removed
+
+    def match(self, model_scope: str, tokens: list[int]) -> list[GlobalMatch]:
+        """Match request tokens against the directory.
+
+        Rolls a chunk-window hash over the request and probes the table every
+        ``probe_stride`` positions; a hit is an exact 64-bit poly match (the dict
+        key is the full hash). De-duplicates by ``object_key``. Mirrors
+        ``BlendTokenRangeMatcherV3.match_sub_sequence``.
+
+        Args:
+            model_scope: Scope to match within (``f"{model_name}@{cache_salt}"``).
+            tokens: The request tokens.
+
+        Returns:
+            Matches in ascending ``cur_st`` order; empty if nothing matched.
+        """
+        if len(tokens) < self._chunk_size:
+            return []
+        arr = np.array(tokens, dtype=np.uint64)
+        rolling = rolling_hash_windows_numba(arr, self._chunk_size, POLY_BASE)
+        n_positions = int(rolling.shape[0])
+        matches: list[GlobalMatch] = []
+        seen: set[str] = set()
+        with self._lock:
+            for q_pos in range(0, n_positions, self._probe_stride):
+                loc = self._index.get((model_scope, int(rolling[q_pos])))
+                if loc is None or loc.object_key in seen:
+                    continue
+                seen.add(loc.object_key)
+                matches.append(
+                    GlobalMatch(
+                        object_key=loc.object_key, old_st=loc.old_st, cur_st=q_pos
+                    )
+                )
+        return matches

--- a/lmcache/v1/mp_coordinator/config.py
+++ b/lmcache/v1/mp_coordinator/config.py
@@ -35,6 +35,12 @@ class MPCoordinatorConfig:
             cycle (0.0 to 1.0).
         trigger_watermark: Eviction fires when usage reaches this fraction
             of the quota (0.0 to 1.0).
+        blend_chunk_size: Tokens per chunk for the global CacheBlend directory
+            (the match unit). Must equal the LMCache chunk size the blend servers
+            use, so the coordinator chunks published/queried tokens the same way.
+        blend_probe_stride: Positions between match probes. With partial-fill
+            reuse any offset is usable, so ``1`` (probe every offset) gives full
+            recall; raise only to trade recall for coordinator CPU.
     """
 
     host: str = "0.0.0.0"
@@ -44,6 +50,8 @@ class MPCoordinatorConfig:
     eviction_check_interval: float = 5.0
     eviction_ratio: float = 0.2
     trigger_watermark: float = 1.0
+    blend_chunk_size: int = 256
+    blend_probe_stride: int = 1
 
     def __post_init__(self) -> None:
         """Validate timing parameters.
@@ -63,6 +71,10 @@ class MPCoordinatorConfig:
             raise ValueError(
                 "trigger_watermark must be between 0.0 (exclusive) and 1.0"
             )
+        if self.blend_chunk_size < 1:
+            raise ValueError("blend_chunk_size must be positive")
+        if self.blend_probe_stride < 1:
+            raise ValueError("blend_probe_stride must be positive")
 
     @classmethod
     def from_env(cls) -> "MPCoordinatorConfig":
@@ -101,4 +113,8 @@ class MPCoordinatorConfig:
             ),
             eviction_ratio=_num("EVICTION_RATIO", cls.eviction_ratio, float),
             trigger_watermark=_num("TRIGGER_WATERMARK", cls.trigger_watermark, float),
+            blend_chunk_size=int(_num("BLEND_CHUNK_SIZE", cls.blend_chunk_size, int)),
+            blend_probe_stride=int(
+                _num("BLEND_PROBE_STRIDE", cls.blend_probe_stride, int)
+            ),
         )

--- a/lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py
@@ -51,7 +51,7 @@ def _directory(request: Request) -> GlobalBlendMatcher:
 
 
 @router.post("/blend/fingerprints")
-async def publish_fingerprints(
+def publish_fingerprints(
     body: BlendFingerprintRequest, request: Request
 ) -> BlendFingerprintResponse:
     """Register published chunk fingerprints (idempotent).
@@ -74,9 +74,7 @@ async def publish_fingerprints(
 
 
 @router.delete("/blend/fingerprints")
-async def evict_fingerprints(
-    body: BlendEvictRequest, request: Request
-) -> BlendEvictResponse:
+def evict_fingerprints(body: BlendEvictRequest, request: Request) -> BlendEvictResponse:
     """Evict fingerprints by storage key (idempotent).
 
     Returns:
@@ -88,9 +86,7 @@ async def evict_fingerprints(
 
 
 @router.post("/blend/match")
-async def match_fingerprints(
-    body: BlendMatchRequest, request: Request
-) -> BlendMatchResponse:
+def match_fingerprints(body: BlendMatchRequest, request: Request) -> BlendMatchResponse:
     """Match a request's rolling-hash array against the directory.
 
     Returns:

--- a/lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""REST resource for the global CacheBlend fingerprint directory.
+
+Blend mp-servers publish chunk fingerprints on STORE (``POST
+/blend/fingerprints``) and query them on LOOKUP (``POST /blend/match``).
+Endpoints operate on the shared :class:`GlobalBlendMatcher` reached via
+``app.state.blend_directory``.
+"""
+
+# Third Party
+from fastapi import APIRouter, Request
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_coordinator.blend_directory import (
+    GlobalBlendMatcher,
+    StoreRange,
+)
+from lmcache.v1.mp_coordinator.schemas import (
+    BlendEvictRequest,
+    BlendEvictResponse,
+    BlendFingerprintRequest,
+    BlendFingerprintResponse,
+    BlendMatchRequest,
+    BlendMatchResponse,
+    GlobalMatchModel,
+)
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+
+def _directory(request: Request) -> GlobalBlendMatcher:
+    """Return the shared blend directory from app state.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        The shared :class:`GlobalBlendMatcher`.
+
+    Raises:
+        RuntimeError: If the directory is not initialized (wired by
+            ``create_app``, so this should not happen in practice).
+    """
+    directory = getattr(request.app.state, "blend_directory", None)
+    if directory is None:
+        raise RuntimeError("blend directory not initialized")
+    return directory
+
+
+@router.post("/blend/fingerprints")
+async def publish_fingerprints(
+    body: BlendFingerprintRequest, request: Request
+) -> BlendFingerprintResponse:
+    """Register published chunk fingerprints (idempotent).
+
+    Returns:
+        Number of fingerprints newly inserted.
+    """
+    directory = _directory(request)
+    ranges = [
+        StoreRange(
+            model_scope=r.model_scope,
+            tokens=r.tokens,
+            object_keys=r.object_keys,
+            old_st_base=r.old_st_base,
+        )
+        for r in body.ranges
+    ]
+    inserted = directory.register(ranges) if ranges else 0
+    return BlendFingerprintResponse(inserted=inserted)
+
+
+@router.delete("/blend/fingerprints")
+async def evict_fingerprints(
+    body: BlendEvictRequest, request: Request
+) -> BlendEvictResponse:
+    """Evict fingerprints by storage key (idempotent).
+
+    Returns:
+        Number of fingerprint entries removed.
+    """
+    directory = _directory(request)
+    removed = directory.remove(body.object_keys) if body.object_keys else 0
+    return BlendEvictResponse(removed=removed)
+
+
+@router.post("/blend/match")
+async def match_fingerprints(
+    body: BlendMatchRequest, request: Request
+) -> BlendMatchResponse:
+    """Match a request's rolling-hash array against the directory.
+
+    Returns:
+        Matched chunks (``object_key`` / ``old_st`` / ``cur_st``), ascending by
+        ``cur_st``.
+    """
+    directory = _directory(request)
+    matches = directory.match(body.model_scope, body.tokens)
+    return BlendMatchResponse(
+        matches=[
+            GlobalMatchModel(object_key=m.object_key, old_st=m.old_st, cur_st=m.cur_st)
+            for m in matches
+        ]
+    )

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -182,3 +182,101 @@ class L2StatusListResponse(BaseModel):
 
     total_gb: float
     by_cache_salt: list[L2StatusResponse]
+
+
+# -- Global CacheBlend fingerprint directory ------------------------------
+
+
+class StoreRangeModel(BaseModel):
+    """Wire form of one published stored token range (see ``StoreRange``).
+
+    The coordinator chunks ``tokens`` at its chunk size and hashes each chunk;
+    chunk ``i`` maps to ``object_keys[i]`` at ``old_st_base + i * chunk_size``.
+
+    Attributes:
+        model_scope: ``f"{model_name}@{cache_salt}"`` reuse scope.
+        tokens: The stored tokens (``token_ids[start:end]``).
+        object_keys: Shared-L2 storage key (hex) per chunk, in order.
+        old_st_base: Token position of the range's first token.
+    """
+
+    model_scope: str
+    tokens: list[int] = Field(default_factory=list)
+    object_keys: list[str] = Field(default_factory=list)
+    old_st_base: int = Field(ge=0)
+
+
+class BlendFingerprintRequest(BaseModel):
+    """Body of ``POST /blend/fingerprints``: register stored ranges.
+
+    Attributes:
+        ranges: Stored token ranges to register (idempotent).
+    """
+
+    ranges: list[StoreRangeModel] = Field(default_factory=list)
+
+
+class BlendFingerprintResponse(BaseModel):
+    """Reply to ``POST /blend/fingerprints``.
+
+    Attributes:
+        inserted: Number of fingerprints newly registered.
+    """
+
+    inserted: int
+
+
+class BlendEvictRequest(BaseModel):
+    """Body of ``DELETE /blend/fingerprints``: evict by storage key.
+
+    Attributes:
+        object_keys: ``object_key`` values to evict.
+    """
+
+    object_keys: list[str] = Field(default_factory=list)
+
+
+class BlendEvictResponse(BaseModel):
+    """Reply to ``DELETE /blend/fingerprints``.
+
+    Attributes:
+        removed: Number of fingerprint entries evicted.
+    """
+
+    removed: int
+
+
+class BlendMatchRequest(BaseModel):
+    """Body of ``POST /blend/match``.
+
+    Attributes:
+        model_scope: Scope to match within.
+        tokens: The request tokens (the coordinator hashes and probes them).
+    """
+
+    model_scope: str
+    tokens: list[int] = Field(default_factory=list)
+
+
+class GlobalMatchModel(BaseModel):
+    """Wire form of one matched chunk (see ``GlobalMatch``).
+
+    Attributes:
+        object_key: Shared-L2 storage key of the matched chunk.
+        old_st: Token position in the stored sequence (re-RoPE source).
+        cur_st: Token position in the request (re-RoPE target).
+    """
+
+    object_key: str
+    old_st: int
+    cur_st: int
+
+
+class BlendMatchResponse(BaseModel):
+    """Reply to ``POST /blend/match``.
+
+    Attributes:
+        matches: Matched chunks, ascending by ``cur_st``.
+    """
+
+    matches: list[GlobalMatchModel]

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -375,30 +375,6 @@ class CBMatchResult:
 
 
 @dataclass
-class CBGlobalSegment:
-    """One reusable chunk located in the fleet-wide coordinator directory.
-
-    Chunk-granular, parallel to ``CBMatchResult`` but pointing at a shared-L2
-    storage key instead of a local hash. Identifies the chunk's KV in the shared
-    L2 and the positions needed to re-RoPE it.
-
-    Attributes:
-        object_key: Hex of the chunk's storage key (``ObjectKey`` chunk hash);
-            expanded to per-rank object keys at retrieve.
-        old_st: Start token position in the stored sequence (re-RoPE source).
-        old_ed: End token position in the stored sequence.
-        cur_st: Start token position in the request (re-RoPE target).
-        cur_ed: End token position in the request.
-    """
-
-    object_key: str
-    old_st: int
-    old_ed: int
-    cur_st: int
-    cur_ed: int
-
-
-@dataclass
 class CBUnifiedLookupResult:
     """Resolved payload of ``CB_UNIFIED_LOOKUP``: prefix lookup + non-prefix
     fingerprint match, reconciled in one RPC. The RPC returns ``None`` (not this)
@@ -412,15 +388,19 @@ class CBUnifiedLookupResult:
             (cur_st order), each carrying ``(old_st, old_ed, cur_st, cur_ed,
             hash)``. Already sparse-prefetched, so the retrieve set equals the
             prefetched set.
-        global_segments: Block-granular matches found in the fleet coordinator
+        global_segments: Chunk-granular matches found in the fleet coordinator
             directory (shared-L2 reuse), empty when no coordinator is configured
-            or none matched. Consumed by the partial KV transfer path; not yet
-            merged with ``non_prefix_segments`` (the consumer reconciles overlap).
+            or none matched. Same ``CBMatchResult`` shape as
+            ``non_prefix_segments`` -- each ``hash`` is the chunk's content hash,
+            which ``ipc_key_to_object_keys`` expands to per-rank shared-L2 keys
+            at retrieve. The consumer merges these into the single
+            ``cb_match_result`` list it sends to ``CB_RETRIEVE_PRE_COMPUTED_V3``,
+            reconciling any overlap with ``non_prefix_segments``.
     """
 
     prefix_coverage_tokens: int
     non_prefix_segments: list[CBMatchResult]
-    global_segments: list[CBGlobalSegment] = field(default_factory=list)
+    global_segments: list[CBMatchResult] = field(default_factory=list)
 
 
 _CUSTOMERIZED_SERIALIZERS = {

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -387,20 +387,14 @@ class CBUnifiedLookupResult:
         non_prefix_segments: Fingerprint matches outside the prefix coverage
             (cur_st order), each carrying ``(old_st, old_ed, cur_st, cur_ed,
             hash)``. Already sparse-prefetched, so the retrieve set equals the
-            prefetched set.
-        global_segments: Chunk-granular matches found in the fleet coordinator
-            directory (shared-L2 reuse), empty when no coordinator is configured
-            or none matched. Same ``CBMatchResult`` shape as
-            ``non_prefix_segments`` -- each ``hash`` is the chunk's content hash,
-            which ``ipc_key_to_object_keys`` expands to per-rank shared-L2 keys
-            at retrieve. The consumer merges these into the single
-            ``cb_match_result`` list it sends to ``CB_RETRIEVE_PRE_COMPUTED_V3``,
-            reconciling any overlap with ``non_prefix_segments``.
+            prefetched set. Includes fleet-coordinator (shared-L2) matches:
+            those are merged in before the sparse prefetch -- prefix-covered and
+            locally-duplicated ones dropped -- so they ride the identical
+            prefetch + retrieve path and need no separate handling.
     """
 
     prefix_coverage_tokens: int
     non_prefix_segments: list[CBMatchResult]
-    global_segments: list[CBMatchResult] = field(default_factory=list)
 
 
 _CUSTOMERIZED_SERIALIZERS = {

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -375,6 +375,30 @@ class CBMatchResult:
 
 
 @dataclass
+class CBGlobalSegment:
+    """One reusable chunk located in the fleet-wide coordinator directory.
+
+    Chunk-granular, parallel to ``CBMatchResult`` but pointing at a shared-L2
+    storage key instead of a local hash. Identifies the chunk's KV in the shared
+    L2 and the positions needed to re-RoPE it.
+
+    Attributes:
+        object_key: Hex of the chunk's storage key (``ObjectKey`` chunk hash);
+            expanded to per-rank object keys at retrieve.
+        old_st: Start token position in the stored sequence (re-RoPE source).
+        old_ed: End token position in the stored sequence.
+        cur_st: Start token position in the request (re-RoPE target).
+        cur_ed: End token position in the request.
+    """
+
+    object_key: str
+    old_st: int
+    old_ed: int
+    cur_st: int
+    cur_ed: int
+
+
+@dataclass
 class CBUnifiedLookupResult:
     """Resolved payload of ``CB_UNIFIED_LOOKUP``: prefix lookup + non-prefix
     fingerprint match, reconciled in one RPC. The RPC returns ``None`` (not this)
@@ -386,13 +410,17 @@ class CBUnifiedLookupResult:
             tokens — what the standard LOOKUP would report.
         non_prefix_segments: Fingerprint matches outside the prefix coverage
             (cur_st order), each carrying ``(old_st, old_ed, cur_st, cur_ed,
-            hash)``. Token-aligned (any offset, not block-aligned): the per-token
-            slot scatter handles them. Already resident in L1, so the retrieve
-            set equals the prefetched set.
+            hash)``. Already sparse-prefetched, so the retrieve set equals the
+            prefetched set.
+        global_segments: Block-granular matches found in the fleet coordinator
+            directory (shared-L2 reuse), empty when no coordinator is configured
+            or none matched. Consumed by the partial KV transfer path; not yet
+            merged with ``non_prefix_segments`` (the consumer reconciles overlap).
     """
 
     prefix_coverage_tokens: int
     non_prefix_segments: list[CBMatchResult]
+    global_segments: list[CBGlobalSegment] = field(default_factory=list)
 
 
 _CUSTOMERIZED_SERIALIZERS = {

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -10,9 +10,16 @@ retrieve scatters into the request's paged blocks.
 from dataclasses import dataclass
 from queue import Empty as QueueEmpty
 from queue import Queue
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import threading
 import time
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.mp_coordinator.blend_client import (
+        BlendCoordinatorClient,
+        RemoteMatch,
+    )
 
 # Third Party
 import numpy as np
@@ -31,6 +38,7 @@ from lmcache.v1.distributed.storage_manager import PrefetchHandle
 from lmcache.v1.gpu_connector.gpu_ops import lmcache_memcpy_async_h2d
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.multiprocess.custom_types import (
+    CBGlobalSegment,
     CBMatchResult,
     CBUnifiedLookupResult,
     CudaIPCWrapper,
@@ -39,6 +47,7 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.engine_context import MPCacheEngineContext
 from lmcache.v1.multiprocess.engine_module import HandlerSpec, ThreadPoolType
 from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
+from lmcache.v1.mp_coordinator.blend_client import PENDING
 from lmcache.v1.multiprocess.modules.gpu_transfer import GPUTransferModule
 from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.protocol import RequestType
@@ -80,6 +89,8 @@ class _CBUnifiedJob:
     expanded_uidx: list[int] | None = None
     found_uidx: set[int] | None = None  # stashed when the sparse poll completes
     l2_keys: int = 0  # sparse keys needing an L2 load (0 => no L2 read, span skipped)
+    found_result: list[CBMatchResult] | None = None  # local classify, computed once
+    coord_submitted: bool = False  # coordinator match query was issued
 
 
 class BlendTokenRangeMatcherV3:
@@ -312,6 +323,7 @@ class BlendV3Module:
         ctx: MPCacheEngineContext,
         gpu_transfer: GPUTransferModule,
         lookup_module: LookupModule,
+        coordinator: "BlendCoordinatorClient | None" = None,
     ):
         self._ctx = ctx
         self._gpu_transfer = gpu_transfer
@@ -319,6 +331,9 @@ class BlendV3Module:
         # (registers the prefix prefetch job + session state the retrieve
         # path depends on) inside the single unified RPC.
         self._lookup_module = lookup_module
+        # Optional bridge to the fleet-wide fingerprint directory. ``None`` =>
+        # purely local matching (publish/query paths skipped).
+        self._coordinator = coordinator
 
         self._token_range_matcher = BlendTokenRangeMatcherV3(ctx.chunk_size)
         self._event_bus = ctx.event_bus
@@ -744,6 +759,7 @@ class BlendV3Module:
                 )
             )
             job = _CBUnifiedJob(matches=matches, num_tokens=len(key.token_ids))
+            job.coord_submitted = self._submit_coordinator_match(key)
             with self._cb_jobs_lock:
                 self._cb_jobs[rid] = job
 
@@ -815,17 +831,42 @@ class BlendV3Module:
                     )
                 )
 
-        # --- BOTH legs ready: classify the complement + finalize. ---
-        if job.handle is not None:
-            found = self._sparse_classify(
-                key,
-                job.non_prefix or [],
-                job.found_uidx or set(),
-                job.per_hash_obj_keys or {},
-                job.expanded_uidx or [],
+        # --- Local legs ready: classify the complement once (side effects). ---
+        if job.found_result is None:
+            if job.handle is not None:
+                found = self._sparse_classify(
+                    key,
+                    job.non_prefix or [],
+                    job.found_uidx or set(),
+                    job.per_hash_obj_keys or {},
+                    job.expanded_uidx or [],
+                )
+            else:
+                found = []
+            job.found_result = found
+            num_tokens = job.num_tokens
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.CB_LOOKUP_END,
+                    session_id=rid,
+                    metadata={
+                        "num_tokens": num_tokens,
+                        "fingerprint_hits": len(found),
+                        "prefix_hits": job.prefix_chunks,
+                        "storage_hits": len(found),
+                        "stale_chunks": len(job.non_prefix or []) - len(found),
+                        "no_gpu_context": False,
+                        "hit_tokens": _unique_token_coverage(found),
+                        "requested_tokens": (num_tokens // chunk_size) * chunk_size,
+                    },
+                )
             )
-        else:
-            found = []
+        found = job.found_result
+
+        # --- Global leg: poll the coordinator (bounded defer), best-effort. ---
+        global_segments = self._poll_coordinator_match(job, rid)
+        if global_segments is None:
+            return None  # coordinator still in flight, within the defer budget
 
         prefix_tokens = job.prefix_chunks * chunk_size
         num_tokens = job.num_tokens
@@ -857,6 +898,7 @@ class BlendV3Module:
         return CBUnifiedLookupResult(
             prefix_coverage_tokens=prefix_tokens,
             non_prefix_segments=found,
+            global_segments=global_segments,
         )
 
     def store(
@@ -923,7 +965,127 @@ class BlendV3Module:
                 key.request_id,
             )
 
+        if self._coordinator is not None:
+            self._publish_fingerprints(key, chunk_hashes, tokens_in_range)
+
         return result
+
+    def _publish_fingerprints(
+        self,
+        key: IPCCacheEngineKey,
+        chunk_hashes: list[bytes],
+        tokens_in_range: list[int],
+    ) -> None:
+        """Publish this stored range's chunk fingerprints to the coordinator.
+
+        Best-effort and fire-and-forget (enqueue only): one wire
+        ``ChunkFingerprint`` per stored chunk -- its content poly-hash (the same
+        ``chunk_hash_windows_numba`` the match probes, with the fleet base), its
+        shared-L2 ``object_key`` (the chunk storage key ``th``), and its token
+        position. Never raises into the store path.
+
+        Args:
+            key: The store request key (model/scope/positions).
+            chunk_hashes: Per-chunk storage keys (``th``) for the range.
+            tokens_in_range: The stored tokens ``token_ids[start:end]``.
+        """
+        coordinator = self._coordinator
+        if coordinator is None or not chunk_hashes:
+            return
+        try:
+            model_scope = f"{key.model_name}@{key.cache_salt}"
+            store_range = {
+                "model_scope": model_scope,
+                "tokens": list(tokens_in_range),
+                "object_keys": [h.hex() for h in chunk_hashes],
+                "old_st_base": key.start,
+            }
+            coordinator.enqueue_register([store_range])
+        except Exception:
+            logger.warning(
+                "CB coordinator publish build failed for request %s "
+                "(does not affect store correctness)",
+                key.request_id,
+            )
+
+    def _submit_coordinator_match(self, key: IPCCacheEngineKey) -> bool:
+        """Issue a fleet directory match query for this request (best-effort).
+
+        Args:
+            key: The lookup request key.
+
+        Returns:
+            ``True`` if a query was submitted (so the finalize step should poll
+            for it), ``False`` when there is no coordinator or submission failed.
+        """
+        coordinator = self._coordinator
+        if coordinator is None:
+            return False
+        try:
+            tokens = list(key.token_ids)
+            if len(tokens) < self._ctx.chunk_size:
+                return False
+            model_scope = f"{key.model_name}@{key.cache_salt}"
+            coordinator.submit_match(key.request_id, model_scope, tokens)
+            return True
+        except Exception:
+            logger.warning(
+                "CB coordinator match submit failed for request %s", key.request_id
+            )
+            return False
+
+    def _poll_coordinator_match(
+        self, job: "_CBUnifiedJob", rid: str
+    ) -> "list[CBGlobalSegment] | None":
+        """Poll the coordinator match result, deferring until it resolves.
+
+        Mirrors the prefix/sparse legs: ``return None`` to defer while pending.
+        The result is guaranteed to resolve (matches, or ``[]`` on failure)
+        within the client's HTTP ``request_timeout``, which is the single
+        wall-clock budget bounding how long the lookup waits on this optional
+        leg before proceeding local-only.
+
+        Args:
+            job: The per-request poll state.
+            rid: Request id.
+
+        Returns:
+            The global segments (possibly empty) once resolved, or ``None`` to
+            defer (still in flight).
+        """
+        coordinator = self._coordinator
+        if coordinator is None or not job.coord_submitted:
+            return []
+        poll = coordinator.poll_match(rid)
+        if poll is PENDING:
+            return None  # defer; bounded by the client's request_timeout
+        coordinator.take_match(rid)
+        if isinstance(poll, list):
+            return self._build_global_segments(poll)
+        return []
+
+    def _build_global_segments(
+        self, matches: "list[RemoteMatch]"
+    ) -> list[CBGlobalSegment]:
+        """Convert coordinator matches into chunk-granular global segments.
+
+        Args:
+            matches: Matched chunks returned by the coordinator client.
+
+        Returns:
+            One :class:`CBGlobalSegment` per matched chunk (request order).
+        """
+        chunk_size = self._ctx.chunk_size
+        return [
+            CBGlobalSegment(
+                object_key=m.object_key,
+                old_st=m.old_st,
+                old_ed=m.old_st + chunk_size,
+                cur_st=m.cur_st,
+                cur_ed=m.cur_st + chunk_size,
+            )
+            for m in matches
+        ]
 
     def _drain_fingerprint_queue(self) -> None:
         """Best-effort background drainer for _fingerprint_queue."""

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -36,9 +36,9 @@ from lmcache.v1.distributed.api import (
 )
 from lmcache.v1.distributed.storage_manager import PrefetchHandle
 from lmcache.v1.gpu_connector.gpu_ops import lmcache_memcpy_async_h2d
+from lmcache.v1.mp_coordinator.blend_client import PENDING
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.multiprocess.custom_types import (
-    CBGlobalSegment,
     CBMatchResult,
     CBUnifiedLookupResult,
     CudaIPCWrapper,
@@ -47,7 +47,6 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.engine_context import MPCacheEngineContext
 from lmcache.v1.multiprocess.engine_module import HandlerSpec, ThreadPoolType
 from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
-from lmcache.v1.mp_coordinator.blend_client import PENDING
 from lmcache.v1.multiprocess.modules.gpu_transfer import GPUTransferModule
 from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.protocol import RequestType
@@ -91,6 +90,7 @@ class _CBUnifiedJob:
     l2_keys: int = 0  # sparse keys needing an L2 load (0 => no L2 read, span skipped)
     found_result: list[CBMatchResult] | None = None  # local classify, computed once
     coord_submitted: bool = False  # coordinator match query was issued
+    coord_deadline: float = 0.0  # time.monotonic() wall-clock cutoff for the leg
 
 
 class BlendTokenRangeMatcherV3:
@@ -419,6 +419,10 @@ class BlendV3Module:
 
     def close(self) -> None:
         self._fingerprint_stop.set()
+        if self._coordinator is not None:
+            # Joins the client's daemon thread and closes its httpx.Client;
+            # otherwise the coordinator leg leaks both on server shutdown.
+            self._coordinator.close()
         self._cb_rope_state.clear()
 
     # ------------------------------------------------------------------
@@ -760,6 +764,8 @@ class BlendV3Module:
             )
             job = _CBUnifiedJob(matches=matches, num_tokens=len(key.token_ids))
             job.coord_submitted = self._submit_coordinator_match(key)
+            if job.coord_submitted and self._coordinator is not None:
+                job.coord_deadline = time.monotonic() + self._coordinator.match_budget_s
             with self._cb_jobs_lock:
                 self._cb_jobs[rid] = job
 
@@ -1036,29 +1042,36 @@ class BlendV3Module:
 
     def _poll_coordinator_match(
         self, job: "_CBUnifiedJob", rid: str
-    ) -> "list[CBGlobalSegment] | None":
+    ) -> "list[CBMatchResult] | None":
         """Poll the coordinator match result, deferring until it resolves.
 
         Mirrors the prefix/sparse legs: ``return None`` to defer while pending.
-        The result is guaranteed to resolve (matches, or ``[]`` on failure)
-        within the client's HTTP ``request_timeout``, which is the single
-        wall-clock budget bounding how long the lookup waits on this optional
-        leg before proceeding local-only.
+        A per-lookup wall-clock deadline (``job.coord_deadline``) bounds the
+        total wait: the daemon services match queries serially, so queue backlog
+        can keep a query ``PENDING`` well past one HTTP round-trip. Once the
+        deadline passes, the leg is abandoned and the lookup proceeds local-only
+        (the daemon's later fill, if any, is dropped via ``take_match``).
 
         Args:
             job: The per-request poll state.
             rid: Request id.
 
         Returns:
-            The global segments (possibly empty) once resolved, or ``None`` to
-            defer (still in flight).
+            The global segments (possibly empty) once resolved or timed out, or
+            ``None`` to defer (still in flight and within the deadline).
         """
         coordinator = self._coordinator
         if coordinator is None or not job.coord_submitted:
             return []
         poll = coordinator.poll_match(rid)
         if poll is PENDING:
-            return None  # defer; bounded by the client's request_timeout
+            if time.monotonic() < job.coord_deadline:
+                return None  # defer; bounded by job.coord_deadline
+            coordinator.take_match(rid)
+            logger.warning(
+                "CB coordinator match deadline exceeded for %s; local-only", rid
+            )
+            return []
         coordinator.take_match(rid)
         if isinstance(poll, list):
             return self._build_global_segments(poll)
@@ -1066,23 +1079,29 @@ class BlendV3Module:
 
     def _build_global_segments(
         self, matches: "list[RemoteMatch]"
-    ) -> list[CBGlobalSegment]:
-        """Convert coordinator matches into chunk-granular global segments.
+    ) -> list[CBMatchResult]:
+        """Convert coordinator matches into chunk-granular retrievable segments.
+
+        Each coordinator ``object_key`` is the hex of the chunk's content hash
+        (the same ``th`` a local ``CBMatchResult.hash`` holds), so the matches
+        are returned as ``CBMatchResult`` directly: the retrieve path then
+        expands ``hash`` to per-rank shared-L2 object keys via
+        ``ipc_key_to_object_keys``, identical to local matches.
 
         Args:
             matches: Matched chunks returned by the coordinator client.
 
         Returns:
-            One :class:`CBGlobalSegment` per matched chunk (request order).
+            One :class:`CBMatchResult` per matched chunk (request order).
         """
         chunk_size = self._ctx.chunk_size
         return [
-            CBGlobalSegment(
-                object_key=m.object_key,
+            CBMatchResult(
                 old_st=m.old_st,
                 old_ed=m.old_st + chunk_size,
                 cur_st=m.cur_st,
                 cur_ed=m.cur_st + chunk_size,
+                hash=bytes.fromhex(m.object_key),
             )
             for m in matches
         ]

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -536,30 +536,45 @@ class BlendV3Module:
                 logger.exception("CB fingerprint registration failed (sync drain)")
 
     def _match_fingerprints(self, key: IPCCacheEngineKey) -> list[CBMatchResult]:
-        """Match the query's reusable chunks, leftmost-greedy deduped.
+        """Drain pending registrations and fingerprint-match sub-sequences.
 
-        Drains pending fingerprint registrations, probes the matcher, then keeps
-        a non-overlapping leftmost-greedy subset.
-
-        Args:
-            key (IPCCacheEngineKey): The query request key.
-
-        Returns:
-            list[CBMatchResult]: Non-overlapping matches sorted by cur_st
-            (empty if none).
+        Returns the raw matches (any order, possibly overlapping); the caller
+        applies the prefix filter + overlap dedup once via
+        :meth:`_non_overlapping_after_prefix`.
         """
         self._drain_fingerprints_sync()
-        matches = self._token_range_matcher.match_sub_sequence(list(key.token_ids))
-        if not matches:
-            return []
-        matches.sort(key=lambda r: r.cur_st)
-        deduped: list[CBMatchResult] = []
+        return self._token_range_matcher.match_sub_sequence(list(key.token_ids))
+
+    @staticmethod
+    def _non_overlapping_after_prefix(
+        matches: list[CBMatchResult], prefix_tokens: int
+    ) -> list[CBMatchResult]:
+        """Matches outside the prefix coverage, leftmost-greedy overlap-deduped.
+
+        Drops matches the prefix leg already covers (``cur_st < prefix_tokens``),
+        then keeps a left-to-right non-overlapping subset -- two matches over the
+        same request range can't both scatter. Filtering precedes the dedup so a
+        prefix-covered match cannot suppress a usable one in the greedy pass.
+
+        Args:
+            matches: Candidate matches in any order; ``cur_st``/``cur_ed`` are
+                request token positions.
+            prefix_tokens: Contiguous prefix coverage in tokens; matches starting
+                before it are dropped. Pass ``0`` to keep all (dedup only).
+
+        Returns:
+            Non-overlapping matches in ascending ``cur_st`` order.
+        """
+        kept: list[CBMatchResult] = []
         covered_end = -1
-        for r in matches:
+        for r in sorted(
+            (r for r in matches if r.cur_st >= prefix_tokens),
+            key=lambda r: r.cur_st,
+        ):
             if r.cur_st >= covered_end:
-                deduped.append(r)
+                kept.append(r)
                 covered_end = r.cur_ed
-        return deduped
+        return kept
 
     def _resolve_cb_layout_desc(
         self, model_name: str, world_size: int
@@ -750,18 +765,29 @@ class BlendV3Module:
             # mp.lookup_prefetch (LookupModule self-instruments); prefix_chunks
             # lands on cb.lookup via CB_LOOKUP_END below.
             self._lookup_module.lookup(key, tp_size)
-            # Fingerprint match: CPU-bound, tight span.
-            self._event_bus.publish(
-                Event(event_type=EventType.CB_FINGERPRINT_MATCH_START, session_id=rid)
-            )
-            matches = self._match_fingerprints(key)
-            self._event_bus.publish(
-                Event(
-                    event_type=EventType.CB_FINGERPRINT_MATCH_END,
-                    session_id=rid,
-                    metadata={"matches": len(matches)},
+            # Local and coordinator matching are mutually exclusive: with a
+            # coordinator the fleet directory is the only source, so skip the
+            # local matcher (and its span). The coordinator leg is async
+            # (submitted below, resolved at poll) and is timed by cb.lookup.
+            matches: list[CBMatchResult]
+            if self._coordinator is not None:
+                matches = []
+            else:
+                # Local fingerprint match: CPU-bound, tight span.
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.CB_FINGERPRINT_MATCH_START,
+                        session_id=rid,
+                    )
                 )
-            )
+                matches = self._match_fingerprints(key)
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.CB_FINGERPRINT_MATCH_END,
+                        session_id=rid,
+                        metadata={"matches": len(matches)},
+                    )
+                )
             job = _CBUnifiedJob(matches=matches, num_tokens=len(key.token_ids))
             job.coord_submitted = self._submit_coordinator_match(key)
             if job.coord_submitted and self._coordinator is not None:
@@ -781,9 +807,16 @@ class BlendV3Module:
         # enter the sparse prefetch, so they cannot leak a read lock.
         if not job.sparse_started:
             prefix_tokens = job.prefix_chunks * chunk_size
-            # Any offset is fine: the per-token slot scatter writes
-            # non-block-aligned matches.
-            job.non_prefix = [r for r in job.matches if r.cur_st >= prefix_tokens]
+            if self._coordinator is not None:
+                candidates = self._poll_coordinator_match(job, rid)
+                if candidates is None:
+                    return None  # coordinator still in flight (bounded by deadline)
+            else:
+                candidates = job.matches
+            # Single prefix-filter + overlap dedup over the raw matches
+            job.non_prefix = self._non_overlapping_after_prefix(
+                candidates, prefix_tokens
+            )
             if job.non_prefix:
                 layout_desc = self._resolve_cb_layout_desc(
                     key.model_name, key.world_size
@@ -850,29 +883,7 @@ class BlendV3Module:
             else:
                 found = []
             job.found_result = found
-            num_tokens = job.num_tokens
-            self._event_bus.publish(
-                Event(
-                    event_type=EventType.CB_LOOKUP_END,
-                    session_id=rid,
-                    metadata={
-                        "num_tokens": num_tokens,
-                        "fingerprint_hits": len(found),
-                        "prefix_hits": job.prefix_chunks,
-                        "storage_hits": len(found),
-                        "stale_chunks": len(job.non_prefix or []) - len(found),
-                        "no_gpu_context": False,
-                        "hit_tokens": _unique_token_coverage(found),
-                        "requested_tokens": (num_tokens // chunk_size) * chunk_size,
-                    },
-                )
-            )
         found = job.found_result
-
-        # --- Global leg: poll the coordinator (bounded defer), best-effort. ---
-        global_segments = self._poll_coordinator_match(job, rid)
-        if global_segments is None:
-            return None  # coordinator still in flight, within the defer budget
 
         prefix_tokens = job.prefix_chunks * chunk_size
         num_tokens = job.num_tokens
@@ -904,7 +915,6 @@ class BlendV3Module:
         return CBUnifiedLookupResult(
             prefix_coverage_tokens=prefix_tokens,
             non_prefix_segments=found,
-            global_segments=global_segments,
         )
 
     def store(

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -88,7 +88,6 @@ class _CBUnifiedJob:
     expanded_uidx: list[int] | None = None
     found_uidx: set[int] | None = None  # stashed when the sparse poll completes
     l2_keys: int = 0  # sparse keys needing an L2 load (0 => no L2 read, span skipped)
-    found_result: list[CBMatchResult] | None = None  # local classify, computed once
     coord_submitted: bool = False  # coordinator match query was issued
     coord_deadline: float = 0.0  # time.monotonic() wall-clock cutoff for the leg
 
@@ -870,20 +869,17 @@ class BlendV3Module:
                     )
                 )
 
-        # --- Local legs ready: classify the complement once (side effects). ---
-        if job.found_result is None:
-            if job.handle is not None:
-                found = self._sparse_classify(
-                    key,
-                    job.non_prefix or [],
-                    job.found_uidx or set(),
-                    job.per_hash_obj_keys or {},
-                    job.expanded_uidx or [],
-                )
-            else:
-                found = []
-            job.found_result = found
-        found = job.found_result
+        # --- BOTH legs ready: classify the complement + finalize. ---
+        if job.handle is not None:
+            found = self._sparse_classify(
+                key,
+                job.non_prefix or [],
+                job.found_uidx or set(),
+                job.per_hash_obj_keys or {},
+                job.expanded_uidx or [],
+            )
+        else:
+            found = []
 
         prefix_tokens = job.prefix_chunks * chunk_size
         num_tokens = job.num_tokens

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -202,11 +202,19 @@ def _build_modules(
                 f"'auto', got '{mp_config.supported_transfer_mode}'"
             )
         # First Party
+        from lmcache.v1.mp_coordinator.blend_client import (
+            BlendCoordinatorClient,
+        )
         from lmcache.v1.multiprocess.modules.blend_v3 import BlendV3Module
 
         gpu_transfer = next(m for m in modules if isinstance(m, GPUTransferModule))
         lookup_module = next(m for m in modules if isinstance(m, LookupModule))
-        modules.append(BlendV3Module(ctx, gpu_transfer, lookup_module))
+        # Opt-in: enabled only when LMCACHE_COORDINATOR_URL is set; otherwise
+        # None and the blend module matches purely locally.
+        coordinator = BlendCoordinatorClient.maybe_from_env()
+        modules.append(
+            BlendV3Module(ctx, gpu_transfer, lookup_module, coordinator=coordinator)
+        )
 
     return modules
 

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the blend-server side coordinator client.
+
+The HTTP layer is replaced by an injected ``request_fn`` backed by a real
+``GlobalBlendMatcher``, so the queue/daemon/poll state machine is exercised
+end-to-end against the actual directory without a network or server.
+"""
+
+# Standard
+from collections.abc import Callable
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_coordinator.blend_directory import (
+    GlobalBlendMatcher,
+    StoreRange,
+)
+from lmcache.v1.mp_coordinator.blend_client import (
+    PENDING,
+    BlendCoordinatorClient,
+)
+
+CHUNK = 3
+SCOPE = "model-a@"
+
+
+def _matcher_request(
+    matcher: GlobalBlendMatcher,
+) -> Callable[[str, str, dict], dict]:
+    """request_fn that drives a real matcher, mirroring the coordinator router."""
+
+    def request(method: str, path: str, payload: dict) -> dict:
+        if method == "POST" and path == "/blend/fingerprints":
+            ranges = [
+                StoreRange(
+                    model_scope=r["model_scope"],
+                    tokens=r["tokens"],
+                    object_keys=r["object_keys"],
+                    old_st_base=r["old_st_base"],
+                )
+                for r in payload.get("ranges", [])
+            ]
+            return {"inserted": matcher.register(ranges) if ranges else 0}
+        if method == "DELETE" and path == "/blend/fingerprints":
+            keys = payload.get("object_keys", [])
+            return {"removed": matcher.remove(keys) if keys else 0}
+        if method == "POST" and path == "/blend/match":
+            matches = matcher.match(payload["model_scope"], payload["tokens"])
+            return {
+                "matches": [
+                    {"object_key": m.object_key, "old_st": m.old_st, "cur_st": m.cur_st}
+                    for m in matches
+                ]
+            }
+        raise AssertionError(f"unexpected {method} {path}")
+
+    return request
+
+
+def _range(prefix: str, tokens: list[int]) -> dict:
+    n_chunks = len(tokens) // CHUNK
+    return {
+        "model_scope": SCOPE,
+        "tokens": tokens,
+        "object_keys": [f"{prefix}{i}" for i in range(n_chunks)],
+        "old_st_base": 0,
+    }
+
+
+def _store_range(prefix: str, tokens: list[int]) -> StoreRange:
+    d = _range(prefix, tokens)
+    return StoreRange(**d)
+
+
+def _wait_match(client: BlendCoordinatorClient, rid: str, timeout: float = 2.0):
+    end = time.time() + timeout
+    while time.time() < end:
+        v = client.poll_match(rid)
+        if isinstance(v, list):
+            return v
+        time.sleep(0.005)
+    return client.poll_match(rid)
+
+
+def test_match_after_register():
+    m = GlobalBlendMatcher(chunk_size=CHUNK)
+    doc = [1, 2, 3, 4, 5, 6]
+    m.register([_store_range("K", doc)])
+    client = BlendCoordinatorClient(request_fn=_matcher_request(m))
+    try:
+        client.submit_match("r1", SCOPE, doc)
+        matches = _wait_match(client, "r1")
+        assert isinstance(matches, list)
+        assert [(x.object_key, x.old_st, x.cur_st) for x in matches] == [
+            ("K0", 0, 0),
+            ("K1", 3, 3),
+        ]
+    finally:
+        client.close()
+
+
+def test_publish_reaches_matcher():
+    m = GlobalBlendMatcher(chunk_size=CHUNK)
+    client = BlendCoordinatorClient(request_fn=_matcher_request(m))
+    try:
+        doc = [1, 2, 3]
+        client.enqueue_register([_range("K", doc)])
+        end = time.time() + 2.0
+        ok = False
+        while time.time() < end:
+            if m.match(SCOPE, doc):
+                ok = True
+                break
+            time.sleep(0.005)
+        assert ok
+    finally:
+        client.close()
+
+
+def test_evict_reaches_matcher():
+    m = GlobalBlendMatcher(chunk_size=CHUNK)
+    doc = [1, 2, 3]
+    m.register([_store_range("K", doc)])
+    client = BlendCoordinatorClient(request_fn=_matcher_request(m))
+    try:
+        client.enqueue_evict(["K0"])
+        end = time.time() + 2.0
+        gone = False
+        while time.time() < end:
+            if not m.match(SCOPE, doc):
+                gone = True
+                break
+            time.sleep(0.005)
+        assert gone
+    finally:
+        client.close()
+
+
+def test_poll_none_before_submit():
+    client = BlendCoordinatorClient(request_fn=lambda mth, p, b: {})
+    try:
+        assert client.poll_match("never") is None
+    finally:
+        client.close()
+
+
+def test_submit_is_idempotent():
+    m = GlobalBlendMatcher(chunk_size=CHUNK)
+    doc = [1, 2, 3]
+    m.register([_store_range("K", doc)])
+    client = BlendCoordinatorClient(request_fn=_matcher_request(m))
+    try:
+        client.submit_match("r1", SCOPE, doc)
+        client.submit_match("r1", SCOPE, doc)  # no-op
+        matches = _wait_match(client, "r1")
+        assert isinstance(matches, list) and len(matches) == 1
+    finally:
+        client.close()
+
+
+def test_match_error_degrades_to_empty():
+    def boom(method: str, path: str, payload: dict) -> dict:
+        raise RuntimeError("coordinator down")
+
+    client = BlendCoordinatorClient(request_fn=boom)
+    try:
+        client.submit_match("r1", SCOPE, [1, 2, 3])
+        matches = _wait_match(client, "r1")
+        assert matches == []  # failure -> local-only, never hangs
+    finally:
+        client.close()
+
+
+def test_take_match_clears():
+    m = GlobalBlendMatcher(chunk_size=CHUNK)
+    doc = [1, 2, 3]
+    m.register([_store_range("K", doc)])
+    client = BlendCoordinatorClient(request_fn=_matcher_request(m))
+    try:
+        client.submit_match("r1", SCOPE, doc)
+        _wait_match(client, "r1")
+        client.take_match("r1")
+        assert client.poll_match("r1") is None
+    finally:
+        client.close()
+
+
+def test_maybe_from_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LMCACHE_COORDINATOR_URL", raising=False)
+    assert BlendCoordinatorClient.maybe_from_env() is None
+
+    monkeypatch.setenv("LMCACHE_COORDINATOR_URL", "http://coord:9300")
+    client = BlendCoordinatorClient.maybe_from_env()
+    assert client is not None
+    client.close()
+
+
+def test_pending_sentinel_distinct():
+    assert PENDING is not None and not isinstance(PENDING, list)

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -14,13 +14,13 @@ import time
 import pytest
 
 # First Party
-from lmcache.v1.mp_coordinator.blend_directory import (
-    GlobalBlendMatcher,
-    StoreRange,
-)
 from lmcache.v1.mp_coordinator.blend_client import (
     PENDING,
     BlendCoordinatorClient,
+)
+from lmcache.v1.mp_coordinator.blend_directory import (
+    GlobalBlendMatcher,
+    StoreRange,
 )
 
 CHUNK = 3

--- a/tests/v1/mp_coordinator/test_blend_directory.py
+++ b/tests/v1/mp_coordinator/test_blend_directory.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the coordinator global CacheBlend fingerprint directory."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.mp_coordinator.blend_directory import (
+    GlobalBlendMatcher,
+    StoreRange,
+)
+
+CHUNK = 3
+SCOPE = "model-a@"
+
+
+def store_range(
+    prefix: str, tokens: list[int], *, scope: str = SCOPE, old_st_base: int = 0
+) -> StoreRange:
+    """A StoreRange with one object_key per complete chunk (mirrors publisher)."""
+    n_chunks = len(tokens) // CHUNK
+    return StoreRange(
+        model_scope=scope,
+        tokens=tokens,
+        object_keys=[f"{prefix}{i}" for i in range(n_chunks)],
+        old_st_base=old_st_base,
+    )
+
+
+class TestRegisterMatch:
+    def test_full_reuse(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        doc = [1, 2, 3, 4, 5, 6]  # 2 chunks
+        assert m.register([store_range("K", doc)]) == 2
+        matches = m.match(SCOPE, doc)
+        assert [(x.object_key, x.old_st, x.cur_st) for x in matches] == [
+            ("K0", 0, 0),
+            ("K1", 3, 3),
+        ]
+
+    def test_stride_controls_offset(self) -> None:
+        """A non-chunk-aligned offset is found at stride 1, missed at stride=chunk."""
+        doc = [1, 2, 3, 4, 5, 6]
+        req = [9, 1, 2, 3, 4, 5, 6]  # doc shifted by 1 (preamble 9)
+
+        fine = GlobalBlendMatcher(chunk_size=CHUNK, probe_stride=1)
+        fine.register([store_range("K", doc)])
+        out = fine.match(SCOPE, req)
+        assert [(x.object_key, x.cur_st) for x in out] == [("K0", 1), ("K1", 4)]
+
+        coarse = GlobalBlendMatcher(chunk_size=CHUNK, probe_stride=CHUNK)
+        coarse.register([store_range("K", doc)])  # probes pos 0,3,6 -> misses
+        assert coarse.match(SCOPE, req) == []
+
+    def test_dedup_by_object_key(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        m.register([store_range("K", [1, 2, 3])])  # single chunk K0
+        matches = m.match(SCOPE, [1, 2, 3, 1, 2, 3])  # content repeats
+        assert len(matches) == 1 and matches[0].object_key == "K0"
+
+    def test_scope_isolation(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        m.register([store_range("K", [1, 2, 3], scope="model-a@")])
+        assert m.match("model-b@", [1, 2, 3]) == []
+
+    def test_request_shorter_than_chunk(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        m.register([store_range("K", [1, 2, 3])])
+        assert m.match(SCOPE, [1, 2]) == []
+
+    def test_no_match(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        m.register([store_range("K", [1, 2, 3])])
+        assert m.match(SCOPE, [7, 8, 9]) == []
+
+
+class TestIdempotencyEviction:
+    def test_register_idempotent(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        rng = store_range("K", [1, 2, 3, 4, 5, 6])
+        assert m.register([rng]) == 2
+        assert m.register([rng]) == 0
+        assert len(m.match(SCOPE, [1, 2, 3, 4, 5, 6])) == 2
+
+    def test_remove_evicts(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        m.register([store_range("K", [1, 2, 3, 4, 5, 6])])  # K0, K1
+        assert m.remove(["K0"]) == 1
+        matches = m.match(SCOPE, [1, 2, 3, 4, 5, 6])
+        assert [x.object_key for x in matches] == ["K1"]  # only K0 gone
+
+    def test_remove_unknown_is_noop(self) -> None:
+        assert GlobalBlendMatcher(chunk_size=CHUNK).remove(["nope"]) == 0
+
+    def test_count_mismatch_range_skipped(self) -> None:
+        """A range whose object_keys count != chunk count is skipped, not partial."""
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        doc = [1, 2, 3, 4, 5, 6]  # 2 chunks
+        bad = StoreRange(
+            model_scope=SCOPE,
+            tokens=doc,
+            object_keys=["K0"],  # only 1 key for 2 chunks -> mismatch
+            old_st_base=0,
+        )
+        assert m.register([bad]) == 0
+        assert m.match(SCOPE, doc) == []
+
+
+class TestValidation:
+    def test_bad_chunk_size(self) -> None:
+        with pytest.raises(ValueError):
+            GlobalBlendMatcher(chunk_size=0)
+
+    def test_bad_probe_stride(self) -> None:
+        with pytest.raises(ValueError):
+            GlobalBlendMatcher(chunk_size=CHUNK, probe_stride=0)

--- a/tests/v1/mp_coordinator/test_blend_directory_api.py
+++ b/tests/v1/mp_coordinator/test_blend_directory_api.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the /blend fingerprint directory REST endpoints."""
+
+# Third Party
+from fastapi.testclient import TestClient
+
+# First Party
+from lmcache.v1.mp_coordinator.app import create_app
+from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+
+CHUNK = 3
+SCOPE = "model-a@"
+
+
+def _client() -> TestClient:
+    config = MPCoordinatorConfig(health_check_interval=0.0, blend_chunk_size=CHUNK)
+    return TestClient(create_app(config))
+
+
+def _range(prefix: str, tokens: list[int]) -> dict:
+    n_chunks = len(tokens) // CHUNK
+    return {
+        "model_scope": SCOPE,
+        "tokens": tokens,
+        "object_keys": [f"{prefix}{i}" for i in range(n_chunks)],
+        "old_st_base": 0,
+    }
+
+
+def test_publish_then_match():
+    with _client() as client:
+        doc = [1, 2, 3, 4, 5, 6]
+        resp = client.post("/blend/fingerprints", json={"ranges": [_range("K", doc)]})
+        assert resp.status_code == 200
+        assert resp.json() == {"inserted": 2}
+
+        out = client.post(
+            "/blend/match", json={"model_scope": SCOPE, "tokens": doc}
+        ).json()["matches"]
+        assert [(m["object_key"], m["old_st"], m["cur_st"]) for m in out] == [
+            ("K0", 0, 0),
+            ("K1", 3, 3),
+        ]
+
+
+def test_match_miss_returns_empty():
+    with _client() as client:
+        out = client.post(
+            "/blend/match",
+            json={"model_scope": SCOPE, "tokens": [7, 8, 9]},
+        ).json()
+        assert out == {"matches": []}
+
+
+def test_remove_evicts():
+    with _client() as client:
+        doc = [1, 2, 3, 4, 5, 6]
+        client.post("/blend/fingerprints", json={"ranges": [_range("K", doc)]})
+        resp = client.request(
+            "DELETE", "/blend/fingerprints", json={"object_keys": ["K0", "K1"]}
+        )
+        assert resp.json() == {"removed": 2}
+        out = client.post(
+            "/blend/match", json={"model_scope": SCOPE, "tokens": doc}
+        ).json()
+        assert out == {"matches": []}
+
+
+def test_idempotent_publish():
+    with _client() as client:
+        doc = [1, 2, 3, 4, 5, 6]
+        client.post("/blend/fingerprints", json={"ranges": [_range("K", doc)]})
+        resp = client.post("/blend/fingerprints", json={"ranges": [_range("K", doc)]})
+        assert resp.json() == {"inserted": 0}

--- a/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
+++ b/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
@@ -340,3 +340,79 @@ def test_batched_rope_raises_on_compressed_layout():
 
     with pytest.raises(RuntimeError, match="is compressed"):
         eng._apply_cb_rope_batched(gpu_context, rope_state, 2, [(0, 1, 2)])
+
+
+# ---------------------------------------------------------------------------
+# Coordinator (global) leg: conversion to retrievable CBMatchResult + deadline
+# ---------------------------------------------------------------------------
+
+
+def _coord_engine(chunk_size: int = 4):
+    """A BlendV3Module mock with the coordinator-leg methods bound."""
+    # First Party
+    from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
+
+    eng = MagicMock(spec=v3_mod.BlendV3Module)
+    eng._ctx = SimpleNamespace(chunk_size=chunk_size)
+    eng._build_global_segments = v3_mod.BlendV3Module._build_global_segments.__get__(
+        eng
+    )
+    eng._poll_coordinator_match = v3_mod.BlendV3Module._poll_coordinator_match.__get__(
+        eng
+    )
+    return eng
+
+
+def test_build_global_segments_are_retrievable_cbmatchresults():
+    """Coordinator object_key hex round-trips to the hash the retrieve path
+    resolves via ipc_key_to_object_keys; positions span one chunk."""
+    # First Party
+    from lmcache.v1.mp_coordinator.blend_client import RemoteMatch
+    from lmcache.v1.multiprocess.custom_types import CBMatchResult
+
+    eng = _coord_engine(chunk_size=4)
+    raw = bytes.fromhex("00") * 0 + b"\xab\xcd\xef\x01"
+    matches = [RemoteMatch(object_key=raw.hex(), old_st=8, cur_st=20)]
+
+    segs = eng._build_global_segments(matches)
+
+    assert len(segs) == 1
+    seg = segs[0]
+    assert isinstance(seg, CBMatchResult)
+    assert seg.hash == raw  # hex -> exact bytes the retrieve path expands
+    assert (seg.old_st, seg.old_ed, seg.cur_st, seg.cur_ed) == (8, 12, 20, 24)
+
+
+def test_poll_coordinator_match_deferred_then_resolved():
+    """PENDING within deadline defers (None); a list resolves to segments."""
+    # First Party
+    from lmcache.v1.mp_coordinator.blend_client import PENDING, RemoteMatch
+
+    eng = _coord_engine(chunk_size=4)
+    coordinator = MagicMock()
+    eng._coordinator = coordinator
+    job = SimpleNamespace(coord_submitted=True, coord_deadline=time.monotonic() + 60)
+
+    coordinator.poll_match.return_value = PENDING
+    assert eng._poll_coordinator_match(job, "rid") is None  # defer
+    coordinator.take_match.assert_not_called()
+
+    coordinator.poll_match.return_value = [RemoteMatch("aa", old_st=0, cur_st=4)]
+    out = eng._poll_coordinator_match(job, "rid")
+    assert [s.cur_st for s in out] == [4]
+    coordinator.take_match.assert_called_once_with("rid")
+
+
+def test_poll_coordinator_match_gives_up_past_deadline():
+    """PENDING past the deadline degrades to local-only ([]) and drops state."""
+    # First Party
+    from lmcache.v1.mp_coordinator.blend_client import PENDING
+
+    eng = _coord_engine(chunk_size=4)
+    coordinator = MagicMock()
+    eng._coordinator = coordinator
+    coordinator.poll_match.return_value = PENDING
+    job = SimpleNamespace(coord_submitted=True, coord_deadline=time.monotonic() - 1)
+
+    assert eng._poll_coordinator_match(job, "rid") == []
+    coordinator.take_match.assert_called_once_with("rid")

--- a/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
+++ b/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
@@ -416,3 +416,32 @@ def test_poll_coordinator_match_gives_up_past_deadline():
 
     assert eng._poll_coordinator_match(job, "rid") == []
     coordinator.take_match.assert_called_once_with("rid")
+
+
+def test_non_overlapping_after_prefix():
+    """Prefix filter + leftmost-greedy overlap dedup, filter applied first."""
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import CBMatchResult
+    from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
+
+    f = v3_mod.BlendV3Module._non_overlapping_after_prefix
+
+    def m(cur_st: int, cur_ed: int) -> CBMatchResult:
+        return CBMatchResult(
+            old_st=0, old_ed=cur_ed - cur_st, cur_st=cur_st, cur_ed=cur_ed, hash=b""
+        )
+
+    assert f([], 0) == []
+
+    # Overlap dedup + ascending cur_st: 10-20 overlaps the kept 5-15, dropped.
+    out = f([m(10, 20), m(5, 15), m(15, 25)], 0)
+    assert [(r.cur_st, r.cur_ed) for r in out] == [(5, 15), (15, 25)]
+
+    # Prefix filter drops matches starting before the coverage.
+    out = f([m(0, 10), m(10, 20)], 5)
+    assert [r.cur_st for r in out] == [10]
+
+    # Filter precedes dedup: a prefix-covered match (5-13) must NOT suppress the
+    # usable 10-18 in the greedy pass (dedup-first would drop both -> []).
+    out = f([m(5, 13), m(10, 18)], 8)
+    assert [r.cur_st for r in out] == [10]


### PR DESCRIPTION
**What this PR does / why we need it**:

CacheBlend lookup is local to one mp-server today, so a request routed to another
replica recomputes KV a peer already holds. This adds an **opt-in, fleet-wide
CacheBlend fingerprint directory on the MP coordinator**: blend servers publish
stored ranges on STORE and query request tokens on LOOKUP; the coordinator runs
the match and returns shared-L2 storage keys to prefetch + re-RoPE.

Local and coordinator matching are **mutually exclusive by coordinator
presence**: with a coordinator configured, all fingerprint matching goes through
it (the fleet directory is a superset of the local table) and the local matcher
is skipped; with none, matching is purely local and unchanged.

- **Coordinator owns hashing + matching** (servers send raw tokens + storage
  mapping), so the algorithm can evolve coordinator-only. Same algorithm as the
  local matcher: poly-hash table keyed by `(model_scope, poly_hash)`, strided
  rolling-hash probe; scope `model_name@cache_salt`; TP resolved at retrieve.
- **REST:** `POST`/`DELETE /blend/fingerprints`, `POST /blend/match`.
  `GlobalBlendMatcher` on `app.state`; `mp_coordinator/blend_client.py` (mirrors
  `registrar.py`) bridges the blend module — best-effort publish + non-blocking
  submit/poll match, bounded by a per-lookup deadline (default 50 ms; a slow or
  absent coordinator → no fleet matches that lookup).
- Fleet matches are returned as `CBMatchResult` and **merged into
  `CBUnifiedLookupResult.non_prefix_segments`** (prefix-covered dropped,
  leftmost-greedy overlap dedup), so they ride the existing sparse-prefetch +
  retrieve + re-RoPE path with no protocol change.

Design doc: `docs/design/v1/mp_coordinator/blend_lookup.md`.

**Special notes for your reviewers**:

- Eviction is lazy (stale entry → wasted prefetch → recompute, never wrong KV);
  the `DELETE` route + `remove` are wired/tested for a future eager hook.
- `register` skips (logs error) a range whose chunk count ≠ `object_keys` count
  rather than truncating (a shift would mis-map KV).
- Full `cb_unified_lookup`/`store` path needs the native ext (CI/GPU); the
  coordinator, matcher, client, hashing, and schemas are unit-tested here.

**If applicable**:

- [ ] this PR contains user facing changes - docs added (design doc)
- [x] this PR contains unit tests
