### PR TITLE
refactor: move KV-transfer enums to backend-agnostic header

### DIFF
--- a/csrc/kv_transfer_types.h
+++ b/csrc/kv_transfer_types.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Backend-agnostic KV-transfer type definitions.
+// Moved here from mem_kernels.cuh / mem_kernels_sycl.h to avoid
+// duplicating these enums in every new backend.
+
+enum class TransferDirection : int {
+  H2D = 0,  // Host to Device
+  D2H = 1,  // Device to Host
+};
+
+/*
+Symbol Reference:
+NL: number of layers
+NB: number of blocks/pages
+BS: block/page size
+NBBS: block/page buffer size = NB * BS
+NH: number of heads
+HS: head size
+TWO: 2
+ONE: 1
+
+_ means a dimension within the same tensor
+_ X_ means a dimension across a list
+
+A_X_B_X_C_D_E means:
+kv_cache: List[List[torch.Tensor]]
+len(kv_cache) = A
+len(kv_cache[0]) = B
+kv_cache[0][0].shape = (C, D, E)
+
+The logic for identifying the format currently lives in
+`lmcache/v1/gpu_connector/utils.py`
+*/
+enum class EngineKVFormat : int {
+  NB_NL_TWO_BS_NH_HS = 0,
+  /*
+  used by:
+  - vLLM CROSS_LAYER mode
+  */
+
+  NL_X_TWO_NB_BS_NH_HS = 1,
+  /*
+  used by:
+  - vLLM non-MLA flash attention
+  */
+
+  NL_X_NB_TWO_BS_NH_HS = 2,
+  /*
+  used by:
+  - vLLM non-MLA flash infer
+  */
+
+  NL_X_NB_BS_HS = 3,
+  /*
+  used by:
+  - vLLM MLA
+  */
+
+  TWO_X_NL_X_NBBS_NH_HS = 4,
+  /*
+  used by:
+  - SGLang MHA (flash attention and flash infer)
+  */
+
+  NL_X_NBBS_ONE_HS = 5,
+  /*
+  used by:
+  - SGLang MLA
+  */
+
+  NL_X_TWO_NB_NH_BS_HS = 6,
+  /*
+  used by:
+  - vLLM non-MLA flash attention (HND layout)
+  physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
+  */
+
+  NL_X_NB_TWO_NH_BS_HS = 7,
+  /*
+  used by:
+  - vLLM non-MLA flash infer (HND layout)
+  physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
+  */
+
+  NB_NL_TWO_NH_BS_HS = 8,
+  /*
+  used by:
+  - TRT-LLM cross-layer (HND layout)
+  physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+  */
+
+  TWO_X_NL_X_NB_BS_NH_HS = 9,
+  /*
+  used by:
+  - SGLang MHA via the MP daemon path
+  physical shape per layer: [num_blocks, block_size, num_heads, head_size]
+  */
+
+  NL_X_NB_NH_BS_TWO_HS = 10,
+  /*
+  used by:
+  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
+  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
+  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
+  Currently only reached via the host gather/scatter path, not the CUDA
+  transfer kernels.
+  */
+};

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -7,10 +7,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/util/Exception.h>
 
-enum class TransferDirection : int {
-  H2D = 0,
-  D2H = 1,
-};
+#include "kv_transfer_types.h"
 
 /*
 Symbol Reference:
@@ -35,81 +32,7 @@ kv_cache[0][0].shape = (C, D, E)
 The logic for identifying the format currently lives in
 `lmcache/v1/gpu_connector/utils.py`
 */
-enum class EngineKVFormat : int {
-  NB_NL_TWO_BS_NH_HS = 0,
-  /*
-  used by:
-  - vLLM CROSS_LAYER mode
-  */
 
-  NL_X_TWO_NB_BS_NH_HS = 1,
-  /*
-  used by:
-  - vLLM non-MLA flash attention
-  */
-
-  NL_X_NB_TWO_BS_NH_HS = 2,
-  /*
-  used by:
-  - vLLM non-MLA flash infer
-  */
-
-  NL_X_NB_BS_HS = 3,
-  /*
-  used by:
-  - vLLM MLA
-  */
-
-  TWO_X_NL_X_NBBS_NH_HS = 4,
-  /*
-  used by:
-  - SGLang MHA (flash attention and flash infer)
-  */
-
-  NL_X_NBBS_ONE_HS = 5,
-  /*
-  used by:
-  - SGLang MLA
-  */
-
-  NL_X_TWO_NB_NH_BS_HS = 6,
-  /*
-  used by:
-  - vLLM non-MLA flash attention (HND layout)
-  physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
-  */
-
-  NL_X_NB_TWO_NH_BS_HS = 7,
-  /*
-  used by:
-  - vLLM non-MLA flash infer (HND layout)
-  physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
-  */
-
-  NB_NL_TWO_NH_BS_HS = 8,
-  /*
-  used by:
-  - TRT-LLM cross-layer (HND layout)
-  physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
-  */
-
-  TWO_X_NL_X_NB_BS_NH_HS = 9,
-  /*
-  used by:
-  - SGLang MHA via the MP daemon path
-  physical shape per layer: [num_blocks, block_size, num_heads, head_size]
-  */
-
-  NL_X_NB_NH_BS_TWO_HS = 10,
-  /*
-  used by:
-  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
-  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
-  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
-  Currently only reached via the host gather/scatter path, not the CUDA
-  transfer kernels.
-  */
-};
 
 void multi_layer_kv_transfer(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,

--- a/csrc/sycl/mem_kernels_sycl.h
+++ b/csrc/sycl/mem_kernels_sycl.h
@@ -6,10 +6,9 @@
 #include <ATen/ATen.h>
 #include <c10/util/Exception.h>
 
-enum class TransferDirection : int {
-  H2D = 0,
-  D2H = 1,
-};
+#include "../kv_transfer_types.h"
+
+
 
 /*
 Symbol Reference:
@@ -34,81 +33,7 @@ kv_cache[0][0].shape = (C, D, E)
 The logic for identifying the format currently lives in
 `lmcache/v1/gpu_connector/utils.py`
 */
-enum class EngineKVFormat : int {
-  NB_NL_TWO_BS_NH_HS = 0,
-  /*
-  used by:
-  - vLLM CROSS_LAYER mode
-  */
 
-  NL_X_TWO_NB_BS_NH_HS = 1,
-  /*
-  used by:
-  - vLLM non-MLA flash attention
-  */
-
-  NL_X_NB_TWO_BS_NH_HS = 2,
-  /*
-  used by:
-  - vLLM non-MLA flash infer
-  */
-
-  NL_X_NB_BS_HS = 3,
-  /*
-  used by:
-  - vLLM MLA
-  */
-
-  TWO_X_NL_X_NBBS_NH_HS = 4,
-  /*
-  used by:
-  - SGLang MHA (flash attention and flash infer)
-  */
-
-  NL_X_NBBS_ONE_HS = 5,
-  /*
-  used by:
-  - SGLang MLA
-  */
-
-  NL_X_TWO_NB_NH_BS_HS = 6,
-  /*
-  used by:
-  - vLLM non-MLA flash attention (HND layout)
-  physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
-  */
-
-  NL_X_NB_TWO_NH_BS_HS = 7,
-  /*
-  used by:
-  - vLLM non-MLA flash infer (HND layout)
-  physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
-  */
-
-  NB_NL_TWO_NH_BS_HS = 8,
-  /*
-  used by:
-  - TRT-LLM cross-layer (HND layout)
-  physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
-  */
-
-  TWO_X_NL_X_NB_BS_NH_HS = 9,
-  /*
-  used by:
-  - SGLang MHA via the MP daemon path
-  physical shape per layer: [num_blocks, block_size, num_heads, head_size]
-  */
-
-  NL_X_NB_NH_BS_TWO_HS = 10,
-  /*
-  used by:
-  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
-  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
-  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
-  Currently only reached via the host gather/scatter path, not the SYCL
-  transfer kernels.
-  */
-};
 
 void multi_layer_kv_transfer(
     torch::Tensor& key_value, const torch::Tensor& key_value_ptrs,


### PR DESCRIPTION
## Summary

Move TransferDirection and EngineKVFormat enums from mem_kernels.cuh (CUDA) and mem_kernels_sycl.h (SYCL) into a new shared header csrc/kv_transfer_types.h.

## Motivation

Part of #3676 - avoid duplicating these enums in every new backend.

## Changes

- New file: csrc/kv_transfer_types.h (contains both enums + the format symbol reference comment)
- csrc/mem_kernels.cuh: removed both enums, added #include "kv_transfer_types.h"
- csrc/sycl/mem_kernels_sycl.h: removed both enums, added #include "../kv_transfer_types.h"

## Notes

This is a first step toward the full refactor described in #3676. Future PRs can move the remaining type definitions and utility functions.

Fixes #3676