### PR TITLE
[Core] Add bounded retry for store-side CPU memory admission

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -37,6 +37,9 @@ Basic cache settings that control the core functionality of LMCache.
    * - local_cpu_use_hugepages
      - LMCACHE_LOCAL_CPU_USE_HUGEPAGES
      - Whether to use Linux hugepages (2 MB) for CPU-pinned KV cache memory. Not compatible with P2P mode or shared memory (multiprocess). Requires pre-allocated hugepages (``sysctl vm.nr_hugepages``). Values: true/false. Default: false
+   * - store_admission_retry_ms
+     - LMCACHE_STORE_ADMISSION_RETRY_MS
+     - Maximum milliseconds to retry a store-side CPU memory allocation (re-attempting eviction between retries) before dropping the chunk. Dropped chunks never reach any storage backend, and lookups truncate at the first missing chunk. Default: 0 (drop immediately without retrying)
    * - local_disk
      - LMCACHE_LOCAL_DISK
      - Path (or comma-separated paths) to local disk cache directories. Format: ``"file:///path/to/cache"`` or ``"/path/a,/path/b"`` for multi-device I/O. See ``local_disk_path_sharding`` for how paths are assigned to GPUs.

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -70,6 +70,8 @@ class LMCacheStats:
     interval_local_cpu_evict_keys_count: int  # evict keys count
     interval_local_cpu_evict_failed_count: int  # evict failed count
 
+    interval_store_dropped_chunk_count: int  # store chunks dropped on allocation
+
     interval_forced_unpin_count: int  # forced unpin count due to timeout
 
     # Real time value measurements (will be reset after each log)
@@ -293,6 +295,8 @@ class LMCStatsMonitor:
         self.interval_local_cpu_evict_count = 0
         self.interval_local_cpu_evict_keys_count = 0
         self.interval_local_cpu_evict_failed_count = 0
+
+        self.interval_store_dropped_chunk_count = 0
 
         self.interval_forced_unpin_count = 0
 
@@ -572,6 +576,17 @@ class LMCStatsMonitor:
         self.interval_local_cpu_evict_failed_count += evict_failed_count
 
     @thread_safe
+    def update_store_dropped_chunk_count(self, dropped_count: int):
+        """
+        Record store-path chunks that were dropped because CPU memory
+        could not be allocated for them.
+
+        Args:
+            dropped_count: The number of chunks that were dropped.
+        """
+        self.interval_store_dropped_chunk_count += dropped_count
+
+    @thread_safe
     def update_forced_unpin_count(self, delta: int):
         self.interval_forced_unpin_count += delta
 
@@ -627,6 +642,8 @@ class LMCStatsMonitor:
         self.interval_local_cpu_evict_count = 0
         self.interval_local_cpu_evict_keys_count = 0
         self.interval_local_cpu_evict_failed_count = 0
+
+        self.interval_store_dropped_chunk_count = 0
 
         self.interval_forced_unpin_count = 0
 
@@ -792,6 +809,7 @@ class LMCStatsMonitor:
             interval_local_cpu_evict_count=self.interval_local_cpu_evict_count,
             interval_local_cpu_evict_keys_count=self.interval_local_cpu_evict_keys_count,
             interval_local_cpu_evict_failed_count=self.interval_local_cpu_evict_failed_count,
+            interval_store_dropped_chunk_count=self.interval_store_dropped_chunk_count,
             interval_forced_unpin_count=self.interval_forced_unpin_count,
             local_cache_usage_bytes=self.local_cache_usage_bytes,
             remote_cache_usage_bytes=self.remote_cache_usage_bytes,
@@ -1035,6 +1053,13 @@ class PrometheusLogger:
         self.counter_local_cpu_evict_failed_count = self._create_counter(
             name="lmcache:local_cpu_evict_failed_count",
             documentation="Total number of failed eviction in local cpu backend",
+            labelnames=labelnames,
+        )
+
+        self.counter_store_dropped_chunk_count = self._create_counter(
+            name="lmcache:store_dropped_chunk_count",
+            documentation="Total number of KV chunks dropped on the store path "
+            "because CPU memory allocation failed",
             labelnames=labelnames,
         )
 
@@ -1739,6 +1764,10 @@ class PrometheusLogger:
         self._log_counter(
             self.counter_local_cpu_evict_failed_count,
             stats.interval_local_cpu_evict_failed_count,
+        )
+        self._log_counter(
+            self.counter_store_dropped_chunk_count,
+            stats.interval_store_dropped_chunk_count,
         )
         self._log_counter(
             self.counter_forced_unpin_count,

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    TypeVar,
     Union,
 )
 
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 
 # Standard
 import asyncio
+import functools
 import gc
 import multiprocessing
 import time
@@ -70,6 +72,15 @@ logger = init_logger(__name__)
 ProcessedChunk = Tuple[CacheEngineKey, MemoryObj, int, int]
 # (list of processed chunks, total kv size)
 ProcessTokensInternalResult = Tuple[List[ProcessedChunk], int]
+
+# Result type of a store-side allocation (single or layerwise-batched)
+StoreAllocationT = TypeVar("StoreAllocationT", MemoryObj, List[MemoryObj])
+
+# Sleep between store-side allocation retries (see store_admission_retry_ms)
+STORE_ADMISSION_RETRY_INTERVAL_SEC = 0.002
+
+# Rate limit for the aggregated store-drop warning log
+STORE_DROP_WARNING_INTERVAL_SEC = 10.0
 
 
 class CacheEngineEndSignal:
@@ -218,6 +229,10 @@ class LMCacheEngine:
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
         # Initialize PinMonitor singleton with config
         PinMonitor.GetOrCreate(config, metadata)
+
+        # Aggregation state for the rate-limited store-drop warning
+        self._last_store_drop_warning_time: float = 0.0
+        self._store_drops_since_warning: int = 0
 
         self.post_inited = False
 
@@ -489,12 +504,17 @@ class LMCacheEngine:
                     fmt=self.fmt,
                 )
                 if memory_obj is None:
-                    logger.warning(
-                        "Local cpu memory under pressure so"
-                        " choosing to store only "
-                        f" {len(memory_objs)}"
-                        " total chunks of KV cache."
+                    memory_obj = self._retry_store_allocation(
+                        functools.partial(
+                            self.storage_manager.allocate,
+                            kv_shapes,
+                            kv_dtypes,
+                            busy_loop=False,
+                            fmt=self.fmt,
+                        )
                     )
+                if memory_obj is None:
+                    self._on_store_chunk_dropped(req_id, len(memory_objs))
                     break
 
                 starts.append(start)
@@ -675,10 +695,18 @@ class LMCacheEngine:
             )
 
             if memory_objs_multi_layer is None:
-                logger.warning(
-                    "Local cpu memory under pressure so"
-                    " choosing to not store the KV cache."
+                memory_objs_multi_layer = self._retry_store_allocation(
+                    functools.partial(
+                        self.storage_manager.batched_allocate,
+                        kv_shape_single_layer,
+                        kv_dtype,
+                        batch_size=self.num_layers,
+                        fmt=self.fmt,
+                        busy_loop=False,
+                    )
                 )
+            if memory_objs_multi_layer is None:
+                self._on_store_chunk_dropped(req_id, len(keys))
                 break
 
             starts.append(start)
@@ -1964,6 +1992,79 @@ class LMCacheEngine:
             token_count,
             compress_slot_mapping(slot_mapping_list),
         )
+
+    def _retry_store_allocation(
+        self,
+        allocate_fn: Callable[[], Optional[StoreAllocationT]],
+    ) -> Optional[StoreAllocationT]:
+        """
+        Retry a failed store-side allocation within the configured budget.
+
+        Re-attempts the allocation (which internally re-attempts eviction)
+        every STORE_ADMISSION_RETRY_INTERVAL_SEC seconds until it succeeds
+        or ``store_admission_retry_ms`` milliseconds have elapsed. Under
+        concurrent store pressure, allocations typically fail because the
+        eviction candidates are temporarily pinned by in-flight requests,
+        so a short bounded wait lets the chunk be admitted instead of
+        being dropped.
+
+        :param allocate_fn: Zero-argument callable that performs the
+            allocation and returns the allocation or None on failure.
+
+        :return: The successful allocation, or None if
+            ``store_admission_retry_ms`` is 0 (retries disabled) or the
+            retry budget was exhausted. The budget can be exceeded by at
+            most one retry interval.
+        """
+        retry_ms = self.config.store_admission_retry_ms
+        if retry_ms <= 0:
+            return None
+        deadline = time.monotonic() + retry_ms / 1000.0
+        while time.monotonic() < deadline:
+            time.sleep(STORE_ADMISSION_RETRY_INTERVAL_SEC)
+            allocation = allocate_fn()
+            if allocation is not None:
+                return allocation
+        return None
+
+    def _on_store_chunk_dropped(self, req_id: str, num_stored_chunks: int) -> None:
+        """
+        Account for a store chunk dropped because CPU memory could not be
+        allocated for it. The store path stops at the first failed chunk,
+        so the rest of the request is dropped along with it and none of
+        the dropped chunks reach any storage backend.
+
+        Updates the dropped-chunk statistics and emits a warning that is
+        rate-limited to once every STORE_DROP_WARNING_INTERVAL_SEC seconds
+        (drops in between are aggregated into the next warning) so that
+        sustained memory pressure cannot flood the logs.
+
+        :param str req_id: The request id of the store request.
+
+        :param int num_stored_chunks: The number of chunks of this request
+            that were stored before the drop.
+        """
+        self.stats_monitor.update_store_dropped_chunk_count(1)
+        self._store_drops_since_warning += 1
+        curr_time = time.monotonic()
+        if (
+            curr_time - self._last_store_drop_warning_time
+            < STORE_DROP_WARNING_INTERVAL_SEC
+        ):
+            return
+        logger.warning(
+            "[req_id=%s] Could not allocate CPU memory for a store chunk: "
+            "storing only %d chunks of this request and dropping the rest. "
+            "The dropped chunks will not reach any storage backend "
+            "(%d dropped store chunks since the last warning). Consider "
+            "increasing max_local_cpu_size or setting "
+            "store_admission_retry_ms > 0.",
+            req_id,
+            num_stored_chunks,
+            self._store_drops_since_warning,
+        )
+        self._last_store_drop_warning_time = curr_time
+        self._store_drops_since_warning = 0
 
 
 class LMCacheEngineBuilder:

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -560,6 +560,19 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
         "env_converter": _to_bool,
     },
     # Memory management configurations
+    "store_admission_retry_ms": {
+        "type": int,
+        "default": 0,
+        "env_converter": int,
+        "description": (
+            "Maximum milliseconds to retry a store-side CPU memory allocation "
+            "(re-attempting eviction between retries) before dropping the "
+            "chunk. Useful under concurrent store pressure when eviction "
+            "candidates are temporarily pinned by in-flight requests. "
+            "Default is 0, which drops the chunk immediately without "
+            "retrying (previous behavior)."
+        ),
+    },
     "pin_timeout_sec": {
         "type": int,
         "default": 300,

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1297,7 +1297,10 @@ class AddressManager:
             if block.size >= aligned_size:
                 break
         else:
-            logger.warning(
+            # NOTE: debug level because the caller decides how to handle
+            # allocation pressure (eviction, retry, or drop); a per-attempt
+            # warning floods the logs under sustained memory pressure.
+            logger.debug(
                 "Failed to allocate memory block of size %d "
                 "because no memory is available",
                 size,
@@ -1375,7 +1378,10 @@ class AddressManager:
 
         if remaining > 0:
             # Not enough memory; free list is untouched, no rollback needed
-            logger.warning(
+            # NOTE: debug level because the caller decides how to handle
+            # allocation pressure (eviction, retry, or drop); a per-attempt
+            # warning floods the logs under sustained memory pressure.
+            logger.debug(
                 "Failed to batched allocate %d memory blocks of size %d "
                 "because no enough memory is available (short by %d blocks)",
                 batch_size,

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -93,6 +93,17 @@ def test_on_lookup_finished(stats_monitor):
     assert len(stats_monitor.lookup_requests) == 0
 
 
+def test_update_store_dropped_chunk_count(stats_monitor):
+    stats_monitor.update_store_dropped_chunk_count(dropped_count=2)
+    stats_monitor.update_store_dropped_chunk_count(dropped_count=1)
+    stats = stats_monitor.get_stats_and_clear()
+    assert stats.interval_store_dropped_chunk_count == 3
+
+    # The interval counter resets after each log
+    stats = stats_monitor.get_stats_and_clear()
+    assert stats.interval_store_dropped_chunk_count == 0
+
+
 def test_remote_read_metrics(stats_monitor):
     stats_monitor.update_interval_remote_read_metrics(read_bytes=1024)
     stats_monitor.update_interval_remote_read_metrics(read_bytes=2048)

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -8,6 +8,7 @@ import random
 import shlex
 import subprocess
 import tempfile
+import threading
 import time
 
 # Third Party
@@ -15,6 +16,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache.observability import LMCStatsMonitor
 from lmcache.utils import (
     CacheEngineKey,
     mock_up_broadcast_fn,
@@ -23,6 +25,7 @@ from lmcache.utils import (
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventStatus, EventType
+from lmcache.v1.gpu_connector.mock_gpu_connector import MockGPUConnector
 
 # Local
 from .utils import (
@@ -1448,6 +1451,118 @@ def test_force_store_wait(autorelease_v1):
         for t in list_tokens:
             expected_count = (len(t) // chunk_size) * chunk_size
             assert engine.lookup(t) == expected_count
+
+
+def _create_admission_test_engine(autorelease_v1, store_admission_retry_ms: int):
+    """Create a CPU-only engine with a CPU pool that holds about 5 chunks."""
+    chunk_size = 256
+    kv_shape = (4, 2, chunk_size, 8, 128)
+
+    cfg = LMCacheEngineConfig.from_defaults(
+        chunk_size=chunk_size,
+        local_cpu=True,
+        # one chunk is 4 MiB (2 * 4 * 256 * 8 * 128 * 2 bytes),
+        # so a 0.02 GB pool holds 5 chunks
+        max_local_cpu_size=0.02,
+        store_admission_retry_ms=store_admission_retry_ms,
+    )
+    metadata = dumb_metadata(kv_shape)
+    connector = MockGPUConnector(kv_shape=kv_shape)
+
+    # NOTE: the instance id must be "test" so that the autorelease_v1
+    # fixture destroys the engine (and its stats logger) on teardown
+    engine = autorelease_v1(
+        LMCacheEngineBuilder.get_or_create(
+            "test",
+            cfg,
+            metadata,
+            connector,
+            mock_up_broadcast_fn,
+            mock_up_broadcast_object_fn,
+        )
+    )
+    return engine, metadata, chunk_size
+
+
+def _fill_cpu_pool(engine, metadata, chunk_size):
+    """Allocate chunks (without storing them) until the CPU pool is full."""
+    assert engine.storage_manager is not None
+    held = []
+    while True:
+        memory_obj = engine.storage_manager.allocate(
+            metadata.get_shapes(chunk_size),
+            metadata.get_dtypes(),
+            busy_loop=False,
+        )
+        if memory_obj is None:
+            break
+        held.append(memory_obj)
+    assert held, "Expected to be able to fill the CPU pool"
+    return held
+
+
+@pytest.mark.no_shared_allocator
+def test_store_drop_on_admission_failure(autorelease_v1):
+    """
+    With store_admission_retry_ms=0 (the default), a store that cannot
+    allocate CPU memory drops the chunks immediately: nothing is stored,
+    and the drop is counted in the stats monitor.
+    """
+    engine, metadata, chunk_size = _create_admission_test_engine(
+        autorelease_v1, store_admission_retry_ms=0
+    )
+    held = _fill_cpu_pool(engine, metadata, chunk_size)
+
+    monitor = LMCStatsMonitor.GetOrCreate()
+    drops_before = monitor.interval_store_dropped_chunk_count
+
+    tokens = generate_tokens(2 * chunk_size, "cpu")
+    engine.store(tokens)
+
+    assert engine.lookup(tokens) == 0
+    assert monitor.interval_store_dropped_chunk_count == drops_before + 1
+
+    for memory_obj in held:
+        memory_obj.ref_count_down()
+
+
+@pytest.mark.no_shared_allocator
+def test_store_admission_retry(autorelease_v1):
+    """
+    With store_admission_retry_ms > 0, a store that cannot allocate CPU
+    memory retries within the budget. When memory is freed mid-retry,
+    the store succeeds and no chunk is dropped.
+    """
+    engine, metadata, chunk_size = _create_admission_test_engine(
+        autorelease_v1, store_admission_retry_ms=10000
+    )
+    held = _fill_cpu_pool(engine, metadata, chunk_size)
+
+    monitor = LMCStatsMonitor.GetOrCreate()
+    drops_before = monitor.interval_store_dropped_chunk_count
+
+    def release_held():
+        for memory_obj in held:
+            memory_obj.ref_count_down()
+
+    releaser = threading.Timer(0.2, release_held)
+    releaser.start()
+    try:
+        num_tokens = 2 * chunk_size
+        tokens = generate_tokens(num_tokens, "cpu")
+        engine.store(tokens)
+    finally:
+        releaser.join()
+
+    assert monitor.interval_store_dropped_chunk_count == drops_before
+
+    # Wait for the (potentially asynchronous) put to land in the hot cache
+    timeout = 10
+    start_time = time.time()
+    while engine.lookup(tokens) < num_tokens:
+        if time.time() - start_time > timeout:
+            raise TimeoutError("Store did not complete after memory was freed")
+        time.sleep(0.05)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Adds a new config knob `store_admission_retry_ms` that gives a failed
store-side CPU pool allocation a bounded window to retry (re-attempting
eviction each pass) before the chunk is dropped, and a Prometheus counter
`lmcache:store_dropped_chunk_count` so drops are visible at all.

**Default `0` preserves today's behavior exactly** — a failed store-side
allocation drops immediately, no sleeping, no retry. The retry only applies
to the store path (`store()` / `store_layer()` in `cache_engine.py`); the
retrieve path and every other `busy_loop=False` allocation site (disk-load
staging, NIXL staging, EC engine) are untouched.

### What's happening today

Under concurrent store pressure, `LocalCPUBackend.allocate(eviction=True,
busy_loop=False)` fails transiently — the LRU eviction candidates are pinned
by in-flight requests — and `store()` breaks out of the chunk loop: the
failed chunk and every later chunk of that request are silently dropped and
never reach any storage backend. Because lookups truncate at the first
missing chunk (the vLLM KV-connector contract is contiguous-prefix-only),
sparse drops collapse the retrievability of entire long documents.

We hit this on a production-style benchmark (concurrency 28, ~36k-token
documents, Qwen3-30B, write-through to a storage plugin):

| CPU pool | admission failures | chunks stored | retrievals (3 reps) |
|---|---:|---:|---:|
| 128 GiB | 36,819 | ~54% | 289 |
| 256 GiB (no other change) | — | ~100% | 47,180 (98.9 GB served) |

The 128 GiB row is the storage tier being effectively write-only, and it's
nearly invisible: the only signal is per-attempt WARNING spam from the
allocator, and `lmcache:num_hit_tokens / num_requested_tokens` only count
attempted retrieves, so they read 100% the whole time data is being lost.

Right-sizing `max_local_cpu_size` is the first-order fix, but the right size
depends on workload concurrency and document length, and overshooting wastes
pinned host memory. A few tens of milliseconds of bounded retry lets an
in-flight request unpin an eviction candidate — versus losing the chunk and
later re-prefilling a whole 36k-token document because the lookup truncated
at the hole. The counter makes whatever still drops visible so operators can
size the pool from data.

Relationship to existing knobs: `extra_config.force_store_wait=True` already
busy-loops stores **unboundedly** (with a documented deadlock risk for
concurrent stores) — when set, allocation never returns `None` and this knob
is a no-op. `pd_allocation_timeout_sec` is the analogous bounded timeout but
PD-backend-only. This PR brings the same bounded idea to the default
local-CPU store path.

### Changes

- `lmcache/v1/config.py` — `store_admission_retry_ms: int = 0` in
  `_CONFIG_DEFINITIONS` (env: `LMCACHE_STORE_ADMISSION_RETRY_MS`), placed
  with the memory-management knobs.
- `lmcache/v1/cache_engine.py` — `_retry_store_allocation()` (bounded by a
  `time.monotonic()` deadline, 2 ms interval) wrapping the store-path
  allocations; `_on_store_chunk_dropped()` counts the drop and replaces the
  per-request warning with one aggregated warning rate-limited to once per
  10 s, pointing at `max_local_cpu_size` / `store_admission_retry_ms`.
- `lmcache/observability.py` — `update_store_dropped_chunk_count()` +
  `lmcache:store_dropped_chunk_count` Prometheus counter, same pattern as
  the neighboring `lmcache:local_cpu_evict_failed_count`.
- `lmcache/v1/memory_management.py` — per-attempt out-of-memory warnings in
  `AddressManager.allocate`/`batched_allocate` demoted to debug
  (`PagedTensorMemoryAllocator` already logs the identical condition at
  debug; the caller decides how to handle pressure).
- `docs/source/api_reference/configurations.rst` — knob documented.

### How to test this PR?

```bash
pytest tests/v1/test_cache_engine.py -k "admission" -v
pytest tests/test_observability.py -k "store_dropped" -v
```

- `test_store_drop_on_admission_failure` — real engine via
  `LMCacheEngineBuilder` with `MockGPUConnector` (CPU-only) and a ~5-chunk
  pool, pool held full, knob at default `0`: the store drops (lookup
  returns 0) and the counter increments.
- `test_store_admission_retry` — same setup with
  `store_admission_retry_ms=10000` and a timer freeing the pool 200 ms in:
  the store succeeds and the counter does not move.
- Both use `@pytest.mark.no_shared_allocator` so the small pool takes
  effect; no GPU required (same harness as
  `test_freeze_with_real_cache_engine`, targets the CPU CI lane).

Heads-up for reviewers: I could not run the pytest suite locally (no torch
in this environment) — `ruff check`, `ruff format --check`, `isort`,
`codespell`, and `py_compile` all pass on the touched files; the two engine
tests are written against the existing CPU-only harness and should run in
the CPU lane here.

### Checklist

- [x] Based on `dev`
- [x] DCO sign-off on the commit
- [x] Default-off: no behavior change unless the new knob is set
- [x] Type hints + docstrings on new/changed functions
- [x] New behavior covered by tests (drop path and recovery path, CPU-only)
- [x] Docs updated (`configurations.rst`)
- [x] `ruff` / `isort` / `codespell` clean on touched files
- [ ] Full `pre-commit run --all-files` + pytest (needs CI — no torch locally)
