### PR TITLE
fix(mp): Eliminate Container PID Namespace Collisions in LMCache MP Server Worker Registrations

### DIFF
--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -2,9 +2,9 @@
 # Standard
 from dataclasses import dataclass
 from typing import Optional
-import os
 import threading
 import time
+import uuid
 
 # Third Party
 from sglang.srt.configs.model_config import ModelConfig
@@ -113,7 +113,15 @@ class LMCacheMPConnector:
         self.model_name = sgl_config.model_path
         self.num_layers = len(k_pool)
         self.tp_group = tp_group
-        self.instance_id = os.getpid()
+
+        # Instance id for GPU worker. uuid4-derived (OS entropy) rather
+        # than os.getpid() to avoid collision in containerized deployments.
+        # Masked to 63 bits to stay signed-int64-safe for any msgpack peer.
+        self.instance_id = uuid.uuid4().int & ((1 << 63) - 1)
+        logger.info(
+            "LMCache MP worker adapter created with instance_id=%d",
+            self.instance_id,
+        )
         self._mq_timeout = mq_timeout
         self._heartbeat_interval = heartbeat_interval
         self._registered = False

--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 import os
 import time
+import uuid
 
 # Third Party
 from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import (
@@ -288,7 +289,14 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
             os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
         )
 
-        self._instance_id = os.getpid()
+        # Instance id for GPU worker. uuid4-derived (OS entropy) rather
+        # than os.getpid() to avoid collision in containerized deployments.
+        # Masked to 63 bits to stay signed-int64-safe for any msgpack peer.
+        self._instance_id = uuid.uuid4().int & ((1 << 63) - 1)
+        logger.info(
+            "LMCache MP worker adapter created with instance_id=%d",
+            self._instance_id,
+        )
         self._registered = False
 
         # Third Party

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from unittest.mock import MagicMock
+import os
+import sys
+
+# Mock sglang before importing the adapter
+mock_sglang = MagicMock()
+sys.modules["sglang"] = mock_sglang
+sys.modules["sglang.srt"] = mock_sglang
+sys.modules["sglang.srt.configs"] = mock_sglang
+sys.modules["sglang.srt.configs.model_config"] = mock_sglang
+
+# Third Party
+import pytest  # noqa: E402
+import torch  # noqa: E402
+
+# First Party
+from lmcache.integration.sglang import (  # noqa: E402
+    multi_process_adapter as adapter_mod,
+)
+from lmcache.integration.sglang.multi_process_adapter import (  # noqa: E402
+    LMCacheMPConnector,
+)
+
+
+def _make_sglang_connector() -> LMCacheMPConnector:
+    sgl_config = MagicMock()
+    sgl_config.model_path = "test-model"
+    k_pool = [torch.zeros(1, device="cpu")]
+    v_pool = [torch.zeros(1, device="cpu")]
+    return LMCacheMPConnector(
+        sgl_config=sgl_config,
+        tp_size=1,
+        rank=0,
+        page_size=16,
+        host="localhost",
+        port=5555,
+        k_pool=k_pool,
+        v_pool=v_pool,
+    )
+
+
+@pytest.fixture
+def mock_sglang_adapter(monkeypatch):
+    # Stub the MQ boundary and chunk size
+    fake_client = MagicMock(name="mq_client")
+    monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
+    monkeypatch.setattr(adapter_mod, "get_lmcache_chunk_size", lambda *a, **kw: 256)
+
+    future = MagicMock(name="future")
+    future.result.return_value = None
+    send_mock = MagicMock(name="send_lmcache_request", return_value=future)
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", send_mock)
+
+    # Mock HeartbeatThread
+    monkeypatch.setattr(adapter_mod, "HeartbeatThread", MagicMock())
+
+    # Bypass CUDA IPC wrappers
+    monkeypatch.setattr(adapter_mod, "_wrap_sglang_kv_caches", lambda k, v: [])
+
+
+def test_sglang_instance_id_is_uuid_derived_63_bit_int(mock_sglang_adapter) -> None:
+    """instance_id is a 63-bit int, not the PID, and unique per connector."""
+    connector = _make_sglang_connector()
+
+    assert isinstance(connector.instance_id, int)
+    assert not isinstance(connector.instance_id, bool)
+    assert 0 <= connector.instance_id < (1 << 63)
+    assert connector.instance_id != os.getpid()
+
+    connector2 = _make_sglang_connector()
+    assert connector.instance_id != connector2.instance_id
+
+
+def test_sglang_instance_id_logged_at_info_on_construction(
+    mock_sglang_adapter, monkeypatch
+) -> None:
+    """The constructor logs instance_id at INFO for correlating server-side
+    reap warnings. The module logger does not propagate (``propagate=False``),
+    so the test spies on it directly instead of using ``caplog``."""
+    messages: list[str] = []
+
+    def spy_info(msg: object, *args: object, **kwargs: object) -> None:
+        messages.append(str(msg) % args if args else str(msg))
+
+    monkeypatch.setattr(adapter_mod.logger, "info", spy_info)
+
+    connector = _make_sglang_connector()
+
+    assert any(str(connector.instance_id) in msg for msg in messages)

--- a/tests/v1/test_trtllm_mp_adapter.py
+++ b/tests/v1/test_trtllm_mp_adapter.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from unittest.mock import MagicMock
+import os
+import sys
+
+
+class DummyKvCacheConnectorWorker:
+    def __init__(self, llm_args, *args, **kwargs):
+        self._llm_args = llm_args
+
+
+class DummyKvCacheConnectorScheduler:
+    def __init__(self, llm_args, *args, **kwargs):
+        self._llm_args = llm_args
+
+
+# Mock tensorrt_llm before importing the adapter
+mock_tensorrt_llm = MagicMock()
+sys.modules["tensorrt_llm"] = mock_tensorrt_llm
+sys.modules["tensorrt_llm._torch"] = mock_tensorrt_llm
+sys.modules["tensorrt_llm._torch.pyexecutor"] = mock_tensorrt_llm
+sys.modules["tensorrt_llm._torch.pyexecutor.connectors"] = mock_tensorrt_llm
+
+mock_kv_cache_connector = MagicMock()
+mock_kv_cache_connector.KvCacheConnectorWorker = DummyKvCacheConnectorWorker
+mock_kv_cache_connector.KvCacheConnectorScheduler = DummyKvCacheConnectorScheduler
+sys.modules["tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector"] = (
+    mock_kv_cache_connector
+)
+sys.modules["tensorrt_llm.bindings"] = mock_tensorrt_llm
+sys.modules["tensorrt_llm.bindings.internal"] = mock_tensorrt_llm
+sys.modules["tensorrt_llm.bindings.internal.batch_manager"] = mock_tensorrt_llm
+sys.modules["tensorrt_llm.llmapi"] = mock_tensorrt_llm
+sys.modules["tensorrt_llm.llmapi.llm_args"] = mock_tensorrt_llm
+
+# Third Party
+import pytest  # noqa: E402
+
+# First Party
+from lmcache.integration.tensorrt_llm import (  # noqa: E402
+    tensorrt_mp_adapter as adapter_mod,
+)
+from lmcache.integration.tensorrt_llm.tensorrt_mp_adapter import (  # noqa: E402
+    LMCacheMPKvConnectorWorker,
+)
+
+
+def _make_trtllm_worker() -> LMCacheMPKvConnectorWorker:
+    mock_tensorrt_llm.mpi_rank.return_value = 0
+    llm_args = MagicMock()
+    llm_args.tensor_parallel_size = 1
+    llm_args.pipeline_parallel_size = 1
+    llm_args.model = "test-model"
+    llm_args.kv_connector_config = None
+    llm_args.kv_cache_config.tokens_per_block = 16
+    return LMCacheMPKvConnectorWorker(llm_args)
+
+
+@pytest.fixture
+def mock_trtllm_adapter(monkeypatch):
+    # Stub the MQ boundary and chunk size
+    fake_client = MagicMock(name="mq_client")
+    monkeypatch.setattr(adapter_mod, "MessageQueueClient", lambda *a, **kw: fake_client)
+    monkeypatch.setattr(adapter_mod, "_send_request", lambda *a, **kw: MagicMock())
+
+    # Mock zmq
+    monkeypatch.setattr(adapter_mod, "zmq", MagicMock())
+
+
+def test_trtllm_instance_id_is_uuid_derived_63_bit_int(
+    mock_trtllm_adapter,
+) -> None:
+    """instance_id is a 63-bit int, not the PID, and unique per worker."""
+    worker = _make_trtllm_worker()
+
+    assert isinstance(worker._instance_id, int)
+    assert not isinstance(worker._instance_id, bool)
+    assert 0 <= worker._instance_id < (1 << 63)
+    assert worker._instance_id != os.getpid()
+
+    worker2 = _make_trtllm_worker()
+    assert worker._instance_id != worker2._instance_id
+
+
+def test_trtllm_instance_id_logged_at_info_on_construction(
+    mock_trtllm_adapter, monkeypatch
+) -> None:
+    """The constructor logs instance_id at INFO for correlating server-side
+    reap warnings. The module logger does not propagate (``propagate=False``),
+    so the test spies on it directly instead of using ``caplog``."""
+    messages: list[str] = []
+
+    def spy_info(msg: object, *args: object, **kwargs: object) -> None:
+        messages.append(str(msg) % args if args else str(msg))
+
+    monkeypatch.setattr(adapter_mod.logger, "info", spy_info)
+
+    worker = _make_trtllm_worker()
+
+    assert any(str(worker._instance_id) in msg for msg in messages)


### PR DESCRIPTION
**What this PR does / why we need it**:

a follow-up for https://github.com/LMCache/LMCache/pull/3631

When worker containers connect to same shared LMCache MP  server, they query  os.getpid()  and send  1  as  instance_id.
In containerized  setups, PID namespaces isolate processes, causing PID collisions across replicas

Note: The vLLM adapter path is already covered by #3631. This PR extends the unique UUID-derived instance ID behavior to SGLang and TensorRT-LLM adapters

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains unit tests
