### PR TITLE
[MP][Core][HMA] Implement the interface for multi-object group and sliding window support

### DIFF
--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -209,10 +209,11 @@ class PrefetchHandle:
 def ipc_key_to_object_keys(
     ipc_key: IPCCacheEngineKey,
     chunk_hashes: list[bytes],
-    object_group_id: int = 0,
-) -> list[ObjectKey]:
+    object_group_ids: list[int],
+) -> list[list[ObjectKey]]:
     """
-    Convert a single IPCCacheEngineKey and its chunk hashes to a list of ObjectKey.
+    Convert a single IPCCacheEngineKey and its chunk hashes to per-object-group
+    lists of ObjectKey.
 
     When the ipc_key's worker_id is None, each chunk hash is exploded into
     multiple ObjectKeys (one per worker in world_size).
@@ -227,52 +228,50 @@ def ipc_key_to_object_keys(
         ipc_key: The IPC key providing model_name, world_size, worker_id,
             and cache_salt.
         chunk_hashes: List of chunk hash bytes, one per chunk.
-        object_group_id: Index of the object group the chunks belong to.
-            Defaults to 0, the single-group case.
+        object_group_ids: Object group ids to produce keys for.
 
     Returns:
-        list[ObjectKey]: The converted list of ObjectKey.
+        list[list[ObjectKey]]: The i-th element is the list of ObjectKeys
+        for ``object_group_ids[i]``.
     """
     cache_salt = ipc_key.cache_salt
-    storage_keys = []
-    for chunk_hash in chunk_hashes:
-        if ipc_key.worker_id is None:
-            # For look up request, we want to expand to all workers
-            for worker_id in range(ipc_key.world_size):
-                # TODO (ApostaC): include local world size/rank info
-                # in the future once it's in IPCCacheEngineKey
-                kv_rank = ObjectKey.ComputeKVRank(
-                    world_size=ipc_key.world_size,
-                    global_rank=worker_id,
-                    local_world_size=ipc_key.world_size,
-                    local_rank=worker_id,
-                )
 
