### PR TITLE
[CI] Download opt-125m from GitHub release instead of HuggingFace

### DIFF
--- a/.github/scripts/download_opt125m_github.sh
+++ b/.github/scripts/download_opt125m_github.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Download facebook/opt-125m from the LMCache/opt-125m GitHub release
+# and place it into the HuggingFace hub cache structure so vLLM can
+# find it via ``facebook/opt-125m`` without any network call to HF.
+#
+# Environment:
+#   OPT125M_GH_RELEASE  release tag (default: v1.0)
+#   OPT125M_SNAPSHOT    HF snapshot hash (default: 27dcfa...)
+
+set -euo pipefail
+
+GH_RELEASE="${OPT125M_GH_RELEASE:-v1.0}"
+SNAPSHOT="${OPT125M_SNAPSHOT:-27dcfa74d334bc871f3234de431e71c6eeba5dd6}"
+
+HF_CACHE="${HF_HOME:-$HOME/.cache/huggingface}/hub"
+MODEL_DIR="${HF_CACHE}/models--facebook--opt-125m"
+SNAPSHOT_DIR="${MODEL_DIR}/snapshots/${SNAPSHOT}"
+
+if [ -f "${SNAPSHOT_DIR}/pytorch_model.bin" ]; then
+    echo "opt-125m already cached in ${SNAPSHOT_DIR}, skipping download"
+    exit 0
+fi
+
+echo "Downloading opt-125m from GitHub release ${GH_RELEASE}..."
+mkdir -p "${SNAPSHOT_DIR}"
+
+TARBALL="$(mktemp -d)/opt-125m.tar.gz"
+DOWNLOAD_URL="https://github.com/LMCache/opt-125m/archive/refs/tags/${GH_RELEASE}.tar.gz"
+
+for i in $(seq 1 5); do
+    if curl -fsSL --retry 3 -o "${TARBALL}" "${DOWNLOAD_URL}"; then
+        break
+    fi
+    if [ "${i}" -eq 5 ]; then
+        echo "!! Failed to download after 5 attempts: ${DOWNLOAD_URL}"
+        exit 1
+    fi
+    sleep $((10 * i))
+done
+
+# Extract to temp dir first, then move files. GitHub archives
+# produce a top-level dir like ``opt-125m-1.0``.
+EXTRACT_DIR="$(mktemp -d)"
+tar -xzf "${TARBALL}" -C "${EXTRACT_DIR}"
+# Find the inner directory (only one should exist).
+INNER_DIR="$(find "${EXTRACT_DIR}" -mindepth 1 -maxdepth 1 -type d | head -1)"
+mv "${INNER_DIR}"/* "${SNAPSHOT_DIR}/"
+
+rm -rf "${TARBALL}" "${EXTRACT_DIR}"
+
+# Create the refs/main pointer so snapshot_download(local_files_only=True)
+# can resolve the snapshot hash.
+echo "${SNAPSHOT}" > "${MODEL_DIR}/refs/main"
+
+echo "opt-125m cached at ${SNAPSHOT_DIR}"
+ls -lah "${SNAPSHOT_DIR}/"

--- a/.github/scripts/download_opt125m_github.sh
+++ b/.github/scripts/download_opt125m_github.sh
@@ -30,7 +30,7 @@ TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 TARBALL="${TMP_DIR}/opt-125m.tar.gz"
-DOWNLOAD_URL="https://github.com/LMCache/opt-125m/archive/refs/tags/${GH_RELEASE}.tar.gz"
+DOWNLOAD_URL="https://github.com/LMCache/opt-125m/releases/download/${GH_RELEASE}/opt-125m.tar.gz"
 
 for i in $(seq 1 5); do
     if curl -fsSL --retry 3 -o "${TARBALL}" "${DOWNLOAD_URL}"; then
@@ -43,18 +43,11 @@ for i in $(seq 1 5); do
     sleep $((10 * i))
 done
 
-# Extract to temp dir first, then move files. GitHub archives
-# produce a top-level dir like ``opt-125m-1.0``.
+# Extract directly – the tarball contains opt-125m/ at top level.
 EXTRACT_DIR="${TMP_DIR}/extract"
 mkdir -p "${EXTRACT_DIR}"
 tar -xzf "${TARBALL}" -C "${EXTRACT_DIR}"
-# Find the inner directory (only one should exist).
-INNER_DIR="$(find "${EXTRACT_DIR}" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
-if [ -z "${INNER_DIR}" ]; then
-    echo "!! Failed to find extracted directory in ${EXTRACT_DIR}"
-    exit 1
-fi
-mv "${INNER_DIR}"/* "${SNAPSHOT_DIR}/"
+mv "${EXTRACT_DIR}"/opt-125m/* "${SNAPSHOT_DIR}/"
 
 # Create the refs/main pointer so snapshot_download(local_files_only=True)
 # can resolve the snapshot hash.

--- a/.github/scripts/download_opt125m_github.sh
+++ b/.github/scripts/download_opt125m_github.sh
@@ -26,7 +26,10 @@ fi
 echo "Downloading opt-125m from GitHub release ${GH_RELEASE}..."
 mkdir -p "${SNAPSHOT_DIR}"
 
-TARBALL="$(mktemp -d)/opt-125m.tar.gz"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+TARBALL="${TMP_DIR}/opt-125m.tar.gz"
 DOWNLOAD_URL="https://github.com/LMCache/opt-125m/archive/refs/tags/${GH_RELEASE}.tar.gz"
 
 for i in $(seq 1 5); do
@@ -42,16 +45,20 @@ done
 
 # Extract to temp dir first, then move files. GitHub archives
 # produce a top-level dir like ``opt-125m-1.0``.
-EXTRACT_DIR="$(mktemp -d)"
+EXTRACT_DIR="${TMP_DIR}/extract"
+mkdir -p "${EXTRACT_DIR}"
 tar -xzf "${TARBALL}" -C "${EXTRACT_DIR}"
 # Find the inner directory (only one should exist).
-INNER_DIR="$(find "${EXTRACT_DIR}" -mindepth 1 -maxdepth 1 -type d | head -1)"
+INNER_DIR="$(find "${EXTRACT_DIR}" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+if [ -z "${INNER_DIR}" ]; then
+    echo "!! Failed to find extracted directory in ${EXTRACT_DIR}"
+    exit 1
+fi
 mv "${INNER_DIR}"/* "${SNAPSHOT_DIR}/"
-
-rm -rf "${TARBALL}" "${EXTRACT_DIR}"
 
 # Create the refs/main pointer so snapshot_download(local_files_only=True)
 # can resolve the snapshot hash.
+mkdir -p "${MODEL_DIR}/refs"
 echo "${SNAPSHOT}" > "${MODEL_DIR}/refs/main"
 
 echo "opt-125m cached at ${SNAPSHOT_DIR}"

--- a/.github/scripts/run-cpu-e2e-validation.sh
+++ b/.github/scripts/run-cpu-e2e-validation.sh
@@ -345,9 +345,8 @@ else
   echo "✅ numpy<2 installed"
 fi
 
-echo "[Phase 2 / Step 2] Downloading facebook/opt-125m model (cache-aware)"
-HF_DOWNLOAD_FAIL_ON_ERROR=1 \
-  bash "${SHARED_SCRIPTS_DIR}/download_model.sh" facebook/opt-125m
+echo "[Phase 2 / Step 2] Downloading facebook/opt-125m model (GitHub release)"
+bash "${SHARED_SCRIPTS_DIR}/download_opt125m_github.sh"
 echo "✅ Model download/check complete"
 
 echo "[Phase 2 / Step 3] Starting LMCache server"

--- a/.github/workflows/cpu_device.yml
+++ b/.github/workflows/cpu_device.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: opt-125m-gh-v1
+          key: opt-125m-gh-v2
 
       - name: Install vLLM CPU (prebuilt nightly from PyPI)
         run: bash .github/scripts/install_vllm_cpu.sh

--- a/.github/workflows/cpu_device.yml
+++ b/.github/workflows/cpu_device.yml
@@ -94,11 +94,11 @@ jobs:
             pyproject.toml
             requirements/*.txt
 
-      - name: Cache HuggingFace models
+      - name: Cache opt-125m model (GitHub release)
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: hf-opt-125m-v1
+          key: opt-125m-gh-v1
 
       - name: Install vLLM CPU (prebuilt nightly from PyPI)
         run: bash .github/scripts/install_vllm_cpu.sh
@@ -106,12 +106,8 @@ jobs:
       - name: Install lmcache (CPU-only, no vLLM)
         run: bash .github/scripts/install_lmcache_cpu.sh
 
-      - name: Download facebook/opt-125m
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          HF_DOWNLOAD_FAIL_ON_ERROR=1 \
-            bash .github/scripts/download_model.sh facebook/opt-125m
+      - name: Download facebook/opt-125m (GitHub release)
+        run: bash .github/scripts/download_opt125m_github.sh
 
       - name: Server bench — LMCache-driven
         run: |


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add `Fixes #<issue number>` somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding `Refs #<issue number>` will not close the issue but help get maintainer attention.
-->

**What this PR does / why we need it**:

Switch opt-125m model download from HuggingFace to GitHub Release (LMCache/opt-125m). This avoids HF_TOKEN dependency and network flakiness from HuggingFace, making CPU CI more stable.

**Special notes for your reviewers**:

- Added `download_opt125m_github.sh` that downloads from the GitHub release tarball and places files into the HF cache structure
- Updated `cpu_device.yml` workflow and `run-cpu-e2e-validation.sh` to use the new script
- No more `HF_TOKEN` required

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests