### PR TITLE
fix: ensure concurrency safety during StorageManager close

### DIFF
--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -82,6 +82,7 @@ class StorageManager:
         self._lifecycle_lock = threading.Lock()
         # Guards the _l2_adapters and _adapter_descriptors dicts.
         self._adapters_lock = threading.Lock()
+        self._closed = False
         self._registered_l2_listeners: list[L2AdapterListener] = []
         self._l2_adapters: dict[int, L2AdapterInterface] = {}
         self._adapter_descriptors: dict[int, AdapterDescriptor] = {}
@@ -792,6 +793,8 @@ class StorageManager:
             The stable id assigned to the new adapter.
         """
         with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("StorageManager is closed")
             adapter_id, adapter, descriptor = self._build_l2_adapter(config)
             for listener in self._registered_l2_listeners:
                 adapter.register_listener(listener)
@@ -831,6 +834,8 @@ class StorageManager:
                 retry.
         """
         with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("StorageManager is closed")
             if adapter_id not in self._l2_adapters:
                 raise ValueError(f"No L2 adapter with id {adapter_id}")
 
@@ -884,17 +889,27 @@ class StorageManager:
         """
         Close the storage manager and release all resources.
         """
-        self._prefetch_controller.stop()
-        self._store_controller.stop()
-        self._eviction_controller.stop()
-        self._l2_eviction_controller.stop()
+        with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
 
-        PeriodicEventNotifier.shutdown()
+            self._prefetch_controller.stop()
+            self._store_controller.stop()
+            self._eviction_controller.stop()
+            self._l2_eviction_controller.stop()
 
-        for adapter in self._l2_adapters.values():
-            adapter.close()
+            PeriodicEventNotifier.shutdown()
 
-        self._l1_manager.close()
+            with self._adapters_lock:
+                adapters = list(self._l2_adapters.values())
+                self._l2_adapters.clear()
+                self._adapter_descriptors.clear()
+
+            for adapter in adapters:
+                adapter.close()
+
+            self._l1_manager.close()
 
     def report_status(self) -> dict:
         """Return a status dict aggregating all sub-component statuses."""
@@ -926,6 +941,8 @@ class StorageManager:
             listener: The listener to register.
         """
         with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("StorageManager is closed")
             self._registered_l2_listeners.append(listener)
             for adapter in self._l2_adapters.values():
                 adapter.register_listener(listener)

--- a/tests/v1/distributed/test_runtime_adapters.py
+++ b/tests/v1/distributed/test_runtime_adapters.py
@@ -390,3 +390,66 @@ class TestStorageManagerRuntimeAdapters:
             assert pairs[0][1] is a1
         finally:
             sm.close()
+
+    def test_closed_behavior(self, empty_storage_manager_config):
+        """Once closed, StorageManager rejects adapter operations."""
+        sm = StorageManager(empty_storage_manager_config)
+        adapter_id = sm.add_l2_adapter(make_mock_config())
+        assert len(sm.l2_adapters()) == 1
+
+        sm.close()
+
+        # check that list is empty
+        assert sm.l2_adapters() == []
+        assert sm.report_status()["num_l2_adapters"] == 0
+
+        # subsequent calls to close should be safe
+        sm.close()
+
+        # operations should raise RuntimeError
+        with pytest.raises(RuntimeError, match="StorageManager is closed"):
+            sm.add_l2_adapter(make_mock_config())
+
+        with pytest.raises(RuntimeError, match="StorageManager is closed"):
+            sm.delete_l2_adapter(adapter_id)
+
+        class DummyListener:
+            pass
+
+        with pytest.raises(RuntimeError, match="StorageManager is closed"):
+            sm.register_l2_listener(DummyListener())  # type: ignore
+
+    def test_concurrent_close_and_add(self, empty_storage_manager_config):
+        """Verify that concurrent close and add_l2_adapter is thread-safe."""
+        # Standard
+        import threading
+        import time
+
+        sm = StorageManager(empty_storage_manager_config)
+        close_started = threading.Event()
+        errors = []
+
+        def worker():
+            close_started.wait()
+            for _ in range(100):
+                try:
+                    sm.add_l2_adapter(make_mock_config())
+                except RuntimeError as e:
+                    if "closed" in str(e):
+                        break
+                    errors.append(e)
+                except Exception as e:
+                    errors.append(e)
+
+        t = threading.Thread(target=worker)
+        t.start()
+
+        time.sleep(0.01)
+        close_started.set()
+
+        sm.close()
+        t.join()
+
+        assert not errors, f"Unexpected errors during concurrent test: {errors}"
+        assert sm.l2_adapters() == []
+        assert sm.report_status()["num_l2_adapters"] == 0


### PR DESCRIPTION
 

**What this PR does / why we need it**:

Concurrency Risk:

method add_l2_adapter() 和  delete_l2_adapter() serialize execution by holding lock _lifecycle_lock .

close() iterates _l2_adapters.values() directly without holding lock _lifecycle_lock, while concurrent add_l2_adapter/delete_l2_adapter operations may modify same  _l2_adapters  dictionary at the meaning time.

So, this PR strengthens close() to hold the lock to prevent  potential crashes during shutdown scenarios.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
