### PR TITLE
refactor(mp): Rename EngineDrivenContext to TransferBackend

### DIFF
--- a/docs/design/sdk/kvcache.md
+++ b/docs/design/sdk/kvcache.md
@@ -36,7 +36,7 @@ SDK process                                  LMCache MP server
 -----------                                  -----------------
 LMCacheKVCacheContext
   ├ ContiguousTransferWrapper
-  │   └ EngineDrivenContext{Shm,Pickle} ──MQ──▶ EngineDrivenTransferModule
+  │   └ {Shm,Pickle}TransferBackend ──MQ──▶ EngineDrivenTransferModule
   │                                             └ StorageManager (L1 pool, locks, prefetch)
   └ MessageQueueClient ──────────────────ZMQ──▶ LookupModule (LOOKUP / QUERY_PREFETCH_STATUS)
   SharedMemory(name) ◀────────────────────────  L1 POSIX segment (SHM transport only)
@@ -44,7 +44,7 @@ LMCacheKVCacheContext
 
 - **Control plane (ZMQ):** lookup/prefetch, slot reservation, lock release, session end.
 - **Data plane:** **SHM** when the server exposes an L1 pool, otherwise **pickle** over the
-  MQ — both driven through one `EngineDrivenContext`, so the SDK never branches on transport.
+  MQ — both driven through one `TransferBackend`, so the SDK never branches on transport.
 - **`ContiguousTransferWrapper`** ([wrapper/contiguous.py](../../../lmcache/sdk/wrapper/contiguous.py))
   bridges a contiguous `[2, L, T, D]` tensor to the per-chunk `prepare`/`commit` protocol and
   masks the SHM-vs-pickle difference.
@@ -64,7 +64,7 @@ LMCacheKVCacheContext
    only to register the layout; the data plane never touches it.
 5. `create_transfer_context(buffer)` → `EngineDrivenTransferContext.register(...)`, which sends
    `REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT` (server reserves the SHM pool / picks SHM vs pickle).
-6. Wrap `transfer_ctx.engine_driven_context` in a `ContiguousTransferWrapper`.
+6. Wrap `transfer_ctx.backend` in a `ContiguousTransferWrapper`.
 
 `instance_id` is the SDK process PID.
 

--- a/docs/design/v1/multiprocess/engine_driven_transfer_design.md
+++ b/docs/design/v1/multiprocess/engine_driven_transfer_design.md
@@ -25,9 +25,9 @@ Worker adapter (vLLM MP adapter)
   └─ TransferContext (transfer_context/worker_transfer.py)
       ├─ LMCacheDrivenTransferContext  (IPC path via stream/event)
       └─ EngineDrivenTransferContext    (data path via data copying in adapter)
-          └─ EngineDrivenContext (transfer_context/base.py)
-             ├─ EngineDrivenContextPickle (transfer_context/pickle.py)
-             └─ EngineDrivenContextShm    (transfer_context/shm.py)
+          └─ TransferBackend (transfer_context/base.py)
+             ├─ PickleTransferBackend (transfer_context/pickle.py)
+             └─ ShmTransferBackend    (transfer_context/shm.py)
 
 MPCacheServer (server)
 ├─ MPCacheServerContext (engine_context.py)
@@ -92,7 +92,7 @@ Overall data flow:
 - **lmcache-driven path** (CUDA IPC): worker sends a handle, server pulls/pushes
   data directly via device memory.
 - **engine-driven path** (CPU/SHM/pickle): worker gathers/scatters paged KV and
-  exchanges CPU-side data via a transport-specific `EngineDrivenContext`
+  exchanges CPU-side data via a transport-specific `TransferBackend`
   implementation.
 
 ### 2.2 Worker Side: TransferContext
@@ -105,15 +105,15 @@ four lifecycle and transfer operations.
 - **LMCacheDrivenTransferContext** keeps the original CUDA IPC behavior:
   worker sends a handle and server performs direct GPU-side transfer.
 - **EngineDrivenTransferContext** is the engine-driven (non-CUDA) path:
-  worker transfers actual data chunks through `EngineDrivenContext`.
+  worker transfers actual data chunks through a `TransferBackend`.
 
 `EngineDrivenTransferContext` flows:
 - **submit_store**: `prepare_store` → `gather_paged_kv_to_cpu` → `commit_store`
 - **submit_retrieve**: `prepare_retrieve` → `scatter_cpu_to_paged_kv` → `commit_retrieve`
 
 During `register`, worker receives `RegisterEngineDrivenContextResponse(shm_name, pool_size)`
-from server and then calls `create_engine_driven_context(...)` to construct
-`EngineDrivenContextPickle` or `EngineDrivenContextShm`.
+from server and then calls `create_transfer_backend(...)` to construct
+`PickleTransferBackend` or `ShmTransferBackend`.
 
 Why `prepare → data operation → commit`:
 - `prepare_*`: set up transport state (for SHM this allocates/returns shared buffers;
@@ -145,7 +145,7 @@ Server transfer strategy implementations:
 - **ShmTransferStrategy**: SHM slot-based prepare/commit behavior, with pickle
   fallback when inline bytes are provided.
 
-This mirrors the worker split (`EngineDrivenContextPickle` / `EngineDrivenContextShm`):
+This mirrors the worker split (`PickleTransferBackend` / `ShmTransferBackend`):
 both sides keep common request flow while isolating transport-specific logic.
 
 `MPCacheServerContext` is the shared container injected into modules at init.
@@ -183,9 +183,9 @@ It also computes `shm_pool_info` once from `StorageManagerConfig`:
 - `lmcache/v1/multiprocess/modules/engine_driven_transfer.py`: `EngineDrivenTransferModule`
 - `lmcache/v1/multiprocess/modules/server_transfer.py`: `TransferStrategy`, `PickleTransferStrategy`, `ShmTransferStrategy`
 - `lmcache/v1/multiprocess/transfer_context/worker_transfer.py`: `EngineDrivenTransferContext`, `LMCacheDrivenTransferContext`
-- `lmcache/v1/multiprocess/transfer_context/base.py`: `EngineDrivenContext`, `gather_paged_kv_to_cpu`, `scatter_cpu_to_paged_kv`, `compute_kv_layout`
-- `lmcache/v1/multiprocess/transfer_context/pickle.py`: `EngineDrivenContextPickle`
-- `lmcache/v1/multiprocess/transfer_context/shm.py`: `EngineDrivenContextShm`
+- `lmcache/v1/multiprocess/transfer_context/base.py`: `TransferBackend`, `gather_paged_kv_to_cpu`, `scatter_cpu_to_paged_kv`, `compute_kv_layout`
+- `lmcache/v1/multiprocess/transfer_context/pickle.py`: `PickleTransferBackend`
+- `lmcache/v1/multiprocess/transfer_context/shm.py`: `ShmTransferBackend`
 
 ## 3. Protocol & Data Flow
 
@@ -198,7 +198,7 @@ The engine-driven path uses five request types:
    - stores `EngineDrivenContextEntry` (metadata + model/world info)
    - registers `MemoryLayoutDesc` in `LayoutDescRegistry`
    - creates `TransferStrategy` from engine-level `shm_pool_info`
-   - returns `shm_name/pool_size` so worker creates matching `EngineDrivenContext`
+   - returns `shm_name/pool_size` so worker creates matching `TransferBackend`
 
 2. `PREPARE_STORE`  
    Worker asks server/transport to prepare store-side transfer state.

--- a/lmcache/sdk/kvcache.py
+++ b/lmcache/sdk/kvcache.py
@@ -216,7 +216,7 @@ class LMCacheKVCacheContext:
                 f"{type(transfer_ctx).__name__}."
             )
         self._transfer_ctx = ContiguousTransferWrapper(
-            transfer_ctx.engine_driven_context, self._chunk_size
+            transfer_ctx.backend, self._chunk_size
         )
 
     @property

--- a/lmcache/sdk/wrapper/contiguous.py
+++ b/lmcache/sdk/wrapper/contiguous.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""EngineDrivenContext to store/retrieve a contiguous KV tensor for SDK use."""
+"""TransferBackend wrapper to store/retrieve a contiguous KV tensor for SDK use."""
 
 # Future
 from __future__ import annotations
@@ -9,18 +9,18 @@ import torch
 
 # First Party
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
-from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContext
+from lmcache.v1.multiprocess.transfer_context.base import TransferBackend
 
 
 class ContiguousTransferWrapper:
-    """Store/retrieve a contiguous KV tensor through an ``EngineDrivenContext``.
+    """Store/retrieve a contiguous KV tensor through a ``TransferBackend``.
 
     Args:
         context: The engine-driven (SHM or pickle) transport.
         chunk_size: Number of tokens per LMCache chunk.
     """
 
-    def __init__(self, context: EngineDrivenContext, chunk_size: int) -> None:
+    def __init__(self, context: TransferBackend, chunk_size: int) -> None:
         self._context = context
         self._chunk_size = chunk_size
 

--- a/lmcache/v1/multiprocess/transfer_context/__init__.py
+++ b/lmcache/v1/multiprocess/transfer_context/__init__.py
@@ -8,15 +8,15 @@ sub-module.
 
 # Local
 from .base import (
-    EngineDrivenContext,
     EngineDrivenContextMetadata,
+    TransferBackend,
     compute_kv_layout,
-    create_engine_driven_context,
+    create_transfer_backend,
     gather_paged_kv_to_cpu,
     scatter_cpu_to_paged_kv,
 )
-from .pickle import EngineDrivenContextPickle
-from .shm import EngineDrivenContextShm, ShmSlotDescriptor
+from .pickle import PickleTransferBackend
+from .shm import ShmSlotDescriptor, ShmTransferBackend
 from .worker_transfer import (
     EngineDrivenTransferContext,
     LMCacheDrivenTransferContext,
@@ -29,14 +29,14 @@ __all__ = [
     "EngineDrivenTransferContext",
     "LMCacheDrivenTransferContext",
     "MPTransferMode",
-    "EngineDrivenContext",
+    "TransferBackend",
     "EngineDrivenContextMetadata",
-    "EngineDrivenContextPickle",
-    "EngineDrivenContextShm",
+    "PickleTransferBackend",
+    "ShmTransferBackend",
     "ShmSlotDescriptor",
     "TransferContext",
     "compute_kv_layout",
-    "create_engine_driven_context",
+    "create_transfer_backend",
     "create_transfer_context",
     "gather_paged_kv_to_cpu",
     "scatter_cpu_to_paged_kv",

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Non-GPU context abstractions and utilities for multiprocess transport.
+"""Non-GPU transfer-backend abstractions and utilities for multiprocess transport.
 
 This module provides:
 - ``EngineDrivenContextMetadata``: layout metadata dataclass for non-CUDA workers.
-- ``EngineDrivenContext``: abstract base class with a two-phase prepare/commit
+- ``TransferBackend``: abstract base class with a two-phase prepare/commit
   interface for CPU-side KV data transfer. Concrete implementations (e.g.
-  ``EngineDrivenContextPickle``) each decide *how* data is serialised and transported.
-- ``create_engine_driven_context()``: factory that returns the appropriate
-  ``EngineDrivenContext`` subclass.
+  ``PickleTransferBackend``) each decide *how* data is serialised and transported.
+- ``create_transfer_backend()``: factory that returns the appropriate
+  ``TransferBackend`` subclass.
 - ``compute_kv_layout``, ``gather_paged_kv_to_cpu``, ``scatter_cpu_to_paged_kv``:
   shared gather/scatter utilities used by all concrete implementations.
 """
@@ -120,8 +120,8 @@ class EngineDrivenContextMetadata:
     use_mla: bool
 
 
-class EngineDrivenContext(ABC):
-    """Abstract base class for CPU-side KV data transfer contexts.
+class TransferBackend(ABC):
+    """Abstract base class for CPU-side KV data transfer backends.
 
     All concrete implementations share a common message-queue client and
     expose a uniform two-phase ``prepare/commit`` interface so that the
@@ -145,7 +145,7 @@ class EngineDrivenContext(ABC):
 
     @property
     def layout_desc(self) -> MemoryLayoutDesc:
-        """The memory layout descriptor for this context."""
+        """The memory layout descriptor for this backend."""
         return self.metadata.layout_desc
 
     @abstractmethod
@@ -195,7 +195,7 @@ class EngineDrivenContext(ABC):
         ...
 
 
-def create_engine_driven_context(
+def create_transfer_backend(
     metadata: EngineDrivenContextMetadata,
     mq_client: MessageQueueClient,
     mq_timeout: float,
@@ -203,8 +203,8 @@ def create_engine_driven_context(
     pool_size: int,
     *,
     use_pickle: bool = False,
-) -> EngineDrivenContext:
-    """Factory that returns the appropriate :class:`EngineDrivenContext` implementation.
+) -> TransferBackend:
+    """Factory that returns the appropriate :class:`TransferBackend` implementation.
 
     Returns SHM-based implementation when shared-memory pool information is
     available; otherwise falls back to the pickle-based implementation.
@@ -212,7 +212,7 @@ def create_engine_driven_context(
     permission error), gracefully falls back to pickle transport.
 
     Args:
-        metadata: Layout metadata for the non-GPU context.
+        metadata: Layout metadata for the non-GPU transfer backend.
         mq_client: Message-queue client for server communication.
         mq_timeout: Timeout in seconds for blocking MQ requests.
         shm_name: Shared-memory segment name. Empty values force pickle mode.
@@ -222,37 +222,37 @@ def create_engine_driven_context(
             available.
 
     Returns:
-        A concrete :class:`EngineDrivenContext` instance.
+        A concrete :class:`TransferBackend` instance.
     """
     if not shm_name or pool_size <= 0:
         use_pickle = True
 
     if not use_pickle:
         # Local
-        from .shm import EngineDrivenContextShm
+        from .shm import ShmTransferBackend
 
         try:
             logger.info(
-                "Creating EngineDrivenContextShm (shm_name=%s, pool_size=%d)",
+                "Creating ShmTransferBackend (shm_name=%s, pool_size=%d)",
                 shm_name,
                 pool_size,
             )
-            return EngineDrivenContextShm(
+            return ShmTransferBackend(
                 metadata, mq_client, mq_timeout, shm_name, pool_size
             )
         except Exception:
             logger.warning(
-                "Failed to initialize SHM context (shm_name=%s), "
+                "Failed to initialize SHM transfer backend (shm_name=%s), "
                 "falling back to pickle transport",
                 shm_name,
                 exc_info=True,
             )
 
     # Local
-    from .pickle import EngineDrivenContextPickle
+    from .pickle import PickleTransferBackend
 
-    logger.info("Creating EngineDrivenContextPickle (pickle transport)")
-    return EngineDrivenContextPickle(metadata, mq_client, mq_timeout)
+    logger.info("Creating PickleTransferBackend (pickle transport)")
+    return PickleTransferBackend(metadata, mq_client, mq_timeout)
 
 
 # ---------------------------------------------------------------------------

--- a/lmcache/v1/multiprocess/transfer_context/pickle.py
+++ b/lmcache/v1/multiprocess/transfer_context/pickle.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pickle-based EngineDrivenContext implementation for multiprocess mode."""
+"""Pickle-based TransferBackend implementation for multiprocess mode."""
 
 # Standard
 import pickle
@@ -12,13 +12,13 @@ from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transfer_context.base import (
-    EngineDrivenContext,
     EngineDrivenContextMetadata,
+    TransferBackend,
 )
 
 
-class EngineDrivenContextPickle(EngineDrivenContext):
-    """Pickle-based implementation of :class:`EngineDrivenContext`.
+class PickleTransferBackend(TransferBackend):
+    """Pickle-based implementation of :class:`TransferBackend`.
 
     Transport mechanism:
     - **Store**: ``prepare_store`` sends ``PREPARE_STORE`` (returns empty slots

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared-memory EngineDrivenContext implementation for multiprocess mode."""
+"""Shared-memory TransferBackend implementation for multiprocess mode."""
 
 # Standard
 from dataclasses import dataclass
@@ -18,8 +18,8 @@ from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
 from lmcache.v1.multiprocess.transfer_context.base import (
-    EngineDrivenContext,
     EngineDrivenContextMetadata,
+    TransferBackend,
 )
 
 logger = init_logger(__name__)
@@ -78,8 +78,8 @@ class ShmSlotDescriptor:
         )
 
 
-class EngineDrivenContextShm(EngineDrivenContext):
-    """Shared-memory implementation of :class:`EngineDrivenContext`."""
+class ShmTransferBackend(TransferBackend):
+    """Shared-memory implementation of :class:`TransferBackend`."""
 
     def __init__(
         self,

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -23,10 +23,10 @@ from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.protocols.engine import RegisterEngineDrivenContextResponse
 from lmcache.v1.multiprocess.transfer_context.base import (
-    EngineDrivenContext,
     EngineDrivenContextMetadata,
+    TransferBackend,
     compute_kv_layout,
-    create_engine_driven_context,
+    create_transfer_backend,
     gather_paged_kv_to_cpu,
     scatter_cpu_to_paged_kv,
 )
@@ -320,22 +320,23 @@ class EngineDrivenTransferContext(TransferContext):
     """
 
     def __init__(self) -> None:
-        self._engine_driven_context: EngineDrivenContext | None = None
+        self._backend: TransferBackend | None = None
         self._layout_hints: LayoutHints | None = None
         self._engine_kv_format: Any = None
 
     @property
-    def engine_driven_context(self) -> EngineDrivenContext:
-        """Return the underlying SHM/pickle context created by ``register``.
+    def backend(self) -> TransferBackend:
+        """Return the underlying :class:`TransferBackend`.
 
         Raises:
-            RuntimeError: If accessed before ``register`` has run.
+            RuntimeError: If :meth:`register` has not been called yet.
         """
-        if self._engine_driven_context is None:
+        if self._backend is None:
             raise RuntimeError(
-                "EngineDrivenTransferContext is not registered, call register() first."
+                "Engine-driven transfer context is not registered. "
+                "Call register() before accessing backend."
             )
-        return self._engine_driven_context
+        return self._backend
 
     def register(
         self,
@@ -409,18 +410,17 @@ class EngineDrivenTransferContext(TransferContext):
             block_size=block_size,
             use_mla=use_mla_flag,
         )
-        self._engine_driven_context = create_engine_driven_context(
+        self._backend = create_transfer_backend(
             metadata,
             mq_client,
             mq_timeout,
             shm_name=shm_name,
             pool_size=pool_size,
         )
-        supported_transfer_mode = "SHM" if shm_name and pool_size > 0 else "pickle"
         logger.info(
-            "Worker non-GPU transfer context registered (instance_id=%d, mode=%s)",
+            "Worker non-GPU transfer context registered (instance_id=%d, backend=%s)",
             instance_id,
-            supported_transfer_mode,
+            type(self._backend).__name__,
         )
 
     def submit_store(
@@ -433,14 +433,14 @@ class EngineDrivenTransferContext(TransferContext):
         _event: IPCEvent,
         blocks_in_chunk: int,
     ) -> MessagingFuture:
-        if self._engine_driven_context is None:
+        if self._backend is None:
             raise RuntimeError(
                 "Engine-driven transfer context is not registered. "
                 "Call register() before submit_store()."
             )
 
         torch_dev.synchronize()
-        result = self._engine_driven_context.prepare_store(key, instance_id)
+        result = self._backend.prepare_store(key, instance_id)
         out_buffers, chunk_indices = result if result is not None else (None, None)
         # All chunks already in cache — nothing to gather or commit.
         if chunk_indices is not None and len(chunk_indices) == 0:
@@ -459,7 +459,7 @@ class EngineDrivenTransferContext(TransferContext):
         if out_buffers is not None:
             # SHM path uses async device->CPU copies; complete them before commit.
             torch_dev.synchronize()
-        ok = self._engine_driven_context.commit_store(key, instance_id, cpu_chunks)
+        ok = self._backend.commit_store(key, instance_id, cpu_chunks)
 
         future = MessagingFuture()
         future.set_result(ok)
@@ -476,13 +476,13 @@ class EngineDrivenTransferContext(TransferContext):
         blocks_in_chunk: int,
         skip_first_n_tokens: int = 0,
     ) -> MessagingFuture:
-        if self._engine_driven_context is None:
+        if self._backend is None:
             raise RuntimeError(
                 "Engine-driven transfer context is not registered. "
                 "Call register() before submit_retrieve()."
             )
 
-        src_buffers = self._engine_driven_context.prepare_retrieve(key, instance_id)
+        src_buffers = self._backend.prepare_retrieve(key, instance_id)
         ok = src_buffers is not None
         if src_buffers is not None:
             try:
@@ -501,16 +501,16 @@ class EngineDrivenTransferContext(TransferContext):
             # SHM path: ensure all device writes are complete before releasing
             # the SHM slot (server may immediately reuse it after commit_retrieve).
             torch_dev.synchronize()
-        self._engine_driven_context.commit_retrieve(key, instance_id)
+        self._backend.commit_retrieve(key, instance_id)
 
         future: MessagingFuture[bool] = MessagingFuture()
         future.set_result(ok)
         return future
 
     def close(self) -> None:
-        if self._engine_driven_context is not None:
-            self._engine_driven_context.close()
-            self._engine_driven_context = None
+        if self._backend is not None:
+            self._backend.close()
+            self._backend = None
 
 
 def create_transfer_context(

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -29,10 +29,10 @@ from lmcache.v1.multiprocess.protocols.engine import (
 )
 from lmcache.v1.multiprocess.transfer_context.base import (
     EngineDrivenContextMetadata,
-    create_engine_driven_context,
+    create_transfer_backend,
 )
-from lmcache.v1.multiprocess.transfer_context.pickle import EngineDrivenContextPickle
-from lmcache.v1.multiprocess.transfer_context.shm import EngineDrivenContextShm
+from lmcache.v1.multiprocess.transfer_context.pickle import PickleTransferBackend
+from lmcache.v1.multiprocess.transfer_context.shm import ShmTransferBackend
 
 if TYPE_CHECKING:
     # First Party
@@ -421,7 +421,7 @@ def test_musa_data_context_keeps_layout_validation_device_agnostic(
     monkeypatch.setattr(worker_transfer, "compute_kv_layout", _fake_compute_kv_layout)
     monkeypatch.setattr(
         worker_transfer,
-        "create_engine_driven_context",
+        "create_transfer_backend",
         lambda *_args, **_kwargs: MagicMock(),
     )
     future = MagicMock()
@@ -477,7 +477,7 @@ def test_musa_data_context_store_uses_device_agnostic_gather(
     )
     monkeypatch.setattr(
         worker_transfer,
-        "create_engine_driven_context",
+        "create_transfer_backend",
         lambda *_args, **_kwargs: _FakeEngineDrivenContext(),
     )
 
@@ -549,7 +549,7 @@ def test_musa_data_context_retrieve_uses_device_agnostic_scatter(
     )
     monkeypatch.setattr(
         worker_transfer,
-        "create_engine_driven_context",
+        "create_transfer_backend",
         lambda *_args, **_kwargs: _FakeEngineDrivenContext(),
     )
 
@@ -1396,7 +1396,7 @@ def test_engine_driven_context_shm_tensor_view_from_buffer() -> None:
         finally:
             mm.close()
 
-        context = EngineDrivenContextShm(
+        context = ShmTransferBackend(
             metadata=EngineDrivenContextMetadata(
                 layout_desc=MemoryLayoutDesc(
                     shapes=[torch.Size([2, 4])],
@@ -1460,7 +1460,7 @@ def test_engine_driven_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
 
     mq_client.submit_request.side_effect = _submit_request
 
-    context = EngineDrivenContextShm(
+    context = ShmTransferBackend(
         metadata=EngineDrivenContextMetadata(
             layout_desc=MemoryLayoutDesc(
                 shapes=[torch.Size([2, 2])],
@@ -1499,7 +1499,7 @@ def test_engine_driven_context_shm_store_retrieve_flow_with_mocked_mq() -> None:
 
 def test_engine_driven_context_shm_init_raises_when_segment_missing() -> None:
     with pytest.raises(FileNotFoundError, match="No such file or directory"):
-        EngineDrivenContextShm(
+        ShmTransferBackend(
             metadata=EngineDrivenContextMetadata(
                 layout_desc=MemoryLayoutDesc(
                     shapes=[torch.Size([2, 2])],
@@ -1516,7 +1516,7 @@ def test_engine_driven_context_shm_init_raises_when_segment_missing() -> None:
 
 
 def test_create_engine_driven_context_falls_back_to_pickle_without_shm_info() -> None:
-    context = create_engine_driven_context(
+    context = create_transfer_backend(
         metadata=EngineDrivenContextMetadata(
             layout_desc=MemoryLayoutDesc(
                 shapes=[torch.Size([2, 2])],
@@ -1530,11 +1530,11 @@ def test_create_engine_driven_context_falls_back_to_pickle_without_shm_info() ->
         shm_name="",
         pool_size=0,
     )
-    assert isinstance(context, EngineDrivenContextPickle)
+    assert isinstance(context, PickleTransferBackend)
 
 
 def test_create_engine_driven_context_use_pickle_ignores_valid_shm_info() -> None:
-    context = create_engine_driven_context(
+    context = create_transfer_backend(
         metadata=EngineDrivenContextMetadata(
             layout_desc=MemoryLayoutDesc(
                 shapes=[torch.Size([2, 2])],
@@ -1549,14 +1549,14 @@ def test_create_engine_driven_context_use_pickle_ignores_valid_shm_info() -> Non
         pool_size=4096,
         use_pickle=True,
     )
-    assert isinstance(context, EngineDrivenContextPickle)
+    assert isinstance(context, PickleTransferBackend)
 
 
 def test_engine_driven_context_shm_close_is_idempotent() -> None:
     shm_name = f"lmcache_test_close_{os.getpid()}"
     addr = _create_shm_segment(shm_name, 4096)
     try:
-        context = EngineDrivenContextShm(
+        context = ShmTransferBackend(
             metadata=EngineDrivenContextMetadata(
                 layout_desc=MemoryLayoutDesc(
                     shapes=[torch.Size([2, 2])],


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR renames the engine-driven transfer backend class hierarchy for clarity and fixes a redundant naming issue in the log path.

**Changes**:

1. **Rename class hierarchy** — to better reflect their role as transfer backends rather than "contexts":

       Before:
         └─ EngineDrivenTransferContext    (data path via data copying in adapter)
             └─ EngineDrivenContext (transfer_context/base.py)
                ├─ EngineDrivenContextPickle (transfer_context/pickle.py)
                └─ EngineDrivenContextShm    (transfer_context/shm.py)

       After:
         └─ EngineDrivenTransferContext    (data path via data copying in adapter)
             └─ TransferBackend (transfer_context/base.py)
                ├─ PickleTransferBackend (transfer_context/pickle.py)
                └─ ShmTransferBackend    (transfer_context/shm.py)

2. **Remove `supported_transfer_mode` redundant variable** — the old code computed `supported_transfer_mode = "SHM" if shm_name and pool_size > 0 else "pickle"` solely for a log message, which duplicated the selection logic already inside `create_transfer_backend()`. This is now replaced with `type(self._backend).__name__` in the log line, which directly reflects the actual backend type in use, eliminating both the duplicated logic and the confusing `supported_transfer_mode` naming.

**Special notes for your reviewers**:

Pure refactor — no behavior change. The log message now accurately reports the concrete backend class name (e.g. `ShmTransferBackend` / `PickleTransferBackend`) instead of a separately computed string that could diverge from reality.