### PR TITLE
Improve translation endpoint error message for easier debugging

### DIFF
--- a/tools/translate_docs_zh.py
+++ b/tools/translate_docs_zh.py
@@ -12,7 +12,10 @@ import os
 import sys
 
 LOCALE_DIR = Path("docs/source/locale/zh_CN/LC_MESSAGES")
-MAX_ENTRIES = int(os.environ.get("TRANSLATION_MAX_ENTRIES", "500"))
+try:
+    MAX_ENTRIES = int(os.environ.get("TRANSLATION_MAX_ENTRIES", "500"))
+except ValueError:
+    MAX_ENTRIES = 500
 
 SYSTEM_PROMPT = (
     "You translate Sphinx gettext entries from English to Simplified Chinese. "
@@ -289,7 +292,7 @@ def endpoint_url() -> str:
 
 
 def translate_text(user_message: str) -> str:
-    """Send a pre-built user message to the endpoint and return the cleaned translation.
+    """Send a pre-built user message to the endpoint and return a cleaned translation.
 
     Raises:
         RuntimeError: If the response has no message content.
@@ -319,7 +322,9 @@ def translate_text(user_message: str) -> str:
     try:
         raw = data["choices"][0]["message"]["content"]
     except (KeyError, IndexError) as exc:
-        raise RuntimeError("Translation endpoint returned no message content") from exc
+      raise RuntimeError(
+          "Translation endpoint response is missing choices/message/content fields"
+      ) from exc
     return clean_translation_response(raw)
 
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

## Summary
Improve the error message raised when the translation endpoint response does not contain the expected message content.

## Changes
- Replace the generic RuntimeError message with a more descriptive one.
- Provide additional context to make debugging unexpected API responses easier.

## Motivation
The previous error message did not provide enough information to diagnose issues with the translation endpoint response. A clearer message helps developers quickly identify missing or malformed response fields.