### PR TITLE
[feat] L2 Failure Mock Adaptor: Inject Retrieval Failures to Simulate L2 Failures for Testing and wire the segmented  prefix retrieval policy

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fault-injecting L2 adapter (test/diagnostic only).
+
+A thin decorator that wraps a real inner L2 adapter (e.g. ``fs_native``) and
+deterministically drops a subset of keys to simulate partial L2 retrieve
+failures. Used to exercise the *segmented* code paths (gapped found-set ->
+segmented prefetch -> segmented scatter / attention) that no normal workload
+produces, since real caches return clean contiguous-prefix-then-tail results.
+
+Two fault modes, mapping onto the adapter's two read primitives:
+
+* ``miss``  -- clear dropped bits in ``query_lookup_and_lock_result``. The key
+  is reported absent, so the matcher never selects it (a gap at lookup). The
+  inner adapter already locked the key during lookup, so the hidden keys are
+  unlocked here to avoid leaking a read lock.
+* ``error`` -- clear dropped bits in ``query_load_result``. Lookup reported the
+  key present but the load fails (the faithful "L2 retrieve error"); the
+  prefetch controller releases the load-failed read locks itself via the trim
+  mask, so no manual unlock is needed.
+* ``both``  -- apply to both (a key dropped at lookup is also dropped at load).
+
+The drop-set is deterministic: a stable hash of the key bucketed by ``rate``
+(so lookup and load agree within a request and runs reproduce), plus an
+optional ``gap_indices`` set of exact task-positions to drop for precise
+single-gap repros.
+
+Limitations (test scope): serde / eviction configured on this adapter's JSON
+spec are not propagated to the inner adapter (the inner is built directly by
+this adapter's factory, bypassing the StorageManager's per-adapter wrapping).
+Configure the inner adapter for a plain store and keep faults at this layer.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING, Optional
+import hashlib
+import threading
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+from lmcache.v1.distributed.l2_adapters.base import (
+    AdapterUsage,
+    L2AdapterInterface,
+    L2TaskId,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
+    register_l2_adapter_factory,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+logger = init_logger(__name__)
+
+_VALID_MODES = ("miss", "error", "both")
+_HASH_DENOM = 1_000_000
+
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+
+
+class FaultInjectL2AdapterConfig(L2AdapterConfigBase):
+    """Config for the fault-injecting L2 adapter.
+
+    JSON fields:
+    - inner (dict, required): full adapter spec for the wrapped adapter, with
+      its own "type" (e.g. {"type": "fs_native", "base_path": "/dev/shm/x"}).
+    - mode (str): "miss" | "error" | "both". Default "error".
+    - rate (float): per-key drop probability in [0, 1]. Default 0.0 (pass-through).
+    - seed (int): seed for the deterministic per-key hash. Default 0.
+    - gap_indices (list[int]): exact task-positions to always drop (in addition
+      to rate-based drops). Default [] -- mainly for precise unit tests.
+    """
+
+    def __init__(
+        self,
+        inner_config: L2AdapterConfigBase,
+        mode: str,
+        rate: float,
+        seed: int,
+        gap_indices: tuple[int, ...],
+    ) -> None:
+        self.inner_config = inner_config
+        self.mode = mode
+        self.rate = rate
+        self.seed = seed
+        self.gap_indices = gap_indices
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "FaultInjectL2AdapterConfig":
+        inner = d.get("inner")
+        if not isinstance(inner, dict):
+            raise ValueError("'inner' must be an adapter spec dict with a 'type' field")
+        inner_type = inner.get("type")
+        if not isinstance(inner_type, str):
+            raise ValueError("'inner' adapter spec must include a string 'type'")
+
+        # Build the inner adapter config via the registry (lazy-importing its
+        # module if needed), mirroring parse_args_to_l2_adapters_config.
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.config import (  # noqa: PLC0415
+            _L2_ADAPTER_CONFIG_REGISTRY,
+            _ensure_config_loaded,
+        )
+
+        _ensure_config_loaded(inner_type)
+        if inner_type not in _L2_ADAPTER_CONFIG_REGISTRY:
+            raise ValueError(f"unknown inner adapter type {inner_type!r}")
+        inner_cls = _L2_ADAPTER_CONFIG_REGISTRY[inner_type]
+        inner_config = inner_cls.from_dict(inner)
+        inner_config.eviction_config = cls._parse_eviction_config(inner)
+        inner_config.persist_config = cls._parse_persist_config(inner)
+        inner_config.serde_config = cls._parse_serde_config(inner)
+
+        mode = d.get("mode", "error")
+        if mode not in _VALID_MODES:
+            raise ValueError(f"mode must be one of {_VALID_MODES}, got {mode!r}")
+
+        rate = d.get("rate", 0.0)
+        if not isinstance(rate, (int, float)) or not (0.0 <= rate <= 1.0):
+            raise ValueError("rate must be a number in [0, 1]")
+
+        seed = d.get("seed", 0)
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise ValueError("seed must be an integer")
+
+        raw_gap = d.get("gap_indices", [])
+        if not isinstance(raw_gap, list) or any(
+            isinstance(i, bool) or not isinstance(i, int) or i < 0 for i in raw_gap
+        ):
+            raise ValueError("gap_indices must be a list of non-negative integers")
+
+        return cls(
+            inner_config=inner_config,
+            mode=mode,
+            rate=float(rate),
+            seed=seed,
+            gap_indices=tuple(raw_gap),
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        return (
+            "Fault-injecting L2 adapter (test only). Fields:\n"
+            "- inner (dict, required): wrapped adapter spec, e.g. "
+            '{"type":"fs_native","base_path":"/dev/shm/x"}\n'
+            "- mode (str): 'miss' | 'error' | 'both' (default 'error')\n"
+            "- rate (float): per-key drop probability in [0,1] (default 0.0)\n"
+            "- seed (int): deterministic hash seed (default 0)\n"
+            "- gap_indices (list[int]): exact task-positions to always drop"
+        )
+
+
+# -----------------------------------------------------------------------------
+# Adapter (decorator)
+# -----------------------------------------------------------------------------
+
+
+class FaultInjectL2Adapter(L2AdapterInterface):
+    """Decorator over an inner L2 adapter that drops a deterministic key subset.
+
+    All operations delegate to ``inner``; only the two read-result queries are
+    post-processed (bits cleared) according to ``mode``.
+    """
+
+    def __init__(
+        self,
+        inner: L2AdapterInterface,
+        mode: str,
+        rate: float,
+        seed: int,
+        gap_indices: tuple[int, ...],
+    ) -> None:
+        super().__init__(max_capacity_bytes=0)
+        self._inner = inner
+        self._mode = mode
+        self._rate = rate
+        self._seed = seed
+        self._gap_indices = frozenset(gap_indices)
+        # task_id -> keys, so query_*_result can map positions back to keys.
+        self._lookup_keys: dict[L2TaskId, list[ObjectKey]] = {}
+        self._load_keys: dict[L2TaskId, list[ObjectKey]] = {}
+        self._keys_lock = threading.Lock()
+        logger.warning(
+            "FaultInjectL2Adapter ACTIVE (mode=%s rate=%.3f seed=%d gap_indices=%s) "
+            "wrapping %s -- test/diagnostic use only.",
+            mode,
+            rate,
+            seed,
+            sorted(self._gap_indices),
+            type(inner).__name__,
+        )
+
+    # -- drop decision --------------------------------------------------------
+
+    def _should_drop_key(self, key: ObjectKey) -> bool:
+        if self._rate <= 0.0:
+            return False
+        h = hashlib.blake2b(f"{self._seed}:{key!r}".encode(), digest_size=8).digest()
+        bucket = int.from_bytes(h, "big") % _HASH_DENOM
+        return bucket < int(self._rate * _HASH_DENOM)
+
+    def _drop_positions(self, keys: list[ObjectKey]) -> list[int]:
+        dropped = []
+        for i, key in enumerate(keys):
+            if i in self._gap_indices or self._should_drop_key(key):
+                dropped.append(i)
+        return dropped
+
+    # -- event fds (delegate) -------------------------------------------------
+
+    def get_store_event_fd(self) -> int:
+        return self._inner.get_store_event_fd()
+
+    def get_lookup_and_lock_event_fd(self) -> int:
+        return self._inner.get_lookup_and_lock_event_fd()
+
+    def get_load_event_fd(self) -> int:
+        return self._inner.get_load_event_fd()
+
+    # -- store (delegate) -----------------------------------------------------
+
+    def submit_store_task(
+        self, keys: list[ObjectKey], objects: list[MemoryObj]
+    ) -> L2TaskId:
+        return self._inner.submit_store_task(keys, objects)
+
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
+        return self._inner.pop_completed_store_tasks()
+
+    # -- lookup and lock (intercept for 'miss') -------------------------------
+
+    def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
+        task_id = self._inner.submit_lookup_and_lock_task(keys)
+        with self._keys_lock:
+            self._lookup_keys[task_id] = keys
+        return task_id
+
+    def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Bitmap | None:
+        bitmap = self._inner.query_lookup_and_lock_result(task_id)
+        if bitmap is None:
+            return None
+        with self._keys_lock:
+            keys = self._lookup_keys.pop(task_id, None)
+        if self._mode in ("miss", "both") and keys is not None:
+            dropped = self._drop_positions(keys)
+            if dropped:
+                # Clear hidden bits and release the locks the inner adapter took
+                # for those keys during lookup-and-lock (else they leak).
+                hidden_keys = [keys[i] for i in dropped if bitmap.test(i)]
+                for i in dropped:
+                    bitmap.clear(i)
+                if hidden_keys:
+                    self._inner.submit_unlock(hidden_keys)
+                logger.debug(
+                    "FaultInject miss: task %s dropped %d/%d lookup keys",
+                    task_id,
+                    len(dropped),
+                    len(keys),
+                )
+        return bitmap
+
+    def submit_unlock(self, keys: list[ObjectKey]) -> None:
+        self._inner.submit_unlock(keys)
+
+    # -- load (intercept for 'error') -----------------------------------------
+
+    def submit_load_task(
+        self, keys: list[ObjectKey], objects: list[MemoryObj]
+    ) -> L2TaskId:
+        task_id = self._inner.submit_load_task(keys, objects)
+        with self._keys_lock:
+            self._load_keys[task_id] = keys
+        return task_id
+
+    def query_load_result(self, task_id: L2TaskId) -> Bitmap | None:
+        bitmap = self._inner.query_load_result(task_id)
+        if bitmap is None:
+            return None
+        with self._keys_lock:
+            keys = self._load_keys.pop(task_id, None)
+        if self._mode in ("error", "both") and keys is not None:
+            dropped = self._drop_positions(keys)
+            for i in dropped:
+                bitmap.clear(i)
+            if dropped:
+                logger.debug(
+                    "FaultInject error: task %s dropped %d/%d load keys",
+                    task_id,
+                    len(dropped),
+                    len(keys),
+                )
+        return bitmap
+
+    # -- listener / eviction / usage (delegate) -------------------------------
+
+    def register_listener(self, listener: L2AdapterListener) -> None:
+        self._inner.register_listener(listener)
+
+    def delete(self, keys: list[ObjectKey]) -> None:
+        self._inner.delete(keys)
+
+    def get_usage(self) -> AdapterUsage:
+        return self._inner.get_usage()
+
+    @property
+    def supports_global_eviction(self) -> bool:
+        return self._inner.supports_global_eviction
+
+    def report_status(self) -> dict:
+        status = self._inner.report_status()
+        status["fault_inject"] = {
+            "mode": self._mode,
+            "rate": self._rate,
+            "seed": self._seed,
+            "gap_indices": sorted(self._gap_indices),
+        }
+        return status
+
+    def close(self) -> None:
+        with self._keys_lock:
+            self._lookup_keys.clear()
+            self._load_keys.clear()
+        self._inner.close()
+
+
+# -----------------------------------------------------------------------------
+# Registration
+# -----------------------------------------------------------------------------
+
+register_l2_adapter_type("fault_inject", FaultInjectL2AdapterConfig)
+
+
+def _create_fault_inject_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: "Optional[L1MemoryDesc]" = None,
+) -> L2AdapterInterface:
+    """Build the inner adapter from the registry, then wrap it."""
+    # First Party
+    from lmcache.v1.distributed.l2_adapters.factory import (  # noqa: PLC0415
+        create_l2_adapter_from_registry,
+    )
+
+    assert isinstance(config, FaultInjectL2AdapterConfig)
+    inner = create_l2_adapter_from_registry(config.inner_config, l1_memory_desc)
+    return FaultInjectL2Adapter(
+        inner,
+        mode=config.mode,
+        rate=config.rate,
+        seed=config.seed,
+        gap_indices=config.gap_indices,
+    )
+
+
+register_l2_adapter_factory("fault_inject", _create_fault_inject_adapter)

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -511,6 +511,7 @@ class StorageManager:
                 remaining_keys,
                 layout_desc,
                 extra_count=extra_count,
+                policy=policy,
             )
             # The controller indexes its result bitmap over remaining_keys
             # (0-based); map those local indices back to original positions.

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from queue import Empty as QueueEmpty
 from queue import Queue
 from typing import Any
+import os
 import threading
 import time
 
@@ -653,7 +654,18 @@ class BlendV3Module:
                     metadata={"num_tokens": len(key.token_ids)},
                 )
             )
-            self._lookup_module.lookup(key, tp_size)  # submit prefix (non-blocking)
+            # CB_SEGMENTED_PREFIX: request the contiguous prefix with gap-tolerant
+            # retention so a mid-prefix L2 retrieve failure leaves the post-gap
+            # chunks L1-resident (picked up by the sparse leg as L1 hits, hole
+            # recomputed) instead of truncating the prefix at the gap.
+            prefix_policy = (
+                TrimPolicy.SEGMENTED_PREFIX
+                if os.environ.get("CB_SEGMENTED_PREFIX") == "1"
+                else TrimPolicy.PREFIX
+            )
+            self._lookup_module.lookup(
+                key, tp_size, policy=prefix_policy
+            )  # submit prefix (non-blocking)
             job = _CBUnifiedJob(
                 matches=self._match_fingerprints(key),
                 num_tokens=len(key.token_ids),

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -654,13 +654,13 @@ class BlendV3Module:
                     metadata={"num_tokens": len(key.token_ids)},
                 )
             )
-            # CB_SEGMENTED_PREFIX: request the contiguous prefix with gap-tolerant
+            # SEGMENTED_PREFIX: request the contiguous prefix with gap-tolerant
             # retention so a mid-prefix L2 retrieve failure leaves the post-gap
             # chunks L1-resident (picked up by the sparse leg as L1 hits, hole
             # recomputed) instead of truncating the prefix at the gap.
             prefix_policy = (
                 TrimPolicy.SEGMENTED_PREFIX
-                if os.environ.get("CB_SEGMENTED_PREFIX") == "1"
+                if os.environ.get("SEGMENTED_PREFIX") == "1"
                 else TrimPolicy.PREFIX
             )
             self._lookup_module.lookup(

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -11,6 +11,7 @@ import time
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import (
     PrefetchHandle,
+    TrimPolicy,
     ipc_key_to_object_keys,
 )
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -163,6 +164,7 @@ class LookupModule:
         self,
         key: IPCCacheEngineKey,
         tp_size: int,
+        policy: TrimPolicy = TrimPolicy.PREFIX,
     ) -> None:
         """Submit a prefix lookup.
 
@@ -173,6 +175,10 @@ class LookupModule:
         Args:
             key: Cache key with request_id embedded.
             tp_size: Tensor-parallel size for MLA multi-reader locking.
+            policy: Trim policy for the prefetch. ``PREFIX`` (default) truncates
+                at the first gap; ``SEGMENTED_PREFIX`` retains a gapped contiguous
+                request (e.g. a mid-prefix L2 retrieve failure) so the hole is
+                recomputed instead of discarding everything after it.
         """
         model_name, world_size = key.model_name, key.world_size
         self._ctx.event_bus.publish(
@@ -273,6 +279,7 @@ class LookupModule:
             layout_desc,
             extra_count=extra_count,
             external_request_id=key.request_id,
+            policy=policy,
         )
         self._register_prefetch_job(
             _PrefetchJob(

--- a/tests/v1/distributed/test_fault_inject_l2_adapter.py
+++ b/tests/v1/distributed/test_fault_inject_l2_adapter.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for FaultInjectL2Adapter.
+
+The adapter is a decorator that drops a deterministic key subset to simulate
+partial L2 retrieve failures. These tests wrap a real MockL2Adapter and assert
+the two read-result bitmaps have exactly the expected bits cleared (and that
+miss-mode releases the hidden locks), using only public interface methods.
+"""
+
+# Standard
+import select
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fault_inject_l2_adapter import (
+    FaultInjectL2Adapter,
+)
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd
+
+N_KEYS = 8
+
+
+def _object_key(chunk_id: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+def _memory_obj(size: int = 256, fill_value: float = 1.0) -> TensorMemoryObj:
+    raw = torch.empty(size, dtype=torch.float32)
+    raw.fill_(fill_value)
+    meta = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=size * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw, meta, parent_allocator=None)
+
+
+def _wait_fd(event_fd: int, timeout: float = 5.0) -> bool:
+    poll = select.poll()
+    poll.register(event_fd, select.POLLIN)
+    if poll.poll(timeout * 1000):
+        try:
+            consume_fd(event_fd)
+        except BlockingIOError:
+            pass
+        return True
+    return False
+
+
+def _make_adapter(mode: str, rate: float = 0.0, seed: int = 0, gap_indices=()):
+    inner = MockL2Adapter(MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0))
+    wrapper = FaultInjectL2Adapter(
+        inner, mode=mode, rate=rate, seed=seed, gap_indices=tuple(gap_indices)
+    )
+    return wrapper, inner
+
+
+def _store_all(adapter, keys):
+    fd = adapter.get_store_event_fd()
+    adapter.submit_store_task(keys, [_memory_obj() for _ in keys])
+    assert _wait_fd(fd)
+    adapter.pop_completed_store_tasks()
+
+
+def _lookup_bitmap(adapter, keys):
+    fd = adapter.get_lookup_and_lock_event_fd()
+    tid = adapter.submit_lookup_and_lock_task(keys)
+    assert _wait_fd(fd)
+    # query_*_result is non-idempotent (returns non-None once); poll briefly.
+    for _ in range(50):
+        bm = adapter.query_lookup_and_lock_result(tid)
+        if bm is not None:
+            return bm
+        time.sleep(0.01)
+    raise AssertionError("lookup result never ready")
+
+
+def _load_bitmap(adapter, keys):
+    fd = adapter.get_load_event_fd()
+    tid = adapter.submit_load_task(keys, [_memory_obj() for _ in keys])
+    assert _wait_fd(fd)
+    for _ in range(50):
+        bm = adapter.query_load_result(tid)
+        if bm is not None:
+            return bm
+        time.sleep(0.01)
+    raise AssertionError("load result never ready")
+
+
+# =============================================================================
+# Pass-through (rate=0): no faults.
+# =============================================================================
+
+
+def test_rate_zero_is_passthrough():
+    adapter, inner = _make_adapter("both", rate=0.0)
+    try:
+        keys = [_object_key(i) for i in range(N_KEYS)]
+        _store_all(adapter, keys)
+        lookup = _lookup_bitmap(adapter, keys)
+        load = _load_bitmap(adapter, keys)
+        assert lookup.popcount() == N_KEYS
+        assert load.popcount() == N_KEYS
+    finally:
+        adapter.close()
+
+
+# =============================================================================
+# gap_indices: exact, deterministic drops.
+# =============================================================================
+
+
+def test_miss_mode_clears_lookup_gap_only():
+    gap = {2, 5}
+    adapter, inner = _make_adapter("miss", gap_indices=gap)
+    try:
+        keys = [_object_key(i) for i in range(N_KEYS)]
+        _store_all(adapter, keys)
+        lookup = _lookup_bitmap(adapter, keys)
+        # Gapped positions are reported absent; the rest present.
+        for i in range(N_KEYS):
+            assert lookup.test(i) == (i not in gap)
+        # Hidden keys' locks were released, so the inner lock count drops.
+        for _ in range(50):
+            if inner.debug_get_locked_key_count() == N_KEYS - len(gap):
+                break
+            time.sleep(0.01)
+        assert inner.debug_get_locked_key_count() == N_KEYS - len(gap)
+    finally:
+        adapter.close()
+
+
+def test_miss_mode_does_not_touch_load():
+    # miss only post-processes lookup; load is left intact.
+    gap = {3}
+    adapter, inner = _make_adapter("miss", gap_indices=gap)
+    try:
+        keys = [_object_key(i) for i in range(N_KEYS)]
+        _store_all(adapter, keys)
+        _lookup_bitmap(adapter, keys)
+        load = _load_bitmap(adapter, keys)
+        assert load.popcount() == N_KEYS
+    finally:
+        adapter.close()
+
+
+def test_error_mode_clears_load_gap_only():
+    gap = {1, 4, 6}
+    adapter, inner = _make_adapter("error", gap_indices=gap)
+    try:
+        keys = [_object_key(i) for i in range(N_KEYS)]
+        _store_all(adapter, keys)
+        # error mode leaves lookup intact (lookup says present).
+        lookup = _lookup_bitmap(adapter, keys)
+        assert lookup.popcount() == N_KEYS
+        load = _load_bitmap(adapter, keys)
+        for i in range(N_KEYS):
+            assert load.test(i) == (i not in gap)
+    finally:
+        adapter.close()
+
+
+def test_both_mode_clears_lookup_and_load():
+    gap = {0, 7}
+    adapter, inner = _make_adapter("both", gap_indices=gap)
+    try:
+        keys = [_object_key(i) for i in range(N_KEYS)]
+        _store_all(adapter, keys)
+        lookup = _lookup_bitmap(adapter, keys)
+        load = _load_bitmap(adapter, keys)
+        for i in range(N_KEYS):
+            assert lookup.test(i) == (i not in gap)
+            assert load.test(i) == (i not in gap)
+    finally:
+        adapter.close()
+
+
+# =============================================================================
+# rate-based drops: deterministic across instances with the same seed.
+# =============================================================================
+
+
+def test_rate_drop_is_deterministic_across_instances():
+    keys = [_object_key(i) for i in range(64)]
+
+    def dropped_positions(seed):
+        adapter, inner = _make_adapter("error", rate=0.3, seed=seed)
+        try:
+            _store_all(adapter, keys)
+            _lookup_bitmap(adapter, keys)
+            load = _load_bitmap(adapter, keys)
+            return {i for i in range(len(keys)) if not load.test(i)}
+        finally:
+            adapter.close()
+
+    a = dropped_positions(seed=42)
+    b = dropped_positions(seed=42)
+    c = dropped_positions(seed=1234)
+    assert a, "rate=0.3 should drop at least one of 64 keys"
+    assert a == b, "same seed must drop the same keys"
+    # A different seed should (with overwhelming probability) differ.
+    assert a != c
+
+
+def test_rate_drop_within_tolerance():
+    keys = [_object_key(i) for i in range(200)]
+    adapter, inner = _make_adapter("error", rate=0.25, seed=7)
+    try:
+        _store_all(adapter, keys)
+        _lookup_bitmap(adapter, keys)
+        load = _load_bitmap(adapter, keys)
+        dropped = sum(1 for i in range(len(keys)) if not load.test(i))
+        # Deterministic hash bucketing -> roughly rate * N, allow a wide band.
+        assert 25 <= dropped <= 75
+    finally:
+        adapter.close()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
 
**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
