### PR TITLE
feat(mp): introduce device-agnostic DeviceIPCWrapper base for KV-cache IPC

### DIFF
--- a/docs/design/v1/multiprocess/device_ipc_wrapper_design.md
+++ b/docs/design/v1/multiprocess/device_ipc_wrapper_design.md
@@ -1,0 +1,67 @@
+# `DeviceIPCWrapper` — a device-agnostic base for KV-cache IPC
+
+## Motivation
+
+The multiprocess (MP) transport shares a paged KV-cache buffer between the producer process (vLLM / SGLang / TRT-LLM) and the LMCache server by sending an IPC handle for the underlying storage once, at `REGISTER_KV_CACHE` time. Every later `STORE`/`RETRIEVE` carries only paged block IDs, never tensors.
+
+Historically all of these handle wrappers subclassed `CudaIPCWrapper`:
+
+```text
+CudaIPCWrapper
+├── RawCudaIPCWrapper      (TRT-LLM raw cudaMalloc pool)
+└── CpuShmTensorWrapper    (CPU POSIX-SHM, in platform/cpu/shm.py)
+```
+
+In fact a CPU shared-memory wrapper and a TRT-LLM raw-pointer wrapper are not CUDA caching-allocator tensors, yet they inherited `_share_cuda_`- based machinery they never used. It also made non-CUDA backends impossible to add cleanly.
+
+## The new hierarchy
+
+A device-agnostic base, `DeviceIPCWrapper`, now owns everything that is not transport-specific. Each concrete wrapper is a direct sibling:
+
+```text
+DeviceIPCWrapper                        base: contract + (de)serialize
+├── CudaIPCWrapper                      cuda  — torch caching allocator
+├── RawCudaIPCWrapper                   cuda — raw cudaMalloc, TRT-LLM
+└── CpuShmTensorWrapper                 cpu   — POSIX shared memory
+```
+
+All of them live behind a single msgspec ext code 1 and a single `KVCache = list[DeviceIPCWrapper]` wire type, so new device backends can be added as further siblings without touching the wire format.
+
+## What the base class owns
+
+`DeviceIPCWrapper` (in `custom_types.py`) provides the parts that every transport shares:
+
+- **Interface fields** — `dtype`, `shape`, `stride`, `storage_offset`, `device_uuid`. Subclasses populate these in `__init__`; the base uses them for equality and the receiving side uses them to rebuild the logical view.
+- **Device discovery** — `_get_device_uuid`, `_discover_devices`,`_get_device_index_from_uuid`. These are `@classmethod`s (not static) and route through the `torch_dev` abstraction, so they work across device backends, and a subclass can override `_get_device_uuid` if its backend needs a different identity source.
+- **Equality** — `__eq__` uses a `type(self) is type(other)` guard, so two different wrapper subclasses never compare equal even if their fields coincide.
+- **Serialization** — `Serialize`/`Deserialize` are `pickle.dumps` / `pickle.loads`. Pickle preserves the concrete subclass identity across the wire, which is what lets a single ext code carry every wrapper type (see below).
+- **`to_tensor()`** — abstract; raises `NotImplementedError`. Every subclass overrides it with its transport-specific reconstruction.
+
+## How to dispatch
+
+- `_CUSTOMERIZED_SERIALIZERS` is keyed on `DeviceIPCWrapper` with ext code 1, dispatched by `isinstance` in the encoder hook. Every subclass instance therefore encodes through the same path.
+- `Serialize` is `pickle.dumps(obj)` -> the concrete subclass survives on the wire. `Deserialize` reconstructs it and `to_tensor()` dispatches to the correct override.
+- `KVCache = list[DeviceIPCWrapper]` is the registered msgspec type, so a single `list[...]` payload can mix any of the wrappers and the server needs zero per-type branching.
+
+## The concrete wrappers
+
+| Wrapper | Device type | Transport | Reconstruction |
+|---|---|---|---|
+| `CudaIPCWrapper` | `cuda` | `UntypedStorage._share_cuda_()` | `_new_shared_cuda` + `set_()` |
+| `RawCudaIPCWrapper` | `cuda` | `cudaIpcGetMemHandle` (raw ptr) | `cudaIpcOpenMemHandle` → CuPy → DLPack |
+| `CpuShmTensorWrapper` | `cpu` | POSIX `shm_open` | `mmap` same segment |
+
+## Platform registration
+
+The factory lookup (`platform/_registry.py`) keys on `tensor.device.type`, so the integration adapter never has an if/elif chain. Each platform sub-package self-registers at import time:
+
+```text
+platform/cuda/__init__.py  ->  register_kv_wrapper("cuda", CudaIPCWrapper)
+platform/cpu/__init__.py   ->  register_kv_wrapper("cpu",  migrate_to_shm_and_wrap)
+```
+
+## Backward compatibility
+
+- Wire format is unchanged. Still ext code 1, still `pickle`-over-`Ext`. Previously serialized payloads round-trip.
+- `CudaIPCWrapper` / `RawCudaIPCWrapper` keep their names, fields, and behavior; only their base class changed. Existing callers and the TRT-LLM adapter are unaffected.
+- The single `isinstance`-based equality check now uses `type(self) is type(other)`, which is stricter and correct.

--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -68,6 +68,7 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
 if TYPE_CHECKING:
     # First Party
     from lmcache.cli.commands.base import BaseCommand
+    from lmcache.v1.multiprocess.custom_types import KVCache
 
 
 # Stash the original (full-install) ImportError so the parser-stub
@@ -452,7 +453,7 @@ def run_server_bench(
             log(
                 "Allocated %d GPU tensors on %s" % (len(allocated), allocated[0].device)
             )
-            kv_wrappers = [CudaIPCWrapper(t) for t in allocated]
+            kv_wrappers: KVCache = [CudaIPCWrapper(t) for t in allocated]
             # Keep the CUDA tensors alive for the lifetime of the
             # bench process -- storage may be reclaimed otherwise --
             # and reuse the same list as the client-side data-mode
@@ -476,7 +477,7 @@ def run_server_bench(
         # Register KV cache before any store/retrieve. In handle mode
         # both GPU (CUDA-IPC) and CPU (POSIX-SHM) paths share the same
         # ``REGISTER_KV_CACHE`` protocol since ``CpuShmTensorWrapper``
-        # is a ``CudaIPCWrapper`` subclass on the wire. In data mode
+        # is a ``DeviceIPCWrapper`` subclass on the wire. In data mode
         # we fall through to the non-GPU registration protocol.
         register_result = _send_register_kv_cache(
             client,

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -55,8 +55,8 @@ try:
         KVLayerGroupInfo,
     )
     from lmcache.v1.multiprocess.custom_types import (
-        CudaIPCWrapper,
         IPCCacheServerKey,
+        KVCache,
         RegisterEngineDrivenContextPayload,
     )
     from lmcache.v1.multiprocess.futures import MessagingFuture
@@ -321,7 +321,7 @@ def _send_register_kv_cache(
     model_name: str = _MODEL_NAME,
     world_size: int = _WORLD_SIZE,
     layout_hints: dict | None = None,
-    kv_caches: list[CudaIPCWrapper] | None = None,
+    kv_caches: KVCache | None = None,
     use_gpu: bool = True,
     use_handle: bool | None = None,
     engine_group_infos: "list[EngineGroupInfo] | None" = None,

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+# Future
+from __future__ import annotations
+
 # Standard
 from dataclasses import dataclass
 from typing import Optional
@@ -30,6 +33,7 @@ from lmcache.utils import EngineType
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheServerKey,
+    KVCache,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType
@@ -40,17 +44,18 @@ logger = init_logger(__name__)
 def _wrap_sglang_kv_caches(
     k_pool: list[torch.Tensor],
     v_pool: list[torch.Tensor],
-) -> list[CudaIPCWrapper]:
+) -> KVCache:
     """Flatten SGLang's depth-2 ``[K_layers, V_layers]`` KV layout into a
-    single flat ``list[CudaIPCWrapper]`` so it fits upstream's wire
+    single flat ``KVCache`` so it fits upstream's wire
     ``KVCache`` payload type. The daemon's
     :func:`normalize_kv_and_discover_format` recognizes this shape from
     ``EngineType.SGLANG`` plus a ``tokens_per_block`` ``LayoutHints`` field
     and splits it back at its midpoint before format detection.
     """
-    return [CudaIPCWrapper(tensor) for tensor in k_pool] + [
-        CudaIPCWrapper(tensor) for tensor in v_pool
-    ]
+    wrapped: KVCache = []
+    wrapped.extend(CudaIPCWrapper(tensor) for tensor in k_pool)
+    wrapped.extend(CudaIPCWrapper(tensor) for tensor in v_pool)
+    return wrapped
 
 
 @dataclass
@@ -137,7 +142,7 @@ class LMCacheMPConnector:
         # (instance_id, kv_cache, model_name, world_size, engine_type,
         # layout_hints, engine_group_infos). SGLang's natural KV layout is depth-2
         # ([K_layers, V_layers]); we flatten it on the wire to fit
-        # ``KVCache = list[CudaIPCWrapper]``. The daemon recognizes the
+        # ``KVCache = list[DeviceIPCWrapper]``. The daemon recognizes the
         # SGLang-MHA flat-of-2NL pattern from ``EngineType.SGLANG`` plus the
         # ``tokens_per_block`` hint and un-flattens + reshapes per layer.
         # SGLang is non-hybrid (a single KV cache group), so engine_group_infos is the

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -23,49 +23,95 @@ Key Types:
 """
 
 
-class CudaIPCWrapper:
+class DeviceIPCWrapper:
+    """Base class for KV-cache IPC wrapper.
+
+    Holds the device-agnostic mechanism shared by all transports: the
+    interface fields (``dtype``/``shape``/``stride``/``storage_offset``/
+    ``device_uuid``), UUID<->ordinal discovery via the ``torch_dev``
+    abstraction, equality, and pickle-based (de)serialization.
+
+    Every wire-level wrapper subclasses this so they share the single
+    msgspec ext code (1) registered for ``DeviceIPCWrapper``: pickle
+    preserves the concrete subclass identity across the wire so
+    ``to_tensor`` dispatches correctly on the receiving side.
+
+    Subclasses implement ``__init__`` (populate the interface fields from a
+    tensor) and ``to_tensor`` (reconstruct the tensor from the handle).
+    """
+
     _discovered_device_mapping: dict[str, int] = {}
     _device_mapping_lock = threading.Lock()
 
-    @staticmethod
-    def _get_device_uuid(device_index: int) -> str:
-        """Get the UUID of a GPU device given its index."""
+    @classmethod
+    def _get_device_uuid(cls, device_index: int) -> str:
+        """Get the UUID of a device given its index."""
         return str(torch_dev.get_device_properties(device_index).uuid)
 
-    @staticmethod
-    def _discover_gpu_devices():
-        """Discover all available GPU devices and map their UUIDs to
-        the physical device ordinals.
+    @classmethod
+    def _discover_devices(cls):
+        """Discover all available accelerator devices and map their UUIDs
+        to the physical device ordinals.
         """
         if not torch_dev.is_available():
             return
 
         num_devices = torch_dev.device_count()
-        with CudaIPCWrapper._device_mapping_lock:
-            if CudaIPCWrapper._discovered_device_mapping:
+        with DeviceIPCWrapper._device_mapping_lock:
+            if DeviceIPCWrapper._discovered_device_mapping:
                 return  # Already discovered
 
             for i in range(num_devices):
-                device_uuid = CudaIPCWrapper._get_device_uuid(i)
-                CudaIPCWrapper._discovered_device_mapping[device_uuid] = i
+                device_uuid = cls._get_device_uuid(i)
+                DeviceIPCWrapper._discovered_device_mapping[device_uuid] = i
 
-    @staticmethod
-    def _get_device_index_from_uuid(device_uuid: str) -> int:
+    @classmethod
+    def _get_device_index_from_uuid(cls, device_uuid: str) -> int:
         """Get the physical device ordinal from its UUID."""
-        CudaIPCWrapper._discover_gpu_devices()
+        cls._discover_devices()
 
-        with CudaIPCWrapper._device_mapping_lock:
-            device_index = CudaIPCWrapper._discovered_device_mapping.get(
+        with DeviceIPCWrapper._device_mapping_lock:
+            device_index = DeviceIPCWrapper._discovered_device_mapping.get(
                 device_uuid, None
             )
 
         if device_index is None:
             raise RuntimeError(
-                f"Device UUID {device_uuid} not found in the discovered devices."
-                "Please make sure the process can see all the GPU devices"
+                f"Device UUID {device_uuid} not found in the discovered "
+                "devices. Please make sure the process can see all the "
+                "accelerator devices"
             )
         return device_index
 
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the tensor in this process from the IPC handle.
+
+        Subclasses implement the transport-specific reconstruction.
+        """
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+        return (
+            self.handle == other.handle
+            and self.dtype == other.dtype
+            and self.shape == other.shape
+            and self.stride == other.stride
+            and self.storage_offset == other.storage_offset
+            and self.device_uuid == other.device_uuid
+        )
+
+    @staticmethod
+    def Serialize(obj: "DeviceIPCWrapper") -> bytes:
+        return pickle.dumps(obj)
+
+    @staticmethod
+    def Deserialize(data: bytes) -> "DeviceIPCWrapper":
+        return pickle.loads(data)
+
+
+class CudaIPCWrapper(DeviceIPCWrapper):
     def __init__(self, tensor: torch.Tensor):
         # First Party
         from lmcache.v1.gpu_connector.kv_format.contiguity import (
@@ -87,7 +133,7 @@ class CudaIPCWrapper:
         self.storage_offset = int(tensor.storage_offset())
 
         device_index = tensor.device.index
-        self.device_uuid = CudaIPCWrapper._get_device_uuid(device_index)
+        self.device_uuid = self._get_device_uuid(device_index)
 
     def to_tensor(self) -> torch.Tensor:
         """
@@ -96,7 +142,7 @@ class CudaIPCWrapper:
             We should call `torch_dev.init()` before using this function
             (guarded by hasattr since not all backends expose init()).
         """
-        device_index = CudaIPCWrapper._get_device_index_from_uuid(self.device_uuid)
+        device_index = self._get_device_index_from_uuid(self.device_uuid)
 
         storage = torch.UntypedStorage._new_shared_cuda(  # noqa: SLF001
             device_index, *self.handle[1:]
@@ -108,28 +154,8 @@ class CudaIPCWrapper:
         t.set_(storage, self.storage_offset, self.shape, self.stride)
         return t
 
-    def __eq__(self, other):
-        if not isinstance(other, CudaIPCWrapper):
-            return False
-        return (
-            self.handle == other.handle
-            and self.dtype == other.dtype
-            and self.shape == other.shape
-            and self.stride == other.stride
-            and self.storage_offset == other.storage_offset
-            and self.device_uuid == other.device_uuid
-        )
 
-    @staticmethod
-    def Serialize(obj: "CudaIPCWrapper") -> bytes:
-        return pickle.dumps(obj)
-
-    @staticmethod
-    def Deserialize(data: bytes) -> "CudaIPCWrapper":
-        return pickle.loads(data)
-
-
-class RawCudaIPCWrapper(CudaIPCWrapper):
+class RawCudaIPCWrapper(DeviceIPCWrapper):
     """IPC wrapper for CUDA tensors allocated outside PyTorch's caching
     allocator.
 
@@ -141,12 +167,13 @@ class RawCudaIPCWrapper(CudaIPCWrapper):
     the tensor on the receiving side via ``cudaIpcOpenMemHandle`` plus
     a CuPy ``UnownedMemory`` → DLPack → ``torch`` round-trip.
 
-    Subclassing (rather than introducing a parallel class with its own
-    msgspec ext code) is load-bearing — msgspec does not support unions
-    of custom ext-encoded types. With subclassing, ``KVCache =
-    list[CudaIPCWrapper]`` continues to type-check, the existing ext
-    code 1 round-trips both wrappers, and pickle preserves the subclass
-    identity through the wire so ``to_tensor`` dispatches correctly.
+    Sharing the ``DeviceIPCWrapper`` base (rather than introducing a
+    parallel class with its own msgspec ext code) is load-bearing —
+    msgspec does not support unions of custom ext-encoded types. With a
+    common base, ``KVCache = list[DeviceIPCWrapper]`` type-checks, the
+    single ext code 1 round-trips every wrapper, and pickle preserves
+    the concrete subclass identity through the wire so ``to_tensor``
+    dispatches correctly.
     """
 
     def __init__(self, tensor: torch.Tensor) -> None:
@@ -173,9 +200,9 @@ class RawCudaIPCWrapper(CudaIPCWrapper):
         self._ipc_handle_reserved = bytes(ipc_handle.reserved)
         self._nbytes = tensor.untyped_storage().nbytes()
 
-        # CudaIPCWrapper interface fields. ``handle`` is unused —
-        # ``to_tensor`` is overridden to bypass it — but kept for
-        # equality/identity checks against the parent class.
+        # DeviceIPCWrapper interface fields. ``handle`` is unused —
+        # ``to_tensor`` is overridden to bypass it — but kept (None) so
+        # the base-class equality check has a value to compare.
         self.handle = None
         self.dtype = tensor.dtype
         self.shape = tuple(tensor.shape)
@@ -183,7 +210,7 @@ class RawCudaIPCWrapper(CudaIPCWrapper):
         self.storage_offset = int(tensor.storage_offset())
 
         device_index = tensor.device.index
-        self.device_uuid = CudaIPCWrapper._get_device_uuid(device_index)
+        self.device_uuid = self._get_device_uuid(device_index)
 
     def to_tensor(self) -> torch.Tensor:
         """Reconstruct the tensor in this process via raw CUDA IPC."""
@@ -197,7 +224,7 @@ class RawCudaIPCWrapper(CudaIPCWrapper):
             # Third Party
             from cuda import cudart
 
-        device_index = CudaIPCWrapper._get_device_index_from_uuid(self.device_uuid)
+        device_index = self._get_device_index_from_uuid(self.device_uuid)
 
         handle = cudart.cudaIpcMemHandle_t()
         handle.reserved = self._ipc_handle_reserved
@@ -314,7 +341,7 @@ class IPCCacheServerKey:
 
 
 # Type exports
-KVCache = list[CudaIPCWrapper]
+KVCache = list[DeviceIPCWrapper]
 
 
 class RegisterEngineDrivenContextPayload(msgspec.Struct):
@@ -407,9 +434,9 @@ class CBUnifiedLookupResult:
 
 
 _CUSTOMERIZED_SERIALIZERS = {
-    CudaIPCWrapper: CustomizedSerdeConfig(
-        serializer=CudaIPCWrapper.Serialize,
-        deserializer=CudaIPCWrapper.Deserialize,
+    DeviceIPCWrapper: CustomizedSerdeConfig(
+        serializer=DeviceIPCWrapper.Serialize,
+        deserializer=DeviceIPCWrapper.Deserialize,
         code=1,
     ),
 }

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -41,7 +41,7 @@ from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.multiprocess.custom_types import (
     CBMatchResult,
     CBUnifiedLookupResult,
-    CudaIPCWrapper,
+    DeviceIPCWrapper,
     IPCCacheServerKey,
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
@@ -441,7 +441,7 @@ class BlendV3Module(InstanceLivenessTarget):
     def cb_register_rope(
         self,
         instance_id: int,
-        cos_sin_cache_ipc: CudaIPCWrapper,
+        cos_sin_cache_ipc: DeviceIPCWrapper,
         head_size: int,
         is_neox_style: bool,
     ) -> None:
@@ -453,7 +453,7 @@ class BlendV3Module(InstanceLivenessTarget):
 
         Args:
             instance_id (int): KV-cache instance to attach rope state to.
-            cos_sin_cache_ipc (CudaIPCWrapper): IPC handle to vLLM's cos/sin
+            cos_sin_cache_ipc (DeviceIPCWrapper): IPC handle to vLLM's cos/sin
                 rope cache.
             head_size (int): Rotary head dimension.
             is_neox_style (bool): True for NeoX (contiguous halves), else GPT-J.

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -18,7 +18,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.multiprocess.affinity_pool import AffinityThreadPool
 from lmcache.v1.multiprocess.custom_types import (
-    CudaIPCWrapper,
+    DeviceIPCWrapper,
     get_customized_decoder,
     get_customized_encoder,
 )
@@ -64,13 +64,13 @@ def unwrap_request_payloads(
 
 
 _SPECIAL_ENCODER_DECODERS = {
-    CudaIPCWrapper: (
-        get_customized_encoder(CudaIPCWrapper),
-        get_customized_decoder(CudaIPCWrapper),
+    DeviceIPCWrapper: (
+        get_customized_encoder(DeviceIPCWrapper),
+        get_customized_decoder(DeviceIPCWrapper),
     ),
-    list[CudaIPCWrapper]: (
-        get_customized_encoder(list[CudaIPCWrapper]),
-        get_customized_decoder(list[CudaIPCWrapper]),
+    list[DeviceIPCWrapper]: (
+        get_customized_encoder(list[DeviceIPCWrapper]),
+        get_customized_decoder(list[DeviceIPCWrapper]),
     ),
     MemoryLayoutDesc: (
         get_customized_encoder(MemoryLayoutDesc),

--- a/lmcache/v1/multiprocess/protocols/blend_v3.py
+++ b/lmcache/v1/multiprocess/protocols/blend_v3.py
@@ -5,7 +5,7 @@
 from lmcache.v1.multiprocess.custom_types import (
     CBMatchResult,
     CBUnifiedLookupResult,
-    CudaIPCWrapper,
+    DeviceIPCWrapper,
     IPCCacheServerKey,
 )
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
@@ -25,7 +25,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Payload: (instance_id, cos_sin_cache_ipc, head_size, is_neox_style).
         # Returns: None.
         "CB_REGISTER_ROPE_V3": ProtocolDefinition(
-            payload_classes=[int, CudaIPCWrapper, int, bool],
+            payload_classes=[int, DeviceIPCWrapper, int, bool],
             response_class=None,
             handler_type=HandlerType.SYNC,
         ),

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -26,7 +26,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
+from lmcache.v1.multiprocess.custom_types import DeviceIPCWrapper
 from lmcache.v1.multiprocess.posix_shm import (
     shm_create_readwrite,
     shm_map_readwrite,
@@ -54,7 +54,7 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-class CpuShmTensorWrapper(CudaIPCWrapper):
+class CpuShmTensorWrapper(DeviceIPCWrapper):
     """IPC wrapper for CPU tensors backed by POSIX shared memory.
 
     Used by the ``lmcache bench kvcache --mode cpu`` path and the
@@ -62,11 +62,11 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
     map the **same** physical pages for the KV cache, mirroring the
     GPU-mode CUDA-IPC zero-copy semantics.
 
-    Subclassing :class:`CudaIPCWrapper` is load-bearing for the same
+    Subclassing :class:`DeviceIPCWrapper` is load-bearing for the same
     reason :class:`RawCudaIPCWrapper` does it: msgspec does not
     support unions of custom ext-encoded types, so all wire-level
     KV-cache wrappers must share the single ext code (1) registered
-    for ``CudaIPCWrapper``. Pickle preserves the subclass identity
+    for ``DeviceIPCWrapper``. Pickle preserves the subclass identity
     so ``to_tensor`` dispatches correctly on both sides.
     """
 
@@ -87,8 +87,8 @@ class CpuShmTensorWrapper(CudaIPCWrapper):
         # underlying storage may be larger when the tensor is a view.
         self.nbytes = tensor.numel() * tensor.element_size()
 
-        # CudaIPCWrapper interface fields. ``handle`` / ``device_uuid``
-        # are unused on the CPU path but kept to satisfy the parent
+        # DeviceIPCWrapper interface fields. ``handle`` / ``device_uuid``
+        # are unused on the CPU path but kept to satisfy the base
         # contract used by equality checks.
         self.handle = None
         self.dtype = tensor.dtype

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -363,32 +363,32 @@ class TestRawCudaIPCWrapperType:
     def test_is_subclass(self) -> None:
         # First Party
         from lmcache.v1.multiprocess.custom_types import (
-            CudaIPCWrapper,
+            DeviceIPCWrapper,
             RawCudaIPCWrapper,
         )
 
-        assert issubclass(RawCudaIPCWrapper, CudaIPCWrapper)
+        assert issubclass(RawCudaIPCWrapper, DeviceIPCWrapper)
 
     def test_kvcache_typing_unchanged(self) -> None:
-        """``KVCache = list[CudaIPCWrapper]`` should accept subclass items
+        """``KVCache = list[DeviceIPCWrapper]`` should accept concrete wrappers
         — load-bearing for msgspec ext-code reuse over ZMQ.
         """
         # First Party
         from lmcache.v1.multiprocess.custom_types import (
-            CudaIPCWrapper,
+            DeviceIPCWrapper,
             KVCache,
             RawCudaIPCWrapper,
         )
 
-        assert KVCache == list[CudaIPCWrapper]
-        # Static check substitute: a Raw* instance fits the list type.
-        assert issubclass(RawCudaIPCWrapper, CudaIPCWrapper)
+        assert KVCache == list[DeviceIPCWrapper]
+        # Static check substitute: a concrete wrapper fits the list type.
+        assert issubclass(RawCudaIPCWrapper, DeviceIPCWrapper)
 
     def test_serde_uses_shared_ext_code(self) -> None:
-        """Ext code 1 dispatches to ``CudaIPCWrapper`` (shared with subclass)."""
+        """Ext code 1 dispatches via ``DeviceIPCWrapper`` for all wrappers."""
         # First Party
         from lmcache.v1.multiprocess import custom_types
 
         registry = custom_types._CUSTOMERIZED_SERIALIZERS  # noqa: PLC2701
-        assert custom_types.CudaIPCWrapper in registry
-        assert registry[custom_types.CudaIPCWrapper].code == 1
+        assert custom_types.DeviceIPCWrapper in registry
+        assert registry[custom_types.DeviceIPCWrapper].code == 1


### PR DESCRIPTION
All KV-cache IPC wrappers (CUDA, CPU-SHM, TRT-LLM raw-CUDA) previously subclassed `CudaIPCWrapper` — a naming and structural pattern that made non-CUDA backends impossible to add cleanly.  This change introduces a device-agnostic base class and reparents the existing wrappers onto it.

lmcache/v1/multiprocess/custom_types.py
  - Add `DeviceIPCWrapper` (new base): holds the shared interface fields :dtype, shape, stride, storage_offset, device_uuid.
  - `CudaIPCWrapper` reparented to `DeviceIPCWrapper`.
  - `RawCudaIPCWrapper` reparented to `DeviceIPCWrapper`.
  - Update `list[CudaIPCWrapper]` to `list[DeviceIPCWrapper]`.
  - `_CUSTOMERIZED_SERIALIZERS` ext-code-1 key updated to `DeviceIPCWrapper`; pickle still preserves concrete subclass identity through the wire so `to_tensor()` dispatches correctly.

lmcache/v1/platform/cpu/shm.py
  - `CpuShmTensorWrapper` reparented to `DeviceIPCWrapper`.

lmcache/v1/multiprocess/mq.py
  - Import and `_SPECIAL_ENCODER_DECODERS` keys updated: `CudaIPCWrapper` / `list[CudaIPCWrapper]` -> `DeviceIPCWrapper` / `list[DeviceIPCWrapper]`.

lmcache/v1/multiprocess/protocols/blend_v3.py
lmcache/v1/multiprocess/modules/blend_v3.py
  - Import and payload-class / type-annotation references updated to `DeviceIPCWrapper`.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Pls refer https://github.com/LMCache/LMCache/issues/3675.  Add RawSyclIPCWrapper to support intel xpu for next step. 

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
