### PR TITLE
[good-first-issue] docs: fix Chinese colon in RST directive in mp/hybrid_models.po

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/mp/hybrid_models.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/mp/hybrid_models.po
@@ -169,7 +169,7 @@ msgstr "另请参阅"
 
 #: ../../source/mp/hybrid_models.rst:86
 msgid ":doc:`quickstart` — launching the LMCache server and a vLLM client."
-msgstr "：doc:`quickstart` — 启动 LMCache 服务器和 vLLM 客户端。"
+msgstr ":doc:`quickstart` — 启动 LMCache 服务器和 vLLM 客户端。"
 
 #: ../../source/mp/hybrid_models.rst:87
 msgid ""


### PR DESCRIPTION
Refs #3539

Fixed a RST syntax error in the Chinese translation of `mp/hybrid_models.po`:
- `：doc:`quickstart`` → `:doc:`quickstart`` (Chinese colon replaced with English colon)

The `msgid` already uses the correct `:doc:` prefix; only the `msgstr` had the incorrect Chinese colon, which would break Sphinx rendering.

- [x] Only `mp/hybrid_models.po` is changed, 1 line
- [x] Changes are purely RST syntax fix

Refs #3692 (same type of fix)