-                storage_keys.append(
-                    ObjectKey(
-                        chunk_hash=chunk_hash,
-                        model_name=ipc_key.model_name,
-                        kv_rank=kv_rank,
-                        object_group_id=object_group_id,
-                        cache_salt=cache_salt,
-                    )
-                )
-        else:
-            kv_rank = ObjectKey.ComputeKVRank(
+    # The (chunk_hash, kv_rank) expansion is independent of the object group,
+    # so compute it once and reuse it for every group.
+    if ipc_key.worker_id is None:
+        # For look up request, we want to expand to all workers
+        # TODO (ApostaC): include local world size/rank info
+        # in the future once it's in IPCCacheEngineKey
+        kv_ranks = [
+            ObjectKey.ComputeKVRank(
+                world_size=ipc_key.world_size,
+                global_rank=worker_id,
+                local_world_size=ipc_key.world_size,
+                local_rank=worker_id,
+            )
+            for worker_id in range(ipc_key.world_size)
+        ]
+    else:
+        kv_ranks = [
+            ObjectKey.ComputeKVRank(
                 world_size=ipc_key.world_size,
                 global_rank=ipc_key.worker_id,
                 local_world_size=ipc_key.world_size,
                 local_rank=ipc_key.worker_id,
             )
+        ]
 
-            storage_keys.append(
-                ObjectKey(
-                    chunk_hash=chunk_hash,
-                    model_name=ipc_key.model_name,
-                    kv_rank=kv_rank,
-                    object_group_id=object_group_id,
-                    cache_salt=cache_salt,
-                )
+    return [
+        [
+            ObjectKey(
+                chunk_hash=chunk_hash,
+                model_name=ipc_key.model_name,
+                kv_rank=kv_rank,
+                object_group_id=object_group_id,
+                cache_salt=cache_salt,
             )
-
-    return storage_keys
+            for chunk_hash in chunk_hashes
+            for kv_rank in kv_ranks
+        ]
+        for object_group_id in object_group_ids
+    ]

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -291,27 +291,16 @@ class KVLayerGroupsManager:
                 :func:`normalize_kv_and_discover_format`.
             gpu_kv_format: Format returned by
                 :func:`normalize_kv_and_discover_format`.
-            num_blocks: Number of paged blocks. Stamped into every
-                ``shape_desc.nb``. Each group's ``shape_desc.bs`` is
-                discovered per-layer via :func:`get_block_size`, so
-                compressed and non-compressed groups can coexist.
+            num_blocks: Number of paged blocks in the device KV cache.
             layout_hints: Engine-provided hints. The manager only reads
                 ``inference_engine_logical_block_size`` (logical tokens
                 per inference-engine block) from it to derive each
                 group's ``compress_ratio`` and ``physical_chunk_size``.
                 ``None`` means every group is treated as non-compressed
                 (``compress_ratio == 1``).
-            engine_group_infos: LMCache-owned engine KV cache group
-                metadata. When present, it is used to keep layers from
-                different engine block-ID spaces in separate LMCache
-                transfer groups.
-            lmcache_logical_chunk_size: Logical tokens per LMCache chunk
-                (one logical token = one inference-engine token).
-                Together with ``compress_ratio`` it determines each
-                group's ``physical_chunk_size =
-                lmcache_logical_chunk_size // compress_ratio``, the
-                number of *physical* slots per chunk fed to the
-                block-level transfer kernel.
+            engine_group_infos: Engine KV cache group metadata, including
+                the engine group ids, and the sliding window information.
+            lmcache_logical_chunk_size: Tokens per LMCache chunk
         """
         # Import here to break a circular import via
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
@@ -455,6 +444,7 @@ class KVLayerGroupsManager:
         return len(self._kernel_groups)
 
     @property
+    @lmcache_deprecate("This function will be removed soon")
     def inference_engine_logical_block_size(self) -> int:
         """Inference-engine-side logical block size.
 
@@ -471,8 +461,6 @@ class KVLayerGroupsManager:
     def get_shape_desc(self, kernel_group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
         """Return the :class:`PageBufferShapeDesc` for *kernel_group_idx*.
 
-        Equivalent to ``self._kernel_groups[kernel_group_idx].shape_desc``.
-
         Args:
             kernel_group_idx: 0-based kernel group index.
 
@@ -481,16 +469,9 @@ class KVLayerGroupsManager:
         """
         return self._kernel_groups[kernel_group_idx].shape_desc
 
+    @lmcache_deprecate("This function will be renamed to get_num_slots_per_chunk")
     def get_physical_chunk_size(self, kernel_group_idx: int) -> int:
         """Return the per-chunk *physical* slot count for *kernel_group_idx*.
-
-        Equivalent to
-        ``self._kernel_groups[kernel_group_idx].physical_chunk_size``.
-        For non-compressed groups this equals
-        ``lmcache_logical_chunk_size``; for compressed groups it equals
-        ``lmcache_logical_chunk_size // compress_ratio`` and is what the
-        block-level transfer kernel must be told (the logical chunk size
-        in *vLLM tokens* is not what the kernel addresses).
 
         Args:
             kernel_group_idx: 0-based kernel group index.

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -406,6 +406,8 @@ class KVLayerGroupsManager:
             or self._kernel_groups[0].shape_desc.bs
         )
 
+        self._lmcache_chunk_size = lmcache_logical_chunk_size
+
         logger.info(
             "KV layer groups: ---\n%s\n---",
             "\n".join(repr(g) for g in self._kernel_groups),
@@ -497,6 +499,48 @@ class KVLayerGroupsManager:
             IndexError: If *kernel_group_idx* is out of range.
         """
         return self._kernel_groups[kernel_group_idx].physical_chunk_size
+
+    def get_subchunk_sw_size_tokens(self, kernel_group_idx: int) -> int:
+        """Return the sub-chunk sliding window size of a given kernel group.
+        The size is measured in the number of tokens.
+
+        This is for the models like DSV4 where the sliding window size is
+        smaller than the tokens in a single lmcache chunk.
+
+        Args:
+            kernel_group_idx: 0-based kernel group index.
+
+        Returns:
+            The sub-chunk sliding window size. Will be the same as the
+            chunk size for non-slding-window models or big-sliding-
+            window models.
+        """
+        # TODO(ApostaC): now here's the 'dummy' implementation.
+        # Need to wire the real sw size from the kernel group info once it's available
+        return self._lmcache_chunk_size
+
+    def get_sw_size_chunks(self, object_group_idx: int) -> int:
+        """Return the sliding window size of a given kernel group,
+        The size is measured in lmcache chunks.
+
+        If the kernel group is non-sliding window, return -1
+
+        Args:
+            object_group_idx: 0-based kernel group index.
+
+        Returns:
+            The sliding window size rounded up to chunks for sliding
+            window models. -1 otherwise.
+
+        Note:
+            It uses object_group_idx, because the kernel groups in the same
+            object group must share the same "big-sliding-window" size -- so that
+            they can be retrieved at the same time from the same object.
+            For small sliding window (subchunk window) models, it will return 1.
+        """
+        # TODO(ApostaC): now here's the 'dummy' implementation.
+        # Need to wire the real sw size from the object group info once it's available
+        return -1
 
     def calculate_num_blocks(self, kernel_group_idx: int, num_tokens: int) -> int:
         """Calculate the number of blocks for a given number of tokens in a

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -182,17 +182,21 @@ class MPCacheEngineContext:
         """Registry mapping (model_name, world_size) to MemoryLayoutDesc."""
         return self._layout_desc_registry
 
-    def resolve_obj_keys(self, key: IPCCacheEngineKey) -> list[ObjectKey]:
-        """Resolve object keys from an IPC cache key.
+    def resolve_obj_keys(
+        self, key: IPCCacheEngineKey, object_group_ids: list[int]
+    ) -> list[list[ObjectKey]]:
+        """Resolve per-object-group object keys from an IPC cache key.
 
         Uses the session manager to track token state and the token hasher
         to compute chunk hashes for the requested range.
 
         Args:
             key: IPC cache key describing model/session/token range.
+            object_group_ids: Object group ids to produce keys for.
 
         Returns:
-            Resolved object keys for the requested token range.
+            The i-th element is the list of ObjectKeys for
+            ``object_group_ids[i]``.
 
         Raises:
             ValueError: If ``key.worker_id`` is ``None``.
@@ -204,7 +208,7 @@ class MPCacheEngineContext:
         ]
         if key.worker_id is None:
             raise ValueError("Must resolve keys with worker_id != None")
-        return ipc_key_to_object_keys(key, chunk_hashes)
+        return ipc_key_to_object_keys(key, chunk_hashes, object_group_ids)
 
     @staticmethod
     def _compute_shm_pool_info(

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -467,6 +467,7 @@ class GPUCacheContext:
         """Returns the PageBufferShapeDesc for the given KV layer group."""
         return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
 
+    @lmcache_deprecate("this function will be renamed to get_num_slots_per_chunk")
     def get_physical_chunk_size(self, group_idx: int) -> int:
         """Returns the per-chunk physical slot count for the given group.
 

--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -597,7 +597,7 @@ class BlendModule:
         # time, so ipc_key_to_object_keys resolves correctly.
         for group in groups:
             chunk_hashes = [r.hash for r in group]
-            obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
+            obj_keys = ipc_key_to_object_keys(key, chunk_hashes, [0])[0]
             handle = self._ctx.storage_manager.submit_prefetch_task(
                 obj_keys,
                 layout_desc,
@@ -827,7 +827,7 @@ class BlendModule:
         # the CB lookup path and via the standard lookup/retrieve path.
         chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(list(key.token_ids))
         # convert to object key
-        obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
+        obj_keys = ipc_key_to_object_keys(key, chunk_hashes, [0])[0]
 
         reserved_dict: dict = {}
         try:
@@ -937,7 +937,7 @@ class BlendModule:
         cb_match_result = sorted(cb_match_result, key=lambda r: r.cur_st)
         num_chunks = len(cb_match_result)
         chunk_hashes = [r.hash for r in cb_match_result]
-        all_obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
+        all_obj_keys = ipc_key_to_object_keys(key, chunk_hashes, [0])[0]
 
         # CPU-synchronous sentinel: GPU retrieve is about to be enqueued.
         self._ctx.event_bus.publish(
@@ -1110,7 +1110,7 @@ class BlendModule:
         chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(list(key.token_ids))
 
         # convert to object key
-        obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
+        obj_keys = ipc_key_to_object_keys(key, chunk_hashes, [0])[0]
 
         reserved_dict: dict = {}
         try:

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -539,7 +539,7 @@ class BlendV3Module:
         world_size = key.world_size
         per_hash_obj_keys: dict[bytes, list] = {}
         all_hashes = [r.hash for r in matches]
-        all_obj_keys = ipc_key_to_object_keys(key, all_hashes)
+        all_obj_keys = ipc_key_to_object_keys(key, all_hashes, [0])[0]
         for i, h in enumerate(all_hashes):
             per_hash_obj_keys[h] = all_obj_keys[i * world_size : (i + 1) * world_size]
 
@@ -906,8 +906,8 @@ class BlendV3Module:
                 all_obj_keys = [k for r in cb_match_result for k in cached[r.hash]]
         else:
             all_obj_keys = ipc_key_to_object_keys(
-                key, [r.hash for r in cb_match_result]
-            )
+                key, [r.hash for r in cb_match_result], [0]
+            )[0]
 
         # Lookup read-locked the full found set, but the connector may have
         # dropped some matches (parent-covered / misaligned) before retrieve,

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -54,7 +54,7 @@ logger = init_logger(__name__)
 def get_layout_desc(
     gpu_context: GPUCacheContext,
     num_tokens: int,
-    object_group_id: int = 0,
+    object_group_id: int,
 ) -> MemoryLayoutDesc:
     """Get the memory layout description for a specific object group.
 
@@ -67,8 +67,6 @@ def get_layout_desc(
         cache_context: The GPU cache context containing the KV cache information.
         num_tokens: The number of tokens to determine the layout for.
         object_group_id: Index of the object group whose layout to build.
-            Defaults to 0; under the current single-object-group assumption this
-            covers every kernel group.
 
     Returns:
         MemoryLayoutDesc: The memory layout description containing shapes and
@@ -81,26 +79,6 @@ def get_layout_desc(
     ]
     shapes, dtypes = zip(*shapes_and_dtypes, strict=False)
     return MemoryLayoutDesc(shapes=list(shapes), dtypes=list(dtypes))
-
-
-def batched_iteration(lst: list, batch_size: int) -> Generator[tuple, None, None]:
-    """Utility function to iterate over a list in batches.
-
-    Args:
-        lst: The list to iterate over.
-        batch_size: The size of each batch.
-
-    Yields:
-        Batches of the list as tuples.
-
-    Raises:
-        ValueError: If batch_size is less than 1.
-    """
-    if batch_size < 1:
-        raise ValueError("batch size must be at least one")
-    it = iter(lst)
-    while batch := tuple(islice(it, batch_size)):
-        yield batch
 
 
 def batched_iteration_with_skip(
@@ -184,13 +162,15 @@ def cut_and_stage_block_ids(
           [13, 14, 17, 18], # swa attention group only needs the last 2 block per chunk
         ]
     """
-    num_kernel_groups = cache_context.kv_layer_groups_manager.num_groups
+    num_kernel_groups = cache_context.kv_layer_groups_manager.num_kernel_groups
     for kernel_group_id in range(num_kernel_groups):
-        # TODO: we need to get the actual sliding window size from the kernel
-        # group
-        placeholder_sliding_window_size = cache_context.lmcache_logical_chunk_size
+        subchunk_sw_size_tokens = (
+            cache_context.kv_layer_groups_manager.get_subchunk_sw_size_tokens(
+                kernel_group_id
+            )
+        )
         tokens_per_chunk = min(
-            cache_context.lmcache_logical_chunk_size, placeholder_sliding_window_size
+            cache_context.lmcache_logical_chunk_size, subchunk_sw_size_tokens
         )
         keep_blocks_per_chunk = cache_context.calculate_num_blocks(
             tokens_per_chunk, kernel_group_id
@@ -282,17 +262,17 @@ def gpu_kv_copy_helper(
         This function expects the caller to stage the block ids (list[list[int]])
         into GPU tensors and pass them in as `block_ids_gpu`.
     """
-    # TODO(ApostaC): this is for the sliding window optimization. We will have
-    # num_objects_to_skip calculated based on the sliding window size.
-    # In most of cases, it will be:
-    # - `len(memory_objs) - chunks_in_sliding_window`
-    # where the `chunks_in_sliding_window` is calculated as:
-    # - `cdiv(sliding_window_size_in_token, chunk_size)`
-    num_objects_to_skip = 0
     lmcache_chunk_size = cache_context.lmcache_logical_chunk_size
-    object_group = cache_context.kv_layer_groups_manager.object_groups[object_group_id]
+    kv_groups_manager = cache_context.kv_layer_groups_manager
+    object_group = kv_groups_manager.object_groups[object_group_id]
     kernel_group_ids = object_group.kernel_group_indices
     is_h2d = direction == lmc_ops.TransferDirection.H2D
+
+    sw_size_chunks = kv_groups_manager.get_sw_size_chunks(object_group_id)
+    if sw_size_chunks == -1:
+        num_objects_to_skip = 0
+    else:
+        num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)
 
     for start_object_idx, memory_object_batch in batched_iteration_with_skip(
         memory_objs, batch_size, skip_count=num_objects_to_skip
@@ -332,15 +312,17 @@ def gpu_kv_copy_helper(
             blocks_per_chunk = cache_context.calculate_num_blocks(
                 lmcache_chunk_size, kernel_group_id
             )
-            # TODO(ApostaC): we need to get the sliding window information
-            # from the kernel group
-            placeholder_blocks_per_window = blocks_per_chunk
+            tokens_per_window = min(
+                lmcache_chunk_size,
+                kv_groups_manager.get_subchunk_sw_size_tokens(kernel_group_id),
+            )
+            blocks_per_window = cache_context.calculate_num_blocks(
+                tokens_per_window, kernel_group_id
+            )
 
             # Get the block ids for this chunk
-            start_block_pos = start_object_idx * placeholder_blocks_per_window
-            end_block_pos = (
-                start_object_idx + batch_len
-            ) * placeholder_blocks_per_window
+            start_block_pos = start_object_idx * blocks_per_window
+            end_block_pos = (start_object_idx + batch_len) * blocks_per_window
 
             block_ids_curr_batch = block_ids_gpu[kernel_group_id][
                 start_block_pos:end_block_pos
@@ -352,7 +334,7 @@ def gpu_kv_copy_helper(
             )
             recalculated_skip_blocks = _recalculate_blocks_to_skip(
                 blocks_per_chunk,
-                placeholder_blocks_per_window,
+                blocks_per_window,
                 orig_skip_blocks,
             )
 
@@ -645,7 +627,9 @@ class GPUTransferModule:
         # group ``i``.
         blocks_per_chunk = [
             cache_context.calculate_num_blocks(self._ctx.chunk_size, group_idx)
-            for group_idx in range(cache_context.kv_layer_groups_manager.num_groups)
+            for group_idx in range(
+                cache_context.kv_layer_groups_manager.num_kernel_groups
+            )
         ]
 
         with (
@@ -866,10 +850,6 @@ class GPUTransferModule:
             ),
         )
 
-        # ``skip_*_in_chunk`` is expressed in engine-block units
-        # (logical tokens), which is what the kernel's
-        # ``skip_blocks_in_chunk`` argument expects regardless
-        # of per-group compression.
         ie_logical_block_size = (
             cache_context.kv_layer_groups_manager.inference_engine_logical_block_size
         )
@@ -888,7 +868,9 @@ class GPUTransferModule:
 
         blocks_per_chunk = [
             cache_context.calculate_num_blocks(self._ctx.chunk_size, group_idx)
-            for group_idx in range(cache_context.kv_layer_groups_manager.num_groups)
+            for group_idx in range(
+                cache_context.kv_layer_groups_manager.num_kernel_groups
+            )
         ]
 
         with (

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -121,7 +121,7 @@ def batched_iteration_with_skip(
         batch_start_idx += len(batch)
 
 
-def cut_and_stage_block_ids(
+def downsample_and_stage_block_ids(
     cache_context: GPUCacheContext,
     block_ids: list[list[int]],
 ) -> list[torch.Tensor]:
@@ -141,9 +141,9 @@ def cut_and_stage_block_ids(
         The cut block id lists, indexed by LMCache KV group index.
 
     Note:
-        This function has some coupled logic with gpu_kv_copy_helper below. The
-        caller need to make sure that the block ids seen by gpu_kv_copy_helper
-        are produced by this function.
+        This function has some coupled logic with transfer_kv_per_object_group below.
+        The caller need to make sure that the block ids seen by
+        transfer_kv_per_object_group are produced by this function.
 
     Example:
         If a model have 2 kernel groups, one is full attention with block size 32,
@@ -228,7 +228,7 @@ def _recalculate_blocks_to_skip(
     return full_windows_to_skip * blocks_per_window + max(0, tail_blocks_to_skip)
 
 
-def gpu_kv_copy_helper(
+def transfer_kv_per_object_group(
     cache_context: GPUCacheContext,
     block_ids_gpu: list[torch.Tensor],
     memory_objs: Sequence[MemoryObj | None],
@@ -237,7 +237,8 @@ def gpu_kv_copy_helper(
     skip_first_n_tokens: int,
     direction: "lmc_ops.TransferDirection",
 ) -> None:
-    """Helper function to transfer a batch of memory objects to/from GPU.
+    """Helper function to transfer memory objects of a single object group
+    to/from GPU, with batching support.
 
     Args:
         cache_context: The GPU cache context containing the KV cache information.
@@ -668,7 +669,7 @@ class GPUTransferModule:
                 event.record()
                 return event.ipc_handle(), False
 
-            block_ids_per_group_gpu = cut_and_stage_block_ids(
+            block_ids_per_group_gpu = downsample_and_stage_block_ids(
                 cache_context, gpu_block_ids
             )
 
@@ -735,7 +736,7 @@ class GPUTransferModule:
                     ]
 
                     # NOTE: batch_size must stay 1 for store.
-                    gpu_kv_copy_helper(
+                    transfer_kv_per_object_group(
                         cache_context,
                         block_ids_per_group_gpu,
                         memory_objs,
@@ -855,22 +856,6 @@ class GPUTransferModule:
             ),
         )
 
-        ie_logical_block_size = (
-            cache_context.kv_layer_groups_manager.inference_engine_logical_block_size
-        )
-
-        # Block IDs are expressed in engine-block units (logical tokens), which
-        # is what the kernel's skip argument expects regardless of per-group
-        # compression. Warn if the skip prefix is not block-aligned.
-        if skip_first_n_tokens % ie_logical_block_size != 0:
-            logger.error(
-                "skip_first_n_tokens (%d) is not aligned to "
-                "inference_engine_logical_block_size (%d); it will be rounded "
-                "down to a block boundary",
-                skip_first_n_tokens,
-                ie_logical_block_size,
-            )
-
         blocks_per_chunk = [
             cache_context.calculate_num_blocks(self._ctx.chunk_size, group_idx)
             for group_idx in range(
@@ -908,7 +893,7 @@ class GPUTransferModule:
                 return event.ipc_handle(), False
 
             # Cut and stage all block_ids to GPU once before the transfer
-            block_ids_per_group_gpu = cut_and_stage_block_ids(
+            block_ids_per_group_gpu = downsample_and_stage_block_ids(
                 cache_context, gpu_block_ids
             )
 
@@ -926,7 +911,7 @@ class GPUTransferModule:
 
                         total_bytes += sum(mo.get_size() for mo in memory_objs)
 
-                        gpu_kv_copy_helper(
+                        transfer_kv_per_object_group(
                             cache_context,
                             block_ids_per_group_gpu,
                             memory_objs,

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -627,7 +627,6 @@ class GPUTransferModule:
             store completed without such a failure.
         """
         st = time.perf_counter()
-        obj_keys = self._ctx.resolve_obj_keys(key, [0])[0]
 
         entry = self._cache_contexts.get(instance_id)
         if entry is None:
@@ -635,8 +634,11 @@ class GPUTransferModule:
         cache_context = entry.cache_context
         model_name = entry.model_name
 
-        # TODO(refactor): only single-object-group transfers are wired up so far.
-        assert cache_context.kv_layer_groups_manager.num_object_groups == 1
+        num_object_groups = cache_context.kv_layer_groups_manager.num_object_groups
+        obj_keys_per_obj_group = self._ctx.resolve_obj_keys(
+            key, list(range(num_object_groups))
+        )
+        num_chunks = len(obj_keys_per_obj_group[0])
 
         # NOTE: different engine groups may have different block sizes, so
         # ``blocks_per_chunk[i]`` is the number of blocks in one chunk for
@@ -661,17 +663,17 @@ class GPUTransferModule:
             # complete. Checked on the raw block ids, before cutting drops the
             # per-chunk blocks that sliding-window groups do not need.
             if any(
-                len(group_block_ids) < len(obj_keys) * bpc
+                len(group_block_ids) < num_chunks * bpc
                 for group_block_ids, bpc in zip(
                     gpu_block_ids, blocks_per_chunk, strict=True
                 )
             ):
                 logger.warning(
                     "STORE block ID underflow for request_id=%s: each group needs "
-                    "len(obj_keys) * blocks_per_chunk block IDs for %d chunks "
+                    "num_chunks * blocks_per_chunk block IDs for %d chunks "
                     "(per-group blocks_per_chunk=%s); skipping the store.",
                     key.request_id,
-                    len(obj_keys),
+                    num_chunks,
                     blocks_per_chunk,
                 )
                 event.record()
@@ -717,31 +719,43 @@ class GPUTransferModule:
             )
 
             reserved_dict: dict[ObjectKey, MemoryObj] = {}
+            all_dict: dict[ObjectKey, MemoryObj] = {}
+            total_bytes: int = 0
             store_succeeded = False
             try:
-                layout_desc = get_layout_desc(
-                    cache_context, self._ctx.chunk_size, object_group_id=0
-                )
-                reserved_dict = self._ctx.storage_manager.reserve_write(
-                    obj_keys, layout_desc, "new"
-                )
+                for obj_group_id in range(num_object_groups):
+                    obj_keys = obj_keys_per_obj_group[obj_group_id]
+                    layout_desc = get_layout_desc(
+                        cache_context,
+                        self._ctx.chunk_size,
+                        object_group_id=obj_group_id,
+                    )
+                    reserved_dict = self._ctx.storage_manager.reserve_write(
+                        obj_keys, layout_desc, "new"
+                    )
+                    all_dict.update(reserved_dict)
+                    if reserved_dict:
+                        total_bytes += next(
+                            iter(reserved_dict.values())
+                        ).get_size() * len(reserved_dict)
 
-                # Keys not in reserved_dict (skipped by the storage manager)
-                # become None entries; the helper skips them for D2H.
-                memory_objs: list[MemoryObj | None] = [
-                    reserved_dict.get(obj_key) for obj_key in obj_keys
-                ]
+                    # Keys not in reserved_dict (skipped by the storage manager)
+                    # become None entries; the helper skips them for D2H.
+                    memory_objs: list[MemoryObj | None] = [
+                        reserved_dict.get(obj_key) for obj_key in obj_keys
+                    ]
 
-                # NOTE: batch_size must stay 1 for store.
-                gpu_kv_copy_helper(
-                    cache_context,
-                    block_ids_per_group_gpu,
-                    memory_objs,
-                    object_group_id=0,
-                    batch_size=1,
-                    skip_first_n_tokens=0,
-                    direction=lmc_ops.TransferDirection.D2H,
-                )
+                    # NOTE: batch_size must stay 1 for store.
+                    gpu_kv_copy_helper(
+                        cache_context,
+                        block_ids_per_group_gpu,
+                        memory_objs,
+                        object_group_id=obj_group_id,
+                        batch_size=1,
+                        skip_first_n_tokens=0,
+                        direction=lmc_ops.TransferDirection.D2H,
+                    )
+
                 store_succeeded = True
             except Exception:
                 logger.exception("Cannot store keys due to exception")
@@ -750,20 +764,15 @@ class GPUTransferModule:
                 event.record()
                 # Fail closed: commit the reserved objects only when every chunk
                 # copied successfully; otherwise the whole store is skipped.
-                stored_count = len(reserved_dict) if store_succeeded else 0
+                stored_count = len(all_dict) if store_succeeded else 0
                 if stored_count:
                     submit_callback_to_stream(
                         cache_context.cupy_stream,
                         "finish_write",
-                        list(reserved_dict.keys()),
+                        list(all_dict.keys()),
                     )
-                # All reserved MemoryObjs share one layout_desc, so per-object
-                # size is identical — avoid summing N identical values.
-                total_bytes = (
-                    next(iter(reserved_dict.values())).get_size() * stored_count
-                    if stored_count
-                    else 0
-                )
+                else:
+                    total_bytes = 0
                 self._ctx.event_bus.publish_on_stream(
                     cache_context.cupy_stream,
                     Event(
@@ -780,10 +789,10 @@ class GPUTransferModule:
                 )
 
         ed = time.perf_counter()
-        if length := len(reserved_dict):
+        if stored_count:
             logger.info(
                 "Stored %d tokens in %.3f seconds",
-                length * self._ctx.chunk_size,
+                num_chunks * self._ctx.chunk_size,
                 ed - st,
             )
         return event.ipc_handle(), True
@@ -820,7 +829,6 @@ class GPUTransferModule:
             ValueError: If no GPU context is registered for the given instance ID.
         """
         st = time.perf_counter()
-        obj_keys = self._ctx.resolve_obj_keys(key, [0])[0]
 
         entry = self._cache_contexts.get(instance_id)
         if entry is None:
@@ -828,8 +836,11 @@ class GPUTransferModule:
         cache_context = entry.cache_context
         model_name = entry.model_name
 
-        # TODO(refactor): only single-object-group transfers are wired up so far.
-        assert cache_context.kv_layer_groups_manager.num_object_groups == 1
+        num_object_groups = cache_context.kv_layer_groups_manager.num_object_groups
+        obj_keys_per_obj_group = self._ctx.resolve_obj_keys(
+            key, list(range(num_object_groups))
+        )
+        num_chunks = len(obj_keys_per_obj_group[0])
 
         # CPU-synchronous sentinel: a GPU retrieve is about to be enqueued.
         # Must be published via publish() (not publish_on_stream) so the
@@ -892,18 +903,18 @@ class GPUTransferModule:
             # block ids, before cutting drops the per-chunk blocks that
             # sliding-window groups do not need.
             if any(
-                len(group_block_ids) < len(obj_keys) * bpc
+                len(group_block_ids) < num_chunks * bpc
                 for group_block_ids, bpc in zip(
                     gpu_block_ids, blocks_per_chunk, strict=True
                 )
             ):
                 logger.error(
                     "RETRIEVE block ID underflow for request_id=%s: each group "
-                    "needs len(obj_keys) * blocks_per_chunk block IDs for %d "
+                    "needs num_chunks * blocks_per_chunk block IDs for %d "
                     "chunks (per-group blocks_per_chunk=%s); skipping the "
                     "retrieve.",
                     key.request_id,
-                    len(obj_keys),
+                    num_chunks,
                     blocks_per_chunk,
                 )
                 event.record()
@@ -915,36 +926,38 @@ class GPUTransferModule:
             )
 
             prefetched_keys: list[ObjectKey] = []
-            retrieve_succeeded = False
             total_bytes = 0
             try:
-                with self._ctx.storage_manager.read_prefetched_results(
-                    obj_keys
-                ) as memory_objs:
-                    if not memory_objs or len(memory_objs) != len(obj_keys):
-                        logger.error("Some keys not found during retrieve!")
-                        return event.ipc_handle(), False
+                for obj_group_id in range(num_object_groups):
+                    obj_keys = obj_keys_per_obj_group[obj_group_id]
+                    with self._ctx.storage_manager.read_prefetched_results(
+                        obj_keys
+                    ) as memory_objs:
+                        if not memory_objs or len(memory_objs) != len(obj_keys):
+                            logger.error("Some keys not found during retrieve!")
+                            return event.ipc_handle(), False
 
-                    prefetched_keys = obj_keys[: len(memory_objs)]
-                    total_bytes = sum(mo.get_size() for mo in memory_objs)
+                        total_bytes += sum(mo.get_size() for mo in memory_objs)
 
-                    gpu_kv_copy_helper(
-                        cache_context,
-                        block_ids_per_group_gpu,
-                        memory_objs,
-                        object_group_id=0,
-                        batch_size=cache_context.max_batch_size,
-                        skip_first_n_tokens=skip_first_n_tokens,
-                        direction=lmc_ops.TransferDirection.H2D,
-                    )
-                # Only set True when with-block exits normally
-                retrieve_succeeded = True
+                        gpu_kv_copy_helper(
+                            cache_context,
+                            block_ids_per_group_gpu,
+                            memory_objs,
+                            object_group_id=obj_group_id,
+                            batch_size=cache_context.max_batch_size,
+                            skip_first_n_tokens=skip_first_n_tokens,
+                            direction=lmc_ops.TransferDirection.H2D,
+                        )
+                        # Extend only after the copy is enqueued: on exception,
+                        # read_prefetched_results releases this group's locks
+                        # itself, and a key must not be released twice.
+                        prefetched_keys.extend(obj_keys)
             except Exception:
                 logger.exception("Cannot retrieve keys due to exception")
                 return event.ipc_handle(), False
             finally:
                 event.record()
-                if retrieve_succeeded:
+                if prefetched_keys:
                     submit_callback_to_stream(
                         cache_context.cupy_stream,
                         "finish_read_prefetched",
@@ -965,7 +978,7 @@ class GPUTransferModule:
                         },
                     ),
                 )
-        tokens_retrieved = len(obj_keys) * self._ctx.chunk_size
+        tokens_retrieved = num_chunks * self._ctx.chunk_size
         ed = time.perf_counter()
         logger.info(
             "Retrieved %d tokens in %.3f seconds",

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -612,7 +612,7 @@ class GPUTransferModule:
             store completed without such a failure.
         """
         st = time.perf_counter()
-        obj_keys = self._ctx.resolve_obj_keys(key)
+        obj_keys = self._ctx.resolve_obj_keys(key, [0])[0]
 
         entry = self._cache_contexts.get(instance_id)
         if entry is None:
@@ -818,7 +818,7 @@ class GPUTransferModule:
             ValueError: If no GPU context is registered for the given instance ID.
         """
         st = time.perf_counter()
-        obj_keys = self._ctx.resolve_obj_keys(key)
+        obj_keys = self._ctx.resolve_obj_keys(key, [0])[0]
 
         entry = self._cache_contexts.get(instance_id)
         if entry is None:

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -269,10 +269,14 @@ def gpu_kv_copy_helper(
     is_h2d = direction == lmc_ops.TransferDirection.H2D
 
     sw_size_chunks = kv_groups_manager.get_sw_size_chunks(object_group_id)
-    if sw_size_chunks == -1:
-        num_objects_to_skip = 0
-    else:
+    if sw_size_chunks >= 1 and is_h2d:
         num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)
+        logger.debug(
+            "Detected sliding window for object group %d: "
+            "skipping the first %d objects in the batch",
+            object_group_id,
+            num_objects_to_skip,
+        )
 
     for start_object_idx, memory_object_batch in batched_iteration_with_skip(
         memory_objs, batch_size, skip_count=num_objects_to_skip

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -4,7 +4,7 @@
 # Standard
 from dataclasses import dataclass
 from itertools import islice
-from typing import Generator
+from typing import Generator, Sequence
 import time
 
 # Third Party
@@ -104,7 +104,7 @@ def batched_iteration(lst: list, batch_size: int) -> Generator[tuple, None, None
 
 
 def batched_iteration_with_skip(
-    lst: list,
+    lst: Sequence,
     batch_size: int,
     skip_count: int,
 ) -> Generator[tuple[int, tuple], None, None]:
@@ -251,7 +251,7 @@ def _recalculate_blocks_to_skip(
 def gpu_kv_copy_helper(
     cache_context: GPUCacheContext,
     block_ids_gpu: list[torch.Tensor],
-    memory_objs: list[MemoryObj],
+    memory_objs: Sequence[MemoryObj | None],
     object_group_id: int,
     batch_size: int,
     skip_first_n_tokens: int,
@@ -265,7 +265,10 @@ def gpu_kv_copy_helper(
             index. It should satisfy `len(block_ids_gpu[i]) == len(memory_objs) *
             blocks_per_chunk[i]` for each group `i`.
             Note that the block IDs list are already on GPU.
-        memory_objs: The list of MemoryObj instances to copy from.
+        memory_objs: The list of MemoryObj instances to copy from. It could be
+            None when allocation or retrieval fails. For store (D2H), it should
+            ignore the None entry and continue copying the rest. For retrieve
+            (H2D), it should raise the error and stop copying.
         object_group_id: Index of the object group being copied.
         batch_size: The number of memory objects to perform batched copy
         skip_first_n_tokens: Number of tokens to skip writing at the start of
@@ -273,6 +276,8 @@ def gpu_kv_copy_helper(
             may be read concurrently by other requests.
         direction: The transfer direction, H2D (retrieve) or D2H (store).
 
+    Raises:
+        ValueError: If it founds None entry in memory_objs when direction is H2D.
     Note:
         This function expects the caller to stage the block ids (list[list[int]])
         into GPU tensors and pass them in as `block_ids_gpu`.
@@ -292,6 +297,16 @@ def gpu_kv_copy_helper(
     for start_object_idx, memory_object_batch in batched_iteration_with_skip(
         memory_objs, batch_size, skip_count=num_objects_to_skip
     ):
+        if any(mo is None for mo in memory_object_batch):
+            if is_h2d:
+                raise ValueError(
+                    "MemoryObj is None for some objects in the batch, cannot "
+                    "perform H2D copy. memory_object_batch: "
+                    f"{memory_object_batch}"
+                )
+            else:
+                continue
+
         batch_len = len(memory_object_batch)
         batch_start_token = start_object_idx * lmcache_chunk_size
         batch_end_token = batch_start_token + batch_len * lmcache_chunk_size
@@ -638,20 +653,17 @@ class GPUTransferModule:
             check_interprocess_event_support()
             event = torch_dev.Event(interprocess=True)
 
-            block_ids_per_group_gpu = cut_and_stage_block_ids(
-                cache_context, gpu_block_ids
-            )
-
             # Fail closed: every LMCache group must have block IDs covering all
             # chunks. A short list (e.g. a caller/protocol bug) would otherwise
             # drive the transfer kernel to read out-of-bounds GPU memory, so skip
             # the whole store and commit nothing rather than caching a partial or
             # garbage entry. A later request can store it once the block IDs are
-            # complete.
+            # complete. Checked on the raw block ids, before cutting drops the
+            # per-chunk blocks that sliding-window groups do not need.
             if any(
-                group_block_ids.shape[0] < len(obj_keys) * bpc
+                len(group_block_ids) < len(obj_keys) * bpc
                 for group_block_ids, bpc in zip(
-                    block_ids_per_group_gpu, blocks_per_chunk, strict=True
+                    gpu_block_ids, blocks_per_chunk, strict=True
                 )
             ):
                 logger.warning(
@@ -664,6 +676,10 @@ class GPUTransferModule:
                 )
                 event.record()
                 return event.ipc_handle(), False
+
+            block_ids_per_group_gpu = cut_and_stage_block_ids(
+                cache_context, gpu_block_ids
+            )
 
             if not hasattr(torch_dev.Event, "from_ipc_handle"):
                 raise RuntimeError(
@@ -710,36 +726,22 @@ class GPUTransferModule:
                     obj_keys, layout_desc, "new"
                 )
 
-                # NOTE: Store is not batched because some obj_keys may be
-                # skipped (not in reserved_dict), making block_ids
-                # non-contiguous. Batching would require torch.cat to
-                # reassemble block_ids, negating the benefit.
-                num_groups = cache_context.kv_layer_groups_manager.num_groups
-                for idx, obj_key in enumerate(obj_keys):
-                    if obj_key in reserved_dict:
-                        memory_obj = reserved_dict[obj_key]
-                    else:
-                        continue
+                # Keys not in reserved_dict (skipped by the storage manager)
+                # become None entries; the helper skips them for D2H.
+                memory_objs: list[MemoryObj | None] = [
+                    reserved_dict.get(obj_key) for obj_key in obj_keys
+                ]
 
-                    # Store is not batched (skipped keys make block_ids
-                    # non-contiguous), so transfer one chunk at a time by slicing
-                    # this chunk's block IDs out of each group's list.
-                    chunk_block_ids_gpu = [
-                        block_ids_per_group_gpu[group_idx][
-                            idx * blocks_per_chunk[group_idx] : (idx + 1)
-                            * blocks_per_chunk[group_idx]
-                        ]
-                        for group_idx in range(num_groups)
-                    ]
-                    gpu_kv_copy_helper(
-                        cache_context,
-                        chunk_block_ids_gpu,
-                        [memory_obj],
-                        object_group_id=0,
-                        batch_size=1,
-                        skip_first_n_tokens=0,
-                        direction=lmc_ops.TransferDirection.D2H,
-                    )
+                # NOTE: batch_size must stay 1 for store.
+                gpu_kv_copy_helper(
+                    cache_context,
+                    block_ids_per_group_gpu,
+                    memory_objs,
+                    object_group_id=0,
+                    batch_size=1,
+                    skip_first_n_tokens=0,
+                    direction=lmc_ops.TransferDirection.D2H,
+                )
                 store_succeeded = True
             except Exception:
                 logger.exception("Cannot store keys due to exception")
@@ -882,13 +884,35 @@ class GPUTransferModule:
             torch_dev.device(cache_context.device),
             torch_dev.stream(cache_context.stream),
         ):
+            check_interprocess_event_support()
+            event = torch_dev.Event(interprocess=True)
+
+            # Fail closed: a short block-id list would drive the transfer
+            # kernel to write out-of-bounds GPU memory. Checked on the raw
+            # block ids, before cutting drops the per-chunk blocks that
+            # sliding-window groups do not need.
+            if any(
+                len(group_block_ids) < len(obj_keys) * bpc
+                for group_block_ids, bpc in zip(
+                    gpu_block_ids, blocks_per_chunk, strict=True
+                )
+            ):
+                logger.error(
+                    "RETRIEVE block ID underflow for request_id=%s: each group "
+                    "needs len(obj_keys) * blocks_per_chunk block IDs for %d "
+                    "chunks (per-group blocks_per_chunk=%s); skipping the "
+                    "retrieve.",
+                    key.request_id,
+                    len(obj_keys),
+                    blocks_per_chunk,
+                )
+                event.record()
+                return event.ipc_handle(), False
+
             # Cut and stage all block_ids to GPU once before the transfer
             block_ids_per_group_gpu = cut_and_stage_block_ids(
                 cache_context, gpu_block_ids
             )
-
-            check_interprocess_event_support()
-            event = torch_dev.Event(interprocess=True)
 
             prefetched_keys: list[ObjectKey] = []
             retrieve_succeeded = False
@@ -903,21 +927,6 @@ class GPUTransferModule:
 
                     prefetched_keys = obj_keys[: len(memory_objs)]
                     total_bytes = sum(mo.get_size() for mo in memory_objs)
-
-                    # Fail closed: a short block-id list would drive the
-                    # transfer kernel to write out-of-bounds GPU memory.
-                    if any(
-                        group_block_ids.shape[0] < len(memory_objs) * bpc
-                        for group_block_ids, bpc in zip(
-                            block_ids_per_group_gpu, blocks_per_chunk, strict=True
-                        )
-                    ):
-                        raise ValueError(
-                            "RETRIEVE block ID underflow for request_id="
-                            f"{key.request_id}: each group needs len(memory_objs) "
-                            f"* blocks_per_chunk block IDs for {len(memory_objs)} "
-                            f"chunks (per-group blocks_per_chunk={blocks_per_chunk})"
-                        )
 
                     gpu_kv_copy_helper(
                         cache_context,

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -269,6 +269,7 @@ def gpu_kv_copy_helper(
     is_h2d = direction == lmc_ops.TransferDirection.H2D
 
     sw_size_chunks = kv_groups_manager.get_sw_size_chunks(object_group_id)
+    num_objects_to_skip = 0
     if sw_size_chunks >= 1 and is_h2d:
         num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)
         logger.debug(

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -7,6 +7,9 @@ from itertools import islice
 from typing import Generator
 import time
 
+# Third Party
+import torch
+
 # First Party
 from lmcache import torch_dev, torch_device_type
 from lmcache.logging import init_logger
@@ -98,6 +101,280 @@ def batched_iteration(lst: list, batch_size: int) -> Generator[tuple, None, None
     it = iter(lst)
     while batch := tuple(islice(it, batch_size)):
         yield batch
+
+
+def batched_iteration_with_skip(
+    lst: list,
+    batch_size: int,
+    skip_count: int,
+) -> Generator[tuple[int, tuple], None, None]:
+    """Utility function to iterate over a list in batches with an initial skip.
+
+    Args:
+        lst: The list to iterate over.
+        batch_size: The size of each batch.
+        skip_count: The number of items to skip at the start of the list.
+
+    Yields:
+        Tuples of (batch_start_idx, batch) where batch is a tuple of items
+        from the list, and batch_start_idx is the "original" index of the first
+        item in the batch.
+
+    Raises:
+        ValueError: If batch_size is less than 1 or skip_count is negative.
+
+    Note:
+        Batch_idx is the index of the batch in the original list, accounting
+        for the skipped items. For example, if skip_count is 10 and batch_size
+        is 5, the first yielded batch will have batch_start_idx=10.
+    """
+    if batch_size < 1:
+        raise ValueError("batch size must be at least one")
+    if skip_count < 0:
+        raise ValueError("skip_count must be non-negative")
+
+    it = iter(lst)
+    # Skip the initial items
+    for _ in range(skip_count):
+        next(it, None)
+    batch_start_idx = skip_count
+    while batch := tuple(islice(it, batch_size)):
+        yield batch_start_idx, batch
+        batch_start_idx += len(batch)
+
+
+def cut_and_stage_block_ids(
+    cache_context: GPUCacheContext,
+    block_ids: list[list[int]],
+) -> list[torch.Tensor]:
+    """Cut the block id lists to skip the unneeded blocks in a chunk and
+    stage it into GPU tensors for later use.
+
+    This mainly targets the case where a portion of the blocks are not
+    needed for every chunk, such as deepseek v4's swa cache.
+
+    Note that the we do NOT do any object-level skipping here.
+
+    Args:
+        cache_context: The GPU cache context containing the KV cache information.
+        block_ids: The original block id lists, indexed by LMCache KV group index.
+
+    Returns:
+        The cut block id lists, indexed by LMCache KV group index.
+
+    Note:
+        This function has some coupled logic with gpu_kv_copy_helper below. The
+        caller need to make sure that the block ids seen by gpu_kv_copy_helper
+        are produced by this function.
+
+    Example:
+        If a model have 2 kernel groups, one is full attention with block size 32,
+        one is swa attention with block size 32 and sliding window size 64, and
+        LMCache has a chunk size of 128. And there are 2 chunks in total (256 tokens).
+
+        The input will be:
+        [
+          [1, 2, 3, 4, 5, 6, 7, 8],  # block ids for the full attention group
+          [11, 12, 13, 14, 15, 16, 17, 18], # block ids for the swa attention group
+        ]
+
+        The output will be
+        [
+          [1, 2, 3, 4, 5, 6, 7, 8],  # full attention group still needs all block ids
+          [13, 14, 17, 18], # swa attention group only needs the last 2 block per chunk
+        ]
+    """
+    num_kernel_groups = cache_context.kv_layer_groups_manager.num_groups
+    for kernel_group_id in range(num_kernel_groups):
+        # TODO: we need to get the actual sliding window size from the kernel
+        # group
+        placeholder_sliding_window_size = cache_context.lmcache_logical_chunk_size
+        tokens_per_chunk = min(
+            cache_context.lmcache_logical_chunk_size, placeholder_sliding_window_size
+        )
+        keep_blocks_per_chunk = cache_context.calculate_num_blocks(
+            tokens_per_chunk, kernel_group_id
+        )
+        total_blocks_per_chunk = cache_context.calculate_num_blocks(
+            cache_context.lmcache_logical_chunk_size, kernel_group_id
+        )
+
+        new_block_ids = []
+        old_block_ids = block_ids[kernel_group_id]
+        assert len(old_block_ids) % total_blocks_per_chunk == 0, (
+            f"len(block_ids[{kernel_group_id}]) should be a multiple "
+            f"of total_blocks_per_chunk ({total_blocks_per_chunk}), but got "
+            f"{len(old_block_ids)}"
+        )
+
+        for i in range(0, len(old_block_ids), total_blocks_per_chunk):
+            chunk_block_ids = old_block_ids[i : i + total_blocks_per_chunk]
+            new_block_ids.extend(chunk_block_ids[-keep_blocks_per_chunk:])
+
+        block_ids[kernel_group_id] = new_block_ids
+
+    # Stage the cut block ids into GPU tensors
+    block_ids_gpu = cache_context.copy_view_block_ids_to_gpu(block_ids)
+    return block_ids_gpu
+
+
+def _recalculate_blocks_to_skip(
+    blocks_per_chunk: int,
+    blocks_per_window: int,
+    blocks_to_skip: int,
+) -> int:
+    """Re-calculate the number of blocks to skip for a batch of chunks based
+    on the blocks per chunk and blocks per sliding window WHEN the window
+    size is smaller than the lmcache chunk size.
+
+    Args:
+        blocks_per_chunk: The total number of blocks in one chunk for the
+            current group.
+        blocks_per_window: The number of blocks in the sliding window
+            for the current group. Should be less than or equal to
+            blocks_per_chunk.
+        blocks_to_skip: The number of blocks to skip.
+
+    Returns:
+        The re-calculated number of blocks to skip for the current batch of
+        chunks.
+    """
+    if blocks_per_chunk == blocks_per_window:
+        return blocks_to_skip
+
+    full_windows_to_skip = blocks_to_skip // blocks_per_chunk
+    tail_blocks = blocks_to_skip % blocks_per_chunk
+    tail_blocks_to_skip = tail_blocks - (blocks_per_chunk - blocks_per_window)
+    return full_windows_to_skip * blocks_per_window + max(0, tail_blocks_to_skip)
+
+
+def gpu_kv_copy_helper(
+    cache_context: GPUCacheContext,
+    block_ids_gpu: list[torch.Tensor],
+    memory_objs: list[MemoryObj],
+    object_group_id: int,
+    batch_size: int,
+    skip_first_n_tokens: int,
+    direction: "lmc_ops.TransferDirection",
+) -> None:
+    """Helper function to transfer a batch of memory objects to/from GPU.
+
+    Args:
+        cache_context: The GPU cache context containing the KV cache information.
+        block_ids_gpu: GPU block IDs to retrieve into, indexed by LMCache KV group
+            index. It should satisfy `len(block_ids_gpu[i]) == len(memory_objs) *
+            blocks_per_chunk[i]` for each group `i`.
+            Note that the block IDs list are already on GPU.
+        memory_objs: The list of MemoryObj instances to copy from.
+        object_group_id: Index of the object group being copied.
+        batch_size: The number of memory objects to perform batched copy
+        skip_first_n_tokens: Number of tokens to skip writing at the start of
+            the retrieve range. This avoids overwriting APC-shared GPU blocks that
+            may be read concurrently by other requests.
+        direction: The transfer direction, H2D (retrieve) or D2H (store).
+
+    Note:
+        This function expects the caller to stage the block ids (list[list[int]])
+        into GPU tensors and pass them in as `block_ids_gpu`.
+    """
+    # TODO(ApostaC): this is for the sliding window optimization. We will have
+    # num_objects_to_skip calculated based on the sliding window size.
+    # In most of cases, it will be:
+    # - `len(memory_objs) - chunks_in_sliding_window`
+    # where the `chunks_in_sliding_window` is calculated as:
+    # - `cdiv(sliding_window_size_in_token, chunk_size)`
+    num_objects_to_skip = 0
+    lmcache_chunk_size = cache_context.lmcache_logical_chunk_size
+    object_group = cache_context.kv_layer_groups_manager.object_groups[object_group_id]
+    kernel_group_ids = object_group.kernel_group_indices
+    is_h2d = direction == lmc_ops.TransferDirection.H2D
+
+    for start_object_idx, memory_object_batch in batched_iteration_with_skip(
+        memory_objs, batch_size, skip_count=num_objects_to_skip
+    ):
+        batch_len = len(memory_object_batch)
+        batch_start_token = start_object_idx * lmcache_chunk_size
+        batch_end_token = batch_start_token + batch_len * lmcache_chunk_size
+
+        effective_start = max(batch_start_token, skip_first_n_tokens)
+        if effective_start >= batch_end_token:
+            continue
+
+        skip_tokens_in_chunk = effective_start - batch_start_token
+
+        # For H2D, copy from CPU to GPU tmp buffers before the kernel launch
+        if is_h2d:
+            for chunk_idx, memory_obj in enumerate(memory_object_batch):
+                lmcache_memcpy_async_h2d(
+                    memory_obj,
+                    cache_context.get_temp_object_group_buffer(
+                        chunk_idx, object_group_id
+                    ),
+                )
+
+        # Do paged KV copy
+        for kernel_group_id in kernel_group_ids:
+            blocks_per_chunk = cache_context.calculate_num_blocks(
+                lmcache_chunk_size, kernel_group_id
+            )
+            # TODO(ApostaC): we need to get the sliding window information
+            # from the kernel group
+            placeholder_blocks_per_window = blocks_per_chunk
+
+            # Get the block ids for this chunk
+            start_block_pos = start_object_idx * placeholder_blocks_per_window
+            end_block_pos = (
+                start_object_idx + batch_len
+            ) * placeholder_blocks_per_window
+
+            block_ids_curr_batch = block_ids_gpu[kernel_group_id][
+                start_block_pos:end_block_pos
+            ]
+
+            # Re-calculate the skip blocks for this kernel group
+            orig_skip_blocks = cache_context.calculate_num_blocks(
+                skip_tokens_in_chunk, kernel_group_id
+            )
+            recalculated_skip_blocks = _recalculate_blocks_to_skip(
+                blocks_per_chunk,
+                placeholder_blocks_per_window,
+                orig_skip_blocks,
+            )
+
+            # Launch kernel
+            group_kv_pointers = cache_context.get_kernel_group_kv_pointers(
+                kernel_group_id
+            )
+            group_lmcache_chunk_size = cache_context.get_physical_chunk_size(
+                kernel_group_id
+            )
+            tmp_gpu_buffers_batched = [
+                cache_context.get_temp_kernel_group_buffer(
+                    i, kernel_group_id
+                ).data_ptr()
+                for i in range(batch_len)
+            ]
+            lmc_ops.multi_layer_block_kv_transfer(
+                group_kv_pointers,
+                tmp_gpu_buffers_batched,
+                block_ids_curr_batch,
+                cache_context.device,
+                direction,
+                cache_context.get_shape_desc(kernel_group_id),
+                group_lmcache_chunk_size,
+                cache_context.gpu_kv_format_,
+                recalculated_skip_blocks,
+            )
+
+        # For D2H, copy from GPU tmp buffers to CPU after the kernel launch
+        if not is_h2d:
+            for chunk_idx, memory_obj in enumerate(memory_object_batch):
+                lmcache_memcpy_async_d2h(
+                    cache_context.get_temp_object_group_buffer(
+                        chunk_idx, object_group_id
+                    ),
+                    memory_obj,
+                )
 
 
 @dataclass
@@ -361,8 +638,8 @@ class GPUTransferModule:
             check_interprocess_event_support()
             event = torch_dev.Event(interprocess=True)
 
-            block_ids_per_group_gpu = cache_context.copy_view_block_ids_to_gpu(
-                gpu_block_ids
+            block_ids_per_group_gpu = cut_and_stage_block_ids(
+                cache_context, gpu_block_ids
             )
 
             # Fail closed: every LMCache group must have block IDs covering all
@@ -444,41 +721,24 @@ class GPUTransferModule:
                     else:
                         continue
 
-                    # Copy from GPU paged buffer to tmp buffer, then to CPU — per
-                    # group. Each group uses its own block-id list (HMA).
-                    for group_idx in range(num_groups):
-                        bpc = blocks_per_chunk[group_idx]
-                        chunk_block_ids_gpu = block_ids_per_group_gpu[group_idx][
-                            idx * bpc : (idx + 1) * bpc
+                    # Store is not batched (skipped keys make block_ids
+                    # non-contiguous), so transfer one chunk at a time by slicing
+                    # this chunk's block IDs out of each group's list.
+                    chunk_block_ids_gpu = [
+                        block_ids_per_group_gpu[group_idx][
+                            idx * blocks_per_chunk[group_idx] : (idx + 1)
+                            * blocks_per_chunk[group_idx]
                         ]
-                        # Store is not batched, so we always use batch_idx=0.
-                        tmp_buffer = cache_context.get_temp_kernel_group_buffer(
-                            0, group_idx
-                        )
-                        group_kv_pointers = cache_context.get_kernel_group_kv_pointers(
-                            group_idx
-                        )
-                        # Kernel contract: ``group_lmcache_chunk_size`` here is the
-                        # number of *physical* slots per chunk for this group
-                        # (= logical chunk_size // compress_ratio).
-                        group_lmcache_chunk_size = (
-                            cache_context.get_physical_chunk_size(group_idx)
-                        )
-                        lmc_ops.multi_layer_block_kv_transfer(
-                            group_kv_pointers,
-                            [tmp_buffer.data_ptr()],
-                            chunk_block_ids_gpu,
-                            cache_context.device,
-                            lmc_ops.TransferDirection.D2H,
-                            cache_context.get_shape_desc(group_idx),
-                            group_lmcache_chunk_size,
-                            cache_context.gpu_kv_format_,
-                            0,
-                        )
-                    # Store is not batched, so we always use batch_idx=0 (single
-                    # slot). Single object group => object_group_idx=0.
-                    lmcache_memcpy_async_d2h(
-                        cache_context.get_temp_object_group_buffer(0, 0), memory_obj
+                        for group_idx in range(num_groups)
+                    ]
+                    gpu_kv_copy_helper(
+                        cache_context,
+                        chunk_block_ids_gpu,
+                        [memory_obj],
+                        object_group_id=0,
+                        batch_size=1,
+                        skip_first_n_tokens=0,
+                        direction=lmc_ops.TransferDirection.D2H,
                     )
                 store_succeeded = True
             except Exception:
@@ -601,99 +861,30 @@ class GPUTransferModule:
             cache_context.kv_layer_groups_manager.inference_engine_logical_block_size
         )
 
-        def _retrieve_loop(keys: list[ObjectKey], memory_objs: list[MemoryObj]) -> None:
-            _BATCH_SIZE = cache_context.max_batch_size
-            groups = cache_context.kv_layer_groups_manager.kv_layer_groups
-            for batch_idx, memory_obj_batch in enumerate(
-                batched_iteration(memory_objs, batch_size=_BATCH_SIZE)
-            ):
-                batch_len = len(memory_obj_batch)
-                chunk_start = batch_idx * self._ctx.chunk_size * _BATCH_SIZE
-                chunk_end = chunk_start + self._ctx.chunk_size * batch_len
+        # Block IDs are expressed in engine-block units (logical tokens), which
+        # is what the kernel's skip argument expects regardless of per-group
+        # compression. Warn if the skip prefix is not block-aligned.
+        if skip_first_n_tokens % ie_logical_block_size != 0:
+            logger.error(
+                "skip_first_n_tokens (%d) is not aligned to "
+                "inference_engine_logical_block_size (%d); it will be rounded "
+                "down to a block boundary",
+                skip_first_n_tokens,
+                ie_logical_block_size,
+            )
 
-                effective_start = max(chunk_start, skip_first_n_tokens)
-                if effective_start >= chunk_end:
-                    # Entire batch is within APC range, skip it
-                    continue
-
-                skip_tokens_in_chunk = max(
-                    0,
-                    min(
-                        effective_start - chunk_start,
-                        self._ctx.chunk_size * batch_len - 1,
-                    ),
-                )
-                if skip_tokens_in_chunk % ie_logical_block_size != 0:
-                    logger.error(
-                        "skip_first_n_tokens (%d) is not aligned to "
-                        "inference_engine_logical_block_size (%d), "
-                        "rounding down from %d tokens to %d blocks",
-                        skip_first_n_tokens,
-                        ie_logical_block_size,
-                        skip_tokens_in_chunk,
-                        skip_tokens_in_chunk // ie_logical_block_size,
-                    )
-                start_chunk_id = batch_idx * _BATCH_SIZE
-                end_chunk_id = start_chunk_id + batch_len
-                # Copy from CPU to GPU tmp buffers, then scatter to paged KV — per group
-                # H2D copy: each memory_obj maps to its own batch slot
-                for chunk_idx, memory_obj in enumerate(memory_obj_batch):
-                    # Single object group => object_group_idx=0.
-                    lmcache_memcpy_async_h2d(
-                        memory_obj,
-                        cache_context.get_temp_object_group_buffer(chunk_idx, 0),
-                    )
-                for group_idx, group in enumerate(groups):
-                    bpc = cache_context.calculate_num_blocks(
-                        self._ctx.chunk_size, group_idx
-                    )
-                    chunk_block_ids_gpu = block_ids_per_group_gpu[group_idx][
-                        start_chunk_id * bpc : end_chunk_id * bpc
-                    ]
-                    if chunk_block_ids_gpu.shape[0] != batch_len * bpc:
-                        # Fail closed: a short block-id slice would make the
-                        # transfer kernel write out-of-bounds GPU memory.
-                        raise ValueError(
-                            "RETRIEVE block ID underflow: "
-                            f"group_idx={group_idx} "
-                            f"engine_group_idx={group.engine_group_idx} "
-                            f"batch={batch_idx} "
-                            f"expected={batch_len * bpc} "
-                            f"got={chunk_block_ids_gpu.shape[0]}"
-                        )
-                    group_skip_blocks = cache_context.calculate_num_blocks(
-                        skip_tokens_in_chunk, group_idx
-                    )
-                    tmp_buffers = [
-                        cache_context.get_temp_kernel_group_buffer(i, group_idx)
-                        for i in range(batch_len)
-                    ]
-                    group_kv_pointers = cache_context.get_kernel_group_kv_pointers(
-                        group_idx
-                    )
-                    group_lmcache_chunk_size = cache_context.get_physical_chunk_size(
-                        group_idx
-                    )
-
-                    lmc_ops.multi_layer_block_kv_transfer(
-                        group_kv_pointers,
-                        [tb.data_ptr() for tb in tmp_buffers],
-                        chunk_block_ids_gpu,
-                        cache_context.device,
-                        lmc_ops.TransferDirection.H2D,
-                        cache_context.get_shape_desc(group_idx),
-                        group_lmcache_chunk_size,
-                        cache_context.gpu_kv_format_,
-                        group_skip_blocks,
-                    )
+        blocks_per_chunk = [
+            cache_context.calculate_num_blocks(self._ctx.chunk_size, group_idx)
+            for group_idx in range(cache_context.kv_layer_groups_manager.num_groups)
+        ]
 
         with (
             torch_dev.device(cache_context.device),
             torch_dev.stream(cache_context.stream),
         ):
-            # Copy all block_ids to GPU once before the loop
-            block_ids_per_group_gpu = cache_context.copy_view_block_ids_to_gpu(
-                gpu_block_ids
+            # Cut and stage all block_ids to GPU once before the transfer
+            block_ids_per_group_gpu = cut_and_stage_block_ids(
+                cache_context, gpu_block_ids
             )
 
             check_interprocess_event_support()
@@ -712,7 +903,31 @@ class GPUTransferModule:
 
                     prefetched_keys = obj_keys[: len(memory_objs)]
                     total_bytes = sum(mo.get_size() for mo in memory_objs)
-                    _retrieve_loop(obj_keys, memory_objs)
+
+                    # Fail closed: a short block-id list would drive the
+                    # transfer kernel to write out-of-bounds GPU memory.
+                    if any(
+                        group_block_ids.shape[0] < len(memory_objs) * bpc
+                        for group_block_ids, bpc in zip(
+                            block_ids_per_group_gpu, blocks_per_chunk, strict=True
+                        )
+                    ):
+                        raise ValueError(
+                            "RETRIEVE block ID underflow for request_id="
+                            f"{key.request_id}: each group needs len(memory_objs) "
+                            f"* blocks_per_chunk block IDs for {len(memory_objs)} "
+                            f"chunks (per-group blocks_per_chunk={blocks_per_chunk})"
+                        )
+
+                    gpu_kv_copy_helper(
+                        cache_context,
+                        block_ids_per_group_gpu,
+                        memory_objs,
+                        object_group_id=0,
+                        batch_size=cache_context.max_batch_size,
+                        skip_first_n_tokens=skip_first_n_tokens,
+                        direction=lmc_ops.TransferDirection.H2D,
+                    )
                 # Only set True when with-block exits normally
                 retrieve_succeeded = True
             except Exception:

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -266,7 +266,7 @@ class LookupModule:
         session.set_tokens(list(key.token_ids))
         session.lookup_ipc_key = key
 
-        obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
+        obj_keys = ipc_key_to_object_keys(key, chunk_hashes, [0])[0]
 
         handle = self._ctx.storage_manager.submit_prefetch_task(
             obj_keys,
@@ -399,7 +399,7 @@ class LookupModule:
         )
         if not chunk_hashes:
             return
-        obj_keys = ipc_key_to_object_keys(key, chunk_hashes)
+        obj_keys = ipc_key_to_object_keys(key, chunk_hashes, [0])[0]
 
         extra_count = compute_extra_count(tp_size, key.world_size)
 
@@ -437,7 +437,7 @@ class LookupModule:
             return
 
         chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in session.get_hashes(0)]
-        obj_keys = ipc_key_to_object_keys(session.lookup_ipc_key, chunk_hashes)
+        obj_keys = ipc_key_to_object_keys(session.lookup_ipc_key, chunk_hashes, [0])[0]
         # unified touch of all keys, which include retrieved and stored keys
         # TODO(chunxiaozheng): when l2 is enabled, the prefetched keys from l2 are temp
         #  and will be deleted after finish_read_prefetched, when we touch all keys,

--- a/lmcache/v1/multiprocess/modules/non_gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/non_gpu_transfer.py
@@ -161,6 +161,11 @@ class NonGPUTransferModule:
     ) -> tuple[int, IPCCacheEngineKey]:
         return (instance_id, key)
 
+    def _resolve_single_group_obj_keys(self, key: IPCCacheEngineKey) -> list[ObjectKey]:
+        """Resolve object keys for the single object group used by
+        non-GPU transfers."""
+        return self._ctx.resolve_obj_keys(key, [0])[0]
+
     def register_kv_cache_non_gpu_context(
         self,
         payload: RegisterNonGpuContextPayload,
@@ -310,7 +315,7 @@ class NonGPUTransferModule:
             key=key,
             instance_id=instance_id,
             context=entry.metadata,
-            resolve_obj_keys=self._ctx.resolve_obj_keys,
+            resolve_obj_keys=self._resolve_single_group_obj_keys,
         )
         session = self._ctx.session_manager.get_or_create(key.request_id)
         session.extras["store_start_time"] = time.perf_counter()
@@ -354,10 +359,12 @@ class NonGPUTransferModule:
             instance_id=instance_id,
             cpu_data=cpu_data,
             context=entry.metadata,
-            resolve_obj_keys=self._ctx.resolve_obj_keys,
+            resolve_obj_keys=self._resolve_single_group_obj_keys,
         )
         if st is not None and result:
-            num_tokens = len(self._ctx.resolve_obj_keys(key)) * self._ctx.chunk_size
+            num_tokens = (
+                len(self._resolve_single_group_obj_keys(key)) * self._ctx.chunk_size
+            )
             logger.info(
                 "Stored %d tokens in %.3f seconds",
                 num_tokens,
@@ -392,7 +399,7 @@ class NonGPUTransferModule:
         response = strategy.prepare_retrieve(
             key=key,
             instance_id=instance_id,
-            resolve_obj_keys=self._ctx.resolve_obj_keys,
+            resolve_obj_keys=self._resolve_single_group_obj_keys,
         )
         session = self._ctx.session_manager.get_or_create(key.request_id)
         session.extras["retrieve_start_time"] = time.perf_counter()
@@ -422,7 +429,9 @@ class NonGPUTransferModule:
         st = session.extras.pop("retrieve_start_time", None)
         result = strategy.commit_retrieve(key=key, instance_id=instance_id)
         if st is not None:
-            num_tokens = len(self._ctx.resolve_obj_keys(key)) * self._ctx.chunk_size
+            num_tokens = (
+                len(self._resolve_single_group_obj_keys(key)) * self._ctx.chunk_size
+            )
             logger.info(
                 "Retrieved %d tokens in %.3f seconds",
                 num_tokens,

--- a/tests/v1/distributed/test_fs_l2_adapter_keys.py
+++ b/tests/v1/distributed/test_fs_l2_adapter_keys.py
@@ -132,7 +132,7 @@ class TestIpcKeyToObjectKeys:
             token_ids=[1, 2, 3],
             cache_salt="alice",
         )
-        out = ipc_key_to_object_keys(k, [b"h1", b"h2"])
+        out = ipc_key_to_object_keys(k, [b"h1", b"h2"], [0])[0]
         assert len(out) == 2
         assert all(o.cache_salt == "alice" for o in out)
 
@@ -149,7 +149,7 @@ class TestIpcKeyToObjectKeys:
             token_ids=[1, 2, 3],
             cache_salt="alice",
         )
-        out = ipc_key_to_object_keys(k, [b"h1"])
+        out = ipc_key_to_object_keys(k, [b"h1"], [0])[0]
         assert len(out) == 4
         assert all(o.cache_salt == "alice" for o in out)
 
@@ -164,10 +164,10 @@ class TestIpcKeyToObjectKeys:
             worker_id=0,
             token_ids=[1],
         )
-        out = ipc_key_to_object_keys(k, [b"h1"])
+        out = ipc_key_to_object_keys(k, [b"h1"], [0])[0]
         assert all(o.cache_salt == "" for o in out)
 
-    def test_object_group_id_defaults_to_zero(self):
+    def test_object_group_id_zero(self):
         # First Party
         from lmcache.v1.distributed.api import ipc_key_to_object_keys
         from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
@@ -178,7 +178,7 @@ class TestIpcKeyToObjectKeys:
             worker_id=0,
             token_ids=[1, 2],
         )
-        out = ipc_key_to_object_keys(k, [b"h1", b"h2"])
+        out = ipc_key_to_object_keys(k, [b"h1", b"h2"], [0])[0]
         assert all(o.object_group_id == 0 for o in out)
 
     def test_object_group_id_propagates_to_all_keys(self):
@@ -194,9 +194,34 @@ class TestIpcKeyToObjectKeys:
             worker_id=None,
             token_ids=[1, 2, 3],
         )
-        out = ipc_key_to_object_keys(k, [b"h1"], object_group_id=3)
+        out = ipc_key_to_object_keys(k, [b"h1"], [3])[0]
         assert len(out) == 4
         assert all(o.object_group_id == 3 for o in out)
+
+    def test_multiple_object_groups(self):
+        """Each requested object group gets its own positional key list."""
+        # First Party
+        from lmcache.v1.distributed.api import ipc_key_to_object_keys
+        from lmcache.v1.multiprocess.custom_types import IPCCacheEngineKey
+
+        k = IPCCacheEngineKey.from_token_ids(
+            model_name="m",
+            world_size=2,
+            worker_id=None,
+            token_ids=[1, 2, 3],
+            cache_salt="alice",
+        )
+        out = ipc_key_to_object_keys(k, [b"h1", b"h2"], [0, 3])
+        assert len(out) == 2
+        # 2 chunks * 2 workers = 4 keys per group.
+        assert all(len(group_keys) == 4 for group_keys in out)
+        assert all(o.object_group_id == 0 for o in out[0])
+        assert all(o.object_group_id == 3 for o in out[1])
+        # The groups differ only in object_group_id.
+        for first, second in zip(out[0], out[1], strict=True):
+            assert first.chunk_hash == second.chunk_hash
+            assert first.kv_rank == second.kv_rank
+            assert first.cache_salt == second.cache_salt
 
 
 class TestObjectKeyValidation:

--- a/tests/v1/multiprocess/test_batched_iteration_with_skip.py
+++ b/tests/v1/multiprocess/test_batched_iteration_with_skip.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``batched_iteration_with_skip``."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.modules.gpu_transfer import (
+    batched_iteration_with_skip,
+)
+
+
+def test_basic_batching_with_skip():
+    """Skipped items are dropped and reported indices stay in original space."""
+    data = list(range(10))
+    result = list(batched_iteration_with_skip(data, batch_size=3, skip_count=2))
+
+    assert result == [
+        (2, (2, 3, 4)),
+        (5, (5, 6, 7)),
+        (8, (8, 9)),
+    ]
+
+
+def test_skip_count_zero_matches_plain_batching():
+    """With skip_count=0 every item is yielded, indexed from 0."""
+    data = list(range(7))
+    result = list(batched_iteration_with_skip(data, batch_size=2, skip_count=0))
+
+    assert result == [
+        (0, (0, 1)),
+        (2, (2, 3)),
+        (4, (4, 5)),
+        (6, (6,)),
+    ]
+    # The concatenation of all batches equals the unskipped tail of the list.
+    flattened = [item for _, batch in result for item in batch]
+    assert flattened == data
+
+
+def test_batch_start_indices_are_original_indices():
+    """Reported start index is the original list index, accounting for skip."""
+    data = list(range(20))
+    result = list(batched_iteration_with_skip(data, batch_size=5, skip_count=10))
+
+    start_indices = [start for start, _ in result]
+    assert start_indices == [10, 15]
+    # The docstring example: skip_count=10, batch_size=5 -> first start idx 10.
+    assert result[0] == (10, (10, 11, 12, 13, 14))
+
+
+def test_partial_final_batch():
+    """The final short batch still reports the correct start index."""
+    data = list(range(8))
+    result = list(batched_iteration_with_skip(data, batch_size=3, skip_count=1))
+
+    assert result == [
+        (1, (1, 2, 3)),
+        (4, (4, 5, 6)),
+        (7, (7,)),
+    ]
+
+
+def test_skip_equal_to_length_yields_nothing():
+    """Skipping the entire list yields no batches."""
+    data = list(range(5))
+    result = list(batched_iteration_with_skip(data, batch_size=2, skip_count=5))
+    assert result == []
+
+
+def test_skip_larger_than_length_yields_nothing():
+    """Skipping past the end of the list yields no batches and does not raise."""
+    data = list(range(5))
+    result = list(batched_iteration_with_skip(data, batch_size=2, skip_count=100))
+    assert result == []
+
+
+def test_empty_list():
+    """An empty input yields no batches regardless of skip_count."""
+    assert list(batched_iteration_with_skip([], batch_size=4, skip_count=0)) == []
+    assert list(batched_iteration_with_skip([], batch_size=4, skip_count=3)) == []
+
+
+def test_batch_size_larger_than_remaining():
+    """A batch_size exceeding the remaining items yields one full-remainder batch."""
+    data = list(range(6))
+    result = list(batched_iteration_with_skip(data, batch_size=100, skip_count=2))
+    assert result == [(2, (2, 3, 4, 5))]
+
+
+@pytest.mark.parametrize("batch_size", [0, -1, -10])
+def test_invalid_batch_size_raises(batch_size):
+    """A batch_size below 1 raises ValueError."""
+    with pytest.raises(ValueError, match="batch size must be at least one"):
+        list(batched_iteration_with_skip([1, 2, 3], batch_size, skip_count=0))
+
+
+@pytest.mark.parametrize("skip_count", [-1, -5])
+def test_negative_skip_count_raises(skip_count):
+    """A negative skip_count raises ValueError."""
+    with pytest.raises(ValueError, match="skip_count must be non-negative"):
+        list(
+            batched_iteration_with_skip([1, 2, 3], batch_size=2, skip_count=skip_count)
+        )
+
+
+def test_returns_tuples_not_lists():
+    """Each yielded batch is a tuple, mirroring batched_iteration."""
+    _, batch = next(
+        batched_iteration_with_skip([1, 2, 3, 4], batch_size=2, skip_count=0)
+    )
+    assert isinstance(batch, tuple)

--- a/tests/v1/multiprocess/test_free_locks.py
+++ b/tests/v1/multiprocess/test_free_locks.py
@@ -105,7 +105,7 @@ def test_server_free_lookup_locks_calls_finish_read_prefetched():
     sentinel_obj_keys = [MagicMock()]
     with patch(
         "lmcache.v1.multiprocess.modules.lookup.ipc_key_to_object_keys",
-        return_value=sentinel_obj_keys,
+        return_value=[sentinel_obj_keys],
     ):
         module.free_lookup_locks(key, 1)
 

--- a/tests/v1/multiprocess/test_non_cuda_data_transfer.py
+++ b/tests/v1/multiprocess/test_non_cuda_data_transfer.py
@@ -602,7 +602,7 @@ def server_module_factory(
         stack.enter_context(
             patch(
                 "lmcache.v1.multiprocess.engine_context.ipc_key_to_object_keys",
-                return_value=object_keys or ["obj"],
+                return_value=[object_keys or ["obj"]],
             )
         )
 

--- a/tests/v1/multiprocess/test_unified_touch.py
+++ b/tests/v1/multiprocess/test_unified_touch.py
@@ -210,7 +210,7 @@ class TestEndSessionTouchKeys:
         assert removed.lookup_ipc_key is not None
 
         chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0)]
-        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
+        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes, [0])[0]
 
         # With world_size=1 and worker_id=None, should have 3 keys
         assert len(obj_keys) == 3
@@ -238,7 +238,7 @@ class TestEndSessionTouchKeys:
         assert removed.lookup_ipc_key is not None
 
         chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0)]
-        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
+        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes, [0])[0]
 
         # 2 chunks * 2 workers = 4 keys
         assert len(obj_keys) == 4
@@ -279,7 +279,7 @@ class TestEndSessionTouchKeys:
         assert removed.lookup_ipc_key is not None
 
         chunk_hashes = [TokenHasher.hash_to_bytes(h) for h in removed.get_hashes(0)]
-        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes)
+        obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes, [0])[0]
         assert len(obj_keys) == 0
 
     def test_end_session_hashes_cover_retrieve_and_store(self, hasher: TokenHasher):


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR does the following things:
1. Unify the h2d/d2h copy code path into a single helper function
2. Add the object group handling logic to the GPU Transfer
3. Add the sliding window support for both kernel group and object group
  a. For kernel group, it's the case where sliding window size < lmcache chunk size
  b. For object group, it's the case where sliding window size = multiple of lmcache chunk size


Need followup:
- Wiring the sliding window size to the object group and kernel group
- Update the prefetch and lookup logic for the sliding window groups
- Correct observability data after considering the object-level skip

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
