### PR TITLE
docs: daily drift check — multi-process mode (2026-06-21)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -176,6 +176,42 @@ The HTTP frontend is included when running ``lmcache server``.
      - ``8080``
      - Port to bind the HTTP server.
 
+P2P
+---
+
+Source: ``lmcache/v1/multiprocess/config.py``
+
+These flags configure peer-to-peer KV cache sharing between MP servers
+(see :doc:`p2p`). They are registered by ``add_p2p_args()`` on the
+``lmcache server`` parser. P2P is enabled when ``--p2p-advertise-url``
+is set, which additionally requires a coordinator URL via
+``--coordinator-url`` (or ``LMCACHE_COORDINATOR_URL``).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Argument
+     - Default
+     - Description
+   * - ``--p2p-advertise-url``
+     - ``""`` (P2P disabled)
+     - Transfer-channel server ``host:port`` this instance advertises to
+       peers. Setting it enables P2P (also requires ``--coordinator-url``).
+   * - ``--p2p-listen-url``
+     - ``""``
+     - Transfer-channel server ``host:port`` to bind. Defaults to
+       ``--p2p-advertise-url``.
+   * - ``--p2p-lookup-timeout``
+     - ``30.0``
+     - Seconds before a peer lookup result counts as a miss.
+   * - ``--p2p-load-timeout``
+     - ``30.0``
+     - Seconds before a peer load counts as a failure.
+   * - ``--p2p-transfer-engine``
+     - ``nixl``
+     - Transfer-channel implementation to use.
+
 L1 Memory Manager
 ------------------
 

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -287,9 +287,10 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
      - (P2P) Look up the given keys and read-lock the locally cached
        prefix. Returns a task id which the caller passes to
        ``P2P_QUERY_LOOKUP_RESULTS`` to poll for the transfer addresses.
-       Part of the peer-to-peer KV cache sharing surface; the handler
-       module is not yet wired into the default
-       ``_build_modules()`` path -- see :doc:`p2p`.
+       Served by ``P2PController`` (loaded unconditionally by
+       ``_build_modules()``); whether this server also acts as a P2P
+       client is controlled by ``--p2p-advertise-url`` -- see
+       :doc:`p2p`.
    * - ``P2P_QUERY_LOOKUP_RESULTS``
      - BLOCKING
      - (P2P) Poll the transfer addresses for a lookup task. Returns a


### PR DESCRIPTION
## Summary

The daily docs-drift-check routine found two places in
`docs/source/mp/` that still disagree with the multi-process P2P
wiring landed in
[#3762 (`6f946c6`)](https://github.com/LMCache/LMCache/commit/6f946c612a9fe285aaf18ea17f43be0ed5bf608d).
After that PR:

- `P2PController` is built unconditionally by
  [`_build_modules()`](https://github.com/LMCache/LMCache/blob/3fcbc3b53f4979b34b1f3abd2bb5b24182266464/lmcache/v1/multiprocess/server.py#L162-L279)
  (see `lmcache/v1/multiprocess/server.py:183` and `:275`) and serves the
  three `P2P_*` request types.
- A new `P2P` CLI argument group is registered on `lmcache server`
  via
  [`add_p2p_args()`](https://github.com/LMCache/LMCache/blob/3fcbc3b53f4979b34b1f3abd2bb5b24182266464/lmcache/v1/multiprocess/config.py#L411-L457),
  with five flags (`--p2p-advertise-url`, `--p2p-listen-url`,
  `--p2p-lookup-timeout`, `--p2p-load-timeout`,
  `--p2p-transfer-engine`).

This PR was originally opened on 2026-06-19 with three doc fixes. The
third item — `docs/source/mp/p2p.rst` still saying "coming soon" — was
already resolved upstream by
[#3780 (`a75763d`)](https://github.com/LMCache/LMCache/commit/a75763d),
which fully fleshed out that page. The branch has been refreshed onto
the current `dev` tip (`3fcbc3b`) and the now-obsolete `p2p.rst` edit
was dropped. The remaining two items below are still stale on `dev` and
are what this PR fixes. Docs-only — no code is touched.

### Drift items found and fixed

**`docs/source/` (user-facing, highest priority)**

| # | Doc | Drift |
|---|---|---|
| 1 | [`docs/source/mp/index.rst`](https://github.com/LMCache/LMCache/blob/3fcbc3b53f4979b34b1f3abd2bb5b24182266464/docs/source/mp/index.rst#L285-L292) (ZMQ Protocol RequestType table) | `P2P_LOOKUP_AND_LOCK` row still claims "*the handler module is not yet wired into the default `_build_modules()` path*". It now **is** wired — see [`server.py#L183-L185, L275`](https://github.com/LMCache/LMCache/blob/3fcbc3b53f4979b34b1f3abd2bb5b24182266464/lmcache/v1/multiprocess/server.py#L183). **Fix:** updated the description to say `P2PController` is loaded unconditionally and `--p2p-advertise-url` controls whether this server also acts as a P2P client. |
| 2 | [`docs/source/mp/configuration.rst`](https://github.com/LMCache/LMCache/blob/3fcbc3b53f4979b34b1f3abd2bb5b24182266464/docs/source/mp/configuration.rst) | Documents every CLI argument accepted by the MP server but **missing all five** `--p2p-*` flags registered by [`add_p2p_args()`](https://github.com/LMCache/LMCache/blob/3fcbc3b53f4979b34b1f3abd2bb5b24182266464/lmcache/v1/multiprocess/config.py#L411-L457). **Fix:** added a new "P2P" section right after "HTTP Frontend" with a table for all five flags and a note that P2P enablement also requires `--coordinator-url`. The user-facing P2P page (`docs/source/mp/p2p.rst`) and the global `lmcache server` reference (`docs/source/cli/server.rst`) already document these flags after #3780; the MP configuration reference was the remaining gap. |

**`docs/design/` (secondary)**

No drift found this run. The P2P L2 adapter design doc
([`docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md`](https://github.com/LMCache/LMCache/blob/3fcbc3b53f4979b34b1f3abd2bb5b24182266464/docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md))
landed with PR #3740 and is consistent with the merged code.

### Proposed fix

Applied in this PR's diff — see the file changes tab. Both touched
files are under `docs/source/mp/`.

### Notes

- Auto-generated by the daily drift-check routine. **Needs human
  review before merge.** Not marked Ready for review.
- No code files were modified.
- No corresponding code-level concerns flagged this run.
- The 2026-06-19 version of this PR was rebased onto current `dev` and
  one already-resolved item (`docs/source/mp/p2p.rst`) was dropped.