### PR TITLE
[Throwawy]: Activation Store

### DIFF
--- a/docs/design/v1/activation_store.md
+++ b/docs/design/v1/activation_store.md
@@ -1,0 +1,114 @@
+# ActivationStore
+
+`ActivationStore` is an LMCache-internal store dedicated to caching per-token
+activation tensors next to KV chunks. It generalizes the hidden-state store
+(PR #3221): the same machinery caches **any** per-token activation -- hidden
+states, query (Q) projections, K/V, MLP intermediates -- keyed by
+`(CacheEngineKey, ActivationKind, layer_idx)`. It exists to support multi-stage
+pipelines (e.g. vLLM-Omni thinker -> talker) and activation-reuse schemes where
+a downstream consumer needs a cached prefix's intermediate activations rather
+than recomputing them.
+
+## Relationship to HiddenStateStore
+
+`HiddenStateStore` (PR #3221) is the `kind=ActivationKind.HIDDEN` special case
+of this store. The only structural change is the slot key: where the
+hidden-state store keyed each chunk by `layer_idx` alone, `ActivationStore` keys
+by `(ActivationKind, layer_idx)`. The pinned pool, chunking, LRU, and
+coupled-eviction logic are unchanged. One deliberate behavioral change: the
+store **preserves the activation's native dtype** (bf16/fp16) instead of forcing
+float32, halving the footprint for typical activations.
+
+## Goals
+
+- Keep KV cache logic and activation cache logic in **separate classes**.
+  `LMCacheEngine` owns one instance and exposes it via `engine.activation_store`.
+- Use a **separate pinned CPU memory pool** so activation allocations cannot
+  fragment the KV pool.
+- **Reuse** existing chunking and key generation
+  (`ChunkedTokenDatabase.process_tokens` -> `CacheEngineKey`) so each activation
+  chunk is keyed identically to its KV counterpart.
+- Implement the **coupled-but-asymmetric** eviction rule:
+  - KV evicted -> activations for that chunk are dropped on next access.
+  - Activation evicted -> KV stays.
+  - Restore stops at the first chunk where the requested activation is missing.
+
+## Class layout
+
+```
+LMCacheEngine
+  - storage_manager     (KV: LocalCPUBackend + LocalDiskBackend + ...)
+  - activation_store    (ActivationStore, owns its own pinned pool)
+       - _allocator     (MixedMemoryAllocator, independent buffer)
+       - _chunks: dict[CacheEngineKey, dict[(ActivationKind, layer_idx), MemoryObj]]
+       - _lru:    OrderedDict[CacheEngineKey, None]
+```
+
+`ActivationStore` does not depend on `StorageManager` for storage. It holds a
+reference to the storage manager (set via `bind_storage_manager()`) so that on
+retrieve it can ask "is KV still here for this key?" via
+`storage_manager.contains(key)`.
+
+## Public API
+
+Integrators call these on **`engine.activation_store`** when it is not `None`
+(when `config.enable_activation_cache` is `True`). Callers **must** check for
+`None` themselves (same pattern as vLLM-Omni `OmniGPUModelRunner`).
+
+- `store_activation(token_ids, activation, *, kind, layer_idx=0, token_offset=0) -> int`
+  Chunks `token_ids` with the engine's `token_database`, copies the matching
+  rows of `activation` into pinned memory under the KV chunk key, returns the
+  number of chunks stored. `token_offset` supports incremental stores (only
+  chunks at or after the offset are written; partially-covered chunks are
+  skipped to stay atomic with KV boundaries).
+- `retrieve_activation(token_ids, *, kind, layer_idx=0) -> torch.Tensor | None`
+  Walks chunks in order. Stops at the first chunk where either KV is missing
+  (lazy coupled-eviction cleanup) or the requested activation slot is missing
+  (prefix-strict). Returns the contiguous prefix tensor (native dtype) or `None`.
+- `close()` -- frees the pinned pool.
+
+Multiple kinds/layers are handled by invoking the calls once per
+`(kind, layer_idx)`.
+
+## Activation kinds and capture points (producer side)
+
+`ActivationKind` enumerates what may be cached. Each is a dense
+`[num_tokens, feature_dim]` tensor mapping 1:1 to tokens. The store is
+capture-agnostic; the producer (vLLM integration) decides where each is read:
+
+| Kind               | feature_dim          | vLLM capture point                                                              |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------- |
+| `HIDDEN`           | hidden_size          | already exposed via EAGLE3 `aux_hidden_states` (`vllm/v1/spec_decode/extract_hidden_states.py`, `gpu_model_runner` aux layers) |
+| `QUERY`            | n_q_heads*head_dim   | needs a forward hook at `q_proj` output (e.g. model `*Attention.forward`)       |
+| `KEY` / `VALUE`    | n_kv_heads*head_dim  | already in the KV cache; cache here only if a non-paged copy is wanted          |
+| `MLP_INTERMEDIATE` | d_ffn                | needs a forward hook at the MLP gate/up output                                  |
+
+Only `HIDDEN` has existing vLLM plumbing; the others require a capture hook.
+
+## Eviction (lazy coupled-check)
+
+- Allocator pressure: `ActivationStore` evicts its own LRU entry and retries;
+  KV is never touched.
+- KV evictions are **not** observed eagerly. On every retrieve we ask
+  `storage_manager.contains(key)`. If KV is gone for a chunk we hold, we drop
+  that activation entry and stop the prefix there.
+
+This keeps the engine surface tiny (no callbacks, no shared index) while
+satisfying: KV evict implies activation evict (next read drops the orphan);
+activation evict does not imply KV evict; restore stops at the first missing
+activation *or* missing KV chunk.
+
+## Configuration
+
+| Field                          | Meaning                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------- |
+| `enable_activation_cache`      | Master toggle. When `False`, `engine.activation_store` is `None`.       |
+| `max_activation_cpu_size` (GiB)| Independent pinned-CPU pool size for the activation allocator.          |
+| `activation_layers`            | Optional allowlist of `layer_idx` values accepted on store.            |
+
+## Why lazy eviction (not callbacks)
+
+- No invasive changes to `LocalCPUBackend` or any cache policy.
+- Works uniformly for any backend implementing `contains()`.
+- Costs one extra `contains()` call per chunk on retrieve -- a cheap dict
+  lookup for the local case.

--- a/lmcache/v1/activation_store.py
+++ b/lmcache/v1/activation_store.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ActivationStore: per-chunk cache for arbitrary per-token activations.
+
+This is a direct generalization of :class:`HiddenStateStore` (PR #3221). The
+storage/eviction machinery is unchanged; the only difference is the key axis.
+Where ``HiddenStateStore`` keys each chunk by ``layer_idx`` alone, this store
+keys by ``(ActivationKind, layer_idx)`` so a single pinned pool can hold hidden
+states, query (Q) projections, K/V, and MLP intermediates side by side.
+
+Constructed by :class:`~lmcache.v1.cache_engine.LMCacheEngine` when
+``config.enable_activation_cache`` is True and exposed as
+``engine.activation_store``. See ``docs/design/v1/activation_store.md``.
+"""
+from collections import OrderedDict
+from enum import Enum
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+
+import torch
+
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObj,
+    MixedMemoryAllocator,
+)
+from lmcache.v1.token_database import TokenDatabase
+
+if TYPE_CHECKING:
+    from lmcache.v1.storage_backend.storage_manager import StorageManager
+
+logger = init_logger(__name__)
+
+_GIB = 1024**3
+
+# Maximum LRU-evict-and-retry attempts in _alloc_chunk. Each retry evicts one
+# entry from this store's own pool (never from KV) before re-attempting the
+# allocation, so the effective "wait" is exhausting our own LRU queue.
+_ACT_ALLOC_MAX_RETRIES = 8
+
+
+class ActivationKind(Enum):
+    """Kind of per-token activation cached alongside KV.
+
+    Every kind is a dense ``[num_tokens, feature_dim]`` tensor that maps 1:1 to
+    tokens, exactly like KV. ``feature_dim`` is kind-dependent (e.g. hidden_size
+    for HIDDEN, ``num_q_heads * head_dim`` for QUERY) and is captured implicitly
+    in the stored tensor shape; the store does not need to know it ahead of time.
+    """
+
+    HIDDEN = "hidden"
+    QUERY = "query"
+    KEY = "key"
+    VALUE = "value"
+    MLP_INTERMEDIATE = "mlp_intermediate"
+
+
+# Composite per-chunk slot key: which activation, at which layer.
+_SlotKey = Tuple[ActivationKind, int]
+
+
+class ActivationStore:
+    """Stand-alone, chunk-aligned cache for per-token activations.
+
+    Keeps one MemoryObj per ``(chunk-key, kind, layer_idx)`` tuple on its own
+    pinned-CPU pool. Chunk keys come from the engine's TokenDatabase, so every
+    activation chunk shares the exact :class:`CacheEngineKey` of the
+    corresponding KV chunk.
+
+    Eviction is "lazy coupled": when a retrieve walks chunks in order, the store
+    asks the bound StorageManager whether KV is still present for each key. If KV
+    is gone, the orphan activation entry is dropped and the prefix ends there (KV
+    evict -> activation evict). When the store's own pool is full, the store
+    evicts its own LRU entry; it never evicts KV.
+
+    Args:
+        config: Engine config. Reads ``enable_activation_cache``,
+            ``max_activation_cpu_size`` (GiB), and ``activation_layers``.
+            Retrieval always uses prefix-strict assembly (stop at the first chunk
+            missing KV or the requested activation slot).
+        token_database: The same TokenDatabase used by the engine, so chunk
+            boundaries and keys match KV exactly.
+    """
+
+    def __init__(
+        self,
+        config: LMCacheEngineConfig,
+        token_database: TokenDatabase,
+    ) -> None:
+        self._config = config
+        self._token_database = token_database
+        self._storage_manager: Optional["StorageManager"] = None
+
+        size_bytes = int(config.max_activation_cpu_size * _GIB)
+        if size_bytes <= 0:
+            raise ValueError(
+                "max_activation_cpu_size must be > 0 when "
+                "enable_activation_cache=True"
+            )
+
+        self._allocator = MixedMemoryAllocator(size_bytes, config=config)
+
+        # CacheEngineKey -> {(kind, layer_idx): MemoryObj}. LRU ordering is held
+        # separately in _lru so we can refresh it cheaply on access.
+        self._chunks: Dict[CacheEngineKey, Dict[_SlotKey, MemoryObj]] = {}
+        self._lru: "OrderedDict[CacheEngineKey, None]" = OrderedDict()
+
+        allowlist = config.activation_layers
+        self._layer_allowlist: Optional[set] = (
+            set(allowlist) if allowlist is not None else None
+        )
+
+        logger.info(
+            "ActivationStore initialized: pool=%.2f GB, layer_allowlist=%s",
+            config.max_activation_cpu_size,
+            self._layer_allowlist,
+        )
+
+    # ------------------------------------------------------------------
+    # Wiring
+    # ------------------------------------------------------------------
+
+    def bind_storage_manager(self, storage_manager: "StorageManager") -> None:
+        """Attach the engine's :class:`StorageManager`.
+
+        Required for coupled eviction. Without it, retrieve falls back to
+        activation-only presence checks.
+        """
+        self._storage_manager = storage_manager
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def store_activation(
+        self,
+        token_ids: Union[torch.Tensor, List[int]],
+        activation: torch.Tensor,
+        *,
+        kind: ActivationKind,
+        layer_idx: int = 0,
+        token_offset: int = 0,
+    ) -> int:
+        """Store ``activation`` chunked under the same keys as KV.
+
+        Args:
+            token_ids: 1-D int tensor or list of the **full** token-ID prefix
+                (same sequence used for KV storage so chunk boundaries and chunk
+                keys align with KV exactly).
+            activation: 2-D tensor of shape
+                ``[len(token_ids) - token_offset, feature_dim]`` (CPU or GPU).
+                Moved to CPU internally; its dtype is preserved (unlike the
+                hidden-state store, which forced float32 -- activations are
+                typically bf16/fp16 and forcing float32 doubles the footprint).
+                Corresponds to ``token_ids[token_offset:]``.
+            kind: Which activation this is (hidden, query, ...).
+            layer_idx: Transformer layer the activation came from. Defaults to 0.
+            token_offset: Number of leading tokens in ``token_ids`` that are
+                **not** present in ``activation`` because they were cached by a
+                prior incremental call. Defaults to 0 (full sequence provided).
+                Only chunks whose token range starts at or after ``token_offset``
+                are written; partially-covered chunks
+                (``start < token_offset < end``) are skipped to keep each chunk
+                atomic.
+
+        Returns:
+            Number of chunks stored (0 when filtered by allowlist or on
+            allocation failure).
+
+        Raises:
+            ValueError: If ``token_offset`` is out of range, or if ``activation``
+                has an unexpected shape.
+            RuntimeError: If an allocated MemoryObj has no backing tensor
+                (indicates an allocator bug).
+        """
+        if (
+            self._layer_allowlist is not None
+            and layer_idx not in self._layer_allowlist
+        ):
+            logger.debug(
+                "ActivationStore: dropping layer_idx=%d (not in allowlist=%s)",
+                layer_idx,
+                self._layer_allowlist,
+            )
+            return 0
+
+        if activation.dim() != 2:
+            raise ValueError(
+                f"activation must be 2-D [num_tokens, feature_dim], "
+                f"got shape {tuple(activation.shape)}"
+            )
+
+        n_toks = (
+            len(token_ids)
+            if isinstance(token_ids, list)
+            else int(token_ids.shape[0])
+        )
+        if not (0 <= token_offset <= n_toks):
+            raise ValueError(
+                f"token_offset ({token_offset}) must be in [0, len(token_ids) "
+                f"({n_toks})]"
+            )
+        expected_rows = n_toks - token_offset
+        if activation.shape[0] != expected_rows:
+            raise ValueError(
+                f"activation first dim ({activation.shape[0]}) must equal "
+                f"len(token_ids) - token_offset ({expected_rows})"
+            )
+
+        act_cpu = activation.detach().to("cpu").contiguous()
+        feature_dim = act_cpu.shape[1]
+        slot: _SlotKey = (kind, layer_idx)
+
+        chunks = self._chunk(token_ids)
+        stored = 0
+        for start, end, key in chunks:
+            # Skip chunks entirely before the provided activation, or partially
+            # covered (keep chunks atomic with KV boundaries).
+            if start < token_offset:
+                continue
+
+            existing = self._chunks.get(key)
+            if existing is not None and slot in existing:
+                # Already cached for this slot; bump LRU.
+                self._lru.pop(key, None)
+                self._lru[key] = None
+                continue
+
+            n = end - start
+            obj = self._alloc_chunk(n, feature_dim, act_cpu.dtype)
+            if obj is None:
+                logger.warning(
+                    "ActivationStore: out of pool memory after eviction; "
+                    "stopping store at chunk start=%d",
+                    start,
+                )
+                break
+            tensor = obj.tensor
+            if tensor is None:
+                obj.ref_count_down()
+                raise RuntimeError(
+                    "ActivationStore: allocator returned MemoryObj with no "
+                    "backing tensor"
+                )
+            tensor.copy_(act_cpu[start - token_offset : end - token_offset])
+
+            slot_map = self._chunks.setdefault(key, {})
+            slot_map[slot] = obj
+            self._lru.pop(key, None)
+            self._lru[key] = None
+            stored += 1
+
+        return stored
+
+    def retrieve_activation(
+        self,
+        token_ids: Union[torch.Tensor, List[int]],
+        *,
+        kind: ActivationKind,
+        layer_idx: int = 0,
+    ) -> Optional[torch.Tensor]:
+        """Retrieve cached rows for ``(kind, layer_idx)`` as a contiguous prefix.
+
+        Walks chunks of ``token_ids`` in order. Stops at the first chunk where
+        either KV is no longer present (lazy coupled-eviction cleanup) or the
+        requested activation slot is missing (prefix-strict).
+
+        Args:
+            token_ids: The token-ID prefix to look up (same keying as KV).
+            kind: Which activation to retrieve.
+            layer_idx: Transformer layer to retrieve. Defaults to 0.
+
+        Returns:
+            CPU tensor of shape ``[num_cached_prefix_tokens, feature_dim]`` in
+            the dtype it was stored with, or None if no chunk is cached.
+
+        Raises:
+            RuntimeError: If a cached MemoryObj has no backing tensor (indicates
+                an allocator bug).
+        """
+        slot: _SlotKey = (kind, layer_idx)
+        chunks = self._chunk(token_ids)
+        out_rows: List[torch.Tensor] = []
+        for _, _, key in chunks:
+            if not self._kv_present(key):
+                # KV evicted -> drop activations for this key and stop.
+                if key in self._chunks:
+                    self._free_key(key)
+                break
+
+            slot_map = self._chunks.get(key)
+            if slot_map is None or slot not in slot_map:
+                # Activation missing for this chunk: prefix-strict stop.
+                break
+
+            obj = slot_map[slot]
+            tensor = obj.tensor
+            if tensor is None:
+                raise RuntimeError(
+                    "ActivationStore: cached MemoryObj has no backing tensor"
+                )
+            out_rows.append(tensor)
+            # Update LRU on hit.
+            self._lru.pop(key, None)
+            self._lru[key] = None
+
+        if not out_rows:
+            return None
+        return torch.cat(out_rows, dim=0)
+
+    # ------------------------------------------------------------------
+    # Introspection / lifecycle
+    # ------------------------------------------------------------------
+
+    def num_cached_chunks(self) -> int:
+        """Return the number of distinct chunk keys currently cached."""
+        return len(self._chunks)
+
+    def has_chunk(
+        self,
+        key: CacheEngineKey,
+        kind: ActivationKind,
+        layer_idx: int = 0,
+    ) -> bool:
+        """Return True if a chunk is cached for ``(key, kind, layer_idx)``."""
+        slot_map = self._chunks.get(key)
+        return slot_map is not None and (kind, layer_idx) in slot_map
+
+    def drop_key(self, key: CacheEngineKey) -> bool:
+        """Manually drop all activation slots for ``key``. Test/admin use."""
+        if key not in self._chunks:
+            return False
+        self._free_key(key)
+        return True
+
+    def close(self) -> None:
+        """Free every cached chunk and the underlying pinned pool."""
+        for key in list(self._chunks.keys()):
+            self._free_key(key)
+        self._allocator.close()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _chunk(
+        self, token_ids: Union[torch.Tensor, List[int]]
+    ) -> List["tuple[int, int, CacheEngineKey]"]:
+        """Return ``[(start, end, key)]`` for ``token_ids`` using the engine TDB.
+
+        Materialized so we can iterate twice (key check and per-chunk copy)
+        without re-running the hashing path.
+        """
+        return list(self._token_database.process_tokens(tokens=token_ids))
+
+    def _kv_present(self, key: CacheEngineKey) -> bool:
+        """True if KV exists in any active backend, or unknown when SM unbound."""
+        if self._storage_manager is None:
+            # Without an SM we cannot distinguish "KV evicted" from "no KV";
+            # treat as present so the prefix walk doesn't truncate spuriously.
+            return True
+        return self._storage_manager.contains(key) is not None
+
+    def _alloc_chunk(
+        self, n_tokens: int, feature_dim: int, dtype: torch.dtype
+    ) -> Optional[MemoryObj]:
+        shape = torch.Size([n_tokens, feature_dim])
+        # TODO(activation-store): add a dedicated MemoryFormat.ACT_TD instead of
+        # reusing EC_TD (same [T, D] layout; distinct name aids introspection).
+        for _ in range(_ACT_ALLOC_MAX_RETRIES):
+            obj = self._allocator.allocate(shape, dtype, MemoryFormat.EC_TD)
+            if obj is not None:
+                return obj
+            # Pressure: drop our LRU entry and retry. Never touches KV.
+            if not self._evict_one_lru():
+                break
+        return None
+
+    def _evict_one_lru(self) -> bool:
+        if not self._lru:
+            return False
+        key, _ = self._lru.popitem(last=False)
+        self._free_key(key)
+        logger.debug("ActivationStore: LRU evicted key=%s", key)
+        return True
+
+    def _free_key(self, key: CacheEngineKey) -> None:
+        slot_map = self._chunks.pop(key, None)
+        self._lru.pop(key, None)
+        if not slot_map:
+            return
+        # ref_count_down is the public release path: it free()s the underlying
+        # buffer when the count reaches zero (mirrors LocalCPUBackend.remove).
+        for obj in slot_map.values():
+            obj.ref_count_down()

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -53,6 +53,7 @@ from lmcache.v1.memory_management import (  # noqa: E501
     PagedTensorMemoryAllocator,
     TensorMemoryObj,
 )
+from lmcache.v1.activation_store import ActivationStore
 from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.pin_monitor import PinMonitor
 from lmcache.v1.storage_backend.storage_manager import StorageManager
@@ -173,6 +174,13 @@ class LMCacheEngine:
         # if save_only_first_rank is True, only the first rank and
         # lookup server workers will initialize the storage_manager
         self.storage_manager: Optional[StorageManager] = None
+
+        # Activation cache (logically separate from KV; lives on its own pinned
+        # pool). Bound to storage_manager in post_init for coupled eviction.
+        # None when disabled in config.
+        self.activation_store: Optional[ActivationStore] = None
+        if config.enable_activation_cache:
+            self.activation_store = ActivationStore(config, token_database)
 
         # KV events
         self.kv_events_enabled = False
@@ -314,6 +322,8 @@ class LMCacheEngine:
                     lmcache_worker=self.lmcache_worker,
                     async_lookup_server=async_lookup_server,
                 )
+                if self.activation_store is not None:
+                    self.activation_store.bind_storage_manager(self.storage_manager)
             self.post_inited = True
 
     def freeze(self, enabled: bool) -> None:
@@ -1607,6 +1617,13 @@ class LMCacheEngine:
             logger.info("storage_manager closed successfully")
         except Exception as e:
             logger.error(f"Error closing storage_manager: {e}")
+
+        if self.activation_store is not None:
+            try:
+                logger.info("Closing activation_store...")
+                self.activation_store.close()
+            except Exception as e:
+                logger.error(f"Error closing activation_store: {e}")
 
         logger.info("LMCacheEngine closed.")
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -600,6 +600,43 @@ _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
             "and environment variables."
         ),
     },
+    # Activation caching (separate pinned pool; chunk keys match KV). Generalizes
+    # the hidden-state cache: one pool holds hidden states, query (Q) projections,
+    # K/V, and MLP intermediates, keyed by (CacheEngineKey, ActivationKind, layer).
+    "enable_activation_cache": {
+        "type": bool,
+        "default": False,
+        "env_converter": _to_bool,
+        "description": (
+            "Enable caching of per-token model activations alongside KV cache "
+            "entries (hidden states, query projections, MLP intermediates, etc.). "
+            "When enabled, activations are stored in a separate CPU pinned memory "
+            "pool and share chunk keys with their corresponding KV entries."
+        ),
+    },
+    "max_activation_cpu_size": {
+        "type": float,
+        "default": 2.0,
+        "env_converter": float,
+        "description": (
+            "Maximum size in GiB of pinned CPU memory for the activation cache. "
+            "Each chunk-slot tensor is shaped [chunk_size, feature_dim] in the "
+            "activation's native dtype. If the budget is too small, activation "
+            "entries may be evicted before their KV counterparts. Required to be "
+            "> 0 when enable_activation_cache=True."
+        ),
+    },
+    "activation_layers": {
+        "type": Optional[list[int]],
+        "default": None,
+        "env_converter": _to_int_list,
+        "description": (
+            "Optional allowlist of transformer layer indices accepted by "
+            "ActivationStore.store_activation. If unset (default), every layer "
+            "index passed on store is cached. Relevant only when "
+            "enable_activation_cache=True."
+        ),
+    },
 }
 
 

--- a/tests/v1/test_activation_store.py
+++ b/tests/v1/test_activation_store.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :class:`ActivationStore` and engine integration.
+
+These tests construct an :class:`ActivationStore` directly so they don't need a
+full :class:`LMCacheEngine`, GPU connector, or storage manager. The KV presence
+side of "coupled eviction" is exercised via a tiny fake storage manager that
+exposes the single ``contains`` method the store consults.
+
+``ActivationStore`` generalizes the hidden-state store (PR #3221): the same pool
+holds any :class:`ActivationKind`, keyed by ``(CacheEngineKey, kind, layer_idx)``.
+Most tests use ``kind=ActivationKind.HIDDEN`` (the hidden-state special case);
+``test_distinct_kinds_share_pool`` and ``test_dtype_is_preserved`` exercise the
+generalization.
+"""
+
+# Standard
+from typing import Optional, Set
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.activation_store import ActivationKind, ActivationStore
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.token_database import ChunkedTokenDatabase
+
+
+CHUNK_SIZE = 8
+FEATURE_DIM = 16
+HIDDEN = ActivationKind.HIDDEN
+
+
+def _metadata() -> LMCacheMetadata:
+    return LMCacheMetadata(
+        model_name="test_model",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.bfloat16,
+        kv_shape=(1, 2, CHUNK_SIZE, 1, FEATURE_DIM),
+    )
+
+
+def _config(
+    *,
+    enable_activation_cache: bool = True,
+    pool_gb: float = 0.05,
+    layers=None,
+) -> LMCacheEngineConfig:
+    """Minimal CPU-only config for activation-store tests."""
+    return LMCacheEngineConfig.from_defaults(
+        chunk_size=CHUNK_SIZE,
+        local_cpu=True,
+        max_local_cpu_size=0.05,
+        local_disk=None,
+        max_local_disk_size=0,
+        remote_url=None,
+        save_unfull_chunk=False,
+        enable_activation_cache=enable_activation_cache,
+        max_activation_cpu_size=pool_gb,
+        activation_layers=layers,
+    )
+
+
+def _token_db(config: LMCacheEngineConfig) -> ChunkedTokenDatabase:
+    db = ChunkedTokenDatabase(config, _metadata())
+    return db
+
+
+class _Fixture:
+    """Bundle a config, one token database, and a fake SM.
+
+    A shared :class:`ChunkedTokenDatabase` instance is essential here: the
+    database lazily resolves its hash function on first use, so two separate
+    instances can pick different ``NONE_HASH`` seeds and produce different keys
+    for the same tokens.
+    """
+
+    def __init__(self, *, layers=None, pool_gb: float = 0.05) -> None:
+        self.config = _config(layers=layers, pool_gb=pool_gb)
+        self.db = _token_db(self.config)
+        self.sm = _FakeStorageManager()
+        self.store = ActivationStore(self.config, self.db)
+        self.store.bind_storage_manager(self.sm)
+
+    def keys_for(self, token_ids):
+        return [key for _, _, key in self.db.process_tokens(tokens=token_ids)]
+
+    def mark_kv_present(self, keys) -> None:
+        self.sm.present.update(keys)
+
+    def close(self) -> None:
+        self.store.close()
+
+
+class _FakeStorageManager:
+    """Implements just the ``contains(key)`` slice the store consults."""
+
+    def __init__(self, present_keys: Optional[Set[CacheEngineKey]] = None) -> None:
+        self.present: Set[CacheEngineKey] = (
+            set(present_keys) if present_keys is not None else set()
+        )
+
+    def contains(self, key, search_range=None, pin: bool = False):  # noqa: D401
+        return "LocalCPUBackend" if key in self.present else None
+
+
+# ---------------------------------------------------------------------------
+# Alignment with KV chunking
+# ---------------------------------------------------------------------------
+
+
+def test_chunks_align_with_kv_keys():
+    """Activations use the engine's TokenDatabase, so keys equal KV chunk keys."""
+    fix = _Fixture()
+    token_ids = list(range(3 * CHUNK_SIZE))  # exactly three full chunks
+    expected_keys = fix.keys_for(token_ids)
+    assert len(expected_keys) == 3
+    fix.mark_kv_present(expected_keys)
+
+    n = fix.store.store_activation(
+        token_ids, torch.randn(len(token_ids), FEATURE_DIM), kind=HIDDEN
+    )
+    assert n == 3
+    for k in expected_keys:
+        assert fix.store.has_chunk(k, HIDDEN, layer_idx=0)
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip retrieve
+# ---------------------------------------------------------------------------
+
+
+def test_store_then_retrieve_roundtrip():
+    fix = _Fixture()
+    token_ids = list(range(2 * CHUNK_SIZE))
+    fix.mark_kv_present(fix.keys_for(token_ids))
+
+    rows = torch.randn(len(token_ids), FEATURE_DIM)
+    assert fix.store.store_activation(token_ids, rows, kind=HIDDEN) == 2
+
+    out = fix.store.retrieve_activation(token_ids, kind=HIDDEN)
+    assert out is not None
+    assert out.shape == (len(token_ids), FEATURE_DIM)
+    torch.testing.assert_close(out, rows)
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Coupled eviction (KV evict implies activation evict on next read)
+# ---------------------------------------------------------------------------
+
+
+def test_kv_eviction_truncates_retrieved_prefix():
+    fix = _Fixture()
+    token_ids = list(range(3 * CHUNK_SIZE))
+    keys = fix.keys_for(token_ids)
+    fix.mark_kv_present(keys)
+
+    rows = torch.randn(len(token_ids), FEATURE_DIM)
+    fix.store.store_activation(token_ids, rows, kind=HIDDEN)
+    assert fix.store.num_cached_chunks() == 3
+
+    fix.sm.present.discard(keys[1])  # simulate KV eviction of chunk #1
+
+    out = fix.store.retrieve_activation(token_ids, kind=HIDDEN)
+    assert out is not None
+    assert out.shape == (CHUNK_SIZE, FEATURE_DIM)
+    torch.testing.assert_close(out, rows[:CHUNK_SIZE])
+    # KV evict -> activation evict (orphan dropped lazily on retrieve).
+    assert not fix.store.has_chunk(keys[1], HIDDEN)
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Activation-only eviction does not touch KV
+# ---------------------------------------------------------------------------
+
+
+def test_activation_eviction_does_not_imply_kv_eviction():
+    fix = _Fixture()
+    token_ids = list(range(2 * CHUNK_SIZE))
+    keys = fix.keys_for(token_ids)
+    fix.mark_kv_present(keys)
+
+    fix.store.store_activation(
+        token_ids, torch.randn(len(token_ids), FEATURE_DIM), kind=HIDDEN
+    )
+    assert fix.store.drop_key(keys[0])  # activation-only LRU-style eviction
+    # KV-side state untouched.
+    assert keys[0] in fix.sm.present
+    assert keys[1] in fix.sm.present
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Partial restore cutoff (activation missing in the middle)
+# ---------------------------------------------------------------------------
+
+
+def test_partial_restore_cutoff_when_activation_missing():
+    fix = _Fixture()
+    token_ids = list(range(3 * CHUNK_SIZE))
+    keys = fix.keys_for(token_ids)
+    fix.mark_kv_present(keys)
+
+    rows = torch.randn(len(token_ids), FEATURE_DIM)
+    fix.store.store_activation(token_ids, rows, kind=HIDDEN)
+    fix.store.drop_key(keys[1])  # activation hole in the middle, KV intact
+
+    out = fix.store.retrieve_activation(token_ids, kind=HIDDEN)
+    assert out is not None
+    # prefix_strict: stop at the missing-activation chunk.
+    assert out.shape == (CHUNK_SIZE, FEATURE_DIM)
+    torch.testing.assert_close(out, rows[:CHUNK_SIZE])
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Multi-layer storage and per-layer retrieve
+# ---------------------------------------------------------------------------
+
+
+def test_multi_layer_store_and_retrieve():
+    fix = _Fixture()
+    token_ids = list(range(2 * CHUNK_SIZE))
+    fix.mark_kv_present(fix.keys_for(token_ids))
+
+    layer0 = torch.randn(len(token_ids), FEATURE_DIM)
+    layer3 = torch.randn(len(token_ids), FEATURE_DIM)
+    assert fix.store.store_activation(token_ids, layer0, kind=HIDDEN, layer_idx=0) > 0
+    assert fix.store.store_activation(token_ids, layer3, kind=HIDDEN, layer_idx=3) > 0
+
+    out0 = fix.store.retrieve_activation(token_ids, kind=HIDDEN, layer_idx=0)
+    out3 = fix.store.retrieve_activation(token_ids, kind=HIDDEN, layer_idx=3)
+    assert out0 is not None and out3 is not None
+    torch.testing.assert_close(out0, layer0)
+    torch.testing.assert_close(out3, layer3)
+    assert fix.store.retrieve_activation(token_ids, kind=HIDDEN, layer_idx=99) is None
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Distinct kinds (hidden vs query) coexist in one pool at the same layer
+# ---------------------------------------------------------------------------
+
+
+def test_distinct_kinds_share_pool():
+    """The generalization: hidden and query at the same layer are independent."""
+    fix = _Fixture()
+    token_ids = list(range(2 * CHUNK_SIZE))
+    fix.mark_kv_present(fix.keys_for(token_ids))
+
+    hidden = torch.randn(len(token_ids), FEATURE_DIM)
+    query = torch.randn(len(token_ids), FEATURE_DIM)
+    assert fix.store.store_activation(token_ids, hidden, kind=HIDDEN) == 2
+    assert (
+        fix.store.store_activation(token_ids, query, kind=ActivationKind.QUERY) == 2
+    )
+
+    out_h = fix.store.retrieve_activation(token_ids, kind=ActivationKind.HIDDEN)
+    out_q = fix.store.retrieve_activation(token_ids, kind=ActivationKind.QUERY)
+    assert out_h is not None and out_q is not None
+    torch.testing.assert_close(out_h, hidden)
+    torch.testing.assert_close(out_q, query)
+    # A kind never stored returns None even though the chunk keys exist.
+    assert fix.store.retrieve_activation(token_ids, kind=ActivationKind.VALUE) is None
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Native dtype is preserved (unlike the float32-forcing hidden-state store)
+# ---------------------------------------------------------------------------
+
+
+def test_dtype_is_preserved():
+    fix = _Fixture()
+    token_ids = list(range(CHUNK_SIZE))
+    fix.mark_kv_present(fix.keys_for(token_ids))
+
+    rows = torch.randn(len(token_ids), FEATURE_DIM, dtype=torch.bfloat16)
+    assert fix.store.store_activation(token_ids, rows, kind=HIDDEN) == 1
+
+    out = fix.store.retrieve_activation(token_ids, kind=HIDDEN)
+    assert out is not None
+    assert out.dtype == torch.bfloat16
+    torch.testing.assert_close(out, rows)
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Layer allowlist filters writes
+# ---------------------------------------------------------------------------
+
+
+def test_layer_allowlist_filters_writes():
+    fix = _Fixture(layers=[0])
+    token_ids = list(range(CHUNK_SIZE))
+    keys = fix.keys_for(token_ids)
+    fix.mark_kv_present(keys)
+
+    rows = torch.randn(len(token_ids), FEATURE_DIM)
+    assert fix.store.store_activation(token_ids, rows, kind=HIDDEN, layer_idx=0) == 1
+    assert fix.store.store_activation(token_ids, rows, kind=HIDDEN, layer_idx=1) == 0
+    assert fix.store.has_chunk(keys[0], HIDDEN, layer_idx=0)
+    assert not fix.store.has_chunk(keys[0], HIDDEN, layer_idx=1)
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# Separate memory pool isolation
+# ---------------------------------------------------------------------------
+
+
+def test_pool_is_independent_object():
+    """Each store owns its own ``MixedMemoryAllocator`` (and pinned buffer).
+
+    Filling one store's pool does not affect a peer store's contents.
+    """
+    fix_a = _Fixture()
+    fix_b = _Fixture()
+    assert fix_a.store._allocator is not fix_b.store._allocator
+
+    n_toks = 4 * CHUNK_SIZE
+    rows = torch.randn(n_toks, FEATURE_DIM)
+    token_ids = list(range(n_toks))
+    fix_a.mark_kv_present(fix_a.keys_for(token_ids))
+    fix_a.store.store_activation(token_ids, rows, kind=HIDDEN)
+    assert fix_a.store.num_cached_chunks() > 0
+    assert fix_b.store.num_cached_chunks() == 0
+    fix_a.close()
+    fix_b.close()
+
+
+# ---------------------------------------------------------------------------
+# Without a bound storage manager, retrieve assumes KV is present.
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_without_bound_sm_returns_full_prefix():
+    cfg = _config()
+    db = _token_db(cfg)
+    store = ActivationStore(cfg, db)  # no SM bound
+
+    token_ids = list(range(2 * CHUNK_SIZE))
+    rows = torch.randn(len(token_ids), FEATURE_DIM)
+    store.store_activation(token_ids, rows, kind=HIDDEN)
+
+    out = store.retrieve_activation(token_ids, kind=HIDDEN)
+    assert out is not None
+    assert out.shape == (len(token_ids), FEATURE_DIM)
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_store_rejects_wrong_shape():
+    fix = _Fixture()
+    with pytest.raises(ValueError):
+        fix.store.store_activation([1, 2, 3], torch.randn(2, FEATURE_DIM), kind=HIDDEN)
+    with pytest.raises(ValueError):
+        fix.store.store_activation([1, 2, 3], torch.randn(3), kind=HIDDEN)
+    fix.close()
+
+
+# ---------------------------------------------------------------------------
+# token_offset: incremental store
+# ---------------------------------------------------------------------------
+
+
+def test_store_with_token_offset_aligns_with_kv_keys():
+    """Calling store incrementally via token_offset stores all chunks with
+    correct KV-aligned keys, and retrieve returns the full concatenated rows.
+
+    Simulates the vllm-omni pattern where:
+    - call 1 covers the first CHUNK_SIZE tokens (offset=0, short token_ids)
+    - call 2 covers the next CHUNK_SIZE tokens (offset=CHUNK_SIZE, full
+      token_ids so chunk keys are KV-aligned across the whole prefix)
+    """
+    fix = _Fixture()
+    token_ids = list(range(2 * CHUNK_SIZE))
+    keys = fix.keys_for(token_ids)
+    fix.mark_kv_present(keys)
+
+    rows = torch.randn(len(token_ids), FEATURE_DIM)
+
+    # First call: only the first chunk's tokens are available so far.
+    n1 = fix.store.store_activation(
+        token_ids[:CHUNK_SIZE], rows[:CHUNK_SIZE], kind=HIDDEN, token_offset=0
+    )
+    assert n1 == 1
+
+    # Second call: full token_ids for correct KV-aligned chunk keys, but the
+    # activation covers only token_ids[CHUNK_SIZE:] (the new tokens).
+    n2 = fix.store.store_activation(
+        token_ids, rows[CHUNK_SIZE:], kind=HIDDEN, token_offset=CHUNK_SIZE
+    )
+    assert n2 == 1
+
+    for k in keys:
+        assert fix.store.has_chunk(k, HIDDEN, layer_idx=0)
+
+    out = fix.store.retrieve_activation(token_ids, kind=HIDDEN)
+    assert out is not None
+    assert out.shape == (len(token_ids), FEATURE_DIM)
+    torch.testing.assert_close(out, rows)
+    fix.close()
+
+
+def test_store_token_offset_rejects_bad_args():
+    """token_offset out of range or mismatched length raises ValueError."""
+    fix = _Fixture()
+    token_ids = list(range(CHUNK_SIZE))
+
+    # Negative offset.
+    with pytest.raises(ValueError):
+        fix.store.store_activation(
+            token_ids,
+            torch.randn(CHUNK_SIZE, FEATURE_DIM),
+            kind=HIDDEN,
+            token_offset=-1,
+        )
+
+    # Offset beyond sequence length.
+    with pytest.raises(ValueError):
+        fix.store.store_activation(
+            token_ids, torch.randn(0, FEATURE_DIM), kind=HIDDEN,
+            token_offset=CHUNK_SIZE + 1,
+        )
+
+    # Activation rows don't match n_toks - token_offset.
+    with pytest.raises(ValueError):
+        fix.store.store_activation(
+            token_ids,
+            torch.randn(CHUNK_SIZE, FEATURE_DIM),  # should be CHUNK_SIZE - 2 rows
+            kind=HIDDEN,
+            token_offset=2,
+        )
+    fix.close()


### PR DESCRIPTION
Generalize the hidden-state store (PR #3221) into ActivationStore: a single chunk-aligned pinned-CPU pool that caches any per-token activation -- hidden states, query (Q) projections, K/V, MLP intermediates -- keyed by (CacheEngineKey, ActivationKind, layer_idx).

The storage/eviction machinery is unchanged from HiddenStateStore: chunk keys come from the engine TokenDatabase (so activation chunks share KV keys), the store owns an independent MixedMemoryAllocator, and eviction is lazy coupled-asymmetric (KV evict -> activation evict on next read; activation evict never touches KV; retrieve is prefix-strict). The only structural change is the slot key gaining an ActivationKind axis; HiddenStateStore becomes the kind=HIDDEN special case. One behavioral change: activations are stored in their native dtype (bf16/fp16) instead of forced float32.

- lmcache/v1/activation_store.py: ActivationStore + ActivationKind enum
- lmcache/v1/cache_engine.py: own/bind/close engine.activation_store
- lmcache/v1/config.py: enable_activation_cache, max_activation_cpu_size, activation_layers
- tests/v1/test_activation_store.py: ported HS suite + multi-kind and dtype-preservation cases (14 passing)
- docs/design/v1/activation_store.md: design + producer-side capture-point table

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
