### PR TITLE
[CI] Trying to make upstream CI green

### DIFF
--- a/.github/workflows/build_cli_artifacts.yml
+++ b/.github/workflows/build_cli_artifacts.yml
@@ -22,9 +22,9 @@ defaults:
     run:
         shell: bash
 
-# Cancel stale runs per ref; PR and dev-push refs differ, so workflow_call is unaffected.
+# Cancel older in-flight runs on the same PR / branch.
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: build-cli-${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -4,10 +4,9 @@ on:
   workflow_call:
   pull_request:
 
-# Cancel older in-flight runs on the same PR / branch. github.ref is
-# refs/pull/<N>/merge on pull_request events, so each PR gets its own group.
+# Cancel older in-flight runs on the same PR / branch.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: code-quality-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,11 @@ on:
 env:
     LC_ALL: en_US.UTF-8
 
+# Cancel superseded runs on the same ref, but never abort a tag/release publish.
+concurrency:
+    group: publish-${{ github.ref }}
+    cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') && github.event_name != 'release' }}
+
 defaults:
     run:
         shell: bash
@@ -103,8 +108,12 @@ jobs:
     # - a commit lands on dev (PR merged)
     publish-test-pypi:
         name: Publish packages to test.pypi.org
+        # Require upstream jobs to have succeeded so a cancelled/skipped build
+        # doesn't trigger a publish that fails on the missing artifact.
         if: |
-            !failure() && !cancelled() &&
+            needs.build-main.result == 'success' &&
+            needs.test.result == 'success' &&
+            needs.code-quality.result == 'success' &&
             needs.changes.outputs.lmcache == 'true' &&
             github.repository_owner == 'LMCache' &&
             github.event_name == 'push' && github.ref == 'refs/heads/dev'
@@ -137,7 +146,9 @@ jobs:
     publish-cli-test-pypi:
         name: Publish lmcache-cli packages to test.pypi.org
         if: |
-            !failure() && !cancelled() &&
+            needs.build-cli.result == 'success' &&
+            needs.test.result == 'success' &&
+            needs.code-quality.result == 'success' &&
             needs.changes.outputs.lmcache == 'true' &&
             github.repository_owner == 'LMCache' &&
             github.event_name == 'push' && github.ref == 'refs/heads/dev'
@@ -171,7 +182,9 @@ jobs:
     publish-pypi:
         name: Publish release to pypi.org
         if: |
-            !failure() && !cancelled() &&
+            needs.build-main.result == 'success' &&
+            needs.test.result == 'success' &&
+            needs.code-quality.result == 'success' &&
             needs.changes.outputs.lmcache == 'true' &&
             github.repository_owner == 'LMCache' && github.event.action == 'published'
         permissions:
@@ -210,7 +223,9 @@ jobs:
     publish-cli-pypi:
         name: Publish lmcache-cli release to pypi.org
         if: |
-            !failure() && !cancelled() &&
+            needs.build-cli.result == 'success' &&
+            needs.test.result == 'success' &&
+            needs.code-quality.result == 'success' &&
             needs.changes.outputs.lmcache == 'true' &&
             github.repository_owner == 'LMCache' && github.event.action == 'published'
         permissions:
@@ -247,7 +262,9 @@ jobs:
     publish-cu129-github-release:
         name: Publish cu129 wheel to GitHub Release
         if: |
-            !failure() && !cancelled() &&
+            needs.build-cu129.result == 'success' &&
+            needs.test.result == 'success' &&
+            needs.code-quality.result == 'success' &&
             needs.changes.outputs.lmcache == 'true' &&
             github.repository_owner == 'LMCache' && github.event.action == 'published'
         permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,9 @@ defaults:
   run:
     shell: bash
 
-# Cancel older in-flight runs on the same PR / branch. github.ref is
-# refs/pull/<N>/merge on pull_request events, so each PR gets its own group.
+# Cancel older in-flight runs on the same PR / branch.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

- `test / code_quality / build_cli` → # Cancel older in-flight runs on the same PR / branch.
- `publish.yml` top-level → # Cancel superseded runs on the same ref, but never abort a tag/release publish.
- `publish-test-pypi` guard → # Require upstream jobs to have succeeded so a cancelled/skipped build doesn't trigger a publish that fails on the missing artifact.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
