### PR TITLE
fix: handle NL_X_NB_NH_BS_TWO_HS in get_group_data_ptrs

### DIFF
--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -1274,6 +1274,7 @@ def get_group_data_ptrs(
         F.NL_X_NB_TWO_NH_BS_HS,
         F.NL_X_NB_BS_HS,
         F.NL_X_NBBS_ONE_HS,
+        F.NL_X_NB_NH_BS_TWO_HS,
     ):
         layers = cast(list[torch.Tensor], kv_caches)
         return [layers[i].data_ptr() for i in layer_indices]


### PR DESCRIPTION
## Problem

`get_group_data_ptrs` raises `ValueError: Unknown GPU KV Format: 10` when the KV cache uses the `NL_X_NB_NH_BS_TWO_HS` layout (value 10), which was added in #3567 but not included in the per-layer branch of this function.

## Fix

Add `NL_X_NB_NH_BS_TWO_HS` to the per-layer list branch in `get_group_data_ptrs`. This format has the same per-layer tensor structure (`NL x [NB, NH, BS, 2, HS]`) as the other formats already handled in that branch.