### PR TITLE
[Fix][MP] Roll back partial FS L2 store batches on failure

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -80,6 +80,33 @@ def _readinto_full(
     return total
 
 
+def _write_full(
+    fd: int,
+    buf: Union[bytearray, memoryview, bytes],
+) -> int:
+    """Loop os.write() until *buf* is fully written.
+
+    A single ``os.write()`` can legally write fewer bytes than requested.
+    Treat a zero-byte write before completion as an error so callers do not
+    publish a truncated cache object.
+
+    Returns:
+        Total number of bytes written.
+
+    Raises:
+        OSError: If the file descriptor stops accepting bytes before *buf*
+            is fully written.
+    """
+    mv = memoryview(buf) if not isinstance(buf, memoryview) else buf
+    total = 0
+    while total < len(mv):
+        n = os.write(fd, mv[total:])
+        if n == 0:
+            raise OSError("write returned 0 before buffer was complete")
+        total += n
+    return total
+
+
 async def _async_readinto_full(
     f,  # aiofiles async file handle
     buf: Union[bytearray, memoryview, bytes],
@@ -91,6 +118,21 @@ async def _async_readinto_full(
         n = await f.readinto(mv[total:])
         if n is None or n == 0:
             break
+        total += n
+    return total
+
+
+async def _async_write_full(
+    f,  # aiofiles async file handle
+    buf: Union[bytearray, memoryview, bytes],
+) -> int:
+    """Async version of :func:`_write_full`."""
+    mv = memoryview(buf) if not isinstance(buf, memoryview) else buf
+    total = 0
+    while total < len(mv):
+        n = await f.write(mv[total:])
+        if n is None or n == 0:
+            raise OSError("write returned no bytes before buffer was complete")
         total += n
     return total
 
@@ -557,7 +599,7 @@ class FSL2Adapter(L2AdapterInterface):
                 os.O_CREAT | os.O_WRONLY | getattr(os, "O_DIRECT", 0),
                 0o644,
             )
-            os.write(fd, buf)
+            _write_full(fd, buf)
         except Exception:
             logger.exception("Failed to O_DIRECT write %s", file_path)
             raise
@@ -578,6 +620,7 @@ class FSL2Adapter(L2AdapterInterface):
     ) -> None:
         success = True
         bytes_written = 0
+        created_files: list[Path] = []
         try:
             for key, obj in zip(keys, objects, strict=True):
                 file_path, tmp_path = self._key_to_file_and_tmp_path(key)
@@ -613,9 +656,10 @@ class FSL2Adapter(L2AdapterInterface):
                         )
                     else:
                         async with aiofiles.open(tmp_path, "wb") as f:
-                            await f.write(buf)
+                            await _async_write_full(f, buf)
 
                     await aiofiles.os.replace(tmp_path, file_path)
+                    created_files.append(file_path)
                     bytes_written += size
                     logger.debug(
                         "FSL2Adapter stored key %s (%d bytes)",
@@ -627,15 +671,31 @@ class FSL2Adapter(L2AdapterInterface):
                         "FSL2Adapter failed to store %s",
                         file_path,
                     )
-                    if await aiofiles.os.path.exists(tmp_path):
+                    try:
                         await aiofiles.os.unlink(tmp_path)
+                    except FileNotFoundError:
+                        pass
                     success = False
+                    break
         except Exception:
             logger.exception(
                 "FSL2Adapter store task %s failed",
                 task_id,
             )
             success = False
+
+        if not success:
+            for file_path in created_files:
+                try:
+                    await aiofiles.os.unlink(file_path)
+                except FileNotFoundError:
+                    pass
+                except Exception:
+                    logger.exception(
+                        "FSL2Adapter failed to roll back stored file %s",
+                        file_path,
+                    )
+            bytes_written = 0
 
         with self._lock:
             self._completed_store_tasks[task_id] = L2StoreResult(success, bytes_written)

--- a/tests/v1/distributed/test_fs_l2_adapter.py
+++ b/tests/v1/distributed/test_fs_l2_adapter.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Behavior tests for the filesystem L2 adapter."""
+
+# Standard
+from collections.abc import Awaitable, Callable, Generator
+from pathlib import Path
+from typing import Any, TypeAlias
+import select
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters import fs_l2_adapter as fsmod
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    FSL2Adapter,
+    FSL2AdapterConfig,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObj,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd
+
+WriteBuffer: TypeAlias = bytearray | memoryview[int] | bytes
+
+
+def create_object_key(chunk_id: int, model_name: str = "test/model") -> ObjectKey:
+    """Create a stable ObjectKey for FS adapter tests."""
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name=model_name,
+        kv_rank=0,
+    )
+
+
+def create_memory_obj(size: int = 16, fill_value: float = 1.0) -> TensorMemoryObj:
+    """Create a CPU TensorMemoryObj with deterministic contents."""
+    raw_data = torch.empty(size, dtype=torch.float32)
+    raw_data.fill_(fill_value)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=size * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
+    """Wait for and consume one adapter event notification."""
+    poll = select.poll()
+    poll.register(event_fd, select.POLLIN)
+    events = poll.poll(timeout * 1000)
+    if events:
+        try:
+            consume_fd(event_fd)
+        except BlockingIOError:
+            pass
+        return True
+    return False
+
+
+@pytest.fixture
+def adapter(tmp_path: Path) -> Generator[FSL2Adapter, None, None]:
+    """Create a filesystem adapter rooted in the pytest temp directory."""
+    config = FSL2AdapterConfig(base_path=str(tmp_path), use_odirect=False)
+    fs_adapter = FSL2Adapter(config)
+    yield fs_adapter
+    fs_adapter.close()
+
+
+def test_failed_store_rolls_back_new_files_but_keeps_existing(
+    adapter: FSL2Adapter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A partial store failure must not publish a partial batch."""
+    existing_key = create_object_key(0)
+    existing_objects: list[MemoryObj] = [create_memory_obj()]
+    store_tid = adapter.submit_store_task([existing_key], existing_objects)
+    assert wait_for_event_fd(adapter.get_store_event_fd())
+    assert adapter.pop_completed_store_tasks()[store_tid].is_successful()
+
+    original_write: Callable[[Any, WriteBuffer], Awaitable[int]] = (
+        fsmod._async_write_full
+    )
+    write_count = 0
+
+    async def fail_second_write(f: Any, buf: WriteBuffer) -> int:
+        nonlocal write_count
+        write_count += 1
+        if write_count == 2:
+            raise OSError("injected write failure")
+        return await original_write(f, buf)
+
+    monkeypatch.setattr(fsmod, "_async_write_full", fail_second_write)
+
+    keys = [existing_key, create_object_key(1), create_object_key(2)]
+    objects: list[MemoryObj] = [
+        create_memory_obj(fill_value=float(i)) for i in range(3)
+    ]
+    failed_tid = adapter.submit_store_task(keys, objects)
+    assert wait_for_event_fd(adapter.get_store_event_fd())
+
+    result = adapter.pop_completed_store_tasks()[failed_tid]
+    assert not result.is_successful()
+    assert result.bytes_transferred() == 0
+
+    lookup_tid = adapter.submit_lookup_and_lock_task(keys)
+    assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+    bitmap = adapter.query_lookup_and_lock_result(lookup_tid)
+    assert bitmap is not None
+    assert bitmap.test(0) is True
+    assert bitmap.test(1) is False
+    assert bitmap.test(2) is False


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes FS L2 store tasks atomic for newly-created files in a batch. If a store fails after publishing one or more new cache files, the adapter now rolls back those files, removes any remaining temp file, reports the task as failed, and returns `0` bytes transferred.

It also hardens the write paths so partial writes are retried until the full buffer is written, preventing truncated cache objects from being published.

**Special notes for your reviewers**:

- Existing cache files are preserved; rollback only removes files created by the failed store task.
- The regression test injects a write failure after one new object has been published, then verifies the pre-existing object remains while the partially-published batch object is removed.

Tests:
- `pytest -q tests/v1/distributed/test_fs_l2_adapter.py::test_failed_store_rolls_back_new_files_but_keeps_existing`

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
