### PR TITLE
[CI] Publish rc release tags as clean pre-releases + gate CLI wheel against native ops

### DIFF
--- a/.github/workflows/build_cli_artifacts.yml
+++ b/.github/workflows/build_cli_artifacts.yml
@@ -46,8 +46,10 @@ jobs:
               with:
                 fetch-depth: 0
 
-            - name: Remove non-release tags
-              run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+$' | xargs -r git tag -d
+            # Keep stable vX.Y.Z and rc/a/b pre-release tags; strip variant tags
+            # (v*-cu129, v*-alpha) that yield invalid PEP 440 versions (see #3123).
+            - name: Remove non-release tags (keep stable + rc/a/b pre-releases)
+              run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+((rc|a|b)[0-9]+)?$' | xargs -r git tag -d
 
             - name: Setup Python 3.13
               uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
@@ -72,13 +74,22 @@ jobs:
               run: |
                 pip install dist/lmcache_cli-*.whl
 
-                # CLI wheel must be pure-Python.
+                # CLI wheel must be pure-Python: no compiled extension bundled.
                 if unzip -l dist/lmcache_cli-*.whl | grep -E '\.(so|pyd)$'; then
                   echo "::error::CLI wheel contains compiled extensions; should be pure-Python"
                   exit 1
                 fi
 
+                # Pure-Python surface must import without torch / native ops.
                 python -c "import lmcache"
+
+                # Native CUDA ops must be unreachable from the slim wheel.
+                if python -c "import lmcache.c_ops" 2>/dev/null; then
+                  echo "::error::CLI wheel can import lmcache.c_ops; native ops must be absent from the pure-Python wheel"
+                  exit 1
+                fi
+                echo "OK: lmcache.c_ops is not importable from the CLI wheel"
+
                 lmcache --help
 
                 # Slim-supported subcommands only (server is full-only).

--- a/.github/workflows/build_cu129_artifacts.yml
+++ b/.github/workflows/build_cu129_artifacts.yml
@@ -35,8 +35,10 @@ jobs:
               with:
                 fetch-depth: 0
 
-            - name: Remove non-release tags
-              run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+$' | xargs -r git tag -d
+            # Keep stable vX.Y.Z and rc/a/b pre-release tags; strip variant tags
+            # (v*-cu129, v*-alpha) that yield invalid PEP 440 versions (see #3123).
+            - name: Remove non-release tags (keep stable + rc/a/b pre-releases)
+              run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+((rc|a|b)[0-9]+)?$' | xargs -r git tag -d
 
             - name: Login to DockerHub
               # Skip when either the username var or the token secret is

--- a/.github/workflows/build_main_artifacts.yml
+++ b/.github/workflows/build_main_artifacts.yml
@@ -35,8 +35,10 @@ jobs:
                 # for setuptools-scm
                 fetch-depth: 0
 
-            - name: Remove non-release tags
-              run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+$' | xargs -r git tag -d
+            # Keep stable vX.Y.Z and rc/a/b pre-release tags; strip variant tags
+            # (v*-cu129, v*-alpha) that yield invalid PEP 440 versions (see #3123).
+            - name: Remove non-release tags (keep stable + rc/a/b pre-releases)
+              run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+((rc|a|b)[0-9]+)?$' | xargs -r git tag -d
 
             - name: Free disk space
               uses: ./.github/actions/free-disk-space


### PR DESCRIPTION
 Description:
  **What this PR does / why we need it**:

  `lmcache-cli` only ever shipped `.devN` pre-releases on PyPI. The build
  workflows strip every tag that isn't `vX.Y.Z`, so an `rc` release (e.g.
  `v0.4.8rc1`) loses its tag and setuptools-scm falls back to the previous
  stable tag, stamping a `0.4.8.devN` build.

  - Broaden the "Remove non-release tags" regex to keep PEP 440 `rc/a/b`
    pre-release tags while still stripping invalid variant tags
    (`v*-cu129`, `v*-alpha`; see #3123). `v0.4.8rc1` now ships as a clean
    `0.4.8rc1` pre-release. Applied to all three build workflows
    (cli / main / cu129) so every artifact agrees on the version.
  - Add a CLI smoke-test gate that fails the build if `import lmcache.c_ops`
    succeeds, ensuring native ops never leak into the pure-Python wheel
    (complements the existing `.so`/`.pyd` bundle check).

  **Special notes for your reviewers**:

  `rc` releases now publish to production PyPI as pre-releases (hidden from
  default `pip install`, installable via `--pre`). A stable `lmcache-cli`
  still requires a clean `vX.Y.Z` tag with a green CLI build.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [ ] this PR contains unit tests, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer 