### PR TITLE
bench: support aligned L1 buffers for L2 adapters

### DIFF
--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -929,6 +929,12 @@ support a clean store -> load round-trip.
    ``"use_odirect": true``) or that talk to a remote service without
    a local cache, the default combined run is usually fine.
 
+   O_DIRECT adapters may also require the benchmark L1 buffer to
+   satisfy the adapter's block alignment. Use ``--l1-align-bytes`` to
+   set that alignment, commonly ``4096`` for local block devices. The
+   payload size (``--data-size-kb * 1024``) must be a multiple of the
+   selected alignment.
+
 
 Quick start
 ~~~~~~~~~~~
@@ -952,6 +958,15 @@ Stress the adapter with more in-flight submits and larger payloads:
        --num-keys 32 --in-flight 4 \
        --data-size-kb 512 \
        --rounds 5 --warmup-rounds 1
+
+Benchmark an O_DIRECT adapter with aligned L1 buffers:
+
+.. code-block:: bash
+
+   lmcache bench l2 \
+       --l2-adapter '{"type":"raw_block","device_path":"/dev/nvme0n1","slot_bytes":4194304,"use_odirect":true,"block_align":4096}' \
+       --data-size-kb 1024 \
+       --l1-align-bytes 4096
 
 Run only one operation (useful to isolate store vs. load throughput):
 
@@ -1019,6 +1034,13 @@ Options
    * - ``--data-size-kb N``
      - ``256``
      - Data size per key, in KiB.
+   * - ``--l1-align-bytes N``
+     - ``1``
+     - Alignment in bytes for benchmark L1 buffers. Use a value
+       at least as large as the adapter's block alignment when
+       benchmarking O_DIRECT backends, for example ``4096`` for local
+       block devices. ``--data-size-kb * 1024`` must be a multiple of
+       this value.
    * - ``--rounds N``
      - ``1``
      - Measurement rounds per operation.
@@ -1166,9 +1188,8 @@ round against the byte pattern that ``store`` wrote (see
    [Verify] OK
 
 Verification is **off** by default because the stricter byte pattern
-also forces every key to allocate its own ``data_size`` buffer
-(otherwise the runner is free to reuse a single shared buffer across
-keys to keep the memory footprint small).
+requires both the store and load object batches to stay resident so the
+loaded data can be compared against the original store pattern.
 
 
 Exit codes

--- a/lmcache/cli/commands/bench/l2_adapter_bench/command.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/command.py
@@ -100,6 +100,15 @@ def register_l2_parser(
         help="Data size per key in KB (default: 256).",
     )
     parser.add_argument(
+        "--l1-align-bytes",
+        type=int,
+        default=1,
+        help=(
+            "Alignment in bytes for benchmark L1 buffers. "
+            "Use 4096 when benchmarking O_DIRECT backends. Default: 1."
+        ),
+    )
+    parser.add_argument(
         "--rounds",
         type=int,
         default=1,
@@ -125,8 +134,8 @@ def register_l2_parser(
             "never stored. Default: 0.0."
         ),
     )
-    # Round-trip verification is OFF by default (cheaper memory
-    # footprint: see make_memory_objects' share_buffer layout).
+    # Round-trip verification is OFF by default because it needs both
+    # store and load object batches resident at the same time.
     # Use --no-skip-verify to enable verification.
     parser.add_argument(
         "--skip-verify",
@@ -168,12 +177,10 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
         args: Parsed CLI arguments from the ``bench l2`` subparser.
     """
     # Lazy imports: keep CLI loadable without torch / native deps.
-    # Third Party
-    import torch
-
     # First Party
     from lmcache.cli.commands.bench.l2_adapter_bench.data import (
         create_l1_memory_desc,
+        make_aligned_tensor,
         make_memory_objects,
         make_object_keys,
         verify_round_trip,
@@ -191,6 +198,17 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
     kb = 1024
     mb = 1024 * 1024
     data_size = args.data_size_kb * kb
+    l1_align_bytes = int(args.l1_align_bytes)
+    if l1_align_bytes <= 0:
+        print("Error: --l1-align-bytes must be positive", file=sys.stderr)
+        sys.exit(2)
+    if data_size % l1_align_bytes != 0:
+        print(
+            "Error: --data-size-kb must produce a payload size that is "
+            "a multiple of --l1-align-bytes",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     in_flight = args.in_flight
     num_keys = args.num_keys
     rounds = args.rounds
@@ -241,8 +259,8 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
 
     # Backing L1 memory buffer for adapters that need an L1 desc.
     # Sized for one in-flight wave of store + load buffers.
-    l1_buffer = torch.empty(2 * keys_per_round * data_size, dtype=torch.uint8)
-    l1_memory_desc = create_l1_memory_desc(l1_buffer)
+    l1_buffer = make_aligned_tensor(2 * keys_per_round * data_size, l1_align_bytes)
+    l1_memory_desc = create_l1_memory_desc(l1_buffer, align_bytes=l1_align_bytes)
 
     log("\n[Init] Creating adapter...")
     try:
@@ -277,20 +295,28 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
             for i in range(in_flight)
         ]
 
-    def _build_round_objs() -> list[list]:
-        """Allocate per-submit object batches for one round.
+    def _build_round_objs(base_offset: int, fill_offset: int = 0) -> list[list]:
+        """Build per-submit object batches backed by the registered L1 buffer.
 
-        Every key in every batch gets its OWN ``data_size`` tensor,
-        pre-filled with a distinguishing byte pattern. This keeps
-        ``verify_round_trip`` meaningful (it can detect cross-key
-        corruption after a store -> load cycle) and keeps the
-        memory layout consistent regardless of whether verify is
-        actually run.
+        Some adapters register the L1 buffer passed through ``L1MemoryDesc``
+        during initialization. The benchmark objects must therefore be views
+        into that same buffer rather than independent tensors allocated
+        elsewhere.
 
-        Per-round (per direction) memory:
-        ``in_flight * num_keys * data_size`` bytes.
+        ``fill_offset`` lets load buffers start with a pattern that differs
+        from store buffers, so round-trip verification catches silent no-op
+        loads that nevertheless report success.
         """
-        return [make_memory_objects(num_keys, data_size) for _ in range(in_flight)]
+        return [
+            make_memory_objects(
+                l1_buffer,
+                num_keys,
+                data_size,
+                base_offset + i * num_keys * data_size,
+                fill_offset=fill_offset,
+            )
+            for i in range(in_flight)
+        ]
 
     # Lookup hit/miss split per round.
     per_round_hit = int(keys_per_round * max_hit_rate)
@@ -338,13 +364,16 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
     def _store_objs(_r: int) -> list[list]:
         nonlocal store_obj_batches
         if store_obj_batches is None:
-            store_obj_batches = _build_round_objs()
+            store_obj_batches = _build_round_objs(0)
         return store_obj_batches
 
     def _load_objs(_r: int) -> list[list]:
         nonlocal load_obj_batches
         if load_obj_batches is None:
-            load_obj_batches = _build_round_objs()
+            load_obj_batches = _build_round_objs(
+                keys_per_round * data_size,
+                fill_offset=1,
+            )
         return load_obj_batches
 
     results: list = []
@@ -418,8 +447,8 @@ def run_l2_adapter_bench(command: "BaseCommand", args: argparse.Namespace) -> No
             # Sanity: store and load used the same key idx range for
             # the last measured round, and load buffers now hold what
             # the adapter returned. Compare against the byte pattern
-            # written by store (i & 0xFF, where i is position within
-            # the batch — see make_memory_objects).
+            # written by the store object batch (i & 0xFF, where i is
+            # position within the batch).
             log(
                 "[Verify] Checking store -> load data integrity for last "
                 "measured round..."

--- a/lmcache/cli/commands/bench/l2_adapter_bench/data.py
+++ b/lmcache/cli/commands/bench/l2_adapter_bench/data.py
@@ -24,6 +24,38 @@ from lmcache.v1.platform import consume_fd
 _KB = 1024
 
 
+def make_aligned_tensor(num_bytes: int, align_bytes: int = 1) -> torch.Tensor:
+    """Create a 1-D uint8 tensor whose data pointer is aligned.
+
+    Args:
+        num_bytes: Number of bytes in the returned tensor.
+        align_bytes: Required data pointer alignment in bytes.
+
+    Returns:
+        A 1-D ``torch.uint8`` tensor with ``num_bytes`` elements.
+
+    Raises:
+        ValueError: If ``num_bytes`` is negative or ``align_bytes`` is
+            not positive.
+        RuntimeError: If the allocated tensor cannot be aligned.
+    """
+    if num_bytes < 0:
+        raise ValueError("num_bytes must be non-negative")
+    if align_bytes <= 0:
+        raise ValueError("align_bytes must be positive")
+    if align_bytes == 1:
+        return torch.empty(num_bytes, dtype=torch.uint8)
+
+    backing = torch.empty(num_bytes + align_bytes - 1, dtype=torch.uint8)
+    offset = (-backing.data_ptr()) % align_bytes
+    aligned = backing[offset : offset + num_bytes]
+    if aligned.data_ptr() % align_bytes != 0:
+        raise RuntimeError(
+            f"failed to allocate {align_bytes}-byte aligned benchmark buffer"
+        )
+    return aligned
+
+
 def make_object_keys(
     num_keys: int, model_name: str = "bench-model", key_offset: int = 0
 ) -> list[ObjectKey]:
@@ -53,23 +85,46 @@ def make_object_keys(
 
 
 def make_memory_objects(
+    buffer: torch.Tensor,
     num_keys: int,
     data_size: int,
+    base_offset: int,
+    fill_offset: int = 0,
 ) -> list[MemoryObj]:
-    """Create *num_keys* ``TensorMemoryObj`` instances of *data_size* bytes.
+    """Create MemoryObj views backed by a shared L1 benchmark buffer.
 
-    Each returned object owns an independent ``data_size``-byte tensor
-    pre-filled with a distinguishing byte pattern (key index mod 256)
-    so that ``verify_round_trip`` can detect cross-key corruption after
-    a store -> load cycle.
+    Each returned object is a ``data_size``-byte slice of ``buffer``,
+    pre-filled with a distinguishing byte pattern
+    ``(key_index + fill_offset) mod 256`` so that ``verify_round_trip``
+    can detect cross-key corruption after a store -> load cycle.
 
-    Per-call memory: ``num_keys * data_size``.
+    Args:
+        buffer: Contiguous benchmark L1 buffer that backs all objects.
+        num_keys: Number of memory objects to create.
+        data_size: Size of each memory object in bytes.
+        base_offset: Byte offset of the first object within ``buffer``.
+        fill_offset: Offset added to each key index before generating the
+            byte fill pattern.
+
+    Returns:
+        ``TensorMemoryObj`` instances whose ``raw_data`` tensors are views
+        into ``buffer``.
+
+    Raises:
+        ValueError: If the requested object range falls outside ``buffer``.
     """
-    # Independent buffers with distinguishing fill patterns for verify.
+    flat_buffer = buffer.view(-1)
     objects: list[MemoryObj] = []
     for i in range(num_keys):
-        raw_tensor = torch.empty(data_size, dtype=torch.uint8)
-        raw_tensor.fill_(i & 0xFF)
+        start = base_offset + i * data_size
+        end = start + data_size
+        if start < 0 or end > flat_buffer.numel():
+            raise ValueError(
+                f"L1 benchmark buffer too small for object {i}: "
+                f"[{start}, {end}) > {flat_buffer.numel()}"
+            )
+        raw_tensor = flat_buffer[start:end]
+        raw_tensor.fill_((i + fill_offset) & 0xFF)
         metadata = MemoryObjMetadata(
             shape=torch.Size([data_size]),
             dtype=torch.uint8,
@@ -88,13 +143,16 @@ def make_memory_objects(
     return objects
 
 
-def create_l1_memory_desc(buffer: torch.Tensor) -> L1MemoryDesc:
+def create_l1_memory_desc(
+    buffer: torch.Tensor,
+    align_bytes: int = 1,
+) -> L1MemoryDesc:
     """Create an L1 memory descriptor for a contiguous test buffer."""
     flat_buffer = buffer.view(-1)
     return L1MemoryDesc(
         ptr=flat_buffer.data_ptr(),
         size=flat_buffer.numel() * flat_buffer.element_size(),
-        align_bytes=flat_buffer.element_size(),
+        align_bytes=align_bytes,
     )
 
 

--- a/tests/cli/commands/bench/l2_adapter_bench/test_data.py
+++ b/tests/cli/commands/bench/l2_adapter_bench/test_data.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.cli.commands.bench.l2_adapter_bench.data import (
+    create_l1_memory_desc,
+    make_aligned_tensor,
+    make_memory_objects,
+)
+
+
+def test_make_aligned_tensor_returns_aligned_buffer() -> None:
+    tensor = make_aligned_tensor(4096 * 3, align_bytes=4096)
+
+    assert tensor.numel() == 4096 * 3
+    assert tensor.dtype == torch.uint8
+    assert tensor.data_ptr() % 4096 == 0
+
+
+def test_create_l1_memory_desc_uses_requested_alignment() -> None:
+    tensor = make_aligned_tensor(8192, align_bytes=4096)
+
+    desc = create_l1_memory_desc(tensor, align_bytes=4096)
+
+    assert desc.ptr == tensor.data_ptr()
+    assert desc.size == 8192
+    assert desc.align_bytes == 4096
+
+
+def test_make_memory_objects_uses_shared_l1_range() -> None:
+    buffer = make_aligned_tensor(4096, align_bytes=1024)
+
+    objects = make_memory_objects(
+        buffer,
+        num_keys=2,
+        data_size=1024,
+        base_offset=1024,
+    )
+
+    assert len(objects) == 2
+    assert objects[0].raw_data.data_ptr() == buffer.data_ptr() + 1024
+    assert objects[1].raw_data.data_ptr() == buffer.data_ptr() + 2048
+    assert torch.all(objects[0].raw_data == 0)
+    assert torch.all(objects[1].raw_data == 1)
+
+
+def test_make_memory_objects_can_use_different_fill_pattern() -> None:
+    buffer = make_aligned_tensor(2048, align_bytes=1024)
+
+    objects = make_memory_objects(
+        buffer,
+        num_keys=2,
+        data_size=1024,
+        base_offset=0,
+        fill_offset=1,
+    )
+
+    assert torch.all(objects[0].raw_data == 1)
+    assert torch.all(objects[1].raw_data == 2)


### PR DESCRIPTION
## What this PR does / why we need it

`lmcache bench l2` could not benchmark O_DIRECT L2 backends such as `raw_block` because the benchmark registered its L1 buffer with `align_bytes=1`. For `raw_block` with `use_odirect=true`, the adapter requires `l1_align_bytes >= block_align`, so adapter creation failed with:

```text
raw_block requires l1_align_bytes >= block_align when use_odirect=true
```

This PR adds `--l1-align-bytes` to `lmcache bench l2`, allocates an aligned benchmark L1 buffer, and creates benchmark `MemoryObj` views from that same registered buffer. With `--l1-align-bytes 4096`, the L2 bench can now exercise O_DIRECT backends correctly.

## Special notes for your reviewers

This only changes the L2 benchmark data path. It does not change LMCache server/runtime L2 adapter behavior.

Previously, the benchmark passed an `L1MemoryDesc` to `create_l2_adapter`, but the actual store/load `MemoryObj` tensors were allocated independently. That meant the registered L1 range was not the memory range used for payload I/O. This PR makes the benchmark payload objects slices of the registered L1 buffer, so the descriptor's address range and alignment describe the actual buffers used by store/load.

The benchmark now validates that `data-size-kb * 1024` is a multiple of `--l1-align-bytes`, because O_DIRECT paths require aligned buffer address, offset, and size.

## Verified with

```bash
.venv/bin/python -m pytest -q tests/cli/commands/bench/l2_adapter_bench/test_data.py
```

Manual raw_block O_DIRECT validation:

```bash
RAW_BLOCK_PATH=/var/tmp/lmcache-l2bench-raw-block.img
rm -f "$RAW_BLOCK_PATH"
truncate -s 512M "$RAW_BLOCK_PATH"

RAW_BLOCK_L2='{
  "type": "raw_block",
  "device_path": "'"$RAW_BLOCK_PATH"'",
  "slot_bytes": 4194304,
  "capacity_bytes": 0,
  "use_odirect": true,
  "block_align": 4096,
  "header_bytes": 4096,
  "meta_total_bytes": 67108864,
  "meta_magic": "PRTST001",
  "io_engine": "posix",
  "load_checkpoint_on_init": false,
  "num_store_workers": 1,
  "num_lookup_workers": 1,
  "num_load_workers": 1
}'

lmcache bench l2 \
  --l2-adapter "$RAW_BLOCK_L2" \
  --num-keys 1 \
  --in-flight 1 \
  --data-size-kb 1024 \
  --l1-align-bytes 4096 \
  --rounds 1 \
  --warmup-rounds 0 \
  --lookup-max-hit-rate 1.0 \
  --no-skip-verify
```

Negative validation with `--l1-align-bytes 1` still fails with the expected raw_block alignment error.

## If applicable

* [x] this PR contains user facing changes - docs added
* [x] this PR contains unit tests