### PR TITLE
[Core][MP] Support Mamba/GDN hybrid models (Qwen3.5)

### DIFF
--- a/.buildkite/k3_tests/multiprocess/scripts/launch-processes.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/launch-processes.sh
@@ -17,9 +17,9 @@ MAX_WORKERS="${MAX_WORKERS:-4}"
 MODEL="${MODEL:-Qwen/Qwen3-14B}"
 BUILD_ID="${BUILD_ID:-local_$$}"
 
-# K8s assigns exactly 2 GPUs as devices 0 and 1
-GPU_FOR_VLLM=0
-GPU_FOR_BASELINE=1
+# K8s assigns exactly 2 GPUs as devices 0 and 1 (overridable for local runs).
+GPU_FOR_VLLM="${GPU_FOR_VLLM:-0}"
+GPU_FOR_BASELINE="${GPU_FOR_BASELINE:-1}"
 echo "Using GPU $GPU_FOR_VLLM for vLLM with LMCache"
 echo "Using GPU $GPU_FOR_BASELINE for vLLM baseline"
 
@@ -68,6 +68,27 @@ fi
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-auto}"
 MAX_MODEL_LEN_ARG="--max-model-len ${MAX_MODEL_LEN}"
 
+# LMCache server chunk size in tokens. Empty -> server default.
+CHUNK_SIZE_ARG=""
+if [ -n "${CHUNK_SIZE:-}" ]; then
+    CHUNK_SIZE_ARG="--chunk-size ${CHUNK_SIZE}"
+fi
+
+# vLLM batch-invariant mode. On by default; GDN/Mamba backends do not support it.
+BATCH_INVARIANT="${BATCH_INVARIANT:-1}"
+
+# Mamba KV cache mode + prefix caching, set only for hybrid Mamba models.
+MAMBA_ARGS=""
+if [ -n "${MAMBA_CACHE_MODE:-}" ]; then
+    MAMBA_ARGS="--mamba-cache-mode ${MAMBA_CACHE_MODE} --enable-prefix-caching"
+fi
+
+# Max tokens per scheduler step. Empty -> vLLM default.
+MAX_NUM_BATCHED_TOKENS_ARG=""
+if [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ]; then
+    MAX_NUM_BATCHED_TOKENS_ARG="--max-num-batched-tokens ${MAX_NUM_BATCHED_TOKENS}"
+fi
+
 # Store PIDs in a file so cleanup.sh can find them
 PID_FILE="/tmp/lmcache_mp_pids_${BUILD_ID}"
 > "$PID_FILE"
@@ -81,6 +102,7 @@ lmcache server \
     --l1-size-gb "$CPU_BUFFER_SIZE" \
     --eviction-policy LRU \
     --max-workers "$MAX_WORKERS" \
+    $CHUNK_SIZE_ARG \
     --port "$LMCACHE_PORT" \
     > "/tmp/build_${BUILD_ID}_lmcache.log" 2>&1 &
 
@@ -105,7 +127,7 @@ echo "Port: $vllm_port"
 CUDA_VISIBLE_DEVICES="${GPU_FOR_VLLM}" \
 VLLM_ENABLE_V1_MULTIPROCESSING=0 \
 VLLM_SERVER_DEV_MODE=1 \
-VLLM_BATCH_INVARIANT=1 \
+VLLM_BATCH_INVARIANT=${BATCH_INVARIANT} \
 PYTHONHASHSEED=0 \
 vllm serve "$MODEL" \
     --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 10}}" \
@@ -115,6 +137,8 @@ vllm serve "$MODEL" \
     $MAX_MODEL_LEN_ARG \
     $ENFORCE_EAGER_ARG \
     $GPU_MEMORY_UTIL_ARG \
+    $MAMBA_ARGS \
+    $MAX_NUM_BATCHED_TOKENS_ARG \
     > "/tmp/build_${BUILD_ID}_vllm.log" 2>&1 &
 
 VLLM_PID=$!

--- a/.buildkite/k3_tests/multiprocess/scripts/run-hma-lm-eval.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-hma-lm-eval.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 # HMA (hybrid memory allocator) correctness test using a real hybrid model.
 #
-# Why google/gemma-4-31B-it:
-#   - Hybrid (sliding-window + full-attention), so vLLM keeps its hybrid KV
-#     cache manager on and exposes multiple KV cache groups.
-#   - Its full layers have a larger head_dim, so the groups get different block
-#     sizes -- this exercises the per-group HMA store/retrieve path.
-#   - Standard paged attention for both layer families, so LMCache's transfer
-#     kernels support it (unlike Mamba/linear-attention hybrids like
-#     Qwen3.5/Qwen3-Next, whose state caches LMCache cannot yet transfer).
-#   - Public, so no HF_TOKEN is required.
+# Models (selected by run-single-test.sh):
+#   - google/gemma-4-31B-it: sliding-window + full-attention hybrid whose full
+#     layers have a larger head_dim, so vLLM gives the KV cache groups
+#     different block sizes -- exercising per-group HMA store/retrieve.
+#   - Qwen/Qwen3.5-0.8B: Mamba/GDN + full-attention hybrid, exercising the
+#     registration-time cache re-views (kv_cache_group_edits.py).
 #
 # Flow (single GPU, no baseline server):
 #   1. vLLM run: lm_eval (gsm8k) against vLLM+LMCache, populating LMCache.
@@ -39,7 +36,8 @@ NUM_CONCURRENT="${NUM_CONCURRENT:-50}"
 # set fits the CPU pool (a too-large set thrashes and the retrieve run misses).
 LIMIT="${LIMIT:-100}"
 # Max abs difference allowed between the two runs' gsm8k scores; 0 requires an
-# exact match.
+# exact match. For non-bit-exact backends, raise LIMIT to shrink run-to-run
+# drift (~1/sqrt(LIMIT)) rather than loosening this.
 SCORE_TOLERANCE="${SCORE_TOLERANCE:-0}"
 # Seconds to let async LMCache stores drain before the retrieve run.
 STORE_DRAIN_SECONDS="${STORE_DRAIN_SECONDS:-20}"
@@ -177,11 +175,11 @@ retrieves_before = int(before_s)
 retrieves_after = int(after_s)
 
 
-def gsm8k_exact_match(results_dir: str) -> float:
-    """Return the gsm8k exact_match score from an lm_eval results directory.
+def gsm8k_score_and_stderr(results_dir: str) -> tuple[float, float]:
+    """Return the gsm8k (exact_match, stderr) from an lm_eval results directory.
 
     Prefers the strict-match variant; falls back to any non-stderr
-    ``exact_match`` metric key.
+    ``exact_match`` metric key (paired with its ``exact_match_stderr`` twin).
 
     Args:
         results_dir: Directory passed to ``lm_eval --output_path``. Searched
@@ -190,7 +188,8 @@ def gsm8k_exact_match(results_dir: str) -> float:
             timestamp).
 
     Returns:
-        The gsm8k ``exact_match`` accuracy as a float in ``[0.0, 1.0]``.
+        ``(score, stderr)``: the gsm8k ``exact_match`` accuracy in
+        ``[0.0, 1.0]`` and its reported sampling stderr (0.0 if absent).
 
     Raises:
         SystemExit: If no ``results_*.json`` exists under ``results_dir`` or the
@@ -205,18 +204,21 @@ def gsm8k_exact_match(results_dir: str) -> float:
     metrics = data["results"]["gsm8k"]
     preferred = "exact_match,strict-match"
     if preferred in metrics:
-        return float(metrics[preferred])
+        stderr = float(metrics.get("exact_match_stderr,strict-match", 0.0))
+        return float(metrics[preferred]), stderr
     for key, value in metrics.items():
         if key.startswith("exact_match,") and "stderr" not in key:
-            return float(value)
+            variant = key.split(",", 1)[1]
+            stderr = float(metrics.get(f"exact_match_stderr,{variant}", 0.0))
+            return float(value), stderr
     raise SystemExit(f"No exact_match metric in {latest}: {sorted(metrics)}")
 
 
-s_vllm = gsm8k_exact_match(vllm_run_dir)
-s_retrieve = gsm8k_exact_match(retrieve_run_dir)
+s_vllm, e_vllm = gsm8k_score_and_stderr(vllm_run_dir)
+s_retrieve, e_retrieve = gsm8k_score_and_stderr(retrieve_run_dir)
 
-print(f"  vLLM run             gsm8k exact_match = {s_vllm:.4f}")
-print(f"  LMCache retrieve run gsm8k exact_match = {s_retrieve:.4f}")
+print(f"  vLLM run             gsm8k exact_match = {s_vllm:.4f} +/- {e_vllm:.4f}")
+print(f"  LMCache retrieve run gsm8k exact_match = {s_retrieve:.4f} +/- {e_retrieve:.4f}")
 print(f"  tolerance = {tol}")
 
 failures = []

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -32,6 +32,24 @@ if [ "$TEST_NAME" = "hma_lm_eval_gemma4" ]; then
     # pipeline sets ATTENTION_BACKEND=auto; its ~63GB of weights also need a
     # higher GPU_MEMORY_UTILIZATION than the default (all set in pipeline.yml).
     export MODEL="${MODEL:-google/gemma-4-31B-it}"
+elif [ "$TEST_NAME" = "hma_lm_eval_qwen3_5" ]; then
+    # Qwen3.5-0.8B is a Mamba/GDN + full-attention hybrid (caches re-viewed at
+    # registration; see lmcache/integration/vllm/kv_cache_group_edits.py).
+    export MODEL="${MODEL:-Qwen/Qwen3.5-0.8B}"
+    export ATTENTION_BACKEND="${ATTENTION_BACKEND:-auto}"
+    # LMCache chunk size must be a multiple of the unified vLLM block size (544).
+    export CHUNK_SIZE="${CHUNK_SIZE:-544}"
+    # GDN supports only the 'align' Mamba cache mode.
+    export MAMBA_CACHE_MODE="${MAMBA_CACHE_MODE:-align}"
+    # 'align' snapshots the Mamba state only at scheduler-step boundaries; cap
+    # the step at the chunk size for one reusable snapshot per chunk.
+    export MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-544}"
+    # GDN has no batch-invariant mode, so runs are not bit-exact; compare within
+    # a score tolerance and use enough samples to shrink run-to-run drift
+    # (~1/sqrt(LIMIT)) well inside it.
+    export BATCH_INVARIANT="${BATCH_INVARIANT:-0}"
+    export SCORE_TOLERANCE="${SCORE_TOLERANCE:-0.05}"
+    export LIMIT="${LIMIT:-300}"
 else
     export MODEL="${MODEL:-Qwen/Qwen3-14B}"
 fi
@@ -101,6 +119,9 @@ case "$TEST_NAME" in
         exec_script="${SCRIPT_DIR}/run-lm-eval.sh"
         ;;
     hma_lm_eval_gemma4)
+        exec_script="${SCRIPT_DIR}/run-hma-lm-eval.sh"
+        ;;
+    hma_lm_eval_qwen3_5)
         exec_script="${SCRIPT_DIR}/run-hma-lm-eval.sh"
         ;;
     vllm_bench)

--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -141,11 +141,15 @@ Block IDs `{group 0: [10,11], group 1: [20,21]}` are sent as
 - The server reproduces grouping with the same `group_layers_by_identity`; real
   tensors remain the source of truth for shape/dtype/stride.
 
-## Not supported
+## Mamba / linear-attention hybrids
 
-Mamba / linear-attention hybrids (e.g. Qwen3-Next): their recurrent state caches
-have no LMCache transfer format yet. vLLM still exposes them as KV cache groups,
-but LMCache cannot store/retrieve those layers.
+Supported via registration-time tensor re-views (e.g. Qwen3.5 GDN): Mamba
+state pairs become opaque page views, and full-attention layers whose logical
+block size was inflated for page-size unification are re-viewed at
+logical-block granularity. See
+[kv-cache-group-edits](kv_cache_group_edits.md) for the design and its
+limits (notably: edited groups are byte-opaque — no content-aware processing,
+no cross-backend cache sharing).
 
 ## Code map
 
@@ -154,6 +158,7 @@ but LMCache cannot store/retrieve those layers.
 | Engine group info (IPC type) + helpers | `lmcache/v1/multiprocess/group_view.py` |
 | Shared grouping primitive | `lmcache/v1/kv_layer_groups.py` |
 | vLLM → `list[EngineGroupInfo]` | `lmcache/integration/vllm/kv_cache_groups.py` |
+| Group metadata edits (Mamba, sub-paged attention) | `lmcache/integration/vllm/kv_cache_group_edits.py` |
 | Register / store / retrieve | `lmcache/integration/vllm/{lmcache_mp_connector,vllm_multi_process_adapter}.py` |
 | Server GPU context / transfer | `lmcache/v1/multiprocess/{gpu_context,modules/gpu_transfer}.py` |
 | ZMQ protocol | `lmcache/v1/multiprocess/protocols/engine.py` |

--- a/docs/design/integration/vllm/kv_cache_group_edits.md
+++ b/docs/design/integration/vllm/kv_cache_group_edits.md
@@ -1,0 +1,150 @@
+# KV Cache Group Edits
+
+## Summary
+
+`lmcache/integration/vllm/kv_cache_group_edits.py` is the single place where
+vLLM KV cache groups are re-presented ("edited") before LMCache registration.
+The connector calls `apply_kv_cache_group_edits(kv_cache_config, kv_caches)`
+once in `register_kv_caches`, and the edited dict feeds both engine-group-info
+creation (`kv_cache_groups.py`) and transfer registration.
+
+LMCache derives each group's transfer metadata (block size, page layout,
+dtype) from the registered tensors, and interprets store/retrieve block IDs in
+vLLM's scheduler-side block-id space (`kv_cache_spec.block_size` units). The
+edits exist to restore one invariant the raw tensors can violate:
+
+> **The registered tensor's paging granularity must equal the block-id
+> granularity.**
+
+## Structure
+
+Each case is one `KVCacheGroupEdit` rule in the module's `_EDITS` registry:
+`matches(spec, kv_cache)` decides **structurally** — from the vLLM spec kind
+(`get_kv_cache_spec_kind`, which also unwraps `UniformTypeKVCacheSpecs`) and
+the registered tensor, never from model name or architecture — and
+`apply(spec, kv_cache)` produces a view over the same storage. First matching
+rule wins; unmatched layers pass through. Covering a new group kind means
+adding one rule.
+
+Model name/arch is deliberately not an input: the same architecture yields
+different group structures depending on runtime decisions
+(`mamba_cache_mode`, attention backend's kernel block size, TP), all of which
+the config + tensors already resolve.
+
+## Edits
+
+Both rules apply only to Mamba-hybrid models (the registry is only consulted
+when `kv_cache_config.has_mamba_layers`).
+
+### 1. Mamba state pages
+
+A Mamba / linear-attention layer (e.g. Qwen3.5 GDN) registers `[conv_state,
+ssm_state]` — two tensors with different shapes and dtypes, laid out
+contiguously in one padded page (`conv | ssm | pad`). The raw pair trips
+format discovery (the SSM view starts mid-page). The edit reinterprets each
+page as one bf16 tensor shaped `(num_blocks, 2, block_size, 1, head_size)`
+over the same storage, where `head_size` is derived so the bytes fill the page
+exactly.
+
+### 2. Sub-paged full attention
+
+vLLM unifies page sizes across hybrid groups by inflating the attention
+*logical* block size (`vllm/platforms/interface.py:_align_hybrid_block_size`;
+Qwen3.5-0.8B: 544), while the attention backend re-pages the physical tensor
+at its own *kernel* block size (`vllm/v1/worker/utils.py:
+prepare_kernel_block_sizes`; FlashAttention on hybrids: 32). Logical block `n`
+then occupies the `k = logical/kernel` contiguous kernel pages
+`n*k .. n*k+k-1` (vLLM expands the worker-side block table the same way,
+`BlockTable.map_to_kernel_blocks`); the scheduler-side block IDs LMCache
+receives stay logical.
+
+Registering the raw kernel-paged tensor makes LMCache discover
+`block_size == kernel < logical`, and `_derive_compression_metadata`
+(`lmcache/v1/kv_layer_groups.py`) misclassifies the group as compressed:
+only `1/k` of each chunk's KV is transferred, addressed against the kernel
+page space. The edit re-views the tensor as
+`(num_kernel_pages / k, 2, logical_block_size, 1, head_size)` — a pure
+`view()`, valid because `k` kernel pages tile each logical page's bytes
+exactly (enforced; see Invariants).
+
+## Startup validation
+
+`validate_kv_cache_groups` (called at connector init and again at
+registration) rejects group specs the transfer path cannot serve correctly,
+with one aggregated error: `CrossAttentionSpec`, and Mamba with
+`mamba_cache_mode != "align"` (no reusable snapshots). Declared slot
+compression (`compress_ratio > 1` / `tq_slot_size > 0`, e.g. DeepSeek-V4) is
+*not* rejected — those groups are served by the compression path in
+`lmcache/v1/kv_layer_groups.py` and only skipped by the edits here. Note the
+compression path still derives per-group ratios from the unified vLLM block
+size; switching it to per-group block sizes is pending in a separate PR.
+
+Reference: vLLM PR #42828 (Mooncake store HMA support) uses the same
+validate-and-reject-up-front pattern, and is the reference design for the
+deferred follow-ups (per-group store/load masks; manager-mirroring hit
+computation). Caveat for the latter: LMCache's lookup doubles as prefetch, so
+vLLM's lookup-first-then-trim flow does not map directly. See the module
+docstring for the full check-when list.
+
+## Non-edit: declared compression
+
+Groups whose spec *declares* slot compression — `MLAAttentionSpec.
+compress_ratio > 1` (DeepSeek-V4 slot packing, `storage_block_size <
+block_size`) or `TQFullAttentionSpec.tq_slot_size > 0` — genuinely store fewer
+physical slots than logical tokens. They must reach the compression path in
+`lmcache/v1/kv_layer_groups.py` unedited. (DeepSeek-V3.2's `fp8_ds_mla` cache
+packs *bytes per slot*, not slots per block: its specs keep
+`block_size == scheduler block size` and `compress_ratio == 1`, so it never
+needs an edit either.)
+
+The sub-paged rule's `matches` excludes declared-compression specs by their
+own fields (`compress_ratio` / `tq_slot_size`), and its `apply` additionally
+verifies by byte accounting that `k` kernel pages tile the logical page's
+bytes exactly — any *undeclared* packed layout fails with a loud `ValueError`
+rather than being transferred wrongly.
+
+## The opaque-page contract
+
+An edited view's dims are addressing metadata only (block id → byte range).
+The named dims are **not** semantic: a Mamba view's "K plane" is conv/ssm
+bytes, and a sub-paged attention view's "K plane" interleaves true K and V at
+kernel-page granularity (true K is not contiguous across kernel pages, so no
+logical-block view can have a pure-K plane). The synthetic head shape
+`(1, page_bytes / (2 * block_size * elem))` signals this deliberately.
+
+Byte transport round-trips correctly because store and retrieve share the same
+bijective block-id → bytes mapping. Consequences:
+
+- **Valid**: store/retrieve through the MP transfer path on the same engine
+  configuration.
+- **Not valid** for edited groups: content-aware processing (serde
+  compression, blending, head resharding, layout conversion), and sharing
+  cache entries across engines whose attention backends choose different
+  kernel block sizes (the byte order inside a logical page is
+  backend-dependent).
+
+## Invariants
+
+- Edits are pure tensor views over the registered storage — never copies.
+- A sub-paged view is only produced when `kernel_page_bytes * k ==
+  spec.page_size_bytes`; any mismatch raises `ValueError` (fail loudly rather
+  than silently transfer a compressed layout).
+- After edits, every registered tensor's block dim equals its group's
+  `kv_cache_spec.block_size`, so the server derives `compress_ratio == 1` for
+  these groups.
+
+## Code map
+
+| Area | File |
+|---|---|
+| Edits (this doc) | `lmcache/integration/vllm/kv_cache_group_edits.py` |
+| Caller | `lmcache/integration/vllm/lmcache_mp_connector.py` (`register_kv_caches`) |
+| Compression-ratio derivation (downstream consumer) | `lmcache/v1/kv_layer_groups.py` |
+| vLLM block-size inflation | `vllm/platforms/interface.py` (`_align_hybrid_block_size`) |
+| vLLM kernel-page split + block-table expansion | `vllm/v1/worker/utils.py`, `vllm/v1/worker/block_table.py` |
+| End-to-end test | `.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh` (`hma_lm_eval_qwen3_5`) |
+
+Testing is end-to-end only (the `hma_lm_eval_qwen3_5` store-vs-retrieve gsm8k
+check): the edit internals are expected to change as more group kinds are
+covered, so tests pin the observable contract — faithful retrieve — rather
+than view shapes.

--- a/docs/source/mp/hybrid_models.rst
+++ b/docs/source/mp/hybrid_models.rst
@@ -34,6 +34,9 @@ configuration. Examples:
    * - gpt-oss
      - Interleaved sliding-window + full
      - Supported
+   * - Qwen3.5 (and other Gated-DeltaNet hybrids)
+     - Interleaved Mamba/GDN + full
+     - Supported (see below)
    * - Llama, Qwen2/Qwen3 (dense), Mistral, …
      - Single attention type
      - Supported
@@ -48,16 +51,54 @@ detects the model's KV cache groups automatically at registration time.
    back to a single unified group). You do not need
    ``--no-disable-hybrid-kv-cache-manager`` or any related flag.
 
+Mamba / Linear-Attention Hybrids
+--------------------------------
+
+Models that interleave **Mamba / Gated-DeltaNet layers** with full attention
+(e.g. ``Qwen/Qwen3.5-0.8B``) are supported. Their recurrent state caches are
+reinterpreted as opaque pages at registration time, so prefix caching and KV
+reuse work end to end. They need three extra flags:
+
+#. vLLM must run with prefix caching and the ``align`` Mamba cache mode::
+
+       vllm serve Qwen/Qwen3.5-0.8B \
+           --enable-prefix-caching --mamba-cache-mode align \
+           --kv-transfer-config \
+           '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+
+#. The LMCache server's ``--chunk-size`` must be a multiple of vLLM's unified
+   block size for the model (vLLM logs ``Setting attention block size to N
+   tokens`` at startup; for Qwen3.5-0.8B, ``N = 544``)::
+
+       lmcache server --chunk-size 544 --l1-size-gb 100 --eviction-policy LRU
+
+#. ``--max-num-batched-tokens`` must be at least the unified block size and
+   below twice it (LMCache raises at engine startup otherwise; setting it
+   equal to the block size is the simple choice)::
+
+       vllm serve ... --max-num-batched-tokens 544
+
+   ``align`` mode snapshots the Mamba state only at the *end* of each
+   scheduler step; a larger budget would let one step skip block boundaries,
+   leaving no snapshot for LMCache to store at those prefixes.
+
+Caveats:
+
+- Generation is **not bit-exact** between a cached and a fresh run: GDN
+  backends do not support vLLM's batch-invariant mode. Expect score-level
+  equivalence, not token-level.
+- The cached pages are byte-opaque, so content-aware features (CacheGen
+  compression, CacheBlend) do not apply, and cache entries must not be shared
+  across engines with different attention backends or kernel block sizes.
+
+See the :doc:`Qwen3.5 recipe <../recipes/qwen3_5>` for the validated
+end-to-end commands.
+
 What Is Not Supported Yet
 -------------------------
 
-- **Mamba / linear-attention hybrids** (e.g. Qwen3-Next, Qwen3.5, and other
-  Gated-DeltaNet models). These layers keep a recurrent *state cache* (a
-  convolution + SSM state) instead of a paged key/value cache, which LMCache's
-  transfer path cannot represent today. Such models will fail to register with
-  the LMCache server. Tracking support is future work.
-- **DeepSeek-V4-style compressed / indexer caches** are likewise not yet
-  handled by the multiprocess connector.
+- **DeepSeek-V4-style compressed / indexer caches** are not yet handled by the
+  multiprocess connector.
 
 Verifying Correctness
 ---------------------

--- a/docs/source/recipes/index.rst
+++ b/docs/source/recipes/index.rst
@@ -26,8 +26,8 @@ Each recipe page is intentionally minimal:
 - **Caveats** -- known limitations, if any.
 
 For the generic LMCache + engine wiring (ports, remote hosts, in-process mode,
-sending a first request), see :doc:`../getting_started/quickstart` and
-:doc:`../mp/quickstart`. Recipes assume those pages as a prerequisite.
+sending a first request), see :doc:`../mp/quickstart`. Recipes assume that
+page as a prerequisite.
 
 Supported architectures
 -----------------------
@@ -93,6 +93,13 @@ Supported architectures
      - —
      - :doc:`qwen3`
 
+   * - ``Qwen3_5ForConditionalGeneration``
+     - ``Qwen/Qwen3.5-0.8B``
+     - ✓
+     - —
+     - —
+     - :doc:`qwen3_5`
+
    * - ``LlamaForCausalLM``
      - ``meta-llama/Meta-Llama-3.1-70B-Instruct``
      - ✓
@@ -138,6 +145,7 @@ To add a new architecture:
    devstral
    gpt_oss
    qwen3
+   qwen3_5
    llama
    phi3
    mixtral

--- a/docs/source/recipes/qwen3_5.rst
+++ b/docs/source/recipes/qwen3_5.rst
@@ -1,0 +1,96 @@
+.. _recipe_qwen3_5:
+
+Qwen3_5ForConditionalGeneration
+===============================
+
+A hybrid architecture interleaving Mamba / Gated-DeltaNet (GDN) linear-attention
+layers with full-attention layers. LMCache reinterprets the recurrent state
+caches as opaque pages at registration time; see :doc:`../mp/hybrid_models`.
+
+Validated models
+----------------
+
+- `Qwen/Qwen3.5-0.8B <https://huggingface.co/Qwen/Qwen3.5-0.8B>`_
+
+.. tab-set::
+   :sync-group: engine
+
+   .. tab-item:: vLLM
+
+      **Engine documentation:**
+      `Qwen3.5 in vLLM supported models
+      <https://docs.vllm.ai/en/latest/models/supported_models.html#text-generation>`_
+      (architecture ``Qwen3_5ForConditionalGeneration``).
+
+      **Status:** Validated with LMCache.
+
+      Start the LMCache MP server. ``--chunk-size`` must be a multiple of
+      vLLM's unified block size for the model — vLLM logs ``Setting attention
+      block size to N tokens`` at startup; for Qwen3.5-0.8B, ``N = 544``:
+
+      .. code-block:: bash
+
+         lmcache server --chunk-size 544 --l1-size-gb 100 --eviction-policy LRU
+
+      |
+
+      **Qwen3.5-0.8B** (1 GPU):
+
+      .. code-block:: bash
+
+         vllm serve Qwen/Qwen3.5-0.8B \
+             --enable-prefix-caching \
+             --mamba-cache-mode align \
+             --max-num-batched-tokens 544 \
+             --kv-transfer-config \
+             '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+
+      ``--mamba-cache-mode align`` is required (GDN does not support the
+      ``all`` mode). ``--max-num-batched-tokens`` must be at least the unified
+      block size and below twice it — LMCache raises at engine startup
+      otherwise. ``align`` snapshots the Mamba state only at scheduler-step
+      ends, so each prefill step must advance exactly one block for every
+      block boundary to hold a reusable snapshot.
+
+      For the generic LMCache + vLLM wiring (ports, remote hosts, in-process
+      mode), see :doc:`../mp/quickstart`.
+
+   .. tab-item:: SGLang
+
+      **Status:** Not validated with LMCache.
+
+   .. tab-item:: TRT-LLM
+
+      **Status:** Not supported. LMCache TRT-LLM integration is in progress.
+
+CacheBlend support
+------------------
+
+Not supported: the hybrid groups' cached pages are byte-opaque (see Caveats).
+
+Compression support
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Method
+     - Status
+     - Notes
+   * - :doc:`CacheGen <../kv_cache_optimizations/compression/cachegen>`
+     - Not supported
+     - Hybrid groups' cached pages are byte-opaque.
+
+Caveats
+-------
+
+- Generation is **not bit-exact** between a cached and a fresh run: GDN
+  backends do not support vLLM's batch-invariant mode. Expect score-level
+  equivalence, not token-level (the CI gate is the ``hma_lm_eval_qwen3_5``
+  gsm8k store-vs-retrieve comparison).
+- Cached pages for the Mamba and full-attention groups are byte-opaque views,
+  so content-aware processing does not apply, and cache entries must not be
+  shared across engines with different attention backends or kernel block
+  sizes.
+- vLLM's Mamba prefix caching in ``align`` mode is experimental.

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Centralized edits to vLLM kv cache specs.
+
+This is needed to mask out attention-specific details while making sure that
+LMCache can still store / load KV cache correctly.
+
+Currently there are two edits, one per :class:`KVCacheGroupEdit` subclass
+below. Both are for Mamba-hybrid models; the registry is only consulted when
+``kv_cache_config.has_mamba_layers``. :func:`validate_kv_cache_groups`
+additionally rejects, at startup, group specs the transfer path cannot serve
+correctly yet (see its docstring).
+
+Reference design: vLLM PR #42828 ("[KVConnector][DSV4] HMA support for
+Mooncake store connector") solves the same problem class for an external KV
+store. Check it again when working on any of the following:
+
+- Extending :func:`validate_kv_cache_groups` (its connector validates and
+  rejects unsupported specs up front, with one aggregated error).
+- Per-group store/load masks (SWA / Mamba tail-only transfer, the
+  "sliding-window load-plan trimming" deferred in the hybrid design doc):
+  its ``MooncakeStoreCoordinator.store_mask`` / ``load_mask`` derive masks
+  from vLLM's own per-spec managers. Requires per-group objects in LMCache
+  (``ObjectKey.object_group_id``, LMCache #3608).
+- Hit-length computation for hybrid models: its ``ExternalCachedBlockPool``
+  duck-types vLLM's ``BlockPool`` over a ``(group_id, hash)`` existence set
+  and reuses ``KVCacheSpecRegistry`` manager classes, so promised hits are
+  consumable by construction. NOTE: LMCache's lookup doubles as prefetch, so
+  vLLM's lookup-first-then-trim flow does not map directly -- this needs its
+  own design before borrowing.
+- Eagle + HMA: see its ``apply_eagle`` notes (the eagle last-block prune must
+  be applied exactly once between hit-length and mask computation).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from abc import ABC, abstractmethod
+from collections import Counter
+from collections.abc import Mapping
+from typing import TypeAlias
+
+# Third Party
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheSpec,
+    KVCacheSpecKind,
+    get_kv_cache_spec_kind,
+)
+import torch
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+# One registered cache value: a paged KV tensor, or [conv_state, ssm_state]
+# for Mamba layers.
+RegisteredKVCache: TypeAlias = torch.Tensor | list[torch.Tensor]
+
+# Synthetic head count for a reinterpreted page. The page is opaque bytes, so
+# one "head" holding the whole per-(K/V) slab is enough; head_size is derived
+# to fill the page.
+_SYNTHETIC_NUM_HEADS = 1
+
+# Standard-paged (non-MLA) attention kinds eligible for the sub-paged edit.
+_SUBPAGEABLE_ATTENTION_KINDS = frozenset(
+    {
+        KVCacheSpecKind.FULL_ATTENTION,
+        KVCacheSpecKind.SLIDING_WINDOW,
+        KVCacheSpecKind.CHUNKED_LOCAL_ATTENTION,
+        KVCacheSpecKind.SINK_FULL_ATTENTION,
+    }
+)
+
+
+def _declares_slot_compression(spec: KVCacheSpec) -> bool:
+    """Return whether a spec declares slot compression (must not be edited).
+
+    Covers ``MLAAttentionSpec.compress_ratio > 1`` (DeepSeek-V4 slot packing)
+    and ``TQFullAttentionSpec.tq_slot_size > 0`` (TurboQuant slots); such
+    groups belong to the compression path in ``lmcache.v1.kv_layer_groups``.
+    """
+    return (
+        getattr(spec, "compress_ratio", 1) > 1 or getattr(spec, "tq_slot_size", 0) > 0
+    )
+
+
+def _leaf_specs(spec: KVCacheSpec) -> list[KVCacheSpec]:
+    """Return a group spec's leaf specs, unwrapping ``UniformTypeKVCacheSpecs``."""
+    inner = getattr(spec, "kv_cache_specs", None)
+    if isinstance(inner, dict):
+        return list(inner.values())
+    return [spec]
+
+
+def validate_kv_cache_groups(kv_cache_config: KVCacheConfig | None) -> None:
+    """Reject KV cache group specs the transfer path cannot serve correctly.
+
+    Rejected, with one aggregated error listing every offending group:
+
+    - ``CrossAttentionSpec`` (encoder-decoder caches).
+    - Mamba groups with ``mamba_cache_mode != "align"``: other modes keep no
+      reusable per-block state snapshots.
+
+    Specs declaring slot compression (``compress_ratio > 1`` /
+    ``tq_slot_size > 0``, e.g. DeepSeek-V4) are NOT rejected: they are served
+    by the compression path in ``lmcache.v1.kv_layer_groups`` and merely
+    skipped by the edits here (see ``_declares_slot_compression``).
+
+    Args:
+        kv_cache_config: vLLM ``KVCacheConfig``; ``None`` skips validation
+            (callers without the config validate again at registration).
+
+    Raises:
+        ValueError: Listing every unsupported group and why.
+    """
+    if kv_cache_config is None:
+        return
+    unsupported: list[str] = []
+    for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
+        for spec in _leaf_specs(group.kv_cache_spec):
+            kind = get_kv_cache_spec_kind(spec)
+            if kind == KVCacheSpecKind.CROSS_ATTENTION:
+                unsupported.append(f"group {group_idx}: CrossAttentionSpec")
+            elif (
+                kind == KVCacheSpecKind.MAMBA
+                and getattr(spec, "mamba_cache_mode", "none") != "align"
+            ):
+                unsupported.append(
+                    f"group {group_idx}: MambaSpec with mamba_cache_mode="
+                    f"'{getattr(spec, 'mamba_cache_mode', 'none')}' "
+                    f"(only 'align' keeps reusable state snapshots)"
+                )
+    if unsupported:
+        raise ValueError(
+            "LMCache cannot serve this model's KV cache groups: "
+            + "; ".join(unsupported)
+            + ". See lmcache/integration/vllm/kv_cache_group_edits.py."
+        )
+
+
+def _synthetic_attention_shape(elems_per_page: int, block_size: int) -> tuple[int, int]:
+    """Factor a page's element count into the synthetic attention layout.
+
+    Args:
+        elems_per_page: Total elements in one page (one logical block).
+        block_size: Logical block size (tokens per page).
+
+    Returns:
+        ``(num_heads, head_size)`` such that
+        ``2 * block_size * num_heads * head_size == elems_per_page``.
+
+    Raises:
+        ValueError: If the page size does not factor into the target shape.
+    """
+    denom = 2 * block_size * _SYNTHETIC_NUM_HEADS
+    if elems_per_page % denom != 0:
+        raise ValueError(
+            f"page ({elems_per_page} elems) does not factor into "
+            f"(2, block_size={block_size}, num_heads={_SYNTHETIC_NUM_HEADS}, head_size)"
+        )
+    return _SYNTHETIC_NUM_HEADS, elems_per_page // denom
+
+
+class KVCacheGroupEdit(ABC):
+    """One structural edit rule for a KV cache group's registered cache.
+
+    ``matches`` must be side-effect free and decide purely from the vLLM spec
+    and the registered cache value; ``apply`` must return a view over the same
+    storage (never a copy). ``name`` labels the rule in logs.
+    """
+
+    name: str
+
+    @abstractmethod
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        """Return whether this rule applies to the layer's registered cache.
+
+        Args:
+            spec: The layer's vLLM KV cache spec (from its group).
+            kv_cache: The layer's registered cache value -- a tensor, or a
+                list of tensors for Mamba layers.
+        """
+
+    @abstractmethod
+    def apply(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> torch.Tensor:
+        """Return the edited view for a layer this rule matched.
+
+        Args:
+            spec: The layer's vLLM KV cache spec (from its group).
+            kv_cache: The layer's registered cache value.
+
+        Raises:
+            ValueError: If the cache's layout violates the rule's invariants.
+        """
+
+
+class _MambaPageViewEdit(KVCacheGroupEdit):
+    """Convert a Mamba page to its equivalent: a sliding-window-style layer.
+
+    A Mamba layer registers ``[conv_state, ssm_state]`` -- two tensors with
+    different shapes and dtypes sharing one padded page per block
+    (``conv | ssm | pad``) -- which LMCache's attention-shaped transfer path
+    cannot represent. Each page is one recurrent state snapshot, equivalent
+    for caching purposes to one block of a sliding-window attention layer with
+    window == block_size: only the last matched block is ever consumed. The
+    edit reinterprets the page buffer as one
+    ``[#blocks, 2, block_size, 1, head_size]`` tensor in the conv state's
+    dtype, with ``head_size`` derived to fill the page exactly.
+
+    The view's dims are addressing metadata only; the bytes are opaque
+    (conv | ssm | pad, not K/V), so content-aware processing does not apply.
+    """
+
+    name = "mamba-page-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        return get_kv_cache_spec_kind(spec) == KVCacheSpecKind.MAMBA
+
+    def apply(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> torch.Tensor:
+        # vLLM lays out one padded page per block as (conv | ssm | pad), and
+        # the conv state is the view that starts at the page base: its leading
+        # dim is the block count and its per-block stride is one full page.
+        # Re-striding it therefore covers the whole page, ssm and pad included.
+        if not isinstance(kv_cache, list) or not kv_cache:
+            raise ValueError(
+                f"expected a Mamba [conv_state, ssm_state] tensor list, "
+                f"got {type(kv_cache).__name__}"
+            )
+        conv_state = kv_cache[0]
+        if conv_state.storage_offset() != 0:
+            raise ValueError(
+                f"Mamba conv state must view the page base, got "
+                f"storage_offset={conv_state.storage_offset()}"
+            )
+        if conv_state.stride(0) * conv_state.element_size() != spec.page_size_bytes:
+            raise ValueError(
+                f"Mamba conv state per-block stride "
+                f"({conv_state.stride(0) * conv_state.element_size()} bytes) "
+                f"does not equal the page size ({spec.page_size_bytes} bytes)"
+            )
+        num_blocks = conv_state.shape[0]
+        elems_per_page = spec.page_size_bytes // conv_state.element_size()
+        num_heads, head_size = _synthetic_attention_shape(
+            elems_per_page, spec.block_size
+        )
+        flat = conv_state.as_strided((num_blocks, elems_per_page), (elems_per_page, 1))
+        return flat.reshape(num_blocks, 2, spec.block_size, num_heads, head_size)
+
+
+class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
+    """Re-view a kernel-paged attention tensor as logical-block pages.
+
+    For a Mamba-hybrid model vLLM inflates the attention block size to align
+    with the Mamba page (e.g. 544 for Qwen3.5-0.8B), and that size is used for
+    all prefix-caching logic at the scheduler. But at the worker the attention
+    kernel has to run at block size 32 for numerical stability (vLLM #27753,
+    working around the NaN-propagation issue
+    Dao-AILab/flash-attention#1974), so the registered tensor is paged as
+
+        ``[#blocks, 2, 32, #heads, head_size]``
+
+    which makes LMCache detect block size 32, mistake the group for a
+    DeepSeek-compression layer (``block size < scheduler block size``), and
+    corrupt the store/retrieve. Fix: re-view the tensor at the scheduler
+    block size (one logical block = its 17 contiguous kernel pages),
+
+        ``[#blocks / 17, 2, 544, 1, head_size']``
+
+    Cost: before this fix ``kv_caches[:, 0]`` is just the K tensor; after, it
+    interleaves K and V at kernel-page granularity. The bytes round-trip
+    correctly (store and retrieve share the mapping), but the dims are no
+    longer semantic, so content-aware processing does not apply.
+    """
+
+    name = "subpaged-attention-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        return (
+            # Standard-paged attention only; MLA layouts and declared slot
+            # compression (DeepSeek) belong to other transfer paths.
+            get_kv_cache_spec_kind(spec) in _SUBPAGEABLE_ATTENTION_KINDS
+            and not _declares_slot_compression(spec)
+            # (num_blocks, 2, block_size, num_heads, head_size) layout whose
+            # block dim disagrees with the scheduler block-id unit -- the
+            # backend re-paged the tensor at its kernel block size.
+            and isinstance(kv_cache, torch.Tensor)
+            and kv_cache.ndim == 5
+            and kv_cache.shape[2] != spec.block_size
+        )
+
+    def apply(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> torch.Tensor:
+        """Re-view ``kv_cache`` at logical-block granularity.
+
+        The tensor is kernel-paged as ``(num_kernel_pages, 2,
+        kernel_block_size, num_kv_heads, head_size)``; the result is
+        ``(num_logical_blocks, 2, spec.block_size, num_heads, head_size)``
+        over the same storage.
+
+        Raises:
+            ValueError: If the layout is not the expected kernel-paged shape,
+                the sizes do not divide evenly, or the kernel pages of one
+                logical block do not tile its page bytes exactly (which would
+                indicate an undeclared packed layout that must not be edited).
+        """
+        if not isinstance(kv_cache, torch.Tensor) or kv_cache.shape[1] != 2:
+            got = (
+                tuple(kv_cache.shape)
+                if isinstance(kv_cache, torch.Tensor)
+                else type(kv_cache).__name__
+            )
+            raise ValueError(
+                f"expected a (num_blocks, 2, block_size, num_heads, head_size) "
+                f"attention KV tensor, got {got}"
+            )
+        logical_block_size = spec.block_size
+        kernel_block_size = kv_cache.shape[2]
+        if logical_block_size % kernel_block_size != 0:
+            raise ValueError(
+                f"logical block size {logical_block_size} is not a multiple of "
+                f"kernel block size {kernel_block_size}"
+            )
+        ratio = logical_block_size // kernel_block_size
+
+        num_kernel_pages = kv_cache.shape[0]
+        if num_kernel_pages % ratio != 0:
+            raise ValueError(
+                f"kernel page count {num_kernel_pages} is not a multiple of "
+                f"the logical/kernel block ratio {ratio}"
+            )
+        kernel_page_bytes = kv_cache.shape[1:].numel() * kv_cache.element_size()
+        if kernel_page_bytes * ratio != spec.page_size_bytes:
+            raise ValueError(
+                f"{ratio} kernel pages ({kernel_page_bytes * ratio} bytes) do "
+                f"not tile the logical page ({spec.page_size_bytes} bytes)"
+            )
+        if not kv_cache.is_contiguous():
+            raise ValueError(
+                "kernel-paged attention KV tensor must be contiguous to "
+                "re-view as logical pages"
+            )
+
+        num_blocks = num_kernel_pages // ratio
+        elems_per_page = spec.page_size_bytes // kv_cache.element_size()
+        num_heads, head_size = _synthetic_attention_shape(
+            elems_per_page, logical_block_size
+        )
+        return kv_cache.view(num_blocks, 2, logical_block_size, num_heads, head_size)
+
+
+# Rule registry, in match priority order.
+_EDITS: tuple[KVCacheGroupEdit, ...] = (
+    _MambaPageViewEdit(),
+    _SubpagedAttentionViewEdit(),
+)
+
+
+def apply_kv_cache_group_edits(
+    kv_cache_config: KVCacheConfig | None,
+    kv_caches: Mapping[str, RegisteredKVCache],
+) -> dict[str, RegisteredKVCache]:
+    """Apply all KV cache group metadata edits for LMCache registration.
+
+    Each layer is checked against the ``_EDITS`` rules (first match wins) and
+    re-viewed by the matching rule; layers matching no rule pass through
+    unchanged. ``None`` configs and configs without Mamba groups are returned
+    as-is (as a dict): all current rules only apply to Mamba-hybrid models.
+
+    Args:
+        kv_cache_config: vLLM ``KVCacheConfig`` (read for per-group specs).
+        kv_caches: Registered tensors keyed by layer name. Mamba entries are
+            ``[conv_state, ssm_state]`` lists; others are single tensors.
+
+    Returns:
+        A new ``dict`` with edited layers re-viewed, others untouched.
+
+    Raises:
+        ValueError: If the groups fail :func:`validate_kv_cache_groups`, or a
+            matched layer's cache layout violates its rule's invariants (see
+            each rule's ``apply``).
+    """
+    # Backstop for connectors initialized without a kv_cache_config.
+    validate_kv_cache_groups(kv_cache_config)
+    if kv_cache_config is None or not kv_cache_config.has_mamba_layers:
+        return dict(kv_caches)
+
+    edited = dict(kv_caches)
+    counts: Counter[str] = Counter()
+    for group in kv_cache_config.kv_cache_groups:
+        spec = group.kv_cache_spec
+        for name in group.layer_names:
+            for edit in _EDITS:
+                if edit.matches(spec, kv_caches[name]):
+                    edited[name] = edit.apply(spec, kv_caches[name])
+                    counts[edit.name] += 1
+                    break
+    logger.info(
+        "KV cache group edits applied: %s",
+        dict(counts) if counts else "none",
+    )
+    return edited

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -38,6 +38,10 @@ import zmq
 # First Party
 from lmcache import torch_dev
 from lmcache.banner import print_banner_once
+from lmcache.integration.vllm.kv_cache_group_edits import (
+    apply_kv_cache_group_edits,
+    validate_kv_cache_groups,
+)
 from lmcache.integration.vllm.kv_cache_groups import (
     create_engine_group_infos_from_vllm,
 )
@@ -97,6 +101,43 @@ logger = lmcache_init_logger(__name__)
 
 
 # Helper functions
+def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
+    """Reject scheduler configs that can skip Mamba state snapshots.
+
+    In ``mamba_cache_mode="align"`` vLLM snapshots the recurrent state only at
+    the end of each scheduler step, and a step that advances more than one
+    block fills the skipped block-table positions with the null block
+    (``MambaManager.allocate_new_blocks``). LMCache keys chunks by token hash,
+    so a skipped boundary would be stored as null-block garbage under a valid
+    key and silently corrupt any request that later resumes from that prefix.
+    Requiring ``block_size <= max_num_batched_tokens < 2 * block_size`` makes
+    vLLM's block-aligned splitting (``Scheduler._mamba_block_aligned_split``)
+    advance every mid-prefill step by exactly one block, so every chunk
+    boundary holds a real snapshot.
+
+    Args:
+        vllm_config: The vLLM config; only Mamba-hybrid models in ``align``
+            cache mode are constrained, others pass.
+
+    Raises:
+        ValueError: If ``max_num_batched_tokens`` is not in
+            ``[block_size, 2 * block_size)``.
+    """
+    if getattr(vllm_config.cache_config, "mamba_cache_mode", "none") != "align":
+        return
+    block_size = vllm_config.cache_config.block_size
+    max_batched = vllm_config.scheduler_config.max_num_batched_tokens
+    if not (block_size <= max_batched < 2 * block_size):
+        raise ValueError(
+            f"Mamba-hybrid models with LMCache require "
+            f"block_size <= max_num_batched_tokens < 2 * block_size so every "
+            f"prefill step advances exactly one block and every block boundary "
+            f"gets a state snapshot; got max_num_batched_tokens={max_batched}, "
+            f"block_size={block_size}. Set --max-num-batched-tokens "
+            f"{block_size}."
+        )
+
+
 def build_parallel_strategy_from_vllm_config(
     vllm_config: "VllmConfig",
 ) -> ParallelStrategy:
@@ -478,6 +519,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     ):
         super().__init__(vllm_config, role, kv_cache_config)
 
+        # Fail fast, before the server handshake below.
+        validate_mamba_step_alignment(vllm_config)
+        validate_kv_cache_groups(getattr(self, "_kv_cache_config", None))
+
         assert vllm_config.kv_transfer_config is not None
         server_host = vllm_config.kv_transfer_config.get_from_extra_config(
             "lmcache.mp.host", "tcp://localhost"
@@ -569,6 +614,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         logger.info("Registering kv caches!")
         kv_cache_config = getattr(self, "_kv_cache_config", None)
+        # Must precede both group-info creation and transfer registration so
+        # they see the same edited views.
+        kv_caches = apply_kv_cache_group_edits(kv_cache_config, kv_caches)
         engine_group_infos = create_engine_group_infos_from_vllm(
             kv_cache_config,
             kv_caches,


### PR DESCRIPTION
**What this PR does / why we need it**:

Support Mamba-like models such as Qwen 3.5.

**Special notes for your reviewers**:

- Edited views are byte-opaque (dims are addressing-only; K/V interleaved), so CacheGen/CacheBlend and cross-backend sharing are invalid for these groups — see `docs/design/integration/vllm/kv_cache_group_edits.md`.
- GDN has no batch-invariant mode, hence the tolerance-based check.
- The test is wired in `run-single-test.sh` but not yet a `pipeline.yml` step.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)