### PR TITLE
fix(memory): gracefully handle CPU RAM OOM across all CPU allocators

### DIFF
--- a/lmcache/v1/health_monitor/checks/remote_backend_check.py
+++ b/lmcache/v1/health_monitor/checks/remote_backend_check.py
@@ -286,6 +286,10 @@ class RemoteBackendHealthCheck(HealthCheck):
         try:
             # put
             put_obj = self.backend.local_cpu_backend.allocate(shapes, dtypes, fmt)
+            if put_obj is None:
+                logger.warning("Health check skipped: CPU memory allocation failed.")
+                yield None, None
+                return
             future = self.backend.submit_put_task(key, put_obj)
             future.result(timeout=self._get_ping_timeout())
             # get

--- a/lmcache/v1/lazy_memory_allocator.py
+++ b/lmcache/v1/lazy_memory_allocator.py
@@ -117,8 +117,21 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
                 self._final_size, dtype=torch.uint8, device="cpu", pin_memory=False
             )
 
-        # Pin the first `curr_size` bytes (aligned to the internal chunk size)
-        self._pin_memory_chunk(0, self._curr_size)
+        # Pin the first `curr_size` bytes (aligned to the internal chunk size).
+        # If pinning fails at init (OS OOM), mark the allocator as OOM and skip
+        # the expansion thread — allocate() will return None for all requests.
+        self._cpu_oom = False
+        try:
+            self._pin_memory_chunk(0, self._curr_size)
+        except RuntimeError:
+            logger.warning(
+                "LazyMemoryAllocator: failed to pin %d bytes of CPU memory at init; "
+                "CPU cache will be unavailable. "
+                "Reduce local_cpu_memory_size in your LMCache config if this persists.",
+                self._curr_size,
+            )
+            self._cpu_oom = True
+            self._curr_size = 0
 
         # Create the tensor memory allocator
         self._allocator = TensorMemoryAllocator(
@@ -134,12 +147,15 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         # completely determined by the address manager.
         self._address_manager = self._allocator.address_manager
 
-        # Launch the background expansion thread
+        # Launch the background expansion thread (skipped when already OOM at init)
         self._stop_expand = threading.Event()
-        self._expand_thread = threading.Thread(
-            target=self._expand_worker, daemon=True, name="lazy-mem-expand-thread"
-        )
-        self._expand_thread.start()
+        if not self._cpu_oom:
+            self._expand_thread: Optional[threading.Thread] = threading.Thread(
+                target=self._expand_worker, daemon=True, name="lazy-mem-expand-thread"
+            )
+            self._expand_thread.start()
+        else:
+            self._expand_thread = None
 
     # Public methods
     def allocate(
@@ -149,6 +165,8 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
+        if self._cpu_oom:
+            return None
         obj = self._allocator.allocate(shapes, dtypes, fmt, allocator_type)
         # HACK(ApostaC): reset the parent allocator to this lazy allocator
         # There should be a cleaner way to decouple lazy allocator and
@@ -165,6 +183,8 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = None,
     ) -> Optional[List[MemoryObj]]:
+        if self._cpu_oom:
+            return None
         # HACK(ApostaC): reset the parent allocator to this lazy allocator
         # There should be a cleaner way to decouple lazy allocator and
         # tensor memory allocator
@@ -195,9 +215,10 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         self._allocator.batched_free(memory_objs, allocator_type, update_stats)
 
     def close(self):
-        # Stop the background expansion thread
+        # Stop the background expansion thread (None when init-time OOM skipped it)
         self._stop_expand.set()
-        self._expand_thread.join()
+        if self._expand_thread is not None:
+            self._expand_thread.join()
 
         # Unpin all pinned memory chunks
         for ptr, size in self._pin_record:
@@ -276,7 +297,18 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
             for i in range(self.COMMIT_SIZE // self.PIN_CHUNK_SIZE):
                 if self._curr_size >= self._final_size:
                     break
-                self._pin_memory_chunk(self._curr_size, self.PIN_CHUNK_SIZE)
+                try:
+                    self._pin_memory_chunk(self._curr_size, self.PIN_CHUNK_SIZE)
+                except RuntimeError:
+                    logger.warning(
+                        "LazyMemoryAllocator: failed to pin chunk at offset %d bytes; "
+                        "CPU cache capacity capped at %d bytes. "
+                        "Reduce local_cpu_memory_size if this persists.",
+                        self._curr_size,
+                        self._curr_size,
+                    )
+                    self._cpu_oom = True
+                    return
                 self._curr_size += self.PIN_CHUNK_SIZE
 
             expand_size = self._curr_size - last_commit_size

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -2223,11 +2223,25 @@ class PinMemoryAllocator(MemoryAllocatorInterface):
         :param int size: The size of the pinned memory in bytes.
         """
         self.size = size
-        self.buffer = _allocate_cpu_memory(size)
+        self._cpu_oom = False
+        try:
+            self.buffer = _allocate_cpu_memory(size)
+        except RuntimeError:
+            logger.warning(
+                "PinMemoryAllocator: failed to allocate %d bytes of pinned CPU "
+                "memory — CPU cache will be unavailable. Reduce "
+                "local_cpu_memory_size in your LMCache config if this persists.",
+                size,
+            )
+            self._cpu_oom = True
+            self.buffer = torch.empty(0, dtype=torch.uint8)
+
         self._unregistered = False
 
         self.allocator: MemoryAllocatorInterface
-        if use_paging:
+        if self._cpu_oom:
+            self.allocator = TensorMemoryAllocator(self.buffer)
+        elif use_paging:
             assert "shapes" in kwargs, (
                 "shapes must be specified for paged memory allocator"
             )
@@ -2244,7 +2258,9 @@ class PinMemoryAllocator(MemoryAllocatorInterface):
         else:
             self.allocator = TensorMemoryAllocator(self.buffer)
 
-        self.host_mem_lock = threading.Lock() if not use_paging else nullcontext()
+        self.host_mem_lock = (
+            threading.Lock() if not use_paging and not self._cpu_oom else nullcontext()
+        )
 
     @_lmcache_nvtx_annotate
     def allocate(
@@ -2331,15 +2347,28 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
             self.shm_name = kwargs.get("shm_name", None)
 
         self.size = size
+        self._cpu_oom = False
 
-        self.buffer = _allocate_cpu_memory(
-            size, self.numa_mapping, self.shm_name, use_hugepages=use_hugepages
-        )
+        try:
+            self.buffer = _allocate_cpu_memory(
+                size, self.numa_mapping, self.shm_name, use_hugepages=use_hugepages
+            )
+        except RuntimeError:
+            logger.warning(
+                "MixedMemoryAllocator: failed to allocate %d bytes of pinned CPU "
+                "memory — CPU cache will be unavailable. Reduce "
+                "local_cpu_memory_size in your LMCache config if this persists.",
+                size,
+            )
+            self._cpu_oom = True
+            self.buffer = torch.empty(0, dtype=torch.uint8)
 
         self._unregistered = False
 
         self.pin_allocator: MemoryAllocatorInterface
-        if use_paging:
+        if self._cpu_oom:
+            self.pin_allocator = TensorMemoryAllocator(self.buffer)
+        elif use_paging:
             assert "shapes" in kwargs, (
                 "shapes must be specified for paged memory allocator"
             )
@@ -2358,7 +2387,9 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
                 self.buffer, align_bytes=self.align_bytes
             )
 
-        self.host_mem_lock = threading.Lock() if not use_paging else nullcontext()
+        self.host_mem_lock = (
+            threading.Lock() if not use_paging and not self._cpu_oom else nullcontext()
+        )
 
         self.buffer_allocator = BufferAllocator("cpu")
 

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -2771,7 +2771,7 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
     """
 
     def __init__(self):
-        pass
+        self._cpu_oom = False
 
     def init_gpu_memory_allocator(
         self,
@@ -2801,7 +2801,19 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
         fmt: MemoryFormat = MemoryFormat.KV_2LTD,
         numa_mapping: Optional[NUMAMapping] = None,
     ):
-        self.cpu_buffer = _allocate_cpu_memory(size, numa_mapping)
+        try:
+            self.cpu_buffer = _allocate_cpu_memory(size, numa_mapping)
+            self._cpu_oom = False
+        except RuntimeError:
+            logger.warning(
+                "PagedCpuGpuMemoryAllocator: failed to allocate %d bytes of "
+                "CPU pinned memory — CPU cache will be unavailable. Reduce "
+                "local_cpu_memory_size in your LMCache config if this persists.",
+                size,
+            )
+            self._cpu_oom = True
+            self.cpu_buffer = torch.empty(0, dtype=torch.uint8)
+
         self.cpu_allocator = PagedTensorMemoryAllocator(
             self.cpu_buffer,
             shapes,
@@ -2820,6 +2832,8 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
         if allocator_type == "gpu":
             return self.gpu_allocator.allocate(shapes, dtypes, fmt)
         elif allocator_type == "cpu":
+            if self._cpu_oom:
+                return None
             return self.cpu_allocator.allocate(shapes, dtypes, fmt)
         else:
             raise ValueError(f"Unsupported allocator type: {allocator_type}")
@@ -2835,6 +2849,8 @@ class PagedCpuGpuMemoryAllocator(MemoryAllocatorInterface):
         if allocator_type == "gpu":
             return self.gpu_allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
         elif allocator_type == "cpu":
+            if self._cpu_oom:
+                return None
             return self.cpu_allocator.batched_allocate(shapes, dtypes, batch_size, fmt)
         else:
             raise ValueError(f"Unsupported allocator type: {allocator_type}")

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1805,6 +1805,7 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         self.shapes = shapes
         self.dtypes = dtypes
         self.fmt = fmt
+        self._closed = False
 
         # full chunk size bytes
         self.align_bytes = get_size_bytes(shapes, dtypes)
@@ -2054,9 +2055,28 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         """
         return self.paged_buffers
 
+    def close(self):
+        """
+        Release the underlying buffer.
+
+        Must be called only after any NIXL agent that registered this buffer
+        has already called ``deregister_memory`` (i.e. after the agent's own
+        ``close()``). Calling ``close()`` in the wrong order leaves NIXL
+        holding a stale registration against freed memory.
+        """
+        if not self._closed:
+            del self.buffer
+            self._closed = True
+
     def __del__(self):
-        # FIXME: NIXL-related memory leak should be handled somewhere (else).
-        del self.buffer
+        if not self._closed:
+            logger.warning(
+                "PagedTensorMemoryAllocator.close() was never called. "
+                "Any NIXL agent that registered this buffer may have leaked "
+                "its memory registration. Always call close() explicitly "
+                "after the NIXL agent has been closed."
+            )
+            del self.buffer
 
 
 class BufferAllocator(MemoryAllocatorInterface):
@@ -2452,6 +2472,9 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
                 torch_dev.synchronize()
             if self.buffer.numel() == 0:
                 return
+            # Close the paged sub-allocator before freeing the backing buffer so
+            # that any NIXL agent registered against its pages is already gone.
+            self.pin_allocator.close()
             _free_cpu_memory(
                 self.buffer,
                 self.size,

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -655,6 +655,11 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         evict_keys_count = 0
         num_attempts = 0
+        # Counts consecutive iterations where eviction made no progress.
+        # Prevents an infinite busy-loop when all blocks are pinned.
+        stalled_attempts = 0
+        # TODO: make max_stalled_attempts and time_to_wait configurable
+        max_stalled_attempts = 100  # 10 seconds at 0.1s per sleep
         while True:
             # whether or not this request needs to wait or other requests
             wait_other_requests = True
@@ -671,6 +676,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                         # we can continue trying to evict from the hot_cache
                         # and don't need to wait for other requests yet
                         wait_other_requests = False
+                        stalled_attempts = 0
                         logger.debug(
                             f"Evicting {len(evict_keys)} chunks from cpu memory"
                         )
@@ -687,6 +693,18 @@ class LocalCPUBackend(AllocatorBackendInterface):
                     logger.debug(
                         "Not busy looping because we are not immediately able to evict"
                     )
+                    break
+
+                stalled_attempts += 1
+                if stalled_attempts >= max_stalled_attempts:
+                    logger.warning(
+                        "CPU memory eviction made no progress after %d attempts "
+                        "(%.1f s). All blocks may be pinned. "
+                        "Giving up on allocation.",
+                        stalled_attempts,
+                        stalled_attempts * 0.1,
+                    )
+                    memory_obj = None
                     break
 
                 # TODO: make time_to_wait a config
@@ -761,10 +779,19 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_objs is not None or not eviction:
             return memory_objs
 
-        assert isinstance(self.memory_allocator, MixedMemoryAllocator)
+        if not isinstance(self.memory_allocator, MixedMemoryAllocator):
+            raise ValueError(
+                f"batched_allocate eviction requires MixedMemoryAllocator, "
+                f"got {type(self.memory_allocator).__name__}"
+            )
 
         evict_keys_count = 0
         num_attempts = 0
+        # Counts consecutive iterations where eviction made no progress.
+        # Prevents an infinite busy-loop when all blocks are pinned.
+        stalled_attempts = 0
+        # TODO: make max_stalled_attempts and time_to_wait configurable
+        max_stalled_attempts = 100  # 10 seconds at 0.1s per sleep
         while True:
             wait_other_requests = True
             if self.use_hot:
@@ -800,6 +827,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                                 continue
 
                             wait_other_requests = False
+                            stalled_attempts = 0
                             evict_keys_count += len(old_mem_objs)
                             for key in evict_key_all_layer:
                                 self.cache_policy.update_on_force_evict(key)
@@ -821,6 +849,18 @@ class LocalCPUBackend(AllocatorBackendInterface):
                     logger.debug(
                         "Not busy looping because we are not immediately able to evict"
                     )
+                    break
+
+                stalled_attempts += 1
+                if stalled_attempts >= max_stalled_attempts:
+                    logger.warning(
+                        "CPU memory eviction made no progress after %d attempts "
+                        "(%.1f s). All blocks may be pinned. "
+                        "Giving up on batched allocation.",
+                        stalled_attempts,
+                        stalled_attempts * 0.1,
+                    )
+                    memory_objs = None
                     break
 
                 # TODO: make time_to_wait a config

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -656,6 +656,108 @@ class TestLocalCPUBackendAllocatorRecovery:
         allocator.close()
 
 
+    def test_allocate_returns_none_after_stall_cap_when_full_and_no_candidates(
+        self, monkeypatch
+    ):
+        """allocate(busy_loop=True) must return None (not hang) when RAM is
+        exhausted and hot_cache has no eviction candidates."""
+        monkeypatch.setattr(
+            "lmcache.v1.storage_backend.local_cpu_backend.time.sleep",
+            lambda _: None,
+        )
+        chunk_bytes = 4096
+        shape = torch.Size([1, chunk_bytes])
+        config = create_test_config()
+        PinMonitor.GetOrCreate(config)
+        allocator = MixedMemoryAllocator(chunk_bytes)
+        backend = LocalCPUBackend(config=config, memory_allocator=allocator)
+
+        # Consume the only free block; do not store in hot_cache so there are
+        # no eviction candidates.
+        held = backend.allocate(shape, torch.uint8, busy_loop=False)
+        assert held is not None
+
+        result = backend.allocate(shape, torch.uint8, busy_loop=True)
+
+        assert result is None, "Expected None after stall cap, not an infinite loop"
+
+        held.ref_count_down()
+        allocator.close()
+
+    def test_batched_allocate_returns_none_after_stall_cap_when_all_blocks_pinned(
+        self, monkeypatch
+    ):
+        """batched_allocate(busy_loop=True) must return None (not hang) when
+        all cached groups are pinned and eviction can make no progress."""
+        monkeypatch.setattr(
+            "lmcache.v1.storage_backend.local_cpu_backend.time.sleep",
+            lambda _: None,
+        )
+        chunk_bytes = 4096
+        batch_size = 2
+        shape = torch.Size([1, chunk_bytes])
+        config = create_test_config()
+        PinMonitor.GetOrCreate(config)
+        allocator = MixedMemoryAllocator(chunk_bytes * batch_size)
+        backend = LocalCPUBackend(config=config, memory_allocator=allocator)
+        layer_keys = create_test_key("stall_cap_pinned").split_layers(batch_size)
+
+        objs = backend.batched_allocate(
+            shape, torch.uint8, batch_size=batch_size,
+            fmt=MemoryFormat.KV_T2D, busy_loop=False,
+        )
+        assert objs is not None
+        backend.batched_submit_put_task(layer_keys, objs)
+        for obj in objs:
+            obj.ref_count_down()
+
+        # Pin one key so the whole group is ineligible for eviction.
+        assert backend.pin(layer_keys[0])
+
+        result = backend.batched_allocate(
+            shape, torch.uint8, batch_size=batch_size,
+            fmt=MemoryFormat.KV_T2D, busy_loop=True,
+        )
+
+        assert result is None, "Expected None after stall cap, not an infinite loop"
+
+        assert backend.unpin(layer_keys[0])
+        backend.clear()
+        allocator.close()
+
+    def test_batched_allocate_raises_value_error_for_non_mixed_allocator(self):
+        """batched_allocate must raise ValueError (not AssertionError) when
+        the injected allocator is not a MixedMemoryAllocator and RAM is full."""
+
+        class _AlwaysFullAllocator:
+            """Stub that always reports allocation failure."""
+
+            align_bytes = 4096
+
+            def allocate(self, shapes, dtypes, fmt, allocator_type=None):
+                return None
+
+            def batched_allocate(self, shapes, dtypes, batch_size, fmt,
+                                 allocator_type=None):
+                return None
+
+            def close(self):
+                pass
+
+        config = create_test_config()
+        PinMonitor.GetOrCreate(config)
+        backend = LocalCPUBackend(
+            config=config, memory_allocator=_AlwaysFullAllocator()
+        )
+
+        shape = torch.Size([1, 4096])
+        with pytest.raises(ValueError, match="MixedMemoryAllocator"):
+            backend.batched_allocate(
+                shape, torch.uint8, batch_size=2,
+                fmt=MemoryFormat.KV_T2D, busy_loop=False,
+            )
+
+
 class TestLocalCPUBackendAllocatorAlignment:
     def test_rust_odirect_auto_alignment_for_mixed_allocator(self, monkeypatch):
         config = create_test_config(local_cpu=True)

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -956,3 +956,75 @@ class TestHugepageAllocation:
         assert total > 0
         assert free >= 0
         assert page_mb == 2
+
+
+class TestPagedTensorMemoryAllocatorClose:
+    """Tests for the close() lifecycle on PagedTensorMemoryAllocator."""
+
+    def _make_allocator(self) -> PagedTensorMemoryAllocator:
+        shape = torch.Size([2, 32, 16, 128])
+        dtype = torch.bfloat16
+        fmt = MemoryFormat.KV_2LTD
+        chunk_bytes = shape.numel() * dtype.itemsize
+        tensor_buffer = torch.zeros(chunk_bytes * 4, dtype=torch.uint8, device="cpu")
+        return PagedTensorMemoryAllocator(tensor_buffer, [shape], [dtype], fmt)
+
+    def test_close_sets_closed_flag(self):
+        """close() marks the allocator as closed."""
+        allocator = self._make_allocator()
+        assert not allocator._closed
+        allocator.close()
+        assert allocator._closed
+
+    def test_close_idempotent(self):
+        """Calling close() twice does not raise."""
+        allocator = self._make_allocator()
+        allocator.close()
+        allocator.close()
+
+    def test_del_warns_if_close_not_called(self):
+        """__del__ emits a warning when close() was never called."""
+        from unittest.mock import patch
+
+        import lmcache.v1.memory_management as mm_module
+
+        allocator = self._make_allocator()
+        with patch.object(mm_module.logger, "warning") as mock_warn:
+            allocator.__del__()
+        messages = " ".join(str(a) for call in mock_warn.call_args_list for a in call[0])
+        assert "close() was never called" in messages
+
+    def test_del_silent_after_close(self):
+        """__del__ is silent when close() was already called."""
+        from unittest.mock import patch
+
+        import lmcache.v1.memory_management as mm_module
+
+        allocator = self._make_allocator()
+        allocator.close()
+        with patch.object(mm_module.logger, "warning") as mock_warn:
+            allocator.__del__()
+        messages = " ".join(str(a) for call in mock_warn.call_args_list for a in call[0])
+        assert "close() was never called" not in messages
+
+    def test_mixed_allocator_close_calls_pin_allocator_close(self):
+        """MixedMemoryAllocator.close() propagates close() to its PagedTensorMemoryAllocator."""
+        LMCStatsMonitor.GetOrCreate()
+        total_size = 1024 * 1024 * 16  # 16 MB
+        shape = torch.Size([2, 32, 16, 128])
+        dtype = torch.bfloat16
+        fmt = MemoryFormat.KV_2LTD
+        allocator = MixedMemoryAllocator(
+            total_size,
+            use_paging=True,
+            shapes=[shape],
+            dtypes=[dtype],
+            fmt=fmt,
+        )
+        pin_alloc = allocator.pin_allocator
+        assert isinstance(pin_alloc, PagedTensorMemoryAllocator)
+        assert not pin_alloc._closed
+
+        allocator.close()
+
+        assert pin_alloc._closed

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -17,6 +17,7 @@ from lmcache.v1.memory_management import (
     MemoryFormat,
     MemoryObjMetadata,
     MixedMemoryAllocator,
+    PagedCpuGpuMemoryAllocator,
     PagedTensorMemoryAllocator,
     PinMemoryAllocator,
     TensorMemoryAllocator,
@@ -1228,3 +1229,46 @@ class TestLazyMemoryAllocatorCpuOom:
         result = allocator.allocate(torch.Size([512, 512]), torch.float32)
         assert result is None
         allocator.close()
+
+
+class TestPagedCpuGpuMemoryAllocatorCpuOom:
+    """Tests for PagedCpuGpuMemoryAllocator graceful handling of CPU RAM exhaustion."""
+
+    _SHAPE = torch.Size([2, 32, 16, 128])
+    _DTYPE = torch.bfloat16
+    _FMT = MemoryFormat.KV_2LTD
+
+    def _make_oom_allocator(self) -> PagedCpuGpuMemoryAllocator:
+        from unittest.mock import patch
+
+        with patch(
+            "lmcache.v1.memory_management._allocate_cpu_memory",
+            side_effect=RuntimeError("mmap failed: out of memory"),
+        ):
+            alloc = PagedCpuGpuMemoryAllocator()
+            alloc.init_cpu_memory_allocator(
+                1024 * 1024 * 64,
+                [self._SHAPE],
+                [self._DTYPE],
+                self._FMT,
+            )
+        return alloc
+
+    def test_oom_sets_flag(self):
+        """_cpu_oom is True when _allocate_cpu_memory raises at init."""
+        alloc = self._make_oom_allocator()
+        assert alloc._cpu_oom
+
+    def test_oom_allocate_returns_none(self):
+        """allocate() with allocator_type='cpu' returns None after CPU OOM."""
+        alloc = self._make_oom_allocator()
+        result = alloc.allocate(self._SHAPE, self._DTYPE, self._FMT, allocator_type="cpu")
+        assert result is None
+
+    def test_oom_batched_allocate_returns_none(self):
+        """batched_allocate() with allocator_type='cpu' returns None after CPU OOM."""
+        alloc = self._make_oom_allocator()
+        result = alloc.batched_allocate(
+            self._SHAPE, self._DTYPE, 4, self._FMT, allocator_type="cpu"
+        )
+        assert result is None

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -1028,3 +1028,107 @@ class TestPagedTensorMemoryAllocatorClose:
         allocator.close()
 
         assert pin_alloc._closed
+
+
+class TestPinMemoryAllocatorCpuOom:
+    """Tests for PinMemoryAllocator graceful handling of CPU RAM exhaustion."""
+
+    def test_oom_sets_flag(self):
+        """_cpu_oom is True when _allocate_cpu_memory raises RuntimeError."""
+        from unittest.mock import patch
+
+        LMCStatsMonitor.GetOrCreate()
+        with patch(
+            "lmcache.v1.memory_management._allocate_cpu_memory",
+            side_effect=RuntimeError("mmap failed: out of memory"),
+        ):
+            allocator = PinMemoryAllocator(1024 * 1024 * 64)
+
+        assert allocator._cpu_oom
+
+    def test_oom_allocate_returns_none(self):
+        """allocate() returns None after CPU OOM — same contract as a full pool."""
+        from unittest.mock import patch
+
+        LMCStatsMonitor.GetOrCreate()
+        with patch(
+            "lmcache.v1.memory_management._allocate_cpu_memory",
+            side_effect=RuntimeError("mmap failed: out of memory"),
+        ):
+            allocator = PinMemoryAllocator(1024 * 1024 * 64)
+
+        result = allocator.allocate(torch.Size([128, 128]), torch.float16)
+        assert result is None
+
+    def test_oom_close_does_not_raise(self):
+        """close() is safe to call when the allocator OOM'd at init."""
+        from unittest.mock import patch
+
+        LMCStatsMonitor.GetOrCreate()
+        with patch(
+            "lmcache.v1.memory_management._allocate_cpu_memory",
+            side_effect=RuntimeError("mmap failed: out of memory"),
+        ):
+            allocator = PinMemoryAllocator(1024 * 1024 * 64)
+
+        allocator.close()
+
+
+class TestMixedMemoryAllocatorCpuOom:
+    """Tests for MixedMemoryAllocator graceful handling of CPU RAM exhaustion."""
+
+    def test_oom_sets_flag(self):
+        """_cpu_oom is True when _allocate_cpu_memory raises RuntimeError."""
+        from unittest.mock import patch
+
+        LMCStatsMonitor.GetOrCreate()
+        with patch(
+            "lmcache.v1.memory_management._allocate_cpu_memory",
+            side_effect=RuntimeError("mmap failed: out of memory"),
+        ):
+            allocator = MixedMemoryAllocator(1024 * 1024 * 64)
+
+        assert allocator._cpu_oom
+
+    def test_oom_allocate_kv_returns_none(self):
+        """allocate() returns None for KV formats after CPU OOM."""
+        from unittest.mock import patch
+
+        LMCStatsMonitor.GetOrCreate()
+        with patch(
+            "lmcache.v1.memory_management._allocate_cpu_memory",
+            side_effect=RuntimeError("mmap failed: out of memory"),
+        ):
+            allocator = MixedMemoryAllocator(1024 * 1024 * 64)
+
+        result = allocator.allocate(
+            torch.Size([2, 32, 16, 128]), torch.bfloat16, MemoryFormat.KV_2LTD
+        )
+        assert result is None
+
+    def test_oom_close_does_not_raise(self):
+        """close() is safe to call when the allocator OOM'd at init."""
+        from unittest.mock import patch
+
+        LMCStatsMonitor.GetOrCreate()
+        with patch(
+            "lmcache.v1.memory_management._allocate_cpu_memory",
+            side_effect=RuntimeError("mmap failed: out of memory"),
+        ):
+            allocator = MixedMemoryAllocator(1024 * 1024 * 64)
+
+        allocator.close()
+
+    def test_oom_close_idempotent(self):
+        """close() can be called multiple times after OOM without raising."""
+        from unittest.mock import patch
+
+        LMCStatsMonitor.GetOrCreate()
+        with patch(
+            "lmcache.v1.memory_management._allocate_cpu_memory",
+            side_effect=RuntimeError("mmap failed: out of memory"),
+        ):
+            allocator = MixedMemoryAllocator(1024 * 1024 * 64)
+
+        allocator.close()
+        allocator.close()

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -1132,3 +1132,99 @@ class TestMixedMemoryAllocatorCpuOom:
 
         allocator.close()
         allocator.close()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="LazyMemoryAllocator requires CUDA for memory pinning",
+)
+class TestLazyMemoryAllocatorCpuOom:
+    """Tests for LazyMemoryAllocator graceful handling of CPU RAM exhaustion."""
+
+    @pytest.fixture
+    def lazy_allocator_cls(self):
+        from lmcache.v1.lazy_memory_allocator import LazyMemoryAllocator
+
+        return LazyMemoryAllocator
+
+    def test_init_oom_sets_flag(self, lazy_allocator_cls):
+        """_cpu_oom is True when _pin_memory_chunk raises at init."""
+        from unittest.mock import patch
+
+        with patch.object(
+            lazy_allocator_cls,
+            "_pin_memory_chunk",
+            side_effect=RuntimeError("cudaHostRegister failed: out of memory"),
+        ):
+            allocator = lazy_allocator_cls(init_size=1 << 26, final_size=1 << 27)
+
+        assert allocator._cpu_oom
+        allocator.close()
+
+    def test_init_oom_allocate_returns_none(self, lazy_allocator_cls):
+        """allocate() returns None after init-time pin failure."""
+        from unittest.mock import patch
+
+        with patch.object(
+            lazy_allocator_cls,
+            "_pin_memory_chunk",
+            side_effect=RuntimeError("cudaHostRegister failed: out of memory"),
+        ):
+            allocator = lazy_allocator_cls(init_size=1 << 26, final_size=1 << 27)
+
+        result = allocator.allocate(torch.Size([512, 512]), torch.float32)
+        assert result is None
+        allocator.close()
+
+    def test_init_oom_batched_allocate_returns_none(self, lazy_allocator_cls):
+        """batched_allocate() returns None after init-time pin failure."""
+        from unittest.mock import patch
+
+        with patch.object(
+            lazy_allocator_cls,
+            "_pin_memory_chunk",
+            side_effect=RuntimeError("cudaHostRegister failed: out of memory"),
+        ):
+            allocator = lazy_allocator_cls(init_size=1 << 26, final_size=1 << 27)
+
+        result = allocator.batched_allocate(torch.Size([512, 512]), torch.float32, 4)
+        assert result is None
+        allocator.close()
+
+    def test_init_oom_close_does_not_raise(self, lazy_allocator_cls):
+        """close() is safe when the allocator OOM'd at init (no thread was started)."""
+        from unittest.mock import patch
+
+        with patch.object(
+            lazy_allocator_cls,
+            "_pin_memory_chunk",
+            side_effect=RuntimeError("cudaHostRegister failed: out of memory"),
+        ):
+            allocator = lazy_allocator_cls(init_size=1 << 26, final_size=1 << 27)
+
+        allocator.close()
+
+    def test_expansion_oom_sets_flag_and_thread_exits(self, lazy_allocator_cls):
+        """_expand_worker sets _cpu_oom and exits cleanly on mid-expansion pin failure."""
+        from unittest.mock import patch
+
+        original = lazy_allocator_cls._pin_memory_chunk
+        call_count = {"n": 0}
+
+        def fail_after_first(self_inner, offset, size):
+            call_count["n"] += 1
+            if call_count["n"] > 1:
+                raise RuntimeError("cudaHostRegister failed: out of memory")
+            original(self_inner, offset, size)
+
+        with patch.object(lazy_allocator_cls, "_pin_memory_chunk", fail_after_first):
+            allocator = lazy_allocator_cls(init_size=1 << 26, final_size=1 << 27)
+            # Join inside the patch context so the thread still sees the mock.
+            allocator._expand_thread.join(timeout=5.0)
+
+        assert not allocator._expand_thread.is_alive(), "expand thread did not exit"
+        assert allocator._cpu_oom
+
+        result = allocator.allocate(torch.Size([512, 512]), torch.float32)
+        assert result is None
+        allocator.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

When the host runs out of CPU RAM, multiple allocator classes crashed the engine instead of degrading gracefully:

- `PinMemoryAllocator` and `MixedMemoryAllocator` raised an unhandled `RuntimeError` from `_allocate_cpu_memory()` at `__init__` time, killing the engine on startup.
- `LazyMemoryAllocator._expand_worker` let `cudaHostRegister` failures propagate uncaught, silently killing the background expansion thread and under-delivering address space with no notification to the main thread.
- `PagedTensorMemoryAllocator` lacked an explicit `close()`, so NIXL agents that registered its pages could hold stale registrations after the backing buffer was freed (also incorrect teardown order in `MixedMemoryAllocator.close()`).
- `PagedCpuGpuMemoryAllocator.init_cpu_memory_allocator` (used by the NIXL/PD disaggregation path) had no OOM guard and would crash with an unhandled `RuntimeError`.

This PR makes all CPU KV cache paths graceful:

- `PinMemoryAllocator` and `MixedMemoryAllocator` now catch `RuntimeError` at init, log a `WARNING`, set `_cpu_oom=True`, and return `None` from `allocate()` / `batched_allocate()` — matching the existing "pool full" contract. The engine keeps running without CPU cache offload instead of crashing.
- `LazyMemoryAllocator` applies the same treatment at both crash sites: init-time pin failure sets `_cpu_oom` and skips the expansion thread; mid-expansion failure logs the capped capacity, sets `_cpu_oom`, and lets the thread exit cleanly.
- `PagedTensorMemoryAllocator` gains an explicit `close()` (with `_closed` guard) called by `MixedMemoryAllocator.close()` before freeing the backing buffer, preserving correct NIXL deregistration order.
- `PagedCpuGpuMemoryAllocator.init_cpu_memory_allocator` now wraps `_allocate_cpu_memory` in try/except, stubs the cpu buffer with `torch.empty(0)` on failure, and guards `allocate()` / `batched_allocate()` to return `None` when `_cpu_oom` is set.

**Out of scope**: `nixl_storage_backend.py` also calls `_allocate_cpu_memory` for its RDMA transfer buffer — that call is intentionally left unguarded. The NIXL storage backend cannot function without that buffer, so OOM there is a hard failure, not a graceful-degrade candidate.

**Design note**: The `_cpu_oom` stub uses `torch.empty(0)` + `TensorMemoryAllocator(empty_tensor)`, so `close()` benefits from the existing `numel() == 0` early-exit guard without needing new branches in teardown. All CPU KV cache allocators now share a consistent OOM contract: `allocate()` returns `None`, engine keeps running without CPU cache.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests