### PR TITLE
[MP][P2P] Finalize P2P wiring

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -47,6 +47,16 @@ steps:
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
         artifact_paths: ["*.log"]
 
+      # Two LMCache MP instances + two vLLM instances + one coordinator on a
+      # single 2-GPU pod (localhost). Verifies engine B serves a long prompt's
+      # KV from engine A over P2P.
+      - label: ":compression: p2p"
+        command: .buildkite/k3_tests/multiprocess/run.sh p2p
+        timeout_in_minutes: 30
+        agents: { queue: "k8s" }
+        plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
+        artifact_paths: ["*.log"]
+
   - group: ":compression: Multiprocess (1-GPU)"
     steps:
       - label: ":compression: lm_eval"

--- a/.buildkite/k3_tests/multiprocess/run.sh
+++ b/.buildkite/k3_tests/multiprocess/run.sh
@@ -3,12 +3,12 @@
 # Usage: run.sh <test_name>
 #   test_name: lm_eval | hma_lm_eval_gemma4 | vllm_bench | long_doc_qa
 #              | long_doc_qa_l2 | fault_tolerance | deadlock | restart_recovery
-#              | gds_smoke_test
+#              | gds_smoke_test | p2p
 # Thin wrapper: sets up environment, then delegates to scripts/.
 # No Docker -- all processes run natively in the pod.
 set -euo pipefail
 
-TEST_NAME="${1:?Usage: $0 <test_name>  (lm_eval|hma_lm_eval_gemma4|vllm_bench|long_doc_qa|long_doc_qa_l2|fault_tolerance|deadlock|restart_recovery|cache_stats|http_api)}"
+TEST_NAME="${1:?Usage: $0 <test_name>  (lm_eval|hma_lm_eval_gemma4|vllm_bench|long_doc_qa|long_doc_qa_l2|fault_tolerance|deadlock|restart_recovery|cache_stats|http_api|p2p)}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 

--- a/.buildkite/k3_tests/multiprocess/scripts/run-p2p.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-p2p.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# P2P end-to-end test: two LMCache MP instances + two vLLM instances + one
+# coordinator, all in a single 2-GPU pod over localhost.
+#
+# Topology:
+#   coordinator           : http://127.0.0.1:12300
+#   lmcache A (GPU 0)      : zmq 6555, http 7555, p2p-advertise 127.0.0.1:8555
+#   lmcache B (GPU 1)      : zmq 6556, http 7556, p2p-advertise 127.0.0.1:8556
+#   vLLM A    (GPU 0)      : port 8000, connector -> lmcache A (mp.port 6555)
+#   vLLM B    (GPU 1)      : port 8001, connector -> lmcache B (mp.port 6556)
+#
+# Flow:
+#   1. Both lmcache servers register with the coordinator and discover each
+#      other; each creates a P2P L2 adapter for its peer.
+#   2. Send a long prompt to vLLM A (cold) -> stored in lmcache A's L1.
+#   3. Send the same prompt to vLLM B. B's L1 is empty and its only L2 adapter
+#      is the P2P adapter pointing at A, so any LMCache hit on B must have been
+#      fetched from A over P2P.
+#   4. Assert B's num_lmcache_cached_tokens > 0.
+#
+# Self-contained: launches every process itself and records PIDs in the shared
+# PID file so cleanup.sh tears them down on exit.
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
+
+MODEL="${MODEL:-Qwen/Qwen3-14B}"
+BUILD_ID="${BUILD_ID:-local_$$}"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/lmcache_ci_results_${BUILD_ID}}"
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-300}"
+CPU_BUFFER_SIZE="${CPU_BUFFER_SIZE:-80}"
+MAX_WORKERS="${MAX_WORKERS:-4}"
+
+# Ports (localhost, single pod).
+COORDINATOR_PORT="${COORDINATOR_PORT:-12300}"
+COORDINATOR_URL="http://127.0.0.1:${COORDINATOR_PORT}"
+LMCACHE_A_PORT=6555; LMCACHE_A_HTTP=7555; LMCACHE_A_P2P="127.0.0.1:8555"
+LMCACHE_B_PORT=6556; LMCACHE_B_HTTP=7556; LMCACHE_B_P2P="127.0.0.1:8556"
+VLLM_A_PORT=8000
+VLLM_B_PORT=8001
+
+# Tell cleanup.sh which ports to free (PID-file kill covers the rest).
+export VLLM_PORT="$VLLM_A_PORT"
+export VLLM_BASELINE_PORT="$VLLM_B_PORT"
+export LMCACHE_PORT="$LMCACHE_A_PORT"
+
+# GPUs: K8s assigns devices 0 and 1.
+GPU_A="${GPU_FOR_A:-0}"
+GPU_B="${GPU_FOR_B:-1}"
+
+P2P_DIR="$RESULTS_DIR/p2p"
+mkdir -p "$P2P_DIR"
+
+PID_FILE="/tmp/lmcache_mp_pids_${BUILD_ID}"
+> "$PID_FILE"
+
+# vLLM GPU-memory fraction: clamp on very large GPUs so APC does not cover the
+# whole prefix and hide the LMCache path (mirrors launch-processes.sh).
+GPU_MEMORY_UTIL_ARG=""
+GPU_MEMORY_MB=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits -i "${GPU_A}" | tr -d ' ')
+GPU_MEMORY_GB=$((GPU_MEMORY_MB / 1024))
+echo "Detected GPU memory: ${GPU_MEMORY_GB}GB"
+if [ -n "${GPU_MEMORY_UTILIZATION:-}" ]; then
+    GPU_MEMORY_UTIL_ARG="--gpu-memory-utilization ${GPU_MEMORY_UTILIZATION}"
+elif [ "$GPU_MEMORY_GB" -gt 90 ]; then
+    GPU_MEMORY_UTIL_ARG="--gpu-memory-utilization 0.5"
+fi
+
+CONNECTOR_CONFIG() {
+    # $1 = lmcache mp port
+    echo "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $1, \"lmcache.mp.mq_timeout\": 10}}"
+}
+
+launch_lmcache() {
+    # $1=gpu $2=zmq_port $3=http_port $4=p2p_advertise $5=instance_id $6=logname
+    CUDA_VISIBLE_DEVICES="$1" \
+    lmcache server \
+        --l1-size-gb "$CPU_BUFFER_SIZE" \
+        --eviction-policy LRU \
+        --max-workers "$MAX_WORKERS" \
+        --port "$2" \
+        --http-port "$3" \
+        --host 127.0.0.1 \
+        --instance-id "$5" \
+        --coordinator-url "$COORDINATOR_URL" \
+        --coordinator-advertise-ip 127.0.0.1 \
+        --p2p-advertise-url "$4" \
+        > "/tmp/build_${BUILD_ID}_${6}.log" 2>&1 &
+    local pid=$!
+    echo "$pid" >> "$PID_FILE"
+    echo "$pid"
+}
+
+launch_vllm() {
+    # $1=gpu $2=serving_port $3=lmcache_mp_port $4=logname
+    # Unset VLLM_PORT so vLLM's get_open_port() picks a random internal port
+    # for torch.distributed instead of colliding on serving_port+1.
+    env -u VLLM_PORT \
+    CUDA_VISIBLE_DEVICES="$1" \
+    VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+    VLLM_SERVER_DEV_MODE=1 \
+    VLLM_BATCH_INVARIANT=1 \
+    PYTHONHASHSEED=0 \
+    vllm serve "$MODEL" \
+        --kv-transfer-config "$(CONNECTOR_CONFIG "$3")" \
+        --attention-backend FLASH_ATTN \
+        --port "$2" \
+        --no-async-scheduling \
+        --max-model-len auto \
+        $GPU_MEMORY_UTIL_ARG \
+        > "/tmp/build_${BUILD_ID}_${4}.log" 2>&1 &
+    local pid=$!
+    echo "$pid" >> "$PID_FILE"
+    echo "$pid"
+}
+
+# ── Step 1: coordinator ──────────────────────────────────────
+echo "=== Launching coordinator on ${COORDINATOR_URL} ==="
+lmcache coordinator --host 0.0.0.0 --port "$COORDINATOR_PORT" \
+    > "/tmp/build_${BUILD_ID}_coordinator.log" 2>&1 &
+echo "$!" >> "$PID_FILE"
+echo "Waiting for coordinator health..."
+for _ in $(seq 1 30); do
+    if curl -sf "${COORDINATOR_URL}/healthz" > /dev/null 2>&1; then break; fi
+    sleep 1
+done
+
+# ── Step 2: two LMCache MP servers ───────────────────────────
+echo "=== Launching LMCache servers ==="
+launch_lmcache "$GPU_A" "$LMCACHE_A_PORT" "$LMCACHE_A_HTTP" "$LMCACHE_A_P2P" \
+    "p2p-a-${BUILD_ID}" "lmcache_a" > /dev/null
+launch_lmcache "$GPU_B" "$LMCACHE_B_PORT" "$LMCACHE_B_HTTP" "$LMCACHE_B_P2P" \
+    "p2p-b-${BUILD_ID}" "lmcache_b" > /dev/null
+echo "Waiting for LMCache servers to initialize..."
+sleep 10
+
+# ── Step 3: wait for P2P discovery (A must see B as a peer) ──
+echo "=== Waiting for P2P peer discovery ==="
+discovered=false
+for _ in $(seq 1 "$MAX_WAIT_SECONDS"); do
+    peers=$(curl -sf "http://127.0.0.1:${LMCACHE_A_HTTP}/status" 2>/dev/null \
+        | python3 -c "import json,sys; print(json.load(sys.stdin).get('p2p_peer_count', 0))" \
+        2>/dev/null || echo 0)
+    if [ "${peers:-0}" -ge 1 ]; then
+        echo "lmcache A discovered ${peers} P2P peer(s)."
+        discovered=true
+        break
+    fi
+    sleep 2
+done
+if [ "$discovered" != "true" ]; then
+    echo "FAIL: lmcache A did not discover its P2P peer in time"
+    echo "--- lmcache A log (tail) ---"; tail -50 "/tmp/build_${BUILD_ID}_lmcache_a.log" || true
+    echo "--- lmcache B log (tail) ---"; tail -50 "/tmp/build_${BUILD_ID}_lmcache_b.log" || true
+    echo "--- coordinator instances ---"; curl -s "${COORDINATOR_URL}/instances" || true
+    exit 1
+fi
+
+# ── Step 4: two vLLM servers ─────────────────────────────────
+echo "=== Launching vLLM servers ==="
+launch_vllm "$GPU_A" "$VLLM_A_PORT" "$LMCACHE_A_PORT" "vllm_a" > /dev/null
+launch_vllm "$GPU_B" "$VLLM_B_PORT" "$LMCACHE_B_PORT" "vllm_b" > /dev/null
+
+wait_for_vllm() {
+    local port="$1" name="$2" logfile="$3"
+    echo "Waiting for $name on port $port..."
+    local deadline=$(( $(date +%s) + MAX_WAIT_SECONDS ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if curl -sf "http://localhost:${port}/health" > /dev/null 2>&1 \
+           || curl -sf "http://localhost:${port}/v1/models" > /dev/null 2>&1; then
+            echo "$name is ready."
+            return 0
+        fi
+        sleep 5
+    done
+    echo "FAIL: $name did not become ready in ${MAX_WAIT_SECONDS}s"
+    tail -100 "$logfile" 2>/dev/null || true
+    return 1
+}
+wait_for_vllm "$VLLM_A_PORT" "vLLM A" "/tmp/build_${BUILD_ID}_vllm_a.log"
+wait_for_vllm "$VLLM_B_PORT" "vLLM B" "/tmp/build_${BUILD_ID}_vllm_b.log"
+
+# ── Step 5: long prompt to A (cold), then B (P2P hit) ────────
+LONG_CONTENT="Explain the history of computer science in great detail. $(printf 'The Turing machine is a fundamental concept in theoretical computer science that defines an abstract machine capable of manipulating symbols on a strip of tape according to a table of rules. %.0s' {1..20})"
+
+send_request() {
+    # $1=port $2=label $3=output_file
+    local http_code
+    http_code=$(curl -s -o "$3" -w "%{http_code}" \
+        -X POST "http://localhost:${1}/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"model\": \"${MODEL}\",
+            \"messages\": [{\"role\": \"user\", \"content\": $(python3 -c "import json;print(json.dumps('$LONG_CONTENT'))")}],
+            \"max_tokens\": 1,
+            \"kv_transfer_params\": {\"cached_token_stats\": true}
+        }")
+    if [ "$http_code" -ne 200 ]; then
+        echo "FAIL: $2 returned HTTP $http_code"; cat "$3"; return 1
+    fi
+    echo "$2: HTTP 200 OK"
+}
+
+echo "=== Step 5a: cold request to vLLM A (populates lmcache A) ==="
+send_request "$VLLM_A_PORT" "engine-A-cold" "$P2P_DIR/a_cold.json"
+
+# Let A's store complete and become lockable before B looks it up over P2P.
+sleep 8
+
+echo "=== Step 5b: same request to vLLM B (should hit A over P2P) ==="
+send_request "$VLLM_B_PORT" "engine-B-p2p" "$P2P_DIR/b_p2p.json"
+
+# ── Step 6: assert B got a P2P cache hit ─────────────────────
+echo "=== Step 6: verify P2P cache hit on engine B ==="
+python3 -c "
+import json, sys
+
+with open('$P2P_DIR/b_p2p.json') as f:
+    data = json.load(f)
+
+stats = (data.get('kv_transfer_params') or {}).get('cached_token_stats')
+if stats is None:
+    print('FAIL: cached_token_stats missing from engine B response')
+    print(data)
+    sys.exit(1)
+
+lmcache_hits = stats['num_lmcache_cached_tokens']
+vllm_hits = stats['num_vllm_cached_tokens']
+print(f'engine B num_vllm_cached_tokens:    {vllm_hits}')
+print(f'engine B num_lmcache_cached_tokens: {lmcache_hits}')
+
+# B never saw this prompt and its only L2 adapter is the P2P adapter to A, so a
+# positive LMCache hit can only have come from A over P2P.
+if lmcache_hits <= 0:
+    print('FAIL: engine B had no LMCache hits; P2P fetch did not happen')
+    sys.exit(1)
+
+print(f'PASS: engine B served {lmcache_hits} tokens from peer A over P2P')
+"
+
+echo "============================================"
+echo "=== P2P test PASSED ==="
+echo "============================================"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -84,7 +84,7 @@ echo "Results dir: $RESULTS_DIR"
 echo ""
 
 # Tests that handle their own server lifecycle (different GPU/model config)
-SELF_CONTAINED_TESTS=" deadlock "
+SELF_CONTAINED_TESTS=" deadlock p2p "
 
 # Tests that compare against a baseline vLLM (no LMCache) on a second GPU.
 # Only these need the baseline server (and thus a 2-GPU pod); everything
@@ -154,6 +154,9 @@ case "$TEST_NAME" in
     cache_stats)
         exec_script="${SCRIPT_DIR}/run-cache-stats.sh"
         ;;
+    p2p)
+        exec_script="${SCRIPT_DIR}/run-p2p.sh"
+        ;;
     http_api)
         exec_script="${SCRIPT_DIR}/run-http-api.sh"
         ;;
