### PR TITLE
[fix] pin uv index-strategy for nightly vLLM image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,8 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache \
         VLLM_PRECOMPILED_WHEEL_VARIANT=${CUDA_TAG} uv pip install --prerelease=allow \
             'vllm[runai,tensorizer,flashinfer]' \
             --extra-index-url https://wheels.vllm.ai/nightly/${CUDA_TAG} \
-            --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} ; \
+            --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
+            --index-strategy unsafe-first-match ; \
     else \
         VLLM_PRECOMPILED_WHEEL_VARIANT=${CUDA_TAG} uv pip install --prerelease=allow \
             "vllm[runai,tensorizer,flashinfer]==${VLLM_VERSION}" ; \


### PR DESCRIPTION
 
  Description:
  **What this PR does / why we need it**:

  The nightly container image build (`dev.yml`) fails at `docker/Dockerfile` while
  installing `vllm[runai,tensorizer,flashinfer]` from the nightly index. It's the
  only vLLM install in the Dockerfile without an `--index-strategy`, so it uses
  uv's default `first-match`, which pins `cuda-python` to `12.9.0`
  (`cuda-bindings<12.10`) and collides with `torch 2.11.0+cu130`
  (`cuda-bindings>=13.0.3`) → resolution is unsatisfiable.

  Adding `--index-strategy unsafe-first-match` lets `cuda-python` fall through to a
  CUDA-13-compatible version while keeping the real nightly wheel. Verified with a
  dry-run resolve (py3.12 / linux-x86_64): resolves cleanly to
  `vllm 0.22.1rc1.dev511 + torch 2.11.0+cu130 + cuda-bindings 13.0.3`. Also covers
  the cu12.9 nightly image, which routes through the same stage.

  **Special notes for your reviewers**:

  `unsafe-first-match`, not `unsafe-best-match`: the latter also resolves but
  silently swaps the nightly wheel for the PyPI stable (`vllm 0.23.0`), defeating
  the purpose of a nightly image.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [ ] this PR contains unit tests