### PR TITLE
[observability] blend server trace sub-spans + V3 hit-rate breakdown

### DIFF
--- a/docs/design/v1/mp_observability/blend_v3_observability.md
+++ b/docs/design/v1/mp_observability/blend_v3_observability.md
@@ -1,0 +1,206 @@
+# CacheBlend V3 Observability — Design
+
+**Status:** Proposal · **Scope:** unify CB V3 tracing across the vLLM plugin
+(scheduler + worker) and the LMCache blend server into one distributed trace,
+plus the metrics each side exposes.
+
+## 1. Goal
+
+A single CB request touches **three processes**:
+
+```
+vLLM scheduler ──CB_UNIFIED_LOOKUP──▶ LMCache blend server
+vLLM worker    ──CB_RETRIEVE_V3─────▶ LMCache blend server
+vLLM worker    ── model forward (FULL_RECOMP → CHECK → PARTIAL)
+```
+
+Today these are observed by **two disjoint systems**:
+
+| side | mechanism | output |
+|---|---|---|
+| LMCache blend server | EventBus → `BlendTracingSubscriber` (`subscribers/tracing/cb_server.py`) | **OTel spans** (`cb.request` + children), OTLP export |
+| vLLM plugin (connector/shim/attn) | `_cb_span` / `_cb_stats_emit` (`lmcache_cacheblend/connector.py`) | **ad-hoc JSONL** (`CB_PROFILE=1`) |
+
+They never share a trace: you cannot see, in one view, that a slow request's
+time went into the server-side L2 load vs the worker-side scatter vs the PARTIAL
+forward. **Goal: one `cb.request` trace spanning all three processes**, with
+sub-spans owned by whichever process did the work, plus aligned metrics.
+
+## 2. The unified trace model
+
+One trace per `request_id`. Process owner in brackets; cross-process children
+linked by trace-context propagation (§5).
+
+```
+cb.request                         [scheduler — root]  request_id, model, world_size, n_prompt_tokens
+│
+├─ cb.schedule                     [scheduler]  the get_num_new_matched_tokens defer loop
+│  ├─ cb.lookup.rpc                [scheduler]  CB_UNIFIED_LOOKUP incl. N poll re-issues; attr: n_polls
+│  │  └─ cb.lookup                 [SERVER]  ← cross-process child
+│  │     ├─ cb.fingerprint_match   [server]  n_probes, table_hits, matches (token-stride=1, any offset)
+│  │     ├─ cb.prefix_lookup       [server]  prefix_chunks
+│  │     ├─ cb.sparse_prefetch     [server]  n_keys, l1_hits, l2_misses
+│  │     │  └─ cb.l2_load          [server·IO]  chunks, bytes, ms        (coalesced L2→L1)
+│  │     └─ cb.classify            [server]  found, stale, per_rank_ok
+│  │        ↳ on end: stamp hit_rate / prefix_coverage_tokens / n_non_prefix_tokens on cb.request
+│  └─ cb.build_meta                [scheduler]  broadcast metadata to workers
+│
+└─ cb.execute                      [worker]
+   ├─ cb.start_load_kv             [worker]  submit + stream-wait (may fire 2×: partial→full block alloc)
+   │  └─ cb.retrieve               [SERVER]  ← cross-process child
+   │     └─ cb.scatter             [server·GPU]  scattered_tokens, n_prefix, n_shifted (re-RoPE'd), dropped
+   │        (re-RoPE folded in — interleaved per-batch, not a separate span)
+   └─ cb.model_forward             [worker]  the sliced forward
+      ├─ cb.full_recomp            [worker·GPU]  layers 0..cl-1
+      ├─ cb.check                  [worker·GPU]  layer cl; imp_count, recomp_ratio
+      └─ cb.partial                [worker·GPU]  layers cl+1..L; dispatch=flex|unified, imp_empty
+```
+
+This is the contract both sides implement against. The server owns `cb.lookup`
+and `cb.retrieve` subtrees; the plugin owns everything else.
+
+### 2.1 V3 reuse is token-granular (#3582)
+
+As of #3582, CB matches and scatters at **token** granularity, not vLLM-block /
+chunk granularity — which is what the spans/attrs below must reflect:
+
+- **Matching** runs at `probe_stride=1`, so the shared body is found at *any*
+  token offset (`cb_unified_lookup` no longer filters non-prefix matches to a
+  chunk-aligned `cur_st`). `cb.fingerprint_match` reports token-offset matches,
+  not aligned chunks.
+- **Scatter** writes per-token via `multi_layer_kv_transfer` with
+  `slot_mapping = block_id[pos // bs] * bs + pos % bs`. The reused token range is
+  written slot-by-slot, so a **partial vLLM block** holding both matched and
+  recomputed tokens is written correctly with **no block-alignment trim on the
+  write** — the old whole-block scatter path and block-aligned drop checks are
+  gone. `cb.scatter`'s unit is `scattered_tokens` / `slot_writes`.
+- **L2 storage stays chunk-granular** (256-token chunks): a non-block-aligned
+  match still fetches whole chunks (`cb.l2_load` = chunks/bytes), then
+  `cb.scatter` writes only the matched token sub-range. So `cb.l2_load` is
+  measured in chunks while `cb.scatter` is measured in tokens/slots.
+- **`cb.start_load_kv` may fire twice** (vLLM allocates the request's blocks
+  partial-then-full). The first pass writes only slots inside the
+  already-allocated block table — a slot-bound guard (`cur_ed > num_slots`),
+  *not* a block-alignment trim; the second writes the rest. Expect two
+  `cb.retrieve` children, the first with `scattered_tokens` < total.
+
+## 3. LMCache-server side — what to expose
+
+The server already emits `cb.request` / `cb.lookup` / `cb.retrieve` via the
+EventBus. Two changes:
+
+**(a) Finer V3 events for the lookup/retrieve subtrees.** V3 currently emits only
+`CB_LOOKUP_START/END` and `CB_RETRIEVE_START/END` — too coarse for the subtree in
+§2. Add paired events (CPU-sync for compute, `publish_on_stream` for GPU ops so
+timing is GPU-accurate):
+
+| new event pair | span | timing source |
+|---|---|---|
+| `CB_FINGERPRINT_MATCH_*` | `cb.fingerprint_match` | CPU |
+| `CB_PREFIX_LOOKUP_*` | `cb.prefix_lookup` | CPU |
+| `CB_SPARSE_PREFETCH_*` | `cb.sparse_prefetch` (+ existing L2 prefetch span as `cb.l2_load`) | CPU + IO |
+| `CB_SCATTER_*` | `cb.scatter` (re-RoPE folded in via `n_shifted`) | `publish_on_stream` (GPU) |
+
+`BlendTracingSubscriber.SPAN_DEFS` gains the matching entries; all nest under
+`cb.lookup` / `cb.retrieve` via the existing `SpanRegistry`.
+
+**(b) Simplify the deferral logic for the V3 model.** The current root-close
+deferral (`_waiting_for_store_final`, the `STORE_FINAL_SUBMITTED` bridge) is V2-only
+and **inert under V3** (V3 never emits those). Under V3 the request ends at
+`CB_RETRIEVE_END` (no async store-final after inference). Gate the `cb.request`
+close on `_pending_gpu_ops[sid] == 0` only, and drop the V2 store-final bridge
+from the V3 path. (The V2-only event handlers stay for `blend_legacy`.)
+
+**Span attributes (server):** `request_id`, `prefix_coverage_tokens`,
+`fingerprint_hits`, `storage_hits`, `stale_chunks`, `hit_tokens`,
+`requested_tokens`, `hit_rate`, `prefix_hit_tokens`, `non_prefix_hit_tokens`,
+`scatter_ms`, `scattered_tokens`, `slot_writes`, `partial_blocks`,
+`n_shifted_tokens`, `n_prefix_tokens` (token-granular per §2.1 — not chunks).
+
+**V3 hit rate.** `hit_rate = hit_tokens / requested_tokens`, where the numerator
+counts **both reuse paths**: `hit_tokens = prefix_hit_tokens +
+non_prefix_hit_tokens`. The two ranges are disjoint (the non-prefix complement
+is `cur_st >= prefix coverage`), so they sum without double-counting. Both
+components are also recorded individually on `cb.request` so a dashboard can
+split prefix-reuse vs re-RoPE'd non-prefix reuse.
+
+**Metrics (already present, keep):** the `lmcache_blend.*` counters
+(`lookup_requests`, `lookup_hit_tokens`, `lookup_storage_hits`,
+`lookup_stale_chunks`, `retrieve_requests`, `retrieve_failures`,
+`chunks_evicted`, …). Note the V2-only store counters won't populate under V3 —
+document, or recompute the "stored" notion from the unified path.
+
+## 4. vLLM-plugin side — what to expose
+
+The plugin's `_cb_span` spans (`sched.gnnmt`, `gnnmt.cb_unified_submit/poll`,
+`sched.build_meta`, `slk.*`, `shim.wrapper.{prepare,fwd}`, `flex.*`,
+`cb_admission_check`) already cover the §2 plugin subtree — but as **JSONL, not
+OTel**. Make `_cb_span` dual-mode:
+
+- when an OTel tracer is available → emit an **OTel span** (start/end, attributes);
+- always (under `CB_PROFILE`) → keep the JSONL line (cheap local profiling).
+
+Mapping plugin span → unified name: `sched.gnnmt`→`cb.schedule`,
+`gnnmt.cb_unified_*`→`cb.lookup.rpc`, `sched.build_meta`→`cb.build_meta`,
+`slk.*`→`cb.start_load_kv`, `shim.wrapper.fwd`→`cb.model_forward`,
+`flex.*` + the layer hooks → `cb.full_recomp`/`cb.check`/`cb.partial`.
+
+**Tracer source.** vLLM has its own OTel (`--otlp-traces-endpoint`) and creates a
+per-request span. Prefer to **reuse vLLM's tracer** so CB spans nest under vLLM's
+request span intra-process; if vLLM tracing is off, the plugin owns a tracer
+pointed at the same OTLP endpoint as the LMCache server. Gate on a single
+`CB_TRACING=1` (or reuse `--enable-tracing` semantics) so it's off by default.
+
+## 5. Unification — linking the three processes
+
+The blocker (from the surface map): **the RPC envelope carries no trace-context**
+— `IPCCacheEngineKey` and `CBUnifiedLookupResult` have no `traceparent` field. Two
+ways to bridge:
+
+**Option A — propagate W3C trace-context through the RPC (recommended).**
+Add an optional `trace_context: str | None` (W3C `traceparent`) to the CB RPC
+payloads (the lookup key + the retrieve args). The scheduler/worker **inject**
+the current span's context; the server **extracts** it and starts `cb.lookup` /
+`cb.retrieve` as remote children of it. Result: a *true* parent→child distributed
+trace across processes. Cost: one optional protocol field (backward-compatible —
+`None` when tracing off), an `inject`/`extract` at the two RPC boundaries.
+
+**Option B — deterministic trace-id from `request_id` (zero protocol change).**
+Both sides derive a 128-bit trace-id `= hash(request_id)` and tag every span with
+it (+ `request_id` attribute). Backends group by trace-id, so the spans land in
+one trace — but there are **no cross-process parent links** (sibling spans, not
+nested). Use if the protocol field is undesirable short-term.
+
+**Recommendation:** Option A. The field is tiny, optional, and gives real
+parent/child causality (e.g. "the 90 ms gnnmt was 50 ms server L2-load + 40 ms
+poll-wait"). Keep `request_id` as a span attribute regardless, so Option B is a
+trivial fallback. The `SpanRegistry` already handles intra-process nesting on
+each side; Option A only adds the *cross*-process edge.
+
+## 6. Phasing
+
+1. **Plugin OTel** — make `_cb_span` dual-mode (OTel + JSONL); reuse vLLM's tracer;
+   gate with `CB_TRACING`. (plugin repo)
+2. **V3 server sub-spans** — add the §3(a) events + `SPAN_DEFS`; simplify the
+   §3(b) V3 deferral. (LMCache) — **DONE**: `cb.fingerprint_match` /
+   `cb.prefix_lookup` / `cb.sparse_prefetch` nest under `cb.lookup`; `cb.scatter`
+   (re-RoPE folded) nests under `cb.retrieve`; `hit_rate` = prefix + non-prefix.
+   `cb.l2_load` GB/s is already covered by the existing `L2ThroughputSubscriber`
+   (`L2_LOAD_TASK_*`), correlated by request; nesting that span under
+   `cb.sparse_prefetch` is a cross-subsystem follow-up.
+3. **Cross-process link** — add the optional `trace_context` RPC field; inject on
+   the plugin side, extract on the server side. (both repos, in lockstep)
+4. **Dashboards** — one trace view + the `lmcache_blend.*` / plugin latency metrics
+   aligned on `request_id`.
+
+Each phase is independently useful (1 and 2 give per-process traces; 3 unifies).
+
+## 7. Open questions
+
+- Reuse vLLM's tracer/provider, or a CB-owned one? (affects nesting under vLLM's
+  request span vs a standalone `cb.request` root)
+- Is the protocol field (Option A) acceptable for upstream, or start with the
+  deterministic-trace-id fallback (Option B)?
+- Sampling: per-request tracing is expensive at scale — head sampling at the
+  scheduler (propagated via the same `trace_context`) so a sampled-out request is
+  cheap on all three processes.

--- a/docs/design/v1/mp_observability/blend_v3_observability.md
+++ b/docs/design/v1/mp_observability/blend_v3_observability.md
@@ -36,9 +36,9 @@ cb.request                         [scheduler — root]  request_id, model, worl
 │
 ├─ cb.schedule                     [scheduler]  the get_num_new_matched_tokens defer loop
 │  ├─ cb.lookup.rpc                [scheduler]  CB_UNIFIED_LOOKUP incl. N poll re-issues; attr: n_polls
-│  │  └─ cb.lookup                 [SERVER]  ← cross-process child
+│  │  └─ cb.lookup                 [SERVER]  ← cross-process child; attr prefix_chunks
 │  │     ├─ cb.fingerprint_match   [server]  n_probes, table_hits, matches (token-stride=1, any offset)
-│  │     ├─ cb.prefix_lookup       [server]  prefix_chunks
+│  │     │  (no cb.prefix_lookup span — prefix is traced by mp.lookup_prefetch)
 │  │     ├─ cb.sparse_prefetch     [server]  n_keys, l1_hits, l2_misses
 │  │     │  └─ cb.l2_load          [server·IO]  chunks, bytes, ms        (coalesced L2→L1)
 │  │     └─ cb.classify            [server]  found, stale, per_rank_ok
@@ -97,7 +97,7 @@ timing is GPU-accurate):
 | new event pair | span | timing source |
 |---|---|---|
 | `CB_FINGERPRINT_MATCH_*` | `cb.fingerprint_match` | CPU |
-| `CB_PREFIX_LOOKUP_*` | `cb.prefix_lookup` | CPU |
+| (prefix lookup) | `mp.lookup_prefetch` (reused; `prefix_chunks` attr on `cb.lookup`) | CPU |
 | `CB_SPARSE_PREFETCH_*` | `cb.sparse_prefetch` (+ existing L2 prefetch span as `cb.l2_load`) | CPU + IO |
 | `CB_SCATTER_*` | `cb.scatter` (re-RoPE folded in via `n_shifted`) | `publish_on_stream` (GPU) |
 
@@ -183,7 +183,8 @@ each side; Option A only adds the *cross*-process edge.
    gate with `CB_TRACING`. (plugin repo)
 2. **V3 server sub-spans** — add the §3(a) events + `SPAN_DEFS`; simplify the
    §3(b) V3 deferral. (LMCache) — **DONE**: `cb.fingerprint_match` /
-   `cb.prefix_lookup` / `cb.sparse_prefetch` nest under `cb.lookup`; `cb.scatter`
+   `cb.sparse_prefetch` nest under `cb.lookup` (prefix lookup reuses
+   `mp.lookup_prefetch`; `prefix_chunks` is a `cb.lookup` attr); `cb.scatter`
    (re-RoPE folded) nests under `cb.retrieve`; `hit_rate` = prefix + non-prefix.
    `cb.l2_load` GB/s is already covered by the existing `L2ThroughputSubscriber`
    (`L2_LOAD_TASK_*`), correlated by request; nesting that span under

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -82,14 +82,71 @@ request  [═══════════════════════�
 Store-only requests (no lookup phase) do not carry these attributes.
 
 The pre-provisioned **LMCache** dashboard under **Dashboards** shows cache hit
-rate, StorageManager read/write rates, and the live trace panel.
+rate, StorageManager read/write rates, and the live trace panel. The collapsed
+**CacheBlend** row adds blend-server panels (see below).
+
+## CacheBlend (blend server) traces
+
+When LMCache runs the **blend** engine (`lmcache server --engine-type blend`),
+CacheBlend V3 emits its own span tree to Tempo alongside the standard spans.
+Expand the collapsed **CacheBlend** row on the dashboard, or query Tempo:
+
+```
+# All CacheBlend request traces
+{ name = "cb.request" }
+
+# Requests that actually blended non-prefix (shifted) KV
+{ name = "cb.request" && span.non_prefix_hit_tokens > 0 }
+
+# The token-scatter GPU step
+{ name = "cb.scatter" }
+```
+
+Click a `cb.request` row to open the waterfall:
+
+```
+cb.request
+  cb.lookup
+    cb.fingerprint_match   match probe hashes vs stored fingerprints
+    cb.prefix_lookup       prefix KV (L1 + L2-promoted)
+    cb.sparse_prefetch     non-prefix (shifted) chunks, sparse L2->L1
+                           (emitted only on an actual L2 load; carries l2_keys)
+  cb.retrieve
+    cb.scatter             L1 -> paged KV per-token slot-scatter + re-RoPE
+  cb.store_pre_computed
+  cb.store_final
+```
+
+The root `cb.request` span carries the V3 hit-rate breakdown
+(`hit_rate = prefix + non-prefix`):
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `prefix_hit_tokens` | int | tokens reused from the prefix (L1+L2) |
+| `non_prefix_hit_tokens` | int | tokens reused from sparse non-prefix chunks |
+| `hit_tokens` | int | `prefix_hit_tokens + non_prefix_hit_tokens` |
+| `requested_tokens` | int | total chunk-aligned tokens submitted |
+| `hit_rate` | float | `hit_tokens / requested_tokens` |
+| `prefix_hit_rate` | float | `prefix_hit_tokens / requested_tokens` |
+| `non_prefix_hit_rate` | float | `non_prefix_hit_tokens / requested_tokens` (sums to `hit_rate`) |
+
+The **CacheBlend Hit Rate & Chunks** panel overlays the overall token hit rate
+(Prometheus) with the per-request prefix/non-prefix breakdown via
+[TraceQL metrics](https://grafana.com/docs/tempo/latest/metrics-from-traces/),
+served by Tempo's `local-blocks` metrics generator (enabled in `tempo.yml`):
+
+```
+# prefix vs non-prefix hit rate over time
+{ name = "cb.request" } | avg_over_time(span.prefix_hit_rate)
+{ name = "cb.request" } | avg_over_time(span.non_prefix_hit_rate)
+```
 
 ## Files
 
 ```
 docker-compose.yml          — 4-service stack (collector, tempo, prometheus, grafana)
 otel-collector.yml          — OTLP receiver → Tempo + Prometheus fan-out
-tempo.yml                   — local trace storage
+tempo.yml                   — local trace storage + local-blocks TraceQL metrics
 prometheus.yml              — scrapes lmcache metrics from collector
 grafana/provisioning/       — auto-provisioned datasources + dashboard
 start-server.sh             — launches LMCache server + vLLM with OTLP enabled

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -106,9 +106,8 @@ Click a `cb.request` row to open the waterfall:
 
 ```
 cb.request
-  cb.lookup
+  cb.lookup                (attr prefix_chunks; prefix timing is in mp.lookup_prefetch)
     cb.fingerprint_match   match probe hashes vs stored fingerprints
-    cb.prefix_lookup       prefix KV (L1 + L2-promoted)
     cb.sparse_prefetch     non-prefix (shifted) chunks, sparse L2->L1
                            (emitted only on an actual L2 load; carries l2_keys)
   cb.retrieve

--- a/examples/observability/grafana/provisioning/dashboards/lmcache.json
+++ b/examples/observability/grafana/provisioning/dashboards/lmcache.json
@@ -2680,7 +2680,7 @@
           "datasource": {
             "uid": "tempo"
           },
-          "description": "Waterfall of CacheBlend (blend server) request spans: cb.request \u2192 cb.lookup {cb.fingerprint_match, cb.prefix_lookup, cb.sparse_prefetch}, cb.retrieve {cb.scatter}, cb.store_pre_computed, cb.store_final. Click a row for the full Tempo waterfall.",
+          "description": "Waterfall of CacheBlend (blend server) request spans: cb.request \u2192 cb.lookup {cb.fingerprint_match, cb.sparse_prefetch}, cb.retrieve {cb.scatter}, cb.store_pre_computed, cb.store_final. Click a row for the full Tempo waterfall.",
           "fieldConfig": {
             "defaults": {},
             "overrides": []

--- a/examples/observability/grafana/provisioning/dashboards/lmcache.json
+++ b/examples/observability/grafana/provisioning/dashboards/lmcache.json
@@ -2348,7 +2348,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "description": "CacheBlend token-level hit rate and chunk throughput for store and retrieve paths.",
+          "description": "Overall blend token hit rate (left, %) and chunk throughput (right, ops/s). Prometheus.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2389,6 +2389,8 @@
                 }
               },
               "mappings": [],
+              "min": 0,
+              "unit": "percentunit",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -2397,14 +2399,13 @@
                     "value": null
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
-                  "id": "byRegexp",
-                  "options": "/chunks/"
+                  "id": "byFrameRefID",
+                  "options": "B"
                 },
                 "properties": [
                   {
@@ -2414,6 +2415,90 @@
                   {
                     "id": "custom.axisPlacement",
                     "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "chunks/s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "C"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ops"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "chunks/s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "D"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ops"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "chunks/s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "E"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ops"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "chunks/s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "F"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "ops"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.axisLabel",
+                    "value": "chunks/s"
                   }
                 ]
               }
@@ -2482,6 +2567,154 @@
           ],
           "title": "CacheBlend Hit Rate & Chunks",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Prefix vs non-prefix token hit rate (each / requested tokens; they sum to the overall hit rate). Prometheus.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "unit": "percentunit",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 92
+          },
+          "id": 34,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "refId": "A",
+              "expr": "rate(lmcache_blend_lookup_prefix_hit_tokens_total[$__rate_interval]) / rate(lmcache_blend_lookup_requested_tokens_total[$__rate_interval])",
+              "legendFormat": "prefix hit rate"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "refId": "B",
+              "expr": "rate(lmcache_blend_lookup_non_prefix_hit_tokens_total[$__rate_interval]) / rate(lmcache_blend_lookup_requested_tokens_total[$__rate_interval])",
+              "legendFormat": "non-prefix hit rate"
+            }
+          ],
+          "title": "CacheBlend prefix vs non-prefix hit rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "tempo"
+          },
+          "description": "Waterfall of CacheBlend (blend server) request spans: cb.request \u2192 cb.lookup {cb.fingerprint_match, cb.prefix_lookup, cb.sparse_prefetch}, cb.retrieve {cb.scatter}, cb.store_pre_computed, cb.store_final. Click a row for the full Tempo waterfall.",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 100
+          },
+          "id": 51,
+          "options": {
+            "dedupStrategy": "none",
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Start time"
+              }
+            ],
+            "spanFilters": {
+              "criticalPathOnly": false,
+              "matchesOnly": false
+            }
+          },
+          "targets": [
+            {
+              "limit": 20,
+              "query": "{ name = \"cb.request\" }",
+              "queryType": "traceql",
+              "refId": "A"
+            }
+          ],
+          "title": "CacheBlend Request Traces",
+          "type": "traces"
         }
       ]
     },
@@ -2553,6 +2786,6 @@
   "timezone": "browser",
   "title": "LMCache",
   "uid": "lmcache-standard",
-  "version": 2,
+  "version": 8,
   "weekStart": ""
 }

--- a/examples/observability/tempo.yml
+++ b/examples/observability/tempo.yml
@@ -10,6 +10,23 @@ distributor:
         http:
           endpoint: 0.0.0.0:4318
 
+# Keep recent traces in the local-blocks processor so Grafana can compute
+# TraceQL metrics (span latency / rate graphs) without a separate backend.
+metrics_generator:
+  processor:
+    local_blocks:
+      flush_to_storage: true
+      # Cut/complete blocks quickly so TraceQL-metrics see recent traces within
+      # seconds (sparse demo traffic otherwise sits in an open block for minutes).
+      trace_idle_period: 5s
+      flush_check_period: 5s
+      max_block_duration: 30s
+      complete_block_timeout: 1h
+  storage:
+    path: /var/tempo/generator/wal
+  traces_storage:
+    path: /var/tempo/generator/traces
+
 storage:
   trace:
     backend: local
@@ -17,3 +34,9 @@ storage:
       path: /var/tempo/blocks
     wal:
       path: /var/tempo/wal
+
+# Turn on the local-blocks processor for the (single, default) tenant.
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [local-blocks]

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -105,6 +105,21 @@ class EventType(Enum):
     CB_FINGERPRINTS_REGISTERED = "cb.fingerprints.registered"
     CB_CHUNKS_EVICTED = "cb.chunks.evicted"
 
+    # CB V3 lookup sub-spans (CPU) — nest under cb.lookup. Submitted-once but
+    # END may fire on a later poll (the non-blocking lookup re-issues), so the
+    # span captures submit→resident incl. poll-wait.
+    CB_FINGERPRINT_MATCH_START = "cb.fingerprint_match.start"
+    CB_FINGERPRINT_MATCH_END = "cb.fingerprint_match.end"
+    CB_PREFIX_LOOKUP_START = "cb.prefix_lookup.start"
+    CB_PREFIX_LOOKUP_END = "cb.prefix_lookup.end"
+    CB_SPARSE_PREFETCH_START = "cb.sparse_prefetch.start"
+    CB_SPARSE_PREFETCH_END = "cb.sparse_prefetch.end"
+
+    # CB V3 retrieve sub-span (GPU) — nest under cb.retrieve. Emitted via
+    # publish_on_stream for GPU-accurate timing of the L1->paged scatter.
+    CB_SCATTER_START = "cb.scatter.start"
+    CB_SCATTER_END = "cb.scatter.end"
+
     # Cache Blending (CB) events — lifecycle sentinels (CPU-synchronous)
     CB_REQUEST_START = "cb.request.start"
     CB_STORE_PRE_COMPUTED_SUBMITTED = "cb.store_pre_computed.submitted"

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -110,8 +110,9 @@ class EventType(Enum):
     # span captures submit→resident incl. poll-wait.
     CB_FINGERPRINT_MATCH_START = "cb.fingerprint_match.start"
     CB_FINGERPRINT_MATCH_END = "cb.fingerprint_match.end"
-    CB_PREFIX_LOOKUP_START = "cb.prefix_lookup.start"
-    CB_PREFIX_LOOKUP_END = "cb.prefix_lookup.end"
+    # No cb.prefix_lookup span: the prefix lookup is already traced by
+    # mp.lookup_prefetch (CB reuses LookupModule). prefix_chunks rides on
+    # cb.lookup via CB_LOOKUP_END instead.
     CB_SPARSE_PREFETCH_START = "cb.sparse_prefetch.start"
     CB_SPARSE_PREFETCH_END = "cb.sparse_prefetch.end"
 

--- a/lmcache/v1/mp_observability/subscribers/metrics/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/cb_server.py
@@ -67,6 +67,16 @@ class BlendMetricsSubscriber(EventSubscriber):
             ),
             unit="tokens",
         )
+        self._lookup_prefix_hit_tokens = meter.create_counter(
+            "lmcache_blend.lookup_prefix_hit_tokens",
+            description="Tokens served by blend from the prefix (L1+L2).",
+            unit="tokens",
+        )
+        self._lookup_non_prefix_hit_tokens = meter.create_counter(
+            "lmcache_blend.lookup_non_prefix_hit_tokens",
+            description="Tokens served by blend from non-prefix (shifted) chunks.",
+            unit="tokens",
+        )
         self._lookup_fingerprint_hits = meter.create_counter(
             "lmcache_blend.lookup_fingerprint_hits",
             description="Chunks matched by local fingerprint table",
@@ -149,6 +159,10 @@ class BlendMetricsSubscriber(EventSubscriber):
     def _on_lookup_end(self, event: Event) -> None:
         self._lookup_requested_tokens.add(event.metadata["requested_tokens"])
         self._lookup_hit_tokens.add(event.metadata["hit_tokens"])
+        self._lookup_prefix_hit_tokens.add(event.metadata.get("prefix_hit_tokens", 0))
+        self._lookup_non_prefix_hit_tokens.add(
+            event.metadata.get("non_prefix_hit_tokens", 0)
+        )
         self._lookup_fingerprint_hits.add(event.metadata["fingerprint_hits"])
         self._lookup_storage_hits.add(event.metadata["storage_hits"])
         self._lookup_stale_chunks.add(event.metadata["stale_chunks"])

--- a/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
@@ -72,6 +72,21 @@ class BlendTracingSubscriber(EventSubscriber):
         EventType.CB_LOOKUP_START: "cb.lookup",
         EventType.CB_RETRIEVE_START: "cb.retrieve",
         EventType.CB_STORE_FINAL_START: "cb.store_final",
+        # V3 lookup sub-spans (nest under cb.lookup, see _SPAN_PARENTS).
+        EventType.CB_FINGERPRINT_MATCH_START: "cb.fingerprint_match",
+        EventType.CB_PREFIX_LOOKUP_START: "cb.prefix_lookup",
+        EventType.CB_SPARSE_PREFETCH_START: "cb.sparse_prefetch",
+        # V3 retrieve sub-span (nests under cb.retrieve).
+        EventType.CB_SCATTER_START: "cb.scatter",
+    }
+
+    # Child span -> parent span name for nesting; absent => nest under the
+    # cb.request root (the default for the top-level lookup/retrieve/store spans).
+    _SPAN_PARENTS: dict[str, str] = {
+        "cb.fingerprint_match": "cb.lookup",
+        "cb.prefix_lookup": "cb.lookup",
+        "cb.sparse_prefetch": "cb.lookup",
+        "cb.scatter": "cb.retrieve",
     }
 
     _END_TO_START: dict[EventType, EventType] = {
@@ -79,6 +94,10 @@ class BlendTracingSubscriber(EventSubscriber):
         EventType.CB_LOOKUP_END: EventType.CB_LOOKUP_START,
         EventType.CB_RETRIEVE_END: EventType.CB_RETRIEVE_START,
         EventType.CB_STORE_FINAL_END: EventType.CB_STORE_FINAL_START,
+        EventType.CB_FINGERPRINT_MATCH_END: EventType.CB_FINGERPRINT_MATCH_START,
+        EventType.CB_PREFIX_LOOKUP_END: EventType.CB_PREFIX_LOOKUP_START,
+        EventType.CB_SPARSE_PREFETCH_END: EventType.CB_SPARSE_PREFETCH_START,
+        EventType.CB_SCATTER_END: EventType.CB_SCATTER_START,
     }
 
     # END events that correspond to a SUBMITTED sentinel (decrement ops counter)
@@ -126,6 +145,16 @@ class BlendTracingSubscriber(EventSubscriber):
             EventType.CB_RETRIEVE_END: self._on_end,
             EventType.CB_STORE_FINAL_START: self._on_start,
             EventType.CB_STORE_FINAL_END: self._on_end,
+            # V3 lookup sub-spans (nested under cb.lookup)
+            EventType.CB_FINGERPRINT_MATCH_START: self._on_start,
+            EventType.CB_FINGERPRINT_MATCH_END: self._on_end,
+            EventType.CB_PREFIX_LOOKUP_START: self._on_start,
+            EventType.CB_PREFIX_LOOKUP_END: self._on_end,
+            EventType.CB_SPARSE_PREFETCH_START: self._on_start,
+            EventType.CB_SPARSE_PREFETCH_END: self._on_end,
+            # V3 retrieve sub-span (nested under cb.retrieve, GPU-timed)
+            EventType.CB_SCATTER_START: self._on_start,
+            EventType.CB_SCATTER_END: self._on_end,
             # Point events
             EventType.CB_FINGERPRINTS_REGISTERED: self._on_point,
             EventType.CB_CHUNKS_EVICTED: self._on_point,
@@ -245,7 +274,12 @@ class BlendTracingSubscriber(EventSubscriber):
         sid = event.session_id
         span_name = self._SPAN_DEFS[event.event_type]
 
-        parent_ctx = self._registry.get_context(sid, "cb.request")
+        # Nest under the mapped parent span (e.g. cb.fingerprint_match under
+        # cb.lookup); top-level spans and any orphan fall back to cb.request.
+        parent_name = self._SPAN_PARENTS.get(span_name, "cb.request")
+        parent_ctx = self._registry.get_context(sid, parent_name)
+        if parent_ctx is None and parent_name != "cb.request":
+            parent_ctx = self._registry.get_context(sid, "cb.request")
         span = _tracer.start_span(
             span_name,
             context=parent_ctx,
@@ -303,9 +337,18 @@ class BlendTracingSubscriber(EventSubscriber):
                 )
                 root_span.set_attribute("hit_tokens", hit_tokens)
                 root_span.set_attribute("requested_tokens", requested_tokens)
+                # hit_rate numerator = prefix + non-prefix reuse (hit_tokens).
                 root_span.set_attribute("hit_rate", hit_rate)
                 root_span.set_attribute(
                     "prefix_hits", int(event.metadata.get("prefix_hits", 0))
+                )
+                root_span.set_attribute(
+                    "prefix_hit_tokens",
+                    int(event.metadata.get("prefix_hit_tokens", 0)),
+                )
+                root_span.set_attribute(
+                    "non_prefix_hit_tokens",
+                    int(event.metadata.get("non_prefix_hit_tokens", 0)),
                 )
 
         if event.event_type in self._GPU_OP_END_EVENTS:

--- a/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
@@ -74,7 +74,6 @@ class BlendTracingSubscriber(EventSubscriber):
         EventType.CB_STORE_FINAL_START: "cb.store_final",
         # V3 lookup sub-spans (nest under cb.lookup, see _SPAN_PARENTS).
         EventType.CB_FINGERPRINT_MATCH_START: "cb.fingerprint_match",
-        EventType.CB_PREFIX_LOOKUP_START: "cb.prefix_lookup",
         EventType.CB_SPARSE_PREFETCH_START: "cb.sparse_prefetch",
         # V3 retrieve sub-span (nests under cb.retrieve).
         EventType.CB_SCATTER_START: "cb.scatter",
@@ -84,7 +83,6 @@ class BlendTracingSubscriber(EventSubscriber):
     # cb.request root (the default for the top-level lookup/retrieve/store spans).
     _SPAN_PARENTS: dict[str, str] = {
         "cb.fingerprint_match": "cb.lookup",
-        "cb.prefix_lookup": "cb.lookup",
         "cb.sparse_prefetch": "cb.lookup",
         "cb.scatter": "cb.retrieve",
     }
@@ -95,7 +93,6 @@ class BlendTracingSubscriber(EventSubscriber):
         EventType.CB_RETRIEVE_END: EventType.CB_RETRIEVE_START,
         EventType.CB_STORE_FINAL_END: EventType.CB_STORE_FINAL_START,
         EventType.CB_FINGERPRINT_MATCH_END: EventType.CB_FINGERPRINT_MATCH_START,
-        EventType.CB_PREFIX_LOOKUP_END: EventType.CB_PREFIX_LOOKUP_START,
         EventType.CB_SPARSE_PREFETCH_END: EventType.CB_SPARSE_PREFETCH_START,
         EventType.CB_SCATTER_END: EventType.CB_SCATTER_START,
     }
@@ -148,8 +145,6 @@ class BlendTracingSubscriber(EventSubscriber):
             # V3 lookup sub-spans (nested under cb.lookup)
             EventType.CB_FINGERPRINT_MATCH_START: self._on_start,
             EventType.CB_FINGERPRINT_MATCH_END: self._on_end,
-            EventType.CB_PREFIX_LOOKUP_START: self._on_start,
-            EventType.CB_PREFIX_LOOKUP_END: self._on_end,
             EventType.CB_SPARSE_PREFETCH_START: self._on_start,
             EventType.CB_SPARSE_PREFETCH_END: self._on_end,
             # V3 retrieve sub-span (nested under cb.retrieve, GPU-timed)

--- a/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
@@ -332,23 +332,24 @@ class BlendTracingSubscriber(EventSubscriber):
                 root_span, _ = root_entry
                 hit_tokens = int(event.metadata.get("hit_tokens", 0))
                 requested_tokens = int(event.metadata.get("requested_tokens", 0))
-                hit_rate = (
-                    hit_tokens / requested_tokens if requested_tokens > 0 else 0.0
+                prefix_hit_tokens = int(event.metadata.get("prefix_hit_tokens", 0))
+                non_prefix_hit_tokens = int(
+                    event.metadata.get("non_prefix_hit_tokens", 0)
                 )
+                denom = requested_tokens or 1  # avoid /0; rates are 0 when requested=0
                 root_span.set_attribute("hit_tokens", hit_tokens)
                 root_span.set_attribute("requested_tokens", requested_tokens)
                 # hit_rate numerator = prefix + non-prefix reuse (hit_tokens).
-                root_span.set_attribute("hit_rate", hit_rate)
+                root_span.set_attribute("hit_rate", hit_tokens / denom)
                 root_span.set_attribute(
                     "prefix_hits", int(event.metadata.get("prefix_hits", 0))
                 )
+                root_span.set_attribute("prefix_hit_tokens", prefix_hit_tokens)
+                root_span.set_attribute("non_prefix_hit_tokens", non_prefix_hit_tokens)
+                # Per-component hit rates (sum to hit_rate).
+                root_span.set_attribute("prefix_hit_rate", prefix_hit_tokens / denom)
                 root_span.set_attribute(
-                    "prefix_hit_tokens",
-                    int(event.metadata.get("prefix_hit_tokens", 0)),
-                )
-                root_span.set_attribute(
-                    "non_prefix_hit_tokens",
-                    int(event.metadata.get("non_prefix_hit_tokens", 0)),
+                    "non_prefix_hit_rate", non_prefix_hit_tokens / denom
                 )
 
         if event.event_type in self._GPU_OP_END_EVENTS:

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -255,7 +255,14 @@ class BlendTokenRangeMatcherV3:
             return results
 
     def remove_chunks(self, token_hashes: list[bytes]) -> None:
-        """Evict stale entries; clears poly_hash so re-probes can't match."""
+        """Evict the given chunks from the matcher.
+
+        Clears each chunk's table slot + poly hash so later probes cannot match
+        it. Thread-safe.
+
+        Args:
+            token_hashes (list[bytes]): Content hashes of the chunks to evict.
+        """
         with self._lock:
             for th in token_hashes:
                 cid = self._token_hash_to_compact_id.get(th)
@@ -409,8 +416,22 @@ class BlendV3Module:
         head_size: int,
         is_neox_style: bool,
     ) -> None:
-        """Bolt rope state onto an already-registered cache_contexts entry;
-        idempotent. REGISTER_KV_CACHE must precede this."""
+        """Bolt CB re-RoPE state onto an already-registered KV-cache instance.
+
+        Idempotent; ``REGISTER_KV_CACHE`` must precede this. Strips any
+        YaRN/longrope mscale baked into the rope cache so re-RoPE stays a pure
+        rotation.
+
+        Args:
+            instance_id (int): KV-cache instance to attach rope state to.
+            cos_sin_cache_ipc (CudaIPCWrapper): IPC handle to vLLM's cos/sin
+                rope cache.
+            head_size (int): Rotary head dimension.
+            is_neox_style (bool): True for NeoX (contiguous halves), else GPT-J.
+
+        Raises:
+            ValueError: If ``instance_id`` has no registered KV cache.
+        """
         cache_contexts = self._gpu_transfer.cache_contexts
         if instance_id not in cache_contexts:
             raise ValueError(
@@ -463,7 +484,12 @@ class BlendV3Module:
         )
 
     def cb_unregister_rope(self, instance_id: int) -> None:
-        """Drop rope state. Paged KV cache stays (use UNREGISTER_KV_CACHE)."""
+        """Drop the instance's CB rope state; the paged KV cache is left intact.
+
+        Args:
+            instance_id (int): Instance whose rope state to remove (use
+                ``UNREGISTER_KV_CACHE`` to free the KV cache itself).
+        """
         self._cb_rope_state.pop(instance_id, None)
         self._cb_gpu_contexts.pop(instance_id, None)
         self._cb_gpu_context_meta.pop(instance_id, None)
@@ -498,9 +524,18 @@ class BlendV3Module:
                 logger.exception("CB fingerprint registration failed (sync drain)")
 
     def _match_fingerprints(self, key: IPCCacheEngineKey) -> list[CBMatchResult]:
-        """Drain pending registrations, fingerprint-match sub-sequences, then
-        leftmost-greedy dedup over overlapping ranges. Returns matches sorted
-        by cur_st (empty if none)."""
+        """Match the query's reusable chunks, leftmost-greedy deduped.
+
+        Drains pending fingerprint registrations, probes the matcher, then keeps
+        a non-overlapping leftmost-greedy subset.
+
+        Args:
+            key (IPCCacheEngineKey): The query request key.
+
+        Returns:
+            list[CBMatchResult]: Non-overlapping matches sorted by cur_st
+            (empty if none).
+        """
         self._drain_fingerprints_sync()
         matches = self._token_range_matcher.match_sub_sequence(list(key.token_ids))
         if not matches:
@@ -517,7 +552,16 @@ class BlendV3Module:
     def _resolve_cb_layout_desc(
         self, model_name: str, world_size: int
     ) -> "MemoryLayoutDesc | None":
-        """Find the CB KV buffer layout for (model, world_size), or None."""
+        """Find the CB KV buffer layout for ``(model_name, world_size)``.
+
+        Args:
+            model_name (str): Model name to match.
+            world_size (int): Tensor-parallel world size to match.
+
+        Returns:
+            MemoryLayoutDesc | None: The matching layout, or None if no
+            registered CB GPU context matches.
+        """
         for gpu_id, (m_name, w_size) in self._cb_gpu_context_meta.items():
             if m_name == model_name and w_size == world_size:
                 cb_ctx = self._cb_gpu_contexts[gpu_id]
@@ -533,9 +577,24 @@ class BlendV3Module:
         layout_desc: "MemoryLayoutDesc",
         matches: list[CBMatchResult],
     ) -> "tuple[PrefetchHandle, dict[bytes, list], list[int]]":
-        """Coalesce all matches into one sparse prefetch and submit it
-        (non-blocking). The caller polls query_prefetch_status(handle) then
-        calls :meth:`_sparse_classify` with the found set."""
+        """Coalesce all matches into one sparse L2->L1 prefetch and submit it.
+
+        Non-blocking. Dedups object keys before submit (sparse keeps one read
+        lock per loaded key, so a duplicate would leak). The caller polls
+        ``query_prefetch_status(handle)`` then calls :meth:`_sparse_classify`
+        with the found set.
+
+        Args:
+            key (IPCCacheEngineKey): The request key.
+            layout_desc (MemoryLayoutDesc): CB KV buffer layout for L1 alloc.
+            matches (list[CBMatchResult]): Non-prefix matches to prefetch.
+
+        Returns:
+            tuple[PrefetchHandle, dict[bytes, list], list[int]]: the prefetch
+            handle, per-hash TP-expanded object keys, and each expanded
+            position's deduped-key index (maps the per-key found set back to
+            every chunk).
+        """
         world_size = key.world_size
         per_hash_obj_keys: dict[bytes, list] = {}
         all_hashes = [r.hash for r in matches]
@@ -573,9 +632,22 @@ class BlendV3Module:
         per_hash_obj_keys: dict[bytes, list],
         expanded_uidx: list[int],
     ) -> list[CBMatchResult]:
-        """Classify each chunk found/stale by whether every TP rank's key
-        loaded, run stale-strike bookkeeping, and stash the obj_keys cache for
-        retrieve. Returns the found subset (cur_st order)."""
+        """Classify each prefetched chunk as found or stale, and finalize state.
+
+        A chunk is found only if every TP rank's key loaded; stale chunks take
+        an eviction strike (evicted at threshold, kept while still in-flight).
+        Stashes the found chunks' obj_keys for the retrieve path.
+
+        Args:
+            key (IPCCacheEngineKey): The request key.
+            matches (list[CBMatchResult]): The submitted non-prefix matches.
+            found_uidx (set[int]): Deduped-key indices that loaded.
+            per_hash_obj_keys (dict[bytes, list]): Per-hash TP-expanded keys.
+            expanded_uidx (list[int]): Each expanded position's deduped index.
+
+        Returns:
+            list[CBMatchResult]: The found subset, in cur_st order.
+        """
         world_size = key.world_size
         found_cb_match_result: list[CBMatchResult] = []
         stale_hashes: list[bytes] = []
@@ -631,10 +703,20 @@ class BlendV3Module:
         """Non-blocking single-RPC CB lookup (submit-once, poll-on-recall).
 
         First call submits the prefix lookup + fingerprint match; later calls
-        poll both legs, returning None until the prefix and the sparse
-        complement are both resident in L1 (so a worker thread never blocks on
-        the L2->L1 loads). The prefix job's L1 read locks persist for the
-        retrieve.
+        poll both legs, returning ``None`` until the prefix and the sparse
+        non-prefix complement are both resident in L1 (so a worker thread never
+        blocks on the L2->L1 loads). The prefix job's L1 read locks persist for
+        the retrieve.
+
+        Args:
+            key (IPCCacheEngineKey): Request key (token IDs, request_id, model,
+                world_size).
+            tp_size (int): Tensor-parallel size for the prefix lookup.
+
+        Returns:
+            CBUnifiedLookupResult | None: ``None`` while either leg is still
+            loading (the caller re-issues to poll); on completion, the prefix
+            coverage in tokens plus the found non-prefix segments.
         """
         rid = key.request_id
         chunk_size = self._ctx.chunk_size
@@ -653,11 +735,24 @@ class BlendV3Module:
                     metadata={"num_tokens": len(key.token_ids)},
                 )
             )
-            self._lookup_module.lookup(key, tp_size)  # submit prefix (non-blocking)
-            job = _CBUnifiedJob(
-                matches=self._match_fingerprints(key),
-                num_tokens=len(key.token_ids),
+            # Prefix leg: submit (non-blocking); span ends when it lands below.
+            self._event_bus.publish(
+                Event(event_type=EventType.CB_PREFIX_LOOKUP_START, session_id=rid)
             )
+            self._lookup_module.lookup(key, tp_size)
+            # Fingerprint match: CPU-bound, tight span.
+            self._event_bus.publish(
+                Event(event_type=EventType.CB_FINGERPRINT_MATCH_START, session_id=rid)
+            )
+            matches = self._match_fingerprints(key)
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.CB_FINGERPRINT_MATCH_END,
+                    session_id=rid,
+                    metadata={"matches": len(matches)},
+                )
+            )
+            job = _CBUnifiedJob(matches=matches, num_tokens=len(key.token_ids))
             with self._cb_jobs_lock:
                 self._cb_jobs[rid] = job
 
@@ -667,6 +762,13 @@ class BlendV3Module:
             if p is None:
                 return None  # prefix still loading -> defer
             job.prefix_chunks = p
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.CB_PREFIX_LOOKUP_END,
+                    session_id=rid,
+                    metadata={"prefix_chunks": p},
+                )
+            )
 
         # Prefix done: reconcile the complement outside the prefix coverage and
         # submit one sparse prefetch for it (once). Prefix-covered chunks never
@@ -686,6 +788,17 @@ class BlendV3Module:
                         job.per_hash_obj_keys,
                         job.expanded_uidx,
                     ) = self._sparse_prefetch_submit(key, layout_desc, job.non_prefix)
+                    self._event_bus.publish(
+                        Event(
+                            event_type=EventType.CB_SPARSE_PREFETCH_START,
+                            session_id=rid,
+                            metadata={
+                                "n_chunks": len(job.non_prefix),
+                                "world_size": key.world_size,
+                                "n_keys": len(job.non_prefix) * key.world_size,
+                            },
+                        )
+                    )
                 else:
                     logger.error(
                         "No CB GPU context for model %s ws %d during cb_unified_lookup",
@@ -701,6 +814,13 @@ class BlendV3Module:
             if bm is None:
                 return None  # sparse still loading -> defer
             job.found_uidx = set(bm.get_indices_list())
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.CB_SPARSE_PREFETCH_END,
+                    session_id=rid,
+                    metadata={"found_keys": len(job.found_uidx)},
+                )
+            )
 
         # --- BOTH legs ready: classify the complement + finalize. ---
         if job.handle is not None:
@@ -716,6 +836,10 @@ class BlendV3Module:
 
         prefix_tokens = job.prefix_chunks * chunk_size
         num_tokens = job.num_tokens
+        # V3 hit rate = (prefix + non-prefix) reuse. The two ranges are disjoint
+        # (non_prefix has cur_st >= prefix_tokens), so they sum without double-
+        # counting. hit_tokens carries the sum (the hit_rate numerator).
+        non_prefix_hit_tokens = _unique_token_coverage(found)
         self._event_bus.publish(
             Event(
                 event_type=EventType.CB_LOOKUP_END,
@@ -727,7 +851,9 @@ class BlendV3Module:
                     "storage_hits": len(found),
                     "stale_chunks": len(job.non_prefix or []) - len(found),
                     "no_gpu_context": False,
-                    "hit_tokens": _unique_token_coverage(found),
+                    "prefix_hit_tokens": prefix_tokens,
+                    "non_prefix_hit_tokens": non_prefix_hit_tokens,
+                    "hit_tokens": prefix_tokens + non_prefix_hit_tokens,
                     "requested_tokens": (num_tokens // chunk_size) * chunk_size,
                 },
             )
@@ -746,8 +872,24 @@ class BlendV3Module:
         gpu_block_ids: list[list[int]],
         event_ipc_handle: bytes,
     ) -> tuple[bytes, bool]:
-        """Paged store + matcher fingerprint registration (skips pos-0
-        chunks; fingerprint failures logged, never raised)."""
+        """Paged store, then register the stored chunks as match fingerprints.
+
+        Delegates the KV write to ``GPUTransfer.store``, then (worker 0 only)
+        enqueues the chunk hashes for async fingerprint registration ordered
+        after the L1 commit. Chunk 0 of a position-0 store is skipped (owned by
+        the standard prefix path). Fingerprint failures are logged, never
+        raised — they do not affect store correctness.
+
+        Args:
+            key (IPCCacheEngineKey): Store key (token IDs + ``[start, end)``).
+            instance_id (int): Target KV-cache instance.
+            gpu_block_ids (list[list[int]]): Per-layer-group paged block IDs.
+            event_ipc_handle (bytes): IPC handle to the producer's CUDA event.
+
+        Returns:
+            tuple[bytes, bool]: The underlying ``GPUTransfer.store`` result
+            (event handle, success).
+        """
         result = self._gpu_transfer.store(
             key, instance_id, gpu_block_ids, event_ipc_handle
         )
@@ -819,8 +961,20 @@ class BlendV3Module:
         batch_len: int,
         slots_to_rope: list[tuple[int, int, int]],
     ) -> None:
-        """Re-RoPE tmp-pool slots in-place (K-only, per group); list of
-        (slot_idx, old_st, cur_st)."""
+        """Re-RoPE the given tmp-pool slots in place (K-only, per kernel group).
+
+        Args:
+            gpu_context (GPUCacheContext): The instance's GPU cache context.
+            rope_state (_CBRopeState): Cached cos/sin + head layout.
+            batch_len (int): Number of tmp slots staged for this batch.
+            slots_to_rope (list[tuple[int, int, int]]): ``(slot_idx, old_st,
+                cur_st)`` per shifted slot — re-RoPE K from stored position
+                ``old_st`` to new position ``cur_st``.
+
+        Raises:
+            RuntimeError: On a compressed (compress_ratio != 1) or MLA
+                (kv_size != 2) layout, or a head_size/hidden_dim mismatch.
+        """
         if not slots_to_rope:
             return
         num_groups = gpu_context.kv_layer_groups_manager.num_kernel_groups
@@ -873,9 +1027,31 @@ class BlendV3Module:
         instance_id: int,
         event_ipc_handle: bytes,
     ) -> tuple[bytes, bool]:
-        """Scatter EVERY matched chunk into paged KV (prefix-hit + shifted);
-        K-only re-RoPE on the shifted subset. Drops misaligned matches;
-        MLA layouts unsupported."""
+        """Scatter every matched token range into the request's paged KV.
+
+        Reuses the lookup's prefetched chunks: fills tmp slots, K-only re-RoPEs
+        the shifted (non-prefix) subset, then writes per-token via the slot
+        kernel — so non-block-aligned matches and partial vLLM blocks shared
+        with recomputed tokens are written correctly (no block-alignment trim).
+        Only matches past the currently allocated slots are dropped (vLLM may
+        call this twice: partial- then full-block alloc).
+
+        Args:
+            key (IPCCacheEngineKey): The request key.
+            cb_match_result (list[CBMatchResult]): Matched ranges to scatter
+                (prefix-hit and shifted), any order.
+            gpu_block_ids (list[int]): This request's full paged block table.
+            instance_id (int): Target KV-cache instance.
+            event_ipc_handle (bytes): IPC handle to the forward's CUDA event.
+
+        Returns:
+            tuple[bytes, bool]: The scatter-complete event handle and whether
+            the scatter ran (False if the prefetched objects were unavailable).
+
+        Raises:
+            ValueError: If the instance has no registered KV cache or rope
+                state. MLA layouts are unsupported (raised during re-RoPE).
+        """
         cache_contexts = self._gpu_transfer.cache_contexts
         if instance_id not in cache_contexts:
             raise ValueError(
@@ -1010,6 +1186,29 @@ class BlendV3Module:
                             continue
                         pairs.append((r, memory_obj))
 
+                    # cb.scatter span (GPU): the L1->paged write of every
+                    # applied match. Re-RoPE is folded in (n_shifted) — it is
+                    # interleaved per-batch, so not a separate span.
+                    self._event_bus.publish_on_stream(
+                        gpu_context.cupy_stream,
+                        Event(
+                            event_type=EventType.CB_SCATTER_START,
+                            session_id=key.request_id,
+                            metadata={
+                                "scattered_tokens": sum(
+                                    r.cur_ed - r.cur_st for r, _ in pairs
+                                ),
+                                "n_prefix": sum(
+                                    1 for r, _ in pairs if r.old_st == r.cur_st
+                                ),
+                                "n_shifted": sum(
+                                    1 for r, _ in pairs if r.old_st != r.cur_st
+                                ),
+                                "dropped": len(cb_match_result) - len(pairs),
+                            },
+                        ),
+                    )
+
                     # Consecutive matches → one batched scatter per group.
                     runs: list[list[tuple[CBMatchResult, Any]]] = []
                     for r_obj in pairs:
@@ -1080,6 +1279,14 @@ class BlendV3Module:
                                     block_size=bs,
                                     head_size=rope_state.head_size,
                                 )
+
+                    self._event_bus.publish_on_stream(
+                        gpu_context.cupy_stream,
+                        Event(
+                            event_type=EventType.CB_SCATTER_END,
+                            session_id=key.request_id,
+                        ),
+                    )
             except Exception:
                 logger.exception("Error during retrieving prefetched results")
                 self._event_bus.publish_on_stream(

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -736,10 +736,9 @@ class BlendV3Module:
                     metadata={"num_tokens": len(key.token_ids)},
                 )
             )
-            # Prefix leg: submit (non-blocking); span ends when it lands below.
-            self._event_bus.publish(
-                Event(event_type=EventType.CB_PREFIX_LOOKUP_START, session_id=rid)
-            )
+            # Prefix leg: submit (non-blocking). Already traced upstream by
+            # mp.lookup_prefetch (LookupModule self-instruments); prefix_chunks
+            # lands on cb.lookup via CB_LOOKUP_END below.
             self._lookup_module.lookup(key, tp_size)
             # Fingerprint match: CPU-bound, tight span.
             self._event_bus.publish(
@@ -763,13 +762,6 @@ class BlendV3Module:
             if p is None:
                 return None  # prefix still loading -> defer
             job.prefix_chunks = p
-            self._event_bus.publish(
-                Event(
-                    event_type=EventType.CB_PREFIX_LOOKUP_END,
-                    session_id=rid,
-                    metadata={"prefix_chunks": p},
-                )
-            )
 
         # Prefix done: reconcile the complement outside the prefix coverage and
         # submit one sparse prefetch for it (once). Prefix-covered chunks never
@@ -858,6 +850,7 @@ class BlendV3Module:
                     "num_tokens": num_tokens,
                     "fingerprint_hits": len(found),
                     "prefix_hits": job.prefix_chunks,
+                    "prefix_chunks": job.prefix_chunks,
                     "storage_hits": len(found),
                     "stale_chunks": len(job.non_prefix or []) - len(found),
                     "no_gpu_context": False,

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -79,6 +79,7 @@ class _CBUnifiedJob:
     per_hash_obj_keys: dict | None = None
     expanded_uidx: list[int] | None = None
     found_uidx: set[int] | None = None  # stashed when the sparse poll completes
+    l2_keys: int = 0  # sparse keys needing an L2 load (0 => no L2 read, span skipped)
 
 
 class BlendTokenRangeMatcherV3:
@@ -788,17 +789,22 @@ class BlendV3Module:
                         job.per_hash_obj_keys,
                         job.expanded_uidx,
                     ) = self._sparse_prefetch_submit(key, layout_desc, job.non_prefix)
-                    self._event_bus.publish(
-                        Event(
-                            event_type=EventType.CB_SPARSE_PREFETCH_START,
-                            session_id=rid,
-                            metadata={
-                                "n_chunks": len(job.non_prefix),
-                                "world_size": key.world_size,
-                                "n_keys": len(job.non_prefix) * key.world_size,
-                            },
+                    # Only trace the span when the prefetch actually reads L2;
+                    # all-L1-resident matches do no L2 work worth a span.
+                    job.l2_keys = len(job.handle.l2_orig_indices)
+                    if job.l2_keys > 0:
+                        self._event_bus.publish(
+                            Event(
+                                event_type=EventType.CB_SPARSE_PREFETCH_START,
+                                session_id=rid,
+                                metadata={
+                                    "n_chunks": len(job.non_prefix),
+                                    "world_size": key.world_size,
+                                    "n_keys": len(job.non_prefix) * key.world_size,
+                                    "l2_keys": job.l2_keys,
+                                },
+                            )
                         )
-                    )
                 else:
                     logger.error(
                         "No CB GPU context for model %s ws %d during cb_unified_lookup",
@@ -814,13 +820,17 @@ class BlendV3Module:
             if bm is None:
                 return None  # sparse still loading -> defer
             job.found_uidx = set(bm.get_indices_list())
-            self._event_bus.publish(
-                Event(
-                    event_type=EventType.CB_SPARSE_PREFETCH_END,
-                    session_id=rid,
-                    metadata={"found_keys": len(job.found_uidx)},
+            if job.l2_keys > 0:
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.CB_SPARSE_PREFETCH_END,
+                        session_id=rid,
+                        metadata={
+                            "found_keys": len(job.found_uidx),
+                            "l2_keys": job.l2_keys,
+                        },
+                    )
                 )
-            )
 
         # --- BOTH legs ready: classify the complement + finalize. ---
         if job.handle is not None:

--- a/tests/v1/mp_observability/subscribers/tracing/test_cb_server.py
+++ b/tests/v1/mp_observability/subscribers/tracing/test_cb_server.py
@@ -867,3 +867,171 @@ class TestCBHitRateAttributes:
         root = self._root_span(exporter, sid)
         assert root is not None
         assert root.attributes["prefix_hits"] == 0
+
+    def test_hit_rate_includes_prefix_and_non_prefix(self, exporter):
+        """V3 hit_rate numerator = prefix_hit_tokens + non_prefix_hit_tokens;
+        both are also recorded as separate attributes on the root span."""
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        bus.register_subscriber(BlendTracingSubscriber(SpanRegistry()))
+        bus.start()
+        now = time.time()
+        sid = "cb-hr-split"
+        bus.publish(
+            Event(event_type=EventType.CB_REQUEST_START, session_id=sid, timestamp=now)
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_START,
+                session_id=sid,
+                timestamp=now + 0.001,
+                metadata={"num_tokens": 1024},
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_LOOKUP_END,
+                session_id=sid,
+                timestamp=now + 0.010,
+                metadata={
+                    "prefix_hit_tokens": 256,
+                    "non_prefix_hit_tokens": 256,
+                    "hit_tokens": 512,  # = prefix + non_prefix (set by blend_v3)
+                    "requested_tokens": 1024,
+                },
+            )
+        )
+        bus.publish(
+            Event(
+                event_type=EventType.CB_REQUEST_END,
+                session_id=sid,
+                timestamp=now + 0.011,
+            )
+        )
+        time.sleep(0.2)
+        bus.stop()
+
+        root = self._root_span(exporter, sid)
+        assert root is not None
+        assert root.attributes["prefix_hit_tokens"] == 256
+        assert root.attributes["non_prefix_hit_tokens"] == 256
+        assert root.attributes["hit_tokens"] == 512
+        assert root.attributes["hit_rate"] == 0.5
+
+
+class TestCBLookupSubspans:
+    """V3 lookup sub-spans (cb.fingerprint_match / cb.prefix_lookup /
+    cb.sparse_prefetch) nest under cb.lookup, not the cb.request root."""
+
+    @pytest.fixture
+    def exporter(self):
+        exp = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exp))
+        real_tracer = provider.get_tracer("lmcache_mp.blend")
+        with (
+            patch.object(cb_server_module, "_tracer", real_tracer),
+            patch.object(cb_server_module, "_HAS_OTEL", True),
+        ):
+            yield exp
+        exp.shutdown()
+
+    def _spans_by_name(self, exporter: InMemorySpanExporter, sid: str):
+        return {
+            s.name: s
+            for s in exporter.get_finished_spans()
+            if s.attributes.get("session_id") == sid
+        }
+
+    def test_lookup_subspans_nest_under_cb_lookup(self, exporter):
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        bus.register_subscriber(BlendTracingSubscriber(SpanRegistry()))
+        bus.start()
+        now = time.time()
+        sid = "cb-subspans"
+        seq = [
+            (EventType.CB_REQUEST_START, {}),
+            (EventType.CB_LOOKUP_START, {"num_tokens": 1024}),
+            (EventType.CB_PREFIX_LOOKUP_START, {}),
+            (EventType.CB_FINGERPRINT_MATCH_START, {}),
+            (EventType.CB_FINGERPRINT_MATCH_END, {"matches": 7}),
+            (EventType.CB_PREFIX_LOOKUP_END, {"prefix_chunks": 2}),
+            (EventType.CB_SPARSE_PREFETCH_START, {"n_chunks": 5}),
+            (EventType.CB_SPARSE_PREFETCH_END, {"found_keys": 5}),
+            (EventType.CB_LOOKUP_END, {"num_tokens": 1024}),
+            (EventType.CB_REQUEST_END, {}),
+        ]
+        for i, (et, md) in enumerate(seq):
+            bus.publish(
+                Event(
+                    event_type=et,
+                    session_id=sid,
+                    timestamp=now + i * 0.001,
+                    metadata=md,
+                )
+            )
+        time.sleep(0.3)
+        bus.stop()
+
+        spans = self._spans_by_name(exporter, sid)
+        for name in (
+            "cb.lookup",
+            "cb.fingerprint_match",
+            "cb.prefix_lookup",
+            "cb.sparse_prefetch",
+        ):
+            assert name in spans, f"missing span {name}; have {sorted(spans)}"
+        lookup_id = spans["cb.lookup"].context.span_id
+        for name in ("cb.fingerprint_match", "cb.prefix_lookup", "cb.sparse_prefetch"):
+            assert spans[name].parent is not None, f"{name} has no parent span"
+            assert spans[name].parent.span_id == lookup_id, (
+                f"{name} should nest under cb.lookup"
+            )
+        # cb.lookup itself nests under the cb.request root (unchanged behavior).
+        assert spans["cb.lookup"].parent.span_id == spans["cb.request"].context.span_id
+        # sub-span metadata propagates as attributes.
+        assert spans["cb.fingerprint_match"].attributes.get("matches") == "7"
+        assert spans["cb.sparse_prefetch"].attributes.get("found_keys") == "5"
+
+    def test_scatter_span_nests_under_cb_retrieve(self, exporter):
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        bus.register_subscriber(BlendTracingSubscriber(SpanRegistry()))
+        bus.start()
+        now = time.time()
+        sid = "cb-scatter"
+        seq = [
+            (EventType.CB_REQUEST_START, {}),
+            (EventType.CB_RETRIEVE_START, {"num_chunks": 5}),
+            (
+                EventType.CB_SCATTER_START,
+                {
+                    "scattered_tokens": 1280,
+                    "n_prefix": 1,
+                    "n_shifted": 4,
+                    "dropped": 0,
+                },
+            ),
+            (EventType.CB_SCATTER_END, {}),
+            (EventType.CB_RETRIEVE_END, {}),
+            (EventType.CB_REQUEST_END, {}),
+        ]
+        for i, (et, md) in enumerate(seq):
+            bus.publish(
+                Event(
+                    event_type=et,
+                    session_id=sid,
+                    timestamp=now + i * 0.001,
+                    metadata=md,
+                )
+            )
+        time.sleep(0.3)
+        bus.stop()
+
+        spans = self._spans_by_name(exporter, sid)
+        assert "cb.scatter" in spans, f"missing cb.scatter; have {sorted(spans)}"
+        assert "cb.retrieve" in spans
+        assert (
+            spans["cb.scatter"].parent.span_id == spans["cb.retrieve"].context.span_id
+        ), "cb.scatter should nest under cb.retrieve"
+        assert spans["cb.scatter"].attributes.get("scattered_tokens") == "1280"
+        assert spans["cb.scatter"].attributes.get("n_shifted") == "4"
+        assert spans["cb.scatter"].attributes.get("dropped") == "0"

--- a/tests/v1/mp_observability/subscribers/tracing/test_cb_server.py
+++ b/tests/v1/mp_observability/subscribers/tracing/test_cb_server.py
@@ -919,8 +919,9 @@ class TestCBHitRateAttributes:
 
 
 class TestCBLookupSubspans:
-    """V3 lookup sub-spans (cb.fingerprint_match / cb.prefix_lookup /
-    cb.sparse_prefetch) nest under cb.lookup, not the cb.request root."""
+    """V3 lookup sub-spans (cb.fingerprint_match / cb.sparse_prefetch) nest under
+    cb.lookup, not the cb.request root. The prefix lookup has no cb.* span (it is
+    traced by mp.lookup_prefetch); prefix_chunks rides on cb.lookup."""
 
     @pytest.fixture
     def exporter(self):
@@ -951,13 +952,11 @@ class TestCBLookupSubspans:
         seq = [
             (EventType.CB_REQUEST_START, {}),
             (EventType.CB_LOOKUP_START, {"num_tokens": 1024}),
-            (EventType.CB_PREFIX_LOOKUP_START, {}),
             (EventType.CB_FINGERPRINT_MATCH_START, {}),
             (EventType.CB_FINGERPRINT_MATCH_END, {"matches": 7}),
-            (EventType.CB_PREFIX_LOOKUP_END, {"prefix_chunks": 2}),
             (EventType.CB_SPARSE_PREFETCH_START, {"n_chunks": 5}),
             (EventType.CB_SPARSE_PREFETCH_END, {"found_keys": 5}),
-            (EventType.CB_LOOKUP_END, {"num_tokens": 1024}),
+            (EventType.CB_LOOKUP_END, {"num_tokens": 1024, "prefix_chunks": 2}),
             (EventType.CB_REQUEST_END, {}),
         ]
         for i, (et, md) in enumerate(seq):
@@ -976,12 +975,13 @@ class TestCBLookupSubspans:
         for name in (
             "cb.lookup",
             "cb.fingerprint_match",
-            "cb.prefix_lookup",
             "cb.sparse_prefetch",
         ):
             assert name in spans, f"missing span {name}; have {sorted(spans)}"
+        # No cb.prefix_lookup span (traced by mp.lookup_prefetch instead).
+        assert "cb.prefix_lookup" not in spans
         lookup_id = spans["cb.lookup"].context.span_id
-        for name in ("cb.fingerprint_match", "cb.prefix_lookup", "cb.sparse_prefetch"):
+        for name in ("cb.fingerprint_match", "cb.sparse_prefetch"):
             assert spans[name].parent is not None, f"{name} has no parent span"
             assert spans[name].parent.span_id == lookup_id, (
                 f"{name} should nest under cb.lookup"
@@ -990,6 +990,8 @@ class TestCBLookupSubspans:
         assert spans["cb.lookup"].parent.span_id == spans["cb.request"].context.span_id
         # sub-span metadata propagates as attributes.
         assert spans["cb.fingerprint_match"].attributes.get("matches") == "7"
+        # prefix coverage rides on cb.lookup (no dedicated prefix span).
+        assert spans["cb.lookup"].attributes.get("prefix_chunks") == "2"
         assert spans["cb.sparse_prefetch"].attributes.get("found_keys") == "5"
 
     def test_scatter_span_nests_under_cb_retrieve(self, exporter):


### PR DESCRIPTION
  Description:
  ## What
  Finer-grained OpenTelemetry tracing for CacheBlend V3 requests on the LMCache
  blend server, plus a corrected V3 hit-rate. Implements the design added in this
  PR (`docs/design/v1/mp_observability/blend_v3_observability.md`).

  ## Spans
  Nested under the existing `cb.request` → `cb.lookup` / `cb.retrieve`:
  - **Lookup:** `cb.fingerprint_match`, `cb.prefix_lookup` (submit→resident —
    captures the non-blocking poll-wait), `cb.sparse_prefetch`
    (`n_chunks`/`n_keys`/`world_size`).
  - **Retrieve:** `cb.scatter` (GPU, via `publish_on_stream`;
    `scattered_tokens`/`n_prefix`/`n_shifted`/`dropped`).

  ## Hit rate
  `hit_rate = (prefix_hit_tokens + non_prefix_hit_tokens) / requested_tokens`.
  Previously the numerator counted **only** the non-prefix (re-RoPE'd) reuse and
  silently dropped the prefix; both components are now recorded on `cb.request`.

  ## Notes
  - `BlendTracingSubscriber` gains sub-span→parent nesting (`_SPAN_PARENTS`);
    existing top-level spans are unchanged (default parent `cb.request`), and the
    V2 / `blend_legacy` deferral path is untouched.
  - Re-RoPE is folded into `cb.scatter` as `n_shifted` — it's interleaved
    per-batch, so not a separate span.
  - `cb.l2_load` GB/s is already covered by `L2ThroughputSubscriber`; nesting it
    under `cb.sparse_prefetch` is a cross-subsystem follow-up.

  ## Testing
  `tests/v1/mp_observability/subscribers/tracing/test_cb_server.py` — 25 passing,
  incl. new lookup-nesting, scatter-nesting, and prefix+non-prefix hit-rate tests.
  Pre-commit (ruff / ruff-format / isort / mypy / codespell) clean.

  
<img width="933" height="340" alt="Screenshot 2026-06-09 at 2 28 20 PM" src="https://github.com/user-attachments/assets/df1c32d4-33e0-448c-820a-f9961495a801" />
<img width="1877" height="578" alt="Screenshot 2026-06-09 at 1 20 28 PM" src="https://github.com/user-attachments/assets/24927fb9-b052-4d6c-9b73-a779ccc6fb7f" />

