### PR TITLE
[Obs] Add cb.coordinator_match observability span for coordinator blend lookup

### DIFF
--- a/docs/design/v1/mp_observability/blend_v3_observability.md
+++ b/docs/design/v1/mp_observability/blend_v3_observability.md
@@ -38,6 +38,7 @@ cb.request                         [scheduler — root]  request_id, model, worl
 │  ├─ cb.lookup.rpc                [scheduler]  CB_UNIFIED_LOOKUP incl. N poll re-issues; attr: n_polls
 │  │  └─ cb.lookup                 [SERVER]  ← cross-process child; attr prefix_chunks
 │  │     ├─ cb.fingerprint_match   [server]  n_probes, table_hits, matches (token-stride=1, any offset)
+│  │     │  (cb.coordinator_match instead, when a coordinator is configured)  matches, timed_out
 │  │     │  (no cb.prefix_lookup span — prefix is traced by mp.lookup_prefetch)
 │  │     ├─ cb.sparse_prefetch     [server]  n_keys, l1_hits, l2_misses
 │  │     │  └─ cb.l2_load          [server·IO]  chunks, bytes, ms        (coalesced L2→L1)
@@ -97,6 +98,7 @@ timing is GPU-accurate):
 | new event pair | span | timing source |
 |---|---|---|
 | `CB_FINGERPRINT_MATCH_*` | `cb.fingerprint_match` | CPU |
+| `CB_COORDINATOR_MATCH_*` | `cb.coordinator_match` (fleet directory leg; mutually exclusive with the local matcher) | CPU + IO |
 | (prefix lookup) | `mp.lookup_prefetch` (reused; `prefix_chunks` attr on `cb.lookup`) | CPU |
 | `CB_SPARSE_PREFETCH_*` | `cb.sparse_prefetch` (+ existing L2 prefetch span as `cb.l2_load`) | CPU + IO |
 | `CB_SCATTER_*` | `cb.scatter` (re-RoPE folded in via `n_shifted`) | `publish_on_stream` (GPU) |

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -196,7 +196,7 @@ class BlendCoordinatorClient:
         """Build a client from ``LMCACHE_COORDINATOR_*`` env vars if configured.
 
         Reads ``LMCACHE_COORDINATOR_URL`` (required to enable) and
-        ``LMCACHE_COORDINATOR_BLEND_TIMEOUT`` (default 0.05s). This timeout is the
+        ``LMCACHE_COORDINATOR_BLEND_TIMEOUT`` (default 1.0s). This timeout is the
         wall-clock budget on the optional global leg: the blend module polls
         until the match resolves (matches, or ``[]`` on failure) but gives up
         once the budget elapses, so it bounds how long the critical path waits
@@ -211,7 +211,7 @@ class BlendCoordinatorClient:
         url = os.getenv("LMCACHE_COORDINATOR_URL", "").strip()
         if not url:
             return None
-        timeout = float(os.getenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "0.05"))
+        timeout = float(os.getenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "1.0"))
         logger.info("Blend coordinator client enabled -> %s", url)
         return cls(url, request_timeout=timeout, match_budget_s=timeout)
 

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -116,6 +116,10 @@ class EventType(Enum):
     # MP mp.lookup_prefetch span / hit-rate aggregate).
     CB_PREFIX_LOOKUP_START = "cb.prefix_lookup.start"
     CB_PREFIX_LOOKUP_END = "cb.prefix_lookup.end"
+    # Coordinator (fleet directory) match leg — cross-server analogue of
+    # cb.fingerprint_match. Async: START at submit, END on the resolving poll.
+    CB_COORDINATOR_MATCH_START = "cb.coordinator_match.start"
+    CB_COORDINATOR_MATCH_END = "cb.coordinator_match.end"
     CB_SPARSE_PREFETCH_START = "cb.sparse_prefetch.start"
     CB_SPARSE_PREFETCH_END = "cb.sparse_prefetch.end"
 

--- a/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
+++ b/lmcache/v1/mp_observability/subscribers/tracing/cb_server.py
@@ -76,6 +76,7 @@ class BlendTracingSubscriber(EventSubscriber):
         # V3 lookup sub-spans (nest under cb.lookup, see _SPAN_PARENTS).
         EventType.CB_FINGERPRINT_MATCH_START: "cb.fingerprint_match",
         EventType.CB_PREFIX_LOOKUP_START: "cb.prefix_lookup",
+        EventType.CB_COORDINATOR_MATCH_START: "cb.coordinator_match",
         EventType.CB_SPARSE_PREFETCH_START: "cb.sparse_prefetch",
         # V3 retrieve sub-span (nests under cb.retrieve).
         EventType.CB_SCATTER_START: "cb.scatter",
@@ -86,6 +87,7 @@ class BlendTracingSubscriber(EventSubscriber):
     _SPAN_PARENTS: dict[str, str] = {
         "cb.fingerprint_match": "cb.lookup",
         "cb.prefix_lookup": "cb.lookup",
+        "cb.coordinator_match": "cb.lookup",
         "cb.sparse_prefetch": "cb.lookup",
         "cb.scatter": "cb.retrieve",
     }
@@ -97,6 +99,7 @@ class BlendTracingSubscriber(EventSubscriber):
         EventType.CB_STORE_FINAL_END: EventType.CB_STORE_FINAL_START,
         EventType.CB_FINGERPRINT_MATCH_END: EventType.CB_FINGERPRINT_MATCH_START,
         EventType.CB_PREFIX_LOOKUP_END: EventType.CB_PREFIX_LOOKUP_START,
+        EventType.CB_COORDINATOR_MATCH_END: EventType.CB_COORDINATOR_MATCH_START,
         EventType.CB_SPARSE_PREFETCH_END: EventType.CB_SPARSE_PREFETCH_START,
         EventType.CB_SCATTER_END: EventType.CB_SCATTER_START,
     }
@@ -151,6 +154,8 @@ class BlendTracingSubscriber(EventSubscriber):
             EventType.CB_FINGERPRINT_MATCH_END: self._on_end,
             EventType.CB_PREFIX_LOOKUP_START: self._on_start,
             EventType.CB_PREFIX_LOOKUP_END: self._on_end,
+            EventType.CB_COORDINATOR_MATCH_START: self._on_start,
+            EventType.CB_COORDINATOR_MATCH_END: self._on_end,
             EventType.CB_SPARSE_PREFETCH_START: self._on_start,
             EventType.CB_SPARSE_PREFETCH_END: self._on_end,
             # V3 retrieve sub-span (nested under cb.retrieve, GPU-timed)

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -955,6 +955,14 @@ class BlendV3Module(InstanceLivenessTarget):
             job.coord_submitted = self._submit_coordinator_match(key)
             if job.coord_submitted and self._coordinator is not None:
                 job.coord_deadline = time.monotonic() + self._coordinator.match_budget_s
+                # Coordinator match leg: async span, ended on the resolving poll
+                # (or deadline) in _poll_coordinator_match.
+                self._event_bus.publish(
+                    Event(
+                        event_type=EventType.CB_COORDINATOR_MATCH_START,
+                        session_id=rid,
+                    )
+                )
             with self._cb_jobs_lock:
                 self._cb_jobs[rid] = job
 
@@ -1288,11 +1296,24 @@ class BlendV3Module(InstanceLivenessTarget):
             logger.warning(
                 "CB coordinator match deadline exceeded for %s; local-only", rid
             )
+            self._event_bus.publish(
+                Event(
+                    event_type=EventType.CB_COORDINATOR_MATCH_END,
+                    session_id=rid,
+                    metadata={"matches": 0, "timed_out": True},
+                )
+            )
             return []
         coordinator.take_match(rid)
-        if isinstance(poll, list):
-            return self._build_global_segments(poll)
-        return []
+        segments = self._build_global_segments(poll) if isinstance(poll, list) else []
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.CB_COORDINATOR_MATCH_END,
+                session_id=rid,
+                metadata={"matches": len(segments), "timed_out": False},
+            )
+        )
+        return segments
 
     def _build_global_segments(
         self, matches: "list[RemoteMatch]"

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -193,8 +193,16 @@ def test_maybe_from_env(monkeypatch: pytest.MonkeyPatch):
     assert BlendCoordinatorClient.maybe_from_env() is None
 
     monkeypatch.setenv("LMCACHE_COORDINATOR_URL", "http://coord:9300")
+    monkeypatch.delenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", raising=False)
     client = BlendCoordinatorClient.maybe_from_env()
     assert client is not None
+    assert client.match_budget_s == 1.0  # default timeout
+    client.close()
+
+    monkeypatch.setenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "1.5")
+    client = BlendCoordinatorClient.maybe_from_env()
+    assert client is not None
+    assert client.match_budget_s == 1.5  # env override
     client.close()
 
 

--- a/tests/v1/mp_observability/subscribers/tracing/test_cb_server.py
+++ b/tests/v1/mp_observability/subscribers/tracing/test_cb_server.py
@@ -994,6 +994,43 @@ class TestCBLookupSubspans:
         assert spans["cb.lookup"].attributes.get("prefix_chunks") == "2"
         assert spans["cb.sparse_prefetch"].attributes.get("found_keys") == "5"
 
+    def test_coordinator_match_span_nests_under_cb_lookup(self, exporter):
+        bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
+        bus.register_subscriber(BlendTracingSubscriber(SpanRegistry()))
+        bus.start()
+        now = time.time()
+        sid = "cb-coord-match"
+        seq = [
+            (EventType.CB_REQUEST_START, {}),
+            (EventType.CB_LOOKUP_START, {"num_tokens": 1024}),
+            (EventType.CB_COORDINATOR_MATCH_START, {}),
+            (EventType.CB_COORDINATOR_MATCH_END, {"matches": 3, "timed_out": False}),
+            (EventType.CB_LOOKUP_END, {"num_tokens": 1024, "prefix_chunks": 2}),
+            (EventType.CB_REQUEST_END, {}),
+        ]
+        for i, (et, md) in enumerate(seq):
+            bus.publish(
+                Event(
+                    event_type=et,
+                    session_id=sid,
+                    timestamp=now + i * 0.001,
+                    metadata=md,
+                )
+            )
+        time.sleep(0.3)
+        bus.stop()
+
+        spans = self._spans_by_name(exporter, sid)
+        assert "cb.coordinator_match" in spans, (
+            f"missing cb.coordinator_match; have {sorted(spans)}"
+        )
+        assert (
+            spans["cb.coordinator_match"].parent.span_id
+            == spans["cb.lookup"].context.span_id
+        ), "cb.coordinator_match should nest under cb.lookup"
+        assert spans["cb.coordinator_match"].attributes.get("matches") == "3"
+        assert spans["cb.coordinator_match"].attributes.get("timed_out") == "False"
+
     def test_scatter_span_nests_under_cb_retrieve(self, exporter):
         bus = EventBus(EventBusConfig(enabled=True, max_queue_size=100))
         bus.register_subscriber(BlendTracingSubscriber(SpanRegistry()))

--- a/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
+++ b/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
@@ -354,6 +354,9 @@ def _coord_engine(chunk_size: int = 4):
 
     eng = MagicMock(spec=v3_mod.BlendV3Module)
     eng._ctx = SimpleNamespace(chunk_size=chunk_size)
+    # _event_bus is an instance attr (set in __init__), so spec= omits it;
+    # _poll_coordinator_match publishes CB_COORDINATOR_MATCH_END through it.
+    eng._event_bus = MagicMock()
     eng._build_global_segments = v3_mod.BlendV3Module._build_global_segments.__get__(
         eng
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `cb.coordinator_match` OTel span for the coordinator (fleet directory) blend lookup leg, mirroring the existing local `cb.fingerprint_match` span. START fires at submit, END on the resolving poll (or deadline); nests under `cb.lookup`. Mutually exclusive with the local matcher.

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests