### PR TITLE
[Recipe][Cli] Document vLLM –mamba-align-single-block-prefill for LMCache Mamba/GDN recipes

### DIFF
--- a/docs/source/mp/hybrid_models.rst
+++ b/docs/source/mp/hybrid_models.rst
@@ -133,12 +133,29 @@ Step 2 — derive the three required flags from ``N``
 
        lmcache server --chunk-size 784 --l1-size-gb 100 --eviction-policy LRU
 
-#. **vLLM** ``--max-num-batched-tokens`` **in [N, 2·N)** — setting it equal to
-   ``N`` is the simple, always-valid choice. Outside this range LMCache raises
-   at engine startup. ``align`` mode snapshots the Mamba state only at the
-   *end* of each scheduler step, so each prefill step must advance exactly one
-   block; a larger budget would let a step skip block boundaries, leaving no
-   snapshot for LMCache to store at those prefixes.
+#. **vLLM** must either cap each cacheable Mamba-align prefill step to one
+   unified block or keep ``--max-num-batched-tokens`` in ``[N, 2·N)``. The
+   recommended setting keeps a large global batch budget for decode and static
+   buffers while capping only Mamba-align prefill chunks::
+
+       vllm serve <model> \
+           --enable-prefix-caching --mamba-cache-mode align \
+           --max-num-batched-tokens 8192 \
+           --mamba-align-single-block-prefill \
+           --kv-transfer-config \
+           '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+
+   The legacy safe setting is still valid::
+
+       vllm serve <model> \
+           --enable-prefix-caching --mamba-cache-mode align \
+           --max-num-batched-tokens 784 \
+           --kv-transfer-config \
+           '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+
+   ``align`` mode snapshots the Mamba state only at the *end* of each scheduler
+   step; an uncapped larger budget would let one step skip block boundaries,
+   leaving no snapshot for LMCache to store at those prefixes.
 
 #. **vLLM** ``--mamba-cache-mode align --enable-prefix-caching`` — ``align`` is
    mandatory (GDN backends do not support the ``all`` mode)::
@@ -150,8 +167,9 @@ Step 2 — derive the three required flags from ``N``
            '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
 
 So for a freshly-probed model the whole derivation is just: read ``N`` (step 1),
-then pass ``--chunk-size N`` to the server and ``--max-num-batched-tokens N`` to
-vLLM.
+then pass ``--chunk-size N`` to the server and either use
+``--mamba-align-single-block-prefill`` with a larger vLLM batch budget or set
+``--max-num-batched-tokens N``.
 
 No ``--no-disable-hybrid-kv-cache-manager`` or attention-backend flag is needed;
 ``LMCacheMPConnector`` advertises hybrid support and vLLM auto-selects the GDN

--- a/docs/source/recipes/qwen3_5.rst
+++ b/docs/source/recipes/qwen3_5.rst
@@ -60,22 +60,24 @@ Validated models
          vllm serve Qwen/Qwen3.6-27B \
              --enable-prefix-caching \
              --mamba-cache-mode align \
-             --max-num-batched-tokens 784 \
+             --max-num-batched-tokens 8192 \
+             --mamba-align-single-block-prefill \
              --kv-transfer-config \
              '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
 
       |
 
       **Qwen3.5-0.8B** (1 GPU, ``N = 544``): identical to the above, with
-      ``784`` replaced by ``544`` in both ``--chunk-size`` and
-      ``--max-num-batched-tokens``.
+      ``784`` replaced by ``544`` in ``--chunk-size``.
 
       ``--mamba-cache-mode align`` is required (GDN does not support the
-      ``all`` mode). ``--max-num-batched-tokens`` must be at least the unified
-      block size and below twice it — LMCache raises at engine startup
-      otherwise. ``align`` snapshots the Mamba state only at scheduler-step
-      ends, so each prefill step must advance exactly one block for every
-      block boundary to hold a reusable snapshot.
+      ``all`` mode). ``align`` snapshots the Mamba state only at
+      scheduler-step ends, so cacheable prefill steps must advance exactly one
+      unified block for every block boundary to hold a reusable snapshot.
+      ``--mamba-align-single-block-prefill`` provides that per-request cap
+      while allowing ``--max-num-batched-tokens`` to stay large for batching.
+      Without that cap, ``--max-num-batched-tokens`` must be at least the
+      unified block size and below twice it.
 
       For the generic LMCache + vLLM wiring (ports, remote hosts), see
       :doc:`../mp/quickstart`.

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -110,31 +110,41 @@ def validate_mamba_step_alignment(vllm_config: VllmConfig) -> None:
     (``MambaManager.allocate_new_blocks``). LMCache keys chunks by token hash,
     so a skipped boundary would be stored as null-block garbage under a valid
     key and silently corrupt any request that later resumes from that prefix.
-    Requiring ``block_size <= max_num_batched_tokens < 2 * block_size`` makes
-    vLLM's block-aligned splitting (``Scheduler._mamba_block_aligned_split``)
-    advance every mid-prefill step by exactly one block, so every chunk
-    boundary holds a real snapshot.
+    Requiring either ``block_size <= max_num_batched_tokens < 2 * block_size``
+    or vLLM's ``mamba_align_single_block_prefill`` scheduler cap makes vLLM's
+    block-aligned splitting (``Scheduler._mamba_block_aligned_split``) advance
+    every cacheable prefill step by exactly one block, so every chunk boundary
+    holds a real snapshot.
 
     Args:
         vllm_config: The vLLM config; only Mamba-hybrid models in ``align``
             cache mode are constrained, others pass.
 
     Raises:
-        ValueError: If ``max_num_batched_tokens`` is not in
-            ``[block_size, 2 * block_size)``.
+        ValueError: If ``max_num_batched_tokens`` is below ``block_size``, or
+            if it can schedule multi-block Mamba-align prefill steps.
     """
     if getattr(vllm_config.cache_config, "mamba_cache_mode", "none") != "align":
         return
     block_size = vllm_config.cache_config.block_size
     max_batched = vllm_config.scheduler_config.max_num_batched_tokens
-    if not (block_size <= max_batched < 2 * block_size):
+    single_block_prefill = getattr(
+        vllm_config.scheduler_config, "mamba_align_single_block_prefill", False
+    )
+    if max_batched < block_size or (
+        max_batched >= 2 * block_size and not single_block_prefill
+    ):
         raise ValueError(
             f"Mamba-hybrid models with LMCache require "
-            f"block_size <= max_num_batched_tokens < 2 * block_size so every "
+            f"max_num_batched_tokens >= block_size and either "
+            f"max_num_batched_tokens < 2 * block_size or vLLM's "
+            f"--mamba-align-single-block-prefill enabled, so every cacheable "
             f"prefill step advances exactly one block and every block boundary "
             f"gets a state snapshot; got max_num_batched_tokens={max_batched}, "
-            f"block_size={block_size}. Set --max-num-batched-tokens "
-            f"{block_size}."
+            f"block_size={block_size}, "
+            f"mamba_align_single_block_prefill={single_block_prefill}. Set "
+            f"--max-num-batched-tokens {block_size}, or keep the larger batch "
+            f"and add --mamba-align-single-block-prefill."
         )
 
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR updates the LMCache recipes and CLI documentation to describe the new vLLM flag --mamba-align-single-block-prefill for Mamba/GDN hybrid models.

As background, LMCache PR #3613 introduced external KV Cache Server support for Mamba/GDN hybrid models such as Qwen3.5, allowing LMCache to reuse both attention KV pages and Mamba/GDN recurrent state pages.

With the current integration, `mamba_cache_mode=align` requires careful alignment between vLLM scheduling steps and the unified attention block size to preserve correct Mamba/GDN state snapshots. Without additional scheduler support, users may need to keep `--max-num-batched-tokens` constrained by the attention block size, which can significantly limit batching flexibility and reduce production inference throughput.

This documentation update explains how to use vLLM’s `--mamba-align-single-block-prefill` flag with LMCache. The flag allows users to keep a larger global `--max-num-batched-tokens` value while ensuring cacheable Mamba-align prefill chunks are split at unified block boundaries. This preserves correctness for external KV Cache Server reuse while enabling better scheduling efficiency and inference performance for Mamba/GDN models.
**Special notes for your reviewers**:

Note: This PR is blocked on the acceptance and merge of vLLM PR [#45349](https://github.com/vllm-project/vllm/pull/45349)

**If applicable**:

- [X] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
