### PR TITLE
docs: consolidate daily drift-check fixes (2026-06-18)

### DIFF
--- a/docs/design/cli/commands.md
+++ b/docs/design/cli/commands.md
@@ -192,14 +192,15 @@ RETRIEVE → STORE → END_SESSION``).
 Supports two run modes via ``--mode``:
 
 - **``gpu``** (default) -- allocates real CUDA tensors and uses CUDA IPC
-  (handle transfer path).
+  (LMCache-driven handle transfer path).
 - **``cpu``** -- allocates POSIX-SHM-backed tensors; the server maps the same
-  physical pages for zero-copy STORE/RETRIEVE (data transfer path by default).
-  To use the zero-copy SHM handle path, add ``--transfer-mode handle``.
+  physical pages for zero-copy STORE/RETRIEVE (engine-driven transfer path by
+  default). To use the zero-copy SHM handle path, add
+  ``--transfer-mode lmcache_driven``.
 
 The transfer path can be overridden explicitly with ``--transfer-mode
-{auto,handle,data}``. ``auto`` keeps the historical mapping: gpu→handle,
-cpu→data.
+{auto,engine_driven,lmcache_driven}``. ``auto`` keeps the historical mapping:
+gpu→lmcache_driven, cpu→engine_driven.
 
 ```bash
 $ lmcache bench server \

--- a/docs/design/cli/commands/describe.md
+++ b/docs/design/cli/commands/describe.md
@@ -45,8 +45,8 @@ Slots per block:                         128
 Dtype:                                   torch.float16
 MLA:                                     False
 Attention backend:         vLLM non-MLA flash attention
-GPU KV shape:              NL x [2, NB, BS, NH, HS]
-GPU KV tensor shape:       80 x [2, 2048, 128, 8, 128]
+Engine KV shape:           NL x [2, NB, BS, NH, HS]
+Engine KV tensor shape:    80 x [2, 2048, 128, 8, 128]
 ----------- L2: NixlStoreL2Adapter ------------
 Type:                          NixlStoreL2Adapter
 Health:                                  OK
@@ -88,8 +88,8 @@ programmatic access:
         "dtype": "torch.float16",
         "is_mla": false,
         "attention_backend": "vLLM non-MLA flash attention",
-        "gpu_kv_shape": "NL x [2, NB, BS, NH, HS]",
-        "gpu_kv_concrete_shape": "80 x [2, 2048, 128, 8, 128]"
+        "engine_kv_shape": "NL x [2, NB, BS, NH, HS]",
+        "engine_kv_concrete_shape": "80 x [2, 2048, 128, 8, 128]"
       }
     ],
     "l2_adapters": [
@@ -122,11 +122,11 @@ Each kernel group section includes:
 - **Dtype** and **MLA** — the group's torch dtype and MLA flag.
 - **Attention backend** — which attention implementation is active (e.g.,
   `vLLM non-MLA flash attention`, `vLLM MLA`, `SGLang MHA`), derived from the
-  `GPUKVFormat` enum.
-- **GPU KV shape** — the symbolic tensor layout using short names matching the
-  `GPUKVFormat` enum (NB=num_blocks, NL=num_layers, BS=block_size, NH=num_heads,
+  `EngineKVFormat` enum.
+- **Engine KV shape** — the symbolic tensor layout using short names matching the
+  `EngineKVFormat` enum (NB=num_blocks, NL=num_layers, BS=block_size, NH=num_heads,
   HS=head_size, PBS=page_buffer_size). E.g., `NL x [2, NB, BS, NH, HS]`.
-- **GPU KV tensor shape** — the same layout with actual numeric values substituted
+- **Engine KV tensor shape** — the same layout with actual numeric values substituted
   from the group's `shape_desc` (e.g., `80 x [2, 2048, 128, 8, 128]`), so it is
   group-accurate.
 
@@ -279,20 +279,20 @@ Mirror the same `start_time`, `zmq_endpoint`, and `http_endpoint` additions if
 | `zmq_endpoint` | `MPCacheServer.__init__` + `run_cache_server()` | New constructor kwarg, passed from `MPServerConfig` |
 | `http_endpoint` | `run_http_server()` lifespan + `report_status()` | Set on engine after construction when HTTP is enabled |
 
-### 4. Expose GPU KV format, shape, and attention backend in `kv_cache_layout`
+### 4. Expose engine KV format, shape, and attention backend in `kv_cache_layout`
 
 **Files:** `lmcache/v1/gpu_connector/utils.py`, `lmcache/v1/platform/cuda/cache_context.py`, `lmcache/v1/multiprocess/server.py`
 
-Helper functions in `utils.py` (derived from `legible_print_gpu_kv_format()`):
-- `get_gpu_kv_shape_description(gpu_kv_format)` — symbolic shape (e.g., `NL x [2, NB, BS, NH, HS]`)
-- `get_attention_backend(gpu_kv_format)` — backend name (e.g., `vLLM non-MLA flash attention`)
-- `get_concrete_gpu_kv_shape(kv_caches, gpu_kv_format)` — whole-context shape with actual values
-- `get_concrete_gpu_kv_shape_from_shape_desc(shape_desc, gpu_kv_format)` — **group-accurate** shape with actual values, read from a single kernel group's `PageBufferShapeDesc` (used by `report_status`)
+Helper functions in `utils.py` (derived from `legible_print_engine_kv_format()`):
+- `get_engine_kv_shape_description(engine_kv_format)` — symbolic shape (e.g., `NL x [2, NB, BS, NH, HS]`)
+- `get_attention_backend(engine_kv_format)` — backend name (e.g., `vLLM non-MLA flash attention`)
+- `get_concrete_engine_kv_shape(kv_caches, engine_kv_format)` — whole-context shape with actual values
+- `get_concrete_engine_kv_shape_from_shape_desc(shape_desc, engine_kv_format)` — **group-accurate** shape with actual values, read from a single kernel group's `PageBufferShapeDesc` (used by `report_status`)
 
 `report_status()` is organised **per kernel group**: a small set of context-wide
 fields at the top level, plus a `kernel_groups` list where each entry is
-self-describing. The format-derived fields (`gpu_kv_format`, `gpu_kv_shape`,
-`attention_backend`, `is_mla`) and the group-accurate `gpu_kv_concrete_shape`
+self-describing. The format-derived fields (`engine_kv_format`, `engine_kv_shape`,
+`attention_backend`, `is_mla`) and the group-accurate `engine_kv_concrete_shape`
 live inside each group:
 
 ```python
@@ -310,10 +310,10 @@ live inside each group:
             "tokens_per_block": 128,
             "slots_per_block": 128,
             "dtype": "torch.float16",
-            "gpu_kv_concrete_shape": "80 x [2, 2048, 128, 8, 128]",
+            "engine_kv_concrete_shape": "80 x [2, 2048, 128, 8, 128]",
             "is_mla": false,
-            "gpu_kv_format": "NL_X_TWO_NB_BS_NH_HS",
-            "gpu_kv_shape": "NL x [2, NB, BS, NH, HS]",
+            "engine_kv_format": "NL_X_TWO_NB_BS_NH_HS",
+            "engine_kv_shape": "NL x [2, NB, BS, NH, HS]",
             "attention_backend": "vLLM non-MLA flash attention",
         },
     ],

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -151,5 +151,5 @@ while the MP adapter uses the core's full-bitmap lookup/load API.
 
 - Implementation: `lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py`
 - Shared core: `lmcache/v1/storage_backend/raw_block/core.py`
-- User docs: `docs/source/mp/l2_storage.rst`
+- User docs: `docs/source/mp/l2_storage/raw_block.rst`
 - Rust device layer: `rust/raw_block/README.md`

--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -7,12 +7,12 @@
 > of the kv_caches alongside the format, so callers never need a
 > separate normalization step. Every other module queries KV-cache
 > information via helpers in `lmcache/v1/gpu_connector/utils.py` that
-> accept a `GPUKVFormat` argument.
+> accept an `EngineKVFormat` argument.
 
 "Layout parsing" means: list-nesting depth, tensor-dimension ordering,
 HND vs NHD, MLA vs MHA, per-layer vs cross-layer. All of that is
-encoded in `GPUKVFormat`; downstream code must never re-derive it from
-raw shapes.
+encoded in `EngineKVFormat`; downstream code must never re-derive it
+from raw shapes.
 
 ## Canonical type
 
@@ -54,17 +54,17 @@ consumer for a new layout — the branching belongs in `utils.py`.
 ## Helper surface
 
 Every helper below takes `DiscoverableKVCache` and (where layout matters)
-a `GPUKVFormat`. Nothing else may index raw shapes.
+an `EngineKVFormat`. Nothing else may index raw shapes.
 
 ### Discovery
 
 | Helper | Returns |
 |---|---|
-| `normalize_kv_and_discover_format(kv_caches, engine, layout_hints)` | `tuple[GPUKVFormat, DiscoverableKVCache]` — the one parser. Returns the canonical (permuted-to-contiguous) kv_caches alongside the detected format; callers must use the returned tensor structure for subsequent operations. |
+| `normalize_kv_and_discover_format(kv_caches, engine, layout_hints)` | `tuple[EngineKVFormat, DiscoverableKVCache]` — the one parser. Returns the canonical (permuted-to-contiguous) kv_caches alongside the detected format; callers must use the returned tensor structure for subsequent operations. |
 
 ### Format → engine map
 
-| `GPUKVFormat` | Engine | Layout | Structure |
+| `EngineKVFormat` | Engine | Layout | Structure |
 |---|---|---|---|
 | `NB_NL_TWO_BS_NH_HS` | vLLM cross-layer | NHD | bare 6-D tensor `[NB, NL, 2, BS, NH, HS]` |
 | `NB_NL_TWO_NH_BS_HS` | TRT-LLM cross-layer | HND | bare 6-D tensor `[NB, NL, 2, NH, BS, HS]` |
@@ -95,7 +95,7 @@ either the 4-D bare tensor or `[4-D]`; the function handles both.
 
 ### Scalar accessors
 
-All of these dispatch on `GPUKVFormat`. The ones that can vary per layer
+All of these dispatch on `EngineKVFormat`. The ones that can vary per layer
 take an optional `layer_idx: int = 0`; passing an explicit index enables
 per-layer queries (for heterogeneous groups) without any intermediate
 helper.
@@ -137,7 +137,7 @@ helper.
   1; x = x[0]`). There is no public depth helper and there shouldn't
   be one — `normalize_kv_and_discover_format` encapsulates the
   descent, and downstream code only ever needs the resulting
-  `GPUKVFormat`.
+  `EngineKVFormat`.
 - Wrapping a tensor with `[tensor]` to adapt to a helper's list-depth
   expectation — the accessors take `layer_idx` directly.
 - Hand-rolled pointer assembly (`[t.data_ptr() for t in kv_caches]`) —
@@ -148,7 +148,7 @@ helper.
   use `attempt_permute_to_contiguous_view` which refuses to copy.
 - "Canonicalize" functions that rewrite `kv_caches` to a uniform shape
   before passing to helpers. The helpers already canonicalize by
-  accepting `GPUKVFormat`, and any reshape/normalize step that *is*
+  accepting `EngineKVFormat`, and any reshape/normalize step that *is*
   needed lives inside `normalize_kv_and_discover_format` — callers
   receive the canonical form back from that one call.
 
@@ -189,7 +189,7 @@ permutation from strides and needs no hints.
 `utils.py` sets `# mypy: disable-error-code="union-attr,call-overload"`
 at the file level. This is the **one module** that does format-
 dispatched raw indexing on `DiscoverableKVCache` (`kv_caches.shape[i]`,
-`kv_caches[0][j]`) — the `gpu_kv_format` argument is the proof the
+`kv_caches[0][j]`) — the `engine_kv_format` argument is the proof the
 indexing is well-defined, but mypy can't carry that proof through a
 recursive Union without per-line casts. The file-level directive
 replaces 50+ `# type: ignore` comments scattered through the

--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -744,15 +744,16 @@ Options
    * - ``--mode {gpu,cpu}``
      - ``gpu``
      - Run mode. ``gpu`` allocates real CUDA tensors and uses CUDA IPC
-       (handle path). ``cpu`` allocates POSIX-SHM-backed tensors and
-       uses the data-transfer path (gather/scatter via slot descriptors).
-   * - ``--transfer-mode {auto,handle,data}``
+       (lmcache-driven handle path). ``cpu`` allocates POSIX-SHM-backed tensors
+       and uses the engine-driven (worker-side gather/scatter) path by default.
+   * - ``--transfer-mode {auto,engine_driven,lmcache_driven}``
      - ``auto``
-     - Transport routing for STORE/RETRIEVE. ``handle`` forces the
-       single-shot path (``REGISTER_KV_CACHE`` + ``STORE``/``RETRIEVE``).
-       ``data`` forces the two-phase gather/scatter path
+     - Transport routing for STORE/RETRIEVE. ``lmcache_driven`` forces the
+       single-shot handle path (``REGISTER_KV_CACHE`` + ``STORE``/``RETRIEVE``),
+       which supports both CUDA IPC and CPU SHM zero-copy transfers.
+       ``engine_driven`` forces the worker-side gather/scatter path
        (``REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT`` + ``PREPARE``/``COMMIT``).
-       ``auto`` maps gpu→handle and cpu→data.
+       ``auto`` maps gpu→lmcache_driven and cpu→engine_driven.
    * - ``--num-tokens N``
      - ``512``
      - Tokens per synthetic request.
@@ -797,9 +798,9 @@ CPU mode (no GPU)
 runs on a CPU-only host (``StubCPUDevice``); the bench tool allocates
 POSIX-SHM-backed KV tensors and exercises the full RPC path.
 
-By default ``--mode cpu`` uses the data-transfer path (``auto`` →
-``cpu→data``). To use the zero-copy SHM handle path instead, pass
-``--transfer-mode handle``:
+By default ``--mode cpu`` uses the engine-driven gather/scatter path
+(``auto`` → ``cpu→engine_driven``). To use the zero-copy SHM
+handle path instead, pass ``--transfer-mode lmcache_driven``:
 
 .. code-block:: bash
 
@@ -808,11 +809,11 @@ By default ``--mode cpu`` uses the data-transfer path (``auto`` →
        --host localhost --port 5555 \
        --l1-size-gb 2 --eviction-policy LRU
 
-   # Terminal 2 -- run bench in CPU + handle mode
+   # Terminal 2 -- run bench in CPU + lmcache_driven mode
    lmcache bench server \
        --rpc-url tcp://localhost:5555 \
        --url http://localhost:8080 \
-       --mode cpu --transfer-mode handle \
+       --mode cpu --transfer-mode lmcache_driven \
        --start 0 --end 2
 
 

--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -51,6 +51,12 @@ Options
    * - ``--trigger-watermark RATIO``
      - Eviction fires when usage reaches this fraction of the quota, ``0.0``
        (exclusive) to ``1.0`` (default: ``1.0``).
+   * - ``--blend-chunk-size N``
+     - Tokens per chunk for the global CacheBlend directory; must equal the
+       LMCache chunk size the blend servers use (default: ``256``).
+   * - ``--blend-probe-stride N``
+     - Positions between CacheBlend match probes; ``1`` probes every offset
+       for full recall (default: ``1``).
 
 Configuration
 -------------
@@ -58,9 +64,10 @@ Configuration
 Every flag is optional. Unset flags fall back to the
 ``LMCACHE_MP_COORDINATOR_*`` environment variables (``HOST``, ``PORT``,
 ``INSTANCE_TIMEOUT``, ``HEALTH_CHECK_INTERVAL``, ``EVICTION_CHECK_INTERVAL``,
-``EVICTION_RATIO``, ``TRIGGER_WATERMARK``), and then to the built-in
-defaults. A supplied flag always overrides the matching env-derived value, so
-env-only deployments keep working unchanged.
+``EVICTION_RATIO``, ``TRIGGER_WATERMARK``, ``BLEND_CHUNK_SIZE``,
+``BLEND_PROBE_STRIDE``), and then to the built-in defaults. A supplied flag
+always overrides the matching env-derived value, so env-only deployments keep
+working unchanged.
 
 A second set of env-only knobs controls the startup L2 resync —
 ``LMCACHE_MP_COORDINATOR_ENABLE_STARTUP_RESYNC`` (default ``True``),

--- a/docs/source/cli/describe.rst
+++ b/docs/source/cli/describe.rst
@@ -37,8 +37,8 @@ L2 adapters.
    Dtype:                               torch.float16
    MLA:                                         False
    Attention backend:    vLLM non-MLA flash attention
-   GPU KV shape:             NL x [2, NB, BS, NH, HS]
-   GPU KV tensor shape:   80 x [2, 2048, 128, 8, 128]
+   Engine KV shape:          NL x [2, NB, BS, NH, HS]
+   Engine KV tensor shape: 80 x [2, 2048, 128, 8, 128]
    ------------- L2: NixlStoreL2Adapter -------------
    Type:                           NixlStoreL2Adapter
    Health:                                         OK
@@ -52,8 +52,8 @@ The output shows:
 - **Overview** — health status, engine type, chunk size.
 - **L1 storage** — capacity, usage, eviction policy, cached object count.
 - **Registered models** — per-model KV cache layout: a context-wide summary
-  followed by one kernel group section per kernel group, each with the GPU KV
-  tensor shape (symbolic and concrete), attention backend, and group geometry.
+  followed by one kernel group section per kernel group, each with the engine
+  KV tensor shape (symbolic and concrete), attention backend, and group geometry.
 - **L2 adapters** — type, health, backend, stored objects, and utilization.
 
 Options
@@ -122,8 +122,8 @@ L2 adapters are collected into lists for easy programmatic access:
            "dtype": "torch.float16",
            "is_mla": false,
            "attention_backend": "vLLM non-MLA flash attention",
-           "gpu_kv_shape": "NL x [2, NB, BS, NH, HS]",
-           "gpu_kv_concrete_shape": "80 x [2, 2048, 128, 8, 128]"
+           "engine_kv_shape": "NL x [2, NB, BS, NH, HS]",
+           "engine_kv_concrete_shape": "80 x [2, 2048, 128, 8, 128]"
          }
        ],
        "l2_adapters": [
@@ -138,10 +138,10 @@ L2 adapters are collected into lists for easy programmatic access:
      }
    }
 
-GPU KV Shape Abbreviations
---------------------------
+Engine KV Shape Abbreviations
+-----------------------------
 
-The ``gpu_kv_shape`` field uses short names from the ``GPUKVFormat`` enum:
+The ``engine_kv_shape`` field uses short names from the ``EngineKVFormat`` enum:
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -272,10 +272,10 @@ prefetch jobs. Intended for operators and debugging, not for monitoring
                 "tokens_per_block": 16,
                 "slots_per_block": 16,
                 "dtype": "torch.bfloat16",
-                "gpu_kv_concrete_shape": "...",
+                "engine_kv_concrete_shape": "...",
                 "is_mla": false,
-                "gpu_kv_format": "...",
-                "gpu_kv_shape": "...",
+                "engine_kv_format": "...",
+                "engine_kv_shape": "...",
                 "attention_backend": "..."
               }
             ]

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -7,20 +7,30 @@ used by vLLM. This HTTP API is intended for operators, orchestrators
 (e.g. Kubernetes), and debugging tools — it is **not** on the inference
 data path.
 
-New endpoints are registered automatically from
-``lmcache/v1/multiprocess/http_apis/``: any module named ``*_api.py`` that
-exposes a module-level ``router`` (a :class:`fastapi.APIRouter`) is
-discovered at startup.
+Where the routes come from
+--------------------------
 
-A subset of routes defined under
-``lmcache/v1/internal_api_server/common/`` is also exposed on this HTTP
-server. The module
-``lmcache/v1/multiprocess/http_apis/common_api.py`` aggregates those
-routers (skipping any module listed in ``_MP_INCOMPATIBLE_MODULES``,
-which is currently empty) and forwards them to the auto-discovery
-pipeline. Adding a new compatible module under
-``internal_api_server/common`` therefore requires no wiring changes on
-the MP side.
+Routes are assembled from three sources, all merged into one FastAPI app by
+:class:`~lmcache.v1.multiprocess.http_api_registry.HTTPAPIRegistry` at startup:
+
+- **MP-native routes** — any module named ``*_api.py`` under
+  ``lmcache/v1/multiprocess/http_apis/`` that exposes a module-level
+  ``router`` (a :class:`fastapi.APIRouter`) is auto-discovered. This covers
+  the operational surface: status, cache control, L2 management, quota, and
+  runtime reconfiguration.
+- **Shared "common" routes** —
+  ``lmcache/v1/multiprocess/http_apis/common_api.py`` aggregates every
+  compatible router under ``lmcache/v1/internal_api_server/common/`` (skipping
+  any module listed in ``_MP_INCOMPATIBLE_MODULES``, currently empty) and
+  forwards them to the auto-discovery pipeline. These are the cross-server
+  diagnostics shared with the vLLM-embedded API server (``/env``,
+  ``/loglevel``, ``/metrics``, ``/threads``, ``/periodic-threads*``,
+  ``/run_script``). Adding a new compatible module under
+  ``internal_api_server/common`` requires no wiring changes on the MP side.
+- **Re-exported version routes** —
+  ``lmcache/v1/multiprocess/http_apis/version_api.py`` re-exports the router
+  from ``lmcache/v1/internal_api_server/vllm/version_api.py``, exposing
+  ``/version``, ``/lmc_version``, and ``/commit_id``.
 
 .. contents::
    :local:
@@ -54,14 +64,25 @@ Example:
 All examples below assume the server is reachable at
 ``http://localhost:8080``.
 
-Endpoints
----------
+Endpoint Overview
+-----------------
 
-The table below groups the routes by purpose. The operational surface
-(health, status, cache control) is exposed at top-level paths. Routes
-inherited from the shared
-``internal_api_server`` package are kept at their original paths for
+The routes are grouped by purpose below. The operational surface (health,
+status, cache and storage control) lives at top-level paths; routes inherited
+from the shared ``internal_api_server`` package keep their original paths for
 compatibility with the vLLM-embedded API server.
+
+.. note::
+
+   Several handlers report failure in the response **body** rather than via a
+   non-200 status code (e.g. ``DELETE /l2`` returns ``200`` with ``ok=false``,
+   and ``/periodic-threads-health`` returns ``200`` with ``healthy=false``).
+   The error-field name is also not uniform: ``/healthcheck`` and
+   ``/clear-cache`` use ``reason`` on failure, while ``/status``, ``/conf``,
+   and ``/kvcache/check`` use ``error``. Per-endpoint details below are
+   authoritative.
+
+**Liveness and health**
 
 .. list-table::
    :header-rows: 1
@@ -72,44 +93,86 @@ compatibility with the vLLM-embedded API server.
      - Purpose
    * - GET
      - ``/``
-     - Basic liveness ping.
+     - Static liveness ping (does not touch the engine).
    * - GET
      - ``/healthcheck``
-     - K8s liveness/readiness probe.
+     - K8s liveness/readiness probe; ``503`` until the engine is initialized.
+
+**Inspection and status**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 55
+
+   * - Method
+     - Path
+     - Purpose
    * - GET
      - ``/status``
-     - Detailed engine status for inspection and debugging.
+     - Detailed engine snapshot (L1, L2, registered contexts, sessions,
+       prefetch jobs) for inspection and debugging.
+   * - GET
+     - ``/conf``
+     - Dump the merged server configuration objects (``mp``,
+       ``storage_manager``, ``observability``).
+   * - GET
+     - ``/version``
+     - Combined version string (``"<version>-<commit_id>"``).
+   * - GET
+     - ``/lmc_version``
+     - LMCache package version string.
+   * - GET
+     - ``/commit_id``
+     - Build commit id.
+
+**Cache control**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 55
+
+   * - Method
+     - Path
+     - Purpose
    * - POST
      - ``/clear-cache``
      - Force-clear all KV data in L1 (CPU) memory.
    * - GET
-     - ``/reconfigure/backends``
-     - List backend strings accepted by runtime reconfiguration routes.
-   * - GET
-     - ``/reconfigure/{backend}/status``
-     - Report runtime-manageable L2 adapters for one backend type.
-   * - POST
-     - ``/reconfigure/{backend}/{operation}``
-     - Apply one runtime reconfiguration operation to a backend adapter.
-   * - GET
      - ``/kvcache/check``
-     - Compute MD5 checksums over the GPU KV cache for a set of block IDs.
-       Intended for diagnostics and round-trip integrity checks from
-       ``lmcache bench server``.
+     - Compute MD5 checksums over the engine KV cache for a set of block IDs
+       (diagnostics / round-trip integrity checks).
+
+**L2 storage management**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 55
+
+   * - Method
+     - Path
+     - Purpose
    * - GET
      - ``/l2/adapters``
-     - Enumerate every configured L2 adapter with its ``type_name``
-       and primary flag. Operators read this to learn which value to
-       pass as ``?adapter=`` on the endpoints below.
+     - Enumerate every configured L2 adapter with its ``type_name`` and
+       primary flag.
    * - DELETE
      - ``/l2``
-     - Delete a caller-supplied list of keys from one L2 adapter
-       (default: primary; override with ``?adapter=<type_name>``).
+     - Delete a caller-supplied list of keys from one L2 adapter (default:
+       primary; override with ``?adapter=<type_name>``).
    * - GET
      - ``/l2/keys``
-     - Paginate keys currently resident in one L2 adapter
-       (default: primary; override with ``?adapter=<type_name>``;
-       optionally filtered by ``model_name``).
+     - Paginate keys currently resident in one L2 adapter (optionally
+       filtered by ``model_name``).
+
+**Quota management**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 55
+
+   * - Method
+     - Path
+     - Purpose
    * - GET
      - ``/quota``
      - List every registered ``cache_salt`` quota with live usage.
@@ -121,33 +184,55 @@ compatibility with the vLLM-embedded API server.
      - Read the quota and live usage for a single ``cache_salt``.
    * - DELETE
      - ``/quota/{cache_salt}``
-     - Remove a ``cache_salt``'s quota entry (its data is evicted next
-       cycle).
+     - Remove a ``cache_salt``'s quota entry (its data is evicted next cycle).
+
+**Runtime L2 reconfiguration**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 55
+
+   * - Method
+     - Path
+     - Purpose
    * - GET
-     - ``/conf``
-     - Dump merged server configurations (mp, storage_manager,
-       observability).
+     - ``/reconfigure/backends``
+     - List backend strings accepted by the reconfiguration routes.
    * - GET
-     - ``/version``
-     - Full version descriptor (package version + commit id).
-   * - GET
-     - ``/lmc_version``
-     - LMCache package version string.
-   * - GET
-     - ``/commit_id``
-     - Current build commit id.
-   * - GET
-     - ``/env``
-     - Dump process environment variables (JSON, plain text).
-   * - GET
-     - ``/loglevel``
-     - List or inspect logger levels; also accepts ``level`` to mutate.
+     - ``/reconfigure/{backend}/status``
+     - Report runtime-manageable L2 adapters for one backend type.
+   * - POST
+     - ``/reconfigure/{backend}/{operation}``
+     - Apply one runtime reconfiguration operation to a backend adapter.
+
+**Observability**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 55
+
+   * - Method
+     - Path
+     - Purpose
    * - GET
      - ``/metrics``
      - Prometheus exposition format.
    * - POST
      - ``/metrics/reset``
      - Reset all observability metrics to their initial state.
+
+**Diagnostics and debugging**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 10 35 55
+
+   * - Method
+     - Path
+     - Purpose
+   * - GET
+     - ``/loglevel``
+     - List or inspect logger levels; also accepts ``level`` to mutate one.
    * - GET
      - ``/threads``
      - Enumerate active Python threads and their stack traces.
@@ -160,17 +245,22 @@ compatibility with the vLLM-embedded API server.
    * - GET
      - ``/periodic-threads-health``
      - Quick health check for critical/high-level periodic threads.
+   * - GET
+     - ``/env``
+     - Dump process environment variables (JSON body, ``text/plain``).
    * - POST
      - ``/run_script``
-     - Execute an uploaded Python script in a restricted sandbox. Only
-       modules listed in ``--script-allowed-imports`` can be imported.
+     - Execute an uploaded Python script in a restricted sandbox.
+
+Liveness and Health
+-------------------
 
 ``GET /``
 ~~~~~~~~~
 
 Basic liveness check. Returns a static payload indicating the HTTP server
-is running. Use ``/healthcheck`` instead for probes that also verify
-the cache engine is initialized.
+is running; it does **not** touch the cache engine. Use ``/healthcheck``
+instead for probes that also verify the engine is initialized.
 
 **Response** (``200 OK``):
 
@@ -191,9 +281,11 @@ the cache engine is initialized.
 ~~~~~~~~~~~~~~~~~~~~
 
 Health check endpoint suitable for Kubernetes liveness and readiness
-probes. A ``200`` response implies the HTTP server is alive **and** the
-MP cache engine is initialized. A ``503`` response indicates the engine
-is not yet ready (still initializing, or failed to initialize).
+probes. A ``200`` response means the HTTP server is alive **and** the MP
+cache engine object is wired onto ``app.state``. A ``503`` response
+indicates the engine is not yet present (still initializing, or failed to
+initialize). The check verifies that the engine attribute is set; it does
+not call into the engine to assert deeper liveness.
 
 **Response** (``200 OK``):
 
@@ -235,14 +327,20 @@ is not yet ready (still initializing, or failed to initialize).
       initialDelaySeconds: 5
       periodSeconds: 5
 
+Inspection and Status
+---------------------
+
 ``GET /status``
 ~~~~~~~~~~~~~~~
 
-Returns a detailed snapshot of the MP engine's internal state: L1 cache,
-L2 adapters, registered GPU contexts, active sessions, and in-flight
-prefetch jobs. Intended for operators and debugging, not for monitoring
-(use Prometheus metrics for time-series data — see
-:doc:`observability/index`).
+Returns a detailed snapshot of the MP engine's internal state. The payload is
+assembled by ``MPCacheServer.report_status()``: a fixed set of engine-level
+fields, the full storage-manager status, plus whatever keys each loaded module
+contributes (so the exact key set depends on which modules are active —
+``registered_gpu_ids`` / ``cache_context_meta`` come from the transfer module,
+``active_prefetch_jobs`` from the lookup module, and blend modes add their own
+fields). Intended for operators and debugging, not for monitoring (use
+Prometheus metrics for time-series data — see :doc:`observability/index`).
 
 **Response** (``200 OK``):
 
@@ -253,6 +351,7 @@ prefetch jobs. Intended for operators and debugging, not for monitoring
       "engine_type": "MPCacheServer",
       "chunk_size": 256,
       "hash_algorithm": "builtin-hash",
+      "active_sessions": 2,
       "registered_gpu_ids": [0, 1],
       "cache_context_meta": {
         "0": {
@@ -282,7 +381,6 @@ prefetch jobs. Intended for operators and debugging, not for monitoring
           }
         }
       },
-      "active_sessions": 2,
       "active_prefetch_jobs": 0,
       "storage_manager": {
         "is_healthy": true,
@@ -304,474 +402,6 @@ been initialized:
 .. code-block:: bash
 
     curl -s http://localhost:8080/status | jq
-
-``POST /clear-cache``
-~~~~~~~~~~~~~~~~~~~~~
-
-Force-clears **all** KV cache data currently held in L1 (CPU) memory.
-
-.. warning::
-
-   This endpoint is destructive and bypasses read/write locks. In-flight
-   store or prefetch operations may be corrupted. Use only when the
-   server is idle, or when recovering from a known-bad cache state.
-
-The request body is ignored.
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {
-      "status": "ok"
-    }
-
-**Response** (``503 Service Unavailable``):
-
-.. code-block:: json
-
-    {
-      "status": "error",
-      "reason": "engine not initialized"
-    }
-
-**Example:**
-
-.. code-block:: bash
-
-    curl -s -X POST http://localhost:8080/clear-cache
-
-.. _mp-http-dax-api:
-
-``/reconfigure/{backend}`` — runtime L2 adapter reconfiguration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These endpoints are available when the server has a runtime-reconfigurable L2
-adapter. They only change LMCache runtime mappings and metadata; backend
-resources such as DAX device paths must already exist and be readable and
-writable by the server. The endpoint routes ``backend``, ``operation``, and the
-JSON request body into the generic L2 adapter reconfiguration API, while
-backend-specific validation and migration semantics stay inside the adapter.
-
-Use ``GET /reconfigure/backends`` to list the backend strings that can be used
-in ``/reconfigure/{backend}/status`` and
-``/reconfigure/{backend}/{operation}``.
-If an L2 adapter is wrapped by serde, the backend string is still the configured
-L2 adapter type, not the serde wrapper type.
-
-For Device-DAX, use ``backend=dax``. DAX operations use JSON request bodies
-because DAX paths contain slashes. ``add`` and ``resize`` accept ``size`` as an
-integer byte count or a string such as ``"100GiB"``. ``remove`` supports
-``migrate``, ``evict``, and ``drain``; ``resize`` supports ``migrate`` and
-``evict``.
-
-See :doc:`/kv_cache/storage_backends/dax` for detailed request examples,
-mode semantics, and validation guidance.
-
-``GET /kvcache/check``
-~~~~~~~~~~~~~~~~~~~~~~
-
-Compute MD5 checksums over the GPU KV cache, grouped ``chunk_size`` blocks
-per hashed chunk. MP mode addresses KV storage by block IDs natively (the
-same units used by ``STORE`` / ``RETRIEVE``), so the endpoint is fully
-block-centric: ``block_ids`` enumerates the target blocks and
-``chunk_size`` counts blocks per chunk. Intended for diagnostics and
-round-trip integrity checks from ``lmcache bench server`` — not for the
-inference data path.
-
-**Query parameters:**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 15 60
-
-   * - Name
-     - Required
-     - Description
-   * - ``block_ids``
-     - yes
-     - GPU block IDs in mixed format, e.g. ``"0,[2,5],8"``.
-   * - ``chunk_size``
-     - yes
-     - Positive integer — number of blocks per hashed chunk.
-   * - ``instance_id``
-     - no (default ``0``)
-     - Registered GPU context ID on the engine.
-   * - ``layerwise``
-     - no (default ``false``)
-     - If ``true``, return per-layer checksums keyed by ``"layer_<idx>"``;
-       otherwise a single aggregated digest per chunk over all layers.
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {
-      "status": "success",
-      "chunk_size": 2,
-      "num_chunks": 2,
-      "chunk_checksums": ["<md5>", "<md5>"],
-      "layerwise": false,
-      "block_id_ranges": "0,[2,5],8"
-    }
-
-When ``layerwise=true``, ``chunk_checksums`` is a dict keyed by
-``"layer_<idx>"`` whose values are per-layer lists.
-
-**HTTP status codes:**
-
-- ``200``: success.
-- ``400``: ``block_ids`` missing/malformed, or ``chunk_size`` missing or
-  non-positive.
-- ``404``: ``instance_id`` not registered, or the registered KV tensors
-  are empty.
-- ``501``: engine has no ``cache_contexts``, or the KV format is not
-  supported by this endpoint (page-buffer-fused and cross-layer layouts
-  are declined until a real need appears).
-- ``503``: engine not yet initialized on ``app.state``.
-
-**Example:**
-
-.. code-block:: bash
-
-    curl -s "http://localhost:8080/kvcache/check?block_ids=0,1,2,3&chunk_size=2"
-
-    curl -s "http://localhost:8080/kvcache/check?block_ids=0,1,2,3&chunk_size=2&layerwise=true"
-
-.. _mp-http-l2-keys-api:
-
-``/l2`` — L2 keys management
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Three endpoints — ``GET /l2/adapters``, ``DELETE /l2``, and
-``GET /l2/keys`` — let operators enumerate the configured L2
-backends, purge keys from one, and enumerate what is currently
-resident.
-
-``DELETE /l2`` and ``GET /l2/keys`` accept an optional
-``?adapter=<type_name>`` query parameter to target a specific adapter.
-Omit the selector to target the **primary** (first-configured)
-adapter — the v1 behavior, preserved for clients that don't care
-about multi-adapter deployments. When multiple adapters share a
-``type_name``, the first match wins. Use ``GET /l2/adapters`` to learn
-the valid selectors.
-
-All three are intended for operator / admin workflows ("purge this
-user's keys", "show me what's resident", "garbage-collect orphans
-after a rename"). They are **not** on the inference data path.
-
-L1 is intentionally not touched. Keys deleted from L2 may still return
-from L1 until the L1 eviction controller expires them naturally;
-callers that need an L1+L2 purge should layer their own L1
-invalidation or wait for natural L1 eviction.
-
-The coordinator's eviction loop uses ``DELETE /l2`` automatically (see
-:doc:`coordinator` — "L2 usage tracking and eviction"); the
-``GET /l2/keys`` endpoint also powers the coordinator's startup
-resync. Manual ``curl`` usage is reserved for ad-hoc operator
-actions and debugging.
-
-For full request/response semantics, pagination, error codes, and the
-event flow back to the coordinator, see the design doc at
-``docs/design/v1/multiprocess/l2_apis.md``.
-
-``GET /l2/adapters``
-^^^^^^^^^^^^^^^^^^^^
-
-Enumerate every L2 adapter the engine has loaded, in configuration
-order.
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {
-      "adapters": [
-        {"index": 0, "type_name": "S3L2Adapter", "primary": true},
-        {"index": 1, "type_name": "FSL2Adapter", "primary": false}
-      ]
-    }
-
-``primary`` is ``true`` only on the first entry. An engine that has
-no L2 backends returns ``{"adapters": []}`` (still ``200`` — the
-engine is initialized, it just has no L2 storage).
-
-**HTTP status codes:**
-
-- ``200``: success (including the no-adapters case).
-- ``503``: engine not initialized.
-
-**Example:**
-
-.. code-block:: bash
-
-    curl -s http://localhost:8080/l2/adapters | jq
-
-``DELETE /l2``
-^^^^^^^^^^^^^^
-
-Delete a caller-supplied list of keys from one L2 adapter.
-Idempotent: keys absent from the adapter are skipped silently; keys
-currently locked by in-flight store/load tasks are skipped so the
-delete never corrupts an active transfer.
-
-**Query parameters:**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 18 13 69
-
-   * - Name
-     - Default
-     - Description
-   * - ``adapter``
-     - primary
-     - ``type_name`` of the target adapter (see ``GET /l2/adapters``).
-       Omit to target the primary (first-configured) adapter. First
-       match wins when multiple adapters share a ``type_name``.
-
-Per-key successful deletions fire ``on_l2_keys_deleted`` on the
-adapter's listeners — when the coordinator is wired (see
-``--coordinator-l2-event-reporting``), the deletions show up at the
-coordinator's ``POST /l2/events`` as ``"type": "delete"`` events. The
-coordinator's eviction + usage trackers learn about the deletion from
-that event flow, not from the response of this call.
-
-**Body:** ``{"keys": [EncodedObjectKey, ...]}`` where each
-``EncodedObjectKey`` is
-
-.. code-block:: json
-
-    {
-      "chunk_hash_hex": "abc123...",
-      "model_name": "meta-llama/Llama-3-8B",
-      "kv_rank": 0,
-      "object_group_id": 0,
-      "cache_salt": "user-a"
-    }
-
-The batch is capped at ``10000`` keys per request.
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {
-      "requested": 2,
-      "adapter": "S3L2Adapter",
-      "ok": true
-    }
-
-On adapter-level failure the response is still ``200`` with
-``ok=false`` and an ``error`` field carrying the reason.
-
-**HTTP status codes:**
-
-- ``200``: request reached the adapter (check ``ok`` for outcome).
-- ``400``: batch exceeds the limit, or a key payload violates an
-  ``ObjectKey`` invariant (bad hex, ``@`` in ``model_name``, forbidden
-  ``cache_salt`` character).
-- ``404``: ``?adapter=<name>`` does not match any configured adapter.
-- ``422``: Pydantic-level body-shape failure (missing ``keys``,
-  wrong field types).
-- ``503``: engine not initialized, or no L2 adapters configured.
-
-**Example:**
-
-.. code-block:: bash
-
-    curl -s -X DELETE http://localhost:8080/l2 \
-        -H 'Content-Type: application/json' \
-        -d '{
-            "keys": [
-              {"chunk_hash_hex": "aa", "model_name": "m",
-               "kv_rank": 0, "object_group_id": 0, "cache_salt": "user-a"}
-            ]
-        }'
-
-``GET /l2/keys``
-^^^^^^^^^^^^^^^^
-
-Paginate keys currently resident in one L2 adapter.
-
-**Query parameters:**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 22 13 65
-
-   * - Name
-     - Default
-     - Description
-   * - ``adapter``
-     - primary
-     - ``type_name`` of the target adapter (see ``GET /l2/adapters``).
-       Omit to target the primary (first-configured) adapter. First
-       match wins when multiple adapters share a ``type_name``.
-   * - ``model_name``
-     - none
-     - Restrict the result to keys whose ``model_name`` matches.
-   * - ``page_size``
-     - ``500``
-     - Max entries per page. Clamped to ``[1, 5000]``.
-   * - ``page_token``
-     - none
-     - Opaque cursor from the previous page's ``next_page_token``.
-       Omit on the first call; pass back verbatim on subsequent calls.
-
-The page token is private to the adapter; do not parse or modify it.
-Adapters that support listing (currently only the S3 adapter via
-``ListObjectsV2``) guarantee best-effort consistency, not snapshot
-isolation — concurrent stores or deletes during a paginated walk may
-cause keys to appear, disappear, or shift between pages.
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {
-      "adapter": "S3L2Adapter",
-      "entries": [
-        {
-          "key": {
-            "chunk_hash_hex": "abc123",
-            "model_name": "meta-llama/Llama-3-8B",
-            "kv_rank": 0,
-            "object_group_id": 0,
-            "cache_salt": "user-a"
-          },
-          "size_bytes": 4194304
-        }
-      ],
-      "next_page_token": "opaque-cursor-string"
-    }
-
-``next_page_token`` is ``null`` when the listing is exhausted.
-
-**HTTP status codes:**
-
-- ``200``: success.
-- ``400``: malformed ``page_token`` (adapter-level).
-- ``404``: ``?adapter=<name>`` does not match any configured adapter.
-- ``501``: selected adapter does not implement listing. In v1 only
-  ``S3L2Adapter`` does; adapters wrapped by ``SerdeL2AdapterWrapper``
-  inherit the wrapped adapter's behavior.
-- ``503``: engine not initialized, or no L2 adapters configured.
-
-**Example:** paginate every key for a model.
-
-.. code-block:: bash
-
-    next=""
-    while :; do
-      page=$(curl -s "http://localhost:8080/l2/keys?model_name=meta-llama/Llama-3-8B&page_size=500&page_token=$next")
-      echo "$page" | jq '.entries[]'
-      next=$(echo "$page" | jq -r '.next_page_token // empty')
-      [ -z "$next" ] && break
-    done
-
-.. _mp-http-quota-api:
-
-``/quota`` — per-``cache_salt`` quota management
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These endpoints manage the per-``cache_salt`` storage budgets consumed by
-the ``IsolatedLRU`` eviction policy (selected via
-``--eviction-policy IsolatedLRU``). Quotas are **soft**: setting a limit
-does not reject writes — any over-budget ``cache_salt`` is evicted at
-the next eviction cycle (~1 s).
-A ``cache_salt`` with no registered quota has an effective limit of
-``0`` bytes, so its data is cleared next cycle (allowlist semantics).
-
-These endpoints are no-ops on engines that did not start with
-``--eviction-policy IsolatedLRU``: the ``QuotaManager`` is still
-present, but the LRU policy ignores the registered quotas.
-
-**URL escaping for the empty salt.** ``cache_salt=""`` (un-salted /
-anonymous traffic) cannot appear in a URL path parameter, so the API
-accepts the sentinel ``_default`` in its place. ``PUT /quota/_default``
-sets the quota for ``cache_salt=""``. A user that legitimately stores
-data with ``cache_salt="_default"`` cannot be managed via this HTTP API
-distinctly from anonymous traffic — both map to the same path parameter;
-pick any other value (e.g. ``"default"``) to disambiguate.
-
-``PUT /quota/{cache_salt}``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Create or update a quota.
-
-**Body:** ``{"limit_gb": <float>}`` (required, finite, non-negative).
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {"cache_salt": "alice", "limit_gb": 10.0, "status": "ok"}
-
-**Errors:** ``400`` for malformed JSON, missing ``limit_gb``, non-numeric
-``limit_gb``, ``nan`` / ``inf``, or negative values; ``503`` if the
-engine is not initialized.
-
-**Example:**
-
-.. code-block:: bash
-
-    curl -s -X PUT http://localhost:8080/quota/alice \
-        -H 'Content-Type: application/json' \
-        -d '{"limit_gb": 10.0}'
-
-``GET /quota/{cache_salt}``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Read the current quota and live usage for one ``cache_salt``.
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {
-      "cache_salt": "alice",
-      "limit_gb": 10.0,
-      "current_usage_gb": 2.137,
-      "exists": true
-    }
-
-``exists`` is ``false`` when no quota was ever registered for this
-``cache_salt`` (``limit_gb`` is then ``0.0`` and ``current_usage_gb``
-reflects whatever bytes are currently cached for that salt — those bytes
-will evict next cycle under ``IsolatedLRU``).
-
-``DELETE /quota/{cache_salt}``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Remove a ``cache_salt``'s quota entry. Any bytes still cached under this
-``cache_salt`` become over-budget on the next eviction cycle (effective
-limit drops to ``0``) and will be evicted.
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {"cache_salt": "alice", "status": "removed"}
-
-When no quota was registered for the given ``cache_salt``, the response
-is ``{"cache_salt": "...", "status": "not_found"}`` (still ``200 OK``).
-
-``GET /quota``
-^^^^^^^^^^^^^^^^^^
-
-List every registered quota alongside its live usage.
-
-**Response** (``200 OK``):
-
-.. code-block:: json
-
-    {
-      "users": {
-        "alice": {"limit_gb": 10.0, "current_usage_gb": 2.137},
-        "bob":   {"limit_gb":  4.0, "current_usage_gb": 0.812}
-      }
-    }
 
 ``GET /conf``
 ~~~~~~~~~~~~~
@@ -816,63 +446,642 @@ onto ``app.state`` yet:
 
     curl -s http://localhost:8080/conf | jq
 
-``GET /version``
-~~~~~~~~~~~~~~~~
+``GET /version``, ``GET /lmc_version``, ``GET /commit_id``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Returns the full version descriptor (package version combined with the
-current commit id), formatted by ``lmcache.utils.get_version()``.
+Version descriptors. Each returns a bare JSON **string** (not an object):
+
+- ``GET /version`` — the combined descriptor from
+  ``lmcache.utils.get_version()``, formatted ``"<version>-<commit_id>"``
+  (e.g. ``"0.3.1-ca79ea33"``). On a source checkout without build-time
+  version metadata, each missing component falls back to the literal
+  ``"NA"`` (so a metadata-less build returns ``"NA-NA"``).
+- ``GET /lmc_version`` — the raw package version string
+  (``lmcache.utils.VERSION``); empty string ``""`` when the generated
+  ``lmcache._version`` module is absent.
+- ``GET /commit_id`` — the git commit id baked into the build
+  (``lmcache.utils.COMMIT_ID``); empty string ``""`` when unavailable.
+
+All three are unconditional ``200 OK``.
+
+**Examples:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/version
+    curl -s http://localhost:8080/lmc_version
+    curl -s http://localhost:8080/commit_id
+
+Cache Control
+-------------
+
+``POST /clear-cache``
+~~~~~~~~~~~~~~~~~~~~~
+
+Force-clears **all** KV cache data currently held in L1 (CPU) memory
+(delegates to the ``ManagementModule``).
+
+.. warning::
+
+   This endpoint is destructive and bypasses read/write locks. In-flight
+   store or prefetch operations may be corrupted. Use only when the
+   server is idle, or when recovering from a known-bad cache state.
+
+The request body is ignored.
 
 **Response** (``200 OK``):
 
 .. code-block:: json
 
-    "0.3.x+<commit-id>"
+    {
+      "status": "ok"
+    }
+
+**Response** (``503 Service Unavailable``):
+
+.. code-block:: json
+
+    {
+      "status": "error",
+      "reason": "engine not initialized"
+    }
 
 **Example:**
 
 .. code-block:: bash
 
-    curl -s http://localhost:8080/version
+    curl -s -X POST http://localhost:8080/clear-cache
 
-``GET /lmc_version``
+``GET /kvcache/check``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Compute MD5 checksums over the engine KV cache, grouped ``chunk_size`` blocks
+per hashed chunk. MP mode addresses KV storage by block IDs natively (the
+same units used by ``STORE`` / ``RETRIEVE``), so the endpoint is fully
+block-centric: ``block_ids`` enumerates the target blocks and
+``chunk_size`` counts blocks per chunk. Intended for diagnostics and
+round-trip integrity checks from ``lmcache bench server`` — not for the
+inference data path.
+
+**Query parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Name
+     - Required
+     - Description
+   * - ``block_ids``
+     - yes
+     - Engine block IDs in mixed format, e.g. ``"0,[2,5],8"``.
+   * - ``chunk_size``
+     - yes
+     - Positive integer — number of blocks per hashed chunk.
+   * - ``instance_id``
+     - no (default ``0``)
+     - Registered KV context ID on the engine.
+   * - ``layerwise``
+     - no (default ``false``)
+     - If ``true``, return per-layer checksums keyed by ``"layer_<idx>"``;
+       otherwise a single aggregated digest per chunk over all layers.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "status": "success",
+      "chunk_size": 2,
+      "num_chunks": 2,
+      "chunk_checksums": ["<md5>", "<md5>"],
+      "layerwise": false,
+      "block_id_ranges": "0,[2,5],8"
+    }
+
+When ``layerwise=true``, ``chunk_checksums`` is a dict keyed by
+``"layer_<idx>"`` whose values are per-layer lists.
+
+**HTTP status codes:**
+
+- ``200``: success.
+- ``400``: ``block_ids`` missing/malformed, or ``chunk_size`` missing or
+  non-positive.
+- ``404``: ``instance_id`` not registered, or the registered KV tensors
+  are empty.
+- ``501``: engine has no ``cache_contexts``, or the KV format is not
+  supported by this endpoint (page-buffer-fused and cross-layer layouts
+  are declined until a real need appears).
+- ``503``: engine not yet initialized on ``app.state``.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s "http://localhost:8080/kvcache/check?block_ids=0,1,2,3&chunk_size=2"
+
+    curl -s "http://localhost:8080/kvcache/check?block_ids=0,1,2,3&chunk_size=2&layerwise=true"
+
+.. _mp-http-l2-keys-api:
+
+L2 Storage Management
+---------------------
+
+Three endpoints — ``GET /l2/adapters``, ``DELETE /l2``, and
+``GET /l2/keys`` — let operators enumerate the configured L2
+backends, purge keys from one, and enumerate what is currently
+resident.
+
+``DELETE /l2`` and ``GET /l2/keys`` accept an optional
+``?adapter=<type_name>`` query parameter to target a specific adapter.
+Omit the selector to target the **primary** (first-configured)
+adapter — the v1 behavior, preserved for clients that don't care
+about multi-adapter deployments. When multiple adapters share a
+``type_name``, the first match wins. Use ``GET /l2/adapters`` to learn
+the valid selectors.
+
+All three are intended for operator / admin workflows ("purge this
+user's keys", "show me what's resident", "garbage-collect orphans
+after a rename"). They are **not** on the inference data path.
+
+L1 is intentionally not touched. Keys deleted from L2 may still return
+from L1 until the L1 eviction controller expires them naturally;
+callers that need an L1+L2 purge should layer their own L1
+invalidation or wait for natural L1 eviction.
+
+The coordinator's eviction loop uses ``DELETE /l2`` automatically (see
+:doc:`coordinator` — "L2 usage tracking and eviction"); the
+``GET /l2/keys`` endpoint also powers the coordinator's startup
+resync. Manual ``curl`` usage is reserved for ad-hoc operator
+actions and debugging.
+
+For full request/response semantics, pagination, error codes, and the
+event flow back to the coordinator, see the design doc at
+``docs/design/v1/multiprocess/l2_apis.md``.
+
+``GET /l2/adapters``
 ~~~~~~~~~~~~~~~~~~~~
 
-Returns the raw LMCache package version string (``lmcache.utils.VERSION``).
+Enumerate every L2 adapter the engine has loaded, in configuration
+order.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "adapters": [
+        {"index": 0, "type_name": "S3L2Adapter", "primary": true},
+        {"index": 1, "type_name": "FSL2Adapter", "primary": false}
+      ]
+    }
+
+``primary`` is ``true`` only on the first entry. An engine that has
+no L2 backends returns ``{"adapters": []}`` (still ``200`` — the
+engine is initialized, it just has no L2 storage).
+
+**HTTP status codes:**
+
+- ``200``: success (including the no-adapters case).
+- ``503``: engine not initialized.
 
 **Example:**
 
 .. code-block:: bash
 
-    curl -s http://localhost:8080/lmc_version
+    curl -s http://localhost:8080/l2/adapters | jq
 
-``GET /commit_id``
+``DELETE /l2``
+~~~~~~~~~~~~~~
+
+Delete a caller-supplied list of keys from one L2 adapter.
+Idempotent: keys absent from the adapter are skipped silently; keys
+currently locked by in-flight store/load tasks are skipped so the
+delete never corrupts an active transfer. The blocking adapter call is
+run off the event loop.
+
+**Query parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 13 69
+
+   * - Name
+     - Default
+     - Description
+   * - ``adapter``
+     - primary
+     - ``type_name`` of the target adapter (see ``GET /l2/adapters``).
+       Omit to target the primary (first-configured) adapter. First
+       match wins when multiple adapters share a ``type_name``.
+
+Per-key successful deletions fire ``on_l2_keys_deleted`` on the
+adapter's listeners — when the coordinator is wired (see
+``--coordinator-l2-event-reporting``), the deletions show up at the
+coordinator's ``POST /l2/events`` as ``"type": "delete"`` events. The
+coordinator's eviction + usage trackers learn about the deletion from
+that event flow, not from the response of this call.
+
+**Body:** ``{"keys": [EncodedObjectKey, ...]}`` where each
+``EncodedObjectKey`` is
+
+.. code-block:: json
+
+    {
+      "chunk_hash_hex": "abc123...",
+      "model_name": "meta-llama/Llama-3-8B",
+      "kv_rank": 0,
+      "object_group_id": 0,
+      "cache_salt": "user-a"
+    }
+
+``object_group_id`` (default ``0``) and ``cache_salt`` (default ``""``)
+are optional for backward compatibility with older wire payloads. The
+batch is capped at ``10000`` keys per request.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "requested": 2,
+      "adapter": "S3L2Adapter",
+      "ok": true
+    }
+
+On adapter-level failure the response is still ``200`` with
+``ok=false`` and an ``error`` field carrying the reason.
+
+**HTTP status codes:**
+
+- ``200``: request reached the adapter (check ``ok`` for outcome).
+- ``400``: batch exceeds the limit, or a key payload violates an
+  ``ObjectKey`` invariant (bad hex, ``@`` in ``model_name``, forbidden
+  ``cache_salt`` character).
+- ``404``: ``?adapter=<name>`` does not match any configured adapter.
+- ``422``: Pydantic-level body-shape failure (missing ``keys``,
+  wrong field types).
+- ``503``: engine not initialized, or no L2 adapters configured.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s -X DELETE http://localhost:8080/l2 \
+        -H 'Content-Type: application/json' \
+        -d '{
+            "keys": [
+              {"chunk_hash_hex": "aa", "model_name": "m",
+               "kv_rank": 0, "object_group_id": 0, "cache_salt": "user-a"}
+            ]
+        }'
+
+``GET /l2/keys``
+~~~~~~~~~~~~~~~~
+
+Paginate keys currently resident in one L2 adapter.
+
+**Query parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 13 65
+
+   * - Name
+     - Default
+     - Description
+   * - ``adapter``
+     - primary
+     - ``type_name`` of the target adapter (see ``GET /l2/adapters``).
+       Omit to target the primary (first-configured) adapter. First
+       match wins when multiple adapters share a ``type_name``.
+   * - ``model_name``
+     - none
+     - Restrict the result to keys whose ``model_name`` matches.
+   * - ``page_size``
+     - ``500``
+     - Max entries per page. Must be in ``[1, 5000]``; an out-of-range
+       value is rejected with ``422`` (it is not silently clamped).
+   * - ``page_token``
+     - none
+     - Opaque cursor from the previous page's ``next_page_token``.
+       Omit on the first call; pass back verbatim on subsequent calls.
+
+The page token is private to the adapter; do not parse or modify it.
+Adapters that support listing (currently only the S3 adapter via
+``ListObjectsV2``) guarantee best-effort consistency, not snapshot
+isolation — concurrent stores or deletes during a paginated walk may
+cause keys to appear, disappear, or shift between pages.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "adapter": "S3L2Adapter",
+      "entries": [
+        {
+          "key": {
+            "chunk_hash_hex": "abc123",
+            "model_name": "meta-llama/Llama-3-8B",
+            "kv_rank": 0,
+            "object_group_id": 0,
+            "cache_salt": "user-a"
+          },
+          "size_bytes": 4194304
+        }
+      ],
+      "next_page_token": "opaque-cursor-string"
+    }
+
+``next_page_token`` is ``null`` when the listing is exhausted.
+
+**HTTP status codes:**
+
+- ``200``: success.
+- ``400``: malformed ``page_token`` (adapter-level).
+- ``404``: ``?adapter=<name>`` does not match any configured adapter.
+- ``422``: ``page_size`` outside ``[1, 5000]``.
+- ``501``: selected adapter does not implement listing. In v1 only
+  ``S3L2Adapter`` does; adapters wrapped by ``SerdeL2AdapterWrapper``
+  inherit the wrapped adapter's behavior.
+- ``503``: engine not initialized, or no L2 adapters configured.
+
+**Example:** paginate every key for a model.
+
+.. code-block:: bash
+
+    next=""
+    while :; do
+      page=$(curl -s "http://localhost:8080/l2/keys?model_name=meta-llama/Llama-3-8B&page_size=500&page_token=$next")
+      echo "$page" | jq '.entries[]'
+      next=$(echo "$page" | jq -r '.next_page_token // empty')
+      [ -z "$next" ] && break
+    done
+
+.. _mp-http-quota-api:
+
+Quota Management
+----------------
+
+These endpoints manage the per-``cache_salt`` storage budgets consumed by
+the ``IsolatedLRU`` eviction policy (selected via
+``--eviction-policy IsolatedLRU``). Quotas are **soft**: setting a limit
+does not reject writes — any over-budget ``cache_salt`` is evicted at
+the next eviction cycle (~1 s).
+A ``cache_salt`` with no registered quota has an effective limit of
+``0`` bytes, so its data is cleared next cycle (allowlist semantics).
+
+These endpoints are no-ops on engines that did not start with
+``--eviction-policy IsolatedLRU``: the ``QuotaManager`` is still
+present, but the LRU policy ignores the registered quotas.
+
+**URL escaping for the empty salt.** ``cache_salt=""`` (un-salted /
+anonymous traffic) cannot appear in a URL path parameter, so the API
+accepts the sentinel ``_default`` in its place. ``PUT /quota/_default``
+sets the quota for ``cache_salt=""``, and ``_default`` is echoed back in
+responses for the empty salt. A user that legitimately stores data with
+``cache_salt="_default"`` cannot be managed via this HTTP API distinctly
+from anonymous traffic — both map to the same path parameter; pick any
+other value (e.g. ``"default"``) to disambiguate.
+
+``PUT /quota/{cache_salt}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create or update a quota.
+
+**Body:** ``{"limit_gb": <float>}`` (required, finite, non-negative).
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {"cache_salt": "alice", "limit_gb": 10.0, "status": "ok"}
+
+**Errors:** ``400`` for malformed JSON, missing ``limit_gb``, non-numeric
+``limit_gb``, ``nan`` / ``inf``, or negative values; ``503`` if the
+engine is not initialized.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s -X PUT http://localhost:8080/quota/alice \
+        -H 'Content-Type: application/json' \
+        -d '{"limit_gb": 10.0}'
+
+``GET /quota/{cache_salt}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read the current quota and live usage for one ``cache_salt``.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "cache_salt": "alice",
+      "limit_gb": 10.0,
+      "current_usage_gb": 2.137,
+      "exists": true
+    }
+
+``exists`` is ``false`` when no quota was ever registered for this
+``cache_salt`` (``limit_gb`` is then ``0.0`` and ``current_usage_gb``
+reflects whatever bytes are currently cached for that salt — those bytes
+will evict next cycle under ``IsolatedLRU``). This endpoint never returns
+``404`` for an unknown salt.
+
+``DELETE /quota/{cache_salt}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Remove a ``cache_salt``'s quota entry. Any bytes still cached under this
+``cache_salt`` become over-budget on the next eviction cycle (effective
+limit drops to ``0``) and will be evicted.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {"cache_salt": "alice", "status": "removed"}
+
+When no quota was registered for the given ``cache_salt``, the response
+is ``{"cache_salt": "...", "status": "not_found"}`` (still ``200 OK``).
+
+``GET /quota``
 ~~~~~~~~~~~~~~~~~~
 
-Returns the git commit id baked into the build (``lmcache.utils.COMMIT_ID``).
+List every registered quota alongside its live usage.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "users": {
+        "alice": {"limit_gb": 10.0, "current_usage_gb": 2.137},
+        "bob":   {"limit_gb":  4.0, "current_usage_gb": 0.812}
+      }
+    }
+
+Only ``cache_salt`` values with a **registered** quota appear; the empty
+salt is reported under the ``_default`` key.
+
+.. _mp-http-dax-api:
+
+Runtime L2 Reconfiguration
+--------------------------
+
+These endpoints are available when the server has a runtime-reconfigurable L2
+adapter. They only change LMCache runtime mappings and metadata; backend
+resources such as DAX device paths must already exist and be readable and
+writable by the server. The endpoint routes ``backend``, ``operation``, and the
+JSON request body into the generic L2 adapter reconfiguration API, while
+backend-specific validation and migration semantics stay inside the adapter.
+
+``backend`` and ``operation`` path segments are normalized (stripped and
+lower-cased). Within a request body, ``adapter_index`` (default ``0``) is
+**backend-local** — it indexes only the adapters of that backend, not the
+engine-wide adapter list. If an L2 adapter is wrapped by serde, the backend
+string is still the configured L2 adapter type, not the serde wrapper type.
+
+``GET /reconfigure/backends``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+List the backend strings that can be used in
+``/reconfigure/{backend}/status`` and
+``/reconfigure/{backend}/{operation}``.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "enabled": true,
+      "num_backends": 1,
+      "backends": ["dax"]
+    }
+
+``enabled`` is ``false`` (and ``backends`` empty) when no reconfigurable
+adapter is present.
+
+**HTTP status codes:** ``200`` on success; ``503`` if the engine is not
+initialized.
+
+``GET /reconfigure/{backend}/status``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Report the runtime-manageable adapters for one backend type. Each adapter
+entry's ``adapter_index`` is rewritten to its **backend-local** 0-based index
+(the value to pass back in operation request bodies).
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "enabled": true,
+      "backend": "dax",
+      "num_adapters": 1,
+      "adapters": [
+        {"adapter_index": 0, "...": "backend-specific adapter fields"}
+      ]
+    }
+
+An unknown or empty backend returns ``enabled=false``, ``num_adapters=0``,
+``adapters=[]`` (it is **not** a ``404``).
+
+**HTTP status codes:** ``200`` on success; ``400`` if ``backend`` is empty;
+``503`` if the engine is not initialized.
+
+``POST /reconfigure/{backend}/{operation}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Apply one reconfiguration operation to a backend adapter. The request body is
+a JSON object whose accepted fields depend on the backend and operation. The
+``200`` response is whatever the storage manager's
+``reconfigure_l2_adapter`` returns (a backend-defined dict).
+
+For the **generic** path (any backend other than ``dax``), the body carries
+``adapter_index`` plus any backend-specific fields, which are forwarded
+verbatim to the adapter.
+
+For **Device-DAX** (``backend=dax``), JSON request bodies are used because DAX
+paths contain slashes. The accepted operations and fields are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - Operation
+     - Body fields
+   * - ``add``
+     - ``device_path`` (str, required), ``size`` (int byte count or string
+       such as ``"100GiB"``, required), ``adapter_index`` (default ``0``).
+   * - ``remove``
+     - ``device_path`` (str, required), ``mode`` (``migrate`` | ``evict`` |
+       ``drain``, default ``migrate``), ``force`` (bool, default ``false``),
+       ``adapter_index`` (default ``0``).
+   * - ``resize``
+     - ``device_path`` (str, required), ``size`` (int or string, required),
+       ``mode`` (``migrate`` | ``evict``, default ``migrate``), ``force``
+       (bool, default ``false``), ``adapter_index`` (default ``0``).
+
+``size`` accepts an integer byte count or a string with a base-1024 unit
+suffix (``b``, ``kib``, ``mib``, ``gib``, ``tib`` and the ``k``/``m``/``g``/``t``
+aliases), e.g. ``"100GiB"``; it must resolve to a positive value.
+
+**HTTP status codes:**
+
+- ``200``: success (body is the storage manager's reconfigure result).
+- ``400``: empty ``backend``/``operation``, an unsupported DAX operation, or
+  an invalid ``size``.
+- ``404``: ``adapter_index`` is out of range for the backend.
+- ``422``: request body fails validation (e.g. a missing required field, or
+  an unknown field in a DAX body — DAX bodies reject extras).
+- ``503``: engine not initialized.
+
+See :doc:`/kv_cache/storage_backends/dax` for detailed request examples,
+mode semantics, and validation guidance.
+
+Observability
+-------------
+
+``GET /metrics``
+~~~~~~~~~~~~~~~~
+
+Prometheus exposition format for every metric registered on the default
+``prometheus_client`` registry (``Content-Type: text/plain``). Scrape this
+directly from Prometheus. See :doc:`observability/index` for the list of
+exported metrics.
 
 **Example:**
 
 .. code-block:: bash
 
-    curl -s http://localhost:8080/commit_id
+    curl -s http://localhost:8080/metrics
 
-``GET /env``
-~~~~~~~~~~~~
+``POST /metrics/reset``
+~~~~~~~~~~~~~~~~~~~~~~~
 
-Dumps the process environment variables as a sorted, pretty-printed
-JSON document. Response ``Content-Type`` is ``text/plain`` so it can be
-piped directly to a terminal.
+Resets all LMCache observability metrics to their initial state
+(``reset_observability_metrics``). Intended for test harnesses and
+benchmarks — not for production.
 
-.. warning::
+**Response** (``200 OK``, ``text/plain``):
 
-   The payload may contain secrets injected via environment
-   variables. Restrict network access to this endpoint in production.
+.. code-block:: text
+
+    ok
 
 **Example:**
 
 .. code-block:: bash
 
-    curl -s http://localhost:8080/env
+    curl -s -X POST http://localhost:8080/metrics/reset
+
+Diagnostics and Debugging
+-------------------------
 
 ``GET /loglevel``
 ~~~~~~~~~~~~~~~~~
@@ -892,8 +1101,11 @@ Inspect or mutate Python logger levels at runtime. All responses are
      - Return the effective level of the named logger.
    * - ``?logger_name=<name>&level=<LEVEL>``
      - Set the named logger (and its handlers) to ``LEVEL``
-       (``DEBUG``/``INFO``/``WARNING``/``ERROR``/``CRITICAL``).
-       Returns ``400`` on an unknown level.
+       (``DEBUG``/``INFO``/``WARNING``/``ERROR``/``CRITICAL``;
+       case-insensitive). Returns ``400`` on an unknown level.
+
+Passing ``level`` without ``logger_name`` matches none of the modes and
+returns ``200`` with a ``null`` body.
 
 **Examples:**
 
@@ -908,44 +1120,12 @@ Inspect or mutate Python logger levels at runtime. All responses are
     # elevate to DEBUG
     curl -s 'http://localhost:8080/loglevel?logger_name=lmcache&level=DEBUG'
 
-``GET /metrics``
-~~~~~~~~~~~~~~~~
-
-Prometheus exposition format for every metric registered on the default
-``prometheus_client`` registry. Scrape this directly from Prometheus.
-See :doc:`observability/index` for the list of exported metrics.
-
-**Example:**
-
-.. code-block:: bash
-
-    curl -s http://localhost:8080/metrics
-
-``POST /metrics/reset``
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Resets all LMCache observability metrics to their initial state
-(``reset_observability_metrics``). Intended for test harnesses and
-benchmarks — not for production.
-
-**Response** (``200 OK``):
-
-.. code-block:: text
-
-    ok
-
-**Example:**
-
-.. code-block:: bash
-
-    curl -s -X POST http://localhost:8080/metrics/reset
-
 ``GET /threads``
 ~~~~~~~~~~~~~~~~
 
 Enumerate active Python threads in the server process along with their
-stack traces, plus a total-count summary. Useful for live debugging of
-hangs or runaway workers.
+stack traces, plus a total-count summary (``Content-Type: text/plain``).
+Useful for live debugging of hangs or runaway workers.
 
 .. list-table::
    :header-rows: 1
@@ -958,6 +1138,11 @@ hangs or runaway workers.
        (case-insensitive).
    * - ``?thread_id=<int>``
      - Keep only the thread with the matching ``ident``.
+
+.. warning::
+
+   The response contains live stack traces and can disclose internal code
+   paths and state. Restrict network access to this endpoint in production.
 
 **Example:**
 
@@ -994,10 +1179,26 @@ level plus per-thread status (last run timestamp, latest summary, etc.).
         "total_count": 4,
         "running_count": 4,
         "active_count": 4,
-        "by_level": {"critical": 1, "high": 2, "medium": 1, "low": 0}
+        "by_level": {
+          "critical": {"total": 1, "running": 1, "active": 1},
+          "high":     {"total": 2, "running": 2, "active": 2},
+          "medium":   {"total": 1, "running": 1, "active": 1},
+          "low":      {"total": 0, "running": 0, "active": 0}
+        }
       },
       "threads": [
-        {"name": "...", "level": "high", "is_running": true, "...": "..."}
+        {
+          "name": "...",
+          "level": "high",
+          "interval": 5.0,
+          "is_running": true,
+          "is_active": true,
+          "last_run_ago": 1.2,
+          "total_runs": 120,
+          "failed_runs": 0,
+          "success_rate": 100.0,
+          "last_summary": {"...": "..."}
+        }
       ]
     }
 
@@ -1010,7 +1211,9 @@ level plus per-thread status (last run timestamp, latest summary, etc.).
 ``GET /periodic-threads/{thread_name}``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Detailed status for a single periodic thread (``404`` if not found).
+Detailed status for a single periodic thread (the same per-thread object
+shown in the ``threads`` list above). Returns ``404`` with
+``{"error": "Thread not found: <name>"}`` if the name is unknown.
 
 **Example:**
 
@@ -1023,7 +1226,8 @@ Detailed status for a single periodic thread (``404`` if not found).
 
 Fast health check covering only ``critical`` and ``high`` level periodic
 threads. A thread is flagged unhealthy when it is marked running but has
-not ticked within its expected interval.
+not ticked within its expected interval. Always returns ``200`` — health
+is conveyed by the ``healthy`` boolean, not the HTTP status.
 
 **Response** (``200 OK``):
 
@@ -1058,11 +1262,64 @@ When something is lagging:
 
     curl -s http://localhost:8080/periodic-threads-health
 
+``GET /env``
+~~~~~~~~~~~~
+
+Dumps the process environment variables as a sorted, pretty-printed
+JSON document. The response ``Content-Type`` is ``text/plain`` so it can be
+piped directly to a terminal.
+
+.. warning::
+
+   The payload contains **every** environment variable, including any
+   secrets injected via the environment. There is no redaction or auth —
+   restrict network access to this endpoint in production.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/env
+
+``POST /run_script``
+~~~~~~~~~~~~~~~~~~~~
+
+Execute an uploaded Python script inside the server process. The script is
+uploaded as multipart form data under the field name ``script`` and is
+``exec``'d with a restricted ``__builtins__`` (only ``print``, ``str``,
+``int``, ``float``, ``list``, ``dict``, ``tuple``, ``set``, and a guarded
+``__import__``). Only modules listed in ``--script-allowed-imports`` can be
+imported; the running FastAPI ``app`` is injected into the script globals.
+If the script assigns a variable named ``result``, its stringified value is
+returned; otherwise the body is ``"Script executed successfully"``
+(``Content-Type: text/plain``).
+
+.. danger::
+
+   This endpoint runs caller-supplied code in-process. The restricted
+   builtins are **not** a security sandbox — combined with the injected
+   ``app`` object and any allowed imports, treat it as full remote code
+   execution. Never expose it on an untrusted network.
+
+**HTTP status codes:**
+
+- ``200``: script executed.
+- ``400``: no ``script`` file provided.
+- ``500``: an exception was raised during import setup or execution
+  (body: ``"Error executing script: <reason>"``).
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s -X POST http://localhost:8080/run_script \
+        -F 'script=@my_script.py'
+
 Adding New Endpoints
 --------------------
 
 Endpoints are auto-discovered from
-``lmcache/v1/multiprocess/http_apis/``. To add a new endpoint:
+``lmcache/v1/multiprocess/http_apis/``. To add a new MP-only endpoint:
 
 1. Create a new module in that directory named ``<name>_api.py``.
 2. Define a module-level ``router = APIRouter()``.
@@ -1079,7 +1336,10 @@ server, add it under ``lmcache/v1/internal_api_server/common/`` instead.
 It will be picked up on the MP side via ``common_api.py`` unless its
 module name is listed in ``_MP_INCOMPATIBLE_MODULES`` there (reserved
 for modules that require vLLM-specific ``app.state`` attributes; the
-list is currently empty).
+list is currently empty). A handler that lives under
+``internal_api_server/vllm/`` can still be surfaced on the MP server by
+adding a thin re-export shim under ``http_apis/`` (as
+``version_api.py`` does for the version endpoints).
 
 When adding a new endpoint, please also add a matching section to this
 page documenting the endpoint's purpose, request/response schema, and

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -93,7 +93,7 @@ Engine and Modules
 All server entry points share the same ``MPCacheServer`` and
 ``StorageManager`` core. ``MPCacheServer`` is now a thin compositor:
 it holds an ``MPCacheServerContext`` and a list of ``EngineModule``
-instances assembled by ``build_engine_modules()`` (in ``server.py``)
+instances assembled by ``_build_modules()`` (in ``server.py``)
 based on ``--engine-type`` and ``--supported-transfer-mode``.
 
 **``server.py``** -- The default ZMQ-only server.  Creates an
@@ -282,6 +282,24 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
        match, reconciles, issues one sparse-coalesced prefetch, and
        classifies per-TP-rank. Returns ``CBUnifiedLookupResult`` (or
        ``None`` while the prefetch is still in flight).
+   * - ``P2P_LOOKUP_AND_LOCK``
+     - BLOCKING
+     - (P2P) Look up the given keys and read-lock the locally cached
+       prefix. Returns a task id which the caller passes to
+       ``P2P_QUERY_LOOKUP_RESULTS`` to poll for the transfer addresses.
+       Part of the peer-to-peer KV cache sharing surface; the handler
+       module is not yet wired into the default
+       ``_build_modules()`` path -- see :doc:`p2p`.
+   * - ``P2P_QUERY_LOOKUP_RESULTS``
+     - BLOCKING
+     - (P2P) Poll the transfer addresses for a lookup task. Returns a
+       list of ``TransferChannelAddress`` once the lookup is complete,
+       or ``None`` while the lookup is still in progress or its
+       results have already been consumed.
+   * - ``P2P_UNLOCK_OBJECTS``
+     - BLOCKING
+     - (P2P) Release the read locks previously taken by
+       ``P2P_LOOKUP_AND_LOCK`` on the given keys.
 
 **Handler types:**
 

--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -603,7 +603,7 @@ for the technique itself.
 
 It has two halves the operator runs together:
 
-- a GPU-resident ``blend_v3`` engine (``lmcache server --engine-type blend``),
+- a GPU-resident CacheBlend V3 engine (``lmcache server --engine-type blend``),
   deployed as a DaemonSet with the **same GPU model as** ``LMCacheEngine``
   (``privileged`` + ``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all``
   + ``hostIPC``, and **no** ``nvidia.com/gpu`` claim) so it shares the vLLM GPU


### PR DESCRIPTION
## Summary

Consolidates the open **daily docs drift-check** PRs into a single branch and
**reconciles every edit against the current `dev` code as the authoritative
source of truth**. Where a prior PR's wording had gone stale (the code moved
after the PR was opened), the edit was corrected or dropped rather than carried
over verbatim.

All of their actionable drift is folded in here (corrected where needed):

closes #3658
closes #3759
closes #3738
closes #3724
closes #3681

## Carried over as-is (still match code)

| Source PR | File | Change |
| --- | --- | --- |
| #3658 | `docs/source/mp/operator.rst` | Drop the stale `` `blend_v3` `` prose label → "CacheBlend V3" (`--engine-type` accepts `default`/`blend`/`blend_legacy`; `blend` = CacheBlend V3). |
| #3681 | `docs/source/cli/describe.rst`, `docs/source/mp/http_api.rst`, `docs/design/cli/commands/describe.md`, `docs/design/v1/gpu_connector/layout-invariant.md` | `gpu_kv_*` → `engine_kv_*`, `GPUKVFormat` → `EngineKVFormat`. Verified against the keys emitted in `lmcache/v1/platform/base_cache_context.py:309-316` and the labels in `lmcache/cli/commands/describe.py:249-250`. |
| #3738 | `docs/source/cli/coordinator.rst` | Document `--blend-chunk-size` / `--blend-probe-stride` (defaults `256`/`1`) and the `BLEND_CHUNK_SIZE` / `BLEND_PROBE_STRIDE` env vars. |
| #3724 | `docs/design/v1/distributed/l2_adapters/raw_block.md` | Redirect the "User docs" link to `docs/source/mp/l2_storage/raw_block.rst` (the monolithic `l2_storage.rst` was split). |
| #3759 | `docs/source/mp/index.rst` | Add the `P2P_LOOKUP_AND_LOCK` / `P2P_QUERY_LOOKUP_RESULTS` / `P2P_UNLOCK_OBJECTS` `RequestType` rows (all `BLOCKING`). |

## Corrected during code reconciliation (prior PRs were stale)

- **`docs/source/cli/bench.rst` + `docs/design/cli/commands.md` — transfer-mode semantics were backwards.**
  Both #3681's `bench.rst` (which also conflicted with `dev`) and the
  cleanly-applied `commands.md` described `engine_driven` / `lmcache_driven`
  with the meanings swapped. Per
  `lmcache/cli/commands/bench/server_bench/command.py` (help text + the
  `use_handle = use_gpu` resolution):
  - `lmcache_driven` = single-shot **handle** path
    (`REGISTER_KV_CACHE` + `STORE`/`RETRIEVE`, CUDA IPC / SHM zero-copy)
  - `engine_driven` = worker-side **gather/scatter** path
    (`REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT` + `PREPARE`/`COMMIT`)
  - `auto` maps **gpu→lmcache_driven, cpu→engine_driven**

  Rewrote the affected table cells and CPU-mode prose/examples to match.
- **`docs/source/cli/bench.rst` — stale RPC name.** #3681 used
  `REGISTER_KV_CACHE_NON_GPU_CONTEXT`, which no longer exists; the enum member
  is now `REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT`
  (`lmcache/v1/multiprocess/protocols/base.py:51`).
- **`docs/source/mp/index.rst` — stale function name.** The module-build
  function is `_build_modules()` (`server.py:159`), not `build_engine_modules()`.
  Fixed both the new P2P note and a pre-existing occurrence at line 96.

## Superseded (dropped)

- **`docs/design/v1/multiprocess/worker_liveness.md`** (#3724): the
  `NonGPUContextEntry` → `EngineDrivenContextEntry` /
  `NonGPUTransferModule` → `EngineDrivenTransferModule` rename is **already
  on `dev`** (and `dev`'s doc is further ahead). `NonGPU*` no longer exists in
  code, so no edit is needed — #3724's version of this file was dropped to take
  `dev`'s.

## Not touched (by established convention)

- Chinese `.po` localization files under `docs/source/locale/zh_CN/` — they are
  regenerated from the English sources by the translation pipeline. They still
  contain the old `handle`/`data` terminology and will refresh on the next sync.

## Notes

- Doc-only change; no code touched.
- Every edit was re-verified against `dev` (`ca79ea33`) after applying.

---
_Generated by [Claude Code](https://claude.com/claude-code)_
