### PR TITLE
Fix: Pass Instance ID to SGLang HeartbeatThread to Enable Server Liveness Tracking

### DIFF
--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -166,6 +166,7 @@ class LMCacheMPConnector:
             mq_client=self.mq_client,
             health_event=self._health_event,
             interval=self._heartbeat_interval,
+            instance_id=self.instance_id,
         )
         self._heartbeat.start()
 


### PR DESCRIPTION


**What this PR does / why we need it**:

  LMCache MP Server runs periodic thread Reaper, which checks last heartbeat time  associated with each  instance_id  (process PID) to determine if worker process died  silently.

Otherwise, omitting  instance_id  (defaulting to  None ) causes server to receive  anonymous heartbeats. Server considers SGLang worker lost. Upon timeout, even if  worker remains alive, server marks worker resources as reclaimable.

SGLang worker should also pass  instance_id  like vLLM worker.
https://github.com/LMCache/LMCache/blob/dev/lmcache/integration/vllm/vllm_multi_process_adapter.py#L1194


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
