### PR TITLE
[DO NOT MERGE][MP][HMA] Example wiring using the sliding window interface in #3612

### DIFF
--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -5,15 +5,85 @@
 from __future__ import annotations
 
 # Standard
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
+
+# Third Party
+from vllm.v1.kv_cache_interface import (
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
 
 if TYPE_CHECKING:
     # First Party
     from lmcache.v1.gpu_connector.utils import LayoutHints
 
 # First Party
+from lmcache.logging import init_logger
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+
+logger = init_logger(__name__)
+
+
+def _resolve_per_layer_sw_sizes(
+    vllm_groups: Sequence[Any],
+    layer_to_idx: Mapping[str, int],
+    num_layers: int,
+) -> list[int]:
+    """Resolve the sliding window size in tokens for each registered KV tensor.
+
+    Only true sliding-window specs (``SlidingWindowSpec`` and subclasses such
+    as ``SlidingWindowMLASpec``) count. ``FullAttentionSpec.sliding_window``
+    is deliberately ignored: it marks SWA layers managed as full attention
+    (hybrid allocator disabled), where vLLM allocates blocks for all tokens so
+    storing and retrieving everything is correct.
+
+    Args:
+        vllm_groups: vLLM ``KVCacheGroupSpec`` instances.
+        layer_to_idx: Layer name to registered tensor index mapping.
+        num_layers: Number of registered KV tensors.
+
+    Returns:
+        A list of length ``num_layers`` mapping each registered tensor index
+        to its sliding window size in tokens, or ``-1`` for
+        non-sliding-window layers.
+    """
+    per_layer_sw_size = [-1] * num_layers
+    for group in vllm_groups:
+        spec = getattr(group, "kv_cache_spec", None)
+        if spec is None:
+            continue
+        for name in group.layer_names:
+            layer_spec = spec
+            if isinstance(spec, UniformTypeKVCacheSpecs):
+                layer_spec = spec.kv_cache_specs[name]
+            if isinstance(layer_spec, SlidingWindowSpec):
+                per_layer_sw_size[layer_to_idx[name]] = layer_spec.sliding_window
+    return per_layer_sw_size
+
+
+def _merge_layer_sw_sizes(per_layer_sw_size: list[int], indices: list[int]) -> int:
+    """Merge the per-layer sliding window sizes of one LMCache group.
+
+    Args:
+        per_layer_sw_size: Sliding window size per registered tensor index.
+        indices: Registered tensor indices of the group's layers.
+
+    Returns:
+        The group's common sliding window size in tokens, or ``-1`` when the
+        layers are not sliding-window attention or mix different window sizes
+        (mixed groups conservatively fall back to full attention).
+    """
+    sw_sizes = {per_layer_sw_size[idx] for idx in indices}
+    if len(sw_sizes) == 1:
+        return sw_sizes.pop()
+    logger.warning(
+        "Layers %s mix different sliding window sizes %s; "
+        "treating the group as full attention",
+        indices,
+        sorted(sw_sizes),
+    )
+    return -1
 
 
 def create_engine_group_infos_from_vllm(
@@ -81,11 +151,15 @@ def create_engine_group_infos_from_vllm(
     # them EXCLUDED_ENGINE_GROUP so they form no group of their own (a
     # wrong-block-size group would corrupt the per-group block-id counts).
     per_layer_group_idx: list[int] | None = None
+    per_layer_sw_size = [-1] * num_layers
     if vllm_groups:
         per_layer_group_idx = [EXCLUDED_ENGINE_GROUP] * num_layers
         for engine_group_id, group in enumerate(vllm_groups):
             for name in group.layer_names:
                 per_layer_group_idx[layer_to_idx[name]] = engine_group_id
+        per_layer_sw_size = _resolve_per_layer_sw_sizes(
+            vllm_groups, layer_to_idx, num_layers
+        )
 
     # Within one vLLM engine group, layers can have different hidden dimensions
     # (e.g. a different head count), which require different GPU copy kernels.
@@ -98,6 +172,7 @@ def create_engine_group_infos_from_vllm(
         EngineGroupInfo(
             engine_group_id=identity[4],
             layer_indices=tuple(indices),
+            sw_size_tokens=_merge_layer_sw_sizes(per_layer_sw_size, indices),
         )
         for identity, indices in group_layers_by_identity(
             normalized_kv_caches,

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -567,6 +567,17 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             if kv_cache_config is not None
             else ()
         )
+
+        if kv_cache_config:
+            logger.warning(
+                "KV cache config has %d groups", len(kv_cache_config.kv_cache_groups)
+            )
+            for idx, group in enumerate(kv_cache_config.kv_cache_groups):
+                logger.warning(
+                    "Group %d has the spec: %s",
+                    idx,
+                    group.kv_cache_spec,
+                )
         # NOTE: Hybrid models can give each group its own block size that is
         # different from ``vllm_block_size`` (e.g. gemma-4: sliding-window
         # groups 32, full-attention groups 16, vllm_block_size 16).

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -191,6 +191,9 @@ class KernelGroupInfo:
     is known."""
     engine_group_idx: int = 0
     """Engine group index (paged-block address space). 0 for non-hybrid."""
+    sw_size_tokens: int = -1
+    """Sliding window size in logical tokens for this group's layers.
+    ``-1`` means the layers are not sliding-window attention."""
 
     def __repr__(self) -> str:
         if not self.layer_indices:
@@ -208,7 +211,8 @@ class KernelGroupInfo:
             f"dtype={self.dtype}, "
             f"compress_ratio={self.compress_ratio}, "
             f"physical_chunk_size={self.physical_chunk_size}, "
-            f"engine_group_idx={self.engine_group_idx})"
+            f"engine_group_idx={self.engine_group_idx}, "
+            f"sw_size_tokens={self.sw_size_tokens})"
         )
 
     @property
@@ -241,8 +245,10 @@ class ObjectGroupInfo:
     """Indices of the kernel groups belonging to this object group, in the
     order they should be laid out in memory."""
 
-    # NOTE: will add fields to indicate the "kv cache type" of this
-    # object group in the follow-up PRs
+    sw_size_chunks: int = -1
+    """Cross-chunk sliding window size in LMCache chunks shared by every
+    kernel group in this object group. ``-1`` means the kernel groups are
+    not sliding-window attention (all chunks are needed)."""
 
 
 class KVLayerGroupsManager:
@@ -310,7 +316,10 @@ class KVLayerGroupsManager:
             make_page_buffer_shape_desc,
             resolve_block_stride_and_log_layout,
         )
-        from lmcache.v1.multiprocess.group_view import get_engine_group_indices
+        from lmcache.v1.multiprocess.group_view import (
+            get_engine_group_indices,
+            get_layer_sw_sizes,
+        )
 
         # Pull the inference-engine logical block size out of
         # ``layout_hints`` once; ``None`` means no compression info
@@ -334,6 +343,7 @@ class KVLayerGroupsManager:
         per_layer_engine_group_idx = get_engine_group_indices(
             engine_group_infos, num_layers
         )
+        per_layer_sw_size = get_layer_sw_sizes(engine_group_infos, num_layers)
 
         groups_by_identity = group_layers_by_identity(
             kv_caches, gpu_kv_format, num_layers, per_layer_engine_group_idx
@@ -387,6 +397,9 @@ class KVLayerGroupsManager:
                     compress_ratio=compress_ratio,
                     physical_chunk_size=physical_chunk_size,
                     engine_group_idx=engine_group_idx,
+                    sw_size_tokens=self._merge_layer_sw_sizes(
+                        per_layer_sw_size, indices
+                    ),
                 )
             )
 
@@ -496,9 +509,10 @@ class KVLayerGroupsManager:
             chunk size for non-slding-window models or big-sliding-
             window models.
         """
-        # TODO(ApostaC): now here's the 'dummy' implementation.
-        # Need to wire the real sw size from the kernel group info once it's available
-        return self._lmcache_chunk_size
+        sw_size_tokens = self._kernel_groups[kernel_group_idx].sw_size_tokens
+        if sw_size_tokens == -1 or sw_size_tokens >= self._lmcache_chunk_size:
+            return self._lmcache_chunk_size
+        return sw_size_tokens
 
     def get_sw_size_chunks(self, object_group_idx: int) -> int:
         """Return the sliding window size of a given kernel group,
@@ -519,9 +533,7 @@ class KVLayerGroupsManager:
             they can be retrieved at the same time from the same object.
             For small sliding window (subchunk window) models, it will return 1.
         """
-        # TODO(ApostaC): now here's the 'dummy' implementation.
-        # Need to wire the real sw size from the object group info once it's available
-        return -1
+        return self._object_groups[object_group_idx].sw_size_chunks
 
     def calculate_num_blocks(self, kernel_group_idx: int, num_tokens: int) -> int:
         """Calculate the number of blocks for a given number of tokens in a
@@ -547,20 +559,65 @@ class KVLayerGroupsManager:
     ) -> list[ObjectGroupInfo]:
         """Detect object groups based on the provided engine group infos.
 
+        Kernel groups sharing the same cross-chunk sliding window size (in
+        LMCache chunks) are bucketed into one object group, so every object
+        group's chunks can be retrieved together from the same memory object.
+        Non-sliding-window kernel groups share the ``-1`` bucket. Object
+        groups are emitted in order of their first member kernel group, so
+        object group indices are deterministic across runs.
+
         Args:
             engine_group_infos: LMCache-owned engine KV cache group metadata.
 
         Returns:
             A list of ObjectGroupInfo instances representing the detected object groups.
         """
-        # TODO: add the real object group detection logic based on
-        # the attention type metadata in the engine group infos once it's
-        # available.
-        # Now, we are using a single object group, which means
-        # all kernel groups' KV caches will be stored in the same memory object.
+        chunk_size = self._lmcache_chunk_size
+        groups_by_sw_size: dict[int, list[int]] = defaultdict(list)
+        for kernel_group_idx, group in enumerate(self._kernel_groups):
+            if group.sw_size_tokens == -1:
+                sw_size_chunks = -1
+            else:
+                sw_size_chunks = (group.sw_size_tokens + chunk_size - 1) // chunk_size
+            groups_by_sw_size[sw_size_chunks].append(kernel_group_idx)
         return [
-            ObjectGroupInfo(kernel_group_indices=list(range(len(self._kernel_groups))))
+            ObjectGroupInfo(
+                kernel_group_indices=kernel_group_indices,
+                sw_size_chunks=sw_size_chunks,
+            )
+            for sw_size_chunks, kernel_group_indices in sorted(
+                groups_by_sw_size.items(), key=lambda kv: kv[1][0]
+            )
         ]
+
+    @staticmethod
+    def _merge_layer_sw_sizes(
+        per_layer_sw_size: "list[int] | None", layer_indices: list[int]
+    ) -> int:
+        """Merge the per-layer sliding window sizes of one kernel group.
+
+        Args:
+            per_layer_sw_size: Sliding window size per registered tensor
+                index, or ``None`` when no engine group metadata exists.
+            layer_indices: Registered tensor indices of the group's layers.
+
+        Returns:
+            The group's common sliding window size in tokens, or ``-1`` when
+            the layers are not sliding-window attention or mix different
+            window sizes.
+        """
+        if per_layer_sw_size is None:
+            return -1
+        sw_sizes = {per_layer_sw_size[idx] for idx in layer_indices}
+        if len(sw_sizes) == 1:
+            return sw_sizes.pop()
+        logger.warning(
+            "Kernel group layers %s mix different sliding window sizes %s; "
+            "treating the group as full attention",
+            layer_indices,
+            sorted(sw_sizes),
+        )
+        return -1
 
     @staticmethod
     def _derive_compression_metadata(

--- a/lmcache/v1/multiprocess/group_view.py
+++ b/lmcache/v1/multiprocess/group_view.py
@@ -41,6 +41,10 @@ class EngineGroupInfo(msgspec.Struct, frozen=True):
     layer_indices: tuple[int, ...] = ()
     """Registered KV tensor indices assigned to this group."""
 
+    sw_size_tokens: int = -1
+    """Sliding window size in tokens for the layers of this group.
+    ``-1`` means the layers are not sliding-window attention."""
+
 
 def num_engine_groups(groups: Sequence[EngineGroupInfo]) -> int:
     """Return the number of engine groups (block-id lists per transfer request).
@@ -217,3 +221,45 @@ def get_engine_group_indices(
             per_layer_engine_group_idx[layer_idx] = group.engine_group_id
 
     return per_layer_engine_group_idx
+
+
+# TODO(ApostaC): this per-layer indirection is over-complicated. Ideally each
+# kernel group maps to a single engine group and one engine group always has a
+# single sliding window size; then the layer -> sw_size_tokens mapping can be
+# dropped and the size read directly per group.
+def get_layer_sw_sizes(
+    groups: Sequence[EngineGroupInfo],
+    num_registered_layers: int,
+) -> list[int] | None:
+    """Return the sliding window size in tokens for each registered KV tensor.
+
+    Args:
+        groups: The LMCache KV groups, in protocol order.
+        num_registered_layers: Number of KV tensors registered with the server,
+            i.e. the length of the per-layer mapping to produce.
+
+    Returns:
+        A list of length ``num_registered_layers`` mapping each registered
+        tensor index to its group's ``sw_size_tokens`` (``-1`` for
+        non-sliding-window layers and layers no group references), or ``None``
+        when there is no group metadata (empty ``groups`` or zero layers).
+
+    Raises:
+        ValueError: If a group references a layer index outside
+            ``[0, num_registered_layers)``.
+    """
+    if not groups or num_registered_layers == 0:
+        return None
+
+    per_layer_sw_size = [-1] * num_registered_layers
+
+    for group in groups:
+        for layer_idx in group.layer_indices:
+            if layer_idx < 0 or layer_idx >= num_registered_layers:
+                raise ValueError(
+                    f"Layer index {layer_idx} is outside registered layer "
+                    f"range [0, {num_registered_layers})"
+                )
+            per_layer_sw_size[layer_idx] = group.sw_size_tokens
+
+    return per_layer_sw_size

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -792,6 +792,8 @@ class GPUTransferModule:
                 num_chunks * self._ctx.chunk_size,
                 ed - st,
             )
+            # ------------------------------------------------------------------------ THIS NEEDS TO BE REMOVED
+            logger.warning("DEBUG: stored bytes: %d", total_bytes)
         return event.ipc_handle(), True
 
     @_lmcache_nvtx_annotate
@@ -964,5 +966,7 @@ class GPUTransferModule:
             tokens_retrieved,
             ed - st,
         )
+        # ------------------------------------------------------------------------ THIS NEEDS TO BE REMOVED
+        logger.warning("DEBUG: retrieved bytes: %d", total_bytes)
 
         return event.ipc_handle(), True

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -792,8 +792,6 @@ class GPUTransferModule:
                 num_chunks * self._ctx.chunk_size,
                 ed - st,
             )
-            # ------------------------------------------------------------------------ THIS NEEDS TO BE REMOVED
-            logger.warning("DEBUG: stored bytes: %d", total_bytes)
         return event.ipc_handle(), True
 
     @_lmcache_nvtx_annotate
@@ -966,7 +964,5 @@ class GPUTransferModule:
             tokens_retrieved,
             ed - st,
         )
-        # ------------------------------------------------------------------------ THIS NEEDS TO BE REMOVED
-        logger.warning("DEBUG: retrieved bytes: %d", total_bytes)
 
         return event.ipc_handle(), True

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -4,6 +4,7 @@
 # Standard
 from dataclasses import dataclass
 from functools import partial
+import itertools
 import threading
 import time
 
@@ -266,7 +267,8 @@ class LookupModule:
         session.set_tokens(list(key.token_ids))
         session.lookup_ipc_key = key
 
-        obj_keys = ipc_key_to_object_keys(key, chunk_hashes, [0])[0]
+        obj_keys_per_group = ipc_key_to_object_keys(key, chunk_hashes, [0])
+        obj_keys = list(itertools.chain.from_iterable(obj_keys_per_group))
 
         handle = self._ctx.storage_manager.submit_prefetch_task(
             obj_keys,

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -267,7 +267,10 @@ class LookupModule:
         session.set_tokens(list(key.token_ids))
         session.lookup_ipc_key = key
 
-        obj_keys_per_group = ipc_key_to_object_keys(key, chunk_hashes, [0])
+        # HACK! This is a hard-code assuming there are two object groups
+        # In reality, we need to get the number of object groups and layout
+        # desc from the registry
+        obj_keys_per_group = ipc_key_to_object_keys(key, chunk_hashes, [0, 1])
         obj_keys = list(itertools.chain.from_iterable(obj_keys_per_group))
 
         handle = self._ctx.storage_manager.submit_prefetch_task(
@@ -373,7 +376,8 @@ class LookupModule:
         with self._prefetch_job_lock:
             self._prefetch_jobs.pop(request_id, None)
 
-        return found_count
+        # HACK: this is a hack just for this demo purpose!
+        return found_count // 2
 
     def free_lookup_locks(
         self,

--- a/tests/v1/test_kv_cache_groups.py
+++ b/tests/v1/test_kv_cache_groups.py
@@ -7,6 +7,7 @@ from lmcache.v1.multiprocess.group_view import (
     EngineGroupInfo,
     expand_engine_block_ids,
     get_engine_group_indices,
+    get_layer_sw_sizes,
     num_engine_group_infos,
     num_engine_groups,
     slice_block_ids_per_group,
@@ -44,11 +45,48 @@ def test_engine_group_infos_expand_engine_block_ids():
     ]
 
 
+def test_layer_sw_sizes_default_to_none():
+    assert get_layer_sw_sizes([], 1) is None
+    assert get_layer_sw_sizes([EngineGroupInfo(0, (0,))], 0) is None
+
+
+def test_layer_sw_sizes_build_per_layer_mapping():
+    """Each layer maps to its group's sw_size_tokens; uncovered layers get -1."""
+    groups = [
+        EngineGroupInfo(0, (0, 2), sw_size_tokens=64),
+        EngineGroupInfo(1, (1,)),
+    ]
+
+    assert get_layer_sw_sizes(groups, 4) == [64, -1, 64, -1]
+
+
+def test_layer_sw_sizes_reject_out_of_range_layer():
+    groups = [EngineGroupInfo(0, (0, 5), sw_size_tokens=64)]
+
+    try:
+        get_layer_sw_sizes(groups, 3)
+    except ValueError as exc:
+        assert "outside registered layer range" in str(exc)
+    else:
+        raise AssertionError("Expected out-of-range layer index to fail")
+
+
+def test_engine_group_info_old_payload_defaults_sw_size():
+    """A pre-sw_size_tokens msgspec payload decodes with the -1 default."""
+    old_payload = {"engine_group_id": 0, "layer_indices": (0, 1)}
+
+    decoded = msgspec.msgpack.decode(
+        msgspec.msgpack.encode(old_payload), type=EngineGroupInfo
+    )
+
+    assert decoded.sw_size_tokens == -1
+
+
 def test_engine_group_infos_msgspec_round_trip():
     """The groups encode/decode losslessly via msgspec (the IPC path)."""
     groups = [
         EngineGroupInfo(0, (0, 2)),
-        EngineGroupInfo(1, (1, 3)),
+        EngineGroupInfo(1, (1, 3), sw_size_tokens=128),
     ]
 
     decoded = msgspec.msgpack.decode(

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -357,8 +357,8 @@ class TestKernelAndObjectGroups:
         assert all(isinstance(g, KernelGroupInfo) for g in manager.kernel_groups)
 
     def test_single_object_group_covers_all_kernel_groups(self):
-        # Two distinct kernel groups (different num_heads) still share one
-        # object group under the current single-object-group assumption.
+        # Two distinct kernel groups (different num_heads), both non-sliding-
+        # window, share the single -1 object group bucket.
         tensors = [
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
             torch.randn(2, 32, 256, 16, 64, dtype=torch.float16),
@@ -369,6 +369,75 @@ class TestKernelAndObjectGroups:
         obj = manager.object_groups[0]
         assert isinstance(obj, ObjectGroupInfo)
         assert obj.kernel_group_indices == list(range(manager.num_kernel_groups))
+        assert obj.sw_size_chunks == -1
+        assert manager.get_sw_size_chunks(0) == -1
+
+    def test_kernel_groups_carry_sw_size_tokens(self):
+        # Same-shape layers split by engine group; the sliding-window group's
+        # window size lands on its kernel group, the other stays -1.
+        tensors = [
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.float16) for _ in range(2)
+        ]
+        manager = _build_manager(
+            tensors,
+            num_blocks=32,
+            engine_group_infos=[
+                EngineGroupInfo(0, (0,)),
+                EngineGroupInfo(1, (1,), sw_size_tokens=64),
+            ],
+        )
+        assert [g.sw_size_tokens for g in manager.kernel_groups] == [-1, 64]
+
+    def test_subchunk_sw_size_tokens(self):
+        # lmcache chunk size is 256 (default). Sub-chunk window (64) is
+        # returned as-is; non-SW (-1) and big-SW (512) return the chunk size.
+        tensors = [
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
+            torch.randn(2, 32, 256, 16, 64, dtype=torch.float16),
+            torch.randn(2, 32, 256, 32, 64, dtype=torch.float16),
+        ]
+        manager = _build_manager(
+            tensors,
+            num_blocks=32,
+            engine_group_infos=[
+                EngineGroupInfo(0, (0,)),
+                EngineGroupInfo(0, (1,), sw_size_tokens=64),
+                EngineGroupInfo(0, (2,), sw_size_tokens=512),
+            ],
+        )
+        assert manager.get_subchunk_sw_size_tokens(0) == 256
+        assert manager.get_subchunk_sw_size_tokens(1) == 64
+        assert manager.get_subchunk_sw_size_tokens(2) == 256
+
+    def test_object_groups_split_by_sw_size_chunks(self):
+        # Four kernel groups: non-SW, sub-chunk window (64 -> 1 chunk),
+        # another window rounding to 1 chunk (100), and a big window
+        # (512 -> 2 chunks). Buckets: -1 -> [0], 1 -> [1, 2], 2 -> [3],
+        # ordered by first member kernel group.
+        tensors = [
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
+            torch.randn(2, 32, 256, 16, 64, dtype=torch.float16),
+            torch.randn(2, 32, 256, 32, 64, dtype=torch.float16),
+            torch.randn(2, 32, 256, 4, 64, dtype=torch.float16),
+        ]
+        manager = _build_manager(
+            tensors,
+            num_blocks=32,
+            engine_group_infos=[
+                EngineGroupInfo(0, (0,)),
+                EngineGroupInfo(0, (1,), sw_size_tokens=64),
+                EngineGroupInfo(0, (2,), sw_size_tokens=100),
+                EngineGroupInfo(0, (3,), sw_size_tokens=512),
+            ],
+        )
+        assert manager.num_object_groups == 3
+        assert [obj.kernel_group_indices for obj in manager.object_groups] == [
+            [0],
+            [1, 2],
+            [3],
+        ]
+        assert [obj.sw_size_chunks for obj in manager.object_groups] == [-1, 1, 2]
+        assert [manager.get_sw_size_chunks(i) for i in range(3)] == [-1, 1, 2]
 
     def test_empty_manager_has_no_groups(self):
         # Empty registration returns early in __init__; both group lists must

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
+from typing import Any
 
 # Third Party
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
 import torch
 
 # First Party
@@ -19,11 +25,32 @@ from lmcache.v1.multiprocess.group_view import (
 @dataclass
 class MockKVCacheGroup:
     layer_names: list[str]
+    kv_cache_spec: Any = None
 
 
 @dataclass
 class MockKVCacheConfig:
     kv_cache_groups: list[MockKVCacheGroup]
+
+
+def _full_attention_spec(sliding_window: "int | None" = None) -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=sliding_window,
+    )
+
+
+def _sliding_window_spec(sliding_window: int) -> SlidingWindowSpec:
+    return SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=sliding_window,
+    )
 
 
 def _same_shape_caches(names: list[str]) -> dict[str, torch.Tensor]:
@@ -79,3 +106,97 @@ def test_conversion_splits_by_lmcache_layer_identity():
         [20],
         [10],
     ]
+
+
+def test_conversion_resolves_sliding_window_size():
+    """A SlidingWindowSpec group carries its window size in tokens."""
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(["layer.0"], _full_attention_spec()),
+                MockKVCacheGroup(["layer.1"], _sliding_window_spec(64)),
+            ]
+        ),
+        _same_shape_caches(["layer.0", "layer.1"]),
+    )
+
+    assert [group.sw_size_tokens for group in spec] == [-1, 64]
+
+
+def test_conversion_ignores_full_attention_sliding_window():
+    """SWA layers managed as full attention (hybrid allocator disabled) are
+    not sliding window: vLLM allocates blocks for all tokens."""
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(
+                    ["layer.0", "layer.1"], _full_attention_spec(sliding_window=1024)
+                ),
+            ]
+        ),
+        _same_shape_caches(["layer.0", "layer.1"]),
+    )
+
+    assert [group.sw_size_tokens for group in spec] == [-1]
+
+
+def test_conversion_defaults_sliding_window_without_spec():
+    """Groups without kv_cache_spec metadata resolve to non-sliding-window."""
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(kv_cache_groups=[MockKVCacheGroup(["layer.0"])]),
+        _same_shape_caches(["layer.0"]),
+    )
+
+    assert [group.sw_size_tokens for group in spec] == [-1]
+
+
+def test_conversion_uniform_type_specs_resolve_per_layer():
+    """Inside a UniformTypeKVCacheSpecs group, per-layer specs decide the
+    window. SW layers with a distinct transfer identity get their own group
+    carrying the window size."""
+    caches = _same_shape_caches(["layer.0", "layer.1"])
+    # layer.1 has a different head count -> distinct transfer identity.
+    caches["layer.1"] = torch.randn(2, 32, 16, 16, 64, dtype=torch.float16)
+    uniform_spec = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={
+            "layer.0": _full_attention_spec(),
+            "layer.1": SlidingWindowSpec(
+                block_size=16,
+                num_kv_heads=16,
+                head_size=64,
+                dtype=torch.float16,
+                sliding_window=512,
+            ),
+        },
+    )
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(
+            kv_cache_groups=[MockKVCacheGroup(["layer.0", "layer.1"], uniform_spec)]
+        ),
+        caches,
+    )
+
+    assert [group.layer_indices for group in spec] == [(0,), (1,)]
+    assert [group.sw_size_tokens for group in spec] == [-1, 512]
+
+
+def test_conversion_mixed_window_layers_fall_back_to_full_attention():
+    """Same-identity layers mixing different windows conservatively resolve
+    to non-sliding-window for the merged group."""
+    uniform_spec = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={
+            "layer.0": _full_attention_spec(),
+            "layer.1": _sliding_window_spec(64),
+        },
+    )
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(
+            kv_cache_groups=[MockKVCacheGroup(["layer.0", "layer.1"], uniform_spec)]
+        ),
+        _same_shape_caches(["layer.0", "layer.1"]),
+    )
+
+    assert [group.layer_indices for group in spec] == [(0, 1)]
+    assert [group.sw_size_tokens for group in spec] == [-1]


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This is an example wiring with Gemma-like sliding window model based on #3612 


After this PR, it will print out this during `retrieve`.
```
[2026-06-10 06:40:28,709] LMCache WARNING: Detected sliding window for object group 0: skipping the first 44 objects in the batch (gpu_transfer.py:275:lmcache.v1.multiprocess.modules.gpu_transfer)
```


What needs to be done:
- Register the layout desc and the object group information in the registry so that the lookup module can get this information.
- Correct observability data after considering the object-level skip

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
