### PR TITLE
[Refactor] Rename LMCacheGroupView to EngineGroupInfo

### DIFF
--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -42,7 +42,7 @@ store/retrieve address those infos directly.
   transfer identity. The list order is the protocol-visible group order; an
   empty list means a single non-hybrid group.
 - Helpers in `group_view.py` operate on `Sequence[EngineGroupInfo]`:
-  `num_engine_groups`, `num_engine_group_infos`, `expand_block_ids_to_views`,
+  `num_engine_groups`, `num_engine_group_infos`, `expand_engine_block_ids`,
   `get_engine_group_indices`.
 - **`KVLayerGroupInfo`** (runtime, server-only): layer indices,
   `PageBufferShapeDesc`, dtype, compress ratio, physical chunk size,
@@ -78,7 +78,7 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
 ## Store and retrieve
 
 vLLM reports block IDs per engine group. The worker adapter re-indexes them to
-engine-group-info order with `expand_block_ids_to_views(engine_group_infos, block_ids)` (each
+engine-group-info order with `expand_engine_block_ids(engine_group_infos, block_ids)` (each
 info reuses its source engine group's block IDs), so `STORE`/`RETRIEVE` receive
 `list[list[int]]` indexed by info order. The server loop is then trivial: for
 info `i`, use `gpu_block_ids[i]`.

--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -8,16 +8,16 @@ connector. It separates three concepts:
 - **Engine KV cache group** — a group defined by the serving engine (vLLM's
   `KVCacheConfig.kv_cache_groups`). Each is one distinct paged-block address
   space; block IDs are only meaningful within one group.
-- **`LMCacheGroupView`** — LMCache's engine-neutral, `msgspec`-encoded view of
-  one such group (`group_view.py`). A `list[LMCacheGroupView]` is the
+- **`EngineGroupInfo`** — LMCache's engine-neutral, `msgspec`-encoded record of
+  one such group (`group_view.py`). A `list[EngineGroupInfo]` is the
   registration contract.
 - **`KVLayerGroupInfo`** — the server's runtime transfer-kernel dispatch unit,
-  built from the views + the real tensors (`kv_layer_groups.py`).
+  built from the engine group infos + the real tensors (`kv_layer_groups.py`).
 
 vLLM groups layers by cache behavior; LMCache must transfer by physical layout
 (kv_size, num_heads, head_size, block_size, dtype) *and* keep distinct engine
-block-id spaces separate. So at registration we build group views, and
-store/retrieve address those views directly.
+block-id spaces separate. So at registration we build engine group infos, and
+store/retrieve address those infos directly.
 
 ## Goals / Non-Goals
 
@@ -36,13 +36,13 @@ store/retrieve address those views directly.
 
 ## Types
 
-- **`LMCacheGroupView`** (`msgspec.Struct`): `engine_group_id` (which engine
-  block group its layers live in; dense from 0) + `layer_indices`. Several views
+- **`EngineGroupInfo`** (`msgspec.Struct`): `engine_group_id` (which engine
+  block group its layers live in; dense from 0) + `layer_indices`. Several infos
   may share an `engine_group_id` when one engine group is split by physical
   transfer identity. The list order is the protocol-visible group order; an
   empty list means a single non-hybrid group.
-- Helpers in `group_view.py` operate on `Sequence[LMCacheGroupView]`:
-  `num_engine_groups`, `num_group_views`, `expand_block_ids_to_views`,
+- Helpers in `group_view.py` operate on `Sequence[EngineGroupInfo]`:
+  `num_engine_groups`, `num_engine_group_infos`, `expand_block_ids_to_views`,
   `get_engine_group_indices`.
 - **`KVLayerGroupInfo`** (runtime, server-only): layer indices,
   `PageBufferShapeDesc`, dtype, compress ratio, physical chunk size,
@@ -52,17 +52,17 @@ store/retrieve address those views directly.
 
 ```text
 vLLM KVCacheConfig + registered kv_caches
-  | integration.vllm.kv_cache_groups.create_group_views_from_vllm
+  | integration.vllm.kv_cache_groups.create_engine_group_infos_from_vllm
   v
-list[LMCacheGroupView]  --REGISTER_KV_CACHE (msgspec)-->  server msgspec-decode
+list[EngineGroupInfo]  --REGISTER_KV_CACHE (msgspec)-->  server msgspec-decode
   | KVLayerGroupsManager validates against real tensors
   v
-KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per view-->  transfer kernels
+KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
 ```
 
 ## Registration
 
-`create_group_views_from_vllm` (the only place that reads vLLM `KVCacheConfig`):
+`create_engine_group_infos_from_vllm` (the only place that reads vLLM `KVCacheConfig`):
 
 1. Inspect registered tensors for physical layout/dtype.
 2. Map each registered layer to its engine group index; layers absent from
@@ -71,17 +71,17 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per view-->  transfer kernels
 3. `group_layers_by_identity` splits layers by transfer identity
    `(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype)` — the
    `engine_group_idx` term keeps identically-shaped layers from different engine
-   groups in separate views.
-4. Emit one `LMCacheGroupView` per identity; send the list in the
+   groups in separate infos.
+4. Emit one `EngineGroupInfo` per identity; send the list in the
    `REGISTER_KV_CACHE` payload (the message queue encodes it).
 
 ## Store and retrieve
 
 vLLM reports block IDs per engine group. The worker adapter re-indexes them to
-group-view order with `expand_block_ids_to_views(group_views, block_ids)` (each
-view reuses its source engine group's block IDs), so `STORE`/`RETRIEVE` receive
-`list[list[int]]` indexed by view order. The server loop is then trivial: for
-view `i`, use `gpu_block_ids[i]`.
+engine-group-info order with `expand_block_ids_to_views(engine_group_infos, block_ids)` (each
+info reuses its source engine group's block IDs), so `STORE`/`RETRIEVE` receive
+`list[list[int]]` indexed by info order. The server loop is then trivial: for
+info `i`, use `gpu_block_ids[i]`.
 
 ### Per-group block sizes
 
@@ -108,7 +108,7 @@ layers in `kv_cache_groups`; a sharing layer is absent from every group's
 `layer_names`. Such a layer's KV physically lives in its target owner's blocks,
 so storing/retrieving the owner already covers it. Registration therefore tags
 unlisted layers with `EXCLUDED_ENGINE_GROUP` and `group_layers_by_identity`
-skips them — they never form their own view. (Placing them in a group would
+skips them — they never form their own info. (Placing them in a group would
 duplicate work and, when their block size differs from the group they default
 into, corrupt the per-group block-id counts.)
 
@@ -124,19 +124,19 @@ vLLM exposes two engine groups — group 0: layers [0,2,4], group 1: [1,3]. If
 layers 0–3 share a shape but layer 4 differs, registration produces:
 
 ```text
-view 0: engine group 0, layers [0, 2]
-view 1: engine group 1, layers [1, 3]
-view 2: engine group 0, layers [4]
+info 0: engine group 0, layers [0, 2]
+info 1: engine group 1, layers [1, 3]
+info 2: engine group 0, layers [4]
 ```
 
 Block IDs `{group 0: [10,11], group 1: [20,21]}` are sent as
-`[[10,11], [20,21], [10,11]]` (views 0 and 2 share group 0's IDs).
+`[[10,11], [20,21], [10,11]]` (infos 0 and 2 share group 0's IDs).
 
 ## Invariants
 
-- The `list[LMCacheGroupView]` order is the protocol-visible group order; callers
-  send one block-id list per view.
-- vLLM-specific access stays in `lmcache.integration.vllm`; views carry neutral
+- The `list[EngineGroupInfo]` order is the protocol-visible group order; callers
+  send one block-id list per info.
+- vLLM-specific access stays in `lmcache.integration.vllm`; infos carry neutral
   metadata only.
 - The server reproduces grouping with the same `group_layers_by_identity`; real
   tensors remain the source of truth for shape/dtype/stride.
@@ -151,9 +151,9 @@ but LMCache cannot store/retrieve those layers.
 
 | Area | File |
 |---|---|
-| Group view (IPC type) + helpers | `lmcache/v1/multiprocess/group_view.py` |
+| Engine group info (IPC type) + helpers | `lmcache/v1/multiprocess/group_view.py` |
 | Shared grouping primitive | `lmcache/v1/kv_layer_groups.py` |
-| vLLM → `list[LMCacheGroupView]` | `lmcache/integration/vllm/kv_cache_groups.py` |
+| vLLM → `list[EngineGroupInfo]` | `lmcache/integration/vllm/kv_cache_groups.py` |
 | Register / store / retrieve | `lmcache/integration/vllm/{lmcache_mp_connector,vllm_multi_process_adapter}.py` |
 | Server GPU context / transfer | `lmcache/v1/multiprocess/{gpu_context,modules/gpu_transfer}.py` |
 | ZMQ protocol | `lmcache/v1/multiprocess/protocols/engine.py` |

--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -294,7 +294,7 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
         layer_groups = parse_kvcache_shape_spec(args.kvcache_shape_spec)
         # One block-id list is sent per LMCache KV group; each shape-spec
         # group becomes its own group server-side.
-        num_group_views = len(layer_groups) or 1
+        num_engine_group_infos = len(layer_groups) or 1
         # Echo the resolved spec so operators can verify that their
         # input was interpreted as intended. The echoed string is a
         # valid ``--kvcache-shape-spec`` itself.
@@ -473,7 +473,7 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
                 http_base=http_base,
                 block_size=block_size,
                 total_blocks=num_blocks,
-                num_group_views=num_group_views,
+                num_engine_group_infos=num_engine_group_infos,
                 use_gpu=use_gpu,
                 use_handle=use_handle,
                 client_tensors=client_tensors,
@@ -492,7 +492,7 @@ def run_server_bench(  # noqa: ARG001  (command kept for symmetry with siblings)
                 http_base=http_base,
                 block_size=block_size,
                 total_blocks=num_blocks,
-                num_group_views=num_group_views,
+                num_engine_group_infos=num_engine_group_infos,
                 use_gpu=use_gpu,
                 use_handle=use_handle,
                 client_tensors=client_tensors,

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -554,7 +554,7 @@ def _send_store(
     key: IPCCacheEngineKey,
     block_offset: int = 0,
     block_size: int = 16,
-    num_group_views: int = 1,
+    num_engine_group_infos: int = 1,
     use_gpu: bool = True,
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
@@ -582,7 +582,7 @@ def _send_store(
         payloads = [
             key,
             _INSTANCE_ID,
-            [block_ids] * num_group_views,
+            [block_ids] * num_engine_group_infos,
             _make_event_handle(use_gpu),
         ]
         result = _call(client, RequestType.STORE, payloads)
@@ -627,7 +627,7 @@ def _send_retrieve(
     hit_chunks: int,
     block_offset: int = 0,
     block_size: int = 16,
-    num_group_views: int = 1,
+    num_engine_group_infos: int = 1,
     use_gpu: bool = True,
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
@@ -654,7 +654,7 @@ def _send_retrieve(
         payloads = [
             key,
             _INSTANCE_ID,
-            [block_ids] * num_group_views,
+            [block_ids] * num_engine_group_infos,
             _make_event_handle(use_gpu),
             0,  # skip_first_n_tokens
         ]
@@ -784,7 +784,7 @@ def _process_request(
     http_base: str = "",
     block_size: int = 16,
     total_blocks: int = 1024,
-    num_group_views: int = 1,
+    num_engine_group_infos: int = 1,
     use_gpu: bool = True,
     use_handle: bool | None = None,
     client_tensors: list["torch.Tensor"] | None = None,
@@ -901,7 +901,7 @@ def _process_request(
             hit_chunks,
             block_offset=block_offset,
             block_size=block_size,
-            num_group_views=num_group_views,
+            num_engine_group_infos=num_engine_group_infos,
             use_gpu=use_gpu,
             use_handle=use_handle,
             client_tensors=client_tensors,
@@ -938,7 +938,7 @@ def _process_request(
             store_key,
             block_offset=store_block_off,
             block_size=block_size,
-            num_group_views=num_group_views,
+            num_engine_group_infos=num_engine_group_infos,
             use_gpu=use_gpu,
             use_handle=use_handle,
             client_tensors=client_tensors,

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -135,12 +135,12 @@ class LMCacheMPConnector:
 
         # Upstream's REGISTER_KV_CACHE protocol takes flat positional args:
         # (instance_id, kv_cache, model_name, world_size, engine_type,
-        # layout_hints, group_views). SGLang's natural KV layout is depth-2
+        # layout_hints, engine_group_infos). SGLang's natural KV layout is depth-2
         # ([K_layers, V_layers]); we flatten it on the wire to fit
         # ``KVCache = list[CudaIPCWrapper]``. The daemon recognizes the
         # SGLang-MHA flat-of-2NL pattern from ``EngineType.SGLANG`` plus the
         # ``tokens_per_block`` hint and un-flattens + reshapes per layer.
-        # SGLang is non-hybrid (a single KV cache group), so group_views is the
+        # SGLang is non-hybrid (a single KV cache group), so engine_group_infos is the
         # empty list -- which the server treats as one group spanning all layers
         # (matching the vLLM non-hybrid and TensorRT-LLM register paths).
         send_lmcache_request(

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Build LMCache group views from vLLM KV cache group metadata."""
+"""Build LMCache engine group infos from vLLM KV cache group metadata."""
 
 # Future
 from __future__ import annotations
@@ -13,15 +13,15 @@ if TYPE_CHECKING:
     from lmcache.v1.gpu_connector.utils import LayoutHints
 
 # First Party
-from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 
 
-def create_group_views_from_vllm(
+def create_engine_group_infos_from_vllm(
     kv_cache_config: Any,
     kv_caches: Mapping[str, Any],
     layout_hints: "LayoutHints | None" = None,
-) -> list[LMCacheGroupView]:
-    """Build the LMCache group views from vLLM metadata and registered tensors.
+) -> list[EngineGroupInfo]:
+    """Build the LMCache engine group infos from vLLM metadata and registered tensors.
 
     This is the single entry point for the vLLM -> LMCache conversion. It reads
     the vLLM-specific fields (``KVCacheConfig.kv_cache_groups`` and
@@ -41,7 +41,7 @@ def create_group_views_from_vllm(
             detection (e.g. ``NHD``/``HND`` and compression metadata).
 
     Returns:
-        The list of ``LMCacheGroupView`` in protocol order, i.e. the LMCache group
+        The list of ``EngineGroupInfo`` in protocol order, i.e. the LMCache group
         order used by store/retrieve block IDs.
     """
     # First Party
@@ -95,7 +95,7 @@ def create_group_views_from_vllm(
     # the shared, engine-neutral primitive the server reuses to reproduce the
     # same grouping from the registered tensors.
     return [
-        LMCacheGroupView(
+        EngineGroupInfo(
             engine_group_id=identity[4],
             layer_indices=tuple(indices),
         )

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -37,7 +37,7 @@ import zmq
 # First Party
 from lmcache import torch_dev
 from lmcache.integration.vllm.kv_cache_groups import (
-    create_group_views_from_vllm,
+    create_engine_group_infos_from_vllm,
 )
 from lmcache.integration.vllm.utils import mla_enabled, vllm_layout_hints
 from lmcache.utils import init_logger as lmcache_init_logger
@@ -619,12 +619,14 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         logger.info("Registering kv caches!")
         kv_cache_config = getattr(self, "_kv_cache_config", None)
-        group_views = create_group_views_from_vllm(
+        engine_group_infos = create_engine_group_infos_from_vllm(
             kv_cache_config,
             kv_caches,
             layout_hints=vllm_layout_hints(),
         )
-        self.worker_adapter.register_kv_caches(kv_caches, group_views=group_views)
+        self.worker_adapter.register_kv_caches(
+            kv_caches, engine_group_infos=engine_group_infos
+        )
         return
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -23,7 +23,7 @@ from lmcache.v1.multiprocess.custom_types import (
 )
 from lmcache.v1.multiprocess.group_view import (
     EngineGroupInfo,
-    expand_block_ids_to_views,
+    expand_engine_block_ids,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
@@ -1054,7 +1054,7 @@ class LMCacheMPWorkerAdapter:
         self._send_register_kv_caches_request(kv_caches)
 
     def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
-        return expand_block_ids_to_views(self.engine_group_infos, op.block_ids)
+        return expand_engine_block_ids(self.engine_group_infos, op.block_ids)
 
     def _send_register_kv_caches_request(
         self, kv_caches: dict[str, torch.Tensor]

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -22,7 +22,7 @@ from lmcache.v1.multiprocess.custom_types import (
     KVCache,
 )
 from lmcache.v1.multiprocess.group_view import (
-    LMCacheGroupView,
+    EngineGroupInfo,
     expand_block_ids_to_views,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
@@ -920,7 +920,7 @@ class LMCacheMPWorkerAdapter:
 
         # Registered kv caches from vLLM
         self.kv_caches: dict[str, torch.Tensor] = {}
-        self.group_views: list[LMCacheGroupView] = []
+        self.engine_group_infos: list[EngineGroupInfo] = []
 
         # Transport context for transfer operations.
         self.transfer_ctx: TransferContext | None = None
@@ -1034,7 +1034,7 @@ class LMCacheMPWorkerAdapter:
     def register_kv_caches(
         self,
         kv_caches: dict[str, torch.Tensor],
-        group_views: Sequence[LMCacheGroupView] = (),
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
         """
         Register the kv caches with LMCache server.
@@ -1042,7 +1042,7 @@ class LMCacheMPWorkerAdapter:
         Args:
             kv_caches: A dict of kv caches to register. The keys are the
                 layer names and the values are the corresponding tensors.
-            group_views: LMCache-owned engine KV cache group metadata.
+            engine_group_infos: LMCache-owned engine KV cache group metadata.
 
         Raises:
             ConnectionError: if the server does not respond within
@@ -1050,11 +1050,11 @@ class LMCacheMPWorkerAdapter:
         """
         logger.info("Registering kv caches")
         self.kv_caches = kv_caches
-        self.group_views = list(group_views)
+        self.engine_group_infos = list(engine_group_infos)
         self._send_register_kv_caches_request(kv_caches)
 
     def _block_ids_per_group(self, op: LoadStoreOp) -> list[list[int]]:
-        return expand_block_ids_to_views(self.group_views, op.block_ids)
+        return expand_block_ids_to_views(self.engine_group_infos, op.block_ids)
 
     def _send_register_kv_caches_request(
         self, kv_caches: dict[str, torch.Tensor]
@@ -1090,7 +1090,7 @@ class LMCacheMPWorkerAdapter:
                 self._mq_timeout,
                 send_request=send_lmcache_request,
                 layout_hints=layout_hints,
-                group_views=self.group_views,
+                engine_group_infos=self.engine_group_infos,
             )
         except TimeoutError:
             raise ConnectionError(

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -20,7 +20,7 @@ import lmcache.c_ops as lmc_ops
 if TYPE_CHECKING:
     # First Party
     from lmcache.v1.gpu_connector.utils import DiscoverableKVCache, LayoutHints
-    from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+    from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 
 logger = init_logger(__name__)
 
@@ -63,7 +63,7 @@ LayerGroupIdentity = KernelGroupIdentity  # Alias for compatibility
 
 # Sentinel ``per_layer_engine_group_idx`` value: a KV tensor tagged with it is
 # excluded from every LMCache group (used for cross-layer KV-sharing layers; see
-# ``create_group_views_from_vllm``).
+# ``create_engine_group_infos_from_vllm``).
 EXCLUDED_ENGINE_GROUP = -1
 
 
@@ -271,7 +271,7 @@ class KVLayerGroupsManager:
         gpu_kv_format: "lmc_ops.GPUKVFormat",
         num_blocks: int,
         layout_hints: "LayoutHints | None" = None,
-        group_views: "Sequence[LMCacheGroupView]" = (),
+        engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         lmcache_logical_chunk_size: int = 256,
     ) -> None:
         """Partition layers into groups keyed by
@@ -301,7 +301,7 @@ class KVLayerGroupsManager:
                 group's ``compress_ratio`` and ``physical_chunk_size``.
                 ``None`` means every group is treated as non-compressed
                 (``compress_ratio == 1``).
-            group_views: LMCache-owned engine KV cache group
+            engine_group_infos: LMCache-owned engine KV cache group
                 metadata. When present, it is used to keep layers from
                 different engine block-ID spaces in separate LMCache
                 transfer groups.
@@ -342,7 +342,9 @@ class KVLayerGroupsManager:
             logger.debug("No KV caches available, skipping KV layer groups building")
             return
 
-        per_layer_engine_group_idx = get_engine_group_indices(group_views, num_layers)
+        per_layer_engine_group_idx = get_engine_group_indices(
+            engine_group_infos, num_layers
+        )
 
         groups_by_identity = group_layers_by_identity(
             kv_caches, gpu_kv_format, num_layers, per_layer_engine_group_idx
@@ -410,7 +412,7 @@ class KVLayerGroupsManager:
         )
 
         # Detect the object groups
-        self._object_groups = self._detect_object_groups(group_views)
+        self._object_groups = self._detect_object_groups(engine_group_infos)
 
     @property
     def kernel_groups(self) -> list[KernelGroupInfo]:
@@ -516,18 +518,18 @@ class KVLayerGroupsManager:
 
     ### Helper methods
     def _detect_object_groups(
-        self, group_views: "Sequence[LMCacheGroupView]"
+        self, engine_group_infos: "Sequence[EngineGroupInfo]"
     ) -> list[ObjectGroupInfo]:
-        """Detect object groups based on the provided group views.
+        """Detect object groups based on the provided engine group infos.
 
         Args:
-            group_views: LMCache-owned engine KV cache group metadata.
+            engine_group_infos: LMCache-owned engine KV cache group metadata.
 
         Returns:
             A list of ObjectGroupInfo instances representing the detected object groups.
         """
         # TODO: add the real object group detection logic based on
-        # the attention type metadata in the group views once it's
+        # the attention type metadata in the engine group infos once it's
         # available.
         # Now, we are using a single object group, which means
         # all kernel groups' KV caches will be stored in the same memory object.

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -38,7 +38,7 @@ from lmcache.v1.gpu_connector.utils import (
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
-from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 
 # Backend selection (c_ops when CUDA is available, otherwise a pure-Python
 # fallback) is handled once in ``lmcache/__init__.py`` via ``_get_backend``,
@@ -342,7 +342,7 @@ class GPUCacheContext:
         kv_caches: KVCache,
         lmcache_logical_chunk_size: int = 256,
         layout_hints: LayoutHints | None = None,
-        group_views: Sequence[LMCacheGroupView] = (),
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
         engine_type: EngineType = EngineType.VLLM,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
@@ -362,7 +362,7 @@ class GPUCacheContext:
             gpu_kv_format=self.gpu_kv_format_,
             num_blocks=self.num_blocks_,
             layout_hints=layout_hints,
-            group_views=group_views,
+            engine_group_infos=engine_group_infos,
             lmcache_logical_chunk_size=lmcache_logical_chunk_size,
         )
 

--- a/lmcache/v1/multiprocess/group_view.py
+++ b/lmcache/v1/multiprocess/group_view.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""LMCache's engine-neutral view of a serving engine's KV cache groups.
+"""LMCache's engine-neutral description of a serving engine's KV cache groups.
 
 An *engine group* is one distinct paged-block address space exposed by the
 serving engine (e.g. one of vLLM's hybrid KV cache groups): block IDs are only
@@ -7,8 +7,8 @@ meaningful within a single group, and layers from different groups must never be
 merged into one LMCache KV group. Engine group ids are assumed dense and
 consecutive starting from 0.
 
-LMCache's neutral KV cache spec is simply a ``list[LMCacheGroupView]`` (passed as
-a ``Sequence[LMCacheGroupView]`` where only order matters). The group order is
+LMCache's neutral KV cache spec is simply a ``list[EngineGroupInfo]`` (passed as
+a ``Sequence[EngineGroupInfo]`` where only order matters). The group order is
 the protocol-visible LMCache group order used by store/retrieve block IDs. An
 empty list means a single non-hybrid group (the default for engines that do not
 report KV cache group metadata). Engine-specific conversion belongs in the
@@ -23,26 +23,26 @@ from typing import cast
 import msgspec
 
 
-class LMCacheGroupView(msgspec.Struct, frozen=True):
+class EngineGroupInfo(msgspec.Struct, frozen=True):
     """One LMCache KV group: layers of one engine group that share a copy kernel.
 
     Carries the layer indices and which engine group they belong to. Several
-    ``LMCacheGroupView`` instances may share the same ``engine_group_id`` when
+    ``EngineGroupInfo`` instances may share the same ``engine_group_id`` when
     one engine group is split by physical transfer identity (e.g. differing
-    hidden dims). A ``list[LMCacheGroupView]`` is carried verbatim in the
+    hidden dims). A ``list[EngineGroupInfo]`` is carried verbatim in the
     ``REGISTER_KV_CACHE`` IPC payload; the message queue handles
     encoding/decoding.
     """
 
     engine_group_id: int
-    """Engine group this view's layers live in (one distinct paged-block address
+    """Engine group these layers live in (one distinct paged-block address
     space). Selects which request block-id list applies. Dense from 0."""
 
     layer_indices: tuple[int, ...] = ()
     """Registered KV tensor indices assigned to this group."""
 
 
-def num_engine_groups(groups: Sequence[LMCacheGroupView]) -> int:
+def num_engine_groups(groups: Sequence[EngineGroupInfo]) -> int:
     """Return the number of engine groups (block-id lists per transfer request).
 
     Engine group ids are assumed dense and consecutive from 0.
@@ -59,7 +59,7 @@ def num_engine_groups(groups: Sequence[LMCacheGroupView]) -> int:
     return max(group.engine_group_id for group in groups) + 1
 
 
-def num_group_views(groups: Sequence[LMCacheGroupView]) -> int:
+def num_engine_group_infos(groups: Sequence[EngineGroupInfo]) -> int:
     """Return the number of LMCache KV groups visible to transfer requests.
 
     Args:
@@ -75,7 +75,7 @@ def num_group_views(groups: Sequence[LMCacheGroupView]) -> int:
 
 
 def _engine_group_id_per_view(
-    groups: Sequence[LMCacheGroupView],
+    groups: Sequence[EngineGroupInfo],
 ) -> tuple[int, ...]:
     """Return, per LMCache group, the engine group it draws block IDs from.
 
@@ -84,7 +84,7 @@ def _engine_group_id_per_view(
 
     Returns:
         A tuple whose length equals the number of LMCache groups (i.e.
-        :func:`num_group_views`); element ``i`` is the engine group id
+        :func:`num_engine_group_infos`); element ``i`` is the engine group id
         that LMCache group ``i`` reads block IDs from. ``(0,)`` for an empty
         ``groups`` (single non-hybrid group).
     """
@@ -94,7 +94,7 @@ def _engine_group_id_per_view(
 
 
 def expand_block_ids_to_views(
-    groups: Sequence[LMCacheGroupView],
+    groups: Sequence[EngineGroupInfo],
     engine_side_block_ids: Sequence[Sequence[int]] | Sequence[int],
 ) -> list[list[int]]:
     """Re-index engine-side block IDs to one list per LMCache group.
@@ -174,7 +174,7 @@ def slice_block_ids_per_group(
 
 
 def get_engine_group_indices(
-    groups: Sequence[LMCacheGroupView],
+    groups: Sequence[EngineGroupInfo],
     num_registered_layers: int,
 ) -> list[int] | None:
     """Return the engine group index for each registered KV tensor.

--- a/lmcache/v1/multiprocess/group_view.py
+++ b/lmcache/v1/multiprocess/group_view.py
@@ -93,11 +93,11 @@ def _engine_group_id_per_view(
     return tuple(group.engine_group_id for group in groups)
 
 
-def expand_block_ids_to_views(
+def expand_engine_block_ids(
     groups: Sequence[EngineGroupInfo],
     engine_side_block_ids: Sequence[Sequence[int]] | Sequence[int],
 ) -> list[list[int]]:
-    """Re-index engine-side block IDs to one list per LMCache group.
+    """Expand the engine-side block id list to the list per LMCache kernel group.
 
     The serving engine reports block IDs per engine group. LMCache transfer
     requests are indexed by LMCache KV group, so each LMCache group reuses the

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -36,7 +36,7 @@ from lmcache.v1.multiprocess.engine_module import (
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
-from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.native_completion import (
     DeviceHostFuncDispatcher,
     submit_callback_to_stream,
@@ -231,7 +231,7 @@ class GPUTransferModule:
         world_size: int,
         engine_type: EngineType,
         layout_hints: LayoutHints,
-        group_views: list[LMCacheGroupView],
+        engine_group_infos: list[EngineGroupInfo],
     ) -> None:
         """Register the KV cache tensors for a given GPU instance ID.
 
@@ -245,7 +245,7 @@ class GPUTransferModule:
                 Forwarded to GPUCacheContext for format detection.
             layout_hints: See LayoutHints.  Forwarded to
                 GPUCacheContext for GPU KV format detection.
-            group_views: Engine-neutral KV cache group metadata
+            engine_group_infos: Engine-neutral KV cache group metadata
                 (already msgspec-decoded by the message queue).
         """
         if instance_id in self._cache_contexts:
@@ -260,7 +260,7 @@ class GPUTransferModule:
             kv_caches,
             self._ctx.chunk_size,
             layout_hints=layout_hints or None,
-            group_views=group_views,
+            engine_group_infos=engine_group_infos,
             engine_type=engine_type,
         )
         self._cache_contexts[instance_id] = ContextEntry(

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -24,7 +24,7 @@ from lmcache.v1.multiprocess.custom_types import (
     KVCache,
     RegisterNonGpuContextPayload,
 )
-from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
 
 
@@ -96,7 +96,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         #   - engine_type: EngineType - Which serving engine produced the
         #     caches (vLLM, SGLang, ...). Drives format detection.
         #   - layout_hints: LayoutHints - See custom_types.LayoutHints.
-        #   - group_views: list[LMCacheGroupView] - Engine-neutral KV cache
+        #   - engine_group_infos: list[EngineGroupInfo] - Engine-neutral KV cache
         #     group metadata (msgspec-encoded by the message queue).
         # Returns: None
         "REGISTER_KV_CACHE": ProtocolDefinition(
@@ -107,7 +107,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
                 int,
                 EngineType,
                 LayoutHints,
-                list[LMCacheGroupView],
+                list[EngineGroupInfo],
             ],
             response_class=None,
             handler_type=HandlerType.SYNC,

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -18,7 +18,7 @@ from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints, is_mla
 from lmcache.v1.multiprocess.custom_types import RegisterNonGpuContextPayload
 from lmcache.v1.multiprocess.futures import MessagingFuture
-from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.protocols.engine import RegisterNonGpuContextResponse
@@ -126,7 +126,7 @@ class TransferContext(ABC):
         mq_timeout: float,
         send_request: SendRequest,
         layout_hints: LayoutHints | None = None,
-        group_views: Sequence[LMCacheGroupView] = (),
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
         """Register KV caches with the server and wait for ACK.
 
@@ -140,7 +140,7 @@ class TransferContext(ABC):
             mq_timeout: Timeout in seconds for synchronous request wait.
             send_request: Request sender callable used to issue MQ requests.
             layout_hints: Optional inference-engine-provided layout hints.
-            group_views: LMCache-owned engine KV cache group metadata.
+            engine_group_infos: LMCache-owned engine KV cache group metadata.
 
         Raises:
             TimeoutError: If server registration does not complete before
@@ -232,7 +232,7 @@ class HandleTransferContext(TransferContext):
         mq_timeout: float,
         send_request: SendRequest,
         layout_hints: LayoutHints | None = None,
-        group_views: Sequence[LMCacheGroupView] = (),
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
         # First Party
         from lmcache.integration.vllm.vllm_multi_process_adapter import wrap_kv_caches
@@ -249,7 +249,7 @@ class HandleTransferContext(TransferContext):
                 world_size,
                 EngineType.VLLM,
                 layout_hints,
-                list(group_views),
+                list(engine_group_infos),
             ],
         )
         future.result(timeout=mq_timeout)
@@ -321,11 +321,11 @@ class DataTransferContext(TransferContext):
         mq_timeout: float,
         send_request: SendRequest,
         layout_hints: LayoutHints | None = None,
-        group_views: Sequence[LMCacheGroupView] = (),
+        engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
         """Register KV caches with the non-GPU context server.
 
-        ``group_views`` is accepted to satisfy the base interface but
+        ``engine_group_infos`` is accepted to satisfy the base interface but
         is currently a no-op: the non-GPU transfer path does not support
         hybrid KV cache groups and rejects multi-group transfers at store /
         retrieve time (see ``_single_group_block_ids``).

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -25,14 +25,14 @@ from lmcache.v1.multiprocess.custom_types import KVCache
 
 if TYPE_CHECKING:
     # First Party
-    from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+    from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 
 
 def create_cache_context(
     kv_caches: KVCache,
     lmcache_logical_chunk_size: int = 256,
     layout_hints: LayoutHints | None = None,
-    group_views: "Sequence[LMCacheGroupView]" = (),
+    engine_group_infos: "Sequence[EngineGroupInfo]" = (),
     engine_type: EngineType = EngineType.VLLM,
 ) -> Any:
     """Create the appropriate cache context.
@@ -50,7 +50,7 @@ def create_cache_context(
         lmcache_logical_chunk_size: Number of tokens per LMCache chunk.
         layout_hints: Optional hints for GPU KV format detection.
             Forwarded verbatim to the concrete context constructor.
-        group_views: Engine-neutral KV cache group metadata.
+        engine_group_infos: Engine-neutral KV cache group metadata.
         engine_type: Which serving engine produced the caches.
 
     Returns:
@@ -70,6 +70,6 @@ def create_cache_context(
         kv_caches,
         lmcache_logical_chunk_size,
         layout_hints,
-        group_views,
+        engine_group_infos,
         engine_type,
     )

--- a/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
+++ b/tests/v1/multiprocess/test_gpu_transfer_layout_registry.py
@@ -72,7 +72,7 @@ def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
         kv_caches: object,
         lmcache_logical_chunk_size: int,
         layout_hints: object = None,
-        group_views: object = (),
+        engine_group_infos: object = (),
         engine_type: object = None,
     ) -> _FakeGPUContext:
         """Return a fake cache context without touching CUDA or wrappers."""

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -13,7 +13,7 @@ from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     KVCache,
 )
-from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocol import KeyType
 
 # ==============================================================================
@@ -41,7 +41,7 @@ def register_kv_cache_handler(
     world_size: int,
     engine_type: EngineType,
     layout_hints: LayoutHints,
-    group_views: list[LMCacheGroupView],
+    engine_group_infos: list[EngineGroupInfo],
 ) -> None:
     """
     Dummy handler for REGISTER_KV_CACHE requests.
@@ -56,7 +56,7 @@ def register_kv_cache_handler(
             ``layout_hints["inference_engine_logical_block_size"]``
             carries the logical tokens-per-engine-block (previously a
             standalone argument).
-        group_views: Engine-neutral KV cache group metadata,
+        engine_group_infos: Engine-neutral KV cache group metadata,
             msgspec-decoded from the request payload.
 
     Returns:
@@ -86,8 +86,8 @@ def register_kv_cache_handler(
         "Expected layout_hints['inference_engine_logical_block_size'] to be int, got "
         f"{type(ie_logical_block_size)}"
     )
-    assert isinstance(group_views, list), (
-        f"Expected group_views to be a list, got {type(group_views)}"
+    assert isinstance(engine_group_infos, list), (
+        f"Expected engine_group_infos to be a list, got {type(engine_group_infos)}"
     )
     # No return value (returns None implicitly)
 

--- a/tests/v1/test_kv_cache_groups.py
+++ b/tests/v1/test_kv_cache_groups.py
@@ -5,7 +5,7 @@ import msgspec
 # First Party
 from lmcache.v1.multiprocess.group_view import (
     EngineGroupInfo,
-    expand_block_ids_to_views,
+    expand_engine_block_ids,
     get_engine_group_indices,
     num_engine_group_infos,
     num_engine_groups,
@@ -30,14 +30,14 @@ def test_engine_group_infos_build_per_layer_engine_group_indices():
     assert get_engine_group_indices(groups, 4) == [0, 1, 0, 1]
 
 
-def test_engine_group_infos_expand_block_ids_to_views():
+def test_engine_group_infos_expand_engine_block_ids():
     groups = [
         EngineGroupInfo(0, (0, 2)),
         EngineGroupInfo(0, (4,)),
         EngineGroupInfo(1, (1, 3)),
     ]
 
-    assert expand_block_ids_to_views(groups, [[10, 11], [20, 21]]) == [
+    assert expand_engine_block_ids(groups, [[10, 11], [20, 21]]) == [
         [10, 11],
         [10, 11],
         [20, 21],

--- a/tests/v1/test_kv_cache_groups.py
+++ b/tests/v1/test_kv_cache_groups.py
@@ -4,37 +4,37 @@ import msgspec
 
 # First Party
 from lmcache.v1.multiprocess.group_view import (
-    LMCacheGroupView,
+    EngineGroupInfo,
     expand_block_ids_to_views,
     get_engine_group_indices,
+    num_engine_group_infos,
     num_engine_groups,
-    num_group_views,
     slice_block_ids_per_group,
 )
 
 
-def test_group_views_default_to_one_engine_group():
+def test_engine_group_infos_default_to_one_engine_group():
     assert num_engine_groups([]) == 1
-    assert num_group_views([]) == 1
+    assert num_engine_group_infos([]) == 1
     assert get_engine_group_indices([], 1) is None
 
 
-def test_group_views_build_per_layer_engine_group_indices():
+def test_engine_group_infos_build_per_layer_engine_group_indices():
     groups = [
-        LMCacheGroupView(0, (0, 2)),
-        LMCacheGroupView(1, (1, 3)),
+        EngineGroupInfo(0, (0, 2)),
+        EngineGroupInfo(1, (1, 3)),
     ]
 
     assert num_engine_groups(groups) == 2
-    assert num_group_views(groups) == 2
+    assert num_engine_group_infos(groups) == 2
     assert get_engine_group_indices(groups, 4) == [0, 1, 0, 1]
 
 
-def test_group_views_expand_block_ids_to_views():
+def test_engine_group_infos_expand_block_ids_to_views():
     groups = [
-        LMCacheGroupView(0, (0, 2)),
-        LMCacheGroupView(0, (4,)),
-        LMCacheGroupView(1, (1, 3)),
+        EngineGroupInfo(0, (0, 2)),
+        EngineGroupInfo(0, (4,)),
+        EngineGroupInfo(1, (1, 3)),
     ]
 
     assert expand_block_ids_to_views(groups, [[10, 11], [20, 21]]) == [
@@ -44,21 +44,21 @@ def test_group_views_expand_block_ids_to_views():
     ]
 
 
-def test_group_views_msgspec_round_trip():
+def test_engine_group_infos_msgspec_round_trip():
     """The groups encode/decode losslessly via msgspec (the IPC path)."""
     groups = [
-        LMCacheGroupView(0, (0, 2)),
-        LMCacheGroupView(1, (1, 3)),
+        EngineGroupInfo(0, (0, 2)),
+        EngineGroupInfo(1, (1, 3)),
     ]
 
     decoded = msgspec.msgpack.decode(
-        msgspec.msgpack.encode(groups), type=list[LMCacheGroupView]
+        msgspec.msgpack.encode(groups), type=list[EngineGroupInfo]
     )
 
     assert decoded == groups
 
 
-def test_group_views_exclude_uncovered_layers():
+def test_engine_group_infos_exclude_uncovered_layers():
     """Layers not referenced by any group are tagged EXCLUDED_ENGINE_GROUP.
 
     Cross-layer KV-sharing layers (e.g. google/gemma-4-E4B-it) alias a target
@@ -69,16 +69,16 @@ def test_group_views_exclude_uncovered_layers():
     from lmcache.v1.kv_layer_groups import EXCLUDED_ENGINE_GROUP
 
     groups = [
-        LMCacheGroupView(0, (0,)),
-        LMCacheGroupView(1, (1,)),
+        EngineGroupInfo(0, (0,)),
+        EngineGroupInfo(1, (1,)),
     ]
 
     # Layer 2 is not covered by any group -> excluded, not an error.
     assert get_engine_group_indices(groups, 3) == [0, 1, EXCLUDED_ENGINE_GROUP]
 
 
-def test_group_views_reject_out_of_range_layer():
-    groups = [LMCacheGroupView(0, (0, 5))]
+def test_engine_group_infos_reject_out_of_range_layer():
+    groups = [EngineGroupInfo(0, (0, 5))]
 
     try:
         get_engine_group_indices(groups, 3)

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -19,7 +19,7 @@ from lmcache.v1.kv_layer_groups import (
     format_kvcache_shape_spec,
     parse_kvcache_shape_spec,
 )
-from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="PageBufferShapeDesc requires CUDA build"
@@ -31,7 +31,7 @@ def _build_manager(
     *,
     num_blocks: int,
     layout_hints: LayoutHints | None = None,
-    group_views: Sequence[LMCacheGroupView] = (),
+    engine_group_infos: Sequence[EngineGroupInfo] = (),
 ) -> KVLayerGroupsManager:
     """Build a manager using the per-layer NHD format.
 
@@ -48,7 +48,7 @@ def _build_manager(
         gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         num_blocks=num_blocks,
         layout_hints=layout_hints,
-        group_views=group_views,
+        engine_group_infos=engine_group_infos,
     )
 
 
@@ -95,9 +95,9 @@ class TestKVLayerGroupsManager:
         manager = _build_manager(
             tensors,
             num_blocks=32,
-            group_views=[
-                LMCacheGroupView(0, (0, 2)),
-                LMCacheGroupView(1, (1, 3)),
+            engine_group_infos=[
+                EngineGroupInfo(0, (0, 2)),
+                EngineGroupInfo(1, (1, 3)),
             ],
         )
 
@@ -108,7 +108,7 @@ class TestKVLayerGroupsManager:
         assert groups_by_engine_group_idx[0].layer_indices == [0, 2]
         assert groups_by_engine_group_idx[1].layer_indices == [1, 3]
 
-    def test_build_rejects_bad_group_views(self):
+    def test_build_rejects_bad_engine_group_infos(self):
         tensors = [
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16) for _ in range(2)
         ]
@@ -116,7 +116,7 @@ class TestKVLayerGroupsManager:
             _build_manager(
                 tensors,
                 num_blocks=32,
-                group_views=[LMCacheGroupView(0, (2,))],
+                engine_group_infos=[EngineGroupInfo(0, (2,))],
             )
 
     def test_build_different_shapes(self):
@@ -380,14 +380,14 @@ class TestKernelAndObjectGroups:
         assert manager.num_object_groups == 0
 
     def test_excluded_layer_left_out_of_all_groups(self):
-        # Layer 2 is referenced by no group view, so it is excluded entirely.
+        # Layer 2 is referenced by no engine group info, so it is excluded entirely.
         tensors = [
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16) for _ in range(3)
         ]
         manager = _build_manager(
             tensors,
             num_blocks=32,
-            group_views=[LMCacheGroupView(0, (0, 1))],
+            engine_group_infos=[EngineGroupInfo(0, (0, 1))],
         )
         grouped = sorted(
             idx for group in manager.kernel_groups for idx in group.layer_indices

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -7,7 +7,7 @@ import torch
 
 # First Party
 from lmcache.integration.vllm.kv_cache_groups import (
-    create_group_views_from_vllm,
+    create_engine_group_infos_from_vllm,
 )
 from lmcache.v1.multiprocess.group_view import (
     expand_block_ids_to_views,
@@ -32,7 +32,7 @@ def _same_shape_caches(names: list[str]) -> dict[str, torch.Tensor]:
 
 def test_conversion_defaults_to_single_group_without_config():
     """No vLLM KV cache groups -> all layers fall into a single engine group."""
-    spec = create_group_views_from_vllm(
+    spec = create_engine_group_infos_from_vllm(
         None, _same_shape_caches(["layer.0", "layer.1"])
     )
 
@@ -43,7 +43,7 @@ def test_conversion_defaults_to_single_group_without_config():
 
 def test_conversion_preserves_engine_group_layers():
     """Two engine groups with identical tensor shape stay separate by group."""
-    spec = create_group_views_from_vllm(
+    spec = create_engine_group_infos_from_vllm(
         MockKVCacheConfig(
             kv_cache_groups=[
                 MockKVCacheGroup(["layer.0", "layer.2"]),
@@ -62,7 +62,7 @@ def test_conversion_splits_by_lmcache_layer_identity():
     caches = _same_shape_caches(["layer.0", "layer.1", "layer.2", "layer.3"])
     # layer.4 has a different head count -> distinct transfer identity.
     caches["layer.4"] = torch.randn(2, 32, 16, 16, 64, dtype=torch.float16)
-    spec = create_group_views_from_vllm(
+    spec = create_engine_group_infos_from_vllm(
         MockKVCacheConfig(
             kv_cache_groups=[
                 MockKVCacheGroup(["layer.0", "layer.2", "layer.4"]),

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -10,7 +10,7 @@ from lmcache.integration.vllm.kv_cache_groups import (
     create_engine_group_infos_from_vllm,
 )
 from lmcache.v1.multiprocess.group_view import (
-    expand_block_ids_to_views,
+    expand_engine_block_ids,
     get_engine_group_indices,
     num_engine_groups,
 )
@@ -74,7 +74,7 @@ def test_conversion_splits_by_lmcache_layer_identity():
 
     assert [group.engine_group_id for group in spec] == [0, 1, 0]
     assert [group.layer_indices for group in spec] == [(0, 2), (1, 3), (4,)]
-    assert expand_block_ids_to_views(spec, [[10], [20]]) == [
+    assert expand_engine_block_ids(spec, [[10], [20]]) == [
         [10],
         [20],
         [10],

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -25,7 +25,7 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
     LoadStoreOp,
     ParallelStrategy,
 )
-from lmcache.v1.multiprocess.group_view import LMCacheGroupView
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocol import RequestType
 
 
@@ -174,10 +174,10 @@ def test_submit_store_request_expands_block_ids_to_views(fake_adapter, monkeypat
     fake_tensor = MagicMock()
     fake_tensor.device.type = "cuda"
     adapter.kv_caches = {"layer.0": fake_tensor}
-    adapter.group_views = [
-        LMCacheGroupView(0, (0, 2)),
-        LMCacheGroupView(0, (4,)),
-        LMCacheGroupView(1, (1, 3)),
+    adapter.engine_group_infos = [
+        EngineGroupInfo(0, (0, 2)),
+        EngineGroupInfo(0, (4,)),
+        EngineGroupInfo(1, (1, 3)),
     ]
     transfer_ctx = MagicMock()
     fake_future = MagicMock()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Since we introduced `KernelGroup` and `ObjectGroup` in #3557, `LMCacheGroup` has become a bit unclear.

This PR renames the old `LMCacheGroupView` to `EngineGroupInfo` for better clarity.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
