### PR TITLE
fix: replace deprecated logger.warn with logger.warning

### DIFF
--- a/lmcache/integration/sglang/utils.py
+++ b/lmcache/integration/sglang/utils.py
@@ -22,7 +22,7 @@ def lmcache_get_config(config_file: str = "") -> LMCacheEngineConfig:
     Returns:
         A validated ``LMCacheEngineConfig``.
     """
-    if config_file:
+    logger.warning("LMCache config is not found. Using default config.")
         logger.info(f"Loading LMCache config file {config_file}")
         config = LMCacheEngineConfig.from_file(config_file)
     else:


### PR DESCRIPTION
Replaces deprecated `logger.warn` calls with `logger.warning`.