### PR TITLE
[Core] Add multi-device raw-block L2 sharding

### DIFF
--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -8,13 +8,18 @@ caller-provided load buffers during prefetch.
 
 **Required fields:**
 
-- ``device_path``: Raw device path or pre-sized file path.
+- ``device_path`` or ``multi_device_paths``: Raw device path(s) or pre-sized
+  file path(s). Use ``device_path`` for a single device; use
+  ``multi_device_paths`` for multi-device sharding.
 - ``slot_bytes``: Fixed slot size in bytes. Must be aligned to ``block_align``.
 
 **Optional fields:**
 
+- ``device_count``: Optional validation count. If set, it must match the number
+  of paths parsed from ``multi_device_paths``.
 - ``capacity_bytes``: Optional cap on the usable device bytes. Default ``0``
-  means use the full device/file size.
+  means use the full device/file size. In multi-device mode, the same cap is
+  applied to each configured device.
 - ``use_odirect``: ``true`` or ``false`` (default ``true``).
 - ``block_align``: Device alignment in bytes (default ``4096``).
 - ``header_bytes``: Per-slot header reservation (default ``4096``).
@@ -42,12 +47,19 @@ caller-provided load buffers during prefetch.
 
 **Notes:**
 
-- ``raw_block`` is a server-owned MP adapter. It does **not** support
-  per-TP device-path mappings in MP mode.
+- ``multi_device_paths`` can be a JSON list or a comma-separated string. Paths
+  must be non-empty and unique.
+- In multi-device mode, each object is routed by
+  ``kv_rank.local_rank % len(multi_device_paths)``. Keep
+  ``multi_device_paths`` in stable local-rank order across restarts so
+  recovered metadata maps to the same raw device.
+- ``raw_block`` is a server-owned MP adapter. It supports single-node
+  multi-device sharding through ``multi_device_paths``; it does **not** support
+  ``per_tp_device_paths`` in MP mode.
 - ``raw_block`` remains ``"type": "raw_block"`` for all supported engines.
 - ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
-  through ``RawBlockCore``. Slot reclamation is driven by the shared/global
-  L2 eviction controller or explicit ``delete()`` calls.
+  through one ``RawBlockCore`` per configured path. Slot reclamation is driven
+  by the shared/global L2 eviction controller or explicit ``delete()`` calls.
 - If ``use_odirect`` is enabled, the server's ``--l1-align-bytes`` should be
   at least ``block_align``.
 - ``persist_enabled`` must remain ``true`` for this adapter.
@@ -65,6 +77,12 @@ caller-provided load buffers during prefetch.
 
     # Basic raw_block with posix I/O
     --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "block_align": 4096, "header_bytes": 4096, "meta_total_bytes": 268435456, "use_odirect": true, "num_store_workers": 2, "num_lookup_workers": 1, "num_load_workers": 4}'
+
+    # With multi-device sharding
+    --l2-adapter '{"type": "raw_block", "multi_device_paths": ["/dev/nvme0n1", "/dev/nvme1n1", "/dev/nvme2n1", "/dev/nvme3n1"], "device_count": 4, "slot_bytes": 1048576, "block_align": 4096, "use_odirect": true}'
+
+    # With multi-device sharding from a comma-separated string
+    --l2-adapter '{"type": "raw_block", "multi_device_paths": "/dev/nvme0n1,/dev/nvme1n1", "slot_bytes": 1048576, "use_odirect": true}'
 
     # With io_uring
     --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "iouring_queue_depth": 256, "use_odirect": true}'

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -8,15 +8,13 @@ caller-provided load buffers during prefetch.
 
 **Required fields:**
 
-- ``device_path`` or ``multi_device_paths``: Raw device path(s) or pre-sized
-  file path(s). Use ``device_path`` for a single device; use
-  ``multi_device_paths`` for multi-device sharding.
+- ``device_paths``: Raw device path(s) or pre-sized file path(s). A single
+  string selects one device; a list of strings or a comma-separated string
+  enables multi-device sharding.
 - ``slot_bytes``: Fixed slot size in bytes. Must be aligned to ``block_align``.
 
 **Optional fields:**
 
-- ``device_count``: Optional validation count. If set, it must match the number
-  of paths parsed from ``multi_device_paths``.
 - ``capacity_bytes``: Optional cap on the usable device bytes. Default ``0``
   means use the full device/file size. In multi-device mode, the same cap is
   applied to each configured device.
@@ -47,14 +45,14 @@ caller-provided load buffers during prefetch.
 
 **Notes:**
 
-- ``multi_device_paths`` can be a JSON list or a comma-separated string. Paths
-  must be non-empty and unique.
+- ``device_paths`` can be a single path string, a list of strings, or a
+  comma-separated string. Paths must be non-empty and unique.
 - In multi-device mode, each object is routed by
-  ``kv_rank.local_rank % len(multi_device_paths)``. Keep
-  ``multi_device_paths`` in stable local-rank order across restarts so
-  recovered metadata maps to the same raw device.
+  ``kv_rank.local_rank % len(device_paths)``. Keep ``device_paths`` in stable
+  local-rank order across restarts so recovered metadata maps to the same raw
+  device.
 - ``raw_block`` is a server-owned MP adapter. It supports single-node
-  multi-device sharding through ``multi_device_paths``; it does **not** support
+  multi-device sharding through ``device_paths``; it does **not** support
   ``per_tp_device_paths`` in MP mode.
 - ``raw_block`` remains ``"type": "raw_block"`` for all supported engines.
 - ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
@@ -63,7 +61,7 @@ caller-provided load buffers during prefetch.
 - If ``use_odirect`` is enabled, the server's ``--l1-align-bytes`` should be
   at least ``block_align``.
 - ``persist_enabled`` must remain ``true`` for this adapter.
-- For ``use_uring_cmd=true``, ``device_path`` must use the NVMe character
+- For ``use_uring_cmd=true``, ``device_paths`` must use the NVMe character
   device node (e.g., ``/dev/ng0n1``) instead of the block device node
   (``/dev/nvme0n1``). The character device provides direct NVMe
   command passthrough.
@@ -76,19 +74,19 @@ caller-provided load buffers during prefetch.
 .. code-block:: bash
 
     # Basic raw_block with posix I/O
-    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "block_align": 4096, "header_bytes": 4096, "meta_total_bytes": 268435456, "use_odirect": true, "num_store_workers": 2, "num_lookup_workers": 1, "num_load_workers": 4}'
+    --l2-adapter '{"type": "raw_block", "device_paths": "/dev/nvme0n1", "slot_bytes": 1048576, "block_align": 4096, "header_bytes": 4096, "meta_total_bytes": 268435456, "use_odirect": true, "num_store_workers": 2, "num_lookup_workers": 1, "num_load_workers": 4}'
 
     # With multi-device sharding
-    --l2-adapter '{"type": "raw_block", "multi_device_paths": ["/dev/nvme0n1", "/dev/nvme1n1", "/dev/nvme2n1", "/dev/nvme3n1"], "device_count": 4, "slot_bytes": 1048576, "block_align": 4096, "use_odirect": true}'
+    --l2-adapter '{"type": "raw_block", "device_paths": ["/dev/nvme0n1", "/dev/nvme1n1", "/dev/nvme2n1", "/dev/nvme3n1"], "slot_bytes": 1048576, "block_align": 4096, "use_odirect": true}'
 
     # With multi-device sharding from a comma-separated string
-    --l2-adapter '{"type": "raw_block", "multi_device_paths": "/dev/nvme0n1,/dev/nvme1n1", "slot_bytes": 1048576, "use_odirect": true}'
+    --l2-adapter '{"type": "raw_block", "device_paths": "/dev/nvme0n1,/dev/nvme1n1", "slot_bytes": 1048576, "use_odirect": true}'
 
     # With io_uring
-    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "iouring_queue_depth": 256, "use_odirect": true}'
+    --l2-adapter '{"type": "raw_block", "device_paths": "/dev/nvme0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "iouring_queue_depth": 256, "use_odirect": true}'
 
     # With io_uring_cmd (NVMe passthrough)
-    --l2-adapter '{"type": "raw_block", "device_path": "/dev/ng0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "use_uring_cmd": true, "iouring_queue_depth": 256, "max_data_transfer_size": 131072, "use_odirect": false}'
+    --l2-adapter '{"type": "raw_block", "device_paths": "/dev/ng0n1", "slot_bytes": 1048576, "io_engine": "io_uring", "use_uring_cmd": true, "iouring_queue_depth": 256, "max_data_transfer_size": 131072, "use_odirect": false}'
 
     # With eviction
-    --l2-adapter '{"type": "raw_block", "device_path": "/dev/nvme0n1", "slot_bytes": 1048576, "load_checkpoint_on_init": false, "eviction": {"eviction_policy": "LRU", "trigger_watermark": 0.9, "eviction_ratio": 0.1}}'
+    --l2-adapter '{"type": "raw_block", "device_paths": "/dev/nvme0n1", "slot_bytes": 1048576, "load_checkpoint_on_init": false, "eviction": {"eviction_policy": "LRU", "trigger_watermark": 0.9, "eviction_ratio": 0.1}}'

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -103,8 +103,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
     def __init__(
         self,
         *,
-        device_path: str | None = None,
-        multi_device_paths: Sequence[str] | str | None = None,
+        device_paths: Sequence[str] | str,
         slot_bytes: int,
         capacity_bytes: int = 0,
         use_odirect: bool = True,
@@ -130,11 +129,10 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         """Initialize raw-block MP adapter configuration.
 
         Args:
-            device_path: Raw device path or pre-sized file path used for L2.
-                Kept for single-device compatibility.
-            multi_device_paths: Raw device paths or pre-sized file paths used for
-                sharded L2. Objects are routed by
-                ``kv_rank.local_rank % len(multi_device_paths)``.
+            device_paths: Raw device path(s) or pre-sized file path(s). A
+                single string selects one device; a list of strings or a
+                comma-separated string enables multi-device sharding. Objects
+                are routed by ``kv_rank.local_rank % len(device_paths)``.
             slot_bytes: Fixed data-slot size in bytes.
             capacity_bytes: Optional cap on usable bytes; zero uses device size.
             use_odirect: Whether to open the raw path with O_DIRECT.
@@ -158,10 +156,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             num_load_workers: Number of load worker threads.
         """
         super().__init__()
-        paths = self._normalize_multi_device_paths(device_path, multi_device_paths)
-        self.multi_device_paths = tuple(paths)
-        self.device_count = len(self.multi_device_paths)
-        self.device_path = self.multi_device_paths[0]
+        paths = self._normalize_device_paths(device_paths)
+        self.device_paths = tuple(paths)
         self.slot_bytes = int(slot_bytes)
         self.capacity_bytes = int(capacity_bytes)
         self.use_odirect = bool(use_odirect)
@@ -197,10 +193,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         if not bool(d.get("persist_enabled", True)):
             raise ValueError("raw_block requires persist_enabled=true")
 
-        multi_device_paths = cls._parse_multi_device_paths(d)
-        device_count = d.get("device_count")
-        if device_count is not None and int(device_count) != len(multi_device_paths):
-            raise ValueError("device_count must match the number of raw-block devices")
+        device_paths = cls._parse_device_paths(d)
 
         slot_bytes = d.get("slot_bytes")
         if not isinstance(slot_bytes, int) or slot_bytes <= 0:
@@ -252,7 +245,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             worker_counts[field_name] = value
 
         return cls(
-            multi_device_paths=multi_device_paths,
+            device_paths=device_paths,
             slot_bytes=slot_bytes,
             capacity_bytes=capacity_bytes,
             use_odirect=bool(d.get("use_odirect", True)),
@@ -281,13 +274,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         """Return human-readable raw-block adapter configuration help."""
         return (
             "raw_block L2 adapter config fields:\n"
-            "- device_path (str): raw device or file path (required for "
-            "single-device mode)\n"
-            "- multi_device_paths (list[str] | str): raw devices or files for "
-            "multi-device mode; objects shard by kv_rank local_rank modulo "
-            "device count\n"
-            "- device_count (int): optional validation count for "
-            "multi_device_paths\n"
+            "- device_paths (str | list[str]): raw device or file path(s); "
+            "a single string selects one device, a list of strings or CSV "
+            "string enables multi-device sharding (required)\n"
             "- slot_bytes (int): slot size in bytes, aligned to block_align "
             "(required)\n"
             "- capacity_bytes (int): optional usable capacity cap "
@@ -323,10 +312,10 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "- num_load_workers (int): load worker threads (default 4)"
         )
 
-    def to_core_config(self, device_path: str | None = None) -> RawBlockCoreConfig:
+    def to_core_config(self, device_path: str) -> RawBlockCoreConfig:
         """Convert this adapter config to the shared RawBlockCore config."""
         return RawBlockCoreConfig(
-            device_path=self.device_path if device_path is None else device_path,
+            device_path=device_path,
             capacity_bytes=self.capacity_bytes,
             block_align=self.block_align,
             header_bytes=self.header_bytes,
@@ -348,55 +337,34 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         )
 
     @staticmethod
-    def _normalize_multi_device_paths(
-        device_path: str | None,
-        multi_device_paths: Sequence[str] | str | None,
-    ) -> list[str]:
+    def _normalize_device_paths(device_paths: Sequence[str] | str) -> list[str]:
         """Return validated raw-block paths in sharding order."""
-        if multi_device_paths is not None:
-            raw_paths: Sequence[str]
-            if isinstance(multi_device_paths, str):
-                raw_paths = multi_device_paths.split(",")
-            else:
-                raw_paths = multi_device_paths
-            paths = []
-            for path in raw_paths:
-                if not isinstance(path, str):
-                    raise ValueError("multi_device_paths must contain only strings")
-                stripped = path.strip()
-                if stripped:
-                    paths.append(stripped)
-        elif isinstance(device_path, str):
-            stripped = device_path.strip()
-            paths = [stripped] if stripped else []
+        raw_paths: Sequence[str]
+        if isinstance(device_paths, str):
+            raw_paths = device_paths.split(",")
         else:
-            paths = []
-
+            raw_paths = device_paths
+        paths = []
+        for path in raw_paths:
+            if not isinstance(path, str):
+                raise ValueError("device_paths must contain only strings")
+            stripped = path.strip()
+            if stripped:
+                paths.append(stripped)
         if not paths:
-            raise ValueError(
-                "device_path or multi_device_paths must provide at least one path"
-            )
+            raise ValueError("device_paths must provide at least one non-empty path")
         if len(set(paths)) != len(paths):
             raise ValueError("raw_block device paths must be unique")
         return paths
 
     @classmethod
-    def _parse_multi_device_paths(cls, d: dict) -> list[str]:
-        raw_paths = d.get("multi_device_paths")
-        if raw_paths is None:
-            if "device_path" not in d:
-                raise ValueError("device_path or multi_device_paths must be provided")
-            device_path = d.get("device_path")
-            if not isinstance(device_path, str):
-                raise ValueError("device_path must be a string")
-            if not device_path:
-                raise ValueError("device_path must be non-empty")
-            return cls._normalize_multi_device_paths(device_path, None)
-        if isinstance(raw_paths, str):
-            return cls._normalize_multi_device_paths(None, raw_paths.split(","))
-        if isinstance(raw_paths, list):
-            return cls._normalize_multi_device_paths(None, raw_paths)
-        raise ValueError("multi_device_paths must be a list of strings or a CSV string")
+    def _parse_device_paths(cls, d: dict) -> list[str]:
+        raw = d.get("device_paths")
+        if raw is None:
+            raise ValueError("device_paths must be provided")
+        if isinstance(raw, (str, list)):
+            return cls._normalize_device_paths(raw)
+        raise ValueError("device_paths must be a string or list of strings")
 
 
 class RawBlockL2Adapter(L2AdapterInterface):
@@ -453,7 +421,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
                     "fixed-buffer registration; zero-copy fixed buffers are "
                     "disabled unless registered by a future MP allocator path"
                 )
-            for device_path in config.multi_device_paths:
+            for device_path in config.device_paths:
                 self._cores.append(
                     RawBlockCore(
                         config.to_core_config(device_path),

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -11,6 +11,7 @@ lookup, and load.
 from __future__ import annotations
 
 # Standard
+from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional
@@ -54,6 +55,7 @@ RawBlockStoreTaskResult = tuple[
     list[ObjectKey],
     list[int],
 ]
+RawBlockDeviceSelector = Callable[[ObjectKey, int], int]
 
 
 def _make_bitmap(size: int) -> "Bitmap":
@@ -63,13 +65,46 @@ def _make_bitmap(size: int) -> "Bitmap":
     return Bitmap(size)
 
 
+def _local_rank_from_kv_rank(kv_rank: int) -> int:
+    """Return the local-rank field packed by ``ObjectKey.ComputeKVRank``."""
+    return int(kv_rank) & 0xFF
+
+
+def _select_device_by_local_rank(key: ObjectKey, device_count: int) -> int:
+    """Select a raw-block device by the key's packed local rank."""
+    return _local_rank_from_kv_rank(key.kv_rank) % device_count
+
+
+def _group_key_indices_by_device(
+    keys: Sequence[ObjectKey],
+    cores: Sequence[RawBlockCore],
+    select_device: RawBlockDeviceSelector,
+) -> dict[RawBlockCore, list[int]]:
+    """Group submitted key indices by selected raw-block core."""
+    device_count = len(cores)
+    if device_count <= 0:
+        raise ValueError("raw_block requires at least one device")
+
+    groups: dict[RawBlockCore, list[int]] = {}
+    for i, key in enumerate(keys):
+        device_index = select_device(key, device_count)
+        if device_index < 0 or device_index >= device_count:
+            raise ValueError(
+                "device selector returned out-of-range index "
+                f"{device_index} for {device_count} raw-block devices"
+            )
+        groups.setdefault(cores[device_index], []).append(i)
+    return groups
+
+
 class RawBlockL2AdapterConfig(L2AdapterConfigBase):
     """Configuration object for the built-in raw-block MP L2 adapter."""
 
     def __init__(
         self,
         *,
-        device_path: str,
+        device_path: str | None = None,
+        multi_device_paths: Sequence[str] | str | None = None,
         slot_bytes: int,
         capacity_bytes: int = 0,
         use_odirect: bool = True,
@@ -91,11 +126,15 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         num_store_workers: int = 2,
         num_lookup_workers: int = 1,
         num_load_workers: int = 4,
-    ):
+    ) -> None:
         """Initialize raw-block MP adapter configuration.
 
         Args:
             device_path: Raw device path or pre-sized file path used for L2.
+                Kept for single-device compatibility.
+            multi_device_paths: Raw device paths or pre-sized file paths used for
+                sharded L2. Objects are routed by
+                ``kv_rank.local_rank % len(multi_device_paths)``.
             slot_bytes: Fixed data-slot size in bytes.
             capacity_bytes: Optional cap on usable bytes; zero uses device size.
             use_odirect: Whether to open the raw path with O_DIRECT.
@@ -119,7 +158,10 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             num_load_workers: Number of load worker threads.
         """
         super().__init__()
-        self.device_path = device_path
+        paths = self._normalize_multi_device_paths(device_path, multi_device_paths)
+        self.multi_device_paths = tuple(paths)
+        self.device_count = len(self.multi_device_paths)
+        self.device_path = self.multi_device_paths[0]
         self.slot_bytes = int(slot_bytes)
         self.capacity_bytes = int(capacity_bytes)
         self.use_odirect = bool(use_odirect)
@@ -148,15 +190,17 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
     @classmethod
     def from_dict(cls, d: dict) -> "RawBlockL2AdapterConfig":
         """Build and validate a raw-block config from ``--l2-adapter`` JSON."""
-        device_path = d.get("device_path")
-        if not isinstance(device_path, str) or not device_path:
-            raise ValueError("device_path must be a non-empty string")
         if "per_tp_device_paths" in d:
             raise ValueError(
                 "per_tp_device_paths is not supported in MP raw_block mode"
             )
         if not bool(d.get("persist_enabled", True)):
             raise ValueError("raw_block requires persist_enabled=true")
+
+        multi_device_paths = cls._parse_multi_device_paths(d)
+        device_count = d.get("device_count")
+        if device_count is not None and int(device_count) != len(multi_device_paths):
+            raise ValueError("device_count must match the number of raw-block devices")
 
         slot_bytes = d.get("slot_bytes")
         if not isinstance(slot_bytes, int) or slot_bytes <= 0:
@@ -208,7 +252,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             worker_counts[field_name] = value
 
         return cls(
-            device_path=device_path,
+            multi_device_paths=multi_device_paths,
             slot_bytes=slot_bytes,
             capacity_bytes=capacity_bytes,
             use_odirect=bool(d.get("use_odirect", True)),
@@ -237,7 +281,13 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         """Return human-readable raw-block adapter configuration help."""
         return (
             "raw_block L2 adapter config fields:\n"
-            "- device_path (str): raw device or file path (required)\n"
+            "- device_path (str): raw device or file path (required for "
+            "single-device mode)\n"
+            "- multi_device_paths (list[str] | str): raw devices or files for "
+            "multi-device mode; objects shard by kv_rank local_rank modulo "
+            "device count\n"
+            "- device_count (int): optional validation count for "
+            "multi_device_paths\n"
             "- slot_bytes (int): slot size in bytes, aligned to block_align "
             "(required)\n"
             "- capacity_bytes (int): optional usable capacity cap "
@@ -273,10 +323,10 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "- num_load_workers (int): load worker threads (default 4)"
         )
 
-    def to_core_config(self) -> RawBlockCoreConfig:
+    def to_core_config(self, device_path: str | None = None) -> RawBlockCoreConfig:
         """Convert this adapter config to the shared RawBlockCore config."""
         return RawBlockCoreConfig(
-            device_path=self.device_path,
+            device_path=self.device_path if device_path is None else device_path,
             capacity_bytes=self.capacity_bytes,
             block_align=self.block_align,
             header_bytes=self.header_bytes,
@@ -297,6 +347,57 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             max_data_transfer_size=self.max_data_transfer_size,
         )
 
+    @staticmethod
+    def _normalize_multi_device_paths(
+        device_path: str | None,
+        multi_device_paths: Sequence[str] | str | None,
+    ) -> list[str]:
+        """Return validated raw-block paths in sharding order."""
+        if multi_device_paths is not None:
+            raw_paths: Sequence[str]
+            if isinstance(multi_device_paths, str):
+                raw_paths = multi_device_paths.split(",")
+            else:
+                raw_paths = multi_device_paths
+            paths = []
+            for path in raw_paths:
+                if not isinstance(path, str):
+                    raise ValueError("multi_device_paths must contain only strings")
+                stripped = path.strip()
+                if stripped:
+                    paths.append(stripped)
+        elif isinstance(device_path, str):
+            stripped = device_path.strip()
+            paths = [stripped] if stripped else []
+        else:
+            paths = []
+
+        if not paths:
+            raise ValueError(
+                "device_path or multi_device_paths must provide at least one path"
+            )
+        if len(set(paths)) != len(paths):
+            raise ValueError("raw_block device paths must be unique")
+        return paths
+
+    @classmethod
+    def _parse_multi_device_paths(cls, d: dict) -> list[str]:
+        raw_paths = d.get("multi_device_paths")
+        if raw_paths is None:
+            if "device_path" not in d:
+                raise ValueError("device_path or multi_device_paths must be provided")
+            device_path = d.get("device_path")
+            if not isinstance(device_path, str):
+                raise ValueError("device_path must be a string")
+            if not device_path:
+                raise ValueError("device_path must be non-empty")
+            return cls._normalize_multi_device_paths(device_path, None)
+        if isinstance(raw_paths, str):
+            return cls._normalize_multi_device_paths(None, raw_paths.split(","))
+        if isinstance(raw_paths, list):
+            return cls._normalize_multi_device_paths(None, raw_paths)
+        raise ValueError("multi_device_paths must be a list of strings or a CSV string")
+
 
 class RawBlockL2Adapter(L2AdapterInterface):
     """MP L2 adapter that persists KV objects into raw-block slots."""
@@ -305,7 +406,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
         self,
         config: RawBlockL2AdapterConfig,
         l1_memory_desc: "Optional[L1MemoryDesc]" = None,
-    ):
+    ) -> None:
         """Initialize the MP raw-block L2 adapter.
 
         Args:
@@ -334,7 +435,9 @@ class RawBlockL2Adapter(L2AdapterInterface):
             )
 
         self._closed = False
+        self._cores: list[RawBlockCore] = []
         self._core: RawBlockCore
+        self._select_device = _select_device_by_local_rank
         self._store_efd: EventNotifier | None = None
         self._lookup_efd: EventNotifier | None = None
         self._load_efd: EventNotifier | None = None
@@ -343,15 +446,23 @@ class RawBlockL2Adapter(L2AdapterInterface):
         self._load_pool: ThreadPoolExecutor
 
         try:
-            self._core = RawBlockCore(config.to_core_config(), key_namespace="object")
             if config.io_engine == "io_uring":
                 logger.warning(
                     "RawBlockL2Adapter: MP raw_block uses io_uring without "
                     "fixed-buffer registration; zero-copy fixed buffers are "
                     "disabled unless registered by a future MP allocator path"
                 )
-            self._max_capacity_bytes = int(
-                self._core.report_status().get("usable_capacity_bytes", 0)
+            for device_path in config.multi_device_paths:
+                self._cores.append(
+                    RawBlockCore(
+                        config.to_core_config(device_path),
+                        key_namespace="object",
+                    )
+                )
+            self._core = self._cores[0]
+            self._max_capacity_bytes = sum(
+                int(core.report_status().get("usable_capacity_bytes", 0))
+                for core in self._cores
             )
             self._seed_usage_from_core_snapshot()
 
@@ -485,8 +596,9 @@ class RawBlockL2Adapter(L2AdapterInterface):
 
     def submit_unlock(self, keys: list[ObjectKey]) -> None:
         """Release L2 locks acquired by lookup-and-lock."""
-        encoded_keys = [encode_object_key(key).encoded for key in keys]
-        self._core.unlock_many(encoded_keys)
+        specs = [encode_object_key(key) for key in keys]
+        for core, indices in self._group_key_indices(keys).items():
+            core.unlock_many([specs[i].encoded for i in indices])
 
     def submit_load_task(
         self,
@@ -532,12 +644,24 @@ class RawBlockL2Adapter(L2AdapterInterface):
 
     def delete(self, keys: list[ObjectKey]) -> None:
         """Delete keys from raw-block L2 and notify listeners for removals."""
-        encoded_keys = [encode_object_key(key).encoded for key in keys]
-        metas = self._core.get_metadata_many(encoded_keys)
-        deleted_bitmap = self._core.delete_many(encoded_keys, force=False)
+        specs = [encode_object_key(key) for key in keys]
+        metas: list[Any] = [None] * len(keys)
+        deleted_bitmap: list[bool] = [False] * len(keys)
+        for core, indices in self._group_key_indices(keys).items():
+            encoded_keys = [specs[i].encoded for i in indices]
+            core_metas = core.get_metadata_many(encoded_keys)
+            core_deleted = core.delete_many(encoded_keys, force=False)
+            for local_idx, meta, deleted in zip(
+                indices,
+                core_metas,
+                core_deleted,
+                strict=True,
+            ):
+                metas[local_idx] = meta
+                deleted_bitmap[local_idx] = deleted
         deleted_keys: list[ObjectKey] = []
         deleted_sizes: list[int] = []
-        for key, meta, deleted in zip(keys, metas, deleted_bitmap, strict=False):
+        for key, meta, deleted in zip(keys, metas, deleted_bitmap, strict=True):
             if not deleted:
                 continue
             deleted_keys.append(key)
@@ -572,7 +696,8 @@ class RawBlockL2Adapter(L2AdapterInterface):
         self._lookup_pool.shutdown(wait=True)
         self._load_pool.shutdown(wait=True)
 
-        self._core.close()
+        for core in self._cores:
+            core.close()
 
         with self._lock:
             store_efd = self._store_efd
@@ -591,19 +716,25 @@ class RawBlockL2Adapter(L2AdapterInterface):
 
     def report_status(self) -> dict:
         """Return adapter health, task counters, and core status."""
-        core_status = self._core.report_status()
+        core_statuses = [core.report_status() for core in self._cores]
+        is_core_healthy = all(
+            status.get("is_healthy", True) for status in core_statuses
+        )
         with self._lock:
-            return {
-                "is_healthy": core_status.get("is_healthy", True) and not self._closed,
+            status = {
+                "is_healthy": is_core_healthy and not self._closed,
                 "type": "RawBlockL2Adapter",
+                "device_count": len(self._cores),
                 "store_inflight_task_count": self._store_inflight_tasks,
                 "lookup_inflight_task_count": self._lookup_inflight_tasks,
                 "load_inflight_task_count": self._load_inflight_tasks,
                 "completed_store_task_count": len(self._completed_store_tasks),
                 "completed_lookup_task_count": len(self._completed_lookup_tasks),
                 "completed_load_task_count": len(self._completed_load_tasks),
-                "core": core_status,
+                "core": core_statuses[0],
+                "cores": core_statuses,
             }
+            return status
 
     def _raise_if_closed_locked(self) -> None:
         if self._closed:
@@ -636,15 +767,16 @@ class RawBlockL2Adapter(L2AdapterInterface):
     def _snapshot_indexed_object_keys(self) -> list[ObjectKey]:
         """Return decoded ObjectKeys for all indexed raw-block entries."""
         keys: list[ObjectKey] = []
-        for encoded_key in self._core.snapshot_indexed_keys():
-            try:
-                keys.append(decode_object_key(encoded_key))
-            except Exception as e:
-                logger.warning(
-                    "RawBlockL2Adapter could not decode indexed key %r: %s",
-                    encoded_key,
-                    e,
-                )
+        for core in self._cores:
+            for encoded_key in core.snapshot_indexed_keys():
+                try:
+                    keys.append(decode_object_key(encoded_key))
+                except Exception as e:
+                    logger.warning(
+                        "RawBlockL2Adapter could not decode indexed key %r: %s",
+                        encoded_key,
+                        e,
+                    )
         return keys
 
     def _run_store_task(
@@ -666,17 +798,24 @@ class RawBlockL2Adapter(L2AdapterInterface):
             - raw-block slot byte charges aligned with the newly stored keys
         """
         specs = [encode_object_key(key) for key in keys]
-        put_result = self._core.put_many(specs, objects)
-        stored_encoded = set(put_result.stored_keys)
+        results = [False] * len(keys)
+        stored_encoded: set[str] = set()
+        for core, indices in self._group_key_indices(keys).items():
+            core_specs = [specs[i] for i in indices]
+            core_objects = [objects[i] for i in indices]
+            put_result = core.put_many(core_specs, core_objects)
+            for local_idx, ok in zip(indices, put_result.results, strict=True):
+                results[local_idx] = ok
+            stored_encoded.update(put_result.stored_keys)
         slot_bytes = int(self._core.slot_bytes)
         stored_keys: list[ObjectKey] = []
         stored_sizes: list[int] = []
-        for key, spec in zip(keys, specs, strict=False):
+        for key, spec in zip(keys, specs, strict=True):
             if spec.encoded not in stored_encoded:
                 continue
             stored_keys.append(key)
             stored_sizes.append(slot_bytes)
-        return all(put_result.results), stored_keys, stored_sizes
+        return all(results), stored_keys, stored_sizes
 
     def _finish_store_task(
         self,
@@ -707,11 +846,12 @@ class RawBlockL2Adapter(L2AdapterInterface):
 
     def _run_lookup_task(self, keys: list[ObjectKey]) -> Bitmap:
         specs = [encode_object_key(key) for key in keys]
-        exists = self._core.exists_many([spec.encoded for spec in specs], lock=True)
         bitmap = _make_bitmap(len(keys))
-        for i, ok in enumerate(exists):
-            if ok:
-                bitmap.set(i)
+        for core, indices in self._group_key_indices(keys).items():
+            exists = core.exists_many([specs[i].encoded for i in indices], lock=True)
+            for local_idx, ok in zip(indices, exists, strict=True):
+                if ok:
+                    bitmap.set(local_idx)
         return bitmap
 
     def _finish_lookup_task(
@@ -734,14 +874,25 @@ class RawBlockL2Adapter(L2AdapterInterface):
         objects: list[MemoryObj],
     ) -> tuple[Bitmap, list[ObjectKey]]:
         specs = [encode_object_key(key) for key in keys]
-        results = self._core.load_many_into([spec.encoded for spec in specs], objects)
         bitmap = _make_bitmap(len(keys))
         accessed_keys: list[ObjectKey] = []
-        for i, ok in enumerate(results):
-            if ok:
-                bitmap.set(i)
-                accessed_keys.append(keys[i])
+        for core, indices in self._group_key_indices(keys).items():
+            results = core.load_many_into(
+                [specs[i].encoded for i in indices],
+                [objects[i] for i in indices],
+            )
+            for local_idx, ok in zip(indices, results, strict=True):
+                if ok:
+                    bitmap.set(local_idx)
+                    accessed_keys.append(keys[local_idx])
         return bitmap, accessed_keys
+
+    def _group_key_indices(
+        self,
+        keys: Sequence[ObjectKey],
+    ) -> dict[RawBlockCore, list[int]]:
+        """Group submitted key indices by owning raw-block core."""
+        return _group_key_indices_by_device(keys, self._cores, self._select_device)
 
     def _finish_load_task(
         self, task_id: L2TaskId, bitmap_size: int, future: Future[Any]
@@ -777,8 +928,8 @@ class RawBlockL2Adapter(L2AdapterInterface):
                 pool.shutdown(wait=False, cancel_futures=True)
                 setattr(self, pool_name, None)
 
-        core = getattr(self, "_core", None)
-        if core is not None:
+        cores = getattr(self, "_cores", [])
+        for core in cores:
             core.close()
 
         for fd_name in ("_store_efd", "_lookup_efd", "_load_efd"):

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Callable, Sequence
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional
 import threading
@@ -444,6 +444,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
         self._store_pool: ThreadPoolExecutor
         self._lookup_pool: ThreadPoolExecutor
         self._load_pool: ThreadPoolExecutor
+        self._shard_pool: ThreadPoolExecutor
 
         try:
             if config.io_engine == "io_uring":
@@ -481,6 +482,10 @@ class RawBlockL2Adapter(L2AdapterInterface):
             self._load_pool = ThreadPoolExecutor(
                 max_workers=config.num_load_workers,
                 thread_name_prefix="rawblk-load",
+            )
+            self._shard_pool = ThreadPoolExecutor(
+                max_workers=max(1, len(self._cores)),
+                thread_name_prefix="rawblk-shard",
             )
         except Exception:
             self._cleanup_after_init_failure()
@@ -695,6 +700,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
         self._store_pool.shutdown(wait=True)
         self._lookup_pool.shutdown(wait=True)
         self._load_pool.shutdown(wait=True)
+        self._shard_pool.shutdown(wait=True)
 
         for core in self._cores:
             core.close()
@@ -798,12 +804,22 @@ class RawBlockL2Adapter(L2AdapterInterface):
             - raw-block slot byte charges aligned with the newly stored keys
         """
         specs = [encode_object_key(key) for key in keys]
+
+        def _store_shard(
+            core: RawBlockCore, indices: list[int]
+        ) -> tuple[list[int], Any]:
+            return indices, core.put_many(
+                [specs[i] for i in indices], [objects[i] for i in indices]
+            )
+
+        shard_futs = [
+            self._shard_pool.submit(_store_shard, core, indices)
+            for core, indices in self._group_key_indices(keys).items()
+        ]
         results = [False] * len(keys)
         stored_encoded: set[str] = set()
-        for core, indices in self._group_key_indices(keys).items():
-            core_specs = [specs[i] for i in indices]
-            core_objects = [objects[i] for i in indices]
-            put_result = core.put_many(core_specs, core_objects)
+        for fut in as_completed(shard_futs):
+            indices, put_result = fut.result()
             for local_idx, ok in zip(indices, put_result.results, strict=True):
                 results[local_idx] = ok
             stored_encoded.update(put_result.stored_keys)
@@ -846,9 +862,21 @@ class RawBlockL2Adapter(L2AdapterInterface):
 
     def _run_lookup_task(self, keys: list[ObjectKey]) -> Bitmap:
         specs = [encode_object_key(key) for key in keys]
+
+        def _lookup_shard(
+            core: RawBlockCore, indices: list[int]
+        ) -> tuple[list[int], list[bool]]:
+            return indices, core.exists_many(
+                [specs[i].encoded for i in indices], lock=True
+            )
+
+        shard_futs = [
+            self._shard_pool.submit(_lookup_shard, core, indices)
+            for core, indices in self._group_key_indices(keys).items()
+        ]
         bitmap = _make_bitmap(len(keys))
-        for core, indices in self._group_key_indices(keys).items():
-            exists = core.exists_many([specs[i].encoded for i in indices], lock=True)
+        for fut in as_completed(shard_futs):
+            indices, exists = fut.result()
             for local_idx, ok in zip(indices, exists, strict=True):
                 if ok:
                     bitmap.set(local_idx)
@@ -874,17 +902,26 @@ class RawBlockL2Adapter(L2AdapterInterface):
         objects: list[MemoryObj],
     ) -> tuple[Bitmap, list[ObjectKey]]:
         specs = [encode_object_key(key) for key in keys]
-        bitmap = _make_bitmap(len(keys))
-        accessed_keys: list[ObjectKey] = []
-        for core, indices in self._group_key_indices(keys).items():
-            results = core.load_many_into(
+
+        def _load_shard(
+            core: RawBlockCore, indices: list[int]
+        ) -> tuple[list[int], list[bool]]:
+            return indices, core.load_many_into(
                 [specs[i].encoded for i in indices],
                 [objects[i] for i in indices],
             )
+
+        shard_futs = [
+            self._shard_pool.submit(_load_shard, core, indices)
+            for core, indices in self._group_key_indices(keys).items()
+        ]
+        bitmap = _make_bitmap(len(keys))
+        for fut in as_completed(shard_futs):
+            indices, results = fut.result()
             for local_idx, ok in zip(indices, results, strict=True):
                 if ok:
                     bitmap.set(local_idx)
-                    accessed_keys.append(keys[local_idx])
+        accessed_keys = [keys[i] for i in range(len(keys)) if bitmap.test(i)]
         return bitmap, accessed_keys
 
     def _group_key_indices(
@@ -922,7 +959,7 @@ class RawBlockL2Adapter(L2AdapterInterface):
             logger.debug("event notifier was closed before signaling")
 
     def _cleanup_after_init_failure(self) -> None:
-        for pool_name in ("_store_pool", "_lookup_pool", "_load_pool"):
+        for pool_name in ("_store_pool", "_lookup_pool", "_load_pool", "_shard_pool"):
             pool = getattr(self, pool_name, None)
             if pool is not None:
                 pool.shutdown(wait=False, cancel_futures=True)

--- a/tests/v1/distributed/test_l2_adapter_factory.py
+++ b/tests/v1/distributed/test_l2_adapter_factory.py
@@ -88,7 +88,7 @@ class TestFactoryRegistry:
 
     def test_raw_block_factory_is_registered(self):
         config = RawBlockL2AdapterConfig(
-            device_path="/tmp/raw-block-dev",
+            device_paths="/tmp/raw-block-dev",
             slot_bytes=64 * 1024,
             use_odirect=False,
             meta_enable_periodic=False,
@@ -128,7 +128,7 @@ class TestFactoryRegistry:
                 f.truncate(8 * 1024 * 1024)
 
             config = RawBlockL2AdapterConfig(
-                device_path=dev_path,
+                device_paths=dev_path,
                 slot_bytes=64 * 1024,
                 use_odirect=False,
                 meta_total_bytes=1 * 1024 * 1024,
@@ -168,53 +168,44 @@ class TestRawBlockL2AdapterConfig:
         config.update(overrides)
         return config
 
-    def test_multi_device_paths_from_dict(self):
+    def test_device_paths_list_from_dict(self):
         cfg = RawBlockL2AdapterConfig.from_dict(
-            self._config_dict(
-                multi_device_paths=["/tmp/raw0", "/tmp/raw1"],
-                device_count=2,
-            )
+            self._config_dict(device_paths=["/tmp/raw0", "/tmp/raw1"])
         )
 
-        assert cfg.multi_device_paths == ("/tmp/raw0", "/tmp/raw1")
-        assert cfg.device_path == "/tmp/raw0"
+        assert cfg.device_paths == ("/tmp/raw0", "/tmp/raw1")
 
-    def test_multi_device_paths_from_csv(self):
+    def test_device_paths_csv_from_dict(self):
         cfg = RawBlockL2AdapterConfig.from_dict(
-            self._config_dict(multi_device_paths="/tmp/raw0,/tmp/raw1")
+            self._config_dict(device_paths="/tmp/raw0,/tmp/raw1")
         )
 
-        assert cfg.multi_device_paths == ("/tmp/raw0", "/tmp/raw1")
+        assert cfg.device_paths == ("/tmp/raw0", "/tmp/raw1")
 
-    def test_device_count_mismatch_raises(self):
-        with pytest.raises(ValueError, match="device_count"):
-            RawBlockL2AdapterConfig.from_dict(
-                self._config_dict(
-                    multi_device_paths=["/tmp/raw0", "/tmp/raw1"],
-                    device_count=3,
-                )
-            )
+    def test_device_paths_single_string_from_dict(self):
+        cfg = RawBlockL2AdapterConfig.from_dict(
+            self._config_dict(device_paths="/tmp/raw0")
+        )
+
+        assert cfg.device_paths == ("/tmp/raw0",)
 
     def test_duplicate_device_paths_raise(self):
         with pytest.raises(ValueError, match="unique"):
             RawBlockL2AdapterConfig.from_dict(
-                self._config_dict(multi_device_paths=["/tmp/raw0", "/tmp/raw0"])
+                self._config_dict(device_paths=["/tmp/raw0", "/tmp/raw0"])
             )
 
-    def test_missing_device_path_raises_missing_path_error(self):
-        with pytest.raises(
-            ValueError,
-            match="device_path or multi_device_paths must be provided",
-        ):
+    def test_missing_device_paths_raises(self):
+        with pytest.raises(ValueError, match="device_paths must be provided"):
             RawBlockL2AdapterConfig.from_dict(self._config_dict())
 
-    def test_non_string_device_path_raises_string_error(self):
-        with pytest.raises(ValueError, match="device_path must be a string"):
-            RawBlockL2AdapterConfig.from_dict(self._config_dict(device_path=123))
+    def test_wrong_type_device_paths_raises(self):
+        with pytest.raises(ValueError, match="device_paths must be a string or list"):
+            RawBlockL2AdapterConfig.from_dict(self._config_dict(device_paths=123))
 
-    def test_empty_device_path_raises_non_empty_error(self):
-        with pytest.raises(ValueError, match="device_path must be non-empty"):
-            RawBlockL2AdapterConfig.from_dict(self._config_dict(device_path=""))
+    def test_empty_device_paths_raises(self):
+        with pytest.raises(ValueError, match="at least one non-empty path"):
+            RawBlockL2AdapterConfig.from_dict(self._config_dict(device_paths=""))
 
 
 # =========================================================

--- a/tests/v1/distributed/test_l2_adapter_factory.py
+++ b/tests/v1/distributed/test_l2_adapter_factory.py
@@ -154,6 +154,69 @@ class TestFactoryRegistry:
             get_type_name_for_config(_UnknownConfig())
 
 
+class TestRawBlockL2AdapterConfig:
+    """Tests for raw-block L2 adapter config parsing."""
+
+    SLOT_BYTES = 64 * 1024
+
+    def _config_dict(self, **overrides: object) -> dict[str, object]:
+        """Return a minimal raw-block config dict with test-specific overrides."""
+        config: dict[str, object] = {
+            "type": "raw_block",
+            "slot_bytes": self.SLOT_BYTES,
+        }
+        config.update(overrides)
+        return config
+
+    def test_multi_device_paths_from_dict(self):
+        cfg = RawBlockL2AdapterConfig.from_dict(
+            self._config_dict(
+                multi_device_paths=["/tmp/raw0", "/tmp/raw1"],
+                device_count=2,
+            )
+        )
+
+        assert cfg.multi_device_paths == ("/tmp/raw0", "/tmp/raw1")
+        assert cfg.device_path == "/tmp/raw0"
+
+    def test_multi_device_paths_from_csv(self):
+        cfg = RawBlockL2AdapterConfig.from_dict(
+            self._config_dict(multi_device_paths="/tmp/raw0,/tmp/raw1")
+        )
+
+        assert cfg.multi_device_paths == ("/tmp/raw0", "/tmp/raw1")
+
+    def test_device_count_mismatch_raises(self):
+        with pytest.raises(ValueError, match="device_count"):
+            RawBlockL2AdapterConfig.from_dict(
+                self._config_dict(
+                    multi_device_paths=["/tmp/raw0", "/tmp/raw1"],
+                    device_count=3,
+                )
+            )
+
+    def test_duplicate_device_paths_raise(self):
+        with pytest.raises(ValueError, match="unique"):
+            RawBlockL2AdapterConfig.from_dict(
+                self._config_dict(multi_device_paths=["/tmp/raw0", "/tmp/raw0"])
+            )
+
+    def test_missing_device_path_raises_missing_path_error(self):
+        with pytest.raises(
+            ValueError,
+            match="device_path or multi_device_paths must be provided",
+        ):
+            RawBlockL2AdapterConfig.from_dict(self._config_dict())
+
+    def test_non_string_device_path_raises_string_error(self):
+        with pytest.raises(ValueError, match="device_path must be a string"):
+            RawBlockL2AdapterConfig.from_dict(self._config_dict(device_path=123))
+
+    def test_empty_device_path_raises_non_empty_error(self):
+        with pytest.raises(ValueError, match="device_path must be non-empty"):
+            RawBlockL2AdapterConfig.from_dict(self._config_dict(device_path=""))
+
+
 # =========================================================
 # Tests: PluginL2AdapterConfig parsing
 # =========================================================

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -139,29 +139,15 @@ def _wait_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
 
 
 def _make_config(
-    device_path: str | list[str],
+    device_paths: str | list[str],
     *,
     slot_bytes: int = 64 * 1024,
     capacity_bytes: int = 0,
     io_engine: str = "posix",
     use_uring_cmd: bool = False,
 ) -> RawBlockL2AdapterConfig:
-    if isinstance(device_path, str):
-        return RawBlockL2AdapterConfig(
-            device_path=device_path,
-            slot_bytes=slot_bytes,
-            capacity_bytes=capacity_bytes,
-            use_odirect=False,
-            block_align=4096,
-            header_bytes=4096,
-            meta_total_bytes=1 * 1024 * 1024,
-            meta_enable_periodic=False,
-            num_store_workers=2,
-            num_lookup_workers=1,
-            num_load_workers=2,
-        )
     return RawBlockL2AdapterConfig(
-        multi_device_paths=device_path,
+        device_paths=device_paths,
         slot_bytes=slot_bytes,
         capacity_bytes=capacity_bytes,
         use_odirect=False,
@@ -179,7 +165,7 @@ def _make_config(
 
 def _config_dict(**overrides) -> dict[str, object]:
     config: dict[str, object] = {
-        "device_path": "/tmp/raw-block-test-device",
+        "device_paths": "/tmp/raw-block-test-device",
         "slot_bytes": 64 * 1024,
         "use_odirect": False,
     }
@@ -266,7 +252,7 @@ def test_raw_block_l2_adapter_config_parses_uring_flags():
     cfg = RawBlockL2AdapterConfig.from_dict(
         {
             "type": "raw_block",
-            "device_path": "/tmp/raw-block-dev",
+            "device_paths": "/tmp/raw-block-dev",
             "slot_bytes": 64 * 1024,
             "use_odirect": False,
             "io_engine": "io_uring",
@@ -280,7 +266,7 @@ def test_raw_block_l2_adapter_config_parses_uring_flags():
         RawBlockL2AdapterConfig.from_dict(
             {
                 "type": "raw_block",
-                "device_path": "/tmp/raw-block-dev",
+                "device_paths": "/tmp/raw-block-dev",
                 "slot_bytes": 64 * 1024,
                 "use_uring_cmd": True,
             }

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -48,22 +48,27 @@ requires_raw_block_ext = pytest.mark.skipif(
 class _RecordingListener(L2AdapterListener):
     def __init__(self):
         self.stored: list[list[ObjectKey]] = []
+        self.stored_sizes: list[list[int] | None] = []
         self.accessed: list[list[ObjectKey]] = []
         self.deleted: list[list[ObjectKey]] = []
+        self.deleted_sizes: list[list[int] | None] = []
 
     def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]):
         self.stored.append(list(keys))
+        self.stored_sizes.append(list(sizes))
 
     def on_l2_keys_accessed(self, keys: list[ObjectKey]):
         self.accessed.append(list(keys))
 
     def on_l2_keys_deleted(self, keys: list[ObjectKey]):
         self.deleted.append(list(keys))
+        self.deleted_sizes.append(None)
 
 
 class _FailingListener(L2AdapterListener):
     def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]):
         del keys
+        del sizes
         raise RuntimeError("store listener failed")
 
     def on_l2_keys_accessed(self, keys: list[ObjectKey]):
@@ -78,11 +83,13 @@ def _create_object_key(
     chunk_id: int,
     model_name: str = "test_model",
     cache_salt: str = "",
+    *,
+    kv_rank: int = 0,
 ) -> ObjectKey:
     return ObjectKey(
         chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
         model_name=model_name,
-        kv_rank=0,
+        kv_rank=kv_rank,
         cache_salt=cache_salt,
     )
 
@@ -132,15 +139,29 @@ def _wait_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
 
 
 def _make_config(
-    device_path: str,
+    device_path: str | list[str],
     *,
     slot_bytes: int = 64 * 1024,
     capacity_bytes: int = 0,
     io_engine: str = "posix",
     use_uring_cmd: bool = False,
 ) -> RawBlockL2AdapterConfig:
+    if isinstance(device_path, str):
+        return RawBlockL2AdapterConfig(
+            device_path=device_path,
+            slot_bytes=slot_bytes,
+            capacity_bytes=capacity_bytes,
+            use_odirect=False,
+            block_align=4096,
+            header_bytes=4096,
+            meta_total_bytes=1 * 1024 * 1024,
+            meta_enable_periodic=False,
+            num_store_workers=2,
+            num_lookup_workers=1,
+            num_load_workers=2,
+        )
     return RawBlockL2AdapterConfig(
-        device_path=device_path,
+        multi_device_paths=device_path,
         slot_bytes=slot_bytes,
         capacity_bytes=capacity_bytes,
         use_odirect=False,
@@ -202,6 +223,23 @@ def test_raw_block_l2_adapter_config_explicit_io_engine_wins_over_legacy_flag():
 def test_raw_block_l2_adapter_config_validates_iouring_queue_depth():
     with pytest.raises(ValueError, match="iouring_queue_depth"):
         RawBlockL2AdapterConfig.from_dict(_config_dict(iouring_queue_depth=0))
+
+
+def _create_object_key_with_local_rank(
+    chunk_id: int,
+    local_rank: int,
+    *,
+    local_world_size: int = 2,
+) -> ObjectKey:
+    return _create_object_key(
+        chunk_id,
+        kv_rank=ObjectKey.ComputeKVRank(
+            world_size=local_world_size,
+            global_rank=local_rank,
+            local_world_size=local_world_size,
+            local_rank=local_rank,
+        ),
+    )
 
 
 def _run_store(adapter: RawBlockL2Adapter, keys, objects) -> bool:
@@ -308,6 +346,209 @@ def test_raw_block_l2_adapter_store_lookup_load_roundtrip():
             assert torch.count_nonzero(load_buffers[1].tensor) == 0
 
             adapter.submit_unlock([key1, key_miss, key3])
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_multi_device_roundtrip_and_recovery():
+    device_count = 2
+    local_ranks = list(range(device_count))
+    with tempfile.TemporaryDirectory() as td:
+        dev_paths = [
+            os.path.join(td, f"dev{local_rank}.bin") for local_rank in local_ranks
+        ]
+        for dev_path in dev_paths:
+            with open(dev_path, "wb") as f:
+                f.truncate(8 * 1024 * 1024)
+
+        config = _make_config(dev_paths)
+        keys = [
+            _create_object_key_with_local_rank(
+                1000 + local_rank,
+                local_rank,
+                local_world_size=device_count,
+            )
+            for local_rank in local_ranks
+        ]
+        objects = [
+            _create_memory_obj(fill_value=float(100 + local_rank))
+            for local_rank in local_ranks
+        ]
+
+        adapter1 = RawBlockL2Adapter(config)
+        try:
+            assert _run_store(adapter1, keys, objects) is True
+            status = adapter1.report_status()
+            assert status["device_count"] == device_count
+            indexed_key_counts = [core["indexed_key_count"] for core in status["cores"]]
+            assert indexed_key_counts == [1] * device_count
+        finally:
+            adapter1.close()
+
+        adapter2 = RawBlockL2Adapter(config)
+        try:
+            _, lookup_bitmap = _run_lookup(adapter2, keys)
+            assert lookup_bitmap is not None
+            assert lookup_bitmap.get_indices_list() == [0, 1]
+
+            load_buffers = [
+                _create_memory_obj(fill_value=0.0),
+                _create_memory_obj(fill_value=0.0),
+            ]
+            _, load_bitmap = _run_load(adapter2, keys, load_buffers)
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0, 1]
+            assert torch.equal(load_buffers[0].tensor, objects[0].tensor)
+            assert torch.equal(load_buffers[1].tensor, objects[1].tensor)
+
+            adapter2.submit_unlock(keys)
+        finally:
+            adapter2.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_four_device_local_rank_distribution_and_order():
+    device_count = 4
+    local_ranks = list(range(device_count))
+    with tempfile.TemporaryDirectory() as td:
+        dev_paths = [
+            os.path.join(td, f"dev{local_rank}.bin") for local_rank in local_ranks
+        ]
+        for dev_path in dev_paths:
+            with open(dev_path, "wb") as f:
+                f.truncate(8 * 1024 * 1024)
+
+        keys_by_local_rank = [
+            _create_object_key_with_local_rank(
+                3000 + local_rank,
+                local_rank,
+                local_world_size=device_count,
+            )
+            for local_rank in local_ranks
+        ]
+        objects_by_local_rank = [
+            _create_memory_obj(fill_value=float(300 + local_rank))
+            for local_rank in local_ranks
+        ]
+        store_local_ranks = list(reversed(local_ranks))
+
+        adapter = RawBlockL2Adapter(_make_config(dev_paths))
+        try:
+            store_keys = [
+                keys_by_local_rank[local_rank] for local_rank in store_local_ranks
+            ]
+            store_objects = [
+                objects_by_local_rank[local_rank] for local_rank in store_local_ranks
+            ]
+            assert (
+                _run_store(
+                    adapter,
+                    store_keys,
+                    store_objects,
+                )
+                is True
+            )
+            status = adapter.report_status()
+            assert status["device_count"] == device_count
+            indexed_key_counts = [core["indexed_key_count"] for core in status["cores"]]
+            assert indexed_key_counts == [1] * device_count
+
+            missing_local_rank = local_ranks[1]
+            miss = _create_object_key_with_local_rank(
+                3999,
+                missing_local_rank,
+                local_world_size=device_count,
+            )
+            lookup_local_ranks = [
+                local_ranks[2],
+                None,
+                local_ranks[0],
+                local_ranks[-1],
+            ]
+            lookup_keys = [
+                miss if local_rank is None else keys_by_local_rank[local_rank]
+                for local_rank in lookup_local_ranks
+            ]
+            expected_hit_indices = [
+                request_index
+                for request_index, local_rank in enumerate(lookup_local_ranks)
+                if local_rank is not None
+            ]
+
+            _, lookup_bitmap = _run_lookup(adapter, lookup_keys)
+            assert lookup_bitmap is not None
+            assert lookup_bitmap.get_indices_list() == expected_hit_indices
+
+            load_buffers = [_create_memory_obj(fill_value=0.0) for _ in lookup_keys]
+            _, load_bitmap = _run_load(adapter, lookup_keys, load_buffers)
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == expected_hit_indices
+            for request_index, local_rank in enumerate(lookup_local_ranks):
+                if local_rank is None:
+                    assert torch.count_nonzero(load_buffers[request_index].tensor) == 0
+                else:
+                    assert torch.equal(
+                        load_buffers[request_index].tensor,
+                        objects_by_local_rank[local_rank].tensor,
+                    )
+
+            adapter.submit_unlock(lookup_keys)
+        finally:
+            adapter.close()
+
+
+@requires_raw_block_ext
+def test_raw_block_l2_adapter_multi_device_delete_preserves_other_devices():
+    device_count = 3
+    with tempfile.TemporaryDirectory() as td:
+        dev_paths = [os.path.join(td, f"dev{i}.bin") for i in range(device_count)]
+        for dev_path in dev_paths:
+            with open(dev_path, "wb") as f:
+                f.truncate(8 * 1024 * 1024)
+
+        keys = [
+            _create_object_key_with_local_rank(
+                4100 + rank,
+                rank,
+                local_world_size=device_count,
+            )
+            for rank in range(device_count)
+        ]
+        objects = [
+            _create_memory_obj(fill_value=float(410 + rank))
+            for rank in range(device_count)
+        ]
+        listener = _RecordingListener()
+        adapter = RawBlockL2Adapter(_make_config(dev_paths))
+        adapter.register_listener(listener)
+
+        try:
+            assert _run_store(adapter, keys, objects) is True
+            adapter.delete([keys[1]])
+
+            status = adapter.report_status()
+            assert [core["indexed_key_count"] for core in status["cores"]] == [
+                1,
+                0,
+                1,
+            ]
+            assert listener.deleted == [[keys[1]]]
+            assert listener.deleted_sizes == [None]
+
+            _, lookup_bitmap = _run_lookup(adapter, keys)
+            assert lookup_bitmap is not None
+            assert lookup_bitmap.get_indices_list() == [0, 2]
+
+            load_buffers = [_create_memory_obj(fill_value=0.0) for _ in keys]
+            _, load_bitmap = _run_load(adapter, keys, load_buffers)
+            assert load_bitmap is not None
+            assert load_bitmap.get_indices_list() == [0, 2]
+            assert torch.equal(load_buffers[0].tensor, objects[0].tensor)
+            assert torch.count_nonzero(load_buffers[1].tensor) == 0
+            assert torch.equal(load_buffers[2].tensor, objects[2].tensor)
+
+            adapter.submit_unlock(keys)
         finally:
             adapter.close()
 

--- a/tests/v1/multiprocess/test_raw_block_l2_adapter.py
+++ b/tests/v1/multiprocess/test_raw_block_l2_adapter.py
@@ -41,7 +41,7 @@ _EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
 def _make_adapter(tmp_path: Path) -> RawBlockL2Adapter:
     path = make_raw_block_file(tmp_path)
     config = RawBlockL2AdapterConfig(
-        device_path=str(path),
+        device_paths=str(path),
         capacity_bytes=RAW_BLOCK_CI_CAPACITY_BYTES,
         block_align=RAW_BLOCK_CI_BLOCK_ALIGN,
         header_bytes=RAW_BLOCK_CI_HEADER_BYTES,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds single-node multi-device support for the MP `raw_block` L2 adapter.d

- Replaces `device_path` with `device_paths`, accepting a single path, a list of paths, or a comma-separated string.
- Creates one `RawBlockCore` per configured path and shards objects by `kv_rank.local_rank % len(device_paths)`.
- Runs per-device store, lookup, and load work through a dedicated shard pool so shard I/O can proceed concurrently.
- Preserves request ordering for lookup/load results after parallel shard completion.
- Updates raw-block L2 docs and examples for `device_paths`.

**Special notes for your reviewers**:

This intentionally supports the single-node sharding case only. Device ordering must stay stable across restarts so recovered metadata maps back to the same raw device.

Tests were not run locally for this PR body request.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests