### PR TITLE
docs: daily drift check — multi-process mode (2026-06-17)

### DIFF
--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -51,6 +51,12 @@ Options
    * - ``--trigger-watermark RATIO``
      - Eviction fires when usage reaches this fraction of the quota, ``0.0``
        (exclusive) to ``1.0`` (default: ``1.0``).
+   * - ``--blend-chunk-size N``
+     - Tokens per chunk for the global CacheBlend directory; must equal the
+       LMCache chunk size the blend servers use (default: ``256``).
+   * - ``--blend-probe-stride N``
+     - Positions between CacheBlend match probes; ``1`` probes every offset
+       for full recall (default: ``1``).
 
 Configuration
 -------------
@@ -58,9 +64,10 @@ Configuration
 Every flag is optional. Unset flags fall back to the
 ``LMCACHE_MP_COORDINATOR_*`` environment variables (``HOST``, ``PORT``,
 ``INSTANCE_TIMEOUT``, ``HEALTH_CHECK_INTERVAL``, ``EVICTION_CHECK_INTERVAL``,
-``EVICTION_RATIO``, ``TRIGGER_WATERMARK``), and then to the built-in
-defaults. A supplied flag always overrides the matching env-derived value, so
-env-only deployments keep working unchanged.
+``EVICTION_RATIO``, ``TRIGGER_WATERMARK``, ``BLEND_CHUNK_SIZE``,
+``BLEND_PROBE_STRIDE``), and then to the built-in defaults. A supplied flag
+always overrides the matching env-derived value, so env-only deployments keep
+working unchanged.
 
 See :doc:`/mp/coordinator` for the coordinator's architecture, registration
 protocol, and HTTP API.


### PR DESCRIPTION
## Summary

Daily docs drift check for **multi-process (MP) mode**, scoped to `docs/source/` and `docs/design/`. One drift item found in `docs/source/`; nothing actionable in `docs/design/`.

### `docs/source/`

- **`docs/source/cli/coordinator.rst`** — missing the two new `lmcache coordinator` flags introduced by [#3731](https://github.com/LMCache/LMCache/pull/3731) ("Expose CacheBlend coordinator knobs as CLI flags"):
  - `--blend-chunk-size` (and its `LMCACHE_MP_COORDINATOR_BLEND_CHUNK_SIZE` env var)
  - `--blend-probe-stride` (and its `LMCACHE_MP_COORDINATOR_BLEND_PROBE_STRIDE` env var)

  PR #3731 updated the MP architecture page (`docs/source/mp/coordinator.rst`) but missed the exhaustive CLI reference page that lists every flag and env var the command accepts. The CLI page still describes the pre-#3731 surface.

### `docs/design/`

No drift found this run. The MP-relevant design pages (`docs/design/v1/mp_coordinator/`, `docs/design/v1/multiprocess/`) are consistent with the current MP server/coordinator code under `lmcache/v1/multiprocess/` and `lmcache/v1/mp_coordinator/`.

## Evidence

| Stale doc | Authoritative code | Notes |
| --- | --- | --- |
| [`docs/source/cli/coordinator.rst` lines 26-63](https://github.com/LMCache/LMCache/blob/8891000/docs/source/cli/coordinator.rst#L26-L63) (Options table + Configuration env-var list) | [`lmcache/cli/commands/coordinator.py` lines 104-121](https://github.com/LMCache/LMCache/blob/8891000/lmcache/cli/commands/coordinator.py#L104-L121) (argparse adds `--blend-chunk-size` / `--blend-probe-stride`) and [`lmcache/v1/mp_coordinator/config.py` lines 38-55](https://github.com/LMCache/LMCache/blob/8891000/lmcache/v1/mp_coordinator/config.py#L38-L55) (defaults `256` / `1`, env prefix `LMCACHE_MP_COORDINATOR_`) | Companion doc `docs/source/mp/coordinator.rst` was already updated in #3731; only the CLI reference page lagged. |

## Proposed fix (already applied in this PR)

`docs/source/cli/coordinator.rst`:

- Adds `--blend-chunk-size N` and `--blend-probe-stride N` rows to the **Options** table with defaults `256` and `1`.
- Appends `BLEND_CHUNK_SIZE` and `BLEND_PROBE_STRIDE` to the `LMCACHE_MP_COORDINATOR_*` env-var list in the **Configuration** paragraph.

Wording is copied from the in-code argparse `help=` text and `docs/source/mp/coordinator.rst` so the three sources stay in sync.

## What was checked

- Cross-checked every page under `docs/source/mp/` and `docs/source/cli/` (especially the recently-restructured MP docs from [#3665](https://github.com/LMCache/LMCache/pull/3665)) against `lmcache/v1/multiprocess/`, `lmcache/v1/mp_coordinator/`, and `lmcache/cli/commands/coordinator.py` on `dev` at `8891000` (HEAD as of 2026-06-17).
- Verified that the [#3679](https://github.com/LMCache/LMCache/pull/3679) rename (`GPUTransferModule` → `LMCacheDrivenTransferModule`, `NonGPUTransferModule` → `EngineDrivenTransferModule`) is fully reflected in English `docs/source/` pages — only `docs/source/locale/zh_CN/LC_MESSAGES/mp/architecture.po` still mentions the old names, and that file is regenerated by the translation bot.
- Verified that the new MP server flags from [#3664](https://github.com/LMCache/LMCache/pull/3664) (`--worker-reap-timeout-seconds`, `--worker-registration-grace-seconds`) and [#3697](https://github.com/LMCache/LMCache/pull/3697) (`--enable-segmented-prefix`) are documented in `docs/source/mp/configuration.rst`. `docs/source/cli/server.rst` only enumerates "commonly used flags" and explicitly defers to `lmcache server --help` for the full list, so its omission of these flags is by design and is **not** flagged as drift.

## Notes

- Auto-generated by the daily drift-check routine; please review before merging.
- Doc-only change. No code touched.
- Do not merge without human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_014v2fenAo6AaqvTaJYf23ZT)_