### PR TITLE
feat(musa): add guarded MUSA MP handle wrapper

### DIFF
--- a/docs/design/v1/multiprocess/device_ipc_wrapper_design.md
+++ b/docs/design/v1/multiprocess/device_ipc_wrapper_design.md
@@ -22,7 +22,8 @@ A device-agnostic base, `DeviceIPCWrapper`, now owns everything that is not tran
 DeviceIPCWrapper                        base: contract + (de)serialize
 ├── CudaIPCWrapper                      cuda  — torch caching allocator
 ├── RawCudaIPCWrapper                   cuda — raw cudaMalloc, TRT-LLM
-└── CpuShmTensorWrapper                 cpu   — POSIX shared memory
+├── CpuShmTensorWrapper                 cpu   — POSIX shared memory
+└── MusaIPCWrapper                      musa  — TorchMUSA memory IPC
 ```
 
 All of them live behind a single msgspec ext code 1 and a single `KVCache = list[DeviceIPCWrapper]` wire type, so new device backends can be added as further siblings without touching the wire format.
@@ -51,6 +52,7 @@ transport shares:
 | `CudaIPCWrapper` | `cuda` | `UntypedStorage._share_cuda_()` | `_new_shared_cuda` + `set_()` |
 | `RawCudaIPCWrapper` | `cuda` | `cudaIpcGetMemHandle` (raw ptr) | `cudaIpcOpenMemHandle` → CuPy → DLPack |
 | `CpuShmTensorWrapper` | `cpu` | POSIX `shm_open` | `mmap` same segment |
+| `MusaIPCWrapper` | `musa` | TorchMUSA memory IPC handle | `ipc_open_mem_handle` + DLPack / tensor view |
 
 ## Platform registration
 

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -187,11 +187,10 @@ def _release_partial_kv_wrappers(wrappers: list[Any]) -> None:
 def wrap_one_kv_cache(tensor: torch.Tensor) -> Any:
     """Dispatch by ``tensor.device.type`` via the platform registry.
 
-    Concrete factories self-register at import time (CUDA in
-    ``lmcache.v1.platform.cuda``, CPU SHM in
-    ``lmcache.v1.platform.cpu``), so this call site stays free of
-    if/elif chains and new accelerators plug in by registering a
-    sibling factory.
+    Concrete factories are auto-discovered from
+    ``DeviceIPCWrapper`` subclasses under ``lmcache.v1.platform``, so
+    this call site stays free of if/elif chains and new accelerators
+    plug in by shipping a sibling wrapper class.
     """
     return platform_registry.get_kv_wrapper_factory(tensor.device.type)(tensor)
 

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -87,6 +87,12 @@ def _build_lmcache_driven_context(device_type: str) -> "TransferContext":
             "%r: no KV-cache wrapper factory is registered. "
             "Use mode 'engine_driven' or 'auto' instead." % device_type
         ) from exc
+    if not platform_registry.is_available(device_type):
+        raise ValueError(
+            "MP transfer mode 'lmcache_driven' is not available for device type "
+            "%r: required platform capability checks failed. "
+            "Use mode 'engine_driven' or 'auto' instead." % device_type
+        )
     return LMCacheDrivenTransferContext()
 
 

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -13,13 +13,12 @@ packages so each can evolve independently:
 * :mod:`lmcache.v1.platform.cuda` -- CUDA-backed implementations.
 * :mod:`lmcache.v1.platform.cpu`  -- CPU-only fallbacks.
 
-Backend self-registration is filesystem-driven: every direct
-sub-package below ``platform/`` is auto-imported here, which fires its
-``__init__.py`` side effects (``register_kv_wrapper`` /
-``register_availability``).  The ``BaseCacheContext`` subclass that
-each backend ships under ``platform/<backend>/cache_context.py`` is
-discovered separately on first :func:`create_cache_context` call via
-:mod:`lmcache.v1.utils.subclass_discovery`, keyed by the subclass'
+Backend availability is filesystem-driven: every direct sub-package
+below ``platform/`` is auto-imported here, which fires lightweight
+``__init__.py`` side effects such as ``register_availability``.
+KV-cache IPC wrappers and ``BaseCacheContext`` subclasses are
+discovered separately on first use via
+:mod:`lmcache.v1.utils.subclass_discovery`, keyed by each subclass'
 ``device_type`` ClassVar.  Adding a new accelerator therefore
 requires *zero* edits to this module -- drop a new
 ``platform/<backend>/`` package and it will be picked up
@@ -47,13 +46,10 @@ logger = init_logger(__name__)
 def _bootstrap_backends() -> None:
     """Import every direct sub-package under ``lmcache.v1.platform``.
 
-    Each backend sub-package self-registers with
-    :mod:`lmcache.v1.platform._registry` from its ``__init__.py``
-    (KV-cache wrapper factory, availability predicate, lazy
-    cache-context class).  Importing the sub-package is therefore
-    enough -- we deliberately do **not** force-import the heavy
-    ``cache_context`` leaf module here, so platform bootstrap stays
-    free of the circular import chain through
+    Backend ``__init__.py`` files should keep side effects lightweight
+    (for example, availability predicates). KV-cache wrapper and
+    cache-context classes are discovered from leaf modules lazily, so
+    platform bootstrap stays free of the circular import chain through
     ``lmcache.gpu_connector``.
     """
     for _, short_name, is_pkg in pkgutil.iter_modules(__path__):

--- a/lmcache/v1/platform/musa/__init__.py
+++ b/lmcache/v1/platform/musa/__init__.py
@@ -1,2 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MUSA-specific platform helpers."""
+"""MUSA-specific platform primitives.
+
+The MUSA IPC wrapper is discovered from
+:mod:`lmcache.v1.platform.musa.ipc` by the platform registry. Importing this
+package only registers the explicit availability predicate so MUSA workers keep
+using the Stage3 data path unless the Stage4 handle path is fully available and
+explicitly enabled.
+"""
+
+# First Party
+from lmcache.v1.platform._registry import register_availability
+
+
+def _musa_handle_transfer_is_available() -> bool:
+    """Return whether the optional MUSA handle path can be selected."""
+    # First Party
+    from lmcache.v1.platform.musa.ipc import is_musa_handle_transfer_available
+
+    return is_musa_handle_transfer_available()
+
+
+register_availability("musa", _musa_handle_transfer_is_available)

--- a/lmcache/v1/platform/musa/ipc.py
+++ b/lmcache/v1/platform/musa/ipc.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional MUSA IPC wrapper used by the Stage4 MP handle path.
+
+The MUSA handle path is deliberately fail-closed. This module exposes a
+``DeviceIPCWrapper`` subclass for the platform registry to auto-discover, but
+it only constructs wrappers when the user explicitly enables the path and every
+required handle-path capability is present.
+"""
+
+# Standard
+from typing import ClassVar, Protocol, cast
+import importlib
+import inspect
+import os
+import threading
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.gpu_connector.kv_format.contiguity import (
+    attempt_permute_to_contiguous_view,
+)
+from lmcache.v1.gpu_connector.utils import assert_contiguous
+from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
+
+ENV_MUSA_HANDLE_TRANSFER = "LMCACHE_MUSA_HANDLE_TRANSFER"
+
+_REQUIRED_TORCH_MUSA_IPC_SYMBOLS = (
+    "ipc_get_mem_handle",
+    "ipc_open_mem_handle",
+)
+
+
+class _TorchMusaIPCModule(Protocol):
+    """TorchMUSA surface required by the Stage4.1 handle capability gate."""
+
+    def ipc_get_mem_handle(self, tensor: torch.Tensor) -> object:
+        """Export a MUSA tensor as a process-portable IPC handle."""
+
+    def ipc_open_mem_handle(
+        self,
+        handle: bytes,
+        nbytes: int,
+        device_index: int,
+    ) -> object:
+        """Import a MUSA IPC handle in the current process."""
+
+
+def is_musa_handle_transfer_enabled() -> bool:
+    """Return whether users opted into the experimental MUSA handle path."""
+    return os.environ.get(ENV_MUSA_HANDLE_TRANSFER, "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def is_torch_musa_available() -> bool:
+    """Return whether TorchMUSA is importable and reports a visible device."""
+    torch_musa = get_torch_musa_module()
+    if torch_musa is None:
+        return False
+    is_available = getattr(torch_musa, "is_available", None)
+    if not callable(is_available):
+        return False
+    try:
+        return bool(is_available())
+    except Exception:
+        return False
+
+
+def get_torch_musa_module() -> object | None:
+    """Return the TorchMUSA module when this PyTorch build exposes it.
+
+    Returns:
+        ``torch.musa`` when present, otherwise ``None``.
+    """
+    if not hasattr(torch, "musa"):
+        # torch_musa registers torch.musa as an import side effect.
+        try:
+            importlib.import_module("torch_musa")
+        except ImportError:
+            pass
+    if not hasattr(torch, "musa"):
+        return None
+    return torch.musa  # type: ignore[attr-defined]
+
+
+def check_torch_musa_ipc_support(torch_musa: object) -> bool:
+    """Return whether TorchMUSA exposes memory IPC primitives."""
+    return all(
+        callable(getattr(torch_musa, symbol, None))
+        for symbol in _REQUIRED_TORCH_MUSA_IPC_SYMBOLS
+    )
+
+
+def check_torch_musa_event_support(torch_musa: object) -> bool:
+    """Return whether TorchMUSA exposes IPC event ordering primitives."""
+    event_cls = getattr(torch_musa, "Event", None)
+    if event_cls is None or not hasattr(event_cls, "from_ipc_handle"):
+        return False
+    return _has_interprocess_parameter(event_cls) or _has_interprocess_parameter(
+        getattr(event_cls, "__new__", None)
+    )
+
+
+def is_musa_block_transfer_available() -> bool:
+    """Return whether server-side MUSA block transfer is production-ready.
+
+    Stage4.1 only adds the safe integration boundary. Until Stage4.3 wires and
+    validates the server-side MUSA block-transfer primitive, forced MUSA handle
+    mode must remain unavailable even if TorchMUSA memory/event IPC exists.
+    """
+    return False
+
+
+def is_musa_handle_transfer_available() -> bool:
+    """Return whether forced MUSA MP handle mode may be selected.
+
+    Availability requires all four conditions:
+    - explicit user opt-in through :data:`ENV_MUSA_HANDLE_TRANSFER`;
+    - a visible TorchMUSA runtime;
+    - TorchMUSA memory IPC and interprocess event support;
+    - a validated server-side MUSA block-transfer primitive.
+    """
+    if not is_musa_handle_transfer_enabled():
+        return False
+    if not is_torch_musa_available():
+        return False
+    torch_musa = get_torch_musa_module()
+    return (
+        torch_musa is not None
+        and check_torch_musa_ipc_support(torch_musa)
+        and check_torch_musa_event_support(torch_musa)
+        and is_musa_block_transfer_available()
+    )
+
+
+class MusaIPCWrapper(DeviceIPCWrapper):
+    """Wire-compatible wrapper for MUSA memory IPC handles.
+
+    The class subclasses :class:`DeviceIPCWrapper` so it shares the
+    device-agnostic ``KVCache = list[DeviceIPCWrapper]`` msgspec wire type with
+    CUDA and CPU wrappers. Pickle preserves the subclass identity, and the
+    receiver calls this class's :meth:`to_tensor` implementation to reconstruct
+    a MUSA tensor.
+    """
+
+    #: ``torch.device.type`` this wrapper handles (used by auto-discovery).
+    device_type: ClassVar[str] = "musa"
+
+    #: Marked ``True`` so auto-discovery picks this as the default factory.
+    _is_default_wrapper: ClassVar[bool] = True
+
+    _discovered_device_mapping: dict[str, int] = {}
+    _device_mapping_lock = threading.Lock()
+
+    @classmethod
+    def wrap(cls, tensor: torch.Tensor) -> "MusaIPCWrapper":
+        """Factory used by the platform registry auto-discovery.
+
+        Args:
+            tensor: A MUSA tensor to export through TorchMUSA IPC.
+
+        Returns:
+            A new :class:`MusaIPCWrapper` wrapping ``tensor`` for the
+            multiprocess wire.
+        """
+        return cls(tensor)
+
+    def __init__(self, tensor: torch.Tensor) -> None:
+        """Export a MUSA tensor through the TorchMUSA IPC runtime.
+
+        Args:
+            tensor: A contiguous MUSA tensor to export.
+
+        Raises:
+            ValueError: If ``tensor`` is not a MUSA tensor or cannot be
+                represented as a zero-offset contiguous view.
+            RuntimeError: If the Stage4 MUSA handle capability is unavailable.
+        """
+        tensor_view = attempt_permute_to_contiguous_view(tensor)
+        if (
+            not isinstance(tensor_view, torch.Tensor)
+            or tensor_view.device.type != "musa"
+        ):
+            raise ValueError("expected a MUSA tensor for MusaIPCWrapper")
+        tensor = tensor_view
+        assert_contiguous(tensor)
+
+        module = _torch_musa_module_if_ready()
+        if module is None:
+            raise RuntimeError(
+                "MUSA IPC handle transfer is not available. Set "
+                f"{ENV_MUSA_HANDLE_TRANSFER}=1 with compatible TorchMUSA "
+                "memory/event IPC support and a validated MUSA block-transfer "
+                "backend, or use MP transfer mode 'engine_driven' or 'auto'."
+            )
+
+        self._musa_ipc_handle = _coerce_ipc_handle(module.ipc_get_mem_handle(tensor))
+        self._nbytes = tensor.untyped_storage().nbytes()
+
+        self.handle = None
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+
+        device_index = tensor.device.index
+        self.device_uuid = self._get_device_uuid(
+            0 if device_index is None else device_index
+        )
+
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the MUSA tensor in this process."""
+        module = _torch_musa_module_if_ready()
+        if module is None:
+            raise RuntimeError(
+                "MUSA IPC handle transfer is not available in the receiver process."
+            )
+
+        device_index = self._get_device_index_from_uuid(self.device_uuid)
+        raw = module.ipc_open_mem_handle(
+            self._musa_ipc_handle,
+            self._nbytes,
+            device_index,
+        )
+        if isinstance(raw, torch.Tensor):
+            tensor = raw
+        else:
+            tensor = torch.from_dlpack(raw)
+
+        if tensor.dtype == torch.uint8 and self.dtype != torch.uint8:
+            tensor = tensor.view(self.dtype)
+        return tensor.as_strided(self.shape, self.stride, self.storage_offset)
+
+    @classmethod
+    def _get_device_uuid(cls, device_index: int) -> str:
+        """Return a stable MUSA device identifier for ``device_index``."""
+        props = torch.musa.get_device_properties(device_index)  # type: ignore[attr-defined]
+        uuid = getattr(props, "uuid", None)
+        if uuid is not None:
+            return str(uuid)
+        pci_bus_id = getattr(props, "pci_bus_id", None)
+        if pci_bus_id is not None:
+            return str(pci_bus_id)
+        name = getattr(props, "name", "musa")
+        return f"{name}:{device_index}"
+
+    @classmethod
+    def _discover_devices(cls) -> None:
+        """Discover visible MUSA devices and cache their identifiers."""
+        if not is_torch_musa_available():
+            return
+
+        with cls._device_mapping_lock:
+            if cls._discovered_device_mapping:
+                return
+
+            for i in range(torch.musa.device_count()):  # type: ignore[attr-defined]
+                device_uuid = cls._get_device_uuid(i)
+                cls._discovered_device_mapping[device_uuid] = i
+
+    @classmethod
+    def _get_device_index_from_uuid(cls, device_uuid: str) -> int:
+        """Resolve the sender's MUSA device identifier in this process."""
+        cls._discover_devices()
+
+        with cls._device_mapping_lock:
+            device_index = cls._discovered_device_mapping.get(device_uuid)
+
+        if device_index is None:
+            raise RuntimeError(
+                f"MUSA device UUID {device_uuid} not found in visible devices. "
+                "Please make sure the worker and server see the same MUSA devices."
+            )
+        return device_index
+
+
+def _torch_musa_module_if_ready() -> _TorchMusaIPCModule | None:
+    """Return TorchMUSA when all handle-path capability gates pass."""
+    if not is_musa_handle_transfer_enabled():
+        return None
+    if not is_torch_musa_available():
+        return None
+    module = get_torch_musa_module()
+    if (
+        module is None
+        or not check_torch_musa_ipc_support(module)
+        or not check_torch_musa_event_support(module)
+        or not is_musa_block_transfer_available()
+    ):
+        return None
+    return cast(_TorchMusaIPCModule, module)
+
+
+def _coerce_ipc_handle(handle: object) -> bytes:
+    """Normalize a MUSA IPC handle into bytes for pickle/msgspec transport."""
+    if isinstance(handle, bytes):
+        return handle
+    if isinstance(handle, bytearray):
+        return bytes(handle)
+    if isinstance(handle, memoryview):
+        return handle.tobytes()
+    raise TypeError("MUSA IPC handle must be bytes-like")
+
+
+def _has_interprocess_parameter(obj: object) -> bool:
+    """Return whether ``obj`` accepts the ``interprocess`` event parameter."""
+    if not callable(obj):
+        return False
+    try:
+        signature = inspect.signature(obj)
+    except (TypeError, ValueError):
+        return False
+    return "interprocess" in signature.parameters

--- a/tests/v1/test_musa_mp_handle.py
+++ b/tests/v1/test_musa_mp_handle.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from types import SimpleNamespace
+from typing import cast
+import importlib
+
+# Third Party
+import pytest
+import torch
+
+
+class _FakeMusaEvent:
+    """Minimal TorchMUSA Event facade for capability-gate tests."""
+
+    def __init__(self, interprocess: bool = False) -> None:
+        self.interprocess = interprocess
+
+    @classmethod
+    def from_ipc_handle(cls, _device: object, _handle: bytes) -> "_FakeMusaEvent":
+        """Reconstruct an event from an IPC handle."""
+        return cls(interprocess=True)
+
+
+class _FakeDevice:
+    """Minimal device object exposing only ``type`` for factory routing tests."""
+
+    type = "musa"
+
+
+class _FakeMusaTensor:
+    """Minimal tensor-like object exposing a MUSA device for routing tests."""
+
+    device = _FakeDevice()
+
+
+def _fake_musa_kv_caches() -> dict[str, torch.Tensor]:
+    """Return a typed KV cache mapping backed by a minimal MUSA tensor facade."""
+    return cast(dict[str, torch.Tensor], {"layer_0": _FakeMusaTensor()})
+
+
+def test_musa_handle_transfer_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stage4 MUSA handle transfer is opt-in and unavailable by default."""
+    # First Party
+    from lmcache.v1.platform.musa import ipc
+
+    monkeypatch.delenv(ipc.ENV_MUSA_HANDLE_TRANSFER, raising=False)
+
+    assert ipc.is_musa_handle_transfer_enabled() is False
+    assert ipc.is_musa_handle_transfer_available() is False
+
+
+def test_musa_handle_transfer_requires_torch_musa(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in alone is not enough without a visible TorchMUSA runtime."""
+    # First Party
+    from lmcache.v1.platform.musa import ipc
+
+    monkeypatch.setenv(ipc.ENV_MUSA_HANDLE_TRANSFER, "1")
+    monkeypatch.setattr(ipc, "is_torch_musa_available", lambda: False)
+
+    assert ipc.is_musa_handle_transfer_available() is False
+
+
+def test_get_torch_musa_module_imports_torch_musa_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TorchMUSA may register ``torch.musa`` only after ``torch_musa`` import."""
+    # First Party
+    from lmcache.v1.platform.musa import ipc
+
+    fake_torch = SimpleNamespace()
+    torch_musa = SimpleNamespace(is_available=lambda: True)
+
+    def import_module(name: str) -> object:
+        assert name == "torch_musa"
+        fake_torch.musa = torch_musa
+        return SimpleNamespace()
+
+    monkeypatch.setattr(ipc, "torch", fake_torch)
+    monkeypatch.setattr(ipc.importlib, "import_module", import_module)
+
+    assert ipc.get_torch_musa_module() is torch_musa
+    assert ipc.is_torch_musa_available() is True
+
+
+def test_musa_handle_transfer_requires_event_and_block_transfer_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Memory IPC alone is not enough to enable the MUSA handle path."""
+    # First Party
+    from lmcache.v1.platform.musa import ipc
+
+    torch_musa = SimpleNamespace(
+        ipc_get_mem_handle=lambda _tensor: b"handle",
+        ipc_open_mem_handle=lambda _handle, nbytes, _device: torch.empty(
+            nbytes,
+            dtype=torch.uint8,
+        ),
+    )
+
+    monkeypatch.setenv(ipc.ENV_MUSA_HANDLE_TRANSFER, "1")
+    monkeypatch.setattr(ipc, "is_torch_musa_available", lambda: True)
+    monkeypatch.setattr(ipc, "get_torch_musa_module", lambda: torch_musa)
+
+    assert ipc.check_torch_musa_ipc_support(torch_musa) is True
+    assert ipc.check_torch_musa_event_support(torch_musa) is False
+    assert ipc.is_musa_handle_transfer_available() is False
+
+
+def test_musa_handle_transfer_available_when_all_capabilities_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forced MUSA handle mode is available only after all gates pass."""
+    # First Party
+    from lmcache.v1.platform.musa import ipc
+
+    torch_musa = SimpleNamespace(
+        ipc_get_mem_handle=lambda _tensor: b"handle",
+        ipc_open_mem_handle=lambda _handle, nbytes, _device: torch.empty(
+            nbytes,
+            dtype=torch.uint8,
+        ),
+        Event=_FakeMusaEvent,
+    )
+
+    monkeypatch.setenv(ipc.ENV_MUSA_HANDLE_TRANSFER, "1")
+    monkeypatch.setattr(ipc, "is_torch_musa_available", lambda: True)
+    monkeypatch.setattr(ipc, "get_torch_musa_module", lambda: torch_musa)
+    monkeypatch.setattr(ipc, "is_musa_block_transfer_available", lambda: True)
+
+    assert ipc.check_torch_musa_ipc_support(torch_musa) is True
+    assert ipc.check_torch_musa_event_support(torch_musa) is True
+    assert ipc.is_musa_handle_transfer_available() is True
+
+
+def test_musa_handle_transfer_rejects_incomplete_torch_musa_runtime() -> None:
+    """Missing TorchMUSA IPC symbols keep Stage4 handle mode disabled."""
+    # First Party
+    from lmcache.v1.platform.musa import ipc
+
+    torch_musa = SimpleNamespace(ipc_get_mem_handle=lambda _tensor: b"handle")
+
+    assert ipc.check_torch_musa_ipc_support(torch_musa) is False
+
+
+def test_musa_platform_discovers_factory_and_registers_capability_predicate() -> None:
+    """The MUSA wrapper is auto-discovered while availability stays explicit."""
+    # First Party
+    from lmcache.v1.platform import _registry as platform_registry
+    import lmcache.v1.platform.musa as musa_platform
+
+    snapshot = platform_registry.snapshot()
+    try:
+        platform_registry.reset_for_tests()
+        importlib.reload(musa_platform)
+
+        factory = platform_registry.get_kv_wrapper_factory("musa")
+
+        assert platform_registry.is_available("musa") is False
+        assert callable(factory)
+        with pytest.raises(ValueError, match="expected a MUSA tensor"):
+            factory(torch.empty(1))
+    finally:
+        platform_registry.restore(snapshot)
+
+
+def test_create_transfer_context_auto_keeps_musa_on_data_path() -> None:
+    """Stage4 must not silently switch MUSA auto mode away from Stage3 data path."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import (
+        EngineDrivenTransferContext,
+        create_transfer_context,
+    )
+
+    context = create_transfer_context(_fake_musa_kv_caches())
+
+    assert isinstance(context, EngineDrivenTransferContext)
+
+
+def test_create_transfer_context_musa_handle_requires_capability() -> None:
+    """Forced MUSA handle mode fails closed when the Stage4 capability is absent."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import create_transfer_context
+
+    with pytest.raises(ValueError, match="not available"):
+        create_transfer_context(_fake_musa_kv_caches(), mode="lmcache_driven")
+
+
+def test_create_transfer_context_musa_handle_allowed_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forced MUSA handle mode is allowed once the platform reports capability."""
+    # First Party
+    from lmcache.v1.multiprocess.transfer_context import (
+        LMCacheDrivenTransferContext,
+        create_transfer_context,
+    )
+    from lmcache.v1.platform import _registry as platform_registry
+
+    snapshot = platform_registry.snapshot()
+    try:
+        platform_registry.register_kv_wrapper("musa", lambda tensor: tensor)
+        platform_registry.register_availability("musa", lambda: True)
+
+        context = create_transfer_context(
+            _fake_musa_kv_caches(),
+            mode="lmcache_driven",
+        )
+    finally:
+        platform_registry.restore(snapshot)
+
+    assert isinstance(context, LMCacheDrivenTransferContext)
+
+
+def test_musa_ipc_wrapper_rejects_non_musa_tensor() -> None:
+    """The MUSA IPC wrapper never accepts CPU tensors by accident."""
+    # First Party
+    from lmcache.v1.platform.musa.ipc import MusaIPCWrapper
+
+    with pytest.raises(ValueError, match="expected a MUSA tensor"):
+        MusaIPCWrapper(torch.empty(4))
+
+
+def test_musa_ipc_wrapper_uses_device_agnostic_wire_base() -> None:
+    """Stage4 uses the device-agnostic KVCache wire base for MUSA handles."""
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import DeviceIPCWrapper, KVCache
+    from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
+    from lmcache.v1.platform.musa.ipc import MusaIPCWrapper
+
+    assert issubclass(MusaIPCWrapper, DeviceIPCWrapper)
+    assert not issubclass(MusaIPCWrapper, CudaIPCWrapper)
+    assert MusaIPCWrapper.device_type == "musa"
+    assert KVCache == list[DeviceIPCWrapper]


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds the Stage 4.1 safety boundary for the MUSA MP handle path on top of the `DeviceIPCWrapper` platform auto-discovery design from LMCache/LMCache#3829.

It adds a `MusaIPCWrapper` boundary, registers MUSA availability through the platform registry, and gates explicit MUSA `lmcache_driven` mode behind required capability checks. In `auto` mode, MUSA continues to use the existing Stage 3 engine-driven data path, so CPU/CUDA behavior should remain unaffected.

## Special notes for reviewers

This PR intentionally does not enable a production MUSA handle-transfer path yet. It adds the fail-closed capability gate and wrapper boundary.

The handle path remains disabled unless all required conditions are met:
- explicit opt-in through `LMCACHE_MUSA_HANDLE_TRANSFER`
- visible TorchMUSA runtime
- TorchMUSA memory IPC support
- TorchMUSA IPC event support
- validated server-side MUSA block-transfer support

Missing capability fails early with a clear error and recommends `engine_driven` or `auto`.

## Validation

- Focused validation run locally:
```bash
.venv/bin/python -m pytest -q \
  tests/v1/test_musa_mp_handle.py \
  tests/v1/multiprocess/test_engine_driven_transfer.py \
  tests/v1/multiprocess/test_mq.py
Result: 73 passed, 1 skipped.
```
- E2E test with vllm 0.20 passed.


**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests