### PR TITLE
test(operator): CacheBlend operator integration smoke (GPU)

### DIFF
--- a/.buildkite/operator/integration/tests.yaml
+++ b/.buildkite/operator/integration/tests.yaml
@@ -1,3 +1,11 @@
+# The CacheBlend integration spec (cacheblend_integration_smoke_test.go) pulls a
+# PRIVATE payload image. Set these as pipeline secrets in the Buildkite UI (same
+# mechanism as HF_TOKEN); they propagate through `make test-e2e-gpu-kind` ->
+# `go test` -> the spec via os.Getenv. Do NOT hardcode the token here.
+#   CACHEBLEND_REGISTRY_USER   docker registry username (e.g. Docker Hub user)
+#   CACHEBLEND_REGISTRY_TOKEN  docker registry read-only PAT
+#   CACHEBLEND_REGISTRY_SERVER optional, default https://index.docker.io/v1/
+# When USER/TOKEN are unset the spec Skips, so this build stays green without them.
 env:
   GPU_KIND_CLUSTER: "operator-test-e2e-gpu-${BUILDKITE_BUILD_NUMBER}"
 

--- a/operator/AGENTS.md
+++ b/operator/AGENTS.md
@@ -283,7 +283,7 @@ Timeout is 60 min — cold image pulls + model download routinely eat
 #### CacheBlend integration knobs
 
 `cacheblend_integration_smoke_test.go` pulls a **private** payload image
-(`tensormesh/cacheblend-plugin:nightly-latest`). It builds a
+(`tensormesh/cacheblend-plugin:latest-nightly`). It builds a
 `dockerconfigjson` pull Secret in the test namespace from env credentials, so
 set these (in Buildkite: pipeline secrets, same mechanism as `HF_TOKEN`):
 
@@ -292,11 +292,11 @@ set these (in Buildkite: pipeline secrets, same mechanism as `HF_TOKEN`):
 - `CACHEBLEND_REGISTRY_SERVER` — registry server (default
   `https://index.docker.io/v1/` for Docker Hub).
 - `CACHEBLEND_PAYLOAD_IMAGE` — override the private plugin image (default
-  `tensormesh/cacheblend-plugin:nightly-latest`).
+  `tensormesh/cacheblend-plugin:latest-nightly`).
 - `CACHEBLEND_ENGINE_IMAGE` — blend server image (default
   `lmcache/vllm-openai:latest-nightly`). `VLLM_IMAGE` (also defaults to
   `latest-nightly` for this spec) / `VLLM_MODEL` apply as above. Engine, vLLM,
-  and the nightly-latest payload plugin must share a compatibility window.
+  and the latest-nightly payload plugin must share a compatibility window.
 - `CACHEBLEND_BACKEND_LOG_PATTERN` — regex proving vLLM loaded the CUSTOM
   attention backend (default `Using AttentionBackendEnum\.CUSTOM backend`).
 - `SKIP_CACHEBLEND_INTEGRATION=true` — skip this spec.

--- a/operator/AGENTS.md
+++ b/operator/AGENTS.md
@@ -123,6 +123,7 @@ Both names point at the same image; only the hostnames differ.
 |---|---|
 | `runtime_smoke_test.go` | HTTP `/conf` round-trip — proves CR field values reach the live LMCache server (not just the K8s objects) by asserting `mp.port` / `mp.chunk_size` / `mp.max_workers` / `mp.hash_algorithm` / `http.http_port` against the running pod's `/conf` payload. |
 | `vllm_integration_smoke_test.go` | vLLM + LMCache round-trip — spins up a vLLM `Deployment` configured against the operator's `<engine>-connection` ConfigMap with `--no-enable-prefix-caching`, sends the same long prompt twice, and asserts `lmcache:num_hit_tokens` on the LMCache `/metrics` endpoint increments on the second call. |
+| `cacheblend_integration_smoke_test.go` | vLLM + CacheBlendEngine round-trip — reconciles a `CacheBlendEngine` (blend server DaemonSet), creates an args-only vLLM `Deployment` that opts into CacheBlend injection (label `lmcache.ai/cacheblend-inject` + engine annotation), and asserts: the mutating webhook stamped `cacheblend-injected=true` and injected `--attention-backend CUSTOM`; vLLM logs the CUSTOM backend banner and serves `/v1/models`; the engine logs `Registered CB rope state for instance N` after a completion; the completion returns HTTP 200. Pulls the PRIVATE payload image via a `dockerconfigjson` Secret built from `CACHEBLEND_REGISTRY_USER`/`CACHEBLEND_REGISTRY_TOKEN` — **Skips** if those are unset. |
 
 ### Prerequisites
 
@@ -278,6 +279,27 @@ Use when targeting OpenShift / EKS / GKE GPU clusters. Prerequisites:
 
 Timeout is 60 min — cold image pulls + model download routinely eat
 20+ min before the first inference.
+
+#### CacheBlend integration knobs
+
+`cacheblend_integration_smoke_test.go` pulls a **private** payload image
+(`tensormesh/cacheblend-plugin:nightly-latest`). It builds a
+`dockerconfigjson` pull Secret in the test namespace from env credentials, so
+set these (in Buildkite: pipeline secrets, same mechanism as `HF_TOKEN`):
+
+- `CACHEBLEND_REGISTRY_USER` / `CACHEBLEND_REGISTRY_TOKEN` — registry username +
+  read-only PAT. **Unset ⇒ the spec Skips** (keeps credential-less clusters green).
+- `CACHEBLEND_REGISTRY_SERVER` — registry server (default
+  `https://index.docker.io/v1/` for Docker Hub).
+- `CACHEBLEND_PAYLOAD_IMAGE` — override the private plugin image (default
+  `tensormesh/cacheblend-plugin:nightly-latest`).
+- `CACHEBLEND_ENGINE_IMAGE` — blend server image (default
+  `lmcache/vllm-openai:latest-nightly`). `VLLM_IMAGE` (also defaults to
+  `latest-nightly` for this spec) / `VLLM_MODEL` apply as above. Engine, vLLM,
+  and the nightly-latest payload plugin must share a compatibility window.
+- `CACHEBLEND_BACKEND_LOG_PATTERN` — regex proving vLLM loaded the CUSTOM
+  attention backend (default `Using AttentionBackendEnum\.CUSTOM backend`).
+- `SKIP_CACHEBLEND_INTEGRATION=true` — skip this spec.
 
 ---
 

--- a/operator/test/e2e/cacheblend_integration_smoke_test.go
+++ b/operator/test/e2e/cacheblend_integration_smoke_test.go
@@ -128,6 +128,12 @@ var _ = Describe("vLLM + CacheBlendEngine integration smoke (GPU)", Ordered, fun
 		cbe, err := utils.NewCBEFromFixture("cacheblendengine.yaml", nsName, "cb-integration")
 		Expect(err).NotTo(HaveOccurred())
 		setImageSpec(&cbe.Spec.Image, engineImage)
+		// The fixture always carries an injection block, but guard against a
+		// future fixture edit dropping it — a nil Injection here would panic
+		// rather than fail the spec cleanly.
+		if cbe.Spec.Injection == nil {
+			cbe.Spec.Injection = &lmcachev1alpha1.InjectionSpec{}
+		}
 		setImageSpec(&cbe.Spec.Injection.PayloadImage, payloadImage)
 		Expect(utils.ApplyCBE(ctx, k8sClient, cbe)).To(Succeed())
 

--- a/operator/test/e2e/cacheblend_integration_smoke_test.go
+++ b/operator/test/e2e/cacheblend_integration_smoke_test.go
@@ -1,0 +1,276 @@
+//go:build e2e && e2e_gpu
+// +build e2e,e2e_gpu
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	lmcachev1alpha1 "github.com/LMCache/LMCache/api/v1alpha1"
+	"github.com/LMCache/LMCache/test/utils"
+)
+
+// vLLM + CacheBlendEngine round-trip (e2e_gpu): verifies the full CacheBlend
+// operator integration on a GPU node.
+//
+// The flow exercises every moving part:
+//  1. A CacheBlendEngine reconciles into a node-local `lmcache server
+//     --engine-type blend` DaemonSet pod.
+//  2. A vLLM Deployment opts in to CacheBlend injection (label + engine
+//     annotation). The mutating webhook injects the CacheBlend vLLM flags
+//     (--attention-backend CUSTOM, --kv-transfer-config <engine>, etc.), the
+//     cb-plugin init container, hostIPC, and the private payload's pull secret.
+//  3. vLLM loads the CUSTOM attention backend (asserted on the injected args
+//     AND on vLLM's own startup banner), starts, and serves /v1/models.
+//  4. A completion request drives a forward pass, which makes vLLM's connector
+//     register its rope cache with the engine — the engine logs
+//     "Registered CB rope state for instance N".
+//  5. The completion returns HTTP 200.
+//
+// Because failurePolicy on the webhook is Ignore (fail-open), a missing webhook
+// would admit the vLLM pod UNMUTATED and silently degrade this to a non-blend
+// run. We defend against that by asserting the webhook's success stamp
+// (lmcache.ai/cacheblend-injected=true) and the injected arg directly off the
+// pod object — not just on runtime behaviour.
+//
+// Knobs:
+//   - VLLM_MODEL                    HF model id. Default Qwen/Qwen2.5-0.5B.
+//   - VLLM_IMAGE                    vLLM image. Default lmcache/vllm-openai:latest-nightly.
+//   - CACHEBLEND_ENGINE_IMAGE       blend server image. Default lmcache/vllm-openai:latest-nightly.
+//   - CACHEBLEND_PAYLOAD_IMAGE      PRIVATE plugin image. Default
+//     tensormesh/cacheblend-plugin:nightly-latest.
+//   - CACHEBLEND_REGISTRY_USER      Docker registry username for the payload image.
+//   - CACHEBLEND_REGISTRY_TOKEN     Docker registry password / PAT (read-only pull).
+//   - CACHEBLEND_REGISTRY_SERVER    Registry server. Default https://index.docker.io/v1/.
+//   - CACHEBLEND_BACKEND_LOG_PATTERN  Regex proving the CUSTOM backend loaded.
+//     Default `Using AttentionBackendEnum\.CUSTOM backend`.
+//   - SKIP_CACHEBLEND_INTEGRATION   "true" skips this spec.
+//
+// When CACHEBLEND_REGISTRY_USER/TOKEN are unset the spec Skips (the private
+// payload image cannot be pulled), so the suite stays green on clusters
+// without registry credentials.
+var _ = Describe("vLLM + CacheBlendEngine integration smoke (GPU)", Ordered, func() {
+	const pullSecretName = "cacheblend-registry"
+
+	var (
+		ctx    context.Context
+		nsName string
+	)
+
+	BeforeEach(func() {
+		if os.Getenv("SKIP_CACHEBLEND_INTEGRATION") == "true" {
+			Skip("SKIP_CACHEBLEND_INTEGRATION=true; skipping CacheBlend round-trip spec")
+		}
+		if os.Getenv("CACHEBLEND_REGISTRY_USER") == "" || os.Getenv("CACHEBLEND_REGISTRY_TOKEN") == "" {
+			Skip("CACHEBLEND_REGISTRY_USER/CACHEBLEND_REGISTRY_TOKEN unset; " +
+				"cannot pull the private cacheblend-plugin payload image")
+		}
+		ctx = context.Background()
+		nsName = createTestNamespace(ctx)
+	})
+
+	AfterEach(func() {
+		recordOnFailure(nsName)
+		// The vLLM Deployment, the CacheBlendEngine, and the pull Secret are
+		// all in the test namespace, so namespace deletion (DeferCleanup in
+		// createTestNamespace) cleans everything up. No explicit teardown.
+	})
+
+	It("injects CacheBlend, registers rope state on the engine, and serves a completion", func() {
+		model := envDefault("VLLM_MODEL", "Qwen/Qwen2.5-0.5B")
+		// nightly by default: the engine, vLLM, and the nightly-latest payload
+		// plugin must sit in the same CacheBlend compatibility window.
+		vllmImage := envDefault("VLLM_IMAGE", "lmcache/vllm-openai:latest-nightly")
+		engineImage := envDefault("CACHEBLEND_ENGINE_IMAGE", "lmcache/vllm-openai:latest-nightly")
+		payloadImage := envDefault("CACHEBLEND_PAYLOAD_IMAGE", "tensormesh/cacheblend-plugin:nightly-latest")
+		backendLog := regexp.MustCompile(
+			envDefault("CACHEBLEND_BACKEND_LOG_PATTERN", `Using AttentionBackendEnum\.CUSTOM backend`))
+
+		By("creating the private-registry pull Secret from env credentials")
+		Expect(utils.CreateDockerConfigJSONSecret(
+			ctx, k8sClient, nsName, pullSecretName,
+			envDefault("CACHEBLEND_REGISTRY_SERVER", "https://index.docker.io/v1/"),
+			os.Getenv("CACHEBLEND_REGISTRY_USER"),
+			os.Getenv("CACHEBLEND_REGISTRY_TOKEN"),
+		)).To(Succeed())
+
+		By("applying the CacheBlendEngine")
+		cbe, err := utils.NewCBEFromFixture("cacheblendengine.yaml", nsName, "cb-integration")
+		Expect(err).NotTo(HaveOccurred())
+		setImageSpec(&cbe.Spec.Image, engineImage)
+		setImageSpec(&cbe.Spec.Injection.PayloadImage, payloadImage)
+		Expect(utils.ApplyCBE(ctx, k8sClient, cbe)).To(Succeed())
+
+		key := engineKey(nsName, cbe.Name)
+		Expect(utils.WaitCBEReconciled(ctx, k8sClient, key, 60*time.Second)).To(Succeed())
+
+		By("waiting for the CacheBlend engine DaemonSet pod to become Ready")
+		// 8 min covers the cold pull of the engine image on a fresh GPU node.
+		enginePod, err := utils.WaitDaemonSetPodReady(ctx, k8sClient, key, 8*time.Minute)
+		Expect(err).NotTo(HaveOccurred(), "CacheBlend engine pod did not become Ready")
+
+		By("verifying the blend engine logged its ZMQ listening line")
+		Eventually(func() int {
+			return countLogLines(ctx, nsName, enginePod, cbServerListeningLine)
+		}, 60*time.Second, 2*time.Second).Should(BeNumerically(">=", 1),
+			"blend engine never logged 'LMCache ZMQ cache server is running' — server did not bind")
+
+		By("applying the vLLM Deployment that opts into CacheBlend injection")
+		vllmRaw, err := utils.LoadFixture("vllm_cacheblend_deployment.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		vllmYAML := substituteVLLMPlaceholders(string(vllmRaw), nsName, cbe.Name, model, vllmImage)
+		vllmDeploy := &appsv1.Deployment{}
+		Expect(yaml.Unmarshal([]byte(vllmYAML), vllmDeploy)).To(Succeed())
+		Expect(k8sClient.Create(ctx, vllmDeploy)).To(Succeed())
+
+		By("verifying the mutating webhook injected CacheBlend into the vLLM pod")
+		// The mutation happens at admission, so the pod carries the stamp and
+		// the injected args as soon as it exists — no need to wait for Running.
+		Eventually(func(g Gomega) {
+			pod := firstPodForDeployment(ctx, nsName, vllmDeploy)
+			g.Expect(pod).NotTo(BeNil(), "no vLLM pod created yet")
+			g.Expect(pod.Annotations).To(HaveKeyWithValue("lmcache.ai/cacheblend-injected", "true"),
+				"webhook did not stamp cacheblend-injected=true; injection did not fire "+
+					"(skip-reason=%q)", pod.Annotations["lmcache.ai/cacheblend-skip-reason"])
+			args := vllmContainerArgs(pod)
+			g.Expect(argValue(args, "--attention-backend")).To(Equal("CUSTOM"),
+				"injected args missing '--attention-backend CUSTOM': %v", args)
+		}, 60*time.Second, 2*time.Second).Should(Succeed())
+
+		By("waiting for the vLLM Deployment to become Available (model load + connector handshake)")
+		// 15 min — cold image pull (~10GB) + payload init container pull +
+		// model config download + vLLM startup. /v1/models gates readiness.
+		Expect(utils.WaitDeploymentAvailable(
+			ctx, k8sClient,
+			types.NamespacedName{Namespace: nsName, Name: vllmDeploy.Name},
+			15*time.Minute,
+		)).To(Succeed(), "vLLM did not become Available — check pod events / logs")
+
+		vllmPod := firstPodForDeployment(ctx, nsName, vllmDeploy)
+		Expect(vllmPod).NotTo(BeNil(), "vLLM pod disappeared after the Deployment became Available")
+
+		By("verifying vLLM logged the CUSTOM attention backend banner")
+		Eventually(func() int {
+			return countLogLines(ctx, nsName, vllmPod.Name, backendLog)
+		}, 60*time.Second, 2*time.Second).Should(BeNumerically(">=", 1),
+			"vLLM never logged the CUSTOM attention backend banner (pattern %q) — "+
+				"the injected --attention-backend CUSTOM did not take effect", backendLog.String())
+
+		By("port-forwarding to the vLLM service for completion requests")
+		vllmCloser, vllmBaseURL, err := utils.PortForward(
+			utils.PortForwardSpec{Namespace: nsName, Target: "deployment/" + vllmDeploy.Name},
+			"0:8000",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		defer vllmCloser()
+		Expect(utils.WaitHTTP200(ctx, vllmBaseURL+"/v1/models", 60*time.Second)).To(Succeed())
+
+		By("sending a /v1/completions request and asserting HTTP 200")
+		Expect(postCompletion(ctx, vllmBaseURL, model, buildLongPrompt())).To(Succeed())
+
+		By("verifying the engine logged 'Registered CB rope state for instance N'")
+		// The forward pass drives vLLM's connector to send CB_REGISTER_ROPE_V3,
+		// which the engine handles and logs. kubectl log streaming buffers a
+		// beat behind, so poll.
+		Eventually(func() int {
+			return countLogLines(ctx, nsName, enginePod, cbRopeRegisteredLine)
+		}, 60*time.Second, 2*time.Second).Should(BeNumerically(">=", 1),
+			"engine never logged 'Registered CB rope state' — the CacheBlend rope "+
+				"handshake from vLLM did not reach the engine")
+
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"CacheBlend round-trip satisfied (engine pod=%s, vLLM pod=%s)\n",
+			enginePod, vllmPod.Name)
+	})
+})
+
+// cbServerListeningLine matches the blend engine's "server is listening" INFO
+// line (server.py), proving the lmcache server bound its ZMQ socket.
+var cbServerListeningLine = regexp.MustCompile(`LMCache ZMQ cache server is running`)
+
+// cbRopeRegisteredLine matches the engine-side log emitted by
+// BlendV3.cb_register_rope on every CB_REGISTER_ROPE_V3 message
+// (modules/blend_v3.py). Its presence proves the vLLM connector negotiated
+// the CacheBlend rope handshake with the engine.
+var cbRopeRegisteredLine = regexp.MustCompile(`Registered CB rope state for instance \d+`)
+
+// setImageSpec rewrites an ImageSpec's repository+tag from a "repo:tag" image
+// reference (the env-knob form), allocating the ImageSpec if nil. A reference
+// with no tag defaults the tag to "latest". The split is on the LAST colon, so
+// it does not handle a registry-host:port prefix on an untagged reference —
+// the smoke knobs never use that form.
+func setImageSpec(spec **lmcachev1alpha1.ImageSpec, ref string) {
+	repo, tag := ref, "latest"
+	if i := strings.LastIndex(ref, ":"); i >= 0 && !strings.Contains(ref[i+1:], "/") {
+		repo, tag = ref[:i], ref[i+1:]
+	}
+	if *spec == nil {
+		*spec = &lmcachev1alpha1.ImageSpec{}
+	}
+	(*spec).Repository = &repo
+	(*spec).Tag = &tag
+}
+
+// firstPodForDeployment returns the first non-terminating pod selected by the
+// Deployment's pod selector, or nil if none exist yet. Returns the typed Pod
+// so callers can read both annotations (injection stamp) and container args.
+func firstPodForDeployment(ctx context.Context, ns string, dep *appsv1.Deployment) *corev1.Pod {
+	pods := &corev1.PodList{}
+	if err := k8sClient.List(ctx, pods,
+		client.InNamespace(ns),
+		client.MatchingLabels(dep.Spec.Selector.MatchLabels),
+	); err != nil {
+		return nil
+	}
+	for i := range pods.Items {
+		if pods.Items[i].DeletionTimestamp == nil {
+			return &pods.Items[i]
+		}
+	}
+	return nil
+}
+
+// vllmContainerArgs returns the args of the vLLM container in the pod (the one
+// named "vllm", falling back to the first container). The mutating webhook
+// appends the CacheBlend flags to this container's args.
+func vllmContainerArgs(pod *corev1.Pod) []string {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == "vllm" {
+			return pod.Spec.Containers[i].Args
+		}
+	}
+	if len(pod.Spec.Containers) > 0 {
+		return pod.Spec.Containers[0].Args
+	}
+	return nil
+}

--- a/operator/test/e2e/cacheblend_integration_smoke_test.go
+++ b/operator/test/e2e/cacheblend_integration_smoke_test.go
@@ -68,7 +68,7 @@ import (
 //   - VLLM_IMAGE                    vLLM image. Default lmcache/vllm-openai:latest-nightly.
 //   - CACHEBLEND_ENGINE_IMAGE       blend server image. Default lmcache/vllm-openai:latest-nightly.
 //   - CACHEBLEND_PAYLOAD_IMAGE      PRIVATE plugin image. Default
-//     tensormesh/cacheblend-plugin:nightly-latest.
+//     tensormesh/cacheblend-plugin:latest-nightly.
 //   - CACHEBLEND_REGISTRY_USER      Docker registry username for the payload image.
 //   - CACHEBLEND_REGISTRY_TOKEN     Docker registry password / PAT (read-only pull).
 //   - CACHEBLEND_REGISTRY_SERVER    Registry server. Default https://index.docker.io/v1/.
@@ -108,11 +108,11 @@ var _ = Describe("vLLM + CacheBlendEngine integration smoke (GPU)", Ordered, fun
 
 	It("injects CacheBlend, registers rope state on the engine, and serves a completion", func() {
 		model := envDefault("VLLM_MODEL", "Qwen/Qwen2.5-0.5B")
-		// nightly by default: the engine, vLLM, and the nightly-latest payload
+		// nightly by default: the engine, vLLM, and the latest-nightly payload
 		// plugin must sit in the same CacheBlend compatibility window.
 		vllmImage := envDefault("VLLM_IMAGE", "lmcache/vllm-openai:latest-nightly")
 		engineImage := envDefault("CACHEBLEND_ENGINE_IMAGE", "lmcache/vllm-openai:latest-nightly")
-		payloadImage := envDefault("CACHEBLEND_PAYLOAD_IMAGE", "tensormesh/cacheblend-plugin:nightly-latest")
+		payloadImage := envDefault("CACHEBLEND_PAYLOAD_IMAGE", "tensormesh/cacheblend-plugin:latest-nightly")
 		backendLog := regexp.MustCompile(
 			envDefault("CACHEBLEND_BACKEND_LOG_PATTERN", `Using AttentionBackendEnum\.CUSTOM backend`))
 
@@ -170,7 +170,9 @@ var _ = Describe("vLLM + CacheBlendEngine integration smoke (GPU)", Ordered, fun
 		By("waiting for the vLLM Deployment to become Available (model load + connector handshake)")
 		// 15 min — cold image pull (~10GB) + payload init container pull +
 		// model config download + vLLM startup. /v1/models gates readiness.
-		Expect(utils.WaitDeploymentAvailable(
+		// Fails fast (~seconds) if the private payload pull is wedged
+		// (bad/missing pull secret, wrong tag) rather than burning the timeout.
+		Expect(utils.WaitDeploymentAvailableOrImagePullError(
 			ctx, k8sClient,
 			types.NamespacedName{Namespace: nsName, Name: vllmDeploy.Name},
 			15*time.Minute,

--- a/operator/test/e2e/smoke_helpers_test.go
+++ b/operator/test/e2e/smoke_helpers_test.go
@@ -130,7 +130,13 @@ func dumpNamespace(ns string) {
 	for _, args := range [][]string{
 		{"get", "events", "-n", ns, "--sort-by=.lastTimestamp"},
 		{"get", "lmcacheengines", "-n", ns, "-o", "yaml"},
+		{"get", "cacheblendengines", "-n", ns, "-o", "yaml"},
 		{"get", "pods", "-n", ns, "-o", "wide"},
+		// imagePullSecrets is not rendered by `describe pod`; print it
+		// explicitly so a wedged private-image pull can be triaged as
+		// "secret not attached" vs "bad credentials".
+		{"get", "pods", "-n", ns, "-o",
+			"jsonpath={range .items[*]}{.metadata.name}{\" imagePullSecrets=\"}{.spec.imagePullSecrets}{\"\\n\"}{end}"},
 		{"describe", "pods", "-n", ns},
 	} {
 		out, _ := exec.Command("kubectl", args...).CombinedOutput()

--- a/operator/test/utils/cbe.go
+++ b/operator/test/utils/cbe.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	lmcachev1alpha1 "github.com/LMCache/LMCache/api/v1alpha1"
+)
+
+// NewCBEFromFixture loads a fixture YAML, decodes it as a CacheBlendEngine,
+// and overrides metadata.name and metadata.namespace with the supplied
+// values. It mirrors NewLMCFromFixture for the CacheBlend engine type so the
+// GPU smoke tier can parameterise a fixture against a fresh namespace. Callers
+// can mutate the returned object further (e.g. inject env-driven images and
+// pull secrets) before applying.
+func NewCBEFromFixture(fixtureName, namespace, name string) (*lmcachev1alpha1.CacheBlendEngine, error) {
+	data, err := LoadFixture(fixtureName)
+	if err != nil {
+		return nil, err
+	}
+	cbe := &lmcachev1alpha1.CacheBlendEngine{}
+	if err := yaml.Unmarshal(data, cbe); err != nil {
+		return nil, fmt.Errorf("decode fixture %q: %w", fixtureName, err)
+	}
+	if name != "" {
+		cbe.Name = name
+	}
+	if namespace != "" {
+		cbe.Namespace = namespace
+	}
+	// Strip any server-side metadata that may have leaked through.
+	cbe.ResourceVersion = ""
+	cbe.UID = ""
+	cbe.Generation = 0
+	return cbe, nil
+}
+
+// ApplyCBE creates the CacheBlendEngine if absent, or patches it (spec only)
+// if it already exists. The status subresource is left untouched. Mirrors
+// ApplyLMC.
+func ApplyCBE(ctx context.Context, c client.Client, cbe *lmcachev1alpha1.CacheBlendEngine) error {
+	existing := &lmcachev1alpha1.CacheBlendEngine{}
+	err := c.Get(ctx, client.ObjectKeyFromObject(cbe), existing)
+	if apierrors.IsNotFound(err) {
+		return c.Create(ctx, cbe)
+	}
+	if err != nil {
+		return fmt.Errorf("get CacheBlendEngine %s/%s: %w", cbe.Namespace, cbe.Name, err)
+	}
+	patch := client.MergeFrom(existing.DeepCopy())
+	existing.Spec = cbe.Spec
+	existing.Labels = cbe.Labels
+	existing.Annotations = cbe.Annotations
+	if err := c.Patch(ctx, existing, patch); err != nil {
+		return fmt.Errorf("patch CacheBlendEngine %s/%s: %w", cbe.Namespace, cbe.Name, err)
+	}
+	*cbe = *existing
+	return nil
+}
+
+// WaitCBEReconciled polls until status.observedGeneration matches the CR's
+// metadata.generation AND the ConfigValid condition is True. This is the
+// "controller saw and validated the spec" signal — it does NOT require the
+// engine pod to be Running (use WaitDaemonSetPodReady for that, keyed on the
+// same namespaced name since the engine DaemonSet is named after the CR).
+// The CacheBlendEngine controller reuses the LMCacheEngine condition
+// constants, so ConditionConfigValid is the right key here.
+func WaitCBEReconciled(ctx context.Context, c client.Client, key types.NamespacedName, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		cbe := &lmcachev1alpha1.CacheBlendEngine{}
+		if err := c.Get(ctx, key, cbe); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		if cbe.Generation == 0 || cbe.Status.ObservedGeneration != cbe.Generation {
+			return false, nil
+		}
+		cond := meta.FindStatusCondition(cbe.Status.Conditions, lmcachev1alpha1.ConditionConfigValid)
+		return cond != nil && cond.Status == "True", nil
+	})
+}

--- a/operator/test/utils/fixtures/cacheblendengine.yaml
+++ b/operator/test/utils/fixtures/cacheblendengine.yaml
@@ -1,0 +1,50 @@
+# CacheBlendEngine used by the e2e_gpu CacheBlend integration spec.
+#
+# NewCBEFromFixture decodes this YAML into a typed CacheBlendEngine and
+# overrides metadata.name / metadata.namespace. The spec then overrides the
+# two env-driven, deployment-specific bits before applying:
+#
+#   - spec.image                       (CACHEBLEND_ENGINE_IMAGE; the lmcache
+#                                       blend server image — public by default)
+#   - spec.injection.payloadImage      (CACHEBLEND_PAYLOAD_IMAGE; the PRIVATE
+#                                       cacheblend-plugin init-container image)
+#
+# spec.injection.imagePullSecrets references the docker-registry Secret the
+# spec creates in this namespace from CACHEBLEND_REGISTRY_USER/TOKEN. The
+# mutating webhook appends it to the vLLM pod so the payload init container
+# can pull the private image.
+apiVersion: lmcache.lmcache.ai/v1alpha1
+kind: CacheBlendEngine
+metadata:
+  name: cb-integration
+spec:
+  # The lmcache blend server image. Public; pinned to the same image the
+  # vLLM workload uses so a fresh GPU node pulls it only once. Nightly to stay
+  # in the CacheBlend compatibility window with the nightly-latest payload.
+  image:
+    repository: lmcache/vllm-openai
+    tag: latest-nightly
+    pullPolicy: IfNotPresent
+
+  # L1 cache is REQUIRED. 8 GiB is plenty for the small smoke model.
+  l1:
+    sizeGB: 8
+
+  injection:
+    # The PRIVATE cacheblend-plugin init-container image. The spec overrides
+    # repository/tag from CACHEBLEND_PAYLOAD_IMAGE; these are the defaults.
+    payloadImage:
+      repository: tensormesh/cacheblend-plugin
+      tag: nightly-latest
+      pullPolicy: IfNotPresent
+    # Pull secret for the private payload image. Created by the spec in this
+    # namespace (name must match the spec's pullSecretName constant).
+    imagePullSecrets:
+      - name: cacheblend-registry
+
+  # Place the engine on the GPU worker so the vLLM pod (same nodeSelector)
+  # co-schedules — CacheBlend's CUDA-IPC KV handoff requires colocation.
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
+
+  logLevel: INFO

--- a/operator/test/utils/fixtures/cacheblendengine.yaml
+++ b/operator/test/utils/fixtures/cacheblendengine.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   # The lmcache blend server image. Public; pinned to the same image the
   # vLLM workload uses so a fresh GPU node pulls it only once. Nightly to stay
-  # in the CacheBlend compatibility window with the nightly-latest payload.
+  # in the CacheBlend compatibility window with the latest-nightly payload.
   image:
     repository: lmcache/vllm-openai
     tag: latest-nightly
@@ -35,7 +35,7 @@ spec:
     # repository/tag from CACHEBLEND_PAYLOAD_IMAGE; these are the defaults.
     payloadImage:
       repository: tensormesh/cacheblend-plugin
-      tag: nightly-latest
+      tag: latest-nightly
       pullPolicy: IfNotPresent
     # Pull secret for the private payload image. Created by the spec in this
     # namespace (name must match the spec's pullSecretName constant).

--- a/operator/test/utils/fixtures/vllm_cacheblend_deployment.yaml
+++ b/operator/test/utils/fixtures/vllm_cacheblend_deployment.yaml
@@ -1,0 +1,92 @@
+# vLLM Deployment used by the e2e_gpu CacheBlend integration spec.
+#
+# Unlike vllm_deployment.yaml (the LMCacheEngine round-trip), this pod OPTS IN
+# to CacheBlend dependency injection via the mutating webhook. The webhook
+# appends the CacheBlend vLLM flags (--attention-backend CUSTOM,
+# --kv-transfer-config <engine>, --block-size 64, --pipeline-parallel-size 1,
+# --no-enable-chunked-prefill, --no-async-scheduling, --enforce-eager), the
+# cb-plugin init container + emptyDir + PYTHONPATH, hostIPC=true, and the
+# engine's payload imagePullSecrets.
+#
+# Placeholders substituted by the spec (substituteVLLMPlaceholders):
+#   __NAMESPACE__    — engine namespace (PSS-privileged; webhook injects hostIPC)
+#   __ENGINE_NAME__  — CacheBlendEngine metadata.name (bound via annotation)
+#   __MODEL__        — Hugging Face model id
+#   __VLLM_IMAGE__   — container image (default lmcache/vllm-openai:latest)
+#
+# CRITICAL: the vLLM container MUST launch via the image ENTRYPOINT
+# (["vllm","serve"]) with args ONLY. A `command:` override makes the webhook
+# SKIP injection (it stamps lmcache.ai/cacheblend-skip-reason=command-override)
+# because appended args can't reach `vllm serve`. Do NOT add --attention-backend
+# or --kv-transfer-config here — the webhook injects both.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-cacheblend
+  namespace: __NAMESPACE__
+  labels:
+    app: vllm-cacheblend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-cacheblend
+  template:
+    metadata:
+      labels:
+        app: vllm-cacheblend
+        # OPT-IN: the webhook's objectSelector matches this label.
+        lmcache.ai/cacheblend-inject: "true"
+      annotations:
+        # BIND: names the CacheBlendEngine (same namespace) to inject for.
+        lmcache.ai/cacheblend-engine: "__ENGINE_NAME__"
+    spec:
+      # Needed for GPU access; the blend engine shares THIS pod's GPU via CUDA
+      # IPC, so engine + pod must land on the same GPU node.
+      runtimeClassName: nvidia
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      # NOTE: do NOT set hostIPC here or mount an emptyDir at /dev/shm — the
+      # webhook injects hostIPC=true (shared host /dev/shm for CUDA IPC); an
+      # emptyDir would shadow it and break cudaIpcOpenMemHandle.
+      containers:
+        - name: vllm
+          image: __VLLM_IMAGE__
+          imagePullPolicy: IfNotPresent
+          # Args-only launch (image ENTRYPOINT is ["vllm","serve"]). --load-format
+          # dummy skips weight download (the smoke asserts startup + rope
+          # registration + HTTP 200, not generation quality). gpu-memory low so
+          # the node-local blend engine has headroom on the shared GPU.
+          args:
+            - "__MODEL__"
+            - "--port"
+            - "8000"
+            - "--gpu-memory-utilization"
+            - "0.5"
+            - "--load-format"
+            - "dummy"
+          env:
+            # Deterministic prefix hashing across processes — required by LMCache.
+            - name: PYTHONHASHSEED
+              value: "0"
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "all"
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: "all"
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            # /v1/models is ready only after the model is loaded onto the GPU
+            # — a strong signal vLLM started AND the CacheBlend connector
+            # negotiated with the engine (otherwise vllm crashes during init).
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 60

--- a/operator/test/utils/secret.go
+++ b/operator/test/utils/secret.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CreateDockerConfigJSONSecret creates a kubernetes.io/dockerconfigjson pull
+// Secret in the given namespace, equivalent to
+//
+//	kubectl create secret docker-registry <name> \
+//	  --docker-server=<server> --docker-username=<username> --docker-password=<password>
+//
+// It is used by the GPU smoke tier to pull the PRIVATE cacheblend-plugin
+// payload image: the credentials arrive as env vars (e.g. from the Buildkite
+// pipeline secret store) and this Secret is referenced by the engine's
+// injection.imagePullSecrets, which the mutating webhook appends to the vLLM
+// pod that runs the payload init container.
+//
+// The Secret is recreated (delete-then-create) if one of the same name already
+// exists so reruns against a reused namespace pick up rotated credentials. The
+// password is never logged.
+func CreateDockerConfigJSONSecret(
+	ctx context.Context,
+	c client.Client,
+	namespace, name, server, username, password string,
+) error {
+	if server == "" || username == "" || password == "" {
+		return fmt.Errorf(
+			"docker-registry secret %s/%s: server, username and password are all required", namespace, name)
+	}
+
+	// .dockerconfigjson schema: {"auths":{"<server>":{username,password,auth}}}.
+	// "auth" is base64(username:password) — Docker reads this field; username
+	// and password are kept too for tooling that inspects the entry.
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	dockerCfg := map[string]any{
+		"auths": map[string]any{
+			server: map[string]any{
+				"username": username,
+				"password": password,
+				"auth":     auth,
+			},
+		},
+	}
+	raw, err := json.Marshal(dockerCfg)
+	if err != nil {
+		return fmt.Errorf("marshal dockerconfigjson for %s/%s: %w", namespace, name, err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Type:       corev1.SecretTypeDockerConfigJson,
+		Data:       map[string][]byte{corev1.DockerConfigJsonKey: raw},
+	}
+
+	err = c.Create(ctx, secret)
+	if apierrors.IsAlreadyExists(err) {
+		existing := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+		if delErr := c.Delete(ctx, existing); delErr != nil && !apierrors.IsNotFound(delErr) {
+			return fmt.Errorf("replace docker-registry secret %s/%s: delete: %w", namespace, name, delErr)
+		}
+		err = c.Create(ctx, secret)
+	}
+	if err != nil {
+		return fmt.Errorf("create docker-registry secret %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}

--- a/operator/test/utils/wait.go
+++ b/operator/test/utils/wait.go
@@ -111,3 +111,66 @@ func WaitDeploymentAvailable(
 		return false, nil
 	})
 }
+
+// WaitDeploymentAvailableOrImagePullError is WaitDeploymentAvailable with a
+// fast-fail short-circuit: it returns a descriptive error the moment any pod
+// selected by the Deployment has a container or init container wedged in
+// ImagePullBackOff. A wrong image/tag, a missing pull Secret, or a credential
+// without pull access never resolves on its own, so blocking for the full
+// timeout only delays a guaranteed failure (and buries the registry's own
+// error message, which ImagePullBackOff's waiting state carries verbatim).
+// Returns nil once Available, the pull error when a pull is wedged, or the
+// poll timeout error otherwise.
+func WaitDeploymentAvailableOrImagePullError(
+	ctx context.Context,
+	c client.Client,
+	key types.NamespacedName,
+	timeout time.Duration,
+) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		dep := &appsv1.Deployment{}
+		if err := c.Get(ctx, key, dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		for _, cond := range dep.Status.Conditions {
+			if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		if msg := imagePullBackOff(ctx, c, key.Namespace, dep.Spec.Selector.MatchLabels); msg != "" {
+			return false, fmt.Errorf(
+				"deployment %s will never become Available — image pull wedged: %s", key, msg)
+		}
+		return false, nil
+	})
+}
+
+// imagePullBackOff scans pods matching sel and returns a one-line description
+// (pod, container, image, kubelet message) of the first container or init
+// container in ImagePullBackOff, or "" if none. The kubelet message is the
+// registry's own error (e.g. "pull access denied" / "manifest unknown"), which
+// is what a caller needs to tell a credential problem from a wrong tag.
+func imagePullBackOff(ctx context.Context, c client.Client, ns string, sel map[string]string) string {
+	pods := &corev1.PodList{}
+	if err := c.List(ctx, pods, client.InNamespace(ns), client.MatchingLabels(sel)); err != nil {
+		return ""
+	}
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.DeletionTimestamp != nil {
+			continue
+		}
+		statuses := append(append([]corev1.ContainerStatus{},
+			p.Status.InitContainerStatuses...), p.Status.ContainerStatuses...)
+		for _, cs := range statuses {
+			if w := cs.State.Waiting; w != nil && w.Reason == "ImagePullBackOff" {
+				return fmt.Sprintf("pod %s container %q image %q: %s",
+					p.Name, cs.Name, cs.Image, w.Message)
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## What

Adds an `e2e_gpu` smoke spec exercising the full **CacheBlend operator** path on a GPU node, mirroring the existing `vllm_integration_smoke_test.go`:

1. Reconcile a `CacheBlendEngine` → blend-server DaemonSet pod Ready, engine logs its ZMQ listening line.
2. Apply an **args-only** vLLM `Deployment` that opts into CacheBlend injection (label + engine annotation).
3. Assert the mutating webhook fired off the pod object — `lmcache.ai/cacheblend-injected=true` and injected `--attention-backend CUSTOM` (guards the fail-open `failurePolicy: Ignore`).
4. vLLM becomes Available, logs the CUSTOM attention-backend banner, serves `/v1/models`.
5. A `/v1/completions` request drives a forward pass → engine logs `Registered CB rope state for instance N`.
6. Completion returns HTTP 200.

## Files

- `operator/test/e2e/cacheblend_integration_smoke_test.go` — the spec (`//go:build e2e && e2e_gpu`).
- `operator/test/utils/cbe.go` — `NewCBEFromFixture` / `ApplyCBE` / `WaitCBEReconciled`.
- `operator/test/utils/secret.go` — `CreateDockerConfigJSONSecret` builds the private payload-image pull Secret from env creds.
- `operator/test/utils/fixtures/{cacheblendengine,vllm_cacheblend_deployment}.yaml` — fixtures. The vLLM one is **args-only**: a `command:` override makes the webhook skip injection.
- `operator/AGENTS.md`, `.buildkite/operator/integration/tests.yaml` — document knobs + required Buildkite registry secrets.

## Private payload image

The injected `cb-plugin` init container pulls the **private** `tensormesh/cacheblend-plugin:nightly-latest`. The spec builds a `dockerconfigjson` Secret in the test namespace from:

- `CACHEBLEND_REGISTRY_USER` / `CACHEBLEND_REGISTRY_TOKEN` — set as Buildkite pipeline **secrets** (same mechanism as `HF_TOKEN`).
- `CACHEBLEND_REGISTRY_SERVER` — optional, default `https://index.docker.io/v1/`.

**When USER/TOKEN are unset the spec Skips**, so the suite stays green without credentials. Engine + vLLM + payload all default to the `latest-nightly` / `nightly-latest` compatibility window; override via `CACHEBLEND_ENGINE_IMAGE` / `VLLM_IMAGE` / `CACHEBLEND_PAYLOAD_IMAGE`.

## Test

Runs as part of `make test-e2e-gpu-kind` (the existing GPU tier — shares the Kind + GPU Operator + cert-manager + operator + webhook setup).