### PR TITLE
[CI/CD] Add structural parity test for native_storage_ops fallback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,8 +57,9 @@ repos:
   hooks:
   - id: mypy
     language_version: python3.12 
-    args: [--config-file=pyproject.toml, --exclude, 'lmcache/native_storage_ops\.py']
+    args: [--config-file=pyproject.toml]
     #args: [--ignore-missing-imports]
+    exclude: '^lmcache/native_storage_ops\.py$'
     additional_dependencies:
       - tokenize-rt==6.1.0 # For better dynamic analysis performance
       - msgspec[mypy]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
   hooks:
   - id: mypy
     language_version: python3.12 
-    args: [--config-file=pyproject.toml]
+    args: [--config-file=pyproject.toml, --exclude, 'lmcache/native_storage_ops\.py']
     #args: [--ignore-missing-imports]
     additional_dependencies:
       - tokenize-rt==6.1.0 # For better dynamic analysis performance

--- a/lmcache/native_storage_ops.py
+++ b/lmcache/native_storage_ops.py
@@ -1,0 +1,499 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python fallback implementations for ``lmcache.native_storage_ops``.
+
+The C++ extension (``native_storage_ops.cpython-*.so``) is the production path
+and is preferred whenever it is available. This Python module exists so that
+CPU-only / non-CUDA environments and CI runners that lack the compiled
+extension can still ``import lmcache.native_storage_ops`` without raising
+``ImportError``.
+
+Public API mirrors ``lmcache/native_storage_ops.pyi`` exactly:
+
+* :class:`TTLLock`
+* :class:`Bitmap`
+* :class:`ParallelPatternMatcher`
+* :class:`PeriodicEventNotifier`
+* :class:`RangePatternMatcher`
+
+Performance notice
+------------------
+These implementations prioritize correctness and portability over speed. They
+are NOT a replacement for the C++ implementation on performance-critical paths
+(e.g. :class:`TTLLock` is backed by ``std::atomic`` in C++ but uses
+``threading.Lock`` here). Use them only when the native extension is
+unavailable.
+
+Originally inspired by PR #2784 (by @darsh7807). This module supersedes that
+PR by:
+
+* Adding the missing :class:`PeriodicEventNotifier` class (now used by
+  ``v1.distributed.storage_manager``).
+* Filling in :meth:`Bitmap.batched_set` and :meth:`Bitmap.__repr__` which were
+  absent from the original draft.
+* Tightening :class:`RangePatternMatcher` validation to reject patterns
+  longer than 5 elements, matching the C++ contract.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Sequence
+from typing import Any, Optional, Set
+import os
+import struct
+import threading
+import time
+
+__all__ = [
+    "TTLLock",
+    "Bitmap",
+    "ParallelPatternMatcher",
+    "PeriodicEventNotifier",
+    "RangePatternMatcher",
+]
+
+
+# ---------------------------------------------------------------------------
+# TTLLock
+# ---------------------------------------------------------------------------
+class TTLLock:
+    """Thread-safe lock with TTL (Time-To-Live) semantics.
+
+    Mirrors the C++ ``TTLLock``. The lock maintains a counter that can be
+    incremented by :meth:`lock` and decremented by :meth:`unlock`. If the TTL
+    expires the lock is considered released regardless of the counter.
+
+    Notes
+    -----
+    The C++ implementation uses ``std::atomic`` for lock-free operation. This
+    Python fallback uses :class:`threading.Lock`, which is correct under the
+    GIL but has different performance characteristics. Use :func:`time.monotonic`
+    so that wall-clock adjustments cannot break TTL semantics.
+    """
+
+    def __init__(self, ttl_second: int = 300) -> None:
+        self._ttl_ms: int = int(ttl_second * 1000)
+        self._mu: threading.Lock = threading.Lock()
+        self._count: int = 0
+        self._expire_at_ms: int = 0
+
+    @staticmethod
+    def _now_ms() -> int:
+        return int(time.monotonic() * 1000)
+
+    def _expired(self) -> bool:
+        return self._expire_at_ms <= self._now_ms()
+
+    def lock(self) -> None:
+        """Increment the counter and refresh the TTL.
+
+        If the previous TTL has expired, the counter is reset before the
+        increment, so a stale (expired) state always becomes count == 1.
+        """
+        with self._mu:
+            if self._expired():
+                self._count = 0
+            self._count += 1
+            self._expire_at_ms = self._now_ms() + self._ttl_ms
+
+    def unlock(self) -> None:
+        """Decrement the counter (clamped at zero).
+
+        Intentionally does NOT clear the counter on TTL expiration; that is the
+        responsibility of :meth:`is_locked` / :meth:`lock`. Clearing here would
+        break the counting-semaphore contract under concurrent holders.
+        """
+        with self._mu:
+            if self._count > 0:
+                self._count -= 1
+
+    def is_locked(self) -> bool:
+        """Return True iff the lock is currently held and not expired."""
+        with self._mu:
+            if self._expired():
+                self._count = 0
+                return False
+            return self._count > 0
+
+    def reset(self) -> None:
+        """Reset the lock to the initial state (counter = 0, TTL expired)."""
+        with self._mu:
+            self._count = 0
+            self._expire_at_ms = 0
+
+
+# ---------------------------------------------------------------------------
+# Bitmap
+# ---------------------------------------------------------------------------
+class Bitmap:
+    """Bitmap for tracking the success/failure of L2 storage operations.
+
+    Each bit represents the state of a single key. Out-of-range single-bit
+    operations are silently ignored to match the C++ contract (which makes
+    callers' lives easier when sizes change).
+    """
+
+    __slots__ = ("_data", "_size")
+
+    def __init__(self, size: int, prefix_bits: Optional[int] = None) -> None:
+        if size < 0:
+            raise ValueError("size must be non-negative")
+
+        self._size = size
+        if size == 0:
+            self._data = bytearray()
+        else:
+            num_bytes = (size + 7) // 8
+            self._data = bytearray(num_bytes)
+
+        if prefix_bits is not None:
+            prefix_bits = int(prefix_bits)
+            if prefix_bits > 0:
+                if prefix_bits > size:
+                    prefix_bits = size
+                for i in range(prefix_bits):
+                    self.set(i)
+
+    # -- helpers ------------------------------------------------------------
+    def _byte_index(self, bit_index: int) -> int:
+        return bit_index // 8
+
+    def _bit_offset(self, bit_index: int) -> int:
+        return bit_index % 8
+
+    # -- single-bit ops -----------------------------------------------------
+    def set(self, index: int) -> None:
+        if 0 <= index < self._size:
+            byte_idx = self._byte_index(index)
+            bit_offset = self._bit_offset(index)
+            self._data[byte_idx] |= 1 << bit_offset
+
+    def batched_set(self, indices: Sequence[int]) -> None:
+        for i in indices:
+            self.set(i)
+
+    def clear(self, index: int) -> None:
+        if 0 <= index < self._size:
+            byte_idx = self._byte_index(index)
+            bit_offset = self._bit_offset(index)
+            self._data[byte_idx] &= ~(1 << bit_offset)
+
+    def test(self, index: int) -> bool:
+        if 0 <= index < self._size:
+            byte_idx = self._byte_index(index)
+            bit_offset = self._bit_offset(index)
+            return bool((self._data[byte_idx] >> bit_offset) & 1)
+        return False
+
+    # -- aggregates ---------------------------------------------------------
+    def popcount(self) -> int:
+        if not self._data:
+            return 0
+        count = 0
+        num_full_bytes = self._size // 8
+        for i in range(num_full_bytes):
+            count += bin(self._data[i]).count("1")
+        remaining_bits = self._size % 8
+        if remaining_bits > 0:
+            last_byte = self._data[-1]
+            mask = (1 << remaining_bits) - 1
+            count += bin(last_byte & mask).count("1")
+        return count
+
+    def count_leading_zeros(self) -> int:
+        if self._size == 0:
+            return 0
+        count = 0
+        num_full_bytes = self._size // 8
+        for i in range(num_full_bytes):
+            b = self._data[i]
+            if b == 0:
+                count += 8
+            else:
+                count += (b & -b).bit_length() - 1
+                return count
+        remaining_bits = self._size % 8
+        if remaining_bits > 0:
+            last_byte = self._data[-1]
+            mask = (1 << remaining_bits) - 1
+            last_byte &= mask
+            if last_byte == 0:
+                count += remaining_bits
+            else:
+                count += (last_byte & -last_byte).bit_length() - 1
+        return count
+
+    def count_leading_ones(self) -> int:
+        inverted = ~self
+        return inverted.count_leading_zeros()
+
+    # -- bitwise ops --------------------------------------------------------
+    def __and__(self, other: "Bitmap") -> "Bitmap":
+        result_size = min(self._size, other._size)
+        result = Bitmap(result_size)
+        for i in range(min(len(self._data), len(other._data))):
+            result._data[i] = self._data[i] & other._data[i]
+        return result
+
+    def __or__(self, other: "Bitmap") -> "Bitmap":
+        result_size = min(self._size, other._size)
+        result = Bitmap(result_size)
+        for i in range(min(len(self._data), len(other._data))):
+            result._data[i] = self._data[i] | other._data[i]
+        # Clear bits beyond size in the last byte to maintain the invariant.
+        remaining = result_size % 8
+        if remaining and result._data:
+            result._data[-1] &= (1 << remaining) - 1
+        return result
+
+    def __invert__(self) -> "Bitmap":
+        result = Bitmap(self._size)
+        for i in range(len(self._data)):
+            result._data[i] = ~self._data[i] & 0xFF
+        remaining_bits = self._size % 8
+        if remaining_bits > 0 and self._data:
+            mask = (1 << remaining_bits) - 1
+            result._data[-1] &= mask
+        return result
+
+    # -- introspection ------------------------------------------------------
+    def get_indices_list(self) -> list[int]:
+        indices: list[int] = []
+        for i in range(len(self._data)):
+            byte = self._data[i]
+            bit_base = i * 8
+            bit = 0
+            while byte and bit < 8:
+                if byte & 1:
+                    idx = bit_base + bit
+                    if idx < self._size:
+                        indices.append(idx)
+                byte >>= 1
+                bit += 1
+        return indices
+
+    def get_indices_set(self) -> Set[int]:
+        return set(self.get_indices_list())
+
+    def gather(self, items: Sequence[Any]) -> list[Any]:
+        return [items[i] for i in self.get_indices_list() if i < len(items)]
+
+    def __repr__(self) -> str:
+        if self._size == 0:
+            return ""
+        chars = []
+        for i in range(self._size):
+            chars.append("1" if self.test(i) else "0")
+        return "".join(chars)
+
+
+# ---------------------------------------------------------------------------
+# ParallelPatternMatcher
+# ---------------------------------------------------------------------------
+class ParallelPatternMatcher:
+    """Find every starting position where ``pattern`` occurs in ``data``.
+
+    Naive O(n*m) sliding window. The C++ implementation parallelizes this; the
+    Python fallback prioritizes correctness only.
+    """
+
+    __slots__ = ("_pattern",)
+
+    def __init__(self, pattern: list[int]) -> None:
+        if not pattern:
+            raise ValueError("pattern must not be empty")
+        self._pattern: list[int] = list(pattern)
+
+    def match(self, data: list[int]) -> list[int]:
+        pat = self._pattern
+        m = len(pat)
+        if m == 0 or len(data) < m:
+            return []
+        return [i for i in range(len(data) - m + 1) if data[i : i + m] == pat]
+
+
+# ---------------------------------------------------------------------------
+# PeriodicEventNotifier
+# ---------------------------------------------------------------------------
+class PeriodicEventNotifier:
+    """Singleton that periodically signals registered file descriptors.
+
+    A daemon thread writes to every registered fd at a configurable interval.
+    The thread sleeps when no fds are registered and wakes automatically when
+    the first fd is added.
+
+    Differences from the C++ implementation
+    ---------------------------------------
+    * Uses :class:`threading.Condition` for synchronization, similar to C++'s
+      std::condition_variable but with Python semantics.
+    * Tolerates ``OSError`` from ``os.write`` (the user may have closed the fd
+      externally).
+    * The background thread is a daemon so it never blocks interpreter exit,
+      but callers should still call :meth:`shutdown` for clean teardown.
+    """
+
+    _instance: Optional["PeriodicEventNotifier"] = None
+    _class_lock: threading.Lock = threading.Lock()
+
+    # Created via :meth:`create`; do not call this constructor directly.
+    def __init__(self, interval_ms: int, use_eventfd: bool) -> None:
+        # Clamped to >= 1 ms to mirror the C++ behaviour.
+        self._interval_s: float = max(int(interval_ms), 1) / 1000.0
+        self._use_eventfd: bool = bool(use_eventfd)
+
+        self._fds: Set[int] = set()
+        self._lock: threading.Lock = threading.Lock()
+        self._cv: threading.Condition = threading.Condition(self._lock)
+        self._stop: bool = False
+
+        self._thread: threading.Thread = threading.Thread(
+            target=self._run,
+            name="PeriodicEventNotifier",
+            daemon=True,
+        )
+
+    # -- lifecycle (static API) --------------------------------------------
+    @staticmethod
+    def create(interval_ms: int, use_eventfd: bool) -> None:
+        """Create the singleton. Idempotent: a second call is a no-op."""
+        with PeriodicEventNotifier._class_lock:
+            if PeriodicEventNotifier._instance is not None:
+                return
+            inst = PeriodicEventNotifier(interval_ms, use_eventfd)
+            PeriodicEventNotifier._instance = inst
+            inst._thread.start()
+
+    @staticmethod
+    def get() -> Optional["PeriodicEventNotifier"]:
+        """Return the singleton instance, or None if not yet created."""
+        return PeriodicEventNotifier._instance
+
+    @staticmethod
+    def shutdown() -> None:
+        """Shut the singleton down and join its thread. Idempotent."""
+        with PeriodicEventNotifier._class_lock:
+            inst = PeriodicEventNotifier._instance
+            if inst is None:
+                return
+            with inst._cv:
+                inst._stop = True
+                inst._cv.notify()
+            PeriodicEventNotifier._instance = None
+        # Join outside the class lock to avoid deadlocking with anything the
+        # background thread may try to acquire on its way out.
+        inst._thread.join()
+
+    # -- instance API -------------------------------------------------------
+    def register_fd(self, fd: int) -> None:
+        """Register a file descriptor for periodic signalling."""
+        with self._cv:
+            self._fds.add(int(fd))
+            self._cv.notify()
+
+    def unregister_fd(self, fd: int) -> None:
+        """Unregister a previously-registered fd. No-op if not registered."""
+        with self._cv:
+            self._fds.discard(int(fd))
+
+    def set_interval_ms(self, interval_ms: int) -> None:
+        """Change the notification interval (clamped to >= 1 ms)."""
+        with self._cv:
+            self._interval_s = max(int(interval_ms), 1) / 1000.0
+            self._cv.notify()  # let the running loop pick up the new interval
+
+    # -- background loop ----------------------------------------------------
+    def _run(self) -> None:
+        # eventfd write semantics: 8-byte uint64 (native byte order).
+        eventfd_payload = struct.pack("@Q", 1)
+        # Pipe write semantics: a single byte is sufficient to wake a reader.
+        pipe_payload = b"\x00"
+
+        while True:
+            with self._cv:
+                # Wait until there are fds to signal, or shutdown was requested.
+                self._cv.wait_for(lambda: self._fds or self._stop)
+                if self._stop:
+                    break
+                fds_snapshot = list(self._fds)
+                payload_use_eventfd = self._use_eventfd
+                interval = self._interval_s
+
+            payload = eventfd_payload if payload_use_eventfd else pipe_payload
+            for fd in fds_snapshot:
+                try:
+                    os.write(fd, payload)
+                except OSError:
+                    # The fd may have been closed externally; silently ignore.
+                    # The user is expected to call unregister_fd() on close.
+                    pass
+
+            # Wait for next tick or early shutdown. Using wait_for(predicate)
+            # avoids the lost-wakeup race where shutdown() fires while we're
+            # between releasing the lock above and re-acquiring it here.
+            with self._cv:
+                self._cv.wait_for(lambda: self._stop, timeout=interval)
+                if self._stop:
+                    break
+
+
+# ---------------------------------------------------------------------------
+# RangePatternMatcher
+# ---------------------------------------------------------------------------
+class RangePatternMatcher:
+    """Find ``(start, end)`` ranges in ``data`` delimited by two patterns.
+
+    Returns minimal ranges: when multiple end-pattern occurrences follow a
+    start-pattern occurrence, the FIRST end is matched.
+    """
+
+    __slots__ = ("_start", "_end")
+
+    _MAX_PATTERN_LEN: int = 5
+
+    def __init__(
+        self,
+        start_pattern: list[int],
+        end_pattern: list[int],
+    ) -> None:
+        if not start_pattern or not end_pattern:
+            raise ValueError("patterns must not be empty")
+        if (
+            len(start_pattern) > self._MAX_PATTERN_LEN
+            or len(end_pattern) > self._MAX_PATTERN_LEN
+        ):
+            raise ValueError(
+                f"patterns must not have more than {self._MAX_PATTERN_LEN} elements"
+            )
+        self._start: list[int] = list(start_pattern)
+        self._end: list[int] = list(end_pattern)
+
+    def match(self, data: list[int]) -> list[tuple[int, int]]:
+        ranges: list[tuple[int, int]] = []
+        start_len = len(self._start)
+        end_len = len(self._end)
+        n = len(data)
+        if n < start_len + end_len:
+            return ranges
+
+        i = 0
+        while i <= n - start_len:
+            if data[i : i + start_len] == self._start:
+                # Found start; scan forward for the first end pattern.
+                search_idx = i + start_len
+                matched = False
+                while search_idx <= n - end_len:
+                    if data[search_idx : search_idx + end_len] == self._end:
+                        end_idx = search_idx + end_len
+                        ranges.append((i, end_idx))
+                        # Skip past the matched range to avoid producing
+                        # nested / overlapping matches.
+                        i = end_idx
+                        matched = True
+                        break
+                    search_idx += 1
+                if not matched:
+                    i += 1
+            else:
+                i += 1
+        return ranges

--- a/lmcache/native_storage_ops.py
+++ b/lmcache/native_storage_ops.py
@@ -164,22 +164,53 @@ class Bitmap:
 
     # -- single-bit ops -----------------------------------------------------
     def set(self, index: int) -> None:
+        """Set the bit at the specified index to 1.
+
+        Out-of-range indices are silently ignored.
+
+        Args:
+            index: The bit position to set.
+        """
         if 0 <= index < self._size:
             byte_idx = self._byte_index(index)
             bit_offset = self._bit_offset(index)
             self._data[byte_idx] |= 1 << bit_offset
 
     def batched_set(self, indices: Sequence[int]) -> None:
+        """Set multiple bits at once.
+
+        Out-of-range indices are silently ignored.
+
+        Args:
+            indices: Sequence of bit positions to set.
+        """
         for i in indices:
             self.set(i)
 
     def clear(self, index: int) -> None:
+        """Clear the bit at the specified index (set to 0).
+
+        Out-of-range indices are silently ignored.
+
+        Args:
+            index: The bit position to clear.
+        """
         if 0 <= index < self._size:
             byte_idx = self._byte_index(index)
             bit_offset = self._bit_offset(index)
             self._data[byte_idx] &= ~(1 << bit_offset)
 
     def test(self, index: int) -> bool:
+        """Return True if the bit at the specified index is set.
+
+        Returns False for out-of-range indices.
+
+        Args:
+            index: The bit position to test.
+
+        Returns:
+            True if the bit is set, False otherwise.
+        """
         if 0 <= index < self._size:
             byte_idx = self._byte_index(index)
             bit_offset = self._bit_offset(index)
@@ -188,6 +219,11 @@ class Bitmap:
 
     # -- aggregates ---------------------------------------------------------
     def popcount(self) -> int:
+        """Return the number of set bits (population count).
+
+        Returns:
+            The count of bits that are set to 1.
+        """
         if not self._data:
             return 0
         count = 0
@@ -202,6 +238,12 @@ class Bitmap:
         return count
 
     def count_leading_zeros(self) -> int:
+        """Return the number of consecutive zero bits starting from index 0.
+
+        Returns:
+            The count of leading zero bits. Returns 0 if bit 0 is set,
+            and ``size`` if all bits are zero.
+        """
         if self._size == 0:
             return 0
         count = 0
@@ -225,6 +267,12 @@ class Bitmap:
         return count
 
     def count_leading_ones(self) -> int:
+        """Return the number of consecutive one bits starting from index 0.
+
+        Returns:
+            The count of leading one bits. Returns 0 if bit 0 is clear,
+            and ``size`` if all bits are set.
+        """
         inverted = ~self
         return inverted.count_leading_zeros()
 
@@ -259,6 +307,11 @@ class Bitmap:
 
     # -- introspection ------------------------------------------------------
     def get_indices_list(self) -> list[int]:
+        """Return a sorted list of indices of all set bits.
+
+        Returns:
+            A list of bit positions (in ascending order) that are set to 1.
+        """
         indices: list[int] = []
         for i in range(len(self._data)):
             byte = self._data[i]
@@ -274,9 +327,23 @@ class Bitmap:
         return indices
 
     def get_indices_set(self) -> Set[int]:
+        """Return a set of indices of all set bits.
+
+        Returns:
+            A set of bit positions that are set to 1.
+        """
         return set(self.get_indices_list())
 
     def gather(self, items: Sequence[Any]) -> list[Any]:
+        """Collect items at positions where the corresponding bit is set.
+
+        Args:
+            items: A sequence to index into. Items beyond ``len(items)`` are
+                silently skipped.
+
+        Returns:
+            A list of elements from ``items`` at the set bit positions.
+        """
         return [items[i] for i in self.get_indices_list() if i < len(items)]
 
     def __repr__(self) -> str:
@@ -306,6 +373,14 @@ class ParallelPatternMatcher:
         self._pattern: list[int] = list(pattern)
 
     def match(self, data: list[int]) -> list[int]:
+        """Find all starting positions where the pattern occurs in data.
+
+        Args:
+            data: The integer sequence to search in.
+
+        Returns:
+            A sorted list of starting positions where the pattern is found.
+        """
         pat = self._pattern
         m = len(pat)
         if m == 0 or len(data) < m:
@@ -432,7 +507,12 @@ class PeriodicEventNotifier:
             # avoids the lost-wakeup race where shutdown() fires while we're
             # between releasing the lock above and re-acquiring it here.
             with self._cv:
-                self._cv.wait_for(lambda: self._stop, timeout=interval)
+                current_interval = self._interval_s
+
+                def _should_wake(ci: float = current_interval) -> bool:
+                    return self._stop or not self._fds or self._interval_s != ci
+
+                self._cv.wait_for(_should_wake, timeout=interval)
                 if self._stop:
                     break
 
@@ -469,6 +549,20 @@ class RangePatternMatcher:
         self._end: list[int] = list(end_pattern)
 
     def match(self, data: list[int]) -> list[tuple[int, int]]:
+        """Find all (start, end) ranges delimited by the start/end patterns.
+
+        Produces minimal non-overlapping ranges: for each start-pattern
+        occurrence, the first subsequent end-pattern occurrence is matched.
+
+        Args:
+            data: The integer sequence to search in.
+
+        Returns:
+            A list of ``(start_pos, end_pos)`` tuples where ``start_pos`` is
+            the index of the first element of the start pattern and
+            ``end_pos`` is the index one past the last element of the end
+            pattern.
+        """
         ranges: list[tuple[int, int]] = []
         start_len = len(self._start)
         end_len = len(self._end)

--- a/lmcache/native_storage_ops.py
+++ b/lmcache/native_storage_ops.py
@@ -23,15 +23,6 @@ are NOT a replacement for the C++ implementation on performance-critical paths
 ``threading.Lock`` here). Use them only when the native extension is
 unavailable.
 
-Originally inspired by PR #2784 (by @darsh7807). This module supersedes that
-PR by:
-
-* Adding the missing :class:`PeriodicEventNotifier` class (now used by
-  ``v1.distributed.storage_manager``).
-* Filling in :meth:`Bitmap.batched_set` and :meth:`Bitmap.__repr__` which were
-  absent from the original draft.
-* Tightening :class:`RangePatternMatcher` validation to reject patterns
-  longer than 5 elements, matching the C++ contract.
 """
 
 # Future

--- a/lmcache/native_storage_ops.py
+++ b/lmcache/native_storage_ops.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 # Standard
 from collections.abc import Sequence
 from typing import Any, Optional, Set
+import errno
 import os
 import struct
 import threading
@@ -489,10 +490,13 @@ class PeriodicEventNotifier:
             for fd in fds_snapshot:
                 try:
                     os.write(fd, payload)
-                except OSError:
-                    # The fd may have been closed externally; silently ignore.
-                    # The user is expected to call unregister_fd() on close.
-                    pass
+                except OSError as e:
+                    # The fd may have been closed externally.
+                    # Automatically unregister it on EBADF/EPIPE to avoid
+                    # repeated write attempts on every tick (CPU overhead).
+                    if e.errno in (errno.EBADF, errno.EPIPE):
+                        self.unregister_fd(fd)
+                    # Other errors are silently ignored.
 
             # Wait for next tick or early shutdown. Using wait_for(predicate)
             # avoids the lost-wakeup race where shutdown() fires while we're

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ platform = "linux"
 modules = ["lmcache", "tests", "benchmarks"]
 exclude = [
     'lmcache/integration/vllm/lmcache_mp_connector_.*\.py',
+    'lmcache/native_storage_ops\.py',
 ]
 
 disable_error_code = [

--- a/tests/v1/test_native_storage_ops_parity.py
+++ b/tests/v1/test_native_storage_ops_parity.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Verify that every public class/method in the Python fallback
+``lmcache.native_storage_ops`` matches the C++ extension
+``native_storage_ops.cpython-*.so``.
+
+Mirrors the structure of ``test_c_ops_fallback_parity.py`` but adapted to a
+class-based API.  Three parity dimensions only — purely structural, no
+behavior testing:
+
+1. Class existence    - every class in the .so has a fallback class.
+2. Method existence   - every public method (and selected dunders) on the
+                        .so class exists on the fallback class.
+3. Method signature   - parameter names, count, and defaults match.
+                        ``Bitmap.__init__`` is overloaded in pybind11; the
+                        Python single-signature is accepted as long as it
+                        is call-compatible with EVERY .so overload.
+
+Requires the compiled extension (``.so``) to be importable.  Automatically
+skipped on CPU-only / non-CUDA CI where only the Python fallback is present.
+
+Helper functions are intentionally duplicated from
+``test_c_ops_fallback_parity.py`` rather than extracted into a shared module
+to keep each parity suite self-contained.
+"""
+
+# Standard
+from typing import Any
+import importlib
+import importlib.util
+import inspect
+import os
+import re
+
+# Third Party
+import pytest
+
+# Strategy for getting both the .so and the .py fallback in the same process:
+#
+# When the C++ extension is built, ``lmcache.native_storage_ops`` lives next
+# to ``native_storage_ops.py`` as ``native_storage_ops.cpython-*.so``.
+# Python's import machinery prefers the .so over the .py, so a normal
+# ``import lmcache.native_storage_ops`` returns the compiled extension when
+# it is available and falls back to the .py module otherwise.
+#
+# To compare the two we therefore:
+#   1. ``import lmcache.native_storage_ops`` → ``so_mod``.  This is the
+#      production module.  If the .so was not built, this still imports
+#      the .py fallback; we detect that case and skip the whole suite.
+#   2. Locate ``native_storage_ops.py`` on disk and load it explicitly via
+#      ``importlib.util.spec_from_file_location`` → ``fallback``.  Doing it
+#      by file path bypasses the import-machinery preference and guarantees
+#      we get the Python implementation regardless of whether the .so is
+#      already loaded.
+try:
+    # First Party
+    import lmcache.native_storage_ops as so_mod  # type: ignore[import-not-found]
+
+    _so_file = getattr(so_mod, "__file__", "") or ""
+    _is_extension = _so_file.endswith((".so", ".pyd"))
+
+    # Locate the .py fallback file.  ``find_spec`` is unreliable here because
+    # it returns the .so spec when the extension is loaded; we instead walk
+    # the package's __path__ entries looking for the literal .py file.
+    _fallback_path: str | None = None
+    # First Party
+    import lmcache as _lmcache_pkg
+
+    for _candidate_dir in list(_lmcache_pkg.__path__):
+        _candidate = os.path.join(_candidate_dir, "native_storage_ops.py")
+        if os.path.isfile(_candidate):
+            _fallback_path = _candidate
+            break
+
+    if not _is_extension or _fallback_path is None:
+        raise ImportError(
+            "native_storage_ops .so not built or .py fallback file not found"
+        )
+
+    _fallback_spec = importlib.util.spec_from_file_location(
+        "_native_storage_ops_fallback", _fallback_path
+    )
+    if _fallback_spec is None or _fallback_spec.loader is None:
+        raise ImportError("could not build a spec for the .py fallback")
+    fallback = importlib.util.module_from_spec(_fallback_spec)
+    _fallback_spec.loader.exec_module(fallback)
+
+    HAS_SO = True
+except (ImportError, AttributeError, OSError):
+    so_mod = None  # type: ignore[assignment]
+    fallback = None  # type: ignore[assignment]
+    HAS_SO = False
+
+
+# Five classes that make up the public API of native_storage_ops.
+TARGET_CLASS_NAMES: tuple[str, ...] = (
+    "TTLLock",
+    "Bitmap",
+    "ParallelPatternMatcher",
+    "PeriodicEventNotifier",
+    "RangePatternMatcher",
+)
+
+# Dunder methods we explicitly check (they implement real business logic
+# rather than Python boilerplate).  Other dunders like ``__class__``,
+# ``__hash__``, ``__init_subclass__`` are skipped to avoid noise.
+TESTED_DUNDERS: frozenset[str] = frozenset(
+    {"__init__", "__and__", "__or__", "__invert__", "__repr__"}
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers (duplicated from test_c_ops_fallback_parity.py with overload support)
+# ─────────────────────────────────────────────────────────────────────────────
+def _normalize_default(value_str: str) -> Any:
+    """Normalize a default-value string for comparison.
+
+    pybind11 docstrings render booleans lowercase (``false``/``true``); the
+    Python ``inspect`` representation renders them as ``False``/``True``.
+    Both spellings collapse to the same Python object after this pass.
+    """
+    s = value_str.strip()
+    if s.lower() == "false":
+        return False
+    if s.lower() == "true":
+        return True
+    if s in ("None", "none"):
+        return None
+    if (s.startswith("'") and s.endswith("'")) or (
+        s.startswith('"') and s.endswith('"')
+    ):
+        return s[1:-1]
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    return s
+
+
+def _split_params(params_str: str) -> list[str]:
+    """Split a ``"a: int, b: list[int] = [1, 2]"`` string at top-level commas."""
+    params: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for ch in params_str:
+        if ch in "([{":
+            depth += 1
+            current.append(ch)
+        elif ch in ")]}":
+            depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            params.append("".join(current).strip())
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        params.append("".join(current).strip())
+    return params
+
+
+def _parse_param_list(params_str: str) -> list[tuple[str, bool, Any]]:
+    """Parse ``"a: int, b: int = 5"`` → ``[("a", False, None), ("b", True, 5)]``."""
+    if not params_str.strip():
+        return []
+    result: list[tuple[str, bool, Any]] = []
+    for raw in _split_params(params_str):
+        colon_idx = raw.find(":")
+        if colon_idx == -1:
+            name = raw.split("=")[0].strip()
+        else:
+            name = raw[:colon_idx].strip()
+        has_default = "=" in raw
+        default_value: Any = None
+        if has_default:
+            default_value = _normalize_default(raw.split("=", 1)[1])
+        result.append((name, has_default, default_value))
+    return result
+
+
+def _strip_self_param(
+    params: list[tuple[str, bool, Any]],
+) -> list[tuple[str, bool, Any]]:
+    """Drop a leading ``self``/``cls`` param if present.
+
+    pybind11 method docstrings include ``self: ClassName`` as the first
+    parameter; ``inspect.signature`` on a Python method *also* includes
+    ``self``.  We strip both so the comparisons line up regardless of how
+    each side was extracted.
+    """
+    if params and params[0][0] in ("self", "cls"):
+        return params[1:]
+    return params
+
+
+def _parse_pybind_overloads(
+    method: Any,
+) -> list[list[tuple[str, bool, Any]]] | None:
+    """Parse the docstring of a pybind11-bound method into a list of overload
+    signatures.  Always returns a list (one entry for non-overloaded methods,
+    multiple for overloaded ones), or ``None`` if parsing fails.
+
+    pybind11 emits one of two shapes:
+
+      Single signature:
+          method_name(self: Cls, arg: int) -> ret
+
+      Overloaded:
+          method_name(*args, **kwargs)
+          Overloaded function.
+
+          1. method_name(self: Cls, size: int) -> None
+          2. method_name(self: Cls, size: int, prefix_bits: int) -> None
+    """
+    doc = getattr(method, "__doc__", None)
+    if not doc:
+        return None
+
+    # Overloaded form — collect every "N. name(...)" line.
+    if "Overloaded function." in doc:
+        overloads: list[list[tuple[str, bool, Any]]] = []
+        for line in doc.split("\n"):
+            stripped = line.strip()
+            m = re.match(r"\d+\.\s*\w+\((.*)\)\s*->", stripped)
+            if m:
+                overloads.append(_strip_self_param(_parse_param_list(m.group(1))))
+        return overloads if overloads else None
+
+    # Single-signature form — first line.
+    first = doc.strip().split("\n")[0]
+    m = re.match(r"\w+\((.*)\)\s*->", first)
+    if m is None:
+        return None
+    return [_strip_self_param(_parse_param_list(m.group(1)))]
+
+
+def _get_python_params(func: Any) -> list[tuple[str, bool, Any]]:
+    """Extract ``[(name, has_default, default_value)]`` via inspect.signature."""
+    sig = inspect.signature(func)
+    out: list[tuple[str, bool, Any]] = []
+    for p in sig.parameters.values():
+        if p.name in ("self", "cls"):
+            continue
+        has_default = p.default is not inspect.Parameter.empty
+        default_value = _normalize_default(repr(p.default)) if has_default else None
+        out.append((p.name, has_default, default_value))
+    return out
+
+
+def _has_real_names(params: list[tuple[str, bool, Any]]) -> bool:
+    """pybind11 falls back to ``arg0``/``arg1``/... when no ``py::arg()`` was
+    given.  In that case names are not meaningful and only count is checked.
+    """
+    return bool(params) and not any(
+        re.match(r"^arg\d+$", name) for name, _, _ in params
+    )
+
+
+def _public_methods(cls: type) -> dict[str, Any]:
+    """Return ``{name: callable}`` for the methods we want to compare."""
+    out: dict[str, Any] = {}
+    for name, obj in inspect.getmembers(cls):
+        if not callable(obj):
+            continue
+        if name in TESTED_DUNDERS or not name.startswith("_"):
+            out[name] = obj
+    return out
+
+
+def _params_compatible(
+    py_params: list[tuple[str, bool, Any]],
+    so_params: list[tuple[str, bool, Any]],
+    *,
+    check_names: bool,
+) -> tuple[bool, str]:
+    """Return ``(ok, reason)``.
+
+    "Compatible" means: a Python caller using exactly the .so's parameter
+    spelling (positional or keyword) would also be a valid call to the
+    Python implementation.
+
+    Rules
+    -----
+    * The Python signature MUST accept at least as many positional args as
+      the .so exposes.
+    * For each .so param, the Python side MUST have a same-position
+      parameter.  If ``check_names`` is True, names must also match.
+    * If the .so param has a default, the Python side MUST also have a
+      default with the same value (otherwise callers relying on the
+      default break).  The Python side MAY add a default where the .so
+      has none (backward-compatible widening).
+    * The Python side MAY have additional trailing parameters as long as
+      they all carry defaults (so the .so call shape still works).
+    """
+    if len(py_params) < len(so_params):
+        return (
+            False,
+            f"param count: .so has {len(so_params)}, fallback has {len(py_params)}",
+        )
+
+    for i, (so_p, py_p) in enumerate(zip(so_params, py_params, strict=False)):
+        so_name, so_has_def, so_default = so_p
+        py_name, py_has_def, py_default = py_p
+        if check_names and so_name != py_name:
+            return False, f"param #{i} name: .so='{so_name}', fallback='{py_name}'"
+        if so_has_def:
+            if not py_has_def:
+                return (
+                    False,
+                    f"param #{i} ('{py_name}'): .so has default={so_default!r} "
+                    f"but fallback has no default",
+                )
+            if so_default != py_default:
+                return (
+                    False,
+                    f"param #{i} ('{py_name}'): default mismatch "
+                    f".so={so_default!r}, fallback={py_default!r}",
+                )
+
+    # Trailing extras on the Python side must all be optional.
+    for j in range(len(so_params), len(py_params)):
+        py_name, py_has_def, _ = py_params[j]
+        if not py_has_def:
+            return (
+                False,
+                f"fallback has extra required parameter '{py_name}' at "
+                f"position #{j} not present in .so",
+            )
+
+    return True, ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Discovery
+# ─────────────────────────────────────────────────────────────────────────────
+_so_classes: dict[str, type] = (
+    {
+        name: getattr(so_mod, name)
+        for name in TARGET_CLASS_NAMES
+        if hasattr(so_mod, name)
+    }
+    if HAS_SO
+    else {}
+)
+_fallback_classes: dict[str, type] = {
+    name: getattr(fallback, name)
+    for name in TARGET_CLASS_NAMES
+    if hasattr(fallback, name)
+}
+_shared_class_names: list[str] = sorted(set(_so_classes) & set(_fallback_classes))
+
+
+def _shared_method_names(cls_name: str) -> list[str]:
+    if cls_name not in _so_classes or cls_name not in _fallback_classes:
+        return []
+    so_methods = _public_methods(_so_classes[cls_name])
+    py_methods = _public_methods(_fallback_classes[cls_name])
+    return sorted(set(so_methods) & set(py_methods))
+
+
+_method_param_ids: list[tuple[str, str]] = [
+    (cls_name, m_name)
+    for cls_name in _shared_class_names
+    for m_name in _shared_method_names(cls_name)
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Structural parity tests
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.skipif(not HAS_SO, reason="native_storage_ops .so not available")
+def test_all_so_classes_have_fallback() -> None:
+    """Every target class exposed by the .so must exist in the Python fallback."""
+    missing = sorted(set(_so_classes) - set(_fallback_classes))
+    assert not missing, (
+        f".so classes missing from native_storage_ops fallback: {missing}"
+    )
+
+
+@pytest.mark.skipif(not HAS_SO, reason="native_storage_ops .so not available")
+@pytest.mark.parametrize(
+    "cls_name",
+    _shared_class_names if _shared_class_names else ["__placeholder__"],
+)
+def test_class_method_existence(cls_name: str) -> None:
+    """Every public method (and tested dunder) on the .so class must also be
+    defined on the fallback class.  Extra methods on the fallback are fine
+    (e.g. helpers).
+    """
+    if cls_name == "__placeholder__":
+        pytest.skip("No shared classes between .so and fallback")
+    so_methods = _public_methods(_so_classes[cls_name])
+    py_methods = _public_methods(_fallback_classes[cls_name])
+    missing = sorted(set(so_methods) - set(py_methods))
+    assert not missing, (
+        f"{cls_name}: methods present in .so but missing from fallback: {missing}"
+    )
+
+
+@pytest.mark.skipif(not HAS_SO, reason="native_storage_ops .so not available")
+@pytest.mark.parametrize(
+    ("cls_name", "method_name"),
+    _method_param_ids if _method_param_ids else [("__placeholder__", "x")],
+)
+def test_method_signature_parity(cls_name: str, method_name: str) -> None:
+    """Each shared method's signature on the fallback must be call-compatible
+    with every .so overload.
+
+    "Call-compatible" means: a caller writing code against the .so signature
+    will also successfully call the fallback.  Adding optional keyword
+    parameters in the fallback is fine; removing or renaming required ones
+    is not.
+    """
+    if cls_name == "__placeholder__":
+        pytest.skip("No shared methods to compare")
+
+    so_method = _public_methods(_so_classes[cls_name])[method_name]
+    py_method = _public_methods(_fallback_classes[cls_name])[method_name]
+
+    so_overloads = _parse_pybind_overloads(so_method)
+    if so_overloads is None:
+        pytest.skip(
+            f"{cls_name}.{method_name}: cannot parse .so signature from docstring"
+        )
+
+    try:
+        py_params = _get_python_params(py_method)
+    except (ValueError, TypeError):
+        pytest.skip(f"{cls_name}.{method_name}: cannot inspect fallback signature")
+
+    # The Python single signature must be call-compatible with at least one
+    # .so overload, AND we expect it to cover ALL of them — otherwise the
+    # fallback silently drops a public calling convention.
+    failures: list[str] = []
+    # mypy: so_overloads cannot be None here due to skip above
+    assert so_overloads is not None
+    for so_params in so_overloads:
+        check_names = _has_real_names(so_params)
+        ok, reason = _params_compatible(py_params, so_params, check_names=check_names)
+        if not ok:
+            failures.append(f"  overload {[p[0] for p in so_params]}: {reason}")
+
+    assert not failures, (
+        f"{cls_name}.{method_name}: fallback signature "
+        f"{[p[0] for p in py_params]} is not call-compatible with all "
+        f".so overloads:\n" + "\n".join(failures)
+    )

--- a/tests/v1/test_native_storage_ops_parity.py
+++ b/tests/v1/test_native_storage_ops_parity.py
@@ -4,8 +4,7 @@ Verify that every public class/method in the Python fallback
 ``lmcache.native_storage_ops`` matches the C++ extension
 ``native_storage_ops.cpython-*.so``.
 
-Mirrors the structure of ``test_c_ops_fallback_parity.py`` but adapted to a
-class-based API.  Three parity dimensions only — purely structural, no
+Three parity dimensions only — purely structural, no
 behavior testing:
 
 1. Class existence    - every class in the .so has a fallback class.
@@ -19,9 +18,6 @@ behavior testing:
 Requires the compiled extension (``.so``) to be importable.  Automatically
 skipped on CPU-only / non-CUDA CI where only the Python fallback is present.
 
-Helper functions are intentionally duplicated from
-``test_c_ops_fallback_parity.py`` rather than extracted into a shared module
-to keep each parity suite self-contained.
 """
 
 # Standard
@@ -110,7 +106,7 @@ TESTED_DUNDERS: frozenset[str] = frozenset(
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Helpers (duplicated from test_c_ops_fallback_parity.py with overload support)
+# Helpers for parsing docstrings
 # ─────────────────────────────────────────────────────────────────────────────
 def _normalize_default(value_str: str) -> Any:
     """Normalize a default-value string for comparison.


### PR DESCRIPTION
## What this PR does / why we need it

Add structural parity tests for `native_storage_ops` to ensure the C++ extension and Python fallback remain in sync across three dimensions:
- **Class existence** — every class in the `.so` has a fallback class
- **Method existence** — every public method on the `.so` class exists on the fallback class
- **Method signature** — parameter names, count, and defaults are call-compatible

This mirrors the approach in #3507 (c_ops parity tests) but adapted for a class-based API.

## Special notes for reviewers

- **Structural checks only** — no behavior testing
- **Auto-skips** when `.so` is not available (CPU-only / CI environments)
- Signature parsing falls back to parameter count check when pybind11 uses `arg0`/`arg1` naming

## Checklist

- [x] This PR contains unit tests