### PR TITLE
[CI][Fix] Pin fastapi<0.137 for vLLM CPU e2e

### DIFF
--- a/.github/scripts/install_vllm_cpu.sh
+++ b/.github/scripts/install_vllm_cpu.sh
@@ -34,6 +34,13 @@ ${PIP_BIN} install vllm-cpu-nightly \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   ${PIP_INSTALL_EXTRA_ARGS}
 
+# FastAPI 0.137 wraps included routers as `_IncludedRouter` (no `.path`), which
+# prometheus-fastapi-instrumentator (vLLM metrics) 500s on. Temp pin until fix:
+# https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370
+# shellcheck disable=SC2086
+${PIP_BIN} install "fastapi<0.137" \
+  ${PIP_INSTALL_EXTRA_ARGS}
+
 python - <<'PY'
 import importlib.metadata as md
 import pathlib


### PR DESCRIPTION
**What this PR does / why we need it**:

FastAPI 0.137 wraps included routers as `_IncludedRouter` (no `.path`), which prometheus-fastapi-instrumentator 500s on, so the CPU-device vLLM e2e job times out on `/v1/models`. Pin `fastapi<0.137` as a temporary CI workaround
https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
