### PR TITLE
[MP] perf(nixl_store_dynamic): load a request's chunks concurrently

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
@@ -732,23 +732,27 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         objects: list[MemoryObj],
         task_id: L2TaskId,
     ) -> None:
-        """Load all found keys from their files via dynamic DMA reads.
+        """Execute a queued load task for ``task_id``.
 
-        The per-key reads are issued **concurrently** (``asyncio.gather``)
-        rather than awaited one at a time. Each ``dynamic_load_file`` still
-        registers/transfers/deregisters its own file, but the transfers now
-        overlap instead of serializing, so a single multi-chunk request no
-        longer pays (chunks x per-file latency) in series. This is the
-        dominant cost of single-request KV loads.
-
-        TODO: register a request's files in a single ``register_memory``
-        call (one transfer / one deregister), like the static adapter's
-        flat-index path. The consideration is one large per-request
-        registration list instead of many small ones.
+        For each requested key present in this adapter, read its stored
+        data into the caller-provided ``objects[i]`` and set bit ``i`` of
+        the result bitmap; keys that are missing or fail to load are left
+        unset. The bitmap is recorded under ``task_id`` (retrieve via
+        ``query_load_result``) and the load event fd is signaled.
         """
         bitmap = Bitmap(len(keys))
         accessed_keys: list[ObjectKey] = []
         try:
+            # Read every present key's file concurrently (asyncio.gather
+            # below) so a multi-chunk request does not pay per-file NIXL
+            # latency serially -- the dominant cost of a single-request load.
+            #
+            # TODO(perf): batch a request's files into one NIXL
+            # ``register_memory`` (a single transfer + single deregister),
+            # like the static adapter's pre-registered flat-index pool,
+            # instead of the current per-file register/transfer/deregister.
+            # Trade-off: one large per-request registration list vs. many
+            # small ones.
             coros = []
             found_positions: list[int] = []
             for i, key in enumerate(keys):

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
@@ -732,10 +732,25 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         objects: list[MemoryObj],
         task_id: L2TaskId,
     ) -> None:
-        """Load each found key from its file via dynamic DMA read."""
+        """Load all found keys from their files via dynamic DMA reads.
+
+        The per-key reads are issued **concurrently** (``asyncio.gather``)
+        rather than awaited one at a time. Each ``dynamic_load_file`` still
+        registers/transfers/deregisters its own file, but the transfers now
+        overlap instead of serializing, so a single multi-chunk request no
+        longer pays (chunks x per-file latency) in series. This is the
+        dominant cost of single-request KV loads.
+
+        TODO: register a request's files in a single ``register_memory``
+        call (one transfer / one deregister), like the static adapter's
+        flat-index path. The consideration is one large per-request
+        registration list instead of many small ones.
+        """
         bitmap = Bitmap(len(keys))
         accessed_keys: list[ObjectKey] = []
         try:
+            coros = []
+            found_positions: list[int] = []
             for i, key in enumerate(keys):
                 with self._lock:
                     storage_obj = self._memory_objects.get(key)
@@ -747,12 +762,28 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
                 mem_indices = self.nixl_agent.get_memory_indices(mem_addr, mem_size)
                 file_path = self.nixl_agent.get_file_path_for_key(key)
 
-                await self.nixl_agent.dynamic_load_file(
-                    mem_indices, file_path, self.nixl_agent.l1_align_bytes
+                coros.append(
+                    self.nixl_agent.dynamic_load_file(
+                        mem_indices, file_path, self.nixl_agent.l1_align_bytes
+                    )
                 )
+                found_positions.append(i)
 
-                bitmap.set(i)
-                accessed_keys.append(key)
+            if coros:
+                # return_exceptions=True so one chunk's failure doesn't
+                # discard the chunks that loaded successfully: mark each
+                # key by its own result rather than all-or-nothing.
+                results = await asyncio.gather(*coros, return_exceptions=True)
+                for pos, result in zip(found_positions, results, strict=True):
+                    if isinstance(result, BaseException):
+                        logger.error(
+                            "Dynamic NIXL load failed for key %s: %r",
+                            keys[pos],
+                            result,
+                        )
+                        continue
+                    bitmap.set(pos)
+                    accessed_keys.append(keys[pos])
 
         except Exception:
             logger.exception("Dynamic NIXL load task %d failed", task_id)

--- a/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
@@ -389,7 +389,7 @@ class TestLoadInterface:
         adpt.pop_completed_store_tasks()
 
         # Lookup and lock
-        task_id = adpt.submit_lookup_and_lock_task(keys)
+        task_id = adpt.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
         wait_for_event_fd(adpt.get_lookup_and_lock_event_fd())
         adpt.query_lookup_and_lock_result(task_id)
 
@@ -428,7 +428,7 @@ class TestLoadInterface:
         wait_for_event_fd(adpt.get_store_event_fd())
         adpt.pop_completed_store_tasks()
 
-        task_id = adpt.submit_lookup_and_lock_task(keys)
+        task_id = adpt.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
         wait_for_event_fd(adpt.get_lookup_and_lock_event_fd())
         adpt.query_lookup_and_lock_result(task_id)
 

--- a/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
@@ -369,6 +369,92 @@ class TestLoadInterface:
 
         adpt.submit_unlock([key])
 
+    def test_load_multiple_keys_concurrent(self, adapter):
+        """A multi-key load task reads every chunk correctly.
+
+        Exercises the concurrent (gather-based) load loop: store several
+        keys, then load them all in a single task and verify each landed in
+        its own page with the right data.
+        """
+        adpt, buf, _ = adapter
+        keys = [create_object_key(i) for i in range(1, 4)]
+        fills = [11.0, 22.0, 33.0]
+        store_objs = [
+            create_memory_obj(buf, page_index=i, fill_value=fills[i]) for i in range(3)
+        ]
+
+        # Store all three
+        adpt.submit_store_task(keys, store_objs)
+        wait_for_event_fd(adpt.get_store_event_fd())
+        adpt.pop_completed_store_tasks()
+
+        # Lookup and lock
+        task_id = adpt.submit_lookup_and_lock_task(keys)
+        wait_for_event_fd(adpt.get_lookup_and_lock_event_fd())
+        adpt.query_lookup_and_lock_result(task_id)
+
+        # Load all three into separate pages (3, 4, 5) in ONE task
+        load_objs = [
+            create_memory_obj(buf, page_index=3 + i, fill_value=0.0) for i in range(3)
+        ]
+        task_id = adpt.submit_load_task(keys, load_objs)
+        wait_for_event_fd(adpt.get_load_event_fd())
+
+        bitmap = adpt.query_load_result(task_id)
+        assert bitmap is not None
+        for i in range(3):
+            assert bitmap.test(i)
+            page = 3 + i
+            loaded = buf[page * PAGE_SIZE : (page + 1) * PAGE_SIZE].view(torch.float32)
+            assert torch.all(loaded == fills[i])
+
+        adpt.submit_unlock(keys)
+
+    def test_load_partial_failure_marks_only_successful(self, adapter):
+        """One chunk's failure must not discard the others in the same task.
+
+        With ``asyncio.gather(..., return_exceptions=True)``, a single failed
+        load (here: its backing file is removed) is reported as failed for
+        that key while the sibling keys still load successfully.
+        """
+        adpt, buf, tmp_dir = adapter
+        keys = [create_object_key(i) for i in range(1, 4)]
+        fills = [11.0, 22.0, 33.0]
+        store_objs = [
+            create_memory_obj(buf, page_index=i, fill_value=fills[i]) for i in range(3)
+        ]
+
+        adpt.submit_store_task(keys, store_objs)
+        wait_for_event_fd(adpt.get_store_event_fd())
+        adpt.pop_completed_store_tasks()
+
+        task_id = adpt.submit_lookup_and_lock_task(keys)
+        wait_for_event_fd(adpt.get_lookup_and_lock_event_fd())
+        adpt.query_lookup_and_lock_result(task_id)
+
+        # Sabotage the middle key's backing file so its load raises.
+        os.remove(os.path.join(tmp_dir, _object_key_to_filename(keys[1])))
+
+        load_objs = [
+            create_memory_obj(buf, page_index=3 + i, fill_value=0.0) for i in range(3)
+        ]
+        task_id = adpt.submit_load_task(keys, load_objs)
+        wait_for_event_fd(adpt.get_load_event_fd())
+
+        bitmap = adpt.query_load_result(task_id)
+        assert bitmap is not None
+        assert bitmap.test(0)  # loaded ok
+        assert not bitmap.test(1)  # file removed -> failed, not crashed
+        assert bitmap.test(2)  # loaded ok despite sibling failure
+
+        # The two successful loads landed correct data.
+        for i in (0, 2):
+            page = 3 + i
+            loaded = buf[page * PAGE_SIZE : (page + 1) * PAGE_SIZE].view(torch.float32)
+            assert torch.all(loaded == fills[i])
+
+        adpt.submit_unlock(keys)
+
     def test_query_load_result_clears_result(self, adapter):
         adpt, buf, _ = adapter
         key = create_object_key(1)


### PR DESCRIPTION
  The dynamic L2 adapter loaded each chunk of a request **serially**
  (`for key: await dynamic_load_file`), so a single multi-chunk request paid
  `num_chunks × (per-file register + transfer + poll + deregister)` in series —
  the dominant cost of single-request KV loads. Issue the per-chunk reads with
  `asyncio.gather` so the transfers overlap.
  
  ## Measured
  MP, Qwen3-14B-FP8, 256 docs / 1.25 TB, NIXL POSIX (DIO + io_uring), `before → after PR`:
  
  | cons | app-BW (GB/s) | TTFT p50 (ms) | TTFT p99 (ms) |
  |----:|:-------------:|:-------------:|:-------------:|
  | 1 | 4.7 → 20.0 | 1039 → 243 | 1051 → 254 |
  | 2 | 9.1 → 38.8 | 1068 → 247 | 1084 → 295 |
  | 4 | 21.2 → 58.3 | 903 → 312 | 1089 → 554 |
  | 8 | 43.7 → 70.3 | 857 → 566 | 1045 → 754 |
  
  **Static `nixl_store` adapter under identical conditions (reference target):**
  
  | cons | app-BW (GB/s) | TTFT p50 (ms) | TTFT p99 (ms) |
  |----:|:-------------:|:-------------:|:-------------:|
  | 1 | 22.9 | 212 | 224 |
  | 2 | 42.0 | 227 | 276 |
  | 4 | 62.9 | 307 | 463 |
  | 8 | 70.8 | 573 | 824 |
  
  After the fix, dynamic is **on par with static**: cons=8 saturates the storage
  fabric (~70 GB/s) and single-request **TTFT drops ~4×**.
  
  ## Notes
  Each chunk still registers/deregisters its own file. **TODO:** register a
  request's files in a single batched call (like the static adapter); the
  consideration is one large per-request registration list instead of many
  small ones.
  
  Adds a multi-key load test exercising the concurrent path.
