### PR TITLE
[Perf][RawBlock] Batch io_uring put_many writes in bounded chunks

### DIFF
--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -43,6 +43,7 @@ _DEFAULT_META_VERSION = 1
 _META_HEADER_STRUCT = struct.Struct("<8sIQQI")
 RAW_BLOCK_IO_ENGINES = frozenset({"posix", "io_uring"})
 DEFAULT_IOURING_QUEUE_DEPTH = 256
+_MAX_PUT_MANY_IO_URING_BATCH_KEYS = 64
 _MAX_FDP_PLACEMENT_ID = 0xFFFF
 
 # FDP placement ID semantics are shared by design across raw-block write paths.
@@ -722,6 +723,12 @@ class RawBlockCore:
     ) -> RawBlockPutManyResult:
         """Persist a batch of memory objects into raw-block slots.
 
+        With ``io_engine='io_uring'`` and more than one key, writes are
+        submitted in batches and failure is no longer independent per key: a
+        device write failure rolls back every key submitted in the same batch.
+        Batches are bounded, so a request larger than one batch can leave
+        earlier batches committed while a later one rolls back.
+
         Args:
             keys: Ordered raw-block key specs corresponding to ``objs``.
             objs: Memory objects whose byte buffers should be written.
@@ -730,10 +737,10 @@ class RawBlockCore:
                 0 is rejected because default writes already use that mapping.
 
         Returns:
-            Per-key success results and newly stored encoded keys. If no free
-            raw-block slot is available, that key is reported as failed; slot
-            reclamation is owned by the adapter/controller calling
-            ``delete_many``.
+            Per-key success results and newly stored encoded keys. A key is
+            reported as failed when no free raw-block slot is available or when
+            its payload does not fit a slot. Slot reclamation is owned by the
+            adapter/controller calling ``delete_many``.
 
         Raises:
             ValueError: If either sequence is empty, sequence lengths do not
@@ -748,6 +755,9 @@ class RawBlockCore:
             len(keys),
             field_name="placement_ids",
         )
+
+        if self.io_engine == "io_uring" and len(keys) > 1:
+            return self._put_many_batch_io(keys, objs, per_key_placement_ids)
 
         results = [False] * len(keys)
         stored_keys: list[str] = []
@@ -1223,6 +1233,15 @@ class RawBlockCore:
         except Exception:
             return None
 
+    def _payload_fits_slot(self, payload_len: int) -> bool:
+        """Return whether a logical payload can fit in one raw-block slot."""
+        payload_capacity = self.slot_bytes - self.header_bytes
+        if payload_len > payload_capacity:
+            return False
+        if self._requires_transfer_alignment:
+            return round_up(payload_len, self.block_align) <= payload_capacity
+        return True
+
     def _prepare_write_payload(self, memory_obj: MemoryObj) -> tuple[Any, int, int]:
         """Prepare the payload buffer and lengths for a raw-block write.
 
@@ -1521,6 +1540,10 @@ class RawBlockCore:
             int(payload_len) == int(total_len)
             for payload_len, total_len in zip(payload_lens, total_lens, strict=True)
         )
+        # batched_write carries a single length per entry, so it cannot express
+        # O_DIRECT padding where payload_len < total_len. Fall back to
+        # write_uring, which takes both lengths and lets Rust build the aligned
+        # padded transfer.
         if can_batch:
             batch_id = raw_dev.batched_write(
                 [int(offset) for offset in offsets],
@@ -1716,6 +1739,253 @@ class RawBlockCore:
         except Exception as e:
             logger.error("RawBlockCore write failed for %s: %s", key.encoded, e)
             return False
+
+    def _put_many_batch_io(
+        self,
+        keys: Sequence[RawBlockKeySpec],
+        objs: Sequence[MemoryObj],
+        placement_ids: Sequence[PlacementId],
+    ) -> RawBlockPutManyResult:
+        """Persist objects using bounded io_uring batch submissions.
+
+        Large ``put_many`` calls are split into chunks so one caller cannot
+        monopolize the RawBlockCore lock while planning slots, and so the
+        transient memory a single batch holds stays bounded.
+
+        Each key contributes at least two write entries (header + payload).
+        The io_uring_cmd path splits those further by
+        ``max_data_transfer_size``, so one chunk can expand to many more
+        entries there. Alignment and padding are handled by the existing write
+        paths, which may allocate bounce buffers retained until I/O completes.
+
+        Args:
+            keys: Ordered raw-block key specs corresponding to ``objs``.
+            objs: Memory objects whose byte buffers should be written.
+            placement_ids: Normalized per-key FDP placement identifiers, one
+                entry per key. ``None`` entries omit the directive.
+
+        Returns:
+            Per-key success results aligned with ``keys`` and the list of
+            encoded keys that were newly committed to the index.
+
+        Raises:
+            ValueError: If ``keys``, ``objs``, and ``placement_ids`` do not all
+                have the same length.
+        """
+        if len(keys) <= _MAX_PUT_MANY_IO_URING_BATCH_KEYS:
+            return self._put_many_batch_io_chunk(keys, objs, placement_ids)
+
+        results = [False] * len(keys)
+        stored_keys: list[str] = []
+        first_occurrences: dict[str, int] = {}
+        unique_plan: list[tuple[int, RawBlockKeySpec, MemoryObj, PlacementId]] = []
+        duplicate_indices: list[tuple[int, int]] = []
+
+        # Deduplicate before chunking so duplicates that cross chunk boundaries
+        # still inherit the first occurrence result without being rewritten.
+        for i, (key, obj, placement_id) in enumerate(
+            zip(keys, objs, placement_ids, strict=True)
+        ):
+            first_index = first_occurrences.get(key.encoded)
+            if first_index is not None:
+                duplicate_indices.append((i, first_index))
+                continue
+            first_occurrences[key.encoded] = i
+            unique_plan.append((i, key, obj, placement_id))
+
+        chunk_size = _MAX_PUT_MANY_IO_URING_BATCH_KEYS
+        for start in range(0, len(unique_plan), chunk_size):
+            chunk = unique_plan[start : start + chunk_size]
+            chunk_result = self._put_many_batch_io_chunk(
+                [key for _, key, _, _ in chunk],
+                [obj for _, _, obj, _ in chunk],
+                [placement_id for _, _, _, placement_id in chunk],
+            )
+            for local_i, (global_i, _key, _obj, _placement_id) in enumerate(chunk):
+                results[global_i] = chunk_result.results[local_i]
+            stored_keys.extend(chunk_result.stored_keys)
+
+        for duplicate_i, first_i in duplicate_indices:
+            results[duplicate_i] = results[first_i]
+
+        return RawBlockPutManyResult(results=results, stored_keys=stored_keys)
+
+    def _put_many_batch_io_chunk(
+        self,
+        keys: Sequence[RawBlockKeySpec],
+        objs: Sequence[MemoryObj],
+        placement_ids: Sequence[PlacementId],
+    ) -> RawBlockPutManyResult:
+        """Persist one bounded chunk through a single ``_write_buffers`` call.
+
+        Eligible new keys are submitted through one ``_write_buffers`` call so
+        the io_uring path can batch those writes when their lengths allow it.
+
+        Failures before submission are reported per key: already indexed keys
+        report success without rewriting, duplicates of keys already reserved
+        in this chunk share that key's final result, and keys with no free
+        slot, payloads that cannot fit one slot, or buffer preparation errors
+        fail individually.
+        Once a combined device write is submitted, any write failure rolls back
+        every submitted new key and commits none of them.
+
+        Args:
+            keys: Ordered raw-block key specs corresponding to ``objs``. Must be
+                the same length as ``objs``.
+            objs: Memory objects whose byte buffers should be written. Must be
+                the same length as ``keys``.
+            placement_ids: Normalized per-key FDP placement identifiers. Must be
+                the same length as ``keys``. Each key's header and payload write
+                inherit that key's identifier; ``None`` omits the directive.
+
+        Returns:
+            Per-key success results aligned with ``keys`` and the list of
+            encoded keys that were newly committed to the index.
+
+        Raises:
+            ValueError: If ``keys``, ``objs``, and ``placement_ids`` do not all
+                have the same length.
+        """
+        results = [False] * len(keys)
+        stored_keys: list[str] = []
+        write_plan: list[tuple[int, RawBlockKeySpec, MemoryObj, int, PlacementId]] = []
+        planned_keys: set[str] = set()
+        batch_duplicates: list[tuple[int, str]] = []
+
+        # Reserve slots for eligible first-occurrence keys under the lock.
+        with self._lock:
+            for i, (key, obj, placement_id) in enumerate(
+                zip(keys, objs, placement_ids, strict=True)
+            ):
+                if self._closed:
+                    break
+                encoded_key = key.encoded
+                if encoded_key in self._index:
+                    results[i] = True
+                    continue
+                if encoded_key in planned_keys:
+                    batch_duplicates.append((i, encoded_key))
+                    continue
+                if encoded_key in self._inflight:
+                    continue
+                payload_len = len(obj.byte_array)
+                if not self._payload_fits_slot(payload_len):
+                    logger.warning(
+                        "RawBlockCore: payload for key %s does not fit slot",
+                        encoded_key,
+                    )
+                    continue
+                try:
+                    offset = self._allocate_slot_locked(placement_id)
+                except RuntimeError:
+                    logger.warning(
+                        "RawBlockCore: no free slot available for key %s",
+                        key.encoded,
+                    )
+                    continue
+                meta = DiskCacheMetadata(
+                    path=f"{self.device_path}@{offset}",
+                    size=payload_len,
+                    shape=obj.metadata.shape,
+                    dtype=obj.metadata.dtype,
+                    cached_positions=obj.metadata.cached_positions,
+                    fmt=obj.metadata.fmt,
+                    pin_count=0,
+                )
+                self._inflight[encoded_key] = _Inflight(offset=offset, meta=meta)
+                planned_keys.add(encoded_key)
+                write_plan.append((i, key, obj, offset, placement_id))
+
+        if not write_plan:
+            return RawBlockPutManyResult(results=results, stored_keys=stored_keys)
+
+        # Build header/payload write entries outside the lock. Preparation
+        # failures happen before device submission and are isolated per key.
+        offsets: list[int] = []
+        buffers: list[Any] = []
+        payload_lens: list[int] = []
+        total_lens: list[int] = []
+        write_placement_ids: list[PlacementId] = []
+        prepared_plan: list[tuple[int, RawBlockKeySpec, MemoryObj, int]] = []
+        write_succeeded = True
+        for i, key, obj, offset, placement_id in write_plan:
+            try:
+                header = self._encode_header(key.slot_identity, len(obj.byte_array))
+                hdr_total = (
+                    round_up(len(header), self.block_align)
+                    if self._requires_transfer_alignment
+                    else len(header)
+                )
+                buf, payload_len, total_len = self._prepare_write_payload(obj)
+            except Exception as e:
+                logger.error(
+                    "RawBlockCore batch buffer preparation failed for %s: %s",
+                    key.encoded,
+                    e,
+                )
+                with self._lock:
+                    inflight = self._inflight.pop(key.encoded, None)
+                    if inflight is not None:
+                        self._append_free_slot_locked(
+                            self._offset_to_slot(int(inflight.offset))
+                        )
+                        self._meta_dirty_total += 1
+                continue
+
+            # Queue the key only once every fallible step has succeeded, so a
+            # failed key never leaves a header behind for a slot that the
+            # rollback above just returned to the free list.
+            offsets.extend((offset, offset + self.header_bytes))
+            buffers.extend((header, buf))
+            payload_lens.extend((hdr_total, payload_len))
+            total_lens.extend((hdr_total, total_len))
+            write_placement_ids.extend((placement_id, placement_id))
+            prepared_plan.append((i, key, obj, offset))
+
+        if prepared_plan:
+            with self._lock:
+                self._inflight_io_count += len(prepared_plan)
+            try:
+                self._write_buffers(
+                    offsets,
+                    buffers,
+                    payload_lens,
+                    total_lens,
+                    write_placement_ids,
+                )
+            except Exception as e:
+                write_succeeded = False
+                logger.error("RawBlockCore batched write failed: %s", e)
+            finally:
+                with self._lock:
+                    self._inflight_io_count -= len(prepared_plan)
+                    self._last_io_ts = time.monotonic()
+
+        # Commit successful writes, or roll back submitted keys if the device
+        # write failed.
+        with self._lock:
+            for i, key, _obj, _offset in prepared_plan:
+                inflight = self._inflight.pop(key.encoded, None)
+                if inflight is None:
+                    continue
+                if not write_succeeded or inflight.canceled:
+                    self._append_free_slot_locked(
+                        self._offset_to_slot(int(inflight.offset))
+                    )
+                    self._meta_dirty_total += 1
+                    continue
+                self._index[key.encoded] = _Entry(
+                    offset=inflight.offset,
+                    size=inflight.meta.size,
+                    meta=inflight.meta,
+                )
+                self._meta_dirty_total += 1
+                results[i] = True
+                stored_keys.append(key.encoded)
+            for i, encoded_key in batch_duplicates:
+                results[i] = encoded_key in self._index
+
+        return RawBlockPutManyResult(results=results, stored_keys=stored_keys)
 
     def _encode_header(self, slot_identity: int, payload_len: int) -> bytes:
         """Encode a fixed-size raw-block slot header."""

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -4,9 +4,14 @@
 from __future__ import annotations
 
 # Standard
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 import ctypes
 import dataclasses
+import importlib.util
 import stat
 import sys
 import types
@@ -15,6 +20,7 @@ import types
 import pytest
 
 # First Party
+from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.raw_block import (
     RawBlockCore,
     RawBlockCoreConfig,
@@ -36,7 +42,12 @@ from tests.v1.storage_backend.raw_block_test_utils import (
 )
 import lmcache.v1.storage_backend.raw_block.core as raw_block_core
 
-pytest.importorskip("lmcache_rust_raw_block_io")
+Buffer = bytes | bytearray | memoryview
+
+requires_rust_raw_block_io = pytest.mark.skipif(
+    importlib.util.find_spec("lmcache_rust_raw_block_io") is None,
+    reason="lmcache_rust_raw_block_io is not installed",
+)
 
 
 def test_normalize_raw_block_placement_ids_rejects_out_of_range() -> None:
@@ -46,7 +57,7 @@ def test_normalize_raw_block_placement_ids_rejects_out_of_range() -> None:
         normalize_raw_block_placement_ids([65536], 1)
 
 
-class _RecordingRawDevice:
+class _RecordingUringCmdRawDevice:
     def __init__(self) -> None:
         self.offsets: list[int] = []
         self.buffers: list[memoryview] = []
@@ -111,7 +122,7 @@ def test_raw_block_core_uring_cmd_write_padding_uses_aligned_chunks(monkeypatch)
     core = RawBlockCore.__new__(RawBlockCore)
     core.block_align = 4096
     core.max_data_transfer_size = 4096
-    raw_dev = _RecordingRawDevice()
+    raw_dev = _RecordingUringCmdRawDevice()
     monkeypatch.setattr(core, "_rawdev", lambda: raw_dev)
 
     payload = bytes([3]) * 5000
@@ -134,7 +145,7 @@ def test_raw_block_core_uring_cmd_read_copyback_uses_aligned_chunks(monkeypatch)
     core = RawBlockCore.__new__(RawBlockCore)
     core.block_align = 4096
     core.max_data_transfer_size = 4096
-    raw_dev = _RecordingRawDevice()
+    raw_dev = _RecordingUringCmdRawDevice()
     monkeypatch.setattr(core, "_rawdev", lambda: raw_dev)
 
     payload = bytes([5]) * 5000
@@ -154,6 +165,7 @@ def test_raw_block_core_uring_cmd_read_copyback_uses_aligned_chunks(monkeypatch)
     )
 
 
+@requires_rust_raw_block_io
 def test_raw_block_core_store_load_and_exists(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -188,6 +200,7 @@ def test_raw_block_core_store_load_and_exists(tmp_path):
         core.close()
 
 
+@requires_rust_raw_block_io
 def test_raw_block_core_duplicate_put_keeps_original_payload(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -213,6 +226,7 @@ def test_raw_block_core_duplicate_put_keeps_original_payload(tmp_path):
         core.close()
 
 
+@requires_rust_raw_block_io
 def test_raw_block_core_delete_and_missing_load(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -235,6 +249,7 @@ def test_raw_block_core_delete_and_missing_load(tmp_path):
         core.close()
 
 
+@requires_rust_raw_block_io
 @pytest.mark.parametrize(
     ("field_name", "mismatched_value"),
     [
@@ -274,6 +289,574 @@ def test_raw_block_core_rejects_checkpoint_layout_mismatch(
         core.close()
 
 
+@dataclass
+class _BatchedWriteCall:
+    """Recorded arguments of one fake ``batched_write`` invocation."""
+
+    offsets: list[int]
+    buffer_byte_lens: list[int]
+    total_lens: list[int]
+    placement_ids: list[int | None]
+
+
+@dataclass
+class _RecordingRawDevice:
+    """In-memory raw device that records io_uring batched submissions.
+
+    The fake mirrors the subset of the Rust raw-device interface that
+    ``RawBlockCore`` uses for both the io_uring and posix write/read paths.
+    Stored bytes are keyed by device offset so round-trip reads return what
+    was written.
+    """
+
+    size: int
+    store: dict[int, bytes] = field(default_factory=dict)
+    batched_write_calls: list[_BatchedWriteCall] = field(default_factory=list)
+    wait_iouring_count: int = 0
+    pwrite_count: int = 0
+    write_uring_count: int = 0
+    fail_batched_write: bool = False
+    fail_after_write_entries: int | None = None
+    fail_completion_entries: set[int] = field(default_factory=set)
+    batch_results: dict[int, list[bool]] = field(default_factory=dict)
+    next_batch_id: int = 0
+
+    def size_bytes(self) -> int:
+        return self.size
+
+    def _submit_batch(self, count: int) -> int:
+        """Register an accepted batch and its per-entry completion results.
+
+        Entry indices listed in ``fail_completion_entries`` complete with a
+        failure, which models the device accepting the submission and only
+        then reporting an error for individual I/Os.
+        """
+        self.next_batch_id += 1
+        self.batch_results[self.next_batch_id] = [
+            index not in self.fail_completion_entries for index in range(count)
+        ]
+        return self.next_batch_id
+
+    def batched_write(
+        self,
+        offsets: Sequence[int],
+        buffers: Sequence[Buffer],
+        total_lens: Sequence[int],
+        placement_ids: Sequence[int | None] | None = None,
+    ) -> int:
+        self.batched_write_calls.append(
+            _BatchedWriteCall(
+                offsets=[int(off) for off in offsets],
+                buffer_byte_lens=[len(bytes(buf)) for buf in buffers],
+                total_lens=[int(total) for total in total_lens],
+                placement_ids=list(placement_ids or [None] * len(offsets)),
+            )
+        )
+        if self.fail_batched_write:
+            raise RuntimeError("injected batched_write failure")
+        for i, (off, buf, total) in enumerate(
+            zip(offsets, buffers, total_lens, strict=True)
+        ):
+            if (
+                self.fail_after_write_entries is not None
+                and i >= self.fail_after_write_entries
+            ):
+                raise RuntimeError("injected partial batched_write failure")
+            self.store[int(off)] = bytes(buf)[: int(total)]
+        return self._submit_batch(len(offsets))
+
+    def wait_iouring(self, batch_id: int) -> tuple[list[bool], list[tuple[int, str]]]:
+        self.wait_iouring_count += 1
+        results = self.batch_results.pop(batch_id)
+        errors = [
+            (index, "injected completion failure")
+            for index, succeeded in enumerate(results)
+            if not succeeded
+        ]
+        return results, errors
+
+    def batched_read(
+        self,
+        offsets: Sequence[int],
+        buffers: Sequence[Buffer],
+        total_lens: Sequence[int],
+    ) -> int:
+        for off, buf, total in zip(offsets, buffers, total_lens, strict=True):
+            self._copy_into(int(off), buf, int(total))
+        return self._submit_batch(len(offsets))
+
+    def pwrite_from_buffer(
+        self, offset: int, buf: Buffer, payload_len: int, total_len: int
+    ) -> None:
+        self.pwrite_count += 1
+        self.store[int(offset)] = bytes(buf)[: int(total_len)]
+
+    def write_uring(
+        self,
+        offset: int,
+        buf: Buffer,
+        payload_len: int,
+        total_len: int,
+        placement_id: int | None = None,
+    ) -> None:
+        self.write_uring_count += 1
+        self.store[int(offset)] = bytes(buf)[: int(total_len)]
+
+    def pread_into(
+        self, offset: int, buf: Buffer, payload_len: int, total_len: int
+    ) -> None:
+        self._copy_into(int(offset), buf, int(total_len))
+
+    def close(self) -> None:
+        pass
+
+    def _copy_into(self, offset: int, buf: Buffer, total_len: int) -> None:
+        data = self.store.get(offset, b"")
+        view = memoryview(buf).cast("B")
+        n = min(len(data), total_len, len(view))
+        if n:
+            view[:n] = data[:n]
+
+
+def _make_core_with_fake(
+    path: Path,
+    fake: _RecordingRawDevice,
+    io_engine: str,
+    capacity_bytes: int | None = None,
+) -> RawBlockCore:
+    """Build a RawBlockCore wired to a fake raw device for a given engine.
+
+    When ``capacity_bytes`` is given it overrides the config capacity so a
+    test can constrain the number of allocatable slots.
+    """
+    config = replace(
+        make_raw_block_core_config(path),
+        io_engine=io_engine,
+        load_checkpoint_on_init=False,
+    )
+    if capacity_bytes is not None:
+        config = replace(config, capacity_bytes=capacity_bytes)
+    with patch.object(RawBlockCore, "_rawdev", return_value=fake):
+        core = RawBlockCore(config, key_namespace="object")
+    core.set_raw_device_for_testing(fake)
+    return core
+
+
+def _available_slots(status: Mapping[str, int]) -> int:
+    """Return slots still allocatable from the free list plus the high-water tail."""
+    return status["free_slot_count"] + (status["max_slots"] - status["next_slot"])
+
+
+def test_raw_block_core_io_uring_put_many_single_submit(tmp_path: Path) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(10)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(10)]
+
+        put_result = core.put_many(specs, objects)
+
+        assert put_result.results == [True] * 10
+        assert put_result.stored_keys == [spec.encoded for spec in specs]
+
+        assert len(fake.batched_write_calls) == 1
+        call = fake.batched_write_calls[0]
+        assert len(call.offsets) == 20
+        assert len(call.buffer_byte_lens) == 20
+        assert len(call.total_lens) == 20
+        assert fake.wait_iouring_count == 1
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_chunks_large_batches(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(70)]
+        keys = specs[:65] + [specs[0]] + specs[65:]
+        payloads = [bytes([i + 1]) * 1024 for i in range(len(keys))]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        put_result = core.put_many(keys, objects)
+
+        assert put_result.results == [True] * len(keys)
+        assert put_result.stored_keys == [spec.encoded for spec in specs]
+        assert [len(call.offsets) for call in fake.batched_write_calls] == [128, 12]
+        assert fake.wait_iouring_count == 2
+
+        loaded = make_empty_memory_obj(len(payloads[0]))
+        assert core.load_many_into([specs[0].encoded], [loaded]) == [True]
+        assert memory_obj_bytes(loaded) == payloads[0]
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_header_buffer_length_guard(tmp_path: Path) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(4)]
+        objects = [make_memory_obj(bytes([i + 1]) * 2048) for i in range(4)]
+
+        core.put_many(specs, objects)
+
+        call = fake.batched_write_calls[0]
+        for buf_len, total_len in zip(
+            call.buffer_byte_lens, call.total_lens, strict=True
+        ):
+            assert buf_len >= total_len
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_round_trip(tmp_path: Path) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(10)]
+        payloads = [bytes([i + 1]) * (1024 + i * 16) for i in range(10)]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        assert core.put_many(specs, objects).results == [True] * 10
+
+        loaded = [make_empty_memory_obj(len(payload)) for payload in payloads]
+        load_result = core.load_many_into([spec.encoded for spec in specs], loaded)
+
+        assert load_result == [True] * 10
+        assert [memory_obj_bytes(obj) for obj in loaded] == payloads
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_skips_already_indexed(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        first_specs = [encode_object_key(make_object_key(i)) for i in range(5)]
+        first_objs = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(5)]
+        assert core.put_many(first_specs, first_objs).results == [True] * 5
+
+        new_specs = [encode_object_key(make_object_key(i)) for i in range(5, 10)]
+        new_objs = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(5, 10)]
+        combined_specs = first_specs + new_specs
+        combined_objs = first_objs + new_objs
+
+        result = core.put_many(combined_specs, combined_objs)
+
+        assert result.results == [True] * 10
+        assert result.stored_keys == [spec.encoded for spec in new_specs]
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_all_or_nothing_rollback(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        before = _available_slots(core.report_status())
+
+        specs = [encode_object_key(make_object_key(i)) for i in range(5)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(5)]
+
+        fake.fail_batched_write = True
+        result = core.put_many(specs, objects)
+
+        assert result.results == [False] * 5
+        assert result.stored_keys == []
+
+        status = core.report_status()
+        assert status["inflight_key_count"] == 0
+        assert status["indexed_key_count"] == 0
+        assert _available_slots(status) == before
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_partial_slot_exhaustion(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    # Capacity leaves room for exactly 3 data slots after the metadata region,
+    # so the last keys of a 5-key batch find no free slot.
+    capacity = RAW_BLOCK_CI_META_TOTAL_BYTES + 3 * RAW_BLOCK_CI_SLOT_BYTES
+    core = _make_core_with_fake(
+        path, fake, io_engine="io_uring", capacity_bytes=capacity
+    )
+
+    try:
+        assert core.report_status()["max_slots"] == 3
+
+        specs = [encode_object_key(make_object_key(i)) for i in range(5)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(5)]
+
+        result = core.put_many(specs, objects)
+
+        # First three keys allocate a slot and commit; the slot-starved tail
+        # fails individually while the batch for the rest still succeeds.
+        assert result.results == [True, True, True, False, False]
+        assert result.stored_keys == [spec.encoded for spec in specs[:3]]
+
+        # Only the committed keys were written: one batched_write of 2*3 entries.
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.batched_write_calls[0].offsets) == 6
+
+        status = core.report_status()
+        assert status["indexed_key_count"] == 3
+        assert status["inflight_key_count"] == 0
+        assert _available_slots(status) == 0
+
+        loaded = [make_empty_memory_obj(1024) for _ in range(3)]
+        load_result = core.load_many_into([spec.encoded for spec in specs[:3]], loaded)
+        assert load_result == [True] * 3
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_duplicate_keys_in_batch(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        spec = encode_object_key(make_object_key(51))
+        original = b"original-batch-payload"
+        duplicate = b"duplicate-must-not-overwrite"
+
+        result = core.put_many(
+            [spec, spec],
+            [make_memory_obj(original), make_memory_obj(duplicate)],
+        )
+
+        assert result.results == [True, True]
+        assert result.stored_keys == [spec.encoded]
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.batched_write_calls[0].offsets) == 2
+
+        loaded = make_empty_memory_obj(len(original))
+        assert core.load_many_into([spec.encoded], [loaded]) == [True]
+        assert memory_obj_bytes(loaded) == original
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_oversize_key_isolated(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        before = _available_slots(core.report_status())
+        specs = [encode_object_key(make_object_key(i)) for i in range(60, 65)]
+        payloads = [
+            b"a" * 1024,
+            b"b" * 2048,
+            b"c" * RAW_BLOCK_CI_SLOT_BYTES,
+            b"d" * 3072,
+            b"e" * 4096,
+        ]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        result = core.put_many(specs, objects)
+
+        assert result.results == [True, True, False, True, True]
+        expected_stored = [spec.encoded for i, spec in enumerate(specs) if i != 2]
+        assert result.stored_keys == expected_stored
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.batched_write_calls[0].offsets) == 8
+
+        status = core.report_status()
+        assert status["inflight_key_count"] == 0
+        assert status["indexed_key_count"] == 4
+        assert _available_slots(status) == before - 4
+
+        loaded_payloads = [payload for i, payload in enumerate(payloads) if i != 2]
+        loaded = [make_empty_memory_obj(len(payload)) for payload in loaded_payloads]
+        assert core.load_many_into(expected_stored, loaded) == [True] * 4
+        assert [memory_obj_bytes(obj) for obj in loaded] == loaded_payloads
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_prep_failure_leaves_no_orphan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A buffer-preparation failure must queue nothing for the failed key.
+
+    The failed key's slot is returned to the free list, so leaving its header
+    in the shared submission would write into a slot the allocator considers
+    free.
+    """
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    real_prepare = RawBlockCore._prepare_write_payload
+    prepare_calls: list[int] = []
+
+    def failing_prepare(
+        self: RawBlockCore, memory_obj: MemoryObj
+    ) -> tuple[object, int, int]:
+        prepare_calls.append(len(memory_obj.byte_array))
+        if len(prepare_calls) == 2:
+            raise RuntimeError("injected preparation failure")
+        return real_prepare(self, memory_obj)
+
+    monkeypatch.setattr(RawBlockCore, "_prepare_write_payload", failing_prepare)
+
+    try:
+        before = _available_slots(core.report_status())
+        specs = [encode_object_key(make_object_key(i)) for i in range(80, 83)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(3)]
+
+        result = core.put_many(specs, objects)
+
+        assert result.results == [True, False, True]
+        assert result.stored_keys == [specs[0].encoded, specs[2].encoded]
+
+        # Only the two surviving keys may reach the device, each contributing a
+        # header and a payload entry.
+        assert len(fake.batched_write_calls) == 1
+        submitted = fake.batched_write_calls[0].offsets
+        assert len(submitted) == 4
+
+        # Nothing may be written into the failed key's reclaimed slot.
+        failed_slot_offset = RAW_BLOCK_CI_META_TOTAL_BYTES + RAW_BLOCK_CI_SLOT_BYTES
+        failed_slot_end = failed_slot_offset + RAW_BLOCK_CI_SLOT_BYTES
+        assert not [
+            offset
+            for offset in submitted
+            if failed_slot_offset <= offset < failed_slot_end
+        ]
+
+        status = core.report_status()
+        assert status["inflight_key_count"] == 0
+        assert status["indexed_key_count"] == 2
+        assert _available_slots(status) == before - 2
+
+        # The reclaimed slot stays usable for a later key.
+        reuse_spec = encode_object_key(make_object_key(90))
+        assert core.put_many([reuse_spec], [make_memory_obj(b"z" * 1024)]).results == [
+            True
+        ]
+        assert fake.batched_write_calls[1].offsets[0] == failed_slot_offset
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_partial_submission_rolls_back(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024, fail_after_write_entries=3)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        before = _available_slots(core.report_status())
+        specs = [encode_object_key(make_object_key(i)) for i in range(70, 74)]
+        objects = [make_memory_obj(bytes([i]) * 1024) for i in range(4)]
+
+        result = core.put_many(specs, objects)
+
+        assert result.results == [False] * 4
+        assert result.stored_keys == []
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.store) == 3
+
+        status = core.report_status()
+        assert status["inflight_key_count"] == 0
+        assert status["indexed_key_count"] == 0
+        assert _available_slots(status) == before
+        assert core.exists_many([spec.encoded for spec in specs]) == [False] * 4
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_completion_failure_rolls_back(
+    tmp_path: Path,
+) -> None:
+    # Unlike the sibling test above, the submission is accepted and every entry
+    # reaches the device; only the completion bitmap reports a failed I/O. The
+    # batch still has to roll back as a unit.
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(
+        size=128 * 1024 * 1024,
+        fail_completion_entries={5},
+    )
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        before = _available_slots(core.report_status())
+        specs = [encode_object_key(make_object_key(i)) for i in range(74, 78)]
+        objects = [make_memory_obj(bytes([i]) * 1024) for i in range(4)]
+
+        result = core.put_many(specs, objects)
+
+        assert result.results == [False] * 4
+        assert result.stored_keys == []
+        # One submission, awaited once, with every header/payload entry written.
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.batched_write_calls[0].offsets) == 8
+        assert fake.wait_iouring_count == 1
+        assert len(fake.store) == 8
+
+        status = core.report_status()
+        assert status["inflight_key_count"] == 0
+        assert status["indexed_key_count"] == 0
+        assert _available_slots(status) == before
+        assert core.exists_many([spec.encoded for spec in specs]) == [False] * 4
+    finally:
+        core.close()
+
+
+def test_raw_block_core_posix_put_many_uses_sequential_pwrite(tmp_path: Path) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="posix")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(3)]
+        payloads = [bytes([i + 1]) * 1024 for i in range(3)]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        put_result = core.put_many(specs, objects)
+
+        assert put_result.results == [True] * 3
+        assert fake.batched_write_calls == []
+        assert fake.pwrite_count == 6
+
+        loaded = [make_empty_memory_obj(len(payload)) for payload in payloads]
+        load_result = core.load_many_into([spec.encoded for spec in specs], loaded)
+        assert load_result == [True] * 3
+        assert [memory_obj_bytes(obj) for obj in loaded] == payloads
+    finally:
+        core.close()
+
+
+@requires_rust_raw_block_io
 def test_raw_block_core_recovers_checkpoint_from_temp_file(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -298,6 +881,7 @@ def test_raw_block_core_recovers_checkpoint_from_temp_file(tmp_path):
         recovered.close()
 
 
+@requires_rust_raw_block_io
 def test_raw_block_core_rebuilds_missing_free_slots_from_checkpoint(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -532,9 +1116,11 @@ def test_raw_block_core_put_many_preserves_none_and_positive_placement(
         )
 
         assert put_result.results == [True, True]
+        # The io_uring path submits the whole batch at once, so both keys share
+        # one submission and each key's header/payload entries carry that key's
+        # placement identifier.
         assert [call[2] for call in raw_device.batched_write_calls] == [
-            [None, None],
-            [1, 1],
+            [None, None, 1, 1],
         ]
     finally:
         core.close()
@@ -596,6 +1182,51 @@ def test_raw_block_core_put_many_chunks_uring_cmd_with_placement_ids(
             RAW_BLOCK_CI_BLOCK_ALIGN,
         ]
         assert placement_ids == [7, 7, 7]
+    finally:
+        core.close()
+
+
+def test_raw_block_core_put_many_batches_uring_cmd_keys_into_one_submission(
+    tmp_path, monkeypatch
+):
+    # The io_uring_cmd path splits every write by max_data_transfer_size, so a
+    # multi-key batch has to expand each key into a variable number of chunks
+    # and still carry that key's placement id on each of them.
+    core, raw_device = _make_fake_io_uring_core(
+        tmp_path,
+        monkeypatch,
+        use_uring_cmd=True,
+        max_data_transfer_size=RAW_BLOCK_CI_BLOCK_ALIGN,
+    )
+    specs = [encode_object_key(make_object_key(i)) for i in range(510, 513)]
+    payloads = [
+        b"a" * (RAW_BLOCK_CI_BLOCK_ALIGN * 2),  # aligned -> 2 payload chunks
+        b"b" * (RAW_BLOCK_CI_BLOCK_ALIGN + 904),  # unaligned -> padded to 2
+        b"c" * RAW_BLOCK_CI_BLOCK_ALIGN,  # aligned -> 1 payload chunk
+    ]
+
+    try:
+        result = core.put_many(
+            specs,
+            [make_memory_obj(payload) for payload in payloads],
+            placement_ids=[7, 8, 9],
+        )
+
+        assert result.results == [True] * 3
+        assert result.stored_keys == [spec.encoded for spec in specs]
+
+        # All three keys share a single submission.
+        assert len(raw_device.batched_write_calls) == 1
+        offsets, total_lens, placement_ids = raw_device.batched_write_calls[0]
+
+        # Per key: one header chunk plus ceil(padded_payload / mdts) chunks.
+        assert total_lens == [RAW_BLOCK_CI_BLOCK_ALIGN] * 8
+        assert placement_ids == [7, 7, 7, 8, 8, 8, 9, 9]
+
+        # Passthrough rejects unaligned chunks, and no two entries may target
+        # the same device offset.
+        assert all(offset % RAW_BLOCK_CI_BLOCK_ALIGN == 0 for offset in offsets)
+        assert len(set(offsets)) == 8
     finally:
         core.close()
 
@@ -752,6 +1383,7 @@ def test_raw_block_core_omitted_placement_clears_previous_affinity(
         core.close()
 
 
+@requires_rust_raw_block_io
 def test_raw_block_core_does_not_restore_slot_affinity_from_checkpoint(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = dataclasses.replace(


### PR DESCRIPTION
**What this PR does / why we need it**:

  With `io_engine="io_uring"`, `put_many` of N>1 keys previously issued one
  io_uring submit/wait per key, so the device wrote them one at a time.
  This routes that case to `_put_many_batch_io`, which groups eligible keys into
  bounded io_uring chunks and submits each chunk through one `_write_buffers` call
  (header+payload entries), so writes in that chunk can be in flight concurrently.

  Large calls are capped at 64 keys per chunk. The cap limits keys, not entries:
  on the regular io_uring path each key contributes two write entries (header +
  payload), so a chunk submits at most 128, while on the `io_uring_cmd` path those
  entries are split further by `max_data_transfer_size` and a chunk can submit
  more. The cap bounds RawBlockCore lock hold time and the memory a single batch
  holds.

  Commit and rollback are per chunk: if the device write for a chunk fails, every
  new key submitted in that chunk is rolled back and none are committed to the
  index. This is a chunk-level index commit boundary, not device-write atomicity
  -- bytes may already have reached the device. Pre-submit failures stay per key:
  already-indexed keys report success without rewriting, and oversized payloads or
  slot exhaustion fail only that key. The POSIX path is unchanged.

  For non-`uring_cmd` io_uring writes, padded O_DIRECT writes intentionally fall
  back to per-entry `write_uring`, because the current Rust `batched_write` API
  does not carry separate `payload_len` and `total_len` values. True batched
  padded O_DIRECT support is left for a follow-up Rust API change.

  **Special notes for your reviewers**:

  Contract is covered by fake-io_uring-device unit tests: single-submit-per-chunk
  behavior on batchable writes, bounded chunking, round-trip, already-indexed
  skip, same-batch duplicates, oversize isolation, chunk-level write-failure
  rollback, partial-submission rollback, failed-completion rollback, partial
  slot-exhaustion, `io_uring_cmd` multi-key batching with per-key placement IDs,
  and POSIX stays sequential.

  Real-NVMe speedup is not covered in CI because it requires a suitable
  kernel and a scratch raw-block device; validation was performed locally.
  On a local Samsung PM1753 32TB NVMe SSD, at the time of that measurement,
  _put_many_batch_io reduced put_many wall-clock latency by 49–66% at p50 and
  56–77% at p95 across the evaluated workloads.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
