### PR TITLE
[CI] Add publish-image-rc job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -305,13 +305,14 @@ jobs:
                     dist/*.whl
 
     # Build container image and push to DockerHub when:
-    # - a new GitHub release is created
+    # - a new stable GitHub release is created (non-RC)
     publish-image:
         name: Publish image to DockerHub
         if: |
             needs.publish-pypi.result == 'success' &&
             !cancelled() &&
-            github.repository_owner == 'LMCache' && github.event.action == 'published'
+            github.repository_owner == 'LMCache' && github.event.action == 'published' &&
+            !contains(github.ref_name, 'rc')
 
         runs-on: ubuntu-latest
         needs: [publish-pypi, publish-cu129-github-release]
@@ -465,3 +466,64 @@ jobs:
               run: |
                 docker push lmcache/standalone:latest-cu129
                 docker push lmcache/standalone:${{ env.LATEST_TAG }}-cu129
+
+    # Build RC container image and push to DockerHub when:
+    # - a new RC GitHub release is created (e.g. v0.4.8rc1)
+    # Only pushes lmcache/vllm-openai:<tag> — does not touch latest or other image variants.
+    publish-image-rc:
+        name: Publish RC image to DockerHub
+        if: |
+            needs.publish-pypi.result == 'success' &&
+            !cancelled() &&
+            github.repository_owner == 'LMCache' && github.event.action == 'published' &&
+            contains(github.ref_name, 'rc')
+
+        runs-on: ubuntu-latest
+        needs: [publish-pypi]
+
+        steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+              with:
+                disable-sudo-and-containers: false
+                egress-policy: audit
+
+            - name: Login to DockerHub
+              uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+              with:
+                username: ${{ vars.DOCKERHUB_USERNAME }}
+                password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+            - name: Checkout code
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              with:
+                fetch-depth: 0
+
+            - name: Free disk space
+              uses: ./.github/actions/free-disk-space
+
+            - name: Get the release tag
+              run: |
+                REF="${{ github.ref_name }}"
+                [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]] && echo "LATEST_RC_TAG=$REF" >> "$GITHUB_ENV"
+
+            - name: Build lmcache/vllm-openai container image (cu13)
+              run: |
+                docker build \
+                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
+                --build-arg CUDA_VERSION=13.0 \
+                --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
+                --target image-release \
+                --tag lmcache/vllm-openai:${{ env.LATEST_RC_TAG }} \
+                --file docker/Dockerfile .
+
+            - name: Smoke test lmcache/vllm-openai (cu13)
+              run: |
+                docker run --rm --entrypoint lmcache lmcache/vllm-openai:${{ env.LATEST_RC_TAG }} --help
+
+            - name: Push lmcache/vllm-openai RC image to DockerHub
+              run: |
+                docker push lmcache/vllm-openai:${{ env.LATEST_RC_TAG }}


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Add new `publish-image-rc` job triggers only for RC releases and pushes `lmcache/vllm-openai:vX.Y.Zrc1`.


**Special notes for your reviewers**:
1. `publish-image` now skips RC releases via !contains(github.ref_name, 'rc') in the job-level if condition.
2. New `publish-image-rc` job triggers only for RC releases and pushes `lmcache/vllm-openai:vX.Y.Zrc1` only, leaving all other image variants untouched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
