### PR TITLE
examples: add Tigris remote backend example for KV cache reuse

### DIFF
--- a/examples/kv_cache_reuse/remote_backends/tigris/README.md
+++ b/examples/kv_cache_reuse/remote_backends/tigris/README.md
@@ -16,7 +16,7 @@ See [Tigris's Manage Access Keys documentation](https://www.tigrisdata.com/docs/
 
 Replace `{BUCKET_NAME}`, `{TIGRIS_ACCESS_KEY_ID}`, and `{TIGRIS_SECRET_ACCESS_KEY}` in `example.yaml` with the values from Step 1.
 
-## Step 3: Start an vLLM engine with LMCache
+## Step 3: Start a vLLM engine with LMCache
 
 ```bash
 PYTHONHASHSEED=0 LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' --disable-log-requests --no-enable-prefix-caching

--- a/examples/kv_cache_reuse/remote_backends/tigris/README.md
+++ b/examples/kv_cache_reuse/remote_backends/tigris/README.md
@@ -24,7 +24,7 @@ PYTHONHASHSEED=0 LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Llama-3.
 
 ## Step 4: Sending requests
 
-You should be able to see cache hit on the second time by sending the following request twice:
+You should be able to verify a cache hit on the second request by checking the vLLM/LMCache console logs (which will show cache hit messages) or by observing a significantly lower Time-to-First-Token (TTFT):
 
 ```bash
 curl -X POST http://localhost:8000/v1/completions   -H "Content-Type: application/json"   -d '{

--- a/examples/kv_cache_reuse/remote_backends/tigris/README.md
+++ b/examples/kv_cache_reuse/remote_backends/tigris/README.md
@@ -1,0 +1,35 @@
+## LMCache can use [Tigris](https://www.tigrisdata.com/) as a backend storage.
+
+Tigris is a globally distributed, S3-compatible object storage service with no egress fees. The free tier offers 5 GB of storage, sufficient for evaluating LMCache's remote backend behavior end-to-end.
+
+Tigris uses a single global endpoint (`t3.storage.dev`) and serves requests from the region closest to the caller, so no availability-zone colocation is required between your inference host and the bucket.
+
+## Step 1: Create a Tigris bucket and access key
+
+1. Sign up at the [Tigris Console](https://console.storage.dev/) — free, no credit card required.
+2. Create a bucket and note the bucket name.
+3. From the sidebar, open **Access Keys** and select **Create New Access Key**. Note the **Access Key ID** (prefixed with `tid_`) and **Secret Access Key** (prefixed with `tsec_`); the secret is only displayed once.
+
+See [Tigris's Manage Access Keys documentation](https://www.tigrisdata.com/docs/iam/manage-access-key/) for details.
+
+## Step 2: Fill out `example.yaml`
+
+Replace `{BUCKET_NAME}`, `{TIGRIS_ACCESS_KEY_ID}`, and `{TIGRIS_SECRET_ACCESS_KEY}` in `example.yaml` with the values from Step 1.
+
+## Step 3: Start an vLLM engine with LMCache
+
+```bash
+PYTHONHASHSEED=0 LMCACHE_CONFIG_FILE=example.yaml vllm serve meta-llama/Llama-3.1-8B-Instruct --kv-transfer-config '{"kv_connector":"LMCacheConnectorV1", "kv_role":"kv_both"}' --disable-log-requests --no-enable-prefix-caching
+```
+
+## Step 4: Sending requests
+
+You should be able to see cache hit on the second time by sending the following request twice:
+
+```bash
+curl -X POST http://localhost:8000/v1/completions   -H "Content-Type: application/json"   -d '{
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "prompt": "'"$(printf 'Elaborate the significance of KV cache in language models. %.0s' {1..1000})"'",
+    "max_tokens": 10
+  }'
+```

--- a/examples/kv_cache_reuse/remote_backends/tigris/example.yaml
+++ b/examples/kv_cache_reuse/remote_backends/tigris/example.yaml
@@ -1,0 +1,18 @@
+chunk_size: 256
+local_cpu: False
+max_local_cpu_size: 10
+save_unfull_chunk: False
+
+remote_url: "s3://{BUCKET_NAME}.t3.storage.dev"
+remote_serde: "naive"
+
+blocking_timeout_secs: 100
+
+extra_config:
+  save_chunk_meta: False
+  s3_num_io_threads: 64
+  s3_prefer_http2: True
+  s3_region: "auto"
+  s3_enable_s3express: False
+  aws_access_key_id: "{TIGRIS_ACCESS_KEY_ID}"
+  aws_secret_access_key: "{TIGRIS_SECRET_ACCESS_KEY}"


### PR DESCRIPTION
## Summary

Adds a Tigris example alongside the existing `s3/` example under `examples/kv_cache_reuse/remote_backends/`. Same structure (`README.md` + `example.yaml`), no code changes — the S3 L2 adapter already supports the configuration through its existing custom-endpoint code path.

## Why

[Tigris](https://www.tigrisdata.com/) is an S3-compatible object storage service with a single global endpoint and no egress fees. For KV cache spillover workloads that read repeatedly from the remote tier (multi-turn agentic workloads, multi-region inference), the egress cost and per-AZ colocation requirement of standard S3 are real operational concerns; Tigris's global routing sidesteps both.

## What changed

- `examples/kv_cache_reuse/remote_backends/tigris/README.md` — 4-step setup matching the format of `s3/README.md`
- `examples/kv_cache_reuse/remote_backends/tigris/example.yaml` — config matching the structure of `s3/example.yaml`, with the Tigris-specific defaults: virtual-hosted URL `s3://{BUCKET_NAME}.t3.storage.dev`, `s3_region: auto` (required for SigV4 signing but ignored by the service), `s3_enable_s3express: False` (Tigris is not S3 Express).

## Verified

- YAML parses cleanly
- Endpoint URL format matches the `S3L2AdapterConfig` docstring (`virtual-hosted bucket URL: 's3://<bucket>.<host>'`)
- Tested end-to-end with vLLM and Llama-3.1-8B-Instruct against a free-tier Tigris bucket using the example's serve command

## Notes

- Base branch: `dev` per `AGENTS.md`.
- DCO signed.
- No new dependencies, no code changes.
- Disclosure: I work at Tigris Data. Happy to revise framing or scope if the example doesn't fit the directory's intent.