### PR TITLE
refactor: extract BaseCacheContext ABC shared by GPU and CPU cache contexts

### DIFF
--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -22,15 +22,12 @@ if TYPE_CHECKING:
 # First Party
 from lmcache import torch_dev
 from lmcache.logging import init_logger
-from lmcache.utils import EngineType, lmcache_deprecate
+from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.gds_context import get_gds_context
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
-    get_attention_backend,
-    get_concrete_engine_kv_shape_from_shape_desc,
     get_device,
     get_dtype,
-    get_engine_kv_shape_description,
     get_group_data_ptrs,
     get_num_blocks,
     get_num_layers,
@@ -40,12 +37,7 @@ from lmcache.v1.gpu_connector.utils import (
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
-
-# Backend selection (c_ops when CUDA is available, otherwise a pure-Python
-# fallback) is handled once in ``lmcache/__init__.py`` via ``_get_backend``,
-# which aliases the chosen module as ``lmcache.c_ops`` in ``sys.modules``.
-# Importing it here transparently works in both CUDA and CPU-only envs.
-import lmcache.c_ops as lmc_ops
+from lmcache.v1.platform.base_cache_context import BaseCacheContext
 
 logger = init_logger(__name__)
 
@@ -348,7 +340,7 @@ class _TempGPUBuffer:
         )
 
 
-class GPUCacheContext:
+class GPUCacheContext(BaseCacheContext):
     """
     Manages the shape and pointers to vLLM GPU KV cache tensors.
     """
@@ -362,7 +354,7 @@ class GPUCacheContext:
         engine_type: EngineType = EngineType.VLLM,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
-        self.engine_kv_format_, self.kv_caches_ = normalize_kv_and_discover_format(
+        self._engine_kv_format, self.kv_caches_ = normalize_kv_and_discover_format(
             unwrapped,
             engine_type,
             layout_hints=layout_hints,
@@ -439,14 +431,6 @@ class GPUCacheContext:
         return get_dtype(self.kv_caches_, self.engine_kv_format_)
 
     @property
-    def device(self) -> torch.device:
-        return self.device_
-
-    @property
-    def kv_tensors(self) -> list[torch.Tensor]:
-        return self.kv_caches_
-
-    @property
     def stream(self) -> Any:
         """
         Returns the GPU stream for KV cache operations
@@ -456,60 +440,6 @@ class GPUCacheContext:
     @property
     def cupy_stream(self) -> "cupy.cuda.Stream":
         return self.cupy_stream_
-
-    @property
-    def num_layers(self) -> int:
-        """
-        Returns the number of layers in the model
-        """
-        return self.num_layers_
-
-    @property
-    def num_blocks(self) -> int:
-        """
-        Returns the number of blocks in the KV cache
-        """
-        return self.num_blocks_
-
-    @property
-    def is_mla(self) -> bool:
-        """
-        Returns whether the model uses MLA
-        """
-        return self.is_mla_
-
-    @property
-    def hidden_dim_sizes(self) -> list[int]:
-        """Returns the hidden dimension sizes for each KV layer group."""
-        return [
-            group.hidden_dim_size
-            for group in self.kv_layer_groups_manager_.kv_layer_groups
-        ]
-
-    @property
-    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
-        """Returns the KV layer groups manager."""
-        return self.kv_layer_groups_manager_
-
-    def get_shape_desc(self, kernel_group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
-        """Returns the PageBufferShapeDesc for the given KV layer group."""
-        return self.kv_layer_groups_manager_.get_shape_desc(kernel_group_idx)
-
-    def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
-        """Returns the number of slots per lmcache chunk when doing
-        D/H transfer.
-
-        This function will take into account that for subchunk sliding window
-        case, the transfer slots will be smaller than the "actual" slots per
-        chunk (which is calculated based on the lmcache chunk size).
-
-        Args:
-            kernel_group_idx: Index of the kernel group.
-
-        Returns:
-            The number of used slots per lmcache chunk when doing D/H transfer.
-        """
-        return self.kv_layer_groups_manager.get_slots_per_chunk_in_sw(kernel_group_idx)
 
     def get_kernel_group_kv_pointers(self, kernel_group_idx: int) -> torch.Tensor:
         """Returns the pre-computed GPU tensor of KV cache pointers for the
@@ -577,88 +507,6 @@ class GPUCacheContext:
             num_tokens, kernel_group_idx
         )
 
-    def copy_view_block_ids_to_gpu(
-        self, block_ids_per_group: list[list[int]]
-    ) -> list[torch.Tensor]:
-        """Copy block IDs for each LMCache KV layer group to GPU.
-
-        The outer list is indexed by LMCache KV group index. All inner lists
-        are packed into the shared GPU buffer once, and this returns one
-        non-overlapping tensor view per LMCache group.
-        """
-        offsets = [0]
-        flat: array.array = array.array("l")
-        for view_block_ids in block_ids_per_group:
-            flat.extend(view_block_ids)
-            offsets.append(len(flat))
-
-        total = offsets[-1]
-        if total > self.block_ids_buffer_.shape[0]:
-            raise ValueError(
-                f"block ID total {total} exceeds the pre-allocated buffer "
-                f"size {self.block_ids_buffer_.shape[0]}"
-            )
-        if total:
-            cpu_tensor = torch.frombuffer(flat, dtype=torch.long)
-            self.block_ids_buffer_[:total].copy_(cpu_tensor, non_blocking=True)
-
-        return [
-            self.block_ids_buffer_[offsets[i] : offsets[i + 1]]
-            for i in range(len(block_ids_per_group))
-        ]
-
-    @lmcache_deprecate("will be refactored")
-    def get_kv_buffer_shape(
-        self, logical_num_tokens: int, group_idx: int = 0
-    ) -> torch.Size:
-        """
-        Returns the shape of the KV buffer for the given number of
-        *logical* tokens.
-
-        For a compressed group (``compress_ratio > 1``) every
-        ``compress_ratio`` logical tokens are packed into a single
-        physical slot, so the returned shape's token dimension is
-        ``num_tokens // compress_ratio``. Callers therefore always
-        pass logical-token counts and never need to know per-group
-        compression ratios.
-
-        Args:
-            logical_num_tokens: Number of *logical* tokens. Must be a multiple
-                of the group's ``compress_ratio``.
-            group_idx: Index of the KV layer group (default 0).
-        """
-        # TODO: remove this!
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        compress_ratio = group.tokens_per_block // group.slots_per_block
-        if logical_num_tokens % compress_ratio != 0:
-            raise ValueError(
-                f"logical_num_tokens ({logical_num_tokens}) is not a multiple of "
-                f"compress_ratio ({compress_ratio}) for group {group_idx}"
-            )
-        num_slots = logical_num_tokens // compress_ratio
-        sd = group.shape_desc
-        return torch.Size(
-            (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
-        )
-
-    def calculate_num_blocks(self, num_tokens: int, kernel_group_idx: int) -> int:
-        """Calculate the number of blocks for a given number of tokens in a
-        specified kernel group.
-
-        Args:
-            kernel_group_idx: 0-based index of the kernel group.
-            num_tokens: The total number of tokens to be processed for the group.
-
-        Returns:
-            The number of blocks.
-
-        Raises:
-            IndexError: If *kernel_group_idx* is out of range.
-        """
-        return self.kv_layer_groups_manager.calculate_num_blocks(
-            kernel_group_idx, num_tokens
-        )
-
     def cache_size_per_token(self) -> int:
         """
         Returns the cache size per *logical* token (in bytes), summed
@@ -671,81 +519,6 @@ class GPUCacheContext:
         from integer division is acceptable.
         """
         return self._temp_buffer.get_cache_size_per_token()
-
-    def report_status(self) -> dict:
-        """Return this context's KV cache layout metadata for ``/status``.
-
-        Returns:
-            A dict with these top-level fields:
-
-            - ``num_layers`` (int): total layers in the model.
-            - ``num_blocks`` (int)
-            - ``cache_size_per_token`` (int): bytes per logical token,
-              summed across groups.
-            - ``kernel_groups`` (list[dict]): one entry per kernel group,
-              each with:
-
-              - ``kernel_group_idx`` (int): index into ``manager.kernel_groups``.
-              - ``engine_group_idx`` (int): paged-block address space.
-              - ``object_group_idx`` (int): owning object group.
-              - ``num_layers`` (int): layers in this group.
-              - ``layer_indices`` (list[int]): the group's layer indices.
-              - ``tokens_per_block`` (int): logical tokens per paged chunk.
-              - ``slots_per_block`` (int): physical slots per paged
-                chunk (``slots_per_block``, i.e. ``shape_desc.bs``).
-              - ``compress_ratio`` (int)
-              - ``dtype`` (str): stringified torch dtype.
-              - ``gpu_kv_concrete_shape`` (str): group-accurate numeric shape.
-              - ``is_mla`` (bool)
-              - ``engine_kv_format`` (str): engine KV format enum name.
-              - ``engine_kv_shape`` (str): symbolic shape description.
-              - ``attention_backend`` (str)
-        """
-        manager = self.kv_layer_groups_manager
-        kernel_groups = manager.kernel_groups
-
-        # Reverse-map each kernel group to its owning object group.
-        kernel_group_to_object_group: dict[int, int] = {
-            kg_idx: og_idx
-            for og_idx, og in enumerate(manager.object_groups)
-            for kg_idx in og.kernel_group_indices
-        }
-
-        engine_kv_format = self.engine_kv_format_
-        group_reports: list[dict] = []
-        for kernel_group_idx, group in enumerate(kernel_groups):
-            group_reports.append(
-                {
-                    "kernel_group_idx": kernel_group_idx,
-                    "engine_group_idx": group.engine_group_idx,
-                    "object_group_idx": kernel_group_to_object_group.get(
-                        kernel_group_idx, 0
-                    ),
-                    "num_layers": group.num_layers,
-                    "layer_indices": list(group.layer_indices),
-                    "tokens_per_block": group.tokens_per_block,
-                    "slots_per_block": group.slots_per_block,
-                    "dtype": str(group.dtype),
-                    "engine_kv_concrete_shape": (
-                        get_concrete_engine_kv_shape_from_shape_desc(
-                            group.shape_desc, engine_kv_format
-                        )
-                    ),
-                    "is_mla": is_mla(engine_kv_format),
-                    "engine_kv_format": engine_kv_format.name,
-                    "engine_kv_shape": get_engine_kv_shape_description(
-                        engine_kv_format
-                    ),
-                    "attention_backend": get_attention_backend(engine_kv_format),
-                }
-            )
-
-        return {
-            "num_layers": self.num_layers,
-            "num_blocks": self.num_blocks,
-            "cache_size_per_token": self.cache_size_per_token(),
-            "kernel_groups": group_reports,
-        }
 
 
 class PlainGPUCacheContext:

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -46,7 +46,6 @@ from lmcache.v1.multiprocess.custom_types import (
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 from lmcache.v1.multiprocess.engine_module import HandlerSpec, ThreadPoolType
-from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
 from lmcache.v1.multiprocess.modules.gpu_transfer import GPUTransferModule
 from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.protocol import RequestType
@@ -56,6 +55,7 @@ from lmcache.v1.multiprocess.token_hasher import (
     rolling_hash_windows_numba,
     update_table_id_numba,
 )
+from lmcache.v1.platform.base_cache_context import BaseCacheContext
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
@@ -1137,7 +1137,7 @@ class BlendV3Module:
 
     def _apply_cb_rope_batched(
         self,
-        gpu_context: GPUCacheContext,
+        gpu_context: BaseCacheContext,
         rope_state: _CBRopeState,
         batch_len: int,
         slots_to_rope: list[tuple[int, int, int]],

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -38,13 +38,13 @@ from lmcache.v1.multiprocess.engine_module import (
     HandlerSpec,
     ThreadPoolType,
 )
-from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.native_completion import (
     DeviceHostFuncDispatcher,
     submit_callback_to_stream,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.platform.base_cache_context import BaseCacheContext
 from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
 
@@ -52,7 +52,7 @@ logger = init_logger(__name__)
 
 
 def get_layout_desc(
-    gpu_context: GPUCacheContext,
+    gpu_context: BaseCacheContext,
     num_tokens: int,
     object_group_id: int,
 ) -> MemoryLayoutDesc:
@@ -122,7 +122,7 @@ def batched_iteration_with_skip(
 
 
 def downsample_and_stage_block_ids(
-    cache_context: GPUCacheContext,
+    cache_context: BaseCacheContext,
     block_ids: list[list[int]],
 ) -> list[torch.Tensor]:
     """Cut the block id lists to skip the unneeded blocks in a chunk and
@@ -229,7 +229,7 @@ def _recalculate_blocks_to_skip(
 
 
 def transfer_kv_per_object_group(
-    cache_context: GPUCacheContext,
+    cache_context: BaseCacheContext,
     block_ids_gpu: list[torch.Tensor],
     memory_objs: Sequence[MemoryObj | None],
     object_group_id: int,
@@ -398,7 +398,7 @@ class ContextEntry:
         world_size: The world size associated with this KV cache.
     """
 
-    cache_context: GPUCacheContext
+    cache_context: BaseCacheContext
     model_name: str
     world_size: int
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -37,7 +37,6 @@ from lmcache.v1.multiprocess.engine_module import (
     HandlerSpec,
     ThreadPoolType,
 )
-from lmcache.v1.multiprocess.gpu_context import GPUCacheContext
 from lmcache.v1.multiprocess.modules.gpu_transfer import GPUTransferModule
 from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.modules.management import ManagementModule
@@ -48,6 +47,7 @@ from lmcache.v1.multiprocess.protocol import (
     get_handler_type,
     get_payload_classes,
 )
+from lmcache.v1.platform.base_cache_context import BaseCacheContext
 
 logger = init_logger(__name__)
 
@@ -112,7 +112,7 @@ class MPCacheServer:
         return self._context.storage_manager
 
     @property
-    def gpu_contexts(self) -> dict[int, GPUCacheContext] | None:
+    def gpu_contexts(self) -> dict[int, BaseCacheContext] | None:
         """Used by ``/kvcache/check``; unwraps :class:`ContextEntry`."""
         for module in self._modules:
             if isinstance(module, GPUTransferModule):

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Abstract base class for platform cache contexts.
+
+Defines the common interface shared by :class:`GPUCacheContext` and
+:class:`CpuCacheContext`.  Concrete subclasses provide
+device-specific implementations of stream / buffer / copy primitives
+while the base class owns layout-agnostic helpers (shape calculation,
+status reporting, block-ID staging).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+import array
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.gpu_connector.utils import (
+    get_attention_backend,
+    get_concrete_engine_kv_shape_from_shape_desc,
+    get_engine_kv_shape_description,
+    is_mla,
+)
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+
+if TYPE_CHECKING:
+    # First Party
+    import lmcache.c_ops as lmc_ops
+
+
+class BaseCacheContext(ABC):
+    """Abstract base for GPU and CPU cache contexts.
+
+    Subclasses must set the following instance attributes in
+    :meth:`__init__` and the class-level annotations below keep
+    static analysis happy without polluting the ABC with a
+    concrete :meth:`__init__`.
+    """
+
+    # -- Set by subclass __init__ (annotations silence IDE warnings) --
+
+    _engine_kv_format: Any
+    device_: torch.device
+    kv_caches_: list[torch.Tensor]
+    num_layers_: int
+    num_blocks_: int
+    is_mla_: bool
+    kv_layer_groups_manager_: KVLayerGroupsManager
+    block_ids_buffer_: torch.Tensor
+    lmcache_tokens_per_chunk: int
+
+    # ------------------------------------------------------------------
+    # Abstract -- subclasses MUST implement
+    # ------------------------------------------------------------------
+
+    @property
+    @abstractmethod
+    def dtype(self) -> torch.dtype:
+        """Returns the dtype of the KV cache tensors."""
+        ...
+
+    @property
+    @abstractmethod
+    def stream(self) -> Any:
+        """Returns the device-specific stream for async operations."""
+        ...
+
+    @property
+    @abstractmethod
+    def cupy_stream(self) -> Any:
+        """Returns the cupy ExternalStream wrapping *stream*."""
+        ...
+
+    @property
+    @abstractmethod
+    def max_batch_size(self) -> int:
+        """Returns the maximum number of concurrent batches."""
+        ...
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release device-specific resources (GDS staging buffers, etc.)."""
+        ...
+
+    @abstractmethod
+    def get_kernel_group_kv_pointers(self, kernel_group_idx: int) -> torch.Tensor:
+        """Returns the KV-cache pointer tensor for *kernel_group_idx*."""
+        ...
+
+    @abstractmethod
+    def get_temp_kernel_group_buffer(
+        self, batch_idx: int, kernel_group_idx: int
+    ) -> torch.Tensor:
+        """Returns a typed temp-buffer view for a (batch, kernel-group)
+        pair."""
+        ...
+
+    @abstractmethod
+    def get_temp_object_group_buffer(
+        self, batch_idx: int, object_group_idx: int
+    ) -> torch.Tensor:
+        """Returns a flat uint8 temp-buffer view for a (batch, object-group)
+        pair."""
+        ...
+
+    @abstractmethod
+    def get_kernel_group_shape_dtype(
+        self,
+        num_tokens: int,
+        kernel_group_idx: int,
+    ) -> tuple[torch.Size, torch.dtype]:
+        """Returns ``(shape, dtype)`` for *kernel_group_idx*."""
+        ...
+
+    @abstractmethod
+    def cache_size_per_token(self) -> int:
+        """Returns cache size per logical token in bytes (all groups)."""
+        ...
+
+    # ------------------------------------------------------------------
+    # Concrete -- shared implementations
+    # ------------------------------------------------------------------
+
+    @property
+    def engine_kv_format_(self) -> Any:
+        """Returns the EngineKVFormat enum value."""
+        return self._engine_kv_format
+
+    @property
+    def device(self) -> torch.device:
+        """Returns the device where KV-cache tensors live."""
+        return self.device_
+
+    @property
+    def kv_tensors(self) -> list[torch.Tensor]:
+        """Returns the list of per-layer KV cache tensors."""
+        return self.kv_caches_
+
+    @property
+    def num_layers(self) -> int:
+        """Returns the number of layers in the model."""
+        return self.num_layers_
+
+    @property
+    def num_blocks(self) -> int:
+        """Returns the number of blocks in the KV cache."""
+        return self.num_blocks_
+
+    @property
+    def is_mla(self) -> bool:
+        """Returns whether the model uses MLA."""
+        return self.is_mla_
+
+    @property
+    def hidden_dim_sizes(self) -> list[int]:
+        """Returns hidden dimension sizes per KV layer group."""
+        return [
+            group.hidden_dim_size
+            for group in self.kv_layer_groups_manager_.kv_layer_groups
+        ]
+
+    @property
+    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
+        """Returns the KV layer groups manager."""
+        return self.kv_layer_groups_manager_
+
+    def calculate_num_blocks(self, num_tokens: int, kernel_group_idx: int) -> int:
+        """Calculate the number of blocks for *num_tokens* in a kernel
+        group."""
+        return self.kv_layer_groups_manager_.calculate_num_blocks(
+            kernel_group_idx, num_tokens
+        )
+
+    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
+        """Returns the PageBufferShapeDesc for *group_idx*."""
+        return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
+
+    def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
+        """Returns the number of slots per lmcache chunk for D/H
+        transfer."""
+        return self.kv_layer_groups_manager_.get_slots_per_chunk_in_sw(kernel_group_idx)
+
+    def get_kv_buffer_shape(
+        self, logical_num_tokens: int, group_idx: int = 0
+    ) -> torch.Size:
+        """Returns the KV buffer shape for *logical_num_tokens*."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        compress_ratio = group.tokens_per_block // group.slots_per_block
+        if logical_num_tokens % compress_ratio != 0:
+            raise ValueError(
+                "logical_num_tokens (%d) is not a multiple of "
+                "compress_ratio (%d) for group %d"
+                % (logical_num_tokens, compress_ratio, group_idx)
+            )
+        num_slots = logical_num_tokens // compress_ratio
+        sd = group.shape_desc
+        return torch.Size(
+            (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
+        )
+
+    def copy_view_block_ids_to_gpu(
+        self, block_ids_per_group: list[list[int]]
+    ) -> list[torch.Tensor]:
+        """Copy per-group block IDs into the shared staging buffer.
+
+        Returns one non-overlapping view per LMCache group.
+        """
+        offsets = [0]
+        flat: array.array = array.array("l")
+        for view_block_ids in block_ids_per_group:
+            flat.extend(view_block_ids)
+            offsets.append(len(flat))
+
+        total = offsets[-1]
+        if total > self.block_ids_buffer_.shape[0]:
+            raise ValueError(
+                "block ID total %d exceeds the pre-allocated buffer "
+                "size %d" % (total, self.block_ids_buffer_.shape[0])
+            )
+        if total:
+            cpu_tensor = torch.frombuffer(flat, dtype=torch.long)
+            self.block_ids_buffer_[:total].copy_(cpu_tensor, non_blocking=True)
+
+        return [
+            self.block_ids_buffer_[offsets[i] : offsets[i + 1]]
+            for i in range(len(block_ids_per_group))
+        ]
+
+    # ------------------------------------------------------------------
+    # Derived properties (pure helpers)
+    # ------------------------------------------------------------------
+
+    @property
+    def engine_kv_shape(self) -> str:
+        """Returns the symbolic KV cache layout description."""
+        return get_engine_kv_shape_description(self._engine_kv_format)
+
+    @property
+    def attention_backend(self) -> str:
+        """Returns the attention backend name."""
+        return get_attention_backend(self._engine_kv_format)
+
+    @property
+    def concrete_engine_kv_shape(self) -> str:
+        """Returns the engine KV shape with actual numeric values."""
+        group = self.kv_layer_groups_manager_.kv_layer_groups[0]
+        return get_concrete_engine_kv_shape_from_shape_desc(
+            group.shape_desc, self._engine_kv_format
+        )
+
+    # ------------------------------------------------------------------
+    # Shared report_status
+    # ------------------------------------------------------------------
+
+    def report_status(self) -> dict:
+        """Return this context's KV cache layout metadata."""
+        manager = self.kv_layer_groups_manager_
+        kernel_groups = manager.kernel_groups
+
+        kernel_group_to_object_group: dict[int, int] = {
+            kg_idx: og_idx
+            for og_idx, og in enumerate(manager.object_groups)
+            for kg_idx in og.kernel_group_indices
+        }
+
+        engine_kv_format = self._engine_kv_format
+        group_reports: list[dict] = []
+        for kernel_group_idx, group in enumerate(kernel_groups):
+            group_reports.append(
+                {
+                    "kernel_group_idx": kernel_group_idx,
+                    "engine_group_idx": group.engine_group_idx,
+                    "object_group_idx": kernel_group_to_object_group.get(
+                        kernel_group_idx, 0
+                    ),
+                    "num_layers": group.num_layers,
+                    "layer_indices": list(group.layer_indices),
+                    "tokens_per_block": group.tokens_per_block,
+                    "slots_per_block": group.slots_per_block,
+                    "dtype": str(group.dtype),
+                    "engine_kv_concrete_shape": (
+                        get_concrete_engine_kv_shape_from_shape_desc(
+                            group.shape_desc, engine_kv_format
+                        )
+                    ),
+                    "is_mla": is_mla(engine_kv_format),
+                    "engine_kv_format": engine_kv_format.name,
+                    "engine_kv_shape": get_engine_kv_shape_description(
+                        engine_kv_format
+                    ),
+                    "attention_backend": get_attention_backend(engine_kv_format),
+                }
+            )
+
+        return {
+            "num_layers": self.num_layers_,
+            "num_blocks": self.num_blocks_,
+            "cache_size_per_token": self.cache_size_per_token(),
+            "kernel_groups": group_reports,
+        }

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -161,7 +161,7 @@ class BaseCacheContext(ABC):
         """Returns hidden dimension sizes per KV layer group."""
         return [
             group.hidden_dim_size
-            for group in self.kv_layer_groups_manager_.kv_layer_groups
+            for group in self.kv_layer_groups_manager.kv_layer_groups
         ]
 
     @property
@@ -172,24 +172,24 @@ class BaseCacheContext(ABC):
     def calculate_num_blocks(self, num_tokens: int, kernel_group_idx: int) -> int:
         """Calculate the number of blocks for *num_tokens* in a kernel
         group."""
-        return self.kv_layer_groups_manager_.calculate_num_blocks(
+        return self.kv_layer_groups_manager.calculate_num_blocks(
             kernel_group_idx, num_tokens
         )
 
     def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
         """Returns the PageBufferShapeDesc for *group_idx*."""
-        return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
+        return self.kv_layer_groups_manager.get_shape_desc(group_idx)
 
     def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
         """Returns the number of slots per lmcache chunk for D/H
         transfer."""
-        return self.kv_layer_groups_manager_.get_slots_per_chunk_in_sw(kernel_group_idx)
+        return self.kv_layer_groups_manager.get_slots_per_chunk_in_sw(kernel_group_idx)
 
     def get_kv_buffer_shape(
         self, logical_num_tokens: int, group_idx: int = 0
     ) -> torch.Size:
         """Returns the KV buffer shape for *logical_num_tokens*."""
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        group = self.kv_layer_groups_manager.kv_layer_groups[group_idx]
         compress_ratio = group.tokens_per_block // group.slots_per_block
         if logical_num_tokens % compress_ratio != 0:
             raise ValueError(
@@ -238,19 +238,19 @@ class BaseCacheContext(ABC):
     @property
     def engine_kv_shape(self) -> str:
         """Returns the symbolic KV cache layout description."""
-        return get_engine_kv_shape_description(self._engine_kv_format)
+        return get_engine_kv_shape_description(self.engine_kv_format_)
 
     @property
     def attention_backend(self) -> str:
         """Returns the attention backend name."""
-        return get_attention_backend(self._engine_kv_format)
+        return get_attention_backend(self.engine_kv_format_)
 
     @property
     def concrete_engine_kv_shape(self) -> str:
         """Returns the engine KV shape with actual numeric values."""
-        group = self.kv_layer_groups_manager_.kv_layer_groups[0]
+        group = self.kv_layer_groups_manager.kv_layer_groups[0]
         return get_concrete_engine_kv_shape_from_shape_desc(
-            group.shape_desc, self._engine_kv_format
+            group.shape_desc, self.engine_kv_format_
         )
 
     # ------------------------------------------------------------------
@@ -259,7 +259,7 @@ class BaseCacheContext(ABC):
 
     def report_status(self) -> dict:
         """Return this context's KV cache layout metadata."""
-        manager = self.kv_layer_groups_manager_
+        manager = self.kv_layer_groups_manager
         kernel_groups = manager.kernel_groups
 
         kernel_group_to_object_group: dict[int, int] = {
@@ -268,7 +268,7 @@ class BaseCacheContext(ABC):
             for kg_idx in og.kernel_group_indices
         }
 
-        engine_kv_format = self._engine_kv_format
+        engine_kv_format = self.engine_kv_format_
         group_reports: list[dict] = []
         for kernel_group_idx, group in enumerate(kernel_groups):
             group_reports.append(
@@ -298,8 +298,8 @@ class BaseCacheContext(ABC):
             )
 
         return {
-            "num_layers": self.num_layers_,
-            "num_blocks": self.num_blocks_,
+            "num_layers": self.num_layers,
+            "num_blocks": self.num_blocks,
             "cache_size_per_token": self.cache_size_per_token(),
             "kernel_groups": group_reports,
         }

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 # First Party
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform.base_cache_context import BaseCacheContext
 from lmcache.v1.platform.cpu.cache_context import CpuCacheContext
 
 if TYPE_CHECKING:
@@ -38,7 +39,7 @@ def create_cache_context(
     layout_hints: LayoutHints | None = None,
     engine_group_infos: "Sequence[EngineGroupInfo]" = (),
     engine_type: EngineType = EngineType.VLLM,
-) -> Any:
+) -> BaseCacheContext:
     """Create the appropriate cache context.
 
     The signature mirrors :class:`GPUCacheContext` so callers can

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 # Standard
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
-import array
 import os
 
 # Third Party
@@ -31,9 +30,6 @@ from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
-    get_attention_backend,
-    get_concrete_engine_kv_shape_from_shape_desc,
-    get_engine_kv_shape_description,
     get_group_data_ptrs,
     get_num_blocks,
     get_num_layers,
@@ -42,8 +38,8 @@ from lmcache.v1.gpu_connector.utils import (
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform.base_cache_context import BaseCacheContext
 from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
-import lmcache.c_ops as lmc_ops
 
 if TYPE_CHECKING:
     # First Party
@@ -52,7 +48,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-class CpuCacheContext:
+class CpuCacheContext(BaseCacheContext):
     """CPU-only cache context with the same public API as
     :class:`GPUCacheContext`.
 
@@ -145,7 +141,7 @@ class CpuCacheContext:
 
         # Temporary buffer for transfers (same layout as
         # GPUCacheContext but on CPU).
-        self.max_batch_size = 4
+        self._max_batch_size = 4
         self.tmp_chunk_group_offsets_: list[int] = [0]
         for group_idx, group in enumerate(
             self.kv_layer_groups_manager_.kv_layer_groups
@@ -224,14 +220,9 @@ class CpuCacheContext:
         return self.kv_caches_[0].dtype
 
     @property
-    def device(self) -> torch.device:
-        """Returns the device (always CPU)."""
-        return self.device_
-
-    @property
-    def kv_tensors(self) -> list[torch.Tensor]:
-        """Returns the list of per-layer KV cache tensors."""
-        return self.kv_caches_
+    def max_batch_size(self) -> int:
+        """Returns the maximum number of concurrent batches."""
+        return self._max_batch_size
 
     @property
     def kv_pointers(self) -> torch.Tensor:
@@ -264,26 +255,6 @@ class CpuCacheContext:
         return self.kv_layer_groups_manager_.kv_layer_groups[0].shape_desc.bs
 
     @property
-    def num_layers(self) -> int:
-        """Returns the number of layers in the model."""
-        return self.num_layers_
-
-    @property
-    def num_blocks(self) -> int:
-        """Returns the number of blocks in the KV cache."""
-        return self.num_blocks_
-
-    @property
-    def is_mla(self) -> bool:
-        """Returns whether the model uses MLA."""
-        return self.is_mla_
-
-    @property
-    def hidden_dim_sizes(self) -> list[int]:
-        """Returns hidden dimension sizes per KV layer group."""
-        return self.hidden_dim_sizes_
-
-    @property
     def group_slots_per_blocks(self) -> list[int]:
         """Per-group physical slot count (``shape_desc.bs``) in group
         order."""
@@ -291,67 +262,6 @@ class CpuCacheContext:
             group.shape_desc.bs
             for group in self.kv_layer_groups_manager_.kv_layer_groups
         ]
-
-    @property
-    def kv_layer_groups_manager(self) -> KVLayerGroupsManager:
-        """Returns the KV layer groups manager."""
-        return self.kv_layer_groups_manager_
-
-    @property
-    def engine_kv_format_(self):
-        """Returns the GPU KV format enum (API parity with GPUCacheContext)."""
-        return self._engine_kv_format
-
-    @property
-    def engine_kv_shape(self) -> str:
-        """Returns the symbolic GPU KV cache layout description."""
-        return get_engine_kv_shape_description(self._engine_kv_format)
-
-    @property
-    def attention_backend(self) -> str:
-        """Returns the attention backend name."""
-        return get_attention_backend(self._engine_kv_format)
-
-    @property
-    def concrete_engine_kv_shape(self) -> str:
-        """Returns the engine KV shape with actual numeric values."""
-        group = self.kv_layer_groups_manager_.kv_layer_groups[0]
-        return get_concrete_engine_kv_shape_from_shape_desc(
-            group.shape_desc, self._engine_kv_format
-        )
-
-    def calculate_num_blocks(self, num_tokens: int, kernel_group_idx: int) -> int:
-        """Calculate the number of blocks for a given number of tokens.
-
-        Mirrors :meth:`GPUCacheContext.calculate_num_blocks`.
-
-        Args:
-            num_tokens: The total number of tokens to be processed.
-            kernel_group_idx: 0-based index of the kernel group.
-
-        Returns:
-            The number of blocks.
-        """
-        return self.kv_layer_groups_manager_.calculate_num_blocks(
-            kernel_group_idx, num_tokens
-        )
-
-    def get_shape_desc(self, group_idx: int) -> "lmc_ops.PageBufferShapeDesc":
-        """Returns the PageBufferShapeDesc for the given group."""
-        return self.kv_layer_groups_manager_.get_shape_desc(group_idx)
-
-    def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
-        """Returns the number of slots per lmcache chunk when doing D/H transfer.
-
-        Mirrors :meth:`GPUCacheContext.get_slots_per_chunk_in_sw`.
-
-        Args:
-            kernel_group_idx: Index of the kernel group.
-
-        Returns:
-            The number of used slots per lmcache chunk when doing D/H transfer.
-        """
-        return self.kv_layer_groups_manager_.get_slots_per_chunk_in_sw(kernel_group_idx)
 
     def blocks_for_tokens(self, num_logical_tokens: int, group_idx: int) -> int:
         """Number of blocks that span *num_logical_tokens* for a group.
@@ -408,30 +318,6 @@ class CpuCacheContext:
             (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
         )
         return shape, group.dtype
-
-    def get_kv_buffer_shape(
-        self, logical_num_tokens: int, group_idx: int = 0
-    ) -> torch.Size:
-        """Returns the KV buffer shape for the given number of
-        *logical* tokens.
-
-        Mirrors :meth:`GPUCacheContext.get_kv_buffer_shape`:
-        divides by ``compress_ratio`` and uses ``sd.kv_size`` so
-        compressed groups (MLA etc.) get the correct shape.
-        """
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
-        compress_ratio = group.tokens_per_block // group.slots_per_block
-        if logical_num_tokens % compress_ratio != 0:
-            raise ValueError(
-                "logical_num_tokens (%d) is not a multiple of "
-                "compress_ratio (%d) for group %d"
-                % (logical_num_tokens, compress_ratio, group_idx)
-            )
-        num_slots = logical_num_tokens // compress_ratio
-        sd = group.shape_desc
-        return torch.Size(
-            (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
-        )
 
     def get_tmp_gpu_buffer_flat(self, chunk_idx: int) -> torch.Tensor:
         """Returns the flat uint8 temp buffer for the given chunk."""
@@ -548,88 +434,6 @@ class CpuCacheContext:
         buf = self.block_ids_buffer_[:n]
         buf.copy_(cpu_tensor)
         return buf
-
-    def copy_view_block_ids_to_gpu(
-        self, block_ids_per_group: list[list[int]]
-    ) -> list[torch.Tensor]:
-        """CPU-side counterpart to ``GPUCacheContext.copy_view_block_ids_to_gpu``.
-
-        Packs all per-group block IDs into the shared CPU buffer and
-        returns one non-overlapping view per LMCache group. The name
-        is kept for API parity; on a CPU-only host the buffer simply
-        lives on the host.
-        """
-        offsets = [0]
-        flat: array.array = array.array("l")
-        for view_block_ids in block_ids_per_group:
-            flat.extend(view_block_ids)
-            offsets.append(len(flat))
-
-        total = offsets[-1]
-        if total > self.block_ids_buffer_.shape[0]:
-            raise ValueError(
-                "block ID total %d exceeds the pre-allocated buffer "
-                "size %d" % (total, self.block_ids_buffer_.shape[0])
-            )
-        if total:
-            cpu_tensor = torch.frombuffer(flat, dtype=torch.long)
-            self.block_ids_buffer_[:total].copy_(cpu_tensor)
-
-        return [
-            self.block_ids_buffer_[offsets[i] : offsets[i + 1]]
-            for i in range(len(block_ids_per_group))
-        ]
-
-    def report_status(self) -> dict:
-        """Return this context's KV cache layout metadata.
-
-        Mirrors :meth:`GPUCacheContext.report_status` so
-        ``GPUTransferModule.report_status`` can duck-type across backends.
-        """
-        manager = self.kv_layer_groups_manager_
-        kernel_groups = manager.kernel_groups
-
-        kernel_group_to_object_group: dict[int, int] = {
-            kg_idx: og_idx
-            for og_idx, og in enumerate(manager.object_groups)
-            for kg_idx in og.kernel_group_indices
-        }
-
-        engine_kv_format = self._engine_kv_format
-        group_reports: list[dict] = []
-        for kernel_group_idx, group in enumerate(kernel_groups):
-            group_reports.append(
-                {
-                    "kernel_group_idx": kernel_group_idx,
-                    "engine_group_idx": group.engine_group_idx,
-                    "object_group_idx": kernel_group_to_object_group.get(
-                        kernel_group_idx, 0
-                    ),
-                    "num_layers": group.num_layers,
-                    "layer_indices": list(group.layer_indices),
-                    "tokens_per_block": group.tokens_per_block,
-                    "slots_per_block": group.slots_per_block,
-                    "dtype": str(group.dtype),
-                    "engine_kv_concrete_shape": (
-                        get_concrete_engine_kv_shape_from_shape_desc(
-                            group.shape_desc, engine_kv_format
-                        )
-                    ),
-                    "is_mla": is_mla(engine_kv_format),
-                    "engine_kv_format": engine_kv_format.name,
-                    "engine_kv_shape": get_engine_kv_shape_description(
-                        engine_kv_format
-                    ),
-                    "attention_backend": get_attention_backend(engine_kv_format),
-                }
-            )
-
-        return {
-            "num_layers": self.num_layers_,
-            "num_blocks": self.num_blocks_,
-            "cache_size_per_token": self.cache_size_per_token(),
-            "kernel_groups": group_reports,
-        }
 
     def cache_size_per_token(self) -> int:
         """Returns cache size per *logical* token in bytes,


### PR DESCRIPTION
GPUCacheContext and CpuCacheContext were duck-typing through a bunch of shared properties and methods. Extract them into a BaseCacheContext ABC with class-level annotations so both type-checkers and humans can see the contract clearly.