### PR TITLE
rename GPUKVFormat -> EngineKVFormat, gpu_kv_* -> engine_kv_*

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -30,33 +30,34 @@ namespace lmc {
 
 // inline helper to check MLA (callable from device and host)
 __host__ __device__ __forceinline__ bool is_mla(
-    const GPUKVFormat gpu_kv_format) {
-  return gpu_kv_format == GPUKVFormat::NL_X_NB_BS_HS ||   // vllm MLA
-         gpu_kv_format == GPUKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
+    const EngineKVFormat engine_kv_format) {
+  return engine_kv_format == EngineKVFormat::NL_X_NB_BS_HS ||   // vllm MLA
+         engine_kv_format == EngineKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
 }
 
 // inline helper to check HND layout (callable from device and host)
 __host__ __device__ __forceinline__ bool is_hnd(
-    const GPUKVFormat gpu_kv_format) {
-  return gpu_kv_format ==
-             GPUKVFormat::NL_X_TWO_NB_NH_BS_HS ||             // flash attn HND
-         gpu_kv_format == GPUKVFormat::NL_X_NB_TWO_NH_BS_HS;  // flash infer HND
+    const EngineKVFormat engine_kv_format) {
+  return engine_kv_format ==
+             EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||  // flash attn HND
+         engine_kv_format ==
+             EngineKVFormat::NL_X_NB_TWO_NH_BS_HS;  // flash infer HND
 }
 
 // All paged (non-MLA) formats rely on block_size for offset computation.
-inline void check_block_size(const GPUKVFormat gpu_kv_format,
+inline void check_block_size(const EngineKVFormat engine_kv_format,
                              const int block_size) {
-  TORCH_CHECK(is_mla(gpu_kv_format) || block_size > 0,
-              "block_size is required (must be > 0) for GPUKVFormat ",
-              static_cast<int>(gpu_kv_format));
+  TORCH_CHECK(is_mla(engine_kv_format) || block_size > 0,
+              "block_size is required (must be > 0) for EngineKVFormat ",
+              static_cast<int>(engine_kv_format));
 }
 
 // HND formats additionally need head_size to decompose scalar offsets.
-inline void check_head_size(const GPUKVFormat gpu_kv_format,
+inline void check_head_size(const EngineKVFormat engine_kv_format,
                             const int head_size) {
-  TORCH_CHECK(!is_hnd(gpu_kv_format) || head_size > 0,
-              "head_size is required (must be > 0) for GPUKVFormat ",
-              static_cast<int>(gpu_kv_format));
+  TORCH_CHECK(!is_hnd(engine_kv_format) || head_size > 0,
+              "head_size is required (must be > 0) for EngineKVFormat ",
+              static_cast<int>(engine_kv_format));
 }
 
 template <typename scalar_t>
@@ -146,7 +147,7 @@ __global__ void reshape_and_cache_back_flash_kernel(
   }
 }
 
-template <typename scalar_t, GPUKVFormat format>
+template <typename scalar_t, EngineKVFormat format>
 __global__ void single_layer_kv_transfer_kernel(
     scalar_t* __restrict__ lmc_key_value_cache,
     scalar_t* __restrict__ vllm_key_value_cache,
@@ -155,9 +156,9 @@ __global__ void single_layer_kv_transfer_kernel(
     const int lmc_stride, const int lmc_value_offset, const int num_heads,
     const int head_size_in_64bit, const int block_size,
     const TransferDirection direction) {
-  constexpr bool USE_MLA = (format == GPUKVFormat::NL_X_NB_BS_HS);
-  constexpr bool HND_LAYOUT = (format == GPUKVFormat::NL_X_TWO_NB_NH_BS_HS ||
-                               format == GPUKVFormat::NL_X_NB_TWO_NH_BS_HS);
+  constexpr bool USE_MLA = (format == EngineKVFormat::NL_X_NB_BS_HS);
+  constexpr bool HND_LAYOUT = (format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||
+                               format == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
 
   const int64_t token_idx = blockIdx.x;
   const int64_t slot_idx = slot_mapping[token_idx];
@@ -212,7 +213,7 @@ __global__ void single_layer_kv_transfer_kernel(
   }
 }
 
-template <GPUKVFormat format>
+template <EngineKVFormat format>
 __device__ __forceinline__ int64_t page_buffer_offset(
     const int k_or_v, const int token_idx, const int scalar_offset,
     const int scalars_per_token, const int page_buffer_size,
@@ -230,7 +231,7 @@ __device__ __forceinline__ int64_t page_buffer_offset(
   scalar_offset into (head_idx, head_offset)
 
   The job of page_buffer_offset is to translate these logical arguments into a
-  physical address based on the GPUKVFormat.
+  physical address based on the EngineKVFormat.
 
   NOTE(perf): For HND formats, threads within a warp access non-contiguous
   addresses when crossing head boundaries (stride BS*HS between heads),
@@ -245,17 +246,17 @@ __device__ __forceinline__ int64_t page_buffer_offset(
   */
 
   // vllm cross layer
-  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_BS_NH_HS) {
     return k_or_v * page_buffer_size * scalars_per_token +
            token_idx * scalars_per_token + scalar_offset;
   }
   // vllm flash attention (NHD)
-  else if constexpr (format == GPUKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+  else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS) {
     return k_or_v * page_buffer_size * scalars_per_token +
            token_idx * scalars_per_token + scalar_offset;
   }
   // vllm flash infer (NHD)
-  else if constexpr (format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS) {
+  else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS) {
     const int block_idx = token_idx / block_size;
     const int block_offset = token_idx % block_size;
     return block_idx * 2 * block_size * scalars_per_token +
@@ -263,12 +264,12 @@ __device__ __forceinline__ int64_t page_buffer_offset(
            block_offset * scalars_per_token + scalar_offset;
   }
   // MLA formats: vLLM (NL_X_NB_BS_HS) and SGLang (NL_X_NBBS_ONE_HS)
-  else if constexpr (format == GPUKVFormat::NL_X_NB_BS_HS ||
-                     format == GPUKVFormat::NL_X_NBBS_ONE_HS) {
+  else if constexpr (format == EngineKVFormat::NL_X_NB_BS_HS ||
+                     format == EngineKVFormat::NL_X_NBBS_ONE_HS) {
     return token_idx * scalars_per_token + scalar_offset;
   }
   // vllm flash attention (HND) — physical: [2, NB, NH, BS, HS]
-  else if constexpr (format == GPUKVFormat::NL_X_TWO_NB_NH_BS_HS) {
+  else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS) {
     const int block_idx = token_idx / block_size;
     const int block_offset = token_idx % block_size;
     const int head_idx = scalar_offset / head_size;
@@ -280,7 +281,7 @@ __device__ __forceinline__ int64_t page_buffer_offset(
            head_offset;
   }
   // vllm flash infer (HND) — physical: [NB, 2, NH, BS, HS]
-  else if constexpr (format == GPUKVFormat::NL_X_NB_TWO_NH_BS_HS) {
+  else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS) {
     const int block_idx = token_idx / block_size;
     const int block_offset = token_idx % block_size;
     const int head_idx = scalar_offset / head_size;
@@ -364,7 +365,7 @@ __global__ void single_layer_kv_transfer_sgl_kernel(
  * key_value[block.z, block.y, block.x, thread.x] <=> ptrs[block.y][block.z,
  * slot_id, thread.x]
  */
-template <typename scalar_t, bool DIRECTION, GPUKVFormat format>
+template <typename scalar_t, bool DIRECTION, EngineKVFormat format>
 __global__ void load_and_reshape_multi_layer_kernel(
     scalar_t* __restrict__ key_value,           // [2, num_layer, num_tokens,
                                                 // scalars_per_token]
@@ -527,7 +528,7 @@ void multi_layer_kv_transfer_templated(
     const torch::Tensor& key_value_ptrs,  // [num_layers]
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
-    const TransferDirection direction, const GPUKVFormat gpu_kv_format,
+    const TransferDirection direction, const EngineKVFormat engine_kv_format,
     const int block_size, const int head_size, const int skip_prefix_n_tokens) {
   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
   T** page_buffer_ptrs =
@@ -546,10 +547,10 @@ void multi_layer_kv_transfer_templated(
   // to match scalars_per_token (num_xwords) which is also in xword units.
   int head_size_xword = head_size > 0 ? head_size / elements_per_xword : 0;
 
-  lmc::check_block_size(gpu_kv_format, block_size);
-  lmc::check_head_size(gpu_kv_format, head_size_xword);
+  lmc::check_block_size(engine_kv_format, block_size);
+  lmc::check_head_size(engine_kv_format, head_size_xword);
 
-  int k_or_v_size = lmc::is_mla(gpu_kv_format) ? 1 : 2;
+  int k_or_v_size = lmc::is_mla(engine_kv_format) ? 1 : 2;
 
   dim3 grid(num_transfer_tokens, num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));
@@ -558,56 +559,64 @@ void multi_layer_kv_transfer_templated(
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   if (direction == TransferDirection::H2D) {
-    switch (gpu_kv_format) {
-      case GPUKVFormat::NB_NL_TWO_BS_NH_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NB_NL_TWO_BS_NH_HS);
+    switch (engine_kv_format) {
+      case EngineKVFormat::NB_NL_TWO_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false, EngineKVFormat::NB_NL_TWO_BS_NH_HS);
         break;
-      case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);
+      case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_TWO_NB_BS_NH_HS);
         break;
-      case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);
+      case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_TWO_BS_NH_HS);
         break;
-      case GPUKVFormat::NL_X_NB_BS_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NL_X_NB_BS_HS);
+      case EngineKVFormat::NL_X_NB_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false, EngineKVFormat::NL_X_NB_BS_HS);
         break;
-      case GPUKVFormat::NL_X_NBBS_ONE_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NL_X_NBBS_ONE_HS);
+      case EngineKVFormat::NL_X_NBBS_ONE_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false, EngineKVFormat::NL_X_NBBS_ONE_HS);
         break;
-      case GPUKVFormat::NL_X_TWO_NB_NH_BS_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NL_X_TWO_NB_NH_BS_HS);
+      case EngineKVFormat::NL_X_TWO_NB_NH_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_TWO_NB_NH_BS_HS);
         break;
-      case GPUKVFormat::NL_X_NB_TWO_NH_BS_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NL_X_NB_TWO_NH_BS_HS);
+      case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
         break;
       default:
-        throw std::runtime_error("Unsupported GPUKVFormat");
+        throw std::runtime_error("Unsupported EngineKVFormat");
     }
   } else {
-    switch (gpu_kv_format) {
-      case GPUKVFormat::NB_NL_TWO_BS_NH_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NB_NL_TWO_BS_NH_HS);
+    switch (engine_kv_format) {
+      case EngineKVFormat::NB_NL_TWO_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true, EngineKVFormat::NB_NL_TWO_BS_NH_HS);
         break;
-      case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);
+      case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_TWO_NB_BS_NH_HS);
         break;
-      case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);
+      case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_TWO_BS_NH_HS);
         break;
-      case GPUKVFormat::NL_X_NB_BS_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NL_X_NB_BS_HS);
+      case EngineKVFormat::NL_X_NB_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true, EngineKVFormat::NL_X_NB_BS_HS);
         break;
-      case GPUKVFormat::NL_X_NBBS_ONE_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NL_X_NBBS_ONE_HS);
+      case EngineKVFormat::NL_X_NBBS_ONE_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true, EngineKVFormat::NL_X_NBBS_ONE_HS);
         break;
-      case GPUKVFormat::NL_X_TWO_NB_NH_BS_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NL_X_TWO_NB_NH_BS_HS);
+      case EngineKVFormat::NL_X_TWO_NB_NH_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_TWO_NB_NH_BS_HS);
         break;
-      case GPUKVFormat::NL_X_NB_TWO_NH_BS_HS:
-        LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NL_X_NB_TWO_NH_BS_HS);
+      case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
         break;
       default:
-        throw std::runtime_error("Unsupported GPUKVFormat");
+        throw std::runtime_error("Unsupported EngineKVFormat");
     }
   }
 }
@@ -621,17 +630,17 @@ void multi_layer_kv_transfer(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format, const int block_size, const int head_size,
-    const int skip_prefix_n_tokens) {
+    const EngineKVFormat engine_kv_format, const int block_size,
+    const int head_size, const int skip_prefix_n_tokens) {
   int num_origin_elements = key_value.size(3);
   int copy_size = num_origin_elements * key_value.element_size();
 #ifndef LAUNCH_MULTI_LAYER_KV_TRANSFER
-  #define LAUNCH_MULTI_LAYER_KV_TRANSFER(type)                               \
-    do {                                                                     \
-      multi_layer_kv_transfer_templated<type>(                               \
-          key_value, key_value_ptrs, slot_mapping, paged_memory_device,      \
-          page_buffer_size, direction, gpu_kv_format, block_size, head_size, \
-          skip_prefix_n_tokens);                                             \
+  #define LAUNCH_MULTI_LAYER_KV_TRANSFER(type)                          \
+    do {                                                                \
+      multi_layer_kv_transfer_templated<type>(                          \
+          key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
+          page_buffer_size, direction, engine_kv_format, block_size,    \
+          head_size, skip_prefix_n_tokens);                             \
     } while (0)
 #endif
   if (copy_size % 8 == 0) {
@@ -680,14 +689,14 @@ void multi_layer_kv_transfer_unilateral(
     const torch::Tensor& key_value_ptrs,  // [num_layers*2]
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
-    const TransferDirection direction, const GPUKVFormat gpu_kv_format) {
-  const bool use_mla = lmc::is_mla(gpu_kv_format);
+    const TransferDirection direction, const EngineKVFormat engine_kv_format) {
+  const bool use_mla = lmc::is_mla(engine_kv_format);
   // MLA case collapses back to multi_layer_kv_transfer
   // (vLLM and SGLang indexing are compatible)
   if (use_mla) {
     return multi_layer_kv_transfer(key_value, key_value_ptrs, slot_mapping,
                                    paged_memory_device, page_buffer_size,
-                                   direction, gpu_kv_format);
+                                   direction, engine_kv_format);
   }
 
   int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
@@ -753,7 +762,7 @@ void single_layer_kv_transfer(
                                // MLA: [num_blocks, block_size, head_size]
 
     torch::Tensor& slot_mapping,  // [num_tokens]
-    const TransferDirection direction, const GPUKVFormat gpu_kv_format,
+    const TransferDirection direction, const EngineKVFormat engine_kv_format,
     const bool token_major  // true: lmc_key_value_cache is
                             // [num_tokens, 2, num_heads*head_size]
                             // false: lmc_key_value_cache is
@@ -780,8 +789,8 @@ void single_layer_kv_transfer(
   int head_size_in_64bit;
   int block_size;
 
-  const bool use_mla = lmc::is_mla(gpu_kv_format);
-  const bool hnd_layout = lmc::is_hnd(gpu_kv_format);
+  const bool use_mla = lmc::is_mla(engine_kv_format);
+  const bool hnd_layout = lmc::is_hnd(engine_kv_format);
 
   if (use_mla) {
     // MLA format: [num_blocks, block_size, head_size]
@@ -800,8 +809,8 @@ void single_layer_kv_transfer(
     head_size_in_64bit = vllm_key_value_cache.size(4) / elements_per_entry;
   }
 
-  lmc::check_block_size(gpu_kv_format, block_size);
-  lmc::check_head_size(gpu_kv_format, head_size_in_64bit);
+  lmc::check_block_size(engine_kv_format, block_size);
+  lmc::check_head_size(engine_kv_format, head_size_in_64bit);
 
   int lmc_stride;
   int lmc_value_offset;
@@ -824,12 +833,12 @@ void single_layer_kv_transfer(
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(0) / elements_per_entry;
     vllm_value_offset = 0;  // No separate K/V for MLA
-  } else if (gpu_kv_format == GPUKVFormat::NL_X_TWO_NB_BS_NH_HS ||
-             gpu_kv_format == GPUKVFormat::NL_X_TWO_NB_NH_BS_HS) {
+  } else if (engine_kv_format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS ||
+             engine_kv_format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS) {
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(1) / elements_per_entry;
     vllm_value_offset = vllm_key_value_cache.stride(0) / elements_per_entry;
-  } else {  // gpu_kv_format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS
+  } else {  // engine_kv_format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(0) / elements_per_entry;
     vllm_value_offset = vllm_key_value_cache.stride(1) / elements_per_entry;
@@ -844,7 +853,7 @@ void single_layer_kv_transfer(
       device_of(vllm_key_value_cache));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  // Dispatch to the appropriate template specialization based on GPUKVFormat
+  // Dispatch to the appropriate template specialization based on EngineKVFormat
 #define LAUNCH_SINGLE_LAYER_KERNEL(FORMAT)                                     \
   lmc::single_layer_kv_transfer_kernel<int64_t, FORMAT>                        \
       <<<grid, block, 0, stream>>>(                                            \
@@ -854,21 +863,21 @@ void single_layer_kv_transfer(
           direction);                                                          \
   break;
 
-  switch (gpu_kv_format) {
-    case GPUKVFormat::NL_X_NB_BS_HS:
-      LAUNCH_SINGLE_LAYER_KERNEL(GPUKVFormat::NL_X_NB_BS_HS)
-    case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
-      LAUNCH_SINGLE_LAYER_KERNEL(GPUKVFormat::NL_X_TWO_NB_BS_NH_HS)
-    case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
-      LAUNCH_SINGLE_LAYER_KERNEL(GPUKVFormat::NL_X_NB_TWO_BS_NH_HS)
-    case GPUKVFormat::NL_X_TWO_NB_NH_BS_HS:
-      LAUNCH_SINGLE_LAYER_KERNEL(GPUKVFormat::NL_X_TWO_NB_NH_BS_HS)
-    case GPUKVFormat::NL_X_NB_TWO_NH_BS_HS:
-      LAUNCH_SINGLE_LAYER_KERNEL(GPUKVFormat::NL_X_NB_TWO_NH_BS_HS)
+  switch (engine_kv_format) {
+    case EngineKVFormat::NL_X_NB_BS_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_NB_BS_HS)
+    case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_TWO_NB_BS_NH_HS)
+    case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_NB_TWO_BS_NH_HS)
+    case EngineKVFormat::NL_X_TWO_NB_NH_BS_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_TWO_NB_NH_BS_HS)
+    case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:
+      LAUNCH_SINGLE_LAYER_KERNEL(EngineKVFormat::NL_X_NB_TWO_NH_BS_HS)
     default:
       TORCH_CHECK(false,
-                  "Unsupported GPUKVFormat for single_layer_kv_transfer: ",
-                  static_cast<int>(gpu_kv_format));
+                  "Unsupported EngineKVFormat for single_layer_kv_transfer: ",
+                  static_cast<int>(engine_kv_format));
   }
 #undef LAUNCH_SINGLE_LAYER_KERNEL
 }

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -35,7 +35,7 @@ kv_cache[0][0].shape = (C, D, E)
 The logic for identifying the format currently lives in
 `lmcache/v1/gpu_connector/utils.py`
 */
-enum class GPUKVFormat : int {
+enum class EngineKVFormat : int {
   NB_NL_TWO_BS_NH_HS = 0,
   /*
   used by:
@@ -115,7 +115,7 @@ void multi_layer_kv_transfer(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format, const int block_size = 0,
+    const EngineKVFormat engine_kv_format, const int block_size = 0,
     const int head_size = 0, const int skip_prefix_n_tokens = 0);
 
 // collapses to multi_layer_kv_transfer for MLA
@@ -123,13 +123,13 @@ void multi_layer_kv_transfer_unilateral(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format);
+    const EngineKVFormat engine_kv_format);
 
 void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
                               torch::Tensor& vllm_key_value_cache,
                               torch::Tensor& slot_mapping,
                               const TransferDirection direction,
-                              const GPUKVFormat gpu_kv_format,
+                              const EngineKVFormat engine_kv_format,
                               const bool token_major = false);
 
 void single_layer_kv_transfer_sgl(torch::Tensor& lmc_key_value_cache,

--- a/csrc/mp_mem_kernels.cu
+++ b/csrc/mp_mem_kernels.cu
@@ -22,46 +22,46 @@ namespace {
 /**
  * Calculate the offset for the current block in the paged buffer
  */
-template <typename ScalarType, GPUKVFormat format>
+template <typename ScalarType, EngineKVFormat format>
 __device__ inline size_t calculate_engine_global_offset(
     const int k_or_v, const int engine_block_idx, const int layer_idx,
     const PageBufferShapeDesc shape_desc) {
   size_t scalars_per_block = shape_desc.scalars_per_block<ScalarType>();
-  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_BS_NH_HS) {
     // Cross-layer: single tensor [NB, NL, 2, BS, NH, HS]
     return k_or_v * scalars_per_block +
            layer_idx * shape_desc.kv_size * scalars_per_block +
            engine_block_idx * shape_desc.kv_size * scalars_per_block *
                shape_desc.nl;
-  } else if constexpr (format == GPUKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS) {
     // Normal: L tensors [2, NB, BS, NH, HS]
     return engine_block_idx * scalars_per_block +
            k_or_v * shape_desc.nb * scalars_per_block;
-  } else if constexpr (format == GPUKVFormat::NL_X_TWO_NB_NH_BS_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS) {
     // Normal HND: L tensors [2, NB, NH, BS, HS]
     return engine_block_idx * scalars_per_block +
            k_or_v * shape_desc.nb * scalars_per_block;
-  } else if constexpr (format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS) {
     // Flash Infer: L tensors [NB, 2, BS, NH, HS]
     return engine_block_idx * shape_desc.kv_size * scalars_per_block +
            k_or_v * scalars_per_block;
-  } else if constexpr (format == GPUKVFormat::NL_X_NB_TWO_NH_BS_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS) {
     // Flash Infer HND: L tensors [NB, 2, NH, BS, HS]
     return engine_block_idx * shape_desc.kv_size * scalars_per_block +
            k_or_v * scalars_per_block;
-  } else if constexpr (format == GPUKVFormat::NL_X_NB_BS_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_BS_HS) {
     // MLA: L tensors [NB, BS, HS]
     return engine_block_idx * scalars_per_block;
-  } else if constexpr (format == GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
+  } else if constexpr (format == EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
     // SGLang MHA (in-process): 2L tensors [NBBS, NH, HS]
     return engine_block_idx * scalars_per_block;
-  } else if constexpr (format == GPUKVFormat::TWO_X_NL_X_NB_BS_NH_HS) {
+  } else if constexpr (format == EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS) {
     // SGLang MHA (MP daemon): 2L tensors [NB, BS, NH, HS]
     return engine_block_idx * scalars_per_block;
-  } else if constexpr (format == GPUKVFormat::NL_X_NBBS_ONE_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_NBBS_ONE_HS) {
     // SGLang MLA: L tensors [NBBS, 1, HS]
     return engine_block_idx * scalars_per_block;
-  } else if constexpr (format == GPUKVFormat::NB_NL_TWO_NH_BS_HS) {
+  } else if constexpr (format == EngineKVFormat::NB_NL_TWO_NH_BS_HS) {
     // TRT-LLM cross-layer HND: single tensor [NB, NL, 2, NH, BS, HS]
     // same block-level strides as NB_NL_TWO_BS_NH_HS
     return k_or_v * scalars_per_block +
@@ -75,15 +75,15 @@ __device__ inline size_t calculate_engine_global_offset(
  * Calculate the offset for the current token against the start
  * of the block in the paged buffer.
  */
-template <typename ScalarType, GPUKVFormat format>
+template <typename ScalarType, EngineKVFormat format>
 __device__ inline size_t calculate_engine_local_offset(
     const int token_offset, const int head_idx,
     const PageBufferShapeDesc shape_desc) {
   size_t scalars_per_head = shape_desc.scalars_per_head<ScalarType>();
   size_t scalars_per_token = shape_desc.scalars_per_token<ScalarType>();
-  if constexpr (format == GPUKVFormat::NB_NL_TWO_NH_BS_HS ||
-                format == GPUKVFormat::NL_X_TWO_NB_NH_BS_HS ||
-                format == GPUKVFormat::NL_X_NB_TWO_NH_BS_HS) {
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_NH_BS_HS ||
+                format == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||
+                format == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS) {
     // HND: [NH, BS, HS] — heads are outermost within a block
     size_t scalars_per_head_block =
         shape_desc.bs * scalars_per_head;  // BS * HS
@@ -98,7 +98,7 @@ __device__ inline size_t calculate_engine_local_offset(
  * Calculate the global offset for the current `block` in the LMCache object.
  * The `block` here is the memory region corresponding to a thread-block.
  */
-template <typename ScalarType, GPUKVFormat format>
+template <typename ScalarType, EngineKVFormat format>
 __device__ inline size_t calculate_lmcache_global_offset(
     const int k_or_v,
     const int
@@ -117,7 +117,7 @@ __device__ inline size_t calculate_lmcache_global_offset(
  * Calculate the local offset for the current token against the start of the
  * block in the LMCache object.
  */
-template <typename ScalarType, GPUKVFormat format>
+template <typename ScalarType, EngineKVFormat format>
 __device__ inline size_t calculate_lmcache_local_offset(
     const int token_offset, const int head_idx,
     const PageBufferShapeDesc shape_desc) {
@@ -165,7 +165,7 @@ __device__ inline void warp_copy(ScalarType* __restrict__ dst,
   }
 }
 
-template <typename ScalarType, bool lmcache_to_engine, GPUKVFormat format>
+template <typename ScalarType, bool lmcache_to_engine, EngineKVFormat format>
 __device__ void multi_layer_block_transfer_single_block(
     ScalarType* __restrict__ lmcache_object,
     ScalarType** __restrict__ paged_buffer_ptrs, const int engine_block_idx,
@@ -185,15 +185,15 @@ __device__ void multi_layer_block_transfer_single_block(
           k_or_v, offset_in_lmcache_block, layer_idx, lmcache_chunk_size,
           shape_desc);
   ScalarType* paged_buffer_layer_ptr;
-  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS ||
-                format == GPUKVFormat::NB_NL_TWO_NH_BS_HS) {
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_BS_NH_HS ||
+                format == EngineKVFormat::NB_NL_TWO_NH_BS_HS) {
     paged_buffer_layer_ptr = (ScalarType*)paged_buffer_ptrs[0];
-  } else if constexpr (format == GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
+  } else if constexpr (format == EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS) {
     // SGLang MHA (in-process): ptrs[0..NL-1] = K per layer, ptrs[NL..2NL-1] = V
     // per layer
     paged_buffer_layer_ptr =
         (ScalarType*)paged_buffer_ptrs[k_or_v * shape_desc.nl + layer_idx];
-  } else if constexpr (format == GPUKVFormat::TWO_X_NL_X_NB_BS_NH_HS) {
+  } else if constexpr (format == EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS) {
     // SGLang MHA (MP daemon): ptrs[0..NL-1] = K per layer, ptrs[NL..2NL-1] = V
     // per layer
     paged_buffer_layer_ptr =
@@ -223,7 +223,7 @@ __device__ void multi_layer_block_transfer_single_block(
   }
 }
 
-template <typename ScalarType, bool lmcache_to_engine, GPUKVFormat format>
+template <typename ScalarType, bool lmcache_to_engine, EngineKVFormat format>
 __global__ void multi_layer_block_transfer_kernel(
     MemoryObj4<ScalarType> lmcache_objects,
     ScalarType** __restrict__ paged_buffer_ptrs,
@@ -259,41 +259,41 @@ __global__ void multi_layer_block_transfer_kernel(
                                    skip_prefix_n_blocks);                \
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-#define DISPATCH_FORMAT(DIRECTION)                                   \
-  switch (gpu_kv_format) {                                           \
-    case GPUKVFormat::NB_NL_TWO_BS_NH_HS:                            \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NB_NL_TWO_BS_NH_HS);     \
-      break;                                                         \
-    case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:                          \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);   \
-      break;                                                         \
-    case GPUKVFormat::NL_X_TWO_NB_NH_BS_HS:                          \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_TWO_NB_NH_BS_HS);   \
-      break;                                                         \
-    case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:                          \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);   \
-      break;                                                         \
-    case GPUKVFormat::NL_X_NB_TWO_NH_BS_HS:                          \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_NB_TWO_NH_BS_HS);   \
-      break;                                                         \
-    case GPUKVFormat::NL_X_NB_BS_HS:                                 \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_NB_BS_HS);          \
-      break;                                                         \
-    case GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS:                         \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS);  \
-      break;                                                         \
-    case GPUKVFormat::TWO_X_NL_X_NB_BS_NH_HS:                        \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::TWO_X_NL_X_NB_BS_NH_HS); \
-      break;                                                         \
-    case GPUKVFormat::NL_X_NBBS_ONE_HS:                              \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NL_X_NBBS_ONE_HS);       \
-      break;                                                         \
-    case GPUKVFormat::NB_NL_TWO_NH_BS_HS:                            \
-      LAUNCH_KERNEL(DIRECTION, GPUKVFormat::NB_NL_TWO_NH_BS_HS);     \
-      break;                                                         \
-    default:                                                         \
-      TORCH_CHECK(false, "Unsupported GPUKVFormat: ",                \
-                  static_cast<int>(gpu_kv_format));                  \
+#define DISPATCH_FORMAT(DIRECTION)                                      \
+  switch (engine_kv_format) {                                           \
+    case EngineKVFormat::NB_NL_TWO_BS_NH_HS:                            \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NB_NL_TWO_BS_NH_HS);     \
+      break;                                                            \
+    case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_TWO_NB_BS_NH_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_TWO_NB_NH_BS_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_TWO_NB_NH_BS_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NB_TWO_BS_NH_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:                          \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);   \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NB_BS_HS:                                 \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NB_BS_HS);          \
+      break;                                                            \
+    case EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS:                         \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS);  \
+      break;                                                            \
+    case EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS:                        \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS); \
+      break;                                                            \
+    case EngineKVFormat::NL_X_NBBS_ONE_HS:                              \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NL_X_NBBS_ONE_HS);       \
+      break;                                                            \
+    case EngineKVFormat::NB_NL_TWO_NH_BS_HS:                            \
+      LAUNCH_KERNEL(DIRECTION, EngineKVFormat::NB_NL_TWO_NH_BS_HS);     \
+      break;                                                            \
+    default:                                                            \
+      TORCH_CHECK(false, "Unsupported EngineKVFormat: ",                \
+                  static_cast<int>(engine_kv_format));                  \
   }
 
 template <typename ScalarType>
@@ -302,7 +302,7 @@ void multi_layer_block_kv_transfer_templated(
     std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
     const torch::Device& device, TransferDirection direction,
     PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
-    GPUKVFormat gpu_kv_format, int skip_prefix_n_blocks) {
+    EngineKVFormat engine_kv_format, int skip_prefix_n_blocks) {
   // --- Validation ---
   int num_objects = static_cast<int>(lmcache_objects_ptrs.size());
   TORCH_CHECK(num_objects >= 1 && num_objects <= 4,
@@ -364,7 +364,7 @@ void multi_layer_block_kv_transfer_templated(
   do {                                                                     \
     multi_layer_block_kv_transfer_templated<type>(                         \
         paged_buffer_ptrs_tensor, lmcache_objects_ptrs, block_ids, device, \
-        direction, shape_desc, lmcache_chunk_size, gpu_kv_format,          \
+        direction, shape_desc, lmcache_chunk_size, engine_kv_format,       \
         skip_prefix_n_blocks);                                             \
   } while (0)
 
@@ -373,7 +373,7 @@ void multi_layer_block_kv_transfer(
     std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
     const torch::Device& device, TransferDirection direction,
     PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
-    GPUKVFormat gpu_kv_format, int skip_prefix_n_blocks) {
+    EngineKVFormat engine_kv_format, int skip_prefix_n_blocks) {
   int head_bytes = shape_desc.hs * shape_desc.element_size;
   TORCH_CHECK(head_bytes % sizeof(uint16_t) == 0, "head_size * element_size (",
               head_bytes, ") must be divisible by 2 for vectorized access");

--- a/csrc/mp_mem_kernels.cuh
+++ b/csrc/mp_mem_kernels.cuh
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "mem_kernels.cuh"  // TransferDirection, GPUKVFormat
+#include "mem_kernels.cuh"  // TransferDirection, EngineKVFormat
 
 #include <c10/cuda/CUDAGuard.h>
 #include <vector>
@@ -79,7 +79,7 @@ struct MemoryObj4 {
  * @param direction                 H2D (LMCache->vLLM) or D2H (vLLM->LMCache)
  * @param shape_desc                Shape descriptor for the paged buffer
  * @param lmcache_chunk_size        Tokens per LMCache memory object
- * @param gpu_kv_format             GPUKVFormat identifier
+ * @param engine_kv_format             EngineKVFormat identifier
  * @param skip_prefix_n_blocks      Number of blocks to skip at the beginning
  */
 void multi_layer_block_kv_transfer(
@@ -87,4 +87,4 @@ void multi_layer_block_kv_transfer(
     std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
     const torch::Device& device, TransferDirection direction,
     PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
-    GPUKVFormat gpu_kv_format, int skip_prefix_n_blocks);
+    EngineKVFormat engine_kv_format, int skip_prefix_n_blocks);

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -21,32 +21,32 @@ PYBIND11_MODULE(c_ops, m) {
       .value("H2D", TransferDirection::H2D)
       .value("D2H", TransferDirection::D2H)
       .export_values();
-  py::enum_<GPUKVFormat>(m, "GPUKVFormat")
-      .value("NB_NL_TWO_BS_NH_HS", GPUKVFormat::NB_NL_TWO_BS_NH_HS)
-      .value("NL_X_TWO_NB_BS_NH_HS", GPUKVFormat::NL_X_TWO_NB_BS_NH_HS)
-      .value("NL_X_NB_TWO_BS_NH_HS", GPUKVFormat::NL_X_NB_TWO_BS_NH_HS)
-      .value("NL_X_NB_BS_HS", GPUKVFormat::NL_X_NB_BS_HS)
-      .value("TWO_X_NL_X_NBBS_NH_HS", GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS)
-      .value("NL_X_NBBS_ONE_HS", GPUKVFormat::NL_X_NBBS_ONE_HS)
-      .value("NL_X_TWO_NB_NH_BS_HS", GPUKVFormat::NL_X_TWO_NB_NH_BS_HS)
-      .value("NL_X_NB_TWO_NH_BS_HS", GPUKVFormat::NL_X_NB_TWO_NH_BS_HS)
-      .value("NB_NL_TWO_NH_BS_HS", GPUKVFormat::NB_NL_TWO_NH_BS_HS)
-      .value("TWO_X_NL_X_NB_BS_NH_HS", GPUKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
-      .value("NL_X_NB_NH_BS_TWO_HS", GPUKVFormat::NL_X_NB_NH_BS_TWO_HS)
+  py::enum_<EngineKVFormat>(m, "EngineKVFormat")
+      .value("NB_NL_TWO_BS_NH_HS", EngineKVFormat::NB_NL_TWO_BS_NH_HS)
+      .value("NL_X_TWO_NB_BS_NH_HS", EngineKVFormat::NL_X_TWO_NB_BS_NH_HS)
+      .value("NL_X_NB_TWO_BS_NH_HS", EngineKVFormat::NL_X_NB_TWO_BS_NH_HS)
+      .value("NL_X_NB_BS_HS", EngineKVFormat::NL_X_NB_BS_HS)
+      .value("TWO_X_NL_X_NBBS_NH_HS", EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS)
+      .value("NL_X_NBBS_ONE_HS", EngineKVFormat::NL_X_NBBS_ONE_HS)
+      .value("NL_X_TWO_NB_NH_BS_HS", EngineKVFormat::NL_X_TWO_NB_NH_BS_HS)
+      .value("NL_X_NB_TWO_NH_BS_HS", EngineKVFormat::NL_X_NB_TWO_NH_BS_HS)
+      .value("NB_NL_TWO_NH_BS_HS", EngineKVFormat::NB_NL_TWO_NH_BS_HS)
+      .value("TWO_X_NL_X_NB_BS_NH_HS", EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
+      .value("NL_X_NB_NH_BS_TWO_HS", EngineKVFormat::NL_X_NB_NH_BS_TWO_HS)
       .export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),
         py::arg("slot_mapping"), py::arg("paged_memory_device"),
         py::arg("page_buffer_size"), py::arg("direction"),
-        py::arg("gpu_kv_format"), py::arg("block_size") = 0,
+        py::arg("engine_kv_format"), py::arg("block_size") = 0,
         py::arg("head_size") = 0, py::arg("skip_prefix_n_tokens") = 0,
         py::call_guard<py::gil_scoped_release>());
   m.def("multi_layer_kv_transfer_unilateral",
         &multi_layer_kv_transfer_unilateral);
   m.def("single_layer_kv_transfer", &single_layer_kv_transfer,
         py::arg("lmc_key_value_cache"), py::arg("vllm_key_value_cache"),
-        py::arg("slot_mapping"), py::arg("direction"), py::arg("gpu_kv_format"),
-        py::arg("token_major") = false);
+        py::arg("slot_mapping"), py::arg("direction"),
+        py::arg("engine_kv_format"), py::arg("token_major") = false);
   m.def("single_layer_kv_transfer_sgl", &single_layer_kv_transfer_sgl,
         py::arg("lmc_key_value_cache"), py::arg("sgl_key_cache"),
         py::arg("sgl_value_cache"), py::arg("slot_mapping"),
@@ -87,7 +87,7 @@ PYBIND11_MODULE(c_ops, m) {
         py::arg("paged_buffer_ptrs_tensor"), py::arg("lmcache_objects_ptrs"),
         py::arg("block_ids"), py::arg("device"), py::arg("direction"),
         py::arg("shape_desc"), py::arg("lmcache_chunk_size"),
-        py::arg("gpu_kv_format"), py::arg("skip_prefix_n_blocks"),
+        py::arg("engine_kv_format"), py::arg("skip_prefix_n_blocks"),
         py::call_guard<py::gil_scoped_release>());
   py::class_<PageBufferShapeDesc>(m, "PageBufferShapeDesc")
       .def(py::init<>())
@@ -118,4 +118,6 @@ PYBIND11_MODULE(c_ops, m) {
     }
     return out;
   });
+  // Backward-compat alias: GPUKVFormat -> EngineKVFormat
+  m.attr("GPUKVFormat") = m.attr("EngineKVFormat");
 }

--- a/csrc/sycl/mem_kernels_sycl.cpp
+++ b/csrc/sycl/mem_kernels_sycl.cpp
@@ -62,29 +62,29 @@ inline int round_up_to_sg(int n) {
 // ---------------------------------------------------------------------------
 namespace lmc {
 
-inline bool is_mla(const GPUKVFormat gpu_kv_format) {
-  return gpu_kv_format == GPUKVFormat::NL_X_NB_BS_HS ||   // vLLM MLA
-         gpu_kv_format == GPUKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
+inline bool is_mla(const EngineKVFormat engine_kv_format) {
+  return engine_kv_format == EngineKVFormat::NL_X_NB_BS_HS ||   // vLLM MLA
+         engine_kv_format == EngineKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
 }
 
-template <GPUKVFormat format>
+template <EngineKVFormat format>
 inline int64_t page_buffer_offset(const int k_or_v, const int token_idx,
                                   const int scalar_offset,
                                   const int scalars_per_token,
                                   const int page_buffer_size,
                                   const int block_size) {
   // vLLM cross layer
-  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_BS_NH_HS) {
     return k_or_v * page_buffer_size * scalars_per_token +
            token_idx * scalars_per_token + scalar_offset;
   }
   // vLLM flash attention
-  else if constexpr (format == GPUKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+  else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS) {
     return k_or_v * page_buffer_size * scalars_per_token +
            token_idx * scalars_per_token + scalar_offset;
   }
   // vLLM flash infer
-  else if constexpr (format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS) {
+  else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS) {
     const int block_idx = token_idx / block_size;
     const int block_offset = token_idx % block_size;
     return block_idx * 2 * block_size * scalars_per_token +
@@ -92,8 +92,8 @@ inline int64_t page_buffer_offset(const int k_or_v, const int token_idx,
            block_offset * scalars_per_token + scalar_offset;
   }
   // MLA formats: vLLM (NL_X_NB_BS_HS) and SGLang (NL_X_NBBS_ONE_HS)
-  else if constexpr (format == GPUKVFormat::NL_X_NB_BS_HS ||
-                     format == GPUKVFormat::NL_X_NBBS_ONE_HS) {
+  else if constexpr (format == EngineKVFormat::NL_X_NB_BS_HS ||
+                     format == EngineKVFormat::NL_X_NBBS_ONE_HS) {
     return token_idx * scalars_per_token + scalar_offset;
   }
 }
@@ -102,25 +102,25 @@ inline int64_t page_buffer_offset(const int k_or_v, const int token_idx,
 /// page_buffer_offset(k_or_v, slot, i, ...) == base_offset(...) + i.
 /// Hoisting this out of the inner loop avoids re-computing the
 /// integer division / modulo (flash_infer) on every iteration.
-template <GPUKVFormat format>
+template <EngineKVFormat format>
 inline int64_t page_buffer_base_offset(const int k_or_v, const int token_idx,
                                        const int scalars_per_token,
                                        const int page_buffer_size,
                                        const int block_size) {
-  if constexpr (format == GPUKVFormat::NB_NL_TWO_BS_NH_HS) {
+  if constexpr (format == EngineKVFormat::NB_NL_TWO_BS_NH_HS) {
     return k_or_v * page_buffer_size * scalars_per_token +
            token_idx * scalars_per_token;
-  } else if constexpr (format == GPUKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS) {
     return k_or_v * page_buffer_size * scalars_per_token +
            token_idx * scalars_per_token;
-  } else if constexpr (format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS) {
     const int block_idx = token_idx / block_size;
     const int block_offset = token_idx % block_size;
     return block_idx * 2 * block_size * scalars_per_token +
            k_or_v * block_size * scalars_per_token +
            block_offset * scalars_per_token;
-  } else if constexpr (format == GPUKVFormat::NL_X_NB_BS_HS ||
-                       format == GPUKVFormat::NL_X_NBBS_ONE_HS) {
+  } else if constexpr (format == EngineKVFormat::NL_X_NB_BS_HS ||
+                       format == EngineKVFormat::NL_X_NBBS_ONE_HS) {
     return token_idx * scalars_per_token;
   }
 }
@@ -191,7 +191,7 @@ T* get_kernel_ptr(TENSOR_TYPE& tensor) {
  *   - Work-group size rounded to a sub-group multiple for full SIMD
  *     utilisation
  */
-template <typename scalar_t, bool DIRECTION, GPUKVFormat format>
+template <typename scalar_t, bool DIRECTION, EngineKVFormat format>
 void submit_multi_layer_kernel(sycl::queue& queue, scalar_t* key_value_ptr,
                                scalar_t** page_buffer_ptrs,
                                const int64_t* slot_mapping_ptr,
@@ -248,7 +248,7 @@ void submit_multi_layer_kernel(sycl::queue& queue, scalar_t* key_value_ptr,
  * V separately. Slot mapping, pointer-array lookup, and flash_infer's
  * block-index division are each performed once and reused for both.
  */
-template <typename scalar_t, bool DIRECTION, GPUKVFormat format>
+template <typename scalar_t, bool DIRECTION, EngineKVFormat format>
 void submit_multi_layer_kernel_fused_kv(
     sycl::queue& queue, scalar_t* key_value_ptr, scalar_t** page_buffer_ptrs,
     const int64_t* slot_mapping_ptr, int scalars_per_token, int num_tokens,
@@ -364,7 +364,7 @@ void submit_multi_layer_unilateral_kernel(
 }
 
 // ---------------------------------------------------------------------------
-// Macros to dispatch multi-layer kernels with a specific GPUKVFormat.
+// Macros to dispatch multi-layer kernels with a specific EngineKVFormat.
 // MLA formats (k_or_v_size==1) use the per-component kernel.
 // Non-MLA formats (k_or_v_size==2) use the fused K+V kernel.
 // ---------------------------------------------------------------------------
@@ -388,7 +388,7 @@ void multi_layer_kv_transfer_templated(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format, const int block_size,
+    const EngineKVFormat engine_kv_format, const int block_size,
     const int skip_prefix_n_tokens) {
   T* key_value_ptr = get_kernel_ptr<T, torch::Tensor>(key_value);
   T** page_buffer_ptrs =
@@ -402,7 +402,7 @@ void multi_layer_kv_transfer_templated(
   int elements_per_xword = sizeof(T) / key_value.element_size();
   int num_xwords = num_origin_elements / elements_per_xword;
 
-  int k_or_v_size = lmc::is_mla(gpu_kv_format) ? 1 : 2;
+  int k_or_v_size = lmc::is_mla(engine_kv_format) ? 1 : 2;
 
   // Round up to a sub-group multiple so every sub-group is full.
   int wg_size = round_up_to_sg(std::min(num_xwords, MAX_WG_SIZE));
@@ -415,63 +415,63 @@ void multi_layer_kv_transfer_templated(
   // (k_or_v_size==1) use the per-component kernel.
   if (k_or_v_size == 2) {
     if (direction == TransferDirection::H2D) {
-      switch (gpu_kv_format) {
-        case GPUKVFormat::NB_NL_TWO_BS_NH_HS:
-          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(T, false,
-                                             GPUKVFormat::NB_NL_TWO_BS_NH_HS);
+      switch (engine_kv_format) {
+        case EngineKVFormat::NB_NL_TWO_BS_NH_HS:
+          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(
+              T, false, EngineKVFormat::NB_NL_TWO_BS_NH_HS);
           break;
-        case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
-          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(T, false,
-                                             GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);
+        case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:
+          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(
+              T, false, EngineKVFormat::NL_X_TWO_NB_BS_NH_HS);
           break;
-        case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
-          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(T, false,
-                                             GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);
+        case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:
+          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(
+              T, false, EngineKVFormat::NL_X_NB_TWO_BS_NH_HS);
           break;
         default:
-          throw std::runtime_error("Unsupported non-MLA GPUKVFormat");
+          throw std::runtime_error("Unsupported non-MLA EngineKVFormat");
       }
     } else {
-      switch (gpu_kv_format) {
-        case GPUKVFormat::NB_NL_TWO_BS_NH_HS:
-          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(T, true,
-                                             GPUKVFormat::NB_NL_TWO_BS_NH_HS);
+      switch (engine_kv_format) {
+        case EngineKVFormat::NB_NL_TWO_BS_NH_HS:
+          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(
+              T, true, EngineKVFormat::NB_NL_TWO_BS_NH_HS);
           break;
-        case GPUKVFormat::NL_X_TWO_NB_BS_NH_HS:
-          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(T, true,
-                                             GPUKVFormat::NL_X_TWO_NB_BS_NH_HS);
+        case EngineKVFormat::NL_X_TWO_NB_BS_NH_HS:
+          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(
+              T, true, EngineKVFormat::NL_X_TWO_NB_BS_NH_HS);
           break;
-        case GPUKVFormat::NL_X_NB_TWO_BS_NH_HS:
-          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(T, true,
-                                             GPUKVFormat::NL_X_NB_TWO_BS_NH_HS);
+        case EngineKVFormat::NL_X_NB_TWO_BS_NH_HS:
+          LAUNCH_FUSED_KV_KERNEL_WITH_FORMAT(
+              T, true, EngineKVFormat::NL_X_NB_TWO_BS_NH_HS);
           break;
         default:
-          throw std::runtime_error("Unsupported non-MLA GPUKVFormat");
+          throw std::runtime_error("Unsupported non-MLA EngineKVFormat");
       }
     }
   } else {
     // MLA path (k_or_v_size == 1)
     if (direction == TransferDirection::H2D) {
-      switch (gpu_kv_format) {
-        case GPUKVFormat::NL_X_NB_BS_HS:
-          LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NL_X_NB_BS_HS);
+      switch (engine_kv_format) {
+        case EngineKVFormat::NL_X_NB_BS_HS:
+          LAUNCH_KERNEL_WITH_FORMAT(T, false, EngineKVFormat::NL_X_NB_BS_HS);
           break;
-        case GPUKVFormat::NL_X_NBBS_ONE_HS:
-          LAUNCH_KERNEL_WITH_FORMAT(T, false, GPUKVFormat::NL_X_NBBS_ONE_HS);
+        case EngineKVFormat::NL_X_NBBS_ONE_HS:
+          LAUNCH_KERNEL_WITH_FORMAT(T, false, EngineKVFormat::NL_X_NBBS_ONE_HS);
           break;
         default:
-          throw std::runtime_error("Unsupported MLA GPUKVFormat");
+          throw std::runtime_error("Unsupported MLA EngineKVFormat");
       }
     } else {
-      switch (gpu_kv_format) {
-        case GPUKVFormat::NL_X_NB_BS_HS:
-          LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NL_X_NB_BS_HS);
+      switch (engine_kv_format) {
+        case EngineKVFormat::NL_X_NB_BS_HS:
+          LAUNCH_KERNEL_WITH_FORMAT(T, true, EngineKVFormat::NL_X_NB_BS_HS);
           break;
-        case GPUKVFormat::NL_X_NBBS_ONE_HS:
-          LAUNCH_KERNEL_WITH_FORMAT(T, true, GPUKVFormat::NL_X_NBBS_ONE_HS);
+        case EngineKVFormat::NL_X_NBBS_ONE_HS:
+          LAUNCH_KERNEL_WITH_FORMAT(T, true, EngineKVFormat::NL_X_NBBS_ONE_HS);
           break;
         default:
-          throw std::runtime_error("Unsupported MLA GPUKVFormat");
+          throw std::runtime_error("Unsupported MLA EngineKVFormat");
       }
     }
   }
@@ -487,8 +487,8 @@ void multi_layer_kv_transfer(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format, const int block_size, const int head_size,
-    const int skip_prefix_n_tokens) {
+    const EngineKVFormat engine_kv_format, const int block_size,
+    const int head_size, const int skip_prefix_n_tokens) {
   // head_size is currently unused in the SYCL implementation; accepted to
   // keep ABI parity with the CUDA c_ops binding so callers can pass the
   // same kwargs to either backend.
@@ -500,7 +500,7 @@ void multi_layer_kv_transfer(
   do {                                                                \
     multi_layer_kv_transfer_templated<type>(                          \
         key_value, key_value_ptrs, slot_mapping, paged_memory_device, \
-        page_buffer_size, direction, gpu_kv_format, block_size,       \
+        page_buffer_size, direction, engine_kv_format, block_size,    \
         skip_prefix_n_tokens);                                        \
   } while (0)
   if (copy_size % 8 == 0) {
@@ -522,13 +522,13 @@ void multi_layer_kv_transfer_unilateral(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format) {
-  const bool use_mla = lmc::is_mla(gpu_kv_format);
+    const EngineKVFormat engine_kv_format) {
+  const bool use_mla = lmc::is_mla(engine_kv_format);
   // MLA case collapses back to multi_layer_kv_transfer
   if (use_mla) {
     return multi_layer_kv_transfer(key_value, key_value_ptrs, slot_mapping,
                                    paged_memory_device, page_buffer_size,
-                                   direction, gpu_kv_format);
+                                   direction, engine_kv_format);
   }
 
   int64_t* key_value_ptr = get_kernel_ptr<int64_t, torch::Tensor>(key_value);
@@ -630,7 +630,7 @@ void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
                               torch::Tensor& vllm_key_value_cache,
                               torch::Tensor& slot_mapping,
                               const TransferDirection direction,
-                              const GPUKVFormat gpu_kv_format,
+                              const EngineKVFormat engine_kv_format,
                               const bool token_major) {
   int64_t* lmc_key_value_cache_ptr =
       get_kernel_ptr<int64_t, torch::Tensor>(lmc_key_value_cache);
@@ -646,7 +646,7 @@ void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
   int head_size_in_64bit;
   int block_size;
 
-  const bool use_mla = lmc::is_mla(gpu_kv_format);
+  const bool use_mla = lmc::is_mla(engine_kv_format);
 
   if (use_mla) {
     num_heads = 1;
@@ -677,18 +677,18 @@ void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(0) / elements_per_entry;
     vllm_value_offset = 0;
-  } else if (gpu_kv_format == GPUKVFormat::NL_X_TWO_NB_BS_NH_HS) {
+  } else if (engine_kv_format == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS) {
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(1) / elements_per_entry;
     vllm_value_offset = vllm_key_value_cache.stride(0) / elements_per_entry;
-  } else if (gpu_kv_format == GPUKVFormat::NL_X_NB_TWO_BS_NH_HS) {
+  } else if (engine_kv_format == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS) {
     vllm_block_key_stride_in_64bit =
         vllm_key_value_cache.stride(0) / elements_per_entry;
     vllm_value_offset = vllm_key_value_cache.stride(1) / elements_per_entry;
   } else {
     throw std::runtime_error(
-        "Unsupported non-MLA GPUKVFormat in single_layer_kv_transfer: " +
-        std::to_string(static_cast<int>(gpu_kv_format)));
+        "Unsupported non-MLA EngineKVFormat in single_layer_kv_transfer: " +
+        std::to_string(static_cast<int>(engine_kv_format)));
   }
 
   int n = num_heads * head_size_in_64bit;

--- a/csrc/sycl/mem_kernels_sycl.h
+++ b/csrc/sycl/mem_kernels_sycl.h
@@ -34,7 +34,7 @@ kv_cache[0][0].shape = (C, D, E)
 The logic for identifying the format currently lives in
 `lmcache/v1/gpu_connector/utils.py`
 */
-enum class GPUKVFormat : int {
+enum class EngineKVFormat : int {
   NB_NL_TWO_BS_NH_HS = 0,
   /*
   used by:
@@ -114,7 +114,7 @@ void multi_layer_kv_transfer(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format, const int block_size = 0,
+    const EngineKVFormat engine_kv_format, const int block_size = 0,
     const int head_size = 0, const int skip_prefix_n_tokens = 0);
 
 // collapses to multi_layer_kv_transfer for MLA
@@ -122,13 +122,13 @@ void multi_layer_kv_transfer_unilateral(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
-    const GPUKVFormat gpu_kv_format);
+    const EngineKVFormat engine_kv_format);
 
 void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
                               torch::Tensor& vllm_key_value_cache,
                               torch::Tensor& slot_mapping,
                               const TransferDirection direction,
-                              const GPUKVFormat gpu_kv_format,
+                              const EngineKVFormat engine_kv_format,
                               const bool token_major = false);
 
 void single_layer_kv_transfer_sgl(torch::Tensor& lmc_key_value_cache,

--- a/csrc/sycl/pybind_sycl.cpp
+++ b/csrc/sycl/pybind_sycl.cpp
@@ -16,30 +16,30 @@ PYBIND11_MODULE(xpu_ops, m) {
       .value("H2D", TransferDirection::H2D)
       .value("D2H", TransferDirection::D2H)
       .export_values();
-  py::enum_<GPUKVFormat>(m, "GPUKVFormat")
-      .value("NB_NL_TWO_BS_NH_HS", GPUKVFormat::NB_NL_TWO_BS_NH_HS)
-      .value("NL_X_TWO_NB_BS_NH_HS", GPUKVFormat::NL_X_TWO_NB_BS_NH_HS)
-      .value("NL_X_NB_TWO_BS_NH_HS", GPUKVFormat::NL_X_NB_TWO_BS_NH_HS)
-      .value("NL_X_NB_BS_HS", GPUKVFormat::NL_X_NB_BS_HS)
-      .value("TWO_X_NL_X_NBBS_NH_HS", GPUKVFormat::TWO_X_NL_X_NBBS_NH_HS)
-      .value("NL_X_NBBS_ONE_HS", GPUKVFormat::NL_X_NBBS_ONE_HS)
-      .value("NL_X_TWO_NB_NH_BS_HS", GPUKVFormat::NL_X_TWO_NB_NH_BS_HS)
-      .value("NL_X_NB_TWO_NH_BS_HS", GPUKVFormat::NL_X_NB_TWO_NH_BS_HS)
-      .value("NB_NL_TWO_NH_BS_HS", GPUKVFormat::NB_NL_TWO_NH_BS_HS)
-      .value("TWO_X_NL_X_NB_BS_NH_HS", GPUKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
-      .value("NL_X_NB_NH_BS_TWO_HS", GPUKVFormat::NL_X_NB_NH_BS_TWO_HS)
+  py::enum_<EngineKVFormat>(m, "EngineKVFormat")
+      .value("NB_NL_TWO_BS_NH_HS", EngineKVFormat::NB_NL_TWO_BS_NH_HS)
+      .value("NL_X_TWO_NB_BS_NH_HS", EngineKVFormat::NL_X_TWO_NB_BS_NH_HS)
+      .value("NL_X_NB_TWO_BS_NH_HS", EngineKVFormat::NL_X_NB_TWO_BS_NH_HS)
+      .value("NL_X_NB_BS_HS", EngineKVFormat::NL_X_NB_BS_HS)
+      .value("TWO_X_NL_X_NBBS_NH_HS", EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS)
+      .value("NL_X_NBBS_ONE_HS", EngineKVFormat::NL_X_NBBS_ONE_HS)
+      .value("NL_X_TWO_NB_NH_BS_HS", EngineKVFormat::NL_X_TWO_NB_NH_BS_HS)
+      .value("NL_X_NB_TWO_NH_BS_HS", EngineKVFormat::NL_X_NB_TWO_NH_BS_HS)
+      .value("NB_NL_TWO_NH_BS_HS", EngineKVFormat::NB_NL_TWO_NH_BS_HS)
+      .value("TWO_X_NL_X_NB_BS_NH_HS", EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
+      .value("NL_X_NB_NH_BS_TWO_HS", EngineKVFormat::NL_X_NB_NH_BS_TWO_HS)
       .export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),
         py::arg("slot_mapping"), py::arg("paged_memory_device"),
         py::arg("page_buffer_size"), py::arg("direction"),
-        py::arg("gpu_kv_format"), py::arg("block_size") = 0,
+        py::arg("engine_kv_format"), py::arg("block_size") = 0,
         py::arg("head_size") = 0, py::arg("skip_prefix_n_tokens") = 0,
         py::call_guard<py::gil_scoped_release>());
   m.def("single_layer_kv_transfer", &single_layer_kv_transfer,
         py::arg("lmc_key_value_cache"), py::arg("vllm_key_value_cache"),
-        py::arg("slot_mapping"), py::arg("direction"), py::arg("gpu_kv_format"),
-        py::arg("token_major") = false,
+        py::arg("slot_mapping"), py::arg("direction"),
+        py::arg("engine_kv_format"), py::arg("token_major") = false,
         py::call_guard<py::gil_scoped_release>());
   m.def("single_layer_kv_transfer_sgl", &single_layer_kv_transfer_sgl,
         py::arg("lmc_key_value_cache"), py::arg("sgl_key_cache"),
@@ -50,7 +50,7 @@ PYBIND11_MODULE(xpu_ops, m) {
         &multi_layer_kv_transfer_unilateral, py::arg("key_value"),
         py::arg("key_value_ptrs"), py::arg("slot_mapping"),
         py::arg("paged_memory_device"), py::arg("page_buffer_size"),
-        py::arg("direction"), py::arg("gpu_kv_format"),
+        py::arg("direction"), py::arg("engine_kv_format"),
         py::call_guard<py::gil_scoped_release>());
   m.def("load_and_reshape_flash", &load_and_reshape_flash);
   m.def("reshape_and_cache_back_flash", &reshape_and_cache_back_flash);
@@ -72,4 +72,6 @@ PYBIND11_MODULE(xpu_ops, m) {
         py::arg("bytestreams"), py::arg("lengths"), py::arg("output"));
   m.def("decode_fast_prefsum", &decode_fast_prefsum_xpu, py::arg("cdf"),
         py::arg("bytestreams"), py::arg("lengths_prefsum"), py::arg("output"));
+  // Backward-compat alias: GPUKVFormat -> EngineKVFormat
+  m.attr("GPUKVFormat") = m.attr("EngineKVFormat");
 }

--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -246,8 +246,8 @@ class KVCacheDescriber:
                 ("dtype", "Dtype"),
                 ("is_mla", "MLA"),
                 ("attention_backend", "Attention backend"),
-                ("gpu_kv_shape", "GPU KV shape"),
-                ("gpu_kv_concrete_shape", "GPU KV tensor shape"),
+                ("engine_kv_shape", "Engine KV shape"),
+                ("engine_kv_concrete_shape", "Engine KV tensor shape"),
             ):
                 if _key in group:
                     sec.add(_key, _label, group[_key])

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -127,12 +127,12 @@ def create_engine_group_infos_from_vllm(
     )
 
     # Inspect the real registered tensors for physical layout and dtype.
-    gpu_kv_format, normalized_kv_caches = normalize_kv_and_discover_format(
+    engine_kv_format, normalized_kv_caches = normalize_kv_and_discover_format(
         list(kv_caches.values()),
         EngineType.VLLM,
         layout_hints=layout_hints,
     )
-    num_layers = get_num_layers(normalized_kv_caches, gpu_kv_format)
+    num_layers = get_num_layers(normalized_kv_caches, engine_kv_format)
 
     # vLLM-specific field access (confined to this function): map each
     # registered KV tensor to its vLLM engine KV cache group index. vLLM places
@@ -183,7 +183,7 @@ def create_engine_group_infos_from_vllm(
         )
         for identity, indices in group_layers_by_identity(
             normalized_kv_caches,
-            gpu_kv_format,
+            engine_kv_format,
             num_layers,
             per_layer_group_idx,
         )

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -257,8 +257,8 @@ class TransferDirection(IntEnum):
     D2H = 1
 
 
-class GPUKVFormat(IntEnum):
-    """Enumeration of different GPU KV cache memory layouts."""
+class EngineKVFormat(IntEnum):
+    """Enumeration of different engine KV cache memory layouts."""
 
     # used by: vLLM CROSS_LAYER mode
     NB_NL_TWO_BS_NH_HS = 0
@@ -295,6 +295,10 @@ class GPUKVFormat(IntEnum):
     # [num_blocks, num_heads, block_size, 2, head_size] -- the K/V "2" axis is
     # second-to-last, recovered by splitting the fused [..., 2 * head_size].
     NL_X_NB_NH_BS_TWO_HS = 10
+
+
+# Backward-compat alias
+GPUKVFormat = EngineKVFormat
 
 
 class PageBufferShapeDesc:
@@ -545,7 +549,7 @@ def multi_layer_kv_transfer(
     paged_memory_device: torch.device,
     page_buffer_size: int,
     direction: TransferDirection,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     block_size: int = 0,
     head_size: int = 0,
     skip_prefix_n_tokens: int = 0,
@@ -561,7 +565,7 @@ def multi_layer_kv_transfer(
 
     # TODO: Implement head_size support for HND layouts (NL_X_TWO_NB_NH_BS_HS,
     # NL_X_NB_TWO_NH_BS_HS) as next step.
-    if int(gpu_kv_format) in (
+    if int(engine_kv_format) in (
         int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS),
         int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS),
     ):
@@ -591,11 +595,11 @@ def multi_layer_kv_transfer(
     valid_slots = slots_kv[valid_mask_kv].to(paged_memory_device)
 
     # 2. Determine architecture variant and tensor dimensions.
-    is_mla = int(gpu_kv_format) in (
+    is_mla = int(engine_kv_format) in (
         int(GPUKVFormat.NL_X_NB_BS_HS),
         int(GPUKVFormat.NL_X_NBBS_ONE_HS),
     )
-    is_flash_infer = int(gpu_kv_format) == int(GPUKVFormat.NL_X_NB_TWO_BS_NH_HS)
+    is_flash_infer = int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_TWO_BS_NH_HS)
 
     num_layers = key_value.size(1)
     hidden_size = key_value.size(3)
@@ -679,7 +683,7 @@ def multi_layer_kv_transfer_unilateral(
     paged_memory_device: torch.device,
     page_buffer_size: int,
     direction: TransferDirection,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
 ):
     """
     Python fallback for multi_layer_kv_transfer_unilateral
@@ -702,7 +706,7 @@ def multi_layer_kv_transfer_unilateral(
         H2D = LMCache  -> PagedBuffer
         D2H = PagedBuffer -> LMCache
     """
-    is_mla = int(gpu_kv_format) in (
+    is_mla = int(engine_kv_format) in (
         int(GPUKVFormat.NL_X_NB_BS_HS),
         int(GPUKVFormat.NL_X_NBBS_ONE_HS),
     )
@@ -717,7 +721,7 @@ def multi_layer_kv_transfer_unilateral(
             paged_memory_device,
             page_buffer_size,
             direction,
-            gpu_kv_format,
+            engine_kv_format,
             0,  # block_size unused for MLA formats
         )
     # ── Non-MLA path: unilateral (separate K/V buffers per layer) ──
@@ -754,34 +758,34 @@ def multi_layer_kv_transfer_unilateral(
                 key_value[kv_idx, layer_id, valid_mask_kv, :] = gathered.to(kv_device)
 
 
-def _is_cross_layer_format(gpu_kv_format: GPUKVFormat) -> bool:
+def _is_cross_layer_format(engine_kv_format: GPUKVFormat) -> bool:
     """Return True when a KV format uses a single cross-layer tensor."""
-    return int(gpu_kv_format) in (
+    return int(engine_kv_format) in (
         int(GPUKVFormat.NB_NL_TWO_BS_NH_HS),
         int(GPUKVFormat.NB_NL_TWO_NH_BS_HS),
     )
 
 
-def _is_sglang_mha_format(gpu_kv_format: GPUKVFormat) -> bool:
+def _is_sglang_mha_format(engine_kv_format: GPUKVFormat) -> bool:
     """Return True when a KV format uses SGLang MHA layout (2*NL tensors)."""
-    return int(gpu_kv_format) in (
+    return int(engine_kv_format) in (
         int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS),
         int(GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS),
     )
 
 
-def _is_hnd_format(gpu_kv_format: GPUKVFormat) -> bool:
+def _is_hnd_format(engine_kv_format: GPUKVFormat) -> bool:
     """Return True when a per-layer KV format stores heads before block tokens (HND)."""
-    return int(gpu_kv_format) in (
+    return int(engine_kv_format) in (
         int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS),
         int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS),
         int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS),
     )
 
 
-def _is_mla_format(gpu_kv_format: GPUKVFormat) -> bool:
+def _is_mla_format(engine_kv_format: GPUKVFormat) -> bool:
     """Return True when a KV format uses MLA paged layout."""
-    return int(gpu_kv_format) in (
+    return int(engine_kv_format) in (
         int(GPUKVFormat.NL_X_NB_BS_HS),
         int(GPUKVFormat.NL_X_NBBS_ONE_HS),
     )
@@ -809,7 +813,7 @@ def _is_ptr_tensor(x: object) -> bool:
 
 
 def _per_layer_paged_shape(
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     nb: int,
     bs: int,
     nh: int,
@@ -818,7 +822,7 @@ def _per_layer_paged_shape(
     """Return the logical shape of a single per-layer paged buffer tensor.
 
     Args:
-        gpu_kv_format: The format enum that describes how K/V tokens are laid out.
+        engine_kv_format: The format enum that describes how K/V tokens are laid out.
         nb: Number of blocks in the paged buffer (``shape_desc.nb``).
         bs: Tokens per block / block size (``shape_desc.bs``).
         nh: Number of attention heads (``shape_desc.nh``).
@@ -828,7 +832,7 @@ def _per_layer_paged_shape(
         A tuple representing the shape needed to reconstruct one layer's tensor
         from a raw pointer via :func:`_tensor_from_ptr`.
     """
-    fmt = int(gpu_kv_format)
+    fmt = int(engine_kv_format)
     if fmt == int(GPUKVFormat.NL_X_NBBS_ONE_HS):
         return (nb * bs, 1, hs)
     if fmt == int(GPUKVFormat.NL_X_NB_BS_HS):
@@ -901,7 +905,7 @@ def _infer_kv_dtype(
 
 def _normalize_paged_layers(
     paged_buffer_ptrs_tensor: "torch.Tensor | list",
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     shape_desc: "PageBufferShapeDesc | None" = None,
     device: "torch.device | str | None" = None,
     dtype: "torch.dtype | None" = None,
@@ -918,7 +922,7 @@ def _normalize_paged_layers(
         - ``list[list[torch.Tensor]]`` (2 x NL) for SGLang MHA formats.
         - ``list[torch.Tensor]`` (per-layer) for all other formats.
     """
-    if _is_cross_layer_format(gpu_kv_format):
+    if _is_cross_layer_format(engine_kv_format):
         if isinstance(paged_buffer_ptrs_tensor, torch.Tensor):
             if _is_ptr_tensor(paged_buffer_ptrs_tensor):
                 # 1-D pointer tensor with a single entry → reconstruct full tensor.
@@ -932,7 +936,7 @@ def _normalize_paged_layers(
                 bs = int(shape_desc.bs)
                 nh = int(shape_desc.nh)
                 hs = int(shape_desc.hs)
-                if int(gpu_kv_format) == int(GPUKVFormat.NB_NL_TWO_NH_BS_HS):
+                if int(engine_kv_format) == int(GPUKVFormat.NB_NL_TWO_NH_BS_HS):
                     shape: tuple[int, ...] = (nb, nl, 2, nh, bs, hs)
                 else:
                     shape = (nb, nl, 2, bs, nh, hs)
@@ -943,7 +947,7 @@ def _normalize_paged_layers(
             "Cross-layer formats require a single torch.Tensor input; "
             "got: " + type(paged_buffer_ptrs_tensor).__name__
         )
-    if _is_sglang_mha_format(gpu_kv_format):
+    if _is_sglang_mha_format(engine_kv_format):
         if _is_ptr_tensor(paged_buffer_ptrs_tensor):
             # 1-D pointer tensor [K_L0,...,K_LN-1, V_L0,...,V_LN-1] → nested list.
             if shape_desc is None or device is None or dtype is None:
@@ -956,7 +960,7 @@ def _normalize_paged_layers(
             bs = int(shape_desc.bs)
             nh = int(shape_desc.nh)
             hs = int(shape_desc.hs)
-            is_flat = int(gpu_kv_format) == int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS)
+            is_flat = int(engine_kv_format) == int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS)
             per_layer_shape: tuple[int, ...] = (
                 (nb * bs, nh, hs) if is_flat else (nb, bs, nh, hs)
             )
@@ -1010,7 +1014,7 @@ def _normalize_paged_layers(
         bs = int(shape_desc.bs)
         nh = int(shape_desc.nh)
         hs = int(shape_desc.hs)
-        per_shape = _per_layer_paged_shape(gpu_kv_format, nb, bs, nh, hs)
+        per_shape = _per_layer_paged_shape(engine_kv_format, nb, bs, nh, hs)
         return [
             _tensor_from_ptr(int(p.item()), per_shape, dtype, device)
             for p in paged_buffer_ptrs_tensor
@@ -1031,14 +1035,14 @@ def _normalize_lmcache_objects(
     lmcache_objects_ptrs: "list[int] | list[torch.Tensor]",
     shape_desc: "PageBufferShapeDesc | None" = None,
     lmcache_chunk_size: "int | None" = None,
-    gpu_kv_format: "GPUKVFormat | None" = None,
+    engine_kv_format: "GPUKVFormat | None" = None,
     dtype: "torch.dtype | None" = None,
 ) -> list[torch.Tensor]:
     """Normalize LMCache object inputs to chunk tensors.
 
     Accepts either a list of chunk tensors or a ``list[int]`` of raw CPU pointers.
     When a pointer list is provided *shape_desc*, *lmcache_chunk_size*,
-    *gpu_kv_format*, and *dtype* must be supplied so the tensors can be
+    *engine_kv_format*, and *dtype* must be supplied so the tensors can be
     reconstructed via :func:`_tensor_from_ptr` on the CPU.
     """
     if not isinstance(lmcache_objects_ptrs, list):
@@ -1055,19 +1059,19 @@ def _normalize_lmcache_objects(
         if (
             shape_desc is None
             or lmcache_chunk_size is None
-            or gpu_kv_format is None
+            or engine_kv_format is None
             or dtype is None
         ):
             raise ValueError(
                 "_normalize_lmcache_objects: shape_desc, lmcache_chunk_size, "
-                "gpu_kv_format, and dtype are required when lmcache_objects_ptrs "
+                "engine_kv_format, and dtype are required when lmcache_objects_ptrs "
                 "contains raw int pointers"
             )
         nl = int(shape_desc.nl)
         nh = int(shape_desc.nh)
         hs = int(shape_desc.hs)
         chunk_tokens = lmcache_chunk_size
-        if _is_mla_format(gpu_kv_format):
+        if _is_mla_format(engine_kv_format):
             chunk_shape: tuple[int, ...] = (nl, chunk_tokens, hs)
         else:
             chunk_shape = (2, nl, chunk_tokens, nh * hs)
@@ -1098,7 +1102,7 @@ def multi_layer_block_kv_transfer(
     direction: TransferDirection,
     shape_desc: PageBufferShapeDesc,
     lmcache_chunk_size: int,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     skip_prefix_n_blocks: int,
 ) -> None:
     """Python fallback implementation of block-based multi-layer KV transfer.
@@ -1115,7 +1119,7 @@ def multi_layer_block_kv_transfer(
         direction: Transfer direction (H2D or D2H).
         shape_desc: Shape descriptor of the page buffer.
         lmcache_chunk_size: Chunk size of LMCache objects.
-        gpu_kv_format: GPU KV cache format.
+        engine_kv_format: GPU KV cache format.
         skip_prefix_n_blocks: Number of leading blocks to skip.
 
     Returns:
@@ -1144,7 +1148,7 @@ def multi_layer_block_kv_transfer(
     )
     normalized = _normalize_paged_layers(
         paged_buffer_ptrs_tensor,
-        gpu_kv_format,
+        engine_kv_format,
         shape_desc=shape_desc,
         device=device,
         dtype=kv_dtype,
@@ -1153,7 +1157,7 @@ def multi_layer_block_kv_transfer(
         lmcache_objects_ptrs,
         shape_desc=shape_desc,
         lmcache_chunk_size=lmcache_chunk_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
         dtype=kv_dtype,
     )
     n_block_ids = (
@@ -1164,7 +1168,7 @@ def multi_layer_block_kv_transfer(
     blocks_per_object = lmcache_chunk_size // int(shape_desc.bs)
     block_size = int(shape_desc.bs)
 
-    if _is_cross_layer_format(gpu_kv_format):
+    if _is_cross_layer_format(engine_kv_format):
         _transfer_cross_layer(
             normalized,
             object_tensors,
@@ -1172,11 +1176,11 @@ def multi_layer_block_kv_transfer(
             n_block_ids,
             blocks_per_object,
             block_size,
-            gpu_kv_format,
+            engine_kv_format,
             is_d2h,
             skip_prefix_n_blocks,
         )
-    elif _is_sglang_mha_format(gpu_kv_format):
+    elif _is_sglang_mha_format(engine_kv_format):
         _transfer_sglang_mha(
             normalized,
             object_tensors,
@@ -1184,11 +1188,11 @@ def multi_layer_block_kv_transfer(
             n_block_ids,
             blocks_per_object,
             block_size,
-            gpu_kv_format,
+            engine_kv_format,
             is_d2h,
             skip_prefix_n_blocks,
         )
-    elif _is_mla_format(gpu_kv_format):
+    elif _is_mla_format(engine_kv_format):
         _transfer_per_layer_mla(
             normalized,
             object_tensors,
@@ -1196,11 +1200,11 @@ def multi_layer_block_kv_transfer(
             n_block_ids,
             blocks_per_object,
             block_size,
-            gpu_kv_format,
+            engine_kv_format,
             is_d2h,
             skip_prefix_n_blocks,
         )
-    elif _is_hnd_format(gpu_kv_format):
+    elif _is_hnd_format(engine_kv_format):
         _transfer_per_layer_hnd(
             normalized,
             object_tensors,
@@ -1208,7 +1212,7 @@ def multi_layer_block_kv_transfer(
             n_block_ids,
             blocks_per_object,
             block_size,
-            gpu_kv_format,
+            engine_kv_format,
             is_d2h,
             skip_prefix_n_blocks,
         )
@@ -1220,7 +1224,7 @@ def multi_layer_block_kv_transfer(
             n_block_ids,
             blocks_per_object,
             block_size,
-            gpu_kv_format,
+            engine_kv_format,
             is_d2h,
             skip_prefix_n_blocks,
         )
@@ -1280,13 +1284,13 @@ def _transfer_cross_layer(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
     """Handle cross-layer formats: single tensor [NB, NL, 2, ...]."""
     # NHD: [NB, NL, 2, BS, NH, HS]  HND: [NB, NL, 2, NH, BS, HS]
-    is_hnd = int(gpu_kv_format) == int(GPUKVFormat.NB_NL_TWO_NH_BS_HS)
+    is_hnd = int(engine_kv_format) == int(GPUKVFormat.NB_NL_TWO_NH_BS_HS)
     num_layers = paged_tensor.shape[1]
 
     if is_hnd:
@@ -1362,14 +1366,14 @@ def _transfer_sglang_mha(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
     """Handle SGLang MHA formats: 2*NL tensors (list[list[Tensor]])."""
     # TWO_X_NL_X_NBBS_NH_HS: each tensor [NB*BS, NH, HS]
     # TWO_X_NL_X_NB_BS_NH_HS: each tensor [NB, BS, NH, HS]
-    is_flat = int(gpu_kv_format) == int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS)
+    is_flat = int(engine_kv_format) == int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS)
     num_layers = len(paged_tensors[0])
 
     # Determine target device from first tensor
@@ -1442,7 +1446,7 @@ def _transfer_per_layer_mla(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
@@ -1450,7 +1454,7 @@ def _transfer_per_layer_mla(
     if not layer_tensors or not object_tensors:
         return
 
-    is_flat = int(gpu_kv_format) == int(GPUKVFormat.NL_X_NBBS_ONE_HS)
+    is_flat = int(engine_kv_format) == int(GPUKVFormat.NL_X_NBBS_ONE_HS)
     target_device = layer_tensors[0].device
     if is_flat:
         token_offsets = torch.arange(block_size, dtype=torch.long, device=target_device)
@@ -1516,7 +1520,7 @@ def _transfer_per_layer_hnd(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
@@ -1528,9 +1532,9 @@ def _transfer_per_layer_hnd(
     block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
 
     first_layer = layer_tensors[0]
-    if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+    if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
         first_k = first_layer[0]
-    elif int(gpu_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+    elif int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
         first_k = first_layer[:, :, :, 0]
     else:
         first_k = first_layer[:, 0]
@@ -1569,7 +1573,7 @@ def _transfer_per_layer_hnd(
                 device=target_device,
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+                if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
                     k_t, v_t = layer[0], layer[1]
                     torch.index_select(k_t, 0, eff_idx, out=scratch)
                     chunk_gpu[0, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
@@ -1579,7 +1583,7 @@ def _transfer_per_layer_hnd(
                     chunk_gpu[1, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
                         scratch.permute(0, 2, 1, 3)
                     )
-                elif int(gpu_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+                elif int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
                     k_t, v_t = layer[:, :, :, 0], layer[:, :, :, 1]
                     torch.index_select(k_t, 0, eff_idx, out=scratch)
                     chunk_gpu[0, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
@@ -1607,9 +1611,9 @@ def _transfer_per_layer_hnd(
                 target_device, non_blocking=True
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+                if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
                     k_t, v_t = layer[0], layer[1]
-                elif int(gpu_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+                elif int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
                     k_t, v_t = layer[:, :, :, 0], layer[:, :, :, 1]
                 else:
                     k_t, v_t = layer[:, 0], layer[:, 1]
@@ -1624,7 +1628,7 @@ def _transfer_per_layer_hnd(
                     .reshape(n_valid, block_size, nh, hs)
                     .permute(0, 2, 1, 3)
                 )
-                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS):
+                if int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS):
                     layer.index_copy_(
                         0, eff_idx, torch.stack([k_blocks, v_blocks], dim=1)
                     )
@@ -1640,7 +1644,7 @@ def _transfer_per_layer_nhd(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
@@ -1652,7 +1656,7 @@ def _transfer_per_layer_nhd(
     block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
 
     first_layer = layer_tensors[0]
-    if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+    if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
         first_k = first_layer[0]
     else:
         first_k = first_layer[:, 0]
@@ -1683,7 +1687,7 @@ def _transfer_per_layer_nhd(
                 device=target_device,
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+                if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
                     k_t, v_t = layer[0], layer[1]
                     torch.index_select(
                         k_t,
@@ -1715,7 +1719,7 @@ def _transfer_per_layer_nhd(
                 target_device, non_blocking=True
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+                if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
                     k_t, v_t = layer[0], layer[1]
                     k_t.index_copy_(
                         0,
@@ -1744,7 +1748,7 @@ def single_layer_kv_transfer(
     vllm_key_value_cache: torch.Tensor,
     slot_mapping: torch.Tensor,
     direction: TransferDirection,
-    gpu_kv_format: GPUKVFormat,
+    engine_kv_format: GPUKVFormat,
     token_major: bool = False,
 ):
     """
@@ -1782,7 +1786,7 @@ def single_layer_kv_transfer(
     valid_token_indices = torch.nonzero(valid_mask_kv, as_tuple=True)[0]
     valid_slots = slots_kv[valid_mask_kv].to(paged_memory_device)
 
-    is_mla = int(gpu_kv_format) in (
+    is_mla = int(engine_kv_format) in (
         int(GPUKVFormat.NL_X_NB_BS_HS),
         int(GPUKVFormat.NL_X_NBBS_ONE_HS),
     )
@@ -1809,7 +1813,7 @@ def single_layer_kv_transfer(
     else:
         # ── Non-MLA format ──
         # Determine vLLM layout and block_size
-        is_two_major = int(gpu_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS)
+        is_two_major = int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS)
         # flash attn:
         #   [2, num_blocks, block_size, num_heads, head_size]
         #   -> dim2 = block_size

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -549,7 +549,7 @@ def multi_layer_kv_transfer(
     paged_memory_device: torch.device,
     page_buffer_size: int,
     direction: TransferDirection,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     block_size: int = 0,
     head_size: int = 0,
     skip_prefix_n_tokens: int = 0,
@@ -566,8 +566,8 @@ def multi_layer_kv_transfer(
     # TODO: Implement head_size support for HND layouts (NL_X_TWO_NB_NH_BS_HS,
     # NL_X_NB_TWO_NH_BS_HS) as next step.
     if int(engine_kv_format) in (
-        int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS),
-        int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS),
+        int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS),
+        int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS),
     ):
         raise NotImplementedError(
             "HND layouts (NL_X_TWO_NB_NH_BS_HS, NL_X_NB_TWO_NH_BS_HS) "
@@ -596,10 +596,10 @@ def multi_layer_kv_transfer(
 
     # 2. Determine architecture variant and tensor dimensions.
     is_mla = int(engine_kv_format) in (
-        int(GPUKVFormat.NL_X_NB_BS_HS),
-        int(GPUKVFormat.NL_X_NBBS_ONE_HS),
+        int(EngineKVFormat.NL_X_NB_BS_HS),
+        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
     )
-    is_flash_infer = int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_TWO_BS_NH_HS)
+    is_flash_infer = int(engine_kv_format) == int(EngineKVFormat.NL_X_NB_TWO_BS_NH_HS)
 
     num_layers = key_value.size(1)
     hidden_size = key_value.size(3)
@@ -683,7 +683,7 @@ def multi_layer_kv_transfer_unilateral(
     paged_memory_device: torch.device,
     page_buffer_size: int,
     direction: TransferDirection,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
 ):
     """
     Python fallback for multi_layer_kv_transfer_unilateral
@@ -707,8 +707,8 @@ def multi_layer_kv_transfer_unilateral(
         D2H = PagedBuffer -> LMCache
     """
     is_mla = int(engine_kv_format) in (
-        int(GPUKVFormat.NL_X_NB_BS_HS),
-        int(GPUKVFormat.NL_X_NBBS_ONE_HS),
+        int(EngineKVFormat.NL_X_NB_BS_HS),
+        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
     )
 
     # MLA case collapses back to multi_layer_kv_transfer
@@ -758,36 +758,36 @@ def multi_layer_kv_transfer_unilateral(
                 key_value[kv_idx, layer_id, valid_mask_kv, :] = gathered.to(kv_device)
 
 
-def _is_cross_layer_format(engine_kv_format: GPUKVFormat) -> bool:
+def _is_cross_layer_format(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when a KV format uses a single cross-layer tensor."""
     return int(engine_kv_format) in (
-        int(GPUKVFormat.NB_NL_TWO_BS_NH_HS),
-        int(GPUKVFormat.NB_NL_TWO_NH_BS_HS),
+        int(EngineKVFormat.NB_NL_TWO_BS_NH_HS),
+        int(EngineKVFormat.NB_NL_TWO_NH_BS_HS),
     )
 
 
-def _is_sglang_mha_format(engine_kv_format: GPUKVFormat) -> bool:
+def _is_sglang_mha_format(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when a KV format uses SGLang MHA layout (2*NL tensors)."""
     return int(engine_kv_format) in (
-        int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS),
-        int(GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS),
+        int(EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS),
+        int(EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS),
     )
 
 
-def _is_hnd_format(engine_kv_format: GPUKVFormat) -> bool:
+def _is_hnd_format(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when a per-layer KV format stores heads before block tokens (HND)."""
     return int(engine_kv_format) in (
-        int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS),
-        int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS),
-        int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS),
+        int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS),
+        int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS),
+        int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
     )
 
 
-def _is_mla_format(engine_kv_format: GPUKVFormat) -> bool:
+def _is_mla_format(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when a KV format uses MLA paged layout."""
     return int(engine_kv_format) in (
-        int(GPUKVFormat.NL_X_NB_BS_HS),
-        int(GPUKVFormat.NL_X_NBBS_ONE_HS),
+        int(EngineKVFormat.NL_X_NB_BS_HS),
+        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
     )
 
 
@@ -813,7 +813,7 @@ def _is_ptr_tensor(x: object) -> bool:
 
 
 def _per_layer_paged_shape(
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     nb: int,
     bs: int,
     nh: int,
@@ -833,21 +833,21 @@ def _per_layer_paged_shape(
         from a raw pointer via :func:`_tensor_from_ptr`.
     """
     fmt = int(engine_kv_format)
-    if fmt == int(GPUKVFormat.NL_X_NBBS_ONE_HS):
+    if fmt == int(EngineKVFormat.NL_X_NBBS_ONE_HS):
         return (nb * bs, 1, hs)
-    if fmt == int(GPUKVFormat.NL_X_NB_BS_HS):
+    if fmt == int(EngineKVFormat.NL_X_NB_BS_HS):
         return (nb, bs, hs)
-    if fmt == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+    if fmt == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
         return (2, nb, nh, bs, hs)
-    if fmt == int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS):
+    if fmt == int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS):
         return (nb, 2, nh, bs, hs)
-    if fmt == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+    if fmt == int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS):
         # vLLM CPU blocks-first fused KV: K and V interleaved at the
         # second-to-last dim so each layer is [NB, NH, BS, 2, HS].
         return (nb, nh, bs, 2, hs)
-    if fmt == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+    if fmt == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS):
         return (2, nb, bs, nh, hs)
-    if fmt == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+    if fmt == int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS):
         return (nb, nh, bs, 2, hs)
     # Covers NL_X_NB_TWO_BS_NH_HS and any future NHD variants.
     return (nb, 2, bs, nh, hs)
@@ -905,7 +905,7 @@ def _infer_kv_dtype(
 
 def _normalize_paged_layers(
     paged_buffer_ptrs_tensor: "torch.Tensor | list",
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     shape_desc: "PageBufferShapeDesc | None" = None,
     device: "torch.device | str | None" = None,
     dtype: "torch.dtype | None" = None,
@@ -936,7 +936,7 @@ def _normalize_paged_layers(
                 bs = int(shape_desc.bs)
                 nh = int(shape_desc.nh)
                 hs = int(shape_desc.hs)
-                if int(engine_kv_format) == int(GPUKVFormat.NB_NL_TWO_NH_BS_HS):
+                if int(engine_kv_format) == int(EngineKVFormat.NB_NL_TWO_NH_BS_HS):
                     shape: tuple[int, ...] = (nb, nl, 2, nh, bs, hs)
                 else:
                     shape = (nb, nl, 2, bs, nh, hs)
@@ -960,7 +960,7 @@ def _normalize_paged_layers(
             bs = int(shape_desc.bs)
             nh = int(shape_desc.nh)
             hs = int(shape_desc.hs)
-            is_flat = int(engine_kv_format) == int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS)
+            is_flat = int(engine_kv_format) == int(EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS)
             per_layer_shape: tuple[int, ...] = (
                 (nb * bs, nh, hs) if is_flat else (nb, bs, nh, hs)
             )
@@ -1035,7 +1035,7 @@ def _normalize_lmcache_objects(
     lmcache_objects_ptrs: "list[int] | list[torch.Tensor]",
     shape_desc: "PageBufferShapeDesc | None" = None,
     lmcache_chunk_size: "int | None" = None,
-    engine_kv_format: "GPUKVFormat | None" = None,
+    engine_kv_format: "EngineKVFormat | None" = None,
     dtype: "torch.dtype | None" = None,
 ) -> list[torch.Tensor]:
     """Normalize LMCache object inputs to chunk tensors.
@@ -1102,7 +1102,7 @@ def multi_layer_block_kv_transfer(
     direction: TransferDirection,
     shape_desc: PageBufferShapeDesc,
     lmcache_chunk_size: int,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     skip_prefix_n_blocks: int,
 ) -> None:
     """Python fallback implementation of block-based multi-layer KV transfer.
@@ -1284,13 +1284,13 @@ def _transfer_cross_layer(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
     """Handle cross-layer formats: single tensor [NB, NL, 2, ...]."""
     # NHD: [NB, NL, 2, BS, NH, HS]  HND: [NB, NL, 2, NH, BS, HS]
-    is_hnd = int(engine_kv_format) == int(GPUKVFormat.NB_NL_TWO_NH_BS_HS)
+    is_hnd = int(engine_kv_format) == int(EngineKVFormat.NB_NL_TWO_NH_BS_HS)
     num_layers = paged_tensor.shape[1]
 
     if is_hnd:
@@ -1366,14 +1366,14 @@ def _transfer_sglang_mha(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
     """Handle SGLang MHA formats: 2*NL tensors (list[list[Tensor]])."""
     # TWO_X_NL_X_NBBS_NH_HS: each tensor [NB*BS, NH, HS]
     # TWO_X_NL_X_NB_BS_NH_HS: each tensor [NB, BS, NH, HS]
-    is_flat = int(engine_kv_format) == int(GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS)
+    is_flat = int(engine_kv_format) == int(EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS)
     num_layers = len(paged_tensors[0])
 
     # Determine target device from first tensor
@@ -1446,7 +1446,7 @@ def _transfer_per_layer_mla(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
@@ -1454,7 +1454,7 @@ def _transfer_per_layer_mla(
     if not layer_tensors or not object_tensors:
         return
 
-    is_flat = int(engine_kv_format) == int(GPUKVFormat.NL_X_NBBS_ONE_HS)
+    is_flat = int(engine_kv_format) == int(EngineKVFormat.NL_X_NBBS_ONE_HS)
     target_device = layer_tensors[0].device
     if is_flat:
         token_offsets = torch.arange(block_size, dtype=torch.long, device=target_device)
@@ -1520,7 +1520,7 @@ def _transfer_per_layer_hnd(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
@@ -1532,9 +1532,9 @@ def _transfer_per_layer_hnd(
     block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
 
     first_layer = layer_tensors[0]
-    if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+    if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
         first_k = first_layer[0]
-    elif int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+    elif int(engine_kv_format) == int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS):
         first_k = first_layer[:, :, :, 0]
     else:
         first_k = first_layer[:, 0]
@@ -1573,7 +1573,7 @@ def _transfer_per_layer_hnd(
                 device=target_device,
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+                if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
                     k_t, v_t = layer[0], layer[1]
                     torch.index_select(k_t, 0, eff_idx, out=scratch)
                     chunk_gpu[0, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
@@ -1583,7 +1583,7 @@ def _transfer_per_layer_hnd(
                     chunk_gpu[1, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
                         scratch.permute(0, 2, 1, 3)
                     )
-                elif int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+                elif int(engine_kv_format) == int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS):
                     k_t, v_t = layer[:, :, :, 0], layer[:, :, :, 1]
                     torch.index_select(k_t, 0, eff_idx, out=scratch)
                     chunk_gpu[0, layer_idx].view(n_valid, block_size, nh0, hs0).copy_(
@@ -1611,9 +1611,9 @@ def _transfer_per_layer_hnd(
                 target_device, non_blocking=True
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_NH_BS_HS):
+                if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS):
                     k_t, v_t = layer[0], layer[1]
-                elif int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_NH_BS_TWO_HS):
+                elif int(engine_kv_format) == int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS):
                     k_t, v_t = layer[:, :, :, 0], layer[:, :, :, 1]
                 else:
                     k_t, v_t = layer[:, 0], layer[:, 1]
@@ -1628,7 +1628,7 @@ def _transfer_per_layer_hnd(
                     .reshape(n_valid, block_size, nh, hs)
                     .permute(0, 2, 1, 3)
                 )
-                if int(engine_kv_format) == int(GPUKVFormat.NL_X_NB_TWO_NH_BS_HS):
+                if int(engine_kv_format) == int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS):
                     layer.index_copy_(
                         0, eff_idx, torch.stack([k_blocks, v_blocks], dim=1)
                     )
@@ -1644,7 +1644,7 @@ def _transfer_per_layer_nhd(
     n_block_ids: int,
     blocks_per_object: int,
     block_size: int,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     is_d2h: bool,
     skip_prefix_n_blocks: int,
 ) -> None:
@@ -1656,7 +1656,7 @@ def _transfer_per_layer_nhd(
     block_ids_dev = torch.as_tensor(block_ids, dtype=torch.long, device=target_device)
 
     first_layer = layer_tensors[0]
-    if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+    if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS):
         first_k = first_layer[0]
     else:
         first_k = first_layer[:, 0]
@@ -1687,7 +1687,7 @@ def _transfer_per_layer_nhd(
                 device=target_device,
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+                if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS):
                     k_t, v_t = layer[0], layer[1]
                     torch.index_select(
                         k_t,
@@ -1719,7 +1719,7 @@ def _transfer_per_layer_nhd(
                 target_device, non_blocking=True
             )
             for layer_idx, layer in enumerate(layer_tensors):
-                if int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS):
+                if int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS):
                     k_t, v_t = layer[0], layer[1]
                     k_t.index_copy_(
                         0,
@@ -1748,7 +1748,7 @@ def single_layer_kv_transfer(
     vllm_key_value_cache: torch.Tensor,
     slot_mapping: torch.Tensor,
     direction: TransferDirection,
-    engine_kv_format: GPUKVFormat,
+    engine_kv_format: EngineKVFormat,
     token_major: bool = False,
 ):
     """
@@ -1787,8 +1787,8 @@ def single_layer_kv_transfer(
     valid_slots = slots_kv[valid_mask_kv].to(paged_memory_device)
 
     is_mla = int(engine_kv_format) in (
-        int(GPUKVFormat.NL_X_NB_BS_HS),
-        int(GPUKVFormat.NL_X_NBBS_ONE_HS),
+        int(EngineKVFormat.NL_X_NB_BS_HS),
+        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
     )
 
     if is_mla:
@@ -1813,7 +1813,7 @@ def single_layer_kv_transfer(
     else:
         # ── Non-MLA format ──
         # Determine vLLM layout and block_size
-        is_two_major = int(engine_kv_format) == int(GPUKVFormat.NL_X_TWO_NB_BS_NH_HS)
+        is_two_major = int(engine_kv_format) == int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS)
         # flash attn:
         #   [2, num_blocks, block_size, num_heads, head_size]
         #   -> dim2 = block_size

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -245,7 +245,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
         if idx in self.kv_cache_pointers_on_gpu:
             return self.kv_cache_pointers_on_gpu[idx]
 
-        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+        self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
             kv_caches, EngineType.VLLM, layout_hints=self.layout_hints
         )
 
@@ -254,10 +254,10 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             self.num_layers, dtype=torch.int64, device=self.device
         )
         self.kv_cache_pointers_on_gpu[idx].copy_(self.kv_cache_pointers)
-        self.num_blocks = get_num_blocks(kv_caches, self.gpu_kv_format)
-        self.block_size = get_block_size(kv_caches, self.gpu_kv_format)
+        self.num_blocks = get_num_blocks(kv_caches, self.engine_kv_format)
+        self.block_size = get_block_size(kv_caches, self.engine_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
-        self.head_size = get_head_size(kv_caches, self.gpu_kv_format)
+        self.head_size = get_head_size(kv_caches, self.engine_kv_format)
 
         return self.kv_cache_pointers_on_gpu[idx]
 
@@ -320,7 +320,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
             self.device,
             self.page_buffer_size,
             lmc_ops.TransferDirection.H2D,
-            self.gpu_kv_format,
+            self.engine_kv_format,
             block_size=self.block_size,
             head_size=self.head_size,
             skip_prefix_n_tokens=skip_prefix_n_tokens,
@@ -368,7 +368,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     self.kvcaches[0].device,
                     self.page_buffer_size,
                     lmc_ops.TransferDirection.D2H,
-                    self.gpu_kv_format,
+                    self.engine_kv_format,
                     block_size=self.block_size,
                     head_size=self.head_size,
                 )
@@ -383,7 +383,7 @@ class VLLMPagedMemGPUConnectorV2(GPUConnectorInterface):
                     self.kvcaches[0].device,
                     self.page_buffer_size,
                     lmc_ops.TransferDirection.D2H,
-                    self.gpu_kv_format,
+                    self.engine_kv_format,
                     block_size=self.block_size,
                     head_size=self.head_size,
                 )
@@ -461,18 +461,18 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.init:
             return
 
-        self.gpu_kv_format, self.kvcaches = normalize_kv_and_discover_format(
+        self.engine_kv_format, self.kvcaches = normalize_kv_and_discover_format(
             self.kvcaches, EngineType.VLLM, layout_hints=self.layout_hints
         )
-        self.num_blocks = get_num_blocks(self.kvcaches, self.gpu_kv_format)
-        self.block_size = get_block_size(self.kvcaches, self.gpu_kv_format)
+        self.num_blocks = get_num_blocks(self.kvcaches, self.engine_kv_format)
+        self.block_size = get_block_size(self.kvcaches, self.engine_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
-        self.head_size = get_head_size(self.kvcaches, self.gpu_kv_format)
+        self.head_size = get_head_size(self.kvcaches, self.engine_kv_format)
 
         if self.metadata.kv_layer_groups_manager is None:
             self.metadata.kv_layer_groups_manager = KVLayerGroupsManager(
                 self.kvcaches,
-                gpu_kv_format=self.gpu_kv_format,
+                engine_kv_format=self.engine_kv_format,
                 num_blocks=self.num_blocks,
             )
         klg_manager = self.metadata.kv_layer_groups_manager
@@ -514,7 +514,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         self.group_kv_cache_pointers_on_gpu = []
         for group in klg_manager.kv_layer_groups:
             ptrs = get_group_data_ptrs(
-                self.kvcaches, self.gpu_kv_format, group.layer_indices
+                self.kvcaches, self.engine_kv_format, group.layer_indices
             )
             cpu = torch.empty(len(ptrs), dtype=torch.int64, device="cpu")
             cpu.numpy()[:] = ptrs
@@ -557,7 +557,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                 self.device,
                 self.page_buffer_size,
                 lmc_ops.TransferDirection.H2D,
-                self.gpu_kv_format,
+                self.engine_kv_format,
                 block_size=self.block_size,
                 head_size=self.head_size,
                 skip_prefix_n_tokens=skip_prefix_n_tokens,
@@ -588,7 +588,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                         self.device,
                         self.page_buffer_size,
                         lmc_ops.TransferDirection.D2H,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         block_size=self.block_size,
                         head_size=self.head_size,
                     )
@@ -606,7 +606,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
                         self.device,
                         self.page_buffer_size,
                         lmc_ops.TransferDirection.D2H,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         block_size=self.block_size,
                         head_size=self.head_size,
                     )
@@ -731,14 +731,16 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
             # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
             # in layerwise mode.
 
-            self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
                 kv_caches, EngineType.VLLM, layout_hints=self.layout_hints
             )
             self.kvcaches = kv_caches
-            assert_is_vllm_flash_attn_or_flash_infer(self.gpu_kv_format)
-            self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
+            assert_is_vllm_flash_attn_or_flash_infer(self.engine_kv_format)
+            self.tokens_per_layer = get_tokens_per_layer(
+                kv_caches, self.engine_kv_format
+            )
             self.elements_per_layer = get_elements_per_layer(
-                kv_caches, self.gpu_kv_format
+                kv_caches, self.engine_kv_format
             )
             logger.info(
                 f"Lazily initializing GPU buffer (max tokens={self.tokens_per_layer})."
@@ -857,7 +859,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     self.kvcaches[layer_id - 2],
                     slot_mapping_full,
                     lmc_ops.TransferDirection.H2D,
-                    self.gpu_kv_format,
+                    self.engine_kv_format,
                     token_major=False,  # shape is [2, num_tokens, hidden_dim]
                 )
                 del self.buffer_mapping[layer_id - 2]
@@ -1017,7 +1019,7 @@ class VLLMBufferLayerwiseGPUConnector(GPUConnectorInterface):
                     self.kvcaches[layer_id],
                     slot_mapping_full,
                     lmc_ops.TransferDirection.D2H,
-                    self.gpu_kv_format,
+                    self.engine_kv_format,
                     token_major=False,  # shape is [2, num_tokens, hidden_dim]
                 )
                 for (buf_start, buf_end), memory_obj, old_positions in zip(
@@ -1144,14 +1146,16 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
             # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
             # in layerwise mode.
 
-            self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
                 kv_caches, EngineType.VLLM, layout_hints=self.layout_hints
             )
             self.kvcaches = kv_caches
-            assert_is_vllm_mla_or_flash_attn_or_flash_infer(self.gpu_kv_format)
-            self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
+            assert_is_vllm_mla_or_flash_attn_or_flash_infer(self.engine_kv_format)
+            self.tokens_per_layer = get_tokens_per_layer(
+                kv_caches, self.engine_kv_format
+            )
             self.elements_per_layer = get_elements_per_layer(
-                kv_caches, self.gpu_kv_format
+                kv_caches, self.engine_kv_format
             )
             logger.info(
                 f"Lazily initializing GPU buffer (max tokens={self.tokens_per_layer})."
@@ -1267,7 +1271,7 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                             self.kvcaches[layer_id],
                             slot_mapping_full,
                             lmc_ops.TransferDirection.H2D,
-                            self.gpu_kv_format,
+                            self.engine_kv_format,
                             token_major=True,
                         )
 
@@ -1277,7 +1281,7 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                         self.kvcaches[layer_id],
                         slot_mapping_full,
                         lmc_ops.TransferDirection.H2D,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         token_major=True,
                     )
         yield
@@ -1377,7 +1381,7 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                         self.kvcaches[layer_id],
                         slot_mapping_full,
                         lmc_ops.TransferDirection.D2H,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         token_major=True,
                     )
                 for start, end, memory_obj in zip(
@@ -1395,7 +1399,7 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
                             lmc_ops.TransferDirection.D2H,
-                            self.gpu_kv_format,
+                            self.engine_kv_format,
                             token_major=True,
                         )
                     # Set metadata format
@@ -1468,13 +1472,13 @@ class SGLangGPUConnector(GPUConnectorInterface):
             logger.info(f"GPU buffer: {self.gpu_buffer.shape}")
 
     def _initialize_pointers(self, kv_caches: DiscoverableKVCache) -> torch.Tensor:
-        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+        self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
             kv_caches, EngineType.SGLANG
         )
-        num_layers = get_num_layers(kv_caches, self.gpu_kv_format)
+        num_layers = get_num_layers(kv_caches, self.engine_kv_format)
         # SGLang registers every layer as one group; pass all indices in order.
         ptrs = get_group_data_ptrs(
-            kv_caches, self.gpu_kv_format, list(range(num_layers))
+            kv_caches, self.engine_kv_format, list(range(num_layers))
         )
         assert len(ptrs) == self.num_kv_cache, (
             f"Expected {self.num_kv_cache} KV cache pointers, got {len(ptrs)}"
@@ -1490,7 +1494,7 @@ class SGLangGPUConnector(GPUConnectorInterface):
             )
         self.kv_cache_pointers_on_gpu[idx].copy_(self.kv_cache_pointers)
 
-        self.page_buffer_size = get_page_buffer_size(kv_caches, self.gpu_kv_format)
+        self.page_buffer_size = get_page_buffer_size(kv_caches, self.engine_kv_format)
         return self.kv_cache_pointers_on_gpu[idx]
 
     @_lmcache_nvtx_annotate
@@ -1545,7 +1549,7 @@ class SGLangGPUConnector(GPUConnectorInterface):
             get_device(kvcaches),
             self.page_buffer_size,
             lmc_ops.TransferDirection.H2D,
-            self.gpu_kv_format,
+            self.engine_kv_format,
         )
 
     @_lmcache_nvtx_annotate
@@ -1588,7 +1592,7 @@ class SGLangGPUConnector(GPUConnectorInterface):
                 get_device(kvcaches),
                 self.page_buffer_size,
                 lmc_ops.TransferDirection.D2H,
-                self.gpu_kv_format,
+                self.engine_kv_format,
             )
         else:
             # kvcaches -> gpu_buffer -> memobj
@@ -1601,7 +1605,7 @@ class SGLangGPUConnector(GPUConnectorInterface):
                 get_device(kvcaches),
                 self.page_buffer_size,
                 lmc_ops.TransferDirection.D2H,
-                self.gpu_kv_format,
+                self.engine_kv_format,
             )
             memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
@@ -1677,12 +1681,14 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
         Also, the first request might be a bit slower due to buffer creation.
         """
         if self.use_gpu and self.gpu_buffer_allocator is None:
-            self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
                 kv_caches, EngineType.SGLANG
             )
-            self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
+            self.tokens_per_layer = get_tokens_per_layer(
+                kv_caches, self.engine_kv_format
+            )
             self.elements_per_layer = get_elements_per_layer(
-                kv_caches, self.gpu_kv_format
+                kv_caches, self.engine_kv_format
             )
             logger.info(
                 f"Lazily initializing GPU buffer (max tokens={self.tokens_per_layer})."

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -1980,7 +1980,7 @@ class TRTLLMGPUConnector(GPUConnectorInterface):
         self.kv_cache_tensor: Optional[torch.Tensor] = None
         self.paged_buffer_ptrs: Optional[torch.Tensor] = None
         self.shape_desc: Optional["lmc_ops.PageBufferShapeDesc"] = None
-        self._kv_format: Optional["lmc_ops.GPUKVFormat"] = None
+        self._kv_format: Optional["lmc_ops.EngineKVFormat"] = None
         self.tokens_per_block: Optional[int] = None
         self.blocks_per_chunk: Optional[int] = None
 

--- a/lmcache/v1/gpu_connector/hpu_connector.py
+++ b/lmcache/v1/gpu_connector/hpu_connector.py
@@ -303,19 +303,19 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
                 fake_shape,
             )
 
-        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+        self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
             kv_caches, EngineType.VLLM
         )
-        self.num_layers = get_num_layers(kv_caches, self.gpu_kv_format)
-        self.num_blocks = get_num_blocks(kv_caches, self.gpu_kv_format)
-        self.block_size = get_block_size(kv_caches, self.gpu_kv_format)
-        self.page_buffer_size = get_page_buffer_size(kv_caches, self.gpu_kv_format)
-        self.hidden_dim_size = get_hidden_dim_size(kv_caches, self.gpu_kv_format)
-        self.head_size = get_head_size(kv_caches, self.gpu_kv_format)
-        self.use_mla = is_mla(self.gpu_kv_format)
-        self.dtype = get_dtype(kv_caches, self.gpu_kv_format)
+        self.num_layers = get_num_layers(kv_caches, self.engine_kv_format)
+        self.num_blocks = get_num_blocks(kv_caches, self.engine_kv_format)
+        self.block_size = get_block_size(kv_caches, self.engine_kv_format)
+        self.page_buffer_size = get_page_buffer_size(kv_caches, self.engine_kv_format)
+        self.hidden_dim_size = get_hidden_dim_size(kv_caches, self.engine_kv_format)
+        self.head_size = get_head_size(kv_caches, self.engine_kv_format)
+        self.use_mla = is_mla(self.engine_kv_format)
+        self.dtype = get_dtype(kv_caches, self.engine_kv_format)
         self.num_heads = (
-            1 if self.use_mla else get_num_heads(kv_caches, self.gpu_kv_format)
+            1 if self.use_mla else get_num_heads(kv_caches, self.engine_kv_format)
         )
 
         self._attributes_initialized = True
@@ -324,7 +324,7 @@ class VLLMPagedMemHPUConnectorV2(GPUConnectorInterface):
             "num_layers: %d, num_blocks: %d, block_size: %d, "
             "page_buffer_size: %d, hidden_dim_size: %d, head_size: %d, "
             "use_mla: %s, dtype: %s, num_heads: %d",
-            self.gpu_kv_format,
+            self.engine_kv_format,
             self.num_layers,
             self.num_blocks,
             self.block_size,

--- a/lmcache/v1/gpu_connector/musa_connectors.py
+++ b/lmcache/v1/gpu_connector/musa_connectors.py
@@ -298,19 +298,19 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
         self.device = kv_caches[0].device
         assert self.device.type == "musa", "The device should be MUSA."
 
-        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+        self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
             kv_caches, EngineType.VLLM
         )
-        self.num_layers = get_num_layers(kv_caches, self.gpu_kv_format)
-        self.num_blocks = get_num_blocks(kv_caches, self.gpu_kv_format)
-        self.block_size = get_block_size(kv_caches, self.gpu_kv_format)
-        self.page_buffer_size = get_page_buffer_size(kv_caches, self.gpu_kv_format)
-        self.hidden_dim_size = get_hidden_dim_size(kv_caches, self.gpu_kv_format)
-        self.head_size = get_head_size(kv_caches, self.gpu_kv_format)
-        self.use_mla = is_mla(self.gpu_kv_format)
-        self.dtype = get_dtype(kv_caches, self.gpu_kv_format)
+        self.num_layers = get_num_layers(kv_caches, self.engine_kv_format)
+        self.num_blocks = get_num_blocks(kv_caches, self.engine_kv_format)
+        self.block_size = get_block_size(kv_caches, self.engine_kv_format)
+        self.page_buffer_size = get_page_buffer_size(kv_caches, self.engine_kv_format)
+        self.hidden_dim_size = get_hidden_dim_size(kv_caches, self.engine_kv_format)
+        self.head_size = get_head_size(kv_caches, self.engine_kv_format)
+        self.use_mla = is_mla(self.engine_kv_format)
+        self.dtype = get_dtype(kv_caches, self.engine_kv_format)
         self.num_heads = (
-            1 if self.use_mla else get_num_heads(kv_caches, self.gpu_kv_format)
+            1 if self.use_mla else get_num_heads(kv_caches, self.engine_kv_format)
         )
 
         self._attributes_initialized = True
@@ -319,7 +319,7 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
             "num_layers: %d, num_blocks: %d, block_size: %d, "
             "page_buffer_size: %d, hidden_dim_size: %d, head_size: %d, "
             "use_mla: %s, dtype: %s, num_heads: %d",
-            self.gpu_kv_format,
+            self.engine_kv_format,
             self.num_layers,
             self.num_blocks,
             self.block_size,
@@ -333,7 +333,7 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
 
     def _validate_supported_kv_format(self) -> None:
         """Reject KV layouts that this torch-based MUSA path cannot index."""
-        if self.gpu_kv_format in _SUPPORTED_MUSA_KV_FORMATS:
+        if self.engine_kv_format in _SUPPORTED_MUSA_KV_FORMATS:
             return
 
         supported = (
@@ -342,5 +342,5 @@ class VLLMPagedMemMUSAConnectorV2(VLLMPagedMemGPUConnectorV2):
         )
         raise ValueError(
             "VLLMPagedMemMUSAConnectorV2 supports only "
-            f"{supported}; got {self.gpu_kv_format}."
+            f"{supported}; got {self.engine_kv_format}."
         )

--- a/lmcache/v1/gpu_connector/musa_connectors.py
+++ b/lmcache/v1/gpu_connector/musa_connectors.py
@@ -30,8 +30,8 @@ logger = init_logger(__name__)
 
 
 _SUPPORTED_MUSA_KV_FORMATS = (
-    lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-    lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+    lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+    lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
 )
 
 

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -52,7 +52,7 @@ DiscoverableKVCache = Union[torch.Tensor, list["DiscoverableKVCache"]]
 _ATTRIBUTE_NOT_EXIST_ERROR = (
     "trying to access an attribute of the GPU KV Cache "
     "that does not exist for the format detected {format}. "
-    "A misalignment with the GPUKVFormat must be resolved"
+    "A misalignment with the EngineKVFormat must be resolved"
 )
 
 
@@ -242,7 +242,7 @@ def assert_contiguous(tensor: torch.Tensor) -> None:
         raise ValueError("tensor is not contiguous")
 
 
-def is_cross_layer_format(engine_kv_format: "lmc_ops.GPUKVFormat") -> bool:
+def is_cross_layer_format(engine_kv_format: "lmc_ops.EngineKVFormat") -> bool:
     """Return ``True`` if *engine_kv_format* stores all layers in one tensor.
 
     Cross-layer formats — ``NB_NL_TWO_BS_NH_HS`` (vLLM, NHD) and
@@ -251,8 +251,8 @@ def is_cross_layer_format(engine_kv_format: "lmc_ops.GPUKVFormat") -> bool:
     layer index.
     """
     return engine_kv_format in (
-        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS,
     )
 
 
@@ -287,51 +287,51 @@ def assert_layerwise_gpu_connector(gpu_connector: "GPUConnectorInterface"):
     assert isinstance(gpu_connector, valid_connectors)
 
 
-def get_engine_kv_shape_description(engine_kv_format: "lmc_ops.GPUKVFormat") -> str:
+def get_engine_kv_shape_description(engine_kv_format: "lmc_ops.EngineKVFormat") -> str:
     """Return a human-readable shape description for the GPU KV format.
 
-    Uses short names matching the ``GPUKVFormat`` enum convention:
+    Uses short names matching the ``EngineKVFormat`` enum convention:
     NB=num_blocks, NL=num_layers, BS=block_size, NH=num_heads,
     HS=head_size, PBS=page_buffer_size (NB*BS).
     """
-    _SHAPE_DESCRIPTIONS: dict["lmc_ops.GPUKVFormat", str] = {
-        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS: "[NB, NL, 2, BS, NH, HS]",
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS: "NL x [2, NB, BS, NH, HS]",
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS: "NL x [NB, 2, BS, NH, HS]",
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS: "NL x [NB, BS, HS]",
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS: "2 x NL x [PBS, NH, HS]",
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS: ("2 x NL x [NB, BS, NH, HS]"),
-        lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS: "NL x [PBS, 1, HS]",
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS: "NL x [2, NB, NH, BS, HS]",
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS: "NL x [NB, 2, NH, BS, HS]",
-        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "[NB, NL, 2, NH, BS, HS]",
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS: "NL x [NB, NH, BS, 2, HS]",
+    _SHAPE_DESCRIPTIONS: dict["lmc_ops.EngineKVFormat", str] = {
+        lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS: "[NB, NL, 2, BS, NH, HS]",
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS: "NL x [2, NB, BS, NH, HS]",
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS: "NL x [NB, 2, BS, NH, HS]",
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS: "NL x [NB, BS, HS]",
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS: "2 x NL x [PBS, NH, HS]",
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS: ("2 x NL x [NB, BS, NH, HS]"),
+        lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS: "NL x [PBS, 1, HS]",
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS: "NL x [2, NB, NH, BS, HS]",
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS: "NL x [NB, 2, NH, BS, HS]",
+        lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS: "[NB, NL, 2, NH, BS, HS]",
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS: "NL x [NB, NH, BS, 2, HS]",
     }
     return _SHAPE_DESCRIPTIONS.get(engine_kv_format, f"Unknown ({engine_kv_format})")
 
 
-def get_attention_backend(engine_kv_format: "lmc_ops.GPUKVFormat") -> str:
+def get_attention_backend(engine_kv_format: "lmc_ops.EngineKVFormat") -> str:
     """Return the attention backend name for the GPU KV format."""
-    _ATTENTION_BACKENDS: dict["lmc_ops.GPUKVFormat", str] = {
-        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS: "vLLM CROSS_LAYER",
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS: "vLLM non-MLA flash attention",
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS: "vLLM non-MLA flash infer",
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS: "vLLM MLA",
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS: (
+    _ATTENTION_BACKENDS: dict["lmc_ops.EngineKVFormat", str] = {
+        lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS: "vLLM CROSS_LAYER",
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS: "vLLM non-MLA flash attention",
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS: "vLLM non-MLA flash infer",
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS: "vLLM MLA",
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS: (
             "SGLang MHA (flash attention and flash infer)"
         ),
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS: (
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS: (
             "SGLang MHA via MP daemon (4-D inner)"
         ),
-        lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS: "SGLang MLA",
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS: (
+        lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS: "SGLang MLA",
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS: (
             "vLLM non-MLA flash attention (HND layout)"
         ),
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS: (
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS: (
             "vLLM non-MLA flash infer (HND layout)"
         ),
-        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "TRT-LLM cross-layer (HND layout)",
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS: (
+        lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS: "TRT-LLM cross-layer (HND layout)",
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS: (
             "vLLM non-MLA blocks-first, fused K/V"
         ),
     }
@@ -350,7 +350,7 @@ def get_concrete_engine_kv_shape(
     hs = get_head_size(kv_caches, engine_kv_format)
 
     fmt = engine_kv_format
-    F = lmc_ops.GPUKVFormat
+    F = lmc_ops.EngineKVFormat
 
     if fmt == F.NB_NL_TWO_BS_NH_HS:
         nb = get_num_blocks(kv_caches, fmt)
@@ -452,7 +452,7 @@ def get_concrete_engine_kv_shape_from_shape_desc(
     pbs = nb * bs
 
     fmt = engine_kv_format
-    F = lmc_ops.GPUKVFormat
+    F = lmc_ops.EngineKVFormat
 
     if fmt == F.NB_NL_TWO_BS_NH_HS:
         return f"[{nb}, {nl}, 2, {bs}, {nh}, {hs}]"
@@ -533,7 +533,7 @@ def normalize_kv_and_discover_format(
     kv_caches: DiscoverableKVCache,
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None" = None,
-) -> tuple["lmc_ops.GPUKVFormat", DiscoverableKVCache]:
+) -> tuple["lmc_ops.EngineKVFormat", DiscoverableKVCache]:
     """
     Normalize ``kv_caches`` into the canonical form and discover its GPU KV format.
 
@@ -559,7 +559,7 @@ def normalize_kv_and_discover_format(
         returned tensor structure for subsequent operations — it shares
         storage with the input but may be a permuted view.
 
-    Please see csrc/mem_kernels.cuh for the naming schema of the GPUKVFormat.
+    Please see csrc/mem_kernels.cuh for the naming schema of the EngineKVFormat.
     """
     kv_caches = attempt_permute_to_contiguous_view(kv_caches)
 
@@ -653,7 +653,7 @@ def normalize_kv_and_discover_format(
 
     if serving_engine == EngineType.TRTLLM:
         if list_depth == 0 and tensor_dim == 6:
-            detected_format = lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+            detected_format = lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS
     elif serving_engine == EngineType.VLLM:
         kv_layout = layout_hints.get("kv_layout")
         # NOTE: vLLM's CPU attention backend stores KV cache in HND layout.
@@ -672,21 +672,21 @@ def normalize_kv_and_discover_format(
         is_hnd = kv_layout == "HND"
         if list_depth == 0:
             # vllm cross layer
-            detected_format = lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS
+            detected_format = lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS
         elif list_depth == 1:
             if tensor_dim == 5:
                 if probe.shape[0] == 2:
                     # vllm non-MLA flash attention
                     if is_hnd:
-                        detected_format = lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS
+                        detected_format = lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
                     else:
-                        detected_format = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+                        detected_format = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
                 elif probe.shape[1] == 2:
                     # vllm non-MLA flash infer
                     if is_hnd:
-                        detected_format = lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS
+                        detected_format = lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS
                     else:
-                        detected_format = lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS
+                        detected_format = lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS
             elif tensor_dim == 4:
                 # vLLM non-MLA blocks-first attention: K/V fused into the
                 # trailing dim -> [NB, NH, BS, 2*head_size].
@@ -702,23 +702,23 @@ def normalize_kv_and_discover_format(
                     layer.reshape(*layer.shape[:3], 2, last_dim // 2)
                     for layer in kv_caches
                 ]
-                detected_format = lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS
+                detected_format = lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS
             elif tensor_dim == 3:
                 # vllm MLA
-                detected_format = lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
+                detected_format = lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
     elif serving_engine == EngineType.SGLANG:
         if list_depth == 1:
             if probe.shape[1] == 1:
                 # sglang MLA
-                detected_format = lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS
+                detected_format = lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS
         elif list_depth == 2:
             # sglang MHA (flash attention and flash infer)
             if tensor_dim == 4:
                 # MP path: reshaped per-layer tensor exposes block_size as
                 # ``shape[1]``; ``num_blocks`` as ``shape[0]``.
-                detected_format = lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS
+                detected_format = lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS
             else:
-                detected_format = lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
+                detected_format = lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS
 
     if detected_format is not None:
         legible_print_engine_kv_format(detected_format)
@@ -731,70 +731,70 @@ def normalize_kv_and_discover_format(
 
 
 def get_num_layers(
-    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.EngineKVFormat"
 ) -> int:
     """
     Get the number of layers from the kv_caches
     """
     if engine_kv_format in (
-        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.shape[1]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         return len(kv_caches)
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
     ):
         return len(kv_caches[0])
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         return len(kv_caches)
     else:
         raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_num_blocks(
-    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.EngineKVFormat"
 ) -> int:
     """
     Get the number of blocks from the kv_caches
     """
     if engine_kv_format in (
-        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.shape[0]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
     ):
         # [2, num_blocks, ...] — shape[1] is num_blocks
         return kv_caches[0].shape[1]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         # [num_blocks, ...] — shape[0] is num_blocks
         return kv_caches[0].shape[0]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS:
         return kv_caches[0].shape[0]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # SGLang MHA 3-D inner: ``(page_buffer_size, num_heads, head_size)``
         # folds num_blocks into shape[0]; not separable here.
         raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=engine_kv_format))
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # SGLang MHA 4-D inner (MP path): num_blocks at shape[0].
         return kv_caches[0][0].shape[0]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=engine_kv_format))
     else:
         raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
@@ -802,7 +802,7 @@ def get_num_blocks(
 
 def get_block_size(
     kv_caches: DiscoverableKVCache,
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     layer_idx: int = 0,
 ) -> int:
     """Return the block size (tokens per block) for layer ``layer_idx``.
@@ -813,79 +813,79 @@ def get_block_size(
     is ignored. Raises ``ValueError`` for NBBS-fused formats, which
     have no separate BS dim.
     """
-    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[3]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — block_size at shape[4]
         return kv_caches.shape[4]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         # block_size at shape[2]: NHD [..., BS, NH, HS] and the CPU fused
         # layout [NB, NH, BS, 2, HS] both carry block_size at shape[2].
         return kv_caches[layer_idx].shape[2]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # HND: [..., NH, BS, HS] — block_size at shape[3]
         return kv_caches[layer_idx].shape[3]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS:
         return kv_caches[layer_idx].shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # SGLang MHA 3-D inner: block_size folded into shape[0]; not separable.
         raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=engine_kv_format))
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # SGLang MHA 4-D inner (MP path): block_size at shape[1].
         return kv_caches[0][0].shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=engine_kv_format))
     else:
         raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_page_buffer_size(
-    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.EngineKVFormat"
 ) -> int:
     """
     Get page buffer size (num_blocks * block_size) from the kv_caches
     """
-    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS:
         # [num_blocks, num_layers, 2, block_size, num_heads, head_size]
         return kv_caches.shape[0] * kv_caches.shape[3]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS:
         # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
         return kv_caches.shape[0] * kv_caches.shape[4]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS:
         # list[num_layers] of [2, num_blocks, block_size, num_heads, head_size]
         return kv_caches[0].shape[1] * kv_caches[0].shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS:
         # list[num_layers] of [2, num_blocks, num_heads, block_size, head_size]
         # num_blocks=shape[1], block_size=shape[3]
         return kv_caches[0].shape[1] * kv_caches[0].shape[3]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS:
         # list[num_layers] of [num_blocks, 2, block_size, num_heads, head_size]
         return kv_caches[0].shape[0] * kv_caches[0].shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS:
         # list[num_layers] of [num_blocks, 2, num_heads, block_size, head_size]
         # num_blocks=shape[0], block_size=shape[3]
         return kv_caches[0].shape[0] * kv_caches[0].shape[3]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # list[num_layers] of [num_blocks, num_heads, block_size, 2, head_size]
         # num_blocks=shape[0], block_size=shape[2]
         return kv_caches[0].shape[0] * kv_caches[0].shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size]
         return kv_caches[0].shape[0] * kv_caches[0].shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # list[2] -> list[num_layers] of [page_buffer_size, num_heads, head_size]
         return kv_caches[0][0].shape[0]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # list[2] -> list[num_layers] of [num_blocks, block_size, num_heads, head_size]
         return kv_caches[0][0].shape[0] * kv_caches[0][0].shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         # list[num_layers] of [page_buffer_size, 1, head_size]
         return kv_caches[0].shape[0]
     else:
@@ -894,42 +894,42 @@ def get_page_buffer_size(
 
 def get_num_heads(
     kv_caches: DiscoverableKVCache,
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     layer_idx: int = 0,
 ) -> int:
     """
     Get the number of heads for a layer (defaults to layer 0).
     """
-    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[4]  # global for cross-layer
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — num_heads at shape[3]
         return kv_caches.shape[3]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
     ):
         # NHD: [..., BS, NH, HS] — num_heads at shape[3]
         return kv_caches[layer_idx].shape[3]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # HND: [..., NH, BS, HS] — num_heads at shape[2]
         return kv_caches[layer_idx].shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # CPU fused: [NB, NH, BS, 2, HS] — num_heads at shape[1]
         return kv_caches[layer_idx].shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS:
         # MLA: heads are absorbed into hidden dim, so num_heads = 1
         return 1
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # 3-D inner: (PBS, NH, HS) — NH at shape[1].
         return kv_caches[0][layer_idx].shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # 4-D inner: (NB, BS, NH, HS) — NH at shape[2].
         return kv_caches[0][layer_idx].shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         return kv_caches[layer_idx].shape[1]
     else:
         raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
@@ -937,43 +937,43 @@ def get_num_heads(
 
 def get_hidden_dim_size(
     kv_caches: DiscoverableKVCache,
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     layer_idx: int = 0,
 ) -> int:
     """
     Get the hidden dimension for a layer (defaults to layer 0).
     """
-    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[4] * kv_caches.shape[5]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — hidden = NH * HS
         return kv_caches.shape[3] * kv_caches.shape[5]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
     ):
         # NHD: [..., NH, HS] — hidden_dim = shape[3] * shape[4]
         return kv_caches[layer_idx].shape[3] * kv_caches[layer_idx].shape[4]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # HND: [..., NH, BS, HS] — hidden_dim = NH * HS = shape[2] * shape[4]
         return kv_caches[layer_idx].shape[2] * kv_caches[layer_idx].shape[4]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # CPU fused: [NB, NH, BS, 2, HS] — hidden_dim = NH * HS = shape[1] * shape[4]
         return kv_caches[layer_idx].shape[1] * kv_caches[layer_idx].shape[4]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS:
         return kv_caches[layer_idx].shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # 3-D inner: (PBS, NH, HS) — hidden = shape[1] * shape[2].
         inner = kv_caches[0][layer_idx]
         return inner.shape[1] * inner.shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # 4-D inner: (NB, BS, NH, HS) — hidden = shape[2] * shape[3].
         inner = kv_caches[0][layer_idx]
         return inner.shape[2] * inner.shape[3]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         return kv_caches[layer_idx].shape[2]
     else:
         raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
@@ -981,85 +981,85 @@ def get_hidden_dim_size(
 
 def get_head_size(
     kv_caches: DiscoverableKVCache,
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     layer_idx: int = 0,
 ) -> int:
     """
     Get the head size for a layer (defaults to layer 0).
     """
     if engine_kv_format in (
-        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.shape[5]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         # All these per-layer non-MLA layouts carry head_size as the last dim
         return kv_caches[layer_idx].shape[4]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS:
         return kv_caches[layer_idx].shape[2]
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
     ):
         # HS is the last dim in both 3-D and 4-D inner forms.
         return kv_caches[0][layer_idx].shape[-1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         return kv_caches[layer_idx].shape[2]
     else:
         raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_tokens_per_layer(
-    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.EngineKVFormat"
 ) -> int:
     """
     Get the number of tokens per layer from the kv_caches
     (num_blocks * block_size or page_buffer_size)
     """
-    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS:
         # [num_blocks, num_layers, 2, block_size, num_heads, head_size]
         return kv_caches.shape[0] * kv_caches.shape[3]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS:
         # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
         return kv_caches.shape[0] * kv_caches.shape[4]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS:
         # list[num_layers] of [2, num_blocks, block_size, num_heads, head_size]
         k_cache_shape = kv_caches[0][0].shape
         return k_cache_shape[0] * k_cache_shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS:
         # list[num_layers] of [2, num_blocks, num_heads, block_size, head_size]
         # k_cache = kv_caches[0][0] → (NB, NH, BS, HS); tokens = NB * BS
         k_cache_shape = kv_caches[0][0].shape
         return k_cache_shape[0] * k_cache_shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS:
         # list[num_layers] of [num_blocks, 2, block_size, num_heads, head_size]
         k_cache_shape = kv_caches[0][:, 0].shape
         return k_cache_shape[0] * k_cache_shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS:
         # list[num_layers] of [num_blocks, 2, num_heads, block_size, head_size]
         # k_cache = kv_caches[0][:, 0] → (NB, NH, BS, HS); tokens = NB * BS
         k_cache_shape = kv_caches[0][:, 0].shape
         return k_cache_shape[0] * k_cache_shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # list[num_layers] of [num_blocks, num_heads, block_size, 2, head_size]
         # tokens = NB * BS = shape[0] * shape[2]
         return kv_caches[0].shape[0] * kv_caches[0].shape[2]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size]
         return kv_caches[0].shape[0] * kv_caches[0].shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # list[2] -> list[num_layers] of [page_buffer_size, num_heads, head_size]
         return kv_caches[0][0].shape[0]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # list[2] -> list[num_layers] of [num_blocks, block_size, num_heads, head_size]
         return kv_caches[0][0].shape[0] * kv_caches[0][0].shape[1]
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         # list[num_layers] of [page_buffer_size, 1, head_size]
         return kv_caches[0].shape[0]
     else:
@@ -1067,13 +1067,13 @@ def get_tokens_per_layer(
 
 
 def get_elements_per_layer(
-    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.EngineKVFormat"
 ) -> int:
     """
     Get the number of elements per layer from the kv_caches
     (including both K and V for non-MLA)
     """
-    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS:
         # [num_blocks, num_layers, 2, block_size, num_heads, head_size]
         # For one layer: [num_blocks, 2, block_size, num_heads, head_size]
         num_blocks = kv_caches.shape[0]
@@ -1081,7 +1081,7 @@ def get_elements_per_layer(
         num_heads = kv_caches.shape[4]
         head_size = kv_caches.shape[5]
         return num_blocks * 2 * block_size * num_heads * head_size
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS:
         # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
         num_blocks = kv_caches.shape[0]
         num_heads = kv_caches.shape[3]
@@ -1089,68 +1089,70 @@ def get_elements_per_layer(
         head_size = kv_caches.shape[5]
         return num_blocks * 2 * num_heads * block_size * head_size
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
     ):
         # [2, num_blocks, ...] — k_cache is kv_caches[0][0]
         k_cache_shape = kv_caches[0][0].shape
         return k_cache_shape.numel() * 2
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # [num_blocks, 2, ...] — k_cache is kv_caches[0][:, 0]
         k_cache_shape = kv_caches[0][:, 0].shape
         return k_cache_shape.numel() * 2
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # [NB, NH, BS, 2, HS] — K/V at dim 3; k_cache is kv_caches[0][:, :, :, 0]
         k_cache_shape = kv_caches[0][:, :, :, 0].shape
         return k_cache_shape.numel() * 2
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size] (MLA)
         return kv_caches[0].numel()
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
     ):
         # list[2] -> list[num_layers] of K/V tensors; both ranks have the
         # same total element count, just laid out differently.
         return kv_caches[0][0].numel() * 2
-    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS:
         # list[num_layers] of [page_buffer_size, 1, head_size] (MLA)
         return kv_caches[0].numel()
     else:
         raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
-def assert_is_vllm_flash_attn_or_flash_infer(engine_kv_format: "lmc_ops.GPUKVFormat"):
+def assert_is_vllm_flash_attn_or_flash_infer(
+    engine_kv_format: "lmc_ops.EngineKVFormat",
+):
     """
     Ensure that we have a GPU KV Cache Format
     that is either vLLM's flash attention or flash infer.
     """
     assert engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS,
     )
 
 
-def is_hnd(engine_kv_format: "lmc_ops.GPUKVFormat") -> bool:
+def is_hnd(engine_kv_format: "lmc_ops.EngineKVFormat") -> bool:
     """
     Check if the GPU KV Format uses HND physical layout
     """
     return engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS,
     )
 
 
 def assert_is_vllm_mla_or_flash_attn_or_flash_infer(
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
 ) -> None:
     """
     Ensure that we have a GPU KV Cache Format that is either
@@ -1167,50 +1169,50 @@ def assert_is_vllm_mla_or_flash_attn_or_flash_infer(
         AssertionError: If *engine_kv_format* is not one of the accepted formats.
     """
     assert engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
     )
 
 
-def is_mla(engine_kv_format: "lmc_ops.GPUKVFormat") -> bool:
+def is_mla(engine_kv_format: "lmc_ops.EngineKVFormat") -> bool:
     """
     Check if the GPU KV Format is MLA
     """
     return (
-        engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS  # vllm MLA
-        or engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS  # sglang MLA
+        engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS  # vllm MLA
+        or engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS  # sglang MLA
     )
 
 
 def get_dtype(
     kv_caches: DiscoverableKVCache,
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     layer_idx: int = 0,
 ) -> torch.dtype:
     """
     Get the dtype for a layer (defaults to layer 0).
     """
     if engine_kv_format in (
-        lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.dtype
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
-        lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS,
-        lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         return kv_caches[layer_idx].dtype
     elif engine_kv_format in (
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
     ):
         return kv_caches[0][layer_idx].dtype
     else:
@@ -1219,7 +1221,7 @@ def get_dtype(
 
 def get_group_data_ptrs(
     kv_caches: DiscoverableKVCache,
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     layer_indices: list[int],
 ) -> list[int]:
     """Return device pointers for a group of layers in the order the transfer
@@ -1250,7 +1252,7 @@ def get_group_data_ptrs(
     Raises:
         ValueError: If *engine_kv_format* is not recognized.
     """
-    F = lmc_ops.GPUKVFormat
+    F = lmc_ops.EngineKVFormat
     if engine_kv_format in (F.NB_NL_TWO_BS_NH_HS, F.NB_NL_TWO_NH_BS_HS):
         tensor = cast(torch.Tensor, kv_caches)
         return [tensor.data_ptr()]
@@ -1278,7 +1280,7 @@ def get_device(kv_caches: DiscoverableKVCache) -> torch.device:
 
     Descends into any list nesting until a tensor is found; assumes all
     tensors in *kv_caches* live on the same device (true for every
-    current :class:`GPUKVFormat`).
+    current :class:`EngineKVFormat`).
     """
     probe: DiscoverableKVCache = kv_caches
     while isinstance(probe, list):
@@ -1305,14 +1307,14 @@ def get_device(kv_caches: DiscoverableKVCache) -> torch.device:
 # properly-tested branch when a concrete use case lands.
 _BLOCK_AXIS_FORMATS: frozenset = frozenset(
     {
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
     }
 )
 
 
 def resolve_block_stride_and_log_layout(
     kv_caches: DiscoverableKVCache,
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     layer_idx: int,
     group_idx: int,
 ) -> Optional[int]:
@@ -1320,7 +1322,7 @@ def resolve_block_stride_and_log_layout(
 
     Single entry point for :class:`KVLayerGroupsManager` to obtain the
     ``block_stride_elems`` value for :class:`PageBufferShapeDesc` and emit
-    a one-shot layout audit line. All ``GPUKVFormat``-aware reasoning is
+    a one-shot layout audit line. All ``EngineKVFormat``-aware reasoning is
     kept here so callers never touch a "representative KV cache" tensor.
 
     * Block-axis formats (:data:`_BLOCK_AXIS_FORMATS`): ``stride(0)`` is
@@ -1356,18 +1358,18 @@ def resolve_block_stride_and_log_layout(
         #   per-layer; K & V share shape/stride by construction.
         # - Other formats: ``kv_caches`` is already a per-layer list.
         if engine_kv_format in (
-            lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
-            lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
+            lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS,
+            lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS,
         ):
             if not isinstance(kv_caches, torch.Tensor):
                 raise TypeError(
-                    "Cross-layer GPUKVFormat expects a single backing "
+                    "Cross-layer EngineKVFormat expects a single backing "
                     f"torch.Tensor, got {type(kv_caches).__name__}."
                 )
             return kv_caches
         if engine_kv_format in (
-            lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
-            lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
+            lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS,
+            lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
         ):
             return kv_caches[0][layer_idx]  # type: ignore[index]
         return kv_caches[layer_idx]  # type: ignore[index]
@@ -1438,7 +1440,7 @@ def resolve_block_stride_and_log_layout(
 
 def make_page_buffer_shape_desc(
     kv_caches: DiscoverableKVCache,
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     layer_idx: int,
     num_layers_in_group: int,
     num_blocks: int,
@@ -1514,7 +1516,7 @@ def _get_head_size_view(
     kv_cache_layer: Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]],
     *,
     use_mla: bool,
-    engine_kv_format: Optional["lmc_ops.GPUKVFormat"] = None,
+    engine_kv_format: Optional["lmc_ops.EngineKVFormat"] = None,
 ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
     """
     Returns flattened views for index_copy/index_select.
@@ -1557,7 +1559,7 @@ def _get_head_size_view(
 
     # If we have the format enum, decode explicitly.
     if engine_kv_format is not None:
-        if engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
+        if engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS:
             # per-layer: [2, NB, BS, NH, HS]
             if t.shape[0] != 2:
                 raise ValueError(
@@ -1565,7 +1567,7 @@ def _get_head_size_view(
                 )
             k, v = t[0], t[1]  # [NB,BS,NH,HS]
 
-        elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+        elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS:
             # per-layer: [NB, 2, BS, NH, HS]
             if t.shape[1] != 2:
                 raise ValueError(

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # This module is the single layer that performs format-dispatched raw
 # indexing on DiscoverableKVCache values (kv_caches.shape[i],
-# kv_caches[0][j]); the gpu_kv_format argument is the proof the
+# kv_caches[0][j]); the engine_kv_format argument is the proof the
 # indexing is well-defined. Silence union-attr errors only for this
 # file so the accessors can take DiscoverableKVCache without 50+
 # per-line type: ignore comments.
@@ -242,15 +242,15 @@ def assert_contiguous(tensor: torch.Tensor) -> None:
         raise ValueError("tensor is not contiguous")
 
 
-def is_cross_layer_format(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
-    """Return ``True`` if *gpu_kv_format* stores all layers in one tensor.
+def is_cross_layer_format(engine_kv_format: "lmc_ops.GPUKVFormat") -> bool:
+    """Return ``True`` if *engine_kv_format* stores all layers in one tensor.
 
     Cross-layer formats — ``NB_NL_TWO_BS_NH_HS`` (vLLM, NHD) and
     ``NB_NL_TWO_NH_BS_HS`` (TRT-LLM, HND) — are represented as a single
     bare :class:`torch.Tensor` rather than a list-of-tensors keyed by
     layer index.
     """
-    return gpu_kv_format in (
+    return engine_kv_format in (
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
     )
@@ -287,7 +287,7 @@ def assert_layerwise_gpu_connector(gpu_connector: "GPUConnectorInterface"):
     assert isinstance(gpu_connector, valid_connectors)
 
 
-def get_gpu_kv_shape_description(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
+def get_engine_kv_shape_description(engine_kv_format: "lmc_ops.GPUKVFormat") -> str:
     """Return a human-readable shape description for the GPU KV format.
 
     Uses short names matching the ``GPUKVFormat`` enum convention:
@@ -307,10 +307,10 @@ def get_gpu_kv_shape_description(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS: "[NB, NL, 2, NH, BS, HS]",
         lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS: "NL x [NB, NH, BS, 2, HS]",
     }
-    return _SHAPE_DESCRIPTIONS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
+    return _SHAPE_DESCRIPTIONS.get(engine_kv_format, f"Unknown ({engine_kv_format})")
 
 
-def get_attention_backend(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
+def get_attention_backend(engine_kv_format: "lmc_ops.GPUKVFormat") -> str:
     """Return the attention backend name for the GPU KV format."""
     _ATTENTION_BACKENDS: dict["lmc_ops.GPUKVFormat", str] = {
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS: "vLLM CROSS_LAYER",
@@ -335,21 +335,21 @@ def get_attention_backend(gpu_kv_format: "lmc_ops.GPUKVFormat") -> str:
             "vLLM non-MLA blocks-first, fused K/V"
         ),
     }
-    return _ATTENTION_BACKENDS.get(gpu_kv_format, f"Unknown ({gpu_kv_format})")
+    return _ATTENTION_BACKENDS.get(engine_kv_format, f"Unknown ({engine_kv_format})")
 
 
-def get_concrete_gpu_kv_shape(
-    kv_caches: DiscoverableKVCache, gpu_kv_format: "lmc_ops.GPUKVFormat"
+def get_concrete_engine_kv_shape(
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.EngineKVFormat"
 ) -> str:
     """Return the shape with actual numeric values substituted.
 
     For example, instead of ``NL x [2, NB, BS, NH, HS]``
     this returns ``80 x [2, 2048, 128, 8, 128]``.
     """
-    nl = get_num_layers(kv_caches, gpu_kv_format)
-    hs = get_head_size(kv_caches, gpu_kv_format)
+    nl = get_num_layers(kv_caches, engine_kv_format)
+    hs = get_head_size(kv_caches, engine_kv_format)
 
-    fmt = gpu_kv_format
+    fmt = engine_kv_format
     F = lmc_ops.GPUKVFormat
 
     if fmt == F.NB_NL_TWO_BS_NH_HS:
@@ -414,12 +414,12 @@ def get_concrete_gpu_kv_shape(
         bs = get_block_size(kv_caches, fmt)
         return f"{nl} x [{nb}, {nh}, {bs}, 2, {hs}]"
 
-    return f"Unknown ({gpu_kv_format})"
+    return f"Unknown ({engine_kv_format})"
 
 
-def get_concrete_gpu_kv_shape_from_shape_desc(
+def get_concrete_engine_kv_shape_from_shape_desc(
     shape_desc: "lmc_ops.PageBufferShapeDesc",
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
 ) -> str:
     """Return the concrete shape for a single kernel group's ``shape_desc``.
 
@@ -437,7 +437,7 @@ def get_concrete_gpu_kv_shape_from_shape_desc(
         shape_desc: The kernel group's shape descriptor. Numeric values
             are pulled from its ``nl``/``nb``/``bs``/``nh``/``hs`` fields;
             the page-buffer-size (``PBS``) formats use ``nb * bs``.
-        gpu_kv_format: The GPU KV format that determines the symbolic
+        engine_kv_format: The GPU KV format that determines the symbolic
             shape template.
 
     Returns:
@@ -451,7 +451,7 @@ def get_concrete_gpu_kv_shape_from_shape_desc(
     hs = shape_desc.hs
     pbs = nb * bs
 
-    fmt = gpu_kv_format
+    fmt = engine_kv_format
     F = lmc_ops.GPUKVFormat
 
     if fmt == F.NB_NL_TWO_BS_NH_HS:
@@ -484,17 +484,19 @@ def get_concrete_gpu_kv_shape_from_shape_desc(
     if fmt == F.NB_NL_TWO_NH_BS_HS:
         return f"[{nb}, {nl}, 2, {nh}, {bs}, {hs}]"
 
-    return f"Unknown ({gpu_kv_format})"
+    return f"Unknown ({engine_kv_format})"
 
 
-def legible_print_gpu_kv_format(gpu_kv_format: "lmc_ops.GPUKVFormat"):
+def legible_print_engine_kv_format(
+    engine_kv_format: "lmc_ops.EngineKVFormat",
+):
     """
-    Print the GPU KV Format in a legible way
+    Print the engine KV Format in a legible way
     """
-    shape = get_gpu_kv_shape_description(gpu_kv_format)
-    backend = get_attention_backend(gpu_kv_format)
+    shape = get_gpu_kv_shape_description(engine_kv_format)
+    backend = get_attention_backend(engine_kv_format)
     if shape.startswith("Unknown"):
-        logger.warning(f"Unknown GPU KV Format: {gpu_kv_format}")
+        logger.warning(f"Unknown GPU KV Format: {engine_kv_format}")
     else:
         logger.info("GPU KV Format: %s", shape)
         logger.info("Currently used by:\n  - %s", backend)
@@ -553,7 +555,7 @@ def normalize_kv_and_discover_format(
         layout_hints: See :class:`~lmcache.v1.multiprocess.custom_types.LayoutHints`.
 
     Returns:
-        ``(gpu_kv_format, normalized_kv_caches)``. Callers must use the
+        ``(engine_kv_format, normalized_kv_caches)``. Callers must use the
         returned tensor structure for subsequent operations — it shares
         storage with the input but may be a permuted view.
 
@@ -719,7 +721,7 @@ def normalize_kv_and_discover_format(
                 detected_format = lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
 
     if detected_format is not None:
-        legible_print_gpu_kv_format(detected_format)
+        legible_print_engine_kv_format(detected_format)
         return detected_format, kv_caches
     else:
         raise ValueError(
@@ -729,17 +731,17 @@ def normalize_kv_and_discover_format(
 
 
 def get_num_layers(
-    kv_caches: DiscoverableKVCache, gpu_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
 ) -> int:
     """
     Get the number of layers from the kv_caches
     """
-    if gpu_kv_format in (
+    if engine_kv_format in (
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.shape[1]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
@@ -748,59 +750,59 @@ def get_num_layers(
         lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         return len(kv_caches)
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
         lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
     ):
         return len(kv_caches[0])
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
         return len(kv_caches)
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_num_blocks(
-    kv_caches: DiscoverableKVCache, gpu_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
 ) -> int:
     """
     Get the number of blocks from the kv_caches
     """
-    if gpu_kv_format in (
+    if engine_kv_format in (
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.shape[0]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
     ):
         # [2, num_blocks, ...] — shape[1] is num_blocks
         return kv_caches[0].shape[1]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         # [num_blocks, ...] — shape[0] is num_blocks
         return kv_caches[0].shape[0]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         return kv_caches[0].shape[0]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # SGLang MHA 3-D inner: ``(page_buffer_size, num_heads, head_size)``
         # folds num_blocks into shape[0]; not separable here.
-        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=gpu_kv_format))
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=engine_kv_format))
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # SGLang MHA 4-D inner (MP path): num_blocks at shape[0].
         return kv_caches[0][0].shape[0]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
-        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=gpu_kv_format))
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=engine_kv_format))
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_block_size(
     kv_caches: DiscoverableKVCache,
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     layer_idx: int = 0,
 ) -> int:
     """Return the block size (tokens per block) for layer ``layer_idx``.
@@ -811,12 +813,12 @@ def get_block_size(
     is ignored. Raises ``ValueError`` for NBBS-fused formats, which
     have no separate BS dim.
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[3]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — block_size at shape[4]
         return kv_caches.shape[4]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
@@ -824,173 +826,173 @@ def get_block_size(
         # block_size at shape[2]: NHD [..., BS, NH, HS] and the CPU fused
         # layout [NB, NH, BS, 2, HS] both carry block_size at shape[2].
         return kv_caches[layer_idx].shape[2]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # HND: [..., NH, BS, HS] — block_size at shape[3]
         return kv_caches[layer_idx].shape[3]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         return kv_caches[layer_idx].shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # SGLang MHA 3-D inner: block_size folded into shape[0]; not separable.
-        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=gpu_kv_format))
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=engine_kv_format))
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # SGLang MHA 4-D inner (MP path): block_size at shape[1].
         return kv_caches[0][0].shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
-        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=gpu_kv_format))
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+        raise ValueError(_ATTRIBUTE_NOT_EXIST_ERROR.format(format=engine_kv_format))
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_page_buffer_size(
-    kv_caches: DiscoverableKVCache, gpu_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
 ) -> int:
     """
     Get page buffer size (num_blocks * block_size) from the kv_caches
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         # [num_blocks, num_layers, 2, block_size, num_heads, head_size]
         return kv_caches.shape[0] * kv_caches.shape[3]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
         return kv_caches.shape[0] * kv_caches.shape[4]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
         # list[num_layers] of [2, num_blocks, block_size, num_heads, head_size]
         return kv_caches[0].shape[1] * kv_caches[0].shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
         # list[num_layers] of [2, num_blocks, num_heads, block_size, head_size]
         # num_blocks=shape[1], block_size=shape[3]
         return kv_caches[0].shape[1] * kv_caches[0].shape[3]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
         # list[num_layers] of [num_blocks, 2, block_size, num_heads, head_size]
         return kv_caches[0].shape[0] * kv_caches[0].shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
         # list[num_layers] of [num_blocks, 2, num_heads, block_size, head_size]
         # num_blocks=shape[0], block_size=shape[3]
         return kv_caches[0].shape[0] * kv_caches[0].shape[3]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # list[num_layers] of [num_blocks, num_heads, block_size, 2, head_size]
         # num_blocks=shape[0], block_size=shape[2]
         return kv_caches[0].shape[0] * kv_caches[0].shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size]
         return kv_caches[0].shape[0] * kv_caches[0].shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # list[2] -> list[num_layers] of [page_buffer_size, num_heads, head_size]
         return kv_caches[0][0].shape[0]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # list[2] -> list[num_layers] of [num_blocks, block_size, num_heads, head_size]
         return kv_caches[0][0].shape[0] * kv_caches[0][0].shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
         # list[num_layers] of [page_buffer_size, 1, head_size]
         return kv_caches[0].shape[0]
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_num_heads(
     kv_caches: DiscoverableKVCache,
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     layer_idx: int = 0,
 ) -> int:
     """
     Get the number of heads for a layer (defaults to layer 0).
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[4]  # global for cross-layer
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — num_heads at shape[3]
         return kv_caches.shape[3]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
     ):
         # NHD: [..., BS, NH, HS] — num_heads at shape[3]
         return kv_caches[layer_idx].shape[3]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # HND: [..., NH, BS, HS] — num_heads at shape[2]
         return kv_caches[layer_idx].shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # CPU fused: [NB, NH, BS, 2, HS] — num_heads at shape[1]
         return kv_caches[layer_idx].shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         # MLA: heads are absorbed into hidden dim, so num_heads = 1
         return 1
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # 3-D inner: (PBS, NH, HS) — NH at shape[1].
         return kv_caches[0][layer_idx].shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # 4-D inner: (NB, BS, NH, HS) — NH at shape[2].
         return kv_caches[0][layer_idx].shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
         return kv_caches[layer_idx].shape[1]
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_hidden_dim_size(
     kv_caches: DiscoverableKVCache,
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     layer_idx: int = 0,
 ) -> int:
     """
     Get the hidden dimension for a layer (defaults to layer 0).
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         return kv_caches.shape[4] * kv_caches.shape[5]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # HND cross-layer: [NB, NL, 2, NH, BS, HS] — hidden = NH * HS
         return kv_caches.shape[3] * kv_caches.shape[5]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
     ):
         # NHD: [..., NH, HS] — hidden_dim = shape[3] * shape[4]
         return kv_caches[layer_idx].shape[3] * kv_caches[layer_idx].shape[4]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # HND: [..., NH, BS, HS] — hidden_dim = NH * HS = shape[2] * shape[4]
         return kv_caches[layer_idx].shape[2] * kv_caches[layer_idx].shape[4]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # CPU fused: [NB, NH, BS, 2, HS] — hidden_dim = NH * HS = shape[1] * shape[4]
         return kv_caches[layer_idx].shape[1] * kv_caches[layer_idx].shape[4]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         return kv_caches[layer_idx].shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # 3-D inner: (PBS, NH, HS) — hidden = shape[1] * shape[2].
         inner = kv_caches[0][layer_idx]
         return inner.shape[1] * inner.shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # 4-D inner: (NB, BS, NH, HS) — hidden = shape[2] * shape[3].
         inner = kv_caches[0][layer_idx]
         return inner.shape[2] * inner.shape[3]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
         return kv_caches[layer_idx].shape[2]
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_head_size(
     kv_caches: DiscoverableKVCache,
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     layer_idx: int = 0,
 ) -> int:
     """
     Get the head size for a layer (defaults to layer 0).
     """
-    if gpu_kv_format in (
+    if engine_kv_format in (
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.shape[5]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
@@ -999,79 +1001,79 @@ def get_head_size(
     ):
         # All these per-layer non-MLA layouts carry head_size as the last dim
         return kv_caches[layer_idx].shape[4]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         return kv_caches[layer_idx].shape[2]
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
         lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
     ):
         # HS is the last dim in both 3-D and 4-D inner forms.
         return kv_caches[0][layer_idx].shape[-1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
         return kv_caches[layer_idx].shape[2]
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_tokens_per_layer(
-    kv_caches: DiscoverableKVCache, gpu_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
 ) -> int:
     """
     Get the number of tokens per layer from the kv_caches
     (num_blocks * block_size or page_buffer_size)
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         # [num_blocks, num_layers, 2, block_size, num_heads, head_size]
         return kv_caches.shape[0] * kv_caches.shape[3]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
         return kv_caches.shape[0] * kv_caches.shape[4]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
         # list[num_layers] of [2, num_blocks, block_size, num_heads, head_size]
         k_cache_shape = kv_caches[0][0].shape
         return k_cache_shape[0] * k_cache_shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
         # list[num_layers] of [2, num_blocks, num_heads, block_size, head_size]
         # k_cache = kv_caches[0][0] → (NB, NH, BS, HS); tokens = NB * BS
         k_cache_shape = kv_caches[0][0].shape
         return k_cache_shape[0] * k_cache_shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
         # list[num_layers] of [num_blocks, 2, block_size, num_heads, head_size]
         k_cache_shape = kv_caches[0][:, 0].shape
         return k_cache_shape[0] * k_cache_shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
         # list[num_layers] of [num_blocks, 2, num_heads, block_size, head_size]
         # k_cache = kv_caches[0][:, 0] → (NB, NH, BS, HS); tokens = NB * BS
         k_cache_shape = kv_caches[0][:, 0].shape
         return k_cache_shape[0] * k_cache_shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # list[num_layers] of [num_blocks, num_heads, block_size, 2, head_size]
         # tokens = NB * BS = shape[0] * shape[2]
         return kv_caches[0].shape[0] * kv_caches[0].shape[2]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size]
         return kv_caches[0].shape[0] * kv_caches[0].shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
         # list[2] -> list[num_layers] of [page_buffer_size, num_heads, head_size]
         return kv_caches[0][0].shape[0]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS:
         # list[2] -> list[num_layers] of [num_blocks, block_size, num_heads, head_size]
         return kv_caches[0][0].shape[0] * kv_caches[0][0].shape[1]
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
         # list[num_layers] of [page_buffer_size, 1, head_size]
         return kv_caches[0].shape[0]
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_elements_per_layer(
-    kv_caches: DiscoverableKVCache, gpu_kv_format: "lmc_ops.GPUKVFormat"
+    kv_caches: DiscoverableKVCache, engine_kv_format: "lmc_ops.GPUKVFormat"
 ) -> int:
     """
     Get the number of elements per layer from the kv_caches
     (including both K and V for non-MLA)
     """
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS:
         # [num_blocks, num_layers, 2, block_size, num_heads, head_size]
         # For one layer: [num_blocks, 2, block_size, num_heads, head_size]
         num_blocks = kv_caches.shape[0]
@@ -1079,54 +1081,54 @@ def get_elements_per_layer(
         num_heads = kv_caches.shape[4]
         head_size = kv_caches.shape[5]
         return num_blocks * 2 * block_size * num_heads * head_size
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS:
         # [num_blocks, num_layers, 2, num_heads, block_size, head_size]
         num_blocks = kv_caches.shape[0]
         num_heads = kv_caches.shape[3]
         block_size = kv_caches.shape[4]
         head_size = kv_caches.shape[5]
         return num_blocks * 2 * num_heads * block_size * head_size
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
     ):
         # [2, num_blocks, ...] — k_cache is kv_caches[0][0]
         k_cache_shape = kv_caches[0][0].shape
         return k_cache_shape.numel() * 2
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
     ):
         # [num_blocks, 2, ...] — k_cache is kv_caches[0][:, 0]
         k_cache_shape = kv_caches[0][:, 0].shape
         return k_cache_shape.numel() * 2
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
         # [NB, NH, BS, 2, HS] — K/V at dim 3; k_cache is kv_caches[0][:, :, :, 0]
         k_cache_shape = kv_caches[0][:, :, :, 0].shape
         return k_cache_shape.numel() * 2
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS:
         # list[num_layers] of [num_blocks, block_size, head_size] (MLA)
         return kv_caches[0].numel()
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
         lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
     ):
         # list[2] -> list[num_layers] of K/V tensors; both ranks have the
         # same total element count, just laid out differently.
         return kv_caches[0][0].numel() * 2
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
+    elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS:
         # list[num_layers] of [page_buffer_size, 1, head_size] (MLA)
         return kv_caches[0].numel()
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
-def assert_is_vllm_flash_attn_or_flash_infer(gpu_kv_format: "lmc_ops.GPUKVFormat"):
+def assert_is_vllm_flash_attn_or_flash_infer(engine_kv_format: "lmc_ops.GPUKVFormat"):
     """
     Ensure that we have a GPU KV Cache Format
     that is either vLLM's flash attention or flash infer.
     """
-    assert gpu_kv_format in (
+    assert engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
@@ -1135,11 +1137,11 @@ def assert_is_vllm_flash_attn_or_flash_infer(gpu_kv_format: "lmc_ops.GPUKVFormat
     )
 
 
-def is_hnd(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
+def is_hnd(engine_kv_format: "lmc_ops.GPUKVFormat") -> bool:
     """
     Check if the GPU KV Format uses HND physical layout
     """
-    return gpu_kv_format in (
+    return engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
@@ -1148,7 +1150,7 @@ def is_hnd(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
 
 
 def assert_is_vllm_mla_or_flash_attn_or_flash_infer(
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
 ) -> None:
     """
     Ensure that we have a GPU KV Cache Format that is either
@@ -1162,9 +1164,9 @@ def assert_is_vllm_mla_or_flash_attn_or_flash_infer(
         - ``NL_X_NB_BS_HS`` (MLA)
 
     Raises:
-        AssertionError: If *gpu_kv_format* is not one of the accepted formats.
+        AssertionError: If *engine_kv_format* is not one of the accepted formats.
     """
-    assert gpu_kv_format in (
+    assert engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,
@@ -1173,30 +1175,30 @@ def assert_is_vllm_mla_or_flash_attn_or_flash_infer(
     )
 
 
-def is_mla(gpu_kv_format: "lmc_ops.GPUKVFormat") -> bool:
+def is_mla(engine_kv_format: "lmc_ops.GPUKVFormat") -> bool:
     """
     Check if the GPU KV Format is MLA
     """
     return (
-        gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS  # vllm MLA
-        or gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS  # sglang MLA
+        engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS  # vllm MLA
+        or engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS  # sglang MLA
     )
 
 
 def get_dtype(
     kv_caches: DiscoverableKVCache,
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     layer_idx: int = 0,
 ) -> torch.dtype:
     """
     Get the dtype for a layer (defaults to layer 0).
     """
-    if gpu_kv_format in (
+    if engine_kv_format in (
         lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
     ):
         return kv_caches.dtype
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
         lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
@@ -1206,22 +1208,22 @@ def get_dtype(
         lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS,
     ):
         return kv_caches[layer_idx].dtype
-    elif gpu_kv_format in (
+    elif engine_kv_format in (
         lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
         lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
     ):
         return kv_caches[0][layer_idx].dtype
     else:
-        raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+        raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_group_data_ptrs(
     kv_caches: DiscoverableKVCache,
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     layer_indices: list[int],
 ) -> list[int]:
     """Return device pointers for a group of layers in the order the transfer
-    kernels expect for *gpu_kv_format*.
+    kernels expect for *engine_kv_format*.
 
     The pointer array's *shape* is a property of the format, not of the
     caller. Three buckets, mirroring the kernel dispatch in
@@ -1238,7 +1240,7 @@ def get_group_data_ptrs(
 
     Args:
         kv_caches: Full kv_caches structure.
-        gpu_kv_format: Format returned by :func:`normalize_kv_and_discover_format`.
+        engine_kv_format: Format returned by :func:`normalize_kv_and_discover_format`.
         layer_indices: 0-based layer indices in the group, in the order
             the kernel should iterate them. Ignored for cross-layer.
 
@@ -1246,18 +1248,18 @@ def get_group_data_ptrs(
         Device pointers (int), in kernel-expected order.
 
     Raises:
-        ValueError: If *gpu_kv_format* is not recognized.
+        ValueError: If *engine_kv_format* is not recognized.
     """
     F = lmc_ops.GPUKVFormat
-    if gpu_kv_format in (F.NB_NL_TWO_BS_NH_HS, F.NB_NL_TWO_NH_BS_HS):
+    if engine_kv_format in (F.NB_NL_TWO_BS_NH_HS, F.NB_NL_TWO_NH_BS_HS):
         tensor = cast(torch.Tensor, kv_caches)
         return [tensor.data_ptr()]
-    if gpu_kv_format in (F.TWO_X_NL_X_NBBS_NH_HS, F.TWO_X_NL_X_NB_BS_NH_HS):
+    if engine_kv_format in (F.TWO_X_NL_X_NBBS_NH_HS, F.TWO_X_NL_X_NB_BS_NH_HS):
         k, v = cast(list[list[torch.Tensor]], kv_caches)
         return [k[i].data_ptr() for i in layer_indices] + [
             v[i].data_ptr() for i in layer_indices
         ]
-    if gpu_kv_format in (
+    if engine_kv_format in (
         F.NL_X_TWO_NB_BS_NH_HS,
         F.NL_X_NB_TWO_BS_NH_HS,
         F.NL_X_TWO_NB_NH_BS_HS,
@@ -1268,7 +1270,7 @@ def get_group_data_ptrs(
     ):
         layers = cast(list[torch.Tensor], kv_caches)
         return [layers[i].data_ptr() for i in layer_indices]
-    raise ValueError(f"Unknown GPU KV Format: {gpu_kv_format}")
+    raise ValueError(f"Unknown GPU KV Format: {engine_kv_format}")
 
 
 def get_device(kv_caches: DiscoverableKVCache) -> torch.device:
@@ -1310,7 +1312,7 @@ _BLOCK_AXIS_FORMATS: frozenset = frozenset(
 
 def resolve_block_stride_and_log_layout(
     kv_caches: DiscoverableKVCache,
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     layer_idx: int,
     group_idx: int,
 ) -> Optional[int]:
@@ -1332,7 +1334,7 @@ def resolve_block_stride_and_log_layout(
 
     Args:
         kv_caches: Full KV cache structure (already normalised).
-        gpu_kv_format: Format of ``kv_caches``.
+        engine_kv_format: Format of ``kv_caches``.
         layer_idx: 0-based layer index used as the layout probe.
         group_idx: 0-based group index, used only for logging.
 
@@ -1353,7 +1355,7 @@ def resolve_block_stride_and_log_layout(
         # - SGL MHA: outer list is K/V (length 2), inner list is
         #   per-layer; K & V share shape/stride by construction.
         # - Other formats: ``kv_caches`` is already a per-layer list.
-        if gpu_kv_format in (
+        if engine_kv_format in (
             lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS,
             lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS,
         ):
@@ -1363,7 +1365,7 @@ def resolve_block_stride_and_log_layout(
                     f"torch.Tensor, got {type(kv_caches).__name__}."
                 )
             return kv_caches
-        if gpu_kv_format in (
+        if engine_kv_format in (
             lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
             lmc_ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
         ):
@@ -1373,7 +1375,7 @@ def resolve_block_stride_and_log_layout(
     rep = _pick_layout_probe_tensor()
 
     block_stride_elems: Optional[int]
-    if gpu_kv_format in _BLOCK_AXIS_FORMATS and rep.ndim > 0:
+    if engine_kv_format in _BLOCK_AXIS_FORMATS and rep.ndim > 0:
         block_stride_elems = int(rep.stride(0))
     else:
         # Non-block-axis format: detect forbidden dim-0 padding.
@@ -1386,7 +1388,7 @@ def resolve_block_stride_and_log_layout(
                 raise ValueError(
                     "resolve_block_stride_and_log_layout: group's probe "
                     f"tensor has dim-0 padding ({padding} elements per "
-                    f"block) but gpu_kv_format={gpu_kv_format!r} is not "
+                    f"block) but engine_kv_format={engine_kv_format!r} is not "
                     "a supported dim-0-padded format (only "
                     "NL_X_NB_BS_HS is); downstream transfer kernels "
                     "cannot honour this padding and would read/write "
@@ -1436,7 +1438,7 @@ def resolve_block_stride_and_log_layout(
 
 def make_page_buffer_shape_desc(
     kv_caches: DiscoverableKVCache,
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     layer_idx: int,
     num_layers_in_group: int,
     num_blocks: int,
@@ -1447,7 +1449,7 @@ def make_page_buffer_shape_desc(
 
     Args:
         kv_caches: Full kv_caches structure.
-        gpu_kv_format: Format returned by :func:`normalize_kv_and_discover_format`.
+        engine_kv_format: Format returned by :func:`normalize_kv_and_discover_format`.
         layer_idx: 0-based index of the representative layer.
         num_layers_in_group: Number of layers in the group (``nl``).
         num_blocks: Number of paged blocks (``nb``).
@@ -1468,17 +1470,17 @@ def make_page_buffer_shape_desc(
         A populated ``PageBufferShapeDesc``.
     """
     desc = lmc_ops.PageBufferShapeDesc()
-    desc.kv_size = 1 if is_mla(gpu_kv_format) else 2
+    desc.kv_size = 1 if is_mla(engine_kv_format) else 2
     desc.nl = num_layers_in_group
     desc.nb = num_blocks
     desc.bs = block_size
     desc.nh = (
         1
-        if is_mla(gpu_kv_format)
-        else get_num_heads(kv_caches, gpu_kv_format, layer_idx)
+        if is_mla(engine_kv_format)
+        else get_num_heads(kv_caches, engine_kv_format, layer_idx)
     )
-    desc.hs = get_head_size(kv_caches, gpu_kv_format, layer_idx)
-    dtype = get_dtype(kv_caches, gpu_kv_format, layer_idx)
+    desc.hs = get_head_size(kv_caches, engine_kv_format, layer_idx)
+    dtype = get_dtype(kv_caches, engine_kv_format, layer_idx)
     desc.element_size = dtype.itemsize
     # The C++ PageBufferShapeDesc has no ``dtype`` field, but the
     # pure-Python CPU fallback (``python_ops_fallback``) does -- and
@@ -1512,12 +1514,12 @@ def _get_head_size_view(
     kv_cache_layer: Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]],
     *,
     use_mla: bool,
-    gpu_kv_format: Optional["lmc_ops.GPUKVFormat"] = None,
+    engine_kv_format: Optional["lmc_ops.GPUKVFormat"] = None,
 ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
     """
     Returns flattened views for index_copy/index_select.
 
-    If gpu_kv_format is provided, use it to interpret tensor layout explicitly.
+    If engine_kv_format is provided, use it to interpret tensor layout explicitly.
     If not provided, fall back to current structural behavior:
       - MLA: expects Tensor [P, B, HS]
       - Non-MLA: expects either
@@ -1554,27 +1556,28 @@ def _get_head_size_view(
         raise ValueError(f"Expected 5D tensor for non-MLA, got {t.shape}")
 
     # If we have the format enum, decode explicitly.
-    if gpu_kv_format is not None:
-        if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
+    if engine_kv_format is not None:
+        if engine_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
             # per-layer: [2, NB, BS, NH, HS]
             if t.shape[0] != 2:
                 raise ValueError(
-                    f"{gpu_kv_format} expects [2,NB,BS,NH,HS], got {t.shape}"
+                    f"{engine_kv_format} expects [2,NB,BS,NH,HS], got {t.shape}"
                 )
             k, v = t[0], t[1]  # [NB,BS,NH,HS]
 
-        elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+        elif engine_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
             # per-layer: [NB, 2, BS, NH, HS]
             if t.shape[1] != 2:
                 raise ValueError(
-                    f"{gpu_kv_format} expects [NB,2,BS,NH,HS], got {t.shape}"
+                    f"{engine_kv_format} expects [NB,2,BS,NH,HS], got {t.shape}"
                 )
             k, v = t[:, 0], t[:, 1]  # [NB,BS,NH,HS]
 
         else:
             # Other formats are either MLA-only or require upstream normalization.
             raise NotImplementedError(
-                f"gpu_kv_format={gpu_kv_format} not supported in non-MLA path here. "
+                f"engine_kv_format={engine_kv_format} "
+                "not supported in non-MLA path here. "
                 "Normalize to (k,v) tuple [NB,BS,NH,HS] per-layer before calling."
             )
 
@@ -1587,7 +1590,7 @@ def _get_head_size_view(
             k, v = t[:, 0], t[:, 1]
         else:
             raise ValueError(
-                f"gpu_kv_format is None and tensor does not look like stacked KV. "
+                f"engine_kv_format is None and tensor does not look like stacked KV. "
                 f"Expected axis0==2 or axis1==2, got {t.shape}"
             )
 
@@ -1599,3 +1602,10 @@ def _get_head_size_view(
         raise ValueError(f"k/v shape mismatch after decode: {k.shape} vs {v.shape}")
 
     return k.view(nb * bs, nh * hs), v.view(nb * bs, nh * hs)
+
+
+# Backward-compat aliases
+get_gpu_kv_shape_description = get_engine_kv_shape_description
+get_concrete_gpu_kv_shape = get_concrete_engine_kv_shape
+get_concrete_gpu_kv_shape_from_shape_desc = get_concrete_engine_kv_shape_from_shape_desc
+legible_print_gpu_kv_format = legible_print_engine_kv_format

--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -1287,7 +1287,7 @@ class SGLangXPUConnector(GPUConnectorInterface):
 
         # For TWO_X_NL_X_NBBS_NH_HS format, kv_caches is [[k_list], [v_list]]
         # We need to flatten it to [k0, k1, ..., v0, v1, ...]
-        if self.engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+        if self.engine_kv_format == lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS:
             flat_kv_caches = kv_caches[0] + kv_caches[1]  # [k_list] + [v_list]
             device = flat_kv_caches[0].device
         else:

--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -129,11 +129,11 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
         )
         self.kv_cache_pointers_on_gpu[idx].copy_(self.kv_cache_pointers)
 
-        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+        self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
             kv_caches, EngineType.VLLM
         )
-        self.num_blocks = get_num_blocks(kv_caches, self.gpu_kv_format)
-        self.block_size = get_block_size(kv_caches, self.gpu_kv_format)
+        self.num_blocks = get_num_blocks(kv_caches, self.engine_kv_format)
+        self.block_size = get_block_size(kv_caches, self.engine_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
 
         return self.kv_cache_pointers_on_gpu[idx]
@@ -197,7 +197,7 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
             self.device,
             self.page_buffer_size,
             lmc_ops.TransferDirection.H2D,
-            self.gpu_kv_format,
+            self.engine_kv_format,
             self.block_size,
             skip_prefix_n_tokens,
         )
@@ -244,7 +244,7 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
                     self.kvcaches[0].device,
                     self.page_buffer_size,
                     lmc_ops.TransferDirection.D2H,
-                    self.gpu_kv_format,
+                    self.engine_kv_format,
                     self.block_size,
                 )
             else:
@@ -258,7 +258,7 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
                     self.kvcaches[0].device,
                     self.page_buffer_size,
                     lmc_ops.TransferDirection.D2H,
-                    self.gpu_kv_format,
+                    self.engine_kv_format,
                     self.block_size,
                 )
                 memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
@@ -355,11 +355,11 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
             kv_cache_pointers_on_gpu.copy_(kv_cache_pointers)
             self.group_kv_cache_pointers_on_gpu.append(kv_cache_pointers_on_gpu)
 
-        self.gpu_kv_format, self.kvcaches = normalize_kv_and_discover_format(
+        self.engine_kv_format, self.kvcaches = normalize_kv_and_discover_format(
             self.kvcaches, EngineType.VLLM
         )
-        self.num_blocks = get_num_blocks(self.kvcaches, self.gpu_kv_format)
-        self.block_size = get_block_size(self.kvcaches, self.gpu_kv_format)
+        self.num_blocks = get_num_blocks(self.kvcaches, self.engine_kv_format)
+        self.block_size = get_block_size(self.kvcaches, self.engine_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
 
         self.init = True
@@ -397,7 +397,7 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
                 self.device,
                 self.page_buffer_size,
                 lmc_ops.TransferDirection.H2D,
-                self.gpu_kv_format,
+                self.engine_kv_format,
                 self.block_size,
                 skip_prefix_n_tokens,
             )
@@ -427,7 +427,7 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
                         self.device,
                         self.page_buffer_size,
                         lmc_ops.TransferDirection.D2H,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         self.block_size,
                     )
             else:
@@ -444,7 +444,7 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
                         self.device,
                         self.page_buffer_size,
                         lmc_ops.TransferDirection.D2H,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         self.block_size,
                     )
                     memory_obj_tensor = memory_obj.get_tensor(i)
@@ -558,13 +558,15 @@ class VLLMBufferLayerwiseXPUConnector(GPUConnectorInterface):
             # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
             # in layerwise mode.
 
-            self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
                 kv_caches, EngineType.VLLM
             )
-            assert_is_vllm_flash_attn_or_flash_infer(self.gpu_kv_format)
-            self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
+            assert_is_vllm_flash_attn_or_flash_infer(self.engine_kv_format)
+            self.tokens_per_layer = get_tokens_per_layer(
+                kv_caches, self.engine_kv_format
+            )
             self.elements_per_layer = get_elements_per_layer(
-                kv_caches, self.gpu_kv_format
+                kv_caches, self.engine_kv_format
             )
             logger.info(
                 f"Lazily initializing GPU buffer (max tokens={self.tokens_per_layer})."
@@ -680,7 +682,7 @@ class VLLMBufferLayerwiseXPUConnector(GPUConnectorInterface):
                     self.kvcaches[layer_id - 2],
                     slot_mapping_full,
                     lmc_ops.TransferDirection.H2D,
-                    self.gpu_kv_format,
+                    self.engine_kv_format,
                     token_major=False,  # shape is [2, num_tokens, hidden_dim]
                 )
                 del self.buffer_mapping[layer_id - 2]
@@ -840,7 +842,7 @@ class VLLMBufferLayerwiseXPUConnector(GPUConnectorInterface):
                     self.kvcaches[layer_id],
                     slot_mapping_full,
                     lmc_ops.TransferDirection.D2H,
-                    self.gpu_kv_format,
+                    self.engine_kv_format,
                     token_major=False,  # shape is [2, num_tokens, hidden_dim]
                 )
                 for (buf_start, buf_end), memory_obj, old_positions in zip(
@@ -957,13 +959,15 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
             # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
             # in layerwise mode.
 
-            self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+            self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
                 kv_caches, EngineType.VLLM
             )
-            assert_is_vllm_flash_attn_or_flash_infer(self.gpu_kv_format)
-            self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
+            assert_is_vllm_flash_attn_or_flash_infer(self.engine_kv_format)
+            self.tokens_per_layer = get_tokens_per_layer(
+                kv_caches, self.engine_kv_format
+            )
             self.elements_per_layer = get_elements_per_layer(
-                kv_caches, self.gpu_kv_format
+                kv_caches, self.engine_kv_format
             )
             logger.info(
                 f"Lazily initializing GPU buffer (max tokens={self.tokens_per_layer})."
@@ -1077,7 +1081,7 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
                             lmc_ops.TransferDirection.H2D,
-                            self.gpu_kv_format,
+                            self.engine_kv_format,
                             token_major=True,
                         )
 
@@ -1087,7 +1091,7 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                         self.kvcaches[layer_id],
                         slot_mapping_full,
                         lmc_ops.TransferDirection.H2D,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         token_major=True,
                     )
         yield
@@ -1185,7 +1189,7 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                         self.kvcaches[layer_id],
                         slot_mapping_full,
                         lmc_ops.TransferDirection.D2H,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         token_major=True,
                     )
                 for start, end, memory_obj in zip(
@@ -1203,7 +1207,7 @@ class VLLMPagedMemLayerwiseXPUConnector(GPUConnectorInterface):
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
                             lmc_ops.TransferDirection.D2H,
-                            self.gpu_kv_format,
+                            self.engine_kv_format,
                             token_major=True,
                         )
                     # Set metadata format
@@ -1277,13 +1281,13 @@ class SGLangXPUConnector(GPUConnectorInterface):
 
     def _initialize_pointers(self, kv_caches: List[torch.Tensor]) -> torch.Tensor:
         # Discover format first to handle flattening correctly
-        self.gpu_kv_format, kv_caches = normalize_kv_and_discover_format(
+        self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
             kv_caches, EngineType.SGLANG
         )
 
         # For TWO_X_NL_X_NBBS_NH_HS format, kv_caches is [[k_list], [v_list]]
         # We need to flatten it to [k0, k1, ..., v0, v1, ...]
-        if self.gpu_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
+        if self.engine_kv_format == lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS:
             flat_kv_caches = kv_caches[0] + kv_caches[1]  # [k_list] + [v_list]
             device = flat_kv_caches[0].device
         else:
@@ -1306,7 +1310,7 @@ class SGLangXPUConnector(GPUConnectorInterface):
         # sglang MLA kv_caches[0].shape: [num_pages * page_size, 1, head_size]
         # sglang MHA kv_caches: [[k_list], [v_list]]
         # each with shape [num_pages * page_size, num_heads, head_size]
-        self.page_buffer_size = get_page_buffer_size(kv_caches, self.gpu_kv_format)
+        self.page_buffer_size = get_page_buffer_size(kv_caches, self.engine_kv_format)
         return self.kv_cache_pointers_on_gpu[idx]
 
     @_lmcache_nvtx_annotate
@@ -1361,7 +1365,7 @@ class SGLangXPUConnector(GPUConnectorInterface):
             kvcaches[0][0].device,
             self.page_buffer_size,
             lmc_ops.TransferDirection.H2D,
-            self.gpu_kv_format,
+            self.engine_kv_format,
         )
 
     @_lmcache_nvtx_annotate
@@ -1404,7 +1408,7 @@ class SGLangXPUConnector(GPUConnectorInterface):
                 kvcaches[0][0].device,
                 self.page_buffer_size,
                 lmc_ops.TransferDirection.D2H,
-                self.gpu_kv_format,
+                self.engine_kv_format,
             )
         else:
             # kvcaches -> gpu_buffer -> memobj
@@ -1417,7 +1421,7 @@ class SGLangXPUConnector(GPUConnectorInterface):
                 kvcaches[0][0].device,
                 self.page_buffer_size,
                 lmc_ops.TransferDirection.D2H,
-                self.gpu_kv_format,
+                self.engine_kv_format,
             )
             memory_obj.tensor.copy_(tmp_gpu_buffer, non_blocking=True)
 
@@ -1476,7 +1480,7 @@ class SGLangLayerwiseXPUConnector(GPUConnectorInterface):
             self.num_kv_cache, dtype=torch.uint64, device="cpu"
         )
         self.use_gpu = use_gpu
-        self.gpu_kv_format = None
+        self.engine_kv_format = None
         self.gpu_buffer_allocator: Optional[GPUMemoryAllocator] = None
 
     def _lazy_initialize_buffer(self, kv_caches):
@@ -1489,13 +1493,15 @@ class SGLangLayerwiseXPUConnector(GPUConnectorInterface):
         discovered_format, normalized_kv_caches = normalize_kv_and_discover_format(
             kv_caches, EngineType.SGLANG
         )
-        if self.gpu_kv_format is None:
-            self.gpu_kv_format = discovered_format
+        if self.engine_kv_format is None:
+            self.engine_kv_format = discovered_format
 
         if self.use_gpu and self.gpu_buffer_allocator is None:
-            self.tokens_per_layer = get_tokens_per_layer(kv_caches, self.gpu_kv_format)
+            self.tokens_per_layer = get_tokens_per_layer(
+                kv_caches, self.engine_kv_format
+            )
             self.elements_per_layer = get_elements_per_layer(
-                normalized_kv_caches, self.gpu_kv_format
+                normalized_kv_caches, self.engine_kv_format
             )
             logger.info(
                 f"Lazily initializing GPU buffer (max tokens={self.tokens_per_layer})."
@@ -1601,7 +1607,7 @@ class SGLangLayerwiseXPUConnector(GPUConnectorInterface):
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
                             lmc_ops.TransferDirection.H2D,
-                            self.gpu_kv_format,
+                            self.engine_kv_format,
                             token_major=True,
                         )
                     else:
@@ -1621,7 +1627,7 @@ class SGLangLayerwiseXPUConnector(GPUConnectorInterface):
                         self.kvcaches[layer_id],
                         slot_mapping_full,
                         lmc_ops.TransferDirection.H2D,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         token_major=True,
                     )
                 else:
@@ -1724,7 +1730,7 @@ class SGLangLayerwiseXPUConnector(GPUConnectorInterface):
                         self.kvcaches[layer_id],
                         slot_mapping_full,
                         lmc_ops.TransferDirection.D2H,
-                        self.gpu_kv_format,
+                        self.engine_kv_format,
                         token_major=True,
                     )
                 else:
@@ -1758,7 +1764,7 @@ class SGLangLayerwiseXPUConnector(GPUConnectorInterface):
                             self.kvcaches[layer_id],
                             slot_mapping[start:end],
                             lmc_ops.TransferDirection.D2H,
-                            self.gpu_kv_format,
+                            self.engine_kv_format,
                             token_major=True,
                         )
                     else:

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -69,7 +69,7 @@ EXCLUDED_ENGINE_GROUP = -1
 
 def group_layers_by_identity(
     kv_caches: "DiscoverableKVCache",
-    engine_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.EngineKVFormat",
     num_layers: int,
     per_layer_engine_group_idx: Sequence[int] | None = None,
 ) -> list[tuple[LayerGroupIdentity, list[int]]]:
@@ -277,7 +277,7 @@ class KVLayerGroupsManager:
     def __init__(
         self,
         kv_caches: "DiscoverableKVCache",
-        engine_kv_format: "lmc_ops.GPUKVFormat",
+        engine_kv_format: "lmc_ops.EngineKVFormat",
         num_blocks: int,
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         lmcache_tokens_per_chunk: int = 256,
@@ -659,7 +659,7 @@ def parse_kvcache_shape_spec(
         dtype       := "float16" | "float32" | "bfloat16" | "uint8"
         layer_count := positive integer
 
-    **Field semantics** (names aligned with ``GPUKVFormat``; see
+    **Field semantics** (names aligned with ``EngineKVFormat``; see
     :func:`lmcache.v1.gpu_connector.utils.get_engine_kv_shape_description`):
 
     * ``kv_size`` -- leading dim (``2`` for standard K/V, ``1`` for MLA).

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -69,7 +69,7 @@ EXCLUDED_ENGINE_GROUP = -1
 
 def group_layers_by_identity(
     kv_caches: "DiscoverableKVCache",
-    gpu_kv_format: "lmc_ops.GPUKVFormat",
+    engine_kv_format: "lmc_ops.GPUKVFormat",
     num_layers: int,
     per_layer_engine_group_idx: Sequence[int] | None = None,
 ) -> list[tuple[LayerGroupIdentity, list[int]]]:
@@ -81,7 +81,7 @@ def group_layers_by_identity(
     Args:
         kv_caches: Registered KV cache structure inspected for per-layer shape
             and dtype.
-        gpu_kv_format: Format descriptor returned by
+        engine_kv_format: Format descriptor returned by
             :func:`normalize_kv_and_discover_format`, used to read heads/sizes.
         num_layers: Number of registered KV tensors to partition.
         per_layer_engine_group_idx: Optional per-registered-index engine
@@ -106,7 +106,7 @@ def group_layers_by_identity(
         is_mla,
     )
 
-    mla = is_mla(gpu_kv_format)
+    mla = is_mla(engine_kv_format)
     kv_size = 1 if mla else 2
     groups_dict: dict[LayerGroupIdentity, list[int]] = defaultdict(list)
     for idx in range(num_layers):
@@ -119,10 +119,10 @@ def group_layers_by_identity(
         # KV-sharing layers, whose KV lives in their target owner's blocks).
         if engine_group_idx == EXCLUDED_ENGINE_GROUP:
             continue
-        nh = 1 if mla else get_num_heads(kv_caches, gpu_kv_format, idx)
-        hs = get_head_size(kv_caches, gpu_kv_format, idx)
-        dt = get_dtype(kv_caches, gpu_kv_format, idx)
-        bs = get_block_size(kv_caches, gpu_kv_format, idx)
+        nh = 1 if mla else get_num_heads(kv_caches, engine_kv_format, idx)
+        hs = get_head_size(kv_caches, engine_kv_format, idx)
+        dt = get_dtype(kv_caches, engine_kv_format, idx)
+        bs = get_block_size(kv_caches, engine_kv_format, idx)
 
         identity = LayerGroupIdentity(
             kv_size=kv_size,
@@ -277,7 +277,7 @@ class KVLayerGroupsManager:
     def __init__(
         self,
         kv_caches: "DiscoverableKVCache",
-        gpu_kv_format: "lmc_ops.GPUKVFormat",
+        engine_kv_format: "lmc_ops.GPUKVFormat",
         num_blocks: int,
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         lmcache_tokens_per_chunk: int = 256,
@@ -297,7 +297,7 @@ class KVLayerGroupsManager:
         Args:
             kv_caches: KV cache structure accepted by
                 :func:`normalize_kv_and_discover_format`.
-            gpu_kv_format: Format returned by
+            engine_kv_format: Format returned by
                 :func:`normalize_kv_and_discover_format`.
             num_blocks: Number of paged blocks in the device KV cache.
             engine_group_infos: Engine KV cache group metadata, one info per
@@ -317,7 +317,7 @@ class KVLayerGroupsManager:
         self._kernel_groups: list[KernelGroupInfo] = []
         self._object_groups: list[ObjectGroupInfo] = []
 
-        num_layers = get_num_layers(kv_caches, gpu_kv_format)
+        num_layers = get_num_layers(kv_caches, engine_kv_format)
         if num_layers == 0:
             logger.debug("No KV caches available, skipping KV layer groups building")
             return
@@ -327,7 +327,7 @@ class KVLayerGroupsManager:
         )
 
         groups_by_identity = group_layers_by_identity(
-            kv_caches, gpu_kv_format, num_layers, per_layer_engine_group_idx
+            kv_caches, engine_kv_format, num_layers, per_layer_engine_group_idx
         )
 
         # Engine group infos are produced by the same group_layers_by_identity
@@ -347,13 +347,13 @@ class KVLayerGroupsManager:
         ):
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,
-                gpu_kv_format,
+                engine_kv_format,
                 layer_idx=indices[0],
                 group_idx=group_idx,
             )
             shape_desc = make_page_buffer_shape_desc(
                 kv_caches,
-                gpu_kv_format,
+                engine_kv_format,
                 layer_idx=indices[0],
                 num_layers_in_group=len(indices),
                 num_blocks=num_blocks,
@@ -660,7 +660,7 @@ def parse_kvcache_shape_spec(
         layer_count := positive integer
 
     **Field semantics** (names aligned with ``GPUKVFormat``; see
-    :func:`lmcache.v1.gpu_connector.utils.get_gpu_kv_shape_description`):
+    :func:`lmcache.v1.gpu_connector.utils.get_engine_kv_shape_description`):
 
     * ``kv_size`` -- leading dim (``2`` for standard K/V, ``1`` for MLA).
     * ``NB`` -- ``num_blocks``: paged-KV block count.

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -27,10 +27,10 @@ from lmcache.v1.gpu_connector.gds_context import get_gds_context
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     get_attention_backend,
-    get_concrete_gpu_kv_shape_from_shape_desc,
+    get_concrete_engine_kv_shape_from_shape_desc,
     get_device,
     get_dtype,
-    get_gpu_kv_shape_description,
+    get_engine_kv_shape_description,
     get_group_data_ptrs,
     get_num_blocks,
     get_num_layers,
@@ -362,20 +362,20 @@ class GPUCacheContext:
         engine_type: EngineType = EngineType.VLLM,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
-        self.gpu_kv_format_, self.kv_caches_ = normalize_kv_and_discover_format(
+        self.engine_kv_format_, self.kv_caches_ = normalize_kv_and_discover_format(
             unwrapped,
             engine_type,
             layout_hints=layout_hints,
         )
         self.device_ = get_device(self.kv_caches_)
-        self.is_mla_ = is_mla(self.gpu_kv_format_)
-        self.num_layers_ = get_num_layers(self.kv_caches_, self.gpu_kv_format_)
-        self.num_blocks_ = get_num_blocks(self.kv_caches_, self.gpu_kv_format_)
+        self.is_mla_ = is_mla(self.engine_kv_format_)
+        self.num_layers_ = get_num_layers(self.kv_caches_, self.engine_kv_format_)
+        self.num_blocks_ = get_num_blocks(self.kv_caches_, self.engine_kv_format_)
         self.lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
 
         self.kv_layer_groups_manager_ = KVLayerGroupsManager(
             self.kv_caches_,
-            gpu_kv_format=self.gpu_kv_format_,
+            engine_kv_format=self.engine_kv_format_,
             num_blocks=self.num_blocks_,
             engine_group_infos=engine_group_infos,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
@@ -384,7 +384,7 @@ class GPUCacheContext:
         self.group_kv_pointers_: list[torch.Tensor] = []
         for group in self.kv_layer_groups_manager_.kv_layer_groups:
             ptrs = get_group_data_ptrs(
-                self.kv_caches_, self.gpu_kv_format_, group.layer_indices
+                self.kv_caches_, self.engine_kv_format_, group.layer_indices
             )
             self.group_kv_pointers_.append(list_to_gpu_tensor(ptrs, self.device_))
 
@@ -436,7 +436,7 @@ class GPUCacheContext:
 
     @property
     def dtype(self) -> torch.dtype:
-        return get_dtype(self.kv_caches_, self.gpu_kv_format_)
+        return get_dtype(self.kv_caches_, self.engine_kv_format_)
 
     @property
     def device(self) -> torch.device:
@@ -697,8 +697,8 @@ class GPUCacheContext:
               - ``dtype`` (str): stringified torch dtype.
               - ``gpu_kv_concrete_shape`` (str): group-accurate numeric shape.
               - ``is_mla`` (bool)
-              - ``gpu_kv_format`` (str): GPU KV format enum name.
-              - ``gpu_kv_shape`` (str): symbolic shape description.
+              - ``engine_kv_format`` (str): engine KV format enum name.
+              - ``engine_kv_shape`` (str): symbolic shape description.
               - ``attention_backend`` (str)
         """
         manager = self.kv_layer_groups_manager
@@ -711,7 +711,7 @@ class GPUCacheContext:
             for kg_idx in og.kernel_group_indices
         }
 
-        gpu_kv_format = self.gpu_kv_format_
+        engine_kv_format = self.engine_kv_format_
         group_reports: list[dict] = []
         for kernel_group_idx, group in enumerate(kernel_groups):
             group_reports.append(
@@ -726,13 +726,17 @@ class GPUCacheContext:
                     "tokens_per_block": group.tokens_per_block,
                     "slots_per_block": group.slots_per_block,
                     "dtype": str(group.dtype),
-                    "gpu_kv_concrete_shape": get_concrete_gpu_kv_shape_from_shape_desc(
-                        group.shape_desc, gpu_kv_format
+                    "engine_kv_concrete_shape": (
+                        get_concrete_engine_kv_shape_from_shape_desc(
+                            group.shape_desc, engine_kv_format
+                        )
                     ),
-                    "is_mla": is_mla(gpu_kv_format),
-                    "gpu_kv_format": gpu_kv_format.name,
-                    "gpu_kv_shape": get_gpu_kv_shape_description(gpu_kv_format),
-                    "attention_backend": get_attention_backend(gpu_kv_format),
+                    "is_mla": is_mla(engine_kv_format),
+                    "engine_kv_format": engine_kv_format.name,
+                    "engine_kv_shape": get_engine_kv_shape_description(
+                        engine_kv_format
+                    ),
+                    "attention_backend": get_attention_backend(engine_kv_format),
                 }
             )
 

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -159,14 +159,14 @@ async def kvcache_check(
             content={"error": "kv_caches empty"},
         )
 
-    gpu_kv_format = ctx.gpu_kv_format_
-    block_axis = _BLOCK_AXIS_BY_FORMAT.get(gpu_kv_format)
+    engine_kv_format = ctx.engine_kv_format_
+    block_axis = _BLOCK_AXIS_BY_FORMAT.get(engine_kv_format)
     if block_axis is None:
         return JSONResponse(
             status_code=501,
             content={
                 "error": "checksum not supported for GPU KV format %s"
-                % gpu_kv_format.name
+                % engine_kv_format.name
             },
         )
 

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -33,11 +33,11 @@ router = APIRouter()
 # semantics don't map cleanly onto a single layer tensor, and the diagnostic
 # API declines them with HTTP 501 until a real need appears.
 _BLOCK_AXIS_BY_FORMAT: dict[Any, int] = {
-    lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS: 1,  # [2, NB, BS, NH, HS]
-    lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS: 0,  # [NB, 2, BS, NH, HS]
-    lmc_ops.GPUKVFormat.NL_X_NB_BS_HS: 0,  # MLA: [NB, BS, HS]
-    lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS: 1,  # [2, NB, NH, BS, HS]
-    lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS: 0,  # [NB, 2, NH, BS, HS]
+    lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS: 1,  # [2, NB, BS, NH, HS]
+    lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS: 0,  # [NB, 2, BS, NH, HS]
+    lmc_ops.EngineKVFormat.NL_X_NB_BS_HS: 0,  # MLA: [NB, BS, HS]
+    lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS: 1,  # [2, NB, NH, BS, HS]
+    lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS: 0,  # [NB, 2, NH, BS, HS]
 }
 
 

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1461,7 +1461,7 @@ class BlendV3Module:
                                     gpu_context.device,
                                     page_buffer_size,
                                     lmc_ops.TransferDirection.H2D,
-                                    gpu_context.gpu_kv_format_,
+                                    gpu_context.engine_kv_format_,
                                     block_size=bs,
                                     head_size=rope_state.head_size,
                                 )

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -365,7 +365,7 @@ def transfer_kv_per_object_group(
                 direction,
                 cache_context.get_shape_desc(kernel_group_id),
                 group_lmcache_chunk_size,
-                cache_context.gpu_kv_format_,
+                cache_context.engine_kv_format_,
                 recalculated_skip_blocks,
             )
 
@@ -388,7 +388,7 @@ class ContextEntry:
     for the wrapper list at registration time -- a
     :class:`GPUCacheContext` for CUDA-IPC wrappers, a
     :class:`CpuCacheContext` for POSIX-SHM wrappers. Both expose
-    the same ``kv_tensors`` / ``gpu_kv_format_`` / ``num_layers`` / ...
+    the same ``kv_tensors`` / ``engine_kv_format_`` / ``num_layers`` / ...
     duck-typed surface, so downstream consumers stay agnostic.
 
     Args:

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -272,7 +272,7 @@ def compute_kv_layout(
 
     Returns:
         Tuple of ``(block_size, num_layers, hidden_dim_size, dtype_str,``
-        ``gpu_kv_format)``.
+        ``engine_kv_format)``.
 
     Raises:
         ValueError: If ``kv_caches`` is empty.
@@ -289,14 +289,14 @@ def compute_kv_layout(
     if not tensors:
         raise ValueError("kv_caches is empty. Cannot compute KV layout.")
 
-    gpu_kv_format, normalized = normalize_kv_and_discover_format(
+    engine_kv_format, normalized = normalize_kv_and_discover_format(
         tensors, EngineType.VLLM, layout_hints=layout_hints
     )
-    block_size = get_block_size(normalized, gpu_kv_format)
-    num_layers = get_num_layers(normalized, gpu_kv_format)
-    hidden_dim_size = get_hidden_dim_size(normalized, gpu_kv_format)
+    block_size = get_block_size(normalized, engine_kv_format)
+    num_layers = get_num_layers(normalized, engine_kv_format)
+    hidden_dim_size = get_hidden_dim_size(normalized, engine_kv_format)
     dtype_str = str(tensors[0].dtype).replace("torch.", "")
-    return block_size, num_layers, hidden_dim_size, dtype_str, gpu_kv_format
+    return block_size, num_layers, hidden_dim_size, dtype_str, engine_kv_format
 
 
 def gather_paged_kv_to_cpu(
@@ -304,7 +304,7 @@ def gather_paged_kv_to_cpu(
     block_ids: list[int],
     blocks_per_chunk: int,
     layout_hints: LayoutHints | None = None,
-    gpu_kv_format: "lmc_ops.GPUKVFormat" | None = None,
+    engine_kv_format: "lmc_ops.GPUKVFormat" | None = None,
     out: list[torch.Tensor] | None = None,
     chunk_indices: list[int] | None = None,
 ) -> list[torch.Tensor]:
@@ -315,7 +315,7 @@ def gather_paged_kv_to_cpu(
         block_ids: Flattened block IDs for all chunks.
         blocks_per_chunk: Number of paged blocks in one LMCache chunk.
         layout_hints: Optional engine layout hints.
-        gpu_kv_format: Optional pre-detected KV format.
+        engine_kv_format: Optional pre-detected KV format.
         out: Optional pre-allocated output tensors.  If provided, length
             must be at least ``len(chunk_indices)`` when ``chunk_indices``
             is given, or the total number of chunks otherwise.  Any extra
@@ -352,19 +352,19 @@ def gather_paged_kv_to_cpu(
     fmt, normalized = normalize_kv_and_discover_format(
         tensors, EngineType.VLLM, layout_hints=layout_hints
     )
-    if gpu_kv_format is None:
-        gpu_kv_format = fmt
+    if engine_kv_format is None:
+        engine_kv_format = fmt
 
-    block_size = get_block_size(normalized, gpu_kv_format)
-    num_layers = get_num_layers(normalized, gpu_kv_format)
-    hidden_dim_size = get_hidden_dim_size(normalized, gpu_kv_format)
-    num_blocks = get_num_blocks(normalized, gpu_kv_format)
+    block_size = get_block_size(normalized, engine_kv_format)
+    num_layers = get_num_layers(normalized, engine_kv_format)
+    hidden_dim_size = get_hidden_dim_size(normalized, engine_kv_format)
+    num_blocks = get_num_blocks(normalized, engine_kv_format)
     num_chunks = len(block_ids) // blocks_per_chunk
     chunk_tokens = blocks_per_chunk * block_size
 
     shape_desc = make_page_buffer_shape_desc(
         normalized,
-        gpu_kv_format,
+        engine_kv_format,
         layer_idx=0,
         num_layers_in_group=num_layers,
         num_blocks=num_blocks,
@@ -390,7 +390,7 @@ def gather_paged_kv_to_cpu(
     staged_chunks = []
 
     if out is None:
-        use_mla = is_mla(gpu_kv_format)
+        use_mla = is_mla(engine_kv_format)
         if use_mla:
             chunks = [
                 torch.empty(
@@ -464,7 +464,7 @@ def gather_paged_kv_to_cpu(
                 lmc_ops.TransferDirection.D2H,
                 shape_desc,
                 chunk_tokens,
-                gpu_kv_format,
+                engine_kv_format,
                 0,
             )
 
@@ -508,7 +508,7 @@ def gather_paged_kv_to_cpu(
                     lmc_ops.TransferDirection.D2H,
                     shape_desc,
                     chunk_tokens,
-                    gpu_kv_format,
+                    engine_kv_format,
                     0,
                 )
 
@@ -545,7 +545,7 @@ def scatter_cpu_to_paged_kv(
     blocks_per_chunk: int,
     skip_first_n_tokens: int = 0,
     layout_hints: LayoutHints | None = None,
-    gpu_kv_format: "lmc_ops.GPUKVFormat" | None = None,
+    engine_kv_format: "lmc_ops.GPUKVFormat" | None = None,
 ) -> None:
     """Scatter CPU chunk tensors back into paged KV tensors.
 
@@ -562,7 +562,7 @@ def scatter_cpu_to_paged_kv(
             to the nearest whole block and an error is logged (matching the
             GPU transfer path).
         layout_hints: Optional engine layout hints.
-        gpu_kv_format: Optional pre-detected KV format.
+        engine_kv_format: Optional pre-detected KV format.
 
     Raises:
         ValueError: If ``block_ids`` is shorter than
@@ -594,12 +594,12 @@ def scatter_cpu_to_paged_kv(
     fmt, normalized = normalize_kv_and_discover_format(
         tensors, EngineType.VLLM, layout_hints=layout_hints
     )
-    if gpu_kv_format is None:
-        gpu_kv_format = fmt
+    if engine_kv_format is None:
+        engine_kv_format = fmt
 
-    block_size = get_block_size(normalized, gpu_kv_format)
-    num_layers = get_num_layers(normalized, gpu_kv_format)
-    num_blocks = get_num_blocks(normalized, gpu_kv_format)
+    block_size = get_block_size(normalized, engine_kv_format)
+    num_layers = get_num_layers(normalized, engine_kv_format)
+    num_blocks = get_num_blocks(normalized, engine_kv_format)
     chunk_tokens = blocks_per_chunk * block_size
 
     # Block-level transfer can only skip whole blocks. A non-aligned prefix is
@@ -618,7 +618,7 @@ def scatter_cpu_to_paged_kv(
 
     shape_desc = make_page_buffer_shape_desc(
         normalized,
-        gpu_kv_format,
+        engine_kv_format,
         layer_idx=0,
         num_layers_in_group=num_layers,
         num_blocks=num_blocks,
@@ -648,7 +648,7 @@ def scatter_cpu_to_paged_kv(
             lmc_ops.TransferDirection.H2D,
             shape_desc,
             chunk_tokens,
-            gpu_kv_format,
+            engine_kv_format,
             skip_prefix_n_blocks,
         )
     else:
@@ -705,7 +705,7 @@ def scatter_cpu_to_paged_kv(
                 lmc_ops.TransferDirection.H2D,
                 shape_desc,
                 chunk_tokens,
-                gpu_kv_format,
+                engine_kv_format,
                 skip_prefix_n_blocks if i == 0 else 0,
             )
     # Fast path: The async GPU copy might still be in progress.

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -263,7 +263,7 @@ def create_non_gpu_context(
 def compute_kv_layout(
     kv_caches: dict[str, torch.Tensor],
     layout_hints: LayoutHints | None = None,
-) -> tuple[int, int, int, str, "lmc_ops.GPUKVFormat"]:
+) -> tuple[int, int, int, str, "lmc_ops.EngineKVFormat"]:
     """Compute KV layout metadata from KV tensors.
 
     Args:
@@ -304,7 +304,7 @@ def gather_paged_kv_to_cpu(
     block_ids: list[int],
     blocks_per_chunk: int,
     layout_hints: LayoutHints | None = None,
-    engine_kv_format: "lmc_ops.GPUKVFormat" | None = None,
+    engine_kv_format: "lmc_ops.EngineKVFormat" | None = None,
     out: list[torch.Tensor] | None = None,
     chunk_indices: list[int] | None = None,
 ) -> list[torch.Tensor]:
@@ -545,7 +545,7 @@ def scatter_cpu_to_paged_kv(
     blocks_per_chunk: int,
     skip_first_n_tokens: int = 0,
     layout_hints: LayoutHints | None = None,
-    engine_kv_format: "lmc_ops.GPUKVFormat" | None = None,
+    engine_kv_format: "lmc_ops.EngineKVFormat" | None = None,
 ) -> None:
     """Scatter CPU chunk tensors back into paged KV tensors.
 

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -308,7 +308,7 @@ class DataTransferContext(TransferContext):
     def __init__(self) -> None:
         self._non_gpu_context: NonGpuContext | None = None
         self._layout_hints: LayoutHints | None = None
-        self._gpu_kv_format: Any = None
+        self._engine_kv_format: Any = None
 
     def register(
         self,
@@ -338,12 +338,12 @@ class DataTransferContext(TransferContext):
             num_layers,
             hidden_dim_size,
             dtype_str,
-            gpu_kv_format,
+            engine_kv_format,
         ) = compute_kv_layout(kv_caches, layout_hints=layout_hints)
         self._layout_hints = layout_hints
-        self._gpu_kv_format = gpu_kv_format
+        self._engine_kv_format = engine_kv_format
 
-        use_mla_flag = is_mla(gpu_kv_format)
+        use_mla_flag = is_mla(engine_kv_format)
         shape = (
             torch.Size([num_layers, blocks_in_chunk * block_size, hidden_dim_size])
             if use_mla_flag
@@ -425,7 +425,7 @@ class DataTransferContext(TransferContext):
             _single_group_block_ids(block_ids),
             blocks_in_chunk,
             layout_hints=self._layout_hints,
-            gpu_kv_format=self._gpu_kv_format,
+            engine_kv_format=self._engine_kv_format,
             out=out_buffers,
             chunk_indices=chunk_indices,
         )
@@ -466,7 +466,7 @@ class DataTransferContext(TransferContext):
                     blocks_in_chunk,
                     skip_first_n_tokens=skip_first_n_tokens,
                     layout_hints=self._layout_hints,
-                    gpu_kv_format=self._gpu_kv_format,
+                    engine_kv_format=self._engine_kv_format,
                 )
             except (RuntimeError, ValueError, TypeError, IndexError):
                 logger.exception("Failed to scatter retrieved CPU context chunks")

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -32,8 +32,8 @@ from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     get_attention_backend,
-    get_concrete_gpu_kv_shape_from_shape_desc,
-    get_gpu_kv_shape_description,
+    get_concrete_engine_kv_shape_from_shape_desc,
+    get_engine_kv_shape_description,
     get_group_data_ptrs,
     get_num_blocks,
     get_num_layers,
@@ -97,7 +97,7 @@ class CpuCacheContext:
         # PageBufferShapeDesc here. ``layout_hints`` / ``engine_type``
         # are forwarded so the signature matches GPUCacheContext.
         (
-            self._gpu_kv_format,
+            self._engine_kv_format,
             kv_caches_normalized,
         ) = normalize_kv_and_discover_format(
             unwrapped,
@@ -105,12 +105,12 @@ class CpuCacheContext:
             layout_hints=layout_hints,
         )
         self.kv_caches_: list[torch.Tensor] = list(kv_caches_normalized)
-        self.is_mla_ = is_mla(self._gpu_kv_format)
-        self.num_layers_ = get_num_layers(self.kv_caches_, self._gpu_kv_format)
-        self.num_blocks_ = get_num_blocks(self.kv_caches_, self._gpu_kv_format)
+        self.is_mla_ = is_mla(self._engine_kv_format)
+        self.num_layers_ = get_num_layers(self.kv_caches_, self._engine_kv_format)
+        self.num_blocks_ = get_num_blocks(self.kv_caches_, self._engine_kv_format)
         self.kv_layer_groups_manager_ = KVLayerGroupsManager(
             self.kv_caches_,
-            gpu_kv_format=self._gpu_kv_format,
+            engine_kv_format=self._engine_kv_format,
             num_blocks=self.num_blocks_,
             engine_group_infos=engine_group_infos,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
@@ -122,7 +122,7 @@ class CpuCacheContext:
             torch.tensor(
                 get_group_data_ptrs(
                     self.kv_caches_,
-                    self.gpu_kv_format_,
+                    self.engine_kv_format_,
                     group.layer_indices,
                 ),
                 dtype=torch.long,
@@ -294,26 +294,26 @@ class CpuCacheContext:
         return self.kv_layer_groups_manager_
 
     @property
-    def gpu_kv_format_(self):
+    def engine_kv_format_(self):
         """Returns the GPU KV format enum (API parity with GPUCacheContext)."""
-        return self._gpu_kv_format
+        return self._engine_kv_format
 
     @property
-    def gpu_kv_shape(self) -> str:
+    def engine_kv_shape(self) -> str:
         """Returns the symbolic GPU KV cache layout description."""
-        return get_gpu_kv_shape_description(self._gpu_kv_format)
+        return get_engine_kv_shape_description(self._engine_kv_format)
 
     @property
     def attention_backend(self) -> str:
         """Returns the attention backend name."""
-        return get_attention_backend(self._gpu_kv_format)
+        return get_attention_backend(self._engine_kv_format)
 
     @property
-    def concrete_gpu_kv_shape(self) -> str:
-        """Returns the GPU KV shape with actual numeric values."""
+    def concrete_engine_kv_shape(self) -> str:
+        """Returns the engine KV shape with actual numeric values."""
         group = self.kv_layer_groups_manager_.kv_layer_groups[0]
-        return get_concrete_gpu_kv_shape_from_shape_desc(
-            group.shape_desc, self._gpu_kv_format
+        return get_concrete_engine_kv_shape_from_shape_desc(
+            group.shape_desc, self._engine_kv_format
         )
 
     def calculate_num_blocks(self, num_tokens: int, kernel_group_idx: int) -> int:
@@ -591,7 +591,7 @@ class CpuCacheContext:
             for kg_idx in og.kernel_group_indices
         }
 
-        gpu_kv_format = self._gpu_kv_format
+        engine_kv_format = self._engine_kv_format
         group_reports: list[dict] = []
         for kernel_group_idx, group in enumerate(kernel_groups):
             group_reports.append(
@@ -606,15 +606,17 @@ class CpuCacheContext:
                     "tokens_per_block": group.tokens_per_block,
                     "slots_per_block": group.slots_per_block,
                     "dtype": str(group.dtype),
-                    "gpu_kv_concrete_shape": (
-                        get_concrete_gpu_kv_shape_from_shape_desc(
-                            group.shape_desc, gpu_kv_format
+                    "engine_kv_concrete_shape": (
+                        get_concrete_engine_kv_shape_from_shape_desc(
+                            group.shape_desc, engine_kv_format
                         )
                     ),
-                    "is_mla": is_mla(gpu_kv_format),
-                    "gpu_kv_format": gpu_kv_format.name,
-                    "gpu_kv_shape": get_gpu_kv_shape_description(gpu_kv_format),
-                    "attention_backend": get_attention_backend(gpu_kv_format),
+                    "is_mla": is_mla(engine_kv_format),
+                    "engine_kv_format": engine_kv_format.name,
+                    "engine_kv_shape": get_engine_kv_shape_description(
+                        engine_kv_format
+                    ),
+                    "attention_backend": get_attention_backend(engine_kv_format),
                 }
             )
 

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -47,10 +47,10 @@ SAMPLE_STATUS = {
                         "tokens_per_block": 16,
                         "slots_per_block": 16,
                         "dtype": "torch.float16",
-                        "gpu_kv_concrete_shape": "32 x [2, 2048, 16, 8, 128]",
+                        "engine_kv_concrete_shape": "32 x [2, 2048, 16, 8, 128]",
                         "is_mla": False,
-                        "gpu_kv_format": "NL_X_TWO_NB_BS_NH_HS",
-                        "gpu_kv_shape": "NL x [2, NB, BS, NH, HS]",
+                        "engine_kv_format": "NL_X_TWO_NB_BS_NH_HS",
+                        "engine_kv_shape": "NL x [2, NB, BS, NH, HS]",
                         "attention_backend": "vLLM non-MLA flash attention",
                     },
                 ],
@@ -208,8 +208,8 @@ class TestDescribeKvcacheFields:
         assert kg["dtype"] == "torch.float16"
         assert kg["is_mla"] is False
         assert kg["attention_backend"] == "vLLM non-MLA flash attention"
-        assert kg["gpu_kv_shape"] == "NL x [2, NB, BS, NH, HS]"
-        assert kg["gpu_kv_concrete_shape"] == "32 x [2, 2048, 16, 8, 128]"
+        assert kg["engine_kv_shape"] == "NL x [2, NB, BS, NH, HS]"
+        assert kg["engine_kv_concrete_shape"] == "32 x [2, 2048, 16, 8, 128]"
 
     def test_unhealthy(self):
         """Verify health shows UNHEALTHY when is_healthy is False."""

--- a/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
@@ -50,7 +50,7 @@ def test_discovery_splits_fused_axis():
     fmt, norm = U.normalize_kv_and_discover_format(
         _raw_blocks_first_caches(), EngineType.VLLM, HINTS
     )
-    assert fmt == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS
+    assert fmt == lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS
     # 4D [NB, NH, BS, 2*HS] -> canonical 5D [NB, NH, BS, 2, HS]
     assert tuple(norm[0].shape) == (NB, NH, BS, 2, HS)
 

--- a/tests/v1/gpu_connector/test_concrete_shape.py
+++ b/tests/v1/gpu_connector/test_concrete_shape.py
@@ -32,7 +32,7 @@ def _make_shape_desc(
 def test_concrete_shape_vllm_flash_attn():
     sd = _make_shape_desc(kv_size=2, nl=32, nb=2048, bs=16, nh=8, hs=128)
     out = get_concrete_gpu_kv_shape_from_shape_desc(
-        sd, lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+        sd, lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
     )
     assert out == "32 x [2, 2048, 16, 8, 128]"
 
@@ -40,7 +40,7 @@ def test_concrete_shape_vllm_flash_attn():
 def test_concrete_shape_vllm_mla():
     sd = _make_shape_desc(kv_size=1, nl=61, nb=1024, bs=64, nh=1, hs=512)
     out = get_concrete_gpu_kv_shape_from_shape_desc(
-        sd, lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
+        sd, lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
     )
     assert out == "61 x [1024, 64, 512]"
 
@@ -49,7 +49,7 @@ def test_concrete_shape_uses_pbs_for_folded_formats():
     # NL_X_NBBS_ONE_HS folds num_blocks * block_size into one PBS dim.
     sd = _make_shape_desc(kv_size=1, nl=2, nb=32, bs=16, nh=1, hs=128)
     out = get_concrete_gpu_kv_shape_from_shape_desc(
-        sd, lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS
+        sd, lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS
     )
     assert out == "2 x [512, 1, 128]"  # 512 == 32 * 16
 
@@ -57,7 +57,7 @@ def test_concrete_shape_uses_pbs_for_folded_formats():
 def test_concrete_shape_is_group_accurate():
     # Two groups with different layer counts produce different shapes for
     # the same format — the whole-context helper could not do this.
-    fmt = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+    fmt = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
     g0 = _make_shape_desc(kv_size=2, nl=4, nb=128, bs=16, nh=8, hs=64)
     g1 = _make_shape_desc(kv_size=2, nl=2, nb=128, bs=16, nh=16, hs=64)
     assert get_concrete_gpu_kv_shape_from_shape_desc(g0, fmt) == (

--- a/tests/v1/gpu_connector/test_utils_shape_desc.py
+++ b/tests/v1/gpu_connector/test_utils_shape_desc.py
@@ -30,7 +30,7 @@ def test_make_shape_desc_vllm_flash_attn_nhd():
     kv_caches = [torch.empty(2, 32, 16, 8, 64, dtype=torch.bfloat16) for _ in range(4)]
     sd = make_page_buffer_shape_desc(
         kv_caches,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
         layer_idx=0,
         num_layers_in_group=4,
         num_blocks=32,
@@ -49,7 +49,7 @@ def test_make_shape_desc_vllm_flash_infer_nhd():
     kv_caches = [torch.empty(32, 2, 16, 8, 64, dtype=torch.float16) for _ in range(2)]
     sd = make_page_buffer_shape_desc(
         kv_caches,
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
         layer_idx=0,
         num_layers_in_group=2,
         num_blocks=32,
@@ -64,7 +64,7 @@ def test_make_shape_desc_vllm_mla():
     kv_caches = [torch.empty(32, 16, 512, dtype=torch.bfloat16) for _ in range(3)]
     sd = make_page_buffer_shape_desc(
         kv_caches,
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
         layer_idx=0,
         num_layers_in_group=3,
         num_blocks=32,
@@ -79,7 +79,7 @@ def test_make_shape_desc_sglang_mla():
     kv_caches = [torch.empty(512, 1, 128, dtype=torch.bfloat16) for _ in range(2)]
     sd = make_page_buffer_shape_desc(
         kv_caches,
-        lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS,
+        lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS,
         layer_idx=0,
         num_layers_in_group=2,
         num_blocks=32,
@@ -96,7 +96,7 @@ def test_make_shape_desc_sglang_mha():
     kv_caches = [k, v]
     sd = make_page_buffer_shape_desc(
         kv_caches,
-        lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS,
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS,
         layer_idx=0,
         num_layers_in_group=4,
         num_blocks=32,
@@ -113,7 +113,7 @@ def test_per_layer_scalar_accessors_per_layer_list():
         torch.randn(2, 32, 16, 8 + i, 64, dtype=torch.float16, device="cuda")
         for i in range(3)  # distinct num_heads per layer: 8, 9, 10
     ]
-    fmt = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+    fmt = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
 
     assert get_num_heads(kv_caches, fmt, layer_idx=0) == 8
     assert get_num_heads(kv_caches, fmt, layer_idx=2) == 10
@@ -126,7 +126,7 @@ def test_per_layer_scalar_accessors_sglang_mha():
     k = [torch.randn(512, 8, 64, dtype=torch.bfloat16, device="cuda") for _ in range(2)]
     v = [torch.randn(512, 8, 64, dtype=torch.bfloat16, device="cuda") for _ in range(2)]
     kv_caches = [k, v]
-    fmt = lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
+    fmt = lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS
 
     assert get_num_heads(kv_caches, fmt, layer_idx=0) == 8
     assert get_dtype(kv_caches, fmt, layer_idx=1) == torch.bfloat16
@@ -137,7 +137,7 @@ def test_get_group_data_ptrs_per_layer_list_flattens_in_order():
         torch.randn(2, 32, 16, 8, 64, dtype=torch.float16, device="cuda")
         for _ in range(4)
     ]
-    fmt = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+    fmt = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
 
     ptrs = get_group_data_ptrs(kv_caches, fmt, [0, 2, 3])
     assert ptrs == [
@@ -153,7 +153,7 @@ def test_get_group_data_ptrs_sglang_mha_groups_k_before_v():
     k = [torch.randn(512, 8, 64, dtype=torch.bfloat16, device="cuda") for _ in range(3)]
     v = [torch.randn(512, 8, 64, dtype=torch.bfloat16, device="cuda") for _ in range(3)]
     kv_caches = [k, v]
-    fmt = lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
+    fmt = lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS
 
     ptrs = get_group_data_ptrs(kv_caches, fmt, [0, 1, 2])
     expected = [
@@ -173,7 +173,7 @@ def test_get_group_data_ptrs_cross_layer_returns_single_base():
     per-layer offsets from shape_desc.nl internally. The group helper
     must return a single base pointer, not num_layers entries."""
     big = torch.empty(32, 80, 2, 16, 8, 64, dtype=torch.bfloat16, device="cuda")
-    fmt = lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS
+    fmt = lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS
     ptrs = get_group_data_ptrs(big, fmt, list(range(80)))
     assert ptrs == [big.data_ptr()]
 

--- a/tests/v1/multiprocess/test_gpu_context.py
+++ b/tests/v1/multiprocess/test_gpu_context.py
@@ -90,14 +90,16 @@ def _make_kv_tensors(
 def _build_manager(
     tensors: list[torch.Tensor],
     num_blocks: int = 4,
-    gpu_kv_format: "lmc_ops.GPUKVFormat" = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+    engine_kv_format: "lmc_ops.EngineKVFormat" = (
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+    ),
     engine_group_infos: Sequence[EngineGroupInfo] = (),
     lmcache_tokens_per_chunk: int = 256,
 ) -> KVLayerGroupsManager:
     """Build a real :class:`KVLayerGroupsManager` from synthetic tensors."""
     return KVLayerGroupsManager(
         tensors,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
         num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
         lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/tests/v1/multiprocess/test_gpu_context.py
+++ b/tests/v1/multiprocess/test_gpu_context.py
@@ -97,7 +97,7 @@ def _build_manager(
     """Build a real :class:`KVLayerGroupsManager` from synthetic tensors."""
     return KVLayerGroupsManager(
         tensors,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
         num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
         lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
@@ -501,10 +501,10 @@ class TestGPUCacheContextReportStatus:
         "tokens_per_block",
         "slots_per_block",
         "dtype",
-        "gpu_kv_concrete_shape",
+        "engine_kv_concrete_shape",
         "is_mla",
-        "gpu_kv_format",
-        "gpu_kv_shape",
+        "engine_kv_format",
+        "engine_kv_shape",
         "attention_backend",
     }
 
@@ -523,7 +523,7 @@ class TestGPUCacheContextReportStatus:
         assert group["num_layers"] == 4
         assert group["layer_indices"] == [0, 1, 2, 3]
         assert group["is_mla"] is False
-        assert group["gpu_kv_format"] == "NL_X_TWO_NB_BS_NH_HS"
+        assert group["engine_kv_format"] == "NL_X_TWO_NB_BS_NH_HS"
         assert group["dtype"] == str(ctx.dtype)
 
     def test_report_status_multi_group(self) -> None:

--- a/tests/v1/multiprocess/test_http_server.py
+++ b/tests/v1/multiprocess/test_http_server.py
@@ -46,7 +46,7 @@ def mock_gpu_ctx():
     )
     type(ctx).block_size = PropertyMock(return_value=4)
     # KV tensors are built as [2, NB, BS, NH, HS] -> NL_X_TWO_NB_BS_NH_HS.
-    ctx.gpu_kv_format_ = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+    ctx.engine_kv_format_ = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
     return ctx
 
 

--- a/tests/v1/multiprocess/test_http_server.py
+++ b/tests/v1/multiprocess/test_http_server.py
@@ -46,7 +46,7 @@ def mock_gpu_ctx():
     )
     type(ctx).block_size = PropertyMock(return_value=4)
     # KV tensors are built as [2, NB, BS, NH, HS] -> NL_X_TWO_NB_BS_NH_HS.
-    ctx.engine_kv_format_ = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+    ctx.engine_kv_format_ = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
     return ctx
 
 

--- a/tests/v1/multiprocess/test_non_cuda_data_transfer.py
+++ b/tests/v1/multiprocess/test_non_cuda_data_transfer.py
@@ -491,7 +491,7 @@ def test_gather_scatter_roundtrip_hnd_layout(
     assert num_layers == 2
     assert hidden_dim == 16
     assert dtype_str == "float32"
-    assert detected_kv_format == getattr(lmc_ops.GPUKVFormat, expected_format)
+    assert detected_kv_format == getattr(lmc_ops.EngineKVFormat, expected_format)
 
     blocks_per_chunk = 2
     gathered = gather_paged_kv_to_cpu(
@@ -512,7 +512,7 @@ def test_gather_scatter_roundtrip_hnd_layout(
     )
 
     for name in source:
-        if detected_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
+        if detected_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS:
             assert torch.allclose(source[name][:, 0], destination[name][:, 4])
             assert torch.allclose(source[name][:, 1], destination[name][:, 5])
         else:

--- a/tests/v1/multiprocess/test_non_cuda_data_transfer.py
+++ b/tests/v1/multiprocess/test_non_cuda_data_transfer.py
@@ -499,7 +499,7 @@ def test_gather_scatter_roundtrip_hnd_layout(
         [0, 1],
         blocks_per_chunk,
         layout_hints=layout_hints,
-        gpu_kv_format=detected_kv_format,
+        engine_kv_format=detected_kv_format,
     )
     destination = {name: torch.zeros_like(tensor) for name, tensor in source.items()}
     scatter_cpu_to_paged_kv(
@@ -508,7 +508,7 @@ def test_gather_scatter_roundtrip_hnd_layout(
         gathered,
         blocks_per_chunk,
         layout_hints=layout_hints,
-        gpu_kv_format=detected_kv_format,
+        engine_kv_format=detected_kv_format,
     )
 
     for name in source:

--- a/tests/v1/storage_backend/test_dax_backend.py
+++ b/tests/v1/storage_backend/test_dax_backend.py
@@ -63,7 +63,7 @@ def _create_multi_group_metadata(chunk_size: int = 16) -> LMCacheMetadata:
     ]
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_caches,
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
         num_blocks=1,
     )
     return metadata

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -142,13 +142,13 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     gpu_kv_dst = generate_kv_cache_paged_list_tensors(
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     dtype = get_dtype(gpu_kv_src, gpu_kv_format)
 
@@ -274,7 +274,7 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_fo
                 dtype=dtypes[i],
                 num_layers=8,
                 head_size=head_sizes[i],
-                gpu_kv_format=gpu_kv_format,
+                engine_kv_format=gpu_kv_format,
             )
             groups.append(kv_group)
             for j, layer_tensor in enumerate(kv_group):
@@ -397,13 +397,13 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     gpu_kv_dst = generate_kv_cache_paged_list_tensors(
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     dtype = get_dtype(gpu_kv_src, gpu_kv_format)
 
@@ -952,7 +952,7 @@ def _create_metadata(use_mla, kv_caches, gpu_kv_format):
     kv_list = list(kv_caches.values())
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
         num_blocks=get_num_blocks(kv_list, gpu_kv_format),
     )
     return metadata

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -112,19 +112,19 @@ def patch_pin_allocator():
 
 @pytest.mark.parametrize("use_gpu", [True, False])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
     ],  # vllm MLA
 )
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV2",
 )
-def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
-    use_mla = gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
+def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, engine_kv_format):
+    use_mla = engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
     num_blocks = 100
     block_size = 16
     num_layers = 32
@@ -142,15 +142,15 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     gpu_kv_dst = generate_kv_cache_paged_list_tensors(
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
-    dtype = get_dtype(gpu_kv_src, gpu_kv_format)
+    dtype = get_dtype(gpu_kv_src, engine_kv_format)
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
@@ -168,7 +168,7 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
                 slot_mapping,
                 num_heads,
                 head_size,
-                gpu_kv_format,
+                engine_kv_format,
             )
 
     connector = VLLMPagedMemGPUConnectorV2(
@@ -225,7 +225,7 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
         )
     else:
         check_paged_kv_cache_equal(
-            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, gpu_kv_format
+            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, engine_kv_format
         )
     allocator.close()
 
@@ -233,19 +233,21 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
 @pytest.mark.parametrize("use_gpu", [True, False])
 @pytest.mark.parametrize("num_groups", [1, 2, 3])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
     ],  # vllm MLA
 )
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemGPUConnectorV3",
 )
-def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_format):
-    use_mla = gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
+def test_vllm_paged_connector_v3_with_gpu_and_mla(
+    use_gpu, num_groups, engine_kv_format
+):
+    use_mla = engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
     head_sizes = [64, 66, 66]
     dtypes = [torch.uint8, torch.bfloat16, torch.uint8]
     num_blocks = 100
@@ -274,7 +276,7 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_fo
                 dtype=dtypes[i],
                 num_layers=8,
                 head_size=head_sizes[i],
-                engine_kv_format=gpu_kv_format,
+                engine_kv_format=engine_kv_format,
             )
             groups.append(kv_group)
             for j, layer_tensor in enumerate(kv_group):
@@ -297,12 +299,12 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_fo
                     slot_mapping,
                     num_heads,
                     head_sizes[i],
-                    gpu_kv_format,
+                    engine_kv_format,
                 )
 
     # create metadata and init kv layer groups
-    metadata = _create_metadata(use_mla, src_kv_caches, gpu_kv_format)
-    metadata2 = _create_metadata(use_mla, dst_kv_caches, gpu_kv_format)
+    metadata = _create_metadata(use_mla, src_kv_caches, engine_kv_format)
+    metadata2 = _create_metadata(use_mla, dst_kv_caches, engine_kv_format)
 
     # connector will copy with src_kv_groups
     connector = VLLMPagedMemGPUConnectorV3(
@@ -362,24 +364,24 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_fo
                 slot_mapping,
                 num_heads,
                 head_sizes[i],
-                gpu_kv_format,
+                engine_kv_format,
             )
     allocator.close()
 
 
 @pytest.mark.parametrize("use_gpu", [True])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
     ],
 )
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="TODO: Add non-CUDA implementation to VLLMPagedMemLayerwiseGPUConnector",
 )
-def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
+def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, engine_kv_format):
     num_blocks = 100
     block_size = 16
     num_layers = 32
@@ -397,15 +399,15 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     gpu_kv_dst = generate_kv_cache_paged_list_tensors(
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
-    dtype = get_dtype(gpu_kv_src, gpu_kv_format)
+    dtype = get_dtype(gpu_kv_src, engine_kv_format)
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
@@ -413,7 +415,7 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
     # Check the gpu_kv is not the same before copying
     with pytest.raises(AssertionError):
         check_paged_kv_cache_equal(
-            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, gpu_kv_format
+            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, engine_kv_format
         )
 
     connector = VLLMPagedMemLayerwiseGPUConnector(
@@ -482,7 +484,7 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
     assert connector.gpu_buffer_allocator.memcheck()
 
     check_paged_kv_cache_equal(
-        gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, gpu_kv_format
+        gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, engine_kv_format
     )
 
     allocator.close()
@@ -933,7 +935,7 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
     allocator.close()
 
 
-def _create_metadata(use_mla, kv_caches, gpu_kv_format):
+def _create_metadata(use_mla, kv_caches, engine_kv_format):
     # First Party
     from lmcache.v1.gpu_connector.utils import get_num_blocks
     from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -952,7 +954,7 @@ def _create_metadata(use_mla, kv_caches, gpu_kv_format):
     kv_list = list(kv_caches.values())
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
-        engine_kv_format=gpu_kv_format,
-        num_blocks=get_num_blocks(kv_list, gpu_kv_format),
+        engine_kv_format=engine_kv_format,
+        num_blocks=get_num_blocks(kv_list, engine_kv_format),
     )
     return metadata

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -39,13 +39,14 @@ else:
 # Mock c_ops when not available
 if lmc_ops is None:
 
-    class MockGPUKVFormat:
+    class MockEngineKVFormat:
         NL_X_TWO_NB_BS_NH_HS = 0
         NL_X_NB_TWO_BS_NH_HS = 1
         NL_X_NB_BS_HS = 2
 
     class MockCOps:
-        GPUKVFormat = MockGPUKVFormat
+        EngineKVFormat = MockEngineKVFormat
+        GPUKVFormat = MockEngineKVFormat
 
     lmc_ops = MockCOps()
 

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -43,7 +43,7 @@ def _build_manager(
 
     return KVLayerGroupsManager(
         tensors,
-        gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        engine_kv_format=lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
         num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
     )

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -199,11 +199,11 @@ def test_extract_and_load_back(num_tokens):
 @pytest.mark.parametrize(
     "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
     ],
 )
-def test_multi_layer_kernel(num_tokens, gpu_kv_format):
+def test_multi_layer_kernel(num_tokens, engine_kv_format):
     device = "cuda"
 
     num_blocks = 1000
@@ -214,10 +214,10 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
     num_layers = 32
     dtype = torch.bfloat16
     kv_cache = generate_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, engine_kv_format=gpu_kv_format
+        num_blocks, device, block_size, dtype, engine_kv_format=engine_kv_format
     )
     # old deprecated kernels only handle vllm non-MLA flash attention format
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+    if engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS:
         kv_cache_force_old = [
             kv_layer.clone().permute(1, 0, 2, 3, 4).contiguous()
             for kv_layer in kv_cache
@@ -284,7 +284,7 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
             kv_cache[0].device,
             page_buffer_size,
             lmc_ops.TransferDirection.D2H,
-            gpu_kv_format,
+            engine_kv_format,
             block_size,
         )
         memory_obj_new_list.append(memory_obj_new)
@@ -302,7 +302,7 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
 
     # Generate new paged kv_cache
     kv_cache_new = generate_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, engine_kv_format=gpu_kv_format
+        num_blocks, device, block_size, dtype, engine_kv_format=engine_kv_format
     )
 
     kv_cache_pointers_new = torch.empty(
@@ -320,7 +320,7 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
             kv_cache_new[0].device,
             page_buffer_size,
             lmc_ops.TransferDirection.H2D,
-            gpu_kv_format,
+            engine_kv_format,
             block_size,
         )
 
@@ -328,7 +328,7 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
         kv_cache,
         kv_cache_new,
         slot_mapping,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
 
     mem_allocator.close()
@@ -338,9 +338,9 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
 @pytest.mark.parametrize("head_size", [576, 66])  # Use 68 for dsv32 (132x int8)
 @pytest.mark.parametrize(
     "engine_kv_format",
-    [lmc_ops.GPUKVFormat.NL_X_NB_BS_HS],  # vllm MLA
+    [lmc_ops.EngineKVFormat.NL_X_NB_BS_HS],  # vllm MLA
 )
-def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
+def test_multi_layer_kernel_use_mla(num_tokens, head_size, engine_kv_format):
     device = "cuda"
 
     num_blocks = 1000
@@ -355,7 +355,7 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
         dtype,
         num_layers,
         head_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
@@ -415,7 +415,7 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
             kv_cache[0].device,
             0,
             lmc_ops.TransferDirection.D2H,
-            gpu_kv_format,
+            engine_kv_format,
             block_size,
         )
         memory_obj_new_list.append(memory_obj_new)
@@ -445,7 +445,7 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
         dtype,
         num_layers,
         head_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
 
     kv_cache_pointers_new = torch.empty(
@@ -463,7 +463,7 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
             kv_cache_new[0].device,
             0,
             lmc_ops.TransferDirection.H2D,
-            gpu_kv_format,
+            engine_kv_format,
             block_size,
         )
 
@@ -488,11 +488,11 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
 @pytest.mark.parametrize(
     "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
     ],
 )
-def test_single_layer_kernel(num_tokens, token_major, gpu_kv_format):
+def test_single_layer_kernel(num_tokens, token_major, engine_kv_format):
     device = "cuda"
 
     num_layers = 32
@@ -503,10 +503,10 @@ def test_single_layer_kernel(num_tokens, token_major, gpu_kv_format):
     hidden_dim_size = num_heads * head_size
     dtype = torch.bfloat16
     kv_cache = generate_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, engine_kv_format=gpu_kv_format
+        num_blocks, device, block_size, dtype, engine_kv_format=engine_kv_format
     )
     kv_cache_new = generate_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, engine_kv_format=gpu_kv_format
+        num_blocks, device, block_size, dtype, engine_kv_format=engine_kv_format
     )
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device)
@@ -526,7 +526,7 @@ def test_single_layer_kernel(num_tokens, token_major, gpu_kv_format):
             kv_cache[layer_id],
             slot_mapping,
             lmc_ops.TransferDirection.D2H,
-            gpu_kv_format,
+            engine_kv_format,
             token_major,
         )
         lmc_ops.single_layer_kv_transfer(
@@ -534,7 +534,7 @@ def test_single_layer_kernel(num_tokens, token_major, gpu_kv_format):
             kv_cache_new[layer_id],
             slot_mapping,
             lmc_ops.TransferDirection.H2D,
-            gpu_kv_format,
+            engine_kv_format,
             token_major,
         )
 
@@ -542,7 +542,7 @@ def test_single_layer_kernel(num_tokens, token_major, gpu_kv_format):
         kv_cache,
         kv_cache_new,
         slot_mapping,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
 
 
@@ -550,11 +550,11 @@ def test_single_layer_kernel(num_tokens, token_major, gpu_kv_format):
 @pytest.mark.parametrize(
     "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,  # vllm HND flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,  # vllm HND flash infer
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,  # vllm HND flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,  # vllm HND flash infer
     ],
 )
-def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
+def test_multi_layer_kernel_hnd(num_tokens, engine_kv_format):
     """Round-trip test for HND multi-layer kernel: D2H then H2D."""
     device = "cuda"
 
@@ -573,7 +573,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
         dtype,
         num_layers=num_layers,
         head_size=head_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     page_buffer_size = num_blocks * block_size
 
@@ -604,7 +604,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
             kv_cache[0].device,
             page_buffer_size,
             lmc_ops.TransferDirection.D2H,
-            gpu_kv_format,
+            engine_kv_format,
             block_size,
             head_size=head_size,
         )
@@ -619,7 +619,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
         dtype,
         num_layers=num_layers,
         head_size=head_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     kv_cache_pointers_new = torch.empty(
         num_layers, dtype=torch.int64, device="cpu", pin_memory=True
@@ -635,7 +635,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
             kv_cache_new[0].device,
             page_buffer_size,
             lmc_ops.TransferDirection.H2D,
-            gpu_kv_format,
+            engine_kv_format,
             block_size,
             head_size=head_size,
         )
@@ -645,7 +645,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
         kv_cache,
         kv_cache_new,
         slot_mapping,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     mem_allocator.close()
 
@@ -655,11 +655,11 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
 @pytest.mark.parametrize(
     "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,  # vllm HND flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,  # vllm HND flash infer
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,  # vllm HND flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS,  # vllm HND flash infer
     ],
 )
-def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
+def test_single_layer_kernel_hnd(num_tokens, token_major, engine_kv_format):
     """Round-trip test for HND single-layer kernel: D2H then H2D per layer."""
     device = "cuda"
 
@@ -678,7 +678,7 @@ def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
         dtype,
         num_layers=num_layers,
         head_size=head_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     kv_cache_new = generate_kv_cache_paged_list_tensors(
         num_blocks,
@@ -687,7 +687,7 @@ def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
         dtype,
         num_layers=num_layers,
         head_size=head_size,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device)
@@ -707,7 +707,7 @@ def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
             kv_cache[layer_id],
             slot_mapping,
             lmc_ops.TransferDirection.D2H,
-            gpu_kv_format,
+            engine_kv_format,
             token_major,
         )
         lmc_ops.single_layer_kv_transfer(
@@ -715,7 +715,7 @@ def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
             kv_cache_new[layer_id],
             slot_mapping,
             lmc_ops.TransferDirection.H2D,
-            gpu_kv_format,
+            engine_kv_format,
             token_major,
         )
 
@@ -723,7 +723,7 @@ def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
         kv_cache,
         kv_cache_new,
         slot_mapping,
-        engine_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
 
 

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -29,7 +29,7 @@ else:
 # Mock c_ops when not available
 if lmc_ops is None:
 
-    class MockGPUKVFormat:
+    class MockEngineKVFormat:
         NL_X_TWO_NB_BS_NH_HS = 0
         NL_X_NB_TWO_BS_NH_HS = 1
         NL_X_NB_BS_HS = 2
@@ -41,7 +41,8 @@ if lmc_ops is None:
         D2H = 1
 
     class MockCOps:
-        GPUKVFormat = MockGPUKVFormat
+        EngineKVFormat = MockEngineKVFormat
+        GPUKVFormat = MockEngineKVFormat
         TransferDirection = MockTransferDirection
 
     lmc_ops = MockCOps()

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -197,7 +197,7 @@ def test_extract_and_load_back(num_tokens):
 
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
@@ -214,7 +214,7 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
     num_layers = 32
     dtype = torch.bfloat16
     kv_cache = generate_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, gpu_kv_format=gpu_kv_format
+        num_blocks, device, block_size, dtype, engine_kv_format=gpu_kv_format
     )
     # old deprecated kernels only handle vllm non-MLA flash attention format
     if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
@@ -302,7 +302,7 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
 
     # Generate new paged kv_cache
     kv_cache_new = generate_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, gpu_kv_format=gpu_kv_format
+        num_blocks, device, block_size, dtype, engine_kv_format=gpu_kv_format
     )
 
     kv_cache_pointers_new = torch.empty(
@@ -328,7 +328,7 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
         kv_cache,
         kv_cache_new,
         slot_mapping,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
 
     mem_allocator.close()
@@ -337,7 +337,7 @@ def test_multi_layer_kernel(num_tokens, gpu_kv_format):
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
 @pytest.mark.parametrize("head_size", [576, 66])  # Use 68 for dsv32 (132x int8)
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [lmc_ops.GPUKVFormat.NL_X_NB_BS_HS],  # vllm MLA
 )
 def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
@@ -355,7 +355,7 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
         dtype,
         num_layers,
         head_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
@@ -445,7 +445,7 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
         dtype,
         num_layers,
         head_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
 
     kv_cache_pointers_new = torch.empty(
@@ -486,7 +486,7 @@ def test_multi_layer_kernel_use_mla(num_tokens, head_size, gpu_kv_format):
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
 @pytest.mark.parametrize("token_major", [True, False])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
@@ -503,10 +503,10 @@ def test_single_layer_kernel(num_tokens, token_major, gpu_kv_format):
     hidden_dim_size = num_heads * head_size
     dtype = torch.bfloat16
     kv_cache = generate_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, gpu_kv_format=gpu_kv_format
+        num_blocks, device, block_size, dtype, engine_kv_format=gpu_kv_format
     )
     kv_cache_new = generate_kv_cache_paged_list_tensors(
-        num_blocks, device, block_size, dtype, gpu_kv_format=gpu_kv_format
+        num_blocks, device, block_size, dtype, engine_kv_format=gpu_kv_format
     )
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device)
@@ -542,13 +542,13 @@ def test_single_layer_kernel(num_tokens, token_major, gpu_kv_format):
         kv_cache,
         kv_cache_new,
         slot_mapping,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
 
 
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,  # vllm HND flash attention
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,  # vllm HND flash infer
@@ -573,7 +573,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
         dtype,
         num_layers=num_layers,
         head_size=head_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     page_buffer_size = num_blocks * block_size
 
@@ -619,7 +619,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
         dtype,
         num_layers=num_layers,
         head_size=head_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     kv_cache_pointers_new = torch.empty(
         num_layers, dtype=torch.int64, device="cpu", pin_memory=True
@@ -645,7 +645,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
         kv_cache,
         kv_cache_new,
         slot_mapping,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     mem_allocator.close()
 
@@ -653,7 +653,7 @@ def test_multi_layer_kernel_hnd(num_tokens, gpu_kv_format):
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024])
 @pytest.mark.parametrize("token_major", [True, False])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
         lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS,  # vllm HND flash attention
         lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS,  # vllm HND flash infer
@@ -678,7 +678,7 @@ def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
         dtype,
         num_layers=num_layers,
         head_size=head_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     kv_cache_new = generate_kv_cache_paged_list_tensors(
         num_blocks,
@@ -687,7 +687,7 @@ def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
         dtype,
         num_layers=num_layers,
         head_size=head_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device)
@@ -723,7 +723,7 @@ def test_single_layer_kernel_hnd(num_tokens, token_major, gpu_kv_format):
         kv_cache,
         kv_cache_new,
         slot_mapping,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=gpu_kv_format,
     )
 
 

--- a/tests/v1/test_mp_mem_kernels.py
+++ b/tests/v1/test_mp_mem_kernels.py
@@ -43,16 +43,16 @@ def _create_zero_tensor(
 
 
 # Format enum values from c_ops
-FMT_NORMAL = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
-FMT_CROSS_LAYER = lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS
-FMT_FLASH_INFER = lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS
-FMT_MLA = lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
-FMT_SGLANG_MHA = lmc_ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
-FMT_SGLANG_MLA = lmc_ops.GPUKVFormat.NL_X_NBBS_ONE_HS
-FMT_NORMAL_HND = lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS
-FMT_FLASH_INFER_HND = lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS
+FMT_NORMAL = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+FMT_CROSS_LAYER = lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS
+FMT_FLASH_INFER = lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS
+FMT_MLA = lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
+FMT_SGLANG_MHA = lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS
+FMT_SGLANG_MLA = lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS
+FMT_NORMAL_HND = lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
+FMT_FLASH_INFER_HND = lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS
 
-# Format parameters: (gpu_kv_format, num_layers, num_heads, head_size, is_mla)
+# Format parameters: (engine_kv_format, num_layers, num_heads, head_size, is_mla)
 # Use small layer counts to keep GPU memory usage low in CI
 FORMAT_PARAMS = [
     (FMT_NORMAL, 4, 8, 128, False),
@@ -67,7 +67,7 @@ FORMAT_PARAMS = [
 
 
 def create_vllm_tensors(
-    gpu_kv_format,
+    engine_kv_format,
     nl: int,
     nb: int,
     bs: int,
@@ -77,35 +77,35 @@ def create_vllm_tensors(
     device: torch.device,
 ) -> list[torch.Tensor]:
     nbbs = nb * bs
-    if gpu_kv_format == FMT_NORMAL:
+    if engine_kv_format == FMT_NORMAL:
         shape = [2, nb, bs, nh, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_NORMAL_HND:
+    elif engine_kv_format == FMT_NORMAL_HND:
         shape = [2, nb, nh, bs, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_CROSS_LAYER:
+    elif engine_kv_format == FMT_CROSS_LAYER:
         shape = [nb, nl, 2, bs, nh, hs]
         return [_create_random_tensor(shape, dtype, device)]
-    elif gpu_kv_format == FMT_FLASH_INFER:
+    elif engine_kv_format == FMT_FLASH_INFER:
         shape = [nb, 2, bs, nh, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_FLASH_INFER_HND:
+    elif engine_kv_format == FMT_FLASH_INFER_HND:
         shape = [nb, 2, nh, bs, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_MLA:
+    elif engine_kv_format == FMT_MLA:
         shape = [nb, bs, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_SGLANG_MHA:
+    elif engine_kv_format == FMT_SGLANG_MHA:
         shape = [nbbs, nh, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(2 * nl)]
-    elif gpu_kv_format == FMT_SGLANG_MLA:
+    elif engine_kv_format == FMT_SGLANG_MLA:
         shape = [nbbs, 1, hs]
         return [_create_random_tensor(shape, dtype, device) for _ in range(nl)]
-    raise ValueError(f"Unknown format: {gpu_kv_format}")
+    raise ValueError(f"Unknown format: {engine_kv_format}")
 
 
 def create_zero_vllm_tensors(
-    gpu_kv_format,
+    engine_kv_format,
     nl: int,
     nb: int,
     bs: int,
@@ -115,31 +115,31 @@ def create_zero_vllm_tensors(
     device: torch.device,
 ) -> list[torch.Tensor]:
     nbbs = nb * bs
-    if gpu_kv_format == FMT_NORMAL:
+    if engine_kv_format == FMT_NORMAL:
         shape = [2, nb, bs, nh, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_NORMAL_HND:
+    elif engine_kv_format == FMT_NORMAL_HND:
         shape = [2, nb, nh, bs, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_CROSS_LAYER:
+    elif engine_kv_format == FMT_CROSS_LAYER:
         shape = [nb, nl, 2, bs, nh, hs]
         return [_create_zero_tensor(shape, dtype, device)]
-    elif gpu_kv_format == FMT_FLASH_INFER:
+    elif engine_kv_format == FMT_FLASH_INFER:
         shape = [nb, 2, bs, nh, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_FLASH_INFER_HND:
+    elif engine_kv_format == FMT_FLASH_INFER_HND:
         shape = [nb, 2, nh, bs, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_MLA:
+    elif engine_kv_format == FMT_MLA:
         shape = [nb, bs, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(nl)]
-    elif gpu_kv_format == FMT_SGLANG_MHA:
+    elif engine_kv_format == FMT_SGLANG_MHA:
         shape = [nbbs, nh, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(2 * nl)]
-    elif gpu_kv_format == FMT_SGLANG_MLA:
+    elif engine_kv_format == FMT_SGLANG_MLA:
         shape = [nbbs, 1, hs]
         return [_create_zero_tensor(shape, dtype, device) for _ in range(nl)]
-    raise ValueError(f"Unknown format: {gpu_kv_format}")
+    raise ValueError(f"Unknown format: {engine_kv_format}")
 
 
 def create_memory_objects(
@@ -167,7 +167,7 @@ def create_memory_objects(
 
 def get_block_data(
     vllm_tensors: list[torch.Tensor],
-    gpu_kv_format,
+    engine_kv_format,
     nl: int,
     bs: int,
     nh: int,
@@ -176,24 +176,24 @@ def get_block_data(
     """Extract all layer data for a given block."""
     results = []
     for layer_idx in range(nl):
-        if gpu_kv_format == FMT_NORMAL:
+        if engine_kv_format == FMT_NORMAL:
             results.append(vllm_tensors[layer_idx][:, block_idx, :, :, :].clone())
-        elif gpu_kv_format == FMT_NORMAL_HND:
+        elif engine_kv_format == FMT_NORMAL_HND:
             results.append(vllm_tensors[layer_idx][:, block_idx, :, :, :].clone())
-        elif gpu_kv_format == FMT_CROSS_LAYER:
+        elif engine_kv_format == FMT_CROSS_LAYER:
             results.append(vllm_tensors[0][block_idx, layer_idx, :, :, :, :].clone())
-        elif gpu_kv_format == FMT_FLASH_INFER:
+        elif engine_kv_format == FMT_FLASH_INFER:
             results.append(vllm_tensors[layer_idx][block_idx, :, :, :, :].clone())
-        elif gpu_kv_format == FMT_FLASH_INFER_HND:
+        elif engine_kv_format == FMT_FLASH_INFER_HND:
             results.append(vllm_tensors[layer_idx][block_idx, :, :, :, :].clone())
-        elif gpu_kv_format == FMT_MLA:
+        elif engine_kv_format == FMT_MLA:
             results.append(vllm_tensors[layer_idx][block_idx, :, :].clone())
-        elif gpu_kv_format == FMT_SGLANG_MHA:
+        elif engine_kv_format == FMT_SGLANG_MHA:
             ts, ed = block_idx * bs, (block_idx + 1) * bs
             k = vllm_tensors[layer_idx][ts:ed, :, :].clone()
             v = vllm_tensors[nl + layer_idx][ts:ed, :, :].clone()
             results.append(torch.stack([k, v], dim=0))
-        elif gpu_kv_format == FMT_SGLANG_MLA:
+        elif engine_kv_format == FMT_SGLANG_MLA:
             ts, ed = block_idx * bs, (block_idx + 1) * bs
             results.append(vllm_tensors[layer_idx][ts:ed, 0, :].clone())
     return results
@@ -208,7 +208,7 @@ def call_block_kernel(
     vllm_tensors: list[torch.Tensor],
     mem_objects: list[torch.Tensor],
     block_ids: list[int],
-    gpu_kv_format,
+    engine_kv_format,
     direction,
     nl: int,
     nb: int,
@@ -243,7 +243,7 @@ def call_block_kernel(
         direction,
         shape_desc,
         tokens_per_object,
-        gpu_kv_format,
+        engine_kv_format,
         skip_prefix_n_blocks,
     )
 
@@ -261,7 +261,7 @@ TOTAL_BLOCKS = NUM_MEMORY_OBJECTS * BLOCKS_PER_OBJECT  # 64
 
 
 @pytest.mark.parametrize(
-    "gpu_kv_format,nl,nh,hs,is_mla",
+    "engine_kv_format,nl,nh,hs,is_mla",
     FORMAT_PARAMS,
     ids=[
         "normal",
@@ -278,7 +278,9 @@ TOTAL_BLOCKS = NUM_MEMORY_OBJECTS * BLOCKS_PER_OBJECT  # 64
     "dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16", "fp8"]
 )
 @pytest.mark.parametrize("mem_device", ["cuda", "cpu"], ids=["mem_gpu", "mem_cpu"])
-def test_block_transfer_roundtrip(gpu_kv_format, nl, nh, hs, is_mla, dtype, mem_device):
+def test_block_transfer_roundtrip(
+    engine_kv_format, nl, nh, hs, is_mla, dtype, mem_device
+):
     """
     D2H -> H2D roundtrip with different block IDs proves data flows through
     memory objects.
@@ -289,9 +291,11 @@ def test_block_transfer_roundtrip(gpu_kv_format, nl, nh, hs, is_mla, dtype, mem_
     hidden_dim = nh * hs
 
     # Create tensors
-    source_vllm = create_vllm_tensors(gpu_kv_format, nl, NB, BS, nh, hs, dtype, device)
+    source_vllm = create_vllm_tensors(
+        engine_kv_format, nl, NB, BS, nh, hs, dtype, device
+    )
     target_vllm = create_zero_vllm_tensors(
-        gpu_kv_format, nl, NB, BS, nh, hs, dtype, device
+        engine_kv_format, nl, NB, BS, nh, hs, dtype, device
     )
     mem_objects = create_memory_objects(
         kv_dim,
@@ -316,7 +320,7 @@ def test_block_transfer_roundtrip(gpu_kv_format, nl, nh, hs, is_mla, dtype, mem_
         source_vllm,
         mem_objects,
         block_ids_d2h,
-        gpu_kv_format,
+        engine_kv_format,
         lmc_ops.TransferDirection.D2H,
         nl,
         NB,
@@ -333,7 +337,7 @@ def test_block_transfer_roundtrip(gpu_kv_format, nl, nh, hs, is_mla, dtype, mem_
         target_vllm,
         mem_objects,
         block_ids_h2d,
-        gpu_kv_format,
+        engine_kv_format,
         lmc_ops.TransferDirection.H2D,
         nl,
         NB,
@@ -348,10 +352,10 @@ def test_block_transfer_roundtrip(gpu_kv_format, nl, nh, hs, is_mla, dtype, mem_
     # Verify: target[h2d_block] == source[d2h_block]
     for i in range(TOTAL_BLOCKS):
         src_data = get_block_data(
-            source_vllm, gpu_kv_format, nl, BS, nh, block_ids_d2h[i]
+            source_vllm, engine_kv_format, nl, BS, nh, block_ids_d2h[i]
         )
         tgt_data = get_block_data(
-            target_vllm, gpu_kv_format, nl, BS, nh, block_ids_h2d[i]
+            target_vllm, engine_kv_format, nl, BS, nh, block_ids_h2d[i]
         )
         for layer_idx in range(nl):
             assert torch.equal(src_data[layer_idx], tgt_data[layer_idx]), (
@@ -360,7 +364,7 @@ def test_block_transfer_roundtrip(gpu_kv_format, nl, nh, hs, is_mla, dtype, mem_
 
 
 @pytest.mark.parametrize(
-    "gpu_kv_format,nl,nh,hs,is_mla",
+    "engine_kv_format,nl,nh,hs,is_mla",
     FORMAT_PARAMS,
     ids=[
         "normal",
@@ -374,16 +378,18 @@ def test_block_transfer_roundtrip(gpu_kv_format, nl, nh, hs, is_mla, dtype, mem_
     ],
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=["bf16"])
-def test_block_transfer_skip_prefix(gpu_kv_format, nl, nh, hs, is_mla, dtype):
+def test_block_transfer_skip_prefix(engine_kv_format, nl, nh, hs, is_mla, dtype):
     """Verify skip_prefix_n_blocks=4 skips the first 4 blocks globally."""
     device = torch.device("cuda")
     kv_dim = 1 if is_mla else 2
     hidden_dim = nh * hs
     skip = 4
 
-    source_vllm = create_vllm_tensors(gpu_kv_format, nl, NB, BS, nh, hs, dtype, device)
+    source_vllm = create_vllm_tensors(
+        engine_kv_format, nl, NB, BS, nh, hs, dtype, device
+    )
     target_vllm = create_zero_vllm_tensors(
-        gpu_kv_format, nl, NB, BS, nh, hs, dtype, device
+        engine_kv_format, nl, NB, BS, nh, hs, dtype, device
     )
     mem_objects = create_memory_objects(
         kv_dim,
@@ -407,7 +413,7 @@ def test_block_transfer_skip_prefix(gpu_kv_format, nl, nh, hs, is_mla, dtype):
         source_vllm,
         mem_objects,
         block_ids_d2h,
-        gpu_kv_format,
+        engine_kv_format,
         lmc_ops.TransferDirection.D2H,
         nl,
         NB,
@@ -425,7 +431,7 @@ def test_block_transfer_skip_prefix(gpu_kv_format, nl, nh, hs, is_mla, dtype):
         target_vllm,
         mem_objects,
         block_ids_h2d,
-        gpu_kv_format,
+        engine_kv_format,
         lmc_ops.TransferDirection.H2D,
         nl,
         NB,
@@ -441,10 +447,10 @@ def test_block_transfer_skip_prefix(gpu_kv_format, nl, nh, hs, is_mla, dtype):
     # Non-skipped blocks should match
     for i in range(skip, TOTAL_BLOCKS):
         src_data = get_block_data(
-            source_vllm, gpu_kv_format, nl, BS, nh, block_ids_d2h[i]
+            source_vllm, engine_kv_format, nl, BS, nh, block_ids_d2h[i]
         )
         tgt_data = get_block_data(
-            target_vllm, gpu_kv_format, nl, BS, nh, block_ids_h2d[i]
+            target_vllm, engine_kv_format, nl, BS, nh, block_ids_h2d[i]
         )
         for layer_idx in range(nl):
             assert torch.equal(src_data[layer_idx], tgt_data[layer_idx]), (
@@ -454,7 +460,7 @@ def test_block_transfer_skip_prefix(gpu_kv_format, nl, nh, hs, is_mla, dtype):
     # Skipped blocks in target should remain zero
     for i in range(skip):
         tgt_data = get_block_data(
-            target_vllm, gpu_kv_format, nl, BS, nh, block_ids_h2d[i]
+            target_vllm, engine_kv_format, nl, BS, nh, block_ids_h2d[i]
         )
         for layer_idx in range(nl):
             block = tgt_data[layer_idx]

--- a/tests/v1/test_musa_connector.py
+++ b/tests/v1/test_musa_connector.py
@@ -101,13 +101,15 @@ def _patch_musa_connector_attrs(
     block_size: int,
     num_heads: int,
     head_size: int,
-    gpu_kv_format: lmc_ops.GPUKVFormat = lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+    engine_kv_format: lmc_ops.EngineKVFormat = (
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+    ),
 ) -> None:
     """Patch connector layout discovery so transfer logic can run on CPU."""
 
     def _initialize_attributes(_kv_caches: list[torch.Tensor]) -> None:
         conn.device = torch.device("cpu")
-        conn.gpu_kv_format = gpu_kv_format
+        conn.engine_kv_format = engine_kv_format
         conn.num_layers = num_layers
         conn.num_blocks = num_blocks
         conn.block_size = block_size
@@ -230,7 +232,7 @@ def test_musa_connector_rejects_unsupported_kv_layout(
         block_size=block_size,
         num_heads=num_heads,
         head_size=head_size,
-        gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,
+        engine_kv_format=lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,
     )
 
     kvcaches_dst = [

--- a/tests/v1/test_python_ops_fallback.py
+++ b/tests/v1/test_python_ops_fallback.py
@@ -822,27 +822,27 @@ def scenario_single_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.
         device=device,
     ).to(torch.int64)
 
-    # (gpu_kv_format, is_mla, token_major, direction)
+    # (engine_kv_format, is_mla, token_major, direction)
     # direction: False = LMC→vLLM (H2D), True = vLLM→LMC (D2H)
     test_cases = [
         # flash attn: [2, NB, BS, NH, HS] — two_major
-        (ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS, False, True, False),
-        (ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS, False, False, False),
-        (ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS, False, True, True),
+        (ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS, False, True, False),
+        (ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS, False, False, False),
+        (ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS, False, True, True),
         # flash infer: [NB, 2, BS, NH, HS]
-        (ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS, False, True, False),
-        (ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS, False, False, False),
-        (ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS, False, True, True),
+        (ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS, False, True, False),
+        (ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS, False, False, False),
+        (ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS, False, True, True),
         # vLLM MLA: [NB, BS, HS]
-        (ops.GPUKVFormat.NL_X_NB_BS_HS, True, True, False),
-        (ops.GPUKVFormat.NL_X_NB_BS_HS, True, True, True),
+        (ops.EngineKVFormat.NL_X_NB_BS_HS, True, True, False),
+        (ops.EngineKVFormat.NL_X_NB_BS_HS, True, True, True),
     ]
 
-    for gpu_kv_format, is_mla, token_major, direction in test_cases:
+    for engine_kv_format, is_mla, token_major, direction in test_cases:
         dir_tag = "v2l" if direction else "l2v"
-        is_two_major = gpu_kv_format == ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+        is_two_major = engine_kv_format == ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
         case_desc = (
-            f"fmt={gpu_kv_format}, MLA={is_mla}, TM={token_major}, Dir={dir_tag}"
+            f"fmt={engine_kv_format}, MLA={is_mla}, TM={token_major}, Dir={dir_tag}"
         )
 
         # ── 1. Setup Shapes ──
@@ -926,7 +926,7 @@ def scenario_single_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.
             vllm_tensor,
             slot_mapping,
             xfer_dir,
-            gpu_kv_format,
+            engine_kv_format,
             token_major,
         )
         device_sync(device)
@@ -965,11 +965,11 @@ def scenario_single_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.
         if is_mla:
             lmc_shape = (num_tokens, hidden_size)
             vllm_shape = (num_blocks, block_size, hidden_size)
-            fmt = ops.GPUKVFormat.NL_X_NB_BS_HS
+            fmt = ops.EngineKVFormat.NL_X_NB_BS_HS
         else:
             lmc_shape = (num_tokens, 2, hidden_size)
             vllm_shape = (2, num_blocks, block_size, num_heads, head_size)
-            fmt = ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+            fmt = ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
 
         lmc_size = 1
         for s in lmc_shape:
@@ -1178,13 +1178,13 @@ def scenario_multi_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.T
     )
 
     # ── Format-specific test cases ──
-    # Each: (gpu_kv_format, is_mla, block_size_arg)
+    # Each: (engine_kv_format, is_mla, block_size_arg)
     format_cases = [
-        (ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS, False, 1),  # vLLM cross layer
-        (ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS, False, 1),  # flash attn
-        (ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS, False, block_size),  # flash infer
-        (ops.GPUKVFormat.NL_X_NB_BS_HS, True, 1),  # vLLM MLA
-        (ops.GPUKVFormat.NL_X_NBBS_ONE_HS, True, 1),  # SGLang MLA
+        (ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS, False, 1),  # vLLM cross layer
+        (ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS, False, 1),  # flash attn
+        (ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS, False, block_size),  # flash infer
+        (ops.EngineKVFormat.NL_X_NB_BS_HS, True, 1),  # vLLM MLA
+        (ops.EngineKVFormat.NL_X_NBBS_ONE_HS, True, 1),  # SGLang MLA
     ]
 
     # Decide mode based on the running device.
@@ -1192,12 +1192,12 @@ def scenario_multi_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.T
     # only the Python fallback supports list[Tensor].
     use_tensor_list = device not in ("cpu", "cuda", "xpu")
 
-    for gpu_kv_format, is_mla, bs_arg in format_cases:
+    for engine_kv_format, is_mla, bs_arg in format_cases:
         k_or_v_size = 1 if is_mla else 2
 
         for direction in [True, False]:
             dir_tag = "paged2lmc" if direction else "lmc2paged"
-            fmt_name = str(gpu_kv_format).split(".")[-1]
+            fmt_name = str(engine_kv_format).split(".")[-1]
 
             # ── 1. LMCache Tensor ──
             lmc_shape = (k_or_v_size, num_layers, num_tokens, head_size)
@@ -1220,7 +1220,7 @@ def scenario_multi_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.T
             # ── 2. Paged Buffers (one per layer) ──
             page_buffers = []
             for ly in range(num_layers):
-                if gpu_kv_format == ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+                if engine_kv_format == ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS:
                     num_blocks = page_buffer_size // bs_arg
                     pb = torch.zeros(
                         (num_blocks, 2, bs_arg, head_size),
@@ -1250,7 +1250,10 @@ def scenario_multi_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.T
                                 + s * 10
                                 + torch.arange(head_size, device=device)
                             ).to(dtype)
-                            if gpu_kv_format == ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+                            if (
+                                engine_kv_format
+                                == ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS
+                            ):
                                 blk_idx = s // bs_arg
                                 blk_off = s % bs_arg
                                 pb[blk_idx, kv, blk_off] = val
@@ -1286,7 +1289,7 @@ def scenario_multi_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.T
                 torch.device(device),
                 page_buffer_size,
                 xfer_dir,
-                gpu_kv_format,
+                engine_kv_format,
                 bs_arg,
             )
             device_sync(device)
@@ -1298,7 +1301,7 @@ def scenario_multi_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.T
                     for kv in range(k_or_v_size):
                         lmc_val = key_value[kv, ly, t_id]
 
-                        if gpu_kv_format == ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+                        if engine_kv_format == ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS:
                             blk_idx = s_idx // bs_arg
                             blk_off = s_idx % bs_arg
                             paged_val = page_buffers[ly][blk_idx, kv, blk_off]
@@ -1320,7 +1323,7 @@ def scenario_multi_layer_kv_transfer(ops: Any, device: str) -> dict[str, torch.T
 
     # ── 6. Collect ONE canonical result for cross-backend comparison ──
     # Use flash attn format (NL_X_TWO_NB_BS_NH_HS), re-run canonical cases
-    canonical_format = ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+    canonical_format = ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
     results: dict[str, torch.Tensor] = {}
     for direction in [True, False]:
         dir_tag = "paged2lmc" if direction else "lmc2paged"
@@ -1401,15 +1404,18 @@ def scenario_multi_layer_kv_transfer_unilateral(
         device=device,
     )
 
-    # ── Test cases: (gpu_kv_format, is_mla) ──
+    # ── Test cases: (engine_kv_format, is_mla) ──
     format_cases = [
-        (ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS, False),  # SGLang MHA (unilateral path)
         (
-            ops.GPUKVFormat.NL_X_NB_BS_HS,
+            ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+            False,
+        ),  # SGLang MHA (unilateral path)
+        (
+            ops.EngineKVFormat.NL_X_NB_BS_HS,
             True,
         ),  # vLLM MLA (delegates to multi_layer_kv_transfer)
         (
-            ops.GPUKVFormat.NL_X_NBBS_ONE_HS,
+            ops.EngineKVFormat.NL_X_NBBS_ONE_HS,
             True,
         ),  # SGLang MLA (delegates to multi_layer_kv_transfer)
     ]
@@ -1419,7 +1425,7 @@ def scenario_multi_layer_kv_transfer_unilateral(
     # only the Python fallback supports list[Tensor].
     use_tensor_list = device not in ("cpu", "cuda", "xpu")
 
-    for gpu_kv_format, is_mla in format_cases:
+    for engine_kv_format, is_mla in format_cases:
         k_or_v_size = 1 if is_mla else 2
 
         for direction in [True, False]:
@@ -1529,7 +1535,7 @@ def scenario_multi_layer_kv_transfer_unilateral(
                 torch.device(device),
                 page_buffer_size,
                 xfer_dir,
-                gpu_kv_format,
+                engine_kv_format,
             )
             device_sync(device)
 
@@ -1549,7 +1555,7 @@ def scenario_multi_layer_kv_transfer_unilateral(
                             lmc_val.to("cpu"),
                             paged_val.to("cpu"),
                             msg=(
-                                f"Mismatch: {gpu_kv_format} {dir_tag} "
+                                f"Mismatch: {engine_kv_format} {dir_tag} "
                                 f"(tensor_list={use_tensor_list}), "
                                 f"KV={kv}, layer={ly}, "
                                 f"token={t_id}, slot={s_idx}"
@@ -1625,7 +1631,7 @@ def scenario_multi_layer_kv_transfer_unilateral(
             torch.device(device),
             page_buffer_size,
             xfer_dir,
-            ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+            ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
         )
         device_sync(device)
 
@@ -1853,7 +1859,7 @@ def scenario_multi_layer_block_kv_transfer(
     shape_desc.hs = head_size
     shape_desc.element_size = dtype.itemsize
     shape_desc.kv_size = 2
-    gpu_kv_format = ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+    engine_kv_format = ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
     num_chunks = num_blocks // blocks_per_chunk
     d2h_chunks = _alloc_chunks((2, num_layers, chunk_tokens, hidden_dim), num_chunks)
     block_ids = list(range(num_blocks))
@@ -1872,7 +1878,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format,
+        engine_kv_format,
         0,
     )
     paged_h2d = [torch.zeros_like(layer) for layer in paged_layers]
@@ -1888,7 +1894,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format,
+        engine_kv_format,
         0,
     )
     for i in range(num_layers):
@@ -1907,7 +1913,7 @@ def scenario_multi_layer_block_kv_transfer(
         )
         for _ in range(num_layers)
     ]
-    gpu_kv_format_fi_nhd = ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS
+    engine_kv_format_fi_nhd = ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS
     d2h_chunks_fi_nhd = _alloc_chunks(
         (2, num_layers, chunk_tokens, hidden_dim), num_chunks
     )
@@ -1927,7 +1933,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_fi_nhd,
+        engine_kv_format_fi_nhd,
         0,
     )
     paged_h2d_fi_nhd = [torch.zeros_like(layer) for layer in paged_layers_fi_nhd]
@@ -1947,7 +1953,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_fi_nhd,
+        engine_kv_format_fi_nhd,
         0,
     )
     for i in range(num_layers):
@@ -1966,7 +1972,7 @@ def scenario_multi_layer_block_kv_transfer(
         )
         for _ in range(num_layers)
     ]
-    gpu_kv_format_hnd = ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS
+    engine_kv_format_hnd = ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
     d2h_chunks_hnd = _alloc_chunks(
         (2, num_layers, chunk_tokens, hidden_dim), num_chunks
     )
@@ -1984,7 +1990,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_hnd,
+        engine_kv_format_hnd,
         0,
     )
     paged_h2d_hnd = [torch.zeros_like(layer) for layer in paged_layers_hnd]
@@ -2002,7 +2008,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_hnd,
+        engine_kv_format_hnd,
         0,
     )
     for i in range(num_layers):
@@ -2021,7 +2027,7 @@ def scenario_multi_layer_block_kv_transfer(
         )
         for _ in range(num_layers)
     ]
-    gpu_kv_format_fi_hnd = ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS
+    engine_kv_format_fi_hnd = ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS
     d2h_chunks_fi_hnd = _alloc_chunks(
         (2, num_layers, chunk_tokens, hidden_dim), num_chunks
     )
@@ -2041,7 +2047,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_fi_hnd,
+        engine_kv_format_fi_hnd,
         0,
     )
     paged_h2d_fi_hnd = [torch.zeros_like(layer) for layer in paged_layers_fi_hnd]
@@ -2061,7 +2067,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_fi_hnd,
+        engine_kv_format_fi_hnd,
         0,
     )
     for i in range(num_layers):
@@ -2087,7 +2093,7 @@ def scenario_multi_layer_block_kv_transfer(
     shape_desc_mla.hs = mla_hidden
     shape_desc_mla.element_size = dtype.itemsize
     shape_desc_mla.kv_size = 1
-    gpu_kv_format_mla = ops.GPUKVFormat.NL_X_NB_BS_HS
+    engine_kv_format_mla = ops.EngineKVFormat.NL_X_NB_BS_HS
     d2h_chunks_mla = _alloc_chunks((num_layers, chunk_tokens, mla_hidden), num_chunks)
     ops.multi_layer_block_kv_transfer(
         paged_layers_mla
@@ -2103,7 +2109,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc_mla,
         chunk_tokens,
-        gpu_kv_format_mla,
+        engine_kv_format_mla,
         0,
     )
     paged_h2d_mla = [torch.zeros_like(layer) for layer in paged_layers_mla]
@@ -2121,7 +2127,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc_mla,
         chunk_tokens,
-        gpu_kv_format_mla,
+        engine_kv_format_mla,
         0,
     )
     for i in range(num_layers):
@@ -2138,7 +2144,7 @@ def scenario_multi_layer_block_kv_transfer(
         torch.randn(num_blocks * block_size, 1, mla_hidden, dtype=dtype).to(device)
         for _ in range(num_layers)
     ]
-    gpu_kv_format_sglang_mla = ops.GPUKVFormat.NL_X_NBBS_ONE_HS
+    engine_kv_format_sglang_mla = ops.EngineKVFormat.NL_X_NBBS_ONE_HS
     d2h_chunks_sglang_mla = _alloc_chunks(
         (num_layers, chunk_tokens, mla_hidden), num_chunks
     )
@@ -2158,7 +2164,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc_mla,
         chunk_tokens,
-        gpu_kv_format_sglang_mla,
+        engine_kv_format_sglang_mla,
         0,
     )
     paged_h2d_sglang_mla = [
@@ -2180,7 +2186,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc_mla,
         chunk_tokens,
-        gpu_kv_format_sglang_mla,
+        engine_kv_format_sglang_mla,
         0,
     )
     for i in range(num_layers):
@@ -2202,7 +2208,7 @@ def scenario_multi_layer_block_kv_transfer(
         head_size,
         dtype=dtype,
     ).to(device)
-    gpu_kv_format_cross_nhd = ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS
+    engine_kv_format_cross_nhd = ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS
     d2h_chunks_cross_nhd = _alloc_chunks(
         (2, num_layers, chunk_tokens, hidden_dim), num_chunks
     )
@@ -2220,7 +2226,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_cross_nhd,
+        engine_kv_format_cross_nhd,
         0,
     )
     paged_h2d_cross_nhd = torch.zeros_like(paged_cross_nhd)
@@ -2238,7 +2244,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_cross_nhd,
+        engine_kv_format_cross_nhd,
         0,
     )
     orig = paged_cross_nhd.cpu()
@@ -2257,7 +2263,7 @@ def scenario_multi_layer_block_kv_transfer(
         head_size,
         dtype=dtype,
     ).to(device)
-    gpu_kv_format_cross_hnd = ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+    engine_kv_format_cross_hnd = ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS
     d2h_chunks_cross_hnd = _alloc_chunks(
         (2, num_layers, chunk_tokens, hidden_dim), num_chunks
     )
@@ -2275,7 +2281,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_cross_hnd,
+        engine_kv_format_cross_hnd,
         0,
     )
     paged_h2d_cross_hnd = torch.zeros_like(paged_cross_hnd)
@@ -2293,7 +2299,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_cross_hnd,
+        engine_kv_format_cross_hnd,
         0,
     )
     orig = paged_cross_hnd.cpu()
@@ -2314,7 +2320,7 @@ def scenario_multi_layer_block_kv_transfer(
             for _ in range(num_layers)
         ],
     ]
-    gpu_kv_format_sglang_nbbs = ops.GPUKVFormat.TWO_X_NL_X_NBBS_NH_HS
+    engine_kv_format_sglang_nbbs = ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS
     d2h_chunks_sglang_nbbs = _alloc_chunks(
         (2, num_layers, chunk_tokens, hidden_dim), num_chunks
     )
@@ -2335,7 +2341,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_sglang_nbbs,
+        engine_kv_format_sglang_nbbs,
         0,
     )
     paged_h2d_sglang_nbbs = [
@@ -2358,7 +2364,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_sglang_nbbs,
+        engine_kv_format_sglang_nbbs,
         0,
     )
     for kv in range(2):
@@ -2386,7 +2392,7 @@ def scenario_multi_layer_block_kv_transfer(
             for _ in range(num_layers)
         ],
     ]
-    gpu_kv_format_sglang_nb = ops.GPUKVFormat.TWO_X_NL_X_NB_BS_NH_HS
+    engine_kv_format_sglang_nb = ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS
     d2h_chunks_sglang_nb = _alloc_chunks(
         (2, num_layers, chunk_tokens, hidden_dim), num_chunks
     )
@@ -2407,7 +2413,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_sglang_nb,
+        engine_kv_format_sglang_nb,
         0,
     )
     paged_h2d_sglang_nb = [
@@ -2430,7 +2436,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_sglang_nb,
+        engine_kv_format_sglang_nb,
         0,
     )
     for kv in range(2):
@@ -2451,7 +2457,7 @@ def scenario_multi_layer_block_kv_transfer(
         )
         for _ in range(num_layers)
     ]
-    gpu_kv_format_nhd = ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS
+    engine_kv_format_nhd = ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
     # With skip=2, effective blocks start at index 2.
     # Object 0 occupies flat indices [0, blocks_per_chunk), skipping first 2.
     # Object 1 occupies flat indices [blocks_per_chunk, 2*blocks_per_chunk).
@@ -2472,7 +2478,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_nhd,
+        engine_kv_format_nhd,
         skip_n,
     )
     paged_h2d_skip = [torch.zeros_like(layer) for layer in paged_layers_skip]
@@ -2490,7 +2496,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_nhd,
+        engine_kv_format_nhd,
         skip_n,
     )
     # Blocks [skip_n:num_blocks] should round-trip at their original positions
@@ -2543,7 +2549,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_nhd,
+        engine_kv_format_nhd,
         0,
     )
     paged_h2d_permuted = [torch.zeros_like(layer) for layer in paged_layers_permuted]
@@ -2563,7 +2569,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc,
         chunk_tokens,
-        gpu_kv_format_nhd,
+        engine_kv_format_nhd,
         0,
     )
     for i in range(num_layers):
@@ -2610,7 +2616,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.D2H,
         shape_desc_mc,
         chunk_tokens,
-        gpu_kv_format_nhd,
+        engine_kv_format_nhd,
         0,
     )
     paged_h2d_mc = [torch.zeros_like(layer) for layer in paged_layers_mc]
@@ -2628,7 +2634,7 @@ def scenario_multi_layer_block_kv_transfer(
         ops.TransferDirection.H2D,
         shape_desc_mc,
         chunk_tokens,
-        gpu_kv_format_nhd,
+        engine_kv_format_nhd,
         0,
     )
     for i in range(num_layers):

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -73,24 +73,24 @@ class TestGPUKVFormatEnum:
         # First Party
         import lmcache.c_ops as lmc_ops
 
-        assert hasattr(lmc_ops.GPUKVFormat, "NB_NL_TWO_NH_BS_HS")
+        assert hasattr(lmc_ops.EngineKVFormat, "NB_NL_TWO_NH_BS_HS")
 
     def test_is_cross_layer_format(self) -> None:
         # First Party
         from lmcache.v1.gpu_connector.utils import is_cross_layer_format
         import lmcache.c_ops as lmc_ops
 
-        assert is_cross_layer_format(lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS)
-        assert is_cross_layer_format(lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS)
-        assert not is_cross_layer_format(lmc_ops.GPUKVFormat.NL_X_NB_BS_HS)
+        assert is_cross_layer_format(lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS)
+        assert is_cross_layer_format(lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS)
+        assert not is_cross_layer_format(lmc_ops.EngineKVFormat.NL_X_NB_BS_HS)
 
     def test_is_hnd(self) -> None:
         # First Party
         from lmcache.v1.gpu_connector.utils import is_hnd
         import lmcache.c_ops as lmc_ops
 
-        assert is_hnd(lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS)
-        assert not is_hnd(lmc_ops.GPUKVFormat.NB_NL_TWO_BS_NH_HS)
+        assert is_hnd(lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS)
+        assert not is_hnd(lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS)
 
 
 @pytest.mark.skipif(not _has_lmc_ops(), reason="lmcache C ops not built")
@@ -121,7 +121,7 @@ class TestNormalizeTRTLLM:
             t, EngineType.TRTLLM, layout_hints=layout_hints
         )
 
-        assert fmt == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+        assert fmt == lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS
         assert isinstance(normalized, torch.Tensor)
         assert tuple(normalized.shape) == (nb, nl, kv, nh, bs, hs)
 
@@ -144,7 +144,7 @@ class TestNormalizeTRTLLM:
         fmt, normalized = normalize_kv_and_discover_format(
             [t], EngineType.TRTLLM, layout_hints=layout_hints
         )
-        assert fmt == lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+        assert fmt == lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS
         assert isinstance(normalized, torch.Tensor)
         assert normalized.shape == (nb, nl, kv, nh, bs, hs)
 
@@ -197,7 +197,7 @@ class TestAccessorsTRTLLM:
         import lmcache.c_ops as lmc_ops
 
         t = self._tensor()
-        assert get_num_layers(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 3
+        assert get_num_layers(t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS) == 3
 
     def test_get_num_blocks(self) -> None:
         # First Party
@@ -205,7 +205,7 @@ class TestAccessorsTRTLLM:
         import lmcache.c_ops as lmc_ops
 
         t = self._tensor()
-        assert get_num_blocks(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 4
+        assert get_num_blocks(t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS) == 4
 
     def test_get_block_size(self) -> None:
         # First Party
@@ -213,7 +213,7 @@ class TestAccessorsTRTLLM:
         import lmcache.c_ops as lmc_ops
 
         t = self._tensor()
-        assert get_block_size(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 16
+        assert get_block_size(t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS) == 16
 
     def test_get_num_heads(self) -> None:
         # First Party
@@ -221,7 +221,7 @@ class TestAccessorsTRTLLM:
         import lmcache.c_ops as lmc_ops
 
         t = self._tensor()
-        assert get_num_heads(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 8
+        assert get_num_heads(t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS) == 8
 
     def test_get_head_size(self) -> None:
         # First Party
@@ -229,7 +229,7 @@ class TestAccessorsTRTLLM:
         import lmcache.c_ops as lmc_ops
 
         t = self._tensor()
-        assert get_head_size(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 64
+        assert get_head_size(t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS) == 64
 
     def test_get_hidden_dim_size(self) -> None:
         # First Party
@@ -237,7 +237,9 @@ class TestAccessorsTRTLLM:
         import lmcache.c_ops as lmc_ops
 
         t = self._tensor()
-        assert get_hidden_dim_size(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 8 * 64
+        assert (
+            get_hidden_dim_size(t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS) == 8 * 64
+        )
 
     def test_get_page_buffer_size(self) -> None:
         # First Party
@@ -245,7 +247,9 @@ class TestAccessorsTRTLLM:
         import lmcache.c_ops as lmc_ops
 
         t = self._tensor()
-        assert get_page_buffer_size(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == 4 * 16
+        assert (
+            get_page_buffer_size(t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS) == 4 * 16
+        )
 
     def test_get_dtype(self) -> None:
         # First Party
@@ -253,7 +257,7 @@ class TestAccessorsTRTLLM:
         import lmcache.c_ops as lmc_ops
 
         t = self._tensor()
-        assert get_dtype(t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS) == torch.bfloat16
+        assert get_dtype(t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS) == torch.bfloat16
 
     def test_get_group_data_ptrs_returns_single_base_pointer(self) -> None:
         # First Party
@@ -262,7 +266,7 @@ class TestAccessorsTRTLLM:
 
         t = self._tensor()
         ptrs = get_group_data_ptrs(
-            t, lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS, list(range(3))
+            t, lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS, list(range(3))
         )
         assert len(ptrs) == 1
         assert ptrs[0] == t.data_ptr()
@@ -276,7 +280,7 @@ class TestAccessorsTRTLLM:
         )
         import lmcache.c_ops as lmc_ops
 
-        fmt = lmc_ops.GPUKVFormat.NB_NL_TWO_NH_BS_HS
+        fmt = lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS
         assert get_gpu_kv_shape_description(fmt) == "[NB, NL, 2, NH, BS, HS]"
         assert "TRT-LLM" in get_attention_backend(fmt)
         assert get_concrete_gpu_kv_shape(self._tensor(), fmt) == (

--- a/tests/v1/test_xpu_connector.py
+++ b/tests/v1/test_xpu_connector.py
@@ -38,13 +38,14 @@ else:
 # Mock c_ops when not available
 if lmc_ops is None:
 
-    class MockGPUKVFormat:
+    class MockEngineKVFormat:
         NL_X_TWO_NB_BS_NH_HS = 0
         NL_X_NB_TWO_BS_NH_HS = 1
         NL_X_NB_BS_HS = 2
 
     class MockCOps:
-        GPUKVFormat = MockGPUKVFormat
+        EngineKVFormat = MockEngineKVFormat
+        GPUKVFormat = MockEngineKVFormat
 
     lmc_ops = MockCOps()
 

--- a/tests/v1/test_xpu_connector.py
+++ b/tests/v1/test_xpu_connector.py
@@ -102,19 +102,19 @@ def patch_pin_allocator():
 
 @pytest.mark.parametrize("use_gpu", [True, False])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
     ],  # vllm MLA
 )
 @pytest.mark.skipif(
     not torch.xpu.is_available(),
     reason="TODO: Add non-XPU implementation to VLLMPagedMemXPUConnectorV2",
 )
-def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
-    use_mla = gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
+def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, engine_kv_format):
+    use_mla = engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
     num_blocks = 100
     block_size = 16
     num_layers = 32
@@ -132,15 +132,15 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     gpu_kv_dst = generate_kv_cache_paged_list_tensors(
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
-    dtype = get_dtype(gpu_kv_src, gpu_kv_format)
+    dtype = get_dtype(gpu_kv_src, engine_kv_format)
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
@@ -158,7 +158,7 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
                 slot_mapping,
                 num_heads,
                 head_size,
-                gpu_kv_format,
+                engine_kv_format,
             )
 
     connector = VLLMPagedMemXPUConnectorV2(
@@ -215,7 +215,7 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
         )
     else:
         check_paged_kv_cache_equal(
-            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, gpu_kv_format
+            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, engine_kv_format
         )
     allocator.close()
 
@@ -223,19 +223,21 @@ def test_vllm_paged_connector_v2_with_gpu_and_mla(use_gpu, gpu_kv_format):
 @pytest.mark.parametrize("use_gpu", [True, False])
 @pytest.mark.parametrize("num_groups", [1, 2, 3])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
-        lmc_ops.GPUKVFormat.NL_X_NB_BS_HS,
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
     ],  # vllm MLA
 )
 @pytest.mark.skipif(
     not torch.xpu.is_available(),
     reason="TODO: Add non-XPU implementation to VLLMPagedMemXPUConnectorV3",
 )
-def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_format):
-    use_mla = gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
+def test_vllm_paged_connector_v3_with_gpu_and_mla(
+    use_gpu, num_groups, engine_kv_format
+):
+    use_mla = engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
     head_sizes = [64, 66, 66]
     dtypes = [torch.uint8, torch.bfloat16, torch.uint8]
     num_blocks = 100
@@ -264,7 +266,7 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_fo
                 dtype=dtypes[i],
                 num_layers=8,
                 head_size=head_sizes[i],
-                gpu_kv_format=gpu_kv_format,
+                engine_kv_format=engine_kv_format,
             )
             groups.append(kv_group)
             for j, layer_tensor in enumerate(kv_group):
@@ -287,12 +289,12 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_fo
                     slot_mapping,
                     num_heads,
                     head_sizes[i],
-                    gpu_kv_format,
+                    engine_kv_format,
                 )
 
     # create metadata and init kv layer groups
-    metadata = _create_metadata(use_mla, src_kv_caches, gpu_kv_format)
-    metadata2 = _create_metadata(use_mla, dst_kv_caches, gpu_kv_format)
+    metadata = _create_metadata(use_mla, src_kv_caches, engine_kv_format)
+    metadata2 = _create_metadata(use_mla, dst_kv_caches, engine_kv_format)
 
     # connector will copy with src_kv_groups
     connector = VLLMPagedMemXPUConnectorV3(
@@ -352,24 +354,24 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(use_gpu, num_groups, gpu_kv_fo
                 slot_mapping,
                 num_heads,
                 head_sizes[i],
-                gpu_kv_format,
+                engine_kv_format,
             )
     allocator.close()
 
 
 @pytest.mark.parametrize("use_gpu", [True])
 @pytest.mark.parametrize(
-    "gpu_kv_format",
+    "engine_kv_format",
     [
-        lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
-        lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # vllm non-MLA flash attention
+        lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS,  # vllm non-MLA flash infer
     ],
 )
 @pytest.mark.skipif(
     not torch.xpu.is_available(),
     reason="TODO: Add non-XPU implementation to VLLMPagedMemLayerwiseXPUConnector",
 )
-def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
+def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, engine_kv_format):
     num_blocks = 100
     block_size = 16
     num_layers = 32
@@ -387,15 +389,15 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
     gpu_kv_dst = generate_kv_cache_paged_list_tensors(
         num_blocks=num_blocks,
         device=device,
         block_size=block_size,
-        gpu_kv_format=gpu_kv_format,
+        engine_kv_format=engine_kv_format,
     )
-    dtype = get_dtype(gpu_kv_src, gpu_kv_format)
+    dtype = get_dtype(gpu_kv_src, engine_kv_format)
 
     slot_mapping = random.sample(range(0, num_blocks * block_size), num_tokens)
     slot_mapping = torch.tensor(slot_mapping, device=device, dtype=torch.int64)
@@ -403,7 +405,7 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
     # Check the gpu_kv is not the same before copying
     with pytest.raises(AssertionError):
         check_paged_kv_cache_equal(
-            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, gpu_kv_format
+            gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, engine_kv_format
         )
 
     connector = VLLMPagedMemLayerwiseXPUConnector(
@@ -472,7 +474,7 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, gpu_kv_format):
     assert connector.gpu_buffer_allocator.memcheck()
 
     check_paged_kv_cache_equal(
-        gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, gpu_kv_format
+        gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, engine_kv_format
     )
 
     allocator.close()
@@ -808,7 +810,7 @@ def test_vllm_paged_connector_v2_to_gpu_bench(benchmark):
     allocator.close()
 
 
-def _create_metadata(use_mla, kv_caches, gpu_kv_format):
+def _create_metadata(use_mla, kv_caches, engine_kv_format):
     # First Party
     from lmcache.v1.gpu_connector.utils import get_num_blocks
     from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -827,7 +829,7 @@ def _create_metadata(use_mla, kv_caches, gpu_kv_format):
     kv_list = list(kv_caches.values())
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
-        gpu_kv_format=gpu_kv_format,
-        num_blocks=get_num_blocks(kv_list, gpu_kv_format),
+        engine_kv_format=engine_kv_format,
+        num_blocks=get_num_blocks(kv_list, engine_kv_format),
     )
     return metadata

--- a/tests/v1/test_xpu_sglang_connector.py
+++ b/tests/v1/test_xpu_sglang_connector.py
@@ -796,7 +796,7 @@ def test_sglang_layerwise_uses_mla_kernel_transfers(monkeypatch):
         dst,
         slot_map,
         direction,
-        gpu_kv_format,
+        engine_kv_format,
         token_major=False,
     ):
         single_layer_calls.append((direction, token_major))
@@ -805,7 +805,7 @@ def test_sglang_layerwise_uses_mla_kernel_transfers(monkeypatch):
             dst,
             slot_map,
             direction,
-            gpu_kv_format,
+            engine_kv_format,
             token_major,
         )
 

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -37,10 +37,10 @@ else:
     # First Party
     lmc_ops = None
 
-# Define mock GPUKVFormat enum if c_ops is not available
+# Define mock EngineKVFormat enum if c_ops is not available
 if lmc_ops is None:
 
-    class MockGPUKVFormat:
+    class MockEngineKVFormat:
         NL_X_TWO_NB_BS_NH_HS = 0
         NL_X_NB_TWO_BS_NH_HS = 1
         NL_X_NB_BS_HS = 2
@@ -49,7 +49,8 @@ if lmc_ops is None:
         NL_X_NB_NH_BS_TWO_HS = 5
 
     class MockCOps:
-        GPUKVFormat = MockGPUKVFormat
+        EngineKVFormat = MockEngineKVFormat
+        GPUKVFormat = MockEngineKVFormat
 
     lmc_ops = MockCOps()
 

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -291,7 +291,7 @@ def generate_kv_cache_paged_list_tensors(
     num_layers=32,
     head_size=128,
     # default vllm non-MLA flash attention
-    gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+    engine_kv_format=lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
 ):
     """
     Instead of Tuple[Tuple[Tensor, Tensor]], return List[Tensor]
@@ -299,24 +299,24 @@ def generate_kv_cache_paged_list_tensors(
     """
     ret = []
     # only support vllm MLA format for now
-    use_mla = gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_BS_HS
+    use_mla = engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
     num_heads = 1 if use_mla else 8
     if use_mla:
         shape = [num_blocks, block_size, head_size]
     else:
-        if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
+        if engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS:
             shape = [2, num_blocks, block_size, num_heads, head_size]
-        elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+        elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS:
             shape = [num_blocks, 2, block_size, num_heads, head_size]
-        elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
+        elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS:
             shape = [2, num_blocks, num_heads, block_size, head_size]
-        elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
+        elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS:
             shape = [num_blocks, 2, num_heads, block_size, head_size]
-        elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_NH_BS_TWO_HS:
+        elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS:
             # blocks-first, K/V fused into the trailing dim
             shape = [num_blocks, num_heads, block_size, 2, head_size]
         else:
-            raise ValueError(f"Unsupported gpu_kv_format: {gpu_kv_format}")
+            raise ValueError(f"Unsupported engine_kv_format: {engine_kv_format}")
 
     for i in range(num_layers):
         # TODO(chunxiaozheng): support more dtypes
@@ -445,13 +445,13 @@ def check_paged_kv_cache_equal(
     slot_mapping,
     num_heads=8,
     head_size=128,
-    gpu_kv_format=lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS,
+    engine_kv_format=lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
 ):
     """
     check whether two paged kv caches are the same at slot_mapping
     """
 
-    if gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_BS_NH_HS:
+    if engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS:
         token_dim = 0
         num_tokens = slot_mapping.shape[0]
         for left_kv_layer, right_kv_layer in zip(left, right, strict=False):
@@ -473,7 +473,7 @@ def check_paged_kv_cache_equal(
             assert (left_k[slot_mapping, :, :] == right_k[slot_mapping, :, :]).all()
             assert (left_v[slot_mapping, :, :] == right_v[slot_mapping, :, :]).all()
 
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_BS_NH_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS:
         token_dim = 0
         num_tokens = slot_mapping.shape[0]
         for left_kv_layer, right_kv_layer in zip(left, right, strict=False):
@@ -499,7 +499,7 @@ def check_paged_kv_cache_equal(
             assert (left_k[slot_mapping, :, :] == right_k[slot_mapping, :, :]).all()
             assert (left_v[slot_mapping, :, :] == right_v[slot_mapping, :, :]).all()
 
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_TWO_NB_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS:
         # HND flash attention: [2, num_blocks, num_heads, block_size, head_size]
         # Flatten [num_blocks, num_heads, block_size, head_size] ->
         #   swap to [num_blocks, block_size, num_heads, head_size] ->
@@ -535,7 +535,7 @@ def check_paged_kv_cache_equal(
             assert (left_k[slot_mapping, :, :] == right_k[slot_mapping, :, :]).all()
             assert (left_v[slot_mapping, :, :] == right_v[slot_mapping, :, :]).all()
 
-    elif gpu_kv_format == lmc_ops.GPUKVFormat.NL_X_NB_TWO_NH_BS_HS:
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS:
         # HND flash infer: [num_blocks, 2, num_heads, block_size, head_size]
         # left_kv_layer[:, 0] -> [num_blocks, num_heads, block_size, head_size]
         num_tokens = slot_mapping.shape[0]


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

GPUKVFormat does not always mean GPU (CPU/HPU/XPU...), rename to EngineKVFormat to describe the inference engine layout. Keep backward compat aliases (GPUKVFormat = EngineKVFormat) so existing callers like lmc_ops.GPUKVFormat.XXX still work.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