@@ -162,7 +165,7 @@ case "$TEST_NAME" in
         ;;
     *)
         echo "Unknown test: $TEST_NAME"
-        echo "Valid tests: lm_eval, hma_lm_eval_gemma4, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock, restart_recovery, cache_stats, http_api, gds_smoke_test"
+        echo "Valid tests: lm_eval, hma_lm_eval_gemma4, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock, restart_recovery, cache_stats, http_api, gds_smoke_test, p2p"
         exit 1
         ;;
 esac

--- a/lmcache/cli/commands/server.py
+++ b/lmcache/cli/commands/server.py
@@ -50,9 +50,11 @@ class ServerCommand(BaseCommand):
                 add_coordinator_args,
                 add_http_frontend_args,
                 add_mp_server_args,
+                add_p2p_args,
             )
 
             add_mp_server_args(parser)
+            add_p2p_args(parser)
             add_storage_manager_args(parser)
             add_http_frontend_args(parser)
             add_observability_args(parser)

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -313,6 +313,28 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
         )
 
 
+def l1_exposes_single_memory_region(config: StorageManagerConfig) -> bool:
+    """Whether L1 is a single host-memory region a transfer channel can register.
+
+    This is the requirement for L2 adapters that register the whole L1 buffer
+    for RDMA (e.g. the P2P adapter). GDS L1 exposes no registerable buffer, and
+    Device-DAX L1 is not host DRAM the transfer channel can register.
+
+    Args:
+        config: Storage manager configuration to inspect.
+
+    Returns:
+        ``True`` when L1 is a single registerable host-memory region, ``False``
+        for GDS L1 or Device-DAX L1.
+    """
+    l1_config = config.l1_manager_config
+    if l1_config.gds_l1_config is not None:
+        return False
+    if l1_config.memory_config.devdax_path:
+        return False
+    return True
+
+
 def add_storage_manager_args(
     parser: argparse.ArgumentParser,
 ) -> argparse.ArgumentParser:

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -314,18 +314,14 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
 
 
 def l1_exposes_single_memory_region(config: StorageManagerConfig) -> bool:
-    """Whether L1 is a single host-memory region a transfer channel can register.
-
-    This is the requirement for L2 adapters that register the whole L1 buffer
-    for RDMA (e.g. the P2P adapter). GDS L1 exposes no registerable buffer, and
-    Device-DAX L1 is not host DRAM the transfer channel can register.
+    """Whether L1 is a single memory region a transfer channel can register.
 
     Args:
         config: Storage manager configuration to inspect.
 
     Returns:
-        ``True`` when L1 is a single registerable host-memory region, ``False``
-        for GDS L1 or Device-DAX L1.
+        ``True`` if L1 is a single registerable memory region, ``False`` for
+        GDS L1 or Device-DAX L1.
     """
     l1_config = config.l1_manager_config
     if l1_config.gds_l1_config is not None:

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -20,7 +20,7 @@ from lmcache.v1.distributed.api import (
 )
 from lmcache.v1.distributed.config import EvictionConfig, StorageManagerConfig
 from lmcache.v1.distributed.error import L1Error, strerror
-from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.internal_api import L1MemoryDesc, L2AdapterListener
 from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.distributed.l2_adapters import create_l2_adapter
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
@@ -688,6 +688,11 @@ class StorageManager:
         storage manager creates the registry at construction time.
         """
         return self._quota_manager
+
+    @property
+    def l1_memory_desc(self) -> L1MemoryDesc:
+        """Descriptor of the L1 memory buffer backing this storage manager."""
+        return self._l1_memory_desc
 
     def get_l2_usages(
         self,

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -427,37 +427,46 @@ class NixlTransferChannelContext(TransferChannelContext):
 
         # Not yet known: actively connect to the peer and perform the handshake.
         client = self._connect(peer_advertise_url)
-        self.register_client(peer_advertise_url, client)
-        return client
+        return self.register_client(peer_advertise_url, client)
 
     def get_num_connected_clients(self) -> int:
         with self._lock:
             return len(self._clients)
 
-    def register_client(self, key: str, client: NixlTransferChannelClient) -> None:
+    def register_client(
+        self, key: str, client: NixlTransferChannelClient
+    ) -> NixlTransferChannelClient:
         """
         Register a client for the given key (peer advertise url).
 
+        A client already registered for ``key`` is kept; ``client`` is then a
+        redundant duplicate (the active connect and the peer's inbound
+        connection can race) and is closed.
+
         Args:
             key: The peer advertise url to register the client under.
-            client: The NixlTransferChannelClient instance to register.
-        """
-        old_client = None
-        with self._lock:
-            old_client = self._clients.get(key)
-            self._clients[key] = client
+            client: A freshly created NixlTransferChannelClient for the peer.
 
-        if old_client is not None and old_client is not client:
-            logger.warning(
-                "Overwriting existing transfer channel client for %s.",
-                key,
+        Returns:
+            The canonical client for ``key``: the previously registered one if
+            present, otherwise ``client``.
+        """
+        with self._lock:
+            existing = self._clients.get(key)
+            if existing is None:
+                self._clients[key] = client
+                return client
+            if existing is client:
+                return client
+
+        logger.debug("Reusing existing transfer channel client for %s", key)
+        try:
+            client.close()
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Error closing duplicate transfer channel client for %s", key
             )
-            try:
-                old_client.close()
-            except Exception:  # noqa: BLE001
-                logger.exception(
-                    "Error closing old transfer channel client for %s", key
-                )
+        return existing
 
     ############################################################
     # Cleanup

--- a/lmcache/v1/mp_coordinator/http_apis/instances_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/instances_api.py
@@ -76,6 +76,7 @@ async def register_instance(
             last_heartbeat_time=time.monotonic(),
             metadata=dict(body.metadata),
             p2p_advertised_url=body.p2p_advertised_url,
+            mq_port=body.mq_port,
         )
     )
     logger.info("Registered instance %s at %s:%s", instance_id, body.ip, body.http_port)
@@ -130,6 +131,7 @@ async def list_instances(request: Request) -> Any:
             "registration_time": instance.registration_time,
             "metadata": instance.metadata,
             "p2p_advertised_url": instance.p2p_advertised_url,
+            "mq_port": instance.mq_port,
         }
         for instance in _registry(request).all_instances()
     ]

--- a/lmcache/v1/mp_coordinator/registrar.py
+++ b/lmcache/v1/mp_coordinator/registrar.py
@@ -37,6 +37,8 @@ async def register(
     http_port: int,
     advertise_ip: str,
     instance_id: str = "",
+    p2p_advertised_url: str = "",
+    mq_port: int = 0,
 ) -> str:
     """Register an MP server with the coordinator and return its id.
 
@@ -46,6 +48,10 @@ async def register(
         http_port: This MP server's HTTP port to advertise.
         advertise_ip: IP the coordinator should reach this server at.
         instance_id: Desired id; empty lets the coordinator assign one.
+        p2p_advertised_url: Transfer-channel URL to advertise for P2P. Empty
+            when P2P is disabled.
+        mq_port: Port of this server's ZMQ message-queue server for P2P lookup
+            RPCs. 0 when P2P is disabled.
 
     Returns:
         The registered instance id (coordinator-assigned if ``instance_id`` was
@@ -55,7 +61,11 @@ async def register(
         httpx.HTTPError: If the request fails or returns a non-2xx status.
     """
     body = RegisterRequest(
-        instance_id=instance_id, ip=advertise_ip, http_port=http_port
+        instance_id=instance_id,
+        ip=advertise_ip,
+        http_port=http_port,
+        p2p_advertised_url=p2p_advertised_url,
+        mq_port=mq_port,
     )
     response = await client.post(f"{base_url}/instances", json=body.model_dump())
     response.raise_for_status()
@@ -70,6 +80,8 @@ async def keep_registered(
     instance_id: str = "",
     advertise_ip: str = "",
     heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL,
+    p2p_advertised_url: str = "",
+    mq_port: int = 0,
 ) -> None:
     """Register, heartbeat on a timer, and deregister on cancellation.
 
@@ -89,6 +101,10 @@ async def keep_registered(
         advertise_ip: IP the coordinator should reach this server at; defaults to
             the machine's outbound IP.
         heartbeat_interval: Seconds between heartbeats.
+        p2p_advertised_url: Transfer-channel URL to advertise for P2P. Empty
+            when P2P is disabled.
+        mq_port: Port of this server's ZMQ message-queue server for P2P lookup
+            RPCs. 0 when P2P is disabled.
     """
     base_url = coordinator_url.rstrip("/")
     ip = advertise_ip or get_ip()
@@ -103,6 +119,8 @@ async def keep_registered(
                         http_port=http_port,
                         advertise_ip=ip,
                         instance_id=instance_id,
+                        p2p_advertised_url=p2p_advertised_url,
+                        mq_port=mq_port,
                     )
                     logger.info("Registered with coordinator as %s", assigned_id)
                 else:

--- a/lmcache/v1/mp_coordinator/registry.py
+++ b/lmcache/v1/mp_coordinator/registry.py
@@ -37,6 +37,9 @@ class MPInstance:
         metadata: Free-form string key/value pairs supplied at registration.
         p2p_advertised_url: URL this instance advertises for peer-to-peer
             transfers. Empty when the instance does not participate in P2P.
+        mq_port: Port of the instance's ZMQ message-queue server that P2P peers
+            send lookup/unlock RPCs to, reachable at this instance's ``ip``. 0
+            when P2P is disabled.
     """
 
     instance_id: str
@@ -46,6 +49,7 @@ class MPInstance:
     last_heartbeat_time: float
     metadata: dict[str, str] = field(default_factory=dict)
     p2p_advertised_url: str = ""
+    mq_port: int = 0
 
 
 class InstanceRegistry:

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -76,6 +76,9 @@ class RegisterRequest(BaseModel):
         p2p_advertised_url: URL the instance advertises for peer-to-peer
             transfers. Optional -- empty when the instance does not participate
             in P2P.
+        mq_port: Port of the instance's ZMQ message-queue server that P2P peers
+            send lookup/unlock RPCs to, reachable at the instance's ``ip``.
+            Optional -- 0 when P2P is disabled.
     """
 
     instance_id: Annotated[str, StringConstraints(strip_whitespace=True)] = ""
@@ -83,6 +86,7 @@ class RegisterRequest(BaseModel):
     http_port: int = Field(ge=1, le=65535)
     metadata: dict[str, str] = Field(default_factory=dict)
     p2p_advertised_url: Annotated[str, StringConstraints(strip_whitespace=True)] = ""
+    mq_port: int = Field(default=0, ge=0, le=65535)
 
 
 class RegisterResponse(BaseModel):

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -61,6 +61,10 @@ class MPServerConfig:
     )
     """Runtime plugin configuration (locations + extra config)."""
 
+    p2p_config: "P2PConfig" = field(default_factory=lambda: P2PConfig())
+    """Peer-to-peer configuration. P2P is enabled when its advertise URL is
+    set."""
+
     shm_name: str | None = None
     """SHM segment name for engine-driven KV transfer.
     None: auto-allocate (default). "": force pickle. Other: use that name."""
@@ -121,6 +125,45 @@ class RuntimePluginConfig:
     via the JSON config blob.
     Accepts a JSON string on the command line.
     """
+
+
+@dataclass
+class P2PConfig:
+    """Configuration for peer-to-peer KV transfer.
+
+    P2P is enabled when :attr:`advertise_url` is non-empty. It additionally
+    requires a coordinator URL for peer discovery (validated at startup).
+    """
+
+    advertise_url: str = ""
+    """Transfer-channel server ``host:port`` this instance advertises to peers.
+    Empty disables P2P."""
+
+    listen_url: str = ""
+    """Transfer-channel server ``host:port`` to bind and listen on. Empty
+    defers to :attr:`advertise_url`."""
+
+    lookup_timeout: float = 30.0
+    """Seconds before a peer lookup result counts as a miss."""
+
+    load_timeout: float = 30.0
+    """Seconds before a peer load counts as a failure."""
+
+    transfer_engine: str = "nixl"
+    """Transfer-channel implementation to use."""
+
+    @property
+    def enabled(self) -> bool:
+        """Whether P2P is enabled (an advertise URL is configured)."""
+        return bool(self.advertise_url)
+
+    @property
+    def effective_listen_url(self) -> str:
+        """The listen URL, defaulting to the advertise URL when unset."""
+        return self.listen_url or self.advertise_url
+
+
+DEFAULT_P2P_CONFIG = P2PConfig()
 
 
 DEFAULT_MP_SERVER_CONFIG = MPServerConfig()
@@ -357,10 +400,80 @@ def parse_args_to_mp_server_config(
             locations=(args.runtime_plugin_locations or []),
             extra_config=plugin_extra,
         ),
+        p2p_config=parse_args_to_p2p_config(args),
         shm_name=args.shm_name,
         script_allowed_imports=args.script_allowed_imports or [],
         worker_reap_timeout_seconds=args.worker_reap_timeout_seconds,
         worker_registration_grace_seconds=args.worker_registration_grace_seconds,
+    )
+
+
+def add_p2p_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:
+    """Add peer-to-peer configuration arguments to an existing parser.
+
+    Args:
+        parser: The argument parser to add arguments to.
+
+    Returns:
+        The same parser with P2P arguments added.
+    """
+    group = parser.add_argument_group(
+        "P2P", "Configuration for peer-to-peer KV transfer"
+    )
+    group.add_argument(
+        "--p2p-advertise-url",
+        type=str,
+        default="",
+        help="Transfer-channel server host:port this instance advertises to "
+        "peers. Setting it enables P2P (also requires --coordinator-url).",
+    )
+    group.add_argument(
+        "--p2p-listen-url",
+        type=str,
+        default="",
+        help="Transfer-channel server host:port to bind. Defaults to "
+        "--p2p-advertise-url.",
+    )
+    group.add_argument(
+        "--p2p-lookup-timeout",
+        type=float,
+        default=30.0,
+        help="Seconds before a peer lookup result counts as a miss. Default is 30.",
+    )
+    group.add_argument(
+        "--p2p-load-timeout",
+        type=float,
+        default=30.0,
+        help="Seconds before a peer load counts as a failure. Default is 30.",
+    )
+    group.add_argument(
+        "--p2p-transfer-engine",
+        type=str,
+        default="nixl",
+        help="Transfer-channel implementation to use. Default is nixl.",
+    )
+    return parser
+
+
+def parse_args_to_p2p_config(
+    args: argparse.Namespace,
+) -> P2PConfig:
+    """Convert parsed command line arguments to a P2PConfig.
+
+    Args:
+        args: Parsed arguments from the argument parser.
+
+    Returns:
+        The configuration object.
+    """
+    return P2PConfig(
+        advertise_url=getattr(args, "p2p_advertise_url", "") or "",
+        listen_url=getattr(args, "p2p_listen_url", "") or "",
+        lookup_timeout=getattr(args, "p2p_lookup_timeout", 30.0),
+        load_timeout=getattr(args, "p2p_load_timeout", 30.0),
+        transfer_engine=getattr(args, "p2p_transfer_engine", "nixl"),
     )
 
 

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -27,12 +27,14 @@ from lmcache.v1.mp_observability.config import (
 )
 from lmcache.v1.mp_observability.event_bus import get_event_bus
 from lmcache.v1.multiprocess.config import (
+    DEFAULT_COORDINATOR_CONFIG,
     CoordinatorConfig,
     HTTPFrontendConfig,
     MPServerConfig,
     add_coordinator_args,
     add_http_frontend_args,
     add_mp_server_args,
+    add_p2p_args,
     parse_args_to_coordinator_config,
     parse_args_to_http_frontend_config,
     parse_args_to_mp_server_config,
@@ -70,6 +72,7 @@ async def lifespan(app: FastAPI):
         torch_dev.is_available(),
     )
     mp_config = _configs["mp"]
+    coordinator_config = _configs.get("coordinator") or DEFAULT_COORDINATOR_CONFIG
 
     result = run_cache_server(
         mp_config=mp_config,
@@ -77,6 +80,7 @@ async def lifespan(app: FastAPI):
         obs_config=_configs["observability"],
         return_engine=True,
         start_prometheus_http_server=False,
+        coordinator_config=coordinator_config,
     )
     assert result is not None, "run_cache_server returned None with return_engine=True"
     zmq_server, engine = result
@@ -108,14 +112,9 @@ async def lifespan(app: FastAPI):
     # the keep_registered task registers, heartbeats, and deregisters on
     # shutdown. Best-effort: failures are logged and retried, never fatal.
     http_config = _configs.get("http")
-    coordinator_config = _configs.get("coordinator")
     coordinator_client = None
     coordinator_registration_task = None
-    if (
-        coordinator_config is not None
-        and coordinator_config.url
-        and http_config is not None
-    ):
+    if coordinator_config.url and http_config is not None:
         coordinator_client = httpx.AsyncClient(timeout=10.0)
         # Canonical id resolved by run_cache_server above; shared with
         # the OTel service.instance.id so membership matches metrics/traces.
@@ -127,6 +126,8 @@ async def lifespan(app: FastAPI):
                 instance_id=mp_config.instance_id,
                 advertise_ip=coordinator_config.advertise_ip,
                 heartbeat_interval=coordinator_config.heartbeat_interval,
+                p2p_advertised_url=mp_config.p2p_config.advertise_url,
+                mq_port=mp_config.port if mp_config.p2p_config.enabled else 0,
             )
         )
     # Optionally report L2 store/lookup events to the coordinator for
@@ -210,7 +211,16 @@ def run_http_server(
         obs_config: Configuration for the observability stack
         coordinator_config: Configuration for MP coordinator registration
             (an empty URL disables registration)
+
+    Raises:
+        ValueError: If P2P is enabled without a coordinator URL.
     """
+    if mp_config.p2p_config.enabled and not coordinator_config.url:
+        raise ValueError(
+            "P2P requires a coordinator for peer discovery: set "
+            "--coordinator-url (or LMCACHE_COORDINATOR_URL) when "
+            "--p2p-advertise-url is set."
+        )
     _configs["mp"] = mp_config
     _configs["storage_manager"] = storage_manager_config
     _configs["observability"] = obs_config
@@ -241,6 +251,7 @@ def parse_args():
     )
     add_http_frontend_args(parser)
     add_mp_server_args(parser)
+    add_p2p_args(parser)
     add_storage_manager_args(parser)
     add_observability_args(parser)
     add_coordinator_args(parser)

--- a/lmcache/v1/multiprocess/http_server.py
+++ b/lmcache/v1/multiprocess/http_server.py
@@ -16,6 +16,7 @@ from lmcache.logging import init_logger
 from lmcache.v1.distributed.config import (
     StorageManagerConfig,
     add_storage_manager_args,
+    l1_exposes_single_memory_region,
     parse_args_to_config,
 )
 from lmcache.v1.mp_coordinator.l2.event_listener import L2EventListener
@@ -213,14 +214,22 @@ def run_http_server(
             (an empty URL disables registration)
 
     Raises:
-        ValueError: If P2P is enabled without a coordinator URL.
+        ValueError: If P2P is enabled without a coordinator URL, or with an L1
+            tier that is not a single registerable memory region.
     """
-    if mp_config.p2p_config.enabled and not coordinator_config.url:
-        raise ValueError(
-            "P2P requires a coordinator for peer discovery: set "
-            "--coordinator-url (or LMCACHE_COORDINATOR_URL) when "
-            "--p2p-advertise-url is set."
-        )
+    if mp_config.p2p_config.enabled:
+        if not coordinator_config.url:
+            raise ValueError(
+                "P2P requires a coordinator for peer discovery: set "
+                "--coordinator-url (or LMCACHE_COORDINATOR_URL) when "
+                "--p2p-advertise-url is set."
+            )
+        if not l1_exposes_single_memory_region(storage_manager_config):
+            raise ValueError(
+                "P2P requires a single L1 memory region the transfer channel "
+                "can register; it is incompatible with GDS L1 (--gds-l1-path) "
+                "and Device-DAX L1 (--l1-devdax-path)."
+            )
     _configs["mp"] = mp_config
     _configs["storage_manager"] = storage_manager_config
     _configs["observability"] = obs_config

--- a/lmcache/v1/multiprocess/modules/p2p_controller.py
+++ b/lmcache/v1/multiprocess/modules/p2p_controller.py
@@ -88,11 +88,8 @@ class _P2PLookupJob:
 class P2PController:
     """Serves lookup requests from peers and maintains one L2 adapter per peer.
 
-    When P2P is enabled (the config carries an advertise URL), the controller
-    initializes the transfer-channel context, then runs a background thread that
-    polls the coordinator for live peers and adds/removes a peer L2 adapter on
-    the storage manager to match. It also answers lookup/unlock RPCs that peers'
-    adapters send back to this instance.
+    P2P is enabled when ``p2p_config`` carries an advertise URL; otherwise the
+    controller only answers lookup/unlock RPCs.
 
     Args:
         ctx: Shared engine context providing the storage manager and friends.

--- a/lmcache/v1/multiprocess/modules/p2p_controller.py
+++ b/lmcache/v1/multiprocess/modules/p2p_controller.py
@@ -366,6 +366,9 @@ class P2PController:
         except (httpx.HTTPError, ValueError) as e:
             logger.warning("P2P instance discovery failed: %s", e)
             return self._apply_state(_P2PState.UNREGISTERED, {})
+        except Exception:
+            logger.exception("Unexpected error during P2P instance discovery")
+            return self._apply_state(_P2PState.UNREGISTERED, {})
 
         if not self._is_self_registered(instances):
             return self._apply_state(_P2PState.UNREGISTERED, {})

--- a/lmcache/v1/multiprocess/modules/p2p_controller.py
+++ b/lmcache/v1/multiprocess/modules/p2p_controller.py
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
-"""LookupModule: lookup, prefetch polling, and session lifecycle."""
+"""P2PController: peer discovery, adapter lifecycle, and lookup serving."""
 
 # Standard
 from dataclasses import dataclass
+from enum import Enum
 from functools import partial
 import threading
+
+# Third Party
+import httpx
 
 # First Party
 from lmcache.logging import init_logger
@@ -13,19 +17,63 @@ from lmcache.v1.distributed.api import (
     ObjectKey,
     PrefetchHandle,
 )
+from lmcache.v1.distributed.l2_adapters.p2p_l2_adapter import P2PL2AdapterConfig
+from lmcache.v1.distributed.transfer_channel import (
+    delete_transfer_channel_context,
+    initialize_transfer_channel_context,
+)
 from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
 from lmcache.v1.mp_observability.otel_init import register_gauge
+from lmcache.v1.multiprocess.config import CoordinatorConfig, P2PConfig
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
 from lmcache.v1.multiprocess.engine_module import (
     HandlerSpec,
     ThreadPoolType,
 )
 from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.periodic_thread import (
+    PeriodicThread,
+    ThreadLevel,
+    ThreadRunSummary,
+    create_periodic_thread,
+)
 
 logger = init_logger(__name__)
 
 # Sentinel address for keys that were not found (or fell past the L1 prefix).
 _INVALID_ADDRESS = TransferChannelAddress(offset=-1, size=0)
+
+# Consecutive missed polls a peer may be absent before its adapter is removed.
+_MAX_MISSES = 3
+
+
+class _P2PState(Enum):
+    """Registration state of this instance as seen by the coordinator."""
+
+    REGISTERED = "registered"
+    DISCONNECTED = "disconnected"
+    UNREGISTERED = "unregistered"
+
+
+@dataclass
+class _PeerInstance:
+    """A peer's P2P-relevant connection info parsed from ``GET /instances``."""
+
+    instance_id: str
+    ip: str
+    p2p_advertised_url: str
+    mq_port: int
+
+
+@dataclass
+class _PeerAdapter:
+    """Bookkeeping for a P2P L2 adapter created for a single peer."""
+
+    adapter_id: int
+    ip: str
+    p2p_advertised_url: str
+    mq_port: int
+    consecutive_misses: int = 0
 
 
 @dataclass
@@ -38,20 +86,74 @@ class _P2PLookupJob:
 
 
 class P2PController:
-    """Handles lookup/prefetch/unlock requests from peer P2P adapters
+    """Serves lookup requests from peers and maintains one L2 adapter per peer.
+
+    When P2P is enabled (the config carries an advertise URL), the controller
+    initializes the transfer-channel context, then runs a background thread that
+    polls the coordinator for live peers and adds/removes a peer L2 adapter on
+    the storage manager to match. It also answers lookup/unlock RPCs that peers'
+    adapters send back to this instance.
 
     Args:
-        ctx: Shared engine context providing storage manager, token hasher,
-            session manager, event bus, layout descriptor registry, and
-            chunk size.
+        ctx: Shared engine context providing the storage manager and friends.
+        p2p_config: Peer-to-peer configuration; inert when its advertise URL is
+            empty.
+        coordinator_config: Coordinator connection used for peer discovery.
+        instance_id: Stable id of this instance, used to exclude itself from the
+            discovered peer set.
     """
 
-    def __init__(self, ctx: MPCacheServerContext) -> None:
+    def __init__(
+        self,
+        ctx: MPCacheServerContext,
+        p2p_config: P2PConfig,
+        coordinator_config: CoordinatorConfig,
+        instance_id: str,
+    ) -> None:
         self._ctx = ctx
+        self._p2p_config = p2p_config
+        self._instance_id = instance_id
         self._next_task_id = 0
         self._jobs: dict[int, _P2PLookupJob] = {}
         self._job_lock = threading.Lock()
+
+        # Orchestration state (guarded by _orch_lock; written only by the poll
+        # thread, read by report_status).
+        self._orch_lock = threading.Lock()
+        self._state = _P2PState.UNREGISTERED
+        self._adapters: dict[str, _PeerAdapter] = {}
+
+        self._instances_url = ""
+        self._http_client: httpx.Client | None = None
+        self._poll_thread: PeriodicThread | None = None
+
+        if p2p_config.enabled:
+            self._start_orchestration(coordinator_config)
+
         self._setup_metrics()
+
+    def _start_orchestration(self, coordinator_config: CoordinatorConfig) -> None:
+        """Initialize the transfer channel and start the peer-poll thread.
+
+        Args:
+            coordinator_config: Coordinator connection used for peer discovery.
+        """
+        initialize_transfer_channel_context(
+            self._p2p_config.transfer_engine,
+            self._ctx.storage_manager.l1_memory_desc,
+            listen_url=self._p2p_config.effective_listen_url,
+            advertise_url=self._p2p_config.advertise_url,
+        )
+        self._instances_url = coordinator_config.url.rstrip("/") + "/instances"
+        timeout = max(1.0, coordinator_config.heartbeat_interval)
+        self._http_client = httpx.Client(timeout=timeout)
+        self._poll_thread = create_periodic_thread(
+            name="p2p-controller-thread",
+            interval=coordinator_config.heartbeat_interval,
+            execute_fn=self._poll_cycle,
+            level=ThreadLevel.MEDIUM,
+        )
+        self._poll_thread.start()
 
     @property
     def context(self) -> MPCacheServerContext:
@@ -82,19 +184,39 @@ class P2PController:
             ),
         ]
 
-    def report_status(self) -> dict[str, int]:
+    def report_status(self) -> dict[str, object]:
         """Return module-specific status information.
 
         Returns:
-            Dictionary with the count of active prefetch jobs.
+            Dictionary with the active lookup-job count, the P2P registration
+            state, and the set of connected peer instance ids.
         """
+        with self._orch_lock:
+            state = self._state.value
+            peers = sorted(self._adapters.keys())
         return {
             "active_p2p_lookup_jobs": self._active_job_count(),
+            "p2p_enabled": self._p2p_config.enabled,
+            "p2p_state": state,
+            "p2p_peer_count": len(peers),
+            "p2p_peers": peers,
         }
 
     def close(self) -> None:
-        """Release resources owned by this module (no-op)."""
-        pass
+        """Stop the poll thread and release peer adapters and the channel."""
+        if self._poll_thread is not None:
+            self._poll_thread.stop()
+            self._poll_thread = None
+
+        for peer_id in list(self._adapters.keys()):
+            self._remove_adapter(peer_id)
+
+        if self._http_client is not None:
+            self._http_client.close()
+            self._http_client = None
+
+        if self._p2p_config.enabled:
+            delete_transfer_channel_context()
 
     # -----------------------------------------------------------------
     # RPC Handlers
@@ -229,6 +351,212 @@ class P2PController:
                 size=obj.shm_byte_length,
             )
         return addresses
+
+    # -----------------------------------------------------------------
+    # Orchestration (poll thread)
+    # -----------------------------------------------------------------
+
+    def _poll_cycle(self) -> ThreadRunSummary:
+        """Run one discovery cycle: poll the coordinator and reconcile adapters.
+
+        Returns:
+            A summary of the cycle's resulting state and adapter changes.
+        """
+        try:
+            instances = self._fetch_instances()
+        except httpx.TimeoutException:
+            return self._apply_state(_P2PState.DISCONNECTED, {})
+        except (httpx.HTTPError, ValueError) as e:
+            logger.warning("P2P instance discovery failed: %s", e)
+            return self._apply_state(_P2PState.UNREGISTERED, {})
+
+        if not self._is_self_registered(instances):
+            return self._apply_state(_P2PState.UNREGISTERED, {})
+
+        upstream = {
+            inst.instance_id: inst
+            for inst in instances
+            if inst.instance_id != self._instance_id
+            and inst.p2p_advertised_url
+            and inst.ip
+            and inst.mq_port
+        }
+        return self._apply_state(_P2PState.REGISTERED, upstream)
+
+    def _fetch_instances(self) -> list[_PeerInstance]:
+        """Fetch and parse the coordinator's active-instance list.
+
+        Returns:
+            The parsed peer instances.
+
+        Raises:
+            httpx.HTTPError: If the request fails or returns a non-2xx status.
+            ValueError: If the response body is not the expected shape.
+        """
+        assert self._http_client is not None
+        response = self._http_client.get(self._instances_url)
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict) or not isinstance(body.get("instances"), list):
+            raise ValueError("malformed /instances response")
+        instances: list[_PeerInstance] = []
+        for raw in body["instances"]:
+            instance_id = raw.get("instance_id", "")
+            if not instance_id:
+                continue
+            instances.append(
+                _PeerInstance(
+                    instance_id=instance_id,
+                    ip=raw.get("ip", ""),
+                    p2p_advertised_url=raw.get("p2p_advertised_url", ""),
+                    mq_port=int(raw.get("mq_port", 0) or 0),
+                )
+            )
+        return instances
+
+    def _is_self_registered(self, instances: list[_PeerInstance]) -> bool:
+        """Return whether this instance appears in ``instances`` with our URL.
+
+        Args:
+            instances: The peer instances parsed from the coordinator.
+
+        Returns:
+            ``True`` if our instance id is present and advertises our URL.
+        """
+        return any(
+            inst.instance_id == self._instance_id
+            and inst.p2p_advertised_url == self._p2p_config.advertise_url
+            for inst in instances
+        )
+
+    def _apply_state(
+        self,
+        state: _P2PState,
+        upstream: dict[str, _PeerInstance],
+    ) -> ThreadRunSummary:
+        """Record the new state and reconcile adapters against ``upstream``.
+
+        Args:
+            state: The registration state derived from this cycle.
+            upstream: Peer instances to maintain adapters for (empty unless
+                registered).
+
+        Returns:
+            A summary describing the state and adapter changes this cycle.
+        """
+        with self._orch_lock:
+            self._state = state
+        added, removed = self._reconcile(upstream)
+        return ThreadRunSummary(
+            success=True,
+            message=(
+                f"state={state.value} peers={len(upstream)} "
+                f"added={added} removed={removed}"
+            ),
+        )
+
+    def _reconcile(self, upstream: dict[str, _PeerInstance]) -> tuple[int, int]:
+        """Bring the local peer adapters in line with ``upstream``.
+
+        Args:
+            upstream: The peers that should each have a live adapter.
+
+        Returns:
+            A ``(added, removed)`` count of adapter changes this cycle.
+        """
+        added = 0
+        removed = 0
+        for peer_id, inst in upstream.items():
+            current = self._adapters.get(peer_id)
+            if current is None:
+                if self._add_adapter(inst):
+                    added += 1
+            elif self._peer_changed(current, inst):
+                self._remove_adapter(peer_id)
+                removed += 1
+                if self._add_adapter(inst):
+                    added += 1
+            else:
+                current.consecutive_misses = 0
+
+        for peer_id in list(self._adapters.keys()):
+            if peer_id in upstream:
+                continue
+            adapter = self._adapters[peer_id]
+            adapter.consecutive_misses += 1
+            if adapter.consecutive_misses > _MAX_MISSES:
+                self._remove_adapter(peer_id)
+                removed += 1
+        return added, removed
+
+    @staticmethod
+    def _peer_changed(adapter: _PeerAdapter, inst: _PeerInstance) -> bool:
+        """Return whether a peer's advertised connection info changed.
+
+        Args:
+            adapter: The currently tracked adapter for the peer.
+            inst: The peer's freshly discovered info.
+
+        Returns:
+            ``True`` if any connection field differs.
+        """
+        return (
+            adapter.p2p_advertised_url != inst.p2p_advertised_url
+            or adapter.ip != inst.ip
+            or adapter.mq_port != inst.mq_port
+        )
+
+    def _add_adapter(self, inst: _PeerInstance) -> bool:
+        """Create and register a peer L2 adapter for ``inst``.
+
+        Args:
+            inst: The peer to connect to.
+
+        Returns:
+            ``True`` if the adapter was created and tracked.
+        """
+        config = P2PL2AdapterConfig(
+            peer_mq_server_url=f"tcp://{inst.ip}:{inst.mq_port}",
+            peer_transfer_channel_server_url=inst.p2p_advertised_url,
+            lookup_timeout_s=self._p2p_config.lookup_timeout,
+            load_timeout_s=self._p2p_config.load_timeout,
+        )
+        try:
+            adapter_id = self._ctx.storage_manager.add_l2_adapter(config)
+        except Exception:
+            logger.exception("Failed to add P2P adapter for peer %s", inst.instance_id)
+            return False
+        with self._orch_lock:
+            self._adapters[inst.instance_id] = _PeerAdapter(
+                adapter_id=adapter_id,
+                ip=inst.ip,
+                p2p_advertised_url=inst.p2p_advertised_url,
+                mq_port=inst.mq_port,
+            )
+        logger.debug(
+            "Added P2P adapter %d for peer %s (%s)",
+            adapter_id,
+            inst.instance_id,
+            inst.p2p_advertised_url,
+        )
+        return True
+
+    def _remove_adapter(self, peer_id: str) -> None:
+        """Drain and remove the peer L2 adapter for ``peer_id``.
+
+        Args:
+            peer_id: Instance id of the peer whose adapter to remove.
+        """
+        with self._orch_lock:
+            adapter = self._adapters.pop(peer_id, None)
+        if adapter is None:
+            return
+        try:
+            self._ctx.storage_manager.delete_l2_adapter(adapter.adapter_id)
+        except Exception:
+            logger.exception("Failed to remove P2P adapter for peer %s", peer_id)
+            return
+        logger.debug("Removed P2P adapter for peer %s", peer_id)
 
     def _active_job_count(self) -> int:
         """Return the number of active P2P lookup jobs (thread-safe)."""

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -27,6 +27,8 @@ from lmcache.v1.mp_observability.config import (
 )
 from lmcache.v1.mp_observability.trace import maybe_initialize_trace_recorder
 from lmcache.v1.multiprocess.config import (
+    DEFAULT_COORDINATOR_CONFIG,
+    CoordinatorConfig,
     MPServerConfig,
     add_mp_server_args,
     parse_args_to_mp_server_config,
@@ -46,6 +48,7 @@ from lmcache.v1.multiprocess.modules.lmcache_driven_transfer import (
 )
 from lmcache.v1.multiprocess.modules.lookup import LookupModule
 from lmcache.v1.multiprocess.modules.management import ManagementModule
+from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
 from lmcache.v1.multiprocess.mq import MessageQueueServer
 from lmcache.v1.multiprocess.protocol import (
     RequestType,
@@ -159,12 +162,15 @@ def add_handler_helper(
 def _build_modules(
     ctx: MPCacheServerContext,
     mp_config: MPServerConfig,
+    coordinator_config: CoordinatorConfig,
 ) -> list[EngineModule]:
     """Assemble the list of engine modules based on configuration.
 
     Args:
         ctx: The shared engine context.
         mp_config: Server configuration determining which modules to load.
+        coordinator_config: Coordinator connection used by the P2P controller
+            for peer discovery.
 
     Returns:
         List of initialized engine modules.
@@ -174,6 +180,12 @@ def _build_modules(
         supported_transfer_mode="engine_driven".
     """
     lookup_module = LookupModule(ctx)
+    p2p_controller = P2PController(
+        ctx,
+        mp_config.p2p_config,
+        coordinator_config,
+        mp_config.instance_id,
+    )
 
     # Build the transfer and blend modules first so the ManagementModule can
     # be constructed with them as liveness targets / reap listeners. They are
@@ -258,7 +270,13 @@ def _build_modules(
     # and joins the reaper before those modules clear their state and before
     # storage_manager.close() runs.
     blend_modules = [blend_module] if blend_module is not None else []
-    return [lookup_module, management, *transfer_modules, *blend_modules]
+    return [
+        lookup_module,
+        p2p_controller,
+        management,
+        *transfer_modules,
+        *blend_modules,
+    ]
 
 
 def run_cache_server(
@@ -267,6 +285,7 @@ def run_cache_server(
     obs_config: ObservabilityConfig,
     return_engine: bool = False,
     start_prometheus_http_server: bool = True,
+    coordinator_config: CoordinatorConfig = DEFAULT_COORDINATOR_CONFIG,
 ) -> tuple[MessageQueueServer, MPCacheServer] | None:
     """Run the LMCache cache server with ZMQ message queue.
 
@@ -274,6 +293,8 @@ def run_cache_server(
         mp_config: Configuration for the ZMQ multiprocess server.
         storage_manager_config: Configuration for the storage manager.
         obs_config: Configuration for the observability stack.
+        coordinator_config: Coordinator connection used by the P2P controller
+            for peer discovery.
         return_engine: If True, return (server, engine) after starting;
                        if False, run blocking loop to keep server alive.
         start_prometheus_http_server: Whether to start a standalone
@@ -329,7 +350,7 @@ def run_cache_server(
         hash_algorithm=mp_config.hash_algorithm,
     )
 
-    modules = _build_modules(ctx, mp_config)
+    modules = _build_modules(ctx, mp_config, coordinator_config)
     engine = MPCacheServer(ctx, modules)
 
     zmq_context = zmq.Context.instance()

--- a/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter_integration.py
+++ b/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter_integration.py
@@ -53,6 +53,10 @@ from lmcache.v1.distributed.transfer_channel import (  # noqa: E402
 from lmcache.v1.distributed.transfer_channel.impl.nixl_impl import (  # noqa: E402
     NixlTransferChannelContext,
 )
+from lmcache.v1.multiprocess.config import (  # noqa: E402
+    CoordinatorConfig,
+    P2PConfig,
+)
 from lmcache.v1.multiprocess.modules.p2p_controller import P2PController  # noqa: E402
 from lmcache.v1.multiprocess.mq import MessageQueueServer  # noqa: E402
 from lmcache.v1.multiprocess.protocol import get_payload_classes  # noqa: E402
@@ -138,7 +142,12 @@ def test_p2p_adapter_end_to_end():
         )
 
         # --- Peer side: MQ server hosting the P2P controller ---
-        controller = P2PController(_PeerContext(peer_sm))
+        controller = P2PController(
+            _PeerContext(peer_sm),
+            P2PConfig(),
+            CoordinatorConfig(),
+            instance_id="peer",
+        )
         peer_mq_url = f"tcp://{_next_url()}"
         mq_server = MessageQueueServer(peer_mq_url, zmq.Context.instance())
         specs = controller.get_handlers()

--- a/tests/v1/distributed/test_l1_single_region.py
+++ b/tests/v1/distributed/test_l1_single_region.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``l1_exposes_single_memory_region`` (P2P L1 compatibility)."""
+
+# First Party
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    GdsL1Config,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+    l1_exposes_single_memory_region,
+)
+from lmcache.v1.distributed.l2_adapters.config import L2AdaptersConfig
+
+_SIZE = 128 * 1024 * 1024
+
+
+def _config(
+    memory_config: L1MemoryManagerConfig,
+    gds_l1_config: GdsL1Config | None = None,
+) -> StorageManagerConfig:
+    return StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=memory_config,
+            gds_l1_config=gds_l1_config,
+            write_ttl_seconds=600,
+            read_ttl_seconds=300,
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+        l2_adapter_config=L2AdaptersConfig(adapters=[]),
+    )
+
+
+def test_plain_dram_is_single_region():
+    config = _config(L1MemoryManagerConfig(size_in_bytes=_SIZE, use_lazy=False))
+    assert l1_exposes_single_memory_region(config) is True
+
+
+def test_gds_l1_is_not_single_region():
+    config = _config(
+        L1MemoryManagerConfig(size_in_bytes=_SIZE, use_lazy=False),
+        gds_l1_config=GdsL1Config(file_location="/tmp/gds_slab", size_in_bytes=_SIZE),
+    )
+    assert l1_exposes_single_memory_region(config) is False
+
+
+def test_devdax_l1_is_not_single_region():
+    config = _config(
+        L1MemoryManagerConfig(
+            size_in_bytes=_SIZE,
+            use_lazy=False,
+            devdax_path="/dev/dax0.0",
+            shm_name="",
+        )
+    )
+    assert l1_exposes_single_memory_region(config) is False

--- a/tests/v1/distributed/transfer_channel/test_nixl_impl.py
+++ b/tests/v1/distributed/transfer_channel/test_nixl_impl.py
@@ -20,6 +20,7 @@ an existing context's connected clients short of closing it.
 """
 
 # Standard
+from unittest.mock import MagicMock
 import itertools
 import time
 
@@ -170,6 +171,21 @@ def test_get_client_is_idempotent(shared_contexts):
     first = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
     second = ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
     assert first is second
+
+
+def test_register_client_keeps_first_and_closes_duplicate(fresh_contexts):
+    """A racing second registration keeps the first client and closes the dup."""
+    ctx_a, _, _, _ = fresh_contexts
+    key = "10.255.255.1:65000"
+    first = MagicMock()
+    second = MagicMock()
+
+    assert ctx_a.register_client(key, first) is first
+    # The peer's inbound connection registers a duplicate for the same key.
+    assert ctx_a.register_client(key, second) is first
+    second.close.assert_called_once()
+    first.close.assert_not_called()
+    assert ctx_a.get_num_connected_clients() == 1
 
 
 def test_connecting_registers_clients_on_both_sides(fresh_contexts):

--- a/tests/v1/mp_coordinator/test_api.py
+++ b/tests/v1/mp_coordinator/test_api.py
@@ -31,6 +31,34 @@ def test_register_lists_then_deregister():
         assert client.get("/instances").json()["instances"] == []
 
 
+def test_register_round_trips_p2p_and_mq_fields():
+    with _client() as client:
+        client.post(
+            "/instances",
+            json={
+                "instance_id": "i1",
+                "ip": "10.0.0.1",
+                "http_port": 8080,
+                "p2p_advertised_url": "10.0.0.1:7600",
+                "mq_port": 5555,
+            },
+        )
+        listed = client.get("/instances").json()["instances"]
+        assert listed[0]["ip"] == "10.0.0.1"
+        assert listed[0]["p2p_advertised_url"] == "10.0.0.1:7600"
+        assert listed[0]["mq_port"] == 5555
+
+
+def test_register_defaults_mq_port_when_absent():
+    with _client() as client:
+        client.post(
+            "/instances",
+            json={"instance_id": "i1", "ip": "127.0.0.1", "http_port": 8080},
+        )
+        listed = client.get("/instances").json()["instances"]
+        assert listed[0]["mq_port"] == 0
+
+
 def test_re_register_reports_true():
     with _client() as client:
         client.post(

--- a/tests/v1/mp_coordinator/test_registrar.py
+++ b/tests/v1/mp_coordinator/test_registrar.py
@@ -42,6 +42,54 @@ def test_register_returns_assigned_id():
     asyncio.run(run())
 
 
+def test_register_forwards_p2p_and_mq_fields():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Standard
+        import json
+
+        captured.update(json.loads(request.content))
+        return httpx.Response(200, json={"instance_id": "i1", "re_registered": False})
+
+    async def run():
+        async with _client(handler) as client:
+            await register(
+                client,
+                _BASE,
+                http_port=8080,
+                advertise_ip="10.0.0.1",
+                instance_id="i1",
+                p2p_advertised_url="10.0.0.1:7600",
+                mq_port=5555,
+            )
+
+    asyncio.run(run())
+    # The MQ server is reachable at the same advertised ip, so no separate
+    # mq_ip is sent -- only the port.
+    assert captured["ip"] == "10.0.0.1"
+    assert captured["p2p_advertised_url"] == "10.0.0.1:7600"
+    assert captured["mq_port"] == 5555
+
+
+def test_register_omits_mq_port_when_p2p_disabled():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Standard
+        import json
+
+        captured.update(json.loads(request.content))
+        return httpx.Response(200, json={"instance_id": "i1", "re_registered": False})
+
+    async def run():
+        async with _client(handler) as client:
+            await register(client, _BASE, http_port=8080, advertise_ip="10.0.0.1")
+
+    asyncio.run(run())
+    assert captured["mq_port"] == 0
+
+
 async def _run_loop_briefly(client: httpx.AsyncClient, **kwargs) -> None:
     """Run keep_registered for a few ticks, then cancel it."""
     task = asyncio.create_task(

--- a/tests/v1/multiprocess/test_p2p_controller.py
+++ b/tests/v1/multiprocess/test_p2p_controller.py
@@ -459,6 +459,18 @@ def test_poll_cycle_registered_excludes_self_and_adds_peer():
     assert status["p2p_peers"] == ["peerA"]
 
 
+def test_poll_cycle_unexpected_error_does_not_crash():
+    """An unexpected parsing error is caught and maps to Unregistered."""
+    controller, _ = _make_controller()
+    client = _enable_polling(controller)
+    # A non-dict entry makes parsing raise AttributeError (raw.get on a str).
+    client.get.return_value = _instances_response(["not-a-dict"])
+
+    summary = controller._poll_cycle()  # must not raise
+    assert summary.success is True
+    assert controller.report_status()["p2p_state"] == _P2PState.UNREGISTERED.value
+
+
 def test_poll_cycle_skips_peer_without_p2p_url():
     """A peer that advertises no p2p url is not adapted."""
     controller, ctx = _make_controller()

--- a/tests/v1/multiprocess/test_p2p_controller.py
+++ b/tests/v1/multiprocess/test_p2p_controller.py
@@ -8,12 +8,20 @@ definitions, MemoryLayoutDesc wire serialization, and server handlers.
 from unittest.mock import MagicMock
 
 # Third Party
+import httpx
 import torch
 
 # First Party
 from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.l2_adapters.p2p_l2_adapter import P2PL2AdapterConfig
 from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
-from lmcache.v1.multiprocess.modules.p2p_controller import P2PController
+from lmcache.v1.multiprocess.config import CoordinatorConfig, P2PConfig
+from lmcache.v1.multiprocess.modules.p2p_controller import (
+    _MAX_MISSES,
+    P2PController,
+    _P2PState,
+    _PeerInstance,
+)
 from lmcache.v1.multiprocess.mq import msgspec_decode, msgspec_encode
 from lmcache.v1.multiprocess.protocol import (
     RequestType,
@@ -130,8 +138,14 @@ def test_transfer_channel_address_validity():
 
 
 def _make_controller() -> tuple[P2PController, MagicMock]:
+    """Build a P2P-disabled controller (no thread / transfer channel)."""
     ctx = MagicMock()
-    controller = P2PController(ctx)
+    controller = P2PController(
+        ctx,
+        P2PConfig(),
+        CoordinatorConfig(),
+        instance_id="self",
+    )
     return controller, ctx
 
 
@@ -242,9 +256,12 @@ def test_report_status_counts_active_jobs():
     ctx.storage_manager.submit_prefetch_task.return_value = MagicMock(
         l1_found_indices=()
     )
-    assert controller.report_status() == {"active_p2p_lookup_jobs": 0}
+    assert controller.report_status()["active_p2p_lookup_jobs"] == 0
     controller.p2p_lookup_and_lock([_make_key(0)], _make_layout_desc())
-    assert controller.report_status() == {"active_p2p_lookup_jobs": 1}
+    status = controller.report_status()
+    assert status["active_p2p_lookup_jobs"] == 1
+    assert status["p2p_enabled"] is False
+    assert status["p2p_state"] == _P2PState.UNREGISTERED.value
 
 
 def test_get_handlers_covers_all_p2p_request_types():
@@ -256,3 +273,201 @@ def test_get_handlers_covers_all_p2p_request_types():
         RequestType.P2P_QUERY_LOOKUP_RESULTS,
         RequestType.P2P_UNLOCK_OBJECTS,
     }
+
+
+# ============================================================================
+# Orchestration: adapter reconcile
+# ============================================================================
+
+
+def _peer(
+    instance_id: str,
+    url: str = "tc-host:9",
+    ip: str = "10.0.0.2",
+    mq_port: int = 5555,
+) -> _PeerInstance:
+    return _PeerInstance(
+        instance_id=instance_id,
+        ip=ip,
+        p2p_advertised_url=url,
+        mq_port=mq_port,
+    )
+
+
+def test_reconcile_adds_new_peer():
+    """A newly discovered peer gets one P2P L2 adapter with the right urls."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.return_value = 7
+
+    controller._apply_state(_P2PState.REGISTERED, {"peerA": _peer("peerA")})
+
+    ctx.storage_manager.add_l2_adapter.assert_called_once()
+    config = ctx.storage_manager.add_l2_adapter.call_args.args[0]
+    assert isinstance(config, P2PL2AdapterConfig)
+    assert config.peer_mq_server_url == "tcp://10.0.0.2:5555"
+    assert config.peer_transfer_channel_server_url == "tc-host:9"
+    assert controller.report_status()["p2p_peers"] == ["peerA"]
+
+
+def test_reconcile_no_op_when_peer_unchanged():
+    """A still-present, unchanged peer is not re-added on the next cycle."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.return_value = 7
+
+    controller._apply_state(_P2PState.REGISTERED, {"peerA": _peer("peerA")})
+    controller._apply_state(_P2PState.REGISTERED, {"peerA": _peer("peerA")})
+
+    ctx.storage_manager.add_l2_adapter.assert_called_once()
+    ctx.storage_manager.delete_l2_adapter.assert_not_called()
+
+
+def test_reconcile_keeps_peer_within_grace():
+    """A peer absent for up to _MAX_MISSES cycles keeps its adapter."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.return_value = 7
+
+    controller._apply_state(_P2PState.REGISTERED, {"peerA": _peer("peerA")})
+    for _ in range(_MAX_MISSES):
+        controller._apply_state(_P2PState.REGISTERED, {})
+
+    ctx.storage_manager.delete_l2_adapter.assert_not_called()
+    assert controller.report_status()["p2p_peers"] == ["peerA"]
+
+
+def test_reconcile_removes_peer_after_grace():
+    """A peer absent beyond _MAX_MISSES cycles has its adapter removed."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.return_value = 7
+
+    controller._apply_state(_P2PState.REGISTERED, {"peerA": _peer("peerA")})
+    for _ in range(_MAX_MISSES + 1):
+        controller._apply_state(_P2PState.REGISTERED, {})
+
+    ctx.storage_manager.delete_l2_adapter.assert_called_once_with(7)
+    assert controller.report_status()["p2p_peers"] == []
+
+
+def test_reconcile_readds_on_url_change():
+    """A peer whose advertised url changes is removed and re-added."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.side_effect = [7, 8]
+
+    controller._apply_state(_P2PState.REGISTERED, {"peerA": _peer("peerA", url="a:1")})
+    controller._apply_state(_P2PState.REGISTERED, {"peerA": _peer("peerA", url="b:2")})
+
+    ctx.storage_manager.delete_l2_adapter.assert_called_once_with(7)
+    assert ctx.storage_manager.add_l2_adapter.call_count == 2
+    latest = ctx.storage_manager.add_l2_adapter.call_args.args[0]
+    assert latest.peer_transfer_channel_server_url == "b:2"
+
+
+def test_close_removes_all_adapters():
+    """close drains every tracked peer adapter."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.side_effect = [7, 8]
+    controller._apply_state(
+        _P2PState.REGISTERED,
+        {"peerA": _peer("peerA"), "peerB": _peer("peerB", mq_port=5556)},
+    )
+
+    controller.close()
+
+    removed = {c.args[0] for c in ctx.storage_manager.delete_l2_adapter.call_args_list}
+    assert removed == {7, 8}
+
+
+# ============================================================================
+# Orchestration: poll-cycle state machine
+# ============================================================================
+
+
+def _enable_polling(
+    controller: P2PController, advertise_url: str = "me:1"
+) -> MagicMock:
+    """Point a controller's poll loop at a mock coordinator client."""
+    controller._p2p_config = P2PConfig(advertise_url=advertise_url)
+    controller._instances_url = "http://coordinator/instances"
+    client = MagicMock()
+    controller._http_client = client
+    return client
+
+
+def _instances_response(instances: list[dict]) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"instances": instances}
+    return response
+
+
+def _entry(
+    instance_id: str,
+    url: str,
+    ip: str = "10.0.0.9",
+    mq_port: int = 5555,
+) -> dict:
+    return {
+        "instance_id": instance_id,
+        "ip": ip,
+        "p2p_advertised_url": url,
+        "mq_port": mq_port,
+    }
+
+
+def test_poll_cycle_timeout_is_disconnected():
+    """A request timeout maps to the Disconnected state."""
+    controller, _ = _make_controller()
+    client = _enable_polling(controller)
+    client.get.side_effect = httpx.TimeoutException("boom")
+
+    controller._poll_cycle()
+    assert controller.report_status()["p2p_state"] == _P2PState.DISCONNECTED.value
+
+
+def test_poll_cycle_http_error_is_unregistered():
+    """A non-timeout HTTP error maps to the Unregistered state."""
+    controller, _ = _make_controller()
+    client = _enable_polling(controller)
+    client.get.side_effect = httpx.HTTPError("boom")
+
+    controller._poll_cycle()
+    assert controller.report_status()["p2p_state"] == _P2PState.UNREGISTERED.value
+
+
+def test_poll_cycle_self_absent_is_unregistered():
+    """Not finding our own instance in the listing is Unregistered."""
+    controller, _ = _make_controller()
+    client = _enable_polling(controller)
+    client.get.return_value = _instances_response([_entry("other", "tc:1")])
+
+    controller._poll_cycle()
+    assert controller.report_status()["p2p_state"] == _P2PState.UNREGISTERED.value
+
+
+def test_poll_cycle_registered_excludes_self_and_adds_peer():
+    """When registered, peers (but not self) get adapters."""
+    controller, ctx = _make_controller()
+    ctx.storage_manager.add_l2_adapter.return_value = 7
+    client = _enable_polling(controller, advertise_url="me:1")
+    client.get.return_value = _instances_response(
+        [_entry("self", "me:1"), _entry("peerA", "tc:1")]
+    )
+
+    controller._poll_cycle()
+
+    status = controller.report_status()
+    assert status["p2p_state"] == _P2PState.REGISTERED.value
+    assert status["p2p_peers"] == ["peerA"]
+
+
+def test_poll_cycle_skips_peer_without_p2p_url():
+    """A peer that advertises no p2p url is not adapted."""
+    controller, ctx = _make_controller()
+    client = _enable_polling(controller, advertise_url="me:1")
+    client.get.return_value = _instances_response(
+        [_entry("self", "me:1"), _entry("peerA", "")]
+    )
+
+    controller._poll_cycle()
+
+    ctx.storage_manager.add_l2_adapter.assert_not_called()
+    assert controller.report_status()["p2p_peers"] == []


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

_Doc update and example will be in a follow up PR._

**Local test results:**
- Total KV cache volume: 150GB
- LMCache instance 1: 100 GB L1
- LMCache instance 2: 100 GB L1

Single LMCache: 
```
======= Engine Benchmark Result (long-doc-qa) =========
-------------------- Configuration ---------------------
Engine URL:                               localhost:8100
Model:                                    Qwen/Qwen3-14B
Workload:                                    long-doc-qa
----------------------- Results ------------------------
Successful requests:                                  98
Failed requests:                                       0
Benchmark duration (s):                            84.43
Total input tokens:                               981362
Total output tokens:                               12544
Input throughput (tok/s):                       11622.90
Output throughput (tok/s):                        148.57
----------------- Time to First Token ------------------
Mean TTFT (ms):                                  1562.02
P50 TTFT (ms):                                   1647.87
P90 TTFT (ms):                                   2374.86
P99 TTFT (ms):                                   2424.56
-------------------- Decoding Speed --------------------
Mean decode (tok/s):                               51.78
P99 decode (tok/s):                                74.87
========================================================
```

Run on the second LMCache where the 100 GB KV cache is in the first LMCache instance
```
======= Engine Benchmark Result (long-doc-qa) =========
-------------------- Configuration ---------------------
Engine URL:                               localhost:8101
Model:                                    Qwen/Qwen3-14B
Workload:                                    long-doc-qa
----------------------- Results ------------------------
Successful requests:                                  98
Failed requests:                                       0
Benchmark duration (s):                            62.38
Total input tokens:                               981362
Total output tokens:                               12544
Input throughput (tok/s):                       15731.95
Output throughput (tok/s):                        201.09
----------------- Time to First Token ------------------
Mean TTFT (ms):                                   412.16
P50 TTFT (ms):                                    467.86
P90 TTFT (ms):                                    581.49
P99 TTFT (ms):                                    717.92
-------------------- Decoding Speed --------------------
Mean decode (tok/s):                               47.26
P99 decode (tok/s):                                50.68
========================================================

```

<img width="2642" height="1246" alt="image" src="https://github.com/user-attachments/assets/762cc156-0379-44cb-bd96-6ff9ae5e97ff" />



**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
