### PR TITLE
Fix LocalDiskBackend write failure cleanup

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -323,12 +323,13 @@ class LocalDiskBackend(StorageBackendInterface):
             logger.debug(f"Put task for {key} is already in progress.")
             return None
 
-        self.disk_worker.insert_put_task(key)
-
         # TODO(Jiayi): Fragmentation is not considered here.
         required_size = memory_obj.get_physical_size()
+        self.disk_worker.insert_put_task(key)
+
         all_evict_keys = []
         evict_success = True
+        reserved_new_key = False
         with self.disk_lock:
             while self.current_cache_size + required_size > self.max_cache_size:
                 evict_keys = self.cache_policy.get_evict_candidates(
@@ -348,10 +349,13 @@ class LocalDiskBackend(StorageBackendInterface):
 
                 all_evict_keys.extend(evict_keys)
             if evict_success:
-                self.current_cache_size += required_size
-                self.cache_policy.update_on_put(key)
+                if key not in self.dict:
+                    self.current_cache_size += required_size
+                    self.cache_policy.update_on_put(key)
+                    reserved_new_key = True
 
         if not evict_success:
+            self.disk_worker.remove_put_task(key)
             return None
 
         memory_obj.ref_count_up()
@@ -363,6 +367,8 @@ class LocalDiskBackend(StorageBackendInterface):
                 key=key,
                 memory_obj=memory_obj,
                 on_complete_callback=on_complete_callback,
+                reserved_new_key=reserved_new_key,
+                reserved_size=required_size,
             ),
             self.loop,
         )
@@ -521,6 +527,8 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
         memory_obj: MemoryObj,
         on_complete_callback: Optional[Callable[[CacheEngineKey], None]] = None,
+        reserved_new_key: bool = True,
+        reserved_size: Optional[int] = None,
     ) -> None:
         """
         Convert KV to bytes and async store bytes to disk.
@@ -528,49 +536,45 @@ class LocalDiskBackend(StorageBackendInterface):
         :param on_complete_callback: Optional callback invoked after the disk
             write completes for this key. Callback exceptions are caught and
             logged.
+        :param reserved_new_key: Whether submit_put_task reserved capacity and
+            cache policy state for a newly stored key.
+        :param reserved_size: Physical size reserved by submit_put_task.
         """
-        kv_chunk = memory_obj.tensor
-        assert kv_chunk is not None
-        buffer = memory_obj.byte_array
-        path = self._key_to_path(key)
-
-        size = memory_obj.get_physical_size()
-        shape = memory_obj.metadata.shape
-        dtype = memory_obj.metadata.dtype
-        fmt = memory_obj.metadata.fmt
-        cached_positions = memory_obj.metadata.cached_positions
-
-        ref_count_released = False
+        size = reserved_size
         try:
-            byte_size = len(buffer)
-            self.usage += byte_size
-            self.stats_monitor.update_local_storage_usage(self.usage)
+            if size is None:
+                size = memory_obj.get_physical_size()
+            kv_chunk = memory_obj.tensor
+            assert kv_chunk is not None
+            buffer = memory_obj.byte_array
+            path = self._key_to_path(key)
 
             # TODO(Jiayi): need to add ref count in disk memory object
             self.write_file(buffer, path)
+            shape = memory_obj.metadata.shape
+            dtype = memory_obj.metadata.dtype
+            fmt = memory_obj.metadata.fmt
+            cached_positions = memory_obj.metadata.cached_positions
 
-            # ref count down here because there's a ref_count_up in
-            # `submit_put_task` above.
-            # Ref count down better be before `insert_key` for testing
-            # purposes (e.g., testing mem_leak).
-            # TODO(Jiayi): This could be problematic if the
-            # freed memory object is immediately reused.
-            memory_obj.ref_count_down()
-            ref_count_released = True
-
+            if reserved_new_key:
+                with self.disk_lock:
+                    self.usage += size
+                    self.stats_monitor.update_local_storage_usage(self.usage)
             self.insert_key(
                 key, size, shape, dtype, fmt, cached_positions=cached_positions
             )
         except Exception:
-            with self.disk_lock:
-                self.current_cache_size = max(0.0, self.current_cache_size - size)
-                self.cache_policy.update_on_force_evict(key)
-            self.usage = max(0, self.usage - len(buffer))
-            self.stats_monitor.update_local_storage_usage(self.usage)
-            if not ref_count_released:
-                memory_obj.ref_count_down()
+            if reserved_new_key and size is not None:
+                with self.disk_lock:
+                    self.current_cache_size = max(
+                        0.0, self.current_cache_size - size
+                    )
+                    self.cache_policy.update_on_force_evict(key)
             raise
         finally:
+            # ref count down here because there's a ref_count_up in
+            # `submit_put_task` above.
+            memory_obj.ref_count_down()
             self.disk_worker.remove_put_task(key)
 
         # Call the completion callback if provided

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -534,29 +534,44 @@ class LocalDiskBackend(StorageBackendInterface):
         buffer = memory_obj.byte_array
         path = self._key_to_path(key)
 
-        size = len(buffer)
-        self.usage += size
-        self.stats_monitor.update_local_storage_usage(self.usage)
-
-        # TODO(Jiayi): need to add ref count in disk memory object
-        self.write_file(buffer, path)
-
-        # ref count down here because there's a ref_count_up in
-        # `submit_put_task` above.
-        # Ref count down better be before `insert_key` for testing
-        # purposes (e.g., testing mem_leak).
-        # TODO(Jiayi): This could be problematic if the
-        # freed memory object is immediately reused.
         size = memory_obj.get_physical_size()
         shape = memory_obj.metadata.shape
         dtype = memory_obj.metadata.dtype
         fmt = memory_obj.metadata.fmt
         cached_positions = memory_obj.metadata.cached_positions
-        memory_obj.ref_count_down()
 
-        self.insert_key(key, size, shape, dtype, fmt, cached_positions=cached_positions)
+        ref_count_released = False
+        try:
+            byte_size = len(buffer)
+            self.usage += byte_size
+            self.stats_monitor.update_local_storage_usage(self.usage)
 
-        self.disk_worker.remove_put_task(key)
+            # TODO(Jiayi): need to add ref count in disk memory object
+            self.write_file(buffer, path)
+
+            # ref count down here because there's a ref_count_up in
+            # `submit_put_task` above.
+            # Ref count down better be before `insert_key` for testing
+            # purposes (e.g., testing mem_leak).
+            # TODO(Jiayi): This could be problematic if the
+            # freed memory object is immediately reused.
+            memory_obj.ref_count_down()
+            ref_count_released = True
+
+            self.insert_key(
+                key, size, shape, dtype, fmt, cached_positions=cached_positions
+            )
+        except Exception:
+            with self.disk_lock:
+                self.current_cache_size = max(0.0, self.current_cache_size - size)
+                self.cache_policy.update_on_force_evict(key)
+            self.usage = max(0, self.usage - len(buffer))
+            self.stats_monitor.update_local_storage_usage(self.usage)
+            if not ref_count_released:
+                memory_obj.ref_count_down()
+            raise
+        finally:
+            self.disk_worker.remove_put_task(key)
 
         # Call the completion callback if provided
         if on_complete_callback is not None:

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -566,9 +566,7 @@ class LocalDiskBackend(StorageBackendInterface):
         except Exception:
             if reserved_new_key and size is not None:
                 with self.disk_lock:
-                    self.current_cache_size = max(
-                        0.0, self.current_cache_size - size
-                    )
+                    self.current_cache_size = max(0.0, self.current_cache_size - size)
                     self.cache_policy.update_on_force_evict(key)
             raise
         finally:

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -450,56 +450,62 @@ class LocalDiskBackend(StorageBackendInterface):
     ) -> list[MemoryObj]:
         mem_objs: list[MemoryObj] = []
         paths: list[str] = []
+        load_keys: list[CacheEngineKey] = []
 
         logger.debug(f"lookup_id: {lookup_id}; Prefetching {len(keys)} keys from disk.")
         for key in keys:
-            self.disk_lock.acquire()
-            assert key in self.dict, f"Key {key} not found in disk cache after pinning"
-
-            path = self.dict[key].path
-            dtype = self.dict[key].dtype
-            shape = self.dict[key].shape
-            fmt = self.dict[key].fmt
-
-            assert dtype is not None
-            assert shape is not None
-
-            # busy_loop=False prevents spinning on the event loop thread;
-            # if staging memory is exhausted the caller will get a logged
-            # error rather than a silent deadlock.
-            memory_obj = self.local_cpu_backend.allocate(
-                shape,
-                dtype,
-                fmt,
-                busy_loop=False,
-            )
-
-            if memory_obj is None:
-                logger.error(
-                    "Memory allocation failed during async disk load for key %s. "
-                    "CPU staging pool may be exhausted (unpin() not called after "
-                    "a previous retrieve). Returning partial results.",
-                    key,
+            with self.disk_lock:
+                assert key in self.dict, (
+                    f"Key {key} not found in disk cache after pinning"
                 )
-                return mem_objs
 
-            self.dict[key].pin()
+                path = self.dict[key].path
+                dtype = self.dict[key].dtype
+                shape = self.dict[key].shape
+                fmt = self.dict[key].fmt
 
-            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
-            # Update cache recency
-            self.cache_policy.update_on_hit(key, self.dict)
+                assert dtype is not None
+                assert shape is not None
 
-            self.disk_lock.release()
+                # busy_loop=False prevents spinning on the event loop thread;
+                # if staging memory is exhausted the caller will get a logged
+                # error rather than a silent deadlock.
+                memory_obj = self.local_cpu_backend.allocate(
+                    shape,
+                    dtype,
+                    fmt,
+                    busy_loop=False,
+                )
+
+                if memory_obj is None:
+                    logger.error(
+                        "Memory allocation failed during async disk load for key %s. "
+                        "CPU staging pool may be exhausted (unpin() not called after "
+                        "a previous retrieve). Returning partial results.",
+                        key,
+                    )
+                    break
+
+                self.dict[key].pin()
+
+                # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
+                # Update cache recency
+                self.cache_policy.update_on_hit(key, self.dict)
+
             logger.debug(f"Prefetching {key} from disk.")
             memory_obj.pin()
             mem_objs.append(memory_obj)
             paths.append(path)
+            load_keys.append(key)
+
+        if not mem_objs:
+            return []
 
         return await self.disk_worker.submit_task(
             "prefetch",
             self.batched_async_load_bytes_from_disk,
             paths=paths,
-            keys=keys,
+            keys=load_keys,
             memory_objs=mem_objs,
         )
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from unittest.mock import MagicMock, PropertyMock, patch
+from typing import Any, Callable
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import asyncio
 import os
 import shutil
@@ -323,6 +324,137 @@ class TestAsyncSaveBytesToDiskExceptionSafety:
         assert local_disk_backend.usage == physical_size
         mock_force_evict.assert_not_called()
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class TestBatchedGetNonBlockingAllocationFailure:
+    """Regression tests for async disk-load staging allocation failures."""
+
+    async def _run_prefetch_task(
+        self,
+        task_type: str,
+        task: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Run the submitted prefetch task inline for deterministic assertions."""
+        assert task_type == "prefetch"
+        return task(*args, **kwargs)
+
+    def _insert_disk_key(
+        self,
+        backend: LocalDiskBackend,
+        key: CacheEngineKey,
+        path: str,
+    ) -> None:
+        """Insert disk metadata and matching cache policy state."""
+        backend.dict[key] = DiskCacheMetadata(
+            path=path,
+            size=16,
+            shape=torch.Size([1]),
+            dtype=torch.bfloat16,
+            cached_positions=None,
+            fmt=MemoryFormat.KV_2LTD,
+            pin_count=0,
+        )
+        backend.cache_policy.update_on_put(key)
+
+    def _make_memory_obj(self) -> MagicMock:
+        """Create a staged memory object mock for disk-load tests."""
+        memory_obj = MagicMock(spec=MemoryObj)
+        memory_obj.byte_array = bytearray(16)
+        memory_obj.metadata = MemoryObjMetadata(
+            shape=torch.Size([1]),
+            dtype=torch.bfloat16,
+            address=0,
+            phy_size=16,
+            fmt=MemoryFormat.KV_2LTD,
+            ref_count=1,
+        )
+        return memory_obj
+
+    def _close_backend(
+        self,
+        backend: LocalDiskBackend,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        """Close the disk worker without blocking on a stopped event loop."""
+        loop.run_until_complete(backend.disk_worker.executor.shutdown_async(wait=True))
+        backend.local_cpu_backend.memory_allocator.close()
+
+    def test_first_allocation_failure_releases_disk_lock(
+        self,
+        local_disk_backend: LocalDiskBackend,
+        async_loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        """A first-key staging allocation miss must not leave disk_lock held."""
+        key = create_test_key(301)
+        self._insert_disk_key(local_disk_backend, key, "/tmp/key-301.pt")
+
+        try:
+            with patch.object(
+                local_disk_backend.local_cpu_backend,
+                "allocate",
+                return_value=None,
+            ):
+                with patch.object(
+                    local_disk_backend.disk_worker,
+                    "submit_task",
+                    new=AsyncMock(side_effect=self._run_prefetch_task),
+                ) as mock_submit:
+                    result = async_loop.run_until_complete(
+                        local_disk_backend.batched_get_non_blocking("lookup", [key])
+                    )
+
+            assert result == []
+            mock_submit.assert_not_awaited()
+            assert local_disk_backend.dict[key].pin_count == 0
+            assert local_disk_backend.disk_lock.acquire(blocking=False)
+            local_disk_backend.disk_lock.release()
+        finally:
+            self._close_backend(local_disk_backend, async_loop)
+
+    def test_later_allocation_failure_loads_only_collected_prefix(
+        self,
+        local_disk_backend: LocalDiskBackend,
+        async_loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        """A later allocation miss returns a loaded prefix, not raw staging buffers."""
+        key1 = create_test_key(302)
+        key2 = create_test_key(303)
+        path1 = "/tmp/key-302.pt"
+        path2 = "/tmp/key-303.pt"
+        self._insert_disk_key(local_disk_backend, key1, path1)
+        self._insert_disk_key(local_disk_backend, key2, path2)
+        memory_obj = self._make_memory_obj()
+
+        try:
+            with patch.object(
+                local_disk_backend.local_cpu_backend,
+                "allocate",
+                side_effect=[memory_obj, None],
+            ):
+                with patch.object(local_disk_backend, "read_file") as mock_read:
+                    with patch.object(
+                        local_disk_backend.disk_worker,
+                        "submit_task",
+                        new=AsyncMock(side_effect=self._run_prefetch_task),
+                    ) as mock_submit:
+                        result = async_loop.run_until_complete(
+                            local_disk_backend.batched_get_non_blocking(
+                                "lookup", [key1, key2]
+                            )
+                        )
+
+            assert result == [memory_obj]
+            mock_submit.assert_awaited_once()
+            mock_read.assert_called_once_with(key1, memory_obj.byte_array, path1)
+            memory_obj.pin.assert_called_once_with()
+            assert local_disk_backend.dict[key1].pin_count == 0
+            assert local_disk_backend.dict[key2].pin_count == 0
+            assert local_disk_backend.disk_lock.acquire(blocking=False)
+            local_disk_backend.disk_lock.release()
+        finally:
+            self._close_backend(local_disk_backend, async_loop)
 
 
 class TestMultiPathDiskBackend:

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 import asyncio
 import os
 import shutil
@@ -242,6 +242,85 @@ class TestAsyncSaveBytesToDiskExceptionSafety:
         assert local_disk_backend.current_cache_size == 0.0
         assert local_disk_backend.usage == 0
         on_complete_callback.assert_not_called()
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_pre_write_failure_releases_memory_obj_and_put_task(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Cleanup must run even when byte-array conversion fails before I/O."""
+        key = create_test_key(202)
+        physical_size = 4096
+        memory_obj = MagicMock(spec=MemoryObj)
+        memory_obj.tensor = torch.empty(1)
+        memory_obj.get_physical_size.return_value = physical_size
+
+        local_disk_backend.disk_worker.insert_put_task(key)
+        local_disk_backend.current_cache_size = physical_size
+        local_disk_backend.cache_policy.update_on_put(key)
+
+        with patch.object(
+            type(memory_obj),
+            "byte_array",
+            new_callable=PropertyMock,
+            side_effect=OSError("conversion failed"),
+        ):
+            with pytest.raises(OSError, match="conversion failed"):
+                local_disk_backend.async_save_bytes_to_disk(key, memory_obj)
+
+        memory_obj.ref_count_down.assert_called_once_with()
+        assert not local_disk_backend.exists_in_put_tasks(key)
+        assert key not in local_disk_backend.dict
+        assert local_disk_backend.current_cache_size == 0.0
+        assert local_disk_backend.usage == 0
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_existing_key_write_failure_keeps_old_cache_state(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """A failed rewrite must not evict bookkeeping for an existing key."""
+        key = create_test_key(203)
+        physical_size = 4096
+        shape = torch.Size([28, 2, 256, 8, 128])
+        metadata = DiskCacheMetadata(
+            path="/old/path.pt",
+            size=physical_size,
+            shape=shape,
+            dtype=torch.bfloat16,
+            cached_positions=None,
+            fmt=MemoryFormat.KV_2LTD,
+            pin_count=0,
+        )
+        memory_obj = MagicMock(spec=MemoryObj)
+        memory_obj.tensor = torch.empty(1)
+        memory_obj.byte_array = b"0" * 16
+        memory_obj.get_physical_size.return_value = physical_size
+
+        local_disk_backend.dict[key] = metadata
+        local_disk_backend.current_cache_size = physical_size
+        local_disk_backend.usage = physical_size
+        local_disk_backend.disk_worker.insert_put_task(key)
+
+        with patch.object(
+            local_disk_backend,
+            "write_file",
+            side_effect=OSError("disk full"),
+        ):
+            with patch.object(
+                local_disk_backend.cache_policy, "update_on_force_evict"
+            ) as mock_force_evict:
+                with pytest.raises(OSError, match="disk full"):
+                    local_disk_backend.async_save_bytes_to_disk(
+                        key,
+                        memory_obj,
+                        reserved_new_key=False,
+                    )
+
+        memory_obj.ref_count_down.assert_called_once_with()
+        assert not local_disk_backend.exists_in_put_tasks(key)
+        assert local_disk_backend.dict[key] is metadata
+        assert local_disk_backend.current_cache_size == physical_size
+        assert local_disk_backend.usage == physical_size
+        mock_force_evict.assert_not_called()
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -262,6 +262,7 @@ class TestAsyncSaveBytesToDiskExceptionSafety:
             type(memory_obj),
             "byte_array",
             new_callable=PropertyMock,
+            create=True,
             side_effect=OSError("conversion failed"),
         ):
             with pytest.raises(OSError, match="conversion failed"):

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -14,7 +14,7 @@ import torch
 from lmcache.utils import CacheEngineKey, DiskCacheMetadata
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import _parse_local_disk
-from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj, MemoryObjMetadata
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
@@ -194,6 +194,54 @@ class TestLocalDiskBackend:
 
         assert result is None
 
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class TestAsyncSaveBytesToDiskExceptionSafety:
+    """Regression tests for LocalDiskBackend write failure cleanup."""
+
+    def test_write_failure_releases_memory_obj_and_put_task(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """A failed disk write must not leak refcounts or in-flight put tasks."""
+        key = create_test_key(201)
+        physical_size = 4096
+        memory_obj = MagicMock(spec=MemoryObj)
+        memory_obj.tensor = torch.empty(1)
+        memory_obj.byte_array = b"0" * 16
+        memory_obj.get_physical_size.return_value = physical_size
+        memory_obj.metadata = MemoryObjMetadata(
+            shape=torch.Size([1]),
+            dtype=torch.bfloat16,
+            address=0,
+            phy_size=physical_size,
+            fmt=MemoryFormat.KV_2LTD,
+            ref_count=1,
+        )
+        on_complete_callback = MagicMock()
+
+        local_disk_backend.disk_worker.insert_put_task(key)
+        local_disk_backend.current_cache_size = physical_size
+        local_disk_backend.cache_policy.update_on_put(key)
+
+        with patch.object(
+            local_disk_backend,
+            "write_file",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(OSError, match="disk full"):
+                local_disk_backend.async_save_bytes_to_disk(
+                    key,
+                    memory_obj,
+                    on_complete_callback=on_complete_callback,
+                )
+
+        memory_obj.ref_count_down.assert_called_once_with()
+        assert not local_disk_backend.exists_in_put_tasks(key)
+        assert key not in local_disk_backend.dict
+        assert local_disk_backend.current_cache_size == 0.0
+        assert local_disk_backend.usage == 0
+        on_complete_callback.assert_not_called()
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes LocalDiskBackend cleanup when async disk writes fail. If `write_file()` raises, the backend now releases the memory object reference, removes the in-flight put task, and rolls back local disk accounting/policy state.

Also fixes async disk-load staging allocation failures in `batched_get_non_blocking()`: the disk lock is released on allocation failure, already collected prefix keys are loaded before returning, and the backend no longer returns raw staging buffers that were never read from disk.

**Special notes for your reviewers**:

This is scoped to local disk failure cleanup paths and does not attempt to resolve broader local disk lifecycle TODOs.

**Tests**:

- `.venv312/bin/pytest -q tests/v1/storage_backend/test_local_disk_backend.py::TestBatchedGetNonBlockingAllocationFailure`
- `.venv312/bin/pytest -q tests/v1/storage_backend/test_local_disk_backend.py` (31 passed, 19 pre-existing executor cleanup warnings)

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
