### PR TITLE
Fix: Prevent Version Drift  for Lightweight Images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -376,6 +376,7 @@ jobs:
             - name: Build lmcache/vllm-openai:lightweight
               run: |
                 docker build \
+                --build-arg LMCACHE_VERSION=${{ env.LATEST_TAG }} \
                 --tag lmcache/vllm-openai:lightweight --tag lmcache/vllm-openai:${{ env.LATEST_TAG }}-lightweight \
                 --file docker/Dockerfile.lightweight .
 

--- a/docker/Dockerfile.lightweight
+++ b/docker/Dockerfile.lightweight
@@ -2,7 +2,10 @@
 # Note: You will not be able to run Prefill-Decode Disaggregation (PD) with this image because NIXL is not installed.
 FROM vllm/vllm-openai:latest
 
-RUN uv pip install --system --no-cache lmcache
+ARG LMCACHE_VERSION=""
+
+RUN VER=$(echo "${LMCACHE_VERSION}" | sed 's/^v//') && \
+    uv pip install --system --no-cache "lmcache${VER:+==${VER}}"
 
 
 # Build: 


### PR DESCRIPTION


**What this PR does / why we need it**:

when building the release image in .github/workflows/publish.yml   , it specifies the release version to build the image, with --build-arg LMCACHE_VERSION.


```
# https://github.com/weizhoublue/LMCache/blob/dev/.github/workflows/publish.yml#L349

         - name: Build lmcache/vllm-openai container image (cu13)
              run: |
                docker build \
                --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.09-cuda13.0-devel-ubuntu24.04 \
                --build-arg CUDA_VERSION=13.0 \
                --build-arg LMCACHE_VERSION=${{ env.LATEST_TAG }} \
                --build-arg torch_cuda_arch_list='7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX' \
                --target image-release \
                --tag lmcache/vllm-openai:latest --tag lmcache/vllm-openai:${{ env.LATEST_TAG }} \
                --file docker/Dockerfile .
```

but when it comes to build lmcache/vllm-openai:lightweight in the next step , it always builds the latest version in the image. It looks not to match the design.

so the solution could add arg LMCACHE_VERSION in the Dockerfile.lightweight. When the LMCACHE_VERSION is empty, it will install the latest version.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
