### PR TITLE
[Feat] Server-side worker liveness tracking and reaping (2/2)

### DIFF
--- a/docs/design/v1/multiprocess/worker_liveness.md
+++ b/docs/design/v1/multiprocess/worker_liveness.md
@@ -102,30 +102,33 @@ readers use the locked accessors `get_and_touch_context_entry` (get-and-refresh)
 `reap_timeout / 4`. Each scan calls `reap_stale_instances` on every target: under
 the module lock, collect ids whose staleness exceeds their window and pop them;
 outside the lock, run the same cleanup as a client unregister and log a WARNING
-per instance (repeated reaps of one id signal a too-small timeout). Reaped ids fan
-out to every `InstanceReapListener.drop_instance_state(id)`; `BlendV3Module` drops
+per instance (repeated reaps of one id signal a too-small timeout). Reaped ids are
+then passed to `drop_instance_state(id)` on every target; `BlendV3Module` drops
 the reaped instance's per-instance CB state (e.g. rope state) there. (It no longer
 mirrors the GPU cache context — that mirror was removed upstream, so reaping the
 GPU entry now frees the context directly.) Collect+pop shares the module lock with
 register's refresh, serializing every register-vs-reap race; on close, the reaper
 is stopped and joined before any module clears state.
 
-### 5.4 Public protocols and config
+### 5.4 Public protocol and config
 
 ```python
 class InstanceLivenessTarget(Protocol):
+    # All methods default to a no-op; an implementer overrides only its role.
     def touch_instance(self, instance_id: int) -> None: ...
     def reap_stale_instances(
         self, reap_timeout_s: float, registration_grace_s: float
     ) -> list[int]: ...
     def tracked_instance_count(self) -> int: ...
-
-class InstanceReapListener(Protocol):
     def drop_instance_state(self, instance_id: int) -> None: ...
 ```
 
-Both transfer modules implement `InstanceLivenessTarget`; `BlendV3Module` is an
-`InstanceReapListener`; `ManagementModule` receives both by constructor injection.
+One protocol covers both reaper-driven roles. The transfer modules override the
+liveness methods (`touch`/`reap`/`count`); `BlendV3Module` overrides only
+`drop_instance_state` to drop its mirrored CB state. `ManagementModule` receives
+all targets in a single injected list. (Earlier a separate one-method
+`InstanceReapListener` held `drop_instance_state`; it was folded in since only
+`BlendV3Module` ever implemented it.)
 
 Config: `worker_reap_timeout_seconds` (default `120.0`; `0` disables, otherwise
 `>= 30.0`) and `worker_registration_grace_seconds` (default `3600.0`; `>=` the

--- a/docs/design/v1/multiprocess/worker_liveness.md
+++ b/docs/design/v1/multiprocess/worker_liveness.md
@@ -5,12 +5,12 @@ the vLLM multiprocess adapter.
 
 ## 1. Problem
 
-When a vLLM worker dies without sending `UNREGISTER_KV_CACHE` (SIGKILL, OOM-kill,
-node loss), its per-instance state leaks on the MP server forever: the GPU
-`ContextEntry` (a `GPUCacheContext` holding CUDA IPC handles), the
-`NonGPUContextEntry` + `TransferStrategy` pair, and any blend-mode per-instance
-state (e.g. CB rope caches). Nothing observes worker death; on a shared server,
-leaked contexts accumulate until device memory is exhausted.
+When an engine worker dies without sending `UNREGISTER_KV_CACHE` (SIGKILL,
+OOM-kill, node loss), its per-instance state leaks on the MP server forever: the
+LMCache-driven `ContextEntry` (a `GPUCacheContext` holding CUDA IPC handles), the
+`EngineDrivenContextEntry` + `TransferStrategy` pair, and any blend-mode
+per-instance state (e.g. CB rope caches). Nothing observes worker death; on a
+shared server, leaked contexts accumulate until device memory is exhausted.
 
 Worse, `instance_id` is `os.getpid()`: containerized pods reuse small PIDs, so a
 new worker can register with a dead worker's id, and the idempotent register
@@ -31,7 +31,7 @@ when the server returns the unhealthy-to-healthy edge fires the recover callback
 which re-registers — a noop when the entry survived.
 
 ```
-vLLM worker adapter                              MP server
+engine worker adapter                            MP server
 +---------------------------+                   +--------------------------------------+
 | HeartbeatThread           |   PING [id]       | ManagementModule                     |
 |  (instance_id, 10s)  -----+------------------>|  ping(id) -> touch_instance(id)      |
@@ -39,11 +39,12 @@ vLLM worker adapter                              MP server
 |   (starts healthy)        |                   |   -> reap_stale_instances(           |
 |  unhealthy->healthy edge  |                   |        timeout, registration_grace)  |
 |   -> re-register callback |   REGISTER        |   -> drop_instance_state(id) fan-out |
-|  freeze-gap detection ->  +------------------>|        |                |            |
-|   force 1 unhealthy cycle |   STORE/RETRIEVE  |        v                v            |
-|                           |   (refresh too)   | GPU / NonGPU            BlendV3      |
-| register_kv_caches        |                   |  TransferModule         (CB rope     |
-|  (no pings until traffic) |                   |  Entry{.., last_seen,    dropped)    |
+|                           +------------------>|        |                |            |
+| register_kv_caches        |   STORE/RETRIEVE  |        v                v            |
+|  (no pings until traffic) |   (refresh too)   | LMCacheDriven/          BlendV3      |
+|                           |                   |  EngineDriven           (CB rope     |
+|                           |                   |  TransferModule          dropped)    |
+|                           |                   |  Entry{.., last_seen,               |
 |                           |                   |   has_liveness_signal}               |
 +---------------------------+                   |  _lock (leaf); pop -> cleanup        |
                                                 +--------------------------------------+
@@ -73,13 +74,13 @@ Every id-carrying request reads the same field, so no other payloads change.
 
 ### 5.1 Liveness state and two-tier windows
 
-`ContextEntry` (GPU) and `NonGPUContextEntry` gain `last_seen: float`
-(`time.monotonic()`) and `has_liveness_signal: bool`, latched only by PING. The
-flag selects the staleness window: an entry that has pinged provably runs the
-heartbeat protocol and is judged on the reap timeout; one that never pinged (e.g.
-still warming under lazy start) is judged on the generous registration grace.
-`last_seen` is refreshed by PING (`touch_instance`: refresh if present, never
-insert), register (create and NOOP paths), and every GPU and non-GPU transfer
+`ContextEntry` (LMCache-driven) and `EngineDrivenContextEntry` gain
+`last_seen: float` (`time.monotonic()`) and `has_liveness_signal: bool`, latched
+only by PING. The flag selects the staleness window: an entry that has pinged
+provably runs the heartbeat protocol and is judged on the reap timeout; one that
+never pinged (e.g. still warming under lazy start) is judged on the generous
+registration grace. `last_seen` is refreshed by PING (`touch_instance`: refresh
+if present, never insert), register (create and NOOP paths), and every transfer
 path, so a worker mid-transfer is never reaped; traffic never latches the flag.
 
 ### 5.2 Locking
@@ -88,11 +89,11 @@ The reaper runs on its own thread, so the per-instance dicts are now mutated off
 the MQ handler threads. Each transfer module gains one `threading.Lock` so the
 reaper's scan-and-pop cannot race a concurrent register/unregister/transfer (which
 would otherwise corrupt the dict or hand out a half-removed entry). In
-`NonGPUTransferModule` the context and strategy dicts mutate as a pair under that
-lock, so a reap racing a re-register can never strand a fresh context without its
+`EngineDrivenTransferModule` the context and strategy dicts mutate as a pair under
+that lock, so a reap racing a re-register can never strand a fresh context without its
 strategy. It is a leaf lock — never held across context construction, storage
 calls, or any other component — so no thread ever holds two locks. External
-readers use the locked accessors `get_context_entry` (get-and-refresh) and
+readers use the locked accessors `get_and_touch_context_entry` (get-and-refresh) and
 `context_entries_snapshot` instead of touching the dict directly.
 
 ### 5.3 Reaper
@@ -129,9 +130,9 @@ Both transfer modules implement `InstanceLivenessTarget`; `BlendV3Module` is an
 Config: `worker_reap_timeout_seconds` (default `120.0`; `0` disables, otherwise
 `>= 30.0`) and `worker_registration_grace_seconds` (default `3600.0`; `>=` the
 reap timeout — a tighter grace would reap warming workers faster than crashed
-ones), with matching CLI flags. Freeze-gap recovery additionally requires the
-timeout `>= 3 x` the client's `lmcache.mp.heartbeat_interval`; the worker adapter
-warns at startup when `3 x interval` exceeds the 30 s config floor.
+ones), with matching CLI flags. Keep the timeout `>= 3 x` the client's
+`lmcache.mp.heartbeat_interval` so a few missed pings never reap a live worker;
+the worker adapter warns at startup when `3 x interval` exceeds the 30 s floor.
 
 ## 6. Adapter Side
 
@@ -142,23 +143,11 @@ warmup; the registration grace covers that window. It starts healthy (the event
 is set at construction), so the first store/retrieve is not gated. A live worker
 then pings every interval, refreshing its server-side `last_seen`, so it is never
 reaped while alive — no re-registration is needed at start. The recover callback
-re-registers only on a genuine recovery edge (Section 6.2/6.3). A retrieve dropped
+re-registers only on a genuine recovery edge (Section 6.2). A retrieve dropped
 while the server is unhealthy is still reported via `get_finished` so async loads
 cannot hang.
 
-### 6.2 Freeze-gap detection
-
-A whole-process freeze longer than the reap window (SIGSTOP, cgroup freezer, VM
-migration) produces no ping failures and no traffic: the server reaps while the
-client's `health_event` stays set, so on thaw no edge would fire and every store
-would hit a missing context. `HeartbeatThread` therefore tracks the time of its
-last successful cycle; when a ping succeeds while considered healthy and the gap
-exceeds `3 x interval`, it clears `health_event` and returns, forcing one
-unhealthy cycle — the next ping takes the normal edge and re-registers. Forcing a
-cycle keeps the recover callback from racing live submissions on `transfer_ctx`
-and drains futures parked between thaw and detection.
-
-### 6.3 Recovery after a reap
+### 6.2 Recovery after a reap
 
 ```
 T0        outage begins; pings time out -> health_event cleared, traffic stops
@@ -172,7 +161,7 @@ T1        recover callback re-registers (id absent -> fresh context) before
 A shorter outage hits the NOOP register path, which refreshes `last_seen` and
 builds nothing — the server never asks a worker to re-register.
 
-### 6.4 Shutdown
+### 6.3 Shutdown
 
 `shutdown()` stops the heartbeat before sending UNREGISTER, so no stray ping
 lands on a closing client. The heartbeat cycle skips the recover callback and
@@ -188,6 +177,5 @@ stop is already requested — a straggling cycle cannot re-create a ghost contex
 | Worker alive but never pinged, idle past the grace | Reaped while alive only if it never pinged (heartbeat never started). Once the heartbeat is running, pings refresh `last_seen` every interval, so a live worker is never reaped regardless of traffic. |
 | Heartbeat thread starved, worker transferring | Store/retrieve/prepare/commit refresh `last_seen`; never reaped. |
 | Partition shorter than the reap window | No reap. On heal, the recover callback re-registers; the NOOP path refreshes `last_seen`; zero context churn. |
-| Whole-process freeze past the reap window | Reaped during the freeze. On thaw, freeze-gap detection forces one unhealthy cycle (parked futures drained), then edge → re-register. Worst case ~2 heartbeat intervals of degraded traffic. |
 | Worker crash + restart | The new process gets a fresh uuid-derived id and a fresh entry; the dead id is reaped independently. No PID-reuse aliasing. |
 | Mixed client/server versions | Every PING fails the payload-count check; the client sits permanently unhealthy. Loud, never silent corruption; upgrade both sides together. |

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -98,6 +98,21 @@ Source: ``lmcache/v1/multiprocess/config.py``
        ``""`` (empty string): disable SHM and force the pickle transfer
        path.  Any other value: use that exact name for the SHM pool
        segment.
+   * - ``--worker-reap-timeout-seconds``
+     - ``120.0``
+     - Silence budget (seconds) after which a worker that has sent at
+       least one heartbeat PING but then gone quiet has its KV cache
+       registration reaped, freeing the leaked GPU context and CUDA IPC
+       handles. ``0`` disables reaping. Keep this at least 3x the vLLM
+       adapter's ``lmcache.mp.heartbeat_interval`` (default 10s) so a few
+       missed pings never reap a live worker; the adapter warns at startup
+       if its interval is raised without raising this.
+   * - ``--worker-registration-grace-seconds``
+     - ``3600.0``
+     - Silence budget (seconds) for a worker that registered but has never
+       sent a PING (still warming up, or died before its first request).
+       Must be >= ``--worker-reap-timeout-seconds``. Generous by default so
+       slow model warmup is never mistaken for a dead worker.
 
 Lookup Hash Logging
 -------------------

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -103,7 +103,7 @@ Source: ``lmcache/v1/multiprocess/config.py``
      - Silence budget (seconds) after which a worker that has sent at
        least one heartbeat PING but then gone quiet has its KV cache
        registration reaped, freeing the leaked GPU context and CUDA IPC
-       handles. ``0`` disables reaping. Keep this at least 3x the vLLM
+       handles. ``0`` disables reaping. Keep this at least 3x the engine
        adapter's ``lmcache.mp.heartbeat_interval`` (default 10s) so a few
        missed pings never reap a live worker; the adapter warns at startup
        if its interval is raised without raising this.

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -271,14 +271,21 @@ def _raise_server_unreachable(server_url: str, timeout: float) -> NoReturn:
 def send_ping(
     mq_client: MessageQueueClient,
     timeout: float,
+    instance_id: int | None = None,
 ) -> bool:
     """Send a PING request and return the result.
+
+    Args:
+        mq_client: The message queue client.
+        timeout: Seconds to wait for the server's response.
+        instance_id: The worker's instance ID so the server can refresh its
+            liveness, or None for an untracked prober (scheduler adapter).
 
     Returns:
         True if server is healthy, False on timeout or error.
     """
     try:
-        future = send_lmcache_request(mq_client, RequestType.PING, [])
+        future = send_lmcache_request(mq_client, RequestType.PING, [instance_id])
         return future.result(timeout=timeout)
     except TimeoutError:
         return False
@@ -389,6 +396,7 @@ class HeartbeatThread(PeriodicThread):
         mq_client: MessageQueueClient,
         health_event: threading.Event,
         interval: float = DEFAULT_HEARTBEAT_INTERVAL,
+        instance_id: int | None = None,
     ):
         """
         Args:
@@ -398,6 +406,9 @@ class HeartbeatThread(PeriodicThread):
                 Adapters check this event to decide whether to proceed
                 with operations or enter degraded mode.
             interval: Seconds between heartbeat pings and ping timeout.
+            instance_id: The worker's instance ID sent with each PING so the
+                server can refresh its liveness, or None for an untracked
+                prober (the scheduler adapter).
         """
         super().__init__(
             name="lmcache-heartbeat",
@@ -407,6 +418,7 @@ class HeartbeatThread(PeriodicThread):
         self._mq_client = mq_client
         self._health_event = health_event
         self._interval = interval
+        self._instance_id = instance_id
 
         # Optional callback invoked on the unhealthy->healthy edge,
         # before the health event is set. See register_recover_callback.
@@ -445,7 +457,9 @@ class HeartbeatThread(PeriodicThread):
         UNREGISTER must not re-register a ghost context.
         """
         was_healthy = self._health_event.is_set()
-        healthy = send_ping(self._mq_client, timeout=self._interval)
+        healthy = send_ping(
+            self._mq_client, timeout=self._interval, instance_id=self._instance_id
+        )
 
         if self.stop_requested:
             return ThreadRunSummary(
@@ -1181,6 +1195,7 @@ class LMCacheMPWorkerAdapter:
                 mq_client=self.mq_client,
                 health_event=self._health_event,
                 interval=self._heartbeat_interval,
+                instance_id=self.instance_id,
             )
             heartbeat.register_recover_callback(self._reregister_kv_caches_callback)
             heartbeat.start()

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, NoReturn, Protocol
 import enum
 import os
 import threading
+import time
 import uuid
 
 # Third Party
@@ -419,6 +420,11 @@ class HeartbeatThread(PeriodicThread):
         self._health_event = health_event
         self._interval = interval
         self._instance_id = instance_id
+        # Monotonic time of the last successful cycle, used for freeze-gap
+        # detection. Baselined in start() (not here): under lazy start,
+        # construction can precede the first cycle by the whole warmup, which
+        # would otherwise misfire the detector on the first ping.
+        self._last_success: float = 0.0
 
         # Optional callback invoked on the unhealthy->healthy edge,
         # before the health event is set. See register_recover_callback.
@@ -449,6 +455,15 @@ class HeartbeatThread(PeriodicThread):
         """
         self._recover_callback = callback
 
+    def start(self) -> threading.Thread | None:
+        """Baseline the freeze-gap clock, then start the thread.
+
+        Returns:
+            The started thread, or None if already running.
+        """
+        self._last_success = time.monotonic()
+        return super().start()
+
     def _execute(self) -> ThreadRunSummary:
         """Run one heartbeat cycle: ping, recover callback, event update.
 
@@ -467,6 +482,21 @@ class HeartbeatThread(PeriodicThread):
                 message="stop requested; skipping health update",
             )
 
+        # Freeze-gap: a ping that succeeds while still "healthy" after a long
+        # no-ping gap means the whole process was frozen (SIGSTOP, cgroup
+        # freezer, VM migration) past the server's reap window, so the server
+        # may have reaped us. No edge would fire to re-register, so force one
+        # unhealthy cycle; the next success then takes the recovery edge.
+        now = time.monotonic()
+        if healthy and was_healthy and now - self._last_success > 3 * self._interval:
+            self._health_event.clear()
+            logger.warning(
+                "LMCache heartbeat gap of %.1fs (> 3x interval); forcing "
+                "re-registration in case the server reaped this worker",
+                now - self._last_success,
+            )
+            return ThreadRunSummary(success=True, message="freeze-gap")
+
         need_trigger_recover = (
             healthy and not was_healthy and self._recover_callback is not None
         )
@@ -481,6 +511,9 @@ class HeartbeatThread(PeriodicThread):
 
         if healthy:
             self._health_event.set()
+            # Stamp after the callback so a slow re-registration does not
+            # itself count as a freeze gap on the next cycle.
+            self._last_success = time.monotonic()
             if not was_healthy:
                 logger.warning(
                     "LMCache server is healthy again — resuming normal operation"

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, NoReturn, Protocol
 import enum
 import os
 import threading
-import time
 import uuid
 
 # Third Party
@@ -420,11 +419,6 @@ class HeartbeatThread(PeriodicThread):
         self._health_event = health_event
         self._interval = interval
         self._instance_id = instance_id
-        # Monotonic time of the last successful cycle, used for freeze-gap
-        # detection. Baselined in start() (not here): under lazy start,
-        # construction can precede the first cycle by the whole warmup, which
-        # would otherwise misfire the detector on the first ping.
-        self._last_success: float = 0.0
 
         # Optional callback invoked on the unhealthy->healthy edge,
         # before the health event is set. See register_recover_callback.
@@ -455,15 +449,6 @@ class HeartbeatThread(PeriodicThread):
         """
         self._recover_callback = callback
 
-    def start(self) -> threading.Thread | None:
-        """Baseline the freeze-gap clock, then start the thread.
-
-        Returns:
-            The started thread, or None if already running.
-        """
-        self._last_success = time.monotonic()
-        return super().start()
-
     def _execute(self) -> ThreadRunSummary:
         """Run one heartbeat cycle: ping, recover callback, event update.
 
@@ -482,21 +467,6 @@ class HeartbeatThread(PeriodicThread):
                 message="stop requested; skipping health update",
             )
 
-        # Freeze-gap: a ping that succeeds while still "healthy" after a long
-        # no-ping gap means the whole process was frozen (SIGSTOP, cgroup
-        # freezer, VM migration) past the server's reap window, so the server
-        # may have reaped us. No edge would fire to re-register, so force one
-        # unhealthy cycle; the next success then takes the recovery edge.
-        now = time.monotonic()
-        if healthy and was_healthy and now - self._last_success > 3 * self._interval:
-            self._health_event.clear()
-            logger.warning(
-                "LMCache heartbeat gap of %.1fs (> 3x interval); forcing "
-                "re-registration in case the server reaped this worker",
-                now - self._last_success,
-            )
-            return ThreadRunSummary(success=True, message="freeze-gap")
-
         need_trigger_recover = (
             healthy and not was_healthy and self._recover_callback is not None
         )
@@ -511,9 +481,6 @@ class HeartbeatThread(PeriodicThread):
 
         if healthy:
             self._health_event.set()
-            # Stamp after the callback so a slow re-registration does not
-            # itself count as a freeze gap on the next cycle.
-            self._last_success = time.monotonic()
             if not was_healthy:
                 logger.warning(
                     "LMCache server is healthy again — resuming normal operation"
@@ -1217,7 +1184,7 @@ class LMCacheMPWorkerAdapter:
         ``last_seen``, so it is never reaped while alive -- no re-registration
         is needed at startup, and the first store/retrieve is not gated. The
         recover callback still re-registers on a genuine unhealthy->healthy
-        edge (server restart) and on freeze-gap recovery.
+        edge (server restart).
         """
         if self._heartbeat is not None:
             return

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -69,6 +69,39 @@ class MPServerConfig:
     ``run_cache_server``) so metrics, traces, and coordinator state all key on
     the same id. Set via ``--instance-id``; defaults to a random UUID v4."""
 
+    worker_reap_timeout_seconds: float = 120.0
+    """Silence budget (seconds) after which a ping-proven worker's KV cache
+    registration is reaped. 0 disables worker reaping. Keep it >= 3 x the vLLM
+    adapter's heartbeat interval so a few missed pings never reap a live
+    worker."""
+
+    worker_registration_grace_seconds: float = 3600.0
+    """Silence budget (seconds) for a worker that registered but has never
+    sent a PING (model warmup, or death before its first request). Must be
+    >= worker_reap_timeout_seconds."""
+
+    def __post_init__(self) -> None:
+        """Validate the worker-reaping timeouts.
+
+        Raises:
+            ValueError: If a timeout is non-finite, the reap timeout is
+                negative or a non-zero value below the 30 s floor, or the
+                registration grace is below the reap timeout.
+        """
+        reap = self.worker_reap_timeout_seconds
+        grace = self.worker_registration_grace_seconds
+        if not math.isfinite(reap) or reap < 0 or (reap != 0 and reap < 30.0):
+            raise ValueError(
+                "worker reap timeout must be 0 (disabled) or >= 30s; keep it "
+                ">= 3 x your configured lmcache.mp.heartbeat_interval "
+                f"(default 10s); got {reap}"
+            )
+        if not math.isfinite(grace) or grace < reap:
+            raise ValueError(
+                "worker registration grace must be >= the worker reap timeout "
+                f"({reap}s); got {grace}"
+            )
+
 
 @dataclass
 class RuntimePluginConfig:
@@ -257,6 +290,22 @@ def add_mp_server_args(
         help="Python modules that the /run_script endpoint is allowed to "
         "import. Example: --script-allowed-imports numpy pandas",
     )
+    mp_group.add_argument(
+        "--worker-reap-timeout-seconds",
+        type=float,
+        default=120.0,
+        help="Silence budget (s) before a ping-proven worker's KV cache "
+        "registration is reaped. 0 disables reaping. Must be >= 3 x the "
+        "vLLM adapter's heartbeat interval. Default is 120.",
+    )
+    mp_group.add_argument(
+        "--worker-registration-grace-seconds",
+        type=float,
+        default=3600.0,
+        help="Silence budget (s) for a worker that registered but never "
+        "pinged (model warmup or early death). Must be >= the worker reap "
+        "timeout. Default is 3600.",
+    )
     return parser
 
 
@@ -296,6 +345,8 @@ def parse_args_to_mp_server_config(
         ),
         shm_name=args.shm_name,
         script_allowed_imports=args.script_allowed_imports or [],
+        worker_reap_timeout_seconds=args.worker_reap_timeout_seconds,
+        worker_registration_grace_seconds=args.worker_registration_grace_seconds,
     )
 
 

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -71,8 +71,8 @@ class MPServerConfig:
 
     worker_reap_timeout_seconds: float = 120.0
     """Silence budget (seconds) after which a ping-proven worker's KV cache
-    registration is reaped. 0 disables worker reaping. Keep it >= 3 x the vLLM
-    adapter's heartbeat interval so a few missed pings never reap a live
+    registration is reaped. 0 disables worker reaping. Keep it >= 3 x the
+    engine adapter's heartbeat interval so a few missed pings never reap a live
     worker."""
 
     worker_registration_grace_seconds: float = 3600.0
@@ -296,7 +296,7 @@ def add_mp_server_args(
         default=120.0,
         help="Silence budget (s) before a ping-proven worker's KV cache "
         "registration is reaped. 0 disables reaping. Must be >= 3 x the "
-        "vLLM adapter's heartbeat interval. Default is 120.",
+        "engine adapter's heartbeat interval. Default is 120.",
     )
     mp_group.add_argument(
         "--worker-registration-grace-seconds",

--- a/lmcache/v1/multiprocess/engine_module.py
+++ b/lmcache/v1/multiprocess/engine_module.py
@@ -63,3 +63,65 @@ class EngineModule(Protocol):
     def close(self) -> None:
         """Release resources owned by this module."""
         ...
+
+
+class InstanceLivenessTarget(Protocol):
+    """A module that tracks per-worker liveness and reaps stale workers.
+
+    Implemented by transfer modules owning per-instance state keyed by
+    ``instance_id``. The management module drives these from the PING
+    handler and the periodic reaper; no caller touches the module's
+    private state directly.
+    """
+
+    def touch_instance(self, instance_id: int) -> None:
+        """Refresh the worker's last-seen time and mark it ping-proven.
+
+        A no-op if the instance is not tracked (already reaped or never
+        registered).
+
+        Args:
+            instance_id: The worker's opaque instance ID.
+        """
+        ...
+
+    def reap_stale_instances(
+        self, reap_timeout_s: float, registration_grace_s: float
+    ) -> list[int]:
+        """Evict and clean up workers that have gone silent.
+
+        An instance that has sent at least one PING is judged against
+        ``reap_timeout_s``; one that has never pinged (warming up, or dead
+        before its first request) is judged against ``registration_grace_s``.
+
+        Args:
+            reap_timeout_s: Silence budget for ping-proven instances.
+            registration_grace_s: Silence budget for never-pinged instances;
+                must be >= ``reap_timeout_s``.
+
+        Returns:
+            The instance IDs reaped during this scan.
+        """
+        ...
+
+    def tracked_instance_count(self) -> int:
+        """Return the number of currently tracked instances."""
+        ...
+
+
+class InstanceReapListener(Protocol):
+    """A module notified when an instance is reaped, to drop mirrored state.
+
+    Implemented by modules holding a second reference to a reaped instance's
+    resources (e.g. blend rope mirrors of a GPU cache context).
+    """
+
+    def drop_instance_state(self, instance_id: int) -> None:
+        """Release any state mirrored for the reaped instance.
+
+        A no-op if the listener holds nothing for the instance.
+
+        Args:
+            instance_id: The reaped worker's instance ID.
+        """
+        ...

--- a/lmcache/v1/multiprocess/engine_module.py
+++ b/lmcache/v1/multiprocess/engine_module.py
@@ -66,24 +66,32 @@ class EngineModule(Protocol):
 
 
 class InstanceLivenessTarget(Protocol):
-    """A module that tracks per-worker liveness and reaps stale workers.
+    """A module the periodic reaper drives, in either or both of two roles.
 
-    Implemented by transfer modules owning per-instance state keyed by
-    ``instance_id``. The management module drives these from the PING
-    handler and the periodic reaper; no caller touches the module's
-    private state directly.
+    * **Liveness owner** -- tracks per-worker registrations keyed by
+      ``instance_id``, refreshed on PING and scanned for staleness
+      (``touch_instance`` / ``reap_stale_instances`` /
+      ``tracked_instance_count``). The transfer modules fill this role.
+    * **State mirror** -- holds a second reference to a reaped instance's
+      resources and releases it on demand (``drop_instance_state``).
+      ``BlendV3Module`` fills this role for its per-instance CB state.
+
+    Every method defaults to a no-op, so an implementer subclasses this
+    protocol and overrides only the role it fills. The management module
+    drives all targets from the PING handler and the reaper; no caller
+    touches a module's private state directly.
     """
 
     def touch_instance(self, instance_id: int) -> None:
         """Refresh the worker's last-seen time and mark it ping-proven.
 
         A no-op if the instance is not tracked (already reaped or never
-        registered).
+        registered), or for a target that owns no liveness state.
 
         Args:
             instance_id: The worker's opaque instance ID.
         """
-        ...
+        return
 
     def reap_stale_instances(
         self, reap_timeout_s: float, registration_grace_s: float
@@ -100,28 +108,23 @@ class InstanceLivenessTarget(Protocol):
                 must be >= ``reap_timeout_s``.
 
         Returns:
-            The instance IDs reaped during this scan.
+            The instance IDs reaped during this scan; empty for a target
+            that owns no liveness state.
         """
-        ...
+        return []
 
     def tracked_instance_count(self) -> int:
-        """Return the number of currently tracked instances."""
-        ...
-
-
-class InstanceReapListener(Protocol):
-    """A module notified when an instance is reaped, to drop mirrored state.
-
-    Implemented by modules holding a second reference to a reaped instance's
-    resources (e.g. blend rope mirrors of a GPU cache context).
-    """
+        """Return the number of currently tracked instances (0 if none)."""
+        return 0
 
     def drop_instance_state(self, instance_id: int) -> None:
-        """Release any state mirrored for the reaped instance.
+        """Release any state mirrored for a reaped instance.
 
-        A no-op if the listener holds nothing for the instance.
+        Called for every reaped ``instance_id``. A no-op unless the target
+        keeps a second reference to that instance's resources (only mirrors
+        such as ``BlendV3Module`` override this).
 
         Args:
             instance_id: The reaped worker's instance ID.
         """
-        ...
+        return

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -406,7 +406,7 @@ class BlendV3Module:
     def report_status(self) -> dict:
         # Meta is derived live from MP server gpu_transfe
 
-        cache_contexts = self._transfer_module.cache_contexts
+        cache_contexts = self._transfer_module.context_entries_snapshot()
 
         def _meta(iid: int) -> "tuple[str, int] | None":
             entry = cache_contexts.get(iid)
@@ -453,8 +453,7 @@ class BlendV3Module:
         Raises:
             ValueError: If ``instance_id`` has no registered KV cache.
         """
-        cache_contexts = self._transfer_module.cache_contexts
-        if instance_id not in cache_contexts:
+        if self._transfer_module.get_context_entry(instance_id) is None:
             raise ValueError(
                 f"Instance {instance_id} has no paged KV cache registered; "
                 "send REGISTER_KV_CACHE before CB_REGISTER_ROPE_V3."
@@ -506,12 +505,25 @@ class BlendV3Module:
                 ``UNREGISTER_KV_CACHE`` to free the KV cache itself).
         """
         self._cb_rope_state.pop(instance_id, None)
-        if instance_id not in self._transfer_module.cache_contexts:
+        if self._transfer_module.get_context_entry(instance_id) is None:
             logger.warning(
                 "cb_unregister_rope: instance %d not registered", instance_id
             )
             return
         logger.info("Unregistered CB rope state for instance %d", instance_id)
+
+    def drop_instance_state(self, instance_id: int) -> None:
+        """Drop blend state for a reaped instance (InstanceReapListener).
+
+        Only the CB rope state is held per instance; the GPU cache context is
+        owned by ``LMCacheDrivenTransferModule`` (no mirror here), so reaping
+        the GPU entry frees it directly. A no-op if no rope state is held.
+
+        Args:
+            instance_id: The reaped worker's instance ID.
+        """
+        if self._cb_rope_state.pop(instance_id, None) is not None:
+            logger.info("Dropped CB rope state for reaped instance %d", instance_id)
 
     # ------------------------------------------------------------------
     # Unified lookup (CB_UNIFIED_LOOKUP) + shared helpers
@@ -964,7 +976,7 @@ class BlendV3Module:
             job = (tokens_in_range, chunk_hashes, start_chunk_idx, key.start)
             with self._pending_fp_lock:
                 self._pending_fp_hashes.update(chunk_hashes[start_chunk_idx:])
-            entry = self._transfer_module.cache_contexts.get(instance_id)
+            entry = self._transfer_module.get_context_entry(instance_id)
             gpu_ctx = entry.cache_context if entry is not None else None
             if gpu_ctx is not None and gpu_ctx.cupy_stream is not None:
                 gpu_ctx.cupy_stream.launch_host_func(
@@ -1237,8 +1249,8 @@ class BlendV3Module:
             ValueError: If the instance has no registered KV cache or rope
                 state. MLA layouts are unsupported (raised during re-RoPE).
         """
-        cache_contexts = self._transfer_module.cache_contexts
-        if instance_id not in cache_contexts:
+        entry = self._transfer_module.get_context_entry(instance_id)
+        if entry is None:
             raise ValueError(
                 f"Instance {instance_id} not registered for paged KV cache"
             )
@@ -1247,7 +1259,7 @@ class BlendV3Module:
                 f"Instance {instance_id} has no CB rope state; "
                 "send CB_REGISTER_ROPE_V3 before CB_RETRIEVE_PRE_COMPUTED_V3."
             )
-        gpu_context = cache_contexts[instance_id].cache_context
+        gpu_context = entry.cache_context
         rope_state = self._cb_rope_state[instance_id]
         chunk_size = self._ctx.chunk_size
 

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -45,7 +45,11 @@ from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
-from lmcache.v1.multiprocess.engine_module import HandlerSpec, ThreadPoolType
+from lmcache.v1.multiprocess.engine_module import (
+    HandlerSpec,
+    InstanceLivenessTarget,
+    ThreadPoolType,
+)
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     LMCacheDrivenTransferModule,
 )
@@ -314,7 +318,7 @@ def _unique_token_coverage(results: list[CBMatchResult]) -> int:
     return coverage
 
 
-class BlendV3Module:
+class BlendV3Module(InstanceLivenessTarget):
     """Paged-aware V3 CacheBlend. Wraps LMCacheDrivenTransfer STORE to register
     fingerprints; serves CB rope/lookup/retrieve RPCs; reads cross-module
     GPU state via :class:`LMCacheDrivenTransferModule.cache_contexts`."""
@@ -513,7 +517,7 @@ class BlendV3Module:
         logger.info("Unregistered CB rope state for instance %d", instance_id)
 
     def drop_instance_state(self, instance_id: int) -> None:
-        """Drop blend state for a reaped instance (InstanceReapListener).
+        """Drop blend state for a reaped instance (InstanceLivenessTarget hook).
 
         Only the CB rope state is held per instance; the GPU cache context is
         owned by ``LMCacheDrivenTransferModule`` (no mirror here), so reaping

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -453,7 +453,7 @@ class BlendV3Module:
         Raises:
             ValueError: If ``instance_id`` has no registered KV cache.
         """
-        if self._transfer_module.get_context_entry(instance_id) is None:
+        if self._transfer_module.get_and_touch_context_entry(instance_id) is None:
             raise ValueError(
                 f"Instance {instance_id} has no paged KV cache registered; "
                 "send REGISTER_KV_CACHE before CB_REGISTER_ROPE_V3."
@@ -505,7 +505,7 @@ class BlendV3Module:
                 ``UNREGISTER_KV_CACHE`` to free the KV cache itself).
         """
         self._cb_rope_state.pop(instance_id, None)
-        if self._transfer_module.get_context_entry(instance_id) is None:
+        if self._transfer_module.get_and_touch_context_entry(instance_id) is None:
             logger.warning(
                 "cb_unregister_rope: instance %d not registered", instance_id
             )
@@ -976,7 +976,7 @@ class BlendV3Module:
             job = (tokens_in_range, chunk_hashes, start_chunk_idx, key.start)
             with self._pending_fp_lock:
                 self._pending_fp_hashes.update(chunk_hashes[start_chunk_idx:])
-            entry = self._transfer_module.get_context_entry(instance_id)
+            entry = self._transfer_module.get_and_touch_context_entry(instance_id)
             gpu_ctx = entry.cache_context if entry is not None else None
             if gpu_ctx is not None and gpu_ctx.cupy_stream is not None:
                 gpu_ctx.cupy_stream.launch_host_func(
@@ -1249,7 +1249,7 @@ class BlendV3Module:
             ValueError: If the instance has no registered KV cache or rope
                 state. MLA layouts are unsupported (raised during re-RoPE).
         """
-        entry = self._transfer_module.get_context_entry(instance_id)
+        entry = self._transfer_module.get_and_touch_context_entry(instance_id)
         if entry is None:
             raise ValueError(
                 f"Instance {instance_id} not registered for paged KV cache"

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -23,6 +23,7 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext, ShmPoolInfo
 from lmcache.v1.multiprocess.engine_module import (
     HandlerSpec,
+    InstanceLivenessTarget,
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
@@ -63,7 +64,7 @@ class EngineDrivenContextEntry:
     has_liveness_signal: bool = False
 
 
-class EngineDrivenTransferModule:
+class EngineDrivenTransferModule(InstanceLivenessTarget):
     """Handles Engine-driven KV cache transfer operations.
 
     Owns non-GPU context registrations and provides handlers for

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -50,11 +50,17 @@ class EngineDrivenContextEntry:
         metadata: Layout metadata describing the non-CUDA chunk format.
         model_name: The name of the model associated with this context.
         world_size: The world size associated with this context.
+        last_seen: ``time.monotonic()`` of the most recent activity from this
+            instance (register, PING, prepare/commit). Drives reaping.
+        has_liveness_signal: True once the instance has sent at least one
+            PING. Selects the reap window. Latched only by PING.
     """
 
     metadata: EngineDrivenContextMetadata
     model_name: str
     world_size: int
+    last_seen: float = 0.0
+    has_liveness_signal: bool = False
 
 
 class EngineDrivenTransferModule:
@@ -72,6 +78,13 @@ class EngineDrivenTransferModule:
         self._ctx = ctx
         self._engine_driven_contexts: dict[int, EngineDrivenContextEntry] = {}
         self._strategies: dict[int, TransferStrategy] = {}
+        # Guards _engine_driven_contexts and _strategies together: they are
+        # inserted and popped as a pair so "strategy present iff entry
+        # present" always holds (a reap racing a re-register can never strand
+        # a context without its strategy). The reaper mutates them off the MQ
+        # main loop. Distinct from _pending_shm_lock, which is never held
+        # together with this lock.
+        self._lock = threading.Lock()
         self._pending_shm_writes: dict[
             tuple[int, IPCCacheServerKey], list[ObjectKey]
         ] = {}
@@ -136,7 +149,9 @@ class EngineDrivenTransferModule:
         registered_non_cuda_ids: list[int] = []
         non_cuda_context_meta: dict[str, dict] = {}
 
-        for instance_id, entry in self._engine_driven_contexts.items():
+        with self._lock:
+            entries = dict(self._engine_driven_contexts)
+        for instance_id, entry in entries.items():
             registered_non_cuda_ids.append(instance_id)
             non_cuda_context_meta[str(instance_id)] = {
                 "model_name": entry.model_name,
@@ -152,8 +167,128 @@ class EngineDrivenTransferModule:
 
     def close(self) -> None:
         """Release resources owned by this module."""
-        self._engine_driven_contexts.clear()
-        self._strategies.clear()
+        with self._lock:
+            self._engine_driven_contexts.clear()
+            self._strategies.clear()
+
+    def touch_instance(self, instance_id: int) -> None:
+        """Refresh the worker's last-seen time and mark it ping-proven.
+
+        A no-op if the instance is not tracked.
+
+        Args:
+            instance_id: The worker instance ID.
+        """
+        now = time.monotonic()
+        with self._lock:
+            entry = self._engine_driven_contexts.get(instance_id)
+            if entry is not None:
+                entry.last_seen = now
+                entry.has_liveness_signal = True
+
+    def tracked_instance_count(self) -> int:
+        """Return the number of currently registered non-GPU instances."""
+        with self._lock:
+            return len(self._engine_driven_contexts)
+
+    def reap_stale_instances(
+        self, reap_timeout_s: float, registration_grace_s: float
+    ) -> list[int]:
+        """Reap non-GPU registrations that have gone silent.
+
+        A ping-proven instance is judged against ``reap_timeout_s``; one that
+        has never pinged against the larger ``registration_grace_s``. The
+        entry and its strategy are popped as a pair under the lock; cleanup
+        (pending-transfer sweep, layout-registry unregister) runs outside it.
+
+        Args:
+            reap_timeout_s: Silence budget for ping-proven instances.
+            registration_grace_s: Silence budget for never-pinged instances.
+
+        Returns:
+            The instance IDs reaped this scan.
+        """
+        now = time.monotonic()
+        reaped: list[tuple[int, EngineDrivenContextEntry]] = []
+        with self._lock:
+            stale_ids = [
+                iid
+                for iid, entry in self._engine_driven_contexts.items()
+                if now - entry.last_seen
+                > (
+                    reap_timeout_s
+                    if entry.has_liveness_signal
+                    else registration_grace_s
+                )
+            ]
+            for iid in stale_ids:
+                entry = self._engine_driven_contexts.pop(iid)
+                self._strategies.pop(iid, None)
+                reaped.append((iid, entry))
+        for iid, entry in reaped:
+            self._release_entry(iid, entry)
+            logger.warning(
+                "Reaped non-GPU instance %d: silent for %.1fs (pinged=%s)",
+                iid,
+                now - entry.last_seen,
+                entry.has_liveness_signal,
+            )
+        return [iid for iid, _ in reaped]
+
+    def _resolve_for_transfer(
+        self, instance_id: int
+    ) -> tuple[EngineDrivenContextEntry, TransferStrategy]:
+        """Return (entry, strategy) for a transfer, refreshing last_seen.
+
+        Pair-atomicity guarantees the entry exists whenever the strategy
+        does. Refreshes last_seen (no latch) so an active worker is not
+        reaped mid-transfer.
+
+        Args:
+            instance_id: The worker instance ID.
+
+        Returns:
+            The entry and its transfer strategy.
+
+        Raises:
+            ValueError: If the instance is not registered (or was reaped).
+        """
+        now = time.monotonic()
+        with self._lock:
+            entry = self._engine_driven_contexts.get(instance_id)
+            strategy = self._strategies.get(instance_id)
+            if entry is None or strategy is None:
+                raise ValueError(
+                    "non-GPU context not registered (or reaped) for "
+                    f"instance ID {instance_id}"
+                )
+            entry.last_seen = now
+            return entry, strategy
+
+    def _release_entry(self, instance_id: int, entry: EngineDrivenContextEntry) -> None:
+        """Release resources for a popped entry (run outside the lock).
+
+        Sweeps the instance's pending SHM transfers and unregisters its
+        layout descriptor.
+
+        Args:
+            instance_id: The popped instance ID.
+            entry: The popped entry.
+        """
+        with self._pending_shm_lock:
+            stale_writes = [k for k in self._pending_shm_writes if k[0] == instance_id]
+            stale_reads = [k for k in self._pending_shm_reads if k[0] == instance_id]
+            write_obj_keys = [self._pending_shm_writes.pop(k) for k in stale_writes]
+            read_obj_keys = [self._pending_shm_reads.pop(k) for k in stale_reads]
+
+        for obj_keys in write_obj_keys:
+            if obj_keys:
+                self._ctx.storage_manager.finish_write(obj_keys)
+        for obj_keys in read_obj_keys:
+            if obj_keys:
+                self._ctx.storage_manager.finish_read_prefetched(obj_keys)
+
+        self._ctx.layout_desc_registry.unregister(entry.model_name, entry.world_size)
 
     @staticmethod
     def _make_transfer_key(
@@ -183,15 +318,18 @@ class EngineDrivenTransferModule:
         shm_name = self._shm_pool_info["shm_name"]
         pool_size = self._shm_pool_info["pool_size"]
 
-        if payload.instance_id in self._engine_driven_contexts:
-            logger.warning(
-                "Instance %s's KV cache is already registered, "
-                "skipping the new registration",
-                payload.instance_id,
-            )
-            return RegisterEngineDrivenContextResponse(
-                shm_name=shm_name, pool_size=pool_size
-            )
+        now = time.monotonic()
+        with self._lock:
+            existing = self._engine_driven_contexts.get(payload.instance_id)
+            if existing is not None:
+                existing.last_seen = now
+                logger.info(
+                    "Instance %d already registered (non-GPU); refreshing liveness",
+                    payload.instance_id,
+                )
+                return RegisterEngineDrivenContextResponse(
+                    shm_name=shm_name, pool_size=pool_size
+                )
 
         dtype = getattr(torch, payload.dtype_str, None)
         if dtype is None or not isinstance(dtype, torch.dtype):
@@ -216,10 +354,15 @@ class EngineDrivenTransferModule:
             block_size=payload.block_size,
             use_mla=payload.use_mla,
         )
-        self._engine_driven_contexts[payload.instance_id] = EngineDrivenContextEntry(
+        # Build the entry and strategy outside the lock, then insert the pair
+        # atomically so a concurrent reap can never strand one without the
+        # other. REGISTER is SYNC-serialized, so it is the sole inserter.
+        entry = EngineDrivenContextEntry(
             metadata=metadata,
             model_name=payload.model_name,
             world_size=payload.world_size,
+            last_seen=now,
+            has_liveness_signal=False,
         )
         strategy: TransferStrategy = create_transfer_strategy(
             self._ctx.storage_manager,
@@ -230,7 +373,9 @@ class EngineDrivenTransferModule:
             pending_lock=self._pending_shm_lock,
             transfer_key_factory=self._make_transfer_key,
         )
-        self._strategies[payload.instance_id] = strategy
+        with self._lock:
+            self._engine_driven_contexts[payload.instance_id] = entry
+            self._strategies[payload.instance_id] = strategy
 
         logger.info(
             "Registered non-GPU context for instance %d (model=%s, world_size=%d)",
@@ -252,7 +397,10 @@ class EngineDrivenTransferModule:
         Args:
             instance_id: The worker instance identifier.
         """
-        entry = self._engine_driven_contexts.pop(instance_id, None)
+        with self._lock:
+            entry = self._engine_driven_contexts.pop(instance_id, None)
+            if entry is not None:
+                self._strategies.pop(instance_id, None)
         if entry is None:
             logger.warning(
                 "No registered non-GPU context found for instance ID %d",
@@ -260,34 +408,7 @@ class EngineDrivenTransferModule:
             )
             return
 
-        self._strategies.pop(instance_id, None)
-
-        with self._pending_shm_lock:
-            stale_writes = []
-            stale_reads = []
-            for transfer_key in self._pending_shm_writes:
-                if transfer_key[0] == instance_id:
-                    stale_writes.append(transfer_key)
-            for transfer_key in self._pending_shm_reads:
-                if transfer_key[0] == instance_id:
-                    stale_reads.append(transfer_key)
-
-            write_obj_keys = []
-            for transfer_key in stale_writes:
-                write_obj_keys.append(self._pending_shm_writes.pop(transfer_key))
-
-            read_obj_keys = []
-            for transfer_key in stale_reads:
-                read_obj_keys.append(self._pending_shm_reads.pop(transfer_key))
-
-        for obj_keys in write_obj_keys:
-            if obj_keys:
-                self._ctx.storage_manager.finish_write(obj_keys)
-        for obj_keys in read_obj_keys:
-            if obj_keys:
-                self._ctx.storage_manager.finish_read_prefetched(obj_keys)
-
-        self._ctx.layout_desc_registry.unregister(entry.model_name, entry.world_size)
+        self._release_entry(instance_id, entry)
         logger.info("Unregistered non-CUDA context for instance ID %d", instance_id)
 
     @_lmcache_nvtx_annotate
@@ -305,16 +426,7 @@ class EngineDrivenTransferModule:
         Returns:
             PrepareStoreResponse with empty slots for pickle mode.
         """
-        entry = self._engine_driven_contexts.get(instance_id)
-        if entry is None:
-            raise ValueError(
-                f"non-CUDA context not registered for instance ID {instance_id}"
-            )
-        strategy = self._strategies.get(instance_id)
-        if strategy is None:
-            raise ValueError(
-                f"transfer strategy not registered for instance ID {instance_id}"
-            )
+        entry, strategy = self._resolve_for_transfer(instance_id)
         response = strategy.prepare_store(
             key=key,
             instance_id=instance_id,
@@ -346,16 +458,7 @@ class EngineDrivenTransferModule:
             ValueError: If no non-GPU context is registered for the given
                 instance ID.
         """
-        entry = self._engine_driven_contexts.get(instance_id)
-        if entry is None:
-            raise ValueError(
-                f"non-CUDA context not registered for instance ID {instance_id}"
-            )
-        strategy = self._strategies.get(instance_id)
-        if strategy is None:
-            raise ValueError(
-                f"transfer strategy not registered for instance ID {instance_id}"
-            )
+        entry, strategy = self._resolve_for_transfer(instance_id)
         session = self._ctx.session_manager.get_or_create(key.request_id)
         st = session.extras.pop("store_start_time", None)
         result = strategy.commit_store(
@@ -395,11 +498,7 @@ class EngineDrivenTransferModule:
             ValueError: If no non-GPU context is registered for the given
                 instance ID.
         """
-        strategy = self._strategies.get(instance_id)
-        if strategy is None:
-            raise ValueError(
-                f"transfer strategy not registered for instance ID {instance_id}"
-            )
+        _, strategy = self._resolve_for_transfer(instance_id)
         response = strategy.prepare_retrieve(
             key=key,
             instance_id=instance_id,
@@ -424,11 +523,7 @@ class EngineDrivenTransferModule:
         Returns:
             Always ``True``.
         """
-        strategy = self._strategies.get(instance_id)
-        if strategy is None:
-            raise ValueError(
-                f"transfer strategy not registered for instance ID {instance_id}"
-            )
+        _, strategy = self._resolve_for_transfer(instance_id)
         session = self._ctx.session_manager.get_or_create(key.request_id)
         st = session.extras.pop("retrieve_start_time", None)
         result = strategy.commit_retrieve(key=key, instance_id=instance_id)

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -78,12 +78,9 @@ class EngineDrivenTransferModule:
         self._ctx = ctx
         self._engine_driven_contexts: dict[int, EngineDrivenContextEntry] = {}
         self._strategies: dict[int, TransferStrategy] = {}
-        # Guards _engine_driven_contexts and _strategies together: they are
-        # inserted and popped as a pair so "strategy present iff entry
-        # present" always holds (a reap racing a re-register can never strand
-        # a context without its strategy). The reaper mutates them off the MQ
-        # main loop. Distinct from _pending_shm_lock, which is never held
-        # together with this lock.
+        # Guards _engine_driven_contexts and _strategies together (the reaper
+        # mutates them off the MQ main loop). Leaf lock, never held with
+        # _pending_shm_lock.
         self._lock = threading.Lock()
         self._pending_shm_writes: dict[
             tuple[int, IPCCacheServerKey], list[ObjectKey]
@@ -197,9 +194,7 @@ class EngineDrivenTransferModule:
         """Reap non-GPU registrations that have gone silent.
 
         A ping-proven instance is judged against ``reap_timeout_s``; one that
-        has never pinged against the larger ``registration_grace_s``. The
-        entry and its strategy are popped as a pair under the lock; cleanup
-        (pending-transfer sweep, layout-registry unregister) runs outside it.
+        has never pinged against the larger ``registration_grace_s``.
 
         Args:
             reap_timeout_s: Silence budget for ping-proven instances.

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -37,6 +37,7 @@ from lmcache.v1.multiprocess.custom_types import (
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 from lmcache.v1.multiprocess.engine_module import (
     HandlerSpec,
+    InstanceLivenessTarget,
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
@@ -411,7 +412,7 @@ class ContextEntry:
     has_liveness_signal: bool = False
 
 
-class LMCacheDrivenTransferModule:
+class LMCacheDrivenTransferModule(InstanceLivenessTarget):
     """Handles LMCache-driven KV cache transfer operations.
 
     Owns GPU context registrations and provides handlers for

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -451,11 +451,6 @@ class LMCacheDrivenTransferModule:
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
 
-    @property
-    def cache_contexts(self) -> dict[int, ContextEntry]:
-        """Per-instance GPU context registry."""
-        return self._cache_contexts
-
     def get_context_entry(self, instance_id: int) -> ContextEntry | None:
         """Return the entry for ``instance_id``, refreshing its last-seen time.
 

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -451,7 +451,7 @@ class LMCacheDrivenTransferModule:
         """Return the shared engine context. Exposed for testing only."""
         return self._ctx
 
-    def get_context_entry(self, instance_id: int) -> ContextEntry | None:
+    def get_and_touch_context_entry(self, instance_id: int) -> ContextEntry | None:
         """Return the entry for ``instance_id``, refreshing its last-seen time.
 
         The refresh keeps an actively transferring worker from being reaped
@@ -508,8 +508,6 @@ class LMCacheDrivenTransferModule:
 
         A ping-proven instance is judged against ``reap_timeout_s``; one
         that has never pinged against the larger ``registration_grace_s``.
-        Stale entries are collected and popped under the lock, then cleaned
-        up (layout-registry unregister, ``empty_cache``) outside it.
 
         Args:
             reap_timeout_s: Silence budget for ping-proven instances.
@@ -745,7 +743,7 @@ class LMCacheDrivenTransferModule:
         """
         st = time.perf_counter()
 
-        entry = self.get_context_entry(instance_id)
+        entry = self.get_and_touch_context_entry(instance_id)
         if entry is None:
             raise ValueError(f"No GPU context registered for instance ID {instance_id}")
         cache_context = entry.cache_context
@@ -949,7 +947,7 @@ class LMCacheDrivenTransferModule:
         """
         st = time.perf_counter()
 
-        entry = self.get_context_entry(instance_id)
+        entry = self.get_and_touch_context_entry(instance_id)
         if entry is None:
             raise ValueError(f"No GPU context registered for instance ID {instance_id}")
         cache_context = entry.cache_context

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -5,6 +5,7 @@
 from dataclasses import dataclass
 from itertools import islice
 from typing import Generator, Sequence
+import threading
 import time
 
 # Third Party
@@ -396,11 +397,18 @@ class ContextEntry:
             shape and pointers to the registered KV cache tensors.
         model_name: The name of the model associated with this KV cache.
         world_size: The world size associated with this KV cache.
+        last_seen: ``time.monotonic()`` of the most recent activity from
+            this instance (register, PING, store, or retrieve). Drives reaping.
+        has_liveness_signal: True once the instance has sent at least one
+            PING. Selects the reap window (timeout vs registration grace).
+            Latched only by PING, never by traffic.
     """
 
     cache_context: BaseCacheContext
     model_name: str
     world_size: int
+    last_seen: float = 0.0
+    has_liveness_signal: bool = False
 
 
 class LMCacheDrivenTransferModule:
@@ -416,6 +424,12 @@ class LMCacheDrivenTransferModule:
     def __init__(self, ctx: MPCacheServerContext) -> None:
         self._ctx = ctx
         self._cache_contexts: dict[int, ContextEntry] = {}
+        # Guards all reads/writes of _cache_contexts. The reaper mutates it
+        # off the MQ main loop, so register/unregister/store/retrieve and
+        # report_status all serialize through this lock. Held only for dict
+        # ops -- never across context creation, layout-registry calls, or
+        # empty_cache (leaf-lock invariant: no thread holds two locks).
+        self._lock = threading.Lock()
 
         # Route finish_write / finish_read_prefetched through a C++ host
         # callback so the driver thread doesn't acquire the GIL.
@@ -441,6 +455,108 @@ class LMCacheDrivenTransferModule:
     def cache_contexts(self) -> dict[int, ContextEntry]:
         """Per-instance GPU context registry."""
         return self._cache_contexts
+
+    def get_context_entry(self, instance_id: int) -> ContextEntry | None:
+        """Return the entry for ``instance_id``, refreshing its last-seen time.
+
+        The refresh keeps an actively transferring worker from being reaped
+        even if its PINGs are briefly delayed. Does not latch the
+        ping-proven flag -- only PINGs do that.
+
+        Args:
+            instance_id: The worker instance ID.
+
+        Returns:
+            The entry, or None if the instance is not (or no longer) tracked.
+        """
+        now = time.monotonic()
+        with self._lock:
+            entry = self._cache_contexts.get(instance_id)
+            if entry is not None:
+                entry.last_seen = now
+            return entry
+
+    def context_entries_snapshot(self) -> dict[int, ContextEntry]:
+        """Return a shallow copy of the registry for iteration or status.
+
+        Returns:
+            A new dict mapping instance ID to entry; does not refresh
+            last-seen times.
+        """
+        with self._lock:
+            return dict(self._cache_contexts)
+
+    def touch_instance(self, instance_id: int) -> None:
+        """Refresh the worker's last-seen time and mark it ping-proven.
+
+        A no-op if the instance is not tracked.
+
+        Args:
+            instance_id: The worker instance ID.
+        """
+        now = time.monotonic()
+        with self._lock:
+            entry = self._cache_contexts.get(instance_id)
+            if entry is not None:
+                entry.last_seen = now
+                entry.has_liveness_signal = True
+
+    def tracked_instance_count(self) -> int:
+        """Return the number of currently registered instances."""
+        with self._lock:
+            return len(self._cache_contexts)
+
+    def reap_stale_instances(
+        self, reap_timeout_s: float, registration_grace_s: float
+    ) -> list[int]:
+        """Reap GPU registrations that have gone silent.
+
+        A ping-proven instance is judged against ``reap_timeout_s``; one
+        that has never pinged against the larger ``registration_grace_s``.
+        Stale entries are collected and popped under the lock, then cleaned
+        up (layout-registry unregister, ``empty_cache``) outside it.
+
+        Args:
+            reap_timeout_s: Silence budget for ping-proven instances.
+            registration_grace_s: Silence budget for never-pinged instances.
+
+        Returns:
+            The instance IDs reaped this scan.
+        """
+        now = time.monotonic()
+        reaped: list[tuple[int, ContextEntry]] = []
+        with self._lock:
+            stale_ids = [
+                iid
+                for iid, entry in self._cache_contexts.items()
+                if now - entry.last_seen
+                > (
+                    reap_timeout_s
+                    if entry.has_liveness_signal
+                    else registration_grace_s
+                )
+            ]
+            for iid in stale_ids:
+                reaped.append((iid, self._cache_contexts.pop(iid)))
+        for iid, entry in reaped:
+            self._release_entry(entry)
+            logger.warning(
+                "Reaped GPU instance %d: silent for %.1fs (pinged=%s)",
+                iid,
+                now - entry.last_seen,
+                entry.has_liveness_signal,
+            )
+        return [iid for iid, _ in reaped]
+
+    def _release_entry(self, entry: ContextEntry) -> None:
+        """Release resources for a popped entry (run outside the lock).
+
+        Args:
+            entry: The entry removed from the registry.
+        """
+        entry.cache_context.close()
+        self._ctx.layout_desc_registry.unregister(entry.model_name, entry.world_size)
+        torch_dev.empty_cache()
 
     def get_handlers(self) -> list[HandlerSpec]:
         """Return handler specs for all request types this module serves.
@@ -482,7 +598,7 @@ class LMCacheDrivenTransferModule:
         registered_gpu_ids: list[int] = []
         cache_context_meta: dict[str, dict] = {}
 
-        for instance_id, entry in self._cache_contexts.items():
+        for instance_id, entry in self.context_entries_snapshot().items():
             registered_gpu_ids.append(instance_id)
             ctx = entry.cache_context
             cache_context_meta[str(instance_id)] = {
@@ -502,11 +618,12 @@ class LMCacheDrivenTransferModule:
         # in-flight completions reach a live storage manager.
         self._device_host_func_dispatcher.stop()
 
-        had_contexts = len(self._cache_contexts) > 0
-        for entry in self._cache_contexts.values():
+        with self._lock:
+            entries = list(self._cache_contexts.values())
+            self._cache_contexts.clear()
+        for entry in entries:
             entry.cache_context.close()
-        self._cache_contexts.clear()
-        if had_contexts:
+        if entries:
             torch_dev.empty_cache()
 
     def register_kv_cache(
@@ -534,14 +651,22 @@ class LMCacheDrivenTransferModule:
             engine_group_infos: Engine-neutral KV cache group metadata
                 (already msgspec-decoded by the message queue).
         """
-        if instance_id in self._cache_contexts:
-            logger.warning(
-                "Instance %s's KV cache is already registered, "
-                "skipping the new registration",
-                instance_id,
-            )
-            return
+        now = time.monotonic()
+        # NOOP-register: an already-registered instance (e.g. a recovering
+        # worker re-registering on its first ping) refreshes its last-seen
+        # time so a stale entry is not reaped right after recovery. REGISTER
+        # is SYNC-serialized on the MQ main loop, so it is the sole inserter.
+        with self._lock:
+            existing = self._cache_contexts.get(instance_id)
+            if existing is not None:
+                existing.last_seen = now
+                logger.info(
+                    "Instance %d already registered; refreshing liveness",
+                    instance_id,
+                )
+                return
 
+        # Build the context and layout descriptor outside the lock.
         cache_context = create_cache_context(
             kv_caches,
             self._ctx.chunk_size,
@@ -549,16 +674,19 @@ class LMCacheDrivenTransferModule:
             engine_group_infos=engine_group_infos,
             engine_type=engine_type,
         )
-        self._cache_contexts[instance_id] = ContextEntry(
-            cache_context=cache_context,
-            model_name=model_name,
-            world_size=world_size,
-        )
-
         layout_desc = get_layout_desc(
             cache_context, self._ctx.chunk_size, object_group_id=0
         )
         self._ctx.layout_desc_registry.register(model_name, world_size, layout_desc)
+
+        with self._lock:
+            self._cache_contexts[instance_id] = ContextEntry(
+                cache_context=cache_context,
+                model_name=model_name,
+                world_size=world_size,
+                last_seen=now,
+                has_liveness_signal=False,
+            )
 
         logger.info(
             "Registered KV cache for GPU ID %d with %d layers",
@@ -572,17 +700,16 @@ class LMCacheDrivenTransferModule:
         Args:
             instance_id: The GPU instance ID (such as PID).
         """
-        entry = self._cache_contexts.pop(instance_id, None)
+        with self._lock:
+            entry = self._cache_contexts.pop(instance_id, None)
         if entry is None:
             logger.warning(
                 "No registered GPU context found for instance ID %d", instance_id
             )
             return
 
-        entry.cache_context.close()
-        self._ctx.layout_desc_registry.unregister(entry.model_name, entry.world_size)
+        self._release_entry(entry)
         logger.info("Unregistered KV cache for GPU ID %d", instance_id)
-        torch_dev.empty_cache()
 
     @_lmcache_nvtx_annotate
     def store(
@@ -623,7 +750,7 @@ class LMCacheDrivenTransferModule:
         """
         st = time.perf_counter()
 
-        entry = self._cache_contexts.get(instance_id)
+        entry = self.get_context_entry(instance_id)
         if entry is None:
             raise ValueError(f"No GPU context registered for instance ID {instance_id}")
         cache_context = entry.cache_context
@@ -827,7 +954,7 @@ class LMCacheDrivenTransferModule:
         """
         st = time.perf_counter()
 
-        entry = self._cache_contexts.get(instance_id)
+        entry = self.get_context_entry(instance_id)
         if entry is None:
             raise ValueError(f"No GPU context registered for instance ID {instance_id}")
         cache_context = entry.cache_context

--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -72,8 +72,13 @@ class ManagementModule:
         """Release resources owned by this module."""
         pass
 
-    def ping(self) -> bool:
+    def ping(self, instance_id: int | None) -> bool:
         """Respond to a ping request.
+
+        Args:
+            instance_id: The sender's worker instance ID, or None for an
+                untracked prober (the scheduler adapter). Reserved for worker
+                liveness refresh, wired with the reaper; ignored here.
 
         Returns:
             Always True.

--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -2,6 +2,7 @@
 """Management and utility operations for the MPCacheServer."""
 
 # Standard
+from collections.abc import Sequence
 import threading
 
 # First Party
@@ -11,9 +12,17 @@ from lmcache.v1.multiprocess.custom_types import BlockAllocationRecord
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 from lmcache.v1.multiprocess.engine_module import (
     HandlerSpec,
+    InstanceLivenessTarget,
+    InstanceReapListener,
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.periodic_thread import (
+    PeriodicThread,
+    ThreadLevel,
+    ThreadRunSummary,
+    create_periodic_thread,
+)
 
 logger = init_logger(__name__)
 
@@ -23,14 +32,49 @@ class ManagementModule:
 
     Owns the lock used during cache clearing and provides handlers for
     ping, chunk-size queries, clear, debug, and block-allocation reporting.
+    Also owns the periodic reaper that evicts workers which have gone
+    silent, driving the injected liveness targets and reap listeners.
 
     Args:
         ctx: The shared engine context.
+        liveness_targets: Transfer modules whose per-instance registrations
+            are refreshed on PING and scanned by the reaper.
+        reap_listeners: Modules notified (via ``drop_instance_state``) when
+            an instance is reaped, so they can drop mirrored state.
+        worker_reap_timeout_seconds: Silence budget for a ping-proven worker;
+            0 disables reaping (no thread is started).
+        worker_registration_grace_seconds: Silence budget for a worker that
+            registered but never pinged.
     """
 
-    def __init__(self, ctx: MPCacheServerContext) -> None:
+    def __init__(
+        self,
+        ctx: MPCacheServerContext,
+        liveness_targets: Sequence[InstanceLivenessTarget] = (),
+        reap_listeners: Sequence[InstanceReapListener] = (),
+        worker_reap_timeout_seconds: float = 0.0,
+        worker_registration_grace_seconds: float = 0.0,
+    ) -> None:
         self._ctx = ctx
         self._clear_lock = threading.Lock()
+        self._liveness_targets = tuple(liveness_targets)
+        self._reap_listeners = tuple(reap_listeners)
+        self._reap_timeout = worker_reap_timeout_seconds
+        self._reap_grace = worker_registration_grace_seconds
+
+        # Periodic reaper, started only when reaping is enabled and there is
+        # something to scan. Scans every reap_timeout/4, so an instance is
+        # reaped between timeout and timeout + interval after its last signal.
+        self._reaper: PeriodicThread | None = None
+        if self._reap_timeout > 0 and self._liveness_targets:
+            reaper = create_periodic_thread(
+                name="lmcache-mp-worker-reaper",
+                interval=self._reap_timeout / 4,
+                execute_fn=self._reap_cycle,
+                level=ThreadLevel.MEDIUM,
+            )
+            reaper.start()
+            self._reaper = reaper
 
     @property
     def context(self) -> MPCacheServerContext:
@@ -64,26 +108,57 @@ class ManagementModule:
         """Return module-specific status information.
 
         Returns:
-            An empty dict; management has no module-level metrics.
+            A dict with a ``worker_liveness`` summary when reaping targets
+            are present, otherwise empty.
         """
-        return {}
+        if not self._liveness_targets:
+            return {}
+        tracked = sum(t.tracked_instance_count() for t in self._liveness_targets)
+        return {
+            "worker_liveness": {
+                "enabled": self._reaper is not None,
+                "reap_timeout_seconds": self._reap_timeout,
+                "registration_grace_seconds": self._reap_grace,
+                "tracked_instances": tracked,
+            }
+        }
 
     def close(self) -> None:
-        """Release resources owned by this module."""
-        pass
+        """Stop the reaper, if one is running."""
+        if self._reaper is not None:
+            self._reaper.stop()
 
     def ping(self, instance_id: int | None) -> bool:
-        """Respond to a ping request.
+        """Respond to a ping and refresh the sender's liveness.
 
         Args:
             instance_id: The sender's worker instance ID, or None for an
-                untracked prober (the scheduler adapter). Reserved for worker
-                liveness refresh, wired with the reaper; ignored here.
+                untracked prober (the scheduler adapter). When not None, the
+                worker's last-seen time is refreshed on every liveness target.
 
         Returns:
             Always True.
         """
+        if instance_id is not None:
+            for target in self._liveness_targets:
+                target.touch_instance(instance_id)
         return True
+
+    def _reap_cycle(self) -> ThreadRunSummary:
+        """Run one reaper scan: reap stale workers, notify reap listeners.
+
+        Returns:
+            A summary recording how many instances were reaped this scan.
+        """
+        reaped: list[int] = []
+        for target in self._liveness_targets:
+            reaped.extend(
+                target.reap_stale_instances(self._reap_timeout, self._reap_grace)
+            )
+        for instance_id in reaped:
+            for listener in self._reap_listeners:
+                listener.drop_instance_state(instance_id)
+        return ThreadRunSummary(success=True, message=f"reaped={len(reaped)}")
 
     def get_chunk_size(self) -> int:
         """Return the chunk size used for KV cache operations.

--- a/lmcache/v1/multiprocess/modules/management.py
+++ b/lmcache/v1/multiprocess/modules/management.py
@@ -13,7 +13,6 @@ from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 from lmcache.v1.multiprocess.engine_module import (
     HandlerSpec,
     InstanceLivenessTarget,
-    InstanceReapListener,
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
@@ -33,14 +32,14 @@ class ManagementModule:
     Owns the lock used during cache clearing and provides handlers for
     ping, chunk-size queries, clear, debug, and block-allocation reporting.
     Also owns the periodic reaper that evicts workers which have gone
-    silent, driving the injected liveness targets and reap listeners.
+    silent, driving the injected liveness targets.
 
     Args:
         ctx: The shared engine context.
-        liveness_targets: Transfer modules whose per-instance registrations
-            are refreshed on PING and scanned by the reaper.
-        reap_listeners: Modules notified (via ``drop_instance_state``) when
-            an instance is reaped, so they can drop mirrored state.
+        liveness_targets: Modules the reaper drives -- the transfer modules
+            whose per-instance registrations are refreshed on PING and scanned
+            for staleness, plus any state mirror (e.g. ``BlendV3Module``)
+            notified via ``drop_instance_state`` when an instance is reaped.
         worker_reap_timeout_seconds: Silence budget for a ping-proven worker;
             0 disables reaping (no thread is started).
         worker_registration_grace_seconds: Silence budget for a worker that
@@ -51,14 +50,12 @@ class ManagementModule:
         self,
         ctx: MPCacheServerContext,
         liveness_targets: Sequence[InstanceLivenessTarget] = (),
-        reap_listeners: Sequence[InstanceReapListener] = (),
         worker_reap_timeout_seconds: float = 0.0,
         worker_registration_grace_seconds: float = 0.0,
     ) -> None:
         self._ctx = ctx
         self._clear_lock = threading.Lock()
         self._liveness_targets = tuple(liveness_targets)
-        self._reap_listeners = tuple(reap_listeners)
         self._reap_timeout = worker_reap_timeout_seconds
         self._reap_grace = worker_registration_grace_seconds
 
@@ -145,7 +142,10 @@ class ManagementModule:
         return True
 
     def _reap_cycle(self) -> ThreadRunSummary:
-        """Run one reaper scan: reap stale workers, notify reap listeners.
+        """Run one reaper scan: reap stale workers, drop mirrored state.
+
+        Each reaped instance id is passed to ``drop_instance_state`` on every
+        target; it is a no-op for targets that mirror nothing for that id.
 
         Returns:
             A summary recording how many instances were reaped this scan.
@@ -156,8 +156,8 @@ class ManagementModule:
                 target.reap_stale_instances(self._reap_timeout, self._reap_grace)
             )
         for instance_id in reaped:
-            for listener in self._reap_listeners:
-                listener.drop_instance_state(instance_id)
+            for target in self._liveness_targets:
+                target.drop_instance_state(instance_id)
         return ThreadRunSummary(success=True, message=f"reaped={len(reaped)}")
 
     def get_chunk_size(self) -> int:

--- a/lmcache/v1/multiprocess/protocols/controller.py
+++ b/lmcache/v1/multiprocess/protocols/controller.py
@@ -46,10 +46,12 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Payload: [instance_id] -- the sender's worker instance ID, or None
         #   for an untracked prober (the scheduler adapter).
         # Returns: bool - Always True
-        # SYNC: the handler is an O(1) liveness touch, run on the MQ main loop.
+        # BLOCKING on the NORMAL pool: keeps PING off the MQ main loop (where a
+        # slow SYNC REGISTER_KV_CACHE would stall it) and lets pool saturation
+        # surface as worker degraded mode.
         "PING": ProtocolDefinition(
             payload_classes=[int | None],
             response_class=bool,
-            handler_type=HandlerType.SYNC,
+            handler_type=HandlerType.BLOCKING,
         ),
     }

--- a/lmcache/v1/multiprocess/protocols/controller.py
+++ b/lmcache/v1/multiprocess/protocols/controller.py
@@ -43,11 +43,13 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
             handler_type=HandlerType.SYNC,
         ),
         # Ping
-        # Payload: None
+        # Payload: [instance_id] -- the sender's worker instance ID, or None
+        #   for an untracked prober (the scheduler adapter).
         # Returns: bool - Always True
+        # SYNC: the handler is an O(1) liveness touch, run on the MQ main loop.
         "PING": ProtocolDefinition(
-            payload_classes=[],
+            payload_classes=[int | None],
             response_class=bool,
-            handler_type=HandlerType.BLOCKING,
+            handler_type=HandlerType.SYNC,
         ),
     }

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -194,7 +194,8 @@ def _build_modules(
 
     logger.info("Supported transfer mode: %s", mp_config.supported_transfer_mode)
 
-    blend_modules: list[EngineModule] = []
+    # At most one blend module is ever built (engine_type selects one).
+    blend_module: EngineModule | None = None
     reap_listeners: list[InstanceReapListener] = []
 
     if mp_config.engine_type == "blend_legacy":
@@ -207,7 +208,7 @@ def _build_modules(
         # First Party
         from lmcache.v1.multiprocess.modules.blend import BlendModule
 
-        blend_modules.append(BlendModule(ctx))
+        blend_module = BlendModule(ctx)
 
     # "blend" selects CacheBlend V3 (the current implementation).
     if mp_config.engine_type == "blend":
@@ -232,7 +233,7 @@ def _build_modules(
         blend_v3 = BlendV3Module(
             ctx, transfer_module, lookup_module, coordinator=coordinator
         )
-        blend_modules.append(blend_v3)
+        blend_module = blend_v3
         reap_listeners.append(blend_v3)
 
     liveness_targets: list[InstanceLivenessTarget] = [
@@ -251,6 +252,7 @@ def _build_modules(
     # ManagementModule precedes the transfer/blend modules so close() stops
     # and joins the reaper before those modules clear their state and before
     # storage_manager.close() runs.
+    blend_modules = [blend_module] if blend_module is not None else []
     return [lookup_module, management, *transfer_modules, *blend_modules]
 
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -35,6 +35,8 @@ from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 from lmcache.v1.multiprocess.engine_module import (
     EngineModule,
     HandlerSpec,
+    InstanceLivenessTarget,
+    InstanceReapListener,
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.modules.engine_driven_transfer import (
@@ -172,24 +174,28 @@ def _build_modules(
         ValueError: If blend engine is requested with
         supported_transfer_mode="engine_driven".
     """
-    modules: list[EngineModule] = [
-        LookupModule(ctx),
-        ManagementModule(ctx),
-    ]
+    lookup_module = LookupModule(ctx)
 
+    # Build the transfer and blend modules first so the ManagementModule can
+    # be constructed with them as liveness targets / reap listeners. They are
+    # the InstanceLivenessTargets the reaper scans.
+    transfer_modules: list[EngineModule] = []
     if mp_config.supported_transfer_mode == "lmcache_driven":
-        modules.append(LMCacheDrivenTransferModule(ctx))
+        transfer_modules.append(LMCacheDrivenTransferModule(ctx))
     elif mp_config.supported_transfer_mode == "engine_driven":
-        modules.append(EngineDrivenTransferModule(ctx))
+        transfer_modules.append(EngineDrivenTransferModule(ctx))
     elif mp_config.supported_transfer_mode == "auto":
-        modules.append(LMCacheDrivenTransferModule(ctx))
-        modules.append(EngineDrivenTransferModule(ctx))
+        transfer_modules.append(LMCacheDrivenTransferModule(ctx))
+        transfer_modules.append(EngineDrivenTransferModule(ctx))
     else:
         raise ValueError(
             f"Unsupported supported_transfer_mode '{mp_config.supported_transfer_mode}'"
         )
 
     logger.info("Supported transfer mode: %s", mp_config.supported_transfer_mode)
+
+    blend_modules: list[EngineModule] = []
+    reap_listeners: list[InstanceReapListener] = []
 
     if mp_config.engine_type == "blend_legacy":
         if mp_config.supported_transfer_mode == "engine_driven":
@@ -201,7 +207,7 @@ def _build_modules(
         # First Party
         from lmcache.v1.multiprocess.modules.blend import BlendModule
 
-        modules.append(BlendModule(ctx))
+        blend_modules.append(BlendModule(ctx))
 
     # "blend" selects CacheBlend V3 (the current implementation).
     if mp_config.engine_type == "blend":
@@ -218,22 +224,34 @@ def _build_modules(
         from lmcache.v1.multiprocess.modules.blend_v3 import BlendV3Module
 
         transfer_module = next(
-            m for m in modules if isinstance(m, LMCacheDrivenTransferModule)
+            m for m in transfer_modules if isinstance(m, LMCacheDrivenTransferModule)
         )
-        lookup_module = next(m for m in modules if isinstance(m, LookupModule))
         # Opt-in: enabled only when LMCACHE_COORDINATOR_URL is set; otherwise
         # None and the blend module matches purely locally.
         coordinator = BlendCoordinatorClient.maybe_from_env()
-        modules.append(
-            BlendV3Module(
-                ctx,
-                transfer_module,
-                lookup_module,
-                coordinator=coordinator,
-            )
+        blend_v3 = BlendV3Module(
+            ctx, transfer_module, lookup_module, coordinator=coordinator
         )
+        blend_modules.append(blend_v3)
+        reap_listeners.append(blend_v3)
 
-    return modules
+    liveness_targets: list[InstanceLivenessTarget] = [
+        m
+        for m in transfer_modules
+        if isinstance(m, (LMCacheDrivenTransferModule, EngineDrivenTransferModule))
+    ]
+    management = ManagementModule(
+        ctx,
+        liveness_targets=liveness_targets,
+        reap_listeners=reap_listeners,
+        worker_reap_timeout_seconds=mp_config.worker_reap_timeout_seconds,
+        worker_registration_grace_seconds=mp_config.worker_registration_grace_seconds,
+    )
+
+    # ManagementModule precedes the transfer/blend modules so close() stops
+    # and joins the reaper before those modules clear their state and before
+    # storage_manager.close() runs.
+    return [lookup_module, management, *transfer_modules, *blend_modules]
 
 
 def run_cache_server(

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -36,7 +36,6 @@ from lmcache.v1.multiprocess.engine_module import (
     EngineModule,
     HandlerSpec,
     InstanceLivenessTarget,
-    InstanceReapListener,
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.modules.engine_driven_transfer import (
@@ -194,9 +193,16 @@ def _build_modules(
 
     logger.info("Supported transfer mode: %s", mp_config.supported_transfer_mode)
 
+    # Targets the reaper scans (and reap-notifies). The transfer modules own
+    # per-instance liveness; BlendV3Module is appended below as a state mirror.
+    liveness_targets: list[InstanceLivenessTarget] = [
+        m
+        for m in transfer_modules
+        if isinstance(m, (LMCacheDrivenTransferModule, EngineDrivenTransferModule))
+    ]
+
     # At most one blend module is ever built (engine_type selects one).
     blend_module: EngineModule | None = None
-    reap_listeners: list[InstanceReapListener] = []
 
     if mp_config.engine_type == "blend_legacy":
         if mp_config.supported_transfer_mode == "engine_driven":
@@ -234,17 +240,13 @@ def _build_modules(
             ctx, transfer_module, lookup_module, coordinator=coordinator
         )
         blend_module = blend_v3
-        reap_listeners.append(blend_v3)
+        # blend_v3 mirrors per-instance CB rope state, so the reaper must
+        # notify it via drop_instance_state when an instance is reaped.
+        liveness_targets.append(blend_v3)
 
-    liveness_targets: list[InstanceLivenessTarget] = [
-        m
-        for m in transfer_modules
-        if isinstance(m, (LMCacheDrivenTransferModule, EngineDrivenTransferModule))
-    ]
     management = ManagementModule(
         ctx,
         liveness_targets=liveness_targets,
-        reap_listeners=reap_listeners,
         worker_reap_timeout_seconds=mp_config.worker_reap_timeout_seconds,
         worker_registration_grace_seconds=mp_config.worker_registration_grace_seconds,
     )

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -120,7 +120,10 @@ class MPCacheServer:
         """Used by ``/kvcache/check``; unwraps :class:`ContextEntry`."""
         for module in self._modules:
             if isinstance(module, LMCacheDrivenTransferModule):
-                return {i: e.cache_context for i, e in module.cache_contexts.items()}
+                return {
+                    i: e.cache_context
+                    for i, e in module.context_entries_snapshot().items()
+                }
         return None
 
     def clear(self) -> None:

--- a/tests/v1/multiprocess/test_engine_passthroughs.py
+++ b/tests/v1/multiprocess/test_engine_passthroughs.py
@@ -28,7 +28,7 @@ def test_storage_manager_returns_context_storage_manager() -> None:
 def test_cache_contexts_unwraps_entries_from_gpu_transfer_module() -> None:
     gpu0, gpu1 = MagicMock(name="gpu_ctx_0"), MagicMock(name="gpu_ctx_1")
     gpu_transfer = MagicMock(spec=LMCacheDrivenTransferModule)
-    gpu_transfer.cache_contexts = {
+    gpu_transfer.context_entries_snapshot.return_value = {
         0: ContextEntry(cache_context=gpu0, model_name="m", world_size=1),
         7: ContextEntry(cache_context=gpu1, model_name="m", world_size=1),
     }

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for server-side worker liveness tracking and reaping.
+
+Cover the public liveness interfaces of the transfer modules, the
+management reaper wiring, the blend reap listener, and config validation.
+No GPU or live server is required; module-level construction dependencies
+are stubbed.
+"""
+
+# Standard
+from typing import cast
+from unittest.mock import MagicMock
+import threading
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.config import MPServerConfig
+from lmcache.v1.multiprocess.modules import gpu_transfer as gpu_mod
+from lmcache.v1.multiprocess.modules import non_gpu_transfer as non_gpu_mod
+from lmcache.v1.multiprocess.modules.gpu_transfer import ContextEntry, GPUTransferModule
+from lmcache.v1.multiprocess.modules.management import ManagementModule
+from lmcache.v1.multiprocess.modules.non_gpu_transfer import NonGPUTransferModule
+from lmcache.v1.periodic_thread import PeriodicThreadRegistry
+
+
+def _bare_gpu_module() -> GPUTransferModule:
+    """A GPUTransferModule with only the liveness state initialized.
+
+    Bypasses __init__ (which starts a CUDA host-func dispatcher) so the
+    liveness methods can be exercised without GPU hardware.
+    """
+    module = GPUTransferModule.__new__(GPUTransferModule)
+    module._ctx = MagicMock(name="ctx")
+    module._cache_contexts = {}
+    module._lock = threading.Lock()
+    return module
+
+
+def _bare_non_gpu_module() -> NonGPUTransferModule:
+    """A NonGPUTransferModule with only the liveness state initialized."""
+    module = NonGPUTransferModule.__new__(NonGPUTransferModule)
+    module._ctx = MagicMock(name="ctx")
+    module._non_gpu_contexts = {}
+    module._strategies = {}
+    module._lock = threading.Lock()
+    module._pending_shm_writes = {}
+    module._pending_shm_reads = {}
+    module._pending_shm_lock = threading.Lock()
+    return module
+
+
+def test_gpu_register_inserts_unlatched_entry(monkeypatch) -> None:
+    """register_kv_cache inserts an entry that is not yet ping-proven."""
+    monkeypatch.setattr(
+        gpu_mod, "create_cache_context", lambda *a, **kw: MagicMock(num_layers=2)
+    )
+    monkeypatch.setattr(gpu_mod, "get_layout_desc", lambda *a, **kw: MagicMock())
+    module = _bare_gpu_module()
+
+    module.register_kv_cache(1, MagicMock(), "model", 1, MagicMock(), MagicMock(), [])
+
+    assert module.tracked_instance_count() == 1
+    entry = module.get_context_entry(1)
+    assert entry is not None and entry.has_liveness_signal is False
+
+
+def test_gpu_noop_register_refreshes_without_latching(monkeypatch) -> None:
+    """Re-registering a known instance refreshes last_seen but does not
+    rebuild the context or latch the ping-proven flag."""
+    create = MagicMock(return_value=MagicMock(num_layers=2))
+    monkeypatch.setattr(gpu_mod, "create_cache_context", create)
+    monkeypatch.setattr(gpu_mod, "get_layout_desc", lambda *a, **kw: MagicMock())
+    module = _bare_gpu_module()
+    module.register_kv_cache(1, MagicMock(), "model", 1, MagicMock(), MagicMock(), [])
+    module._cache_contexts[1].last_seen = 0.0
+
+    module.register_kv_cache(1, MagicMock(), "model", 1, MagicMock(), MagicMock(), [])
+
+    assert create.call_count == 1  # not rebuilt
+    assert module._cache_contexts[1].last_seen > 0.0  # refreshed
+    assert module._cache_contexts[1].has_liveness_signal is False
+
+
+def test_gpu_touch_latches_get_does_not() -> None:
+    """touch_instance marks ping-proven; get_context_entry only refreshes."""
+    module = _bare_gpu_module()
+    module._cache_contexts[1] = ContextEntry(MagicMock(), "m", 1, last_seen=0.0)
+
+    module.get_context_entry(1)
+    assert module._cache_contexts[1].last_seen > 0.0
+    assert module._cache_contexts[1].has_liveness_signal is False
+
+    module.touch_instance(1)
+    assert module._cache_contexts[1].has_liveness_signal is True
+    module.touch_instance(999)  # absent -> no error
+
+
+def test_gpu_reap_two_tier_windows() -> None:
+    """Ping-proven entries reap at the timeout; never-pinged ones survive
+    until the larger registration grace."""
+    module = _bare_gpu_module()
+    old = time.monotonic() - 1000.0
+    module._cache_contexts[1] = ContextEntry(MagicMock(), "m", 1, old, True)
+    module._cache_contexts[2] = ContextEntry(MagicMock(), "m", 1, old, False)
+    module._cache_contexts[3] = ContextEntry(
+        MagicMock(), "m", 1, time.monotonic(), True
+    )
+
+    reaped = module.reap_stale_instances(120.0, 3600.0)
+
+    assert reaped == [1]  # only the ping-proven stale entry
+    assert module.tracked_instance_count() == 2
+    cast(
+        MagicMock, module._ctx.layout_desc_registry.unregister
+    ).assert_called_once_with("m", 1)
+
+
+def test_gpu_unregister_cleans_up() -> None:
+    """unregister_kv_cache pops and releases; missing id is a no-op."""
+    module = _bare_gpu_module()
+    module._cache_contexts[1] = ContextEntry(MagicMock(), "m", 1, time.monotonic())
+
+    module.unregister_kv_cache(1)
+    assert module.tracked_instance_count() == 0
+    cast(
+        MagicMock, module._ctx.layout_desc_registry.unregister
+    ).assert_called_once_with("m", 1)
+
+    module.unregister_kv_cache(1)  # already gone -> no exception
+
+
+def test_non_gpu_reap_pops_strategy_as_pair() -> None:
+    """Reaping a non-GPU entry pops its strategy in the same scan, keeping
+    'strategy present iff entry present'."""
+    module = _bare_non_gpu_module()
+    old = time.monotonic() - 1000.0
+    module._non_gpu_contexts[1] = non_gpu_mod.NonGPUContextEntry(
+        MagicMock(), "m", 1, old, True
+    )
+    module._strategies[1] = MagicMock()
+    module._non_gpu_contexts[2] = non_gpu_mod.NonGPUContextEntry(
+        MagicMock(), "m", 1, old, False
+    )
+    module._strategies[2] = MagicMock()
+
+    reaped = module.reap_stale_instances(120.0, 3600.0)
+
+    assert reaped == [1]
+    assert 1 not in module._strategies  # strategy popped with the entry
+    assert 2 in module._strategies  # never-pinged survives on grace
+
+
+def test_non_gpu_resolve_for_transfer_refreshes_and_raises() -> None:
+    """_resolve_for_transfer returns (entry, strategy) and refreshes
+    last_seen; an unknown id raises ValueError."""
+    module = _bare_non_gpu_module()
+    module._non_gpu_contexts[1] = non_gpu_mod.NonGPUContextEntry(
+        MagicMock(), "m", 1, 0.0, False
+    )
+    strategy = MagicMock()
+    module._strategies[1] = strategy
+
+    entry, resolved = module._resolve_for_transfer(1)
+    assert resolved is strategy
+    assert entry.last_seen > 0.0
+    assert entry.has_liveness_signal is False  # traffic does not latch
+
+    with pytest.raises(ValueError, match="not registered"):
+        module._resolve_for_transfer(999)
+
+
+class _FakeTarget:
+    """Liveness target double recording touches and yielding scripted reaps."""
+
+    def __init__(self) -> None:
+        self.touched: list[int] = []
+        self.to_reap: list[int] = []
+        self.count = 0
+
+    def touch_instance(self, instance_id: int) -> None:
+        self.touched.append(instance_id)
+
+    def reap_stale_instances(self, timeout: float, grace: float) -> list[int]:
+        reaped = self.to_reap[:]
+        self.to_reap.clear()
+        return reaped
+
+    def tracked_instance_count(self) -> int:
+        return self.count
+
+
+class _FakeListener:
+    """Reap listener double recording dropped instance IDs."""
+
+    def __init__(self) -> None:
+        self.dropped: list[int] = []
+
+    def drop_instance_state(self, instance_id: int) -> None:
+        self.dropped.append(instance_id)
+
+
+@pytest.fixture(autouse=True)
+def _reset_periodic_registry():
+    """Keep the reaper out of the global registry across tests."""
+    PeriodicThreadRegistry.reset()
+    yield
+    PeriodicThreadRegistry.reset()
+
+
+def test_management_ping_touches_targets() -> None:
+    """ping refreshes every target for a real id; None is ignored."""
+    target = _FakeTarget()
+    mgmt = ManagementModule(MagicMock(), liveness_targets=[target])
+
+    assert mgmt.ping(42) is True
+    assert mgmt.ping(None) is True
+    assert target.touched == [42]
+
+
+def test_management_reaper_reaps_and_fans_out() -> None:
+    """The reaper scans targets and notifies listeners for reaped ids."""
+    target = _FakeTarget()
+    listener = _FakeListener()
+    mgmt = ManagementModule(
+        MagicMock(),
+        liveness_targets=[target],
+        reap_listeners=[listener],
+        worker_reap_timeout_seconds=0.4,
+        worker_registration_grace_seconds=0.8,
+    )
+    try:
+        target.to_reap = [7]
+        deadline = time.monotonic() + 2.0
+        while listener.dropped != [7] and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert listener.dropped == [7]
+    finally:
+        mgmt.close()
+
+
+def test_management_reaper_disabled_when_timeout_zero() -> None:
+    """timeout == 0 starts no reaper thread."""
+    mgmt = ManagementModule(
+        MagicMock(),
+        liveness_targets=[_FakeTarget()],
+        worker_reap_timeout_seconds=0.0,
+    )
+    assert mgmt._reaper is None
+    assert mgmt.ping(1) is True
+
+
+def test_management_report_status_summarizes_liveness() -> None:
+    """report_status reports a worker_liveness summary when targets exist."""
+    target = _FakeTarget()
+    target.count = 3
+    mgmt = ManagementModule(
+        MagicMock(),
+        liveness_targets=[target],
+        worker_reap_timeout_seconds=120.0,
+        worker_registration_grace_seconds=3600.0,
+    )
+    try:
+        status = mgmt.report_status()["worker_liveness"]
+        assert status["enabled"] is True
+        assert status["tracked_instances"] == 3
+        assert status["reap_timeout_seconds"] == 120.0
+    finally:
+        mgmt.close()
+
+    assert ManagementModule(MagicMock()).report_status() == {}
+
+
+def test_blend_drop_instance_state_releases_mirror() -> None:
+    """drop_instance_state pops the blend mirrors for a reaped instance."""
+    # First Party
+    from lmcache.v1.multiprocess.modules.blend_v3 import BlendV3Module
+
+    module = BlendV3Module.__new__(BlendV3Module)
+    module._cb_rope_state = {5: MagicMock()}
+    module._cb_gpu_contexts = {5: MagicMock()}
+    module._cb_gpu_context_meta = {5: ("m", 1)}
+
+    module.drop_instance_state(5)
+
+    assert 5 not in module._cb_rope_state
+    assert 5 not in module._cb_gpu_contexts
+    assert 5 not in module._cb_gpu_context_meta
+    module.drop_instance_state(999)  # nothing held -> no error
+
+
+def test_config_rejects_bad_reap_timeouts() -> None:
+    """Validation rejects sub-floor reap timeouts and undersized grace."""
+    with pytest.raises(ValueError, match="reap timeout"):
+        MPServerConfig(worker_reap_timeout_seconds=10.0)
+    with pytest.raises(ValueError, match="registration grace"):
+        MPServerConfig(
+            worker_reap_timeout_seconds=120.0,
+            worker_registration_grace_seconds=60.0,
+        )
+
+
+def test_config_accepts_disabled_and_defaults() -> None:
+    """0 disables reaping; defaults satisfy the grace >= timeout invariant."""
+    MPServerConfig(
+        worker_reap_timeout_seconds=0.0, worker_registration_grace_seconds=0.0
+    )
+    default = MPServerConfig()
+    assert default.worker_reap_timeout_seconds == 120.0
+    assert default.worker_registration_grace_seconds == 3600.0

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -183,7 +183,9 @@ class _FakeTarget:
     def touch_instance(self, instance_id: int) -> None:
         self.touched.append(instance_id)
 
-    def reap_stale_instances(self, timeout: float, grace: float) -> list[int]:
+    def reap_stale_instances(
+        self, reap_timeout_s: float, registration_grace_s: float
+    ) -> list[int]:
         reaped = self.to_reap[:]
         self.to_reap.clear()
         return reaped
@@ -273,21 +275,21 @@ def test_management_report_status_summarizes_liveness() -> None:
     assert ManagementModule(MagicMock()).report_status() == {}
 
 
-def test_blend_drop_instance_state_releases_mirror() -> None:
-    """drop_instance_state pops the blend mirrors for a reaped instance."""
+def test_blend_drop_instance_state_drops_rope_state() -> None:
+    """drop_instance_state pops the reaped instance's CB rope state.
+
+    The GPU context is no longer mirrored in BlendV3Module (reaping the GPU
+    entry frees it directly), so only the rope state is dropped here.
+    """
     # First Party
     from lmcache.v1.multiprocess.modules.blend_v3 import BlendV3Module
 
     module = BlendV3Module.__new__(BlendV3Module)
     module._cb_rope_state = {5: MagicMock()}
-    module._cb_gpu_contexts = {5: MagicMock()}
-    module._cb_gpu_context_meta = {5: ("m", 1)}
 
     module.drop_instance_state(5)
 
     assert 5 not in module._cb_rope_state
-    assert 5 not in module._cb_gpu_contexts
-    assert 5 not in module._cb_gpu_context_meta
     module.drop_instance_state(999)  # nothing held -> no error
 
 

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -18,32 +18,37 @@ import pytest
 
 # First Party
 from lmcache.v1.multiprocess.config import MPServerConfig
-from lmcache.v1.multiprocess.modules import gpu_transfer as gpu_mod
-from lmcache.v1.multiprocess.modules import non_gpu_transfer as non_gpu_mod
-from lmcache.v1.multiprocess.modules.gpu_transfer import ContextEntry, GPUTransferModule
+from lmcache.v1.multiprocess.modules import engine_driven_transfer as non_gpu_mod
+from lmcache.v1.multiprocess.modules import lmcache_driven_transfer as gpu_mod
+from lmcache.v1.multiprocess.modules.engine_driven_transfer import (
+    EngineDrivenTransferModule,
+)
+from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
+    ContextEntry,
+    LMCacheDrivenTransferModule,
+)
 from lmcache.v1.multiprocess.modules.management import ManagementModule
-from lmcache.v1.multiprocess.modules.non_gpu_transfer import NonGPUTransferModule
 from lmcache.v1.periodic_thread import PeriodicThreadRegistry
 
 
-def _bare_gpu_module() -> GPUTransferModule:
-    """A GPUTransferModule with only the liveness state initialized.
+def _bare_gpu_module() -> LMCacheDrivenTransferModule:
+    """A LMCacheDrivenTransferModule with only the liveness state initialized.
 
     Bypasses __init__ (which starts a CUDA host-func dispatcher) so the
     liveness methods can be exercised without GPU hardware.
     """
-    module = GPUTransferModule.__new__(GPUTransferModule)
+    module = LMCacheDrivenTransferModule.__new__(LMCacheDrivenTransferModule)
     module._ctx = MagicMock(name="ctx")
     module._cache_contexts = {}
     module._lock = threading.Lock()
     return module
 
 
-def _bare_non_gpu_module() -> NonGPUTransferModule:
-    """A NonGPUTransferModule with only the liveness state initialized."""
-    module = NonGPUTransferModule.__new__(NonGPUTransferModule)
+def _bare_non_gpu_module() -> EngineDrivenTransferModule:
+    """A EngineDrivenTransferModule with only the liveness state initialized."""
+    module = EngineDrivenTransferModule.__new__(EngineDrivenTransferModule)
     module._ctx = MagicMock(name="ctx")
-    module._non_gpu_contexts = {}
+    module._engine_driven_contexts = {}
     module._strategies = {}
     module._lock = threading.Lock()
     module._pending_shm_writes = {}
@@ -63,7 +68,7 @@ def test_gpu_register_inserts_unlatched_entry(monkeypatch) -> None:
     module.register_kv_cache(1, MagicMock(), "model", 1, MagicMock(), MagicMock(), [])
 
     assert module.tracked_instance_count() == 1
-    entry = module.get_context_entry(1)
+    entry = module.get_and_touch_context_entry(1)
     assert entry is not None and entry.has_liveness_signal is False
 
 
@@ -85,11 +90,11 @@ def test_gpu_noop_register_refreshes_without_latching(monkeypatch) -> None:
 
 
 def test_gpu_touch_latches_get_does_not() -> None:
-    """touch_instance marks ping-proven; get_context_entry only refreshes."""
+    """touch_instance marks ping-proven; get_and_touch_context_entry only refreshes."""
     module = _bare_gpu_module()
     module._cache_contexts[1] = ContextEntry(MagicMock(), "m", 1, last_seen=0.0)
 
-    module.get_context_entry(1)
+    module.get_and_touch_context_entry(1)
     assert module._cache_contexts[1].last_seen > 0.0
     assert module._cache_contexts[1].has_liveness_signal is False
 
@@ -137,11 +142,11 @@ def test_non_gpu_reap_pops_strategy_as_pair() -> None:
     'strategy present iff entry present'."""
     module = _bare_non_gpu_module()
     old = time.monotonic() - 1000.0
-    module._non_gpu_contexts[1] = non_gpu_mod.NonGPUContextEntry(
+    module._engine_driven_contexts[1] = non_gpu_mod.EngineDrivenContextEntry(
         MagicMock(), "m", 1, old, True
     )
     module._strategies[1] = MagicMock()
-    module._non_gpu_contexts[2] = non_gpu_mod.NonGPUContextEntry(
+    module._engine_driven_contexts[2] = non_gpu_mod.EngineDrivenContextEntry(
         MagicMock(), "m", 1, old, False
     )
     module._strategies[2] = MagicMock()
@@ -157,7 +162,7 @@ def test_non_gpu_resolve_for_transfer_refreshes_and_raises() -> None:
     """_resolve_for_transfer returns (entry, strategy) and refreshes
     last_seen; an unknown id raises ValueError."""
     module = _bare_non_gpu_module()
-    module._non_gpu_contexts[1] = non_gpu_mod.NonGPUContextEntry(
+    module._engine_driven_contexts[1] = non_gpu_mod.EngineDrivenContextEntry(
         MagicMock(), "m", 1, 0.0, False
     )
     strategy = MagicMock()

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -178,11 +178,12 @@ def test_non_gpu_resolve_for_transfer_refreshes_and_raises() -> None:
 
 
 class _FakeTarget:
-    """Liveness target double recording touches and yielding scripted reaps."""
+    """Liveness target double recording touches/drops and scripted reaps."""
 
     def __init__(self) -> None:
         self.touched: list[int] = []
         self.to_reap: list[int] = []
+        self.dropped: list[int] = []
         self.count = 0
 
     def touch_instance(self, instance_id: int) -> None:
@@ -197,13 +198,6 @@ class _FakeTarget:
 
     def tracked_instance_count(self) -> int:
         return self.count
-
-
-class _FakeListener:
-    """Reap listener double recording dropped instance IDs."""
-
-    def __init__(self) -> None:
-        self.dropped: list[int] = []
 
     def drop_instance_state(self, instance_id: int) -> None:
         self.dropped.append(instance_id)
@@ -227,23 +221,21 @@ def test_management_ping_touches_targets() -> None:
     assert target.touched == [42]
 
 
-def test_management_reaper_reaps_and_fans_out() -> None:
-    """The reaper scans targets and notifies listeners for reaped ids."""
+def test_management_reaper_reaps_and_drops() -> None:
+    """The reaper scans targets and calls drop_instance_state for reaped ids."""
     target = _FakeTarget()
-    listener = _FakeListener()
     mgmt = ManagementModule(
         MagicMock(),
         liveness_targets=[target],
-        reap_listeners=[listener],
         worker_reap_timeout_seconds=0.4,
         worker_registration_grace_seconds=0.8,
     )
     try:
         target.to_reap = [7]
         deadline = time.monotonic() + 2.0
-        while listener.dropped != [7] and time.monotonic() < deadline:
+        while target.dropped != [7] and time.monotonic() < deadline:
             time.sleep(0.02)
-        assert listener.dropped == [7]
+        assert target.dropped == [7]
     finally:
         mgmt.close()
 

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -46,12 +46,14 @@ class FakeHeartbeatThread:
         mq_client: object = None,
         health_event: threading.Event | None = None,
         interval: float = 0.0,
+        instance_id: int | None = None,
     ) -> None:
         self.mq_client = mq_client
         self.health_event = (
             health_event if health_event is not None else threading.Event()
         )
         self.interval = interval
+        self.instance_id = instance_id
         # Snapshot of the health event at construction time: lets tests
         # assert the adapter starts the heartbeat healthy (event still set).
         self.health_event_set_at_init = self.health_event.is_set()
@@ -435,7 +437,9 @@ def test_heartbeat_first_ping_runs_callback_before_setting_event(
     """Real HeartbeatThread: started with the health event cleared, the
     first successful ping invokes the recover callback while the event
     is still cleared, then sets the event."""
-    monkeypatch.setattr(adapter_mod, "send_ping", lambda mq_client, timeout: True)
+    monkeypatch.setattr(
+        adapter_mod, "send_ping", lambda mq_client, timeout, instance_id=None: True
+    )
     health_event = threading.Event()  # cleared: pessimistic start state
     heartbeat = HeartbeatThread(
         mq_client=MagicMock(name="mq_client"),
@@ -558,7 +562,9 @@ def test_straggler_cycle_after_stop_skips_callback_and_event(monkeypatch) -> Non
     ping_entered = threading.Event()
     release_ping = threading.Event()
 
-    def slow_ping(mq_client: object, timeout: float) -> bool:
+    def slow_ping(
+        mq_client: object, timeout: float, instance_id: int | None = None
+    ) -> bool:
         ping_entered.set()
         release_ping.wait(timeout=10.0)
         return True

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -462,6 +462,63 @@ def test_heartbeat_first_ping_runs_callback_before_setting_event(
     assert event_state_during_callback == [False]
 
 
+def test_freeze_gap_forces_one_unhealthy_cycle(monkeypatch) -> None:
+    """A successful ping after a > 3x-interval gap while still healthy forces
+    one unhealthy cycle (no inline callback); the next success re-registers
+    via the normal recovery edge."""
+    monkeypatch.setattr(
+        adapter_mod, "send_ping", lambda mq_client, timeout, instance_id=None: True
+    )
+    health_event = threading.Event()
+    health_event.set()
+    heartbeat = HeartbeatThread(MagicMock(), health_event, interval=10.0)
+    calls: list[str] = []
+
+    def recover() -> bool:
+        calls.append("recover")
+        return True
+
+    heartbeat.register_recover_callback(recover)
+
+    heartbeat._last_success = time.monotonic() - 100.0  # gap > 3 x interval
+    summary = heartbeat._execute()
+    assert summary.message == "freeze-gap"
+    assert not health_event.is_set()  # forced unhealthy
+    assert calls == []  # callback NOT fired inline
+
+    # Next cycle: was_healthy is now False, so a successful ping takes the
+    # recovery edge and re-registers.
+    summary2 = heartbeat._execute()
+    assert calls == ["recover"]
+    assert health_event.is_set()
+    assert summary2.message == "healthy"
+
+
+def test_freeze_gap_not_tripped_under_normal_cadence(monkeypatch) -> None:
+    """A recent last success keeps a healthy ping healthy (no false trip)."""
+    monkeypatch.setattr(
+        adapter_mod, "send_ping", lambda mq_client, timeout, instance_id=None: True
+    )
+    health_event = threading.Event()
+    health_event.set()
+    heartbeat = HeartbeatThread(MagicMock(), health_event, interval=10.0)
+
+    heartbeat._last_success = time.monotonic()
+    summary = heartbeat._execute()
+    assert summary.message == "healthy"
+    assert health_event.is_set()
+
+
+def test_start_baselines_last_success(monkeypatch) -> None:
+    """start() baselines _last_success so a late lazy start cannot misfire the
+    freeze-gap detector on the first cycle."""
+    monkeypatch.setattr(adapter_mod.PeriodicThread, "start", lambda self: None)
+    heartbeat = HeartbeatThread(MagicMock(), threading.Event(), interval=10.0)
+    heartbeat._last_success = 0.0  # as if constructed long before start
+    heartbeat.start()
+    assert heartbeat._last_success > 0.0
+
+
 def test_dropped_retrieve_reported_once_via_unhealthy_get_finished(
     fake_adapter,
 ) -> None:

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -462,63 +462,6 @@ def test_heartbeat_first_ping_runs_callback_before_setting_event(
     assert event_state_during_callback == [False]
 
 
-def test_freeze_gap_forces_one_unhealthy_cycle(monkeypatch) -> None:
-    """A successful ping after a > 3x-interval gap while still healthy forces
-    one unhealthy cycle (no inline callback); the next success re-registers
-    via the normal recovery edge."""
-    monkeypatch.setattr(
-        adapter_mod, "send_ping", lambda mq_client, timeout, instance_id=None: True
-    )
-    health_event = threading.Event()
-    health_event.set()
-    heartbeat = HeartbeatThread(MagicMock(), health_event, interval=10.0)
-    calls: list[str] = []
-
-    def recover() -> bool:
-        calls.append("recover")
-        return True
-
-    heartbeat.register_recover_callback(recover)
-
-    heartbeat._last_success = time.monotonic() - 100.0  # gap > 3 x interval
-    summary = heartbeat._execute()
-    assert summary.message == "freeze-gap"
-    assert not health_event.is_set()  # forced unhealthy
-    assert calls == []  # callback NOT fired inline
-
-    # Next cycle: was_healthy is now False, so a successful ping takes the
-    # recovery edge and re-registers.
-    summary2 = heartbeat._execute()
-    assert calls == ["recover"]
-    assert health_event.is_set()
-    assert summary2.message == "healthy"
-
-
-def test_freeze_gap_not_tripped_under_normal_cadence(monkeypatch) -> None:
-    """A recent last success keeps a healthy ping healthy (no false trip)."""
-    monkeypatch.setattr(
-        adapter_mod, "send_ping", lambda mq_client, timeout, instance_id=None: True
-    )
-    health_event = threading.Event()
-    health_event.set()
-    heartbeat = HeartbeatThread(MagicMock(), health_event, interval=10.0)
-
-    heartbeat._last_success = time.monotonic()
-    summary = heartbeat._execute()
-    assert summary.message == "healthy"
-    assert health_event.is_set()
-
-
-def test_start_baselines_last_success(monkeypatch) -> None:
-    """start() baselines _last_success so a late lazy start cannot misfire the
-    freeze-gap detector on the first cycle."""
-    monkeypatch.setattr(adapter_mod.PeriodicThread, "start", lambda self: None)
-    heartbeat = HeartbeatThread(MagicMock(), threading.Event(), interval=10.0)
-    heartbeat._last_success = 0.0  # as if constructed long before start
-    heartbeat.start()
-    assert heartbeat._last_success > 0.0
-
-
 def test_dropped_retrieve_reported_once_via_unhealthy_get_finished(
     fake_adapter,
 ) -> None:


### PR DESCRIPTION

**What this PR does / why we need it**:

Second of two PRs (replacing the closed #3231, reworked per review). #3631 added the adapter-side groundwork; this turns on **server-side reaping**: when a vLLM worker dies silently, the MP server reaps its `GPUCacheContext` and CUDA IPC handles instead of leaking them forever.

- **PING carries `instance_id`** (`[] → [int | None]`, kept on BLOCKING/NORMAL dispatch). The server refreshes per-instance `last_seen` on each ping; the worker adapter sends its id, the scheduler sends `None`.
- **Two-tier reaping.** A ping-proven worker is reaped after `worker_reap_timeout_seconds` (120s); a worker that registered but never pinged (warmup, or death before first request) after `worker_registration_grace_seconds` (3600s). Only PING latches "ping-proven"; transfer traffic refreshes `last_seen` without latching.
- **Per-module leaf locks.** The reaper runs off the MQ handler threads, so the GPU and non-GPU registries are lock-guarded. Non-GPU pops its context + strategy as a pair, so a reap racing a re-register can never strand a context without its strategy.
- **Blend reap listener.** `BlendV3Module.drop_instance_state` drops the reaped instance's CB rope state; all blend reads route through the locked `get_context_entry` (the GPU context itself is owned by `GPUTransferModule`, no mirror — reaping the entry frees it directly).
- **Reaper wiring.** `ManagementModule` owns a `PeriodicThread` reaper (scan = timeout/4), started only when reaping is enabled, with the liveness targets / reap listeners injected at composition; it precedes the transfer modules in the module list so `close()` stops it before they clear state.
- **Freeze-gap detection.** A whole-process freeze (SIGSTOP, cgroup freezer, VM migration) past the reap window produces no ping failure and no edge; the heartbeat forces one unhealthy cycle on thaw so the worker re-registers.

**Config**: `--worker-reap-timeout-seconds` (0 disables) and `--worker-registration-grace-seconds`, validated (timeout 0 or ≥30s; grace ≥ timeout). Keep the timeout ≥ 3× the adapter heartbeat interval.

**Design doc**: `docs/design/v1/multiprocess/worker_liveness.md` (covers both PRs).

**Special notes for your reviewers**:

- Server-side unit tests are in `tests/v1/multiprocess/test_worker_liveness.py` (runs in the MP CI job, not the standard suite). 14 tests, no GPU needed.
- Blend `_cb_*` state stays lock-free (per-key atomic pops in `drop_instance_state`), matching existing blend_v3 style.
- `ManagementModule` receives its liveness targets / reap listeners by **constructor injection** (keeps `MPCacheEngineContext` as pure shared state) — discussed and agreed in review.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests