### PR TITLE
(fix) Add missing enum to GPUVKFormat

### DIFF
--- a/csrc/sycl/mem_kernels_sycl.cpp
+++ b/csrc/sycl/mem_kernels_sycl.cpp
@@ -568,10 +568,14 @@ void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(1) / elements_per_entry;
     vllm_value_offset = vllm_key_value_cache.stride(0) / elements_per_entry;
-  } else {  // NL_X_NB_TWO_BS_NH_HS
+  } else if (gpu_kv_format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS) {
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(0) / elements_per_entry;
     vllm_value_offset = vllm_key_value_cache.stride(1) / elements_per_entry;
+  } else {
+    throw std::runtime_error(
+        "Unsupported non-MLA GPUKVFormat in single_layer_kv_transfer: " +
+        std::to_string(static_cast<int>(gpu_kv_format)));
   }
 
   int n = num_heads * head_size_in_64bit;

--- a/csrc/sycl/mem_kernels_sycl.h
+++ b/csrc/sycl/mem_kernels_sycl.h
@@ -98,6 +98,16 @@ enum class GPUKVFormat : int {
   - SGLang MHA via the MP daemon path
   physical shape per layer: [num_blocks, block_size, num_heads, head_size]
   */
+
+  NL_X_NB_NH_BS_TWO_HS = 10,
+  /*
+  used by:
+  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
+  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
+  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
+  Currently only reached via the host gather/scatter path, not the SYCL
+  transfer kernels.
+  */
 };
 
 void multi_layer_kv_transfer(


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When https://github.com/LMCache/LMCache/pull/3567 merged in, it didn't include the NL_X_NB_NH_BS_TWO_HS in the SYCL code (mem_kernels_sycl.h) which is breaking SYCL builds. 

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
