### PR TITLE
[Core][MP] Introduce object_group_id into the ObjectKey

### DIFF
--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -55,6 +55,9 @@ class ObjectKey:
     kv_rank: int
     """ The rank that uniquely identifies the slice of the KV cache """
 
+    object_group_id: int = 0
+    """ Index of the object group this chunk belongs to. """
+
     cache_salt: str = ""
     """ Per-user isolation salt. Same content from different users with
     different cache_salt values produces different ObjectKeys, giving
@@ -78,6 +81,10 @@ class ObjectKey:
         if "@" in self.model_name:
             raise ValueError(
                 f"model_name must not contain '@' (got {self.model_name!r})"
+            )
+        if self.object_group_id < 0:
+            raise ValueError(
+                f"object_group_id must be >= 0 (got {self.object_group_id})"
             )
         bad = self._SALT_FORBIDDEN_CHARS & set(self.cache_salt)
         if bad:
@@ -202,6 +209,7 @@ class PrefetchHandle:
 def ipc_key_to_object_keys(
     ipc_key: IPCCacheEngineKey,
     chunk_hashes: list[bytes],
+    object_group_id: int = 0,
 ) -> list[ObjectKey]:
     """
     Convert a single IPCCacheEngineKey and its chunk hashes to a list of ObjectKey.
@@ -219,6 +227,8 @@ def ipc_key_to_object_keys(
         ipc_key: The IPC key providing model_name, world_size, worker_id,
             and cache_salt.
         chunk_hashes: List of chunk hash bytes, one per chunk.
+        object_group_id: Index of the object group the chunks belong to.
+            Defaults to 0, the single-group case.
 
     Returns:
         list[ObjectKey]: The converted list of ObjectKey.
@@ -243,6 +253,7 @@ def ipc_key_to_object_keys(
                         chunk_hash=chunk_hash,
                         model_name=ipc_key.model_name,
                         kv_rank=kv_rank,
+                        object_group_id=object_group_id,
                         cache_salt=cache_salt,
                     )
                 )
@@ -259,6 +270,7 @@ def ipc_key_to_object_keys(
                     chunk_hash=chunk_hash,
                     model_name=ipc_key.model_name,
                     kv_rank=kv_rank,
+                    object_group_id=object_group_id,
                     cache_salt=cache_salt,
                 )
             )

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -100,22 +100,21 @@ def _object_key_to_filename(key: ObjectKey) -> str:
 
     Unsalted::
 
-        <safe_model>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+        <safe_model>@0x<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>.data
 
     Salted (trailing ``cache_salt``)::
 
-        <safe_model>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
-
-    The 3-field unsalted shape is bit-identical to the pre-cache_salt
-    format, so existing un-salted cache directories remain valid and
-    no migration is needed.
+        <safe_model>@0x<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>@<cache_salt>.data
 
     ``kv_rank`` is written in ``0x`` prefixed hex so each byte
     of the bitmap ``(ws<<24)|(rank<<16)|(local_ws<<8)|local``
-    is directly readable.
+    is directly readable. ``object_group_id`` is written in plain hex.
     """
     safe_model = key.model_name.replace("/", _PATH_SLASH_REPLACEMENT)
-    base = f"{safe_model}{_KEY_SEP}{key.kv_rank:#010x}{_KEY_SEP}{key.chunk_hash.hex()}"
+    base = (
+        f"{safe_model}{_KEY_SEP}{key.kv_rank:#010x}"
+        f"{_KEY_SEP}{key.object_group_id:x}{_KEY_SEP}{key.chunk_hash.hex()}"
+    )
     if key.cache_salt:
         return f"{base}{_KEY_SEP}{key.cache_salt}{_FILE_EXT}"
     return f"{base}{_FILE_EXT}"
@@ -126,7 +125,7 @@ def _filename_to_object_key(
 ) -> Optional[ObjectKey]:
     """Reverse ``_object_key_to_filename``.
 
-    Accepts both the 3-field unsalted shape and the 4-field salted
+    Accepts both the 4-field unsalted shape and the 5-field salted
     shape (trailing ``cache_salt``). Returns ``None`` for anything
     else. Since ``model_name`` is guaranteed not to contain ``@``,
     plain ``split`` suffices — no marker, no rsplit.
