### PR TITLE
[Bugfix] Clear reqs_status on async lookup timeout to prevent KeyError on recall

### DIFF
--- a/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_async_lookup_client.py
@@ -171,9 +171,18 @@ class LMCacheAsyncLookupClient(LookupClientInterface):
                 self.first_lookup_time[lookup_id] = time.time()
             elif req_status is None:
                 time.sleep(self.lookup_backoff_time)
-                if (
-                    time.time() - self.first_lookup_time[lookup_id]
-                ) * 1000 > self.config.lookup_timeout_ms:
+                start_time = self.first_lookup_time.get(lookup_id)
+                if start_time is None:
+                    # This lookup already timed out and was cancelled on an
+                    # earlier call (first_lookup_time was popped while its
+                    # abort is still pending cleanup). Keep telling vLLM to
+                    # recompute instead of dereferencing the missing key,
+                    # which previously raised KeyError and crashed the
+                    # EngineCore (issue #3685). reqs_status[lookup_id] is left
+                    # as None on purpose so the id is not re-registered as a
+                    # fresh lookup while the aborted task may still complete.
+                    return 0
+                if (time.time() - start_time) * 1000 > self.config.lookup_timeout_ms:
                     logger.warning(
                         (
                             "Request %s is still waiting for async lookup "

--- a/tests/v1/lookup_client/test_async_lookup_client_timeout.py
+++ b/tests/v1/lookup_client/test_async_lookup_client_timeout.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #3685.
+
+When ``enable_async_loading`` is set (e.g. together with the nixl backend), an
+async lookup that exceeds ``lookup_timeout_ms`` is cancelled and
+``LMCacheAsyncLookupClient.lookup_cache`` returns 0 so vLLM recomputes. The
+timeout handler used to pop only ``first_lookup_time`` while leaving
+``reqs_status[lookup_id] = None``. The next scheduler call for the same
+``lookup_id`` then re-entered the ``req_status is None`` branch and raised
+``KeyError`` on the already-popped ``first_lookup_time[lookup_id]``, crashing
+the vLLM EngineCore.
+"""
+
+# Standard
+import threading
+import time
+import types
+
+# First Party
+from lmcache.v1.lookup_client.lmcache_async_lookup_client import (
+    LMCacheAsyncLookupClient,
+)
+
+
+def _make_client(timeout_ms: int = 50) -> LMCacheAsyncLookupClient:
+    """Build a client without the zmq/socket-heavy ``__init__``.
+
+    Only the attributes touched by ``lookup_cache`` / ``cancel_lookup`` /
+    ``_cleanup_finished_aborted_lookups`` are wired up.
+    """
+    client = LMCacheAsyncLookupClient.__new__(LMCacheAsyncLookupClient)
+    client.lock = threading.Lock()
+    client.reqs_status = {}
+    client.first_lookup_time = {}
+    client.aborted_lookups = set()
+    client.lookup_backoff_time = 0.0
+    client.config = types.SimpleNamespace(lookup_timeout_ms=timeout_ms)
+    return client
+
+
+def test_lookup_cache_recall_after_timeout_does_not_keyerror() -> None:
+    client = _make_client(timeout_ms=50)
+    lookup_id = "req-nixl-async"
+
+    # 1) First call registers the in-flight async lookup.
+    assert client.lookup_cache(lookup_id) == -1
+
+    # 2) Make the deadline already passed, then recall: the timeout branch
+    #    cancels the lookup and returns 0 so vLLM recomputes.
+    client.first_lookup_time[lookup_id] = time.time() - 10.0
+    assert client.lookup_cache(lookup_id) == 0
+
+    # 3) Recall again with the SAME id. Pre-fix this raised
+    #    ``KeyError: 'req-nixl-async'`` because first_lookup_time[id] had been
+    #    popped while reqs_status[id] was still None, so the call re-entered the
+    #    timeout branch and dereferenced the missing key. After the fix the
+    #    call keeps telling vLLM to recompute (returns 0) without crashing and
+    #    without re-registering the id while its abort is still pending.
+    assert client.lookup_cache(lookup_id) == 0
+    assert client.lookup_cache(lookup_id) == 0


### PR DESCRIPTION
## Summary
Fixes #3685. With `enable_async_loading` (e.g. with the nixl backend), a vLLM EngineCore crash with `KeyError` is raised from `LMCacheAsyncLookupClient.lookup_cache` whenever an async lookup times out and the same `lookup_id` is looked up again.

## Root cause
`lookup_cache` returns `0` (recompute) when an in-flight async lookup exceeds `lookup_timeout_ms`. The timeout handler pops `first_lookup_time` but leaves `reqs_status[lookup_id] = None`. `cancel_lookup` only adds the id to `aborted_lookups`, and `_cleanup_finished_aborted_lookups` skips entries whose status is still `None`, so `reqs_status[lookup_id]` stays `None`. On the **next** call for the same id, `reqs_status.get(lookup_id, -1)` returns `None` (not `-1`), re-entering the `elif req_status is None:` branch, which dereferences the already-popped key:
```python
time.time() - self.first_lookup_time[lookup_id]   # KeyError -> crashes EngineCore
```

## Fix
Guard the dereference: when an in-flight (`None`) status has no `first_lookup_time` entry, the lookup has already timed out and been cancelled on an earlier call, so keep returning `0` (recompute) instead of crashing.

`reqs_status[lookup_id]` is **left as `None`** (not popped) on purpose: popping it would let the same id re-register as a fresh lookup while its aborted task may still complete, after which `_cleanup_finished_aborted_lookups` would send a cleanup message and free the **new** lookup's buffers (race flagged in review). Leaving the status `None` keeps the id in its aborted-pending state until the worker finishes and the existing cleanup path runs.

## Test
Added `tests/v1/lookup_client/test_async_lookup_client_timeout.py` — a GPU-free unit test driving `lookup_cache` through register -> timeout -> recall:
```
PYTHONPATH=. pytest tests/v1/lookup_client/test_async_lookup_client_timeout.py
```
- **WITH** fix: `1 passed`
- **WITHOUT** fix (original `lmcache_async_lookup_client.py`): `FAILED ... lmcache_async_lookup_client.py:175: KeyError: 'req-nixl-async'`

`ruff check` / `ruff format --check` clean on both files.

## Dup-check
Issue open, 0 assignees, 0 comments. No open PR touches `first_lookup_time`/`lookup_cache` (only #3540 touches this file, adding an unrelated param). No unlinked merged fix in the file history.

---
AI-assisted (Claude); every line human-reviewed. DCO signed off.
