### PR TITLE
fix(mq): eliminate flaky test in multiprocess message queue

### DIFF
--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -8,6 +8,7 @@ import inspect
 import itertools
 import queue
 import threading
+import time
 
 # Third Party
 import msgspec
@@ -170,7 +171,9 @@ class ClientPollingLoop:
             inst._notifier.notify()
             cls._instance = None
 
-        inst._thread.join()
+        inst._thread.join(timeout=5.0)
+        if inst._thread.is_alive():
+            logger.warning("ClientPollingLoop thread did not stop within 5 seconds")
         inst._notifier.close()
         logger.debug("ClientPollingLoop shut down")
 
@@ -185,7 +188,11 @@ class ClientPollingLoop:
         done = threading.Event()
         self._ops_queue.put(_PollOp(kind=_OpKind.REGISTER, client=client, done=done))
         self._notifier.notify()
-        done.wait()
+        if not done.wait(timeout=5.0):
+            logger.error(
+                "ClientPollingLoop register timed out – loop thread may be dead"
+            )
+            raise RuntimeError("ClientPollingLoop register timed out")
 
     def unregister(self, client: "MessageQueueClient") -> None:
         """Unregister a client's DEALER socket from the shared poller.
@@ -198,7 +205,11 @@ class ClientPollingLoop:
         done = threading.Event()
         self._ops_queue.put(_PollOp(kind=_OpKind.UNREGISTER, client=client, done=done))
         self._notifier.notify()
-        done.wait()
+        if not done.wait(timeout=5.0):
+            logger.error(
+                "ClientPollingLoop unregister timed out – loop thread may be dead"
+            )
+            # Don't raise; we are in close(), best-effort cleanup.
 
     def notify(self) -> None:
         """Wake the polling loop to process outbound tasks."""
@@ -224,27 +235,58 @@ class ClientPollingLoop:
     def _main_loop(self) -> None:
         """Unified poll loop for all registered clients."""
         notifier_fd = self._notifier.fileno()
+        error_count = 0
+        last_logged_at = 0.0
 
         while not self._is_finished.is_set():
-            self._process_ops()
+            try:
+                self._process_ops()
 
-            socks = dict(self._poller.poll(1000))
+                socks = dict(self._poller.poll(1000))
 
-            # Outbound: shared notifier woke us — drain it, then flush
-            # all clients' output queues.
-            if socks.get(notifier_fd) and socks[notifier_fd] & zmq.POLLIN:
-                self._notifier.consume()
-                for client in self._socket_to_client.values():
-                    client.process_outbound_task()
+                # Outbound: shared notifier woke us — drain it, then flush
+                # all clients' output queues.
+                if socks.get(notifier_fd) and socks[notifier_fd] & zmq.POLLIN:
+                    self._notifier.consume()
+                    for client in self._socket_to_client.values():
+                        client.process_outbound_task()
 
-            # Inbound: dispatch each ready DEALER socket to its client.
-            for sock, event in socks.items():
-                if sock is notifier_fd:
-                    continue
-                if event & zmq.POLLIN:
-                    owner = self._socket_to_client.get(sock)
-                    if owner is not None:
-                        owner.process_inbound()
+                # Inbound: dispatch each ready DEALER socket to its client.
+                for sock, event in socks.items():
+                    if sock is notifier_fd:
+                        continue
+                    if event & zmq.POLLIN:
+                        owner = self._socket_to_client.get(sock)
+                        if owner is not None:
+                            owner.process_inbound()
+
+                # One clean iteration resets the error streak (transient)
+                error_count = 0
+            except Exception as e:
+                error_count += 1
+                now = time.monotonic()
+                if error_count == 1:
+                    logger.error(
+                        "ClientPollingLoop: exception in main loop: %s: %s",
+                        type(e).__name__,
+                        e,
+                        exc_info=True,
+                    )
+                    last_logged_at = now
+                elif now - last_logged_at >= 10.0:
+                    logger.error(
+                        "ClientPollingLoop: %d consecutive "
+                        "exceptions, latest: %s: %s "
+                        "(suppressed stack traces)",
+                        error_count,
+                        type(e).__name__,
+                        e,
+                    )
+                    last_logged_at = now
+
+                # Park ourselves briefly so a tight crash-loop doesn't
+                # burn CPU, then try again.
+                self._is_finished.wait(0.5)
 
         # Drain remaining ops so any waiting threads unblock.
         self._process_ops()
@@ -263,6 +305,7 @@ class MessageQueueClient:
         # Socket
         self.ctx = context
         self.socket = self.ctx.socket(zmq.DEALER)
+        self.socket.setsockopt(zmq.LINGER, 0)
         self.socket.connect(server_url)
 
         # Input queue
@@ -486,6 +529,7 @@ class MessageQueueServer:
         # Socket
         self.ctx = context
         self.socket = self.ctx.socket(zmq.ROUTER)
+        self.socket.setsockopt(zmq.LINGER, 0)
         self.socket.bind(bind_url)
         # Use a cross-platform Notifier instead of zmq PUSH/PULL sockets
         # because blocking handler callbacks run on ThreadPoolExecutor

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -305,16 +305,33 @@ class TestQueryChecksum:
 # ------------------------------------------------------------------ #
 
 
-@pytest.fixture
-def router_endpoint() -> str:
-    """Allocate an ephemeral inproc/tcp endpoint for the ROUTER."""
-    # Use tcp with port=0 so the OS assigns a free port.
+def _allocate_free_tcp_endpoint() -> str:
+    """Pick an ephemeral TCP endpoint via ``port=0`` probe-then-close.
+
+    NOTE: there is an inherent TOCTOU window between the probe-close
+    and the caller's real ``bind()``. Prefer letting the actual
+    consumer ``bind("tcp://127.0.0.1:0")`` itself and read back
+    ``LAST_ENDPOINT`` so the kernel allocation is atomic. This helper
+    is kept for callers that need to know the endpoint up front.
+    """
     ctx = zmq.Context.instance()
     probe = ctx.socket(zmq.ROUTER)
     probe.bind("tcp://127.0.0.1:0")
     endpoint = probe.getsockopt_string(zmq.LAST_ENDPOINT)
     probe.close(linger=0)
     return endpoint
+
+
+@pytest.fixture
+def router_endpoint() -> None:
+    """Sentinel fixture: tell ``_LookupRouter`` to self-allocate.
+
+    Returning ``None`` makes the router bind ``tcp://127.0.0.1:0``
+    and read back ``LAST_ENDPOINT``, so the kernel atomically
+    allocates and reserves the port — no probe-close TOCTOU window
+    (see Buildkite k3-unit-tests build #3090).
+    """
+    return None
 
 
 # ------------------------------------------------------------------ #
@@ -422,17 +439,21 @@ class _LookupRouter:
 
     def __init__(
         self,
-        endpoint: str,
+        endpoint: str | None = None,
         in_progress_polls: int = 1,
         hit_chunks: int = 3,
     ) -> None:
-        self._endpoint = endpoint
         self._in_progress_left = in_progress_polls
         self._hit_chunks = hit_chunks
         self.last_query_request_id: str | None = None
         self._ctx = zmq.Context.instance()
         self._router = self._ctx.socket(zmq.ROUTER)
-        self._router.bind(endpoint)
+        # When endpoint is None, let the kernel atomically allocate a
+        # free TCP port via bind(port=0). Reading LAST_ENDPOINT after
+        # bind avoids the probe-close TOCTOU race.
+        bind_target = endpoint if endpoint is not None else "tcp://127.0.0.1:0"
+        self._router.bind(bind_target)
+        self.endpoint: str = self._router.getsockopt_string(zmq.LAST_ENDPOINT)
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
 
@@ -472,13 +493,13 @@ class TestLookupProtocol:
 
     def test_send_lookup_void_reply_is_success(
         self,
-        router_endpoint: str,
+        router_endpoint: None,
     ) -> None:
         """LOOKUP handler returns None (void) — must not be timeout."""
         router = _LookupRouter(router_endpoint)
         router.start()
         try:
-            client = self._make_client(router_endpoint)
+            client = self._make_client(router.endpoint)
             key = _make_key((1, 9906, 9906), request_id="req-void")
             assert _send_lookup(client, key) is True
             client.close()
@@ -487,7 +508,7 @@ class TestLookupProtocol:
 
     def test_poll_prefetch_status_uses_request_id(
         self,
-        router_endpoint: str,
+        router_endpoint: None,
     ) -> None:
         """QUERY_PREFETCH_STATUS payload is keyed by request_id str."""
         router = _LookupRouter(
@@ -497,7 +518,7 @@ class TestLookupProtocol:
         )
         router.start()
         try:
-            client = self._make_client(router_endpoint)
+            client = self._make_client(router.endpoint)
             hit = _poll_prefetch_status(
                 client,
                 "req-42",

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -265,7 +265,7 @@ class MessageQueueTestHelper:
         if not server_ready:
             # Check if the server reported an error
             server_errors: list[str] = []
-            while not error_queue.empty():
+            while True:
                 try:
                     err_type, err_msg = error_queue.get_nowait()
                     server_errors.append("%s: %s" % (err_type, err_msg))
@@ -339,7 +339,7 @@ class MessageQueueTestHelper:
             )
             # Drain any server-side errors for diagnostics
             backend_errors: list[str] = []
-            while not error_queue.empty():
+            while True:
                 try:
                     err_type, err_msg = error_queue.get_nowait()
                     backend_errors.append("%s: %s" % (err_type, err_msg))

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -60,6 +60,7 @@ def _server_process(
     ready_event: EventClass,
     shutdown_event: EventClass,
     request_handlers: dict[RequestType, Callable],
+    error_queue: mp.Queue,
 ):
     """
     Server process that runs the MessageQueueServer.
@@ -69,36 +70,42 @@ def _server_process(
         ready_event: Event to signal when server is ready
         shutdown_event: Event to signal server shutdown
         request_handlers: Dict mapping RequestType to handler functions
+        error_queue: Queue to report startup errors to the parent process
     """
     # First Party
     from lmcache.v1.multiprocess.protocol import HandlerType
 
-    context = zmq.Context.instance()
-    server = MessageQueueServer(server_url, context)
+    try:
+        context = zmq.Context.instance()
+        server = MessageQueueServer(server_url, context)
 
-    # Register all handlers
-    blocking_types: list[RequestType] = []
-    for request_type, handler in request_handlers.items():
-        payload_classes = get_payload_classes(request_type)
-        handler_type = get_handler_type(request_type)
-        server.add_handler(request_type, payload_classes, handler_type, handler)
-        if handler_type == HandlerType.BLOCKING:
-            blocking_types.append(request_type)
+        # Register all handlers
+        blocking_types: list[RequestType] = []
+        for request_type, handler in request_handlers.items():
+            payload_classes = get_payload_classes(request_type)
+            handler_type = get_handler_type(request_type)
+            server.add_handler(request_type, payload_classes, handler_type, handler)
+            if handler_type == HandlerType.BLOCKING:
+                blocking_types.append(request_type)
 
-    # Assign a normal pool for all blocking handlers in tests
-    if blocking_types:
-        server.add_normal_thread_pool(blocking_types, max_workers=4)
+        # Assign a normal pool for all blocking handlers in tests
+        if blocking_types:
+            server.add_normal_thread_pool(blocking_types, max_workers=4)
 
-    server.start()
+        server.start()
 
-    # Signal that server is ready
-    ready_event.set()
+        # Signal that server is ready
+        ready_event.set()
 
-    # Wait for shutdown signal
-    shutdown_event.wait()
+        # Wait for shutdown signal
+        shutdown_event.wait()
 
-    # Cleanup
-    server.close()
+        # Cleanup
+        server.close()
+    except Exception as e:
+        error_queue.put((type(e).__name__, str(e)))
+        # Re-raise so the process exits with non-zero code
+        raise
 
 
 def _run_client_test(
@@ -238,13 +245,51 @@ class MessageQueueTestHelper:
         """
         ready_event = self.ctx.Event()
         shutdown_event = self.ctx.Event()
+        error_queue: mp.Queue = self.ctx.Queue()
 
         # Start server process
         server_process = self.ctx.Process(
             target=_server_process,
-            args=(self.server_url, ready_event, shutdown_event, self.handlers),
+            args=(
+                self.server_url,
+                ready_event,
+                shutdown_event,
+                self.handlers,
+                error_queue,
+            ),
         )
         server_process.start()
+
+        # Wait for server to be ready or for an error
+        server_ready = ready_event.wait(timeout=5.0)
+        if not server_ready:
+            # Check if the server reported an error
+            server_errors: list[str] = []
+            while not error_queue.empty():
+                try:
+                    err_type, err_msg = error_queue.get_nowait()
+                    server_errors.append("%s: %s" % (err_type, err_msg))
+                except Exception:
+                    break
+            if server_errors:
+                shutdown_event.set()
+                server_process.join(timeout=2)
+                if server_process.is_alive():
+                    server_process.terminate()
+                    server_process.join()
+                pytest.fail(
+                    "Server process failed to start: %s" % "; ".join(server_errors)
+                )
+            # No explicit error – maybe just slow
+            shutdown_event.set()
+            server_process.join(timeout=2)
+            if server_process.is_alive():
+                server_process.terminate()
+                server_process.join()
+            pytest.fail(
+                "Server process did not become ready within timeout "
+                "(exit code: %s)" % server_process.exitcode
+            )
 
         # Start multiple client processes
         client_processes = []
@@ -292,7 +337,17 @@ class MessageQueueTestHelper:
             failure_details = ", ".join(
                 [f"Client {cid}: {reason}" for cid, reason in failed_clients]
             )
-            pytest.fail(f"Some clients failed: {failure_details}")
+            # Drain any server-side errors for diagnostics
+            backend_errors: list[str] = []
+            while not error_queue.empty():
+                try:
+                    err_type, err_msg = error_queue.get_nowait()
+                    backend_errors.append("%s: %s" % (err_type, err_msg))
+                except Exception:
+                    break
+            if backend_errors:
+                failure_details += " (server errors: %s)" % "; ".join(backend_errors)
+            pytest.fail("Some clients failed: %s" % failure_details)
 
         if server_process.exitcode != 0:
             pytest.fail(


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:


The multiprocess MQ tests (`test_mq_noop_request`, `test_mq_query_prefetch_lookup_hits`,
etc.) were flaky — clients would time out with zero diagnostics about what went wrong.

Root causes and fixes:

1. **ZMQ_LINGER hangs** — Both DEALER and ROUTER sockets default to LINGER=-1,
   meaning `close()` blocks until all pending messages are sent. If the peer is
   already dead, this blocks forever. Set LINGER=0 to drop pending messages on close.

2. **Unbounded waits** — `ClientPollingLoop.register/unregister` and `release_instance`
   all used bare `done.wait()` / `thread.join()` with no timeout. If the loop thread
   crashed, the caller would hang. Added 5s timeouts everywhere.

3. **Silent loop crash** — `_main_loop` had no exception handler. A single zmq error
   (e.g. socket closed during poll) would silently kill the thread. Now the loop body
   is wrapped in try/except with rate-limited logging and a 0.5s backoff.

4. **Server startup errors swallowed** — If `_server_process` raised during init,
   the test would just timeout on `ready_event` with no clue. Added an `mp.Queue`
   to pipe startup errors back to the parent; `run_test` now fails fast with the
   actual error message.

5. **Better CI diagnostics** — When a test fails, we now drain any server-side
   error messages and include them in the failure report.

6. **TOCTOU port race in `test_server_bench`** — `router_endpoint` fixture used
   `bind(tcp://127.0.0.1:0)` + close + rebind, leaving a window where another test
   process could grab the same port. Fixed by letting `_LookupRouter` bind
   `tcp://127.0.0.1:0` itself (atomic kernel allocation) and expose the real
   endpoint via `self.endpoint`.

CI runs: https://buildkite.com/lmcache/k3-unit-tests/builds/3010

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests