### PR TITLE
[fix] gpu_connector: fix direct transfer in VLLMPagedMemLayerwiseGPUConnector

### DIFF
--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -1134,18 +1134,18 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
 
     def _lazy_initialize_buffer(self, kv_caches):
         """
-        Lazily initialize the GPU buffer allocator if it is not initialized yet.
-        Currently, we use the `kv_caches` (kv cache pointer) to determine
-        the gpu buffer size in gpu connector.
-        Also, the first request might be a bit slower due to buffer creation.
-        """
-        if self.use_gpu and self.gpu_buffer_allocator is None:
-            logger.info("Lazily initializing GPU buffer.")
-            # NOTE (Jiayi): We use the first layer to determine the gpu buffer size.
-            # NOTE (Jiayi): Using the exact number of tokens in the first layer
-            # is okay since fragmentation shouldn't exist in the `gpu_buffer_allocator`
-            # in layerwise mode.
+        Lazily initialize KV format metadata and, when enabled, the GPU buffer
+        allocator.
 
+        `kv_caches` is used to discover the engine KV layout (required for both
+        direct and buffered transfers). When `use_gpu` is true, the first layer's
+        capacity is also used to size the GPU buffer pool via `elements_per_layer`.
+
+        The first call may be slower due to lazy format discovery; creating the
+        buffer pool adds extra cost when `use_gpu` is enabled.
+        """
+        if not hasattr(self, "engine_kv_format"):
+            # Infer format and per-layer capacity from the first layer's tensor shape.
             self.engine_kv_format, kv_caches = normalize_kv_and_discover_format(
                 kv_caches, EngineType.VLLM, layout_hints=self.layout_hints
             )
@@ -1157,6 +1157,11 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
             self.elements_per_layer = get_elements_per_layer(
                 kv_caches, self.engine_kv_format
             )
+
+        if self.use_gpu and self.gpu_buffer_allocator is None:
+            # NOTE (Jiayi): Size the pool from one layer's full paged capacity
+            # (`elements_per_layer`). Using the first layer is safe in layerwise mode
+            # because the allocator does not suffer from cross-layer fragmentation.
             logger.info(
                 f"Lazily initializing GPU buffer (max tokens={self.tokens_per_layer})."
             )
@@ -1269,7 +1274,7 @@ class VLLMPagedMemLayerwiseGPUConnector(GPUConnectorInterface):
                         lmc_ops.single_layer_kv_transfer(
                             memory_obj.tensor,
                             self.kvcaches[layer_id],
-                            slot_mapping_full,
+                            slot_mapping[start:end],
                             lmc_ops.TransferDirection.H2D,
                             self.engine_kv_format,
                             token_major=True,

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -370,7 +370,7 @@ def test_vllm_paged_connector_v3_with_gpu_and_mla(
     allocator.close()
 
 
-@pytest.mark.parametrize("use_gpu", [True])
+@pytest.mark.parametrize("use_gpu", [True, False])
 @pytest.mark.parametrize(
     "engine_kv_format",
     [
@@ -482,7 +482,8 @@ def test_layerwise_vllm_paged_connector_with_gpu(use_gpu, engine_kv_format):
 
     assert allocator.memcheck()
 
-    assert connector.gpu_buffer_allocator.memcheck()
+    if use_gpu:
+        assert connector.gpu_buffer_allocator.memcheck()
 
     check_paged_kv_cache_equal(
         gpu_kv_src, gpu_kv_dst, slot_mapping, num_heads, head_size, engine_kv_format


### PR DESCRIPTION
## Summary
Fix two bugs in `VLLMPagedMemLayerwiseGPUConnector` that broke the direct (non-buffered) transfer path: KV format metadata was never initialized when `use_gpu=False`, and `batched_to_gpu` passed the wrong `slot_mapping` slice per chunk.

## Bug 1: `_lazy_initialize_buffer` skipped format discovery when `use_gpu=False`
Problem: `_lazy_initialize_buffer` only ran format discovery and metadata setup inside if `self.use_gpu` and `self.gpu_buffer_allocator` is None. When `use_gpu=False`, the function returned without setting engine_kv_format, tokens_per_layer, or elements_per_layer.

Impact: The direct transfer path in `batched_to_gpu` (and batched_from_gpu) still calls `lmc_ops.single_layer_kv_transfer(..., self.engine_kv_format, ...)`, which requires the engine KV layout to be discovered first. With use_gpu=False, that attribute was never initialized, so the direct path could not work.

Fix: Split lazy initialization into two phases:

1. Always discover KV format metadata from `kv_caches` on first use (needed for both direct and buffered transfers).
2. Create the GPU buffer pool only when `use_gpu=True`.

Also updated the docstring and inline comments to reflect this two-phase behavior.

## Bug 2: `batched_to_gpu` used full `slot_mapping` in the direct path
Problem: In the `use_gpu=False` branch, each chunk’s H2D transfer passed `slot_mapping_full` to single_layer_kv_transfer instead of the chunk-local slice `slot_mapping_full[start:end]`.

Impact: For batched requests with multiple chunks, every chunk was mapped using the entire slot mapping. That misaligns token-to-page placement relative to each chunk’s `memory_obj`, leading to incorrect or corrupted KV cache writes. This matches the bug pattern already avoided in `batched_from_gpu`, which correctly uses `slot_mapping[start:end]` in its direct path.

Fix: Pass `slot_mapping_full[start:end]` so each chunk’s transfer only uses the slots corresponding to that chunk’s token range.

Tests
- Parameterize test_layerwise_vllm_paged_connector_with_gpu over use_gpu=[True, False] to cover both buffered and direct paths.
- Guard the gpu_buffer_allocator.memcheck() assertion with if use_gpu, since no allocator is created in direct mode.
Test plan

 pytest 

- [✅] tests/v1/test_gpu_connector.py::test_layerwise_vllm_paged_connector_with_gpu -v passes for both use_gpu=True and use_gpu=False

- [✅] Existing layerwise connector tests still pass with use_gpu=True

<img width="1728" height="1506" alt="image" src="https://github.com/user-attachments/assets/7dfc9001-ee0c-4bf1-a4f8-0fe33e34584e" />
