### PR TITLE
[MP][P2P] Add transfer channel abstraction for MP mode.

### DIFF
--- a/docs/design/tools/transfer_channel_benchmark/README.md
+++ b/docs/design/tools/transfer_channel_benchmark/README.md
@@ -1,0 +1,1 @@
+../../../../lmcache/tools/transfer_channel_benchmark/README.md

--- a/docs/design/v1/distributed/transfer_channel/overall.md
+++ b/docs/design/v1/distributed/transfer_channel/overall.md
@@ -1,0 +1,213 @@
+# Transfer Channel Design
+
+This document describes the **transfer channel** abstraction
+(`lmcache/v1/distributed/transfer_channel/`): its public API, how a read flows
+end to end, the nixl-backed implementation, and how to add a new implementation.
+
+It is intended for developers using the transfer channel to move L1 memory
+objects between peers, or implementing a new transport backend.
+
+## Purpose
+
+The transfer channel provides **peer-to-peer reads** of registered L1 memory.
+A peer registers its L1 buffer once, exchanges metadata with another peer during
+a handshake, and can then read arbitrary `(offset, size)` regions out of the
+remote peer's L1 buffer into its own. Only **reads** are supported today (a peer
+pulls data from a remote; it never pushes).
+
+The abstraction is transport-agnostic; the only implementation today is
+[`nixl`](#nixl-implementation) (RDMA/UCX via the NIXL bindings).
+
+## Architecture Overview
+
+```
+            ┌──────────────────────────────────────────────┐
+            │            TransferChannelContext              │
+            │  (one per peer; owns the transport + L1 reg.)  │
+            │                                                │
+            │  get_transfer_channel_server()  ── singleton ──┼──► TransferChannelServer
+            │  get_transfer_channel_client(peer_url) ────────┼──► TransferChannelClient (per peer)
+            │  get_transfer_channel_address([(off,size)…])   │
+            │  get_num_connected_clients()                   │
+            │  close()                                       │
+            └───────────────┬──────────────┬─────────────────┘
+                            │              │
+              one per ctx   │              │  one per remote peer
+                            ▼              ▼
+                ┌────────────────┐   ┌────────────────────────┐
+                │ ...Server      │   │ ...Client              │
+                │ handshake REP  │   │ submit_read(local,     │
+                │ (metadata only)│   │             remote)    │
+                │                │   │ query_read_status(id)  │
+                │                │   │ close()                │
+                └────────────────┘   └────────────────────────┘
+```
+
+Each peer constructs **one** `TransferChannelContext`. The context eagerly owns
+exactly one `TransferChannelServer` (bound at construction) and a set of
+`TransferChannelClient`s keyed by peer url, created lazily on first use.
+
+The context is also available as a **process-global singleton** through the
+package-level lifecycle functions (see [Global lifecycle](#global-lifecycle)),
+which is the normal entry point for application code.
+
+## Public API
+
+All names below are exported from
+`lmcache.v1.distributed.transfer_channel` (`__init__.py`).
+
+### Data types (`api.py`)
+
+| Type | Fields | Notes |
+|---|---|---|
+| `TransferChannelAddress` | `offset: int`, `size: int` | A transfer-channel address (frozen). `offset` is relative to the L1 base. Wrapped in a class for future extensibility. |
+| `TransferChannelReadResult` | `finished: bool`, `succeeded: list[TransferChannelAddress]` | Result of `query_read_status`. `is_finished()` / `succeed_addresses()` accessors. `succeeded` is empty while in flight or on error. |
+
+### Abstract interfaces (`abstract.py`)
+
+- **`TransferChannelContext`** — owns the server and clients; translates L1
+  `(offset, size)` objects into transfer-channel addresses.
+  - `get_transfer_channel_server() -> TransferChannelServer`
+  - `get_transfer_channel_client(peer_advertise_url: str) -> TransferChannelClient`
+    — get or create a client to the peer. Note: for bidirectional transports
+    (like NIXL) the client may instead be created *passively* when the peer
+    dials this context's server; this is transparent to the caller.
+  - `get_transfer_channel_address(lmcache_addresses: list[tuple[int, int]]) -> list[TransferChannelAddress]`
+    — validate `(offset, size)` pairs against the registered region and convert.
+  - `get_num_connected_clients() -> int`
+  - `close() -> None`
+- **`TransferChannelServer`** — listens for peer connections and exchanges
+  transfer metadata during the handshake. `close()` frees its resources.
+- **`TransferChannelClient`** — reads from one remote peer's memory.
+  - `submit_read(local_addresses, remote_addresses) -> int` — returns a task id.
+    The two address lists must have equal length; element *i* of `remote` is read
+    into element *i* of `local`.
+  - `query_read_status(task_id: int) -> TransferChannelReadResult`
+  - `close() -> None`
+
+### Global lifecycle (`__init__.py`)
+
+The normal way application code obtains a context:
+
+| Function | Purpose |
+|---|---|
+| `initialize_transfer_channel_context(transfer_channel_type, l1_memory_desc, listen_url, advertise_url, **kwargs)` | Create the process-global context via the registered factory. Raises if one already exists, or if the type is unknown. `**kwargs` are forwarded to the factory (e.g. `backends=["UCX"]` for nixl). |
+| `get_transfer_channel_context()` | Return the global context (raises if not initialized). |
+| `delete_transfer_channel_context()` | Close and clear the global context. |
+
+`listen_url` is the `host:port` this peer's singleton server binds to;
+`advertise_url` is the `host:port` this peer announces as its identity (the key
+peers store its reverse client under). `l1_memory_desc` is an
+`L1MemoryDesc(ptr, size, align_bytes)` (`distributed/internal_api.py`),
+typically obtained from `L1MemoryManager.get_l1_memory_desc()`.
+
+## How a read flows
+
+1. **Register.** Each peer builds a context, which registers its whole L1 buffer
+   with the transport and binds its handshake server.
+2. **Connect / handshake.** The reader calls
+   `get_transfer_channel_client(peer_url)`. If no client exists, the context
+   dials the peer's server and exchanges transport metadata (agent identity and
+   the serialized transfer-descriptor list covering the whole buffer).
+3. **Translate addresses.** Both sides express objects as `(offset, size)` pairs
+   relative to their own L1 base. The reader converts its **local**
+   (destination) addresses via `get_transfer_channel_address(...)`. **Remote**
+   (source) addresses are constructed directly as `TransferChannelAddress`
+   instances (they refer to the peer's region, so they are not validated against
+   the local region).
+4. **Submit + poll.** `submit_read(local, remote)` returns a task id; the caller
+   polls `query_read_status(task_id)` until `is_finished()`. On success,
+   `succeed_addresses()` returns the remote addresses that were read.
+
+> **Alignment contract.** Object offsets must be aligned to the registered
+> `align_bytes`, and the reader and the peer must use the **same** `align_bytes`,
+> because the page-index math used to address the remote buffer is computed
+> against the reader's alignment but indexes the peer's page-granular descriptor
+> list.
+
+## nixl implementation
+
+`impl/nixl_impl.py` implements the abstraction over the NIXL bindings (UCX by
+default). It self-registers under the type name `"nixl"` at import time. Notable
+points:
+
+- **One agent per context.** The context creates a single `nixl_agent`, registers
+  the whole L1 buffer once, and builds a page-granular transfer-descriptor list
+  over `[base, base+size)` using `align_bytes` as the page size.
+- **Handshake over ZMQ.** Metadata is exchanged over a ZMQ `REP`/`REQ` socket
+  (not the LMCache MQ — that would be overkill and would leak transfer-channel
+  functions into the global MQ). The messages are a small `msgspec` tagged union
+  (`InitReq`/`InitResp`, `MemRegReq`/`MemRegResp`).
+- **Passive client creation.** When a peer dials this context's server and sends
+  its descriptor list, the server registers a reverse `NixlTransferChannelClient`
+  for that peer, so reads can flow in either direction after a single handshake.
+- **Address → page indices.** `addresses_to_indices` turns `(offset, size)` into
+  the list of page indices `[offset/align, …]`, expanding multi-page objects.
+- **Handshake timeout.** The dialing side sets a `RCVTIMEO` of
+  `_HANDSHAKE_TIMEOUT_MS` (60 s) on the handshake socket. A wrong/unreachable
+  url or a blocked port therefore raises a clear `TimeoutError` instead of
+  hanging forever. The server's `_serve_loop` polls with a 1 s timeout so it can
+  observe shutdown.
+
+## Extending: add a new transfer channel implementation
+
+Implementations live under `impl/` and **self-register a factory** with the
+registry in `factory.py`. There is no central switch statement to edit.
+
+1. **Implement the three interfaces** from `abstract.py`
+   (`TransferChannelContext`, `TransferChannelServer`, `TransferChannelClient`)
+   and use the `api.py` data types. Put the module under `impl/`. If it wraps a
+   third-party library, name the module after the *implementation*, not the
+   library it wraps (e.g. `nixl_impl.py`, not `nixl.py`, to avoid colliding with
+   the third-party `nixl` package).
+
+2. **Provide a factory and register it** at module import time:
+
+   ```python
+   from lmcache.v1.distributed.transfer_channel.factory import (
+       register_transfer_channel_factory,
+   )
+
+   def create_my_transfer_channel_context(
+       l1_memory_desc, listen_url, advertise_url, **kwargs
+   ):
+       return MyTransferChannelContext(...)
+
+   register_transfer_channel_factory("mytype", create_my_transfer_channel_context)
+   ```
+
+   The factory is always called with the keyword arguments `l1_memory_desc`,
+   `listen_url`, `advertise_url`, plus any implementation-specific keyword
+   arguments forwarded by the caller. Registering a duplicate type raises
+   `ValueError`.
+
+3. **Make the module import-loaded** so the registration runs. Add it to
+   `impl/__init__.py` (which the package `__init__.py` imports eagerly). Keep the
+   heavy/optional third-party import lazy (inside the context constructor), so
+   importing the module to register the factory does not require the dependency
+   to be installed.
+
+4. **Use it** via `initialize_transfer_channel_context("mytype", …)`. The
+   `transfer_channel_type` is a plain string identifier (not a module path); it
+   is resolved through the registry, and unknown types raise a `ValueError`
+   listing the registered types.
+
+`register_transfer_channel_factory` and the internal
+`create_transfer_channel_context` live in `factory.py` and are deliberately
+**not** part of the package's public `__all__` — implementations import the
+register function directly from `factory`, and `initialize_transfer_channel_context`
+is the public creation entry point.
+
+## Testing
+
+- Unit tests for the data types, factory registry, and global lifecycle:
+  `tests/v1/distributed/transfer_channel/test_api.py`,
+  `test_factory.py`, `test_context_lifecycle.py`.
+- Integration tests for the nixl implementation (guarded by
+  `pytest.importorskip("nixl")`, public interface only):
+  `tests/v1/distributed/transfer_channel/test_nixl_impl.py`.
+
+## Related
+
+- Throughput benchmark tool: `lmcache/tools/transfer_channel_benchmark/`
+  (design/usage symlinked at `docs/design/tools/transfer_channel_benchmark/`).

--- a/docs/design/v1/distributed/transfer_channel/overall.md
+++ b/docs/design/v1/distributed/transfer_channel/overall.md
@@ -61,7 +61,7 @@ All names below are exported from
 | Type | Fields | Notes |
 |---|---|---|
 | `TransferChannelAddress` | `offset: int`, `size: int` | A transfer-channel address (frozen). `offset` is relative to the L1 base. Wrapped in a class for future extensibility. |
-| `TransferChannelReadResult` | `finished: bool`, `succeeded: list[TransferChannelAddress]` | Result of `query_read_status`. `is_finished()` / `succeed_addresses()` accessors. `succeeded` is empty while in flight or on error. |
+| `TransferChannelReadResult` | `finished: bool`, `succeeded_mask: list[bool]` | Result of `query_read_status`. `is_finished()` accessor. `succeeded_mask` holds a per-object success flag aligned with the submitted addresses; empty while in flight. |
 
 ### Abstract interfaces (`abstract.py`)
 
@@ -116,8 +116,9 @@ typically obtained from `L1MemoryManager.get_l1_memory_desc()`.
    instances (they refer to the peer's region, so they are not validated against
    the local region).
 4. **Submit + poll.** `submit_read(local, remote)` returns a task id; the caller
-   polls `query_read_status(task_id)` until `is_finished()`. On success,
-   `succeed_addresses()` returns the remote addresses that were read.
+   polls `query_read_status(task_id)` until `is_finished()`. The result's
+   `succeeded_mask` holds a per-object success flag aligned with the submitted
+   addresses (all `True` on success, all `False` on error).
 
 > **Alignment contract.** Object offsets must be aligned to the registered
 > `align_bytes`, and the reader and the peer must use the **same** `align_bytes`,

--- a/lmcache/cli/commands/tool/__init__.py
+++ b/lmcache/cli/commands/tool/__init__.py
@@ -15,7 +15,7 @@ import sys
 
 # First Party
 from lmcache.cli.commands.base import BaseCommand
-from lmcache.cli.commands.tool import cache_simulator
+from lmcache.cli.commands.tool import cache_simulator, transfer_channel_benchmark
 
 
 class ToolCommand(BaseCommand):
@@ -46,9 +46,10 @@ class ToolCommand(BaseCommand):
         inner = parser.add_subparsers(
             dest="tool_name",
             required=True,
-            metavar="{cache-simulator}",
+            metavar="{cache-simulator,transfer-channel-benchmark}",
         )
         cache_simulator.register(inner)
+        transfer_channel_benchmark.register(inner)
 
     def execute(self, args: argparse.Namespace) -> None:
         """Dispatch is handled per-tool via parser.set_defaults(func=...).

--- a/lmcache/cli/commands/tool/transfer_channel_benchmark.py
+++ b/lmcache/cli/commands/tool/transfer_channel_benchmark.py
@@ -15,13 +15,15 @@ import sys
 def register(subparsers: argparse._SubParsersAction) -> None:
     """Register the ``transfer-channel-benchmark`` sub-subcommand.
 
-    Imports are lazy so torch / nixl are not loaded at CLI startup.
+    Only the torch-free ``config`` module is imported here, so registering this
+    tool (which happens on every ``lmcache`` invocation) does not require torch
+    or the distributed runtime. Those are imported in ``execute``.
 
     Args:
         subparsers: The subparsers action from the ``lmcache tool`` parser.
     """
     # First Party
-    from lmcache.tools.transfer_channel_benchmark.benchmark import (
+    from lmcache.tools.transfer_channel_benchmark.config import (
         add_benchmark_arguments,
     )
 

--- a/lmcache/cli/commands/tool/transfer_channel_benchmark.py
+++ b/lmcache/cli/commands/tool/transfer_channel_benchmark.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache tool transfer-channel-benchmark`` sub-subcommand wiring.
+
+Argument definitions and execution logic live in the benchmark module:
+
+* :func:`~lmcache.tools.transfer_channel_benchmark.benchmark.add_benchmark_arguments`
+* :func:`~lmcache.tools.transfer_channel_benchmark.benchmark.run_benchmark`
+"""
+
+# Standard
+import argparse
+import sys
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the ``transfer-channel-benchmark`` sub-subcommand.
+
+    Imports are lazy so torch / nixl are not loaded at CLI startup.
+
+    Args:
+        subparsers: The subparsers action from the ``lmcache tool`` parser.
+    """
+    # First Party
+    from lmcache.tools.transfer_channel_benchmark.benchmark import (
+        add_benchmark_arguments,
+    )
+
+    parser = subparsers.add_parser(
+        "transfer-channel-benchmark",
+        help="Benchmark transfer channel read throughput (server/client).",
+        description=(
+            "Throughput benchmark for the LMCache transfer channel. Run one "
+            "process with --role server and another with --role client."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    add_benchmark_arguments(parser)
+    parser.set_defaults(func=execute)
+
+
+def execute(args: argparse.Namespace) -> None:
+    """Run the benchmark and exit non-zero on failure.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    # First Party
+    from lmcache.tools.transfer_channel_benchmark.benchmark import run_benchmark
+
+    if not run_benchmark(args):
+        sys.exit(1)

--- a/lmcache/tools/transfer_channel_benchmark/README.md
+++ b/lmcache/tools/transfer_channel_benchmark/README.md
@@ -88,3 +88,23 @@ the transferred bytes against that pattern (no `--verify` needed on the server).
 - With the default (non-lazy) allocator the whole `--buffer-size` is allocated up
   front and may be CUDA-pinned; keep it within available host memory.
 - Requires a working transfer channel runtime (for `nixl`, a UCX backend).
+
+## Troubleshooting
+
+- **Client hangs after "connected" or during connect, then raises
+  `TimeoutError` after ~60s.** The transfer-channel handshake could not reach the
+  server. Check that `--url`/`--control-url` on the client point at the *server's*
+  reachable address (a common mistake is a typo such as a trailing dot:
+  `10.0.0.5.:7600`), that the server is running, and that the ports are open
+  between hosts:
+  ```bash
+  nc -vz <server-host> 7600   # transfer channel
+  nc -vz <server-host> 7610   # catalog side-channel
+  ```
+  The handshake has a fixed 60s timeout, so a misconfiguration fails with a clear
+  error instead of hanging forever.
+- **`page_size`/`object_size` mismatch error.** The client validates these against
+  the server's catalog; pass the same `--page-size` and `--object-size` on both.
+- **Allocation `RuntimeError` on the server.** The source pool
+  (`--num-source-objects` × `--object-size`) must fit in `--buffer-size`; increase
+  the buffer or reduce the pool/object size.

--- a/lmcache/tools/transfer_channel_benchmark/README.md
+++ b/lmcache/tools/transfer_channel_benchmark/README.md
@@ -89,6 +89,24 @@ the transferred bytes against that pattern (no `--verify` needed on the server).
   front and may be CUDA-pinned; keep it within available host memory.
 - Requires a working transfer channel runtime (for `nixl`, a UCX backend).
 
+## Performance: NUMA placement
+
+On a multi-NUMA host with NICs spread across nodes (e.g. an 8-NIC, 2-socket
+box), run **both** the server and client under `numactl --interleave=all`:
+
+```bash
+numactl --interleave=all \
+python -m lmcache.tools.transfer_channel_benchmark --role server ...
+```
+
+Without it the registered buffer is allocated on a single NUMA node, so only the
+rails local to that node reach full bandwidth and the rest are throttled by the
+cross-socket link — roughly halving throughput. In testing on a 2-NUMA / 8-rail
+host this was the difference between **~110 GB/s** (no interleave) and
+**~210 GB/s** (`--interleave=all`), with everything else identical. Page size
+only matters in the small regime (descriptor-bound below ~64KB); from ~128KB up
+the transfer is bandwidth-bound and flat.
+
 ## Troubleshooting
 
 - **Client hangs after "connected" or during connect, then raises

--- a/lmcache/tools/transfer_channel_benchmark/README.md
+++ b/lmcache/tools/transfer_channel_benchmark/README.md
@@ -1,0 +1,90 @@
+# Transfer Channel Throughput Benchmark
+
+Measures read throughput (GB/s) of the LMCache **transfer channel**
+(`lmcache/v1/distributed/transfer_channel/`) for batched peer-to-peer reads.
+
+Unlike a raw-tensor microbenchmark, this tool uses LMCache's `L1MemoryManager`
+to initialize the registered memory region and to **allocate the transferred
+objects** on both sides, so it exercises the same memory path production uses.
+
+## How it works
+
+The benchmark runs as **two separate processes**:
+
+- **server** — uses an `L1MemoryManager` to allocate a registered L1 buffer and
+  a pool of source memory objects, registers the buffer with the transfer
+  channel, and publishes the source object catalog (`offset`/`size` per object)
+  over a small ZMQ side-channel.
+- **client** — fetches the catalog, allocates its own destination objects via an
+  `L1MemoryManager`, connects the transfer channel, and repeatedly reads a random
+  `--num-objects` subset of the source objects, then reports throughput.
+
+A side-channel is needed because the transfer channel handshake only exchanges
+the whole-buffer registration, not per-object offsets.
+
+> Only the `nixl` transfer channel type is registered today. The tool is generic
+> over `--transfer-channel-type`; an unknown type raises a clear error.
+
+## Usage
+
+Run via the module or the `lmcache` CLI. Start the server first.
+
+### `python -m`
+
+```bash
+# terminal 1 — server
+python -m lmcache.tools.transfer_channel_benchmark \
+  --role server --transfer-channel-type nixl \
+  --url 0.0.0.0:7600 --control-url 0.0.0.0:7610 \
+  --buffer-size 2GB --page-size 512KB --object-size 10MB
+
+# terminal 2 — client
+python -m lmcache.tools.transfer_channel_benchmark \
+  --role client --transfer-channel-type nixl \
+  --url 127.0.0.1:7600 --control-url 127.0.0.1:7610 \
+  --listen-url 0.0.0.0:7601 \
+  --page-size 512KB --object-size 10MB \
+  --num-objects 10 --iters 3 --warmup 1
+```
+
+### `lmcache tool`
+
+```bash
+lmcache tool transfer-channel-benchmark --role server  --url 0.0.0.0:7600 \
+  --control-url 0.0.0.0:7610 --buffer-size 2GB --object-size 10MB
+lmcache tool transfer-channel-benchmark --role client --url 127.0.0.1:7600 \
+  --control-url 127.0.0.1:7610 --object-size 10MB --num-objects 10
+```
+
+The server always writes a deterministic per-object byte pattern (object index
+mod 256) into its source objects, so adding `--verify` on the **client** checks
+the transferred bytes against that pattern (no `--verify` needed on the server).
+
+## Key options
+
+| Option | Role | Meaning |
+| --- | --- | --- |
+| `--role {server,client}` | both | Which side to run (required). |
+| `--transfer-channel-type` | both | Implementation to benchmark (default `nixl`). |
+| `--nixl-backend` | both | nixl backend, e.g. `UCX` (nixl-specific). |
+| `--url` | both | Server binds its transfer-channel server here; client dials it. |
+| `--listen-url` | client | Client's own (mandatory) transfer-channel server bind. |
+| `--control-url` | both | Catalog side-channel: server binds, client connects. |
+| `--buffer-size` | server | Registered L1 source buffer size (e.g. `8GB`). |
+| `--page-size` | both | Page / alignment size; **must match** on both sides. |
+| `--object-size` | both | Per-object size; multiple of `--page-size`. |
+| `--num-objects` | client | Objects transferred per read. |
+| `--num-source-objects` | server | Source pool size (default `5 * --num-objects`). |
+| `--iters` / `--warmup` | client | Measured / warmup read iterations. |
+| `--seed` | client | RNG seed for the read subset. |
+| `--verify` | client | Verify transferred bytes against the server's known pattern. |
+| `--use-lazy` | both | Use the lazy L1 allocator (experimental for registration). |
+| `--server-timeout` | server | Seconds to serve catalog requests before exiting. |
+
+## Notes
+
+- `--page-size` must be identical on server and client (enforced via the catalog
+  handshake) so remote page-index math lines up.
+- With the default (non-lazy) allocator the whole `--buffer-size` is allocated up
+  front and may be CUDA-pinned; keep it within available host memory.
+- Requires a working transfer channel runtime (for `nixl`, a UCX backend).

--- a/lmcache/tools/transfer_channel_benchmark/__init__.py
+++ b/lmcache/tools/transfer_channel_benchmark/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/lmcache/tools/transfer_channel_benchmark/__main__.py
+++ b/lmcache/tools/transfer_channel_benchmark/__main__.py
@@ -6,10 +6,10 @@ import argparse
 import sys
 
 # First Party
-from lmcache.tools.transfer_channel_benchmark.benchmark import (
-    add_benchmark_arguments,
-    run_benchmark,
-)
+# Only the torch-free config module is imported eagerly so that `-h` works
+# without torch installed. The runtime (which needs torch) is imported after
+# arguments are parsed.
+from lmcache.tools.transfer_channel_benchmark.config import add_benchmark_arguments
 
 
 def main() -> int:
@@ -25,6 +25,13 @@ def main() -> int:
     )
     add_benchmark_arguments(parser)
     args = parser.parse_args()
+
+    # Imported here (not at module load) so this entry point can show --help
+    # without requiring torch; importing it raises a clear error if torch is
+    # missing.
+    # First Party
+    from lmcache.tools.transfer_channel_benchmark.benchmark import run_benchmark
+
     return 0 if run_benchmark(args) else 1
 
 

--- a/lmcache/tools/transfer_channel_benchmark/__main__.py
+++ b/lmcache/tools/transfer_channel_benchmark/__main__.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``python -m lmcache.tools.transfer_channel_benchmark`` entry point."""
+
+# Standard
+import argparse
+import sys
+
+# First Party
+from lmcache.tools.transfer_channel_benchmark.benchmark import (
+    add_benchmark_arguments,
+    run_benchmark,
+)
+
+
+def main() -> int:
+    """Parse arguments and run the transfer channel benchmark.
+
+    Returns:
+        Process exit code (0 on success, 1 on failure).
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m lmcache.tools.transfer_channel_benchmark",
+        description="Throughput benchmark for the LMCache transfer channel.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    add_benchmark_arguments(parser)
+    args = parser.parse_args()
+    return 0 if run_benchmark(args) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lmcache/tools/transfer_channel_benchmark/benchmark.py
+++ b/lmcache/tools/transfer_channel_benchmark/benchmark.py
@@ -272,7 +272,7 @@ def client_main(cfg: BenchmarkConfig) -> bool:
                 while not result.is_finished():
                     result = client.query_read_status(task_id)
                 elapsed = time.perf_counter() - start
-                succeeded = len(result.succeed_addresses())
+                succeeded = sum(result.succeeded_mask)
                 if succeeded != cfg.num_objects:
                     raise RuntimeError(
                         f"read failed: {succeeded}/{cfg.num_objects} objects succeeded."

--- a/lmcache/tools/transfer_channel_benchmark/benchmark.py
+++ b/lmcache/tools/transfer_channel_benchmark/benchmark.py
@@ -1,0 +1,505 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Core logic for the transfer channel throughput benchmark.
+
+A *server* process uses an :class:`L1MemoryManager` to initialize a registered
+L1 region, allocates a pool of source memory objects in it, registers the
+region with a transfer channel, and publishes the source object catalog
+(offset/size per object) over a small ZMQ side-channel.
+
+A *client* process fetches the catalog, allocates its own destination objects
+via an :class:`L1MemoryManager`, connects the transfer channel, and issues
+batched reads of a random subset of the source objects, reporting aggregate
+read throughput in GB/s.
+"""
+
+# Standard
+import argparse
+import json
+import random
+import time
+
+# Third Party
+import torch
+import zmq
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.tools.transfer_channel_benchmark.config import (
+    DEFAULT_BUFFER_SIZE,
+    DEFAULT_OBJECT_SIZE,
+    DEFAULT_PAGE_SIZE,
+    BenchmarkConfig,
+    parse_size,
+)
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.distributed.config import L1MemoryManagerConfig
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.memory_manager import L1MemoryManager
+from lmcache.v1.distributed.transfer_channel import (
+    TransferChannelAddress,
+    delete_transfer_channel_context,
+    initialize_transfer_channel_context,
+)
+
+logger = init_logger(__name__)
+
+_CATALOG_REQUEST = b"catalog"
+_LARGE_LAZY_INIT = 20 * 1024**3
+_CLIENT_BUFFER_SLACK = 64 * 1024**2
+
+
+############################################################
+# Argument parsing
+############################################################
+def add_benchmark_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add all benchmark arguments to ``parser``.
+
+    Args:
+        parser: The argument parser (or subparser) to populate.
+    """
+    parser.add_argument(
+        "--role",
+        choices=["server", "client"],
+        required=True,
+        help="server: register a source buffer and serve its object catalog; "
+        "client: read a subset of the server's objects and report throughput.",
+    )
+    parser.add_argument(
+        "--transfer-channel-type",
+        default="nixl",
+        help="Transfer channel implementation to benchmark.",
+    )
+    parser.add_argument(
+        "--nixl-backend",
+        default="UCX",
+        help="nixl backend name (nixl-specific), e.g. UCX.",
+    )
+    parser.add_argument(
+        "--url",
+        default="127.0.0.1:7600",
+        help="server: host:port to bind the transfer-channel server; "
+        "client: the server (peer) advertise url to read from.",
+    )
+    parser.add_argument(
+        "--listen-url",
+        default="0.0.0.0:7601",
+        help="client: host:port for the client's own (mandatory) "
+        "transfer-channel server; it never receives reads here.",
+    )
+    parser.add_argument(
+        "--control-url",
+        default="0.0.0.0:7610",
+        help="benchmark catalog side-channel: server binds here, client "
+        "connects here to fetch the source object catalog.",
+    )
+    parser.add_argument(
+        "--buffer-size",
+        type=parse_size,
+        default=DEFAULT_BUFFER_SIZE,
+        help="server: total registered L1 source buffer size (e.g. 8GB).",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=parse_size,
+        default=DEFAULT_PAGE_SIZE,
+        help="page / alignment size; must match on server and client.",
+    )
+    parser.add_argument(
+        "--object-size",
+        type=parse_size,
+        default=DEFAULT_OBJECT_SIZE,
+        help="size of each transferred object (multiple of --page-size).",
+    )
+    parser.add_argument(
+        "--num-objects",
+        type=int,
+        default=100,
+        help="number of objects transferred per read.",
+    )
+    parser.add_argument(
+        "--num-source-objects",
+        type=int,
+        default=0,
+        help="server source pool size; 0 means 5 * --num-objects.",
+    )
+    parser.add_argument(
+        "--use-lazy",
+        action="store_true",
+        help="use the lazy L1 allocator (experimental for registration).",
+    )
+    parser.add_argument(
+        "--iters", type=int, default=5, help="measured read iterations."
+    )
+    parser.add_argument("--warmup", type=int, default=1, help="warmup read iterations.")
+    parser.add_argument(
+        "--seed", type=int, default=0, help="RNG seed for read-subset selection."
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="verify transferred bytes against a known per-object pattern.",
+    )
+    parser.add_argument(
+        "--server-timeout",
+        type=float,
+        default=1800.0,
+        help="seconds the server serves catalog requests before exiting.",
+    )
+
+
+def build_config(args: argparse.Namespace) -> BenchmarkConfig:
+    """Build a :class:`BenchmarkConfig` from parsed arguments.
+
+    Args:
+        args: Parsed CLI arguments produced by ``add_benchmark_arguments``.
+
+    Returns:
+        The resolved, validated benchmark configuration.
+    """
+    return BenchmarkConfig(
+        role=args.role,
+        transfer_channel_type=args.transfer_channel_type,
+        nixl_backend=args.nixl_backend,
+        url=args.url,
+        listen_url=args.listen_url,
+        control_url=args.control_url,
+        buffer_size=args.buffer_size,
+        page_size=args.page_size,
+        object_size=args.object_size,
+        num_objects=args.num_objects,
+        num_source_objects=args.num_source_objects,
+        use_lazy=args.use_lazy,
+        iters=args.iters,
+        warmup=args.warmup,
+        seed=args.seed,
+        verify=args.verify,
+        server_timeout=args.server_timeout,
+    )
+
+
+############################################################
+# Helpers
+############################################################
+def _zmq_endpoint(url: str) -> str:
+    """Return a ZMQ tcp endpoint for a ``host:port`` (or pass-through url)."""
+    return url if "://" in url else f"tcp://{url}"
+
+
+def _gbps(num_bytes: int, seconds: float) -> float:
+    """Return throughput in GB/s (decimal GB) for ``num_bytes`` over ``seconds``."""
+    return (num_bytes / 1e9) / seconds if seconds > 0 else float("inf")
+
+
+def _create_l1_manager(cfg: BenchmarkConfig, size_bytes: int) -> L1MemoryManager:
+    """Create an L1 memory manager sized to ``size_bytes`` for this benchmark."""
+    manager_config = L1MemoryManagerConfig(
+        size_in_bytes=size_bytes,
+        use_lazy=cfg.use_lazy,
+        init_size_in_bytes=min(_LARGE_LAZY_INIT, size_bytes),
+        align_bytes=cfg.page_size,
+    )
+    return L1MemoryManager(manager_config)
+
+
+def _object_layout(cfg: BenchmarkConfig) -> MemoryLayoutDesc:
+    """Return the layout for a single ``object_size``-byte uint8 object."""
+    return MemoryLayoutDesc(
+        shapes=[torch.Size([cfg.object_size])], dtypes=[torch.uint8]
+    )
+
+
+############################################################
+# Server
+############################################################
+def server_main(cfg: BenchmarkConfig) -> None:
+    """Run the benchmark server: register a buffer and serve its catalog.
+
+    Args:
+        cfg: The benchmark configuration (``role == "server"``).
+
+    Raises:
+        RuntimeError: If the source pool cannot be allocated in the buffer.
+    """
+    pool_bytes = cfg.num_source_objects * cfg.object_size
+    if pool_bytes > cfg.buffer_size:
+        raise RuntimeError(
+            f"source pool ({pool_bytes / 1e9:.2f} GB = {cfg.num_source_objects} "
+            f"x {cfg.object_size / 1024**2:.1f} MiB) does not fit in the "
+            f"{cfg.buffer_size / 1e9:.2f} GB buffer; increase --buffer-size or "
+            f"reduce --num-source-objects / --object-size."
+        )
+
+    logger.debug(
+        "Allocating L1 buffer (%.2f GB) and %d source objects",
+        cfg.buffer_size / 1e9,
+        cfg.num_source_objects,
+    )
+    manager = _create_l1_manager(cfg, cfg.buffer_size)
+    source_objs: list = []
+    try:
+        error, source_objs = manager.allocate(
+            _object_layout(cfg), cfg.num_source_objects
+        )
+        if error != L1Error.SUCCESS:
+            raise RuntimeError(
+                f"Failed to allocate {cfg.num_source_objects} source objects: "
+                f"{error}. Increase --buffer-size or reduce "
+                f"--num-source-objects / --object-size."
+            )
+
+        # Always write a deterministic per-object byte pattern (object index
+        # mod 256) so that a client run with --verify can validate the
+        # transferred bytes without any extra coordination. This is a one-time
+        # cost at startup and does not affect the measured read throughput.
+        for index, obj in enumerate(source_objs):
+            assert obj.tensor is not None, "Failed to allocate tensor!"
+            obj.tensor.fill_(index % 256)
+
+        catalog = [
+            (obj.shm_offset, obj.shm_byte_length, index)
+            for index, obj in enumerate(source_objs)
+        ]
+
+        initialize_transfer_channel_context(
+            cfg.transfer_channel_type,
+            l1_memory_desc=manager.get_l1_memory_desc(),
+            listen_url=cfg.url,
+            advertise_url=cfg.url,
+            backends=[cfg.nixl_backend],
+        )
+        try:
+            _serve_catalog(cfg, catalog)
+        finally:
+            delete_transfer_channel_context()
+    finally:
+        if source_objs:
+            manager.free(source_objs)
+        manager.close()
+
+
+def _serve_catalog(cfg: BenchmarkConfig, catalog: list[tuple[int, int, int]]) -> None:
+    """Serve the source object catalog over a ZMQ REP socket until timeout."""
+    payload = json.dumps(
+        {
+            "page_size": cfg.page_size,
+            "object_size": cfg.object_size,
+            "objects": catalog,
+        }
+    ).encode()
+
+    socket = zmq.Context.instance().socket(zmq.REP)
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.bind(_zmq_endpoint(cfg.control_url))
+    print(
+        f"[server] ready: transfer channel on {cfg.url}, "
+        f"catalog on {cfg.control_url} ({len(catalog)} source objects)",
+        flush=True,
+    )
+
+    poller = zmq.Poller()
+    poller.register(socket, zmq.POLLIN)
+    deadline = time.monotonic() + cfg.server_timeout
+    try:
+        while time.monotonic() < deadline:
+            events = dict(poller.poll(timeout=1000))
+            if socket in events:
+                socket.recv()
+                socket.send(payload)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        socket.close(linger=0)
+        print("[server] shut down", flush=True)
+
+
+############################################################
+# Client
+############################################################
+def client_main(cfg: BenchmarkConfig) -> bool:
+    """Run the benchmark client: read a subset of source objects and report.
+
+    Args:
+        cfg: The benchmark configuration (``role == "client"``).
+
+    Returns:
+        ``True`` on success.
+
+    Raises:
+        ValueError: If the server's page/object size or pool size is
+            incompatible with this client's configuration.
+        RuntimeError: If allocation or a read transfer fails.
+    """
+    catalog = _fetch_catalog(cfg)
+    if catalog["page_size"] != cfg.page_size:
+        raise ValueError(
+            f"page_size mismatch: client {cfg.page_size} vs server "
+            f"{catalog['page_size']}; they must match."
+        )
+    if catalog["object_size"] != cfg.object_size:
+        raise ValueError(
+            f"object_size mismatch: client {cfg.object_size} vs server "
+            f"{catalog['object_size']}; they must match."
+        )
+    source_objs = catalog["objects"]
+    if len(source_objs) < cfg.num_objects:
+        raise ValueError(
+            f"server has only {len(source_objs)} source objects, fewer than "
+            f"--num-objects ({cfg.num_objects})."
+        )
+
+    client_buffer = cfg.num_objects * cfg.object_size + _CLIENT_BUFFER_SLACK
+    manager = _create_l1_manager(cfg, client_buffer)
+    dst_objs: list = []
+    try:
+        error, dst_objs = manager.allocate(_object_layout(cfg), cfg.num_objects)
+        if error != L1Error.SUCCESS:
+            raise RuntimeError(
+                f"Failed to allocate {cfg.num_objects} destination objects: {error}."
+            )
+
+        ctx = initialize_transfer_channel_context(
+            cfg.transfer_channel_type,
+            l1_memory_desc=manager.get_l1_memory_desc(),
+            listen_url=cfg.listen_url,
+            advertise_url=cfg.listen_url,
+            backends=[cfg.nixl_backend],
+        )
+        try:
+            local_addrs = ctx.get_transfer_channel_address(
+                [(obj.shm_offset, obj.shm_byte_length) for obj in dst_objs]
+            )
+            rng = random.Random(cfg.seed)
+            chosen = rng.sample(source_objs, cfg.num_objects)
+            remote_addrs = [
+                TransferChannelAddress(offset=offset, size=size)
+                for offset, size, _ in chosen
+            ]
+            chosen_indices = [index for _, _, index in chosen]
+
+            connect_start = time.perf_counter()
+            client = ctx.get_transfer_channel_client(cfg.url)
+            print(
+                f"[client] connected in {time.perf_counter() - connect_start:.1f}s; "
+                f"reading {cfg.num_objects} objects x "
+                f"{cfg.object_size / 1024**2:.1f} MiB",
+                flush=True,
+            )
+
+            def one_read() -> float:
+                start = time.perf_counter()
+                task_id = client.submit_read(local_addrs, remote_addrs)
+                result = client.query_read_status(task_id)
+                while not result.is_finished():
+                    result = client.query_read_status(task_id)
+                elapsed = time.perf_counter() - start
+                succeeded = len(result.succeed_addresses())
+                if succeeded != cfg.num_objects:
+                    raise RuntimeError(
+                        f"read failed: {succeeded}/{cfg.num_objects} objects succeeded."
+                    )
+                return elapsed
+
+            for _ in range(cfg.warmup):
+                one_read()
+            times = [one_read() for _ in range(cfg.iters)]
+
+            if cfg.verify:
+                _verify(dst_objs, chosen_indices)
+
+            _report(cfg, times)
+            return True
+        finally:
+            delete_transfer_channel_context()
+            del ctx
+    finally:
+        if dst_objs:
+            manager.free(dst_objs)
+        manager.close()
+
+
+def _fetch_catalog(cfg: BenchmarkConfig) -> dict:
+    """Fetch the source object catalog from the server's control socket."""
+    socket = zmq.Context.instance().socket(zmq.REQ)
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.setsockopt(zmq.RCVTIMEO, int(cfg.server_timeout * 1000))
+    socket.connect(_zmq_endpoint(cfg.control_url))
+    try:
+        socket.send(_CATALOG_REQUEST)
+        try:
+            reply = socket.recv()
+        except zmq.Again as exc:
+            raise RuntimeError(
+                f"timed out fetching catalog from {cfg.control_url}; is the "
+                f"server running?"
+            ) from exc
+    finally:
+        socket.close(linger=0)
+    return json.loads(reply)
+
+
+def _verify(dst_objs: list, chosen_indices: list[int]) -> None:
+    """Check each destination object holds the expected per-object byte pattern.
+
+    Raises:
+        RuntimeError: If any destination object does not match.
+    """
+    for obj, index in zip(dst_objs, chosen_indices, strict=False):
+        expected = index % 256
+        tensor = obj.tensor
+        if tensor is None or not bool((tensor == expected).all()):
+            raise RuntimeError(
+                f"verify FAILED for source object {index}: expected all bytes "
+                f"== {expected}."
+            )
+    print(
+        f"[client] verify OK: {len(dst_objs)} objects match expected pattern",
+        flush=True,
+    )
+
+
+def _report(cfg: BenchmarkConfig, times: list[float]) -> None:
+    """Print best/median/mean latency and throughput for the measured reads."""
+    total_bytes = cfg.num_objects * cfg.object_size
+    ordered = sorted(times)
+    best = ordered[0]
+    median = ordered[len(ordered) // 2]
+    mean = sum(ordered) / len(ordered)
+    print("\n==== Transfer channel read throughput ====", flush=True)
+    print(f"  channel type     : {cfg.transfer_channel_type}", flush=True)
+    print(
+        f"  payload per read : {total_bytes / 1e9:.3f} GB "
+        f"({cfg.num_objects} objs x {cfg.object_size / 1024**2:.1f} MiB)",
+        flush=True,
+    )
+    print(f"  iterations       : {cfg.iters} (warmup {cfg.warmup})", flush=True)
+    print(
+        f"  best   : {best * 1e3:8.2f} ms   {_gbps(total_bytes, best):7.2f} GB/s",
+        flush=True,
+    )
+    print(
+        f"  median : {median * 1e3:8.2f} ms   {_gbps(total_bytes, median):7.2f} GB/s",
+        flush=True,
+    )
+    print(
+        f"  mean   : {mean * 1e3:8.2f} ms   {_gbps(total_bytes, mean):7.2f} GB/s",
+        flush=True,
+    )
+
+
+############################################################
+# Entry
+############################################################
+def run_benchmark(args: argparse.Namespace) -> bool:
+    """Dispatch to the server or client role.
+
+    Args:
+        args: Parsed CLI arguments produced by ``add_benchmark_arguments``.
+
+    Returns:
+        ``True`` on success, ``False`` otherwise.
+    """
+    cfg = build_config(args)
+    if cfg.role == "server":
+        server_main(cfg)
+        return True
+    return client_main(cfg)

--- a/lmcache/tools/transfer_channel_benchmark/benchmark.py
+++ b/lmcache/tools/transfer_channel_benchmark/benchmark.py
@@ -19,17 +19,26 @@ import random
 import time
 
 # Third Party
-import torch
 import zmq
+
+# torch is an optional dependency for this benchmark tool. It (and the
+# distributed runtime imported below, which also needs torch) is imported here
+# rather than in config.py so the `lmcache` CLI can register this tool without
+# torch installed. Raise a clear, actionable error if it is missing.
+try:
+    # Third Party
+    import torch
+except ImportError as err:
+    raise ImportError(
+        "PyTorch is required to run the transfer channel benchmark but is not "
+        "installed. Install it (e.g. `pip install torch`) and retry."
+    ) from err
 
 # First Party
 from lmcache.logging import init_logger
 from lmcache.tools.transfer_channel_benchmark.config import (
-    DEFAULT_BUFFER_SIZE,
-    DEFAULT_OBJECT_SIZE,
-    DEFAULT_PAGE_SIZE,
     BenchmarkConfig,
-    parse_size,
+    build_config,
 )
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.distributed.config import L1MemoryManagerConfig
@@ -46,135 +55,6 @@ logger = init_logger(__name__)
 _CATALOG_REQUEST = b"catalog"
 _LARGE_LAZY_INIT = 20 * 1024**3
 _CLIENT_BUFFER_SLACK = 64 * 1024**2
-
-
-############################################################
-# Argument parsing
-############################################################
-def add_benchmark_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add all benchmark arguments to ``parser``.
-
-    Args:
-        parser: The argument parser (or subparser) to populate.
-    """
-    parser.add_argument(
-        "--role",
-        choices=["server", "client"],
-        required=True,
-        help="server: register a source buffer and serve its object catalog; "
-        "client: read a subset of the server's objects and report throughput.",
-    )
-    parser.add_argument(
-        "--transfer-channel-type",
-        default="nixl",
-        help="Transfer channel implementation to benchmark.",
-    )
-    parser.add_argument(
-        "--nixl-backend",
-        default="UCX",
-        help="nixl backend name (nixl-specific), e.g. UCX.",
-    )
-    parser.add_argument(
-        "--url",
-        default="127.0.0.1:7600",
-        help="server: host:port to bind the transfer-channel server; "
-        "client: the server (peer) advertise url to read from.",
-    )
-    parser.add_argument(
-        "--listen-url",
-        default="0.0.0.0:7601",
-        help="client: host:port for the client's own (mandatory) "
-        "transfer-channel server; it never receives reads here.",
-    )
-    parser.add_argument(
-        "--control-url",
-        default="0.0.0.0:7610",
-        help="benchmark catalog side-channel: server binds here, client "
-        "connects here to fetch the source object catalog.",
-    )
-    parser.add_argument(
-        "--buffer-size",
-        type=parse_size,
-        default=DEFAULT_BUFFER_SIZE,
-        help="server: total registered L1 source buffer size (e.g. 8GB).",
-    )
-    parser.add_argument(
-        "--page-size",
-        type=parse_size,
-        default=DEFAULT_PAGE_SIZE,
-        help="page / alignment size; must match on server and client.",
-    )
-    parser.add_argument(
-        "--object-size",
-        type=parse_size,
-        default=DEFAULT_OBJECT_SIZE,
-        help="size of each transferred object (multiple of --page-size).",
-    )
-    parser.add_argument(
-        "--num-objects",
-        type=int,
-        default=100,
-        help="number of objects transferred per read.",
-    )
-    parser.add_argument(
-        "--num-source-objects",
-        type=int,
-        default=0,
-        help="server source pool size; 0 means 5 * --num-objects.",
-    )
-    parser.add_argument(
-        "--use-lazy",
-        action="store_true",
-        help="use the lazy L1 allocator (experimental for registration).",
-    )
-    parser.add_argument(
-        "--iters", type=int, default=5, help="measured read iterations."
-    )
-    parser.add_argument("--warmup", type=int, default=1, help="warmup read iterations.")
-    parser.add_argument(
-        "--seed", type=int, default=0, help="RNG seed for read-subset selection."
-    )
-    parser.add_argument(
-        "--verify",
-        action="store_true",
-        help="verify transferred bytes against a known per-object pattern.",
-    )
-    parser.add_argument(
-        "--server-timeout",
-        type=float,
-        default=1800.0,
-        help="seconds the server serves catalog requests before exiting.",
-    )
-
-
-def build_config(args: argparse.Namespace) -> BenchmarkConfig:
-    """Build a :class:`BenchmarkConfig` from parsed arguments.
-
-    Args:
-        args: Parsed CLI arguments produced by ``add_benchmark_arguments``.
-
-    Returns:
-        The resolved, validated benchmark configuration.
-    """
-    return BenchmarkConfig(
-        role=args.role,
-        transfer_channel_type=args.transfer_channel_type,
-        nixl_backend=args.nixl_backend,
-        url=args.url,
-        listen_url=args.listen_url,
-        control_url=args.control_url,
-        buffer_size=args.buffer_size,
-        page_size=args.page_size,
-        object_size=args.object_size,
-        num_objects=args.num_objects,
-        num_source_objects=args.num_source_objects,
-        use_lazy=args.use_lazy,
-        iters=args.iters,
-        warmup=args.warmup,
-        seed=args.seed,
-        verify=args.verify,
-        server_timeout=args.server_timeout,
-    )
 
 
 ############################################################

--- a/lmcache/tools/transfer_channel_benchmark/config.py
+++ b/lmcache/tools/transfer_channel_benchmark/config.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Configuration for the transfer channel throughput benchmark."""
+"""Configuration and argument parsing for the transfer channel benchmark.
+
+This module is intentionally free of heavy/optional dependencies (torch, the
+``lmcache.v1.distributed`` runtime) so the CLI can build its argument parser
+without importing them. The runtime imports live in ``benchmark.py``.
+"""
 
 # Standard
 from dataclasses import dataclass
+import argparse
 
 _UNITS = {
     "B": 1,
@@ -115,3 +121,132 @@ class BenchmarkConfig:
                 f"num_source_objects ({self.num_source_objects}) must be >= "
                 f"num_objects ({self.num_objects})"
             )
+
+
+def add_benchmark_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add all benchmark arguments to ``parser``.
+
+    Defined here (not in ``benchmark.py``) so the CLI can build its parser
+    without importing torch or the distributed runtime.
+
+    Args:
+        parser: The argument parser (or subparser) to populate.
+    """
+    parser.add_argument(
+        "--role",
+        choices=["server", "client"],
+        required=True,
+        help="server: register a source buffer and serve its object catalog; "
+        "client: read a subset of the server's objects and report throughput.",
+    )
+    parser.add_argument(
+        "--transfer-channel-type",
+        default="nixl",
+        help="Transfer channel implementation to benchmark.",
+    )
+    parser.add_argument(
+        "--nixl-backend",
+        default="UCX",
+        help="nixl backend name (nixl-specific), e.g. UCX.",
+    )
+    parser.add_argument(
+        "--url",
+        default="127.0.0.1:7600",
+        help="server: host:port to bind the transfer-channel server; "
+        "client: the server (peer) advertise url to read from.",
+    )
+    parser.add_argument(
+        "--listen-url",
+        default="0.0.0.0:7601",
+        help="client: host:port for the client's own (mandatory) "
+        "transfer-channel server; it never receives reads here.",
+    )
+    parser.add_argument(
+        "--control-url",
+        default="0.0.0.0:7610",
+        help="benchmark catalog side-channel: server binds here, client "
+        "connects here to fetch the source object catalog.",
+    )
+    parser.add_argument(
+        "--buffer-size",
+        type=parse_size,
+        default=DEFAULT_BUFFER_SIZE,
+        help="server: total registered L1 source buffer size (e.g. 8GB).",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=parse_size,
+        default=DEFAULT_PAGE_SIZE,
+        help="page / alignment size; must match on server and client.",
+    )
+    parser.add_argument(
+        "--object-size",
+        type=parse_size,
+        default=DEFAULT_OBJECT_SIZE,
+        help="size of each transferred object (multiple of --page-size).",
+    )
+    parser.add_argument(
+        "--num-objects",
+        type=int,
+        default=100,
+        help="number of objects transferred per read.",
+    )
+    parser.add_argument(
+        "--num-source-objects",
+        type=int,
+        default=0,
+        help="server source pool size; 0 means 5 * --num-objects.",
+    )
+    parser.add_argument(
+        "--use-lazy",
+        action="store_true",
+        help="use the lazy L1 allocator (experimental for registration).",
+    )
+    parser.add_argument(
+        "--iters", type=int, default=5, help="measured read iterations."
+    )
+    parser.add_argument("--warmup", type=int, default=1, help="warmup read iterations.")
+    parser.add_argument(
+        "--seed", type=int, default=0, help="RNG seed for read-subset selection."
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="verify transferred bytes against a known per-object pattern.",
+    )
+    parser.add_argument(
+        "--server-timeout",
+        type=float,
+        default=1800.0,
+        help="seconds the server serves catalog requests before exiting.",
+    )
+
+
+def build_config(args: argparse.Namespace) -> BenchmarkConfig:
+    """Build a :class:`BenchmarkConfig` from parsed arguments.
+
+    Args:
+        args: Parsed CLI arguments produced by ``add_benchmark_arguments``.
+
+    Returns:
+        The resolved, validated benchmark configuration.
+    """
+    return BenchmarkConfig(
+        role=args.role,
+        transfer_channel_type=args.transfer_channel_type,
+        nixl_backend=args.nixl_backend,
+        url=args.url,
+        listen_url=args.listen_url,
+        control_url=args.control_url,
+        buffer_size=args.buffer_size,
+        page_size=args.page_size,
+        object_size=args.object_size,
+        num_objects=args.num_objects,
+        num_source_objects=args.num_source_objects,
+        use_lazy=args.use_lazy,
+        iters=args.iters,
+        warmup=args.warmup,
+        seed=args.seed,
+        verify=args.verify,
+        server_timeout=args.server_timeout,
+    )

--- a/lmcache/tools/transfer_channel_benchmark/config.py
+++ b/lmcache/tools/transfer_channel_benchmark/config.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration for the transfer channel throughput benchmark."""
+
+# Standard
+from dataclasses import dataclass
+
+_UNITS = {
+    "B": 1,
+    "KB": 1024,
+    "MB": 1024**2,
+    "GB": 1024**3,
+    "TB": 1024**4,
+    "K": 1024,
+    "M": 1024**2,
+    "G": 1024**3,
+    "T": 1024**4,
+}
+
+# Defaults expressed as byte counts so they can be used directly as argparse
+# defaults (argparse applies ``type=parse_size`` only to string inputs).
+DEFAULT_BUFFER_SIZE = 8 * 1024**3
+DEFAULT_PAGE_SIZE = 512 * 1024
+DEFAULT_OBJECT_SIZE = 10 * 1024**2
+
+
+def parse_size(value: str) -> int:
+    """Parse a human-friendly size string into a byte count.
+
+    Args:
+        value: A size such as ``"8GB"``, ``"512KB"``, ``"10MB"`` or a plain
+            integer byte count (e.g. ``"1048576"``).
+
+    Returns:
+        The size in bytes.
+
+    Raises:
+        ValueError: If the string cannot be parsed.
+    """
+    text = str(value).strip().upper()
+    for suffix in ("TB", "GB", "MB", "KB", "T", "G", "M", "K", "B"):
+        if text.endswith(suffix) and text[: -len(suffix)].strip():
+            return int(float(text[: -len(suffix)].strip()) * _UNITS[suffix])
+    return int(text)
+
+
+@dataclass
+class BenchmarkConfig:
+    """Resolved configuration for one benchmark process (server or client).
+
+    Attributes:
+        role: ``"server"`` or ``"client"``.
+        transfer_channel_type: The transfer channel implementation to use
+            (e.g. ``"nixl"``).
+        nixl_backend: The nixl backend name (e.g. ``"UCX"``). Only used by the
+            nixl transfer channel type.
+        url: Server role binds its transfer-channel server here; client role
+            dials this as the peer (server) advertise url to read from.
+        listen_url: Client role binds its own (mandatory) transfer-channel
+            server here. It never receives reads in this benchmark.
+        control_url: Benchmark catalog side-channel. The server binds a ZMQ REP
+            socket here; the client connects to fetch the source object catalog.
+        buffer_size: Size in bytes of the server's registered L1 region.
+        page_size: Page / alignment size in bytes (the L1 ``align_bytes``).
+        object_size: Size in bytes of each transferred object (multiple of
+            ``page_size``).
+        num_objects: Number of objects transferred per read.
+        num_source_objects: Number of source objects the server allocates. The
+            client reads a random ``num_objects``-sized subset of these.
+        use_lazy: Whether the L1 memory manager uses lazy allocation.
+        iters: Number of measured read iterations.
+        warmup: Number of warmup read iterations (not measured).
+        seed: RNG seed for selecting the read subset.
+        verify: Whether to verify transferred bytes against a known pattern.
+        server_timeout: Seconds the server stays up serving catalog requests.
+    """
+
+    role: str
+    transfer_channel_type: str = "nixl"
+    nixl_backend: str = "UCX"
+    url: str = "127.0.0.1:7600"
+    listen_url: str = "0.0.0.0:7601"
+    control_url: str = "0.0.0.0:7610"
+    buffer_size: int = DEFAULT_BUFFER_SIZE
+    page_size: int = DEFAULT_PAGE_SIZE
+    object_size: int = DEFAULT_OBJECT_SIZE
+    num_objects: int = 100
+    num_source_objects: int = 0
+    use_lazy: bool = False
+    iters: int = 5
+    warmup: int = 1
+    seed: int = 0
+    verify: bool = False
+    server_timeout: float = 1800.0
+
+    def __post_init__(self) -> None:
+        """Apply derived defaults and validate the configuration.
+
+        Raises:
+            ValueError: If any field is out of range or mutually inconsistent.
+        """
+        if self.num_source_objects <= 0:
+            self.num_source_objects = 5 * self.num_objects
+
+        if self.page_size <= 0:
+            raise ValueError(f"page_size must be positive, got {self.page_size}")
+        if self.object_size <= 0 or self.object_size % self.page_size != 0:
+            raise ValueError(
+                f"object_size ({self.object_size}) must be a positive multiple "
+                f"of page_size ({self.page_size})"
+            )
+        if self.num_objects < 1:
+            raise ValueError(f"num_objects must be >= 1, got {self.num_objects}")
+        if self.num_source_objects < self.num_objects:
+            raise ValueError(
+                f"num_source_objects ({self.num_source_objects}) must be >= "
+                f"num_objects ({self.num_objects})"
+            )

--- a/lmcache/v1/distributed/transfer_channel/__init__.py
+++ b/lmcache/v1/distributed/transfer_channel/__init__.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+# Future
+from __future__ import annotations
+
 # Standard
 from typing import TYPE_CHECKING
 import threading
@@ -13,10 +16,17 @@ from lmcache.v1.distributed.transfer_channel.api import (
     TransferChannelAddress,
     TransferChannelReadResult,
 )
+from lmcache.v1.distributed.transfer_channel.factory import (
+    TransferChannelType,
+    create_transfer_channel_context,
+)
+
+# Import the implementations so they self-register their factories.
+import lmcache.v1.distributed.transfer_channel.impl  # noqa: F401
 
 if TYPE_CHECKING:
     # First Party
-    from lmcache.v1.distributed.internal_ap import L1MemoryDesc
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
 
 __all__ = [
     "TransferChannelAddress",
@@ -24,6 +34,7 @@ __all__ = [
     "TransferChannelContext",
     "TransferChannelServer",
     "TransferChannelClient",
+    "TransferChannelType",
     "initialize_transfer_channel_context",
     "get_transfer_channel_context",
     "delete_transfer_channel_context",
@@ -34,8 +45,8 @@ _context_lock = threading.Lock()
 
 
 def initialize_transfer_channel_context(
-    transfer_channel_type: str,
-    l1_memory_desc: L1MemoryDesc,
+    transfer_channel_type: TransferChannelType,
+    l1_memory_desc: "L1MemoryDesc",
     listen_url: str,
     advertise_url: str,
     **kwargs,
@@ -48,9 +59,15 @@ def initialize_transfer_channel_context(
         listen_url: ``host:port`` this peer's singleton server binds to.
         advertise_url: ``host:port`` this peer advertises as its identity (the
             key peers store its reverse client under).
+        **kwargs: Implementation-specific keyword arguments forwarded to the
+            factory.
 
     Returns:
         The created context (also retrievable via ``get_transfer_channel_context``).
+
+    Raises:
+        RuntimeError: If a context has already been initialized.
+        ValueError: If no factory is registered for ``transfer_channel_type``.
     """
     global _context
     with _context_lock:
@@ -59,20 +76,13 @@ def initialize_transfer_channel_context(
                 "Transfer channel context already initialized; call "
                 "delete_transfer_channel_context() first."
             )
-        if transfer_channel_type == "nixl":
-            # Third Party
-            from transfer_channel.nixl_impl import NixlTransferChannelContext
-
-            _context = NixlTransferChannelContext(
-                l1_memory_desc=l1_memory_desc,
-                listen_url=listen_url,
-                advertise_url=advertise_url,
-                backends=kwargs.get("backends"),
-            )
-        else:
-            raise ValueError(
-                f"Unsupported transfer_channel_type: {transfer_channel_type!r}"
-            )
+        _context = create_transfer_channel_context(
+            transfer_channel_type=transfer_channel_type,
+            l1_memory_desc=l1_memory_desc,
+            listen_url=listen_url,
+            advertise_url=advertise_url,
+            **kwargs,
+        )
         return _context
 
 

--- a/lmcache/v1/distributed/transfer_channel/__init__.py
+++ b/lmcache/v1/distributed/transfer_channel/__init__.py
@@ -17,7 +17,6 @@ from lmcache.v1.distributed.transfer_channel.api import (
     TransferChannelReadResult,
 )
 from lmcache.v1.distributed.transfer_channel.factory import (
-    TransferChannelType,
     create_transfer_channel_context,
 )
 
@@ -34,7 +33,6 @@ __all__ = [
     "TransferChannelContext",
     "TransferChannelServer",
     "TransferChannelClient",
-    "TransferChannelType",
     "initialize_transfer_channel_context",
     "get_transfer_channel_context",
     "delete_transfer_channel_context",
@@ -45,7 +43,7 @@ _context_lock = threading.Lock()
 
 
 def initialize_transfer_channel_context(
-    transfer_channel_type: TransferChannelType,
+    transfer_channel_type: str,
     l1_memory_desc: "L1MemoryDesc",
     listen_url: str,
     advertise_url: str,

--- a/lmcache/v1/distributed/transfer_channel/__init__.py
+++ b/lmcache/v1/distributed/transfer_channel/__init__.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import TYPE_CHECKING
+import threading
+
+# First Party
+from lmcache.v1.distributed.transfer_channel.abstract import (
+    TransferChannelClient,
+    TransferChannelContext,
+    TransferChannelServer,
+)
+from lmcache.v1.distributed.transfer_channel.api import (
+    TransferChannelAddress,
+    TransferChannelReadResult,
+)
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.internal_ap import L1MemoryDesc
+
+__all__ = [
+    "TransferChannelAddress",
+    "TransferChannelReadResult",
+    "TransferChannelContext",
+    "TransferChannelServer",
+    "TransferChannelClient",
+    "initialize_transfer_channel_context",
+    "get_transfer_channel_context",
+    "delete_transfer_channel_context",
+]
+
+_context: TransferChannelContext | None = None
+_context_lock = threading.Lock()
+
+
+def initialize_transfer_channel_context(
+    transfer_channel_type: str,
+    l1_memory_desc: L1MemoryDesc,
+    listen_url: str,
+    advertise_url: str,
+    **kwargs,
+) -> TransferChannelContext:
+    """Create the global transfer channel context.
+
+    Args:
+        transfer_channel_type: Currently only ``"nixl"`` is supported.
+        l1_memory_desc: Describes the L1 memory region to register.
+        listen_url: ``host:port`` this peer's singleton server binds to.
+        advertise_url: ``host:port`` this peer advertises as its identity (the
+            key peers store its reverse client under).
+
+    Returns:
+        The created context (also retrievable via ``get_transfer_channel_context``).
+    """
+    global _context
+    with _context_lock:
+        if _context is not None:
+            raise RuntimeError(
+                "Transfer channel context already initialized; call "
+                "delete_transfer_channel_context() first."
+            )
+        if transfer_channel_type == "nixl":
+            # Third Party
+            from transfer_channel.nixl_impl import NixlTransferChannelContext
+
+            _context = NixlTransferChannelContext(
+                l1_memory_desc=l1_memory_desc,
+                listen_url=listen_url,
+                advertise_url=advertise_url,
+                backends=kwargs.get("backends"),
+            )
+        else:
+            raise ValueError(
+                f"Unsupported transfer_channel_type: {transfer_channel_type!r}"
+            )
+        return _context
+
+
+def get_transfer_channel_context() -> TransferChannelContext:
+    """Get the global transfer channel context.
+
+    Raises:
+        RuntimeError: If the context has not been initialized yet.
+    """
+    with _context_lock:
+        if _context is None:
+            raise RuntimeError("Transfer channel context not initialized.")
+        return _context
+
+
+def delete_transfer_channel_context() -> None:
+    """Delete the global transfer channel context, if it exists."""
+    global _context
+    with _context_lock:
+        if _context is not None:
+            _context.close()
+            _context = None

--- a/lmcache/v1/distributed/transfer_channel/abstract.py
+++ b/lmcache/v1/distributed/transfer_channel/abstract.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Abstract base classes for the transfer channel abstraction.
+
+Main classes:
+* ``TransferChannelContext`` -- the global singleton that owns the underlying
+  transfer engine, maintains the registered L1 memory, and translates L1 addresses
+  into transfer-channel-specific addresses.
+* ``TransferChannelServer`` -- listens for client connections and exchanges the
+  metadata during the handshake.
+* ``TransferChannelClient`` -- performs the read operations against a peer's
+  memory. Only reads are supported for P2P for now.
+"""
+
+# Standard
+import abc
+
+# First Party
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.transfer_channel.api import (
+    TransferChannelAddress,
+    TransferChannelReadResult,
+)
+
+
+class TransferChannelServer(metaclass=abc.ABCMeta):
+    """Listens for incoming client connections and exchanges transfer metadata."""
+
+    @abc.abstractmethod
+    def __init__(
+        self,
+        listen_url: str,
+        advertise_url: str,
+        l1_memory_desc: L1MemoryDesc,
+    ) -> None:
+        """Creates the server listening on ``listen_url``.
+
+        Args:
+            listen_url: The ``host:port`` to bind and listen on (e.g.
+                ``0.0.0.0:7600``).
+            advertise_url: The ``host:port`` this peer is reachable at and
+                announces in its outgoing handshakes.
+            l1_memory_desc: Describes the L1 memory region to register.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Free the resources created by the server."""
+        raise NotImplementedError
+
+
+class TransferChannelClient(metaclass=abc.ABCMeta):
+    """Performs read operations from a remote peer's memory."""
+
+    @abc.abstractmethod
+    def __init__(self, transfer_channel_server_url: str) -> None:
+        """Connect to the server at ``transfer_channel_server_url``."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def submit_read(
+        self,
+        local_addresses: list[TransferChannelAddress],
+        remote_addresses: list[TransferChannelAddress],
+    ) -> int:
+        """Read data from the remote addresses into the local addresses.
+
+        Args:
+            local_addresses: addresses in the local L1 buffer.
+            remote_addresses: addresses in the remote peer's L1 buffer.
+                Must have the same length as ``local_addresses``.
+
+        Returns:
+            A task id, to be passed to ``query_read_status``.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def query_read_status(self, task_id: int) -> TransferChannelReadResult:
+        """Query the status of a previously submitted read.
+
+        Args:
+            task_id: The task id returned by ``submit_read``.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Terminate in-flight requests, deregister from the server, free resources."""
+        raise NotImplementedError
+
+
+class TransferChannelContext(metaclass=abc.ABCMeta):
+    """Global singleton that owns the server singleton, and all clients."""
+
+    @abc.abstractmethod
+    def get_transfer_channel_server(self) -> TransferChannelServer:
+        """Return the transfer channel server singleton."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_transfer_channel_client(
+        self,
+        peer_advertise_url: str,
+    ) -> TransferChannelClient:
+        """Get or create a client that is connected to the peer identified by
+        ``peer_advertise_url``.
+
+        Args:
+            peer_advertise_url: The ``host:port`` url that can connects to the
+                peer.
+
+        Notes:
+            For some bi-directional transport libraries (like NIXL), the client
+            might be created passively when the current context (server) is
+            connected by the remote peer.
+            This behavior is per implementation and transparent to the caller.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_transfer_channel_address(
+        self,
+        lmcache_addresses: list[tuple[int, int]],
+    ) -> list[TransferChannelAddress]:
+        """Translate ``(offset, size)`` L1 objects into the transfer-channel-specific
+        addresses.
+
+        Args:
+            lmcache_addresses: A list of tuples of the form ``(offset, size)``, where
+                ``offset`` is the offset into the L1 buffer, and ``size`` is the
+                size of the region.
+
+        Returns:
+            A list of transfer-channel-specific addresses that can be used in the
+                client read operations. Must have the same length as
+                ``lmcache_addresses``.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_num_connected_clients(self) -> int:
+        """Return the number of currently connected clients."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Stop and clean up all servers and clients; free context resources."""
+        raise NotImplementedError

--- a/lmcache/v1/distributed/transfer_channel/api.py
+++ b/lmcache/v1/distributed/transfer_channel/api.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Data types exposed by the transfer channel abstraction.
+"""
+
+# Standard
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TransferChannelAddress:
+    """A transfer-channel-specific address, with starting position and size
+    (in bytes).
+
+    A single address corresponds to a single memory object.
+
+    Note:
+        Currently, this is no difference between a tuple of (offset, size).
+        But we are wrapping this as a class for future extensibility (e.g.
+        support non L1 memory).
+    """
+
+    offset: int
+    """ The offset (in bytes) against the L1 base address. """
+
+    size: int
+    """ The size (in bytes) of the memory object. """
+
+
+@dataclass
+class TransferChannelReadResult:
+    """Result of querying a submitted read task."""
+
+    finished: bool
+    """ Whether the transfer has reached a terminal state (done or errored). """
+
+    succeeded: list[TransferChannelAddress] = field(default_factory=list)
+    """ The addresses that were successfully read. Empty while the transfer is still
+    in flight or if it errored. """
+
+    def is_finished(self) -> bool:
+        """Whether the transfer reached a terminal state (done or errored)."""
+        return self.finished
+
+    def succeed_addresses(self) -> list[TransferChannelAddress]:
+        """The addresses that were successfully read."""
+        return self.succeeded

--- a/lmcache/v1/distributed/transfer_channel/api.py
+++ b/lmcache/v1/distributed/transfer_channel/api.py
@@ -34,14 +34,10 @@ class TransferChannelReadResult:
     finished: bool
     """ Whether the transfer has reached a terminal state (done or errored). """
 
-    succeeded: list[TransferChannelAddress] = field(default_factory=list)
-    """ The addresses that were successfully read. Empty while the transfer is still
-    in flight or if it errored. """
+    succeeded_mask: list[bool] = field(default_factory=list)
+    """ Per-object success flags, aligned with the submitted addresses. Empty while
+    the transfer is still in flight. """
 
     def is_finished(self) -> bool:
         """Whether the transfer reached a terminal state (done or errored)."""
         return self.finished
-
-    def succeed_addresses(self) -> list[TransferChannelAddress]:
-        """The addresses that were successfully read."""
-        return self.succeeded

--- a/lmcache/v1/distributed/transfer_channel/factory.py
+++ b/lmcache/v1/distributed/transfer_channel/factory.py
@@ -11,7 +11,7 @@ type name and invokes it.
 from __future__ import annotations
 
 # Standard
-from typing import TYPE_CHECKING, Callable, Literal
+from typing import TYPE_CHECKING, Callable
 
 # First Party
 from lmcache.logging import init_logger
@@ -25,9 +25,6 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-# The set of supported transfer-channel type identifiers.
-TransferChannelType = Literal["nixl"]
-
 # A factory creates a ``TransferChannelContext``. It is always called with the
 # keyword arguments ``l1_memory_desc``, ``listen_url`` and ``advertise_url``,
 # plus any implementation-specific keyword arguments forwarded by the caller.
@@ -38,7 +35,7 @@ _TRANSFER_CHANNEL_FACTORY_REGISTRY: dict[str, TransferChannelFactory] = {}
 
 
 def register_transfer_channel_factory(
-    transfer_channel_type: TransferChannelType,
+    transfer_channel_type: str,
     factory: TransferChannelFactory,
 ) -> None:
     """Register a factory that creates a context for ``transfer_channel_type``.
@@ -64,7 +61,7 @@ def register_transfer_channel_factory(
 
 
 def create_transfer_channel_context(
-    transfer_channel_type: TransferChannelType,
+    transfer_channel_type: str,
     l1_memory_desc: "L1MemoryDesc",
     listen_url: str,
     advertise_url: str,

--- a/lmcache/v1/distributed/transfer_channel/factory.py
+++ b/lmcache/v1/distributed/transfer_channel/factory.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Factory registry for transfer channel contexts.
+
+Each implementation under ``impl/`` self-registers a factory callable via
+``register_transfer_channel_factory`` at import time.
+``create_transfer_channel_context`` looks the factory up by transfer-channel
+type name and invokes it.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING, Callable, Literal
+
+# First Party
+from lmcache.logging import init_logger
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+    from lmcache.v1.distributed.transfer_channel.abstract import (
+        TransferChannelContext,
+    )
+
+logger = init_logger(__name__)
+
+# The set of supported transfer-channel type identifiers.
+TransferChannelType = Literal["nixl"]
+
+# A factory creates a ``TransferChannelContext``. It is always called with the
+# keyword arguments ``l1_memory_desc``, ``listen_url`` and ``advertise_url``,
+# plus any implementation-specific keyword arguments forwarded by the caller.
+TransferChannelFactory = Callable[..., "TransferChannelContext"]
+
+# Registry: transfer-channel type name -> factory callable.
+_TRANSFER_CHANNEL_FACTORY_REGISTRY: dict[str, TransferChannelFactory] = {}
+
+
+def register_transfer_channel_factory(
+    transfer_channel_type: TransferChannelType,
+    factory: TransferChannelFactory,
+) -> None:
+    """Register a factory that creates a context for ``transfer_channel_type``.
+
+    Each implementation module should call this at import time.
+
+    Args:
+        transfer_channel_type: The type name to register the factory under
+            (e.g. ``"nixl"``).
+        factory: A callable invoked with the keyword arguments
+            ``l1_memory_desc``, ``listen_url``, ``advertise_url`` and any
+            implementation-specific keyword arguments, returning a
+            ``TransferChannelContext``.
+
+    Raises:
+        ValueError: If a factory is already registered for this type name.
+    """
+    if transfer_channel_type in _TRANSFER_CHANNEL_FACTORY_REGISTRY:
+        raise ValueError(
+            f"Transfer channel factory already registered: {transfer_channel_type!r}"
+        )
+    _TRANSFER_CHANNEL_FACTORY_REGISTRY[transfer_channel_type] = factory
+
+
+def create_transfer_channel_context(
+    transfer_channel_type: TransferChannelType,
+    l1_memory_desc: "L1MemoryDesc",
+    listen_url: str,
+    advertise_url: str,
+    **kwargs,
+) -> "TransferChannelContext":
+    """Create a transfer channel context using the registered factory.
+
+    Args:
+        transfer_channel_type: The type name of the implementation to create
+            (e.g. ``"nixl"``).
+        l1_memory_desc: Describes the L1 memory region to register.
+        listen_url: ``host:port`` this peer's server binds to.
+        advertise_url: ``host:port`` this peer advertises as its identity.
+        **kwargs: Implementation-specific keyword arguments forwarded to the
+            factory.
+
+    Returns:
+        A new ``TransferChannelContext`` instance.
+
+    Raises:
+        ValueError: If no factory is registered for ``transfer_channel_type``.
+    """
+    factory = _TRANSFER_CHANNEL_FACTORY_REGISTRY.get(transfer_channel_type)
+    if factory is None:
+        known = sorted(_TRANSFER_CHANNEL_FACTORY_REGISTRY)
+        raise ValueError(
+            f"Unsupported transfer_channel_type: {transfer_channel_type!r}. "
+            f"Registered types: {known}"
+        )
+
+    return factory(
+        l1_memory_desc=l1_memory_desc,
+        listen_url=listen_url,
+        advertise_url=advertise_url,
+        **kwargs,
+    )

--- a/lmcache/v1/distributed/transfer_channel/impl/__init__.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transfer channel implementations.
+
+Importing this package imports each implementation module, which in turn
+self-registers its factory via ``register_transfer_channel_factory``.
+"""
+
+# First Party
+from lmcache.v1.distributed.transfer_channel.impl import nixl_impl  # noqa: F401

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Nixl-backed implementation of the transfer channel abstraction."""
+
+# Standard
+from typing import TYPE_CHECKING, Optional, Union
+import importlib
+import math
+import threading
+import uuid
+
+# Third Party
+import msgspec
+import zmq
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.transfer_channel.abstract import (
+    TransferChannelClient,
+    TransferChannelContext,
+    TransferChannelServer,
+)
+from lmcache.v1.distributed.transfer_channel.api import (
+    TransferChannelAddress,
+    TransferChannelReadResult,
+)
+
+if TYPE_CHECKING:
+    # Third Party
+    from nixl._api import nixl_agent, nixl_agent_config, nixl_prepped_dlist_handle
+
+logger = init_logger(__name__)
+
+
+############################################################
+# Helper functions
+############################################################
+def _load_nixl() -> tuple["nixl_agent", "nixl_agent_config"]:
+    """Import the nixl Python bindings, tolerating the cuXX-suffixed packages."""
+    last_err: Optional[Exception] = None
+    for modname in ("nixl._api", "nixl_cu12._api", "nixl_cu13._api"):
+        try:
+            mod = importlib.import_module(modname)
+            return mod.nixl_agent, mod.nixl_agent_config
+        except ImportError as err:  # noqa: PERF203
+            last_err = err
+    raise RuntimeError(
+        "NIXL is not available (tried nixl._api, nixl_cu12._api, nixl_cu13._api)"
+    ) from last_err
+
+
+def _parse_url(url: str) -> tuple[str, int]:
+    """Parse a ``host:port`` (optionally ``tcp://host:port``) into (host, port)."""
+    stripped = url.split("://", 1)[-1]
+    host, _, port = stripped.rpartition(":")
+    if not host or not port:
+        raise ValueError(f"Invalid transfer channel url: {url!r} (expected host:port)")
+    return host, int(port)
+
+
+############################################################
+# Handshake messages (msgspec, tagged union)
+############################################################
+class HandshakeMsgBase(msgspec.Struct, tag=True):
+    pass
+
+
+class InitReq(HandshakeMsgBase):
+    agent_name: str
+    agent_meta: bytes
+
+
+class InitResp(HandshakeMsgBase):
+    agent_name: str
+    agent_meta: bytes
+
+
+class MemRegReq(HandshakeMsgBase):
+    sender_agent_name: str
+    sender_advertise_url: str
+    xfer_descs: bytes
+
+
+class MemRegResp(HandshakeMsgBase):
+    xfer_descs: bytes
+
+
+HandshakeMsg = Union[InitReq, InitResp, MemRegReq, MemRegResp]
+
+
+############################################################
+# Client
+############################################################
+class NixlTransferChannelClient(TransferChannelClient):
+    def __init__(
+        self,
+        context: "NixlTransferChannelContext",
+        remote_agent_name: str,
+        remote_dlist_handle: "nixl_prepped_dlist_handle",
+    ):
+        self._ctx = context
+        self._remote_agent_name = remote_agent_name
+        self._remote_handle = remote_dlist_handle
+
+        self._task_counter = 0
+        # task_id -> (xfer_handle, remote_addresses)
+        self._tasks: dict[int, tuple] = {}
+        self._lock = threading.Lock()
+
+    def submit_read(
+        self,
+        local_addresses: list[TransferChannelAddress],
+        remote_addresses: list[TransferChannelAddress],
+    ) -> int:
+        """Submit a read transfer from the remote addresses to the local addresses.
+
+        Args:
+            local_addresses: The local addresses to read into.
+            remote_addresses: The remote addresses to read from.
+
+        Returns:
+            A unique task ID for this transfer.
+        """
+        if len(local_addresses) != len(remote_addresses):
+            raise ValueError(
+                "local_addresses and remote_addresses must have equal length "
+                f"({len(local_addresses)} != {len(remote_addresses)})"
+            )
+
+        local_idx = self._ctx.addresses_to_indices(local_addresses)
+        remote_idx = self._ctx.addresses_to_indices(remote_addresses)
+
+        agent = self._ctx.agent
+        handle = agent.make_prepped_xfer(
+            "READ",
+            self._ctx.local_handle,
+            local_idx,
+            self._remote_handle,
+            remote_idx,
+        )
+        agent.transfer(handle)
+
+        with self._lock:
+            task_id = self._task_counter
+            self._task_counter += 1
+            self._tasks[task_id] = (handle, list(remote_addresses))
+        return task_id
+
+    def query_read_status(self, task_id: int) -> TransferChannelReadResult:
+        """
+        Query the status of a previously submitted read transfer.
+
+        Args:
+            task_id: The ID of the transfer task to query.
+
+        Returns:
+            A TransferChannelReadResult indicating whether the transfer is finished
+            and which remote addresses succeeded (if finished).
+        """
+        with self._lock:
+            if task_id not in self._tasks:
+                raise KeyError(f"Unknown read task id: {task_id}")
+            handle, remote_addresses = self._tasks[task_id]
+
+        status = self._ctx.agent.check_xfer_state(handle)
+        if status == "PROC":
+            return TransferChannelReadResult(finished=False, succeeded=[])
+
+        # Terminal state (DONE or ERR): release the handle and report.
+        with self._lock:
+            self._tasks.pop(task_id, None)
+        self._ctx.agent.release_xfer_handle(handle)
+
+        if status == "DONE":
+            return TransferChannelReadResult(
+                finished=True, succeeded=list(remote_addresses)
+            )
+
+        # status == "ERR" (or any unexpected state): finished but nothing succeeded.
+        return TransferChannelReadResult(finished=True, succeeded=[])
+
+    def close(self) -> None:
+        """
+        Close the transfer channel, releasing any pending tasks and the remote handle.
+
+        Note:
+            This function does not send any notifications to the server side. The
+            server-side teardown needs to be done by other ways (if needed).
+        """
+        with self._lock:
+            tasks = list(self._tasks.values())
+            self._tasks.clear()
+        for handle, _ in tasks:
+            try:
+                self._ctx.agent.release_xfer_handle(handle)
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                pass
+        if self._remote_handle is not None:
+            try:
+                self._ctx.agent.release_dlist_handle(self._remote_handle)
+            except Exception:  # noqa: BLE001
+                pass
+            self._remote_handle = None
+
+
+############################################################
+# Server
+############################################################
+class NixlTransferChannelServer(TransferChannelServer):
+    """
+    Note:
+        The server uses a ZMQ REP socket for the metadata handshake.
+        It's not using LMCache MQ because we think that's an overkill
+        and we don't want to register the transfer-channel specific
+        functions into the global LMCache MQ.
+    """
+
+    def __init__(
+        self,
+        listen_url: str,
+        advertise_url: str,
+        l1_memory_desc: L1MemoryDesc,
+        context: "NixlTransferChannelContext",
+    ) -> None:
+        self._ctx = context
+        self._listen_url = listen_url
+        self._advertise_url = advertise_url
+        self._l1_memory_desc = l1_memory_desc
+
+        self._running = True
+        self._socket = self._ctx.zmq_context.socket(zmq.REP)
+        self._socket.setsockopt(zmq.LINGER, 0)
+        host, port = _parse_url(listen_url)
+        self._socket.bind(f"tcp://{host}:{port}")
+
+        self._thread = threading.Thread(
+            target=self._serve_loop, name="tc-nixl-server", daemon=True
+        )
+        self._thread.start()
+
+    def _serve_loop(self) -> None:
+        # TODO: use poller to avoid 100ms busy waiting here
+        poller = zmq.Poller()
+        poller.register(self._socket, zmq.POLLIN)
+        while self._running:
+            try:
+                events = dict(poller.poll(timeout=100))  # ms
+                if self._socket not in events:
+                    continue
+                req_bytes = self._socket.recv()
+                req = msgspec.msgpack.decode(req_bytes, type=HandshakeMsg)
+                resp = self._handle_msg(req)
+                self._socket.send(msgspec.msgpack.encode(resp))
+            except Exception:  # noqa: BLE001
+                if self._running:
+                    logger.exception("Error in transfer channel server loop")
+
+    def _handle_msg(self, req: HandshakeMsg) -> HandshakeMsg:
+        agent = self._ctx.agent
+        if isinstance(req, InitReq):
+            # Learn the connecting peer's agent (idempotent on repeat).
+            agent.add_remote_agent(req.agent_meta)
+            return InitResp(
+                agent_name=self._ctx.agent_name,
+                agent_meta=agent.get_agent_metadata(),
+            )
+        elif isinstance(req, MemRegReq):
+            remote_xfer_dlist = agent.deserialize_descs(req.xfer_descs)
+            remote_handle = agent.prep_xfer_dlist(
+                req.sender_agent_name, remote_xfer_dlist
+            )
+
+            self._ctx.register_client(
+                key=req.sender_advertise_url,
+                client=NixlTransferChannelClient(
+                    context=self._ctx,
+                    remote_agent_name=req.sender_agent_name,
+                    remote_dlist_handle=remote_handle,
+                ),
+            )
+            return MemRegResp(xfer_descs=self._ctx.serialized_xfer_descs)
+        else:
+            raise ValueError(f"Unexpected handshake message: {type(req)}")
+
+    def close(self) -> None:
+        """
+        Close the transfer channel server, stopping the serve loop and
+        closing the socket.
+        """
+        self._running = False
+        if self._thread.is_alive():
+            self._thread.join(timeout=5)
+        self._socket.close(linger=0)
+
+
+############################################################
+# Context
+############################################################
+class NixlTransferChannelContext(TransferChannelContext):
+    """Owns the single nixl agent, the registered L1 buffer, and support
+    the address translation.
+    """
+
+    def __init__(
+        self,
+        l1_memory_desc: L1MemoryDesc,
+        listen_url: str,
+        advertise_url: str,
+        backends: Optional[list[str]] = None,
+    ) -> None:
+        """
+        Creates the transfer channel context using nixl.
+
+        Args:
+            l1_memory_desc: The description of the local L1 memory buffer to register.
+            listen_url: The URL to listen on for incoming connections.
+            advertise_url: The URL to advertise to peers for them to connect to us.
+            backends: Optional list of nixl backends to use (e.g., ["UCX"])
+        """
+        nixl_agent, nixl_agent_config = _load_nixl()
+
+        self._l1_memory_desc = l1_memory_desc
+        self._align = l1_memory_desc.align_bytes
+        self.listen_url = listen_url
+        self.advertise_url = advertise_url
+        backends = backends if backends else ["UCX"]
+
+        self.agent_name = str(uuid.uuid4())
+        self.agent = nixl_agent(self.agent_name, nixl_agent_config(backends=backends))
+
+        # Register the whole L1 buffer once (CPU/DRAM, fixed nixl dev_id=0).
+        ptr, size = l1_memory_desc.ptr, l1_memory_desc.size
+        self._reg_descs = self.agent.get_reg_descs([(ptr, size, 0, "")], "cpu")
+        self.agent.register_memory(self._reg_descs)
+
+        # Build + prep a page-granular local xfer dlist over the whole buffer.
+        xfer_list = [
+            (addr, self._align, 0) for addr in range(ptr, ptr + size, self._align)
+        ]
+        self._xfer_descs = self.agent.get_xfer_descs(xfer_list, "cpu")
+        self.local_handle = self.agent.prep_xfer_dlist("", self._xfer_descs, "cpu")
+        self.serialized_xfer_descs = self.agent.get_serialized_descs(self._xfer_descs)
+
+        self.zmq_context = zmq.Context.instance()
+
+        # Clients keyed by the peer's advertised url. Populated either actively
+        # (we dialed the peer) or reactively (the peer connected to our server).
+        self._clients: dict[str, NixlTransferChannelClient] = {}
+        self._lock = threading.Lock()
+
+        # Exactly one server per context, bound eagerly at construction.
+        self._server = NixlTransferChannelServer(
+            listen_url=listen_url,
+            advertise_url=advertise_url,
+            l1_memory_desc=l1_memory_desc,
+            context=self,
+        )
+
+    ############################################################
+    # Address translation
+    ############################################################
+    def get_transfer_channel_address(
+        self,
+        lmcache_addresses: list[tuple[int, int]],
+    ) -> list[TransferChannelAddress]:
+        """
+        Validate the given LMCache addresses (offset, size) against the
+        registered L1 memory region and convert it to TransferChannelAddress
+
+        Args:
+            lmcache_addresses: List of (offset, size) tuples representing the LMCache
+                addresses.
+
+        Returns:
+            A list of TransferChannelAddress corresponding to the given LMCache
+            addresses.
+        """
+        size = self._l1_memory_desc.size
+        out = []
+        for offset, obj_size in lmcache_addresses:
+            if offset < 0 or offset + obj_size > size:
+                raise ValueError(
+                    f"Object [{offset:#x}, {offset + obj_size:#x}) is outside the "
+                    f"registered L1 region [0x0, {size:#x})"
+                )
+            out.append(TransferChannelAddress(offset=offset, size=obj_size))
+        return out
+
+    def addresses_to_indices(
+        self, addresses: list[TransferChannelAddress]
+    ) -> list[int]:
+        """Translate (offset, size) addresses into page indices in the prepped dlist."""
+        indices: list[int] = []
+        for a in addresses:
+            if a.offset % self._align != 0:
+                raise ValueError(
+                    f"Address offset {a.offset} is not aligned to {self._align}"
+                )
+            start = a.offset // self._align
+            n_pages = max(1, math.ceil(a.size / self._align))
+            indices.extend(range(start, start + n_pages))
+        return indices
+
+    ############################################################
+    # Server / client management
+    ############################################################
+    def get_transfer_channel_server(self) -> NixlTransferChannelServer:
+        return self._server
+
+    def get_transfer_channel_client(
+        self,
+        peer_advertise_url: str,
+    ) -> NixlTransferChannelClient:
+        with self._lock:
+            client = self._clients.get(peer_advertise_url)
+            if client is not None:
+                return client
+
+        # Not yet known: actively connect to the peer and perform the handshake.
+        client = self._connect(peer_advertise_url)
+        self.register_client(peer_advertise_url, client)
+        return client
+
+    def get_num_connected_clients(self) -> int:
+        with self._lock:
+            return len(self._clients)
+
+    def register_client(self, key: str, client: NixlTransferChannelClient) -> None:
+        """
+        Register a client for the given key (peer advertise url).
+
+        Args:
+            key: The peer advertise url to register the client under.
+            client: The NixlTransferChannelClient instance to register.
+        """
+        with self._lock:
+            # Don't clobber an existing client view for the same key.
+            self._clients.setdefault(key, client)
+
+    ############################################################
+    # Cleanup
+    ############################################################
+    def close(self) -> None:
+        with self._lock:
+            server = self._server
+            clients = list(self._clients.values())
+            self._clients.clear()
+
+        if server is not None:
+            server.close()
+        for client in clients:
+            client.close()
+
+        try:
+            self.agent.release_dlist_handle(self.local_handle)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self.agent.deregister_memory(self._reg_descs)
+        except Exception:  # noqa: BLE001
+            pass
+
+    ############################################################
+    # Helper functions
+    ############################################################
+    def _connect(self, server_url: str) -> NixlTransferChannelClient:
+        socket = self.zmq_context.socket(zmq.REQ)
+        socket.setsockopt(zmq.LINGER, 0)
+        host, port = _parse_url(server_url)
+        socket.connect(f"tcp://{host}:{port}")
+        try:
+            # Stage 1: exchange agent metadata.
+            socket.send(
+                msgspec.msgpack.encode(
+                    InitReq(
+                        agent_name=self.agent_name,
+                        agent_meta=self.agent.get_agent_metadata(),
+                    )
+                )
+            )
+            init_resp = msgspec.msgpack.decode(socket.recv(), type=HandshakeMsg)
+            assert isinstance(init_resp, InitResp)
+            server_agent_name = self.agent.add_remote_agent(init_resp.agent_meta)
+
+            # Stage 2: exchange transfer-descriptor lists.
+            socket.send(
+                msgspec.msgpack.encode(
+                    MemRegReq(
+                        sender_agent_name=self.agent_name,
+                        sender_advertise_url=self.advertise_url,
+                        xfer_descs=self.serialized_xfer_descs,
+                    )
+                )
+            )
+            memreg_resp = msgspec.msgpack.decode(socket.recv(), type=HandshakeMsg)
+            assert isinstance(memreg_resp, MemRegResp)
+            remote_xfer_dlist = self.agent.deserialize_descs(memreg_resp.xfer_descs)
+            remote_handle = self.agent.prep_xfer_dlist(
+                server_agent_name, remote_xfer_dlist
+            )
+        finally:
+            socket.close(linger=0)
+
+        return NixlTransferChannelClient(
+            context=self,
+            remote_agent_name=server_agent_name,
+            remote_dlist_handle=remote_handle,
+        )

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -445,8 +445,7 @@ class NixlTransferChannelContext(TransferChannelContext):
         old_client = None
         with self._lock:
             old_client = self._clients.get(key)
-            if old_client is None:
-                self._clients[key] = client
+            self._clients[key] = client
 
         if old_client is not None and old_client is not client:
             logger.warning(

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -163,7 +163,7 @@ class NixlTransferChannelClient(TransferChannelClient):
 
         Returns:
             A TransferChannelReadResult indicating whether the transfer is finished
-            and which remote addresses succeeded (if finished).
+            and which objects succeeded (if finished).
         """
         with self._lock:
             if task_id not in self._tasks:
@@ -172,7 +172,7 @@ class NixlTransferChannelClient(TransferChannelClient):
 
         status = self._ctx.agent.check_xfer_state(handle)
         if status == "PROC":
-            return TransferChannelReadResult(finished=False, succeeded=[])
+            return TransferChannelReadResult(finished=False, succeeded_mask=[])
 
         # Terminal state (DONE or ERR): release the handle and report.
         with self._lock:
@@ -181,11 +181,13 @@ class NixlTransferChannelClient(TransferChannelClient):
 
         if status == "DONE":
             return TransferChannelReadResult(
-                finished=True, succeeded=list(remote_addresses)
+                finished=True, succeeded_mask=[True] * len(remote_addresses)
             )
 
         # status == "ERR" (or any unexpected state): finished but nothing succeeded.
-        return TransferChannelReadResult(finished=True, succeeded=[])
+        return TransferChannelReadResult(
+            finished=True, succeeded_mask=[False] * len(remote_addresses)
+        )
 
     def close(self) -> None:
         """

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -24,6 +24,9 @@ from lmcache.v1.distributed.transfer_channel.api import (
     TransferChannelAddress,
     TransferChannelReadResult,
 )
+from lmcache.v1.distributed.transfer_channel.factory import (
+    register_transfer_channel_factory,
+)
 
 if TYPE_CHECKING:
     # Third Party
@@ -239,12 +242,11 @@ class NixlTransferChannelServer(TransferChannelServer):
         self._thread.start()
 
     def _serve_loop(self) -> None:
-        # TODO: use poller to avoid 100ms busy waiting here
         poller = zmq.Poller()
         poller.register(self._socket, zmq.POLLIN)
         while self._running:
             try:
-                events = dict(poller.poll(timeout=100))  # ms
+                events = dict(poller.poll(timeout=1000))  # ms
                 if self._socket not in events:
                     continue
                 req_bytes = self._socket.recv()
@@ -506,3 +508,35 @@ class NixlTransferChannelContext(TransferChannelContext):
             remote_agent_name=server_agent_name,
             remote_dlist_handle=remote_handle,
         )
+
+
+############################################################
+# Factory registration
+############################################################
+def create_nixl_transfer_channel_context(
+    l1_memory_desc: L1MemoryDesc,
+    listen_url: str,
+    advertise_url: str,
+    **kwargs,
+) -> NixlTransferChannelContext:
+    """Create a ``NixlTransferChannelContext``.
+
+    Args:
+        l1_memory_desc: Describes the L1 memory region to register.
+        listen_url: ``host:port`` this peer's server binds to.
+        advertise_url: ``host:port`` this peer advertises as its identity.
+        **kwargs: Accepts ``backends`` (an optional list of nixl backends,
+            e.g. ``["UCX"]``).
+
+    Returns:
+        A new ``NixlTransferChannelContext`` instance.
+    """
+    return NixlTransferChannelContext(
+        l1_memory_desc=l1_memory_desc,
+        listen_url=listen_url,
+        advertise_url=advertise_url,
+        backends=kwargs.get("backends"),
+    )
+
+
+register_transfer_channel_factory("nixl", create_nixl_transfer_channel_context)

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -440,9 +440,23 @@ class NixlTransferChannelContext(TransferChannelContext):
             key: The peer advertise url to register the client under.
             client: The NixlTransferChannelClient instance to register.
         """
+        old_client = None
         with self._lock:
-            # Don't clobber an existing client view for the same key.
-            self._clients.setdefault(key, client)
+            old_client = self._clients.get(key)
+            if old_client is None:
+                self._clients[key] = client
+
+        if old_client is not None and old_client is not client:
+            logger.warning(
+                "Overwriting existing transfer channel client for %s.",
+                key,
+            )
+            try:
+                old_client.close()
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Error closing old transfer channel client for %s", key
+                )
 
     ############################################################
     # Cleanup

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# Timeout for each blocking recv during the client handshake. Without it a
+# misconfigured/unreachable server url would block the connecting thread
+# forever. Hard-coded for now.
+_HANDSHAKE_TIMEOUT_MS = 60_000
+
 
 ############################################################
 # Helper functions
@@ -465,9 +470,34 @@ class NixlTransferChannelContext(TransferChannelContext):
     ############################################################
     # Helper functions
     ############################################################
+    def _recv_handshake(self, socket: "zmq.Socket", server_url: str) -> bytes:
+        """Receive one handshake reply, mapping a timeout to a clear error.
+
+        Args:
+            socket: The REQ socket awaiting the server's reply.
+            server_url: The peer url being dialed (for the error message).
+
+        Returns:
+            The raw reply bytes.
+
+        Raises:
+            TimeoutError: If no reply arrives within the handshake timeout
+                (e.g. the url is wrong/unreachable or the port is blocked).
+        """
+        try:
+            return socket.recv()
+        except zmq.Again as err:
+            raise TimeoutError(
+                f"Timed out after {_HANDSHAKE_TIMEOUT_MS / 1000:.0f}s waiting for "
+                f"a transfer-channel handshake reply from {server_url!r}. Check "
+                f"that the peer is running and that the url/port is correct and "
+                f"reachable."
+            ) from err
+
     def _connect(self, server_url: str) -> NixlTransferChannelClient:
         socket = self.zmq_context.socket(zmq.REQ)
         socket.setsockopt(zmq.LINGER, 0)
+        socket.setsockopt(zmq.RCVTIMEO, _HANDSHAKE_TIMEOUT_MS)
         host, port = _parse_url(server_url)
         socket.connect(f"tcp://{host}:{port}")
         try:
@@ -480,7 +510,9 @@ class NixlTransferChannelContext(TransferChannelContext):
                     )
                 )
             )
-            init_resp = msgspec.msgpack.decode(socket.recv(), type=HandshakeMsg)
+            init_resp = msgspec.msgpack.decode(
+                self._recv_handshake(socket, server_url), type=HandshakeMsg
+            )
             assert isinstance(init_resp, InitResp)
             server_agent_name = self.agent.add_remote_agent(init_resp.agent_meta)
 
@@ -494,7 +526,9 @@ class NixlTransferChannelContext(TransferChannelContext):
                     )
                 )
             )
-            memreg_resp = msgspec.msgpack.decode(socket.recv(), type=HandshakeMsg)
+            memreg_resp = msgspec.msgpack.decode(
+                self._recv_handshake(socket, server_url), type=HandshakeMsg
+            )
             assert isinstance(memreg_resp, MemRegResp)
             remote_xfer_dlist = self.agent.deserialize_descs(memreg_resp.xfer_descs)
             remote_handle = self.agent.prep_xfer_dlist(

--- a/tests/v1/distributed/transfer_channel/__init__.py
+++ b/tests/v1/distributed/transfer_channel/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/distributed/transfer_channel/test_api.py
+++ b/tests/v1/distributed/transfer_channel/test_api.py
@@ -46,10 +46,9 @@ def test_addresses_with_same_fields_are_equal():
 # =========================================================
 # TransferChannelReadResult
 # =========================================================
-def test_read_result_succeeded_defaults_to_empty_list():
+def test_read_result_succeeded_mask_defaults_to_empty_list():
     result = TransferChannelReadResult(finished=False)
-    assert result.succeeded == []
-    assert result.succeed_addresses() == []
+    assert result.succeeded_mask == []
 
 
 def test_read_result_is_finished_reflects_finished_flag():
@@ -59,17 +58,13 @@ def test_read_result_is_finished_reflects_finished_flag():
     assert done.is_finished() is True
 
 
-def test_read_result_succeed_addresses_returns_succeeded():
-    addrs = [
-        TransferChannelAddress(offset=0, size=16),
-        TransferChannelAddress(offset=16, size=16),
-    ]
-    result = TransferChannelReadResult(finished=True, succeeded=addrs)
-    assert result.succeed_addresses() == addrs
+def test_read_result_succeeded_mask_returns_flags():
+    result = TransferChannelReadResult(finished=True, succeeded_mask=[True, False])
+    assert result.succeeded_mask == [True, False]
 
 
-def test_read_result_default_succeeded_lists_are_independent():
+def test_read_result_default_succeeded_masks_are_independent():
     a = TransferChannelReadResult(finished=False)
     b = TransferChannelReadResult(finished=False)
-    a.succeeded.append(TransferChannelAddress(offset=0, size=8))
-    assert b.succeeded == []
+    a.succeeded_mask.append(True)
+    assert b.succeeded_mask == []

--- a/tests/v1/distributed/transfer_channel/test_api.py
+++ b/tests/v1/distributed/transfer_channel/test_api.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for the transfer channel data types.
+
+Tests are written against the public contracts documented in
+``lmcache/v1/distributed/transfer_channel/api.py`` and exercise only the
+public interface.
+"""
+
+# Standard
+import dataclasses
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.transfer_channel import (
+    TransferChannelAddress,
+    TransferChannelReadResult,
+)
+
+
+# =========================================================
+# TransferChannelAddress
+# =========================================================
+def test_address_stores_offset_and_size():
+    addr = TransferChannelAddress(offset=128, size=64)
+    assert addr.offset == 128
+    assert addr.size == 64
+
+
+def test_address_is_immutable():
+    addr = TransferChannelAddress(offset=0, size=16)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        addr.offset = 32  # type: ignore[misc]
+
+
+def test_addresses_with_same_fields_are_equal():
+    a = TransferChannelAddress(offset=10, size=20)
+    b = TransferChannelAddress(offset=10, size=20)
+    c = TransferChannelAddress(offset=10, size=21)
+    assert a == b
+    assert a != c
+
+
+# =========================================================
+# TransferChannelReadResult
+# =========================================================
+def test_read_result_succeeded_defaults_to_empty_list():
+    result = TransferChannelReadResult(finished=False)
+    assert result.succeeded == []
+    assert result.succeed_addresses() == []
+
+
+def test_read_result_is_finished_reflects_finished_flag():
+    in_flight = TransferChannelReadResult(finished=False)
+    done = TransferChannelReadResult(finished=True)
+    assert in_flight.is_finished() is False
+    assert done.is_finished() is True
+
+
+def test_read_result_succeed_addresses_returns_succeeded():
+    addrs = [
+        TransferChannelAddress(offset=0, size=16),
+        TransferChannelAddress(offset=16, size=16),
+    ]
+    result = TransferChannelReadResult(finished=True, succeeded=addrs)
+    assert result.succeed_addresses() == addrs
+
+
+def test_read_result_default_succeeded_lists_are_independent():
+    a = TransferChannelReadResult(finished=False)
+    b = TransferChannelReadResult(finished=False)
+    a.succeeded.append(TransferChannelAddress(offset=0, size=8))
+    assert b.succeeded == []

--- a/tests/v1/distributed/transfer_channel/test_context_lifecycle.py
+++ b/tests/v1/distributed/transfer_channel/test_context_lifecycle.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for the global transfer channel context lifecycle:
+``initialize_transfer_channel_context``, ``get_transfer_channel_context`` and
+``delete_transfer_channel_context``.
+
+Tests are written against the documented contracts in
+``lmcache/v1/distributed/transfer_channel/__init__.py`` and use only the
+public interface.
+"""
+
+# Standard
+from collections.abc import Iterator
+import itertools
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.transfer_channel import (
+    TransferChannelContext,
+    delete_transfer_channel_context,
+    get_transfer_channel_context,
+    initialize_transfer_channel_context,
+)
+from lmcache.v1.distributed.transfer_channel.factory import (
+    register_transfer_channel_factory,
+)
+
+_name_counter = itertools.count()
+
+
+def _unique_type_name() -> str:
+    return f"test_lifecycle_{next(_name_counter)}"
+
+
+class _FakeContext(TransferChannelContext):
+    """Context double that records whether ``close`` was called."""
+
+    def __init__(self, **kwargs) -> None:
+        self.created_kwargs = kwargs
+        self.closed = False
+
+    def get_transfer_channel_server(self):
+        raise NotImplementedError
+
+    def get_transfer_channel_client(self, peer_advertise_url: str):
+        raise NotImplementedError
+
+    def get_transfer_channel_address(self, lmcache_addresses):
+        raise NotImplementedError
+
+    def get_num_connected_clients(self) -> int:
+        return 0
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def fake_type() -> Iterator[str]:
+    """Register a fake factory and guarantee the global context is cleared."""
+    name = _unique_type_name()
+    register_transfer_channel_factory(name, lambda **kw: _FakeContext(**kw))
+    try:
+        yield name
+    finally:
+        delete_transfer_channel_context()
+
+
+def _l1_desc() -> L1MemoryDesc:
+    return L1MemoryDesc(ptr=0, size=4096, align_bytes=256)
+
+
+def test_get_before_initialize_raises_runtime_error(fake_type):
+    with pytest.raises(RuntimeError):
+        get_transfer_channel_context()
+
+
+def test_initialize_returns_context_and_get_returns_same(fake_type):
+    ctx = initialize_transfer_channel_context(
+        transfer_channel_type=fake_type,
+        l1_memory_desc=_l1_desc(),
+        listen_url="0.0.0.0:7600",
+        advertise_url="host:7600",
+    )
+    assert isinstance(ctx, TransferChannelContext)
+    assert get_transfer_channel_context() is ctx
+
+
+def test_double_initialize_raises_runtime_error(fake_type):
+    initialize_transfer_channel_context(
+        transfer_channel_type=fake_type,
+        l1_memory_desc=_l1_desc(),
+        listen_url="0.0.0.0:7600",
+        advertise_url="host:7600",
+    )
+    with pytest.raises(RuntimeError):
+        initialize_transfer_channel_context(
+            transfer_channel_type=fake_type,
+            l1_memory_desc=_l1_desc(),
+            listen_url="0.0.0.0:7601",
+            advertise_url="host:7601",
+        )
+
+
+def test_delete_closes_context_and_get_raises_again(fake_type):
+    ctx = initialize_transfer_channel_context(
+        transfer_channel_type=fake_type,
+        l1_memory_desc=_l1_desc(),
+        listen_url="0.0.0.0:7600",
+        advertise_url="host:7600",
+    )
+    delete_transfer_channel_context()
+    assert ctx.closed is True
+    with pytest.raises(RuntimeError):
+        get_transfer_channel_context()
+
+
+def test_delete_without_initialize_is_noop(fake_type):
+    # Should not raise even when no context exists.
+    delete_transfer_channel_context()
+
+
+def test_reinitialize_after_delete_succeeds(fake_type):
+    first = initialize_transfer_channel_context(
+        transfer_channel_type=fake_type,
+        l1_memory_desc=_l1_desc(),
+        listen_url="0.0.0.0:7600",
+        advertise_url="host:7600",
+    )
+    delete_transfer_channel_context()
+    second = initialize_transfer_channel_context(
+        transfer_channel_type=fake_type,
+        l1_memory_desc=_l1_desc(),
+        listen_url="0.0.0.0:7600",
+        advertise_url="host:7600",
+    )
+    assert second is not first
+    assert get_transfer_channel_context() is second

--- a/tests/v1/distributed/transfer_channel/test_factory.py
+++ b/tests/v1/distributed/transfer_channel/test_factory.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for the transfer channel factory registry.
+
+Tests are written against the documented contracts of
+``register_transfer_channel_factory`` and ``create_transfer_channel_context``
+in ``lmcache/v1/distributed/transfer_channel/factory.py`` and use only the
+public interface.
+"""
+
+# Standard
+import itertools
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.transfer_channel import (
+    TransferChannelContext,
+)
+from lmcache.v1.distributed.transfer_channel.factory import (
+    create_transfer_channel_context,
+    register_transfer_channel_factory,
+)
+
+# Unique-name generator so each test registers a fresh type name (the registry
+# is process-global and rejects duplicate registrations).
+_name_counter = itertools.count()
+
+
+def _unique_type_name() -> str:
+    return f"test_fake_{next(_name_counter)}"
+
+
+class _FakeContext(TransferChannelContext):
+    """Minimal context double recording the kwargs it was created with."""
+
+    def __init__(self, **kwargs) -> None:
+        self.created_kwargs = kwargs
+
+    def get_transfer_channel_server(self):
+        raise NotImplementedError
+
+    def get_transfer_channel_client(self, peer_advertise_url: str):
+        raise NotImplementedError
+
+    def get_transfer_channel_address(self, lmcache_addresses):
+        raise NotImplementedError
+
+    def get_num_connected_clients(self) -> int:
+        return 0
+
+    def close(self) -> None:
+        pass
+
+
+def _l1_desc() -> L1MemoryDesc:
+    return L1MemoryDesc(ptr=0, size=4096, align_bytes=256)
+
+
+# =========================================================
+# register_transfer_channel_factory
+# =========================================================
+def test_create_invokes_registered_factory_with_kwargs():
+    name = _unique_type_name()
+    register_transfer_channel_factory(name, lambda **kw: _FakeContext(**kw))
+
+    desc = _l1_desc()
+    ctx = create_transfer_channel_context(
+        transfer_channel_type=name,
+        l1_memory_desc=desc,
+        listen_url="0.0.0.0:7600",
+        advertise_url="host:7600",
+        backends=["UCX"],
+    )
+
+    assert isinstance(ctx, _FakeContext)
+    assert ctx.created_kwargs["l1_memory_desc"] is desc
+    assert ctx.created_kwargs["listen_url"] == "0.0.0.0:7600"
+    assert ctx.created_kwargs["advertise_url"] == "host:7600"
+    # Implementation-specific kwargs are forwarded as-is.
+    assert ctx.created_kwargs["backends"] == ["UCX"]
+
+
+def test_register_duplicate_type_raises_value_error():
+    name = _unique_type_name()
+    register_transfer_channel_factory(name, lambda **kw: _FakeContext(**kw))
+    with pytest.raises(ValueError):
+        register_transfer_channel_factory(name, lambda **kw: _FakeContext(**kw))
+
+
+# =========================================================
+# create_transfer_channel_context
+# =========================================================
+def test_create_unregistered_type_raises_value_error():
+    with pytest.raises(ValueError):
+        create_transfer_channel_context(
+            transfer_channel_type=_unique_type_name(),
+            l1_memory_desc=_l1_desc(),
+            listen_url="0.0.0.0:7600",
+            advertise_url="host:7600",
+        )

--- a/tests/v1/distributed/transfer_channel/test_nixl_impl.py
+++ b/tests/v1/distributed/transfer_channel/test_nixl_impl.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Integration tests for the nixl-backed transfer channel implementation.
+
+Tests are written against the public contracts documented in
+``transfer_channel/abstract.py`` and ``transfer_channel/api.py`` (the
+``TransferChannelContext`` / ``TransferChannelServer`` / ``TransferChannelClient``
+interfaces). They use only public methods and do not access private fields.
+
+These tests require a working nixl runtime (with a UCX backend) and are skipped
+when nixl is unavailable.
+
+Most tests share a single module-scoped context-pair to avoid paying the (slow)
+nixl agent initialization for every test. The reads are self-verifying -- each
+reads fresh remote data into its target region and checks that region -- so a
+reused buffer and connection do not affect their outcome. The one test that must
+observe a pristine connection state (the 0 -> 1 connection-count transition)
+uses its own function-scoped pair instead, since there is no public way to reset
+an existing context's connected clients short of closing it.
+"""
+
+# Standard
+import itertools
+import time
+
+# Third Party
+import pytest
+import torch
+
+nixl = pytest.importorskip("nixl")
+
+# First Party
+from lmcache.v1.distributed.internal_api import L1MemoryDesc  # noqa: E402
+from lmcache.v1.distributed.transfer_channel.impl.nixl_impl import (  # noqa: E402
+    NixlTransferChannelContext,
+)
+
+_ALIGN = 256
+_BUF_SIZE = 4096
+
+# Each context must bind to a distinct port so multiple pairs can coexist in one
+# process without clashing.
+_port_counter = itertools.count(17900)
+
+
+def _next_url() -> str:
+    return f"127.0.0.1:{next(_port_counter)}"
+
+
+def _make_context_pair():
+    """Create two contexts backed by two distinct CPU buffers.
+
+    ``buf_b`` holds a known byte pattern so transfers can be content-verified;
+    ``buf_a`` starts zeroed. Returns ``(ctx_a, buf_a, ctx_b, buf_b)``.
+    """
+    buf_a = torch.zeros(_BUF_SIZE, dtype=torch.uint8)
+    buf_b = torch.arange(0, 256, dtype=torch.uint8).repeat(_BUF_SIZE // 256)
+    desc_a = L1MemoryDesc(ptr=buf_a.data_ptr(), size=buf_a.numel(), align_bytes=_ALIGN)
+    desc_b = L1MemoryDesc(ptr=buf_b.data_ptr(), size=buf_b.numel(), align_bytes=_ALIGN)
+
+    url_a, url_b = _next_url(), _next_url()
+    ctx_a = NixlTransferChannelContext(desc_a, listen_url=url_a, advertise_url=url_a)
+    ctx_b = NixlTransferChannelContext(desc_b, listen_url=url_b, advertise_url=url_b)
+    return ctx_a, buf_a, ctx_b, buf_b
+
+
+@pytest.fixture(scope="module")
+def shared_contexts():
+    """A single context-pair reused across connection-state-insensitive tests."""
+    ctx_a, buf_a, ctx_b, buf_b = _make_context_pair()
+    try:
+        yield ctx_a, buf_a, ctx_b, buf_b
+    finally:
+        ctx_a.close()
+        ctx_b.close()
+
+
+@pytest.fixture
+def fresh_contexts():
+    """A brand-new context-pair for tests that need pristine connection state."""
+    ctx_a, buf_a, ctx_b, buf_b = _make_context_pair()
+    try:
+        yield ctx_a, buf_a, ctx_b, buf_b
+    finally:
+        ctx_a.close()
+        ctx_b.close()
+
+
+def _wait_finished(client, task_id, timeout_s=5.0):
+    """Poll query_read_status until the task reports finished (or timeout)."""
+    deadline = time.monotonic() + timeout_s
+    result = client.query_read_status(task_id)
+    while not result.is_finished() and time.monotonic() < deadline:
+        time.sleep(0.01)
+        result = client.query_read_status(task_id)
+    return result
+
+
+# =========================================================
+# Address translation (get_transfer_channel_address)
+# =========================================================
+def test_get_address_returns_matching_offsets_and_sizes(shared_contexts):
+    ctx_a, _, _, _ = shared_contexts
+    addrs = ctx_a.get_transfer_channel_address([(0, 512), (1024, 256)])
+    assert len(addrs) == 2
+    assert (addrs[0].offset, addrs[0].size) == (0, 512)
+    assert (addrs[1].offset, addrs[1].size) == (1024, 256)
+
+
+def test_get_address_out_of_region_raises_value_error(shared_contexts):
+    ctx_a, _, _, _ = shared_contexts
+    with pytest.raises(ValueError):
+        ctx_a.get_transfer_channel_address([(_BUF_SIZE, 256)])
+    with pytest.raises(ValueError):
+        ctx_a.get_transfer_channel_address([(_BUF_SIZE - 128, 256)])
+
+
+# =========================================================
+# End-to-end read (submit_read / query_read_status)
+# =========================================================
+def test_read_copies_remote_data_into_local_buffer(shared_contexts):
+    ctx_a, buf_a, ctx_b, buf_b = shared_contexts
+    client = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+
+    local = ctx_a.get_transfer_channel_address([(0, 512)])
+    remote = ctx_b.get_transfer_channel_address([(0, 512)])
+    task_id = client.submit_read(local, remote)
+
+    result = _wait_finished(client, task_id)
+    assert result.is_finished() is True
+    assert result.succeed_addresses() == remote
+    assert torch.equal(buf_a[:512], buf_b[:512])
+
+
+def test_read_into_offset_region(shared_contexts):
+    ctx_a, buf_a, ctx_b, buf_b = shared_contexts
+    client = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+
+    # Read remote [0, 256) into local [1024, 1280).
+    local = ctx_a.get_transfer_channel_address([(1024, 256)])
+    remote = ctx_b.get_transfer_channel_address([(0, 256)])
+    task_id = client.submit_read(local, remote)
+
+    result = _wait_finished(client, task_id)
+    assert result.is_finished() is True
+    assert torch.equal(buf_a[1024:1280], buf_b[0:256])
+
+
+def test_submit_read_mismatched_lengths_raises_value_error(shared_contexts):
+    ctx_a, _, ctx_b, _ = shared_contexts
+    client = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+    local = ctx_a.get_transfer_channel_address([(0, 256)])
+    remote = ctx_b.get_transfer_channel_address([(0, 256), (256, 256)])
+    with pytest.raises(ValueError):
+        client.submit_read(local, remote)
+
+
+def test_query_unknown_task_id_raises_key_error(shared_contexts):
+    ctx_a, _, ctx_b, _ = shared_contexts
+    client = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+    with pytest.raises(KeyError):
+        client.query_read_status(99999)
+
+
+# =========================================================
+# Client / server management
+# =========================================================
+def test_get_client_is_idempotent(shared_contexts):
+    ctx_a, _, ctx_b, _ = shared_contexts
+    first = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+    second = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+    assert first is second
+
+
+def test_connecting_registers_clients_on_both_sides(fresh_contexts):
+    ctx_a, _, ctx_b, _ = fresh_contexts
+    assert ctx_a.get_num_connected_clients() == 0
+    assert ctx_b.get_num_connected_clients() == 0
+
+    ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+
+    # A actively dialed B; B passively learned a reverse client for A.
+    assert ctx_a.get_num_connected_clients() == 1
+    assert ctx_b.get_num_connected_clients() == 1
+
+
+def test_server_is_available_from_context(shared_contexts):
+    ctx_a, _, _, _ = shared_contexts
+    assert ctx_a.get_transfer_channel_server() is not None

--- a/tests/v1/distributed/transfer_channel/test_nixl_impl.py
+++ b/tests/v1/distributed/transfer_channel/test_nixl_impl.py
@@ -128,7 +128,7 @@ def test_read_copies_remote_data_into_local_buffer(shared_contexts):
 
     result = _wait_finished(client, task_id)
     assert result.is_finished() is True
-    assert result.succeed_addresses() == remote
+    assert result.succeeded_mask == [True] * len(remote)
     assert torch.equal(buf_a[:512], buf_b[:512])
 
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Introduces the following main classes:
- TransferChannelContext -- manages the server singleton and all the clients 
- TransferChannelServer -- answer's client's handshake
- TransferChannelClient -- read from peer's memory

**Performance test:**
 | page size | median GB/s | best GB/s | mean GB/s |
  |-----------|:---:|:---:|:---:|
  | 4 KB | 64.9 | 65.7 | 64.8 |
  | 16 KB | 140.5 | 142.4 | 140.3 |
  | 64 KB | 190.4 | 191.4 | 190.3 |
  | 256 KB | 205.1 | 206.0 | 205.1 |
  | 1 MB | 209.1 | 210.2 | 209.1 |
  | 4 MB | 210.0 | 211.1 | 209.7 |


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
