### PR TITLE
[good-first-issue] docs: correct RST syntax and improve Chinese translations in recipes/index.po

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/recipes/index.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/recipes/index.po
@@ -28,7 +28,7 @@ msgid ""
 "This section lists model architectures that have been validated end-to-"
 "end with LMCache, with a recipe page per architecture covering only the "
 "LMCache-specific configuration that diverges from defaults."
-msgstr "本节列出了经过 LMCache 端到端验证的模型架构，每个架构都有一个配方页面，涵盖与默认设置不同的仅 LMCache 特定配置。"
+msgstr "本节列出了经过 LMCache 端到端验证的模型架构，每个架构都有一个使用指南页面，涵盖与默认设置不同的 LMCache 特定配置。"
 
 #: ../../source/recipes/index.rst:10
 msgid ""
@@ -169,7 +169,7 @@ msgstr "``google/gemma-3-4b-it``"
 
 #: ../../source/recipes/index.rst:66
 msgid ":doc:`gemma3`"
-msgstr "`:doc:`gemma3``"
+msgstr ":doc:`gemma3`"
 
 #: ../../source/recipes/index.rst:68
 msgid "``MistralForCausalLM``"
@@ -193,7 +193,7 @@ msgstr "``openai/gpt-oss-120b``"
 
 #: ../../source/recipes/index.rst:80
 msgid ":doc:`gpt_oss`"
-msgstr ":gpt_oss:"
+msgstr ":doc:`gpt_oss`"
 
 #: ../../source/recipes/index.rst:82
 msgid "``Qwen3MoeForCausalLM``"
@@ -205,7 +205,7 @@ msgstr "``Qwen/Qwen3-235B-A22B``"
 
 #: ../../source/recipes/index.rst:87
 msgid ":doc:`qwen3`"
-msgstr "：doc:`qwen3`"
+msgstr ":doc:`qwen3`"
 
 #: ../../source/recipes/index.rst:89
 msgid "``LlamaForCausalLM``"
@@ -217,7 +217,7 @@ msgstr "``meta-llama/Meta-Llama-3.1-70B-Instruct``"
 
 #: ../../source/recipes/index.rst:94
 msgid ":doc:`llama`"
-msgstr "`:doc:`llama`"
+msgstr ":doc:`llama`"
 
 #: ../../source/recipes/index.rst:96
 msgid "``Phi3ForCausalLM``"


### PR DESCRIPTION
Refs #3539

Fixed several issues in the Chinese translation of `recipes/index.po`:

1. **RST syntax fix** - `:gpt_oss:` → `:doc:`gpt_oss`` (was missing `doc:` prefix)
2. **RST syntax fix** - Chinese colon `：doc:` replaced with English `:doc:`
3. **RST syntax fix** - Removed extraneous backticks in `:doc:`gemma3`` and `:doc:`llama`` 
4. **Wording improvement** - Changed "配方页面" to "使用指南页面" (consistent with rest of file)

- [x] Only `recipes/index.po` is changed
- [ ] pre-commit run --all-files passes locally
- [x] Changes are purely language/RST fixes, no content modified

Closes #3539
Signed-off-by: April-Sonnet <2569381344@qq.com>