### PR TITLE
[MP][P2P] Enable runtime registration / deregistration of L2 adapters

### DIFF
--- a/lmcache/v1/distributed/storage_controllers/adapter_lifecycle.py
+++ b/lmcache/v1/distributed/storage_controllers/adapter_lifecycle.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Control-plane operations for runtime add/remove of L2 adapters.
+
+Both :class:`StoreController` and :class:`PrefetchController` own a
+``select.poll()`` loop on a dedicated background thread.  Their poll set,
+eventfd-to-id maps, and in-flight task tables are mutated only by that
+thread.  To add or remove an adapter at runtime without racing the loop,
+external callers enqueue one of these ops and signal a control eventfd;
+the loop applies the op at the top of its next iteration.
+"""
+
+# Standard
+from dataclasses import dataclass
+import threading
+
+# First Party
+from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
+from lmcache.v1.distributed.storage_controllers.store_policy import AdapterDescriptor
+
+
+@dataclass
+class AddAdapterOp:
+    """Attach a new adapter under the stable id ``adapter_id``.
+
+    ``done`` is set by the loop once the adapter's eventfd(s) are
+    registered and the adapter is live for routing.
+    """
+
+    adapter_id: int
+    adapter: L2AdapterInterface
+    descriptor: AdapterDescriptor
+    done: threading.Event
+
+
+@dataclass
+class RemoveAdapterOp:
+    """Begin a graceful drain of the adapter under ``adapter_id``.
+
+    Applying the op marks the adapter as draining (no new work routes to
+    it).  ``done`` is set only once all in-flight work referencing the
+    adapter has finished and its eventfd(s) are unregistered.
+    """
+
+    adapter_id: int
+    done: threading.Event

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -186,9 +186,11 @@ class L2AdapterEvictionState:
 
     def __init__(
         self,
+        adapter_id: int,
         adapter: L2AdapterInterface,
         eviction_config: EvictionConfig,
     ):
+        self.adapter_id = adapter_id
         self.adapter = adapter
         self.eviction_config = eviction_config
         self.eviction_policy = CreateEvictionPolicy(eviction_config)
@@ -219,6 +221,10 @@ class L2EvictionController(StorageControllerInterface):
     ):
         self._adapter_states = l2_adapter_states
         self._quota_manager = quota_manager
+        # Guards ``_adapter_states`` against concurrent runtime add/remove.
+        # Held for the full duration of an eviction pass so a removal does
+        # not detach an adapter mid-``get_usage``/``delete``.
+        self._states_lock = threading.Lock()
         self._stop_flag = threading.Event()
         self._thread = threading.Thread(
             target=self._eviction_loop,
@@ -233,6 +239,23 @@ class L2EvictionController(StorageControllerInterface):
         self._stop_flag.set()
         self._thread.join()
 
+    def add_adapter_state(self, state: L2AdapterEvictionState) -> None:
+        """Register a new adapter's eviction state at runtime."""
+        with self._states_lock:
+            self._adapter_states.append(state)
+
+    def remove_adapter_state(self, adapter_id: int) -> None:
+        """Drop the eviction state for ``adapter_id``.
+
+        Blocks until any in-progress eviction pass finishes (it holds the
+        same lock), so the adapter is guaranteed idle here before the
+        caller closes it. A no-op if the adapter has no eviction state.
+        """
+        with self._states_lock:
+            self._adapter_states = [
+                s for s in self._adapter_states if s.adapter_id != adapter_id
+            ]
+
     def report_status(self) -> dict:
         # NOTE: ``usage.bytes_by_cache_salt`` is intentionally NOT
         # surfaced here. A deployment can have 10k+ salts, so embedding
@@ -241,7 +264,9 @@ class L2EvictionController(StorageControllerInterface):
         # quota endpoints (which pull from ``QuotaManager`` +
         # ``StorageManager.get_usage_bytes_by_cache_salt``).
         adapter_statuses = []
-        for state in self._adapter_states:
+        with self._states_lock:
+            states = list(self._adapter_states)
+        for state in states:
             usage = state.adapter.get_usage()
             adapter_statuses.append(
                 {
@@ -263,8 +288,12 @@ class L2EvictionController(StorageControllerInterface):
     def _eviction_loop(self):
         while not self._stop_flag.is_set():
             time.sleep(1)
-            for state in self._adapter_states:
-                self._check_and_evict(state)
+            # Hold the lock across the whole pass so remove_adapter_state
+            # cannot detach (and the caller close) an adapter while we are
+            # calling into it.
+            with self._states_lock:
+                for state in self._adapter_states:
+                    self._check_and_evict(state)
 
     def _check_and_evict(self, state: L2AdapterEvictionState):
         if state.eviction_policy.support_isolation and self._quota_manager is not None:

--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
@@ -221,9 +221,7 @@ class L2EvictionController(StorageControllerInterface):
     ):
         self._adapter_states = l2_adapter_states
         self._quota_manager = quota_manager
-        # Guards ``_adapter_states`` against concurrent runtime add/remove.
-        # Held for the full duration of an eviction pass so a removal does
-        # not detach an adapter mid-``get_usage``/``delete``.
+        # Guards _adapter_states against concurrent runtime add/remove.
         self._states_lock = threading.Lock()
         self._stop_flag = threading.Event()
         self._thread = threading.Thread(

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -199,9 +199,6 @@ class PrefetchController(StorageControllerInterface):
         max_in_flight: int = 8,
     ) -> None:
         self._l1_manager = l1_manager
-        # Keyed by a stable adapter id (== descriptor ``index``), not list
-        # position, so runtime removal never shifts surviving ids. Initial
-        # ids are the construction-order positions.
         self._l2_adapters: dict[int, L2AdapterInterface] = {
             desc.index: adapter
             for desc, adapter in zip(adapter_descriptors, l2_adapters, strict=True)
@@ -212,14 +209,12 @@ class PrefetchController(StorageControllerInterface):
         self._policy = policy
         self._max_in_flight = max_in_flight
 
-        # Adapters being gracefully drained: still poll for in-flight
-        # completions but receive no new lookups. Maps draining id -> the
-        # Event set once fully drained and unregistered.
+        # Adapters that are being drained and will be removed after all
+        # the in-flight operations are done.
         self._draining: dict[int, threading.Event] = {}
 
-        # Control-plane queue for runtime add/remove, applied on the loop
-        # thread (the only thread allowed to mutate the poll set / fd maps /
-        # adapter dicts).
+        # Control-plane queue for runtime add/remove, used by the internal
+        # loop thread
         self._adapter_ops_lock = threading.Lock()
         self._pending_adapter_ops: list[AddAdapterOp | RemoveAdapterOp] = []
         self._adapter_ctrl_efd = create_event_notifier()
@@ -527,10 +522,8 @@ class PrefetchController(StorageControllerInterface):
         adapter: L2AdapterInterface,
         descriptor: AdapterDescriptor,
     ) -> None:
-        """Attach an adapter at runtime under the stable id ``adapter_id``.
-
-        Enqueues the attach for the background loop and blocks until it is
-        live (its lookup/load eventfds registered in the poll set).
+        """Blocking function to add a new adapter into the prefetch
+        controller with the specified adapter ID and descriptor.
 
         Args:
             adapter_id: Stable id assigned by the StorageManager.
@@ -557,12 +550,11 @@ class PrefetchController(StorageControllerInterface):
             )
 
     def request_remove_adapter(self, adapter_id: int) -> threading.Event:
-        """Begin a graceful drain of the adapter under ``adapter_id``.
+        """Non-blocking function to request the removal of a L2 adapter
+        specified by the adapter ID.
 
-        Non-blocking. New lookups stop routing to the adapter immediately;
-        in-flight requests are allowed to complete. The returned Event is
-        set once the adapter is fully drained and its eventfds are
-        unregistered.
+        New lookups stop routing to the adapter immediately; in-flight
+        requests are allowed to complete.
 
         Args:
             adapter_id: Stable id of the adapter to drain.
@@ -599,8 +591,7 @@ class PrefetchController(StorageControllerInterface):
             poller.register(efd, select.POLLIN)
 
         while not self._stop_flag.is_set():
-            # Apply runtime add/remove first so a draining adapter is out of
-            # the lookup fan-out before any new request starts this iteration.
+            # First, apply runtime add/remove of the L2 adapters.
             self._apply_pending_adapter_ops(poller)
 
             ready = poller.poll(PREFETCH_LOOP_POLL_TIMEOUT_MS)
@@ -651,13 +642,12 @@ class PrefetchController(StorageControllerInterface):
                     "Unexpected error in prefetch loop while starting pending requests"
                 )
 
-            # Finalize any draining adapter no longer referenced by an
-            # in-flight request: unregister its fds and detach it.
+            # Finalize any draining adapter no longer have any in-flight
+            # requests.
             self._finalize_drained_adapters(poller)
 
     def _apply_pending_adapter_ops(self, poller: "select.poll") -> None:
-        """Apply queued add/remove ops on the loop thread (the only thread
-        that may mutate the poll set, fd maps, and adapter dicts)."""
+        """Apply queued add/remove ops on the prefetch loop thread."""
         with self._adapter_ops_lock:
             ops = self._pending_adapter_ops
             self._pending_adapter_ops = []
@@ -686,14 +676,7 @@ class PrefetchController(StorageControllerInterface):
                 )
 
     def _adapter_in_use(self, adapter_id: int) -> bool:
-        """True if any in-flight request still references ``adapter_id``.
-
-        Covers every structure that triggers an adapter call before a
-        request completes: pending lookup/load tasks, the load plan
-        (unlock + finalize), and lookup_results (which may still feed a
-        load plan or an unlock). A request only clears these by completing
-        via ``_complete_request``, so this waits for full completion.
-        """
+        """True if any in-flight request still references ``adapter_id``."""
         for request in self._in_flight_requests.values():
             if (
                 adapter_id in request.pending_lookup_tasks

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -28,6 +28,10 @@ from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
 from lmcache.v1.distributed.storage_controller import StorageControllerInterface
+from lmcache.v1.distributed.storage_controllers.adapter_lifecycle import (
+    AddAdapterOp,
+    RemoveAdapterOp,
+)
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     PrefetchPolicy,
 )
@@ -195,10 +199,30 @@ class PrefetchController(StorageControllerInterface):
         max_in_flight: int = 8,
     ) -> None:
         self._l1_manager = l1_manager
-        self._l2_adapters = l2_adapters
-        self._adapter_descriptors = adapter_descriptors
+        # Keyed by a stable adapter id (== descriptor ``index``), not list
+        # position, so runtime removal never shifts surviving ids. Initial
+        # ids are the construction-order positions.
+        self._l2_adapters: dict[int, L2AdapterInterface] = {
+            desc.index: adapter
+            for desc, adapter in zip(adapter_descriptors, l2_adapters, strict=True)
+        }
+        self._adapter_descriptors: dict[int, AdapterDescriptor] = {
+            desc.index: desc for desc in adapter_descriptors
+        }
         self._policy = policy
         self._max_in_flight = max_in_flight
+
+        # Adapters being gracefully drained: still poll for in-flight
+        # completions but receive no new lookups. Maps draining id -> the
+        # Event set once fully drained and unregistered.
+        self._draining: dict[int, threading.Event] = {}
+
+        # Control-plane queue for runtime add/remove, applied on the loop
+        # thread (the only thread allowed to mutate the poll set / fd maps /
+        # adapter dicts).
+        self._adapter_ops_lock = threading.Lock()
+        self._pending_adapter_ops: list[AddAdapterOp | RemoveAdapterOp] = []
+        self._adapter_ctrl_efd = create_event_notifier()
 
         # In-flight request tracking (background thread only)
         self._in_flight_requests: dict[PrefetchRequestId, InFlightPrefetchRequest] = {}
@@ -246,9 +270,11 @@ class PrefetchController(StorageControllerInterface):
         # share an fd.  See the docstrings in L2AdapterInterface.
         self._lookup_efd_to_adapter: dict[int, int] = {}
         self._load_efd_to_adapter: dict[int, int] = {}
-        for i, adapter in enumerate(self._l2_adapters):
-            self._lookup_efd_to_adapter[adapter.get_lookup_and_lock_event_fd()] = i
-            self._load_efd_to_adapter[adapter.get_load_event_fd()] = i
+        for adapter_id, adapter in self._l2_adapters.items():
+            self._lookup_efd_to_adapter[adapter.get_lookup_and_lock_event_fd()] = (
+                adapter_id
+            )
+            self._load_efd_to_adapter[adapter.get_load_event_fd()] = adapter_id
 
         self._event_bus = get_event_bus()
 
@@ -271,6 +297,19 @@ class PrefetchController(StorageControllerInterface):
                 "L1 bytes reserved by in-flight L2 -> L1 prefetch loads, per adapter",
                 lambda: (
                     PrefetchController._gauge_target.get_inflight_load_bytes_observations()
+                    if PrefetchController._gauge_target is not None
+                    else []
+                ),
+            )
+            register_gauge(
+                "lmcache.l2_prefetch",
+                "lmcache_mp.l2_adapters",
+                (
+                    "Count of L2 adapters attached to the prefetch controller, "
+                    "tagged by ``state`` (active or draining)."
+                ),
+                lambda: (
+                    PrefetchController._gauge_target.get_adapter_state_observations()
                     if PrefetchController._gauge_target is not None
                     else []
                 ),
@@ -400,7 +439,20 @@ class PrefetchController(StorageControllerInterface):
             "load_phase_count": self._status_load_phase_count,
             "completed_results_count": completed_results_count,
             "num_l2_adapters": len(self._l2_adapters),
+            "num_active_adapters": len(self._l2_adapters) - len(self._draining),
+            "num_draining_adapters": len(self._draining),
         }
+
+    def get_adapter_state_observations(
+        self,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """``(count, {"state": ...})`` tuples for the ``lmcache_mp.l2_adapters``
+        gauge. ``len()`` reads are GIL-atomic, safe from the OTel thread."""
+        num_draining = len(self._draining)
+        return [
+            (len(self._l2_adapters) - num_draining, {"state": "active"}),
+            (num_draining, {"state": "draining"}),
+        ]
 
     def _snapshot_inflight_loads(self) -> dict[int, tuple[int, int]]:
         """``{adapter_idx: (count, reserved_bytes)}`` for in-flight L2 -> L1
@@ -421,32 +473,30 @@ class PrefetchController(StorageControllerInterface):
     ) -> list[tuple[int | float, dict[str, object]]]:
         """Per-adapter ``(count, attributes)`` for the
         ``lmcache_mp.num_inflight_l2_loads`` gauge."""
-        return [
-            (
-                count,
-                {
-                    "l2_name": self._adapter_descriptors[idx].type_name,
-                    "adapter_index": idx,
-                },
+        observations: list[tuple[int | float, dict[str, object]]] = []
+        for idx, (count, _) in self._snapshot_inflight_loads().items():
+            desc = self._adapter_descriptors.get(idx)
+            if desc is None:
+                continue
+            observations.append(
+                (count, {"l2_name": desc.type_name, "adapter_index": idx})
             )
-            for idx, (count, _) in self._snapshot_inflight_loads().items()
-        ]
+        return observations
 
     def get_inflight_load_bytes_observations(
         self,
     ) -> list[tuple[int | float, dict[str, object]]]:
         """Per-adapter ``(reserved_bytes, attributes)`` for the
         ``lmcache_mp.inflight_load_memory_usage_bytes`` gauge."""
-        return [
-            (
-                reserved_bytes,
-                {
-                    "l2_name": self._adapter_descriptors[idx].type_name,
-                    "adapter_index": idx,
-                },
+        observations: list[tuple[int | float, dict[str, object]]] = []
+        for idx, (_, reserved_bytes) in self._snapshot_inflight_loads().items():
+            desc = self._adapter_descriptors.get(idx)
+            if desc is None:
+                continue
+            observations.append(
+                (reserved_bytes, {"l2_name": desc.type_name, "adapter_index": idx})
             )
-            for idx, (_, reserved_bytes) in self._snapshot_inflight_loads().items()
-        ]
+        return observations
 
     # =========================================================================
     # Lifecycle
@@ -469,6 +519,62 @@ class PrefetchController(StorageControllerInterface):
         self._thread.join()
         self._cleanup_in_flight_requests()
         self._submission_efd.close()
+        self._adapter_ctrl_efd.close()
+
+    def add_adapter(
+        self,
+        adapter_id: int,
+        adapter: L2AdapterInterface,
+        descriptor: AdapterDescriptor,
+    ) -> None:
+        """Attach an adapter at runtime under the stable id ``adapter_id``.
+
+        Enqueues the attach for the background loop and blocks until it is
+        live (its lookup/load eventfds registered in the poll set).
+
+        Args:
+            adapter_id: Stable id assigned by the StorageManager.
+            adapter: The adapter instance to attach.
+            descriptor: The adapter's descriptor (``descriptor.index`` must
+                equal ``adapter_id``).
+
+        Raises:
+            RuntimeError: If the background loop did not apply the op in
+                time (e.g. the loop is not running).
+        """
+        op = AddAdapterOp(
+            adapter_id=adapter_id,
+            adapter=adapter,
+            descriptor=descriptor,
+            done=threading.Event(),
+        )
+        with self._adapter_ops_lock:
+            self._pending_adapter_ops.append(op)
+        self._adapter_ctrl_efd.notify()
+        if not op.done.wait(timeout=PREFETCH_LOOP_POLL_TIMEOUT_MS / 1000 + 5.0):
+            raise RuntimeError(
+                f"PrefetchController did not attach adapter {adapter_id} in time"
+            )
+
+    def request_remove_adapter(self, adapter_id: int) -> threading.Event:
+        """Begin a graceful drain of the adapter under ``adapter_id``.
+
+        Non-blocking. New lookups stop routing to the adapter immediately;
+        in-flight requests are allowed to complete. The returned Event is
+        set once the adapter is fully drained and its eventfds are
+        unregistered.
+
+        Args:
+            adapter_id: Stable id of the adapter to drain.
+
+        Returns:
+            An Event signaled when the adapter is fully drained.
+        """
+        op = RemoveAdapterOp(adapter_id=adapter_id, done=threading.Event())
+        with self._adapter_ops_lock:
+            self._pending_adapter_ops.append(op)
+        self._adapter_ctrl_efd.notify()
+        return op.done
 
     # =========================================================================
     # Background loop
@@ -486,12 +592,17 @@ class PrefetchController(StorageControllerInterface):
         poller = select.poll()
         submission_fd = self._submission_efd.fileno()
         poller.register(submission_fd, select.POLLIN)
+        poller.register(self._adapter_ctrl_efd.fileno(), select.POLLIN)
         for efd in self._lookup_efd_to_adapter:
             poller.register(efd, select.POLLIN)
         for efd in self._load_efd_to_adapter:
             poller.register(efd, select.POLLIN)
 
         while not self._stop_flag.is_set():
+            # Apply runtime add/remove first so a draining adapter is out of
+            # the lookup fan-out before any new request starts this iteration.
+            self._apply_pending_adapter_ops(poller)
+
             ready = poller.poll(PREFETCH_LOOP_POLL_TIMEOUT_MS)
 
             signaled_adapters: dict[PrefetchPhase, set[int]] = {
@@ -540,6 +651,79 @@ class PrefetchController(StorageControllerInterface):
                     "Unexpected error in prefetch loop while starting pending requests"
                 )
 
+            # Finalize any draining adapter no longer referenced by an
+            # in-flight request: unregister its fds and detach it.
+            self._finalize_drained_adapters(poller)
+
+    def _apply_pending_adapter_ops(self, poller: "select.poll") -> None:
+        """Apply queued add/remove ops on the loop thread (the only thread
+        that may mutate the poll set, fd maps, and adapter dicts)."""
+        with self._adapter_ops_lock:
+            ops = self._pending_adapter_ops
+            self._pending_adapter_ops = []
+        for op in ops:
+            if isinstance(op, AddAdapterOp):
+                self._l2_adapters[op.adapter_id] = op.adapter
+                self._adapter_descriptors[op.adapter_id] = op.descriptor
+                lookup_efd = op.adapter.get_lookup_and_lock_event_fd()
+                load_efd = op.adapter.get_load_event_fd()
+                self._lookup_efd_to_adapter[lookup_efd] = op.adapter_id
+                self._load_efd_to_adapter[load_efd] = op.adapter_id
+                poller.register(lookup_efd, select.POLLIN)
+                poller.register(load_efd, select.POLLIN)
+                logger.info("PrefetchController attached adapter %d", op.adapter_id)
+                op.done.set()
+            elif isinstance(op, RemoveAdapterOp):
+                if op.adapter_id not in self._l2_adapters:
+                    op.done.set()
+                    continue
+                # Mark draining; new lookups skip it. The adapter stays
+                # registered so in-flight requests can still complete.
+                self._draining[op.adapter_id] = op.done
+                logger.info(
+                    "PrefetchController draining adapter %d (no new lookups routed)",
+                    op.adapter_id,
+                )
+
+    def _adapter_in_use(self, adapter_id: int) -> bool:
+        """True if any in-flight request still references ``adapter_id``.
+
+        Covers every structure that triggers an adapter call before a
+        request completes: pending lookup/load tasks, the load plan
+        (unlock + finalize), and lookup_results (which may still feed a
+        load plan or an unlock). A request only clears these by completing
+        via ``_complete_request``, so this waits for full completion.
+        """
+        for request in self._in_flight_requests.values():
+            if (
+                adapter_id in request.pending_lookup_tasks
+                or adapter_id in request.pending_load_tasks
+                or adapter_id in request.load_plan
+                or adapter_id in request.lookup_results
+            ):
+                return True
+        return False
+
+    def _finalize_drained_adapters(self, poller: "select.poll") -> None:
+        """Detach draining adapters no longer referenced by any request."""
+        for adapter_id in list(self._draining):
+            if self._adapter_in_use(adapter_id):
+                continue
+            adapter = self._l2_adapters.pop(adapter_id)
+            self._adapter_descriptors.pop(adapter_id, None)
+            lookup_efd = adapter.get_lookup_and_lock_event_fd()
+            load_efd = adapter.get_load_event_fd()
+            self._lookup_efd_to_adapter.pop(lookup_efd, None)
+            self._load_efd_to_adapter.pop(load_efd, None)
+            for efd in (lookup_efd, load_efd):
+                try:
+                    poller.unregister(efd)
+                except (KeyError, OSError):
+                    pass
+            done = self._draining.pop(adapter_id)
+            logger.info("PrefetchController detached adapter %d", adapter_id)
+            done.set()
+
     def _drain_submission_queue(self) -> None:
         """Move items from the thread-safe submission queue to the
         pending queue."""
@@ -572,15 +756,23 @@ class PrefetchController(StorageControllerInterface):
         extra_count: int = 0,
         policy: TrimPolicy = TrimPolicy.PREFIX,
     ) -> None:
-        """Submit lookup_and_lock to all adapters for a new request."""
-        if not self._l2_adapters:
+        """Submit lookup_and_lock to all live (non-draining) adapters for a
+        new request."""
+        # Skip adapters being drained so a new request never locks keys on
+        # an adapter that is on its way out.
+        routing_adapters = {
+            adapter_id: adapter
+            for adapter_id, adapter in self._l2_adapters.items()
+            if adapter_id not in self._draining
+        }
+        if not routing_adapters:
             self._complete_request(request_id, Bitmap(len(keys)))
             return
 
         pending_lookup_tasks: dict[int, L2TaskId] = {}
-        for i, adapter in enumerate(self._l2_adapters):
+        for adapter_id, adapter in routing_adapters.items():
             task_id = adapter.submit_lookup_and_lock_task(keys)
-            pending_lookup_tasks[i] = task_id
+            pending_lookup_tasks[adapter_id] = task_id
 
         request = InFlightPrefetchRequest(
             request_id=request_id,
@@ -616,11 +808,18 @@ class PrefetchController(StorageControllerInterface):
         self._status_lookup_phase_count -= 1
         self._status_load_phase_count += 1
 
-        # Step 1: get load plan from policy
+        # Step 1: get load plan from policy. Exclude draining adapters so no
+        # new load targets them; any keys they locked during lookup fall
+        # outside the plan and get unlocked in _unlock_unneeded_keys.
+        routing_descriptors = [
+            desc
+            for adapter_id, desc in self._adapter_descriptors.items()
+            if adapter_id not in self._draining
+        ]
         load_plan = self._policy.select_load_plan(
             request.keys,
             request.lookup_results,
-            self._adapter_descriptors,
+            routing_descriptors,
         )
 
         # Step 2: trim the load plan to the policy's retained subset

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -231,11 +231,6 @@ class StoreController(StorageControllerInterface):
         policy: StorePolicy,
     ) -> None:
         self._l1_manager = l1_manager
-        # Adapters and descriptors are keyed by a stable adapter id (== the
-        # descriptor's ``index``) rather than list position, so runtime
-        # removal never shifts the ids of surviving adapters or invalidates
-        # in-flight ``(adapter_id, task_id)`` keys.  Initial ids are the
-        # construction-order positions.
         self._l2_adapters: dict[int, L2AdapterInterface] = {
             desc.index: adapter
             for desc, adapter in zip(adapter_descriptors, l2_adapters, strict=True)
@@ -245,16 +240,12 @@ class StoreController(StorageControllerInterface):
         }
         self._policy = policy
 
-        # Adapters being gracefully drained: still process in-flight
-        # completions and stay registered in the poll set, but no new store
-        # task routes to them.  Maps draining id -> the Event set once the
-        # adapter is fully drained and unregistered.
+        # Adapters that are being drained and will be removed after all
+        # the in-flight operations are done.
         self._draining: dict[int, threading.Event] = {}
 
-        # Control-plane queue for runtime add/remove. External callers append
-        # ops and signal ``_adapter_ctrl_efd``; the background loop applies
-        # them at the top of its iteration so poll set / maps / dicts are
-        # only ever mutated on the loop thread.
+        # Control-plane queue for runtime add/remove, used by the internal
+        # loop thread
         self._adapter_ops_lock = threading.Lock()
         self._pending_adapter_ops: list[AddAdapterOp | RemoveAdapterOp] = []
         self._adapter_ctrl_efd = create_event_notifier()
@@ -349,10 +340,8 @@ class StoreController(StorageControllerInterface):
         adapter: L2AdapterInterface,
         descriptor: AdapterDescriptor,
     ) -> None:
-        """Attach an adapter at runtime under the stable id ``adapter_id``.
-
-        Enqueues the attach for the background loop and blocks until it is
-        live (its store eventfd registered in the poll set).
+        """Blocking function to add a new adapter into the store controller
+        with the specified adapter ID and descriptor.
 
         Args:
             adapter_id: Stable id assigned by the StorageManager.
@@ -379,12 +368,11 @@ class StoreController(StorageControllerInterface):
             )
 
     def request_remove_adapter(self, adapter_id: int) -> threading.Event:
-        """Begin a graceful drain of the adapter under ``adapter_id``.
+        """Non-blocking function to request the removal of a L2 adapter
+        specified by the adapter ID.
 
-        Non-blocking. New store tasks stop routing to the adapter
-        immediately; in-flight tasks are allowed to complete. The returned
-        Event is set once the adapter is fully drained and its eventfd is
-        unregistered.
+        New store tasks stop routing to the adapter immediately; in-flight
+        tasks are allowed to complete.
 
         Args:
             adapter_id: Stable id of the adapter to drain.
@@ -458,8 +446,7 @@ class StoreController(StorageControllerInterface):
             poller.register(efd, select.POLLIN)
 
         while not self._stop_flag.is_set():
-            # Apply runtime add/remove first so a draining adapter is out of
-            # the routing set before any new-key processing this iteration.
+            # First, apply runtime add/remove of the L2 adapters.
             self._apply_pending_adapter_ops(poller)
 
             ready = poller.poll(STORE_LOOP_POLL_TIMEOUT_MS)
@@ -510,13 +497,12 @@ class StoreController(StorageControllerInterface):
                             task_key[1],
                         )
 
-            # Finalize any draining adapter whose in-flight tasks have all
-            # completed: unregister its fd and detach it.
+            # Finalize any draining adapter no longer have any in-flight
+            # tasks.
             self._finalize_drained_adapters(poller)
 
     def _apply_pending_adapter_ops(self, poller: "select.poll") -> None:
-        """Apply queued add/remove ops on the loop thread (the only thread
-        that may mutate the poll set, fd map, and adapter dicts)."""
+        """Apply queued add/remove ops on the store loop thread."""
         with self._adapter_ops_lock:
             ops = self._pending_adapter_ops
             self._pending_adapter_ops = []

--- a/lmcache/v1/distributed/storage_controllers/store_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/store_controller.py
@@ -24,6 +24,10 @@ from lmcache.v1.distributed.internal_api import L1ManagerListener
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
 from lmcache.v1.distributed.storage_controller import StorageControllerInterface
+from lmcache.v1.distributed.storage_controllers.adapter_lifecycle import (
+    AddAdapterOp,
+    RemoveAdapterOp,
+)
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
     StorePolicy,
@@ -227,9 +231,33 @@ class StoreController(StorageControllerInterface):
         policy: StorePolicy,
     ) -> None:
         self._l1_manager = l1_manager
-        self._l2_adapters = l2_adapters
-        self._adapter_descriptors = adapter_descriptors
+        # Adapters and descriptors are keyed by a stable adapter id (== the
+        # descriptor's ``index``) rather than list position, so runtime
+        # removal never shifts the ids of surviving adapters or invalidates
+        # in-flight ``(adapter_id, task_id)`` keys.  Initial ids are the
+        # construction-order positions.
+        self._l2_adapters: dict[int, L2AdapterInterface] = {
+            desc.index: adapter
+            for desc, adapter in zip(adapter_descriptors, l2_adapters, strict=True)
+        }
+        self._adapter_descriptors: dict[int, AdapterDescriptor] = {
+            desc.index: desc for desc in adapter_descriptors
+        }
         self._policy = policy
+
+        # Adapters being gracefully drained: still process in-flight
+        # completions and stay registered in the poll set, but no new store
+        # task routes to them.  Maps draining id -> the Event set once the
+        # adapter is fully drained and unregistered.
+        self._draining: dict[int, threading.Event] = {}
+
+        # Control-plane queue for runtime add/remove. External callers append
+        # ops and signal ``_adapter_ctrl_efd``; the background loop applies
+        # them at the top of its iteration so poll set / maps / dicts are
+        # only ever mutated on the loop thread.
+        self._adapter_ops_lock = threading.Lock()
+        self._pending_adapter_ops: list[AddAdapterOp | RemoveAdapterOp] = []
+        self._adapter_ctrl_efd = create_event_notifier()
 
         self._listener = StoreListener()
         self._l1_manager.register_listener(self._listener)
@@ -256,12 +284,24 @@ class StoreController(StorageControllerInterface):
                     else []
                 ),
             )
+            register_gauge(
+                "lmcache.l2_store",
+                "lmcache_mp.l2_adapters",
+                (
+                    "Count of L2 adapters attached to the store controller, "
+                    "tagged by ``state`` (active or draining)."
+                ),
+                lambda: (
+                    StoreController._gauge_target.get_adapter_state_observations()
+                    if StoreController._gauge_target is not None
+                    else []
+                ),
+            )
 
-        # Map eventfd -> adapter index for quick lookup in poll results
+        # Map store eventfd -> adapter id for quick lookup in poll results
         self._efd_to_adapter_index: dict[int, int] = {}
-        for i, adapter in enumerate(self._l2_adapters):
-            efd = adapter.get_store_event_fd()
-            self._efd_to_adapter_index[efd] = i
+        for adapter_id, adapter in self._l2_adapters.items():
+            self._efd_to_adapter_index[adapter.get_store_event_fd()] = adapter_id
 
         self._stop_flag = threading.Event()
         self._thread = threading.Thread(
@@ -287,17 +327,87 @@ class StoreController(StorageControllerInterface):
         self._thread.join()
         self._cleanup_in_flight_tasks()
         self._listener.close()
+        self._adapter_ctrl_efd.close()
 
     def report_status(self) -> dict:
         """Return a status dict for the store controller."""
         is_healthy = self._thread.is_alive()
+        num_draining = len(self._draining)
         return {
             "is_healthy": is_healthy,
             "thread_alive": is_healthy,
             "pending_keys_count": self._listener.pending_count(),
             "in_flight_task_count": self._status_in_flight_count,
             "num_l2_adapters": len(self._l2_adapters),
+            "num_active_adapters": len(self._l2_adapters) - num_draining,
+            "num_draining_adapters": num_draining,
         }
+
+    def add_adapter(
+        self,
+        adapter_id: int,
+        adapter: L2AdapterInterface,
+        descriptor: AdapterDescriptor,
+    ) -> None:
+        """Attach an adapter at runtime under the stable id ``adapter_id``.
+
+        Enqueues the attach for the background loop and blocks until it is
+        live (its store eventfd registered in the poll set).
+
+        Args:
+            adapter_id: Stable id assigned by the StorageManager.
+            adapter: The adapter instance to attach.
+            descriptor: The adapter's descriptor (``descriptor.index`` must
+                equal ``adapter_id``).
+
+        Raises:
+            RuntimeError: If the background loop did not apply the op in
+                time (e.g. the loop is not running).
+        """
+        op = AddAdapterOp(
+            adapter_id=adapter_id,
+            adapter=adapter,
+            descriptor=descriptor,
+            done=threading.Event(),
+        )
+        with self._adapter_ops_lock:
+            self._pending_adapter_ops.append(op)
+        self._adapter_ctrl_efd.notify()
+        if not op.done.wait(timeout=STORE_LOOP_POLL_TIMEOUT_MS / 1000 + 5.0):
+            raise RuntimeError(
+                f"StoreController did not attach adapter {adapter_id} in time"
+            )
+
+    def request_remove_adapter(self, adapter_id: int) -> threading.Event:
+        """Begin a graceful drain of the adapter under ``adapter_id``.
+
+        Non-blocking. New store tasks stop routing to the adapter
+        immediately; in-flight tasks are allowed to complete. The returned
+        Event is set once the adapter is fully drained and its eventfd is
+        unregistered.
+
+        Args:
+            adapter_id: Stable id of the adapter to drain.
+
+        Returns:
+            An Event signaled when the adapter is fully drained.
+        """
+        op = RemoveAdapterOp(adapter_id=adapter_id, done=threading.Event())
+        with self._adapter_ops_lock:
+            self._pending_adapter_ops.append(op)
+        self._adapter_ctrl_efd.notify()
+        return op.done
+
+    def get_adapter_state_observations(
+        self,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """``(count, {"state": ...})`` tuples for the ``lmcache_mp.l2_adapters``
+        gauge. ``len()`` reads are GIL-atomic, safe from the OTel thread."""
+        num_draining = len(self._draining)
+        return [
+            (len(self._l2_adapters) - num_draining, {"state": "active"}),
+            (num_draining, {"state": "draining"}),
+        ]
 
     def get_inflight_stores_observations(
         self,
@@ -313,16 +423,18 @@ class StoreController(StorageControllerInterface):
         counts: dict[int, int] = defaultdict(int)
         for adapter_index, _ in self._in_flight_tasks.copy():
             counts[adapter_index] += 1
-        return [
-            (
-                count,
-                {
-                    "l2_name": self._adapter_descriptors[idx].type_name,
-                    "adapter_index": idx,
-                },
+        observations: list[tuple[int | float, dict[str, object]]] = []
+        for idx, count in counts.items():
+            # A just-finalized adapter may be gone from the descriptor map
+            # while a stale in-flight snapshot still references it; skip it
+            # rather than KeyError on the OTel reader thread.
+            desc = self._adapter_descriptors.get(idx)
+            if desc is None:
+                continue
+            observations.append(
+                (count, {"l2_name": desc.type_name, "adapter_index": idx})
             )
-            for idx, count in counts.items()
-        ]
+        return observations
 
     # Private methods
 
@@ -340,11 +452,16 @@ class StoreController(StorageControllerInterface):
 
         listener_efd = self._listener.get_event_fd()
         poller.register(listener_efd, select.POLLIN)
+        poller.register(self._adapter_ctrl_efd.fileno(), select.POLLIN)
 
         for efd in self._efd_to_adapter_index:
             poller.register(efd, select.POLLIN)
 
         while not self._stop_flag.is_set():
+            # Apply runtime add/remove first so a draining adapter is out of
+            # the routing set before any new-key processing this iteration.
+            self._apply_pending_adapter_ops(poller)
+
             ready = poller.poll(STORE_LOOP_POLL_TIMEOUT_MS)
 
             signaled_adapters: dict[StorePhase, set[int]] = {
@@ -393,6 +510,63 @@ class StoreController(StorageControllerInterface):
                             task_key[1],
                         )
 
+            # Finalize any draining adapter whose in-flight tasks have all
+            # completed: unregister its fd and detach it.
+            self._finalize_drained_adapters(poller)
+
+    def _apply_pending_adapter_ops(self, poller: "select.poll") -> None:
+        """Apply queued add/remove ops on the loop thread (the only thread
+        that may mutate the poll set, fd map, and adapter dicts)."""
+        with self._adapter_ops_lock:
+            ops = self._pending_adapter_ops
+            self._pending_adapter_ops = []
+        for op in ops:
+            if isinstance(op, AddAdapterOp):
+                self._l2_adapters[op.adapter_id] = op.adapter
+                self._adapter_descriptors[op.adapter_id] = op.descriptor
+                efd = op.adapter.get_store_event_fd()
+                self._efd_to_adapter_index[efd] = op.adapter_id
+                poller.register(efd, select.POLLIN)
+                logger.info("StoreController attached adapter %d", op.adapter_id)
+                op.done.set()
+            elif isinstance(op, RemoveAdapterOp):
+                if op.adapter_id not in self._l2_adapters:
+                    # Already gone (double remove); signal so the caller
+                    # doesn't block.
+                    op.done.set()
+                    continue
+                # Mark draining; routing skips it immediately. The adapter
+                # stays registered so in-flight completions still process.
+                self._draining[op.adapter_id] = op.done
+                logger.info(
+                    "StoreController draining adapter %d (no new stores routed)",
+                    op.adapter_id,
+                )
+
+    def _adapter_in_use(self, adapter_id: int) -> bool:
+        """True if any in-flight store task targets ``adapter_id``."""
+        for task_adapter_id, _ in self._in_flight_tasks:
+            if task_adapter_id == adapter_id:
+                return True
+        return False
+
+    def _finalize_drained_adapters(self, poller: "select.poll") -> None:
+        """Detach draining adapters that no longer have in-flight tasks."""
+        for adapter_id in list(self._draining):
+            if self._adapter_in_use(adapter_id):
+                continue
+            adapter = self._l2_adapters.pop(adapter_id)
+            self._adapter_descriptors.pop(adapter_id, None)
+            efd = adapter.get_store_event_fd()
+            self._efd_to_adapter_index.pop(efd, None)
+            try:
+                poller.unregister(efd)
+            except (KeyError, OSError):
+                pass
+            done = self._draining.pop(adapter_id)
+            logger.info("StoreController detached adapter %d", adapter_id)
+            done.set()
+
     def _process_new_keys(self, keys: list[ObjectKey]) -> None:
         """
         Process a batch of newly written keys.
