### PR TITLE
docs: use model names instead of class names in recipe navigation

### DIFF
--- a/docs/source/mp/hybrid_models.rst
+++ b/docs/source/mp/hybrid_models.rst
@@ -23,25 +23,25 @@ Recipe pages for the validated hybrid-attention architectures:
    :header-rows: 1
    :widths: 34 34 32
 
-   * - Architecture
+   * - Model
      - Attention layout
      - Recipe
-   * - ``Gemma3ForConditionalGeneration``
+   * - Gemma 3
      - Sliding-window + full
      - :doc:`/recipes/gemma3`
-   * - ``Gemma4ForConditionalGeneration``
+   * - Gemma 4
      - Sliding-window + full
      - :doc:`/recipes/gemma4`
-   * - ``GptOssForCausalLM``
+   * - gpt-oss
      - Sliding-window + full
      - :doc:`/recipes/gpt_oss`
-   * - ``Qwen3_5ForConditionalGeneration``
+   * - Qwen3.5 / Qwen3.6 series
      - Mamba / GDN + full
      - :doc:`/recipes/qwen3_5`
-   * - ``DeepseekV4ForCausalLM``
+   * - DeepSeek-V4-Flash
      - Sparse-MLA (multiple KV groups)
      - :doc:`/recipes/deepseek_v4_flash`
-   * - ``GlmMoeDsaForCausalLM``
+   * - GLM 5.1/5.2
      - Dynamic Sparse Attention (multiple KV groups)
      - :doc:`/recipes/glm5_2`
 

--- a/docs/source/recipes/devstral.rst
+++ b/docs/source/recipes/devstral.rst
@@ -1,7 +1,7 @@
 .. _recipe_devstral:
 
-MistralForCausalLM
-===================
+Mistral / Devstral
+==================
 
 Validated models
 ----------------

--- a/docs/source/recipes/gemma3.rst
+++ b/docs/source/recipes/gemma3.rst
@@ -1,7 +1,7 @@
 .. _recipe_gemma3:
 
-Gemma3ForConditionalGeneration
-===============================
+Gemma 3
+=======
 
 Validated models
 ----------------

--- a/docs/source/recipes/glm5_2.rst
+++ b/docs/source/recipes/glm5_2.rst
@@ -1,10 +1,10 @@
 .. _recipe_glm5_2:
 
-GlmMoeDsaForCausalLM
-====================
+GLM 5.1/5.2
+===========
 
 A large Mixture-of-Experts model using **Dynamic Sparse Attention (DSA)**, shared
-by the **GLM-5.2** series. Like DeepSeek-V4-Flash, the sparse-attention path
+by the **GLM-5.1 / GLM-5.2** series. Like DeepSeek-V4-Flash, the sparse-attention path
 splits the model's layers into more than one KV cache group; the
 ``LMCacheMPConnector`` stores and retrieves each group in its own block size, so
 KV reuse works without extra flags.

--- a/docs/source/recipes/gpt_oss.rst
+++ b/docs/source/recipes/gpt_oss.rst
@@ -1,7 +1,7 @@
 .. _recipe_gpt_oss:
 
-GptOssForCausalLM
-==================
+gpt-oss
+=======
 
 Validated models
 ----------------

--- a/docs/source/recipes/llama.rst
+++ b/docs/source/recipes/llama.rst
@@ -1,7 +1,7 @@
 .. _recipe_llama:
 
-LlamaForCausalLM
-====================
+Llama
+=====
 
 Validated models
 ----------------

--- a/docs/source/recipes/minimax_m2.rst
+++ b/docs/source/recipes/minimax_m2.rst
@@ -1,7 +1,7 @@
 .. _recipe_minimax_m2:
 
-MiniMaxM2ForCausalLM
-====================
+MiniMax M2 series
+=================
 
 Validated models
 ----------------

--- a/docs/source/recipes/mixtral.rst
+++ b/docs/source/recipes/mixtral.rst
@@ -1,7 +1,7 @@
 .. _recipe_mixtral:
 
-MixtralForCausalLM
-====================
+Mixtral
+=======
 
 Validated models
 ----------------

--- a/docs/source/recipes/phi3.rst
+++ b/docs/source/recipes/phi3.rst
@@ -1,7 +1,7 @@
 .. _recipe_phi3:
 
-Phi3ForCausalLM
-====================
+Phi-3 / Phi-4
+=============
 
 Validated models
 ----------------

--- a/docs/source/recipes/qwen3.rst
+++ b/docs/source/recipes/qwen3.rst
@@ -1,7 +1,7 @@
 .. _recipe_qwen3:
 
-Qwen3MoeForCausalLM
-====================
+Qwen3 MoE
+=========
 
 Validated models
 ----------------

--- a/docs/source/recipes/qwen3_5.rst
+++ b/docs/source/recipes/qwen3_5.rst
@@ -1,7 +1,7 @@
 .. _recipe_qwen3_5:
 
-Qwen3_5ForConditionalGeneration
-===============================
+Qwen3.5 / Qwen3.6 series
+========================
 
 A hybrid architecture interleaving Mamba / Gated-DeltaNet (GDN) linear-attention
 layers with full-attention layers, shared by the **Qwen3.5 and Qwen3.6**

--- a/docs/source/recipes/uniform_attention_models.rst
+++ b/docs/source/recipes/uniform_attention_models.rst
@@ -38,56 +38,57 @@ Supported architectures
    :header-rows: 1
    :widths: 28 30 10 10 10 12
 
-   * - Architecture
+   * - Model
      - Example HF model
      - vLLM
      - SGLang
      - TRT-LLM
      - Recipe
 
-   * - ``MiniMaxM2ForCausalLM``
+   * - MiniMax M2 series
      - ``MiniMaxAI/MiniMax-M2``
      - ✓
      - —
      - —
      - :doc:`minimax_m2`
 
-   * - ``MistralForCausalLM``
+   * - Mistral / Devstral
      - ``mistralai/Devstral-2-123B-Instruct-2512``
      - ✓
      - —
      - —
      - :doc:`devstral`
 
-   * - ``Qwen3MoeForCausalLM``
+   * - Qwen3 MoE
      - ``Qwen/Qwen3-235B-A22B``
      - ✓
      - —
      - —
      - :doc:`qwen3`
 
-   * - ``LlamaForCausalLM``
+   * - Llama
      - ``meta-llama/Meta-Llama-3.1-70B-Instruct``
      - ✓
      - —
      - —
      - :doc:`llama`
 
-   * - ``Phi3ForCausalLM``
+   * - Phi-3 / Phi-4
      - ``microsoft/Phi-4-mini-instruct``
      - ✓
      - —
      - —
      - :doc:`phi3`
 
-   * - ``MixtralForCausalLM``
+   * - Mixtral
      - ``mistralai/Mixtral-8x7B-Instruct-v0.1``
      - ✓
      - —
      - —
      - :doc:`mixtral`
 
-Legend: ``✓`` validated, ``—`` not validated.
+Legend: ``✓`` validated, ``—`` not validated. The **Model** column is the model
+family; each recipe page lists the exact vLLM architecture class it covers.
 
 Contributing a recipe
 ---------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

The recipe navigation mixed vLLM **model class names** (e.g. `MiniMaxM2ForCausalLM`, `GlmMoeDsaForCausalLM`) with plain **model names** (e.g. `Gemma 4`, `DeepSeek-V4-Flash`), which is inconsistent and unfriendly — most readers don't recognize the class names. This makes every recipe lead with the model / family name instead.

Changes:
- Retitled each recipe page (the title drives the sidebar label):
  - `MiniMaxM2ForCausalLM` → **MiniMax M2 series**
  - `MistralForCausalLM` → **Mistral / Devstral**
  - `Qwen3MoeForCausalLM` → **Qwen3 MoE**
  - `LlamaForCausalLM` → **Llama**
  - `Phi3ForCausalLM` → **Phi-3 / Phi-4**
  - `MixtralForCausalLM` → **Mixtral**
  - `Gemma3ForConditionalGeneration` → **Gemma 3**
  - `GptOssForCausalLM` → **gpt-oss**
  - `Qwen3_5ForConditionalGeneration` → **Qwen3.5 / Qwen3.6 series**
  - `GlmMoeDsaForCausalLM` → **GLM 5.1/5.2**
  - `Gemma 4` and `DeepSeek-V4-Flash` already used model names — left as-is, so the whole list is now consistent.
- Updated the index tables in `uniform_attention_models.rst` and `mp/hybrid_models.rst` to lead with the model name (column renamed `Architecture` → `Model`).

**Special notes for your reviewers**:

- The exact vLLM architecture class is still documented in each recipe page body (every page already references it), so no technical detail is lost. A note in the uniform table legend points readers there.
- For `devstral`/`phi3` the class names didn't match the validated example models (Devstral-2 / Phi-4-mini), so combined family names are used.
- Docs-only change; no code or behavior affected.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests