### PR TITLE
[CI] cu129 images: pin vllm to the cu129 index (drop unsafe-best-match)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,13 +84,12 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
         VLLM_PRECOMPILED_WHEEL_VARIANT=${CUDA_TAG} uv pip install --prerelease=allow \
             'vllm[runai,tensorizer,flashinfer]' \
             --extra-index-url https://wheels.vllm.ai/nightly/${CUDA_TAG} \
-            --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
-            --index-strategy unsafe-best-match ; \
+            --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} ; \
     else \
         VLLM_PRECOMPILED_WHEEL_VARIANT=${CUDA_TAG} uv pip install --prerelease=allow \
             "vllm[runai,tensorizer,flashinfer]==${VLLM_VERSION}" ; \
     fi && \
-    python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
+    python3 -c 'import vllm._C; import torch; print("TORCH=", torch.__version__)' && \
     python3 setup.py bdist_wheel --dist-dir=dist_lmcache && \
     uv pip install ./dist_lmcache/*.whl --verbose
 
@@ -136,8 +135,8 @@ RUN . /opt/venv/bin/activate && \
     VLLM_PRECOMPILED_WHEEL_VARIANT=${CUDA_TAG} uv pip install --prerelease=allow \
         vllm[runai,tensorizer,flashinfer] \
         --extra-index-url https://wheels.vllm.ai/nightly/${CUDA_TAG} \
-        --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
-        --index-strategy unsafe-best-match && \
+        --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} && \
+    python3 -c 'import vllm._C' && \
     uv pip install lmcache==${VER} \
         --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
         --find-links https://github.com/LMCache/LMCache/releases/expanded_assets/v${VER}-cu129 \

--- a/docker/Dockerfile.standalone
+++ b/docker/Dockerfile.standalone
@@ -70,7 +70,6 @@ RUN --mount=type=cache,target=/root/.cache/uv,id=uv-resolver \
         uv pip compile /tmp/req.in --quiet --prerelease=allow \
             --extra-index-url https://wheels.vllm.ai/nightly/${CUDA_TAG} \
             --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
-            --index-strategy unsafe-best-match \
             > /tmp/resolved.txt ; \
     else \
         echo "vllm==${VLLM_VERSION}" > /tmp/req.in && \


### PR DESCRIPTION
## Problem
`lmcache/vllm-openai:latest-nightly-cu129` ships **cu129 torch + a cu13 `vllm._C`**, so `import vllm` fails and the image can't start:
```
ImportError: libcudart.so.13: cannot open shared object file
```

## Cause
The cu129 vLLM install uses `--index-strategy unsafe-best-match`, which selects the highest version across *all* indexes. cu129's nightly wheel (`0.22.1rc1.dev335+…cu129`) is a **lower** PEP440 version than the cu13 **stable** `0.22.1` on PyPI, so uv resolves vllm (and its `nvidia-*-cu13` runtime deps) to the cu13 stable while torch stays cu129 → the mismatch.

## Fix
Drop `--index-strategy unsafe-best-match` for the **cu129** vLLM install so uv's default `first-index` pins vllm to the cu129 nightly index — in both the nightly (`image-build`) and release (`image-release-cu129`) stages. `cu130` (vLLM's primary nightly) is unchanged; the `lmcache` install (pinned `==VER`) is left as-is.

## Validation
`uv pip install --dry-run --no-deps vllm` against the cu129 indexes:

| index-strategy | resolved vllm |
|---|---|
| `unsafe-best-match` (before) | `0.22.1` — cu13 ❌ |
| default `first-index` (after) | `0.22.1rc1.dev335+…cu129` ✅ |

`VLLM_PRECOMPILED_WHEEL_VARIANT` has no effect on wheel resolution (it's source-build only), so the strategy flag is the sole cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
