### PR TITLE
[CI][MP] Register HTTP API routers explicitly to fix AMD unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
       uv pip freeze
 
       LMCACHE_TRACK_USAGE="false" \
-      pytest --maxfail=1 --cov=lmcache \
+      pytest --cov=lmcache \
         --cov-report term --cov-report=html:coverage-test \
         --cov-report=xml:coverage-test.xml --html=durations/test.html \
         --ignore=tests/disagg --ignore=tests/v1/test_pos_kernels.py \

--- a/lmcache/v1/multiprocess/http_api_registry.py
+++ b/lmcache/v1/multiprocess/http_api_registry.py
@@ -1,25 +1,45 @@
 # SPDX-License-Identifier: Apache-2.0
-# Standard
-from pathlib import Path
-
 # Third Party
 from fastapi import APIRouter, FastAPI
 
 # First Party
-from lmcache.logging import init_logger
-from lmcache.v1.utils.router_discovery import discover_api_routers
+from lmcache.v1.multiprocess.http_apis.cache_api import router as cache_router
+from lmcache.v1.multiprocess.http_apis.common_api import router as common_router
+from lmcache.v1.multiprocess.http_apis.conf_api import router as conf_router
+from lmcache.v1.multiprocess.http_apis.healthcheck_api import (
+    router as healthcheck_router,
+)
+from lmcache.v1.multiprocess.http_apis.quota_api import router as quota_router
+from lmcache.v1.multiprocess.http_apis.reconfigure_api import (
+    router as reconfigure_router,
+)
+from lmcache.v1.multiprocess.http_apis.root_api import router as root_router
+from lmcache.v1.multiprocess.http_apis.status_api import router as status_router
+from lmcache.v1.multiprocess.http_apis.version_api import router as version_router
 
-logger = init_logger(__name__)
+# Every multiprocess HTTP API router, registered in import order. Add a new
+# ``http_apis`` module's router here to expose it. Routers are imported
+# explicitly rather than discovered from the filesystem so that registration
+# does not depend on the on-disk package layout, which differs between source
+# checkouts and editable/wheel installs.
+_MP_HTTP_ROUTERS: tuple[APIRouter, ...] = (
+    cache_router,
+    common_router,
+    conf_router,
+    healthcheck_router,
+    quota_router,
+    reconfigure_router,
+    root_router,
+    status_router,
+    version_router,
+)
 
 
 class HTTPAPIRegistry:
-    """
-    Automatically discovers and registers HTTP API routes
-    from the ``http_apis`` sub-package.
+    """Registers the multiprocess HTTP API routers on a FastAPI app.
 
-    Any module whose name ends with ``_api`` and exposes a
-    module-level ``router`` (:class:`~fastapi.APIRouter`) will
-    be picked up automatically.
+    The routers exposed on the multiprocess HTTP server are the ones listed
+    in :data:`_MP_HTTP_ROUTERS`.
     """
 
     def __init__(self, app: FastAPI):
@@ -27,18 +47,8 @@ class HTTPAPIRegistry:
         self.router = APIRouter()
 
     def register_all_apis(self) -> None:
-        """
-        Discover and register all ``*_api`` modules under
-        the ``http_apis`` directory.
-        """
-        apis_path = Path(__file__).parent / "http_apis"
-        if not apis_path.exists():
-            logger.warning("http_apis directory not found")
-            return
-
-        apis_package = f"{__package__}.http_apis"
-
-        for r in discover_api_routers(apis_path, apis_package):
-            self.router.include_router(r)
+        """Register every router in :data:`_MP_HTTP_ROUTERS` on the app."""
+        for router in _MP_HTTP_ROUTERS:
+            self.router.include_router(router)
 
         self.app.include_router(self.router)

--- a/lmcache/v1/multiprocess/http_apis/common_api.py
+++ b/lmcache/v1/multiprocess/http_apis/common_api.py
@@ -1,46 +1,48 @@
 # SPDX-License-Identifier: Apache-2.0
 """Aggregate HTTP routes exposed by ``lmcache.v1.internal_api_server.common``.
 
-This module discovers every ``*_api`` sub-module under the
-``internal_api_server/common`` package and merges their ``router``
-attributes into a single :class:`~fastapi.APIRouter` named
-``router`` so that :class:`HTTPAPIRegistry` picks it up through the
-standard ``http_apis`` auto-discovery mechanism.
+This module merges the ``router`` from every API module under the
+``internal_api_server/common`` package into a single
+:class:`~fastapi.APIRouter` named ``router``, which :class:`HTTPAPIRegistry`
+registers on the multiprocess HTTP server.
 
-Adding a new API module under ``internal_api_server/common`` requires
-no changes here: it is registered automatically.
+To expose a new common API on the multiprocess server, import its ``router``
+below and add it to :data:`_COMMON_ROUTERS`. Routers are imported explicitly
+rather than discovered from the filesystem so that registration does not depend
+on the on-disk package layout, which differs between source checkouts and
+editable/wheel installs.
 
 Note:
-    Some modules under ``internal_api_server/common`` target the
-    vLLM-embedded API server and rely on attributes that only exist
-    on that server's ``app.state`` (e.g. ``lmcache_adapter``).  Such
-    modules are listed in ``_MP_INCOMPATIBLE_MODULES`` and skipped
-    here so they don't raise misleading 500s when invoked on the
-    multiprocess HTTP server.
+    Some modules under ``internal_api_server/common`` target the vLLM-embedded
+    API server and rely on ``app.state`` attributes that only exist there (e.g.
+    ``lmcache_adapter``). Those are simply left out of :data:`_COMMON_ROUTERS`.
 """
-
-# Standard
-from pathlib import Path
 
 # Third Party
 from fastapi import APIRouter
 
 # First Party
-from lmcache.v1 import internal_api_server
-from lmcache.v1.utils.router_discovery import discover_api_routers
+from lmcache.v1.internal_api_server.common.env_api import router as env_router
+from lmcache.v1.internal_api_server.common.loglevel_api import router as loglevel_router
+from lmcache.v1.internal_api_server.common.metrics_api import router as metrics_router
+from lmcache.v1.internal_api_server.common.periodic_thread_api import (
+    router as periodic_thread_router,
+)
+from lmcache.v1.internal_api_server.common.run_script_api import (
+    router as run_script_router,
+)
+from lmcache.v1.internal_api_server.common.thread_api import router as thread_router
+
+# Common API routers that are safe to serve from the multiprocess HTTP server.
+_COMMON_ROUTERS: tuple[APIRouter, ...] = (
+    env_router,
+    loglevel_router,
+    metrics_router,
+    periodic_thread_router,
+    run_script_router,
+    thread_router,
+)
 
 router = APIRouter()
-
-# Modules that depend on vLLM-specific ``app.state`` attributes and
-# therefore cannot run on the multiprocess HTTP server.
-_MP_INCOMPATIBLE_MODULES: frozenset[str] = frozenset()
-
-_common_path = Path(internal_api_server.__file__).parent / "common"
-_common_package = f"{internal_api_server.__name__}.common"
-
-for _discovered in discover_api_routers(
-    _common_path,
-    _common_package,
-    exclude=_MP_INCOMPATIBLE_MODULES,
-):
-    router.include_router(_discovered)
+for _common_router in _COMMON_ROUTERS:
+    router.include_router(_common_router)


### PR DESCRIPTION
**What this PR does / why we need it**:

The `unit-tests-amd` Buildkite pipeline has been red on **every** build — including docs-only and dependabot PRs — so the failure is independent of PR contents.

Root cause: the multiprocess HTTP server builds its routes by *filesystem reflection* (`pkgutil.iter_modules` over `Path(__file__).parent`). Under this pipeline's editable install (`uv pip install -e .`), the nested discovery of `internal_api_server/common` returns no modules, so `common_api.router` ends up empty and `/run_script` (plus `/env`, `/conf`, `/loglevel`, `/metrics`) never register. `test_run_script_endpoint_present` then fails on every build, and `--maxfail=1` aborts the whole suite — turning one environment-sensitive test into an always-red pipeline regardless of the PR.

This PR registers the routers via **explicit imports** instead of filesystem reflection, so registration no longer depends on the on-disk package layout (which differs between source checkouts and editable/wheel installs). It also drops `--maxfail=1` from the bare-metal pipeline so a single failing test can't red the entire matrix.

**Special notes for your reviewers**:

- Behavior is unchanged on a healthy install — the MP server still exposes the same 27 routes (verified locally: all expected endpoints present). Covered by the existing `test_common_api.py` and `test_http_api_registry.py` integration tests, which were the ones going red on AMD.
- `lmcache/v1/utils/router_discovery.py` is intentionally left in place; it is still used by the `mp_coordinator` and `internal_api_server` registries, which share the same latent fragility. Converting those to explicit registration is a sensible follow-up, kept out of scope here.
- Trade-off of the explicit list: adding a new `http_apis`/`common` module now requires one import line (documented in each module's docstring) instead of being auto-discovered.
- I could not reproduce the editable-install failure locally (the `uv` editable build needs the ROCm C-extension toolchain), but the explicit imports remove the failing mechanism by construction.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests