### PR TITLE
[Fix] Fix local disk backend cleanup and locking edge cases

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+from contextlib import nullcontext
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
@@ -237,31 +238,26 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
         force: bool = True,
     ) -> bool:
-        if force:
-            self.disk_lock.acquire()
+        with self.disk_lock if force else nullcontext():
+            if not (meta := self.dict.pop(key, None)):
+                return False
 
-        if not (meta := self.dict.pop(key, None)):
+            path = meta.path
+            size = meta.size
+            self.usage -= size
+            self.stats_monitor.update_local_storage_usage(self.usage)
+
+            # NOTE: The following code will cause deadlock
+            # res = asyncio.run_coroutine_threadsafe(
+            #     self.disk_worker.submit_task("delete", os.remove, path),
+            #     self.loop,
+            # )
+            # res.result()
+
+            os.remove(path)
+
             if force:
-                self.disk_lock.release()
-            return False
-
-        path = meta.path
-        size = meta.size
-        self.usage -= size
-        self.stats_monitor.update_local_storage_usage(self.usage)
-
-        # NOTE: The following code will cause deadlock
-        # res = asyncio.run_coroutine_threadsafe(
-        #     self.disk_worker.submit_task("delete", os.remove, path),
-        #     self.loop,
-        # )
-        # res.result()
-
-        os.remove(path)
-
-        if force:
-            self.cache_policy.update_on_force_evict(key)
-            self.disk_lock.release()
+                self.cache_policy.update_on_force_evict(key)
 
         # Push kv evict msg with batching
         if self.batched_msg_sender is not None:
@@ -590,9 +586,8 @@ class LocalDiskBackend(StorageBackendInterface):
             cached_positions = self.dict[key].cached_positions
             mem_obj.metadata.cached_positions = cached_positions
 
-            self.disk_lock.acquire()
-            self.dict[key].unpin()
-            self.disk_lock.release()
+            with self.disk_lock:
+                self.dict[key].unpin()
 
         return memory_objs
 

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -577,17 +577,39 @@ class LocalDiskBackend(StorageBackendInterface):
 
         logger.debug("Executing `async_load_bytes` from disk.")
         # TODO (Jiayi): handle the case where loading fails.
-        for path, key, mem_obj in zip(paths, keys, memory_objs, strict=False):
+        for index, (path, key, mem_obj) in enumerate(
+            zip(paths, keys, memory_objs, strict=False)
+        ):
             buffer = mem_obj.byte_array
-            self.read_file(key, buffer, path)
+            if not self.read_file(buffer, path):
+                self._remove_stale_disk_entry(key)
+                for stale_mem_obj in memory_objs[index:]:
+                    stale_mem_obj.unpin()
+                    stale_mem_obj.ref_count_down()
+                with self.disk_lock:
+                    for tail_key in keys[index + 1 :]:
+                        if tail_meta := self.dict.get(tail_key):
+                            tail_meta.unpin()
+                return memory_objs[:index]
 
             # TODO(Jiayi): Please recover the metadata in a more
             # elegant way in the future.
-            cached_positions = self.dict[key].cached_positions
-            mem_obj.metadata.cached_positions = cached_positions
-
             with self.disk_lock:
-                self.dict[key].unpin()
+                if (disk_meta := self.dict.get(key)) is None:
+                    logger.warning(
+                        "Metadata for key %s disappeared during disk load", key
+                    )
+                    for stale_mem_obj in memory_objs[index:]:
+                        stale_mem_obj.unpin()
+                        stale_mem_obj.ref_count_down()
+                    for tail_key in keys[index + 1 :]:
+                        if tail_meta := self.dict.get(tail_key):
+                            tail_meta.unpin()
+                    return memory_objs[:index]
+
+                cached_positions = disk_meta.cached_positions
+                disk_meta.unpin()
+            mem_obj.metadata.cached_positions = cached_positions
 
         return memory_objs
 
@@ -607,11 +629,20 @@ class LocalDiskBackend(StorageBackendInterface):
         assert memory_obj is not None, "Memory allocation failed during disk load."
 
         buffer = memory_obj.byte_array
-        self.read_file(key, buffer, path)
+        if not self.read_file(buffer, path):
+            self._remove_stale_disk_entry(key)
+            memory_obj.ref_count_down()
+            return None
 
         # TODO(Jiayi): Please recover the metadata in a more
         # elegant way in the future.
-        cached_positions = self.dict[key].cached_positions
+        with self.disk_lock:
+            disk_meta = self.dict.get(key)
+            if disk_meta is None:
+                logger.warning("Metadata for key %s disappeared during disk load", key)
+                memory_obj.ref_count_down()
+                return None
+            cached_positions = disk_meta.cached_positions
         memory_obj.metadata.cached_positions = cached_positions
 
         return memory_obj
@@ -633,7 +664,7 @@ class LocalDiskBackend(StorageBackendInterface):
         )
 
     @_lmcache_nvtx_annotate
-    def read_file(self, key, buffer, path):
+    def read_file(self, buffer: Any, path: str) -> bool:
         start_time = time.time()
         size = len(buffer)
         fblock_aligned = size % self.os_disk_bs == 0
@@ -653,15 +684,32 @@ class LocalDiskBackend(StorageBackendInterface):
                     fdo.readinto(buffer)
         except FileNotFoundError:
             logger.warning(f"File not found on disk: {path}")
-            if self.dict.get(key, None):
-                self.dict.pop(key)
-            return
+            return False
 
         disk_read_time = time.time() - start_time
         logger.debug(
             f"Disk read size: {size} bytes, "
             f"Bandwidth: {size / disk_read_time / 1e6:.2f} MB/s"
         )
+        return True
+
+    def _remove_stale_disk_entry(self, key: CacheEngineKey) -> None:
+        with self.disk_lock:
+            if meta := self.dict.pop(key, None):
+                new_cache_size = self.current_cache_size - meta.size
+                new_usage = self.usage - meta.size
+                if new_cache_size < 0 or new_usage < 0:
+                    logger.warning(
+                        "Local disk accounting underflow while removing stale "
+                        "key %s: current_cache_size=%s, usage=%s, meta_size=%s",
+                        key,
+                        self.current_cache_size,
+                        self.usage,
+                        meta.size,
+                    )
+                self.current_cache_size = max(0.0, new_cache_size)
+                self.usage = max(0, new_usage)
+                self.stats_monitor.update_local_storage_usage(self.usage)
 
     def get_allocator_backend(self) -> LocalCPUBackend:
         return self.local_cpu_backend

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -448,43 +448,44 @@ class LocalDiskBackend(StorageBackendInterface):
 
         logger.debug(f"lookup_id: {lookup_id}; Prefetching {len(keys)} keys from disk.")
         for key in keys:
-            self.disk_lock.acquire()
-            assert key in self.dict, f"Key {key} not found in disk cache after pinning"
-
-            path = self.dict[key].path
-            dtype = self.dict[key].dtype
-            shape = self.dict[key].shape
-            fmt = self.dict[key].fmt
-
-            assert dtype is not None
-            assert shape is not None
-
-            # busy_loop=False prevents spinning on the event loop thread;
-            # if staging memory is exhausted the caller will get a logged
-            # error rather than a silent deadlock.
-            memory_obj = self.local_cpu_backend.allocate(
-                shape,
-                dtype,
-                fmt,
-                busy_loop=False,
-            )
-
-            if memory_obj is None:
-                logger.error(
-                    "Memory allocation failed during async disk load for key %s. "
-                    "CPU staging pool may be exhausted (unpin() not called after "
-                    "a previous retrieve). Returning partial results.",
-                    key,
+            with self.disk_lock:
+                assert key in self.dict, (
+                    f"Key {key} not found in disk cache after pinning"
                 )
-                return mem_objs
 
-            self.dict[key].pin()
+                path = self.dict[key].path
+                dtype = self.dict[key].dtype
+                shape = self.dict[key].shape
+                fmt = self.dict[key].fmt
 
-            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
-            # Update cache recency
-            self.cache_policy.update_on_hit(key, self.dict)
+                assert dtype is not None
+                assert shape is not None
 
-            self.disk_lock.release()
+                # busy_loop=False prevents spinning on the event loop thread;
+                # if staging memory is exhausted the caller will get a logged
+                # error rather than a silent deadlock.
+                memory_obj = self.local_cpu_backend.allocate(
+                    shape,
+                    dtype,
+                    fmt,
+                    busy_loop=False,
+                )
+
+                if memory_obj is None:
+                    logger.error(
+                        "Memory allocation failed during async disk load for key %s. "
+                        "CPU staging pool may be exhausted (unpin() not called after "
+                        "a previous retrieve). Returning partial results.",
+                        key,
+                    )
+                    return mem_objs
+
+                self.dict[key].pin()
+
+                # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
+                # Update cache recency
+                self.cache_policy.update_on_hit(key, self.dict)
+
             logger.debug(f"Prefetching {key} from disk.")
             memory_obj.pin()
             mem_objs.append(memory_obj)

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -352,6 +352,7 @@ class LocalDiskBackend(StorageBackendInterface):
                 self.cache_policy.update_on_put(key)
 
         if not evict_success:
+            self.disk_worker.remove_put_task(key)
             return None
 
         memory_obj.ref_count_up()

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from contextlib import nullcontext
 from concurrent.futures import Future
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
 import os

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -655,8 +655,8 @@ class LocalDiskBackend(StorageBackendInterface):
                 f.write(buffer)
         else:
             fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_DIRECT, 0o644)
-            os.write(fd, buffer)
-            os.close(fd)
+            with os.fdopen(fd, "wb", buffering=0) as fdo:
+                fdo.write(buffer)
         disk_write_time = time.time() - start_time
         logger.debug(
             f"Disk write size: {size} bytes, "


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes several LocalDiskBackend correctness issues around cleanup, locking, and disk I/O resource handling:

- removes stuck in-flight put markers when disk admission/eviction fails before a put task is queued
- converts manual `disk_lock.acquire()` / `release()` paths to context-managed locking
- cleans up stale disk metadata when a cached file is missing during load
- keeps local disk usage accounting and storage metrics in sync when stale metadata is removed
- avoids leaking O_DIRECT write file descriptors by wrapping them with `os.fdopen(...)`

**Special notes for your reviewers**:

The stale-file path now treats missing disk files as cache metadata drift: it removes the metadata entry under `disk_lock`, adjusts local disk accounting, updates storage usage metrics, and returns a miss instead of raising or returning an invalid object.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests