### PR TITLE
feat(local-disk): extend by_gpu sharding for worker-aware multi-device paths

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -42,10 +42,10 @@ Basic cache settings that control the core functionality of LMCache.
      - Path (or comma-separated paths) to local disk cache directories. Format: ``"file:///path/to/cache"`` or ``"/path/a,/path/b"`` for multi-device I/O. See ``local_disk_path_sharding`` for how paths are assigned to GPUs.
    * - local_disk_path_sharding
      - LMCACHE_LOCAL_DISK_PATH_SHARDING
-     - Strategy for selecting a path when multiple paths are provided. Currently only ``"by_gpu"`` is supported, which selects paths based on GPU device ID (default: "by_gpu").
+     - Strategy for assigning paths when multiple paths are provided. Currently only ``"by_gpu"`` is supported (default: "by_gpu"). Workers are keyed by local rank; when ``#paths > #workers`` each worker gets a contiguous subset so no disk sits idle. Path count and worker count must be equal or an exact multiple of each other.
    * - max_local_disk_size
      - LMCACHE_MAX_LOCAL_DISK_SIZE
-     - Maximum disk cache size in GB. Default: 0.0
+     - Maximum disk cache size in GB. For multi-path local disk, each LocalDiskBackend instance splits this budget evenly across its assigned paths. At initialization, each assigned path's mounted filesystem must have at least its equal-share quota available. Default: 0.0
    * - remote_url
      - LMCACHE_REMOTE_URL
      - Remote storage URL. Format: "protocol://host:port".

--- a/docs/source/kv_cache/storage_backends/local_storage.rst
+++ b/docs/source/kv_cache/storage_backends/local_storage.rst
@@ -69,7 +69,8 @@ For example, with two GPUs and two paths:
 - ``cuda:0`` → ``/mnt/nvme0/kvcache/``
 - ``cuda:1`` → ``/mnt/nvme1/kvcache/``
 
-``max_local_disk_size`` is the **total budget** shared across all paths.
+``max_local_disk_size`` is the **total budget** for each ``LocalDiskBackend`` instance. LMCache splits that budget evenly across the instance's assigned paths. For example, ``512GB`` across four assigned SSD paths becomes ``128GB`` per path.
+In multi-path mode, LMCache treats each assigned path as an independent local disk cache with its own equal-share quota and eviction policy state. Unused space on one path is not borrowed by another path.
 
 **Environment variable example:**
 
@@ -89,9 +90,10 @@ For example, with two GPUs and two paths:
 
 .. note::
 
-    Each GPU worker uses only its assigned path, so O_DIRECT alignment
-    is determined by that path's filesystem block size.  Different
-    devices may have different block sizes without issue.
+    O_DIRECT alignment follows each assigned path's filesystem block size.
+    At initialization, each assigned path's mounted filesystem must have at
+    least its equal-share quota available. LMCache validates currently
+    available filesystem space, not raw SSD capacity.
 
 .. tip::
 

--- a/examples/kv_cache_reuse/local_backends/README.md
+++ b/examples/kv_cache_reuse/local_backends/README.md
@@ -7,6 +7,28 @@ LMCache should be able to reduce the generation time of the second and following
 - `python offload.py -v v0 --use-disk` - Disk offloading implementation for vLLM v0
 - `python offload.py -v v1 --use-disk` - Disk offloading implementation for vLLM v1
 
+## Multi-device disk offloading
+
+`LMCACHE_LOCAL_DISK` accepts a comma-separated list of directories, one per
+storage device. Paths are assigned to workers by the `by_gpu` strategy
+(`LMCACHE_LOCAL_DISK_PATH_SHARDING`, the default), keyed by each worker's
+local rank:
+
+- `#paths == #workers`: one path per worker.
+- `#paths > #workers`: each worker is assigned a contiguous *subset* of paths
+  so no disk sits idle (e.g. TP=2 with 4 disks -> rank 0 owns disks 0-1,
+  rank 1 owns disks 2-3). Within a subset, files are routed by a stable hash
+  of the chunk hash.
+- `#workers > #paths`: workers share paths.
+
+The path count and local worker count must be equal or an exact multiple of
+each other, otherwise startup fails with a clear error.
+
+```bash
+# TP=2, 4 disks -> 2 disks per rank
+python offload.py -v v1 --use-disk --local-disk /mnt/disk0,/mnt/disk1,/mnt/disk2,/mnt/disk3
+```
+
 ## RUST raw block based Disk offloading
 
    # WARNING: This will erase the content of target device.

--- a/examples/kv_cache_reuse/local_backends/offload.py
+++ b/examples/kv_cache_reuse/local_backends/offload.py
@@ -14,7 +14,9 @@ from lmcache.integration.vllm.utils import ENGINE_NAME
 from lmcache.v1.cache_engine import LMCacheEngineBuilder
 
 
-def setup_environment_variables(vllm_version: str, use_disk: bool = False):
+def setup_environment_variables(
+    vllm_version: str, use_disk: bool = False, local_disk: str | None = None
+):
     # LMCache-related environment variables
 
     # LMCache is set to use 256 tokens per chunk
@@ -28,7 +30,7 @@ def setup_environment_variables(vllm_version: str, use_disk: bool = False):
         os.environ["LMCACHE_MAX_LOCAL_CPU_SIZE"] = "5"
 
         # Enable local disk backend in LMCache
-        os.environ["LMCACHE_LOCAL_DISK"] = "file://local_disk/"
+        os.environ["LMCACHE_LOCAL_DISK"] = local_disk or "file://local_disk/"
 
         # Set the maximum size of the local disk size to 10GB
         os.environ["LMCACHE_MAX_LOCAL_DISK_SIZE"] = "10"
@@ -111,6 +113,16 @@ def parse_args():
         action="store_true",
         help="Specify whether to use disk as backend (default: False)",
     )
+    parser.add_argument(
+        "--local-disk",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated disk path(s) for the local disk backend "
+            "(e.g. /mnt/disk0,/mnt/disk1). Requires --use-disk. "
+            "Defaults to file://local_disk/ when not set."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -124,7 +136,7 @@ def main():
         lmcache_connector = "LMCacheConnectorV1"
         model = "mistralai/Mistral-7B-Instruct-v0.2"
 
-    setup_environment_variables(args.version, args.use_disk)
+    setup_environment_variables(args.version, args.use_disk, args.local_disk)
 
     with build_llm_with_lmcache(lmcache_connector, model, args.version) as llm:
         # This example script runs two requests with a shared prefix.

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -35,6 +35,25 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _get_available_space_bytes(path: str) -> int:
+    """Return the currently usable filesystem space for ``path`` in bytes."""
+    stat = os.statvfs(path)
+    fragment_size = stat.f_frsize if stat.f_frsize > 0 else stat.f_bsize
+    return stat.f_bavail * fragment_size
+
+
+def _get_filesystem_id(path: str) -> int:
+    """Return the device id for the filesystem backing ``path``."""
+    return os.stat(path).st_dev
+
+
+def _split_evenly(total_bytes: int, num_parts: int) -> list[int]:
+    """Split ``total_bytes`` across ``num_parts`` nearly-equal integer quotas."""
+    base_quota = total_bytes // num_parts
+    remainder = total_bytes % num_parts
+    return [base_quota + (1 if idx < remainder else 0) for idx in range(num_parts)]
+
+
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
 class LocalDiskWorker:
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
@@ -111,8 +130,7 @@ class LocalDiskBackend(StorageBackendInterface):
         else:
             super().__init__("cpu")
 
-        self.cache_policy = get_cache_policy(config.cache_policy)
-        self.dict = self.cache_policy.init_mutable_mapping()
+        self.dict: dict[CacheEngineKey, DiskCacheMetadata] = {}
 
         self.dst_device = dst_device
 
@@ -122,28 +140,66 @@ class LocalDiskBackend(StorageBackendInterface):
 
         assert config.local_disk is not None
 
+        # Pass local-worker metadata so that, when more disks than workers
+        # are configured, this worker is assigned a contiguous subset of
+        # paths instead of a single one. When metadata is absent the
+        # sharder falls back to the legacy device-index single-path mapping.
+        local_rank = metadata.local_worker_id if metadata is not None else None
+        local_world_size = metadata.local_world_size if metadata is not None else None
+
         sharder = PathSharder(
             raw_csv=config.local_disk,
             strategy=config.local_disk_path_sharding,
             dst_device=dst_device,
+            local_rank=local_rank,
+            local_world_size=local_world_size,
             create_dirs=True,
         )
+        self.path_sharder = sharder
+        self.assigned_paths: list[str] = sharder.assigned_paths
         self.path: str = sharder.selected
 
         logger.info(
-            "Local disk cache path: %s (device %s, %d path(s) configured)",
-            self.path,
+            "Local disk cache strategy=%s device=%s "
+            "configured_paths=%d assigned_paths=%s",
+            sharder.strategy,
             dst_device,
             len(sharder.all_paths),
+            self.assigned_paths,
         )
 
         self.loop = loop
 
         self.use_local_cpu = config.local_cpu
 
-        # Block size (for file system I/O)
-        stat = os.statvfs(self.path)
-        self.os_disk_bs = stat.f_bsize
+        # Block size (for file system I/O), per assigned path so that
+        # multi-path workers use the correct block size for each file.
+        self.path_block_sizes = {
+            path: os.statvfs(path).f_bsize for path in self.assigned_paths
+        }
+        self.os_disk_bs = self.path_block_sizes[self.path]
+        self.path_max_cache_sizes = dict(
+            zip(
+                self.assigned_paths,
+                _split_evenly(
+                    int(config.max_local_disk_size * 1024**3),
+                    len(self.assigned_paths),
+                ),
+                strict=True,
+            )
+        )
+        self.path_current_cache_sizes = {path: 0 for path in self.assigned_paths}
+        self.path_cache_policies = {
+            path: get_cache_policy(config.cache_policy) for path in self.assigned_paths
+        }
+        self.path_dicts = {
+            path: policy.init_mutable_mapping()
+            for path, policy in self.path_cache_policies.items()
+        }
+        self.keys_in_request_by_path: dict[str, List[CacheEngineKey]] = {
+            path: [] for path in self.assigned_paths
+        }
+        self._validate_assigned_path_capacity()
         self.use_odirect = False
 
         if config.extra_config is not None:
@@ -154,13 +210,8 @@ class LocalDiskBackend(StorageBackendInterface):
 
         # TODO(Jiayi): We need a disk space allocator to avoid fragmentation
         # and hide the following details away from the backend.
-        self.max_cache_size = int(config.max_local_disk_size * 1024**3)
-        self.current_cache_size = 0.0
-
-        # to help maintain suffix -> prefix order in the dict
-        # assumption: only one request is looked up at a time
-        # (only one worker per cache engine)
-        self.keys_in_request: List[CacheEngineKey] = []
+        self.max_cache_size = sum(self.path_max_cache_sizes.values())
+        self.current_cache_size = 0
 
         self.lmcache_worker = lmcache_worker
         self.instance_id = config.lmcache_instance_id
@@ -188,7 +239,73 @@ class LocalDiskBackend(StorageBackendInterface):
         self,
         key: CacheEngineKey,
     ) -> str:
-        return os.path.join(self.path, key.to_string().replace("/", "-") + ".pt")
+        base_path = self.path_sharder.resolve_path_for_key(key)
+        return os.path.join(base_path, key.to_string().replace("/", "-") + ".pt")
+
+    def _get_disk_block_size(self, path: str) -> int:
+        # path is always produced by _key_to_path(), which places files
+        # directly under an assigned mount point with no subdirectories.
+        root_path = os.path.dirname(path)
+        return self.path_block_sizes.get(root_path, self.os_disk_bs)
+
+    def _validate_assigned_path_capacity(self) -> None:
+        """Ensure assigned filesystems have enough currently available space."""
+        quotas_by_filesystem: dict[int, tuple[str, int, int]] = {}
+        for path, quota_bytes in self.path_max_cache_sizes.items():
+            filesystem_id = _get_filesystem_id(path)
+            available_bytes = _get_available_space_bytes(path)
+            sample_path, current_required, _ = quotas_by_filesystem.get(
+                filesystem_id,
+                (path, 0, available_bytes),
+            )
+            quotas_by_filesystem[filesystem_id] = (
+                sample_path,
+                current_required + quota_bytes,
+                available_bytes,
+            )
+
+        for path, required_bytes, available_bytes in quotas_by_filesystem.values():
+            if available_bytes < required_bytes:
+                raise ValueError(
+                    "Assigned local disk paths do not have enough available "
+                    "filesystem space for their LMCache quota "
+                    f"(path={path}, available_bytes={available_bytes}, "
+                    f"required_bytes={required_bytes})"
+                )
+
+    def _get_path_for_key(self, key: CacheEngineKey) -> str:
+        """Return the assigned base path for ``key`` on this worker."""
+        return self.path_sharder.resolve_path_for_key(key)
+
+    def _get_cache_path_for_key(self, key: CacheEngineKey) -> str:
+        """Return the path-local cache selected for ``key``."""
+        if meta := self.dict.get(key):
+            return os.path.dirname(meta.path)
+        return self._get_path_for_key(key)
+
+    def _get_path_cache_policy(self, path: str):
+        return self.path_cache_policies[path]
+
+    def _get_path_cache_dict(self, path: str):
+        return self.path_dicts[path]
+
+    def _update_path_usage(self, path: str, size_delta: int) -> None:
+        """Apply a signed usage delta to one assigned path and the global total."""
+        self.path_current_cache_sizes[path] = (
+            self.path_current_cache_sizes.get(path, 0) + size_delta
+        )
+        self.current_cache_size += size_delta
+
+    def _get_evict_candidates_for_path(
+        self,
+        path: str,
+        num_candidates: int = 1,
+    ) -> list[CacheEngineKey]:
+        """Return eviction candidates from one path-local cache."""
+        return self._get_path_cache_policy(path).get_evict_candidates(
+            self._get_path_cache_dict(path),
+            num_candidates=num_candidates,
+        )
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         with self.disk_lock:
@@ -197,15 +314,20 @@ class LocalDiskBackend(StorageBackendInterface):
             if pin:
                 self.dict[key].pin()
                 # vllm lookup sets pin to True
-                self.keys_in_request.append(key)
+                cache_path = self._get_cache_path_for_key(key)
+                self.keys_in_request_by_path[cache_path].append(key)
             return True
 
     def touch_cache(self):
         # flip the order of the keys in the request
         with self.disk_lock:
-            for key in reversed(self.keys_in_request):
-                self.cache_policy.update_on_hit(key, self.dict)
-            self.keys_in_request = []
+            for path, keys_in_request in self.keys_in_request_by_path.items():
+                path_dict = self._get_path_cache_dict(path)
+                path_policy = self._get_path_cache_policy(path)
+                for key in reversed(keys_in_request):
+                    if key in path_dict:
+                        path_policy.update_on_hit(key, path_dict)
+                self.keys_in_request_by_path[path] = []
 
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
         return self.disk_worker.exists_in_put_tasks(key)
@@ -246,7 +368,11 @@ class LocalDiskBackend(StorageBackendInterface):
             return False
 
         path = meta.path
+        base_path = os.path.dirname(path)
+        path_dict = self._get_path_cache_dict(base_path)
+        path_dict.pop(key, None)
         size = meta.size
+        self._update_path_usage(base_path, -size)
         self.usage -= size
         self.stats_monitor.update_local_storage_usage(self.usage)
 
@@ -257,11 +383,16 @@ class LocalDiskBackend(StorageBackendInterface):
         # )
         # res.result()
 
-        os.remove(path)
-
         if force:
-            self.cache_policy.update_on_force_evict(key)
+            self._get_path_cache_policy(base_path).update_on_force_evict(key)
             self.disk_lock.release()
+
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            logger.warning(f"File already removed: {path}")
+        except OSError as e:
+            logger.error(f"Failed to remove file {path}: {e}")
 
         # Push kv evict msg with batching
         if self.batched_msg_sender is not None:
@@ -282,17 +413,22 @@ class LocalDiskBackend(StorageBackendInterface):
         cached_positions: Optional[torch.Tensor] = None,
     ) -> None:
         path = self._key_to_path(key)
+        base_path = os.path.dirname(path)
+        path_dict = self._get_path_cache_dict(base_path)
+        path_policy = self._get_path_cache_policy(base_path)
 
         has_stored = False
         with self.disk_lock:
             if key in self.dict:
                 # Update cache recency
-                self.cache_policy.update_on_hit(key, self.dict)
+                path_policy.update_on_hit(key, path_dict)
                 has_stored = True
             else:
-                self.dict[key] = DiskCacheMetadata(
+                meta = DiskCacheMetadata(
                     path, size, shape, dtype, cached_positions, fmt, 0
                 )
+                self.dict[key] = meta
+                path_dict[key] = meta
 
         # Push kv admit msg with batching
         if self.batched_msg_sender is not None and not has_stored:
@@ -327,29 +463,34 @@ class LocalDiskBackend(StorageBackendInterface):
 
         # TODO(Jiayi): Fragmentation is not considered here.
         required_size = memory_obj.get_physical_size()
-        all_evict_keys = []
+        target_path = self._get_path_for_key(key)
+        path_quota = self.path_max_cache_sizes[target_path]
         evict_success = True
         with self.disk_lock:
-            while self.current_cache_size + required_size > self.max_cache_size:
-                evict_keys = self.cache_policy.get_evict_candidates(
-                    self.dict, num_candidates=1
+            while (
+                self.path_current_cache_sizes[target_path] + required_size > path_quota
+            ):
+                evict_keys = self._get_evict_candidates_for_path(
+                    target_path,
+                    num_candidates=1,
                 )
                 if not evict_keys:
                     logger.warning(
-                        "No eviction candidates found. Disk space under pressure."
+                        "No eviction candidates found for local disk path under "
+                        "pressure (path=%s, required_size=%s, quota=%s, current=%s).",
+                        target_path,
+                        required_size,
+                        path_quota,
+                        self.path_current_cache_sizes[target_path],
                     )
                     evict_success = False
                     break
 
-                for evict_key in evict_keys:
-                    self.current_cache_size -= self.dict[evict_key].size
-
                 self.batched_remove(evict_keys, force=False)
 
-                all_evict_keys.extend(evict_keys)
             if evict_success:
-                self.current_cache_size += required_size
-                self.cache_policy.update_on_put(key)
+                self._update_path_usage(target_path, required_size)
+                self._get_path_cache_policy(target_path).update_on_put(key)
 
         if not evict_success:
             return None
@@ -416,6 +557,7 @@ class LocalDiskBackend(StorageBackendInterface):
             fmt = disk_meta.fmt
             assert dtype is not None
             assert shape is not None
+            assert fmt is not None
 
         # Load is performed outside the lock: it can block for a non-trivial
         # amount of time (CPU staging pool allocation + memcpy from disk) and
@@ -432,7 +574,13 @@ class LocalDiskBackend(StorageBackendInterface):
             # consistent and no update is needed.
             with self.disk_lock:
                 if key in self.dict:
-                    self.cache_policy.update_on_hit(key, self.dict)
+                    cache_path = self._get_cache_path_for_key(key)
+                    path_dict = self._get_path_cache_dict(cache_path)
+                    if key in path_dict:
+                        self._get_path_cache_policy(cache_path).update_on_hit(
+                            key,
+                            path_dict,
+                        )
 
         return memory_obj
 
@@ -481,7 +629,11 @@ class LocalDiskBackend(StorageBackendInterface):
 
             # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
             # Update cache recency
-            self.cache_policy.update_on_hit(key, self.dict)
+            cache_path = self._get_cache_path_for_key(key)
+            self._get_path_cache_policy(cache_path).update_on_hit(
+                key,
+                self._get_path_cache_dict(cache_path),
+            )
 
             self.disk_lock.release()
             logger.debug(f"Prefetching {key} from disk.")
@@ -510,7 +662,8 @@ class LocalDiskBackend(StorageBackendInterface):
                     return num_hit_counts
                 if pin:
                     self.dict[key].pin()
-                    self.keys_in_request.append(key)
+                    cache_path = self._get_cache_path_for_key(key)
+                    self.keys_in_request_by_path[cache_path].append(key)
                 num_hit_counts += 1
         return num_hit_counts
 
@@ -622,7 +775,8 @@ class LocalDiskBackend(StorageBackendInterface):
     def write_file(self, buffer, path):
         start_time = time.time()
         size = len(buffer)
-        if size % self.os_disk_bs != 0 or not self.use_odirect:
+        disk_block_size = self._get_disk_block_size(path)
+        if size % disk_block_size != 0 or not self.use_odirect:
             with open(path, "wb") as f:
                 f.write(buffer)
         else:
@@ -639,7 +793,8 @@ class LocalDiskBackend(StorageBackendInterface):
     def read_file(self, key, buffer, path):
         start_time = time.time()
         size = len(buffer)
-        fblock_aligned = size % self.os_disk_bs == 0
+        disk_block_size = self._get_disk_block_size(path)
+        fblock_aligned = size % disk_block_size == 0
         if not fblock_aligned and self.use_odirect:
             logger.warning(
                 "Cannot use O_DIRECT for this file, "
@@ -656,8 +811,14 @@ class LocalDiskBackend(StorageBackendInterface):
                     fdo.readinto(buffer)
         except FileNotFoundError:
             logger.warning(f"File not found on disk: {path}")
-            if self.dict.get(key, None):
-                self.dict.pop(key)
+            with self.disk_lock:
+                if meta := self.dict.pop(key, None):
+                    cache_path = os.path.dirname(meta.path)
+                    self._get_path_cache_dict(cache_path).pop(key, None)
+                    self._get_path_cache_policy(cache_path).update_on_force_evict(key)
+                    self._update_path_usage(cache_path, -meta.size)
+                    self.usage -= meta.size
+                    self.stats_monitor.update_local_storage_usage(self.usage)
             return
 
         disk_read_time = time.time() - start_time

--- a/lmcache/v1/storage_backend/path_sharder.py
+++ b/lmcache/v1/storage_backend/path_sharder.py
@@ -140,7 +140,7 @@ class PathSharder:
         local_world_size: int | None = None,
         create_dirs: bool = False,
     ) -> None:
-        paths = [p.strip() for p in raw_csv.split(",") if p.strip()]
+        paths = [os.path.normpath(p.strip()) for p in raw_csv.split(",") if p.strip()]
         if not paths:
             raise ValueError("At least one path must be provided")
 

--- a/lmcache/v1/storage_backend/path_sharder.py
+++ b/lmcache/v1/storage_backend/path_sharder.py
@@ -2,20 +2,60 @@
 """Shared path-sharding logic for multi-path storage backends.
 
 A :class:`PathSharder` takes a comma-separated list of directory paths
-and a sharding strategy, then selects a single path for the current
+and a sharding strategy, then assigns one or more paths to the current
 worker.  Both :class:`LocalDiskBackend` and :class:`GdsBackend` delegate
 path selection to this module so the policy lives in one place.
+
+Only the ``"by_gpu"`` strategy exists. Its behavior depends on whether
+the caller supplies local-worker metadata:
+
+* **Without** ``local_rank`` / ``local_world_size`` (e.g. the GDS
+  backend): legacy single-path mapping keyed by the CUDA device index,
+  ``paths[device_id % len(paths)]``.
+* **With** ``local_rank`` / ``local_world_size`` (e.g. the local disk
+  backend): worker-aware assignment keyed by the worker's local rank.
+  When there are more storage devices than workers, a worker is assigned
+  a contiguous *subset* of paths (e.g. 2 GPUs x 4 NVMe drives -> 2 drives
+  per GPU) so that no device sits idle.
+
+The two branches coincide on a single-node tensor-parallel deployment,
+where ``local_rank == device_id`` -- the path layout is unchanged.  They
+diverge only when the physical device index does not match the logical
+worker rank (e.g. ``CUDA_VISIBLE_DEVICES`` masking or data-parallel
+replicas), in which case the worker-aware branch is the coherent choice.
 """
 
 # Standard
-from typing import List
 import os
 
 # First Party
 from lmcache import torch_dev
 from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
 
 logger = init_logger(__name__)
+
+
+def _mix_u64(value: int) -> int:
+    """Mix an integer into a stable 64-bit hash value.
+
+    SplitMix64 provides a cheap deterministic mixer that spreads low-bit
+    patterns before modulo-based path selection, avoiding skew when a
+    worker is assigned only a small number of paths.
+
+    Args:
+        value: Arbitrary integer to mix.
+
+    Returns:
+        A well-distributed 64-bit unsigned integer derived from *value*.
+    """
+    value &= 0xFFFFFFFFFFFFFFFF
+    value ^= value >> 30
+    value = (value * 0xBF58476D1CE4E5B9) & 0xFFFFFFFFFFFFFFFF
+    value ^= value >> 27
+    value = (value * 0x94D049BB133111EB) & 0xFFFFFFFFFFFFFFFF
+    value ^= value >> 31
+    return value
 
 
 def _resolve_device_id(dst_device: str) -> int:
@@ -41,21 +81,32 @@ def _resolve_device_id(dst_device: str) -> int:
 
 
 class PathSharder:
-    """Select one path from a comma-separated list using a sharding policy.
+    """Assign one or more paths from a comma-separated list to a worker.
 
     Args:
         raw_csv: Comma-separated directory paths (e.g.
             ``"/mnt/nvme0/cache,/mnt/nvme1/cache"``).
-        strategy: Sharding strategy name.  Currently only ``"by_gpu"``
-            is supported, which selects ``paths[device_id % len(paths)]``.
-        dst_device: Device string used to derive the worker index
-            (e.g. ``"cuda:0"``, ``"cuda"``, ``"cpu"``).
-        create_dirs: If ``True``, create **all** directories in the
-            list at construction time (not just the selected one).
+        strategy: Sharding strategy name.  Only ``"by_gpu"`` is supported.
+        dst_device: Device string used to derive the worker index when no
+            local-rank metadata is supplied (e.g. ``"cuda:0"``, ``"cuda"``,
+            ``"cpu"``).
+        local_rank: Local worker rank on the current host.  When provided
+            together with *local_world_size*, path assignment is keyed by
+            this rank instead of the device index, enabling subset
+            assignment.  When ``None``, the legacy device-index mapping is
+            used.
+        local_world_size: Number of local workers on the current host.
+            Must be provided together with *local_rank*.
+        create_dirs: If ``True``, create **all** directories in the list at
+            construction time (not just the assigned ones).
 
     Raises:
         ValueError: If *raw_csv* is empty or contains no valid paths.
         ValueError: If *strategy* is not a supported sharding mode.
+        ValueError: If exactly one of *local_rank* / *local_world_size* is
+            provided.
+        ValueError: If the path count and worker count are not equal or an
+            exact multiple of each other.
 
     Example::
 
@@ -66,6 +117,16 @@ class PathSharder:
         )
         sharder.selected   # "/mnt/nvme1/cache"
         sharder.all_paths  # ["/mnt/nvme0/cache", "/mnt/nvme1/cache"]
+
+        # Worker-aware subset (2 workers, 4 paths):
+        sharder = PathSharder(
+            "/d0,/d1,/d2,/d3",
+            strategy="by_gpu",
+            dst_device="cuda:1",
+            local_rank=1,
+            local_world_size=2,
+        )
+        sharder.assigned_paths  # ["/d2", "/d3"]
     """
 
     _SUPPORTED_STRATEGIES = ("by_gpu",)
@@ -75,6 +136,8 @@ class PathSharder:
         raw_csv: str,
         strategy: str,
         dst_device: str,
+        local_rank: int | None = None,
+        local_world_size: int | None = None,
         create_dirs: bool = False,
     ) -> None:
         paths = [p.strip() for p in raw_csv.split(",") if p.strip()]
@@ -87,29 +150,141 @@ class PathSharder:
                 f"Supported: {', '.join(self._SUPPORTED_STRATEGIES)}"
             )
 
-        device_id = _resolve_device_id(dst_device)
+        if (local_rank is None) != (local_world_size is None):
+            raise ValueError(
+                "local_rank and local_world_size must be provided together "
+                f"(got local_rank={local_rank}, "
+                f"local_world_size={local_world_size})"
+            )
 
-        self._all_paths: List[str] = paths
+        self._all_paths: list[str] = paths
         self._strategy: str = strategy
-        self._selected: str = paths[device_id % len(paths)]
+
+        if local_rank is None or local_world_size is None:
+            # Legacy mapping: keep behavior identical to the original
+            # device-index single-path selection.  This is the branch the
+            # GDS backend takes, so it must never gain new validation or
+            # subset behavior.
+            device_id = _resolve_device_id(dst_device)
+            assigned_paths = [paths[device_id % len(paths)]]
+        else:
+            assigned_paths = self._assign_paths_for_worker(
+                paths=paths,
+                local_rank=local_rank,
+                local_world_size=local_world_size,
+            )
+
+        self._assigned_paths: list[str] = assigned_paths
+        self._selected: str = assigned_paths[0]
 
         if create_dirs:
             for p in paths:
                 os.makedirs(p, exist_ok=True)
 
+    def resolve_path_for_key(self, key: CacheEngineKey) -> str:
+        """Resolve the storage path for ``key`` on the current worker.
+
+        Args:
+            key: Cache key whose ``chunk_hash`` selects among the worker's
+                assigned paths when more than one path is assigned.
+
+        Returns:
+            Absolute path to the directory where ``key`` should be stored
+            or read from.
+        """
+        if len(self._assigned_paths) == 1:
+            return self._assigned_paths[0]
+
+        path_index = _mix_u64(int(key.chunk_hash)) % len(self._assigned_paths)
+        return self._assigned_paths[path_index]
+
     # -- public read-only properties -----------------------------------------
 
     @property
     def selected(self) -> str:
-        """The single path chosen for this worker."""
+        """The first assigned path, kept for backward compatibility."""
         return self._selected
 
     @property
-    def all_paths(self) -> List[str]:
+    def all_paths(self) -> list[str]:
         """All configured paths (unmodified order)."""
         return list(self._all_paths)
+
+    @property
+    def assigned_paths(self) -> list[str]:
+        """Paths assigned to the current worker (length >= 1)."""
+        return list(self._assigned_paths)
 
     @property
     def strategy(self) -> str:
         """Name of the active sharding strategy."""
         return self._strategy
+
+    def _assign_paths_for_worker(
+        self,
+        paths: list[str],
+        local_rank: int,
+        local_world_size: int,
+    ) -> list[str]:
+        """Assign a subset of *paths* to the worker identified by *local_rank*.
+
+        Three cases are handled:
+
+        * **workers == paths**: one-to-one mapping; each worker owns exactly
+          one device (e.g. 4 GPUs, 4 NVMe drives).
+        * **workers > paths**: multiple workers share devices; allowed only
+          when the worker count is an exact multiple of the path count
+          (e.g. 4 GPUs, 2 NVMe drives -> GPU 0 and 2 share drive 0, GPU 1
+          and 3 share drive 1).
+        * **workers < paths**: each worker owns a contiguous block of
+          devices; *num_paths* must be divisible by *local_world_size* to
+          guarantee even distribution (e.g. 2 GPUs, 4 NVMe drives -> GPU 0
+          owns drives 0-1, GPU 1 owns drives 2-3).
+
+        Args:
+            paths: Ordered list of all configured storage paths.
+            local_rank: Zero-based index of this worker on the current host.
+            local_world_size: Total number of workers on the current host.
+
+        Returns:
+            List of paths assigned to this worker (length >= 1).
+
+        Raises:
+            ValueError: If *local_world_size* is not positive, if
+                *local_rank* is out of range, or if the worker count and
+                path count are not equal and neither is an exact multiple
+                of the other.
+        """
+        num_paths = len(paths)
+        num_workers = local_world_size
+
+        if num_workers <= 0:
+            raise ValueError(
+                "by_gpu worker-aware assignment requires local_world_size to "
+                f"be positive (got {num_workers})"
+            )
+
+        if local_rank < 0 or local_rank >= num_workers:
+            raise ValueError(
+                "by_gpu worker-aware assignment requires local_rank to be in "
+                f"the range [0, local_world_size) (got local_rank={local_rank}, "
+                f"local_world_size={num_workers})"
+            )
+
+        if (
+            num_workers != num_paths
+            and max(num_workers, num_paths) % min(num_workers, num_paths) != 0
+        ):
+            raise ValueError(
+                "by_gpu worker-aware assignment requires local_world_size and "
+                "num_paths to be equal or exact multiples of each other "
+                f"(got {num_paths} paths and {num_workers} local workers)"
+            )
+
+        if num_workers >= num_paths:
+            return [paths[local_rank % num_paths]]
+
+        paths_per_worker = num_paths // num_workers
+        start = local_rank * paths_per_worker
+        end = start + paths_per_worker
+        return paths[start:end]

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -69,6 +69,19 @@ def create_test_metadata():
     )
 
 
+def create_rank_metadata(local_rank: int, local_world_size: int) -> LMCacheMetadata:
+    """Create LMCacheMetadata with explicit local worker placement."""
+    return LMCacheMetadata(
+        model_name="test_model",
+        world_size=local_world_size,
+        local_world_size=local_world_size,
+        worker_id=local_rank,
+        local_worker_id=local_rank,
+        kv_dtype=torch.bfloat16,
+        kv_shape=(28, 2, 256, 8, 128),
+    )
+
+
 def create_test_key(key_id: int = 0) -> CacheEngineKey:
     """Create a test CacheEngineKey."""
     return CacheEngineKey(
@@ -351,31 +364,28 @@ class TestMultiPathDiskBackend:
     def test_equal_quota_is_split_across_assigned_paths(
         self, async_loop, local_cpu_backend
     ):
-        """Assigned paths share the backend budget evenly."""
+        """max_local_disk_size is split over paths assigned to this worker."""
         dirs = [tempfile.mkdtemp() for _ in range(4)]
         try:
             combined = ",".join(dirs)
-            size = 512 * 1024
-            config = create_test_config(combined, max_disk_size=(4 * size) / 1024**3)
-            metadata = LMCacheMetadata(
-                model_name="test_model",
-                world_size=2,
-                local_world_size=2,
-                worker_id=1,
-                local_worker_id=1,
-                kv_dtype=torch.bfloat16,
-                kv_shape=(28, 2, 256, 8, 128),
+            quota_per_path = 512 * 1024
+            assigned_quota = 2 * quota_per_path
+            config = create_test_config(
+                combined, max_disk_size=assigned_quota / 1024**3
             )
             backend = LocalDiskBackend(
                 config=config,
                 loop=async_loop,
                 local_cpu_backend=local_cpu_backend,
                 dst_device="cuda:1",
-                metadata=metadata,
+                metadata=create_rank_metadata(local_rank=1, local_world_size=2),
             )
             assert backend.assigned_paths == dirs[2:4]
-            assert backend.path_max_cache_sizes == {dirs[2]: size, dirs[3]: size}
-            assert backend.max_cache_size == 2 * size
+            assert backend.path_max_cache_sizes == {
+                dirs[2]: quota_per_path,
+                dirs[3]: quota_per_path,
+            }
+            assert backend.max_cache_size == assigned_quota
         finally:
             for d in dirs:
                 shutil.rmtree(d, ignore_errors=True)
@@ -384,38 +394,51 @@ class TestMultiPathDiskBackend:
     def test_init_fails_when_assigned_path_available_space_is_too_small(
         self, async_loop, local_cpu_backend
     ):
-        """Init fails if assigned filesystems cannot satisfy their quota."""
+        """Init fails when any assigned filesystem is below its quota."""
         dirs = [tempfile.mkdtemp() for _ in range(4)]
         try:
             combined = ",".join(dirs)
-            size = 512 * 1024
-            config = create_test_config(combined, max_disk_size=(4 * size) / 1024**3)
-            metadata = LMCacheMetadata(
-                model_name="test_model",
-                world_size=2,
-                local_world_size=2,
-                worker_id=1,
-                local_worker_id=1,
-                kv_dtype=torch.bfloat16,
-                kv_shape=(28, 2, 256, 8, 128),
+            quota_per_path = 512 * 1024
+            config = create_test_config(
+                combined, max_disk_size=(2 * quota_per_path) / 1024**3
             )
+            metadata = create_rank_metadata(local_rank=1, local_world_size=2)
 
-            real_stats = {path: os.statvfs(path) for path in dirs}
+            real_stat = os.stat
+            real_statvfs = os.statvfs
 
-            class FakeStat:
+            class FakeStatVFS:
                 def __init__(self, *, f_bsize: int, f_frsize: int, f_bavail: int):
                     self.f_bsize = f_bsize
                     self.f_frsize = f_frsize
                     self.f_bavail = f_bavail
 
+            class FakeStat:
+                def __init__(self, *, path: str, st_dev: int):
+                    self.st_dev = st_dev
+                    self.st_mode = real_stat(path).st_mode
+
             def fake_statvfs(path):
                 if path == dirs[2]:
-                    return FakeStat(f_bsize=4096, f_frsize=4096, f_bavail=1)
-                return real_stats[path]
+                    return FakeStatVFS(f_bsize=4096, f_frsize=4096, f_bavail=1)
+                return real_statvfs(path)
 
-            with patch(
-                "lmcache.v1.storage_backend.local_disk_backend.os.statvfs",
-                side_effect=fake_statvfs,
+            def fake_stat(path):
+                if path == dirs[2]:
+                    return FakeStat(path=path, st_dev=100)
+                if path == dirs[3]:
+                    return FakeStat(path=path, st_dev=101)
+                return real_stat(path)
+
+            with (
+                patch(
+                    "lmcache.v1.storage_backend.local_disk_backend.os.statvfs",
+                    side_effect=fake_statvfs,
+                ),
+                patch(
+                    "lmcache.v1.storage_backend.local_disk_backend.os.stat",
+                    side_effect=fake_stat,
+                ),
             ):
                 with pytest.raises(ValueError, match="available filesystem space"):
                     LocalDiskBackend(
@@ -437,20 +460,14 @@ class TestMultiPathDiskBackend:
         dirs = [tempfile.mkdtemp() for _ in range(4)]
         try:
             combined = ",".join(dirs)
-            size = 512 * 1024
-            config = create_test_config(combined, max_disk_size=(4 * size) / 1024**3)
-            metadata = LMCacheMetadata(
-                model_name="test_model",
-                world_size=2,
-                local_world_size=2,
-                worker_id=1,
-                local_worker_id=1,
-                kv_dtype=torch.bfloat16,
-                kv_shape=(28, 2, 256, 8, 128),
+            quota_per_path = 512 * 1024
+            config = create_test_config(
+                combined, max_disk_size=(2 * quota_per_path) / 1024**3
             )
+            metadata = create_rank_metadata(local_rank=1, local_world_size=2)
 
-            real_stats = {path: os.statvfs(path) for path in dirs}
-            real_stat_results = {path: os.stat(path) for path in dirs}
+            real_stat = os.stat
+            real_statvfs = os.statvfs
 
             class FakeStatVFS:
                 def __init__(self, *, f_bsize: int, f_frsize: int, f_bavail: int):
@@ -459,22 +476,23 @@ class TestMultiPathDiskBackend:
                     self.f_bavail = f_bavail
 
             class FakeStat:
-                def __init__(self, *, st_dev: int):
+                def __init__(self, *, path: str, st_dev: int):
                     self.st_dev = st_dev
+                    self.st_mode = real_stat(path).st_mode
 
             def fake_statvfs(path):
                 if path in {dirs[2], dirs[3]}:
                     return FakeStatVFS(
                         f_bsize=4096,
                         f_frsize=4096,
-                        f_bavail=(size + size // 2) // 4096,
+                        f_bavail=(quota_per_path + quota_per_path // 2) // 4096,
                     )
-                return real_stats[path]
+                return real_statvfs(path)
 
             def fake_stat(path):
                 if path in {dirs[2], dirs[3]}:
-                    return FakeStat(st_dev=99)
-                return real_stat_results[path]
+                    return FakeStat(path=path, st_dev=99)
+                return real_stat(path)
 
             with (
                 patch(

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -142,6 +142,9 @@ class TestLocalDiskBackend:
         assert backend.instance_id == "test_instance"
         assert backend.usage == 0
         assert len(backend.dict) == 0
+        assert backend.max_cache_size == int(config.max_local_disk_size * 1024**3)
+        assert backend.path_max_cache_sizes[temp_disk_path] == backend.max_cache_size
+        assert backend.path_current_cache_sizes[temp_disk_path] == 0
 
         local_cpu_backend.memory_allocator.close()
 
@@ -345,6 +348,290 @@ class TestMultiPathDiskBackend:
             shutil.rmtree(dir_b, ignore_errors=True)
             local_cpu_backend.memory_allocator.close()
 
+    def test_equal_quota_is_split_across_assigned_paths(
+        self, async_loop, local_cpu_backend
+    ):
+        """Assigned paths share the backend budget evenly."""
+        dirs = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            combined = ",".join(dirs)
+            size = 512 * 1024
+            config = create_test_config(combined, max_disk_size=(4 * size) / 1024**3)
+            metadata = LMCacheMetadata(
+                model_name="test_model",
+                world_size=2,
+                local_world_size=2,
+                worker_id=1,
+                local_worker_id=1,
+                kv_dtype=torch.bfloat16,
+                kv_shape=(28, 2, 256, 8, 128),
+            )
+            backend = LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cuda:1",
+                metadata=metadata,
+            )
+            assert backend.assigned_paths == dirs[2:4]
+            assert backend.path_max_cache_sizes == {dirs[2]: size, dirs[3]: size}
+            assert backend.max_cache_size == 2 * size
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+    def test_init_fails_when_assigned_path_available_space_is_too_small(
+        self, async_loop, local_cpu_backend
+    ):
+        """Init fails if assigned filesystems cannot satisfy their quota."""
+        dirs = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            combined = ",".join(dirs)
+            size = 512 * 1024
+            config = create_test_config(combined, max_disk_size=(4 * size) / 1024**3)
+            metadata = LMCacheMetadata(
+                model_name="test_model",
+                world_size=2,
+                local_world_size=2,
+                worker_id=1,
+                local_worker_id=1,
+                kv_dtype=torch.bfloat16,
+                kv_shape=(28, 2, 256, 8, 128),
+            )
+
+            real_stats = {path: os.statvfs(path) for path in dirs}
+
+            class FakeStat:
+                def __init__(self, *, f_bsize: int, f_frsize: int, f_bavail: int):
+                    self.f_bsize = f_bsize
+                    self.f_frsize = f_frsize
+                    self.f_bavail = f_bavail
+
+            def fake_statvfs(path):
+                if path == dirs[2]:
+                    return FakeStat(f_bsize=4096, f_frsize=4096, f_bavail=1)
+                return real_stats[path]
+
+            with patch(
+                "lmcache.v1.storage_backend.local_disk_backend.os.statvfs",
+                side_effect=fake_statvfs,
+            ):
+                with pytest.raises(ValueError, match="available filesystem space"):
+                    LocalDiskBackend(
+                        config=config,
+                        loop=async_loop,
+                        local_cpu_backend=local_cpu_backend,
+                        dst_device="cuda:1",
+                        metadata=metadata,
+                    )
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+    def test_init_fails_when_same_filesystem_lacks_combined_quota(
+        self, async_loop, local_cpu_backend
+    ):
+        """Paths on one filesystem are validated against their combined quota."""
+        dirs = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            combined = ",".join(dirs)
+            size = 512 * 1024
+            config = create_test_config(combined, max_disk_size=(4 * size) / 1024**3)
+            metadata = LMCacheMetadata(
+                model_name="test_model",
+                world_size=2,
+                local_world_size=2,
+                worker_id=1,
+                local_worker_id=1,
+                kv_dtype=torch.bfloat16,
+                kv_shape=(28, 2, 256, 8, 128),
+            )
+
+            real_stats = {path: os.statvfs(path) for path in dirs}
+            real_stat_results = {path: os.stat(path) for path in dirs}
+
+            class FakeStatVFS:
+                def __init__(self, *, f_bsize: int, f_frsize: int, f_bavail: int):
+                    self.f_bsize = f_bsize
+                    self.f_frsize = f_frsize
+                    self.f_bavail = f_bavail
+
+            class FakeStat:
+                def __init__(self, *, st_dev: int):
+                    self.st_dev = st_dev
+
+            def fake_statvfs(path):
+                if path in {dirs[2], dirs[3]}:
+                    return FakeStatVFS(
+                        f_bsize=4096,
+                        f_frsize=4096,
+                        f_bavail=(size + size // 2) // 4096,
+                    )
+                return real_stats[path]
+
+            def fake_stat(path):
+                if path in {dirs[2], dirs[3]}:
+                    return FakeStat(st_dev=99)
+                return real_stat_results[path]
+
+            with (
+                patch(
+                    "lmcache.v1.storage_backend.local_disk_backend.os.statvfs",
+                    side_effect=fake_statvfs,
+                ),
+                patch(
+                    "lmcache.v1.storage_backend.local_disk_backend.os.stat",
+                    side_effect=fake_stat,
+                ),
+            ):
+                with pytest.raises(ValueError, match="available filesystem space"):
+                    LocalDiskBackend(
+                        config=config,
+                        loop=async_loop,
+                        local_cpu_backend=local_cpu_backend,
+                        dst_device="cuda:1",
+                        metadata=metadata,
+                    )
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+    def test_path_local_eviction_uses_only_target_path(
+        self, async_loop, local_cpu_backend
+    ):
+        """Quota pressure evicts only entries from the target path."""
+        dir_a = tempfile.mkdtemp()
+        dir_b = tempfile.mkdtemp()
+        try:
+            size = 512 * 1024
+            config = create_test_config(
+                f"{dir_a},{dir_b}", max_disk_size=(2 * size) / 1024**3
+            )
+            metadata = LMCacheMetadata(
+                model_name="test_model",
+                world_size=1,
+                local_world_size=1,
+                worker_id=0,
+                local_worker_id=0,
+                kv_dtype=torch.bfloat16,
+                kv_shape=(28, 2, 256, 8, 128),
+            )
+            backend = LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cuda:0",
+                metadata=metadata,
+            )
+
+            key_a = create_test_key(0)
+            key_b = create_test_key(1)
+            path_a = os.path.dirname(backend._key_to_path(key_a))
+            path_b = os.path.dirname(backend._key_to_path(key_b))
+            assert path_a != path_b
+
+            backend.dict[key_a] = DiskCacheMetadata(
+                backend._key_to_path(key_a), size, None, None, None, None, 0
+            )
+            backend.dict[key_b] = DiskCacheMetadata(
+                backend._key_to_path(key_b), size, None, None, None, None, 0
+            )
+            backend.path_current_cache_sizes[path_a] = size
+            backend.path_current_cache_sizes[path_b] = size
+            backend.current_cache_size = size * 2
+            backend.path_dicts[path_a][key_a] = backend.dict[key_a]
+            backend.path_dicts[path_b][key_b] = backend.dict[key_b]
+            backend.path_cache_policies[path_a].update_on_put(key_a)
+            backend.path_cache_policies[path_b].update_on_put(key_b)
+
+            memory_obj = MagicMock(spec=MemoryObj)
+            memory_obj.tensor = torch.zeros(1)
+            memory_obj.get_physical_size.return_value = size
+            memory_obj.ref_count_up.return_value = None
+
+            backend.disk_worker.submit_task = MagicMock(return_value=asyncio.sleep(0))
+
+            with patch(
+                "lmcache.v1.storage_backend.local_disk_backend."
+                "asyncio.run_coroutine_threadsafe"
+            ) as mock_schedule:
+
+                def _close_coro(coro, _loop):
+                    coro.close()
+                    return MagicMock()
+
+                mock_schedule.side_effect = _close_coro
+                backend.submit_put_task(key_a, memory_obj)
+
+            assert key_a not in backend.dict
+            assert key_b in backend.dict
+            assert backend.path_current_cache_sizes[path_a] == size
+            assert backend.path_current_cache_sizes[path_b] == size
+            assert backend.disk_worker.submit_task.call_args.kwargs["key"] == key_a
+        finally:
+            shutil.rmtree(dir_a, ignore_errors=True)
+            shutil.rmtree(dir_b, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+    def test_worker_aware_subset_assignment(self, async_loop, local_cpu_backend):
+        """With metadata, a worker is assigned a contiguous subset of paths."""
+        dirs = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            combined = ",".join(dirs)
+            config = create_test_config(combined)
+            # 2 local workers, 4 paths: rank 1 owns the second half.
+            metadata = LMCacheMetadata(
+                model_name="test_model",
+                world_size=2,
+                local_world_size=2,
+                worker_id=1,
+                local_worker_id=1,
+                kv_dtype=torch.bfloat16,
+                kv_shape=(28, 2, 256, 8, 128),
+            )
+            backend = LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cuda:1",
+                metadata=metadata,
+            )
+            assert backend.assigned_paths == dirs[2:4]
+            assert backend.path == dirs[2]
+            # _key_to_path must land under one of the assigned dirs.
+            key = create_test_key(7)
+            assert os.path.dirname(backend._key_to_path(key)) in dirs[2:4]
+            # Block size map keyed on the assigned paths only.
+            assert set(backend.path_block_sizes) == set(dirs[2:4])
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
+    def test_no_metadata_single_path_legacy(self, async_loop, local_cpu_backend):
+        """Without metadata, the legacy single-path mapping is used."""
+        dirs = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            combined = ",".join(dirs)
+            config = create_test_config(combined)
+            backend = LocalDiskBackend(
+                config=config,
+                loop=async_loop,
+                local_cpu_backend=local_cpu_backend,
+                dst_device="cuda:2",
+                metadata=None,
+            )
+            # device_id=2 -> 2 % 4 = 2 -> dirs[2], single path.
+            assert backend.assigned_paths == [dirs[2]]
+            assert backend.path == dirs[2]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+            local_cpu_backend.memory_allocator.close()
+
 
 class TestParseLocalDisk:
     """Unit tests for the _parse_local_disk config parser."""
@@ -398,8 +685,10 @@ class TestGetBlockingCachePolicyUpdate:
         dtype: torch.dtype,
     ) -> None:
         """Insert a key into backend.dict without writing anything to disk."""
+        path = backend._key_to_path(key)
+        cache_path = os.path.dirname(path)
         meta = DiskCacheMetadata(
-            path="/nonexistent/path.pt",
+            path=path,
             size=0,
             shape=shape,
             dtype=dtype,
@@ -409,7 +698,8 @@ class TestGetBlockingCachePolicyUpdate:
         )
         with backend.disk_lock:
             backend.dict[key] = meta
-            backend.cache_policy.update_on_put(key)
+            backend.path_dicts[cache_path][key] = meta
+            backend.path_cache_policies[cache_path].update_on_put(key)
 
     def test_no_phantom_hit_when_load_fails(
         self, local_disk_backend: LocalDiskBackend
@@ -419,11 +709,12 @@ class TestGetBlockingCachePolicyUpdate:
         shape = torch.Size([28, 2, 256, 8, 128])
         self._inject_key(local_disk_backend, key, shape, torch.bfloat16)
 
+        cache_path = local_disk_backend._get_cache_path_for_key(key)
         with patch.object(
             local_disk_backend, "load_bytes_from_disk", return_value=None
         ):
             with patch.object(
-                local_disk_backend.cache_policy, "update_on_hit"
+                local_disk_backend.path_cache_policies[cache_path], "update_on_hit"
             ) as mock_update:
                 result = local_disk_backend.get_blocking(key)
 
@@ -440,16 +731,19 @@ class TestGetBlockingCachePolicyUpdate:
         self._inject_key(local_disk_backend, key, shape, torch.bfloat16)
 
         fake_memory_obj = MagicMock(spec=MemoryObj)
+        cache_path = local_disk_backend._get_cache_path_for_key(key)
         with patch.object(
             local_disk_backend, "load_bytes_from_disk", return_value=fake_memory_obj
         ):
             with patch.object(
-                local_disk_backend.cache_policy, "update_on_hit"
+                local_disk_backend.path_cache_policies[cache_path], "update_on_hit"
             ) as mock_update:
                 result = local_disk_backend.get_blocking(key)
 
         assert result is fake_memory_obj
-        mock_update.assert_called_once_with(key, local_disk_backend.dict)
+        mock_update.assert_called_once_with(
+            key, local_disk_backend.path_dicts[cache_path]
+        )
         local_disk_backend.local_cpu_backend.memory_allocator.close()
 
     def test_key_absent_returns_none_without_policy_update(
@@ -459,7 +753,8 @@ class TestGetBlockingCachePolicyUpdate:
         key = create_test_key(103)
 
         with patch.object(
-            local_disk_backend.cache_policy, "update_on_hit"
+            local_disk_backend.path_cache_policies[local_disk_backend.path],
+            "update_on_hit",
         ) as mock_update:
             result = local_disk_backend.get_blocking(key)
 

--- a/tests/v1/storage_backend/test_path_sharder.py
+++ b/tests/v1/storage_backend/test_path_sharder.py
@@ -108,6 +108,16 @@ class TestPathSharder:
             for d in dirs:
                 shutil.rmtree(d, ignore_errors=True)
 
+    def test_normalizes_trailing_slashes(self):
+        d = tempfile.mkdtemp()
+        try:
+            s = PathSharder(f"{d}/", strategy="by_gpu", dst_device="cuda:0")
+            assert s.selected == d
+            assert s.all_paths == [d]
+            assert s.assigned_paths == [d]
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
     @patch(
         "lmcache.v1.storage_backend.path_sharder.torch_dev.is_available",
         return_value=False,

--- a/tests/v1/storage_backend/test_path_sharder.py
+++ b/tests/v1/storage_backend/test_path_sharder.py
@@ -9,9 +9,22 @@ import tempfile
 
 # Third Party
 import pytest
+import torch
 
 # First Party
+from lmcache.utils import CacheEngineKey
 from lmcache.v1.storage_backend.path_sharder import PathSharder
+
+
+def _make_key(chunk_hash: int) -> CacheEngineKey:
+    """Build a minimal CacheEngineKey with the given chunk_hash."""
+    return CacheEngineKey(
+        model_name="m",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=chunk_hash,
+        dtype=torch.float16,
+    )
 
 
 class TestPathSharder:
@@ -204,6 +217,238 @@ class TestPathSharder:
             csv = ",".join(dirs)
             s = PathSharder(csv, strategy="by_gpu", dst_device="cuda:foo")
             assert s.selected == dirs[0]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+
+class TestPathSharderLegacyBranch:
+    """Guard the metadata-absent branch used by GDS and any legacy caller.
+
+    This branch must stay a pure ``paths[device_id % len(paths)]`` mapping
+    with no new validation, so that backends which do not pass local-rank
+    metadata are unaffected by worker-aware assignment.
+    """
+
+    def test_device_id_beyond_num_paths_no_error(self):
+        """device_id >= num_paths must wrap via modulo, never raise."""
+        dirs = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            csv = ",".join(dirs)
+            # 5 % 2 == 1, non-multiple device id, no metadata -> no error.
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cuda:5")
+            assert s.selected == dirs[1]
+            assert s.assigned_paths == [dirs[1]]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_assigned_paths_single_without_metadata(self):
+        """Without metadata, exactly one path is assigned."""
+        dirs = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(csv, strategy="by_gpu", dst_device="cuda:2")
+            assert s.assigned_paths == [dirs[2]]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_partial_metadata_raises(self):
+        """Providing only one of local_rank / local_world_size is an error."""
+        d = tempfile.mkdtemp()
+        try:
+            with pytest.raises(ValueError, match="must be provided together"):
+                PathSharder(d, strategy="by_gpu", dst_device="cuda:0", local_rank=0)
+            with pytest.raises(ValueError, match="must be provided together"):
+                PathSharder(
+                    d,
+                    strategy="by_gpu",
+                    dst_device="cuda:0",
+                    local_world_size=1,
+                )
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+
+class TestPathSharderWorkerAware:
+    """Tests for the metadata-present worker-aware assignment branch."""
+
+    def test_one_to_one_workers_equal_paths(self):
+        """workers == paths -> each rank owns exactly one path."""
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            for r in range(3):
+                s = PathSharder(
+                    csv,
+                    strategy="by_gpu",
+                    dst_device=f"cuda:{r}",
+                    local_rank=r,
+                    local_world_size=3,
+                )
+                assert s.assigned_paths == [dirs[r]]
+                assert s.selected == dirs[r]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_workers_more_than_paths_shares(self):
+        """workers > paths (exact multiple) -> modulo sharing."""
+        dirs = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            csv = ",".join(dirs)
+            # 4 workers, 2 paths: rank 2 -> paths[2 % 2] == paths[0]
+            s = PathSharder(
+                csv,
+                strategy="by_gpu",
+                dst_device="cuda:2",
+                local_rank=2,
+                local_world_size=4,
+            )
+            assert s.assigned_paths == [dirs[0]]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_workers_fewer_than_paths_subset(self):
+        """workers < paths -> contiguous subset per worker."""
+        dirs = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            csv = ",".join(dirs)
+            s0 = PathSharder(
+                csv,
+                strategy="by_gpu",
+                dst_device="cuda:0",
+                local_rank=0,
+                local_world_size=2,
+            )
+            s1 = PathSharder(
+                csv,
+                strategy="by_gpu",
+                dst_device="cuda:1",
+                local_rank=1,
+                local_world_size=2,
+            )
+            assert s0.assigned_paths == dirs[0:2]
+            assert s1.assigned_paths == dirs[2:4]
+            assert s0.selected == dirs[0]
+            assert s1.selected == dirs[2]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_non_divisible_layout_raises(self):
+        """3 paths, 2 workers is neither equal nor an exact multiple."""
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            with pytest.raises(ValueError, match="exact multiples"):
+                PathSharder(
+                    csv,
+                    strategy="by_gpu",
+                    dst_device="cuda:0",
+                    local_rank=0,
+                    local_world_size=2,
+                )
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_workers_more_than_paths_non_multiple_raises(self):
+        """3 workers, 2 paths is not an exact multiple."""
+        dirs = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            csv = ",".join(dirs)
+            with pytest.raises(ValueError, match="exact multiples"):
+                PathSharder(
+                    csv,
+                    strategy="by_gpu",
+                    dst_device="cuda:0",
+                    local_rank=0,
+                    local_world_size=3,
+                )
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_rank_out_of_range_raises(self):
+        dirs = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            csv = ",".join(dirs)
+            with pytest.raises(ValueError, match="range"):
+                PathSharder(
+                    csv,
+                    strategy="by_gpu",
+                    dst_device="cuda:0",
+                    local_rank=2,
+                    local_world_size=2,
+                )
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_non_positive_world_size_raises(self):
+        dirs = [tempfile.mkdtemp() for _ in range(2)]
+        try:
+            csv = ",".join(dirs)
+            with pytest.raises(ValueError, match="positive"):
+                PathSharder(
+                    csv,
+                    strategy="by_gpu",
+                    dst_device="cuda:0",
+                    local_rank=0,
+                    local_world_size=0,
+                )
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+
+class TestResolvePathForKey:
+    """Tests for per-key path routing within a worker's assigned subset."""
+
+    def test_single_path_skips_hashing(self):
+        """A single-path worker always returns that path."""
+        dirs = [tempfile.mkdtemp() for _ in range(3)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(
+                csv,
+                strategy="by_gpu",
+                dst_device="cuda:0",
+                local_rank=0,
+                local_world_size=3,
+            )
+            for h in (0, 1, 12345, 2**63):
+                assert s.resolve_path_for_key(_make_key(h)) == dirs[0]
+        finally:
+            for d in dirs:
+                shutil.rmtree(d, ignore_errors=True)
+
+    def test_subset_routing_deterministic_and_in_subset(self):
+        """Same key -> same path; result always within the assigned subset."""
+        dirs = [tempfile.mkdtemp() for _ in range(4)]
+        try:
+            csv = ",".join(dirs)
+            s = PathSharder(
+                csv,
+                strategy="by_gpu",
+                dst_device="cuda:0",
+                local_rank=0,
+                local_world_size=2,
+            )
+            subset = dirs[0:2]
+            seen = set()
+            for h in range(100):
+                key = _make_key(h)
+                p1 = s.resolve_path_for_key(key)
+                p2 = s.resolve_path_for_key(key)
+                assert p1 == p2
+                assert p1 in subset
+                seen.add(p1)
+            # Over 100 distinct hashes both subset paths should be used.
+            assert seen == set(subset)
         finally:
             for d in dirs:
                 shutil.rmtree(d, ignore_errors=True)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the existing `by_gpu` sharding policy in the local disk
backend to support worker-aware multi-device path assignment.

Previously, local-disk `by_gpu` selected a single path from the physical GPU
device id. That had a few limitations:

1. extra disk paths could remain idle when `#paths > #workers`
2. physical device id is not the right key in data-parallel or device-remapped
   deployments
3. global cache management in multi-path mode could break path locality after
   eviction, causing KV cache to be re-inserted on a different path than the
   one originally mapped for that key

This change extends `by_gpu` to use local worker metadata when available:

- `#paths == #workers`: one path per worker
- `#paths > #workers`: each worker gets a contiguous subset of paths
- `#workers > #paths`: workers share paths by modulo mapping

Within an assigned subset, KV cache is routed by stable per-key hashing.

This PR also changes multi-path local-disk cache management from global to
path-local. Each assigned path now has its own quota, usage tracking, and
eviction-policy state, which keeps cache placement aligned with the intended
path mapping even after eviction.

When local worker metadata is not available, `by_gpu` keeps the legacy
single-path `device_id % num_paths` behavior.

**Special notes for your reviewers**:

- This extends the existing `by_gpu` policy; it does not introduce a new
  sharding mode.
- The worker-aware branch is keyed by local rank, which makes path assignment
  coherent in DP and device-remapped setups.
- Path count and local worker count must be equal or exact multiples;
  unsupported uneven layouts fail at startup.
- In multi-path mode, cache management is path-local rather than global.
- Tests were added for worker-aware assignment, legacy compatibility, subset
  routing, and multi-path local-disk backend behavior.
- Docs and the local backend example were updated accordingly.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests