### PR TITLE
Store Q tensor layerwise

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -485,6 +485,15 @@ class LMCacheMPConnectorMetadata(KVConnectorMetadata):
     def __repr__(self):
         return self.__str__()
 
+def get_tensor(
+    args: dict[str, Any],
+    arg_names: list[str],
+) -> torch.Tensor | None:
+    """Return the first matching tensor argument, or None."""
+    for name in arg_names:
+        if name in args:
+            return args[name]
+    return None
 
 class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     """
@@ -586,6 +595,15 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                         f"a multiple of group {engine_group_idx} "
                         f"tokens_per_block {tokens_per_block}"
                     )
+
+        self.q_caches : dict[tuple[str, str, int], torch.Tensor] = {}
+
+    @property
+    def transfer_intermediate_tensors(self) -> bool:
+        return self._vllm_config.kv_transfer_config.get_from_extra_config(
+            "transfer_intermediate_tensors", False
+        )
+
 
     @property
     def role(self) -> KVConnectorRole:
@@ -703,6 +721,40 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             attn_metadata (AttentionMetadata): the attention metadata.
             **kwargs: additional arguments for the save operation.
         """
+        intermediate_tensors = kwargs.get("intermediate_tensors", None)
+        if intermediate_tensors is None:
+            return
+        query = get_tensor(intermediate_tensors, ["q", "query"])
+        if query is None:
+            return
+
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, LMCacheMPConnectorMetadata)
+
+        query_row_start = 0
+
+        for meta in metadata.requests:
+            if meta.direction != "STORE":
+                continue
+
+            query_num_tokens = meta.op.end - meta.op.start
+            query_row_end = query_row_start + query_num_tokens
+            q_slice = query[query_row_start:query_row_end]
+
+            with torch.cuda.stream(torch.cuda.current_stream()):
+                event = torch.cuda.Event(interprocess=True)
+                event.record()
+
+            self.q_caches[(meta.request_id, layer_name, meta.op.start)] = q_slice
+            
+            self.worker_adapter.submit_query_request(
+                meta.request_id,
+                meta.op,
+                layer_name,
+                q_slice,
+                event
+            )
+            query_row_start += query_num_tokens
         return
 
     def wait_for_save(self):
@@ -758,8 +810,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             The finished saves/sends req ids must belong to a set provided in a
             call to this method (this call or a prior one).
         """
-        val = self.worker_adapter.get_finished(finished_req_ids)
+        (ret_stores, finished_retrieves, q_keys) = self.worker_adapter.get_finished(finished_req_ids)
+        for key in q_keys:
+            self.q_caches.pop(key, None)
         # logger.error("Finished req ids: %s, %s", val[0], val[1])
+        val = ret_stores, finished_retrieves
         return val
 
     def get_block_ids_with_load_errors(self) -> set[int]:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -19,6 +19,7 @@ from lmcache.integration.vllm.utils import vllm_layout_hints
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
+    CudaIPCWrapper,
     IPCCacheServerKey,
     KVCache,
 )
@@ -542,6 +543,7 @@ class LoadStoreOp:
 StoreResult = bool
 RetrieveResult = bool
 LookupResult = int
+QueryResult = bool
 
 
 class LMCacheMPSchedulerAdapter:
@@ -993,10 +995,14 @@ class LMCacheMPWorkerAdapter:
         self.retrieve_futures: dict[
             str, tuple[MessagingFuture[RetrieveResult], list[int]]
         ] = {}
+        self.query_futures: dict[
+            tuple[str, str, int], MessagingFuture[QueryResult] # (request_id, layer_name, pos_start)
+        ] = {}
         # The IPC handle is not enough by itself; CUDA needs the exporting
         # event object to stay alive until the consumer is done with it.
         self.store_events: dict[str, _IpcEvent] = {}
         self.retrieve_events: dict[str, _IpcEvent] = {}
+        self.query_events: dict[tuple[str, str, int], _IpcEvent] = {}
 
         # Block IDs that failed due to retrieve timeout
         self.error_block_ids: set[int] = set()
@@ -1296,6 +1302,79 @@ class LMCacheMPWorkerAdapter:
         self.store_futures[request_id] = future
         self.store_events[request_id] = event
 
+    def cleanup_query_futures(self) -> list[tuple[str, str, int]]:
+        """
+        Clean up finished query futures and events.
+        Called by get_finished.
+
+        Returns:
+            A list of tags for the finished query futures to be sent
+            to vLLM scheduler for cleanup. Each tag is a tuple of
+            (request_id, layer_name, pos_start).
+        """
+        done = []
+        for key, future in self.query_futures.items():
+            if future.query():
+                # result = future.result()
+                done.append(key)
+        for key in done:
+            self.query_futures.pop(key, None)
+            self.query_events.pop(key, None)
+        return done
+
+    @_lmcache_nvtx_annotate
+    def submit_query_request(
+        self,
+        request_id: str,
+        op: LoadStoreOp,
+        layer_name: str,
+        query: torch.Tensor,
+        event: _IpcEvent,
+        cache_salt: str = "",
+    ):
+        """
+        Submit a Query cache request to LMCache
+
+        Args:
+            request_id: The ID of the request
+            op: The LoadStoreOp describing the store operation.
+            layer_name: The name of the layer for which to query.
+            query: The query tensor.
+            event: The CUDA event that is recorded after the current
+                model inference step
+            cache_salt: Per-user isolation salt.
+        """
+        self._ensure_heartbeat_started()
+
+        if not self.is_healthy:
+            return
+
+        assert op.token_ids is not None
+        key = self._create_key(
+            op.token_ids,
+            op.start,
+            op.end,
+            request_id=request_id,
+            cache_salt=cache_salt,
+        )
+        if self.transfer_ctx is None:
+            raise RuntimeError(
+                "Transfer context is not initialized. "
+                "Call register_kv_caches() before submitting store requests."
+            )
+        q_cache = [CudaIPCWrapper(query)]
+        future = self.transfer_ctx.submit_query(
+            request_id,
+            key,
+            self.instance_id,
+            layer_name,
+            q_cache,
+            event,
+        )
+        tag = (request_id, layer_name, op.start)
+        self.query_futures[tag] = future
+        self.query_events[tag] = event
+
     @_lmcache_nvtx_annotate
     def submit_retrieve_request(
         self,
@@ -1303,7 +1382,7 @@ class LMCacheMPWorkerAdapter:
         op: LoadStoreOp,
         event: _IpcEvent,
         cache_salt: str = "",
-    ) -> None:
+    ):
         """
         Submit a KV cache retrieve request to LMCache
 
@@ -1425,7 +1504,7 @@ class LMCacheMPWorkerAdapter:
     @_lmcache_nvtx_annotate
     def get_finished(
         self, finished_req_ids_from_engine: set[str]
-    ) -> tuple[set[str] | None, set[str] | None]:
+    ) -> tuple[set[str] | None, set[str] | None, list]:
         """
         Check and get the finished store and retrieve requests.
 
@@ -1471,6 +1550,7 @@ class LMCacheMPWorkerAdapter:
             dropped = self._dropped_retrieves
             self._dropped_retrieves = set()
             finished_retrieves.update(dropped)
+            q_keys = self.cleanup_query_futures()
 
             ret_stores = self._process_finished_stores(
                 finished_stores, finished_req_ids_from_engine
@@ -1481,7 +1561,7 @@ class LMCacheMPWorkerAdapter:
             # first and deletes the request, so we must not also report it
             # in finished_sending.
             ret_stores -= finished_retrieves
-            return ret_stores, finished_retrieves
+            return ret_stores, finished_retrieves, q_keys
 
         finished_stores = set()
         finished_retrieves = set()
@@ -1521,6 +1601,18 @@ class LMCacheMPWorkerAdapter:
         for request_id in finished_retrieves:
             self.retrieve_futures.pop(request_id, None)
             self.retrieve_events.pop(request_id, None)
+        q_keys = self.cleanup_query_futures()
+        
+
+        # Retrieves dropped while unhealthy still must be reported,
+        # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS. No
+        # finished_sending dedup is needed (unlike the unhealthy branch): a
+        # dropped retrieve's request is parked in WAITING_FOR_REMOTE_KVS until
+        # this report, so it cannot also be engine-finished in the same call.
+        # Swap-drain so a concurrent submit_retrieve_request add is never lost.
+        dropped = self._dropped_retrieves
+        self._dropped_retrieves = set()
+        finished_retrieves.update(dropped)
 
         # Retrieves dropped while unhealthy still must be reported,
         # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS. No
@@ -1548,7 +1640,7 @@ class LMCacheMPWorkerAdapter:
                 kv_rank=self.worker_id,
             )
 
-        return ret_stores, finished_retrieves
+        return ret_stores, finished_retrieves, q_keys
 
     def num_blocks_per_chunk(self) -> int:
         """

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -313,7 +313,7 @@ class IPCCacheServerKey:
 
 # Type exports
 KVCache = list[CudaIPCWrapper]
-
+QCache = list[CudaIPCWrapper]
 
 class RegisterEngineDrivenContextPayload(msgspec.Struct):
     """Payload for the REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT protocol message.

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -5,6 +5,7 @@
 from dataclasses import dataclass
 from typing import TypedDict
 import threading
+import hashlib
 
 # First Party
 from lmcache.logging import init_logger
@@ -226,6 +227,37 @@ class MPCacheServerContext:
         if key.worker_id is None:
             raise ValueError("Must resolve keys with worker_id != None")
         return ipc_key_to_object_keys(key, chunk_hashes, object_group_ids)
+
+    def resolve_q_obj_keys(self, key: IPCCacheEngineKey, layer_name: str) -> list[ObjectKey]:
+        """Resolve object keys from an IPC cache key.
+
+        Uses the session manager to track token state and the token hasher
+        to compute chunk hashes for the requested range.
+
+        Args:
+            key: IPC cache key describing model/session/token range.
+            layer_name: The name of the layer for which to resolve keys.
+
+        Returns:
+            Resolved object keys for the requested token range.
+
+        Raises:
+            ValueError: If ``key.worker_id`` is ``None``.
+        """
+        session = self.session_manager.get_or_create(key.request_id)
+        session.set_tokens(list(key.token_ids))
+        chunk_hashes = [
+            TokenHasher.hash_to_bytes(h) for h in session.get_hashes(key.start, key.end)
+        ]
+        if key.worker_id is None:
+            raise ValueError("Must resolve keys with worker_id != None")
+        layer_prefix = hashlib.blake2b(
+            layer_name.encode("utf-8"),
+            digest_size=8,
+        ).digest()
+        q_chunk_hashes = [b"Q" + layer_prefix + h for h in chunk_hashes]
+        q_obj_keys = ipc_key_to_object_keys(key, q_chunk_hashes)
+        return q_obj_keys
 
     @staticmethod
     def _compute_shm_pool_info(

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -228,7 +228,7 @@ class MPCacheServerContext:
             raise ValueError("Must resolve keys with worker_id != None")
         return ipc_key_to_object_keys(key, chunk_hashes, object_group_ids)
 
-    def resolve_q_obj_keys(self, key: IPCCacheEngineKey, layer_name: str) -> list[ObjectKey]:
+    def resolve_q_obj_keys(self, key: IPCCacheServerKey, layer_name: str) -> list[ObjectKey]:
         """Resolve object keys from an IPC cache key.
 
         Uses the session manager to track token state and the token hasher

--- a/lmcache/v1/multiprocess/protocols/base.py
+++ b/lmcache/v1/multiprocess/protocols/base.py
@@ -54,6 +54,7 @@ class RequestType(enum.Enum):
     COMMIT_STORE = enum.auto()
     PREPARE_RETRIEVE = enum.auto()
     COMMIT_RETRIEVE = enum.auto()
+    QUERY = enum.auto()
 
     # Controller operations
     CLEAR = enum.auto()

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -23,6 +23,7 @@ from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
     KVCache,
     RegisterEngineDrivenContextPayload,
+    QCache,
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
@@ -73,6 +74,7 @@ REQUEST_NAMES = [
     "COMMIT_STORE",
     "PREPARE_RETRIEVE",
     "COMMIT_RETRIEVE",
+    "QUERY"
 ]
 
 # Type alias for cache keys
@@ -235,6 +237,11 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         "COMMIT_RETRIEVE": ProtocolDefinition(
             payload_classes=[KeyType, int],
             response_class=bool,
+            handler_type=HandlerType.BLOCKING,
+        ),
+        "QUERY": ProtocolDefinition(
+            payload_classes=[KeyType, int, str, QCache, bytes],
+            response_class=tuple[bytes, bool],
             handler_type=HandlerType.BLOCKING,
         ),
     }

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -16,7 +16,7 @@ from lmcache import torch_dev
 from lmcache.utils import EngineType, init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints, is_mla
-from lmcache.v1.multiprocess.custom_types import RegisterEngineDrivenContextPayload
+from lmcache.v1.multiprocess.custom_types import QCache, RegisterEngineDrivenContextPayload
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.mq import MessageQueueClient
@@ -180,6 +180,34 @@ class TransferContext(ABC):
         Raises:
             RuntimeError: If register() was not called first.
         """
+    
+    @abstractmethod
+    def submit_query(
+        self,
+        request_id: str,
+        key: Any,
+        instance_id: int,
+        layer_name: str,
+        q_caches: QCache,
+        event: IPCEvent,
+    ) -> MessagingFuture:
+        """Submit a query save request and return a completion future.
+
+        Args:
+            request_id: External request identifier.
+            key: LMCache key object for the store range.
+            instance_id: Worker process instance identifier.
+            layer_name: The name of the layer this query cache belongs to.
+            q_caches: The query cache tensors.
+            event: Synchronization event object.
+            blocks_in_chunk: Number of vLLM blocks per LMCache chunk.
+
+        Returns:
+            A future compatible with adapter-side ``query()``/``result()`` flow.
+
+        Raises:
+            RuntimeError: If register() was not called first.
+        """
 
     @abstractmethod
     def submit_retrieve(
@@ -282,6 +310,26 @@ class LMCacheDrivenTransferContext(TransferContext):
             self._mq_client,
             RequestType.STORE,
             [key, instance_id, block_ids, event.ipc_handle()],
+        ).to_cuda_future()
+
+    def submit_query(
+        self,
+        _request_id: str,
+        key: Any,
+        instance_id: int,
+        layer_name: str,
+        _q_caches: QCache,
+        event: IPCEvent,
+    ) -> MessagingFuture:
+        if self._mq_client is None or self._send_request is None:
+            raise RuntimeError(
+                "Handle transfer context is not registered. "
+                "Call register() before submit_query()."
+            )
+        return self._send_request(
+            self._mq_client,
+            RequestType.QUERY,
+            [key, instance_id, layer_name, _q_caches, event.ipc_handle()],
         ).to_cuda_future()
 
     def submit_retrieve(
@@ -450,6 +498,26 @@ class EngineDrivenTransferContext(TransferContext):
 
         future = MessagingFuture()
         future.set_result(ok)
+        return future
+
+    def submit_query(
+        self,
+        _request_id: str,
+        key: Any,
+        instance_id: int,
+        layer_name: str,
+        _q_caches: QCache,
+        event: IPCEvent,
+    ) -> MessagingFuture:
+        if self._non_gpu_context is None:
+            raise RuntimeError(
+                "Data transfer context is not registered. "
+                "Call register() before submit_store()."
+            )
+
+        # Not yet implemented on the non-GPU path
+        future: MessagingFuture[bool] = MessagingFuture()
+        future.set_result(True)
         return future
 
     def submit_retrieve(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements exporting Q from vLLM into LMCache to enable token dropping techniques outside of inference engine.
Example of printed Query tensor:
```
[2026-06-09 23:43:00,127] LMCache INFO: Query stored 32 for layer=model.layers.0.self_attn.attn, request_id=cmpl-9cde3ce0b20e3866-0-833f6d05 (gpu_transfer.py:633:lmcache.v1.multiprocess.modules.gpu_transfer)
[2026-06-09 23:43:00,128] LMCache INFO: Stored 8192 Query tokens in 0.005 seconds (gpu_transfer.py:643:lmcache.v1.multiprocess.modules.gpu_transfer)[0m
[2026-06-09 23:43:00,139] LMCache INFO: [QUERY_PRINT] shape=(256, 32, 128) tensor=tensor([-0.0435, -0.1060,  0.1777, -0.0105, -0.1221, -0.0583, -0.1250,  0.2793],
       dtype=torch.bfloat16) (storage_manager.py:278:lmcache.v1.distributed.storage_manager)
```

**Special notes for your reviewers**:

Currently, the Q tensor save is done layerwise. Will adjust to KV cache save process in the future.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
