### PR TITLE
[Bugfix] [CLI bench] Unregister KV cache from MP server on bench server exit

### DIFF
--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -61,6 +61,7 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
     _process_request,
     _require_full_install,
     _send_register_kv_cache,
+    _send_unregister_kv_cache,
     shm_open_pool_as_mmap,
 )
 
@@ -314,6 +315,10 @@ def run_server_bench(
     ctx = zmq.Context()
     client = MessageQueueClient(url, ctx)
 
+    # Tracks whether REGISTER_KV_CACHE succeeded so the ``finally`` block
+    # only deregisters a context that was actually registered.
+    registered = False
+
     try:
         # Query chunk size from server
         chunk_size = _get_chunk_size(client)
@@ -483,6 +488,11 @@ def run_server_bench(
         )
         log("REGISTER_KV_CACHE: %s" % ("OK" if register_result else "FAIL"))
         log("")
+        # Mark the registration so the ``finally`` block knows to send the
+        # matching UNREGISTER. The data-mode register returns a response
+        # object (truthy) and the handle-mode register returns a bool;
+        # either way a truthy result means the server holds our context.
+        registered = bool(register_result)
 
         # In data mode the server reply carries the SHM pool name
         # and size; the bench mmaps the same pool so STORE/RETRIEVE
@@ -591,6 +601,21 @@ def run_server_bench(
     except KeyboardInterrupt:
         log("\nStopping...")
     finally:
+        # Deregister our context from the server before tearing down the
+        # client. Otherwise the server keeps the registration (and the
+        # CUDA-IPC / POSIX-SHM mappings it holds) alive forever, leaking
+        # one context entry per bench run. Must run while the client is
+        # still connected, hence before ``client.close()``.
+        if registered:
+            try:
+                ok = _send_unregister_kv_cache(
+                    client,
+                    instance_id=0,
+                    use_handle=use_handle,
+                )
+                log("UNREGISTER_KV_CACHE: %s" % ("OK" if ok else "FAIL"))
+            except zmq.ZMQError as exc:
+                log("  [warning] UNREGISTER_KV_CACHE failed: %s" % exc)
         # Release the bench-side mmap of the server SHM pool first
         # (data mode only; ``server_pool`` stays ``None`` otherwise).
         if "server_pool" in locals() and server_pool is not None:

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -406,6 +406,47 @@ def _send_register_kv_cache(
     return result
 
 
+def _send_unregister_kv_cache(
+    client: MessageQueueClient,
+    instance_id: int = 0,
+    use_handle: bool = True,
+) -> bool:
+    """Deregister a KV cache context from the MP server.
+
+    The inverse of :func:`_send_register_kv_cache`. Without this call
+    the server keeps the bench's registration (and the CUDA-IPC / POSIX
+    SHM mappings it holds) alive forever, leaking one context entry per
+    bench run.
+
+    Dispatches to the correct protocol based on ``use_handle``, mirroring
+    the register path:
+
+    * Handle mode: ``UNREGISTER_KV_CACHE``.
+    * Data mode: ``UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT``.
+
+    Both protocols take a single ``instance_id`` payload and return a void
+    reply, so success is distinguished from an RPC timeout only.
+
+    Args:
+        client: The MP message-queue client.
+        instance_id: The instance ID used at registration time. Must match
+            the ``instance_id`` passed to :func:`_send_register_kv_cache`.
+        use_handle: ``True`` for the handle path (GPU CUDA-IPC / CPU SHM),
+            ``False`` for the engine-driven data path.
+
+    Returns:
+        ``True`` if the server acknowledged the call, ``False`` on RPC
+        timeout.
+    """
+    request_type = (
+        RequestType.UNREGISTER_KV_CACHE
+        if use_handle
+        else RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+    )
+    result = _call(client, request_type, [instance_id])
+    return result is not _TIMEOUT
+
+
 def _send_lookup(
     client: MessageQueueClient,
     key: IPCCacheServerKey,

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -28,6 +28,7 @@ from lmcache.cli.commands.bench.server_bench.helpers import (
     _poll_prefetch_status,
     _query_checksum,
     _send_lookup,
+    _send_unregister_kv_cache,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocols.base import RequestType
@@ -506,6 +507,103 @@ class TestLookupProtocol:
             )
             assert hit == 5
             assert router.last_query_request_id == "req-42"
+            client.close()
+        finally:
+            router.stop()
+
+
+# ------------------------------------------------------------------ #
+#  _send_unregister_kv_cache (deregister on shutdown)                  #
+# ------------------------------------------------------------------ #
+
+
+class _UnregisterRouter:
+    """Fake ROUTER that records UNREGISTER requests and replies void.
+
+    Both ``UNREGISTER_KV_CACHE`` and
+    ``UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT`` carry a single
+    ``instance_id`` payload and return ``None`` (void). This fake
+    records the request type and decoded ``instance_id`` of the last
+    UNREGISTER it saw so the test can assert the bench sends the
+    correct protocol for each transfer mode.
+    """
+
+    def __init__(self, endpoint: str) -> None:
+        self.last_request_type: RequestType | None = None
+        self.last_instance_id: int | None = None
+        self._ctx = zmq.Context.instance()
+        self._router = self._ctx.socket(zmq.ROUTER)
+        self._router.bind(endpoint)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+        self._router.close(linger=0)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            if not self._router.poll(100, zmq.POLLIN):
+                continue
+            frames = self._router.recv_multipart()
+            identity, uid_f, type_f, *payload = frames
+            req_type = msgspec.msgpack.decode(type_f, type=RequestType)
+            if req_type in (
+                RequestType.UNREGISTER_KV_CACHE,
+                RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT,
+            ):
+                self.last_request_type = req_type
+                self.last_instance_id = msgspec.msgpack.decode(payload[0], type=int)
+                # Void reply: no payload frame.
+                self._router.send_multipart([identity, uid_f, type_f])
+
+
+class TestUnregisterKVCache:
+    def _make_client(self, endpoint: str) -> MessageQueueClient:
+        ctx = zmq.Context.instance()
+        return MessageQueueClient(endpoint, ctx)
+
+    def test_handle_mode_sends_unregister_kv_cache(
+        self,
+        router_endpoint: str,
+    ) -> None:
+        """Handle mode uses the GPU/SHM ``UNREGISTER_KV_CACHE`` protocol."""
+        router = _UnregisterRouter(router_endpoint)
+        router.start()
+        try:
+            client = self._make_client(router_endpoint)
+            assert (
+                _send_unregister_kv_cache(client, instance_id=7, use_handle=True)
+                is True
+            )
+            assert router.last_request_type == RequestType.UNREGISTER_KV_CACHE
+            assert router.last_instance_id == 7
+            client.close()
+        finally:
+            router.stop()
+
+    def test_data_mode_sends_engine_driven_unregister(
+        self,
+        router_endpoint: str,
+    ) -> None:
+        """Data mode uses the engine-driven context unregister protocol."""
+        router = _UnregisterRouter(router_endpoint)
+        router.start()
+        try:
+            client = self._make_client(router_endpoint)
+            assert (
+                _send_unregister_kv_cache(client, instance_id=0, use_handle=False)
+                is True
+            )
+            assert (
+                router.last_request_type
+                == RequestType.UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT
+            )
+            assert router.last_instance_id == 0
             client.close()
         finally:
             router.stop()


### PR DESCRIPTION
**What this PR does / why we need it**:

`lmcache bench server` registers a KV cache context with the MP server at startup but never unregisters it on exit, leaking one context entry on the server per bench run.

This PR adds the KV cache unregistration logic to the bench's shutdown path.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests