### PR TITLE
fix: Fix ci lazy allocator memcheck race

### DIFF
--- a/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
@@ -194,8 +194,13 @@ class L1MemoryManager:
             )
 
         address_manager = get_address_manager(self._allocator)
-        free_size = address_manager.get_free_size()
-        total_size = address_manager.get_heap_size()
+        if hasattr(address_manager, "get_usage_snapshot"):
+            free_size, _allocated_size, total_size = (
+                address_manager.get_usage_snapshot()
+            )
+        else:
+            free_size = address_manager.get_free_size()
+            total_size = address_manager.get_heap_size()
         used_size = total_size - free_size
         return used_size, total_size
 

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -350,7 +350,7 @@ class MemoryObj(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def byte_array(self) -> bytes:
+    def byte_array(self) -> bytes | bytearray | memoryview:
         """
         Get the byte array from the MemoryObj.
         The size is will be the physical size instead of the unaligned size.
@@ -886,7 +886,11 @@ class BytesBufferMemoryObj(MemoryObj):
     Wraps a raw flat tensor with some metadata
     """
 
-    def __init__(self, raw_bytes: bytes, metadata: Optional[MemoryObjMetadata] = None):
+    def __init__(
+        self,
+        raw_bytes: bytes | bytearray,
+        metadata: Optional[MemoryObjMetadata] = None,
+    ):
         self.raw_data = raw_bytes
         if metadata is None:
             bytes_shape = torch.Size([len(self.raw_data), 0, 0, 0])
@@ -970,7 +974,7 @@ class BytesBufferMemoryObj(MemoryObj):
         return None
 
     @property
-    def byte_array(self) -> bytes:
+    def byte_array(self) -> bytes | bytearray:
         return self.raw_data
 
     @property
@@ -1093,7 +1097,7 @@ class GDSMemoryObject(MemoryObj):
         return None
 
     @property
-    def byte_array(self) -> bytes:
+    def byte_array(self) -> bytes | bytearray | memoryview:
         raise NotImplementedError(
             f"GDSMemoryObject(slab_offset={self.slab_offset}).byte_array is not "
             "supported; bytes live in the GDS slab file and the staging buffer "
@@ -1545,6 +1549,20 @@ class AddressManager:
         """
         return self._size - self.total_allocated_size
 
+    @synchronized("_lock")
+    def get_usage_snapshot(self) -> tuple[int, int, int]:
+        """Return free, allocated, and heap sizes from one locked snapshot.
+
+        Returns:
+            A tuple of ``(free_size, allocated_size, heap_size)`` in bytes.
+        """
+        return (
+            self._size - self.total_allocated_size,
+            self.total_allocated_size,
+            self._size,
+        )
+
+    @synchronized("_lock")
     def check_consistency(self) -> bool:
         """
         Check if the address manager is consistent.
@@ -1807,20 +1825,18 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         clear = True
         logger.info("Checking memory allocator consistency")
         logger.info(f" - Total active allocations: {self.num_active_allocations}")
-        logger.info(
-            f" - Total allocated size: "
-            f"{self.address_manager.total_allocated_size / 1048576} MB"
-        )
+        (
+            total_free_size,
+            total_allocated_size,
+            heap_size,
+        ) = self.address_manager.get_usage_snapshot()
+        logger.info(f" - Total allocated size: {total_allocated_size / 1048576} MB")
 
         # Check the real total free size
-        total_free_size = self.address_manager.get_free_size()
         logger.info(f" - Total free size: {total_free_size / 1048576} MB")
 
         # Check if the numbers are consistent
-        if (
-            total_free_size + self.address_manager.total_allocated_size
-            != self.address_manager.get_heap_size()
-        ):
+        if total_free_size + total_allocated_size != heap_size:
             logger.error("Memory allocator size is inconsistent")
             logger.error("This implies a bug in the memory allocator")
             clear = False

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -10,7 +10,12 @@ import torch
 # First Party
 from lmcache.observability import LMCStatsMonitor
 from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.distributed.config import L1MemoryManagerConfig
+from lmcache.v1.distributed.memory_manager import (
+    l1_memory_manager as l1_memory_manager_module,
+)
 from lmcache.v1.memory_management import (
+    AddressManager,
     BytesBufferMemoryObj,
     GPUMemoryAllocator,
     HostMemoryAllocator,
@@ -145,6 +150,66 @@ def test_tensor_allocator(use_paging):
         check_allocator(allocator, total_size)
 
     allocator.close()
+
+
+def test_tensor_allocator_memcheck_uses_consistent_address_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """memcheck should not mix allocator state from before and after sbrk."""
+    allocator = TensorMemoryAllocator(
+        torch.zeros(2 * AddressManager.ALIGN_BYTES, dtype=torch.uint8),
+        init_address_space=AddressManager.ALIGN_BYTES,
+    )
+
+    original_get_free_size = allocator.address_manager.get_free_size
+
+    def expand_after_reading_free_size() -> int:
+        free_size = original_get_free_size()
+        allocator.address_manager.sbrk(AddressManager.ALIGN_BYTES)
+        return free_size
+
+    monkeypatch.setattr(
+        allocator.address_manager,
+        "get_free_size",
+        expand_after_reading_free_size,
+    )
+
+    assert allocator.memcheck() is True
+    allocator.close()
+
+
+def test_l1_memory_usage_supports_paged_address_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """L1 usage should support paged address managers without snapshots."""
+    page_size = 1024
+    total_size = 4 * page_size
+    paged_allocator = MixedMemoryAllocator(
+        total_size,
+        use_paging=True,
+        shapes=[torch.Size([page_size])],
+        dtypes=[torch.uint8],
+        fmt=MemoryFormat.KV_2LTD,
+    )
+    monkeypatch.setattr(
+        l1_memory_manager_module,
+        "create_memory_allocator",
+        lambda _config: paged_allocator,
+    )
+    manager = l1_memory_manager_module.L1MemoryManager(
+        L1MemoryManagerConfig(
+            size_in_bytes=total_size,
+            use_lazy=False,
+        )
+    )
+
+    try:
+        assert isinstance(paged_allocator.pin_allocator, PagedTensorMemoryAllocator)
+        address_manager = paged_allocator.pin_allocator.address_manager
+        assert not hasattr(address_manager, "get_usage_snapshot")
+        assert manager.get_memory_usage() == (0, total_size)
+    finally:
+        manager.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a race in memory allocator consistency checks by reading free, allocated, and heap sizes from a single locked `AddressManager` snapshot.

This prevents `TensorMemoryAllocator.memcheck()` and L1 memory usage reporting from mixing allocator state before and after lazy address-space growth.

Issue: https://github.com/LMCache/LMCache/issues/3768

**Special notes for your reviewers**:

The regression test monkeypatches the old `get_free_size()` path to grow the address space after reading free size. `memcheck()` now stays consistent because it uses the new snapshot API instead.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests