### PR TITLE
[WIP] refactor: rename KVCache (list[CudaIPCWrapper]) -> IPCKVCache

### DIFF
--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -43,7 +43,7 @@ def _wrap_sglang_kv_caches(
 ) -> list[CudaIPCWrapper]:
     """Flatten SGLang's depth-2 ``[K_layers, V_layers]`` KV layout into a
     single flat ``list[CudaIPCWrapper]`` so it fits upstream's wire
-    ``KVCache`` payload type. The daemon's
+    ``IPCKVCache`` payload type. The daemon's
     :func:`normalize_kv_and_discover_format` recognizes this shape from
     ``EngineType.SGLANG`` plus a ``tokens_per_block`` ``LayoutHints`` field
     and splits it back at its midpoint before format detection.
@@ -137,7 +137,7 @@ class LMCacheMPConnector:
         # (instance_id, kv_cache, model_name, world_size, engine_type,
         # layout_hints, engine_group_infos). SGLang's natural KV layout is depth-2
         # ([K_layers, V_layers]); we flatten it on the wire to fit
-        # ``KVCache = list[CudaIPCWrapper]``. The daemon recognizes the
+        # ``IPCKVCache = list[CudaIPCWrapper]``. The daemon recognizes the
         # SGLang-MHA flat-of-2NL pattern from ``EngineType.SGLANG`` plus the
         # ``tokens_per_block`` hint and un-flattens + reshapes per layer.
         # SGLang is non-hybrid (a single KV cache group), so engine_group_infos is the

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -19,7 +19,7 @@ from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
     IPCCacheServerKey,
-    KVCache,
+    IPCKVCache,
 )
 from lmcache.v1.multiprocess.group_view import (
     EngineGroupInfo,
@@ -124,7 +124,7 @@ class _IpcEvent(Protocol):
     def ipc_handle(self) -> Any: ...
 
 
-def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
+def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> IPCKVCache:
     # Emit a per-layer (name, shape, dtype) summary so the operator can
     # verify the exact layer set & tensor geometry being shipped to the
     # LMCache server, then the low-noise count of handles being wrapped.
@@ -146,7 +146,7 @@ def wrap_kv_caches(kv_caches: dict[str, torch.Tensor]) -> KVCache:
     # registered with POSIX SHM so the named segments do not outlive
     # the failed batch. CUDA wrappers do not own a named segment and
     # are skipped via the duck-typed ``shm_name`` check.
-    wrappers: KVCache = []
+    wrappers: IPCKVCache = []
     try:
         for tensor in kv_caches.values():
             wrappers.append(wrap_one_kv_cache(tensor))

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -568,7 +568,7 @@ def normalize_kv_and_discover_format(
 
     # SGLang MP hands us a flat ``list[Tensor]`` of length ``2 * num_layers``
     # (first half K layers, second half V layers) so the wire payload fits
-    # ``KVCache = list[CudaIPCWrapper]``. Restore the canonical depth-2
+    # ``IPCKVCache = list[CudaIPCWrapper]``. Restore the canonical depth-2
     # ``[K_layers, V_layers]`` shape, and reshape each per-layer tensor
     # from ``(page_buffer_size, num_heads, head_size)`` to ``(num_blocks,
     # block_size, num_heads, head_size)`` using the engine-supplied

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -141,7 +141,7 @@ class RawCudaIPCWrapper(CudaIPCWrapper):
 
     Subclassing (rather than introducing a parallel class with its own
     msgspec ext code) is load-bearing — msgspec does not support unions
-    of custom ext-encoded types. With subclassing, ``KVCache =
+    of custom ext-encoded types. With subclassing, ``IPCKVCache =
     list[CudaIPCWrapper]`` continues to type-check, the existing ext
     code 1 round-trips both wrappers, and pickle preserves the subclass
     identity through the wire so ``to_tensor`` dispatches correctly.
@@ -312,7 +312,7 @@ class IPCCacheServerKey:
 
 
 # Type exports
-KVCache = list[CudaIPCWrapper]
+IPCKVCache = list[CudaIPCWrapper]
 
 
 class RegisterNonGpuContextPayload(msgspec.Struct):

--- a/lmcache/v1/multiprocess/gpu_context.py
+++ b/lmcache/v1/multiprocess/gpu_context.py
@@ -38,7 +38,7 @@ from lmcache.v1.gpu_connector.utils import (
     normalize_kv_and_discover_format,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
-from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.custom_types import IPCKVCache
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 
 # Backend selection (c_ops when CUDA is available, otherwise a pure-Python
@@ -50,7 +50,7 @@ import lmcache.c_ops as lmc_ops
 logger = init_logger(__name__)
 
 
-def unwrap_kv_cache_tensors(kv_caches: KVCache) -> list[torch.Tensor]:
+def unwrap_kv_cache_tensors(kv_caches: IPCKVCache) -> list[torch.Tensor]:
     unwrapped_tensors = []
     for ipc_wrapper in kv_caches:
         tensor = ipc_wrapper.to_tensor()
@@ -355,7 +355,7 @@ class GPUCacheContext:
 
     def __init__(
         self,
-        kv_caches: KVCache,
+        kv_caches: IPCKVCache,
         lmcache_tokens_per_chunk: int = 256,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
@@ -753,7 +753,7 @@ class PlainGPUCacheContext:
     A plain GPU cache context that have a single contiguous 2LTD buffer
     """
 
-    def __init__(self, kv_caches: KVCache, lmcache_tokens_per_chunk: int = 256):
+    def __init__(self, kv_caches: IPCKVCache, lmcache_tokens_per_chunk: int = 256):
         assert len(kv_caches) == 1, (
             "PlainGPUCacheContext only supports a single KV cache tensor"
         )

--- a/lmcache/v1/multiprocess/modules/blend.py
+++ b/lmcache/v1/multiprocess/modules/blend.py
@@ -27,7 +27,7 @@ from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.multiprocess.custom_types import (
     CBMatchResult,
     IPCCacheServerKey,
-    KVCache,
+    IPCKVCache,
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 from lmcache.v1.multiprocess.engine_module import (
@@ -417,7 +417,7 @@ class BlendModule:
     def cb_register_kv_cache(
         self,
         instance_id: int,
-        kv_caches: KVCache,
+        kv_caches: IPCKVCache,
         model_name: str,
         world_size: int,
     ) -> None:
@@ -425,7 +425,7 @@ class BlendModule:
 
         Args:
             instance_id: Unique identifier for the blend engine instance.
-            kv_caches: KVCache object containing the GPU buffer pointers.
+            kv_caches: IPCKVCache object containing the GPU buffer pointers.
             model_name: The name of the model associated with this KV cache.
             world_size: The world size associated with this KV cache.
         """

--- a/lmcache/v1/multiprocess/modules/gpu_transfer.py
+++ b/lmcache/v1/multiprocess/modules/gpu_transfer.py
@@ -31,7 +31,7 @@ from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
-    KVCache,
+    IPCKVCache,
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 from lmcache.v1.multiprocess.engine_module import (
@@ -512,7 +512,7 @@ class GPUTransferModule:
     def register_kv_cache(
         self,
         instance_id: int,
-        kv_caches: KVCache,
+        kv_caches: IPCKVCache,
         model_name: str,
         world_size: int,
         engine_type: EngineType,

--- a/lmcache/v1/multiprocess/protocols/blend.py
+++ b/lmcache/v1/multiprocess/protocols/blend.py
@@ -7,7 +7,7 @@ This module defines the protocol for:
 """
 
 # First Party
-from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey, KVCache
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey, IPCKVCache
 from lmcache.v1.multiprocess.protocols.base import HandlerType, ProtocolDefinition
 
 # Define request names for this protocol group
@@ -88,12 +88,12 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Register CB KV Cache
         # Payload:
         #   - instance_id: int - Unique identifier for the vLLM instance
-        #   - kv_cache: KVCache - The CB KV cache configuration
+        #   - kv_cache: IPCKVCache - The CB KV cache configuration
         #   - model_name: str - Name of the model associated with the engine
         #   - world_size: int - World size of the engine
         # Returns: None
         "CB_REGISTER_KV_CACHE": ProtocolDefinition(
-            payload_classes=[int, KVCache, str, int],
+            payload_classes=[int, IPCKVCache, str, int],
             response_class=None,
             handler_type=HandlerType.SYNC,
         ),

--- a/lmcache/v1/multiprocess/protocols/engine.py
+++ b/lmcache/v1/multiprocess/protocols/engine.py
@@ -21,7 +21,7 @@ from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
-    KVCache,
+    IPCKVCache,
     RegisterNonGpuContextPayload,
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
@@ -90,7 +90,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Register KV Cache
         # Payload:
         #   - instance_id: int - Unique identifier for the engine instance
-        #   - kv_cache: KVCache - The KV cache configuration
+        #   - kv_cache: IPCKVCache - The KV cache configuration
         #   - model_name: str - Name of the model associated with the engine
         #   - world_size: int - World size of the engine
         #   - engine_type: EngineType - Which serving engine produced the
@@ -102,7 +102,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         "REGISTER_KV_CACHE": ProtocolDefinition(
             payload_classes=[
                 int,
-                KVCache,
+                IPCKVCache,
                 str,
                 int,
                 EngineType,

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 # First Party
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
-from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.custom_types import IPCKVCache
 from lmcache.v1.platform.cpu.cache_context import CpuCacheContext
 
 if TYPE_CHECKING:
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 def create_cache_context(
-    kv_caches: KVCache,
+    kv_caches: IPCKVCache,
     lmcache_tokens_per_chunk: int = 256,
     layout_hints: LayoutHints | None = None,
     engine_group_infos: "Sequence[EngineGroupInfo]" = (),

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -41,7 +41,7 @@ from lmcache.v1.gpu_connector.utils import (
     normalize_kv_and_discover_format,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
-from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.custom_types import IPCKVCache
 from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
 import lmcache.c_ops as lmc_ops
 
@@ -70,7 +70,7 @@ class CpuCacheContext:
 
     def __init__(
         self,
-        kv_caches: KVCache,
+        kv_caches: IPCKVCache,
         lmcache_tokens_per_chunk: int = 256,
         layout_hints: LayoutHints | None = None,
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -23,7 +23,7 @@ from lmcache.v1.multiprocess.config import MPServerConfig
 from lmcache.v1.multiprocess.custom_types import (
     CudaIPCWrapper,
     IPCCacheServerKey,
-    KVCache,
+    IPCKVCache,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import (
@@ -114,7 +114,7 @@ class ClientContext:
             device, num_pages, num_layers, page_size, num_heads, head_size, dtype
         )
 
-    def get_kv_cache(self) -> KVCache:
+    def get_kv_cache(self) -> IPCKVCache:
         """
         Wrap GPU tensors in CudaIPCWrapper for IPC communication.
         """

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -365,7 +365,7 @@ def test_mq_noop_multiple_clients():
 def test_mq_register_kv_cache():
     """
     Test MessageQueue with REGISTER_KV_CACHE request type.
-    REGISTER_KV_CACHE takes (gpu_id: int, kv_cache: KVCache) and returns None.
+    REGISTER_KV_CACHE takes (gpu_id: int, kv_cache: IPCKVCache) and returns None.
     """
     # Create test KV cache (list of CudaIPCWrapper objects)
     kv_cache = []

--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
+++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
@@ -11,7 +11,7 @@ from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
-    KVCache,
+    IPCKVCache,
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocol import KeyType
@@ -36,7 +36,7 @@ def noop_handler() -> str:
 
 def register_kv_cache_handler(
     gpu_id: int,
-    kv_cache: KVCache,
+    kv_cache: IPCKVCache,
     model_name: str,
     world_size: int,
     engine_type: EngineType,

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -370,17 +370,17 @@ class TestRawCudaIPCWrapperType:
         assert issubclass(RawCudaIPCWrapper, CudaIPCWrapper)
 
     def test_kvcache_typing_unchanged(self) -> None:
-        """``KVCache = list[CudaIPCWrapper]`` should accept subclass items
+        """``IPCKVCache = list[CudaIPCWrapper]`` should accept subclass items
         — load-bearing for msgspec ext-code reuse over ZMQ.
         """
         # First Party
         from lmcache.v1.multiprocess.custom_types import (
             CudaIPCWrapper,
-            KVCache,
+            IPCKVCache,
             RawCudaIPCWrapper,
         )
 
-        assert KVCache == list[CudaIPCWrapper]
+        assert IPCKVCache == list[CudaIPCWrapper]
         # Static check substitute: a Raw* instance fits the list type.
         assert issubclass(RawCudaIPCWrapper, CudaIPCWrapper)
 


### PR DESCRIPTION
we should get the naming right on `KVCache` and `DiscoverableKVCache`

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
