### PR TITLE
fix(operator): install cert-manager in e2e smoke suite

### DIFF
--- a/operator/AGENTS.md
+++ b/operator/AGENTS.md
@@ -41,7 +41,16 @@ details.
 Builds the manager image, loads it into a dedicated Kind cluster
 (`operator-test-e2e-<id>` by default), installs CRDs, deploys the controller,
 runs every `//go:build e2e` spec under `test/e2e/`, then tears the
-cluster down. No prereqs beyond Kind + Docker on `$PATH`.
+cluster down. No prereqs beyond Kind + Docker on `$PATH` (plus network
+egress to GitHub).
+
+The suite installs **cert-manager** into the cluster before deploying the
+controller — it issues the mutating webhook's serving cert and injects the
+CA bundle (see `config/certmanager`), so the controller-manager Deployment
+never reaches `Available` without it. Install is skipped when the cluster
+already ships cert-manager (e.g. an existing OpenShift/EKS cluster), and
+the suite only uninstalls what it installed. Override the release with
+`CERT_MANAGER_VERSION` (default `v1.16.3`).
 
 #### `test-e2e-cluster` — existing cluster (OpenShift, EKS, k3s, …)
 

--- a/operator/test/e2e/e2e_suite_test.go
+++ b/operator/test/e2e/e2e_suite_test.go
@@ -54,6 +54,10 @@ var (
 	// Initialised once in BeforeSuite after CRDs are installed; spec files
 	// read it directly without rebuilding their own client.
 	k8sClient client.Client
+	// certManagerInstalledBySuite records whether BeforeSuite installed
+	// cert-manager (vs. finding it pre-installed). AfterSuite only uninstalls
+	// what the suite installed, so a shared cluster's cert-manager is preserved.
+	certManagerInstalledBySuite bool
 )
 
 // envDefault returns os.Getenv(key) or def if the env var is unset/empty.
@@ -76,6 +80,18 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	_, _ = fmt.Fprintf(GinkgoWriter, "manager image: %s (skipImageLoad=%v)\n",
 		managerImage, skipImageLoad)
+
+	// cert-manager must exist before `make deploy` applies the operator's
+	// Issuer/Certificate and the CA-injected mutating webhook. Install it up
+	// front (before the slow image build/load) so its webhook endpoints are
+	// warm by the time we deploy. Skip when the cluster already ships it.
+	By("ensuring cert-manager is installed (required by the operator's webhook serving cert)")
+	if utils.IsCertManagerCRDsInstalled() {
+		By("cert-manager CRDs already present; skipping install")
+	} else {
+		Expect(utils.InstallCertManager()).To(Succeed(), "Failed to install cert-manager")
+		certManagerInstalledBySuite = true
+	}
 
 	if skipImageLoad {
 		// Existing-cluster path: the user pushed the image to a
@@ -137,6 +153,11 @@ var _ = AfterSuite(func() {
 	By("uninstalling CRDs")
 	if _, err := utils.RunMake("uninstall", "ignore-not-found=true"); err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "warning: uninstall failed: %v\n", err)
+	}
+
+	if certManagerInstalledBySuite {
+		By("uninstalling cert-manager")
+		utils.UninstallCertManager()
 	}
 })
 

--- a/operator/test/utils/utils.go
+++ b/operator/test/utils/utils.go
@@ -30,7 +30,74 @@ import (
 const (
 	defaultKindBinary  = "kind"
 	defaultKindCluster = "kind"
+
+	// certManagerDefaultVersion is the cert-manager release installed on the
+	// target cluster when none is already present. cert-manager is a hard
+	// prerequisite for the operator's mutating admission webhook: it mints the
+	// serving certificate (config/certmanager) and injects the CA bundle into
+	// the MutatingWebhookConfiguration. Override with CERT_MANAGER_VERSION.
+	certManagerDefaultVersion = "v1.16.3"
+	// certManagerManifestURLTmpl is the upstream static install manifest,
+	// parameterised by release tag.
+	certManagerManifestURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
+
+// certManagerVersion returns the cert-manager release to install, honoring the
+// CERT_MANAGER_VERSION env var and falling back to certManagerDefaultVersion.
+func certManagerVersion() string {
+	if v := os.Getenv("CERT_MANAGER_VERSION"); v != "" {
+		return v
+	}
+	return certManagerDefaultVersion
+}
+
+// IsCertManagerCRDsInstalled reports whether cert-manager's CRDs are already
+// registered in the target cluster. Used to skip installation (and teardown)
+// when running against a cluster that ships cert-manager (e.g. a shared
+// OpenShift/EKS cluster), so the suite never uninstalls something it did not
+// install.
+func IsCertManagerCRDsInstalled() bool {
+	cmd := exec.Command("kubectl", "get", "crd", "certificates.cert-manager.io", "--ignore-not-found=true")
+	out, err := Run(cmd)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(out, "certificates.cert-manager.io")
+}
+
+// InstallCertManager applies the upstream cert-manager static manifest and
+// blocks until its controller, webhook, and CA-injector Deployments report
+// Available. cert-manager must be ready before `make deploy` applies the
+// operator's Issuer/Certificate and the CA-injected webhook, otherwise the
+// apply is rejected (unknown cert-manager.io kinds) and the serving-cert
+// secret the controller-manager mounts never materialises.
+func InstallCertManager() error {
+	url := fmt.Sprintf(certManagerManifestURLTmpl, certManagerVersion())
+	if _, err := Run(exec.Command("kubectl", "apply", "-f", url)); err != nil {
+		return fmt.Errorf("failed to apply cert-manager manifest %q: %w", url, err)
+	}
+	for _, deploy := range []string{"cert-manager", "cert-manager-webhook", "cert-manager-cainjector"} {
+		cmd := exec.Command("kubectl", "wait", "deployment/"+deploy,
+			"--for=condition=Available",
+			"--namespace=cert-manager",
+			"--timeout=5m",
+		)
+		if _, err := Run(cmd); err != nil {
+			return fmt.Errorf("cert-manager deployment %q did not become Available: %w", deploy, err)
+		}
+	}
+	return nil
+}
+
+// UninstallCertManager removes the cert-manager release installed by
+// InstallCertManager. Best-effort: failures are logged to GinkgoWriter rather
+// than failing the suite, since teardown runs after the specs have reported.
+func UninstallCertManager() {
+	url := fmt.Sprintf(certManagerManifestURLTmpl, certManagerVersion())
+	if _, err := Run(exec.Command("kubectl", "delete", "-f", url, "--ignore-not-found=true")); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "warning: cert-manager uninstall failed: %v\n", err)
+	}
+}
 
 // Run executes the provided command within this context
 func Run(cmd *exec.Cmd) (string, error) {


### PR DESCRIPTION
## Problem

The operator e2e integration test (Buildkite `lmcache-operator-integration-test`) fails in `BeforeSuite`: the controller-manager Deployment never becomes `Available`.

## Root cause

The CacheBlend injection webhook made **cert-manager a hard prerequisite**. `make deploy` (`config/default`) now applies:

- a self-signed `Issuer` + `Certificate` (`cert-manager.io/v1`), and
- a `MutatingWebhookConfiguration` annotated with `cert-manager.io/inject-ca-from`,

and the controller-manager Deployment mounts the cert-manager-issued `webhook-server-cert` secret at `/tmp/k8s-webhook-server/serving-certs`.

On a fresh Kind cluster with no cert-manager, the deploy step is rejected (unknown `cert-manager.io` kinds) and the serving-cert secret never materialises — so the manager pod is stuck `ContainerCreating`, never goes `Available`, and the 3-minute `BeforeSuite` wait times out.

## Fix

Install cert-manager from the e2e `BeforeSuite` before deploying the controller:

- New helpers in `test/utils/utils.go`: `InstallCertManager` (apply upstream manifest, wait for the three cert-manager Deployments to be `Available`), `UninstallCertManager` (best-effort), `IsCertManagerCRDsInstalled` (guard).
- `BeforeSuite` installs cert-manager up front (before the slow image build/load, so its webhook endpoints are warm by deploy time). Install is **skipped** when the cluster already ships cert-manager, and `AfterSuite` only uninstalls what the suite installed — so a shared OpenShift/EKS cluster is left untouched.
- Release is overridable via `CERT_MANAGER_VERSION` (default `v1.16.3`).

Both the M1 (`test-e2e-kind`) and M2/GPU (`test-e2e-gpu-kind`) targets share the single `//go:build e2e` `BeforeSuite`, so both Kind tiers are covered.

`AGENTS.md` updated to document the cert-manager prerequisite and skip/override behaviour.

## Test plan

- `go build ./...` — clean
- `go vet -tags=e2e ./test/...` — clean
- `gofmt` — clean
- Buildkite e2e run on this PR validates the end-to-end path on Kind.