### PR TITLE
docs: daily drift check — multi-process mode (2026-06-18)

### DIFF
--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -282,6 +282,24 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
        match, reconciles, issues one sparse-coalesced prefetch, and
        classifies per-TP-rank. Returns ``CBUnifiedLookupResult`` (or
        ``None`` while the prefetch is still in flight).
+   * - ``P2P_LOOKUP_AND_LOCK``
+     - BLOCKING
+     - (P2P) Look up the given keys and read-lock the locally cached
+       prefix. Returns a task id which the caller passes to
+       ``P2P_QUERY_LOOKUP_RESULTS`` to poll for the transfer addresses.
+       Part of the peer-to-peer KV cache sharing surface; the handler
+       module is not yet wired into the default
+       ``build_engine_modules()`` path -- see :doc:`p2p`.
+   * - ``P2P_QUERY_LOOKUP_RESULTS``
+     - BLOCKING
+     - (P2P) Poll the transfer addresses for a lookup task. Returns a
+       list of ``TransferChannelAddress`` once the lookup is complete,
+       or ``None`` while the lookup is still in progress or its
+       results have already been consumed.
+   * - ``P2P_UNLOCK_OBJECTS``
+     - BLOCKING
+     - (P2P) Release the read locks previously taken by
+       ``P2P_LOOKUP_AND_LOCK`` on the given keys.
 
 **Handler types:**
 


### PR DESCRIPTION
## Summary

Daily docs drift check for **multi-process (MP) mode**, scoped to `docs/source/` and `docs/design/`. One new drift item found in `docs/source/`; nothing actionable in `docs/design/`.

### `docs/source/`

- **`docs/source/mp/index.rst`** — the **"RequestType enum"** table (under *ZMQ Protocol*) was missing the three new P2P request types introduced by [#3728](https://github.com/LMCache/LMCache/pull/3728) ("[MP][P2P] Open a new RPC interface for P2P lookup and lock"):
  - `P2P_LOOKUP_AND_LOCK`
  - `P2P_QUERY_LOOKUP_RESULTS`
  - `P2P_UNLOCK_OBJECTS`

  The doc explicitly states it enumerates the `RequestType` enum "defined in `protocols/base.py`", and `initialize_protocols()` validates at server boot that every enum member has a matching protocol definition — so the three new members are part of the public protocol surface even though the `P2PController` handler module is not yet wired into the default `_build_modules()` path in `lmcache/v1/multiprocess/server.py`.

### `docs/design/`

No new drift found this run. The MP-relevant design pages under `docs/design/v1/multiprocess/`, `docs/design/v1/distributed/`, and `docs/design/v1/mp_coordinator/` were updated alongside their respective code changes (e.g. [#3712](https://github.com/LMCache/LMCache/pull/3712) added `docs/design/v1/distributed/transfer_channel/overall.md`; [#3662](https://github.com/LMCache/LMCache/pull/3662) added `docs/design/v1/multiprocess/l2_apis.md`).

## Evidence

| Stale doc | Authoritative code | Notes |
| --- | --- | --- |
| [`docs/source/mp/index.rst` lines 240-285](https://github.com/LMCache/LMCache/blob/84685ef/docs/source/mp/index.rst#L240-L285) (`RequestType enum` table — ends at `CB_UNIFIED_LOOKUP`, missing the P2P group) | [`lmcache/v1/multiprocess/protocols/base.py` lines 87-90](https://github.com/LMCache/LMCache/blob/84685ef/lmcache/v1/multiprocess/protocols/base.py#L87-L90) (three new `P2P_*` enum members) and [`lmcache/v1/multiprocess/protocols/p2p.py` lines 16-22](https://github.com/LMCache/LMCache/blob/84685ef/lmcache/v1/multiprocess/protocols/p2p.py#L16-L22) (matching `ProtocolDefinition`s, all `BLOCKING`) | Handler implementations live in [`lmcache/v1/multiprocess/modules/p2p_controller.py`](https://github.com/LMCache/LMCache/blob/84685ef/lmcache/v1/multiprocess/modules/p2p_controller.py) but the controller is not instantiated by `_build_modules()` yet, so the RPC is currently unrouted. |

## Proposed fix (already applied in this PR)

`docs/source/mp/index.rst`:

- Adds three new rows to the **`RequestType` enum** table for `P2P_LOOKUP_AND_LOCK`, `P2P_QUERY_LOOKUP_RESULTS`, and `P2P_UNLOCK_OBJECTS`, each marked `BLOCKING` to match `HandlerType.BLOCKING` in `protocols/p2p.py`.
- The first row notes that the handler module is not yet wired into the default `build_engine_modules()` path and points readers at `docs/source/mp/p2p.rst` for the current MP P2P status (still labelled "coming soon").

Descriptions are paraphrased from the protocol-definition comments in `lmcache/v1/multiprocess/protocols/p2p.py` so the doc and the in-code reference stay in sync.

## Carry-over from prior runs (not addressed here)

[#3738](https://github.com/LMCache/LMCache/pull/3738) (the 2026-06-17 drift PR) is still open and still applies as of `dev@84685ef`: `docs/source/cli/coordinator.rst` does not yet document `--blend-chunk-size` / `--blend-probe-stride` from [#3731](https://github.com/LMCache/LMCache/pull/3731). Today's PR intentionally leaves that branch alone so reviewers can land them independently.

## What was checked

- Reviewed every MP-relevant commit on `dev` from 2026-06-17 through 2026-06-18 against `docs/source/mp/`, `docs/source/cli/`, and `docs/source/kv_cache/`:
  - [#3725](https://github.com/LMCache/LMCache/pull/3725) (MUSA MP engine-driven non-handle path), [#3743](https://github.com/LMCache/LMCache/pull/3743) (runtime L2 adapter registration), [#3444](https://github.com/LMCache/LMCache/pull/3444) (PDBackendAsync race fixes), [#3676](https://github.com/LMCache/LMCache/pull/3676) (KV-transfer enum refactor) — code-internal, no user-doc surface affected.
  - [#3732](https://github.com/LMCache/LMCache/pull/3732) (`LMCacheCoordinator` operator CRD) — already added 256 lines to `docs/source/mp/operator.rst`.
  - [#3708](https://github.com/LMCache/LMCache/pull/3708) (coordinator CacheBlend lookup optimization) — already updated `docs/design/v1/mp_coordinator/blend_lookup.md`.
  - [#3728](https://github.com/LMCache/LMCache/pull/3728) (P2P RPC interface) — **drift fixed by this PR.**
  - [#3742](https://github.com/LMCache/LMCache/pull/3742) (GLM 5.2 recipe), [#3744](https://github.com/LMCache/LMCache/pull/3744) (Chinese translation refresh) — pure docs.
  - [#3662](https://github.com/LMCache/LMCache/pull/3662) (L2 resync/eviction via L2 API) — already updated `docs/source/cli/coordinator.rst`, `docs/source/mp/coordinator.rst`, `docs/source/mp/http_api.rst`.
  - [#3711](https://github.com/LMCache/LMCache/pull/3711) (`cb.coordinator_match` span) — already updated `docs/design/v1/mp_observability/blend_v3_observability.md`.
  - [#3584](https://github.com/LMCache/LMCache/pull/3584) (Device-DAX L1 overflow) — already updated `docs/source/mp/configuration.rst`.
  - [#3712](https://github.com/LMCache/LMCache/pull/3712) (transfer channel abstraction) — added design doc; user doc (`docs/source/mp/p2p.rst`) still legitimately reads "coming soon" because the controller is not wired.
  - [#3587](https://github.com/LMCache/LMCache/pull/3587) (`nixl_presence_cache_only`) — touches only the **legacy** `lmcache/v1/storage_backend/nixl_storage_backend.py`; verified that the MP `nixl_store` / `nixl_store_dynamic` adapters under `lmcache/v1/distributed/l2_adapters/` do **not** expose a presence-cache knob, so `docs/source/mp/l2_storage/nixl.rst` is not affected.
- Cross-checked the rest of `docs/source/mp/` against current MP server, storage manager, and coordinator code at `dev@84685ef`. No other inconsistencies found.

## Notes

- Auto-generated by the daily drift-check routine; please review before merging.
- Doc-only change. No code touched.
- Do not merge without human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXDnRsU1wh2RkHbtVRNSTS)_