### PR TITLE
fix(operator): emit --engine-type blend for CacheBlend engine

### DIFF
--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -603,7 +603,7 @@ for the technique itself.
 
 It has two halves the operator runs together:
 
-- a GPU-resident ``blend_v3`` engine (``lmcache server --engine-type blend_v3``),
+- a GPU-resident ``blend_v3`` engine (``lmcache server --engine-type blend``),
   deployed as a DaemonSet with the **same GPU model as** ``LMCacheEngine``
   (``privileged`` + ``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all``
   + ``hostIPC``, and **no** ``nvidia.com/gpu`` claim) so it shares the vLLM GPU
@@ -653,7 +653,7 @@ Deploying a CacheBlendEngine
         imagePullSecrets:
           - name: my-registry-secret
 
-The engine runs ``lmcache server --engine-type blend_v3`` as a DaemonSet and
+The engine runs ``lmcache server --engine-type blend`` as a DaemonSet and
 emits a ``my-cacheblend-connection`` ConfigMap with the ``CBKVConnector``
 ``kv-transfer-config`` (the operator wires the node-local Service host/port and
 the ``cb.*`` tunables).

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -391,7 +391,7 @@ l2Backend, scheduling, overrides, imagePullSecrets) and adds:
 ### The blend engine (controller)
 
 `CacheBlendEngineReconciler` mirrors `LMCacheEngineReconciler` and reconciles a
-DaemonSet running `lmcache server --engine-type blend_v3` (plus
+DaemonSet running `lmcache server --engine-type blend` (plus
 `--l1-align-bytes 16777216`), a node-local lookup Service, a metrics Service, and
 a `<name>-connection` ConfigMap. **GPU model is identical to `LMCacheEngine`**:
 `privileged` + `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` +
@@ -469,7 +469,7 @@ user-supplied `--flag=value`.
 
 | Resource | Name | Purpose |
 |---|---|---|
-| DaemonSet | `cb` | `lmcache server --engine-type blend_v3` on GPU nodes |
+| DaemonSet | `cb` | `lmcache server --engine-type blend` on GPU nodes |
 | Service (node-local) | `cb` | same-node discovery for vLLM (`CBKVConnector`) |
 | Service (headless) | `cb-metrics` | Prometheus scrape target |
 | ConfigMap | `cb-connection` | `CBKVConnector` kv-transfer-config |

--- a/operator/config/samples/lmcache_v1alpha1_cacheblendengine.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_cacheblendengine.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   # -- Container image (the LMCache blend_v3 ENGINE image) --
-  # The engine runs `lmcache server --engine-type blend_v3`. If this image lives
+  # The engine runs `lmcache server --engine-type blend`. If this image lives
   # in a PRIVATE registry, set imagePullSecrets (the Secret must exist in this
   # namespace).
   image:

--- a/operator/internal/controller/cacheblendengine_controller_test.go
+++ b/operator/internal/controller/cacheblendengine_controller_test.go
@@ -135,7 +135,7 @@ var _ = Describe("CacheBlendEngine Controller", func() {
 			Expect(podSpec.Containers).To(HaveLen(1))
 			engineContainer := podSpec.Containers[0]
 
-			Expect(argsContainFlagValue(engineContainer.Args, "--engine-type", "blend_v3")).To(BeTrue())
+			Expect(argsContainFlagValue(engineContainer.Args, "--engine-type", "blend")).To(BeTrue())
 			Expect(argsContainFlagValue(engineContainer.Args, "--l1-align-bytes", "16777216")).To(BeTrue())
 
 			By("Verifying there is no GPU resource claim")

--- a/operator/internal/resources/cacheblend_engine.go
+++ b/operator/internal/resources/cacheblend_engine.go
@@ -26,9 +26,10 @@ import (
 
 const (
 	// cbEngineType is the value of the --engine-type flag that selects the
-	// CacheBlend blend_v3 engine on the lmcache server binary
-	// (cacheblend-plugin/README.md:24).
-	cbEngineType = "blend_v3"
+	// CacheBlend V3 engine on the lmcache server binary. The server maps the
+	// value "blend" to BlendV3Module; "blend_v3" is no longer recognized
+	// (lmcache/v1/multiprocess/server.py).
+	cbEngineType = "blend"
 
 	// cbL1AlignBytes is the value of the --l1-align-bytes flag required by the
 	// blend server (blend_server.sh:31).
@@ -88,7 +89,7 @@ func cbSpecToEngineSpec(spec *lmcachev1alpha1.CacheBlendEngineSpec) *lmcachev1al
 
 // BuildCBEngineArgs returns the server CLI args for the blend_v3 engine: the
 // proven LMCacheEngine serialization (--host/--port/--l1-size-gb/--chunk-size/
-// eviction/prometheus/L2) plus the CacheBlend-specific --engine-type blend_v3 and
+// eviction/prometheus/L2) plus the CacheBlend-specific --engine-type blend and
 // --l1-align-bytes flags. The blend flags are inserted before the user-supplied
 // extraArgs so a user can still override them.
 func BuildCBEngineArgs(spec *lmcachev1alpha1.CacheBlendEngineSpec) []string {

--- a/operator/internal/resources/cacheblend_engine_test.go
+++ b/operator/internal/resources/cacheblend_engine_test.go
@@ -52,7 +52,7 @@ func TestBuildCBEngineArgs_BlendFlags(t *testing.T) {
 	args := BuildCBEngineArgs(&minimalCBEngine().Spec)
 
 	// Blend-specific flags.
-	assertArg(t, args, "--engine-type", "blend_v3")
+	assertArg(t, args, "--engine-type", "blend")
 	assertArg(t, args, "--l1-align-bytes", "16777216")
 
 	// Reuses the proven LMCacheEngine serialization (NOT --l1-size).
@@ -86,8 +86,8 @@ func TestBuildCBEngineArgs_ExtraArgsAfterBlendFlags(t *testing.T) {
 	if firstIdx == lastIdx {
 		t.Fatalf("expected --engine-type to appear twice, got args=%v", args)
 	}
-	if args[firstIdx+1] != "blend_v3" {
-		t.Fatalf("expected operator-set --engine-type blend_v3 first, got %s", args[firstIdx+1])
+	if args[firstIdx+1] != "blend" {
+		t.Fatalf("expected operator-set --engine-type blend first, got %s", args[firstIdx+1])
 	}
 	if args[lastIdx+1] != "override-me" {
 		t.Fatalf("expected user --engine-type override-me last, got %s", args[lastIdx+1])
@@ -144,7 +144,7 @@ func TestBuildCBEngineDaemonSet_GPUAndSecurity(t *testing.T) {
 	}
 
 	// Blend args present on the container.
-	assertArg(t, c.Args, "--engine-type", "blend_v3")
+	assertArg(t, c.Args, "--engine-type", "blend")
 	assertArg(t, c.Args, "--l1-align-bytes", "16777216")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The lmcache server selects the CacheBlend V3 engine via `--engine-type blend` (`lmcache/v1/multiprocess/server.py`); the V2 engine moved to `--engine-type blend_legacy`. The value `blend_v3` is no longer recognized, so the operator-generated CacheBlend DaemonSet started a server that loaded **no** blend module — CacheBlend was silently broken.

This switches the operator's hardcoded engine-type value from `blend_v3` to `blend`, realigning the `CacheBlendEngine` controller with the current server contract.

**Special notes for your reviewers**:

Value-only change to the `--engine-type` flag. The `blend_v3` / `BlendV3Module` naming (module name) is left untouched — only the CLI flag value changed. Sample manifest and operator docs updated to match.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests