### PR TITLE
[feat][cb] fault-inject L2 adapter + segmented-prefix retrieval path

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/fault_inject.md
+++ b/docs/design/v1/distributed/l2_adapters/fault_inject.md
@@ -1,0 +1,87 @@
+# Fault-Injecting L2 Adapter
+
+`lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py`
+
+A **test/diagnostic-only** L2 adapter that wraps a real inner adapter (e.g.
+`fs_native`) and deterministically drops keys on the load read, simulating
+partial L2 retrieve failures. Its purpose is to exercise the **segmented**
+code paths — gapped found-set → segmented prefetch → segmented scatter /
+attention — that a healthy cache never produces, so CacheBlend's
+segmented-prefix handling can be tested without an actual faulty L2.
+
+## Fault model
+
+It faults the **load read primitive only**. A dropped key is reported
+**present at lookup** but its **load fails** — the faithful "L2 retrieve
+error". The lookup-miss case is *intentionally not modeled*: a key absent at
+lookup merely shortens the found-set, which the `PREFIX` trim policy
+(`count_leading_ones`) already covers. Modeling load-failure-after-lookup is
+what produces a *gapped* found-set (hit … miss … hit), the input the
+segmented path is built to handle.
+
+When a load fails, **no unlock is issued here** — the prefetch controller
+releases the load-failed read locks itself via the trim mask.
+
+## Drop selection
+
+A load position is dropped (`_drop_positions` / `_should_drop_key`) if **any**
+of the following hold:
+
+| knob | meaning | use |
+|---|---|---|
+| `drop_chunk_hashes: list[str]` | hex chunk hashes; matched on `ObjectKey.chunk_hash`. **Content-keyed and persistent** — the same chunk fails on every leg / every run. | primary lever for segmented repros (drop one mid chunk → a stable gap) |
+| `gap_indices: list[int]` | exact task-positions to always drop | precise single-gap unit tests |
+| `rate: float` + `seed: int` | per-key drop probability in `[0,1]` via a stable seeded hash of the key, bucketed by `rate` | randomized resilience sweeps; deterministic given the seed |
+
+Defaults are pass-through (`rate=0.0`, empty `gap_indices`/`drop_chunk_hashes`).
+
+## Configuration
+
+Activated through `--l2-adapter` (or the engine L2 spec). The required
+`inner` sub-dict is a full adapter spec — dispatched through the L2 adapter
+config registry — so any inner adapter type works and keeps its own
+eviction/persist/serde config:
+
+```json
+{
+  "type": "fault_inject",
+  "inner": { "type": "fs_native", "base_path": "/dev/shm/cb_l2" },
+  "drop_chunk_hashes": ["3f9a…"],
+  "rate": 0.0,
+  "seed": 0,
+  "gap_indices": []
+}
+```
+
+At startup it logs `FaultInjectL2Adapter ACTIVE (rate=… seed=… gap_indices=…
+drop_chunk_hashes=N) wrapping <inner> -- test/diagnostic use only.`
+
+## Data flow
+
+```
+submit_load_task(keys)         → delegate to inner; stash keys under task_id
+query_load_result(task_id)     → bitmap = inner.query_load_result(task_id)
+                                 for i in _drop_positions(keys): bitmap.clear(i)
+                                 return bitmap        # dropped bits now read "miss"
+```
+
+`submit_load_task` records the per-task key list so `query_load_result` can map
+the dropped bit positions back to keys; the result query is **non-idempotent**
+(a non-`None` bitmap is returned once per task), matching the inner contract.
+
+## Delegation
+
+Everything other than the load-result query passes straight through to the
+inner adapter: store, lookup-and-lock, unlock, delete, the event fds,
+listener registration, usage, and global-eviction support. The fault layer
+holds no data of its own. `report_status()` returns the inner status annotated
+with a `fault_inject` sub-dict (`rate`, `seed`, `gap_indices`,
+`drop_chunk_hashes`) so the active fault config is visible in diagnostics.
+
+## Scope and safety
+
+Test/diagnostic only — never enable in production. It silently makes reads
+fail, so any served KV is intentionally incomplete. The primary consumer is
+the CacheBlend **segmented-prefix** validation (the `ci_v3_l2_hit`
+`segmented_prefix` workload drops a mid chunk to force a gapped prefix, so V3
+loads prefix+tail and recomputes only the gap).

--- a/docs/design/v1/distributed/l2_adapters/fault_inject.md
+++ b/docs/design/v1/distributed/l2_adapters/fault_inject.md
@@ -29,11 +29,21 @@ of the following hold:
 
 | knob | meaning | use |
 |---|---|---|
-| `drop_chunk_hashes: list[str]` | hex chunk hashes; matched on `ObjectKey.chunk_hash`. **Content-keyed and persistent** — the same chunk fails on every leg / every run. | primary lever for segmented repros (drop one mid chunk → a stable gap) |
-| `gap_indices: list[int]` | exact task-positions to always drop | precise single-gap unit tests |
+| `gap_tail_ratios: list[float]` | positions given as **distance-from-tail ÷ load-length** in `[0,1]` (`0.0`=last, `0.5`=middle, `1.0`=first); the dropped slot `round((1-ratio)·(n-1))` is computed from the `n`-key load batch the server actually receives. **Workload-agnostic and self-scaling** — the server needs no advance knowledge of the stored content, and the same fraction picks the right chunk at any context length. | primary lever for segmented repros (drop the mid chunk → a stable gap at any length) |
+| `gap_indices: list[int]` | exact head-relative task-positions to always drop | precise single-gap unit tests |
 | `rate: float` + `seed: int` | per-key drop probability in `[0,1]` via a stable seeded hash of the key, bucketed by `rate` | randomized resilience sweeps; deterministic given the seed |
 
-Defaults are pass-through (`rate=0.0`, empty `gap_indices`/`drop_chunk_hashes`).
+Defaults are pass-through (`rate=0.0`, empty `gap_indices`/`gap_tail_ratios`).
+
+> **Why a ratio and not a chunk hash?** An earlier `drop_chunk_hashes` knob keyed
+> drops on `ObjectKey.chunk_hash` — content-addressed, so the *same* chunk failed
+> on every leg. But it forced the test author (and thus the server config) to know
+> a hash computed from a not-yet-stored workload, which inverted the dependency
+> (the server "knowing" a future workload). `gap_tail_ratios` is a positional rule
+> the server evaluates from the load batch alone, so no content needs to be known
+> in advance. Trade-off: the drop is **per-load-batch**, not content-identical
+> across legs — for the segmented-prefix repro the gap lives in the prefix leg's
+> load, which is exactly what's exercised.
 
 ## Configuration
 
@@ -46,15 +56,18 @@ eviction/persist/serde config:
 {
   "type": "fault_inject",
   "inner": { "type": "fs_native", "base_path": "/dev/shm/cb_l2" },
-  "drop_chunk_hashes": ["3f9a…"],
+  "gap_tail_ratios": [0.5],
   "rate": 0.0,
   "seed": 0,
   "gap_indices": []
 }
 ```
 
+`"gap_tail_ratios": [0.5]` drops the middle chunk of every load — the stable
+mid-prefix gap the segmented repro needs, at any context length.
+
 At startup it logs `FaultInjectL2Adapter ACTIVE (rate=… seed=… gap_indices=…
-drop_chunk_hashes=N) wrapping <inner> -- test/diagnostic use only.`
+gap_tail_ratios=[…]) wrapping <inner> -- test/diagnostic use only.`
 
 ## Data flow
 
@@ -76,12 +89,12 @@ inner adapter: store, lookup-and-lock, unlock, delete, the event fds,
 listener registration, usage, and global-eviction support. The fault layer
 holds no data of its own. `report_status()` returns the inner status annotated
 with a `fault_inject` sub-dict (`rate`, `seed`, `gap_indices`,
-`drop_chunk_hashes`) so the active fault config is visible in diagnostics.
+`gap_tail_ratios`) so the active fault config is visible in diagnostics.
 
 ## Scope and safety
 
 Test/diagnostic only — never enable in production. It silently makes reads
 fail, so any served KV is intentionally incomplete. The primary consumer is
 the CacheBlend **segmented-prefix** validation (the `ci_v3_l2_hit`
-`segmented_prefix` workload drops a mid chunk to force a gapped prefix, so V3
-loads prefix+tail and recomputes only the gap).
+`segmented_prefix` workload sets `gap_tail_ratios=[0.5]` to force a gapped
+prefix, so V3 loads prefix+tail and recomputes only the gap).

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -113,6 +113,13 @@ Source: ``lmcache/v1/multiprocess/config.py``
        sent a PING (still warming up, or died before its first request).
        Must be >= ``--worker-reap-timeout-seconds``. Generous by default so
        slow model warmup is never mistaken for a dead worker.
+   * - ``--enable-segmented-prefix``
+     - ``False``
+     - CacheBlend (``--engine-type blend``) only: on a mid-prefix L2 retrieve
+       failure, retain the gapped prefix so the post-gap chunks stay
+       L1-resident and only the dropped gap is recomputed, instead of
+       truncating the prefix at the gap. No effect for other engines. See
+       :doc:`/mp/l2_storage/fault_inject` for a way to exercise it.
 
 Lookup Hash Logging
 -------------------

--- a/docs/source/mp/l2_storage/fault_inject.rst
+++ b/docs/source/mp/l2_storage/fault_inject.rst
@@ -45,6 +45,19 @@ an ``fs_native`` backend:
 
     --l2-adapter '{"type": "fault_inject", "inner": {"type": "fs_native", "base_path": "/dev/shm/cb_l2"}, "gap_tail_ratios": [0.5]}'
 
+To actually exercise CacheBlend's **segmented-prefix recovery**, pair the gap
+with the server flag ``--enable-segmented-prefix`` (CacheBlend only —
+``--engine-type blend``). The dropped mid chunk produces a gapped found-set;
+with segmented-prefix enabled the prefix leg **retains the post-gap chunks**
+(loads prefix + tail) and recomputes **only the dropped gap**, instead of
+truncating the prefix at the gap:
+
+.. code-block:: bash
+
+    lmcache server … \
+        --l2-adapter '{"type": "fault_inject", "inner": {"type": "fs_native", "base_path": "/dev/shm/cb_l2"}, "gap_tail_ratios": [0.5]}' \
+        --enable-segmented-prefix
+
 Randomly drop ~10% of loads (deterministic given the seed):
 
 .. code-block:: bash

--- a/docs/source/mp/l2_storage/fault_inject.rst
+++ b/docs/source/mp/l2_storage/fault_inject.rst
@@ -1,0 +1,63 @@
+Fault Inject
+============
+
+A **test/diagnostic-only** adapter that wraps a real inner adapter and
+deterministically drops keys on the load read, simulating partial L2 retrieve
+failures.  It exercises CacheBlend's **segmented-prefix** recovery path — a
+gapped found-set (hit … miss … hit) that a healthy cache never produces —
+without needing an actual faulty backend.
+
+.. warning::
+
+   Never enable in production.  It silently makes reads fail, so any KV it
+   serves is intentionally incomplete.
+
+The wrapped backend is given as a full adapter spec under ``inner`` (any
+registered ``type``), so it keeps its own configuration, eviction, persist, and
+serde settings.  Faulting applies to the load read only: a dropped key is
+reported *present at lookup* but its *load fails* (the faithful "L2 retrieve
+error"); the prefetch controller releases the load-failed locks via the trim
+mask.  Everything else (store, lookup, unlock, delete, usage) passes straight
+through to the inner adapter.
+
+**Fields:**
+
+- ``inner`` (required): full adapter spec for the wrapped backend, e.g.
+  ``{"type": "fs_native", "base_path": "/dev/shm/l2"}``.
+- ``gap_tail_ratios``: positions to always drop, given as distance-from-tail
+  fractions of the load length in ``[0, 1]`` (``0.0`` = last chunk, ``0.5`` =
+  middle, ``1.0`` = first).  Workload-agnostic and self-scaling across context
+  lengths.  Default ``[]``.
+- ``gap_indices``: exact head-relative task-positions to always drop.
+  Default ``[]``.
+- ``rate``: per-key drop probability in ``[0, 1]`` via a stable seeded hash of
+  the key.  Default ``0.0`` (pass-through).
+- ``seed``: seed for the ``rate`` hash (deterministic given the seed).
+  Default ``0``.
+
+Defaults are pass-through; set at least one of ``gap_tail_ratios``,
+``gap_indices``, or ``rate`` to drop anything.
+
+Drop a stable mid-prefix gap (the CacheBlend segmented-prefix repro), wrapping
+an ``fs_native`` backend:
+
+.. code-block:: bash
+
+    --l2-adapter '{"type": "fault_inject", "inner": {"type": "fs_native", "base_path": "/dev/shm/cb_l2"}, "gap_tail_ratios": [0.5]}'
+
+Randomly drop ~10% of loads (deterministic given the seed):
+
+.. code-block:: bash
+
+    --l2-adapter '{"type": "fault_inject", "inner": {"type": "fs", "base_path": "/data/l2"}, "rate": 0.1, "seed": 7}'
+
+Drop an exact load position (precise single-gap repro):
+
+.. code-block:: bash
+
+    --l2-adapter '{"type": "fault_inject", "inner": {"type": "fs_native", "base_path": "/dev/shm/cb_l2"}, "gap_indices": [12]}'
+
+At startup the adapter logs ``FaultInjectL2Adapter ACTIVE (rate=… seed=…
+gap_indices=… gap_tail_ratios=[…]) wrapping <inner> -- test/diagnostic use
+only.``, and ``report_status()`` reports the active fault config under a
+``fault_inject`` sub-dict.

--- a/docs/source/mp/l2_storage/supported_storages.rst
+++ b/docs/source/mp/l2_storage/supported_storages.rst
@@ -46,6 +46,9 @@ target.
    * - :doc:`Mock <mock>`
      - ``mock``
      - Testing
+   * - :doc:`Fault Inject <fault_inject>`
+     - ``fault_inject``
+     - Testing
 
 .. toctree::
    :maxdepth: 1
@@ -55,3 +58,4 @@ target.
    remote_and_distributed
    dax
    mock
+   fault_inject

--- a/lmcache/v1/distributed/l2_adapters/config.py
+++ b/lmcache/v1/distributed/l2_adapters/config.py
@@ -91,6 +91,28 @@ def _ensure_config_loaded(name: str) -> None:
     ensure_adapter_loaded(name)
 
 
+def get_l2_adapter_config_class(type_name: str) -> type["L2AdapterConfigBase"]:
+    """Resolve a registered L2-adapter config class by type name.
+
+    Lazily imports the defining module if needed (via
+    :func:`_ensure_config_loaded`), then returns the registered config class.
+    Public accessor so callers need not reach into the private registry.
+
+    Args:
+        type_name: Registered adapter type (e.g. ``"fs_native"``, ``"mock"``).
+
+    Returns:
+        The :class:`L2AdapterConfigBase` subclass registered under *type_name*.
+
+    Raises:
+        ValueError: If *type_name* is not a registered adapter type.
+    """
+    _ensure_config_loaded(type_name)
+    if type_name not in _L2_ADAPTER_CONFIG_REGISTRY:
+        raise ValueError(f"unknown L2 adapter type {type_name!r}")
+    return _L2_ADAPTER_CONFIG_REGISTRY[type_name]
+
+
 def get_registered_l2_adapter_types() -> list[str]:
     """Return all known adapter type names (eager
     and lazy)."""

--- a/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
@@ -115,18 +115,15 @@ class FaultInjectL2AdapterConfig(L2AdapterConfigBase):
         if not isinstance(inner_type, str):
             raise ValueError("'inner' adapter spec must include a string 'type'")
 
-        # Build the inner adapter config via the registry (lazy-importing its
-        # module if needed), mirroring parse_args_to_l2_adapters_config.
+        # Build the inner adapter config via the public registry accessor
+        # (lazy-importing its module if needed), mirroring
+        # parse_args_to_l2_adapters_config.
         # First Party
         from lmcache.v1.distributed.l2_adapters.config import (  # noqa: PLC0415
-            _L2_ADAPTER_CONFIG_REGISTRY,
-            _ensure_config_loaded,
+            get_l2_adapter_config_class,
         )
 
-        _ensure_config_loaded(inner_type)
-        if inner_type not in _L2_ADAPTER_CONFIG_REGISTRY:
-            raise ValueError(f"unknown inner adapter type {inner_type!r}")
-        inner_cls = _L2_ADAPTER_CONFIG_REGISTRY[inner_type]
+        inner_cls = get_l2_adapter_config_class(inner_type)
         inner_config = inner_cls.from_dict(inner)
         inner_config.eviction_config = cls._parse_eviction_config(inner)
         inner_config.persist_config = cls._parse_persist_config(inner)
@@ -248,7 +245,14 @@ class FaultInjectL2Adapter(L2AdapterInterface):
         """
         if self._rate <= 0.0:
             return False
-        h = hashlib.blake2b(f"{self._seed}:{key!r}".encode(), digest_size=8).digest()
+        # Hash the key's stable identity fields directly — never ``repr(key)``,
+        # whose format is for debugging and may change or carry non-deterministic
+        # fields, breaking the lookup-vs-load drop consistency this relies on.
+        ident = (
+            f"{self._seed}:{key.chunk_hash.hex()}:{key.model_name}:"
+            f"{key.kv_rank}:{key.object_group_id}:{key.cache_salt}"
+        )
+        h = hashlib.blake2b(ident.encode(), digest_size=8).digest()
         bucket = int.from_bytes(h, "big") % _HASH_DENOM
         return bucket < int(self._rate * _HASH_DENOM)
 

--- a/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
@@ -1,0 +1,452 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Fault-injecting L2 adapter (test/diagnostic only).
+
+Wraps a real inner L2 adapter (e.g. ``fs_native``) and deterministically
+drops keys to simulate partial L2 retrieve failures, exercising the
+segmented code paths (gapped found-set -> segmented prefetch ->
+segmented scatter/attention) that real caches never produce.
+
+Faults the load read primitive only: a dropped key is reported present
+at lookup but its load fails (the faithful "L2 retrieve error"; the
+prefetch controller releases the load-failed locks via the trim mask).
+The lookup-miss case is intentionally not modeled -- a key absent at
+lookup merely shortens the found-set, which the PREFIX trim policy
+(count_leading_ones) already covers. The drop-set is a stable hash of
+the key bucketed by ``rate``, plus optional ``gap_indices`` for precise
+single-gap repros.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING
+import hashlib
+import threading
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+from lmcache.v1.distributed.l2_adapters.base import (
+    AdapterUsage,
+    L2AdapterInterface,
+    L2TaskId,
+)
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import (
+    register_l2_adapter_factory,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+logger = init_logger(__name__)
+
+_HASH_DENOM = 1_000_000
+
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+
+
+class FaultInjectL2AdapterConfig(L2AdapterConfigBase):
+    """Config for the fault-injecting L2 adapter.
+
+    JSON fields:
+    - inner (dict, required): full adapter spec for the wrapped adapter, with
+      its own "type" (e.g. {"type": "fs_native", "base_path": "/dev/shm/x"}).
+    - rate (float): per-key drop probability in [0, 1]. Default 0.0 (pass-through).
+    - seed (int): seed for the deterministic per-key hash. Default 0.
+    - gap_indices (list[int]): exact task-positions to always drop (in addition
+      to rate-based drops). Default [] -- mainly for precise unit tests.
+    - drop_chunk_hashes (list[str]): hex-encoded chunk hashes to always drop,
+      matched on ObjectKey.chunk_hash. Content-keyed, so the SAME chunk fails in
+      every load task (prefix + sparse legs) -- a persistent single-gap repro.
+      Default [].
+    """
+
+    def __init__(
+        self,
+        inner_config: L2AdapterConfigBase,
+        rate: float,
+        seed: int,
+        gap_indices: tuple[int, ...],
+        drop_chunk_hashes: tuple[str, ...] = (),
+    ) -> None:
+        self.inner_config = inner_config
+        self.rate = rate
+        self.seed = seed
+        self.gap_indices = gap_indices
+        self.drop_chunk_hashes = drop_chunk_hashes
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "FaultInjectL2AdapterConfig":
+        """Parse a fault-inject adapter spec, building the inner config too.
+
+        The ``"inner"`` sub-dict is dispatched through the L2 adapter config
+        registry (lazy-importing its module if needed), mirroring
+        ``parse_args_to_l2_adapters_config`` so the inner adapter's own
+        eviction / persist / serde keys are honored.
+
+        Args:
+            d: The adapter spec dict (see the class docstring for fields).
+
+        Returns:
+            A populated ``FaultInjectL2AdapterConfig``.
+
+        Raises:
+            ValueError: If ``inner`` is missing or malformed, the inner type
+                is unknown, or ``rate`` / ``seed`` / ``gap_indices`` fail
+                validation.
+        """
+        inner = d.get("inner")
+        if not isinstance(inner, dict):
+            raise ValueError("'inner' must be an adapter spec dict with a 'type' field")
+        inner_type = inner.get("type")
+        if not isinstance(inner_type, str):
+            raise ValueError("'inner' adapter spec must include a string 'type'")
+
+        # Build the inner adapter config via the registry (lazy-importing its
+        # module if needed), mirroring parse_args_to_l2_adapters_config.
+        # First Party
+        from lmcache.v1.distributed.l2_adapters.config import (  # noqa: PLC0415
+            _L2_ADAPTER_CONFIG_REGISTRY,
+            _ensure_config_loaded,
+        )
+
+        _ensure_config_loaded(inner_type)
+        if inner_type not in _L2_ADAPTER_CONFIG_REGISTRY:
+            raise ValueError(f"unknown inner adapter type {inner_type!r}")
+        inner_cls = _L2_ADAPTER_CONFIG_REGISTRY[inner_type]
+        inner_config = inner_cls.from_dict(inner)
+        inner_config.eviction_config = cls._parse_eviction_config(inner)
+        inner_config.persist_config = cls._parse_persist_config(inner)
+        inner_config.serde_config = cls._parse_serde_config(inner)
+
+        rate = d.get("rate", 0.0)
+        if not isinstance(rate, (int, float)) or not (0.0 <= rate <= 1.0):
+            raise ValueError("rate must be a number in [0, 1]")
+
+        seed = d.get("seed", 0)
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise ValueError("seed must be an integer")
+
+        raw_gap = d.get("gap_indices", [])
+        if not isinstance(raw_gap, list) or any(
+            isinstance(i, bool) or not isinstance(i, int) or i < 0 for i in raw_gap
+        ):
+            raise ValueError("gap_indices must be a list of non-negative integers")
+
+        raw_hashes = d.get("drop_chunk_hashes", [])
+        if not isinstance(raw_hashes, list) or any(
+            not isinstance(h, str) for h in raw_hashes
+        ):
+            raise ValueError("drop_chunk_hashes must be a list of hex strings")
+        for h in raw_hashes:
+            try:
+                bytes.fromhex(h)
+            except ValueError as e:
+                raise ValueError(f"drop_chunk_hashes entry {h!r} is not hex") from e
+
+        return cls(
+            inner_config=inner_config,
+            rate=float(rate),
+            seed=seed,
+            gap_indices=tuple(raw_gap),
+            drop_chunk_hashes=tuple(raw_hashes),
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        """Return a help string describing this adapter's JSON config fields."""
+        return (
+            "Fault-injecting L2 adapter (test only; drops keys at load to "
+            "simulate L2 retrieve errors). Fields:\n"
+            "- inner (dict, required): wrapped adapter spec, e.g. "
+            '{"type":"fs_native","base_path":"/dev/shm/x"}\n'
+            "- rate (float): per-key drop probability in [0,1] (default 0.0)\n"
+            "- seed (int): deterministic hash seed (default 0)\n"
+            "- gap_indices (list[int]): exact task-positions to always drop\n"
+            "- drop_chunk_hashes (list[str]): hex chunk hashes to always drop "
+            "(content-keyed; persistent across load legs)"
+        )
+
+
+# -----------------------------------------------------------------------------
+# Adapter (decorator)
+# -----------------------------------------------------------------------------
+
+
+class FaultInjectL2Adapter(L2AdapterInterface):
+    """Decorator over an inner L2 adapter that drops a deterministic key subset.
+
+    All operations delegate to ``inner``; only the load-result query is
+    post-processed (dropped bits cleared) to simulate L2 retrieve errors.
+    """
+
+    def __init__(
+        self,
+        inner: L2AdapterInterface,
+        rate: float,
+        seed: int,
+        gap_indices: tuple[int, ...],
+        drop_chunk_hashes: tuple[str, ...] = (),
+    ) -> None:
+        """Wrap ``inner`` with deterministic load-failure injection.
+
+        Args:
+            inner: The real L2 adapter that every operation delegates to.
+            rate: Per-key drop probability in [0, 1]. ``0`` disables
+                rate-based drops (``gap_indices`` still applies).
+            seed: Seed for the deterministic per-key hash, so runs reproduce.
+            gap_indices: Exact task-positions to always drop, in addition to
+                the rate-based drops.
+            drop_chunk_hashes: Hex-encoded chunk hashes to always drop, matched
+                on ``ObjectKey.chunk_hash``. Content-keyed, so the same chunk
+                fails in every load task (a persistent single-gap repro).
+        """
+        # Usage and eviction are delegated to the inner adapter, so the base
+        # class's byte accounting (capacity 0) is intentionally unused here.
+        super().__init__(max_capacity_bytes=0)
+        self._inner = inner
+        self._rate = rate
+        self._seed = seed
+        self._gap_indices = frozenset(gap_indices)
+        self._drop_hash_bytes = frozenset(bytes.fromhex(h) for h in drop_chunk_hashes)
+        # task_id -> load keys, so query_load_result can map a dropped bit
+        # position back to its key.
+        self._load_keys: dict[L2TaskId, list[ObjectKey]] = {}
+        self._keys_lock = threading.Lock()
+        logger.warning(
+            "FaultInjectL2Adapter ACTIVE (rate=%.3f seed=%d gap_indices=%s "
+            "drop_chunk_hashes=%d) wrapping %s -- test/diagnostic use only.",
+            rate,
+            seed,
+            sorted(self._gap_indices),
+            len(self._drop_hash_bytes),
+            type(inner).__name__,
+        )
+
+    # -- drop decision --------------------------------------------------------
+
+    def _should_drop_key(self, key: ObjectKey) -> bool:
+        """Return whether ``key`` falls in the rate-based drop bucket.
+
+        Deterministic in ``(seed, key)``: a stable blake2b hash bucketed by
+        ``rate``, so a key drops (or not) identically at lookup and at load
+        within a request, and reproducibly across runs with the same seed.
+        Returns ``False`` immediately when ``rate <= 0`` (pass-through).
+        """
+        if self._rate <= 0.0:
+            return False
+        h = hashlib.blake2b(f"{self._seed}:{key!r}".encode(), digest_size=8).digest()
+        bucket = int.from_bytes(h, "big") % _HASH_DENOM
+        return bucket < int(self._rate * _HASH_DENOM)
+
+    def _drop_positions(self, keys: list[ObjectKey]) -> list[int]:
+        """Return the positions in ``keys`` to drop, in ascending order.
+
+        A position is dropped if its key's ``chunk_hash`` is in
+        ``drop_chunk_hashes`` (content-keyed, persistent across legs), or it is
+        listed in ``gap_indices`` (an exact, always-drop position), or its key
+        falls in the rate-based bucket per ``_should_drop_key``.
+        """
+        dropped = []
+        for i, key in enumerate(keys):
+            if (
+                key.chunk_hash in self._drop_hash_bytes
+                or i in self._gap_indices
+                or self._should_drop_key(key)
+            ):
+                dropped.append(i)
+        return dropped
+
+    # -- event fds (delegate) -------------------------------------------------
+
+    def get_store_event_fd(self) -> int:
+        """Return the inner adapter's store event fd."""
+        return self._inner.get_store_event_fd()
+
+    def get_lookup_and_lock_event_fd(self) -> int:
+        """Return the inner adapter's lookup-and-lock event fd."""
+        return self._inner.get_lookup_and_lock_event_fd()
+
+    def get_load_event_fd(self) -> int:
+        """Return the inner adapter's load event fd."""
+        return self._inner.get_load_event_fd()
+
+    # -- store (delegate) -----------------------------------------------------
+
+    def submit_store_task(
+        self, keys: list[ObjectKey], objects: list[MemoryObj]
+    ) -> L2TaskId:
+        """Delegate the store task to the inner adapter (store is never faulted)."""
+        return self._inner.submit_store_task(keys, objects)
+
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
+        """Delegate to the inner adapter; store results are passed through."""
+        return self._inner.pop_completed_store_tasks()
+
+    # -- lookup and lock (pure delegation) ------------------------------------
+
+    def submit_lookup_and_lock_task(self, keys: list[ObjectKey]) -> L2TaskId:
+        """Delegate the lookup-and-lock task to the inner adapter (not faulted)."""
+        return self._inner.submit_lookup_and_lock_task(keys)
+
+    def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Bitmap | None:
+        """Delegate to the inner adapter; lookup results are passed through.
+
+        Only the load primitive is faulted, so lookup reports keys present as
+        usual; the gap appears later when their load fails.
+        """
+        return self._inner.query_lookup_and_lock_result(task_id)
+
+    def submit_unlock(self, keys: list[ObjectKey]) -> None:
+        """Delegate the unlock to the inner adapter."""
+        self._inner.submit_unlock(keys)
+
+    # -- load (intercept for 'error') -----------------------------------------
+
+    def submit_load_task(
+        self, keys: list[ObjectKey], objects: list[MemoryObj]
+    ) -> L2TaskId:
+        """Submit a load task, recording ``keys`` for result mapping.
+
+        Thread-safe. The key list is stored under the returned task id so
+        ``query_load_result`` can map dropped bit positions back to keys.
+        """
+        task_id = self._inner.submit_load_task(keys, objects)
+        with self._keys_lock:
+            self._load_keys[task_id] = keys
+        return task_id
+
+    def query_load_result(self, task_id: L2TaskId) -> Bitmap | None:
+        """Query the load result, clearing the dropped keys' bits.
+
+        Delegates to the inner adapter, then clears the bits at the dropped
+        positions. This is the faithful "L2 retrieve error": lookup reported
+        the key present but the load fails. No unlock is needed here; the
+        prefetch controller releases the load-failed read locks itself via the
+        trim mask.
+
+        Thread-safe. Non-idempotent: returns a non-None bitmap only once per
+        ``task_id``.
+
+        Args:
+            task_id: The task id returned by ``submit_load_task``.
+
+        Returns:
+            The post-processed bitmap, or ``None`` if the inner task has not
+            completed yet.
+        """
+        bitmap = self._inner.query_load_result(task_id)
+        if bitmap is None:
+            return None
+        with self._keys_lock:
+            keys = self._load_keys.pop(task_id, None)
+        if keys is not None:
+            dropped = self._drop_positions(keys)
+            for i in dropped:
+                bitmap.clear(i)
+            if dropped:
+                logger.debug(
+                    "FaultInject: task %s dropped %d/%d load keys",
+                    task_id,
+                    len(dropped),
+                    len(keys),
+                )
+        return bitmap
+
+    # -- listener / eviction / usage (delegate) -------------------------------
+
+    def register_listener(self, listener: L2AdapterListener) -> None:
+        """Forward the listener registration to the inner adapter."""
+        self._inner.register_listener(listener)
+
+    def delete(self, keys: list[ObjectKey]) -> None:
+        """Delegate the delete to the inner adapter."""
+        self._inner.delete(keys)
+
+    def get_usage(self) -> AdapterUsage:
+        """Return the inner adapter's usage; this layer holds no data of its own."""
+        return self._inner.get_usage()
+
+    @property
+    def supports_global_eviction(self) -> bool:
+        """Whether the inner adapter supports aggregate usage-based eviction."""
+        return self._inner.supports_global_eviction
+
+    def report_status(self) -> dict:
+        """Return the inner adapter's status, annotated with the fault config.
+
+        Adds a ``"fault_inject"`` sub-dict (rate, seed, gap_indices) so the
+        active fault configuration is visible in diagnostics.
+        """
+        status = self._inner.report_status()
+        status["fault_inject"] = {
+            "rate": self._rate,
+            "seed": self._seed,
+            "gap_indices": sorted(self._gap_indices),
+            "drop_chunk_hashes": sorted(h.hex() for h in self._drop_hash_bytes),
+        }
+        return status
+
+    def close(self) -> None:
+        """Clear the per-task key map, then close the inner adapter."""
+        with self._keys_lock:
+            self._load_keys.clear()
+        self._inner.close()
+
+
+# -----------------------------------------------------------------------------
+# Registration
+# -----------------------------------------------------------------------------
+
+register_l2_adapter_type("fault_inject", FaultInjectL2AdapterConfig)
+
+
+def _create_fault_inject_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: "L1MemoryDesc | None" = None,
+) -> L2AdapterInterface:
+    """Build the inner adapter from the registry, then wrap it for faults.
+
+    Matches the L2 adapter factory signature so it can be registered under
+    the ``"fault_inject"`` type name.
+
+    Args:
+        config: A ``FaultInjectL2AdapterConfig`` whose ``inner_config`` names
+            the wrapped adapter.
+        l1_memory_desc: L1 memory descriptor forwarded to the inner adapter's
+            factory (some adapters need it for aligned buffers); ``None`` when
+            not applicable.
+
+    Returns:
+        A ``FaultInjectL2Adapter`` wrapping the freshly built inner adapter.
+    """
+    # First Party
+    from lmcache.v1.distributed.l2_adapters.factory import (  # noqa: PLC0415
+        create_l2_adapter_from_registry,
+    )
+
+    assert isinstance(config, FaultInjectL2AdapterConfig)
+    inner = create_l2_adapter_from_registry(config.inner_config, l1_memory_desc)
+    return FaultInjectL2Adapter(
+        inner,
+        rate=config.rate,
+        seed=config.seed,
+        gap_indices=config.gap_indices,
+        drop_chunk_hashes=config.drop_chunk_hashes,
+    )
+
+
+register_l2_adapter_factory("fault_inject", _create_fault_inject_adapter)

--- a/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
@@ -66,12 +66,14 @@ class FaultInjectL2AdapterConfig(L2AdapterConfigBase):
       its own "type" (e.g. {"type": "fs_native", "base_path": "/dev/shm/x"}).
     - rate (float): per-key drop probability in [0, 1]. Default 0.0 (pass-through).
     - seed (int): seed for the deterministic per-key hash. Default 0.
-    - gap_indices (list[int]): exact task-positions to always drop (in addition
-      to rate-based drops). Default [] -- mainly for precise unit tests.
-    - drop_chunk_hashes (list[str]): hex-encoded chunk hashes to always drop,
-      matched on ObjectKey.chunk_hash. Content-keyed, so the SAME chunk fails in
-      every load task (prefix + sparse legs) -- a persistent single-gap repro.
-      Default [].
+    - gap_indices (list[int]): exact task-positions (from the head) to always
+      drop. Default [] -- mainly for precise unit tests.
+    - gap_tail_ratios (list[float]): positions to always drop, given as the
+      distance-from-the-tail as a FRACTION of the load length, so the rule is
+      workload-agnostic (the server needs no advance knowledge of the content).
+      The dropped chunk index = round((1 - ratio) * (n - 1)) over the n-key load
+      batch: 0.0 = last chunk, 0.5 = middle, 1.0 = first. Self-scaling across
+      context lengths; a stable mid-prefix gap for the segmented repro. Default [].
     """
 
     def __init__(
@@ -80,13 +82,13 @@ class FaultInjectL2AdapterConfig(L2AdapterConfigBase):
         rate: float,
         seed: int,
         gap_indices: tuple[int, ...],
-        drop_chunk_hashes: tuple[str, ...] = (),
+        gap_tail_ratios: tuple[float, ...] = (),
     ) -> None:
         self.inner_config = inner_config
         self.rate = rate
         self.seed = seed
         self.gap_indices = gap_indices
-        self.drop_chunk_hashes = drop_chunk_hashes
+        self.gap_tail_ratios = gap_tail_ratios
 
     @classmethod
     def from_dict(cls, d: dict) -> "FaultInjectL2AdapterConfig":
@@ -143,23 +145,21 @@ class FaultInjectL2AdapterConfig(L2AdapterConfigBase):
         ):
             raise ValueError("gap_indices must be a list of non-negative integers")
 
-        raw_hashes = d.get("drop_chunk_hashes", [])
-        if not isinstance(raw_hashes, list) or any(
-            not isinstance(h, str) for h in raw_hashes
+        raw_ratios = d.get("gap_tail_ratios", [])
+        if not isinstance(raw_ratios, list) or any(
+            isinstance(x, bool)
+            or not isinstance(x, (int, float))
+            or not (0.0 <= x <= 1.0)
+            for x in raw_ratios
         ):
-            raise ValueError("drop_chunk_hashes must be a list of hex strings")
-        for h in raw_hashes:
-            try:
-                bytes.fromhex(h)
-            except ValueError as e:
-                raise ValueError(f"drop_chunk_hashes entry {h!r} is not hex") from e
+            raise ValueError("gap_tail_ratios must be a list of floats in [0, 1]")
 
         return cls(
             inner_config=inner_config,
             rate=float(rate),
             seed=seed,
             gap_indices=tuple(raw_gap),
-            drop_chunk_hashes=tuple(raw_hashes),
+            gap_tail_ratios=tuple(float(x) for x in raw_ratios),
         )
 
     @classmethod
@@ -172,9 +172,9 @@ class FaultInjectL2AdapterConfig(L2AdapterConfigBase):
             '{"type":"fs_native","base_path":"/dev/shm/x"}\n'
             "- rate (float): per-key drop probability in [0,1] (default 0.0)\n"
             "- seed (int): deterministic hash seed (default 0)\n"
-            "- gap_indices (list[int]): exact task-positions to always drop\n"
-            "- drop_chunk_hashes (list[str]): hex chunk hashes to always drop "
-            "(content-keyed; persistent across load legs)"
+            "- gap_indices (list[int]): exact head-relative positions to drop\n"
+            "- gap_tail_ratios (list[float]): distance-from-tail / load-length "
+            "in [0,1] (0=last, 0.5=middle, 1=first); workload-agnostic"
         )
 
 
@@ -196,7 +196,7 @@ class FaultInjectL2Adapter(L2AdapterInterface):
         rate: float,
         seed: int,
         gap_indices: tuple[int, ...],
-        drop_chunk_hashes: tuple[str, ...] = (),
+        gap_tail_ratios: tuple[float, ...] = (),
     ) -> None:
         """Wrap ``inner`` with deterministic load-failure injection.
 
@@ -205,11 +205,12 @@ class FaultInjectL2Adapter(L2AdapterInterface):
             rate: Per-key drop probability in [0, 1]. ``0`` disables
                 rate-based drops (``gap_indices`` still applies).
             seed: Seed for the deterministic per-key hash, so runs reproduce.
-            gap_indices: Exact task-positions to always drop, in addition to
-                the rate-based drops.
-            drop_chunk_hashes: Hex-encoded chunk hashes to always drop, matched
-                on ``ObjectKey.chunk_hash``. Content-keyed, so the same chunk
-                fails in every load task (a persistent single-gap repro).
+            gap_indices: Exact task-positions (from the head) to always drop,
+                in addition to the rate-based drops.
+            gap_tail_ratios: Positions to always drop, given as distance-from-
+                tail / load-length in [0, 1] (0=last, 0.5=middle, 1=first).
+                Workload-agnostic and self-scaling across context lengths --
+                no advance knowledge of the stored content is needed.
         """
         # Usage and eviction are delegated to the inner adapter, so the base
         # class's byte accounting (capacity 0) is intentionally unused here.
@@ -218,18 +219,18 @@ class FaultInjectL2Adapter(L2AdapterInterface):
         self._rate = rate
         self._seed = seed
         self._gap_indices = frozenset(gap_indices)
-        self._drop_hash_bytes = frozenset(bytes.fromhex(h) for h in drop_chunk_hashes)
+        self._gap_tail_ratios = tuple(gap_tail_ratios)
         # task_id -> load keys, so query_load_result can map a dropped bit
         # position back to its key.
         self._load_keys: dict[L2TaskId, list[ObjectKey]] = {}
         self._keys_lock = threading.Lock()
         logger.warning(
             "FaultInjectL2Adapter ACTIVE (rate=%.3f seed=%d gap_indices=%s "
-            "drop_chunk_hashes=%d) wrapping %s -- test/diagnostic use only.",
+            "gap_tail_ratios=%s) wrapping %s -- test/diagnostic use only.",
             rate,
             seed,
             sorted(self._gap_indices),
-            len(self._drop_hash_bytes),
+            list(self._gap_tail_ratios),
             type(inner).__name__,
         )
 
@@ -259,18 +260,23 @@ class FaultInjectL2Adapter(L2AdapterInterface):
     def _drop_positions(self, keys: list[ObjectKey]) -> list[int]:
         """Return the positions in ``keys`` to drop, in ascending order.
 
-        A position is dropped if its key's ``chunk_hash`` is in
-        ``drop_chunk_hashes`` (content-keyed, persistent across legs), or it is
-        listed in ``gap_indices`` (an exact, always-drop position), or its key
-        falls in the rate-based bucket per ``_should_drop_key``.
+        ``keys`` is the token-ordered chunk batch of one load, so index ``i`` is
+        the chunk's sequence position and ``len(keys)`` the load's chunk count.
+        A position is dropped if it is a ``gap_tail_ratios`` slot (distance-from-
+        tail as a fraction of the load length -- workload-agnostic, computed here
+        from the batch the server received), or it is listed in ``gap_indices``
+        (an exact head-relative position), or its key falls in the rate-based
+        bucket per ``_should_drop_key``.
         """
+        n = len(keys)
+        ratio_idxs = (
+            {int(round((1.0 - ratio) * (n - 1))) for ratio in self._gap_tail_ratios}
+            if n > 0
+            else set()
+        )
         dropped = []
         for i, key in enumerate(keys):
-            if (
-                key.chunk_hash in self._drop_hash_bytes
-                or i in self._gap_indices
-                or self._should_drop_key(key)
-            ):
+            if i in ratio_idxs or i in self._gap_indices or self._should_drop_key(key):
                 dropped.append(i)
         return dropped
 
@@ -400,7 +406,7 @@ class FaultInjectL2Adapter(L2AdapterInterface):
             "rate": self._rate,
             "seed": self._seed,
             "gap_indices": sorted(self._gap_indices),
-            "drop_chunk_hashes": sorted(h.hex() for h in self._drop_hash_bytes),
+            "gap_tail_ratios": list(self._gap_tail_ratios),
         }
         return status
 
@@ -449,7 +455,7 @@ def _create_fault_inject_adapter(
         rate=config.rate,
         seed=config.seed,
         gap_indices=config.gap_indices,
-        drop_chunk_hashes=config.drop_chunk_hashes,
+        gap_tail_ratios=config.gap_tail_ratios,
     )
 
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -516,6 +516,7 @@ class StorageManager:
                 remaining_keys,
                 layout_desc,
                 extra_count=extra_count,
+                policy=policy,
             )
             # The controller indexes its result bitmap over remaining_keys
             # (0-based); map those local indices back to original positions.

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -110,9 +110,12 @@ class EventType(Enum):
     # span captures submit→resident incl. poll-wait.
     CB_FINGERPRINT_MATCH_START = "cb.fingerprint_match.start"
     CB_FINGERPRINT_MATCH_END = "cb.fingerprint_match.end"
-    # No cb.prefix_lookup span: the prefix lookup is already traced by
-    # mp.lookup_prefetch (CB reuses LookupModule). prefix_chunks rides on
-    # cb.lookup via CB_LOOKUP_END instead.
+    # Prefix leg: blend_v3 owns the submit/poll (direct storage_manager), so the
+    # prefix lookup is a CB-namespace span under cb.lookup. Its hit tokens ride
+    # the CB hit-rate metric via CB_LOOKUP_END (CB requests no longer feed the
+    # MP mp.lookup_prefetch span / hit-rate aggregate).
+    CB_PREFIX_LOOKUP_START = "cb.prefix_lookup.start"
+    CB_PREFIX_LOOKUP_END = "cb.prefix_lookup.end"
     CB_SPARSE_PREFETCH_START = "cb.sparse_prefetch.start"
     CB_SPARSE_PREFETCH_END = "cb.sparse_prefetch.end"
 

--- a/lmcache/v1/mp_observability/subscribers/metrics/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/metrics/cb_server.py
@@ -77,6 +77,14 @@ class BlendMetricsSubscriber(EventSubscriber):
             description="Tokens served by blend from non-prefix (shifted) chunks.",
             unit="tokens",
         )
+        self._lookup_segmented_prefix_hit_tokens = meter.create_counter(
+            "lmcache_blend.lookup_segmented_prefix_hit_tokens",
+            description=(
+                "Tokens served by blend from the segmented-prefix tail "
+                "(post-gap same-position chunks reused via the prefix leg)."
+            ),
+            unit="tokens",
+        )
         self._lookup_fingerprint_hits = meter.create_counter(
             "lmcache_blend.lookup_fingerprint_hits",
             description="Chunks matched by local fingerprint table",
@@ -162,6 +170,9 @@ class BlendMetricsSubscriber(EventSubscriber):
         self._lookup_prefix_hit_tokens.add(event.metadata.get("prefix_hit_tokens", 0))
         self._lookup_non_prefix_hit_tokens.add(
             event.metadata.get("non_prefix_hit_tokens", 0)
+        )
+        self._lookup_segmented_prefix_hit_tokens.add(
+            event.metadata.get("segmented_prefix_hit_tokens", 0)
         )
         self._lookup_fingerprint_hits.add(event.metadata["fingerprint_hits"])
         self._lookup_storage_hits.add(event.metadata["storage_hits"])

--- a/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
@@ -23,10 +23,11 @@ conditions hold simultaneously:
 * ``_pending_gpu_ops[sid] == 0``
 * ``sid not in _waiting_for_store_final``
 
-Accepts an optional :class:`~lmcache.v1.mp_observability.subscribers.tracing\
-.span_registry.SpanRegistry` so the ``"cb.request"`` span is automatically
-nested under the MP server ``"request"`` root when both subscribers share the
-same registry.
+``cb.request`` is the trace root: blend_v3 owns the CB lookup end-to-end (prefix
++ non-prefix legs, direct against the storage manager), so a CB request never
+opens an MP ``"request"`` span to nest under. The optional
+:class:`~lmcache.v1.mp_observability.subscribers.tracing.span_registry\
+.SpanRegistry` is used to nest the CB child spans under ``cb.request``.
 """
 
 # Future
@@ -74,6 +75,7 @@ class BlendTracingSubscriber(EventSubscriber):
         EventType.CB_STORE_FINAL_START: "cb.store_final",
         # V3 lookup sub-spans (nest under cb.lookup, see _SPAN_PARENTS).
         EventType.CB_FINGERPRINT_MATCH_START: "cb.fingerprint_match",
+        EventType.CB_PREFIX_LOOKUP_START: "cb.prefix_lookup",
         EventType.CB_SPARSE_PREFETCH_START: "cb.sparse_prefetch",
         # V3 retrieve sub-span (nests under cb.retrieve).
         EventType.CB_SCATTER_START: "cb.scatter",
@@ -83,6 +85,7 @@ class BlendTracingSubscriber(EventSubscriber):
     # cb.request root (the default for the top-level lookup/retrieve/store spans).
     _SPAN_PARENTS: dict[str, str] = {
         "cb.fingerprint_match": "cb.lookup",
+        "cb.prefix_lookup": "cb.lookup",
         "cb.sparse_prefetch": "cb.lookup",
         "cb.scatter": "cb.retrieve",
     }
@@ -93,6 +96,7 @@ class BlendTracingSubscriber(EventSubscriber):
         EventType.CB_RETRIEVE_END: EventType.CB_RETRIEVE_START,
         EventType.CB_STORE_FINAL_END: EventType.CB_STORE_FINAL_START,
         EventType.CB_FINGERPRINT_MATCH_END: EventType.CB_FINGERPRINT_MATCH_START,
+        EventType.CB_PREFIX_LOOKUP_END: EventType.CB_PREFIX_LOOKUP_START,
         EventType.CB_SPARSE_PREFETCH_END: EventType.CB_SPARSE_PREFETCH_START,
         EventType.CB_SCATTER_END: EventType.CB_SCATTER_START,
     }
@@ -145,6 +149,8 @@ class BlendTracingSubscriber(EventSubscriber):
             # V3 lookup sub-spans (nested under cb.lookup)
             EventType.CB_FINGERPRINT_MATCH_START: self._on_start,
             EventType.CB_FINGERPRINT_MATCH_END: self._on_end,
+            EventType.CB_PREFIX_LOOKUP_START: self._on_start,
+            EventType.CB_PREFIX_LOOKUP_END: self._on_end,
             EventType.CB_SPARSE_PREFETCH_START: self._on_start,
             EventType.CB_SPARSE_PREFETCH_END: self._on_end,
             # V3 retrieve sub-span (nested under cb.retrieve, GPU-timed)
@@ -184,7 +190,10 @@ class BlendTracingSubscriber(EventSubscriber):
     # ------------------------------------------------------------------
 
     def _on_request_start(self, event: Event) -> None:
-        """Create the ``"cb.request"`` root span, nested under MP's root if present.
+        """Create the ``"cb.request"`` root span.
+
+        blend_v3 owns the CB lookup end-to-end, so a CB request never opens an MP
+        ``"request"`` span — ``cb.request`` is the trace root.
 
         Args:
             event: ``CB_REQUEST_START`` event with ``session_id`` set.
@@ -195,11 +204,8 @@ class BlendTracingSubscriber(EventSubscriber):
         if self._registry.get_context(sid, "cb.request") is not None:
             logger.warning("CB_REQUEST_START fired twice for session=%s; ignoring", sid)
             return
-        # Nest under the MP server's "request" span when running alongside it.
-        mp_root_ctx = self._registry.get_context(sid, "request")
         root_span = _tracer.start_span(
             "cb.request",
-            context=mp_root_ctx,
             start_time=int(event.timestamp * 1e9),
         )
         root_span.set_attribute("session_id", sid)

--- a/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
@@ -328,21 +328,31 @@ class BlendTracingSubscriber(EventSubscriber):
                 hit_tokens = int(event.metadata.get("hit_tokens", 0))
                 requested_tokens = int(event.metadata.get("requested_tokens", 0))
                 prefix_hit_tokens = int(event.metadata.get("prefix_hit_tokens", 0))
+                seg_prefix_hit_tokens = int(
+                    event.metadata.get("segmented_prefix_hit_tokens", 0)
+                )
                 non_prefix_hit_tokens = int(
                     event.metadata.get("non_prefix_hit_tokens", 0)
                 )
                 denom = requested_tokens or 1  # avoid /0; rates are 0 when requested=0
                 root_span.set_attribute("hit_tokens", hit_tokens)
                 root_span.set_attribute("requested_tokens", requested_tokens)
-                # hit_rate numerator = prefix + non-prefix reuse (hit_tokens).
+                # hit_rate numerator = prefix + segmented-prefix tail + non-prefix
+                # reuse (hit_tokens).
                 root_span.set_attribute("hit_rate", hit_tokens / denom)
                 root_span.set_attribute(
                     "prefix_hits", int(event.metadata.get("prefix_hits", 0))
                 )
                 root_span.set_attribute("prefix_hit_tokens", prefix_hit_tokens)
+                root_span.set_attribute(
+                    "segmented_prefix_hit_tokens", seg_prefix_hit_tokens
+                )
                 root_span.set_attribute("non_prefix_hit_tokens", non_prefix_hit_tokens)
                 # Per-component hit rates (sum to hit_rate).
                 root_span.set_attribute("prefix_hit_rate", prefix_hit_tokens / denom)
+                root_span.set_attribute(
+                    "segmented_prefix_hit_rate", seg_prefix_hit_tokens / denom
+                )
                 root_span.set_attribute(
                     "non_prefix_hit_rate", non_prefix_hit_tokens / denom
                 )

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -45,6 +45,12 @@ class MPServerConfig:
     ('default' for standard prefix caching, 'blend' when cacheblend is enabled).
     """
 
+    enable_segmented_prefix: bool = False
+    """CacheBlend only (engine_type='blend'): on a mid-prefix L2 retrieve
+    failure, retain the gapped contiguous prefix so the post-gap chunks stay
+    L1-resident (served by the sparse leg as L1 hits, the hole recomputed)
+    instead of truncating the prefix at the gap. No effect for other engines."""
+
     supported_transfer_mode: str = "auto"
     """Transfer mode: 'lmcache_driven' for server-driven transfer
     (STORE/RETRIEVE, supports CUDA IPC and CPU SHM), 'engine_driven' for
@@ -306,6 +312,13 @@ def add_mp_server_args(
         "pinged (model warmup or early death). Must be >= the worker reap "
         "timeout. Default is 3600.",
     )
+    mp_group.add_argument(
+        "--enable-segmented-prefix",
+        action="store_true",
+        help="CacheBlend (--engine-type blend) only: on a mid-prefix L2 "
+        "retrieve failure, retain the gapped prefix so post-gap chunks stay "
+        "L1-resident instead of truncating at the gap. No effect otherwise.",
+    )
     return parser
 
 
@@ -338,6 +351,7 @@ def parse_args_to_mp_server_config(
         max_cpu_workers=max_cpu,
         hash_algorithm=args.hash_algorithm,
         engine_type=args.engine_type,
+        enable_segmented_prefix=args.enable_segmented_prefix,
         supported_transfer_mode=args.supported_transfer_mode,
         runtime_plugin_config=RuntimePluginConfig(
             locations=(args.runtime_plugin_locations or []),

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -391,10 +391,17 @@ class CBUnifiedLookupResult:
             those are merged in before the sparse prefetch -- prefix-covered and
             locally-duplicated ones dropped -- so they ride the identical
             prefetch + retrieve path and need no separate handling.
+        segmented_prefix_segments: Post-gap chunks retained by the
+            ``SEGMENTED_PREFIX`` prefix leg (beyond ``count_leading_ones``) — at
+            their original positions (``old_st == cur_st``), so the connector
+            tags them ``prefix`` (pure load, no recompute) and only the gap is
+            recomputed. Sourced from the prefix bitmap, not the fingerprint
+            matcher; empty when ``SEGMENTED_PREFIX`` is off.
     """
 
     prefix_coverage_tokens: int
     non_prefix_segments: list[CBMatchResult]
+    segmented_prefix_segments: list[CBMatchResult] = field(default_factory=list)
 
 
 _CUSTOMERIZED_SERIALIZERS = {

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from queue import Empty as QueueEmpty
 from queue import Queue
 from typing import TYPE_CHECKING, Any
+import os
 import threading
 import time
 
@@ -87,6 +88,7 @@ class _CBUnifiedJob:
     matches: list[CBMatchResult]
     num_tokens: int = 0
     prefix_chunks: int | None = None  # stashed when the prefix poll completes
+    retained_chunks: list[int] | None = None  # SEGMENTED_PREFIX: full gapped set
     sparse_started: bool = False  # prefix done -> sparse leg submitted/skipped
     handle: PrefetchHandle | None = None  # sparse handle, None if no sparse leg
     non_prefix: list[CBMatchResult] | None = None
@@ -778,10 +780,19 @@ class BlendV3Module(InstanceLivenessTarget):
                     metadata={"num_tokens": len(key.token_ids)},
                 )
             )
+            # SEGMENTED_PREFIX: request the contiguous prefix with gap-tolerant
+            # retention so a mid-prefix L2 retrieve failure leaves the post-gap
+            # chunks L1-resident (picked up by the sparse leg as L1 hits, hole
+            # recomputed) instead of truncating the prefix at the gap.
+            prefix_policy = (
+                TrimPolicy.SEGMENTED_PREFIX
+                if os.environ.get("SEGMENTED_PREFIX") == "1"
+                else TrimPolicy.PREFIX
+            )
             # Prefix leg: submit (non-blocking). Already traced upstream by
             # mp.lookup_prefetch (LookupModule self-instruments); prefix_chunks
             # lands on cb.lookup via CB_LOOKUP_END below.
-            self._lookup_module.lookup(key, tp_size)
+            self._lookup_module.lookup(key, tp_size, policy=prefix_policy)
             # Local and coordinator matching are mutually exclusive: with a
             # coordinator the fleet directory is the only source, so skip the
             # local matcher (and its span). The coordinator leg is async
@@ -812,25 +823,43 @@ class BlendV3Module(InstanceLivenessTarget):
             with self._cb_jobs_lock:
                 self._cb_jobs[rid] = job
 
+        segmented = os.environ.get("SEGMENTED_PREFIX") == "1"
+
         # --- Prefix leg: poll (consume-once) until the L1+L2 prefix lands. ---
         if job.prefix_chunks is None:
-            p = self._lookup_module.query_prefetch_status(rid)
-            if p is None:
-                return None  # prefix still loading -> defer
-            job.prefix_chunks = p
+            if segmented:
+                # Segmented: also capture the gapped retained set so the
+                # post-gap chunks are delivered through the prefix leg (below).
+                seg = self._lookup_module.query_prefetch_status_segmented(rid)
+                if seg is None:
+                    return None  # prefix still loading -> defer
+                job.prefix_chunks, job.retained_chunks = seg
+            else:
+                pf = self._lookup_module.query_prefetch_status(rid)
+                if pf is None:
+                    return None  # prefix still loading -> defer
+                job.prefix_chunks = pf
+        # Poll above set it (or we returned); narrow for the arithmetic below.
+        assert job.prefix_chunks is not None
+        prefix_chunks: int = job.prefix_chunks
 
         # Prefix done: reconcile the complement outside the prefix coverage and
         # submit one sparse prefetch for it (once). Prefix-covered chunks never
         # enter the sparse prefetch, so they cannot leak a read lock.
         if not job.sparse_started:
-            prefix_tokens = job.prefix_chunks * chunk_size
+            prefix_tokens = prefix_chunks * chunk_size
             if self._coordinator is not None:
                 candidates = self._poll_coordinator_match(job, rid)
                 if candidates is None:
                     return None  # coordinator still in flight (bounded by deadline)
             else:
                 candidates = job.matches
-            # Single prefix-filter + overlap dedup over the raw matches
+            # Under SEGMENTED_PREFIX the post-gap SAME-position chunks ride the
+            # prefix leg's gapped bitmap (the segmented tail below); keep only
+            # genuinely shifted (re-RoPE) matches here so they are not scattered
+            # twice. Then the single prefix-filter + overlap dedup over the rest.
+            if segmented:
+                candidates = [c for c in candidates if c.old_st != c.cur_st]
             job.non_prefix = self._non_overlapping_after_prefix(
                 candidates, prefix_tokens
             )
@@ -899,11 +928,35 @@ class BlendV3Module(InstanceLivenessTarget):
         else:
             found = []
 
-        prefix_tokens = job.prefix_chunks * chunk_size
+        prefix_tokens = prefix_chunks * chunk_size
         num_tokens = job.num_tokens
-        # V3 hit rate = (prefix + non-prefix) reuse. The two ranges are disjoint
-        # (non_prefix has cur_st >= prefix_tokens), so they sum without double-
-        # counting. hit_tokens carries the sum (the hit_rate numerator).
+
+        # Segmented tail: post-gap chunks the SEGMENTED_PREFIX prefix leg kept
+        # resident (retained index > the leading run). Delivered at their
+        # original positions (old_st == cur_st) so the connector tags them
+        # ``prefix`` (pure load, no recompute); only the gap is recomputed. The
+        # storage key is the same prefix-chained chunk hash the prefix leg used,
+        # so no fingerprint match is needed to retrieve them.
+        segmented_tail: list[CBMatchResult] = []
+        if segmented and job.retained_chunks:
+            chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(
+                list(key.token_ids)
+            )
+            for i in job.retained_chunks:
+                if i < prefix_chunks or i >= len(chunk_hashes):
+                    continue  # leading run (already prefix) / sub-chunk tail
+                st = i * chunk_size
+                segmented_tail.append(
+                    CBMatchResult(
+                        old_st=st,
+                        old_ed=st + chunk_size,
+                        cur_st=st,
+                        cur_ed=st + chunk_size,
+                        hash=chunk_hashes[i],
+                    )
+                )
+
+        seg_tail_tokens = _unique_token_coverage(segmented_tail)
         non_prefix_hit_tokens = _unique_token_coverage(found)
         self._event_bus.publish(
             Event(
@@ -918,8 +971,10 @@ class BlendV3Module(InstanceLivenessTarget):
                     "stale_chunks": len(job.non_prefix or []) - len(found),
                     "no_gpu_context": False,
                     "prefix_hit_tokens": prefix_tokens,
+                    "segmented_prefix_hit_tokens": seg_tail_tokens,
                     "non_prefix_hit_tokens": non_prefix_hit_tokens,
-                    "hit_tokens": prefix_tokens + non_prefix_hit_tokens,
+                    "hit_tokens": prefix_tokens
+                    + _unique_token_coverage(found + segmented_tail),
                     "requested_tokens": (num_tokens // chunk_size) * chunk_size,
                 },
             )
@@ -929,6 +984,7 @@ class BlendV3Module(InstanceLivenessTarget):
         return CBUnifiedLookupResult(
             prefix_coverage_tokens=prefix_tokens,
             non_prefix_segments=found,
+            segmented_prefix_segments=segmented_tail,
         )
 
     def store(

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from queue import Empty as QueueEmpty
 from queue import Queue
 from typing import TYPE_CHECKING, Any
-import os
 import threading
 import time
 
@@ -331,9 +330,13 @@ class BlendV3Module(InstanceLivenessTarget):
         lmcache_driven_transfer: LMCacheDrivenTransferModule,
         lookup_module: LookupModule,
         coordinator: "BlendCoordinatorClient | None" = None,
+        enable_segmented_prefix: bool = False,
     ):
         self._ctx = ctx
         self._transfer_module = lmcache_driven_transfer
+        # Server config (--enable-segmented-prefix): retain the gapped prefix on
+        # a mid-prefix L2 retrieve failure instead of truncating at the gap.
+        self._segmented_prefix = enable_segmented_prefix
         # Reused by cb_unified_lookup to run the standard prefix lookup
         # (registers the prefix prefetch job + session state the retrieve
         # path depends on) inside the single unified RPC.
@@ -786,7 +789,7 @@ class BlendV3Module(InstanceLivenessTarget):
             # recomputed) instead of truncating the prefix at the gap.
             prefix_policy = (
                 TrimPolicy.SEGMENTED_PREFIX
-                if os.environ.get("CB_SEGMENTED_PREFIX") == "1"
+                if self._segmented_prefix
                 else TrimPolicy.PREFIX
             )
             # Prefix leg: submit (non-blocking). Already traced upstream by
@@ -823,7 +826,7 @@ class BlendV3Module(InstanceLivenessTarget):
             with self._cb_jobs_lock:
                 self._cb_jobs[rid] = job
 
-        segmented = os.environ.get("CB_SEGMENTED_PREFIX") == "1"
+        segmented = self._segmented_prefix
 
         # --- Prefix leg: poll (consume-once) until the L1+L2 prefix lands. ---
         if job.prefix_chunks is None:

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -786,7 +786,7 @@ class BlendV3Module(InstanceLivenessTarget):
             # recomputed) instead of truncating the prefix at the gap.
             prefix_policy = (
                 TrimPolicy.SEGMENTED_PREFIX
-                if os.environ.get("SEGMENTED_PREFIX") == "1"
+                if os.environ.get("CB_SEGMENTED_PREFIX") == "1"
                 else TrimPolicy.PREFIX
             )
             # Prefix leg: submit (non-blocking). Already traced upstream by
@@ -823,7 +823,7 @@ class BlendV3Module(InstanceLivenessTarget):
             with self._cb_jobs_lock:
                 self._cb_jobs[rid] = job
 
-        segmented = os.environ.get("SEGMENTED_PREFIX") == "1"
+        segmented = os.environ.get("CB_SEGMENTED_PREFIX") == "1"
 
         # --- Prefix leg: poll (consume-once) until the L1+L2 prefix lands. ---
         if job.prefix_chunks is None:

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -53,7 +53,7 @@ from lmcache.v1.multiprocess.engine_module import (
 from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
     LMCacheDrivenTransferModule,
 )
-from lmcache.v1.multiprocess.modules.lookup import LookupModule
+from lmcache.v1.multiprocess.modules.lookup import compute_extra_count
 from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.token_hasher import (
     TokenHasher,
@@ -86,6 +86,14 @@ class _CBUnifiedJob:
 
     matches: list[CBMatchResult]
     num_tokens: int = 0
+    # Prefix leg (blend_v3-owned submit/poll). ``prefix_handle`` is None when
+    # there is no GPU context / no full chunk (poll reports 0 coverage); the
+    # remaining fields feed MP_LOOKUP_PREFETCH_END at poll time.
+    prefix_handle: PrefetchHandle | None = None
+    prefix_world_size: int = 1
+    prefix_requested_tokens: int = 0
+    prefix_model_name: str = ""
+    prefix_cache_salt: str = ""
     prefix_chunks: int | None = None  # stashed when the prefix poll completes
     retained_chunks: list[int] | None = None  # SEGMENTED_PREFIX: full gapped set
     sparse_started: bool = False  # prefix done -> sparse leg submitted/skipped
@@ -328,7 +336,6 @@ class BlendV3Module(InstanceLivenessTarget):
         self,
         ctx: MPCacheServerContext,
         lmcache_driven_transfer: LMCacheDrivenTransferModule,
-        lookup_module: LookupModule,
         coordinator: "BlendCoordinatorClient | None" = None,
         enable_segmented_prefix: bool = False,
     ):
@@ -337,10 +344,6 @@ class BlendV3Module(InstanceLivenessTarget):
         # Server config (--enable-segmented-prefix): retain the gapped prefix on
         # a mid-prefix L2 retrieve failure instead of truncating at the gap.
         self._segmented_prefix = enable_segmented_prefix
-        # Reused by cb_unified_lookup to run the standard prefix lookup
-        # (registers the prefix prefetch job + session state the retrieve
-        # path depends on) inside the single unified RPC.
-        self._lookup_module = lookup_module
         # Optional bridge to the fleet-wide fingerprint directory. ``None`` =>
         # purely local matching (publish/query paths skipped).
         self._coordinator = coordinator
@@ -745,6 +748,142 @@ class BlendV3Module(InstanceLivenessTarget):
 
         return found_cb_match_result
 
+    def _submit_prefix_leg(
+        self,
+        key: IPCCacheServerKey,
+        tp_size: int,
+        policy: TrimPolicy,
+    ) -> "tuple[PrefetchHandle | None, int, int, str, str]":
+        """Submit the CB prefix prefetch (non-blocking).
+
+        Publishes the same MP_REQUEST_START / MP_LOOKUP_PREFETCH_START / MP_LOOKUP
+        events as the standard prefix lookup and writes the shared session
+        (``set_tokens`` + ``lookup_ipc_key``) so ``end_session``'s L1 keep-alive
+        touch still resolves the request's keys. Non-blocking.
+
+        Args:
+            key (IPCCacheServerKey): Request key (token IDs, request_id, model,
+                world_size).
+            tp_size (int): Tensor-parallel size for MLA multi-reader locking.
+            policy (TrimPolicy): ``PREFIX`` or ``SEGMENTED_PREFIX``.
+
+        Returns:
+            tuple: ``(handle, world_size, requested_tokens, model_name,
+            cache_salt)``. ``handle`` is None when there is no GPU context or no
+            full chunk (poll reports 0 coverage); the trailing fields feed
+            ``MP_LOOKUP_PREFETCH_END`` at poll time.
+        """
+        rid = key.request_id
+        model_name, world_size = key.model_name, key.world_size
+        self._event_bus.publish(
+            Event(event_type=EventType.MP_REQUEST_START, session_id=rid)
+        )
+        self._event_bus.publish(
+            Event(event_type=EventType.MP_LOOKUP_PREFETCH_START, session_id=rid)
+        )
+
+        layout_desc = self._resolve_cb_layout_desc(model_name, world_size)
+        if layout_desc is None:
+            logger.error(
+                "No CB GPU context for model %s ws %d during prefix lookup!",
+                model_name,
+                world_size,
+            )
+            return None, world_size, 0, model_name, key.cache_salt
+
+        chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(list(key.token_ids))
+        if not chunk_hashes:
+            return None, world_size, 0, model_name, key.cache_salt
+
+        # Chunk-aligned tokens submitted: the denominator of the token-level
+        # hit-rate (MP_LOOKUP_PREFETCH_END.requested_tokens). Sub-chunk tail
+        # tokens cannot hit at chunk granularity, so they are excluded.
+        requested_tokens = len(chunk_hashes) * self._ctx.chunk_size
+        if self._event_bus.has_subscribers(EventType.MP_LOOKUP):
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.MP_LOOKUP,
+                    session_id=rid,
+                    metadata={
+                        "request_id": rid,
+                        "chunk_hashes": chunk_hashes,
+                        "model_name": model_name,
+                        "chunk_size": self._ctx.chunk_size,
+                        "seq_len": len(key.token_ids),
+                        "dtypes": [str(d) for d in layout_desc.dtypes],
+                        "shapes": [list(s) for s in layout_desc.shapes],
+                    },
+                )
+            )
+
+        # Shared session: end_session reads lookup_ipc_key + the rolling hashes
+        # to keep the request's KV alive in L1 (and close the trace root).
+        session = self._ctx.session_manager.get_or_create(rid)
+        session.set_tokens(list(key.token_ids))
+        session.lookup_ipc_key = key
+
+        extra_count = compute_extra_count(tp_size, world_size)
+        obj_keys = ipc_key_to_object_keys(key, chunk_hashes, [0])[0]
+        handle = self._ctx.storage_manager.submit_prefetch_task(
+            obj_keys,
+            layout_desc,
+            extra_count=extra_count,
+            external_request_id=rid,
+            policy=policy,
+        )
+        return handle, world_size, requested_tokens, model_name, key.cache_salt
+
+    def _poll_prefix_leg(
+        self, job: "_CBUnifiedJob", rid: str, segmented: bool
+    ) -> "tuple[int, list[int] | None] | None":
+        """Poll the CB prefix handle; on completion publish MP_LOOKUP_PREFETCH_END.
+
+        Consume-once: emits the hit-rate metric exactly once when the prefetch
+        lands. For SEGMENTED_PREFIX also surfaces the gapped retained chunk set.
+
+        Args:
+            job (_CBUnifiedJob): Poll state holding the prefix handle + metric
+                inputs.
+            rid (str): Request ID (event session_id).
+            segmented (bool): SEGMENTED_PREFIX active -> also surface the gapped
+                retained chunk set.
+
+        Returns:
+            tuple | None: ``(leading_chunks, retained_or_None)`` when resident;
+            ``None`` while still loading. ``retained`` is the full gapped chunk
+            set for SEGMENTED_PREFIX, else None.
+        """
+        if job.prefix_handle is not None:
+            bm = self._ctx.storage_manager.query_prefetch_status(job.prefix_handle)
+            if bm is None:
+                return None  # still loading
+            ws = job.prefix_world_size
+            # NOTE(Kuntai): assumes uniform world size and prefix-ordered keys
+            # that break at the first miss.
+            leading = bm.count_leading_ones() // ws
+            retained = (
+                sorted({ki // ws for ki in bm.get_indices_list()})
+                if segmented
+                else None
+            )
+        else:
+            # No GPU context / no full chunk: nothing loaded.
+            leading, retained = 0, ([] if segmented else None)
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id=rid,
+                metadata={
+                    "found_count": leading,
+                    "requested_tokens": job.prefix_requested_tokens,
+                    "hit_tokens": leading * self._ctx.chunk_size,
+                    "model_name": job.prefix_model_name,
+                    "cache_salt": job.prefix_cache_salt,
+                },
+            )
+        )
+        return leading, retained
+
     def cb_unified_lookup(
         self, key: IPCCacheServerKey, tp_size: int
     ) -> CBUnifiedLookupResult | None:
@@ -792,10 +931,16 @@ class BlendV3Module(InstanceLivenessTarget):
                 if self._segmented_prefix
                 else TrimPolicy.PREFIX
             )
-            # Prefix leg: submit (non-blocking). Already traced upstream by
-            # mp.lookup_prefetch (LookupModule self-instruments); prefix_chunks
-            # lands on cb.lookup via CB_LOOKUP_END below.
-            self._lookup_module.lookup(key, tp_size, policy=prefix_policy)
+            # Prefix leg: blend_v3 owns the submit + the mp.lookup_prefetch
+            # span/hit-rate metric; prefix_chunks lands on cb.lookup via
+            # CB_LOOKUP_END below.
+            (
+                prefix_handle,
+                prefix_ws,
+                prefix_req_tokens,
+                prefix_model,
+                prefix_salt,
+            ) = self._submit_prefix_leg(key, tp_size, prefix_policy)
             # Local and coordinator matching are mutually exclusive: with a
             # coordinator the fleet directory is the only source, so skip the
             # local matcher (and its span). The coordinator leg is async
@@ -819,7 +964,15 @@ class BlendV3Module(InstanceLivenessTarget):
                         metadata={"matches": len(matches)},
                     )
                 )
-            job = _CBUnifiedJob(matches=matches, num_tokens=len(key.token_ids))
+            job = _CBUnifiedJob(
+                matches=matches,
+                num_tokens=len(key.token_ids),
+                prefix_handle=prefix_handle,
+                prefix_world_size=prefix_ws,
+                prefix_requested_tokens=prefix_req_tokens,
+                prefix_model_name=prefix_model,
+                prefix_cache_salt=prefix_salt,
+            )
             job.coord_submitted = self._submit_coordinator_match(key)
             if job.coord_submitted and self._coordinator is not None:
                 job.coord_deadline = time.monotonic() + self._coordinator.match_budget_s
@@ -830,18 +983,12 @@ class BlendV3Module(InstanceLivenessTarget):
 
         # --- Prefix leg: poll (consume-once) until the L1+L2 prefix lands. ---
         if job.prefix_chunks is None:
+            res = self._poll_prefix_leg(job, rid, segmented)
+            if res is None:
+                return None  # prefix still loading -> defer
+            job.prefix_chunks, prefix_retained = res
             if segmented:
-                # Segmented: also capture the gapped retained set so the
-                # post-gap chunks are delivered through the prefix leg (below).
-                seg = self._lookup_module.query_prefetch_status_segmented(rid)
-                if seg is None:
-                    return None  # prefix still loading -> defer
-                job.prefix_chunks, job.retained_chunks = seg
-            else:
-                pf = self._lookup_module.query_prefetch_status(rid)
-                if pf is None:
-                    return None  # prefix still loading -> defer
-                job.prefix_chunks = pf
+                job.retained_chunks = prefix_retained
         # Poll above set it (or we returned); narrow for the arithmetic below.
         assert job.prefix_chunks is not None
         prefix_chunks: int = job.prefix_chunks
@@ -857,12 +1004,20 @@ class BlendV3Module(InstanceLivenessTarget):
                     return None  # coordinator still in flight (bounded by deadline)
             else:
                 candidates = job.matches
-            # Under SEGMENTED_PREFIX the post-gap SAME-position chunks ride the
-            # prefix leg's gapped bitmap (the segmented tail below); keep only
-            # genuinely shifted (re-RoPE) matches here so they are not scattered
-            # twice. Then the single prefix-filter + overlap dedup over the rest.
+            # Under SEGMENTED_PREFIX, a same-position match the prefix leg already
+            # retained rides the segmented tail (prefix-class: pure load, no CHECK)
+            # -- drop it here so it is not scattered twice. A same-position match
+            # the tail does NOT cover is a genuine cross-context hit: keep it as
+            # non-prefix (re-RoPE no-ops at delta 0, but it still needs CHECK).
+            # Shifted (cur != old) matches are always kept. Then the single
+            # prefix-filter + overlap dedup over the rest.
             if segmented:
-                candidates = [c for c in candidates if c.old_st != c.cur_st]
+                retained = set(job.retained_chunks or [])
+                candidates = [
+                    c
+                    for c in candidates
+                    if c.old_st != c.cur_st or (c.cur_st // chunk_size) not in retained
+                ]
             job.non_prefix = self._non_overlapping_after_prefix(
                 candidates, prefix_tokens
             )

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -87,13 +87,9 @@ class _CBUnifiedJob:
     matches: list[CBMatchResult]
     num_tokens: int = 0
     # Prefix leg (blend_v3-owned submit/poll). ``prefix_handle`` is None when
-    # there is no GPU context / no full chunk (poll reports 0 coverage); the
-    # remaining fields feed MP_LOOKUP_PREFETCH_END at poll time.
+    # there is no GPU context / no full chunk (poll reports 0 coverage).
     prefix_handle: PrefetchHandle | None = None
     prefix_world_size: int = 1
-    prefix_requested_tokens: int = 0
-    prefix_model_name: str = ""
-    prefix_cache_salt: str = ""
     prefix_chunks: int | None = None  # stashed when the prefix poll completes
     retained_chunks: list[int] | None = None  # SEGMENTED_PREFIX: full gapped set
     sparse_started: bool = False  # prefix done -> sparse leg submitted/skipped
@@ -154,7 +150,7 @@ class BlendTokenRangeMatcherV3:
             token_hashes (list[bytes]): Per-chunk content hashes (one per
                 chunk), used as the dedup/eviction key.
             start_chunk_idx (int): First chunk to index; 1 skips chunk 0 (the
-                standard prefix lookup owns it).
+                prefix lookup leg owns it).
             position_offset (int): Added to each recorded start position (for
                 indexing a tail-slice of a larger sequence).
 
@@ -753,13 +749,15 @@ class BlendV3Module(InstanceLivenessTarget):
         key: IPCCacheServerKey,
         tp_size: int,
         policy: TrimPolicy,
-    ) -> "tuple[PrefetchHandle | None, int, int, str, str]":
+    ) -> "tuple[PrefetchHandle | None, int]":
         """Submit the CB prefix prefetch (non-blocking).
 
-        Publishes the same MP_REQUEST_START / MP_LOOKUP_PREFETCH_START / MP_LOOKUP
-        events as the standard prefix lookup and writes the shared session
-        (``set_tokens`` + ``lookup_ipc_key``) so ``end_session``'s L1 keep-alive
-        touch still resolves the request's keys. Non-blocking.
+        Opens the ``cb.prefix_lookup`` span (CB namespace — CB requests no longer
+        feed the MP request / mp.lookup_prefetch spans or the MP hit-rate
+        aggregate; the CB hit-rate metric carries prefix tokens via
+        CB_LOOKUP_END) and writes the shared session (``set_tokens`` +
+        ``lookup_ipc_key``) so ``end_session``'s L1 keep-alive touch still
+        resolves the request's keys.
 
         Args:
             key (IPCCacheServerKey): Request key (token IDs, request_id, model,
@@ -768,18 +766,13 @@ class BlendV3Module(InstanceLivenessTarget):
             policy (TrimPolicy): ``PREFIX`` or ``SEGMENTED_PREFIX``.
 
         Returns:
-            tuple: ``(handle, world_size, requested_tokens, model_name,
-            cache_salt)``. ``handle`` is None when there is no GPU context or no
-            full chunk (poll reports 0 coverage); the trailing fields feed
-            ``MP_LOOKUP_PREFETCH_END`` at poll time.
+            tuple: ``(handle, world_size)``. ``handle`` is None when there is no
+            GPU context or no full chunk (the poll then reports 0 coverage).
         """
         rid = key.request_id
         model_name, world_size = key.model_name, key.world_size
         self._event_bus.publish(
-            Event(event_type=EventType.MP_REQUEST_START, session_id=rid)
-        )
-        self._event_bus.publish(
-            Event(event_type=EventType.MP_LOOKUP_PREFETCH_START, session_id=rid)
+            Event(event_type=EventType.CB_PREFIX_LOOKUP_START, session_id=rid)
         )
 
         layout_desc = self._resolve_cb_layout_desc(model_name, world_size)
@@ -789,16 +782,14 @@ class BlendV3Module(InstanceLivenessTarget):
                 model_name,
                 world_size,
             )
-            return None, world_size, 0, model_name, key.cache_salt
+            return None, world_size
 
         chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(list(key.token_ids))
         if not chunk_hashes:
-            return None, world_size, 0, model_name, key.cache_salt
+            return None, world_size
 
-        # Chunk-aligned tokens submitted: the denominator of the token-level
-        # hit-rate (MP_LOOKUP_PREFETCH_END.requested_tokens). Sub-chunk tail
-        # tokens cannot hit at chunk granularity, so they are excluded.
-        requested_tokens = len(chunk_hashes) * self._ctx.chunk_size
+        # Lookup-hash logger (chunk hashes, for debug); guarded so the metadata
+        # dict is built only when a subscriber is listening.
         if self._event_bus.has_subscribers(EventType.MP_LOOKUP):
             self._event_bus.publish(
                 Event(
@@ -817,7 +808,7 @@ class BlendV3Module(InstanceLivenessTarget):
             )
 
         # Shared session: end_session reads lookup_ipc_key + the rolling hashes
-        # to keep the request's KV alive in L1 (and close the trace root).
+        # to keep the request's KV alive in L1.
         session = self._ctx.session_manager.get_or_create(rid)
         session.set_tokens(list(key.token_ids))
         session.lookup_ipc_key = key
@@ -831,19 +822,20 @@ class BlendV3Module(InstanceLivenessTarget):
             external_request_id=rid,
             policy=policy,
         )
-        return handle, world_size, requested_tokens, model_name, key.cache_salt
+        return handle, world_size
 
     def _poll_prefix_leg(
         self, job: "_CBUnifiedJob", rid: str, segmented: bool
     ) -> "tuple[int, list[int] | None] | None":
-        """Poll the CB prefix handle; on completion publish MP_LOOKUP_PREFETCH_END.
+        """Poll the CB prefix handle; on completion close the cb.prefix_lookup span.
 
-        Consume-once: emits the hit-rate metric exactly once when the prefetch
-        lands. For SEGMENTED_PREFIX also surfaces the gapped retained chunk set.
+        Consume-once: publishes CB_PREFIX_LOOKUP_END exactly once when the
+        prefetch lands. The prefix hit tokens are accounted on the CB hit-rate
+        metric at CB_LOOKUP_END, not here. For SEGMENTED_PREFIX also surfaces the
+        gapped retained chunk set.
 
         Args:
-            job (_CBUnifiedJob): Poll state holding the prefix handle + metric
-                inputs.
+            job (_CBUnifiedJob): Poll state holding the prefix handle + world size.
             rid (str): Request ID (event session_id).
             segmented (bool): SEGMENTED_PREFIX active -> also surface the gapped
                 retained chunk set.
@@ -871,15 +863,9 @@ class BlendV3Module(InstanceLivenessTarget):
             leading, retained = 0, ([] if segmented else None)
         self._event_bus.publish(
             Event(
-                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                event_type=EventType.CB_PREFIX_LOOKUP_END,
                 session_id=rid,
-                metadata={
-                    "found_count": leading,
-                    "requested_tokens": job.prefix_requested_tokens,
-                    "hit_tokens": leading * self._ctx.chunk_size,
-                    "model_name": job.prefix_model_name,
-                    "cache_salt": job.prefix_cache_salt,
-                },
+                metadata={"prefix_chunks": leading},
             )
         )
         return leading, retained
@@ -931,16 +917,12 @@ class BlendV3Module(InstanceLivenessTarget):
                 if self._segmented_prefix
                 else TrimPolicy.PREFIX
             )
-            # Prefix leg: blend_v3 owns the submit + the mp.lookup_prefetch
-            # span/hit-rate metric; prefix_chunks lands on cb.lookup via
-            # CB_LOOKUP_END below.
-            (
-                prefix_handle,
-                prefix_ws,
-                prefix_req_tokens,
-                prefix_model,
-                prefix_salt,
-            ) = self._submit_prefix_leg(key, tp_size, prefix_policy)
+            # Prefix leg: blend_v3 owns the submit + the cb.prefix_lookup span
+            # (under cb.lookup); prefix hit tokens land on the CB hit-rate
+            # metric via CB_LOOKUP_END below.
+            prefix_handle, prefix_ws = self._submit_prefix_leg(
+                key, tp_size, prefix_policy
+            )
             # Local and coordinator matching are mutually exclusive: with a
             # coordinator the fleet directory is the only source, so skip the
             # local matcher (and its span). The coordinator leg is async
@@ -969,9 +951,6 @@ class BlendV3Module(InstanceLivenessTarget):
                 num_tokens=len(key.token_ids),
                 prefix_handle=prefix_handle,
                 prefix_world_size=prefix_ws,
-                prefix_requested_tokens=prefix_req_tokens,
-                prefix_model_name=prefix_model,
-                prefix_cache_salt=prefix_salt,
             )
             job.coord_submitted = self._submit_coordinator_match(key)
             if job.coord_submitted and self._coordinator is not None:

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -9,6 +9,7 @@ import time
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import (
     PrefetchHandle,
     TrimPolicy,
@@ -324,6 +325,46 @@ class LookupModule:
         found_count = found // job.world_size
         return found_count
 
+    def _poll_and_publish(self, job: _PrefetchJob) -> tuple[int, Bitmap] | None:
+        """Poll a prefetch job's handle; on completion publish the
+        ``MP_LOOKUP_PREFETCH_END`` event and pop the job (exactly-once).
+
+        Shared core of :meth:`query_prefetch_status` and
+        :meth:`query_prefetch_status_segmented`. The caller handles the
+        missing-job case (whose empty return is policy-specific) before calling.
+
+        Args:
+            job: The prefetch job to poll.
+
+        Returns:
+            ``(leading_count, found_bitmap)`` when the prefetch is complete,
+            ``None`` while it is still in progress.
+        """
+        found = self._ctx.storage_manager.query_prefetch_status(job.handle)
+        if found is None:
+            return None
+        # NOTE(Kuntai): this assumes two things:
+        # 1. the world size is the same between keys
+        # 2. the lookup sort the keys in prefix order and breaks at the
+        #    first failure
+        leading = found.count_leading_ones() // job.world_size
+        self._ctx.event_bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id=job.request_id,
+                metadata={
+                    "found_count": leading,
+                    "requested_tokens": job.requested_tokens,
+                    "hit_tokens": leading * self._ctx.chunk_size,
+                    "model_name": job.model_name,
+                    "cache_salt": job.cache_salt,
+                },
+            )
+        )
+        with self._prefetch_job_lock:
+            self._prefetch_jobs.pop(job.request_id, None)
+        return leading, found
+
     def query_prefetch_status(
         self,
         request_id: str,
@@ -351,35 +392,11 @@ class LookupModule:
                 request_id,
             )
             return 0
-
-        found = self._ctx.storage_manager.query_prefetch_status(job.handle)
-        if found is None:
+        result = self._poll_and_publish(job)
+        if result is None:
             return None
-
-        # NOTE(Kuntai): this assumes two things:
-        # 1. the world size is the same between keys
-        # 2. the lookup sort the keys in prefix order and breaks at the
-        #    first failure
-        found_count = found.count_leading_ones() // job.world_size
-
-        self._ctx.event_bus.publish(
-            Event(
-                event_type=EventType.MP_LOOKUP_PREFETCH_END,
-                session_id=job.request_id,
-                metadata={
-                    "found_count": found_count,
-                    "requested_tokens": job.requested_tokens,
-                    "hit_tokens": found_count * self._ctx.chunk_size,
-                    "model_name": job.model_name,
-                    "cache_salt": job.cache_salt,
-                },
-            )
-        )
-
-        with self._prefetch_job_lock:
-            self._prefetch_jobs.pop(request_id, None)
-
-        return found_count
+        leading, _ = result
+        return leading
 
     def query_prefetch_status_segmented(
         self,
@@ -411,31 +428,13 @@ class LookupModule:
                 request_id,
             )
             return 0, []
-
-        found = self._ctx.storage_manager.query_prefetch_status(job.handle)
-        if found is None:
+        result = self._poll_and_publish(job)
+        if result is None:
             return None
-
+        leading, found = result
         ws = job.world_size
-        leading = found.count_leading_ones() // ws
         # Any set shard marks its chunk retained (trim keeps whole chunks).
         retained = sorted({ki // ws for ki in found.get_indices_list()})
-
-        self._ctx.event_bus.publish(
-            Event(
-                event_type=EventType.MP_LOOKUP_PREFETCH_END,
-                session_id=job.request_id,
-                metadata={
-                    "found_count": leading,
-                    "requested_tokens": job.requested_tokens,
-                    "hit_tokens": leading * self._ctx.chunk_size,
-                    "model_name": job.model_name,
-                    "cache_salt": job.cache_salt,
-                },
-            )
-        )
-        with self._prefetch_job_lock:
-            self._prefetch_jobs.pop(request_id, None)
         return leading, retained
 
     def free_lookup_locks(

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -9,10 +9,8 @@ import time
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import (
     PrefetchHandle,
-    TrimPolicy,
     ipc_key_to_object_keys,
 )
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -165,8 +163,6 @@ class LookupModule:
         self,
         key: IPCCacheServerKey,
         tp_size: int,
-        *,
-        policy: TrimPolicy = TrimPolicy.PREFIX,
     ) -> None:
         """Submit a prefix lookup.
 
@@ -177,10 +173,6 @@ class LookupModule:
         Args:
             key: Cache key with request_id embedded.
             tp_size: Tensor-parallel size for MLA multi-reader locking.
-            policy: Trim policy for the prefetch. ``PREFIX`` (default) truncates
-                at the first gap; ``SEGMENTED_PREFIX`` retains a gapped contiguous
-                request (e.g. a mid-prefix L2 retrieve failure) so the hole is
-                recomputed instead of discarding everything after it.
         """
         model_name, world_size = key.model_name, key.world_size
         self._ctx.event_bus.publish(
@@ -281,7 +273,6 @@ class LookupModule:
             layout_desc,
             extra_count=extra_count,
             external_request_id=key.request_id,
-            policy=policy,
         )
         self._register_prefetch_job(
             _PrefetchJob(
@@ -325,46 +316,6 @@ class LookupModule:
         found_count = found // job.world_size
         return found_count
 
-    def _poll_and_publish(self, job: _PrefetchJob) -> tuple[int, Bitmap] | None:
-        """Poll a prefetch job's handle; on completion publish the
-        ``MP_LOOKUP_PREFETCH_END`` event and pop the job (exactly-once).
-
-        Shared core of :meth:`query_prefetch_status` and
-        :meth:`query_prefetch_status_segmented`. The caller handles the
-        missing-job case (whose empty return is policy-specific) before calling.
-
-        Args:
-            job: The prefetch job to poll.
-
-        Returns:
-            ``(leading_count, found_bitmap)`` when the prefetch is complete,
-            ``None`` while it is still in progress.
-        """
-        found = self._ctx.storage_manager.query_prefetch_status(job.handle)
-        if found is None:
-            return None
-        # NOTE(Kuntai): this assumes two things:
-        # 1. the world size is the same between keys
-        # 2. the lookup sort the keys in prefix order and breaks at the
-        #    first failure
-        leading = found.count_leading_ones() // job.world_size
-        self._ctx.event_bus.publish(
-            Event(
-                event_type=EventType.MP_LOOKUP_PREFETCH_END,
-                session_id=job.request_id,
-                metadata={
-                    "found_count": leading,
-                    "requested_tokens": job.requested_tokens,
-                    "hit_tokens": leading * self._ctx.chunk_size,
-                    "model_name": job.model_name,
-                    "cache_salt": job.cache_salt,
-                },
-            )
-        )
-        with self._prefetch_job_lock:
-            self._prefetch_jobs.pop(job.request_id, None)
-        return leading, found
-
     def query_prefetch_status(
         self,
         request_id: str,
@@ -392,50 +343,35 @@ class LookupModule:
                 request_id,
             )
             return 0
-        result = self._poll_and_publish(job)
-        if result is None:
+
+        found = self._ctx.storage_manager.query_prefetch_status(job.handle)
+        if found is None:
             return None
-        leading, _ = result
-        return leading
 
-    def query_prefetch_status_segmented(
-        self,
-        request_id: str,
-    ) -> tuple[int, list[int]] | None:
-        """Poll a prefetch job, returning the leading prefix count and the
-        full retained chunk-index set.
+        # NOTE(Kuntai): this assumes two things:
+        # 1. the world size is the same between keys
+        # 2. the lookup sort the keys in prefix order and breaks at the
+        #    first failure
+        found_count = found.count_leading_ones() // job.world_size
 
-        Identical exactly-once semantics to :meth:`query_prefetch_status`, but
-        for ``SEGMENTED_PREFIX`` it also surfaces the gapped found-set so the
-        caller can deliver the post-gap retained chunks that
-        ``count_leading_ones`` alone discards. A chunk is reported retained when
-        its first worker-shard bit is set; the trim mask retains whole chunks,
-        so the first shard stands in for all of them.
-
-        Args:
-            request_id: The external request ID passed in the lookup key.
-
-        Returns:
-            ``(leading_count, retained_chunk_indices)`` when the prefetch is
-            complete, ``None`` while still in progress, or ``(0, [])`` if the
-            request_id is unknown.
-        """
-        with self._prefetch_job_lock:
-            job = self._prefetch_jobs.get(request_id)
-        if job is None:
-            logger.warning(
-                "Prefetch job for request %s not found (already completed or invalid)",
-                request_id,
+        self._ctx.event_bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id=job.request_id,
+                metadata={
+                    "found_count": found_count,
+                    "requested_tokens": job.requested_tokens,
+                    "hit_tokens": found_count * self._ctx.chunk_size,
+                    "model_name": job.model_name,
+                    "cache_salt": job.cache_salt,
+                },
             )
-            return 0, []
-        result = self._poll_and_publish(job)
-        if result is None:
-            return None
-        leading, found = result
-        ws = job.world_size
-        # Any set shard marks its chunk retained (trim keeps whole chunks).
-        retained = sorted({ki // ws for ki in found.get_indices_list()})
-        return leading, retained
+        )
+
+        with self._prefetch_job_lock:
+            self._prefetch_jobs.pop(request_id, None)
+
+        return found_count
 
     def free_lookup_locks(
         self,

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -11,6 +11,7 @@ import time
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import (
     PrefetchHandle,
+    TrimPolicy,
     ipc_key_to_object_keys,
 )
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -163,6 +164,8 @@ class LookupModule:
         self,
         key: IPCCacheServerKey,
         tp_size: int,
+        *,
+        policy: TrimPolicy = TrimPolicy.PREFIX,
     ) -> None:
         """Submit a prefix lookup.
 
@@ -173,6 +176,10 @@ class LookupModule:
         Args:
             key: Cache key with request_id embedded.
             tp_size: Tensor-parallel size for MLA multi-reader locking.
+            policy: Trim policy for the prefetch. ``PREFIX`` (default) truncates
+                at the first gap; ``SEGMENTED_PREFIX`` retains a gapped contiguous
+                request (e.g. a mid-prefix L2 retrieve failure) so the hole is
+                recomputed instead of discarding everything after it.
         """
         model_name, world_size = key.model_name, key.world_size
         self._ctx.event_bus.publish(
@@ -273,6 +280,7 @@ class LookupModule:
             layout_desc,
             extra_count=extra_count,
             external_request_id=key.request_id,
+            policy=policy,
         )
         self._register_prefetch_job(
             _PrefetchJob(
@@ -372,6 +380,63 @@ class LookupModule:
             self._prefetch_jobs.pop(request_id, None)
 
         return found_count
+
+    def query_prefetch_status_segmented(
+        self,
+        request_id: str,
+    ) -> tuple[int, list[int]] | None:
+        """Poll a prefetch job, returning the leading prefix count and the
+        full retained chunk-index set.
+
+        Identical exactly-once semantics to :meth:`query_prefetch_status`, but
+        for ``SEGMENTED_PREFIX`` it also surfaces the gapped found-set so the
+        caller can deliver the post-gap retained chunks that
+        ``count_leading_ones`` alone discards. A chunk is reported retained when
+        its first worker-shard bit is set; the trim mask retains whole chunks,
+        so the first shard stands in for all of them.
+
+        Args:
+            request_id: The external request ID passed in the lookup key.
+
+        Returns:
+            ``(leading_count, retained_chunk_indices)`` when the prefetch is
+            complete, ``None`` while still in progress, or ``(0, [])`` if the
+            request_id is unknown.
+        """
+        with self._prefetch_job_lock:
+            job = self._prefetch_jobs.get(request_id)
+        if job is None:
+            logger.warning(
+                "Prefetch job for request %s not found (already completed or invalid)",
+                request_id,
+            )
+            return 0, []
+
+        found = self._ctx.storage_manager.query_prefetch_status(job.handle)
+        if found is None:
+            return None
+
+        ws = job.world_size
+        leading = found.count_leading_ones() // ws
+        # Any set shard marks its chunk retained (trim keeps whole chunks).
+        retained = sorted({ki // ws for ki in found.get_indices_list()})
+
+        self._ctx.event_bus.publish(
+            Event(
+                event_type=EventType.MP_LOOKUP_PREFETCH_END,
+                session_id=job.request_id,
+                metadata={
+                    "found_count": leading,
+                    "requested_tokens": job.requested_tokens,
+                    "hit_tokens": leading * self._ctx.chunk_size,
+                    "model_name": job.model_name,
+                    "cache_salt": job.cache_salt,
+                },
+            )
+        )
+        with self._prefetch_job_lock:
+            self._prefetch_jobs.pop(request_id, None)
+        return leading, retained
 
     def free_lookup_locks(
         self,

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -237,7 +237,11 @@ def _build_modules(
         # None and the blend module matches purely locally.
         coordinator = BlendCoordinatorClient.maybe_from_env()
         blend_v3 = BlendV3Module(
-            ctx, transfer_module, lookup_module, coordinator=coordinator
+            ctx,
+            transfer_module,
+            lookup_module,
+            coordinator=coordinator,
+            enable_segmented_prefix=mp_config.enable_segmented_prefix,
         )
         blend_module = blend_v3
         # blend_v3 mirrors per-instance CB rope state, so the reaper must

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -239,7 +239,6 @@ def _build_modules(
         blend_v3 = BlendV3Module(
             ctx,
             transfer_module,
-            lookup_module,
             coordinator=coordinator,
             enable_segmented_prefix=mp_config.enable_segmented_prefix,
         )

--- a/tests/v1/distributed/test_fault_inject_l2_adapter.py
+++ b/tests/v1/distributed/test_fault_inject_l2_adapter.py
@@ -74,9 +74,7 @@ def _wait_fd(event_fd: int, timeout: float = 5.0) -> bool:
     return False
 
 
-def _make_adapter(
-    rate: float = 0.0, seed: int = 0, gap_indices=(), drop_chunk_hashes=()
-):
+def _make_adapter(rate: float = 0.0, seed: int = 0, gap_indices=(), gap_tail_ratios=()):
     """Build a FaultInjectL2Adapter wrapping a fresh MockL2Adapter.
 
     Returns the ``(wrapper, inner)`` pair.
@@ -87,7 +85,7 @@ def _make_adapter(
         rate=rate,
         seed=seed,
         gap_indices=tuple(gap_indices),
-        drop_chunk_hashes=tuple(drop_chunk_hashes),
+        gap_tail_ratios=tuple(gap_tail_ratios),
     )
     return wrapper, inner
 
@@ -169,28 +167,42 @@ def test_load_gap_cleared_lookup_intact():
 
 
 # =============================================================================
-# drop_chunk_hashes: content-keyed, persistent across load tasks.
+# gap_tail_ratios: distance-from-tail / load-length; workload-agnostic.
 # =============================================================================
 
 
-def test_drop_chunk_hashes_content_keyed():
-    """A hashed key is dropped at load by content, regardless of its position;
-    re-loading the same key (a different task) drops it again (persistent)."""
+def test_gap_tail_ratio_position_and_scaling():
+    """A tail-ratio drops the chunk at round((1-ratio)*(n-1)); the absolute
+    index is computed from the load batch, so it scales with length -- no
+    content or position is known in advance."""
     keys = [_object_key(i) for i in range(N_KEYS)]
-    target_hex = keys[3].chunk_hash.hex()
-    adapter, inner = _make_adapter(drop_chunk_hashes=(target_hex,))
+    adapter, inner = _make_adapter(gap_tail_ratios=(0.5,))
     try:
         _store_all(adapter, keys)
         _lookup_bitmap(adapter, keys)
-        # First load: only the targeted hash is cleared, found by content not index.
-        load1 = _load_bitmap(adapter, keys)
-        assert not load1.test(3)
-        assert all(load1.test(i) for i in range(N_KEYS) if i != 3)
-        # A second load of a DIFFERENT key order still drops the same key.
-        reordered = [keys[3], keys[0], keys[1]]
-        load2 = _load_bitmap(adapter, reordered)
-        assert not load2.test(0)  # keys[3] now at position 0
-        assert load2.test(1) and load2.test(2)
+        mid = round(0.5 * (N_KEYS - 1))
+        load = _load_bitmap(adapter, keys)
+        assert not load.test(mid)
+        assert all(load.test(i) for i in range(N_KEYS) if i != mid)
+        # Same ratio on a SHORTER load drops a proportionally-different index
+        # (relative to that batch's tail) -- self-scaling, workload-agnostic.
+        short = keys[:4]
+        load2 = _load_bitmap(adapter, short)
+        assert not load2.test(round(0.5 * (len(short) - 1)))
+    finally:
+        adapter.close()
+
+
+def test_gap_tail_ratio_endpoints():
+    """ratio=0.0 drops the last chunk; ratio=1.0 drops the first."""
+    keys = [_object_key(i) for i in range(N_KEYS)]
+    adapter, inner = _make_adapter(gap_tail_ratios=(0.0, 1.0))
+    try:
+        _store_all(adapter, keys)
+        _lookup_bitmap(adapter, keys)
+        load = _load_bitmap(adapter, keys)
+        assert not load.test(0) and not load.test(N_KEYS - 1)
+        assert all(load.test(i) for i in range(1, N_KEYS - 1))
     finally:
         adapter.close()
 

--- a/tests/v1/distributed/test_fault_inject_l2_adapter.py
+++ b/tests/v1/distributed/test_fault_inject_l2_adapter.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for FaultInjectL2Adapter.
+
+The adapter is a decorator that drops a deterministic key subset at load to
+simulate partial L2 retrieve failures. These tests wrap a real MockL2Adapter
+and assert the load-result bitmap has exactly the expected bits cleared while
+the lookup bitmap is left intact, using only public interface methods.
+"""
+
+# Standard
+import select
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.fault_inject_l2_adapter import (
+    FaultInjectL2Adapter,
+)
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd
+
+N_KEYS = 8
+
+
+def _object_key(chunk_id: int) -> ObjectKey:
+    """Build an ObjectKey from a chunk id (test fixture)."""
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+def _memory_obj(size: int = 256, fill_value: float = 1.0) -> TensorMemoryObj:
+    """Build a filled TensorMemoryObj for use as a store/load buffer."""
+    raw = torch.empty(size, dtype=torch.float32)
+    raw.fill_(fill_value)
+    meta = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=size * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw, meta, parent_allocator=None)
+
+
+def _wait_fd(event_fd: int, timeout: float = 5.0) -> bool:
+    """Wait up to ``timeout`` seconds for ``event_fd`` to signal, draining it.
+
+    Returns True if the fd became readable before the timeout, False otherwise.
+    """
+    poll = select.poll()
+    poll.register(event_fd, select.POLLIN)
+    if poll.poll(timeout * 1000):
+        try:
+            consume_fd(event_fd)
+        except BlockingIOError:
+            pass
+        return True
+    return False
+
+
+def _make_adapter(
+    rate: float = 0.0, seed: int = 0, gap_indices=(), drop_chunk_hashes=()
+):
+    """Build a FaultInjectL2Adapter wrapping a fresh MockL2Adapter.
+
+    Returns the ``(wrapper, inner)`` pair.
+    """
+    inner = MockL2Adapter(MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0))
+    wrapper = FaultInjectL2Adapter(
+        inner,
+        rate=rate,
+        seed=seed,
+        gap_indices=tuple(gap_indices),
+        drop_chunk_hashes=tuple(drop_chunk_hashes),
+    )
+    return wrapper, inner
+
+
+def _store_all(adapter, keys):
+    """Store one memory object per key and drain the completion event."""
+    fd = adapter.get_store_event_fd()
+    adapter.submit_store_task(keys, [_memory_obj() for _ in keys])
+    assert _wait_fd(fd)
+    adapter.pop_completed_store_tasks()
+
+
+def _lookup_bitmap(adapter, keys):
+    """Run a lookup-and-lock for ``keys`` and return its result bitmap."""
+    fd = adapter.get_lookup_and_lock_event_fd()
+    tid = adapter.submit_lookup_and_lock_task(keys)
+    assert _wait_fd(fd)
+    # query_*_result is non-idempotent (returns non-None once); poll briefly.
+    for _ in range(50):
+        bm = adapter.query_lookup_and_lock_result(tid)
+        if bm is not None:
+            return bm
+        time.sleep(0.01)
+    raise AssertionError("lookup result never ready")
+
+
+def _load_bitmap(adapter, keys):
+    """Run a load for ``keys`` and return its result bitmap."""
+    fd = adapter.get_load_event_fd()
+    tid = adapter.submit_load_task(keys, [_memory_obj() for _ in keys])
+    assert _wait_fd(fd)
+    for _ in range(50):
+        bm = adapter.query_load_result(tid)
+        if bm is not None:
+            return bm
+        time.sleep(0.01)
+    raise AssertionError("load result never ready")
+
+
+# =============================================================================
+# Pass-through (rate=0): no faults.
+# =============================================================================
+
+
+def test_rate_zero_is_passthrough():
+    """rate=0 passes every key through unchanged (no drops)."""
+    adapter, inner = _make_adapter(rate=0.0)
+    try:
+        keys = [_object_key(i) for i in range(N_KEYS)]
+        _store_all(adapter, keys)
+        lookup = _lookup_bitmap(adapter, keys)
+        load = _load_bitmap(adapter, keys)
+        assert lookup.popcount() == N_KEYS
+        assert load.popcount() == N_KEYS
+    finally:
+        adapter.close()
+
+
+# =============================================================================
+# gap_indices: exact, deterministic drops.
+# =============================================================================
+
+
+def test_load_gap_cleared_lookup_intact():
+    """A gapped load clears exactly those load bits, leaving lookup intact."""
+    gap = {1, 4, 6}
+    adapter, inner = _make_adapter(gap_indices=gap)
+    try:
+        keys = [_object_key(i) for i in range(N_KEYS)]
+        _store_all(adapter, keys)
+        # Lookup is never faulted (lookup says present).
+        lookup = _lookup_bitmap(adapter, keys)
+        assert lookup.popcount() == N_KEYS
+        load = _load_bitmap(adapter, keys)
+        for i in range(N_KEYS):
+            assert load.test(i) == (i not in gap)
+    finally:
+        adapter.close()
+
+
+# =============================================================================
+# drop_chunk_hashes: content-keyed, persistent across load tasks.
+# =============================================================================
+
+
+def test_drop_chunk_hashes_content_keyed():
+    """A hashed key is dropped at load by content, regardless of its position;
+    re-loading the same key (a different task) drops it again (persistent)."""
+    keys = [_object_key(i) for i in range(N_KEYS)]
+    target_hex = keys[3].chunk_hash.hex()
+    adapter, inner = _make_adapter(drop_chunk_hashes=(target_hex,))
+    try:
+        _store_all(adapter, keys)
+        _lookup_bitmap(adapter, keys)
+        # First load: only the targeted hash is cleared, found by content not index.
+        load1 = _load_bitmap(adapter, keys)
+        assert not load1.test(3)
+        assert all(load1.test(i) for i in range(N_KEYS) if i != 3)
+        # A second load of a DIFFERENT key order still drops the same key.
+        reordered = [keys[3], keys[0], keys[1]]
+        load2 = _load_bitmap(adapter, reordered)
+        assert not load2.test(0)  # keys[3] now at position 0
+        assert load2.test(1) and load2.test(2)
+    finally:
+        adapter.close()
+
+
+# =============================================================================
+# rate-based drops: deterministic across instances with the same seed.
+# =============================================================================
+
+
+def test_rate_drop_is_deterministic_across_instances():
+    """Same seed drops the same keys; a different seed (very likely) differs."""
+    keys = [_object_key(i) for i in range(64)]
+
+    def dropped_positions(seed):
+        adapter, inner = _make_adapter(rate=0.3, seed=seed)
+        try:
+            _store_all(adapter, keys)
+            _lookup_bitmap(adapter, keys)
+            load = _load_bitmap(adapter, keys)
+            return {i for i in range(len(keys)) if not load.test(i)}
+        finally:
+            adapter.close()
+
+    a = dropped_positions(seed=42)
+    b = dropped_positions(seed=42)
+    c = dropped_positions(seed=1234)
+    assert a, "rate=0.3 should drop at least one of 64 keys"
+    assert a == b, "same seed must drop the same keys"
+    # A different seed should (with overwhelming probability) differ.
+    assert a != c
+
+
+def test_rate_drop_within_tolerance():
+    """Rate-based bucketing drops roughly ``rate * N`` keys (wide tolerance)."""
+    keys = [_object_key(i) for i in range(200)]
+    adapter, inner = _make_adapter(rate=0.25, seed=7)
+    try:
+        _store_all(adapter, keys)
+        _lookup_bitmap(adapter, keys)
+        load = _load_bitmap(adapter, keys)
+        dropped = sum(1 for i in range(len(keys)) if not load.test(i))
+        # Deterministic hash bucketing -> roughly rate * N, allow a wide band.
+        assert 25 <= dropped <= 75
+    finally:
+        adapter.close()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -23,6 +23,9 @@ from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey, TrimPolicy
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.l2_adapters.fault_inject_l2_adapter import (
+    FaultInjectL2Adapter,
+)
 from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
     MockL2Adapter,
     MockL2AdapterConfig,
@@ -311,6 +314,88 @@ class TestSingleAdapterPrefetch:
         l1_manager.finish_read(prefix_keys)
         ctrl.stop()
         adapter.close()
+
+    def test_segmented_prefix_with_gap(self, l1_manager):
+        """SEGMENTED_PREFIX retains the post-gap keys: L2 {0,1,3,4} -> {0,1,3,4}.
+
+        The PREFIX counterpart (test_prefix_with_gap) truncates the same gap to
+        {0,1}; SEGMENTED_PREFIX keeps the post-gap chunks L1-resident so only
+        the hole (index 2) needs recomputing.
+        """
+        adapter = make_adapter()
+        layout = make_layout()
+        all_keys = [make_object_key(i) for i in range(5)]
+        # Store only keys 0, 1, 3, 4 (gap at index 2).
+        store_keys_in_l2(adapter, [all_keys[i] for i in [0, 1, 3, 4]], layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(
+            all_keys, layout, policy=TrimPolicy.SEGMENTED_PREFIX
+        )
+        retained = wait_for_prefetch_result_bitmap(ctrl, req_id)
+        assert retained is not None
+        assert retained.get_indices_list() == [0, 1, 3, 4], (
+            "SEGMENTED_PREFIX should retain post-gap keys, got "
+            f"{retained.get_indices_list()}"
+        )
+
+        # Retained keys {0,1,3,4} are read-locked in L1; the gap (2) is absent.
+        retained_keys = [all_keys[i] for i in [0, 1, 3, 4]]
+        read = l1_manager.unsafe_read(retained_keys)
+        for key in retained_keys:
+            assert read[key][0] == L1Error.SUCCESS
+        gap_read = l1_manager.reserve_read([all_keys[2]])
+        assert gap_read[all_keys[2]][0] == L1Error.KEY_NOT_EXIST
+
+        l1_manager.finish_read(retained_keys)
+        ctrl.stop()
+        adapter.close()
+
+    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager):
+        """fault_inject (load fails at index 2) drives the segmented path.
+
+        Lookup reports all 5 keys present; the *load* of index 2 fails (the L2
+        retrieve error the adapter simulates). SEGMENTED_PREFIX retains the
+        post-gap keys {0,1,3,4}; PREFIX truncates at the hole to {0,1}. Distinct
+        key ranges per policy keep the shared L1 from serving the second pass.
+        """
+        layout = make_layout()
+        for base, trim, expected in (
+            (0, TrimPolicy.SEGMENTED_PREFIX, [0, 1, 3, 4]),
+            (10, TrimPolicy.PREFIX, [0, 1]),
+        ):
+            keys = [make_object_key(base + i) for i in range(5)]
+            inner = make_adapter()
+            store_keys_in_l2(inner, keys, layout)  # all 5 present at lookup
+            # Drop task-position 2 at load -> a mid-prefix L2 retrieve failure.
+            fault = FaultInjectL2Adapter(inner, rate=0.0, seed=0, gap_indices=(2,))
+
+            ctrl = PrefetchController(
+                l1_manager=l1_manager,
+                l2_adapters=[fault],
+                adapter_descriptors=[make_descriptor(0)],
+                policy=DefaultPrefetchPolicy(),
+            )
+            ctrl.start()
+            req_id = ctrl.submit_prefetch_request(keys, layout, policy=trim)
+            retained = wait_for_prefetch_result_bitmap(ctrl, req_id)
+            assert retained is not None
+            assert retained.get_indices_list() == expected, (
+                f"{trim.name}: expected {expected}, got {retained.get_indices_list()}"
+            )
+
+            held = [keys[i] for i in retained.get_indices_list()]
+            if held:
+                l1_manager.finish_read(held)
+            ctrl.stop()
+            fault.close()
 
     def test_key0_missing(self, l1_manager):
         """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""


### PR DESCRIPTION
**What this PR does / why we need it**:

Real L2 caches always return a clean contiguous-prefix-then-tail result, so the *segmented* found-set paths (segmented prefetch → scatter → attention) are never exercised by normal workloads. This PR adds a way to trigger them deterministically and wires the segmented-prefix retrieval policy end-to-end.

1. **Fault-inject L2 adapter** (`type: "fault_inject"`) — a decorator over a real inner adapter (e.g. `fs_native`) that drops a deterministic key subset *at load* to simulate partial L2 retrieve failures. Lookup passes through; the gap appears at load failure (the faithful "L2 retrieve error"), and the prefetch controller releases load-failed locks via the trim mask. Drop-set knobs: `rate`, `seed`, `gap_indices`, and `drop_chunk_hashes` (content-keyed, so the same chunk fails across prefix and sparse legs). Auto-discovered via the L2 adapter registry.

2. **Segmented-prefix retrieval** — thread `TrimPolicy` through the prefix lookup path so a mid-prefix gap no longer truncates everything after it. The dense prefetch branch forwards the policy, `LookupModule.lookup` takes a policy arg, and the CB prefix leg is gated on `CB_SEGMENTED_PREFIX=1` to request `SEGMENTED_PREFIX`. Gapped loads now leave post-gap chunks L1-resident (picked up by the sparse leg as L1 hits, the hole recomputed) instead of discarding everything after the gap.

**Special notes for reviewers**:

- The fault-inject adapter is **test/diagnostic only** (logs a warning when active) and gated behind config; no production path changes by default.
- Segmented-prefix delivery is behind the `CB_SEGMENTED_PREFIX` flag, so default prefix-leg behavior is unchanged.

**If applicable**:

- [x] User-facing changes — docs added (`docs/design/.../fault_inject.md`)
- [x] Unit tests (`test_fault_inject_l2_adapter.py`; segmented-prefix coverage in `test_prefetch_controller.py`)