@@ -135,11 +134,11 @@ def _filename_to_object_key(
         return None
     stem = filename[: -len(_FILE_EXT)]
     parts = stem.split(_KEY_SEP)
-    if len(parts) == 3:
-        safe_model, kv_rank_str, chunk_hash_hex = parts
+    if len(parts) == 4:
+        safe_model, kv_rank_str, object_group_str, chunk_hash_hex = parts
         cache_salt = ""
-    elif len(parts) == 4:
-        safe_model, kv_rank_str, chunk_hash_hex, cache_salt = parts
+    elif len(parts) == 5:
+        safe_model, kv_rank_str, object_group_str, chunk_hash_hex, cache_salt = parts
     else:
         return None
 
@@ -147,6 +146,7 @@ def _filename_to_object_key(
     try:
         chunk_hash = bytes.fromhex(chunk_hash_hex)
         kv_rank = int(kv_rank_str, 16)
+        object_group_id = int(object_group_str, 16)
         # ObjectKey.__post_init__ raises ValueError when the decoded
         # model_name / cache_salt violate the forbidden-char or length
         # invariants (e.g. a stray file from another tool on disk).
@@ -156,6 +156,7 @@ def _filename_to_object_key(
             chunk_hash=chunk_hash,
             model_name=model_name,
             kv_rank=kv_rank,
+            object_group_id=object_group_id,
             cache_salt=cache_salt,
         )
     except ValueError:

--- a/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
@@ -80,11 +80,15 @@ class _PartialStoreFailure(RuntimeError):
 def _object_key_to_string(key: ObjectKey) -> str:
     """Serialize an MP ``ObjectKey`` to the shared L2 object-name format.
 
-    Unsalted keys use ``<model_name>@<kv_rank_hex>@<chunk_hash_hex>``. Salted
+    Unsalted keys use
+    ``<model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>``. Salted
     keys append ``@<cache_salt>`` so tenants/users with identical token chunks
     do not collide in the backing bucket.
     """
-    base = f"{key.model_name}@{key.kv_rank:08x}@{key.chunk_hash.hex()}"
+    base = (
+        f"{key.model_name}@{key.kv_rank:08x}"
+        f"@{key.object_group_id:x}@{key.chunk_hash.hex()}"
+    )
     if key.cache_salt:
         return f"{base}@{key.cache_salt}"
     return base

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -53,18 +53,15 @@ def _object_key_to_string(key: ObjectKey) -> str:
 
     Unsalted::
 
-        <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+        <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
 
     Salted (trailing ``cache_salt``)::
 
-        <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
-
-    Keys with ``cache_salt=""`` produce the 3-field shape, which is
-    bit-identical to the format used before ``cache_salt`` existed —
-    so existing un-salted caches remain valid with no migration.
+        <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>@<cache_salt>
     """
     base = (
-        f"{key.model_name}{_KEY_SEP}{key.kv_rank:08x}{_KEY_SEP}{key.chunk_hash.hex()}"
+        f"{key.model_name}{_KEY_SEP}{key.kv_rank:08x}"
+        f"{_KEY_SEP}{key.object_group_id:x}{_KEY_SEP}{key.chunk_hash.hex()}"
     )
     if key.cache_salt:
         return f"{base}{_KEY_SEP}{key.cache_salt}"

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
@@ -73,7 +73,9 @@ def _object_key_to_filename(key: ObjectKey) -> str:
     """
     safe_model_name = key.model_name.replace("/", "--")
     chunk_hex = key.chunk_hash.hex()
-    return f"{safe_model_name}_{key.kv_rank:08x}_{chunk_hex}.bin"
+    return (
+        f"{safe_model_name}_{key.kv_rank:08x}_{key.object_group_id:x}_{chunk_hex}.bin"
+    )
 
 
 # ---------------------------------------------------------------

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -62,19 +62,19 @@ def _object_key_to_string(key: ObjectKey) -> str:
 
     Unsalted::
 
-        <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+        <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
 
     Salted (trailing ``cache_salt``)::
 
-        <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+        <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>@<cache_salt>
 
-    Keys with ``cache_salt=""`` produce the 3-field shape (bit-identical
-    to the pre-``cache_salt`` format), so existing un-salted caches
-    remain valid with no migration. ``@`` in ``model_name`` and
-    ``cache_salt`` is rejected by ``ObjectKey.__post_init__``, so the
-    format is unambiguous.
+    ``@`` in ``model_name`` and ``cache_salt`` is rejected by
+    ``ObjectKey.__post_init__``, so the format is unambiguous.
     """
-    base = f"{key.model_name}@{key.kv_rank:08x}@{key.chunk_hash.hex()}"
+    base = (
+        f"{key.model_name}@{key.kv_rank:08x}"
+        f"@{key.object_group_id:x}@{key.chunk_hash.hex()}"
+    )
     if key.cache_salt:
         return f"{base}@{key.cache_salt}"
     return base

--- a/lmcache/v1/distributed/serde/utils.py
+++ b/lmcache/v1/distributed/serde/utils.py
@@ -39,9 +39,9 @@ def make_temp_key(original_key: ObjectKey) -> ObjectKey:
     effectively zero at any realistic scale, so the same original key
     can be serde'd repeatedly without practical concern.
 
-    ``cache_salt`` is propagated so per-tenant L1 byte accounting and
-    quota / eviction logic continue to attribute temp buffers to the
-    same bucket as the originals.
+    ``cache_salt`` and ``object_group_id`` are propagated so per-tenant
+    L1 byte accounting and quota / eviction logic continue to attribute
+    temp buffers to the same bucket as the originals.
 
     Args:
         original_key: The original ObjectKey to derive from.
@@ -50,5 +50,6 @@ def make_temp_key(original_key: ObjectKey) -> ObjectKey:
         chunk_hash=original_key.chunk_hash + os.urandom(16),
         model_name=original_key.model_name,
         kv_rank=original_key.kv_rank,
+        object_group_id=original_key.object_group_id,
         cache_salt=original_key.cache_salt,
     )

--- a/lmcache/v1/distributed/serde/utils.py
+++ b/lmcache/v1/distributed/serde/utils.py
@@ -39,9 +39,9 @@ def make_temp_key(original_key: ObjectKey) -> ObjectKey:
     effectively zero at any realistic scale, so the same original key
     can be serde'd repeatedly without practical concern.
 
-    ``cache_salt`` and ``object_group_id`` are propagated so per-tenant
-    L1 byte accounting and quota / eviction logic continue to attribute
-    temp buffers to the same bucket as the originals.
+    ``cache_salt`` are propagated so per-tenant L1 byte accounting and
+    quota / eviction logic continue to attribute temp buffers to the
+    same bucket as the originals.
 
     Args:
         original_key: The original ObjectKey to derive from.

--- a/lmcache/v1/mp_observability/trace/codecs.py
+++ b/lmcache/v1/mp_observability/trace/codecs.py
@@ -152,6 +152,7 @@ def _enc_object_key(k: ObjectKey) -> dict[str, Any]:
         "chunk_hash": k.chunk_hash,
         "model_name": k.model_name,
         "kv_rank": k.kv_rank,
+        "object_group_id": k.object_group_id,
     }
 
 
@@ -160,6 +161,7 @@ def _dec_object_key(d: dict[str, Any]) -> ObjectKey:
         chunk_hash=d["chunk_hash"],
         model_name=d["model_name"],
         kv_rank=d["kv_rank"],
+        object_group_id=d.get("object_group_id", 0),
     )
 
 

--- a/lmcache/v1/storage_backend/raw_block/key_codec.py
+++ b/lmcache/v1/storage_backend/raw_block/key_codec.py
@@ -34,14 +34,17 @@ def object_key_to_string(key: ObjectKey) -> str:
         key: Object key supplied by the MP storage layer.
 
     Returns:
-        A stable string containing model name, KV rank, chunk hash, and
-        optional cache salt.
+        A stable string containing model name, KV rank, object group id,
+        chunk hash, and optional cache salt.
 
     Raises:
         AttributeError: If ``key`` does not expose the ObjectKey fields.
     """
     safe_model = urllib.parse.quote(key.model_name, safe="")
-    base = f"{safe_model}{_KEY_SEP}{key.kv_rank:#010x}{_KEY_SEP}{key.chunk_hash.hex()}"
+    base = (
+        f"{safe_model}{_KEY_SEP}{key.kv_rank:#010x}"
+        f"{_KEY_SEP}{key.object_group_id:x}{_KEY_SEP}{key.chunk_hash.hex()}"
+    )
     if key.cache_salt:
         return f"{base}{_KEY_SEP}{key.cache_salt}"
     return base
@@ -61,11 +64,11 @@ def decode_object_key(encoded: str) -> ObjectKey:
             hexadecimal chunk hash.
     """
     parts = encoded.split(_KEY_SEP)
-    if len(parts) == 3:
-        safe_model, kv_rank_str, chunk_hash_hex = parts
+    if len(parts) == 4:
+        safe_model, kv_rank_str, object_group_str, chunk_hash_hex = parts
         cache_salt = ""
-    elif len(parts) == 4:
-        safe_model, kv_rank_str, chunk_hash_hex, cache_salt = parts
+    elif len(parts) == 5:
+        safe_model, kv_rank_str, object_group_str, chunk_hash_hex, cache_salt = parts
     else:
         raise ValueError(f"Invalid raw-block ObjectKey encoding: {encoded!r}")
 
@@ -73,6 +76,7 @@ def decode_object_key(encoded: str) -> ObjectKey:
         chunk_hash=bytes.fromhex(chunk_hash_hex),
         model_name=urllib.parse.unquote(safe_model),
         kv_rank=int(kv_rank_str, 16),
+        object_group_id=int(object_group_str, 16),
         cache_salt=cache_salt,
     )
 

--- a/tests/v1/distributed/serde/test_utils.py
+++ b/tests/v1/distributed/serde/test_utils.py
@@ -6,11 +6,12 @@ from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.serde.utils import make_temp_key
 
 
-def _orig(salt: str = "") -> ObjectKey:
+def _orig(salt: str = "", object_group_id: int = 0) -> ObjectKey:
     return ObjectKey(
         chunk_hash=b"\x00" * 16,
         model_name="model",
         kv_rank=0,
+        object_group_id=object_group_id,
         cache_salt=salt,
     )
 
@@ -25,10 +26,11 @@ def test_make_temp_key_propagates_cache_salt() -> None:
 
 def test_make_temp_key_propagates_other_fields() -> None:
     """Non-hash identity fields are preserved verbatim."""
-    orig = _orig(salt="tenant-X")
+    orig = _orig(salt="tenant-X", object_group_id=3)
     temp = make_temp_key(orig)
     assert temp.model_name == orig.model_name
     assert temp.kv_rank == orig.kv_rank
+    assert temp.object_group_id == orig.object_group_id
 
 
 def test_make_temp_key_differs_from_original() -> None:

--- a/tests/v1/distributed/test_fs_l2_adapter_keys.py
+++ b/tests/v1/distributed/test_fs_l2_adapter_keys.py
@@ -2,9 +2,10 @@
 """
 Unit tests for fs_l2_adapter key serialization helpers.
 
-These helpers round-trip ObjectKey <-> filename. ``cache_salt`` is
-appended as a trailing field when non-empty; unsalted keys use the
-3-field shape that matches what older LMCache builds wrote to disk.
+These helpers round-trip ObjectKey <-> filename. ``object_group_id`` is
+embedded as a fixed field right after ``kv_rank``; ``cache_salt`` is
+appended as a trailing field when non-empty. Unsalted keys use the
+4-field shape and salted keys use the 5-field shape.
 """
 
 # Third Party
@@ -20,7 +21,7 @@ from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
 
 class TestFilenameRoundtrip:
     """``_object_key_to_filename`` and ``_filename_to_object_key`` are
-    exact inverses for both the 3-field (unsalted) and 4-field (salted)
+    exact inverses for both the 4-field (unsalted) and 5-field (salted)
     shapes."""
 
     @pytest.mark.parametrize(
@@ -31,11 +32,13 @@ class TestFilenameRoundtrip:
         ],
     )
     @pytest.mark.parametrize("cache_salt", ["", "alice", "user-abc_123.xyz:42"])
-    def test_roundtrip(self, model_name: str, cache_salt: str):
+    @pytest.mark.parametrize("object_group_id", [0, 1, 255])
+    def test_roundtrip(self, model_name: str, cache_salt: str, object_group_id: int):
         key = ObjectKey(
             chunk_hash=b"\xde\xad\xbe\xef",
             model_name=model_name,
             kv_rank=42,
+            object_group_id=object_group_id,
             cache_salt=cache_salt,
         )
         fn = _object_key_to_filename(key)
@@ -46,26 +49,47 @@ class TestFilenameRoundtrip:
         parsed = _filename_to_object_key(fn)
         assert parsed == key
 
+    def test_object_group_id_distinguishes_filenames(self):
+        """Keys differing only in object_group_id must not collide."""
+        fn0 = _object_key_to_filename(
+            ObjectKey(
+                chunk_hash=b"\xde\xad\xbe\xef",
+                model_name="llama",
+                kv_rank=42,
+                object_group_id=0,
+            )
+        )
+        fn1 = _object_key_to_filename(
+            ObjectKey(
+                chunk_hash=b"\xde\xad\xbe\xef",
+                model_name="llama",
+                kv_rank=42,
+                object_group_id=1,
+            )
+        )
+        assert fn0 != fn1
+
     def test_unsalted_format(self):
-        """Unsalted keys use the 3-field shape — identical to the
-        pre-cache_salt filename format, so existing caches stay valid."""
-        fn = "llama@0x0000002a@deadbeef.data"
+        """Unsalted keys use the 4-field shape."""
+        fn = "llama@0x0000002a@0@deadbeef.data"
         parsed = _filename_to_object_key(fn)
         assert parsed == ObjectKey(
             chunk_hash=b"\xde\xad\xbe\xef",
             model_name="llama",
             kv_rank=42,
+            object_group_id=0,
             cache_salt="",
         )
 
     def test_salted_format(self):
         """Salted keys append ``@<cache_salt>`` before the extension."""
-        fn = "llama@0x0000002a@deadbeef@alice.data"
+        fn = "llama@0x0000002a@2@deadbeef@alice.data"
         parsed = _filename_to_object_key(fn)
         assert parsed == ObjectKey(
             chunk_hash=b"\xde\xad\xbe\xef",
             model_name="llama",
             kv_rank=42,
+            object_group_id=2,
             cache_salt="alice",
         )
 
@@ -75,15 +99,19 @@ class TestFilenameRoundtrip:
     def test_too_few_fields_returns_none(self):
         assert _filename_to_object_key("just-one-field.data") is None
 
+    def test_old_three_field_format_returns_none(self):
+        """The pre-object_group_id 3-field shape is no longer accepted."""
+        assert _filename_to_object_key("llama@0x0000002a@deadbeef.data") is None
+
     def test_too_many_fields_returns_none(self):
-        assert _filename_to_object_key("a@b@c@d@e.data") is None
+        assert _filename_to_object_key("a@b@c@d@e@f.data") is None
 
     def test_salt_with_forbidden_char_returns_none(self):
-        # A filename that parses into 4 fields but whose trailing "salt"
+        # A filename that parses into 5 fields but whose trailing "salt"
         # slot contains a char ObjectKey.__post_init__ rejects (NUL here
         # is impossible in filenames, so use the length cap instead).
         too_long_salt = "x" * 129
-        fn = f"llama@0x0000002a@deadbeef@{too_long_salt}.data"
+        fn = f"llama@0x0000002a@0@deadbeef@{too_long_salt}.data"
         assert _filename_to_object_key(fn) is None
 
 
@@ -138,6 +166,50 @@ class TestIpcKeyToObjectKeys:
         )
         out = ipc_key_to_object_keys(k, [b"h1"])
         assert all(o.cache_salt == "" for o in out)
+
+    def test_object_group_id_defaults_to_zero(self):
+        # First Party
+        from lmcache.v1.distributed.api import ipc_key_to_object_keys
+        from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
+
+        k = IPCCacheEngineKey.from_token_ids(
+            model_name="m",
+            world_size=1,
+            worker_id=0,
+            token_ids=[1, 2],
+        )
+        out = ipc_key_to_object_keys(k, [b"h1", b"h2"])
+        assert all(o.object_group_id == 0 for o in out)
+
+    def test_object_group_id_propagates_to_all_keys(self):
+        """A non-zero object_group_id reaches every produced ObjectKey,
+        including the worker-expansion (scheduler) path."""
+        # First Party
+        from lmcache.v1.distributed.api import ipc_key_to_object_keys
+        from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
+
+        k = IPCCacheEngineKey.from_token_ids(
+            model_name="m",
+            world_size=4,
+            worker_id=None,
+            token_ids=[1, 2, 3],
+        )
+        out = ipc_key_to_object_keys(k, [b"h1"], object_group_id=3)
+        assert len(out) == 4
+        assert all(o.object_group_id == 3 for o in out)
+
+
+class TestObjectKeyValidation:
+    """``ObjectKey.__post_init__`` rejects invalid ``object_group_id``."""
+
+    def test_negative_object_group_id_rejected(self):
+        with pytest.raises(ValueError, match="object_group_id"):
+            ObjectKey(
+                chunk_hash=b"\xde\xad\xbe\xef",
+                model_name="llama",
+                kv_rank=0,
+                object_group_id=-1,
+            )
 
 
 class TestIPCCacheEngineKeyCacheSalt:

--- a/tests/v1/distributed/test_hfbucket_l2_adapter.py
+++ b/tests/v1/distributed/test_hfbucket_l2_adapter.py
@@ -212,7 +212,16 @@ class TestObjectKeySerialization:
             model_name="llama",
             kv_rank=255,
         )
-        assert _object_key_to_string(key) == "llama@000000ff@00010203"
+        assert _object_key_to_string(key) == "llama@000000ff@0@00010203"
+
+    def test_object_group_id_embedded(self) -> None:
+        key = ObjectKey(
+            chunk_hash=b"\x00\x01\x02\x03",
+            model_name="llama",
+            kv_rank=255,
+            object_group_id=5,
+        )
+        assert _object_key_to_string(key) == "llama@000000ff@5@00010203"
 
     def test_cache_salt_appended(self) -> None:
         base_key = ObjectKey(
@@ -226,8 +235,8 @@ class TestObjectKeySerialization:
             kv_rank=255,
             cache_salt="user-42",
         )
-        assert _object_key_to_string(base_key) == "llama@000000ff@00010203"
-        assert _object_key_to_string(salted) == "llama@000000ff@00010203@user-42"
+        assert _object_key_to_string(base_key) == "llama@000000ff@0@00010203"
+        assert _object_key_to_string(salted) == "llama@000000ff@0@00010203@user-42"
         assert _object_key_to_string(base_key) != _object_key_to_string(salted)
 
     def test_bucket_path_uses_prefix_and_encoding(self) -> None:

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -219,19 +219,28 @@ class TestObjectKeySerialization:
         assert _object_key_to_string(k1) != _object_key_to_string(k2)
 
     def test_serialization_format(self):
-        """Unsalted keys use the 3-field shape — identical to the
-        pre-cache_salt wire format, so existing remote storage
-        stays valid."""
+        """Unsalted keys use the 4-field shape with object_group_id
+        embedded right after kv_rank."""
         key = ObjectKey(
             chunk_hash=b"\x00\x01\x02\x03",
             model_name="llama",
             kv_rank=255,
         )
         s = _object_key_to_string(key)
-        assert s == "llama@000000ff@00010203"
+        assert s == "llama@000000ff@0@00010203"
+
+    def test_object_group_id_embedded(self):
+        key = ObjectKey(
+            chunk_hash=b"\x00\x01\x02\x03",
+            model_name="llama",
+            kv_rank=255,
+            object_group_id=5,
+        )
+        s = _object_key_to_string(key)
+        assert s == "llama@000000ff@5@00010203"
 
     def test_salted_serialization_format(self):
-        """Salted keys append ``@<cache_salt>`` as a 4th field."""
+        """Salted keys append ``@<cache_salt>`` as a 5th field."""
         key = ObjectKey(
             chunk_hash=b"\x00\x01\x02\x03",
             model_name="llama",
@@ -239,7 +248,7 @@ class TestObjectKeySerialization:
             cache_salt="alice",
         )
         s = _object_key_to_string(key)
-        assert s == "llama@000000ff@00010203@alice"
+        assert s == "llama@000000ff@0@00010203@alice"
 
     def test_different_salts_produce_different_strings(self):
         base = {
@@ -256,7 +265,7 @@ class TestObjectKeySerialization:
         assert s_empty != s_alice
         assert s_alice != s_bob
         # Empty salt has no trailing "@salt", salted keys do.
-        assert s_empty.count("@") == 2  # 3 fields
+        assert s_empty.count("@") == 3  # 4 fields (model, kv_rank, group, hash)
         assert s_alice.endswith("@alice")
         assert s_bob.endswith("@bob")
 

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -330,7 +330,16 @@ class TestObjectKeySerialization:
             model_name="llama",
             kv_rank=255,
         )
-        assert _object_key_to_string(key) == "llama@000000ff@00010203"
+        assert _object_key_to_string(key) == "llama@000000ff@0@00010203"
+
+    def test_object_group_id_embedded(self):
+        key = ObjectKey(
+            chunk_hash=b"\x00\x01\x02\x03",
+            model_name="llama",
+            kv_rank=255,
+            object_group_id=5,
+        )
+        assert _object_key_to_string(key) == "llama@000000ff@5@00010203"
 
     def test_cache_salt_appended(self):
         """A non-empty cache_salt must be included in the S3 object name so
@@ -347,8 +356,8 @@ class TestObjectKeySerialization:
             kv_rank=255,
             cache_salt="user-42",
         )
-        assert _object_key_to_string(base_key) == "llama@000000ff@00010203"
-        assert _object_key_to_string(salted) == "llama@000000ff@00010203@user-42"
+        assert _object_key_to_string(base_key) == "llama@000000ff@0@00010203"
+        assert _object_key_to_string(salted) == "llama@000000ff@0@00010203@user-42"
         assert _object_key_to_string(base_key) != _object_key_to_string(salted)
 
 

--- a/tests/v1/mp_observability/trace/test_codecs.py
+++ b/tests/v1/mp_observability/trace/test_codecs.py
@@ -50,6 +50,17 @@ class TestObjectKey:
         out = _roundtrip(k)
         assert out == k
 
+    def test_object_group_id_roundtrip(self):
+        k = ObjectKey(
+            chunk_hash=b"\x00\x01\x02",
+            model_name="m",
+            kv_rank=42,
+            object_group_id=7,
+        )
+        out = _roundtrip(k)
+        assert out == k
+        assert out.object_group_id == 7
+
     def test_inside_list(self):
         keys = [
             ObjectKey(chunk_hash=b"a", model_name="m", kv_rank=1),

--- a/tests/v1/storage_backend/test_raw_block_key_codec.py
+++ b/tests/v1/storage_backend/test_raw_block_key_codec.py
@@ -35,3 +35,29 @@ def test_raw_block_object_key_codec_roundtrips_slash_and_sep() -> None:
 
     assert "%2F" in encoded
     assert decoded == key
+
+
+def test_raw_block_object_key_codec_roundtrips_object_group_id() -> None:
+    """object_group_id must survive encode/decode for salted and unsalted keys."""
+    for object_group_id in (0, 1, 255):
+        for cache_salt in ("", "tenant"):
+            key = ObjectKey(
+                chunk_hash=ObjectKey.IntHash2Bytes(789),
+                model_name="org/model",
+                kv_rank=7,
+                object_group_id=object_group_id,
+                cache_salt=cache_salt,
+            )
+            assert decode_object_key(object_key_to_string(key)) == key
+
+
+def test_raw_block_object_group_id_distinguishes_encoding() -> None:
+    """Keys differing only in object_group_id must encode differently."""
+    chunk_hash = ObjectKey.IntHash2Bytes(1)
+    enc0 = object_key_to_string(
+        ObjectKey(chunk_hash=chunk_hash, model_name="m", kv_rank=0, object_group_id=0)
+    )
+    enc1 = object_key_to_string(
+        ObjectKey(chunk_hash=chunk_hash, model_name="m", kv_rank=0, object_group_id=1)
+    )
+    assert enc0 != enc1


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

# Compatibility Warning

> [!IMPORTANT]
> **This PR (and the follow-up PRs) changes the file format of the L2 KV cache when using MP mode.**
> **The L2 KV caches stored before these PR will be invalidated and no longer retrievable!**

> [!IMPORTANT]
> **This PR (and the follow-up PRs) changes the file format of the L2 KV cache when using MP mode.**
> **The L2 KV caches stored before these PR will be invalidated and no longer retrievable!**

> [!IMPORTANT]
> **This PR (and the follow-up PRs) changes the file format of the L2 KV cache when using MP mode.**
> **The L2 KV caches stored before these PR will be invalidated and no longer retrievable!**


**What this PR does / why we need it**:

To support efficient loading of hybrid models' KV cache, we need to separate the KV cache into object groups. Therefore, we need an object_group_id as a field in the ObjectKey

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
