### PR TITLE
[Bugfix] Release P2P transfer-channel client when adapter is removed

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md
+++ b/docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md
@@ -101,7 +101,8 @@ storage manager owns its lifecycle. The config carries the peer's two URLs:
 ## close()
 
 Sets a closed flag (later submits are inert), unregisters the lookup/load fds
-from the periodic notifier, closes the MQ client, and closes the three event
-notifiers. The transfer-channel client is **not** closed here — for
-bi-directional transports (NIXL) it is a shared view owned by the
-`TransferChannelContext`.
+from the periodic notifier, removes the transfer-channel client from the
+`TransferChannelContext` via `remove_transfer_channel_client(peer_url)` (which
+closes it and releases its transport handles), closes the MQ client, and closes
+the three event notifiers. `close()` is idempotent: the closed flag guards
+against a second teardown of these shared resources.

--- a/docs/design/v1/distributed/transfer_channel/overall.md
+++ b/docs/design/v1/distributed/transfer_channel/overall.md
@@ -27,6 +27,7 @@ The abstraction is transport-agnostic; the only implementation today is
             │                                                │
             │  get_transfer_channel_server()  ── singleton ──┼──► TransferChannelServer
             │  get_transfer_channel_client(peer_url) ────────┼──► TransferChannelClient (per peer)
+            │  remove_transfer_channel_client(peer_url)      │
             │  get_transfer_channel_address([(off,size)…])   │
             │  get_num_connected_clients()                   │
             │  close()                                       │
@@ -72,6 +73,12 @@ All names below are exported from
     — get or create a client to the peer. Note: for bidirectional transports
     (like NIXL) the client may instead be created *passively* when the peer
     dials this context's server; this is transparent to the caller.
+  - `remove_transfer_channel_client(peer_advertise_url: str) -> None`
+    — discard the peer's client when reads from it are no longer needed (e.g.
+    its owning L2 adapter is being removed) and free its resources. Outstanding
+    task ids for that client become invalid; a later
+    `get_transfer_channel_client` returns a fresh one. A no-op for an unknown
+    peer.
   - `get_transfer_channel_address(lmcache_addresses: list[tuple[int, int]]) -> list[TransferChannelAddress]`
     — validate `(offset, size)` pairs against the registered region and convert.
   - `get_num_connected_clients() -> int`

--- a/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
@@ -368,6 +368,11 @@ class P2PL2Adapter(L2AdapterInterface):
 
         self._notifier.unregister_fd(self._lookup_efd.fileno())
         self._notifier.unregister_fd(self._load_efd.fileno())
+        # Release the peer's transfer-channel client now that this adapter no
+        # longer reads from it.
+        self._tc_context.remove_transfer_channel_client(
+            self._config.peer_transfer_channel_server_url
+        )
         self._mq_client.close()
         self._store_efd.close()
         self._lookup_efd.close()

--- a/lmcache/v1/distributed/transfer_channel/abstract.py
+++ b/lmcache/v1/distributed/transfer_channel/abstract.py
@@ -119,6 +119,23 @@ class TransferChannelContext(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def remove_transfer_channel_client(self, peer_advertise_url: str) -> None:
+        """Discard the client for ``peer_advertise_url`` and free its resources.
+
+        Call this when reads from the peer are no longer needed (e.g. the
+        owning L2 adapter is being removed). Any task ids previously returned by
+        that client become invalid. A later ``get_transfer_channel_client`` for
+        the same peer returns a fresh client.
+
+        Calling this for a peer with no current client does nothing.
+
+        Args:
+            peer_advertise_url: The ``host:port`` of the peer, as passed to
+                ``get_transfer_channel_client``.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def get_transfer_channel_address(
         self,
         lmcache_addresses: list[tuple[int, int]],

--- a/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/nixl_impl.py
@@ -468,6 +468,31 @@ class NixlTransferChannelContext(TransferChannelContext):
             )
         return existing
 
+    def remove_transfer_channel_client(self, peer_advertise_url: str) -> None:
+        """Discard the client for ``peer_advertise_url`` and free its resources.
+
+        Call this when reads from the peer are no longer needed (e.g. the
+        owning L2 adapter is being removed). Any task ids previously returned by
+        that client become invalid. A later ``get_transfer_channel_client`` for
+        the same peer returns a fresh client. The peer is not notified.
+
+        Calling this for a peer with no current client does nothing.
+
+        Args:
+            peer_advertise_url: The ``host:port`` of the peer, as passed to
+                ``get_transfer_channel_client``.
+        """
+        with self._lock:
+            client = self._clients.pop(peer_advertise_url, None)
+        if client is None:
+            return
+        try:
+            client.close()
+        except Exception:  # noqa: BLE001 - best-effort cleanup
+            logger.exception(
+                "Error closing transfer channel client for %s", peer_advertise_url
+            )
+
     ############################################################
     # Cleanup
     ############################################################

--- a/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py
+++ b/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py
@@ -70,7 +70,7 @@ def _adapter(lookup_timeout_s: float = 10.0, load_timeout_s: float = 10.0):
         )
         adapter = P2PL2Adapter(config)
         try:
-            yield adapter, mq, tc_client, notifier
+            yield adapter, mq, tc_ctx, tc_client, notifier
         finally:
             adapter.close()
 
@@ -149,7 +149,7 @@ def test_factory_creates_adapter():
 
 
 def test_event_fds_are_distinct_and_registered():
-    with _adapter() as (adapter, _mq, _tc, notifier):
+    with _adapter() as (adapter, _mq, _tc_ctx, _tc, notifier):
         fds = {
             adapter.get_store_event_fd(),
             adapter.get_lookup_and_lock_event_fd(),
@@ -175,7 +175,7 @@ def test_lookup_forwards_layout_desc_and_returns_addresses():
         TransferChannelAddress(offset=200, size=20),
         TransferChannelAddress(offset=-1, size=0),  # not found on peer
     ]
-    with _adapter() as (adapter, mq, _tc, _notifier):
+    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
         mq.submit_request.side_effect = _lookup_side_effect(42, addresses)
 
         task_id = adapter.submit_lookup_and_lock_task(keys, _LAYOUT)
@@ -201,7 +201,7 @@ def test_lookup_forwards_layout_desc_and_returns_addresses():
 def test_lookup_query_not_ready_then_ready():
     keys = [_key(0)]
     addresses = [TransferChannelAddress(offset=100, size=10)]
-    with _adapter() as (adapter, mq, _tc, _notifier):
+    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
         responses = iter([_FakeFuture(value=None), _FakeFuture(value=addresses)])
 
         def _dispatch(request_type, payloads, response_cls=None):
@@ -223,7 +223,7 @@ def test_lookup_query_not_ready_then_ready():
 
 def test_lookup_submit_timeout_yields_miss():
     keys = [_key(0), _key(1)]
-    with _adapter() as (adapter, mq, _tc, _notifier):
+    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
 
         def _dispatch(request_type, payloads, response_cls=None):
             if request_type == RequestType.P2P_LOOKUP_AND_LOCK:
@@ -245,7 +245,7 @@ def test_lookup_submit_timeout_yields_miss():
 
 def test_lookup_deadline_expired_yields_miss():
     keys = [_key(0)]
-    with _adapter(lookup_timeout_s=0.01) as (adapter, mq, _tc, _notifier):
+    with _adapter(lookup_timeout_s=0.01) as (adapter, mq, _tc_ctx, _tc, _notifier):
         # Lookup id resolves, but the query is never ready before the deadline.
         def _dispatch(request_type, payloads, response_cls=None):
             if request_type == RequestType.P2P_LOOKUP_AND_LOCK:
@@ -261,7 +261,7 @@ def test_lookup_deadline_expired_yields_miss():
 
 
 def test_query_unknown_task_returns_none():
-    with _adapter() as (adapter, _mq, _tc, _notifier):
+    with _adapter() as (adapter, _mq, _tc_ctx, _tc, _notifier):
         assert adapter.query_lookup_and_lock_result(999) is None
 
 
@@ -272,7 +272,7 @@ def test_query_unknown_task_returns_none():
 
 def test_load_reads_into_local_objects():
     keys = [_key(0), _key(1)]
-    with _adapter() as (adapter, _mq, tc_client, _notifier):
+    with _adapter() as (adapter, _mq, _tc_ctx, tc_client, _notifier):
         adapter._remote_addresses[keys[0]] = TransferChannelAddress(offset=100, size=10)
         adapter._remote_addresses[keys[1]] = TransferChannelAddress(offset=200, size=20)
         tc_client.submit_read.return_value = 55
@@ -304,7 +304,7 @@ def test_load_reads_into_local_objects():
 
 def test_load_not_finished_returns_none():
     keys = [_key(0)]
-    with _adapter() as (adapter, _mq, tc_client, _notifier):
+    with _adapter() as (adapter, _mq, _tc_ctx, tc_client, _notifier):
         adapter._remote_addresses[keys[0]] = TransferChannelAddress(offset=100, size=10)
         tc_client.submit_read.return_value = 1
         tc_client.query_read_status.return_value = TransferChannelReadResult(
@@ -318,7 +318,7 @@ def test_load_not_finished_returns_none():
 
 def test_load_deadline_expired_yields_failure():
     keys = [_key(0)]
-    with _adapter(load_timeout_s=0.01) as (adapter, _mq, tc_client, _notifier):
+    with _adapter(load_timeout_s=0.01) as (adapter, _mq, _tc_ctx, tc_client, _notifier):
         adapter._remote_addresses[keys[0]] = TransferChannelAddress(offset=100, size=10)
         tc_client.submit_read.return_value = 1
         task_id = adapter.submit_load_task(
@@ -337,7 +337,7 @@ def test_load_deadline_expired_yields_failure():
 
 def test_unlock_sends_rpc_and_clears_addresses():
     keys = [_key(0), _key(1)]
-    with _adapter() as (adapter, mq, _tc, _notifier):
+    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
         adapter._remote_addresses[keys[0]] = TransferChannelAddress(offset=1, size=1)
         adapter.submit_unlock(keys)
         unlock_call = mq.submit_request.call_args
@@ -347,13 +347,13 @@ def test_unlock_sends_rpc_and_clears_addresses():
 
 
 def test_unlock_empty_is_noop():
-    with _adapter() as (adapter, mq, _tc, _notifier):
+    with _adapter() as (adapter, mq, _tc_ctx, _tc, _notifier):
         adapter.submit_unlock([])
         mq.submit_request.assert_not_called()
 
 
 def test_store_completes_immediately_without_leaking():
-    with _adapter() as (adapter, _mq, _tc, _notifier):
+    with _adapter() as (adapter, _mq, _tc_ctx, _tc, _notifier):
         task_id = adapter.submit_store_task([_key(0)], [MagicMock()])
         completed = adapter.pop_completed_store_tasks()
         assert set(completed) == {task_id}
@@ -365,7 +365,7 @@ def test_store_completes_immediately_without_leaking():
 
 def test_load_missing_address_is_failure_not_raise():
     keys = [_key(0)]
-    with _adapter() as (adapter, _mq, tc_client, _notifier):
+    with _adapter() as (adapter, _mq, _tc_ctx, tc_client, _notifier):
         # No lookup ran, so no remote address is stashed for this key.
         task_id = adapter.submit_load_task(
             keys, [MagicMock(shm_offset=0, shm_byte_length=10)]
@@ -378,7 +378,7 @@ def test_load_missing_address_is_failure_not_raise():
 
 def test_load_invalid_address_is_failure_not_raise():
     keys = [_key(0)]
-    with _adapter() as (adapter, _mq, tc_client, _notifier):
+    with _adapter() as (adapter, _mq, _tc_ctx, tc_client, _notifier):
         # An invalid stashed address must be rejected, not read.
         adapter._remote_addresses[keys[0]] = TransferChannelAddress(offset=-1, size=0)
         task_id = adapter.submit_load_task(
@@ -391,7 +391,7 @@ def test_load_invalid_address_is_failure_not_raise():
 
 
 def test_report_status():
-    with _adapter() as (adapter, _mq, _tc, _notifier):
+    with _adapter() as (adapter, _mq, _tc_ctx, _tc, _notifier):
         status = adapter.report_status()
         assert status["is_healthy"] is True
         assert status["peer_mq_server_url"] == "tcp://peer:5555"
@@ -401,7 +401,7 @@ def test_report_status():
 
 
 def test_close_unregisters_fds_and_closes_client():
-    with _adapter() as (adapter, mq, _tc, notifier):
+    with _adapter() as (adapter, mq, tc_ctx, _tc, notifier):
         lookup_fd = adapter.get_lookup_and_lock_event_fd()
         load_fd = adapter.get_load_event_fd()
         adapter.close()
@@ -409,3 +409,14 @@ def test_close_unregisters_fds_and_closes_client():
         assert lookup_fd in unregistered
         assert load_fd in unregistered
         mq.close.assert_called()
+        # The transfer-channel client is dropped from the context on close.
+        tc_ctx.remove_transfer_channel_client.assert_called_once_with("peer:7600")
+
+
+def test_close_is_idempotent():
+    with _adapter() as (adapter, mq, tc_ctx, _tc, _notifier):
+        adapter.close()
+        adapter.close()
+        # The second close is a no-op: no duplicate teardown of shared resources.
+        mq.close.assert_called_once()
+        tc_ctx.remove_transfer_channel_client.assert_called_once_with("peer:7600")

--- a/tests/v1/distributed/transfer_channel/test_context_lifecycle.py
+++ b/tests/v1/distributed/transfer_channel/test_context_lifecycle.py
@@ -48,6 +48,9 @@ class _FakeContext(TransferChannelContext):
     def get_transfer_channel_client(self, peer_advertise_url: str):
         raise NotImplementedError
 
+    def remove_transfer_channel_client(self, peer_advertise_url: str) -> None:
+        raise NotImplementedError
+
     def get_transfer_channel_address(self, lmcache_addresses):
         raise NotImplementedError
 

--- a/tests/v1/distributed/transfer_channel/test_factory.py
+++ b/tests/v1/distributed/transfer_channel/test_factory.py
@@ -45,6 +45,9 @@ class _FakeContext(TransferChannelContext):
     def get_transfer_channel_client(self, peer_advertise_url: str):
         raise NotImplementedError
 
+    def remove_transfer_channel_client(self, peer_advertise_url: str) -> None:
+        raise NotImplementedError
+
     def get_transfer_channel_address(self, lmcache_addresses):
         raise NotImplementedError
 

--- a/tests/v1/distributed/transfer_channel/test_nixl_impl.py
+++ b/tests/v1/distributed/transfer_channel/test_nixl_impl.py
@@ -188,6 +188,37 @@ def test_register_client_keeps_first_and_closes_duplicate(fresh_contexts):
     assert ctx_a.get_num_connected_clients() == 1
 
 
+def test_remove_client_closes_and_drops_it(fresh_contexts):
+    """Removing a peer closes its client and drops it from the context."""
+    ctx_a, _, _, _ = fresh_contexts
+    key = "10.255.255.1:65000"
+    client = MagicMock()
+    ctx_a.register_client(key, client)
+    assert ctx_a.get_num_connected_clients() == 1
+
+    ctx_a.remove_transfer_channel_client(key)
+
+    client.close.assert_called_once()
+    assert ctx_a.get_num_connected_clients() == 0
+
+
+def test_remove_unknown_client_is_noop(fresh_contexts):
+    """Removing a peer with no registered client does nothing and does not raise."""
+    ctx_a, _, _, _ = fresh_contexts
+    ctx_a.remove_transfer_channel_client("10.255.255.1:65000")
+    assert ctx_a.get_num_connected_clients() == 0
+
+
+def test_remove_client_after_connect(fresh_contexts):
+    """A live client obtained via get_transfer_channel_client can be removed."""
+    ctx_a, _, ctx_b, _ = fresh_contexts
+    ctx_a.get_transfer_channel_client(ctx_b.advertise_url)
+    assert ctx_a.get_num_connected_clients() == 1
+
+    ctx_a.remove_transfer_channel_client(ctx_b.advertise_url)
+    assert ctx_a.get_num_connected_clients() == 0
+
+
 def test_connecting_registers_clients_on_both_sides(fresh_contexts):
     ctx_a, _, ctx_b, _ = fresh_contexts
     assert ctx_a.get_num_connected_clients() == 0


### PR DESCRIPTION
**What this PR does / why we need it**:

When a P2P L2 adapter is removed, `P2PL2Adapter.close()` tore down its MQ client and event fds but never released the transfer-channel client it had obtained from the shared `NixlTransferChannelContext`. That client stayed registered in the context, leaking its nixl handles (the prepped remote dlist and any in-flight transfer handles) on every adapter removal.

This PR adds a `remove_transfer_channel_client(peer_advertise_url)` method to the `TransferChannelContext` contract (implemented for the nixl backend) and calls it from `P2PL2Adapter.close()`, so the peer's client is closed and dropped from the context when the adapter no longer needs it.

**Special notes for your reviewers**:

- The context keys clients by peer URL with no refcounting, matching the existing one-reader-per-peer assumption. If two adapters ever target the same peer, the first `close()` would drop the shared client — out of scope for this fix.
- `P2PL2Adapter.close()` is now idempotent (guarded by the existing closed flag).
- Removing an unknown/already-removed peer is a no-op.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