@@ -412,7 +586,15 @@ class StoreController(StorageControllerInterface):
 
     def _submit_store_for_single_shape(self, keys: list[ObjectKey]) -> None:
         """Submit ``keys`` (all same shape) to their target adapters."""
-        plan = self._policy.select_store_targets(keys, self._adapter_descriptors)
+        # Only route to adapters that are live (not draining). Descriptors
+        # for draining adapters are kept for in-flight completion handling
+        # but excluded here so no new task targets them.
+        routing_descriptors = [
+            desc
+            for adapter_id, desc in self._adapter_descriptors.items()
+            if adapter_id not in self._draining
+        ]
+        plan = self._policy.select_store_targets(keys, routing_descriptors)
 
         l1_mgr = self._l1_manager
 
@@ -420,12 +602,11 @@ class StoreController(StorageControllerInterface):
             if not target_keys:
                 continue
 
-            if adapter_index >= len(self._l2_adapters):
+            if adapter_index not in self._l2_adapters:
                 logger.error(
-                    "StorePolicy returned invalid adapter index %d "
-                    "(only %d adapters available). Skipping.",
+                    "StorePolicy returned invalid adapter id %d "
+                    "(not among attached adapters). Skipping.",
                     adapter_index,
-                    len(self._l2_adapters),
                 )
                 continue
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -76,21 +76,12 @@ class StorageManager:
         # a ``serde_config``, the adapter is wrapped with
         # ``SerdeL2AdapterWrapper`` so controllers see a plain L2 adapter
         # and serde is transparent.
-        #
-        # Adapters and descriptors are keyed by a stable, monotonic
-        # ``adapter_id`` (never reused or shifted) so runtime add/remove
-        # never invalidates surviving ids or in-flight ``(adapter_id,
-        # task_id)`` keys. Initial ids are the config order ``0..n-1``.
         self._l1_memory_desc = self._l1_manager.get_l1_memory_desc()
         self._next_adapter_id = 0
-        # Serializes add/delete against each other; may be held across a
-        # delete's drain wait. No controller background thread acquires it.
+        # Serializes add_l2_adapter / delete_l2_adapter against each other.
         self._lifecycle_lock = threading.Lock()
-        # Short-lived guard for the adapter/descriptor dicts so lock-free
-        # cross-thread readers (OTel gauges, HTTP status) never observe a
-        # mid-mutation dict.
+        # Guards the _l2_adapters and _adapter_descriptors dicts.
         self._adapters_lock = threading.Lock()
-        # External listeners re-applied to adapters added at runtime.
         self._registered_l2_listeners: list[L2AdapterListener] = []
         self._l2_adapters: dict[int, L2AdapterInterface] = {}
         self._adapter_descriptors: dict[int, AdapterDescriptor] = {}
@@ -786,12 +777,7 @@ class StorageManager:
         return result
 
     def add_l2_adapter(self, config: L2AdapterConfigBase) -> int:
-        """Create and attach a new L2 adapter at runtime.
-
-        Builds the adapter (wrapping it for serde when the config requests
-        it), re-applies any registered L2 listeners, wires it into the
-        store, prefetch, and eviction controllers, and exposes it for
-        routing. The adapter receives a stable id that is never reused.
+        """Blocking function to add a new L2 adapter at runtime. Thread-safe.
 
         Args:
             config: The adapter configuration.
@@ -821,20 +807,21 @@ class StorageManager:
             return adapter_id
 
     def delete_l2_adapter(self, adapter_id: int, timeout: float = 30.0) -> None:
-        """Gracefully drain and detach an L2 adapter at runtime.
+        """Blocking function to drain the L2 adapter gracefully at runtime.
+        Thread-safe.
 
         Stops routing new stores/prefetches to the adapter, waits for its
         in-flight work to finish, removes it from the controllers, and
-        closes it. The adapter's backing data is left intact (detach only).
+        closes it.
 
         Args:
             adapter_id: Stable id of the adapter to remove.
             timeout: Maximum seconds to wait for in-flight work to drain.
 
         Raises:
-            ValueError: If no adapter with ``adapter_id`` is attached.
+            ValueError: If no adapter with ``adapter_id`` is active.
             TimeoutError: If draining did not complete within ``timeout``;
-                the adapter is left attached (draining) so the caller can
+                the adapter is left active (draining) so the caller can
                 retry.
         """
         with self._lifecycle_lock:
@@ -861,10 +848,10 @@ class StorageManager:
             logger.info("Deleted L2 adapter %d", adapter_id)
 
     def l2_adapters(self) -> list[tuple[AdapterDescriptor, L2AdapterInterface]]:
-        """Return all attached L2 adapters paired with descriptors, in
+        """Return all active L2 adapters paired with descriptors, in
         ascending adapter-id order (== configuration order for the initial
-        set, then runtime-added adapters). The first element is the primary
-        adapter; the list is empty when no L2 is configured.
+        set, then runtime-added adapters). The list is empty when no L2 is
+        configured.
 
         Do not cache the returned pairs — ``reconfigure_l2_adapter``,
         ``add_l2_adapter``, and ``delete_l2_adapter`` may change the set at

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -451,7 +451,7 @@ class StorageManager:
             )
 
             prefetch_request_id = -1
-            if remaining_keys and self._l2_adapters:
+            if remaining_keys and self._has_l2_adapters():
                 prefetch_request_id = self._prefetch_controller.submit_prefetch_request(
                     remaining_keys,
                     layout_desc,
@@ -505,7 +505,7 @@ class StorageManager:
         remaining_keys = keys[hit_count:]
         prefetch_request_id = -1
         l2_orig_indices: tuple[int, ...] = ()
-        if remaining_keys and self._l2_adapters:
+        if remaining_keys and self._has_l2_adapters():
             prefetch_request_id = self._prefetch_controller.submit_prefetch_request(
                 remaining_keys,
                 layout_desc,
@@ -692,13 +692,7 @@ class StorageManager:
             silence over a poison observation).
         """
         out: list[tuple[int | float, dict[str, object]]] = []
-        with self._adapters_lock:
-            items = list(self._l2_adapters.items())
-            descriptors = dict(self._adapter_descriptors)
-        for adapter_id, adapter in items:
-            desc = descriptors.get(adapter_id)
-            if desc is None:
-                continue
+        for _adapter_id, desc, adapter in self._snapshot_adapters():
             try:
                 usage = adapter.get_usage()
             except Exception:
@@ -719,9 +713,7 @@ class StorageManager:
         are additive.
         """
         totals: dict[str, int] = {}
-        with self._adapters_lock:
-            adapters = list(self._l2_adapters.values())
-        for adapter in adapters:
+        for _adapter_id, _desc, adapter in self._snapshot_adapters():
             snap = adapter.get_usage().bytes_by_cache_salt
             for salt, used in snap.items():
                 totals[salt] = totals.get(salt, 0) + used
@@ -735,16 +727,18 @@ class StorageManager:
             JSON-serializable status. If no reconfigurable adapter is configured,
             ``enabled`` is ``False`` and the adapter list is empty.
         """
+        type_names = {
+            adapter_id: desc.type_name
+            for adapter_id, desc, _ in self._snapshot_adapters()
+        }
         adapters = []
         for adapter_index, (
             l2_adapter_index,
             adapter,
         ) in enumerate(self._list_reconfigurable_l2_adapters()):
             status = dict(adapter.reconfigure_status())
-            if l2_adapter_index in self._adapter_descriptors:
-                status["backend"] = self._adapter_descriptors[
-                    l2_adapter_index
-                ].type_name
+            if l2_adapter_index in type_names:
+                status["backend"] = type_names[l2_adapter_index]
             status["adapter_index"] = adapter_index
             status["l2_adapter_index"] = l2_adapter_index
             adapters.append(status)
@@ -857,11 +851,9 @@ class StorageManager:
         ``add_l2_adapter``, and ``delete_l2_adapter`` may change the set at
         runtime.
         """
-        with self._adapters_lock:
-            return [
-                (self._adapter_descriptors[adapter_id], adapter)
-                for adapter_id, adapter in sorted(self._l2_adapters.items())
-            ]
+        return [
+            (desc, adapter) for _adapter_id, desc, adapter in self._snapshot_adapters()
+        ]
 
     # Management APIs
     def clear(self, force: bool = False):
@@ -899,7 +891,7 @@ class StorageManager:
         prefetch = self._prefetch_controller.report_status()
         l1_eviction = self._eviction_controller.report_status()
         l2_eviction = self._l2_eviction_controller.report_status()
-        adapters = [a.report_status() for a in self._l2_adapters.values()]
+        adapters = [a.report_status() for _id, _desc, a in self._snapshot_adapters()]
         children = [l1, store, prefetch, l1_eviction, l2_eviction] + adapters
         return {
             "is_healthy": all(c["is_healthy"] for c in children),
@@ -909,7 +901,7 @@ class StorageManager:
             "l1_eviction_controller": l1_eviction,
             "l2_eviction_controller": l2_eviction,
             "l2_adapters": adapters,
-            "num_l2_adapters": len(self._l2_adapters),
+            "num_l2_adapters": len(adapters),
         }
 
     def register_l2_listener(self, listener: L2AdapterListener) -> None:
@@ -936,21 +928,40 @@ class StorageManager:
         """
         return self._l1_manager.memcheck()
 
+    def _snapshot_adapters(
+        self,
+    ) -> list[tuple[int, AdapterDescriptor, L2AdapterInterface]]:
+        """Snapshot the active adapters under the lock, in ascending
+        adapter-id order. Iterate this instead of the live dicts so a
+        concurrent add/delete cannot change them mid-iteration.
+
+        Returns:
+            A list of ``(adapter_id, descriptor, adapter)`` tuples.
+        """
+        with self._adapters_lock:
+            return [
+                (adapter_id, self._adapter_descriptors[adapter_id], adapter)
+                for adapter_id, adapter in sorted(self._l2_adapters.items())
+            ]
+
+    def _has_l2_adapters(self) -> bool:
+        """Return whether any L2 adapter is currently active."""
+        with self._adapters_lock:
+            return bool(self._l2_adapters)
+
     def _build_l2_adapter(
         self,
         config: L2AdapterConfigBase,
     ) -> tuple[int, L2AdapterInterface, AdapterDescriptor]:
-        """Allocate a stable id and construct an adapter + its descriptor.
-
-        Wraps the adapter with ``SerdeL2AdapterWrapper`` when the config
-        carries a ``serde_config``. Does not register the adapter with any
-        controller — the caller wires it up.
+        """Create a L2 adapter instance based on the config.
 
         Args:
             config: The adapter configuration.
 
         Returns:
-            ``(adapter_id, adapter, descriptor)``.
+            A ``(adapter_id, adapter, descriptor)`` tuple. ``adapter_id`` is
+            the freshly allocated stable id, ``adapter`` is the new adapter
+            instance, and ``descriptor`` is its descriptor carrying that id.
         """
         adapter_id = self._next_adapter_id
         self._next_adapter_id += 1
@@ -970,12 +981,6 @@ class StorageManager:
         eviction_config: EvictionConfig | None,
     ) -> bool:
         """Whether to wire an adapter into the L2 eviction controller.
-
-        Aggregate-usage policies (``LRU``, ``noop``) need a capacity
-        (``max_capacity_bytes > 0``) to compute a usage fraction, so an
-        adapter without capacity is skipped for those (logged). Isolated
-        policies (``IsolatedLRU``) track per-cache_salt bytes regardless of
-        capacity, so they are always enabled.
 
         Args:
             adapter: The adapter to evaluate.
@@ -1014,8 +1019,10 @@ class StorageManager:
     def _list_reconfigurable_l2_adapters(
         self,
     ) -> list[tuple[int, L2ReconfigurableAdapter]]:
+        with self._adapters_lock:
+            items = sorted(self._l2_adapters.items())
         adapters: list[tuple[int, L2ReconfigurableAdapter]] = []
-        for l2_adapter_index, adapter in sorted(self._l2_adapters.items()):
+        for l2_adapter_index, adapter in items:
             reconfigurable_adapter = self._unwrap_reconfigurable_l2_adapter(adapter)
             if reconfigurable_adapter is not None:
                 adapters.append((l2_adapter_index, reconfigurable_adapter))

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -6,6 +6,7 @@ Distributed multi-tier storage manager for MP mode
 # Standard
 from contextlib import contextmanager
 from typing import Iterator, Literal, Optional
+import threading
 import time
 
 # First Party
@@ -17,12 +18,13 @@ from lmcache.v1.distributed.api import (
     PrefetchHandle,
     TrimPolicy,
 )
-from lmcache.v1.distributed.config import StorageManagerConfig
+from lmcache.v1.distributed.config import EvictionConfig, StorageManagerConfig
 from lmcache.v1.distributed.error import L1Error, strerror
 from lmcache.v1.distributed.internal_api import L2AdapterListener
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
+from lmcache.v1.distributed.l2_adapters.config import L2AdapterConfigBase
 from lmcache.v1.distributed.l2_adapters.reconfiguration import (
     L2ReconfigurableAdapter,
     L2ReconfigureError,
@@ -74,17 +76,28 @@ class StorageManager:
         # a ``serde_config``, the adapter is wrapped with
         # ``SerdeL2AdapterWrapper`` so controllers see a plain L2 adapter
         # and serde is transparent.
-        l1_memory_desc = self._l1_manager.get_l1_memory_desc()
-        self._l2_adapters: list[L2AdapterInterface] = []
+        #
+        # Adapters and descriptors are keyed by a stable, monotonic
+        # ``adapter_id`` (never reused or shifted) so runtime add/remove
+        # never invalidates surviving ids or in-flight ``(adapter_id,
+        # task_id)`` keys. Initial ids are the config order ``0..n-1``.
+        self._l1_memory_desc = self._l1_manager.get_l1_memory_desc()
+        self._next_adapter_id = 0
+        # Serializes add/delete against each other; may be held across a
+        # delete's drain wait. No controller background thread acquires it.
+        self._lifecycle_lock = threading.Lock()
+        # Short-lived guard for the adapter/descriptor dicts so lock-free
+        # cross-thread readers (OTel gauges, HTTP status) never observe a
+        # mid-mutation dict.
+        self._adapters_lock = threading.Lock()
+        # External listeners re-applied to adapters added at runtime.
+        self._registered_l2_listeners: list[L2AdapterListener] = []
+        self._l2_adapters: dict[int, L2AdapterInterface] = {}
+        self._adapter_descriptors: dict[int, AdapterDescriptor] = {}
         for ac in config.l2_adapter_config.adapters:
-            adapter: L2AdapterInterface = create_l2_adapter(ac, l1_memory_desc)
-            if ac.serde_config is not None:
-                adapter = SerdeL2AdapterWrapper(
-                    inner=adapter,
-                    serde=create_serde_processor(ac.serde_config),
-                    l1_manager=self._l1_manager,
-                )
-            self._l2_adapters.append(adapter)
+            adapter_id, adapter, descriptor = self._build_l2_adapter(ac)
+            self._l2_adapters[adapter_id] = adapter
+            self._adapter_descriptors[adapter_id] = descriptor
 
         PeriodicEventNotifier.create(
             interval_ms=config.periodic_notifier_interval_ms,
@@ -107,41 +120,31 @@ class StorageManager:
         # counts which the base class tracks regardless of capacity,
         # so they are wired up unconditionally.
         l2_eviction_states: list[L2AdapterEvictionState] = []
-        for adapter, ac in zip(
+        for adapter_id, ac in zip(
             self._l2_adapters, config.l2_adapter_config.adapters, strict=True
         ):
-            if ac.eviction_config is None:
-                continue
-            policy_name = ac.eviction_config.eviction_policy
-            if policy_name != "IsolatedLRU" and not adapter.supports_global_eviction:
-                logger.warning(
-                    "L2 adapter %s configured with '%s' eviction but does "
-                    "not support global eviction (max_capacity_bytes=0); "
-                    "skipping aggregate-usage eviction setup.",
-                    type(adapter).__name__,
-                    policy_name,
+            adapter = self._l2_adapters[adapter_id]
+            if self._should_enable_l2_eviction(adapter, ac.eviction_config):
+                assert ac.eviction_config is not None  # make linter happy
+                l2_eviction_states.append(
+                    L2AdapterEvictionState(
+                        adapter_id=adapter_id,
+                        adapter=adapter,
+                        eviction_config=ac.eviction_config,
+                    )
                 )
-                continue
-            l2_eviction_states.append(
-                L2AdapterEvictionState(
-                    adapter=adapter,
-                    eviction_config=ac.eviction_config,
-                )
-            )
         self._l2_eviction_controller = L2EvictionController(
             l2_eviction_states, quota_manager=self._quota_manager
         )
         self._l2_eviction_controller.start()
 
-        self._adapter_descriptors = [
-            AdapterDescriptor(index=i, config=ac)
-            for i, ac in enumerate(config.l2_adapter_config.adapters)
-        ]
-
+        # Controllers receive the initial set as ordered lists; they key
+        # their own copies by ``descriptor.index`` (== adapter_id) and learn
+        # of later changes via add_adapter/request_remove_adapter.
         self._store_controller = StoreController(
             l1_manager=self._l1_manager,
-            l2_adapters=self._l2_adapters,
-            adapter_descriptors=self._adapter_descriptors,
+            l2_adapters=list(self._l2_adapters.values()),
+            adapter_descriptors=list(self._adapter_descriptors.values()),
             policy=create_store_policy(config.store_policy),
         )
         self._store_controller.start()
@@ -149,8 +152,8 @@ class StorageManager:
         # Prefetch controller
         self._prefetch_controller = PrefetchController(
             l1_manager=self._l1_manager,
-            l2_adapters=self._l2_adapters,
-            adapter_descriptors=self._adapter_descriptors,
+            l2_adapters=list(self._l2_adapters.values()),
+            adapter_descriptors=list(self._adapter_descriptors.values()),
             policy=create_prefetch_policy(config.prefetch_policy),
             max_in_flight=config.prefetch_max_in_flight,
         )
@@ -697,9 +700,13 @@ class StorageManager:
             silence over a poison observation).
         """
         out: list[tuple[int | float, dict[str, object]]] = []
-        for adapter, desc in zip(
-            self._l2_adapters, self._adapter_descriptors, strict=True
-        ):
+        with self._adapters_lock:
+            items = list(self._l2_adapters.items())
+            descriptors = dict(self._adapter_descriptors)
+        for adapter_id, adapter in items:
+            desc = descriptors.get(adapter_id)
+            if desc is None:
+                continue
             try:
                 usage = adapter.get_usage()
             except Exception:
@@ -720,7 +727,9 @@ class StorageManager:
         are additive.
         """
         totals: dict[str, int] = {}
-        for adapter in self._l2_adapters:
+        with self._adapters_lock:
+            adapters = list(self._l2_adapters.values())
+        for adapter in adapters:
             snap = adapter.get_usage().bytes_by_cache_salt
             for salt, used in snap.items():
                 totals[salt] = totals.get(salt, 0) + used
@@ -739,7 +748,7 @@ class StorageManager:
             adapter,
         ) in enumerate(self._list_reconfigurable_l2_adapters()):
             status = dict(adapter.reconfigure_status())
-            if l2_adapter_index < len(getattr(self, "_adapter_descriptors", [])):
+            if l2_adapter_index in self._adapter_descriptors:
                 status["backend"] = self._adapter_descriptors[
                     l2_adapter_index
                 ].type_name
@@ -774,6 +783,81 @@ class StorageManager:
         result["adapter_index"] = adapter_index
         return result
 
+    def add_l2_adapter(self, config: L2AdapterConfigBase) -> int:
+        """Create and attach a new L2 adapter at runtime.
+
+        Builds the adapter (wrapping it for serde when the config requests
+        it), re-applies any registered L2 listeners, wires it into the
+        store, prefetch, and eviction controllers, and exposes it for
+        routing. The adapter receives a stable id that is never reused.
+
+        Args:
+            config: The adapter configuration.
+
+        Returns:
+            The stable id assigned to the new adapter.
+        """
+        with self._lifecycle_lock:
+            adapter_id, adapter, descriptor = self._build_l2_adapter(config)
+            for listener in self._registered_l2_listeners:
+                adapter.register_listener(listener)
+            with self._adapters_lock:
+                self._l2_adapters[adapter_id] = adapter
+                self._adapter_descriptors[adapter_id] = descriptor
+            self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+            self._prefetch_controller.add_adapter(adapter_id, adapter, descriptor)
+            if self._should_enable_l2_eviction(adapter, config.eviction_config):
+                assert config.eviction_config is not None  # make linter happy
+                self._l2_eviction_controller.add_adapter_state(
+                    L2AdapterEvictionState(
+                        adapter_id=adapter_id,
+                        adapter=adapter,
+                        eviction_config=config.eviction_config,
+                    )
+                )
+            logger.info("Added L2 adapter %d (%s)", adapter_id, descriptor.type_name)
+            return adapter_id
+
+    def delete_l2_adapter(self, adapter_id: int, timeout: float = 30.0) -> None:
+        """Gracefully drain and detach an L2 adapter at runtime.
+
+        Stops routing new stores/prefetches to the adapter, waits for its
+        in-flight work to finish, removes it from the controllers, and
+        closes it. The adapter's backing data is left intact (detach only).
+
+        Args:
+            adapter_id: Stable id of the adapter to remove.
+            timeout: Maximum seconds to wait for in-flight work to drain.
+
+        Raises:
+            ValueError: If no adapter with ``adapter_id`` is attached.
+            TimeoutError: If draining did not complete within ``timeout``;
+                the adapter is left attached (draining) so the caller can
+                retry.
+        """
+        with self._lifecycle_lock:
+            if adapter_id not in self._l2_adapters:
+                raise ValueError(f"No L2 adapter with id {adapter_id}")
+
+            deadline = time.monotonic() + timeout
+            store_done = self._store_controller.request_remove_adapter(adapter_id)
+            prefetch_done = self._prefetch_controller.request_remove_adapter(adapter_id)
+            if not store_done.wait(timeout=max(0.0, deadline - time.monotonic())):
+                raise TimeoutError(
+                    f"Timed out draining adapter {adapter_id} from store controller"
+                )
+            if not prefetch_done.wait(timeout=max(0.0, deadline - time.monotonic())):
+                raise TimeoutError(
+                    f"Timed out draining adapter {adapter_id} from prefetch controller"
+                )
+
+            self._l2_eviction_controller.remove_adapter_state(adapter_id)
+            with self._adapters_lock:
+                adapter = self._l2_adapters.pop(adapter_id)
+                self._adapter_descriptors.pop(adapter_id, None)
+            adapter.close()
+            logger.info("Deleted L2 adapter %d", adapter_id)
+
     def clear(self, force: bool = False):
         """
         Clear data in the storage manager.
@@ -797,7 +881,7 @@ class StorageManager:
 
         PeriodicEventNotifier.shutdown()
 
-        for adapter in self._l2_adapters:
+        for adapter in self._l2_adapters.values():
             adapter.close()
 
         self._l1_manager.close()
@@ -809,7 +893,7 @@ class StorageManager:
         prefetch = self._prefetch_controller.report_status()
         l1_eviction = self._eviction_controller.report_status()
         l2_eviction = self._l2_eviction_controller.report_status()
-        adapters = [a.report_status() for a in self._l2_adapters]
+        adapters = [a.report_status() for a in self._l2_adapters.values()]
         children = [l1, store, prefetch, l1_eviction, l2_eviction] + adapters
         return {
             "is_healthy": all(c["is_healthy"] for c in children),
@@ -823,13 +907,18 @@ class StorageManager:
         }
 
     def register_l2_listener(self, listener: L2AdapterListener) -> None:
-        """Register a listener on all L2 adapters.
+        """Register a listener on all current and future L2 adapters.
+
+        The listener is recorded so that adapters added later via
+        :meth:`add_l2_adapter` receive it too.
 
         Args:
             listener: The listener to register.
         """
-        for adapter in self._l2_adapters:
-            adapter.register_listener(listener)
+        with self._lifecycle_lock:
+            self._registered_l2_listeners.append(listener)
+            for adapter in self._l2_adapters.values():
+                adapter.register_listener(listener)
 
     # Functions for debugging and testing
     def memcheck(self) -> bool:
@@ -840,6 +929,68 @@ class StorageManager:
             True if memory is consistent, False otherwise.
         """
         return self._l1_manager.memcheck()
+
+    def _build_l2_adapter(
+        self,
+        config: L2AdapterConfigBase,
+    ) -> tuple[int, L2AdapterInterface, AdapterDescriptor]:
+        """Allocate a stable id and construct an adapter + its descriptor.
+
+        Wraps the adapter with ``SerdeL2AdapterWrapper`` when the config
+        carries a ``serde_config``. Does not register the adapter with any
+        controller — the caller wires it up.
+
+        Args:
+            config: The adapter configuration.
+
+        Returns:
+            ``(adapter_id, adapter, descriptor)``.
+        """
+        adapter_id = self._next_adapter_id
+        self._next_adapter_id += 1
+        adapter: L2AdapterInterface = create_l2_adapter(config, self._l1_memory_desc)
+        if config.serde_config is not None:
+            adapter = SerdeL2AdapterWrapper(
+                inner=adapter,
+                serde=create_serde_processor(config.serde_config),
+                l1_manager=self._l1_manager,
+            )
+        descriptor = AdapterDescriptor(index=adapter_id, config=config)
+        return adapter_id, adapter, descriptor
+
+    def _should_enable_l2_eviction(
+        self,
+        adapter: L2AdapterInterface,
+        eviction_config: EvictionConfig | None,
+    ) -> bool:
+        """Whether to wire an adapter into the L2 eviction controller.
+
+        Aggregate-usage policies (``LRU``, ``noop``) need a capacity
+        (``max_capacity_bytes > 0``) to compute a usage fraction, so an
+        adapter without capacity is skipped for those (logged). Isolated
+        policies (``IsolatedLRU``) track per-cache_salt bytes regardless of
+        capacity, so they are always enabled.
+
+        Args:
+            adapter: The adapter to evaluate.
+            eviction_config: The adapter's eviction config, if any.
+
+        Returns:
+            True if an eviction state should be created for this adapter.
+        """
+        if eviction_config is None:
+            return False
+        policy_name = eviction_config.eviction_policy
+        if policy_name != "IsolatedLRU" and not adapter.supports_global_eviction:
+            logger.warning(
+                "L2 adapter %s configured with '%s' eviction but does "
+                "not support global eviction (max_capacity_bytes=0); "
+                "skipping aggregate-usage eviction setup.",
+                type(adapter).__name__,
+                policy_name,
+            )
+            return False
+        return True
 
     def _unwrap_reconfigurable_l2_adapter(
         self,
@@ -858,7 +1009,7 @@ class StorageManager:
         self,
     ) -> list[tuple[int, L2ReconfigurableAdapter]]:
         adapters: list[tuple[int, L2ReconfigurableAdapter]] = []
-        for l2_adapter_index, adapter in enumerate(self._l2_adapters):
+        for l2_adapter_index, adapter in sorted(self._l2_adapters.items()):
             reconfigurable_adapter = self._unwrap_reconfigurable_l2_adapter(adapter)
             if reconfigurable_adapter is not None:
                 adapters.append((l2_adapter_index, reconfigurable_adapter))

--- a/tests/v1/distributed/test_cache_salt_l2_eviction.py
+++ b/tests/v1/distributed/test_cache_salt_l2_eviction.py
@@ -122,7 +122,9 @@ def isolated_lru_setup():
         trigger_watermark=0.8,
         eviction_ratio=0.5,
     )
-    state = L2AdapterEvictionState(adapter=adapter, eviction_config=eviction_config)
+    state = L2AdapterEvictionState(
+        adapter_id=0, adapter=adapter, eviction_config=eviction_config
+    )
     # L2AdapterEvictionState creates its own policy internally; swap in
     # the one we made to observe it from the test side. The listener
     # it attached is stale, but the policy reference the controller

--- a/tests/v1/distributed/test_dax_l2_adapter.py
+++ b/tests/v1/distributed/test_dax_l2_adapter.py
@@ -441,6 +441,7 @@ class _FakeAdapterDescriptor:
 def test_storage_manager_routes_generic_l2_reconfigure_to_adapter():
     sm = StorageManager.__new__(StorageManager)
     adapter = _FakeReconfigurableAdapter()
+    sm._adapters_lock = threading.Lock()
     sm._l2_adapters = {0: cast(L2AdapterInterface, adapter)}
 
     result = sm.reconfigure_l2_adapter(0, "flip", {"enabled": True})
@@ -456,6 +457,7 @@ def test_storage_manager_routes_generic_l2_reconfigure_to_adapter():
 
 def test_storage_manager_finds_serde_wrapped_reconfigurable_adapter():
     sm = StorageManager.__new__(StorageManager)
+    sm._adapters_lock = threading.Lock()
     sm._l2_adapters = {
         0: cast(L2AdapterInterface, _SerdeLikeWrapper(_FakeReconfigurableAdapter()))
     }

--- a/tests/v1/distributed/test_dax_l2_adapter.py
+++ b/tests/v1/distributed/test_dax_l2_adapter.py
@@ -441,7 +441,7 @@ class _FakeAdapterDescriptor:
 def test_storage_manager_routes_generic_l2_reconfigure_to_adapter():
     sm = StorageManager.__new__(StorageManager)
     adapter = _FakeReconfigurableAdapter()
-    sm._l2_adapters = [cast(L2AdapterInterface, adapter)]
+    sm._l2_adapters = {0: cast(L2AdapterInterface, adapter)}
 
     result = sm.reconfigure_l2_adapter(0, "flip", {"enabled": True})
 
@@ -456,10 +456,10 @@ def test_storage_manager_routes_generic_l2_reconfigure_to_adapter():
 
 def test_storage_manager_finds_serde_wrapped_reconfigurable_adapter():
     sm = StorageManager.__new__(StorageManager)
-    sm._l2_adapters = [
-        cast(L2AdapterInterface, _SerdeLikeWrapper(_FakeReconfigurableAdapter()))
-    ]
-    sm._adapter_descriptors = [_FakeAdapterDescriptor("configured_fake")]
+    sm._l2_adapters = {
+        0: cast(L2AdapterInterface, _SerdeLikeWrapper(_FakeReconfigurableAdapter()))
+    }
+    sm._adapter_descriptors = {0: _FakeAdapterDescriptor("configured_fake")}
 
     status = sm.get_l2_adapter_reconfigure_status()
 

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -546,6 +546,7 @@ def test_raw_block_l2_adapter_recovered_keys_seed_l2_eviction_state():
         adapter2 = RawBlockL2Adapter(config)
         try:
             state = L2AdapterEvictionState(
+                0,
                 adapter2,
                 EvictionConfig(eviction_policy="LRU", eviction_ratio=1.0),
             )

--- a/tests/v1/distributed/test_runtime_adapters.py
+++ b/tests/v1/distributed/test_runtime_adapters.py
@@ -88,6 +88,20 @@ def make_descriptor(index: int) -> AdapterDescriptor:
     return AdapterDescriptor(index=index, config=make_mock_config())
 
 
+def adapter_by_id(sm: StorageManager, adapter_id: int) -> MockL2Adapter:
+    """Fetch an active adapter by stable id via the public ``l2_adapters()``
+    API (no private-member access)."""
+    for desc, adapter in sm.l2_adapters():
+        if desc.index == adapter_id:
+            return adapter  # type: ignore[return-value]
+    raise AssertionError(f"no active L2 adapter with id {adapter_id}")
+
+
+def active_adapter_ids(sm: StorageManager) -> set[int]:
+    """Set of active adapter ids exposed by the public ``l2_adapters()`` API."""
+    return {desc.index for desc, _ in sm.l2_adapters()}
+
+
 def write_keys_to_l1(
     l1_manager: L1Manager,
     keys: list[ObjectKey],
@@ -277,7 +291,7 @@ class TestStorageManagerRuntimeAdapters:
         sm = StorageManager(empty_storage_manager_config)
         try:
             adapter_id = sm.add_l2_adapter(make_mock_config())
-            adapter = sm._l2_adapters[adapter_id]
+            adapter = adapter_by_id(sm, adapter_id)
 
             layout = make_layout()
             keys = [make_object_key(i) for i in range(4)]
@@ -329,7 +343,7 @@ class TestStorageManagerRuntimeAdapters:
             assert id2 == 2, "Ids must not be reused after a delete"
 
             # The surviving adapter keeps its original id.
-            assert set(sm._l2_adapters.keys()) == {1, 2}
+            assert active_adapter_ids(sm) == {1, 2}
             assert sm.report_status()["num_l2_adapters"] == 2
         finally:
             sm.close()
@@ -341,7 +355,7 @@ class TestStorageManagerRuntimeAdapters:
             first = sm.add_l2_adapter(make_mock_config())
             sm.delete_l2_adapter(first, timeout=10.0)
             second = sm.add_l2_adapter(make_mock_config())
-            adapter = sm._l2_adapters[second]
+            adapter = adapter_by_id(sm, second)
 
             layout = make_layout()
             keys = [make_object_key(i) for i in range(3)]
@@ -365,14 +379,14 @@ class TestStorageManagerRuntimeAdapters:
             id1 = sm.add_l2_adapter(make_mock_config())
             pairs = sm.l2_adapters()
             assert [d.index for d, _ in pairs] == [id0, id1]
-            assert pairs[0][1] is sm._l2_adapters[id0]
-            assert pairs[1][1] is sm._l2_adapters[id1]
+            a0, a1 = pairs[0][1], pairs[1][1]
+            assert a0 is not a1
 
-            # Deleting the primary leaves the survivor; ordering is by id.
+            # Deleting one leaves the survivor (same instance); order is by id.
             sm.delete_l2_adapter(id0, timeout=10.0)
             pairs = sm.l2_adapters()
             assert len(pairs) == 1
             assert pairs[0][0].index == id1
-            assert pairs[0][1] is sm._l2_adapters[id1]
+            assert pairs[0][1] is a1
         finally:
             sm.close()

--- a/tests/v1/distributed/test_runtime_adapters.py
+++ b/tests/v1/distributed/test_runtime_adapters.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for runtime add/remove of L2 adapters.
+
+Covers both the controller-level primitives (StoreController /
+PrefetchController add_adapter / request_remove_adapter with graceful
+drain) and the StorageManager orchestration (add_l2_adapter /
+delete_l2_adapter), including stable-id semantics and the
+active/draining observability surface.
+"""
+
+# Standard
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+)
+from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.l2_adapters.config import L2AdaptersConfig
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
+from lmcache.v1.distributed.storage_controllers.store_controller import StoreController
+from lmcache.v1.distributed.storage_controllers.store_policy import (
+    AdapterDescriptor,
+    DefaultStorePolicy,
+)
+from lmcache.v1.distributed.storage_manager import StorageManager
+
+# Skip all tests in this module if CUDA is not available
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is not available"
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def make_object_key(chunk_id: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+def make_layout() -> MemoryLayoutDesc:
+    return MemoryLayoutDesc(
+        shapes=[torch.Size([100, 2, 512])],
+        dtypes=[torch.bfloat16],
+    )
+
+
+def should_use_lazy_alloc() -> bool:
+    return torch.cuda.is_available()
+
+
+def wait_for_condition(predicate, timeout: float = 5.0, poll: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll)
+    return False
+
+
+def make_mock_config() -> MockL2AdapterConfig:
+    return MockL2AdapterConfig(max_size_gb=0.01, mock_bandwidth_gb=10.0)
+
+
+def make_adapter() -> MockL2Adapter:
+    return MockL2Adapter(make_mock_config())
+
+
+def make_descriptor(index: int) -> AdapterDescriptor:
+    return AdapterDescriptor(index=index, config=make_mock_config())
+
+
+def write_keys_to_l1(
+    l1_manager: L1Manager,
+    keys: list[ObjectKey],
+    layout: MemoryLayoutDesc,
+) -> None:
+    results = l1_manager.reserve_write(
+        keys=keys,
+        is_temporary=[False] * len(keys),
+        layout_desc=layout,
+        mode="new",
+    )
+    written = [k for k, (e, m) in results.items() if m is not None]
+    if written:
+        l1_manager.finish_write(written)
+
+
+@pytest.fixture
+def l1_manager():
+    config = L1ManagerConfig(
+        memory_config=L1MemoryManagerConfig(
+            size_in_bytes=128 * 1024 * 1024,
+            use_lazy=should_use_lazy_alloc(),
+            init_size_in_bytes=64 * 1024 * 1024,
+            align_bytes=0x1000,
+        ),
+        write_ttl_seconds=600,
+        read_ttl_seconds=300,
+    )
+    mgr = L1Manager(config)
+    yield mgr
+    mgr.close()
+
+
+@pytest.fixture
+def empty_storage_manager_config():
+    """A StorageManagerConfig with no L2 adapters configured."""
+    return StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=128 * 1024 * 1024,
+                use_lazy=should_use_lazy_alloc(),
+                init_size_in_bytes=64 * 1024 * 1024,
+                align_bytes=0x1000,
+            ),
+            write_ttl_seconds=600,
+            read_ttl_seconds=300,
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+        l2_adapter_config=L2AdaptersConfig(adapters=[]),
+    )
+
+
+# =============================================================================
+# StoreController-level tests
+# =============================================================================
+
+
+class TestStoreControllerRuntimeAdapters:
+    def test_add_adapter_routes_new_stores(self, l1_manager):
+        """A key written after add_adapter is stored to the new adapter."""
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[],
+            adapter_descriptors=[],
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+        try:
+            adapter = make_adapter()
+            ctrl.add_adapter(0, adapter, make_descriptor(0))
+
+            assert ctrl.report_status()["num_active_adapters"] == 1
+            assert ctrl.report_status()["num_draining_adapters"] == 0
+
+            layout = make_layout()
+            keys = [make_object_key(i) for i in range(3)]
+            write_keys_to_l1(l1_manager, keys, layout)
+
+            ok = wait_for_condition(
+                lambda: adapter.debug_get_stored_object_count() == 3
+            )
+            assert ok, "Keys should be stored to the runtime-added adapter"
+        finally:
+            ctrl.stop()
+            adapter.close()
+
+    def test_remove_adapter_drains_and_detaches(self, l1_manager):
+        """request_remove_adapter drains in-flight work then detaches."""
+        adapter = make_adapter()
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+        try:
+            layout = make_layout()
+            keys = [make_object_key(i) for i in range(3)]
+            write_keys_to_l1(l1_manager, keys, layout)
+            assert wait_for_condition(
+                lambda: adapter.debug_get_stored_object_count() == 3
+            )
+
+            done = ctrl.request_remove_adapter(0)
+            assert done.wait(timeout=5.0), "Adapter should drain and detach"
+
+            status = ctrl.report_status()
+            assert status["num_l2_adapters"] == 0
+            assert status["num_active_adapters"] == 0
+            assert status["num_draining_adapters"] == 0
+        finally:
+            ctrl.stop()
+            adapter.close()
+
+    def test_remove_stops_new_routing(self, l1_manager):
+        """After removal, new writes are not routed to the removed adapter."""
+        keep = make_adapter()
+        drop = make_adapter()
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[keep, drop],
+            adapter_descriptors=[make_descriptor(0), make_descriptor(1)],
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+        try:
+            done = ctrl.request_remove_adapter(1)
+            assert done.wait(timeout=5.0)
+
+            layout = make_layout()
+            keys = [make_object_key(i) for i in range(3)]
+            write_keys_to_l1(l1_manager, keys, layout)
+
+            assert wait_for_condition(lambda: keep.debug_get_stored_object_count() == 3)
+            # The dropped adapter must not receive the new keys.
+            time.sleep(0.2)
+            assert drop.debug_get_stored_object_count() == 0
+        finally:
+            ctrl.stop()
+            keep.close()
+            drop.close()
+
+    def test_double_remove_is_safe(self, l1_manager):
+        """Removing an already-removed adapter signals immediately."""
+        adapter = make_adapter()
+        ctrl = StoreController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultStorePolicy(),
+        )
+        ctrl.start()
+        try:
+            assert ctrl.request_remove_adapter(0).wait(timeout=5.0)
+            # Second removal of the same (now-detached) id must not hang.
+            assert ctrl.request_remove_adapter(0).wait(timeout=5.0)
+        finally:
+            ctrl.stop()
+            adapter.close()
+
+
+# =============================================================================
+# StorageManager-level tests
+# =============================================================================
+
+
+class TestStorageManagerRuntimeAdapters:
+    def test_add_to_empty_manager(self, empty_storage_manager_config):
+        """add_l2_adapter wires a new adapter into all controllers."""
+        sm = StorageManager(empty_storage_manager_config)
+        try:
+            assert sm.report_status()["num_l2_adapters"] == 0
+
+            adapter_id = sm.add_l2_adapter(make_mock_config())
+            assert adapter_id == 0
+
+            status = sm.report_status()
+            assert status["num_l2_adapters"] == 1
+            assert status["store_controller"]["num_active_adapters"] == 1
+            assert status["prefetch_controller"]["num_active_adapters"] == 1
+        finally:
+            sm.close()
+
+    def test_add_then_store(self, empty_storage_manager_config):
+        """Keys written after add_l2_adapter land in the new adapter."""
+        sm = StorageManager(empty_storage_manager_config)
+        try:
+            adapter_id = sm.add_l2_adapter(make_mock_config())
+            adapter = sm._l2_adapters[adapter_id]
+
+            layout = make_layout()
+            keys = [make_object_key(i) for i in range(4)]
+            ret = sm.reserve_write(keys, layout, mode="new")
+            sm.finish_write(list(ret.keys()))
+
+            assert wait_for_condition(
+                lambda: all(adapter.debug_has_key(k) for k in keys),  # type: ignore
+                timeout=10.0,
+            )
+        finally:
+            sm.close()
+
+    def test_delete_detaches_everywhere(self, empty_storage_manager_config):
+        """delete_l2_adapter drains and removes the adapter from all controllers."""
+        sm = StorageManager(empty_storage_manager_config)
+        try:
+            adapter_id = sm.add_l2_adapter(make_mock_config())
+            assert sm.report_status()["num_l2_adapters"] == 1
+
+            sm.delete_l2_adapter(adapter_id, timeout=10.0)
+
+            status = sm.report_status()
+            assert status["num_l2_adapters"] == 0
+            assert status["store_controller"]["num_l2_adapters"] == 0
+            assert status["prefetch_controller"]["num_l2_adapters"] == 0
+        finally:
+            sm.close()
+
+    def test_delete_unknown_id_raises(self, empty_storage_manager_config):
+        sm = StorageManager(empty_storage_manager_config)
+        try:
+            with pytest.raises(ValueError):
+                sm.delete_l2_adapter(999)
+        finally:
+            sm.close()
+
+    def test_stable_ids_across_add_delete(self, empty_storage_manager_config):
+        """Ids are monotonic and never reused; delete does not shift others."""
+        sm = StorageManager(empty_storage_manager_config)
+        try:
+            id0 = sm.add_l2_adapter(make_mock_config())
+            id1 = sm.add_l2_adapter(make_mock_config())
+            assert (id0, id1) == (0, 1)
+
+            sm.delete_l2_adapter(id0, timeout=10.0)
+
+            id2 = sm.add_l2_adapter(make_mock_config())
+            assert id2 == 2, "Ids must not be reused after a delete"
+
+            # The surviving adapter keeps its original id.
+            assert set(sm._l2_adapters.keys()) == {1, 2}
+            assert sm.report_status()["num_l2_adapters"] == 2
+        finally:
+            sm.close()
+
+    def test_add_after_delete_routes_to_new_adapter(self, empty_storage_manager_config):
+        """A fresh adapter added after a delete receives new stores."""
+        sm = StorageManager(empty_storage_manager_config)
+        try:
+            first = sm.add_l2_adapter(make_mock_config())
+            sm.delete_l2_adapter(first, timeout=10.0)
+            second = sm.add_l2_adapter(make_mock_config())
+            adapter = sm._l2_adapters[second]
+
+            layout = make_layout()
+            keys = [make_object_key(i) for i in range(3)]
+            ret = sm.reserve_write(keys, layout, mode="new")
+            sm.finish_write(list(ret.keys()))
+
+            assert wait_for_condition(
+                lambda: all(adapter.debug_has_key(k) for k in keys),  # type: ignore
+                timeout=10.0,
+            )
+        finally:
+            sm.close()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

- Added 2 new interfaces to StorageManager to allow adding/removing L2 adapters during the runtime.
- Updated the internal management of L2 adapters from a plain list to a dict of `adapter_id` -> `L2AdapterInterface`
- Updated the storage controllers (prefetch, store, eviction) to work with runtime L2 adapter updates

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
