### PR TITLE
ci(operator): tag pre-release images as latest-rc, not latest

### DIFF
--- a/.github/workflows/operator_release.yml
+++ b/.github/workflows/operator_release.yml
@@ -42,9 +42,20 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          # Strip "operator-" prefix from tag to get version
+          # Strip "operator-" prefix from tag to get version (e.g. operator-v0.4.8rc1 -> v0.4.8rc1).
           VERSION="${GITHUB_REF_NAME#operator-}"
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Pre-releases (rc/alpha/beta) get the floating ":latest-rc" tag and must
+          # never move the stable ":latest" image tag or the "operator-latest" alias.
+          # Detect from the version string rather than the GitHub "pre-release" flag
+          # so behavior is robust whether or not that box is ticked in the UI.
+          if [[ "${VERSION}" =~ (rc|alpha|beta) ]]; then
+            echo "FLOATING_TAG=latest-rc" >> "$GITHUB_OUTPUT"
+            echo "IS_PRERELEASE=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "FLOATING_TAG=latest" >> "$GITHUB_OUTPUT"
+            echo "IS_PRERELEASE=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build and push image
         uses: docker/build-push-action@v6
@@ -54,7 +65,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.VERSION }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.FLOATING_TAG }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -70,6 +81,9 @@ jobs:
           files: operator/dist/install.yaml
 
       - name: Update latest release alias
+        # Skip for pre-releases: an rc/alpha/beta must not repoint the stable
+        # "operator-latest" alias (or its install.yaml) at a pre-release build.
+        if: steps.version.outputs.IS_PRERELEASE == 'false'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: operator-latest


### PR DESCRIPTION
**What this PR does / why we need it**:

The operator release workflow tags every published release with the floating `:latest` image tag and repoints the `operator-latest` GitHub release alias (and its `install.yaml`) at it. A pre-release such as `operator-v0.4.8rc1` therefore clobbers the stable `:latest` image and the stable install manifest that production users pull.

This change detects `rc`/`alpha`/`beta` in the release version and:
- pushes the floating tag as `:latest-rc` for pre-releases, `:latest` for stable releases;
- skips the `operator-latest` stable alias update for pre-releases.

The exact version tag (e.g. `:v0.4.8rc1`) is unchanged. Detection reads the version string rather than the GitHub "pre-release" checkbox, so it works regardless of how the release is cut.

**Special notes for your reviewers**:

Stable release behavior is unchanged: `:vX.Y.Z` + `:latest` + `operator-latest` alias update. Pre-release detection is a regex `(rc|alpha|beta)` on the version string.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
