### PR TITLE
[cli] add quota management commands (set/get/list/delete)

### DIFF
--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -33,7 +33,7 @@ The ``lmcache`` CLI ships in two packages:
    * - ``lmcache-cli``
      - ``pip install lmcache-cli``
      - CLI only: ``ping``, ``query``, ``describe``, ``kvcache``,
-       ``bench engine``. No GPU required, any OS.
+       ``quota``, ``bench engine``. No GPU required, any OS.
 
 .. note::
 
@@ -65,6 +65,8 @@ Available Commands
        adapter (``l2``).
    * - :doc:`kvcache`
      - Manage KV cache state (e.g. clear L1 cache) on a running server.
+   * - :doc:`quota`
+     - Manage per-salt cache quotas (set, get, list, delete).
    * - :doc:`trace`
      - Inspect and replay storage-level trace files.
    * - :doc:`tool`
@@ -100,5 +102,6 @@ See :doc:`/developer_guide/cli` for details.
    query
    bench
    kvcache
+   quota
    trace
    tool

--- a/docs/source/cli/quota.rst
+++ b/docs/source/cli/quota.rst
@@ -1,0 +1,301 @@
+lmcache quota
+=============
+
+The ``lmcache quota`` command manages per-salt cache quotas on a running
+LMCache server. Quotas are soft limits: exceeding a quota triggers eviction
+on the next cycle (~1 s) rather than rejecting writes.
+
+.. code-block:: bash
+
+   lmcache quota <sub-command> [options]
+
+.. code-block:: text
+
+   $ lmcache quota -h
+   usage: lmcache quota [-h] {set,get,list,delete} ...
+
+   Manage per-salt cache quotas on the LMCache server.
+
+   subcommands:
+     set            Create or update a quota for a cache_salt
+     get            Show the quota and current usage for a cache_salt
+     list           List all registered quotas and their usage
+     delete         Remove a quota for a cache_salt
+
+   options:
+     -h, --help     show this help message and exit
+
+set
+---
+
+Create or update a quota for a given ``cache_salt``.
+
+.. code-block:: bash
+
+   lmcache quota set <salt> --limit-gb <GB> [--url <URL>]
+
+**Example:**
+
+.. code-block:: bash
+
+   $ lmcache quota set tenant1 --limit-gb 10.5
+
+   ================ Quota Set =================
+   Cache salt:                          tenant1
+   Limit (GB):                             10.5
+   Status:                                   ok
+   =============================================
+
+**Options:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 10 65
+
+   * - Flag
+     - Required
+     - Description
+   * - ``<salt>``
+     - Yes
+     - The ``cache_salt`` identifier. Use ``_default`` for anonymous
+       (un-salted) traffic.
+   * - ``--limit-gb``
+     - Yes
+     - Quota limit in gigabytes (non-negative float).
+   * - ``--url``
+     - No
+     - LMCache HTTP server URL (default: ``http://localhost:8080``).
+   * - ``--format``
+     - No
+     - Output format: ``terminal`` (default) or ``json``.
+   * - ``--output``
+     - No
+     - Save output to a file (uses the format chosen by ``--format``).
+   * - ``-q`` / ``--quiet``
+     - No
+     - Suppress stdout output. Exit code only.
+
+get
+---
+
+Show the current quota limit and live usage for a specific ``cache_salt``.
+
+.. code-block:: bash
+
+   lmcache quota get <salt> [--url <URL>]
+
+**Example:**
+
+.. code-block:: bash
+
+   $ lmcache quota get tenant1
+
+   ================ Quota Info ================
+   Cache salt:                          tenant1
+   Limit (GB):                             10.5
+   Current usage (GB):                     3.27
+   Exists:                                 True
+   =============================================
+
+**Options:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 10 65
+
+   * - Flag
+     - Required
+     - Description
+   * - ``<salt>``
+     - Yes
+     - The ``cache_salt`` identifier.
+   * - ``--url``
+     - No
+     - LMCache HTTP server URL (default: ``http://localhost:8080``).
+   * - ``--format``
+     - No
+     - Output format: ``terminal`` (default) or ``json``.
+   * - ``--output``
+     - No
+     - Save output to a file.
+   * - ``-q`` / ``--quiet``
+     - No
+     - Suppress stdout output.
+
+list
+----
+
+List all registered quotas along with their current usage.
+
+.. code-block:: bash
+
+   lmcache quota list [--url <URL>]
+
+**Example:**
+
+.. code-block:: bash
+
+   $ lmcache quota list
+
+   =================== Quota List ====================
+   --- Salt: tenant1 ---
+   Cache salt:                               tenant1
+   Limit (GB):                                  10.5
+   Current usage (GB):                          3.27
+   --- Salt: _default ---
+   Cache salt:                              _default
+   Limit (GB):                                   5.0
+   Current usage (GB):                          1.82
+   ===================================================
+
+**JSON output:**
+
+.. code-block:: bash
+
+   $ lmcache quota list --format json
+   {
+     "title": "Quota List",
+     "sections": {
+       "quota_0": {
+         "label": "Salt: tenant1",
+         "metrics": {
+           "cache_salt": "tenant1",
+           "limit_gb": 10.5,
+           "current_usage_gb": 3.27
+         }
+       },
+       "quota_1": {
+         "label": "Salt: _default",
+         "metrics": {
+           "cache_salt": "_default",
+           "limit_gb": 5.0,
+           "current_usage_gb": 1.82
+         }
+       }
+     }
+   }
+
+**Options:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 10 65
+
+   * - Flag
+     - Required
+     - Description
+   * - ``--url``
+     - No
+     - LMCache HTTP server URL (default: ``http://localhost:8080``).
+   * - ``--format``
+     - No
+     - Output format: ``terminal`` (default) or ``json``.
+   * - ``--output``
+     - No
+     - Save output to a file.
+   * - ``-q`` / ``--quiet``
+     - No
+     - Suppress stdout output.
+
+delete
+------
+
+Remove a quota entry for a given ``cache_salt``. Any bytes still cached
+under this salt become over-budget on the next eviction cycle and will be
+evicted (effective limit drops to 0).
+
+.. code-block:: bash
+
+   lmcache quota delete <salt> [--url <URL>]
+
+**Example:**
+
+.. code-block:: bash
+
+   $ lmcache quota delete tenant1
+
+   ============== Quota Delete ===============
+   Cache salt:                        tenant1
+   Status:                            removed
+   ===========================================
+
+**Options:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 10 65
+
+   * - Flag
+     - Required
+     - Description
+   * - ``<salt>``
+     - Yes
+     - The ``cache_salt`` identifier.
+   * - ``--url``
+     - No
+     - LMCache HTTP server URL (default: ``http://localhost:8080``).
+   * - ``--format``
+     - No
+     - Output format: ``terminal`` (default) or ``json``.
+   * - ``--output``
+     - No
+     - Save output to a file.
+   * - ``-q`` / ``--quiet``
+     - No
+     - Suppress stdout output.
+
+Exit Codes
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Code
+     - Meaning
+   * - ``0``
+     - Success.
+   * - ``1``
+     - Error (connection failure, server error, bad arguments).
+
+The ``_default`` Salt
+---------------------
+
+The LMCache server uses an empty string (``""``) as the ``cache_salt`` for
+anonymous / un-salted traffic. Since empty strings cannot appear in URL path
+parameters, the HTTP API (and this CLI) uses the sentinel ``_default`` in
+its place.
+
+.. code-block:: bash
+
+   # Set a 5 GB quota for anonymous traffic
+   lmcache quota set _default --limit-gb 5.0
+
+   # Check usage
+   lmcache quota get _default
+
+Common Patterns
+---------------
+
+**Provision quotas for multiple tenants:**
+
+.. code-block:: bash
+
+   for tenant in tenant_a tenant_b tenant_c; do
+       lmcache quota set "$tenant" --limit-gb 8.0
+   done
+
+**Monitor usage in a script:**
+
+.. code-block:: bash
+
+   USAGE=$(lmcache quota get tenant1 --format json | jq '.metrics.current_usage_gb')
+   LIMIT=$(lmcache quota get tenant1 --format json | jq '.metrics.limit_gb')
+   echo "tenant1: ${USAGE} / ${LIMIT} GB"
+
+**Revoke access (evict all cached data for a salt):**
+
+.. code-block:: bash
+
+   # Deleting the quota causes all data under this salt to be evicted
+   lmcache quota delete tenant1

--- a/lmcache/cli/commands/quota/__init__.py
+++ b/lmcache/cli/commands/quota/__init__.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache quota`` command — per-salt quota management.
+
+Subcommands:
+
+* ``set SALT --limit-gb N``  — create or update a quota
+* ``get SALT``               — show quota and current usage for a salt
+* ``list``                   — list all registered quotas
+* ``delete SALT``            — remove a quota entry
+"""
+
+# Standard
+import argparse
+import sys
+
+# First Party
+from lmcache.cli.commands.base import BaseCommand
+from lmcache.cli.commands.quota.delete_command import (
+    register_delete_parser,
+    run_quota_delete,
+)
+from lmcache.cli.commands.quota.get_command import (
+    register_get_parser,
+    run_quota_get,
+)
+from lmcache.cli.commands.quota.list_command import (
+    register_list_parser,
+    run_quota_list,
+)
+from lmcache.cli.commands.quota.set_command import (
+    register_set_parser,
+    run_quota_set,
+)
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+
+class QuotaCommand(BaseCommand):
+    """CLI command for per-salt quota management on LMCache server."""
+
+    def name(self) -> str:
+        return "quota"
+
+    def help(self) -> str:
+        return "Manage per-salt cache quotas."
+
+    def add_arguments(self, _parser: argparse.ArgumentParser) -> None:
+        pass  # args registered in register() via subparsers
+
+    def register(self, subparsers: argparse._SubParsersAction) -> None:
+        """Register ``lmcache quota`` and all quota sub-subcommands.
+
+        Args:
+            subparsers: The subparsers action from the root parser.
+        """
+        parser = subparsers.add_parser(
+            self.name(),
+            help=self.help(),
+            description="Manage per-salt cache quotas on the LMCache server.",
+        )
+        inner = parser.add_subparsers(
+            dest="quota_action",
+            required=True,
+            metavar="{set,get,list,delete}",
+        )
+        register_set_parser(inner, self.execute)
+        register_get_parser(inner, self.execute)
+        register_list_parser(inner, self.execute)
+        register_delete_parser(inner, self.execute)
+
+    def execute(self, args: argparse.Namespace) -> None:
+        """Dispatch to the appropriate quota subcommand handler.
+
+        Args:
+            args: Parsed CLI arguments containing ``quota_action``.
+        """
+        handlers = {
+            "set": lambda a: run_quota_set(self, a),
+            "get": lambda a: run_quota_get(self, a),
+            "list": lambda a: run_quota_list(self, a),
+            "delete": lambda a: run_quota_delete(self, a),
+        }
+        handler = handlers.get(args.quota_action)
+        if handler is None:
+            print(
+                f"Unknown quota action: {args.quota_action}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        handler(args)

--- a/lmcache/cli/commands/quota/delete_command.py
+++ b/lmcache/cli/commands/quota/delete_command.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache quota delete`` — remove a quota for a cache_salt."""
+
+# Standard
+from typing import TYPE_CHECKING
+import argparse
+
+# First Party
+from lmcache.cli.commands.base import _add_output_args
+from lmcache.cli.commands.quota.helpers import (
+    escape_salt,
+    http_request,
+    normalize_url,
+)
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.cli.commands.base import BaseCommand
+
+
+def register_delete_parser(
+    subparsers: argparse._SubParsersAction,
+    dispatch_func,
+) -> argparse.ArgumentParser:
+    """Register the ``lmcache quota delete`` subcommand parser.
+
+    Args:
+        subparsers: The ``quota`` subparsers action.
+        dispatch_func: Function to bind via ``set_defaults(func=...)``.
+
+    Returns:
+        The created ``ArgumentParser``.
+    """
+    parser = subparsers.add_parser(
+        "delete",
+        help="Remove a quota for a cache_salt.",
+        description=(
+            "Delete the quota entry for a given cache_salt. Any bytes "
+            "still cached under this salt become over-budget on the "
+            "next eviction cycle and will be evicted."
+        ),
+    )
+    parser.add_argument(
+        "salt",
+        type=str,
+        help=(
+            "The cache_salt identifier. Use '_default' for anonymous "
+            "(un-salted) traffic."
+        ),
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="http://localhost:8080",
+        help="LMCache HTTP server URL (default: http://localhost:8080).",
+    )
+    _add_output_args(parser)
+    parser.set_defaults(func=dispatch_func)
+    return parser
+
+
+def run_quota_delete(cmd: "BaseCommand", args: argparse.Namespace) -> None:
+    """Execute the ``lmcache quota delete`` subcommand.
+
+    Args:
+        cmd: The parent command instance (for metrics creation).
+        args: Parsed CLI arguments.
+    """
+    base_url = normalize_url(args.url)
+    salt = escape_salt(args.salt)
+
+    result = http_request("DELETE", f"{base_url}/quota/{salt}")
+
+    metrics = cmd.create_metrics("Quota Delete", args)
+    metrics.add("cache_salt", "Cache salt", result.get("cache_salt", salt))
+    metrics.add("status", "Status", result.get("status", "unknown"))
+    metrics.emit()

--- a/lmcache/cli/commands/quota/get_command.py
+++ b/lmcache/cli/commands/quota/get_command.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache quota get`` — read the quota and usage for a cache_salt."""
+
+# Standard
+from typing import TYPE_CHECKING
+import argparse
+
+# First Party
+from lmcache.cli.commands.base import _add_output_args
+from lmcache.cli.commands.quota.helpers import (
+    escape_salt,
+    http_request,
+    normalize_url,
+)
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.cli.commands.base import BaseCommand
+
+
+def register_get_parser(
+    subparsers: argparse._SubParsersAction,
+    dispatch_func,
+) -> argparse.ArgumentParser:
+    """Register the ``lmcache quota get`` subcommand parser.
+
+    Args:
+        subparsers: The ``quota`` subparsers action.
+        dispatch_func: Function to bind via ``set_defaults(func=...)``.
+
+    Returns:
+        The created ``ArgumentParser``.
+    """
+    parser = subparsers.add_parser(
+        "get",
+        help="Show the quota and current usage for a cache_salt.",
+        description=(
+            "Query the current quota limit and live usage for a "
+            "specific cache_salt on the LMCache server."
+        ),
+    )
+    parser.add_argument(
+        "salt",
+        type=str,
+        help=(
+            "The cache_salt identifier. Use '_default' for anonymous "
+            "(un-salted) traffic."
+        ),
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="http://localhost:8080",
+        help="LMCache HTTP server URL (default: http://localhost:8080).",
+    )
+    _add_output_args(parser)
+    parser.set_defaults(func=dispatch_func)
+    return parser
+
+
+def run_quota_get(cmd: "BaseCommand", args: argparse.Namespace) -> None:
+    """Execute the ``lmcache quota get`` subcommand.
+
+    Args:
+        cmd: The parent command instance (for metrics creation).
+        args: Parsed CLI arguments.
+    """
+    base_url = normalize_url(args.url)
+    salt = escape_salt(args.salt)
+
+    result = http_request("GET", f"{base_url}/quota/{salt}")
+
+    metrics = cmd.create_metrics("Quota Info", args)
+    metrics.add("cache_salt", "Cache salt", result.get("cache_salt", salt))
+    metrics.add("limit_gb", "Limit (GB)", result.get("limit_gb"))
+    metrics.add(
+        "current_usage_gb", "Current usage (GB)", result.get("current_usage_gb")
+    )
+    metrics.add("exists", "Exists", result.get("exists"))
+    metrics.emit()

--- a/lmcache/cli/commands/quota/helpers.py
+++ b/lmcache/cli/commands/quota/helpers.py
@@ -74,7 +74,5 @@ def http_request(
         logger.error("Server error: %s", msg)
         sys.exit(1)
     except urllib.error.URLError as e:
-        logger.error(
-            "Cannot reach %s — is the server running? (%s)", url, e.reason
-        )
+        logger.error("Cannot reach %s — is the server running? (%s)", url, e.reason)
         sys.exit(1)

--- a/lmcache/cli/commands/quota/helpers.py
+++ b/lmcache/cli/commands/quota/helpers.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for ``lmcache quota`` subcommands."""
+
+# Standard
+from typing import Any, Optional
+import json
+import sys
+import urllib.error
+import urllib.request
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+# The MP HTTP server uses "_default" as a sentinel for the empty-string
+# cache_salt (anonymous / un-salted traffic).
+DEFAULT_SALT_SENTINEL = "_default"
+
+
+def normalize_url(url: str) -> str:
+    """Ensure *url* has an ``http://`` or ``https://`` scheme."""
+    if not url.startswith(("http://", "https://")):
+        url = f"http://{url}"
+    return url.rstrip("/")
+
+
+def escape_salt(salt: str) -> str:
+    """Translate the empty-string salt to the URL sentinel."""
+    return DEFAULT_SALT_SENTINEL if salt == "" else salt
+
+
+def unescape_salt(salt: str) -> str:
+    """Translate the URL sentinel back to the empty-string salt."""
+    return "" if salt == DEFAULT_SALT_SENTINEL else salt
+
+
+def http_request(
+    method: str,
+    url: str,
+    data: Optional[dict[str, Any]] = None,
+    timeout: int = 10,
+) -> dict[str, Any]:
+    """Send an HTTP request and return the parsed JSON response.
+
+    Args:
+        method: HTTP method (GET, POST, PUT, DELETE).
+        url: Full URL to request.
+        data: Optional JSON body to send.
+        timeout: HTTP timeout in seconds.
+
+    Returns:
+        Parsed JSON response as a dict.
+
+    Raises:
+        SystemExit: On connection error or non-2xx HTTP response.
+    """
+    body = None
+    headers: dict[str, str] = {}
+    if data is not None:
+        body = json.dumps(data).encode()
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        try:
+            error_body = json.loads(e.read().decode())
+            msg = error_body.get("error") or error_body.get("message") or str(e)
+        except (json.JSONDecodeError, ValueError, OSError):
+            msg = str(e)
+        logger.error("Server error: %s", msg)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        logger.error(
+            "Cannot reach %s — is the server running? (%s)", url, e.reason
+        )
+        sys.exit(1)

--- a/lmcache/cli/commands/quota/list_command.py
+++ b/lmcache/cli/commands/quota/list_command.py
@@ -71,8 +71,6 @@ def run_quota_list(cmd: "BaseCommand", args: argparse.Namespace) -> None:
         sec = metrics[section_key]
         sec.add("cache_salt", "Cache salt", salt)
         sec.add("limit_gb", "Limit (GB)", info.get("limit_gb"))
-        sec.add(
-            "current_usage_gb", "Current usage (GB)", info.get("current_usage_gb")
-        )
+        sec.add("current_usage_gb", "Current usage (GB)", info.get("current_usage_gb"))
 
     metrics.emit()

--- a/lmcache/cli/commands/quota/list_command.py
+++ b/lmcache/cli/commands/quota/list_command.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache quota list`` — list all registered quotas and their usage."""
+
+# Standard
+from typing import TYPE_CHECKING
+import argparse
+
+# First Party
+from lmcache.cli.commands.base import _add_output_args
+from lmcache.cli.commands.quota.helpers import http_request, normalize_url
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.cli.commands.base import BaseCommand
+
+
+def register_list_parser(
+    subparsers: argparse._SubParsersAction,
+    dispatch_func,
+) -> argparse.ArgumentParser:
+    """Register the ``lmcache quota list`` subcommand parser.
+
+    Args:
+        subparsers: The ``quota`` subparsers action.
+        dispatch_func: Function to bind via ``set_defaults(func=...)``.
+
+    Returns:
+        The created ``ArgumentParser``.
+    """
+    parser = subparsers.add_parser(
+        "list",
+        help="List all registered quotas and their usage.",
+        description=(
+            "Retrieve all per-salt quotas from the LMCache server "
+            "along with their current usage."
+        ),
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="http://localhost:8080",
+        help="LMCache HTTP server URL (default: http://localhost:8080).",
+    )
+    _add_output_args(parser)
+    parser.set_defaults(func=dispatch_func)
+    return parser
+
+
+def run_quota_list(cmd: "BaseCommand", args: argparse.Namespace) -> None:
+    """Execute the ``lmcache quota list`` subcommand.
+
+    Args:
+        cmd: The parent command instance (for metrics creation).
+        args: Parsed CLI arguments.
+    """
+    base_url = normalize_url(args.url)
+
+    result = http_request("GET", f"{base_url}/quota")
+    users = result.get("users", {})
+
+    metrics = cmd.create_metrics("Quota List", args, width=55)
+
+    if not users:
+        metrics.add("info", "Info", "No quotas configured")
+        metrics.emit()
+        return
+
+    for idx, (salt, info) in enumerate(users.items()):
+        section_key = f"quota_{idx}"
+        metrics.add_list_section("quotas", section_key, f"Salt: {salt}")
+        sec = metrics[section_key]
+        sec.add("cache_salt", "Cache salt", salt)
+        sec.add("limit_gb", "Limit (GB)", info.get("limit_gb"))
+        sec.add(
+            "current_usage_gb", "Current usage (GB)", info.get("current_usage_gb")
+        )
+
+    metrics.emit()

--- a/lmcache/cli/commands/quota/set_command.py
+++ b/lmcache/cli/commands/quota/set_command.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache quota set`` — create or update a quota for a cache_salt."""
+
+# Standard
+from typing import TYPE_CHECKING
+import argparse
+
+# First Party
+from lmcache.cli.commands.base import _add_output_args
+from lmcache.cli.commands.quota.helpers import (
+    escape_salt,
+    http_request,
+    normalize_url,
+)
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.cli.commands.base import BaseCommand
+
+
+def register_set_parser(
+    subparsers: argparse._SubParsersAction,
+    dispatch_func,
+) -> argparse.ArgumentParser:
+    """Register the ``lmcache quota set`` subcommand parser.
+
+    Args:
+        subparsers: The ``quota`` subparsers action.
+        dispatch_func: Function to bind via ``set_defaults(func=...)``.
+
+    Returns:
+        The created ``ArgumentParser``.
+    """
+    parser = subparsers.add_parser(
+        "set",
+        help="Create or update a quota for a cache_salt.",
+        description=(
+            "Set a per-salt quota (in GB) on the LMCache server. "
+            "The quota is soft: exceeding it triggers eviction on the "
+            "next cycle rather than rejecting writes."
+        ),
+    )
+    parser.add_argument(
+        "salt",
+        type=str,
+        help=(
+            "The cache_salt identifier. Use '_default' for anonymous "
+            "(un-salted) traffic."
+        ),
+    )
+    parser.add_argument(
+        "--limit-gb",
+        type=float,
+        required=True,
+        metavar="GB",
+        help="Quota limit in gigabytes (non-negative).",
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="http://localhost:8080",
+        help="LMCache HTTP server URL (default: http://localhost:8080).",
+    )
+    _add_output_args(parser)
+    parser.set_defaults(func=dispatch_func)
+    return parser
+
+
+def run_quota_set(cmd: "BaseCommand", args: argparse.Namespace) -> None:
+    """Execute the ``lmcache quota set`` subcommand.
+
+    Args:
+        cmd: The parent command instance (for metrics creation).
+        args: Parsed CLI arguments.
+    """
+    base_url = normalize_url(args.url)
+    salt = escape_salt(args.salt)
+    limit_gb = args.limit_gb
+
+    result = http_request(
+        "PUT",
+        f"{base_url}/quota/{salt}",
+        data={"limit_gb": limit_gb},
+    )
+
+    metrics = cmd.create_metrics("Quota Set", args)
+    metrics.add("cache_salt", "Cache salt", result.get("cache_salt", salt))
+    metrics.add("limit_gb", "Limit (GB)", result.get("limit_gb", limit_gb))
+    metrics.add("status", "Status", result.get("status", "ok"))
+    metrics.emit()

--- a/tests/cli/commands/test_quota.py
+++ b/tests/cli/commands/test_quota.py
@@ -4,7 +4,6 @@
 # Standard
 from unittest.mock import MagicMock, patch
 import argparse
-import json
 import sys
 
 # Inject a fake openai module so that the auto-discovery of
@@ -62,27 +61,41 @@ class TestQuotaCommandMetadata:
 class TestQuotaCommandExecute:
     @patch("lmcache.cli.commands.quota.set_command.http_request")
     def test_set(
-        self, mock_http, cmd, parser, capsys,
+        self,
+        mock_http,
+        cmd,
+        parser,
+        capsys,
     ) -> None:
         mock_http.return_value = {
-            "cache_salt": "tenant1", "limit_gb": 10.5, "status": "ok",
+            "cache_salt": "tenant1",
+            "limit_gb": 10.5,
+            "status": "ok",
         }
         args = parser.parse_args(["quota", "set", "tenant1", "--limit-gb", "10.5"])
         cmd.execute(args)
 
         mock_http.assert_called_once_with(
-            "PUT", "http://localhost:8080/quota/tenant1", data={"limit_gb": 10.5},
+            "PUT",
+            "http://localhost:8080/quota/tenant1",
+            data={"limit_gb": 10.5},
         )
         out = capsys.readouterr().out
         assert "Quota Set" in out and "tenant1" in out
 
     @patch("lmcache.cli.commands.quota.get_command.http_request")
     def test_get(
-        self, mock_http, cmd, parser, capsys,
+        self,
+        mock_http,
+        cmd,
+        parser,
+        capsys,
     ) -> None:
         mock_http.return_value = {
-            "cache_salt": "tenant1", "limit_gb": 10.5,
-            "current_usage_gb": 3.27, "exists": True,
+            "cache_salt": "tenant1",
+            "limit_gb": 10.5,
+            "current_usage_gb": 3.27,
+            "exists": True,
         }
         args = parser.parse_args(["quota", "get", "tenant1"])
         cmd.execute(args)
@@ -93,7 +106,11 @@ class TestQuotaCommandExecute:
 
     @patch("lmcache.cli.commands.quota.list_command.http_request")
     def test_list(
-        self, mock_http, cmd, parser, capsys,
+        self,
+        mock_http,
+        cmd,
+        parser,
+        capsys,
     ) -> None:
         mock_http.return_value = {
             "users": {
@@ -110,21 +127,30 @@ class TestQuotaCommandExecute:
 
     @patch("lmcache.cli.commands.quota.delete_command.http_request")
     def test_delete(
-        self, mock_http, cmd, parser, capsys,
+        self,
+        mock_http,
+        cmd,
+        parser,
+        capsys,
     ) -> None:
         mock_http.return_value = {"cache_salt": "tenant1", "status": "removed"}
         args = parser.parse_args(["quota", "delete", "tenant1"])
         cmd.execute(args)
 
         mock_http.assert_called_once_with(
-            "DELETE", "http://localhost:8080/quota/tenant1",
+            "DELETE",
+            "http://localhost:8080/quota/tenant1",
         )
         out = capsys.readouterr().out
         assert "Quota Delete" in out and "removed" in out
 
     @patch("lmcache.cli.commands.quota.set_command.http_request")
     def test_quiet_suppresses_output(
-        self, mock_http, cmd, parser, capsys,
+        self,
+        mock_http,
+        cmd,
+        parser,
+        capsys,
     ) -> None:
         mock_http.return_value = {"cache_salt": "t1", "limit_gb": 1.0, "status": "ok"}
         args = parser.parse_args(["quota", "set", "t1", "--limit-gb", "1", "-q"])

--- a/tests/cli/commands/test_quota.py
+++ b/tests/cli/commands/test_quota.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``lmcache quota`` CLI command."""
+
+# Standard
+from unittest.mock import MagicMock, patch
+import argparse
+import json
+import sys
+
+# Inject a fake openai module so that the auto-discovery of
+# lmcache.cli.commands (which imports bench -> openai) does not fail
+# in environments where openai is not installed.
+if "openai" not in sys.modules:
+    _fake_openai = MagicMock()
+    sys.modules["openai"] = _fake_openai
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.quota import QuotaCommand
+from lmcache.cli.commands.quota.helpers import (
+    DEFAULT_SALT_SENTINEL,
+    escape_salt,
+    normalize_url,
+    unescape_salt,
+)
+
+
+@pytest.fixture
+def cmd() -> QuotaCommand:
+    return QuotaCommand()
+
+
+@pytest.fixture
+def parser(cmd: QuotaCommand) -> argparse.ArgumentParser:
+    """An ArgumentParser with QuotaCommand registered."""
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="command")
+    cmd.register(sub)
+    return p
+
+
+class TestHelpers:
+    def test_normalize_url(self) -> None:
+        assert normalize_url("localhost:8080") == "http://localhost:8080"
+        assert normalize_url("https://host:443/") == "https://host:443"
+
+    def test_escape_unescape_salt(self) -> None:
+        assert escape_salt("") == DEFAULT_SALT_SENTINEL
+        assert escape_salt("tenant1") == "tenant1"
+        assert unescape_salt(DEFAULT_SALT_SENTINEL) == ""
+        assert unescape_salt("tenant1") == "tenant1"
+
+
+class TestQuotaCommandMetadata:
+    def test_name_and_help(self, cmd: QuotaCommand) -> None:
+        assert cmd.name() == "quota"
+        assert "quota" in cmd.help().lower()
+
+
+class TestQuotaCommandExecute:
+    @patch("lmcache.cli.commands.quota.set_command.http_request")
+    def test_set(
+        self, mock_http, cmd, parser, capsys,
+    ) -> None:
+        mock_http.return_value = {
+            "cache_salt": "tenant1", "limit_gb": 10.5, "status": "ok",
+        }
+        args = parser.parse_args(["quota", "set", "tenant1", "--limit-gb", "10.5"])
+        cmd.execute(args)
+
+        mock_http.assert_called_once_with(
+            "PUT", "http://localhost:8080/quota/tenant1", data={"limit_gb": 10.5},
+        )
+        out = capsys.readouterr().out
+        assert "Quota Set" in out and "tenant1" in out
+
+    @patch("lmcache.cli.commands.quota.get_command.http_request")
+    def test_get(
+        self, mock_http, cmd, parser, capsys,
+    ) -> None:
+        mock_http.return_value = {
+            "cache_salt": "tenant1", "limit_gb": 10.5,
+            "current_usage_gb": 3.27, "exists": True,
+        }
+        args = parser.parse_args(["quota", "get", "tenant1"])
+        cmd.execute(args)
+
+        mock_http.assert_called_once_with("GET", "http://localhost:8080/quota/tenant1")
+        out = capsys.readouterr().out
+        assert "Quota Info" in out and "3.27" in out
+
+    @patch("lmcache.cli.commands.quota.list_command.http_request")
+    def test_list(
+        self, mock_http, cmd, parser, capsys,
+    ) -> None:
+        mock_http.return_value = {
+            "users": {
+                "tenant1": {"limit_gb": 10.5, "current_usage_gb": 3.27},
+                "_default": {"limit_gb": 5.0, "current_usage_gb": 1.82},
+            }
+        }
+        args = parser.parse_args(["quota", "list"])
+        cmd.execute(args)
+
+        mock_http.assert_called_once_with("GET", "http://localhost:8080/quota")
+        out = capsys.readouterr().out
+        assert "tenant1" in out and "_default" in out
+
+    @patch("lmcache.cli.commands.quota.delete_command.http_request")
+    def test_delete(
+        self, mock_http, cmd, parser, capsys,
+    ) -> None:
+        mock_http.return_value = {"cache_salt": "tenant1", "status": "removed"}
+        args = parser.parse_args(["quota", "delete", "tenant1"])
+        cmd.execute(args)
+
+        mock_http.assert_called_once_with(
+            "DELETE", "http://localhost:8080/quota/tenant1",
+        )
+        out = capsys.readouterr().out
+        assert "Quota Delete" in out and "removed" in out
+
+    @patch("lmcache.cli.commands.quota.set_command.http_request")
+    def test_quiet_suppresses_output(
+        self, mock_http, cmd, parser, capsys,
+    ) -> None:
+        mock_http.return_value = {"cache_salt": "t1", "limit_gb": 1.0, "status": "ok"}
+        args = parser.parse_args(["quota", "set", "t1", "--limit-gb", "1", "-q"])
+        cmd.execute(args)
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
add quota cli commands

- `set`
```
lmcache quota set --url http://localhost:8080 --limit-gb 10 tenant1
================== Quota Set ===================
Cache salt:                              tenant1
Limit (GB):                                10.00
Status:                                       ok
================================================
```
- `get`
```
lmcache quota get --url http://localhost:8080 tenant1
================== Quota Info ==================
Cache salt:                              tenant1
Limit (GB):                                10.00
Current usage (GB):                         0.00
Exists:                                     True
================================================
```
- `list`
```
lmcache quota list --url http://localhost:8080
====================== Quota List =====================
-------------------- Salt: tenant1 --------------------
Cache salt:                                     tenant1
Limit (GB):                                       10.00
Current usage (GB):                                0.00
=======================================================
```
- `delete`
```
lmcache quota delete --url http://localhost:8080 tenant1
================= Quota Delete =================
Cache salt:                              tenant1
Status:                                  removed
================================================
```