### PR TITLE
[Feat] Expose CacheBlend coordinator knobs as CLI flags

### DIFF
--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -23,8 +23,9 @@ Expected log output:
 
 The CLI accepts ``--host``, ``--port``, ``--instance-timeout``,
 ``--health-check-interval``, ``--eviction-check-interval``,
-``--eviction-ratio``, and ``--trigger-watermark``; any flag overrides the
-matching environment variable below. See :doc:`/cli/coordinator` for details.
+``--eviction-ratio``, ``--trigger-watermark``, ``--blend-chunk-size``, and
+``--blend-probe-stride``; any flag overrides the matching environment variable
+below. See :doc:`/cli/coordinator` for details.
 Equivalently, the coordinator can still be launched as a module with
 ``python3 -m lmcache.v1.mp_coordinator``.
 
@@ -64,6 +65,14 @@ variables:
      - ``1.0``
      - Eviction fires when usage reaches this fraction of the quota
        (0.0 exclusive to 1.0).
+   * - ``LMCACHE_MP_COORDINATOR_BLEND_CHUNK_SIZE``
+     - ``256``
+     - Tokens per chunk for the global CacheBlend directory. Must equal the
+       LMCache chunk size the blend servers use.
+   * - ``LMCACHE_MP_COORDINATOR_BLEND_PROBE_STRIDE``
+     - ``1``
+     - Positions between CacheBlend match probes. ``1`` probes every offset
+       for full recall.
 
 Connecting MP servers
 ---------------------

--- a/lmcache/cli/commands/coordinator.py
+++ b/lmcache/cli/commands/coordinator.py
@@ -101,6 +101,24 @@ class CoordinatorCommand(BaseCommand):
                 "quota, 0.0 (exclusive) to 1.0 (default: 1.0)."
             ),
         )
+        parser.add_argument(
+            "--blend-chunk-size",
+            type=int,
+            default=None,
+            help=(
+                "Tokens per chunk for the global CacheBlend directory; must "
+                "equal the LMCache chunk size the blend servers use (default: 256)."
+            ),
+        )
+        parser.add_argument(
+            "--blend-probe-stride",
+            type=int,
+            default=None,
+            help=(
+                "Positions between CacheBlend match probes; 1 probes every "
+                "offset for full recall (default: 1)."
+            ),
+        )
 
     def execute(self, args: argparse.Namespace) -> None:
         """Build the coordinator config and serve the app with uvicorn.
@@ -145,6 +163,8 @@ class CoordinatorCommand(BaseCommand):
                 ("eviction_check_interval", args.eviction_check_interval),
                 ("eviction_ratio", args.eviction_ratio),
                 ("trigger_watermark", args.trigger_watermark),
+                ("blend_chunk_size", args.blend_chunk_size),
+                ("blend_probe_stride", args.blend_probe_stride),
             )
             if value is not None
         }

--- a/tests/cli/commands/test_coordinator.py
+++ b/tests/cli/commands/test_coordinator.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``lmcache coordinator`` CLI command."""
+
+# Standard
+from unittest.mock import MagicMock, patch
+import argparse
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.coordinator import CoordinatorCommand
+
+
+@pytest.fixture
+def cmd():
+    return CoordinatorCommand()
+
+
+@pytest.fixture
+def parser(cmd):
+    """An ArgumentParser with CoordinatorCommand's arguments registered."""
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers()
+    cmd.register(sub)
+    return p
+
+
+class TestCoordinatorCommandMetadata:
+    def test_name(self, cmd):
+        assert cmd.name() == "coordinator"
+
+    def test_help(self, cmd):
+        assert "coordinator" in cmd.help().lower()
+
+
+class TestCoordinatorCommandArguments:
+    def test_all_flags_registered(self, parser):
+        """Every MPCoordinatorConfig field is settable via a CLI flag."""
+        args = parser.parse_args(
+            [
+                "coordinator",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "9999",
+                "--instance-timeout",
+                "15",
+                "--health-check-interval",
+                "7",
+                "--eviction-check-interval",
+                "3",
+                "--eviction-ratio",
+                "0.5",
+                "--trigger-watermark",
+                "0.9",
+                "--blend-chunk-size",
+                "512",
+                "--blend-probe-stride",
+                "2",
+            ]
+        )
+        assert args.host == "127.0.0.1"
+        assert args.port == 9999
+        assert args.blend_chunk_size == 512
+        assert args.blend_probe_stride == 2
+
+    def test_flags_default_to_none(self, parser):
+        """Unset flags default to None so env/config defaults win."""
+        args = parser.parse_args(["coordinator"])
+        assert args.blend_chunk_size is None
+        assert args.blend_probe_stride is None
+
+
+class TestCoordinatorCommandExecute:
+    def test_blend_overrides_applied(self, cmd):
+        """blend_chunk_size/blend_probe_stride flags override the config."""
+        # First Party
+        from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
+
+        args = argparse.Namespace(
+            host=None,
+            port=None,
+            instance_timeout=None,
+            health_check_interval=None,
+            eviction_check_interval=None,
+            eviction_ratio=None,
+            trigger_watermark=None,
+            blend_chunk_size=512,
+            blend_probe_stride=2,
+        )
+
+        captured = {}
+
+        def fake_create_app(config: MPCoordinatorConfig):
+            captured["config"] = config
+            return MagicMock()
+
+        with (
+            patch("uvicorn.run"),
+            patch(
+                "lmcache.v1.mp_coordinator.app.create_app",
+                side_effect=fake_create_app,
+            ),
+        ):
+            cmd.execute(args)
+
+        assert captured["config"].blend_chunk_size == 512
+        assert captured["config"].blend_probe_stride == 2


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `--blend-chunk-size` and `--blend-probe-stride` to the `lmcache coordinator`
command. These are the last two `MPCoordinatorConfig` fields that were only
reachable via `LMCACHE_MP_COORDINATOR_*` env vars; the other 7 already have flags.

`blend_chunk_size` is the global-CacheBlend match unit and **must equal the
LMCache chunk size the blend servers use**, so deployments that run a non-default
chunk size need to be able to set it explicitly rather than relying on the 256
default.

**Special notes for your reviewers**:

Pure CLI surface change: each flag defaults to `None` and falls back to the env
var / config default in `execute()`, matching the existing flags. No behavior
change when the flags are unset.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests