### PR TITLE
[good-first-issue] cleanup: Move type-only imports under TYPE_CHECKING

### DIFF
--- a/lmcache/integration/vllm/lmcache_connector_v1.py
+++ b/lmcache/integration/vllm/lmcache_connector_v1.py
@@ -4,7 +4,6 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 # Third Party
-from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
@@ -20,6 +19,7 @@ from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
 if TYPE_CHECKING:
     # Third Party
     from vllm.attention.backends.abstract import AttentionMetadata
+    from vllm.config import VllmConfig
     from vllm.forward_context import ForwardContext
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.request import Request

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 # Standard
 from collections import defaultdict
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # Third Party
 import torch


### PR DESCRIPTION
**Summary**

Move two imports that are used only for type annotations under `TYPE_CHECKING` guards, reducing unnecessary runtime imports and keeping top-level imports cleaner.

**Changes**

1. **`lmcache/integration/vllm/lmcache_connector_v1.py`**: `VllmConfig` was imported at the top level but only used in a string annotation (`vllm_config: "VllmConfig"`). Moved into the existing `TYPE_CHECKING` block.

2. **`lmcache/v1/kv_layer_groups.py`**: `Sequence` from `collections.abc` was imported at the top level but only used in type annotations (file has `from __future__ import annotations`). Moved under a new `TYPE_CHECKING` guard.

**Testing**

These are purely mechanical import relocations — no runtime behavior changes. Each import was verified to only appear in annotation positions (not instantiated, not used with isinstance, not called).