### PR TITLE
[Model Support]: Group layers w/ EngineKVFormat for MiniMax M3

### DIFF
--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -68,10 +68,12 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
 
 1. Discover each layer's Engine KV format from its registered tensor
    (`normalize_and_discover_per_layer_formats`). Detection is per *layout*, not
-   per engine group: one engine group may mix layouts — e.g. a model's rank-5
-   main K/V layers and a rank-3 key-only sparse-attention indexer cache can land
-   in a single `UniformTypeKVCacheSpecs` group — so each layout within a group
-   is detected and reported separately.
+   per engine group: one engine group may mix layouts — e.g. a model's 5-D main
+   K/V tensors (`[NB, 2, BS, NH, HS]`) and a 3-D key-only sparse-attention
+   indexer cache (`[NB, BS, HS]`) can land in a single `UniformTypeKVCacheSpecs`
+   group — so each layout within a group is detected and reported separately.
+   ("5-D"/"3-D" is the tensor rank: the number of dimensions of one layer's
+   registered KV tensor.)
 2. Map each registered layer to its engine group index; layers absent from
    every group's `layer_names` (cross-layer KV-sharing layers) are tagged
    `EXCLUDED_ENGINE_GROUP` and dropped (see Cross-layer KV sharing).
@@ -79,8 +81,8 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
    `(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype,
    engine_kv_format)` — `engine_group_idx` keeps identically-shaped layers from
    different engine groups in separate infos, and `engine_kv_format` keeps
-   different layouts that share one engine group apart (a rank-5 K/V group vs a
-   rank-3 indexer).
+   different layouts that share one engine group apart (the 5-D K/V vs the 3-D
+   indexer from step 1).
 4. Emit one `EngineGroupInfo` per identity; send the list in the
    `REGISTER_KV_CACHE` payload (the message queue encodes it).
 

--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -66,14 +66,20 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
 
 `create_engine_group_infos_from_vllm` (the only place that reads vLLM `KVCacheConfig`):
 
-1. Inspect registered tensors for physical layout/dtype.
+1. Discover each layer's Engine KV format from its registered tensor
+   (`normalize_and_discover_per_layer_formats`). Detection is per *layout*, not
+   per engine group: one engine group may mix layouts — MiniMax-M3 packs its
+   rank-5 main K/V and rank-3 sparse-attention indexer caches into a single
+   `UniformTypeKVCacheSpecs` group — so each layout within a group is detected
+   and reported separately.
 2. Map each registered layer to its engine group index; layers absent from
    every group's `layer_names` (cross-layer KV-sharing layers) are tagged
    `EXCLUDED_ENGINE_GROUP` and dropped (see Cross-layer KV sharing).
 3. `group_layers_by_identity` splits layers by transfer identity
-   `(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype)` — the
-   `engine_group_idx` term keeps identically-shaped layers from different engine
-   groups in separate infos.
+   `(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype,
+   engine_kv_format)` — `engine_group_idx` keeps identically-shaped layers from
+   different engine groups in separate infos, and `engine_kv_format` keeps
+   different layouts that share one engine group apart (M3's K/V vs indexer).
 4. Emit one `EngineGroupInfo` per identity; send the list in the
    `REGISTER_KV_CACHE` payload (the message queue encodes it).
 

--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -68,10 +68,11 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
 
 1. Discover each layer's Engine KV format from its registered tensor
    (`normalize_and_discover_per_layer_formats`). Detection is per *layout*, not
-   per engine group: one engine group may mix layouts — e.g. a model's 5-D main
-   K/V tensors (`[NB, 2, BS, NH, HS]`) and a 3-D key-only sparse-attention
-   indexer cache (`[NB, BS, HS]`) can land in a single `UniformTypeKVCacheSpecs`
-   group — so each layout within a group is detected and reported separately.
+   per engine group: a single engine group can contain layers whose registered
+   KV tensors have different shapes — for example a 5-D key+value cache
+   (`[NB, 2, BS, NH, HS]`, `kv_size=2`) alongside a 3-D key-only cache
+   (`[NB, BS, HS]`, `kv_size=1`) in one `UniformTypeKVCacheSpecs` group — so each
+   distinct layout within a group is detected and reported separately.
    ("5-D"/"3-D" is the tensor rank: the number of dimensions of one layer's
    registered KV tensor.)
 2. Map each registered layer to its engine group index; layers absent from
@@ -81,8 +82,8 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
    `(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype,
    engine_kv_format)` — `engine_group_idx` keeps identically-shaped layers from
    different engine groups in separate infos, and `engine_kv_format` keeps
-   different layouts that share one engine group apart (the 5-D K/V vs the 3-D
-   indexer from step 1).
+   different layouts that share one engine group apart (the 5-D key+value vs the
+   3-D key-only cache from step 1).
 4. Emit one `EngineGroupInfo` per identity; send the list in the
    `REGISTER_KV_CACHE` payload (the message queue encodes it).
 

--- a/docs/design/integration/vllm/hybrid-kv-cache-groups.md
+++ b/docs/design/integration/vllm/hybrid-kv-cache-groups.md
@@ -68,10 +68,10 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
 
 1. Discover each layer's Engine KV format from its registered tensor
    (`normalize_and_discover_per_layer_formats`). Detection is per *layout*, not
-   per engine group: one engine group may mix layouts — MiniMax-M3 packs its
-   rank-5 main K/V and rank-3 sparse-attention indexer caches into a single
-   `UniformTypeKVCacheSpecs` group — so each layout within a group is detected
-   and reported separately.
+   per engine group: one engine group may mix layouts — e.g. a model's rank-5
+   main K/V layers and a rank-3 key-only sparse-attention indexer cache can land
+   in a single `UniformTypeKVCacheSpecs` group — so each layout within a group
+   is detected and reported separately.
 2. Map each registered layer to its engine group index; layers absent from
    every group's `layer_names` (cross-layer KV-sharing layers) are tagged
    `EXCLUDED_ENGINE_GROUP` and dropped (see Cross-layer KV sharing).
@@ -79,7 +79,8 @@ KVLayerGroupInfo list   --STORE/RETRIEVE block_ids per info-->  transfer kernels
    `(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype,
    engine_kv_format)` — `engine_group_idx` keeps identically-shaped layers from
    different engine groups in separate infos, and `engine_kv_format` keeps
-   different layouts that share one engine group apart (M3's K/V vs indexer).
+   different layouts that share one engine group apart (a rank-5 K/V group vs a
+   rank-3 indexer).
 4. Emit one `EngineGroupInfo` per identity; send the list in the
    `REGISTER_KV_CACHE` payload (the message queue encodes it).
 

--- a/docs/source/mp/hybrid_models.rst
+++ b/docs/source/mp/hybrid_models.rst
@@ -44,6 +44,9 @@ Recipe pages for the validated hybrid-attention architectures:
    * - GLM 5.1/5.2
      - Dynamic Sparse Attention (multiple KV groups)
      - :doc:`/recipes/glm5_2`
+   * - MiniMax-M3
+     - Sparse attention + lightning indexer (mixed KV formats in one group)
+     - :doc:`/recipes/minimax_m3`
 
 .. toctree::
    :hidden:
@@ -55,6 +58,7 @@ Recipe pages for the validated hybrid-attention architectures:
    /recipes/qwen3_5
    /recipes/deepseek_v4_flash
    /recipes/glm5_2
+   /recipes/minimax_m3
 
 What Works
 ----------

--- a/docs/source/recipes/minimax_m3.rst
+++ b/docs/source/recipes/minimax_m3.rst
@@ -94,6 +94,3 @@ Caveats
 - **LMCache chunk size must be a multiple of the block size.** The default
   chunk size (256) already satisfies 128, so no extra flag is needed; if you
   pass ``--chunk-size`` to the server, keep it a multiple of 128.
-- **Overriding the server host.** The default ``lmcache.mp.host`` is
-  ``tcp://localhost``. If you set it explicitly, keep the ``tcp://`` scheme — a
-  bare ``host:port`` fails with a ZMQ ``Invalid argument`` error.

--- a/docs/source/recipes/minimax_m3.rst
+++ b/docs/source/recipes/minimax_m3.rst
@@ -1,0 +1,99 @@
+.. _recipe_minimax_m3:
+
+MiniMax M3
+==========
+
+Validated models
+----------------
+
+- `MiniMaxAI/MiniMax-M3 <https://huggingface.co/MiniMaxAI/MiniMax-M3>`_
+
+.. tab-set::
+   :sync-group: engine
+
+   .. tab-item:: vLLM
+
+      **Engine documentation:**
+      `MiniMax-M3 in vLLM supported models
+      <https://docs.vllm.ai/en/latest/models/supported_models.html#text-generation>`_
+      (architecture ``MiniMaxM3SparseForConditionalGeneration``).
+
+      **Status:** Validated with LMCache.
+
+      Start the LMCache MP server:
+
+      .. code-block:: bash
+
+         lmcache server --l1-size-gb 100 --eviction-policy LRU
+
+      |
+
+      Start vLLM with the LMCache MP connector (8 GPUs):
+
+      .. code-block:: bash
+
+         vllm serve MiniMaxAI/MiniMax-M3 \
+             --tensor-parallel-size 8 \
+             --trust-remote-code \
+             --block-size 128 \
+             --kv-transfer-config \
+             '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+
+      |
+
+      ``--block-size 128`` is **required** for this model (see Caveats); the
+      smaller defaults fail vLLM's KV-cache init. ``--trust-remote-code`` loads
+      M3's custom architecture. Adjust ``--tensor-parallel-size`` to your
+      hardware — M3's weights need eight 140 GB-class GPUs. For the generic
+      LMCache + vLLM wiring (ports, remote hosts), see
+      :doc:`../getting_started/quickstart`.
+
+      If there are any issues with vLLM setup, please refer to the
+      `vLLM Recipes <https://docs.vllm.ai/projects/recipes/en/latest/index.html>`_
+      for more details.
+
+   .. tab-item:: SGLang
+
+      **Status:** Not validated with LMCache.
+
+   .. tab-item:: TRT-LLM
+
+      **Status:** Not validated with LMCache.
+
+CacheBlend support
+------------------
+
+Compression support
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Method
+     - Status
+     - Notes
+   * - :doc:`CacheGen <../kv_cache_optimizations/compression/cachegen>`
+     - Not validated
+     -
+
+Caveats
+-------
+
+- **Sparse attention with a lightning indexer.** M3 runs grouped-query full
+  attention plus a DeepSeek-style sparse-attention indexer. Each sparse layer
+  owns two paged caches — the main K/V (rank-5) and a key-only indexer cache
+  (rank-3) — which vLLM places in a single ``UniformTypeKVCacheSpecs`` engine
+  group. LMCache detects both layouts and stores/retrieves each as its own
+  group; the indexer keys travel with the K/V because they cannot be recomputed
+  from the cached K/V on a hit.
+- **``--block-size 128`` is required.** M3's indexer uses ``sparse_block_size =
+  128``; vLLM cannot reconcile the default block size (16) or 64 across the
+  full-attention and sparse kernels and aborts KV-cache init with
+  ``No common block size``. Use 128.
+- **LMCache chunk size must be a multiple of the block size.** The default
+  chunk size (256) already satisfies 128, so no extra flag is needed; if you
+  pass ``--chunk-size`` to the server, keep it a multiple of 128.
+- **Overriding the server host.** The default ``lmcache.mp.host`` is
+  ``tcp://localhost``. If you set it explicitly, keep the ``tcp://`` scheme — a
+  bare ``host:port`` fails with a ZMQ ``Invalid argument`` error.

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -118,7 +118,7 @@ def create_engine_group_infos_from_vllm(
     # First Party
     from lmcache.utils import EngineType
     from lmcache.v1.gpu_connector.utils import (
-        normalize_and_discover_per_group_formats,
+        normalize_and_discover_per_layer_formats,
     )
     from lmcache.v1.kv_layer_groups import (
         EXCLUDED_ENGINE_GROUP,
@@ -144,7 +144,7 @@ def create_engine_group_infos_from_vllm(
     layer_index_groups = [
         [layer_to_idx[name] for name in group.layer_names] for group in vllm_groups
     ]
-    normalized_kv_caches, engine_kv_formats = normalize_and_discover_per_group_formats(
+    normalized_kv_caches, engine_kv_formats = normalize_and_discover_per_layer_formats(
         per_layer_discoverable_kv_caches,
         layer_index_groups,
         EngineType.VLLM,

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -179,9 +179,9 @@ def create_engine_group_infos_from_vllm(
     # same grouping from the registered tensors.
     return [
         EngineGroupInfo(
-            engine_group_id=identity[4],
+            engine_group_id=identity.engine_group_idx,
             layer_indices=tuple(indices),
-            tokens_per_block=group_tokens_per_block.get(identity[4], 0),
+            tokens_per_block=group_tokens_per_block.get(identity.engine_group_idx, 0),
             sw_size_tokens=_merge_layer_sw_sizes(per_layer_sw_size, indices),
         )
         for identity, indices in group_layers_by_identity(

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -118,21 +118,12 @@ def create_engine_group_infos_from_vllm(
     # First Party
     from lmcache.utils import EngineType
     from lmcache.v1.gpu_connector.utils import (
-        get_num_layers,
-        normalize_kv_and_discover_format,
+        normalize_and_discover_per_group_formats,
     )
     from lmcache.v1.kv_layer_groups import (
         EXCLUDED_ENGINE_GROUP,
         group_layers_by_identity,
     )
-
-    # Inspect the real registered tensors for physical layout and dtype.
-    engine_kv_format, normalized_kv_caches = normalize_kv_and_discover_format(
-        list(kv_caches.values()),
-        EngineType.VLLM,
-        layout_hints=layout_hints,
-    )
-    num_layers = get_num_layers(normalized_kv_caches, engine_kv_format)
 
     # vLLM-specific field access (confined to this function): map each
     # registered KV tensor to its vLLM engine KV cache group index. vLLM places
@@ -140,12 +131,26 @@ def create_engine_group_infos_from_vllm(
     # have disjoint block-id spaces and must not share an LMCache group. ``None``
     # means a single (non-hybrid) group, i.e. every layer shares one block-id
     # space.
+    per_layer_discoverable_kv_caches = list(kv_caches.values())
     layer_to_idx = {name: idx for idx, name in enumerate(kv_caches.keys())}
     vllm_groups = (
         getattr(kv_cache_config, "kv_cache_groups", ()) or ()
         if kv_cache_config is not None
         else ()
     )
+
+    # Detect the Engine KV format of each registered tensor: per engine group
+    # when they mix formats (e.g. MiniMax-M3), one shared format otherwise.
+    layer_index_groups = [
+        [layer_to_idx[name] for name in group.layer_names] for group in vllm_groups
+    ]
+    normalized_kv_caches, engine_kv_formats = normalize_and_discover_per_group_formats(
+        per_layer_discoverable_kv_caches,
+        layer_index_groups,
+        EngineType.VLLM,
+        layout_hints,
+    )
+    num_layers = len(engine_kv_formats)
     # Layers absent from every engine group's ``layer_names`` are cross-layer
     # KV-sharing layers (e.g. google/gemma-4-E4B-it): vLLM aliases them to a
     # target owner's KV tensor, so the owner's group already covers them. Tag
@@ -183,8 +188,7 @@ def create_engine_group_infos_from_vllm(
         )
         for identity, indices in group_layers_by_identity(
             normalized_kv_caches,
-            engine_kv_format,
-            num_layers,
+            engine_kv_formats,
             per_layer_group_idx,
         )
     ]

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -139,8 +139,6 @@ def create_engine_group_infos_from_vllm(
         else ()
     )
 
-    # Detect the Engine KV format of each registered tensor: per engine group
-    # when they mix formats (e.g. MiniMax-M3), one shared format otherwise.
     layer_index_groups = [
         [layer_to_idx[name] for name in group.layer_names] for group in vllm_groups
     ]

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -28,7 +28,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_layers,
     get_page_buffer_size,
     get_tokens_per_layer,
-    normalize_and_discover_per_group_formats,
+    normalize_and_discover_per_layer_formats,
     normalize_kv_and_discover_format,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -467,7 +467,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         # This legacy in-process connector has no engine group metadata, so all
         # layers form one (non-hybrid) group with a single shared format.
         no_engine_groups: list[list[int]] = []
-        self.kvcaches, engine_kv_formats = normalize_and_discover_per_group_formats(
+        self.kvcaches, engine_kv_formats = normalize_and_discover_per_layer_formats(
             self.kvcaches, no_engine_groups, EngineType.VLLM, self.layout_hints
         )
         self.engine_kv_format = engine_kv_formats[0]

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -478,7 +478,6 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
             self.metadata.kv_layer_groups_manager = KVLayerGroupsManager(
                 self.kvcaches,
                 engine_kv_formats=engine_kv_formats,
-                num_blocks=self.num_blocks,
             )
         klg_manager = self.metadata.kv_layer_groups_manager
 

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -464,9 +464,9 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.init:
             return
 
-        empty_engine_groups: list[list[int]] = []
+        empty_layer_index_groups: list[list[int]] = []
         self.kvcaches, engine_kv_formats = normalize_and_discover_per_layer_formats(
-            self.kvcaches, empty_engine_groups, EngineType.VLLM, self.layout_hints
+            self.kvcaches, empty_layer_index_groups, EngineType.VLLM, self.layout_hints
         )
         self.engine_kv_format = engine_kv_formats[0]
         self.num_blocks = get_num_blocks(self.kvcaches, self.engine_kv_format)

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -28,6 +28,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_layers,
     get_page_buffer_size,
     get_tokens_per_layer,
+    normalize_and_discover_per_group_formats,
     normalize_kv_and_discover_format,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -463,9 +464,13 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.init:
             return
 
-        self.engine_kv_format, self.kvcaches = normalize_kv_and_discover_format(
-            self.kvcaches, EngineType.VLLM, layout_hints=self.layout_hints
+        # This legacy in-process connector has no engine group metadata, so all
+        # layers form one (non-hybrid) group with a single shared format.
+        no_engine_groups: list[list[int]] = []
+        self.kvcaches, engine_kv_formats = normalize_and_discover_per_group_formats(
+            self.kvcaches, no_engine_groups, EngineType.VLLM, self.layout_hints
         )
+        self.engine_kv_format = engine_kv_formats[0]
         self.num_blocks = get_num_blocks(self.kvcaches, self.engine_kv_format)
         self.block_size = get_block_size(self.kvcaches, self.engine_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
@@ -474,7 +479,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.metadata.kv_layer_groups_manager is None:
             self.metadata.kv_layer_groups_manager = KVLayerGroupsManager(
                 self.kvcaches,
-                engine_kv_format=self.engine_kv_format,
+                engine_kv_formats=engine_kv_formats,
                 num_blocks=self.num_blocks,
             )
         klg_manager = self.metadata.kv_layer_groups_manager

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -464,11 +464,9 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.init:
             return
 
-        # This legacy in-process connector has no engine group metadata, so all
-        # layers form one (non-hybrid) group with a single shared format.
-        no_engine_groups: list[list[int]] = []
+        empty_engine_groups: list[list[int]] = []
         self.kvcaches, engine_kv_formats = normalize_and_discover_per_layer_formats(
-            self.kvcaches, no_engine_groups, EngineType.VLLM, self.layout_hints
+            self.kvcaches, empty_engine_groups, EngineType.VLLM, self.layout_hints
         )
         self.engine_kv_format = engine_kv_formats[0]
         self.num_blocks = get_num_blocks(self.kvcaches, self.engine_kv_format)

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -263,11 +263,7 @@ def normalize_and_discover_per_layer_formats(
     groups = layer_index_groups or [range(len(kv_caches))]
     detected: dict[int, tuple[DiscoverableKVCache, "lmc_ops.EngineKVFormat"]] = {}
     for indices in groups:
-        # One engine group can still mix layouts: vLLM coalesces a rank-5 K/V
-        # cache and a rank-3 key-only indexer into one UniformTypeKVCacheSpecs
-        # group. A tensor's shape fixes its format, so detect once per distinct
-        # shape and let same-shape layers share the result. Detecting the whole
-        # mixed group at once would stamp the K/V format onto the rank-3 indexer.
+        # One engine group can still mix layouts
         layers_by_shape: dict[Hashable, list[int]] = {}
         for i in indices:
             shape = getattr(kv_caches[i], "shape", None)

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -7,6 +7,7 @@
 # callers keep working unchanged.
 # mypy: disable-error-code="union-attr,call-overload"
 # Standard
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Optional, Union
 
 # Third Party
@@ -221,6 +222,102 @@ def normalize_kv_and_discover_format(
         storage with the input but may be a permuted view.
     """
     return detect_format(kv_caches, serving_engine, layout_hints)
+
+
+def _detect_whole_list_format(
+    per_layer_caches: "Sequence[DiscoverableKVCache]",
+    serving_engine: EngineType,
+    layout_hints: "LayoutHints | None",
+) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
+    """Detect the whole list as one format and repeat it for every layer.
+
+    The canonical single-format path -- used when there are no engine groups or
+    when every group resolved to the same format. Kept identical to the
+    pre-per-group behavior so uniform models stay byte-for-byte unchanged.
+    """
+    # detect_format's detector does isinstance(.., list) and indexes by layer, so
+    # hand it a concrete list (a tuple would skip the fused branch and misdetect).
+    kv_caches = list(per_layer_caches)
+    engine_kv_format, normalized = detect_format(
+        kv_caches, serving_engine, layout_hints
+    )
+    return normalized, [engine_kv_format] * get_num_layers(normalized, engine_kv_format)
+
+
+def normalize_and_discover_per_group_formats(
+    per_layer_discoverable_kv_caches: "Sequence[DiscoverableKVCache]",
+    layer_index_groups: "Sequence[Sequence[int]]",
+    serving_engine: EngineType,
+    layout_hints: "LayoutHints | None" = None,
+) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
+    """Normalize per-layer KV caches and discover one Engine KV format per layer.
+
+    Engines that place differently-formatted layers in different groups -- e.g.
+    MiniMax-M3's K+V main cache (``kv_size=2``) alongside its key-only MLA index
+    cache (``kv_size=1``) -- need each group detected on its own tensors;
+    detecting the whole list at once would collapse to a single format and
+    mis-shape one group. When the groups resolve to differing formats, each group
+    is detected independently and a per-layer format list is returned. Otherwise
+    (no groups, or every group the same format -- every model supported today)
+    the whole list is detected once and the single shared format is repeated for
+    every layer, leaving behavior byte-for-byte unchanged.
+
+    Args:
+        per_layer_discoverable_kv_caches: One KV cache entry per layer (the
+            layer-indexable sequence every call site already builds). A bare
+            fused tensor is intentionally not accepted: per-group detection is
+            inherently per-layer, and ``list()`` on a single tensor would shred
+            it into dim-0 slices.
+        layer_index_groups: Layer indices of each engine group (one inner
+            sequence per group). Empty means a single non-hybrid group.
+        serving_engine: Which serving engine produced the caches.
+        layout_hints: See :class:`LayoutHints`.
+
+    Returns:
+        ``(normalized_kv_caches, engine_kv_formats)``. ``engine_kv_formats`` holds
+        one format per layer (its length is the layer count), ready for
+        :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
+    """
+    # No engine groups: one shared format for every layer.
+    if not layer_index_groups:
+        return _detect_whole_list_format(
+            per_layer_discoverable_kv_caches, serving_engine, layout_hints
+        )
+
+    # Detect each engine group on its own tensors. The loop mutates this copy,
+    # never the input, so the whole-list fallback below still detects on the
+    # original (pristine) entries.
+    normalized_per_layer = list(per_layer_discoverable_kv_caches)
+    per_layer_format: list[Optional["lmc_ops.EngineKVFormat"]] = [None] * len(
+        normalized_per_layer
+    )
+    seen_formats: set[int] = set()
+    for indices in layer_index_groups:
+        group_format, normalized_sub = detect_format(
+            [normalized_per_layer[i] for i in indices],
+            serving_engine,
+            layout_hints,
+        )
+        seen_formats.add(int(group_format))
+        for sub_idx, layer_idx in enumerate(indices):
+            normalized_per_layer[layer_idx] = normalized_sub[sub_idx]
+            per_layer_format[layer_idx] = group_format
+
+    # Groups all resolved to one format: identical to the no-groups case, so take
+    # the same canonical whole-list path rather than trusting the per-group
+    # assembly to match it (keeps uniform models byte-for-byte unchanged).
+    if len(seen_formats) == 1:
+        return _detect_whole_list_format(
+            per_layer_discoverable_kv_caches, serving_engine, layout_hints
+        )
+
+    # Heterogeneous (e.g. MiniMax-M3): return the per-layer formats. Layers in no
+    # group (cross-layer KV sharing) keep their tensor and are skipped downstream;
+    # fill their slot with any detected format so every layer has one.
+    shared = next(fmt for fmt in per_layer_format if fmt is not None)
+    return normalized_per_layer, [
+        fmt if fmt is not None else shared for fmt in per_layer_format
+    ]
 
 
 def get_num_layers(

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -230,35 +230,25 @@ def normalize_and_discover_per_layer_formats(
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None" = None,
 ) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
-    """Normalize the KV caches and discover one Engine KV format per layer.
+    """Normalize the KV caches and return one Engine KV format per layer.
 
-    Engines that place differently-formatted layers in different groups -- e.g.
-    MiniMax-M3's K+V main cache (``kv_size=2``) alongside its key-only MLA index
-    cache (``kv_size=1``) -- need each group detected on its own tensors;
-    detecting the whole list at once would collapse to a single format and
-    mis-shape one group. Each engine group is therefore detected independently and
-    the per-group results are assembled into a per-layer list.
-
-    With no engine groups, one synthetic group spanning every layer is used, which
-    is exactly the old whole-list detection. Normalization
-    (:func:`attempt_permute_to_contiguous_view` plus the detector reshape) is
-    per-tensor, so the assembled per-layer result is byte-for-byte identical to
-    detecting the whole list at once -- uniform models stay unchanged without a
-    separate code path.
+    Reports each layer's own format, so models whose layers do not all share one
+    format -- e.g. MiniMax-M3's K+V main cache (``kv_size=2``) alongside its
+    key-only MLA index cache (``kv_size=1``) -- get a correct per-layer format
+    rather than a single model-wide one.
 
     Args:
-        kv_caches: The registered KV caches. Per-group detection applies only to a
-            layer-indexable ``list`` (one entry per layer); a single fused tensor
-            is single-format by construction and is detected directly.
+        kv_caches: The registered KV caches: a per-layer list, or a single fused
+            tensor for cross-layer formats.
         layer_index_groups: Layer indices of each engine group (one inner
             sequence per group). Empty means a single non-hybrid group.
         serving_engine: Which serving engine produced the caches.
         layout_hints: See :class:`LayoutHints`.
 
     Returns:
-        ``(normalized_kv_caches, engine_kv_formats)``. ``engine_kv_formats`` holds
-        one format per layer (its length is the layer count), ready for
-        :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
+        ``(normalized_kv_caches, engine_kv_formats)``: the canonical KV cache
+        structure and one format per layer (length equals the layer count),
+        ready for :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
     """
     # A single fused tensor is single-format by construction and cannot be indexed
     # by layer; detect it directly and repeat the format for every layer.

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -224,29 +224,6 @@ def normalize_kv_and_discover_format(
     return detect_format(kv_caches, serving_engine, layout_hints)
 
 
-def _layout_signature(layer: object) -> Hashable:
-    """Signature grouping KV layers that share an ``EngineKVFormat``.
-
-    Detection keys on tensor rank and on whether axis 0 or 1 is the K/V ``2``
-    axis, so layers agreeing on those share a format and are detected together
-    (shapes differing only in ``num_blocks`` stay in one split). A different-rank
-    layer -- e.g. a rank-3 key-only indexer cache sharing an engine group with
-    rank-5 K/V -- splits out and gets its own format. Non-tensor entries (nested
-    lists) fall back to one shared signature.
-
-    Args:
-        layer: One layer's registered KV cache (tensor or nested list).
-
-    Returns:
-        A hashable signature; equal signatures are detected together.
-    """
-    shape = getattr(layer, "shape", None)
-    if shape is None:
-        return ("non-tensor",)
-    ndim = len(shape)
-    return (ndim, ndim >= 1 and shape[0] == 2, ndim >= 2 and shape[1] == 2)
-
-
 def normalize_and_discover_per_layer_formats(
     kv_caches: "DiscoverableKVCache",
     layer_index_groups: "Sequence[Sequence[int]]",
@@ -286,21 +263,24 @@ def normalize_and_discover_per_layer_formats(
     groups = layer_index_groups or [range(len(kv_caches))]
     detected: dict[int, tuple[DiscoverableKVCache, "lmc_ops.EngineKVFormat"]] = {}
     for indices in groups:
-        # One engine group can still mix layouts (e.g. a rank-5 K/V group
-        # alongside a rank-3 key-only indexer cache sharing one block-id space).
-        # Format is a per-shape property, so split each group by layout and
-        # detect each split on its own; layers keep their order within a split.
-        splits: dict[Hashable, list[int]] = {}
+        # One engine group can still mix layouts: vLLM coalesces a rank-5 K/V
+        # cache and a rank-3 key-only indexer into one UniformTypeKVCacheSpecs
+        # group. A tensor's shape fixes its format, so detect once per distinct
+        # shape and let same-shape layers share the result. Detecting the whole
+        # mixed group at once would stamp the K/V format onto the rank-3 indexer.
+        layers_by_shape: dict[Hashable, list[int]] = {}
         for i in indices:
-            splits.setdefault(_layout_signature(kv_caches[i]), []).append(i)
-        for split_indices in splits.values():
-            split_format, normalized_split = detect_format(
-                [kv_caches[i] for i in split_indices],
+            shape = getattr(kv_caches[i], "shape", None)
+            key = tuple(shape) if shape is not None else None
+            layers_by_shape.setdefault(key, []).append(i)
+        for same_shape_indices in layers_by_shape.values():
+            fmt, normalized = detect_format(
+                [kv_caches[i] for i in same_shape_indices],
                 serving_engine,
                 layout_hints,
             )
-            for sub_idx, layer_idx in enumerate(split_indices):
-                detected[layer_idx] = (normalized_split[sub_idx], split_format)
+            for sub_idx, layer_idx in enumerate(same_shape_indices):
+                detected[layer_idx] = (normalized[sub_idx], fmt)
 
     # A layer in no group (cross-layer KV sharing) keeps its own tensor and is
     # skipped downstream; give it any detected format so every layer has one.

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -7,7 +7,7 @@
 # callers keep working unchanged.
 # mypy: disable-error-code="union-attr,call-overload"
 # Standard
-from collections.abc import Sequence
+from collections.abc import Hashable, Sequence
 from typing import TYPE_CHECKING, Optional, Union
 
 # Third Party
@@ -224,6 +224,29 @@ def normalize_kv_and_discover_format(
     return detect_format(kv_caches, serving_engine, layout_hints)
 
 
+def _layout_signature(layer: object) -> Hashable:
+    """Signature grouping KV layers that share an ``EngineKVFormat``.
+
+    Detection keys on tensor rank and on whether axis 0 or 1 is the K/V ``2``
+    axis, so layers agreeing on those share a format and are detected together
+    (shapes differing only in ``num_blocks`` stay in one split). A different-rank
+    layer -- e.g. a rank-3 key-only indexer cache sharing an engine group with
+    rank-5 K/V -- splits out and gets its own format. Non-tensor entries (nested
+    lists) fall back to one shared signature.
+
+    Args:
+        layer: One layer's registered KV cache (tensor or nested list).
+
+    Returns:
+        A hashable signature; equal signatures are detected together.
+    """
+    shape = getattr(layer, "shape", None)
+    if shape is None:
+        return ("non-tensor",)
+    ndim = len(shape)
+    return (ndim, ndim >= 1 and shape[0] == 2, ndim >= 2 and shape[1] == 2)
+
+
 def normalize_and_discover_per_layer_formats(
     kv_caches: "DiscoverableKVCache",
     layer_index_groups: "Sequence[Sequence[int]]",
@@ -263,13 +286,21 @@ def normalize_and_discover_per_layer_formats(
     groups = layer_index_groups or [range(len(kv_caches))]
     detected: dict[int, tuple[DiscoverableKVCache, "lmc_ops.EngineKVFormat"]] = {}
     for indices in groups:
-        group_format, normalized_sub = detect_format(
-            [kv_caches[i] for i in indices],
-            serving_engine,
-            layout_hints,
-        )
-        for sub_idx, layer_idx in enumerate(indices):
-            detected[layer_idx] = (normalized_sub[sub_idx], group_format)
+        # One engine group can still mix layouts (e.g. a rank-5 K/V group
+        # alongside a rank-3 key-only indexer cache sharing one block-id space).
+        # Format is a per-shape property, so split each group by layout and
+        # detect each split on its own; layers keep their order within a split.
+        splits: dict[Hashable, list[int]] = {}
+        for i in indices:
+            splits.setdefault(_layout_signature(kv_caches[i]), []).append(i)
+        for split_indices in splits.values():
+            split_format, normalized_split = detect_format(
+                [kv_caches[i] for i in split_indices],
+                serving_engine,
+                layout_hints,
+            )
+            for sub_idx, layer_idx in enumerate(split_indices):
+                detected[layer_idx] = (normalized_split[sub_idx], split_format)
 
     # A layer in no group (cross-layer KV sharing) keeps its own tensor and is
     # skipped downstream; give it any detected format so every layer has one.

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -275,8 +275,7 @@ def normalize_and_discover_per_layer_formats(
     # skipped downstream; give it any detected format so every layer has one.
     fallback_format = next(fmt for _, fmt in detected.values())
     normalized_per_layer = [
-        detected[i][0] if i in detected else kv_caches[i]
-        for i in range(len(kv_caches))
+        detected[i][0] if i in detected else kv_caches[i] for i in range(len(kv_caches))
     ]
     engine_kv_formats = [
         detected[i][1] if i in detected else fallback_format

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -260,10 +260,6 @@ def normalize_and_discover_per_layer_formats(
             normalized, engine_kv_format
         )
 
-    # Detect each engine group on its own tensors; with no groups, one synthetic
-    # group spans every layer (== whole-list detection). Normalization is
-    # per-tensor, so assembling the per-group results matches detecting the whole
-    # list -- uniform models are unchanged.
     groups = layer_index_groups or [range(len(kv_caches))]
     detected: dict[int, tuple[DiscoverableKVCache, "lmc_ops.EngineKVFormat"]] = {}
     for indices in groups:

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -225,19 +225,17 @@ def normalize_kv_and_discover_format(
 
 
 def _detect_whole_list_format(
-    per_layer_caches: "Sequence[DiscoverableKVCache]",
+    kv_caches: "DiscoverableKVCache",
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None",
 ) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
-    """Detect the whole list as one format and repeat it for every layer.
+    """Detect the whole structure as one format and repeat it for every layer.
 
-    The canonical single-format path -- used when there are no engine groups or
-    when every group resolved to the same format. Kept identical to the
-    pre-per-group behavior so uniform models stay byte-for-byte unchanged.
+    The canonical single-format path -- used when there are no engine groups, the
+    caches are a single fused tensor, or every group resolved to the same format.
+    Kept identical to the pre-per-group behavior so uniform models stay
+    byte-for-byte unchanged.
     """
-    # detect_format's detector does isinstance(.., list) and indexes by layer, so
-    # hand it a concrete list (a tuple would skip the fused branch and misdetect).
-    kv_caches = list(per_layer_caches)
     engine_kv_format, normalized = detect_format(
         kv_caches, serving_engine, layout_hints
     )
@@ -245,7 +243,7 @@ def _detect_whole_list_format(
 
 
 def normalize_and_discover_per_group_formats(
-    per_layer_discoverable_kv_caches: "Sequence[DiscoverableKVCache]",
+    kv_caches: "DiscoverableKVCache",
     layer_index_groups: "Sequence[Sequence[int]]",
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None" = None,
@@ -258,16 +256,15 @@ def normalize_and_discover_per_group_formats(
     detecting the whole list at once would collapse to a single format and
     mis-shape one group. When the groups resolve to differing formats, each group
     is detected independently and a per-layer format list is returned. Otherwise
-    (no groups, or every group the same format -- every model supported today)
-    the whole list is detected once and the single shared format is repeated for
-    every layer, leaving behavior byte-for-byte unchanged.
+    (no groups, a single fused tensor, or every group the same format -- every
+    model supported today) the whole structure is detected once and the single
+    shared format is repeated for every layer, leaving behavior byte-for-byte
+    unchanged.
 
     Args:
-        per_layer_discoverable_kv_caches: One KV cache entry per layer (the
-            layer-indexable sequence every call site already builds). A bare
-            fused tensor is intentionally not accepted: per-group detection is
-            inherently per-layer, and ``list()`` on a single tensor would shred
-            it into dim-0 slices.
+        kv_caches: The registered KV caches. Per-group detection applies only to a
+            layer-indexable ``list`` (one entry per layer); a single fused tensor
+            is single-format by construction and takes the whole-list path.
         layer_index_groups: Layer indices of each engine group (one inner
             sequence per group). Empty means a single non-hybrid group.
         serving_engine: Which serving engine produced the caches.
@@ -278,16 +275,16 @@ def normalize_and_discover_per_group_formats(
         one format per layer (its length is the layer count), ready for
         :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
     """
-    # No engine groups: one shared format for every layer.
-    if not layer_index_groups:
-        return _detect_whole_list_format(
-            per_layer_discoverable_kv_caches, serving_engine, layout_hints
-        )
+    # Per-group detection is inherently per-layer, so it applies only to a
+    # layer-indexable list. No groups, or a single fused tensor, means one shared
+    # format for every layer via the canonical whole-list path.
+    if not layer_index_groups or not isinstance(kv_caches, list):
+        return _detect_whole_list_format(kv_caches, serving_engine, layout_hints)
 
-    # Detect each engine group on its own tensors. The loop mutates this copy,
-    # never the input, so the whole-list fallback below still detects on the
-    # original (pristine) entries.
-    normalized_per_layer = list(per_layer_discoverable_kv_caches)
+    # Private writable copy: the loop scatters each group's normalized tensors in
+    # by layer index. The input is never mutated, so the whole-list fallback below
+    # still detects on the original (pristine) entries.
+    normalized_per_layer = list(kv_caches)
     per_layer_format: list[Optional["lmc_ops.EngineKVFormat"]] = [None] * len(
         normalized_per_layer
     )
@@ -307,9 +304,7 @@ def normalize_and_discover_per_group_formats(
     # the same canonical whole-list path rather than trusting the per-group
     # assembly to match it (keeps uniform models byte-for-byte unchanged).
     if len(seen_formats) == 1:
-        return _detect_whole_list_format(
-            per_layer_discoverable_kv_caches, serving_engine, layout_hints
-        )
+        return _detect_whole_list_format(kv_caches, serving_engine, layout_hints)
 
     # Heterogeneous (e.g. MiniMax-M3): return the per-layer formats. Layers in no
     # group (cross-layer KV sharing) keep their tensor and are skipped downstream;

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -224,47 +224,32 @@ def normalize_kv_and_discover_format(
     return detect_format(kv_caches, serving_engine, layout_hints)
 
 
-def _detect_whole_list_format(
-    kv_caches: "DiscoverableKVCache",
-    serving_engine: EngineType,
-    layout_hints: "LayoutHints | None",
-) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
-    """Detect the whole structure as one format and repeat it for every layer.
-
-    The canonical single-format path -- used when there are no engine groups, the
-    caches are a single fused tensor, or every group resolved to the same format.
-    Kept identical to the pre-per-group behavior so uniform models stay
-    byte-for-byte unchanged.
-    """
-    engine_kv_format, normalized = detect_format(
-        kv_caches, serving_engine, layout_hints
-    )
-    return normalized, [engine_kv_format] * get_num_layers(normalized, engine_kv_format)
-
-
 def normalize_and_discover_per_group_formats(
     kv_caches: "DiscoverableKVCache",
     layer_index_groups: "Sequence[Sequence[int]]",
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None" = None,
 ) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
-    """Normalize per-layer KV caches and discover one Engine KV format per layer.
+    """Normalize the KV caches and discover one Engine KV format per layer.
 
     Engines that place differently-formatted layers in different groups -- e.g.
     MiniMax-M3's K+V main cache (``kv_size=2``) alongside its key-only MLA index
     cache (``kv_size=1``) -- need each group detected on its own tensors;
     detecting the whole list at once would collapse to a single format and
-    mis-shape one group. When the groups resolve to differing formats, each group
-    is detected independently and a per-layer format list is returned. Otherwise
-    (no groups, a single fused tensor, or every group the same format -- every
-    model supported today) the whole structure is detected once and the single
-    shared format is repeated for every layer, leaving behavior byte-for-byte
-    unchanged.
+    mis-shape one group. Each engine group is therefore detected independently and
+    the per-group results are scattered back into a per-layer list.
+
+    With no engine groups, one synthetic group spanning every layer is used, which
+    is exactly the old whole-list detection. Normalization
+    (:func:`attempt_permute_to_contiguous_view` plus the detector reshape) is
+    per-tensor, so the assembled per-layer result is byte-for-byte identical to
+    detecting the whole list at once -- uniform models stay unchanged without a
+    separate code path.
 
     Args:
         kv_caches: The registered KV caches. Per-group detection applies only to a
             layer-indexable ``list`` (one entry per layer); a single fused tensor
-            is single-format by construction and takes the whole-list path.
+            is single-format by construction and is detected directly.
         layer_index_groups: Layer indices of each engine group (one inner
             sequence per group). Empty means a single non-hybrid group.
         serving_engine: Which serving engine produced the caches.
@@ -275,40 +260,37 @@ def normalize_and_discover_per_group_formats(
         one format per layer (its length is the layer count), ready for
         :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
     """
-    # Per-group detection is inherently per-layer, so it applies only to a
-    # layer-indexable list. No groups, or a single fused tensor, means one shared
-    # format for every layer via the canonical whole-list path.
-    if not layer_index_groups or not isinstance(kv_caches, list):
-        return _detect_whole_list_format(kv_caches, serving_engine, layout_hints)
+    # A single fused tensor is single-format by construction and cannot be indexed
+    # by layer; detect it directly and repeat the format for every layer.
+    if not isinstance(kv_caches, list):
+        engine_kv_format, normalized = detect_format(
+            kv_caches, serving_engine, layout_hints
+        )
+        return normalized, [engine_kv_format] * get_num_layers(
+            normalized, engine_kv_format
+        )
 
-    # Private writable copy: the loop scatters each group's normalized tensors in
-    # by layer index. The input is never mutated, so the whole-list fallback below
-    # still detects on the original (pristine) entries.
+    # Detect each engine group on its own tensors; with no groups, one synthetic
+    # group spans every layer (== whole-list detection). The loop reads the
+    # pristine input and scatters normalized tensors into a private copy by layer
+    # index, so the input is never mutated.
+    groups = layer_index_groups or [range(len(kv_caches))]
     normalized_per_layer = list(kv_caches)
     per_layer_format: list[Optional["lmc_ops.EngineKVFormat"]] = [None] * len(
         normalized_per_layer
     )
-    seen_formats: set[int] = set()
-    for indices in layer_index_groups:
+    for indices in groups:
         group_format, normalized_sub = detect_format(
-            [normalized_per_layer[i] for i in indices],
+            [kv_caches[i] for i in indices],
             serving_engine,
             layout_hints,
         )
-        seen_formats.add(int(group_format))
         for sub_idx, layer_idx in enumerate(indices):
             normalized_per_layer[layer_idx] = normalized_sub[sub_idx]
             per_layer_format[layer_idx] = group_format
 
-    # Groups all resolved to one format: identical to the no-groups case, so take
-    # the same canonical whole-list path rather than trusting the per-group
-    # assembly to match it (keeps uniform models byte-for-byte unchanged).
-    if len(seen_formats) == 1:
-        return _detect_whole_list_format(kv_caches, serving_engine, layout_hints)
-
-    # Heterogeneous (e.g. MiniMax-M3): return the per-layer formats. Layers in no
-    # group (cross-layer KV sharing) keep their tensor and are skipped downstream;
-    # fill their slot with any detected format so every layer has one.
+    # Layers in no group (cross-layer KV sharing) keep their tensor and are skipped
+    # downstream; fill their slot with any detected format so every layer has one.
     shared = next(fmt for fmt in per_layer_format if fmt is not None)
     return normalized_per_layer, [
         fmt if fmt is not None else shared for fmt in per_layer_format

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -233,9 +233,9 @@ def normalize_and_discover_per_layer_formats(
     """Normalize the KV caches and return one Engine KV format per layer.
 
     Reports each layer's own format, so models whose layers do not all share one
-    format -- e.g. MiniMax-M3's K+V main cache (``kv_size=2``) alongside its
-    key-only MLA index cache (``kv_size=1``) -- get a correct per-layer format
-    rather than a single model-wide one.
+    format -- e.g. a K+V main cache (``kv_size=2``) alongside a key-only MLA index
+    cache (``kv_size=1``) -- get a correct per-layer format rather than a single
+    model-wide one.
 
     Args:
         kv_caches: The registered KV caches: a per-layer list, or a single fused

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -224,7 +224,7 @@ def normalize_kv_and_discover_format(
     return detect_format(kv_caches, serving_engine, layout_hints)
 
 
-def normalize_and_discover_per_group_formats(
+def normalize_and_discover_per_layer_formats(
     kv_caches: "DiscoverableKVCache",
     layer_index_groups: "Sequence[Sequence[int]]",
     serving_engine: EngineType,
@@ -237,7 +237,7 @@ def normalize_and_discover_per_group_formats(
     cache (``kv_size=1``) -- need each group detected on its own tensors;
     detecting the whole list at once would collapse to a single format and
     mis-shape one group. Each engine group is therefore detected independently and
-    the per-group results are scattered back into a per-layer list.
+    the per-group results are assembled into a per-layer list.
 
     With no engine groups, one synthetic group spanning every layer is used, which
     is exactly the old whole-list detection. Normalization
@@ -271,14 +271,11 @@ def normalize_and_discover_per_group_formats(
         )
 
     # Detect each engine group on its own tensors; with no groups, one synthetic
-    # group spans every layer (== whole-list detection). The loop reads the
-    # pristine input and scatters normalized tensors into a private copy by layer
-    # index, so the input is never mutated.
+    # group spans every layer (== whole-list detection). Normalization is
+    # per-tensor, so assembling the per-group results matches detecting the whole
+    # list -- uniform models are unchanged.
     groups = layer_index_groups or [range(len(kv_caches))]
-    normalized_per_layer = list(kv_caches)
-    per_layer_format: list[Optional["lmc_ops.EngineKVFormat"]] = [None] * len(
-        normalized_per_layer
-    )
+    detected: dict[int, tuple[DiscoverableKVCache, "lmc_ops.EngineKVFormat"]] = {}
     for indices in groups:
         group_format, normalized_sub = detect_format(
             [kv_caches[i] for i in indices],
@@ -286,15 +283,20 @@ def normalize_and_discover_per_group_formats(
             layout_hints,
         )
         for sub_idx, layer_idx in enumerate(indices):
-            normalized_per_layer[layer_idx] = normalized_sub[sub_idx]
-            per_layer_format[layer_idx] = group_format
+            detected[layer_idx] = (normalized_sub[sub_idx], group_format)
 
-    # Layers in no group (cross-layer KV sharing) keep their tensor and are skipped
-    # downstream; fill their slot with any detected format so every layer has one.
-    shared = next(fmt for fmt in per_layer_format if fmt is not None)
-    return normalized_per_layer, [
-        fmt if fmt is not None else shared for fmt in per_layer_format
+    # A layer in no group (cross-layer KV sharing) keeps its own tensor and is
+    # skipped downstream; give it any detected format so every layer has one.
+    fallback_format = next(fmt for _, fmt in detected.values())
+    normalized_per_layer = [
+        detected[i][0] if i in detected else kv_caches[i]
+        for i in range(len(kv_caches))
     ]
+    engine_kv_formats = [
+        detected[i][1] if i in detected else fallback_format
+        for i in range(len(kv_caches))
+    ]
+    return normalized_per_layer, engine_kv_formats
 
 
 def get_num_layers(

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -85,9 +85,9 @@ def group_layers_by_identity(
         kv_caches: Registered KV cache structure, one entry per layer.
         engine_kv_formats: One Engine KV format per registered tensor; its length
             is the layer count. Homogeneous models repeat one shared format; a
-            model that mixes formats across engine groups -- e.g. MiniMax-M3's K+V
-            main cache (``kv_size=2``) plus its key-only MLA index cache
-            (``kv_size=1``) -- supplies the differing per-layer formats.
+            model that mixes formats across engine groups -- e.g. a K+V main cache
+            (``kv_size=2``) plus a key-only MLA index cache (``kv_size=1``) --
+            supplies the differing per-layer formats.
         per_layer_engine_group_idx: Optional engine block group id per layer.
             When ``None`` every layer is treated as block group 0 (non-hybrid);
             when present, layers from different engine block groups never share an
@@ -193,10 +193,10 @@ class KernelGroupInfo:
     this alongside ``shape_desc.element_size``."""
     engine_kv_format: "lmc_ops.EngineKVFormat | None" = None
     """Per-group Engine KV format, read via
-    ``BaseCacheContext.get_engine_kv_format`` so mixed-format models (e.g.
-    MiniMax-M3) dispatch each group with its own. ``None`` only for bench
-    bookkeeping groups from :func:`parse_kvcache_shape_spec`, which have no
-    detected format and never transfer; detection-built groups always set it."""
+    ``BaseCacheContext.get_engine_kv_format`` so mixed-format models dispatch each
+    group with its own. ``None`` only for bench bookkeeping groups from
+    :func:`parse_kvcache_shape_spec`, which have no detected format and never
+    transfer; detection-built groups always set it."""
     tokens_per_block: int = 0
     """Logical engine tokens covered by one paged chunk (one engine block
     ID) of this group, as declared by the engine's KV cache spec at
@@ -316,8 +316,8 @@ class KVLayerGroupsManager:
             engine_kv_formats: One Engine KV format per layer (its length is the
                 layer count), from
                 :func:`normalize_and_discover_per_layer_formats`. A model that
-                mixes formats across engine groups (e.g. MiniMax-M3) supplies the
-                differing per-layer formats so each group is shaped with its own;
+                mixes formats across engine groups supplies the differing
+                per-layer formats so each group is shaped with its own;
                 homogeneous models repeat one shared format.
             engine_group_infos: Engine KV cache group metadata, one info per
                 kernel group in kernel-group order, or empty.

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -183,12 +183,17 @@ class KernelGroupInfo:
     """Torch dtype of the KV cache tensors for this group. Used for
     kernel template instantiation; see class docstring for why we keep
     this alongside ``shape_desc.element_size``."""
-    engine_kv_format: "lmc_ops.EngineKVFormat"
+    engine_kv_format: "lmc_ops.EngineKVFormat | None" = None
     """Engine KV format of this group's layers (every layer in a group shares
     one format). The per-group transfer path reads this instead of the cache
     context's single representative format, so a model that mixes formats across
     engine groups -- e.g. MiniMax-M3's K+V main cache and key-only MLA index
-    cache -- dispatches each group with its own format."""
+    cache -- dispatches each group with its own format.
+
+    ``None`` for groups built by :func:`parse_kvcache_shape_spec` (the
+    ``--kvcache-shape-spec`` bench path): those are client-side bookkeeping with
+    no detected format and never drive a transfer, which re-detects server-side.
+    Always set for detection-built groups, which the transfer path reads."""
     tokens_per_block: int = 0
     """Logical engine tokens covered by one paged chunk (one engine block
     ID) of this group, as declared by the engine's KV cache spec at
@@ -660,23 +665,6 @@ class KVLayerGroupsManager:
 # ------------------------------------------------------------------ #
 
 
-def _engine_kv_format_for_shape_spec(kv_size: int) -> "lmc_ops.EngineKVFormat":
-    """The Engine KV format detection would yield for a ``--kvcache-shape-spec``.
-
-    The spec builds kernel groups directly from a shape string, short-circuiting
-    detection, so a group still needs a format. The spec's column order
-    (kv_size, nb, bs, nh, hs) is the NHD per-layer layout, so ``kv_size`` selects
-    K+V (``NL_X_TWO_NB_BS_NH_HS``) vs key-only MLA (``NL_X_NB_BS_HS``).
-
-    These bench/standalone groups are client-side bookkeeping -- shape/dtype drive
-    tensor allocation and block-id maths -- so the format is not read by a
-    transfer kernel, which re-detects it server-side from the registered tensors.
-    """
-    if kv_size == 1:
-        return lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
-    return lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
-
-
 def parse_kvcache_shape_spec(
     spec_str: str,
 ) -> list[KernelGroupInfo]:
@@ -773,7 +761,6 @@ def parse_kvcache_shape_spec(
                 "Shape must be a 5-tuple (kv_size,nb,bs,nh,hs): %s" % group_spec
             )
         kv_size, nb, bs, nh, hs = shape
-        engine_kv_format = _engine_kv_format_for_shape_spec(kv_size)
         shape_desc = lmc_ops.PageBufferShapeDesc()
         shape_desc.kv_size = kv_size
         shape_desc.nl = layer_count
@@ -790,7 +777,6 @@ def parse_kvcache_shape_spec(
                 layer_indices=indices,
                 shape_desc=shape_desc,
                 dtype=dtype,
-                engine_kv_format=engine_kv_format,
             )
         )
         layer_offset += layer_count

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -325,6 +325,7 @@ class KVLayerGroupsManager:
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
         # First Party
         from lmcache.v1.gpu_connector.utils import (
+            get_num_blocks,
             make_page_buffer_shape_desc,
             resolve_block_stride_and_log_layout,
         )
@@ -363,6 +364,16 @@ class KVLayerGroupsManager:
             # Every layer in a group shares one format in practice (the
             # identity's geometry is format-derived), so the first represents it.
             group_format = engine_kv_formats[indices[0]]
+            # Every engine group must share one block-id space (same NB); a single
+            # num_blocks is stamped onto every group's shape_desc. Fail loud if an
+            # engine ever gives a group a different block count.
+            group_num_blocks = get_num_blocks([kv_caches[indices[0]]], group_format)
+            if group_num_blocks != num_blocks:
+                raise ValueError(
+                    f"kernel group {group_idx} has {group_num_blocks} paged "
+                    f"blocks but the context reported {num_blocks}; LMCache "
+                    "requires one shared block-id space across engine groups"
+                )
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,
                 group_format,

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -320,7 +320,6 @@ class KVLayerGroupsManager:
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
         # First Party
         from lmcache.v1.gpu_connector.utils import (
-            get_num_blocks,
             make_page_buffer_shape_desc,
             resolve_block_stride_and_log_layout,
         )
@@ -359,16 +358,6 @@ class KVLayerGroupsManager:
             # Every layer in a group shares one format in practice (the
             # identity's geometry is format-derived), so the first represents it.
             group_format = engine_kv_formats[indices[0]]
-            # Every engine group must share one block-id space (same NB); a single
-            # num_blocks is stamped onto every group's shape_desc. Fail loud if an
-            # engine ever gives a group a different block count.
-            group_num_blocks = get_num_blocks([kv_caches[indices[0]]], group_format)
-            if group_num_blocks != num_blocks:
-                raise ValueError(
-                    f"kernel group {group_idx} has {group_num_blocks} paged "
-                    f"blocks but the context reported {num_blocks}; LMCache "
-                    "requires one shared block-id space across engine groups"
-                )
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,
                 group_format,

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -440,6 +440,18 @@ class KVLayerGroupsManager:
         return self._kernel_groups
 
     @property
+    def num_blocks(self) -> int:
+        """Paged block count, shared across kernel groups (one block-id space).
+
+        Read from the first kernel group's ``shape_desc.nb``, which was computed
+        from that group's own tensor and format -- not a guessed representative.
+        Returns ``0`` when there are no kernel groups.
+        """
+        if not self._kernel_groups:
+            return 0
+        return self._kernel_groups[0].shape_desc.nb
+
+    @property
     @lmcache_deprecate("`kv_layer_groups` is an outdated alias for `kernel_groups`")
     def kv_layer_groups(self) -> list[KernelGroupInfo]:
         """List of :class:`KernelGroupInfo`, one per kernel group."""

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -294,7 +294,6 @@ class KVLayerGroupsManager:
         self,
         kv_caches: "DiscoverableKVCache",
         engine_kv_formats: "Sequence[lmc_ops.EngineKVFormat]",
-        num_blocks: int,
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         lmcache_tokens_per_chunk: int = 256,
     ) -> None:
@@ -311,7 +310,6 @@ class KVLayerGroupsManager:
                 mixes formats across engine groups (e.g. MiniMax-M3) supplies the
                 differing per-layer formats so each group is shaped with its own;
                 homogeneous models repeat one shared format.
-            num_blocks: Number of paged blocks in the device KV cache.
             engine_group_infos: Engine KV cache group metadata, one info per
                 kernel group in kernel-group order, or empty.
             lmcache_logical_chunk_size: Tokens per LMCache chunk
@@ -320,6 +318,7 @@ class KVLayerGroupsManager:
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
         # First Party
         from lmcache.v1.gpu_connector.utils import (
+            get_num_blocks,
             make_page_buffer_shape_desc,
             resolve_block_stride_and_log_layout,
         )
@@ -358,6 +357,9 @@ class KVLayerGroupsManager:
             # Every layer in a group shares one format in practice (the
             # identity's geometry is format-derived), so the first represents it.
             group_format = engine_kv_formats[indices[0]]
+            # Block count is per engine group (each is its own block-id space), so
+            # read it from this group's own tensor rather than a context-wide value.
+            group_num_blocks = get_num_blocks([kv_caches[indices[0]]], group_format)
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,
                 group_format,
@@ -369,7 +371,7 @@ class KVLayerGroupsManager:
                 group_format,
                 layer_idx=indices[0],
                 num_layers_in_group=len(indices),
-                num_blocks=num_blocks,
+                num_blocks=group_num_blocks,
                 block_size=bs,
                 block_stride_elems=block_stride_elems,
             )

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -662,6 +662,23 @@ class KVLayerGroupsManager:
 # ------------------------------------------------------------------ #
 
 
+def _engine_kv_format_for_shape_spec(kv_size: int) -> "lmc_ops.EngineKVFormat":
+    """The Engine KV format detection would yield for a ``--kvcache-shape-spec``.
+
+    The spec builds kernel groups directly from a shape string, short-circuiting
+    detection, so a group still needs a format. The spec's column order
+    (kv_size, nb, bs, nh, hs) is the NHD per-layer layout, so ``kv_size`` selects
+    K+V (``NL_X_TWO_NB_BS_NH_HS``) vs key-only MLA (``NL_X_NB_BS_HS``).
+
+    These bench/standalone groups are client-side bookkeeping -- shape/dtype drive
+    tensor allocation and block-id maths -- so the format is not read by a
+    transfer kernel, which re-detects it server-side from the registered tensors.
+    """
+    if kv_size == 1:
+        return lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
+    return lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+
 def parse_kvcache_shape_spec(
     spec_str: str,
 ) -> list[KernelGroupInfo]:
@@ -758,15 +775,7 @@ def parse_kvcache_shape_spec(
                 "Shape must be a 5-tuple (kv_size,nb,bs,nh,hs): %s" % group_spec
             )
         kv_size, nb, bs, nh, hs = shape
-        # The shape spec fixes a canonical per-layer layout (kv_size, nb, bs, nh,
-        # hs), so recover the matching Engine KV format from kv_size (1 => key-only
-        # MLA, otherwise K+V) -- the spec carries no format enum, but the kernel
-        # group needs one just like the detected path.
-        engine_kv_format = (
-            lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
-            if kv_size == 1
-            else lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
-        )
+        engine_kv_format = _engine_kv_format_for_shape_spec(kv_size)
         shape_desc = lmc_ops.PageBufferShapeDesc()
         shape_desc.kv_size = kv_size
         shape_desc.nl = layer_count

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -46,15 +46,13 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 # distinct identity becomes one LMCache KV group:
 # ``(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype,
 # engine_kv_format)``.
-# The ``engine_group_idx`` slot is the engine group id (one paged-
-# block address space). Block IDs are only meaningful within one such group, so
-# layers from different groups must not share one LMCache group (and thus one
-# transfer-kernel launch) even if their tensor shape and dtype match.
-# ``engine_kv_format`` is in the identity so two layouts that share every other
-# field but differ in axis order (e.g. NHD vs HND with num_heads == block_size)
-# can never merge into one group and be transferred with the wrong layout. It is
-# redundant for current models -- format already tracks ``engine_group_idx`` --
-# but makes "one format per kernel group" true by construction, not by accident.
+# ``engine_group_idx`` is the engine group id (one paged-block address space):
+# block IDs are only meaningful within one group, so layers from different
+# groups must not share an LMCache group even if shape and dtype match.
+# ``engine_kv_format`` keeps layouts that share an engine group from merging --
+# load-bearing when one ``engine_group_idx`` mixes layouts (a rank-5 K/V group
+# alongside a rank-3 key-only indexer cache): this field is what splits them
+# into separate kernel groups, each transferred with its own layout.
 class KernelGroupIdentity(NamedTuple):
     kv_size: int
     num_heads: int

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -184,16 +184,11 @@ class KernelGroupInfo:
     kernel template instantiation; see class docstring for why we keep
     this alongside ``shape_desc.element_size``."""
     engine_kv_format: "lmc_ops.EngineKVFormat | None" = None
-    """Engine KV format of this group's layers (every layer in a group shares
-    one format). The per-group transfer path reads this instead of the cache
-    context's single representative format, so a model that mixes formats across
-    engine groups -- e.g. MiniMax-M3's K+V main cache and key-only MLA index
-    cache -- dispatches each group with its own format.
-
-    ``None`` for groups built by :func:`parse_kvcache_shape_spec` (the
-    ``--kvcache-shape-spec`` bench path): those are client-side bookkeeping with
-    no detected format and never drive a transfer, which re-detects server-side.
-    Always set for detection-built groups, which the transfer path reads."""
+    """Per-group Engine KV format, read via
+    ``BaseCacheContext.get_engine_kv_format`` so mixed-format models (e.g.
+    MiniMax-M3) dispatch each group with its own. ``None`` only for bench
+    bookkeeping groups from :func:`parse_kvcache_shape_spec`, which have no
+    detected format and never transfer; detection-built groups always set it."""
     tokens_per_block: int = 0
     """Logical engine tokens covered by one paged chunk (one engine block
     ID) of this group, as declared by the engine's KV cache spec at

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -183,6 +183,12 @@ class KernelGroupInfo:
     """Torch dtype of the KV cache tensors for this group. Used for
     kernel template instantiation; see class docstring for why we keep
     this alongside ``shape_desc.element_size``."""
+    engine_kv_format: "lmc_ops.EngineKVFormat"
+    """Engine KV format of this group's layers (every layer in a group shares
+    one format). The per-group transfer path reads this instead of the cache
+    context's single representative format, so a model that mixes formats across
+    engine groups -- e.g. MiniMax-M3's K+V main cache and key-only MLA index
+    cache -- dispatches each group with its own format."""
     tokens_per_block: int = 0
     """Logical engine tokens covered by one paged chunk (one engine block
     ID) of this group, as declared by the engine's KV cache spec at
@@ -401,6 +407,7 @@ class KVLayerGroupsManager:
                     layer_indices=indices,
                     shape_desc=shape_desc,
                     dtype=dt,
+                    engine_kv_format=group_format,
                     tokens_per_block=tokens_per_block,
                     engine_group_idx=engine_group_idx,
                     sw_size_tokens=sw_size_tokens,
@@ -751,6 +758,15 @@ def parse_kvcache_shape_spec(
                 "Shape must be a 5-tuple (kv_size,nb,bs,nh,hs): %s" % group_spec
             )
         kv_size, nb, bs, nh, hs = shape
+        # The shape spec fixes a canonical per-layer layout (kv_size, nb, bs, nh,
+        # hs), so recover the matching Engine KV format from kv_size (1 => key-only
+        # MLA, otherwise K+V) -- the spec carries no format enum, but the kernel
+        # group needs one just like the detected path.
+        engine_kv_format = (
+            lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
+            if kv_size == 1
+            else lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+        )
         shape_desc = lmc_ops.PageBufferShapeDesc()
         shape_desc.kv_size = kv_size
         shape_desc.nl = layer_count
@@ -767,6 +783,7 @@ def parse_kvcache_shape_spec(
                 layer_indices=indices,
                 shape_desc=shape_desc,
                 dtype=dtype,
+                engine_kv_format=engine_kv_format,
             )
         )
         layer_offset += layer_count

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -355,10 +355,8 @@ class KVLayerGroupsManager:
         for group_idx, ((_, _, _, bs, engine_group_idx, dt), indices) in enumerate(
             groups_by_identity
         ):
-            # Layers are bucketed by geometry derived from their format, so in
-            # practice every layer in a group shares one format; use the first
-            # layer's. (Promoting format into the identity to make this provable
-            # is a follow-up.)
+            # Every layer in a group shares one format in practice (the
+            # identity's geometry is format-derived), so the first represents it.
             group_format = engine_kv_formats[indices[0]]
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -74,19 +74,13 @@ def group_layers_by_identity(
 ) -> list[tuple[LayerGroupIdentity, list[int]]]:
     """Partition layer indices by :data:`LayerGroupIdentity`.
 
-    This helper is shared by vLLM-side LMCache group inflation and server-side
-    ``KernelGroupInfo`` construction so both sides agree on group order.
-
     Args:
-        kv_caches: Registered KV cache structure inspected for per-layer shape
-            and dtype.
-        engine_kv_formats: One Engine KV format per registered tensor, each
-            returned by :func:`normalize_kv_and_discover_format` and used to read
-            heads/sizes/``kv_size``. Its length is the layer count. Homogeneous
-            models repeat one shared format; a model that mixes formats across
-            engine groups -- e.g. MiniMax-M3's K+V main cache (``kv_size=2``) plus
-            its key-only MLA index cache (``kv_size=1``) -- supplies the differing
-            per-layer formats.
+        kv_caches: Registered KV cache structure, one entry per layer.
+        engine_kv_formats: One Engine KV format per registered tensor; its length
+            is the layer count. Homogeneous models repeat one shared format; a
+            model that mixes formats across engine groups -- e.g. MiniMax-M3's K+V
+            main cache (``kv_size=2``) plus its key-only MLA index cache
+            (``kv_size=1``) -- supplies the differing per-layer formats.
         per_layer_engine_group_idx: Optional engine block group id per layer.
             When ``None`` every layer is treated as block group 0 (non-hybrid);
             when present, layers from different engine block groups never share an
@@ -96,8 +90,7 @@ def group_layers_by_identity(
 
     Returns:
         A list of ``(identity, layer_indices)`` pairs sorted by each group's
-        first layer index, so the group order is deterministic and identical on
-        both the vLLM and server sides.
+        first layer index, so the group order is deterministic.
 
     Raises:
         ValueError: If ``per_layer_engine_group_idx`` is given but its length
@@ -299,17 +292,9 @@ class KVLayerGroupsManager:
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         lmcache_tokens_per_chunk: int = 256,
     ) -> None:
-        """Partition layers into groups keyed by
-        :data:`LayerGroupIdentity`.
+        """Partition the layers into kernel groups for this set of KV caches.
 
-        For each layer ``i`` in ``kv_caches``, read
-        ``(kv_size, num_heads, head_size, dtype)`` via the format-aware
-        accessors in ``utils.py``. Layers with identical identities are
-        bucketed together; each bucket becomes one
-        :class:`KernelGroupInfo`.
-
-        Groups are emitted in the order of their first-appearing layer,
-        so group indices are deterministic across runs.
+        Group order is deterministic across runs.
 
         Args:
             kv_caches: KV cache structure accepted by

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -69,8 +69,7 @@ EXCLUDED_ENGINE_GROUP = -1
 
 def group_layers_by_identity(
     kv_caches: "DiscoverableKVCache",
-    engine_kv_format: "lmc_ops.EngineKVFormat",
-    num_layers: int,
+    engine_kv_formats: "Sequence[lmc_ops.EngineKVFormat]",
     per_layer_engine_group_idx: Sequence[int] | None = None,
 ) -> list[tuple[LayerGroupIdentity, list[int]]]:
     """Partition layer indices by :data:`LayerGroupIdentity`.
@@ -81,21 +80,28 @@ def group_layers_by_identity(
     Args:
         kv_caches: Registered KV cache structure inspected for per-layer shape
             and dtype.
-        engine_kv_format: Format descriptor returned by
-            :func:`normalize_kv_and_discover_format`, used to read heads/sizes.
-        num_layers: Number of registered KV tensors to partition.
-        per_layer_engine_group_idx: Optional per-registered-index engine
-            block group id. When ``None`` every layer is treated as block group
-            0 (non-hybrid); when present, layers from different engine block
-            groups never share an identity even if their tensor shapes match.
-            Layers whose value is ``EXCLUDED_ENGINE_GROUP`` are left out of all
-            groups (e.g. cross-layer KV-sharing layers whose KV lives in their
-            target owner's blocks).
+        engine_kv_formats: One Engine KV format per registered tensor, each
+            returned by :func:`normalize_kv_and_discover_format` and used to read
+            heads/sizes/``kv_size``. Its length is the layer count. Homogeneous
+            models repeat one shared format; a model that mixes formats across
+            engine groups -- e.g. MiniMax-M3's K+V main cache (``kv_size=2``) plus
+            its key-only MLA index cache (``kv_size=1``) -- supplies the differing
+            per-layer formats.
+        per_layer_engine_group_idx: Optional engine block group id per layer.
+            When ``None`` every layer is treated as block group 0 (non-hybrid);
+            when present, layers from different engine block groups never share an
+            identity even if their tensor shapes match. Layers whose value is
+            ``EXCLUDED_ENGINE_GROUP`` are left out of all groups (e.g. cross-layer
+            KV-sharing layers whose KV lives in their target owner's blocks).
 
     Returns:
         A list of ``(identity, layer_indices)`` pairs sorted by each group's
         first layer index, so the group order is deterministic and identical on
         both the vLLM and server sides.
+
+    Raises:
+        ValueError: If ``per_layer_engine_group_idx`` is given but its length
+            does not match ``engine_kv_formats``.
     """
     # First Party
     from lmcache.v1.gpu_connector.utils import (
@@ -106,8 +112,16 @@ def group_layers_by_identity(
         is_mla,
     )
 
-    mla = is_mla(engine_kv_format)
-    kv_size = 1 if mla else 2
+    num_layers = len(engine_kv_formats)
+    if (
+        per_layer_engine_group_idx is not None
+        and len(per_layer_engine_group_idx) != num_layers
+    ):
+        raise ValueError(
+            f"per_layer_engine_group_idx has {len(per_layer_engine_group_idx)} "
+            f"entries but engine_kv_formats has {num_layers} layers"
+        )
+
     groups_dict: dict[LayerGroupIdentity, list[int]] = defaultdict(list)
     for idx in range(num_layers):
         engine_group_idx = (
@@ -119,10 +133,13 @@ def group_layers_by_identity(
         # KV-sharing layers, whose KV lives in their target owner's blocks).
         if engine_group_idx == EXCLUDED_ENGINE_GROUP:
             continue
-        nh = 1 if mla else get_num_heads(kv_caches, engine_kv_format, idx)
-        hs = get_head_size(kv_caches, engine_kv_format, idx)
-        dt = get_dtype(kv_caches, engine_kv_format, idx)
-        bs = get_block_size(kv_caches, engine_kv_format, idx)
+        layer_format = engine_kv_formats[idx]
+        mla = is_mla(layer_format)
+        kv_size = 1 if mla else 2
+        nh = 1 if mla else get_num_heads(kv_caches, layer_format, idx)
+        hs = get_head_size(kv_caches, layer_format, idx)
+        dt = get_dtype(kv_caches, layer_format, idx)
+        bs = get_block_size(kv_caches, layer_format, idx)
 
         identity = LayerGroupIdentity(
             kv_size=kv_size,
@@ -277,7 +294,7 @@ class KVLayerGroupsManager:
     def __init__(
         self,
         kv_caches: "DiscoverableKVCache",
-        engine_kv_format: "lmc_ops.EngineKVFormat",
+        engine_kv_formats: "Sequence[lmc_ops.EngineKVFormat]",
         num_blocks: int,
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         lmcache_tokens_per_chunk: int = 256,
@@ -296,9 +313,13 @@ class KVLayerGroupsManager:
 
         Args:
             kv_caches: KV cache structure accepted by
-                :func:`normalize_kv_and_discover_format`.
-            engine_kv_format: Format returned by
-                :func:`normalize_kv_and_discover_format`.
+                :func:`normalize_and_discover_per_group_formats`.
+            engine_kv_formats: One Engine KV format per layer (its length is the
+                layer count), from
+                :func:`normalize_and_discover_per_group_formats`. A model that
+                mixes formats across engine groups (e.g. MiniMax-M3) supplies the
+                differing per-layer formats so each group is shaped with its own;
+                homogeneous models repeat one shared format.
             num_blocks: Number of paged blocks in the device KV cache.
             engine_group_infos: Engine KV cache group metadata, one info per
                 kernel group in kernel-group order, or empty.
@@ -308,7 +329,6 @@ class KVLayerGroupsManager:
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
         # First Party
         from lmcache.v1.gpu_connector.utils import (
-            get_num_layers,
             make_page_buffer_shape_desc,
             resolve_block_stride_and_log_layout,
         )
@@ -317,7 +337,7 @@ class KVLayerGroupsManager:
         self._kernel_groups: list[KernelGroupInfo] = []
         self._object_groups: list[ObjectGroupInfo] = []
 
-        num_layers = get_num_layers(kv_caches, engine_kv_format)
+        num_layers = len(engine_kv_formats)
         if num_layers == 0:
             logger.debug("No KV caches available, skipping KV layer groups building")
             return
@@ -325,9 +345,8 @@ class KVLayerGroupsManager:
         per_layer_engine_group_idx = get_engine_group_indices(
             engine_group_infos, num_layers
         )
-
         groups_by_identity = group_layers_by_identity(
-            kv_caches, engine_kv_format, num_layers, per_layer_engine_group_idx
+            kv_caches, engine_kv_formats, per_layer_engine_group_idx
         )
 
         # Engine group infos are produced by the same group_layers_by_identity
@@ -345,15 +364,20 @@ class KVLayerGroupsManager:
         for group_idx, ((_, _, _, bs, engine_group_idx, dt), indices) in enumerate(
             groups_by_identity
         ):
+            # Layers are bucketed by geometry derived from their format, so in
+            # practice every layer in a group shares one format; use the first
+            # layer's. (Promoting format into the identity to make this provable
+            # is a follow-up.)
+            group_format = engine_kv_formats[indices[0]]
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,
-                engine_kv_format,
+                group_format,
                 layer_idx=indices[0],
                 group_idx=group_idx,
             )
             shape_desc = make_page_buffer_shape_desc(
                 kv_caches,
-                engine_kv_format,
+                group_format,
                 layer_idx=indices[0],
                 num_layers_in_group=len(indices),
                 num_blocks=num_blocks,

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -313,10 +313,10 @@ class KVLayerGroupsManager:
 
         Args:
             kv_caches: KV cache structure accepted by
-                :func:`normalize_and_discover_per_group_formats`.
+                :func:`normalize_and_discover_per_layer_formats`.
             engine_kv_formats: One Engine KV format per layer (its length is the
                 layer count), from
-                :func:`normalize_and_discover_per_group_formats`. A model that
+                :func:`normalize_and_discover_per_layer_formats`. A model that
                 mixes formats across engine groups (e.g. MiniMax-M3) supplies the
                 differing per-layer formats so each group is shaped with its own;
                 homogeneous models repeat one shared format.

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -44,11 +44,17 @@ DTYPE_MAP: dict[str, torch.dtype] = {
 
 # The tuple that uniquely identifies a set of kernel-equivalent layers; one
 # distinct identity becomes one LMCache KV group:
-# ``(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype)``.
+# ``(kv_size, num_heads, head_size, block_size, engine_group_idx, dtype,
+# engine_kv_format)``.
 # The ``engine_group_idx`` slot is the engine group id (one paged-
 # block address space). Block IDs are only meaningful within one such group, so
 # layers from different groups must not share one LMCache group (and thus one
 # transfer-kernel launch) even if their tensor shape and dtype match.
+# ``engine_kv_format`` is in the identity so two layouts that share every other
+# field but differ in axis order (e.g. NHD vs HND with num_heads == block_size)
+# can never merge into one group and be transferred with the wrong layout. It is
+# redundant for current models -- format already tracks ``engine_group_idx`` --
+# but makes "one format per kernel group" true by construction, not by accident.
 class KernelGroupIdentity(NamedTuple):
     kv_size: int
     num_heads: int
@@ -56,6 +62,7 @@ class KernelGroupIdentity(NamedTuple):
     block_size: int
     engine_group_idx: int
     dtype: torch.dtype
+    engine_kv_format: "lmc_ops.EngineKVFormat"
 
 
 LayerGroupIdentity = KernelGroupIdentity  # Alias for compatibility
@@ -141,6 +148,7 @@ def group_layers_by_identity(
             block_size=bs,
             engine_group_idx=engine_group_idx,
             dtype=dt,
+            engine_kv_format=layer_format,
         )
         groups_dict[identity].append(idx)
     return sorted(groups_dict.items(), key=lambda kv: kv[1][0])
@@ -155,7 +163,7 @@ class KernelGroupInfo:
     :data:`LayerGroupIdentity`; every layer referenced by
     ``layer_indices`` shares the same
     ``(kv_size, num_heads, head_size, block_size, engine_group_idx,
-    dtype)`` signature.
+    dtype, engine_kv_format)`` signature.
     Consumers use ``layer_indices`` to pull the matching device pointers
     out of ``kv_caches`` (via
     :func:`~lmcache.v1.gpu_connector.utils.get_group_data_ptrs`) and
@@ -275,7 +283,8 @@ class KVLayerGroupsManager:
 
     At construction time, every layer in ``kv_caches`` is bucketed by its
     :data:`LayerGroupIdentity` (``(kv_size, num_heads, head_size,
-    block_size, engine_group_idx, dtype)``). Each bucket becomes one
+    block_size, engine_group_idx, dtype, engine_kv_format)``). Each bucket
+    becomes one
     :class:`KernelGroupInfo` holding the layer indices, a shared
     :class:`PageBufferShapeDesc`, and the group's torch dtype.
 
@@ -351,12 +360,13 @@ class KVLayerGroupsManager:
 
         # Emit groups in order of their first-appearing layer so that group
         # indices remain deterministic across runs.
-        for group_idx, ((_, _, _, bs, engine_group_idx, dt), indices) in enumerate(
-            groups_by_identity
-        ):
-            # Every layer in a group shares one format in practice (the
-            # identity's geometry is format-derived), so the first represents it.
-            group_format = engine_kv_formats[indices[0]]
+        for group_idx, (identity, indices) in enumerate(groups_by_identity):
+            bs = identity.block_size
+            engine_group_idx = identity.engine_group_idx
+            dt = identity.dtype
+            # Format is part of the identity, so every layer in the group shares
+            # it -- this is the whole group's format, by construction.
+            group_format = identity.engine_kv_format
             # Block count is per engine group (each is its own block-id space), so
             # read it from this group's own tensor rather than a context-wide value.
             group_num_blocks = get_num_blocks([kv_caches[indices[0]]], group_format)

--- a/lmcache/v1/multiprocess/group_view.py
+++ b/lmcache/v1/multiprocess/group_view.py
@@ -105,6 +105,33 @@ def _engine_group_id_per_view(
     return tuple(group.engine_group_id for group in groups)
 
 
+def engine_group_layer_indices(
+    groups: Sequence[EngineGroupInfo],
+) -> list[list[int]]:
+    """Return each engine group's layer indices, ordered by engine group id.
+
+    Several ``EngineGroupInfo`` may share one ``engine_group_id`` (when one
+    engine group is split by transfer identity); their ``layer_indices`` are
+    unioned. The result feeds per-engine-group KV format detection so the server
+    reconstructs the same per-layer formats the engine side produced.
+
+    Args:
+        groups: The LMCache KV groups, in protocol order.
+
+    Returns:
+        One sorted ``list[int]`` of layer indices per engine group, indexed by
+        engine group id (dense from 0). Empty when ``groups`` is empty (a single
+        non-hybrid group with no per-group split).
+    """
+    if not groups:
+        return []
+    num_groups = max(group.engine_group_id for group in groups) + 1
+    per_group: list[list[int]] = [[] for _ in range(num_groups)]
+    for group in groups:
+        per_group[group.engine_group_id].extend(group.layer_indices)
+    return [sorted(indices) for indices in per_group]
+
+
 def expand_engine_block_ids(
     groups: Sequence[EngineGroupInfo],
     engine_side_block_ids: Sequence[Sequence[int]] | Sequence[int],

--- a/lmcache/v1/multiprocess/group_view.py
+++ b/lmcache/v1/multiprocess/group_view.py
@@ -110,10 +110,8 @@ def engine_group_layer_indices(
 ) -> list[list[int]]:
     """Return each engine group's layer indices, ordered by engine group id.
 
-    Several ``EngineGroupInfo`` may share one ``engine_group_id`` (when one
-    engine group is split by transfer identity); their ``layer_indices`` are
-    unioned. The result feeds per-engine-group KV format detection so the server
-    reconstructs the same per-layer formats the engine side produced.
+    Several ``EngineGroupInfo`` may share one ``engine_group_id``; their
+    ``layer_indices`` are unioned into that group's entry.
 
     Args:
         groups: The LMCache KV groups, in protocol order.

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -159,7 +159,16 @@ async def kvcache_check(
             content={"error": "kv_caches empty"},
         )
 
-    engine_kv_format = ctx.engine_kv_format
+    per_layer_formats = ctx.engine_kv_formats_per_layer()
+    if len({int(fmt) for fmt in per_layer_formats}) > 1:
+        return JSONResponse(
+            status_code=501,
+            content={
+                "error": "checksum not supported for mixed-format models "
+                "(this endpoint assumes one block axis for every layer)"
+            },
+        )
+    engine_kv_format = per_layer_formats[0]
     block_axis = _BLOCK_AXIS_BY_FORMAT.get(engine_kv_format)
     if block_axis is None:
         return JSONResponse(

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -159,8 +159,8 @@ async def kvcache_check(
             content={"error": "kv_caches empty"},
         )
 
-    per_layer_formats = ctx.engine_kv_formats_per_layer()
-    if len({int(fmt) for fmt in per_layer_formats}) > 1:
+    group_formats = ctx.engine_kv_formats()
+    if len({int(fmt) for fmt in group_formats}) > 1:
         return JSONResponse(
             status_code=501,
             content={
@@ -168,7 +168,7 @@ async def kvcache_check(
                 "(this endpoint assumes one block axis for every layer)"
             },
         )
-    engine_kv_format = per_layer_formats[0]
+    engine_kv_format = group_formats[0]
     block_axis = _BLOCK_AXIS_BY_FORMAT.get(engine_kv_format)
     if block_axis is None:
         return JSONResponse(

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -159,9 +159,7 @@ async def kvcache_check(
             content={"error": "kv_caches empty"},
         )
 
-    # Resolve each layer's block axis from its own Engine KV format, so
-    # mixed-format models (e.g. a 5-D key+value group alongside a 3-D key-only
-    # group) are gathered along the correct per-layer axis instead of rejected.
+    # Per-layer block axis, so mixed-format models gather per layer.
     block_axes, axis_err = _resolve_per_layer_block_axes(
         ctx.engine_kv_format_per_layer()
     )
@@ -182,27 +180,14 @@ async def kvcache_check(
 def _resolve_per_layer_block_axes(
     formats_per_layer: list[Optional["lmc_ops.EngineKVFormat"]],
 ) -> tuple[Optional[list[int]], Optional[str]]:
-    """Map each layer's Engine KV format to its ``num_blocks`` axis.
+    """Map each layer to its ``num_blocks`` axis from its Engine KV format.
 
-    Supports mixed-format models: every layer is gathered along the block axis
-    of its own format, so a model whose layers do not share one format (e.g. a
-    5-D key+value group alongside a 3-D key-only group) is checksummed rather
-    than rejected.
+    Each layer uses its own axis, so mixed-format models are checksummed rather
+    than rejected. A ``None`` layer (cross-layer KV sharing) inherits a
+    single-format model's axis and is rejected in a mixed-format one.
 
-    A layer with no format (``None`` -- a cross-layer KV-sharing layer that
-    aliases an owner's blocks) inherits the model's block axis when the model is
-    single-format; in a mixed-format model such a layer is ambiguous (its owner
-    is unknown here) and rejected.
-
-    Args:
-        formats_per_layer: One Engine KV format per layer in layer-index order,
-            or ``None`` for a cross-layer KV-sharing layer (see
-            :meth:`BaseCacheContext.engine_kv_format_per_layer`).
-
-    Returns:
-        ``(block_axes, None)`` with one block axis per layer on success, or
-        ``(None, error_message)`` if a format has no supported block axis or a
-        ``None`` layer cannot be resolved.
+    Returns ``(block_axes, None)``, or ``(None, error)`` if a format is
+    unsupported or a ``None`` layer can't be resolved.
     """
     axis_by_format: dict[int, int] = {}
     for fmt in formats_per_layer:

--- a/lmcache/v1/multiprocess/http_apis/cache_api.py
+++ b/lmcache/v1/multiprocess/http_apis/cache_api.py
@@ -159,55 +159,96 @@ async def kvcache_check(
             content={"error": "kv_caches empty"},
         )
 
-    group_formats = ctx.engine_kv_formats()
-    if len({int(fmt) for fmt in group_formats}) > 1:
-        return JSONResponse(
-            status_code=501,
-            content={
-                "error": "checksum not supported for mixed-format models "
-                "(this endpoint assumes one block axis for every layer)"
-            },
-        )
-    engine_kv_format = group_formats[0]
-    block_axis = _BLOCK_AXIS_BY_FORMAT.get(engine_kv_format)
-    if block_axis is None:
-        return JSONResponse(
-            status_code=501,
-            content={
-                "error": "checksum not supported for GPU KV format %s"
-                % engine_kv_format.name
-            },
-        )
+    # Resolve each layer's block axis from its own Engine KV format, so
+    # mixed-format models (e.g. a 5-D key+value group alongside a 3-D key-only
+    # group) are gathered along the correct per-layer axis instead of rejected.
+    block_axes, axis_err = _resolve_per_layer_block_axes(
+        ctx.engine_kv_format_per_layer()
+    )
+    if block_axes is None:
+        return JSONResponse(status_code=501, content={"error": axis_err})
 
     loop = asyncio.get_running_loop()
     result = await loop.run_in_executor(
         None,
         lambda: _compute_block_checksums(
-            kv_tensors, parsed_blocks, block_axis, chunk_size, layerwise
+            kv_tensors, parsed_blocks, block_axes, chunk_size, layerwise
         ),
     )
     result["block_id_ranges"] = compress_slot_mapping(parsed_blocks)
     return JSONResponse(content=result)
 
 
+def _resolve_per_layer_block_axes(
+    formats_per_layer: list[Optional["lmc_ops.EngineKVFormat"]],
+) -> tuple[Optional[list[int]], Optional[str]]:
+    """Map each layer's Engine KV format to its ``num_blocks`` axis.
+
+    Supports mixed-format models: every layer is gathered along the block axis
+    of its own format, so a model whose layers do not share one format (e.g. a
+    5-D key+value group alongside a 3-D key-only group) is checksummed rather
+    than rejected.
+
+    A layer with no format (``None`` -- a cross-layer KV-sharing layer that
+    aliases an owner's blocks) inherits the model's block axis when the model is
+    single-format; in a mixed-format model such a layer is ambiguous (its owner
+    is unknown here) and rejected.
+
+    Args:
+        formats_per_layer: One Engine KV format per layer in layer-index order,
+            or ``None`` for a cross-layer KV-sharing layer (see
+            :meth:`BaseCacheContext.engine_kv_format_per_layer`).
+
+    Returns:
+        ``(block_axes, None)`` with one block axis per layer on success, or
+        ``(None, error_message)`` if a format has no supported block axis or a
+        ``None`` layer cannot be resolved.
+    """
+    axis_by_format: dict[int, int] = {}
+    for fmt in formats_per_layer:
+        if fmt is None or int(fmt) in axis_by_format:
+            continue
+        axis = _BLOCK_AXIS_BY_FORMAT.get(fmt)
+        if axis is None:
+            return None, "checksum not supported for GPU KV format %s" % fmt.name
+        axis_by_format[int(fmt)] = axis
+
+    shared_axis = (
+        next(iter(axis_by_format.values())) if len(axis_by_format) == 1 else None
+    )
+    block_axes: list[int] = []
+    for fmt in formats_per_layer:
+        if fmt is not None:
+            block_axes.append(axis_by_format[int(fmt)])
+        elif shared_axis is not None:
+            block_axes.append(shared_axis)
+        else:
+            return None, (
+                "checksum not supported: a cross-layer KV-sharing layer in a "
+                "mixed-format model has no resolvable block axis"
+            )
+    return block_axes, None
+
+
 def _compute_block_checksums(
     kv_tensors: list[torch.Tensor],
     block_ids: list[int],
-    block_axis: int,
+    block_axes: list[int],
     chunk_size: int,
     layerwise: bool,
 ) -> dict[str, Any]:
     """Compute MD5 checksums over KV cache blocks, grouped ``chunk_size``
     blocks per chunk.
 
-    The gather is performed in block space on ``block_axis`` of each
-    per-layer KV tensor using :func:`torch.index_select`. ``block_axis``
-    is looked up once per request from :data:`_BLOCK_AXIS_BY_FORMAT`, so
-    adding a new KV format to the endpoint is a single dict entry.
+    The gather is performed in block space on each layer's own block axis
+    (``block_axes[layer]``) via :func:`torch.index_select`, so mixed-format
+    models gather each layer correctly. Per-format axes come from
+    :data:`_BLOCK_AXIS_BY_FORMAT`, so adding a new KV format is a single dict
+    entry.
 
     Each layer's gathered tensor is moved to CPU once, then chunk-level
-    checksums slice it along ``block_axis`` in steps of ``chunk_size``
-    blocks. ``bfloat16`` is upcast to ``float32`` only if present, since
+    checksums slice it along its block axis in steps of ``chunk_size`` blocks.
+    ``bfloat16`` is upcast to ``float32`` only if present, since
     :meth:`torch.Tensor.numpy` does not support it.
     """
     num_blocks = len(block_ids)
@@ -223,27 +264,28 @@ def _compute_block_checksums(
     # Pre-gather each layer's blocks to CPU (one H2D→D2H transfer per
     # layer), then all chunking is CPU-only below.
     layer_blocks: list[torch.Tensor] = []
-    for kv in kv_tensors:
+    for li, kv in enumerate(kv_tensors):
         idx = block_idx_by_device.get(kv.device)
         if idx is None:
             idx = block_idx_cpu.to(kv.device)
             block_idx_by_device[kv.device] = idx
-        gathered = kv.index_select(block_axis, idx).cpu()
+        gathered = kv.index_select(block_axes[li], idx).cpu()
         if gathered.dtype == torch.bfloat16:
             gathered = gathered.to(torch.float32)
         layer_blocks.append(gathered)
 
-    def _chunk_slice(t: torch.Tensor, start: int, end: int) -> torch.Tensor:
-        return t.narrow(block_axis, start, end - start).contiguous()
+    def _chunk_slice(t: torch.Tensor, axis: int, start: int, end: int) -> torch.Tensor:
+        return t.narrow(axis, start, end - start).contiguous()
 
     if layerwise:
         per_layer: dict[str, list[str]] = {}
         for li, blocks in enumerate(layer_blocks):
+            axis = block_axes[li]
             digests: list[str] = []
             for ci in range(num_chunks):
                 s = ci * chunk_size
                 e = min(s + chunk_size, num_blocks)
-                chunk = _chunk_slice(blocks, s, e)
+                chunk = _chunk_slice(blocks, axis, s, e)
                 digests.append(hashlib.md5(chunk.numpy().tobytes()).hexdigest())
             per_layer["layer_%d" % li] = digests
         return {
@@ -259,8 +301,8 @@ def _compute_block_checksums(
         s = ci * chunk_size
         e = min(s + chunk_size, num_blocks)
         md5 = hashlib.md5()
-        for blocks in layer_blocks:
-            chunk = _chunk_slice(blocks, s, e)
+        for li, blocks in enumerate(layer_blocks):
+            chunk = _chunk_slice(blocks, block_axes[li], s, e)
             md5.update(chunk.numpy().tobytes())
         aggregated.append(md5.hexdigest())
     return {

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1689,7 +1689,7 @@ class BlendV3Module(InstanceLivenessTarget):
                                     gpu_context.device,
                                     page_buffer_size,
                                     lmc_ops.TransferDirection.H2D,
-                                    gpu_context.engine_kv_format,
+                                    gpu_context.get_engine_kv_format(group_idx),
                                     block_size=bs,
                                     head_size=rope_state.head_size,
                                 )

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -367,7 +367,7 @@ def transfer_kv_per_object_group(
                 direction,
                 cache_context.get_shape_desc(kernel_group_id),
                 group_lmcache_chunk_size,
-                cache_context.engine_kv_format,
+                cache_context.get_engine_kv_format(kernel_group_id),
                 recalculated_skip_blocks,
             )
 

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -57,7 +57,6 @@ class BaseCacheContext(ABC):
         kv_caches: list[torch.Tensor],
         device: torch.device,
         num_layers: int,
-        num_blocks: int,
         kv_layer_groups_manager: KVLayerGroupsManager,
         block_ids_buffer: torch.Tensor,
         lmcache_tokens_per_chunk: int,
@@ -65,7 +64,6 @@ class BaseCacheContext(ABC):
         self.kv_caches_ = kv_caches
         self.device_ = device
         self.num_layers_ = num_layers
-        self.num_blocks_ = num_blocks
         self.kv_layer_groups_manager_ = kv_layer_groups_manager
         self.block_ids_buffer_ = block_ids_buffer
         self.lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
@@ -153,8 +151,12 @@ class BaseCacheContext(ABC):
 
     @property
     def num_blocks(self) -> int:
-        """Returns the number of blocks in the KV cache."""
-        return self.num_blocks_
+        """Returns the number of blocks in the KV cache.
+
+        Sourced from the kernel groups (one shared block-id space), not a
+        representative-format computation.
+        """
+        return self.kv_layer_groups_manager_.num_blocks
 
     @property
     def hidden_dim_sizes(self) -> list[int]:

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -203,20 +203,14 @@ class BaseCacheContext(ABC):
             )
         return engine_kv_format
 
-    def engine_kv_formats_per_layer(self) -> list["lmc_ops.EngineKVFormat"]:
-        """Returns the Engine KV format of each layer, aligned with kv_tensors.
+    def engine_kv_formats(self) -> list["lmc_ops.EngineKVFormat"]:
+        """Returns the Engine KV format of each kernel group, in group order.
 
-        Each registered KV tensor maps to the format of the kernel group that
-        owns its layer. Mixed-format models (e.g. MiniMax-M3) return differing
-        entries; homogeneous models return one value repeated per layer.
+        A mixed-format model (e.g. MiniMax-M3) returns differing entries; a
+        homogeneous model returns one distinct value.
         """
-        groups = self.kv_layer_groups_manager.kv_layer_groups
-        per_layer: dict[int, "lmc_ops.EngineKVFormat"] = {}
-        for kernel_group_idx, group in enumerate(groups):
-            engine_kv_format = self.get_engine_kv_format(kernel_group_idx)
-            for layer_idx in group.layer_indices:
-                per_layer[layer_idx] = engine_kv_format
-        return [per_layer[layer_idx] for layer_idx in range(self.num_layers)]
+        num_groups = len(self.kv_layer_groups_manager.kernel_groups)
+        return [self.get_engine_kv_format(idx) for idx in range(num_groups)]
 
     def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
         """Returns the number of slots per lmcache chunk for D/H

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -200,14 +200,15 @@ class BaseCacheContext(ABC):
         """Returns the PageBufferShapeDesc for *group_idx*."""
         return self.kv_layer_groups_manager.get_shape_desc(group_idx)
 
-    def get_engine_kv_format(self, group_idx: int) -> "lmc_ops.EngineKVFormat":
-        """Returns the Engine KV format of kernel *group_idx*.
+    def get_engine_kv_format(self, kernel_group_idx: int) -> "lmc_ops.EngineKVFormat":
+        """Returns the Engine KV format of kernel *kernel_group_idx*.
 
         The per-group format -- read by the transfer path so a model mixing
         formats across groups (e.g. MiniMax-M3) dispatches each group with its
         own, instead of the context's single representative ``engine_kv_format``.
         """
-        return self.kv_layer_groups_manager.kv_layer_groups[group_idx].engine_kv_format
+        groups = self.kv_layer_groups_manager.kv_layer_groups
+        return groups[kernel_group_idx].engine_kv_format
 
     def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
         """Returns the number of slots per lmcache chunk for D/H

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -208,6 +208,25 @@ class BaseCacheContext(ABC):
         num_groups = len(self.kv_layer_groups_manager.kernel_groups)
         return [self.get_engine_kv_format(idx) for idx in range(num_groups)]
 
+    def engine_kv_format_per_layer(self) -> list["lmc_ops.EngineKVFormat | None"]:
+        """Returns each layer's Engine KV format, indexed by layer index.
+
+        A model that mixes formats within one engine group (e.g. a 5-D
+        key+value group alongside a 3-D key-only group) yields different
+        formats across layers. ``None`` marks a layer in no kernel group -- a
+        cross-layer KV-sharing layer whose KV physically lives in its owner's
+        blocks (see ``group_layers_by_identity``); its format follows the
+        owner's and is not tracked per layer here.
+        """
+        formats: list["lmc_ops.EngineKVFormat | None"] = [None] * len(self.kv_caches_)
+        for kernel_group_idx, group in enumerate(
+            self.kv_layer_groups_manager.kernel_groups
+        ):
+            fmt = self.get_engine_kv_format(kernel_group_idx)
+            for layer_idx in group.layer_indices:
+                formats[layer_idx] = fmt
+        return formats
+
     def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
         """Returns the number of slots per lmcache chunk for D/H
         transfer."""

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -54,7 +54,6 @@ class BaseCacheContext(ABC):
     def __init__(
         self,
         *,
-        engine_kv_format: Any,
         kv_caches: list[torch.Tensor],
         device: torch.device,
         num_layers: int,
@@ -63,7 +62,6 @@ class BaseCacheContext(ABC):
         block_ids_buffer: torch.Tensor,
         lmcache_tokens_per_chunk: int,
     ) -> None:
-        self.engine_kv_format_ = engine_kv_format
         self.kv_caches_ = kv_caches
         self.device_ = device
         self.num_layers_ = num_layers
@@ -75,12 +73,6 @@ class BaseCacheContext(ABC):
     # ------------------------------------------------------------------
     # Abstract -- subclasses MUST implement
     # ------------------------------------------------------------------
-
-    @property
-    @abstractmethod
-    def dtype(self) -> torch.dtype:
-        """Returns the dtype of the KV cache tensors."""
-        ...
 
     @property
     @abstractmethod
@@ -143,11 +135,6 @@ class BaseCacheContext(ABC):
     # ------------------------------------------------------------------
     # Concrete -- shared implementations
     # ------------------------------------------------------------------
-
-    @property
-    def engine_kv_format(self) -> Any:
-        """Returns the EngineKVFormat enum value."""
-        return self.engine_kv_format_
 
     @property
     def device(self) -> torch.device:
@@ -214,6 +201,21 @@ class BaseCacheContext(ABC):
             )
         return engine_kv_format
 
+    def engine_kv_formats_per_layer(self) -> list["lmc_ops.EngineKVFormat"]:
+        """Returns the Engine KV format of each layer, aligned with kv_tensors.
+
+        Each registered KV tensor maps to the format of the kernel group that
+        owns its layer. Mixed-format models (e.g. MiniMax-M3) return differing
+        entries; homogeneous models return one value repeated per layer.
+        """
+        groups = self.kv_layer_groups_manager.kv_layer_groups
+        per_layer: dict[int, "lmc_ops.EngineKVFormat"] = {}
+        for kernel_group_idx, group in enumerate(groups):
+            engine_kv_format = self.get_engine_kv_format(kernel_group_idx)
+            for layer_idx in group.layer_indices:
+                per_layer[layer_idx] = engine_kv_format
+        return [per_layer[layer_idx] for layer_idx in range(self.num_layers)]
+
     def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
         """Returns the number of slots per lmcache chunk for D/H
         transfer."""
@@ -268,16 +270,6 @@ class BaseCacheContext(ABC):
     # ------------------------------------------------------------------
     # Derived properties (pure helpers)
     # ------------------------------------------------------------------
-
-    @property
-    def engine_kv_shape(self) -> str:
-        """Returns the symbolic KV cache layout description."""
-        return get_engine_kv_shape_description(self.engine_kv_format)
-
-    @property
-    def attention_backend(self) -> str:
-        """Returns the attention backend name."""
-        return get_attention_backend(self.engine_kv_format)
 
     @property
     def concrete_engine_kv_shape(self) -> str:

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -303,7 +303,6 @@ class BaseCacheContext(ABC):
         self,
         kernel_group_idx: int,
         group: Any,
-        engine_kv_format: Any,
         group_map: dict[int, int],
     ) -> dict:
         """Build a status dict for a single kernel group.
@@ -311,6 +310,7 @@ class BaseCacheContext(ABC):
         Override this in subclasses to inject extra per-group fields
         without duplicating the whole :meth:`report_status` method.
         """
+        engine_kv_format = self.get_engine_kv_format(kernel_group_idx)
         return {
             "kernel_group_idx": kernel_group_idx,
             "engine_group_idx": group.engine_group_idx,
@@ -335,13 +335,10 @@ class BaseCacheContext(ABC):
         """Return this context's KV cache layout metadata."""
         manager = self.kv_layer_groups_manager
         kernel_groups = manager.kernel_groups
-        engine_kv_format = self.engine_kv_format
         group_map = self._build_group_report_map()
 
         group_reports = [
-            self._build_single_group_report(
-                kernel_group_idx, group, engine_kv_format, group_map
-            )
+            self._build_single_group_report(kernel_group_idx, group, group_map)
             for kernel_group_idx, group in enumerate(kernel_groups)
         ]
 

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -206,9 +206,20 @@ class BaseCacheContext(ABC):
         The per-group format -- read by the transfer path so a model mixing
         formats across groups (e.g. MiniMax-M3) dispatches each group with its
         own, instead of the context's single representative ``engine_kv_format``.
+
+        Raises:
+            ValueError: If the group has no format (a bookkeeping group built by
+                ``parse_kvcache_shape_spec`` should never reach the transfer
+                path; detection-built groups always carry one).
         """
         groups = self.kv_layer_groups_manager.kv_layer_groups
-        return groups[kernel_group_idx].engine_kv_format
+        engine_kv_format = groups[kernel_group_idx].engine_kv_format
+        if engine_kv_format is None:
+            raise ValueError(
+                f"kernel group {kernel_group_idx} has no engine_kv_format; a "
+                "formatless bookkeeping group reached the transfer path"
+            )
+        return engine_kv_format
 
     def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
         """Returns the number of slots per lmcache chunk for D/H

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -211,12 +211,8 @@ class BaseCacheContext(ABC):
     def engine_kv_format_per_layer(self) -> list["lmc_ops.EngineKVFormat | None"]:
         """Returns each layer's Engine KV format, indexed by layer index.
 
-        A model that mixes formats within one engine group (e.g. a 5-D
-        key+value group alongside a 3-D key-only group) yields different
-        formats across layers. ``None`` marks a layer in no kernel group -- a
-        cross-layer KV-sharing layer whose KV physically lives in its owner's
-        blocks (see ``group_layers_by_identity``); its format follows the
-        owner's and is not tracked per layer here.
+        Formats differ across layers for a mixed-format model. ``None`` marks a
+        layer in no kernel group (a cross-layer KV-sharing layer).
         """
         formats: list["lmc_ops.EngineKVFormat | None"] = [None] * len(self.kv_caches_)
         for kernel_group_idx, group in enumerate(

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -200,6 +200,15 @@ class BaseCacheContext(ABC):
         """Returns the PageBufferShapeDesc for *group_idx*."""
         return self.kv_layer_groups_manager.get_shape_desc(group_idx)
 
+    def get_engine_kv_format(self, group_idx: int) -> "lmc_ops.EngineKVFormat":
+        """Returns the Engine KV format of kernel *group_idx*.
+
+        The per-group format -- read by the transfer path so a model mixing
+        formats across groups (e.g. MiniMax-M3) dispatches each group with its
+        own, instead of the context's single representative ``engine_kv_format``.
+        """
+        return self.kv_layer_groups_manager.kv_layer_groups[group_idx].engine_kv_format
+
     def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
         """Returns the number of slots per lmcache chunk for D/H
         transfer."""
@@ -270,7 +279,7 @@ class BaseCacheContext(ABC):
         """Returns the engine KV shape with actual numeric values."""
         group = self.kv_layer_groups_manager.kv_layer_groups[0]
         return get_concrete_engine_kv_shape_from_shape_desc(
-            group.shape_desc, self.engine_kv_format
+            group.shape_desc, group.engine_kv_format
         )
 
     # ------------------------------------------------------------------

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -186,8 +186,8 @@ class BaseCacheContext(ABC):
         """Returns the Engine KV format of kernel *kernel_group_idx*.
 
         The per-group format -- read by the transfer path so a model mixing
-        formats across groups (e.g. MiniMax-M3) dispatches each group with its
-        own, instead of the context's single representative ``engine_kv_format``.
+        formats across groups dispatches each group with its own, instead of a
+        single representative format.
 
         Raises:
             ValueError: If the group has no format (a bookkeeping group built by
@@ -204,11 +204,7 @@ class BaseCacheContext(ABC):
         return engine_kv_format
 
     def engine_kv_formats(self) -> list["lmc_ops.EngineKVFormat"]:
-        """Returns the Engine KV format of each kernel group, in group order.
-
-        A mixed-format model (e.g. MiniMax-M3) returns differing entries; a
-        homogeneous model returns one distinct value.
-        """
+        """Returns the Engine KV format of each kernel group, in group order."""
         num_groups = len(self.kv_layer_groups_manager.kernel_groups)
         return [self.get_engine_kv_format(idx) for idx in range(num_groups)]
 

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -185,10 +185,6 @@ class BaseCacheContext(ABC):
     def get_engine_kv_format(self, kernel_group_idx: int) -> "lmc_ops.EngineKVFormat":
         """Returns the Engine KV format of kernel *kernel_group_idx*.
 
-        The per-group format -- read by the transfer path so a model mixing
-        formats across groups dispatches each group with its own, instead of a
-        single representative format.
-
         Raises:
             ValueError: If the group has no format (a bookkeeping group built by
                 ``parse_kvcache_shape_spec`` should never reach the transfer

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -59,7 +59,6 @@ class BaseCacheContext(ABC):
         device: torch.device,
         num_layers: int,
         num_blocks: int,
-        is_mla: bool,
         kv_layer_groups_manager: KVLayerGroupsManager,
         block_ids_buffer: torch.Tensor,
         lmcache_tokens_per_chunk: int,
@@ -69,7 +68,6 @@ class BaseCacheContext(ABC):
         self.device_ = device
         self.num_layers_ = num_layers
         self.num_blocks_ = num_blocks
-        self.is_mla_ = is_mla
         self.kv_layer_groups_manager_ = kv_layer_groups_manager
         self.block_ids_buffer_ = block_ids_buffer
         self.lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
@@ -170,11 +168,6 @@ class BaseCacheContext(ABC):
     def num_blocks(self) -> int:
         """Returns the number of blocks in the KV cache."""
         return self.num_blocks_
-
-    @property
-    def is_mla(self) -> bool:
-        """Returns whether the model uses MLA."""
-        return self.is_mla_
 
     @property
     def hidden_dim_sizes(self) -> list[int]:

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -103,8 +103,8 @@ class CPUCacheContext(BaseCacheContext):
         kv_caches_list: list[torch.Tensor] = list(kv_caches_normalized)
         # Group-0 representative, for diagnostics/logging only. Everything that
         # varies per group -- format, dtype, heads, block_size -- is read per
-        # KernelGroupInfo; num_blocks is asserted uniform across groups by the
-        # manager.
+        # KernelGroupInfo; num_blocks is the one shared scalar (a single block-id
+        # space across groups).
         engine_kv_format = engine_kv_formats[0]
         num_layers_val = len(engine_kv_formats)
         num_blocks_val = get_num_blocks(kv_caches_list, engine_kv_format)

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -93,9 +93,6 @@ class CPUCacheContext(BaseCacheContext):
         # GPUCacheContext uses, so we don't need to hand-roll any
         # PageBufferShapeDesc here. ``layout_hints`` / ``engine_type``
         # are forwarded so the signature matches GPUCacheContext.
-        # Detect each engine group's format from the registered tensors so a
-        # model mixing formats across groups (e.g. MiniMax-M3) groups and shapes
-        # correctly. Homogeneous models yield one shared format for every layer.
         (
             kv_caches_normalized,
             engine_kv_formats,

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -119,7 +119,6 @@ class CPUCacheContext(BaseCacheContext):
         block_ids_buffer = torch.empty(_MAX_BLOCK_IDS, dtype=torch.long)
 
         super().__init__(
-            engine_kv_format=engine_kv_format,
             kv_caches=kv_caches_list,
             device=self.device_,
             num_layers=num_layers_val,
@@ -221,11 +220,6 @@ class CPUCacheContext(BaseCacheContext):
         pass
 
     # -- Properties (same API as GPUCacheContext) --
-
-    @property
-    def dtype(self) -> torch.dtype:
-        """Returns the dtype of the KV cache tensors."""
-        return self.kv_caches_[0].dtype
 
     @property
     def max_batch_size(self) -> int:

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -30,7 +30,6 @@ from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     get_group_data_ptrs,
-    get_num_blocks,
     normalize_and_discover_per_layer_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -101,12 +100,7 @@ class CPUCacheContext(BaseCacheContext):
             layout_hints,
         )
         kv_caches_list: list[torch.Tensor] = list(kv_caches_normalized)
-        # Group-0 representative, for diagnostics/logging only. Everything that
-        # varies per group -- format, dtype, heads, block_size, num_blocks -- is
-        # read per KernelGroupInfo.
-        engine_kv_format = engine_kv_formats[0]
         num_layers_val = len(engine_kv_formats)
-        num_blocks_val = get_num_blocks(kv_caches_list, engine_kv_format)
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_list,
             engine_kv_formats=engine_kv_formats,
@@ -122,7 +116,6 @@ class CPUCacheContext(BaseCacheContext):
             kv_caches=kv_caches_list,
             device=self.device_,
             num_layers=num_layers_val,
-            num_blocks=num_blocks_val,
             kv_layer_groups_manager=kv_layer_groups_manager,
             block_ids_buffer=block_ids_buffer,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
@@ -187,7 +180,7 @@ class CPUCacheContext(BaseCacheContext):
         logger.info(
             "CPUCacheContext: %d layers, %d blocks, dtype=%s (shm-backed)",
             self.num_layers_,
-            self.num_blocks_,
+            self.num_blocks,
             self.kv_caches_[0].dtype,
         )
 

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -33,7 +33,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
-    normalize_and_discover_per_group_formats,
+    normalize_and_discover_per_layer_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
@@ -99,7 +99,7 @@ class CPUCacheContext(BaseCacheContext):
         (
             kv_caches_normalized,
             engine_kv_formats,
-        ) = normalize_and_discover_per_group_formats(
+        ) = normalize_and_discover_per_layer_formats(
             unwrapped,
             engine_group_layer_indices(engine_group_infos),
             engine_type,

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -31,8 +31,6 @@ from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     get_group_data_ptrs,
     get_num_blocks,
-    get_num_layers,
-    is_mla,
     normalize_and_discover_per_layer_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -103,11 +101,12 @@ class CPUCacheContext(BaseCacheContext):
             layout_hints,
         )
         kv_caches_list: list[torch.Tensor] = list(kv_caches_normalized)
-        # Representative format for context-wide, format-only queries (identical
-        # to the single detected format for every homogeneous model).
+        # Group-0 representative, for diagnostics/logging only. Everything that
+        # varies per group -- format, dtype, heads, block_size -- is read per
+        # KernelGroupInfo; num_blocks is asserted uniform across groups by the
+        # manager.
         engine_kv_format = engine_kv_formats[0]
-        is_mla_val = is_mla(engine_kv_format)
-        num_layers_val = get_num_layers(kv_caches_list, engine_kv_format)
+        num_layers_val = len(engine_kv_formats)
         num_blocks_val = get_num_blocks(kv_caches_list, engine_kv_format)
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_list,
@@ -127,7 +126,6 @@ class CPUCacheContext(BaseCacheContext):
             device=self.device_,
             num_layers=num_layers_val,
             num_blocks=num_blocks_val,
-            is_mla=is_mla_val,
             kv_layer_groups_manager=kv_layer_groups_manager,
             block_ids_buffer=block_ids_buffer,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -33,10 +33,11 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
-    normalize_kv_and_discover_format,
+    normalize_and_discover_per_group_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.group_view import engine_group_layer_indices
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
 
@@ -92,21 +93,28 @@ class CPUCacheContext(BaseCacheContext):
         # GPUCacheContext uses, so we don't need to hand-roll any
         # PageBufferShapeDesc here. ``layout_hints`` / ``engine_type``
         # are forwarded so the signature matches GPUCacheContext.
+        # Detect each engine group's format from the registered tensors so a
+        # model mixing formats across groups (e.g. MiniMax-M3) groups and shapes
+        # correctly. Homogeneous models yield one shared format for every layer.
         (
-            engine_kv_format,
             kv_caches_normalized,
-        ) = normalize_kv_and_discover_format(
+            engine_kv_formats,
+        ) = normalize_and_discover_per_group_formats(
             unwrapped,
+            engine_group_layer_indices(engine_group_infos),
             engine_type,
-            layout_hints=layout_hints,
+            layout_hints,
         )
         kv_caches_list: list[torch.Tensor] = list(kv_caches_normalized)
+        # Representative format for context-wide, format-only queries (identical
+        # to the single detected format for every homogeneous model).
+        engine_kv_format = engine_kv_formats[0]
         is_mla_val = is_mla(engine_kv_format)
         num_layers_val = get_num_layers(kv_caches_list, engine_kv_format)
         num_blocks_val = get_num_blocks(kv_caches_list, engine_kv_format)
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_list,
-            engine_kv_format=engine_kv_format,
+            engine_kv_formats=engine_kv_formats,
             num_blocks=num_blocks_val,
             engine_group_infos=engine_group_infos,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -102,16 +102,14 @@ class CPUCacheContext(BaseCacheContext):
         )
         kv_caches_list: list[torch.Tensor] = list(kv_caches_normalized)
         # Group-0 representative, for diagnostics/logging only. Everything that
-        # varies per group -- format, dtype, heads, block_size -- is read per
-        # KernelGroupInfo; num_blocks is the one shared scalar (a single block-id
-        # space across groups).
+        # varies per group -- format, dtype, heads, block_size, num_blocks -- is
+        # read per KernelGroupInfo.
         engine_kv_format = engine_kv_formats[0]
         num_layers_val = len(engine_kv_formats)
         num_blocks_val = get_num_blocks(kv_caches_list, engine_kv_format)
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_list,
             engine_kv_formats=engine_kv_formats,
-            num_blocks=num_blocks_val,
             engine_group_infos=engine_group_infos,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
         )

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -137,12 +137,12 @@ class CPUCacheContext(BaseCacheContext):
             torch.tensor(
                 get_group_data_ptrs(
                     self.kv_caches_,
-                    self.engine_kv_format,
+                    self.get_engine_kv_format(idx),
                     group.layer_indices,
                 ),
                 dtype=torch.long,
             )
-            for group in self.kv_layer_groups_manager_.kv_layer_groups
+            for idx, group in enumerate(self.kv_layer_groups_manager_.kv_layer_groups)
         ]
 
         self.kv_cache_pointers_ = torch.tensor(

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -30,8 +30,6 @@ from lmcache.v1.gpu_connector.utils import (
     get_dtype,
     get_group_data_ptrs,
     get_num_blocks,
-    get_num_layers,
-    is_mla,
     normalize_and_discover_per_layer_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -365,12 +363,13 @@ class GPUCacheContext(BaseCacheContext):
             engine_type,
             layout_hints,
         )
-        # Representative format for context-wide, format-only queries (identical
-        # to the single detected format for every homogeneous model).
+        # Group-0 representative, for diagnostics/logging only (e.g.
+        # get_attention_backend). Everything that varies per group -- format,
+        # dtype, heads, block_size -- is read per KernelGroupInfo; num_blocks is
+        # asserted uniform across groups by the manager.
         engine_kv_format = engine_kv_formats[0]
         self.device_ = get_device(kv_caches_norm)
-        is_mla_val = is_mla(engine_kv_format)
-        num_layers_val = get_num_layers(kv_caches_norm, engine_kv_format)
+        num_layers_val = len(engine_kv_formats)
         num_blocks_val = get_num_blocks(kv_caches_norm, engine_kv_format)
 
         kv_layer_groups_manager = KVLayerGroupsManager(
@@ -395,7 +394,6 @@ class GPUCacheContext(BaseCacheContext):
             device=self.device_,
             num_layers=num_layers_val,
             num_blocks=num_blocks_val,
-            is_mla=is_mla_val,
             kv_layer_groups_manager=kv_layer_groups_manager,
             block_ids_buffer=block_ids_buffer,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -364,9 +364,9 @@ class GPUCacheContext(BaseCacheContext):
             layout_hints,
         )
         # Group-0 representative, for diagnostics/logging only (e.g.
-        # get_attention_backend). Everything that varies per group -- format,
-        # dtype, heads, block_size -- is read per KernelGroupInfo; num_blocks is
-        # the one shared scalar (a single block-id space across groups).
+        # get_attention_backend) and the single-group blend path. Everything that
+        # varies per group -- format, dtype, heads, block_size, num_blocks -- is
+        # read per KernelGroupInfo.
         engine_kv_format = engine_kv_formats[0]
         self.device_ = get_device(kv_caches_norm)
         num_layers_val = len(engine_kv_formats)
@@ -375,7 +375,6 @@ class GPUCacheContext(BaseCacheContext):
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_norm,
             engine_kv_formats=engine_kv_formats,
-            num_blocks=num_blocks_val,
             engine_group_infos=engine_group_infos,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
         )

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -407,7 +407,7 @@ class GPUCacheContext(BaseCacheContext):
         self.group_kv_pointers_: list[torch.Tensor] = []
         for group in self.kv_layer_groups_manager_.kv_layer_groups:
             ptrs = get_group_data_ptrs(
-                self.kv_caches_, self.engine_kv_format, group.layer_indices
+                self.kv_caches_, group.engine_kv_format, group.layer_indices
             )
             self.group_kv_pointers_.append(list_to_gpu_tensor(ptrs, self.device_))
 

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -28,7 +28,6 @@ from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     get_device,
     get_group_data_ptrs,
-    get_num_blocks,
     normalize_and_discover_per_layer_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -362,14 +361,8 @@ class GPUCacheContext(BaseCacheContext):
             engine_type,
             layout_hints,
         )
-        # Group-0 representative, for diagnostics/logging only (e.g.
-        # get_attention_backend) and the single-group blend path. Everything that
-        # varies per group -- format, dtype, heads, block_size, num_blocks -- is
-        # read per KernelGroupInfo.
-        engine_kv_format = engine_kv_formats[0]
         self.device_ = get_device(kv_caches_norm)
         num_layers_val = len(engine_kv_formats)
-        num_blocks_val = get_num_blocks(kv_caches_norm, engine_kv_format)
 
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_norm,
@@ -390,7 +383,6 @@ class GPUCacheContext(BaseCacheContext):
             kv_caches=kv_caches_norm,
             device=self.device_,
             num_layers=num_layers_val,
-            num_blocks=num_blocks_val,
             kv_layer_groups_manager=kv_layer_groups_manager,
             block_ids_buffer=block_ids_buffer,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -27,7 +27,6 @@ from lmcache.v1.gpu_connector.gds_context import get_gds_context
 from lmcache.v1.gpu_connector.utils import (
     LayoutHints,
     get_device,
-    get_dtype,
     get_group_data_ptrs,
     get_num_blocks,
     normalize_and_discover_per_layer_formats,
@@ -388,7 +387,6 @@ class GPUCacheContext(BaseCacheContext):
         )
 
         super().__init__(
-            engine_kv_format=engine_kv_format,
             kv_caches=kv_caches_norm,
             device=self.device_,
             num_layers=num_layers_val,
@@ -442,10 +440,6 @@ class GPUCacheContext(BaseCacheContext):
         """
         with torch_dev.stream(self.cuda_stream_):
             get_gds_context().deregister_gpu_buffer(self._temp_buffer.buffer)
-
-    @property
-    def dtype(self) -> torch.dtype:
-        return get_dtype(self.kv_caches_, self.engine_kv_format)
 
     @property
     def stream(self) -> Any:

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -32,7 +32,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
-    normalize_and_discover_per_group_formats,
+    normalize_and_discover_per_layer_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
@@ -362,7 +362,7 @@ class GPUCacheContext(BaseCacheContext):
         # Detect each engine group's format from the registered tensors so a
         # model mixing formats across groups (e.g. MiniMax-M3) groups and shapes
         # correctly. Homogeneous models yield one shared format for every layer.
-        kv_caches_norm, engine_kv_formats = normalize_and_discover_per_group_formats(
+        kv_caches_norm, engine_kv_formats = normalize_and_discover_per_layer_formats(
             unwrapped,
             engine_group_layer_indices(engine_group_infos),
             engine_type,

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -366,7 +366,7 @@ class GPUCacheContext(BaseCacheContext):
         # Group-0 representative, for diagnostics/logging only (e.g.
         # get_attention_backend). Everything that varies per group -- format,
         # dtype, heads, block_size -- is read per KernelGroupInfo; num_blocks is
-        # asserted uniform across groups by the manager.
+        # the one shared scalar (a single block-id space across groups).
         engine_kv_format = engine_kv_formats[0]
         self.device_ = get_device(kv_caches_norm)
         num_layers_val = len(engine_kv_formats)

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -359,9 +359,6 @@ class GPUCacheContext(BaseCacheContext):
         engine_type: EngineType = EngineType.VLLM,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
-        # Detect each engine group's format from the registered tensors so a
-        # model mixing formats across groups (e.g. MiniMax-M3) groups and shapes
-        # correctly. Homogeneous models yield one shared format for every layer.
         kv_caches_norm, engine_kv_formats = normalize_and_discover_per_layer_formats(
             unwrapped,
             engine_group_layer_indices(engine_group_infos),

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -32,11 +32,14 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
-    normalize_kv_and_discover_format,
+    normalize_and_discover_per_group_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
-from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.group_view import (
+    EngineGroupInfo,
+    engine_group_layer_indices,
+)
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 
 logger = init_logger(__name__)
@@ -356,11 +359,18 @@ class GPUCacheContext(BaseCacheContext):
         engine_type: EngineType = EngineType.VLLM,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
-        engine_kv_format, kv_caches_norm = normalize_kv_and_discover_format(
+        # Detect each engine group's format from the registered tensors so a
+        # model mixing formats across groups (e.g. MiniMax-M3) groups and shapes
+        # correctly. Homogeneous models yield one shared format for every layer.
+        kv_caches_norm, engine_kv_formats = normalize_and_discover_per_group_formats(
             unwrapped,
+            engine_group_layer_indices(engine_group_infos),
             engine_type,
-            layout_hints=layout_hints,
+            layout_hints,
         )
+        # Representative format for context-wide, format-only queries (identical
+        # to the single detected format for every homogeneous model).
+        engine_kv_format = engine_kv_formats[0]
         self.device_ = get_device(kv_caches_norm)
         is_mla_val = is_mla(engine_kv_format)
         num_layers_val = get_num_layers(kv_caches_norm, engine_kv_format)
@@ -368,7 +378,7 @@ class GPUCacheContext(BaseCacheContext):
 
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_norm,
-            engine_kv_format=engine_kv_format,
+            engine_kv_formats=engine_kv_formats,
             num_blocks=num_blocks_val,
             engine_group_infos=engine_group_infos,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -400,9 +400,9 @@ class GPUCacheContext(BaseCacheContext):
         )
 
         self.group_kv_pointers_: list[torch.Tensor] = []
-        for group in self.kv_layer_groups_manager_.kv_layer_groups:
+        for idx, group in enumerate(self.kv_layer_groups_manager_.kv_layer_groups):
             ptrs = get_group_data_ptrs(
-                self.kv_caches_, group.engine_kv_format, group.layer_indices
+                self.kv_caches_, self.get_engine_kv_format(idx), group.layer_indices
             )
             self.group_kv_pointers_.append(list_to_gpu_tensor(ptrs, self.device_))
 

--- a/tests/v1/multiprocess/test_compute_mp_checksums.py
+++ b/tests/v1/multiprocess/test_compute_mp_checksums.py
@@ -54,7 +54,7 @@ class TestComputeBlockChecksums5DLayout:
         result = _compute_block_checksums(
             kv,
             block_ids=[0, 1, 2, 3],
-            block_axis=1,
+            block_axes=[1] * len(kv),
             chunk_size=2,
             layerwise=False,
         )
@@ -69,7 +69,7 @@ class TestComputeBlockChecksums5DLayout:
         result = _compute_block_checksums(
             kv,
             block_ids=[0, 1, 2, 3],
-            block_axis=1,
+            block_axes=[1] * len(kv),
             chunk_size=4,
             layerwise=True,
         )
@@ -86,7 +86,7 @@ class TestComputeBlockChecksums5DLayout:
         result = _compute_block_checksums(
             kv,
             block_ids=[0, 1, 2],
-            block_axis=1,
+            block_axes=[1] * len(kv),
             chunk_size=2,
             layerwise=False,
         )
@@ -95,7 +95,9 @@ class TestComputeBlockChecksums5DLayout:
 
     def test_deterministic(self):
         kv = _make_5d_kv()
-        args = dict(block_ids=[0, 1], block_axis=1, chunk_size=2, layerwise=False)
+        args = dict(
+            block_ids=[0, 1], block_axes=[1] * len(kv), chunk_size=2, layerwise=False
+        )
         r1 = _compute_block_checksums(kv, **args)
         r2 = _compute_block_checksums(kv, **args)
         assert r1["chunk_checksums"] == r2["chunk_checksums"]
@@ -105,7 +107,7 @@ class TestComputeBlockChecksums5DLayout:
         result = _compute_block_checksums(
             kv,
             block_ids=[0, 1],
-            block_axis=1,
+            block_axes=[1] * len(kv),
             chunk_size=1,
             layerwise=False,
         )
@@ -118,7 +120,7 @@ class TestComputeBlockChecksums5DLayout:
         result = _compute_block_checksums(
             kv,
             block_ids=[0, 1, 2, 3],
-            block_axis=1,
+            block_axes=[1] * len(kv),
             chunk_size=2,
             layerwise=False,
         )
@@ -132,7 +134,7 @@ class TestComputeBlockChecksums5DLayout:
         result = _compute_block_checksums(
             kv,
             block_ids=[0, 1, 2, 3],
-            block_axis=1,
+            block_axes=[1] * len(kv),
             chunk_size=2,
             layerwise=False,
         )
@@ -149,7 +151,7 @@ class TestComputeBlockChecksums3DMLA:
         result = _compute_block_checksums(
             kv,
             block_ids=[0, 1, 2, 3],
-            block_axis=0,
+            block_axes=[0] * len(kv),
             chunk_size=2,
             layerwise=False,
         )
@@ -161,7 +163,7 @@ class TestComputeBlockChecksums3DMLA:
         result = _compute_block_checksums(
             kv,
             block_ids=[0, 1, 2, 3],
-            block_axis=0,
+            block_axes=[0] * len(kv),
             chunk_size=2,
             layerwise=True,
         )
@@ -177,7 +179,7 @@ class TestComputeBlockChecksums3DMLA:
         result = _compute_block_checksums(
             kv,
             block_ids=block_ids,
-            block_axis=0,
+            block_axes=[0] * len(kv),
             chunk_size=chunk_size,
             layerwise=False,
         )
@@ -203,14 +205,14 @@ class TestBlockSelectionSemantics:
         r1 = _compute_block_checksums(
             kv,
             block_ids=[0, 1],
-            block_axis=0,
+            block_axes=[0] * len(kv),
             chunk_size=2,
             layerwise=False,
         )
         r2 = _compute_block_checksums(
             kv,
             block_ids=[1, 0],
-            block_axis=0,
+            block_axes=[0] * len(kv),
             chunk_size=2,
             layerwise=False,
         )
@@ -221,28 +223,28 @@ class TestBlockSelectionSemantics:
         r_a = _compute_block_checksums(
             kv,
             block_ids=[0, 1],
-            block_axis=0,
+            block_axes=[0] * len(kv),
             chunk_size=1,
             layerwise=False,
         )
         r_b = _compute_block_checksums(
             kv,
             block_ids=[2, 3],
-            block_axis=0,
+            block_axes=[0] * len(kv),
             chunk_size=1,
             layerwise=False,
         )
         assert r_a["chunk_checksums"] != r_b["chunk_checksums"]
 
-    def test_unsupported_block_axis_raises(self):
-        """A block_axis out of range for the tensor ndim must bubble up
+    def test_out_of_range_block_axis_raises(self):
+        """A block axis out of range for the tensor ndim must bubble up
         from ``index_select`` as ``IndexError``."""
         kv = _make_3d_mla_kv()
         with pytest.raises(IndexError):
             _compute_block_checksums(
                 kv,
                 block_ids=[0],
-                block_axis=9,
+                block_axes=[9] * len(kv),
                 chunk_size=1,
                 layerwise=False,
             )

--- a/tests/v1/multiprocess/test_http_server.py
+++ b/tests/v1/multiprocess/test_http_server.py
@@ -45,9 +45,29 @@ def mock_gpu_ctx():
     type(ctx).kv_tensors = PropertyMock(return_value=tensors)
     type(ctx).block_size = PropertyMock(return_value=4)
     # KV tensors are built as [2, NB, BS, NH, HS] -> NL_X_TWO_NB_BS_NH_HS;
-    # one homogeneous kernel group.
-    ctx.engine_kv_formats.return_value = [lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS]
+    # one homogeneous kernel group, so every layer reports the same format.
+    fmt = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+    ctx.engine_kv_formats.return_value = [fmt]
+    ctx.engine_kv_format_per_layer.return_value = [fmt] * len(tensors)
     return ctx
+
+
+@pytest.fixture
+def mock_mixed_engine():
+    """Engine whose context mixes a 5-D key+value layer and a 3-D key-only
+    layer (e.g. a sparse-attention indexer cache) -- the endpoint must gather
+    each along its own block axis instead of rejecting the request."""
+    ctx = MagicMock()
+    kv_kv = torch.randn(2, 4, 4, 2, 8)  # NL_X_TWO_NB_BS_NH_HS, block axis 1
+    kv_idx = torch.randn(4, 4, 8)  # NL_X_NB_BS_HS (key-only), block axis 0
+    type(ctx).kv_tensors = PropertyMock(return_value=[kv_kv, kv_idx])
+    ctx.engine_kv_format_per_layer.return_value = [
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
+    ]
+    engine = MagicMock()
+    engine.cache_contexts = {0: ctx}
+    return engine
 
 
 @pytest.fixture
@@ -110,6 +130,22 @@ class TestKVCacheCheckEndpoint:
         d1 = client_with_engine.get(url).json()
         d2 = client_with_engine.get(url).json()
         assert d1["chunk_checksums"] == d2["chunk_checksums"]
+
+    def test_mixed_format_supported(self, mock_mixed_engine):
+        """A model mixing a 5-D K/V layer and a 3-D key-only layer is gathered
+        per-layer (each along its own block axis), not rejected with 501."""
+        app.state.engine = mock_mixed_engine
+        client = TestClient(app)
+        try:
+            resp = client.get("/kvcache/check?block_ids=0&chunk_size=1&layerwise=true")
+        finally:
+            client.close()
+            app.state.engine = None
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "success"
+        # Both layers checksummed despite different formats / block axes.
+        assert set(data["chunk_checksums"]) == {"layer_0", "layer_1"}
 
     def test_range_block_ids(self, client_with_engine):
         """Range format [0,1] is accepted for block_ids."""

--- a/tests/v1/multiprocess/test_http_server.py
+++ b/tests/v1/multiprocess/test_http_server.py
@@ -44,10 +44,11 @@ def mock_gpu_ctx():
     tensors = _make_kv_tensors()
     type(ctx).kv_tensors = PropertyMock(return_value=tensors)
     type(ctx).block_size = PropertyMock(return_value=4)
-    # KV tensors are built as [2, NB, BS, NH, HS] -> NL_X_TWO_NB_BS_NH_HS.
-    ctx.engine_kv_formats_per_layer.return_value = [
+    # KV tensors are built as [2, NB, BS, NH, HS] -> NL_X_TWO_NB_BS_NH_HS;
+    # one homogeneous kernel group.
+    ctx.engine_kv_formats.return_value = [
         lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
-    ] * len(tensors)
+    ]
     return ctx
 
 

--- a/tests/v1/multiprocess/test_http_server.py
+++ b/tests/v1/multiprocess/test_http_server.py
@@ -41,15 +41,13 @@ def _make_kv_tensors(
 def mock_gpu_ctx():
     """Create a mock GPUCacheContext with kv_tensors."""
     ctx = MagicMock()
-    type(ctx).kv_tensors = PropertyMock(
-        return_value=_make_kv_tensors(),
-    )
+    tensors = _make_kv_tensors()
+    type(ctx).kv_tensors = PropertyMock(return_value=tensors)
     type(ctx).block_size = PropertyMock(return_value=4)
     # KV tensors are built as [2, NB, BS, NH, HS] -> NL_X_TWO_NB_BS_NH_HS.
-    ctx.engine_kv_format_ = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
-    type(ctx).engine_kv_format = PropertyMock(
-        return_value=lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
-    )
+    ctx.engine_kv_formats_per_layer.return_value = [
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+    ] * len(tensors)
     return ctx
 
 

--- a/tests/v1/multiprocess/test_http_server.py
+++ b/tests/v1/multiprocess/test_http_server.py
@@ -54,12 +54,11 @@ def mock_gpu_ctx():
 
 @pytest.fixture
 def mock_mixed_engine():
-    """Engine whose context mixes a 5-D key+value layer and a 3-D key-only
-    layer (e.g. a sparse-attention indexer cache) -- the endpoint must gather
-    each along its own block axis instead of rejecting the request."""
+    """Engine whose context mixes two KV formats (a key+value layer and a
+    key-only layer), so the endpoint gathers each along its own axis."""
     ctx = MagicMock()
-    kv_kv = torch.randn(2, 4, 4, 2, 8)  # NL_X_TWO_NB_BS_NH_HS, block axis 1
-    kv_idx = torch.randn(4, 4, 8)  # NL_X_NB_BS_HS (key-only), block axis 0
+    kv_kv = torch.randn(2, 4, 4, 2, 8)
+    kv_idx = torch.randn(4, 4, 8)
     type(ctx).kv_tensors = PropertyMock(return_value=[kv_kv, kv_idx])
     ctx.engine_kv_format_per_layer.return_value = [
         lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
@@ -132,8 +131,7 @@ class TestKVCacheCheckEndpoint:
         assert d1["chunk_checksums"] == d2["chunk_checksums"]
 
     def test_mixed_format_supported(self, mock_mixed_engine):
-        """A model mixing a 5-D K/V layer and a 3-D key-only layer is gathered
-        per-layer (each along its own block axis), not rejected with 501."""
+        """Two different KV formats are gathered per layer, not rejected."""
         app.state.engine = mock_mixed_engine
         client = TestClient(app)
         try:

--- a/tests/v1/multiprocess/test_http_server.py
+++ b/tests/v1/multiprocess/test_http_server.py
@@ -46,9 +46,7 @@ def mock_gpu_ctx():
     type(ctx).block_size = PropertyMock(return_value=4)
     # KV tensors are built as [2, NB, BS, NH, HS] -> NL_X_TWO_NB_BS_NH_HS;
     # one homogeneous kernel group.
-    ctx.engine_kv_formats.return_value = [
-        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
-    ]
+    ctx.engine_kv_formats.return_value = [lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS]
     return ctx
 
 

--- a/tests/v1/platform/test_gpu_cache_context.py
+++ b/tests/v1/platform/test_gpu_cache_context.py
@@ -99,7 +99,7 @@ def _build_manager(
     """Build a real :class:`KVLayerGroupsManager` from synthetic tensors."""
     return KVLayerGroupsManager(
         tensors,
-        engine_kv_format=engine_kv_format,
+        engine_kv_formats=[engine_kv_format] * len(tensors),
         num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
         lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/tests/v1/platform/test_gpu_cache_context.py
+++ b/tests/v1/platform/test_gpu_cache_context.py
@@ -89,7 +89,6 @@ def _make_kv_tensors(
 
 def _build_manager(
     tensors: list[torch.Tensor],
-    num_blocks: int = 4,
     engine_kv_format: "lmc_ops.EngineKVFormat" = (
         lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
     ),
@@ -100,7 +99,6 @@ def _build_manager(
     return KVLayerGroupsManager(
         tensors,
         engine_kv_formats=[engine_kv_format] * len(tensors),
-        num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
         lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
     )
@@ -117,7 +115,6 @@ def _make_temp_buffer(
     tensors = _make_kv_tensors(specs, num_blocks=num_blocks)
     manager = _build_manager(
         tensors,
-        num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
         lmcache_tokens_per_chunk=chunk_size,
     )

--- a/tests/v1/platform/test_gpu_cache_context.py
+++ b/tests/v1/platform/test_gpu_cache_context.py
@@ -523,7 +523,7 @@ class TestGPUCacheContextReportStatus:
         assert group["layer_indices"] == [0, 1, 2, 3]
         assert group["is_mla"] is False
         assert group["engine_kv_format"] == "NL_X_TWO_NB_BS_NH_HS"
-        assert group["dtype"] == str(ctx.dtype)
+        assert group["dtype"] == str(ctx.kv_tensors[0].dtype)
 
     def test_report_status_multi_group(self) -> None:
         ctx = _make_context(_MULTI_GROUP)

--- a/tests/v1/storage_backend/test_dax_backend.py
+++ b/tests/v1/storage_backend/test_dax_backend.py
@@ -63,8 +63,7 @@ def _create_multi_group_metadata(chunk_size: int = 16) -> LMCacheMetadata:
     ]
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_caches,
-        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
-        num_blocks=1,
+        [lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS] * len(kv_caches),
     )
     return metadata
 

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -956,6 +956,5 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
         engine_kv_formats=[engine_kv_format] * len(kv_list),
-        num_blocks=get_num_blocks(kv_list, engine_kv_format),
     )
     return metadata

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -938,7 +938,6 @@ def test_sglang_connector_with_gpu_and_mla(use_gpu, use_mla):
 
 def _create_metadata(use_mla, kv_caches, engine_kv_format):
     # First Party
-    from lmcache.v1.gpu_connector.utils import get_num_blocks
     from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 
     num_heads = 1 if use_mla else 8

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -955,7 +955,7 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
     kv_list = list(kv_caches.values())
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
-        engine_kv_format=engine_kv_format,
+        engine_kv_formats=[engine_kv_format] * len(kv_list),
         num_blocks=get_num_blocks(kv_list, engine_kv_format),
     )
     return metadata

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -16,6 +16,7 @@ from lmcache.v1.kv_layer_groups import (
     LayerGroupIdentity,
     ObjectGroupInfo,
     format_kvcache_shape_spec,
+    group_layers_by_identity,
     parse_kvcache_shape_spec,
 )
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
@@ -378,6 +379,10 @@ class TestKernelGroupIdentity:
     """The grouping key is a named tuple; ``LayerGroupIdentity`` is its alias."""
 
     def test_fields_and_alias(self):
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        fmt = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
         ident = KernelGroupIdentity(
             kv_size=2,
             num_heads=8,
@@ -385,6 +390,7 @@ class TestKernelGroupIdentity:
             block_size=16,
             engine_group_idx=0,
             dtype=torch.float16,
+            engine_kv_format=fmt,
         )
         assert ident.kv_size == 2
         assert ident.num_heads == 8
@@ -392,14 +398,46 @@ class TestKernelGroupIdentity:
         assert ident.block_size == 16
         assert ident.engine_group_idx == 0
         assert ident.dtype == torch.float16
+        assert ident.engine_kv_format == fmt
         assert LayerGroupIdentity is KernelGroupIdentity
 
     def test_hashable_as_dict_key(self):
-        ident = KernelGroupIdentity(2, 8, 64, 16, 0, torch.float16)
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        fmt = lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+        ident = KernelGroupIdentity(2, 8, 64, 16, 0, torch.float16, fmt)
         assert {ident: "x"}[ident] == "x"
 
     def test_excluded_engine_group_sentinel(self):
         assert EXCLUDED_ENGINE_GROUP == -1
+
+    def test_format_in_identity_splits_same_geometry(self):
+        """Two layers with identical geometry but different layouts (NHD vs HND,
+        num_heads == block_size) must not merge into one kernel group: format is
+        part of the identity, so each gets its own kernel with the correct
+        layout instead of one transferring the other with the wrong axis order.
+        """
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        # NH == BS == 16, so NHD [.., BS, NH, ..] and HND [.., NH, BS, ..] yield
+        # the same kv_size/num_heads/head_size/block_size; only axis order differs.
+        tensors = [
+            torch.randn(2, 32, 16, 16, 64, dtype=torch.float16),
+            torch.randn(2, 32, 16, 16, 64, dtype=torch.float16),
+        ]
+        groups = group_layers_by_identity(
+            tensors,
+            [
+                lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,  # NHD
+                lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS,  # HND
+            ],
+        )
+        # Without the format in the identity these share one geometry and would
+        # have merged into a single group; with it they split into two.
+        assert len(groups) == 2
+        assert {idxs[0] for _, idxs in groups} == {0, 1}
 
 
 class TestKernelAndObjectGroups:

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -104,8 +104,7 @@ class TestKVLayerGroupsManager:
         assert by_group[1].shape_desc.hs == 128
         # Each kernel group persists its own format for the transfer path.
         assert (
-            by_group[0].engine_kv_format
-            == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+            by_group[0].engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
         )
         assert by_group[1].engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
 

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -43,7 +43,7 @@ def _build_manager(
 
     return KVLayerGroupsManager(
         tensors,
-        engine_kv_format=lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        engine_kv_formats=[lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS] * len(tensors),
         num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
     )
@@ -71,6 +71,39 @@ class TestKVLayerGroupsManager:
         assert group.shape_desc.nb == 32
         assert group.shape_desc.bs == 256
         assert group.dtype == torch.float16
+
+    def test_build_mixed_formats_per_group(self):
+        """MiniMax-M3 shape: a K+V group and a key-only MLA group are shaped
+        with their own per-layer formats (kv_size 2 and 1), not one shared
+        format -- the server-side per-group path."""
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        tensors = [
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.bfloat16),  # K+V (rank-5)
+            torch.randn(32, 256, 128, dtype=torch.bfloat16),  # MLA key-only (rank-3)
+        ]
+        manager = KVLayerGroupsManager(
+            tensors,
+            engine_kv_formats=[
+                lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+                lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
+            ],
+            num_blocks=32,
+            engine_group_infos=[
+                EngineGroupInfo(0, (0,)),
+                EngineGroupInfo(1, (1,)),
+            ],
+        )
+
+        groups = manager.kernel_groups
+        assert len(groups) == 2
+        by_group = {g.engine_group_idx: g for g in groups}
+        assert by_group[0].shape_desc.kv_size == 2  # K+V main cache
+        assert by_group[0].shape_desc.nh == 8
+        assert by_group[1].shape_desc.kv_size == 1  # key-only MLA index cache
+        assert by_group[1].shape_desc.nh == 1
+        assert by_group[1].shape_desc.hs == 128
 
     def test_build_multiple_layers_same_shape(self):
         tensors = [

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -28,15 +28,14 @@ pytestmark = pytest.mark.skipif(
 def _build_manager(
     tensors: list[torch.Tensor],
     *,
-    num_blocks: int,
     engine_group_infos: Sequence[EngineGroupInfo] = (),
 ) -> KVLayerGroupsManager:
     """Build a manager using the per-layer NHD format.
 
     Tensors in these tests have shape ``[2, NB, BS, NH, HS]`` — the
     canonical vLLM flash-attention per-layer NHD layout matched by
-    ``GPUKVFormat.NL_X_TWO_NB_BS_NH_HS``. ``bs`` is discovered
-    per-layer from the tensor shapes, so callers no longer pass it.
+    ``GPUKVFormat.NL_X_TWO_NB_BS_NH_HS``. ``bs`` and ``nb`` are discovered
+    per-layer from the tensor shapes, so callers pass neither.
     """
     # First Party
     import lmcache.c_ops as lmc_ops
@@ -44,7 +43,6 @@ def _build_manager(
     return KVLayerGroupsManager(
         tensors,
         engine_kv_formats=[lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS] * len(tensors),
-        num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
     )
 
@@ -53,12 +51,12 @@ class TestKVLayerGroupsManager:
     """Tests for KVLayerGroupsManager construction and lookups."""
 
     def test_build_empty(self):
-        manager = _build_manager([], num_blocks=32)
+        manager = _build_manager([])
         assert manager.kernel_groups == []
 
     def test_build_single_layer(self):
         tensors = [torch.randn(2, 32, 256, 8, 64, dtype=torch.float16)]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
 
         assert len(manager.kernel_groups) == 1
         group = manager.kernel_groups[0]
@@ -89,7 +87,6 @@ class TestKVLayerGroupsManager:
                 lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
                 lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
             ],
-            num_blocks=32,
             engine_group_infos=[
                 EngineGroupInfo(0, (0,)),
                 EngineGroupInfo(1, (1,)),
@@ -115,7 +112,7 @@ class TestKVLayerGroupsManager:
         tensors = [
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16) for _ in range(3)
         ]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
 
         assert len(manager.kernel_groups) == 1
         group = manager.kernel_groups[0]
@@ -130,7 +127,6 @@ class TestKVLayerGroupsManager:
         ]
         manager = _build_manager(
             tensors,
-            num_blocks=32,
             engine_group_infos=[
                 EngineGroupInfo(0, (0, 2)),
                 EngineGroupInfo(1, (1, 3)),
@@ -151,7 +147,6 @@ class TestKVLayerGroupsManager:
         with pytest.raises(ValueError, match="outside registered layer"):
             _build_manager(
                 tensors,
-                num_blocks=32,
                 engine_group_infos=[EngineGroupInfo(0, (2,))],
             )
 
@@ -166,7 +161,6 @@ class TestKVLayerGroupsManager:
         with pytest.raises(ValueError, match="engine group info"):
             _build_manager(
                 tensors,
-                num_blocks=32,
                 engine_group_infos=[EngineGroupInfo(0, (0, 1))],
             )
 
@@ -176,7 +170,7 @@ class TestKVLayerGroupsManager:
             torch.randn(2, 32, 256, 16, 64, dtype=torch.float16),
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
         ]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
         assert len(manager.kernel_groups) == 2
         group1, group2 = manager.kernel_groups
         assert group1.layer_indices == [0, 2]
@@ -190,7 +184,7 @@ class TestKVLayerGroupsManager:
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float32),
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
         ]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
         assert len(manager.kernel_groups) == 2
         group1, group2 = manager.kernel_groups
         assert group1.layer_indices == [0, 2]
@@ -206,7 +200,7 @@ class TestKVLayerGroupsManager:
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),  # nh=8, f16
             torch.randn(2, 32, 256, 16, 64, dtype=torch.float32),  # nh=16, f32
         ]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
         assert len(manager.kernel_groups) == 4
 
         groups_by_key = {(g.shape_desc.nh, g.dtype): g for g in manager.kernel_groups}
@@ -220,7 +214,7 @@ class TestKVLayerGroupsManager:
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
             torch.randn(2, 32, 256, 16, 64, dtype=torch.float16),
         ]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
 
         sd0 = manager.get_shape_desc(0)
         assert sd0.nh == 8
@@ -416,7 +410,7 @@ class TestKernelAndObjectGroups:
         tensors = [
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16) for _ in range(3)
         ]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
         # The deprecated alias must still return the live list, not a bound
         # method (regression guard for the @property/@deprecate ordering).
         assert isinstance(manager.kv_layer_groups, list)
@@ -432,7 +426,7 @@ class TestKernelAndObjectGroups:
             torch.randn(2, 32, 256, 8, 64, dtype=torch.float16),
             torch.randn(2, 32, 256, 16, 64, dtype=torch.float16),
         ]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
         assert manager.num_kernel_groups == 2
         assert manager.num_object_groups == 1
         obj = manager.object_groups[0]
@@ -447,7 +441,6 @@ class TestKernelAndObjectGroups:
         tensors = [torch.randn(2, 32, 32, 8, 64, dtype=torch.float16) for _ in range(2)]
         manager = _build_manager(
             tensors,
-            num_blocks=32,
             engine_group_infos=[
                 EngineGroupInfo(0, (0,)),
                 EngineGroupInfo(1, (1,), sw_size_tokens=64),
@@ -462,7 +455,6 @@ class TestKernelAndObjectGroups:
         with pytest.raises(ValueError, match="sliding window"):
             _build_manager(
                 tensors,
-                num_blocks=32,
                 engine_group_infos=[EngineGroupInfo(0, (0,), sw_size_tokens=64)],
             )
 
@@ -477,7 +469,6 @@ class TestKernelAndObjectGroups:
         ]
         manager = _build_manager(
             tensors,
-            num_blocks=32,
             engine_group_infos=[
                 EngineGroupInfo(0, (0,)),
                 EngineGroupInfo(0, (1,), sw_size_tokens=64),
@@ -503,7 +494,6 @@ class TestKernelAndObjectGroups:
         ]
         manager = _build_manager(
             tensors,
-            num_blocks=32,
             engine_group_infos=[
                 EngineGroupInfo(0, (0,)),
                 EngineGroupInfo(0, (1,), sw_size_tokens=64),
@@ -519,7 +509,7 @@ class TestKernelAndObjectGroups:
     def test_empty_manager_has_no_groups(self):
         # Empty registration returns early in __init__; both group lists must
         # still be initialized (regression guard for missing _object_groups).
-        manager = _build_manager([], num_blocks=32)
+        manager = _build_manager([])
         assert manager.kernel_groups == []
         assert manager.num_kernel_groups == 0
         assert manager.object_groups == []
@@ -532,7 +522,6 @@ class TestKernelAndObjectGroups:
         ]
         manager = _build_manager(
             tensors,
-            num_blocks=32,
             engine_group_infos=[EngineGroupInfo(0, (0, 1))],
         )
         grouped = sorted(
@@ -543,7 +532,7 @@ class TestKernelAndObjectGroups:
     def test_calculate_num_blocks_uncompressed(self):
         # bs=16, compress_ratio=1 -> 256 tokens span 16 blocks.
         tensors = [torch.randn(2, 32, 16, 8, 64, dtype=torch.float16) for _ in range(2)]
-        manager = _build_manager(tensors, num_blocks=32)
+        manager = _build_manager(tensors)
         assert manager.calculate_num_blocks(0, 256) == 16
 
     def test_dsv4_flash_style_mixed_compression(self):
@@ -558,7 +547,6 @@ class TestKernelAndObjectGroups:
         ]
         manager = _build_manager(
             tensors,
-            num_blocks=8,
             engine_group_infos=[
                 EngineGroupInfo(0, (0,), tokens_per_block=256),
                 EngineGroupInfo(0, (1,), tokens_per_block=256),
@@ -582,7 +570,6 @@ class TestKernelAndObjectGroups:
         tensors = [torch.randn(2, 32, 8, 8, 64, dtype=torch.float16) for _ in range(2)]
         manager = _build_manager(
             tensors,
-            num_blocks=32,
             engine_group_infos=[
                 EngineGroupInfo(0, (0, 1), tokens_per_block=16),
             ],

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -104,6 +104,12 @@ class TestKVLayerGroupsManager:
         assert by_group[1].shape_desc.kv_size == 1  # key-only MLA index cache
         assert by_group[1].shape_desc.nh == 1
         assert by_group[1].shape_desc.hs == 128
+        # Each kernel group persists its own format for the transfer path.
+        assert (
+            by_group[0].engine_kv_format
+            == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+        )
+        assert by_group[1].engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
 
     def test_build_multiple_layers_same_shape(self):
         tensors = [
@@ -243,6 +249,19 @@ class TestParseKvcacheShapeSpec:
         assert g.shape_desc.nl == 32
         assert g.dtype == torch.float16
         assert g.layer_indices == list(range(32))
+        # The shape spec carries no format enum; kv_size=2 recovers the K+V one.
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        assert g.engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+    def test_single_group_mla_recovers_key_only_format(self):
+        """kv_size=1 recovers the key-only MLA format (no enum in the spec)."""
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        groups = parse_kvcache_shape_spec("(1,1024,16,1,128):bfloat16:8")
+        assert groups[0].engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
 
     def test_multiple_groups(self):
         """Test parsing multiple groups separated by semicolons."""

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -72,7 +72,7 @@ class TestKVLayerGroupsManager:
         assert group.dtype == torch.float16
 
     def test_build_mixed_formats_per_group(self):
-        """MiniMax-M3 shape: a K+V group and a key-only MLA group are shaped
+        """Mixed-format shape: a K+V group and a key-only MLA group are shaped
         with their own per-layer formats (kv_size 2 and 1), not one shared
         format -- the server-side per-group path."""
         # First Party

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -249,19 +249,9 @@ class TestParseKvcacheShapeSpec:
         assert g.shape_desc.nl == 32
         assert g.dtype == torch.float16
         assert g.layer_indices == list(range(32))
-        # The shape spec carries no format enum; kv_size=2 recovers the K+V one.
-        # First Party
-        import lmcache.c_ops as lmc_ops
-
-        assert g.engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
-
-    def test_single_group_mla_recovers_key_only_format(self):
-        """kv_size=1 recovers the key-only MLA format (no enum in the spec)."""
-        # First Party
-        import lmcache.c_ops as lmc_ops
-
-        groups = parse_kvcache_shape_spec("(1,1024,16,1,128):bfloat16:8")
-        assert groups[0].engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
+        # Bench bookkeeping groups carry no format (the server re-detects); the
+        # spec has no format enum and these never drive a transfer.
+        assert g.engine_kv_format is None
 
     def test_multiple_groups(self):
         """Test parsing multiple groups separated by semicolons."""

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -261,6 +261,42 @@ def test_conversion_mixed_kv_and_mla_groups():
     assert [group.tokens_per_block for group in spec] == [16, 128]
 
 
+def test_conversion_uniform_group_mixes_kv_and_mla_layouts():
+    """vLLM can coalesce a rank-5 K+V group and a rank-3 key-only indexer group
+    into ONE ``UniformTypeKVCacheSpecs`` group, not two. Detection must split it
+    by layout so the indexer gets the rank-3 format instead of inheriting the
+    K/V format; the two land in separate LMCache groups sharing one block-id
+    space."""
+    caches = {
+        **_same_shape_caches(["main.0", "main.1"]),  # rank-5 K+V
+        **_mla_caches(["idx.0", "idx.1"]),  # rank-3 indexer (key-only)
+    }
+    uniform_spec = UniformTypeKVCacheSpecs(
+        block_size=128,
+        kv_cache_specs={
+            "main.0": FullAttentionSpec(block_size=128),
+            "main.1": FullAttentionSpec(block_size=128),
+            "idx.0": MLAAttentionSpec(block_size=128),
+            "idx.1": MLAAttentionSpec(block_size=128),
+        },
+    )
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(["main.0", "main.1", "idx.0", "idx.1"], uniform_spec)
+            ]
+        ),
+        caches,
+    )
+
+    # One vLLM engine group, but two LMCache groups split by per-layer format.
+    assert num_engine_groups(spec) == 1
+    assert [group.engine_group_id for group in spec] == [0, 0]
+    assert [group.layer_indices for group in spec] == [(0, 1), (2, 3)]
+    # Both LMCache groups share the unified block-id space (tokens_per_block).
+    assert [group.tokens_per_block for group in spec] == [128, 128]
+
+
 def test_group_layers_by_identity_uses_per_layer_format():
     """A per-layer Engine KV format gives the K+V layer kv_size=2 and the MLA
     layer kv_size=1, splitting them into separate identities -- the per-group

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -44,6 +44,13 @@ class FullAttentionSpec:
 
 
 @dataclass
+class MLAAttentionSpec:
+    """Key-only, one-vector-per-token spec (e.g. MiniMax-M3's index cache)."""
+
+    block_size: int
+
+
+@dataclass
 class UniformTypeKVCacheSpecs:
     block_size: int
     kv_cache_specs: "dict[str, object]" = field(default_factory=dict)
@@ -62,6 +69,11 @@ class MockKVCacheConfig:
 
 def _same_shape_caches(names: list[str]) -> dict[str, torch.Tensor]:
     return {n: torch.randn(2, 32, 16, 8, 64, dtype=torch.float16) for n in names}
+
+
+def _mla_caches(names: list[str]) -> dict[str, torch.Tensor]:
+    """Key-only rank-3 caches (num_blocks, block_size, head_size), MLA layout."""
+    return {n: torch.randn(32, 16, 128, dtype=torch.bfloat16) for n in names}
 
 
 def test_conversion_defaults_to_single_group_without_config():
@@ -220,4 +232,79 @@ def test_conversion_mixed_window_layers_in_one_group_rejected():
                 kv_cache_groups=[MockKVCacheGroup(["layer.0", "layer.1"], uniform_spec)]
             ),
             _same_shape_caches(["layer.0", "layer.1"]),
+        )
+
+
+def test_conversion_mixed_kv_and_mla_groups():
+    """MiniMax-M3 shape: a K+V FullAttentionSpec group plus a key-only MLA index
+    group are detected per engine group and kept as separate LMCache groups with
+    the correct membership and per-group token packing."""
+    caches = {
+        **_same_shape_caches(["main.0", "main.1"]),
+        **_mla_caches(["idx.0", "idx.1"]),
+    }
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(
+                    ["main.0", "main.1"], FullAttentionSpec(block_size=16)
+                ),
+                MockKVCacheGroup(["idx.0", "idx.1"], MLAAttentionSpec(block_size=128)),
+            ]
+        ),
+        caches,
+    )
+
+    assert num_engine_groups(spec) == 2
+    assert [group.engine_group_id for group in spec] == [0, 1]
+    assert [group.layer_indices for group in spec] == [(0, 1), (2, 3)]
+    assert [group.tokens_per_block for group in spec] == [16, 128]
+
+
+def test_group_layers_by_identity_uses_per_layer_format():
+    """A per-layer Engine KV format gives the K+V layer kv_size=2 and the MLA
+    layer kv_size=1, splitting them into separate identities -- the per-group
+    distinction the single global format cannot express."""
+    # First Party
+    from lmcache.v1.kv_layer_groups import group_layers_by_identity
+    import lmcache.c_ops as lmc_ops
+
+    kv_caches = [
+        torch.randn(2, 32, 16, 8, 64, dtype=torch.bfloat16),  # K+V (rank-5)
+        torch.randn(32, 16, 128, dtype=torch.bfloat16),  # MLA key-only (rank-3)
+    ]
+    per_layer_format = [
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
+    ]
+    groups = group_layers_by_identity(
+        kv_caches,
+        per_layer_format,
+        per_layer_engine_group_idx=[0, 1],
+    )
+
+    kv_size_by_group = {
+        identity.engine_group_idx: identity.kv_size for identity, _ in groups
+    }
+    num_heads_by_group = {
+        identity.engine_group_idx: identity.num_heads for identity, _ in groups
+    }
+    assert kv_size_by_group == {0: 2, 1: 1}
+    # The MLA group collapses heads to 1; the K+V group keeps its head count.
+    assert num_heads_by_group == {0: 8, 1: 1}
+
+
+def test_group_layers_by_identity_rejects_group_idx_length_mismatch():
+    """per_layer_engine_group_idx must hold one entry per layer."""
+    # First Party
+    from lmcache.v1.kv_layer_groups import group_layers_by_identity
+    import lmcache.c_ops as lmc_ops
+
+    kv_caches = [torch.randn(2, 32, 16, 8, 64, dtype=torch.bfloat16)]
+    # One layer (one format) but two engine-group ids.
+    with pytest.raises(ValueError, match="per_layer_engine_group_idx"):
+        group_layers_by_identity(
+            kv_caches,
+            [lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS],
+            per_layer_engine_group_idx=[0, 1],
         )

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -45,7 +45,7 @@ class FullAttentionSpec:
 
 @dataclass
 class MLAAttentionSpec:
-    """Key-only, one-vector-per-token spec (e.g. MiniMax-M3's index cache)."""
+    """Key-only, one-vector-per-token spec (an MLA index cache)."""
 
     block_size: int
 
@@ -236,7 +236,7 @@ def test_conversion_mixed_window_layers_in_one_group_rejected():
 
 
 def test_conversion_mixed_kv_and_mla_groups():
-    """MiniMax-M3 shape: a K+V FullAttentionSpec group plus a key-only MLA index
+    """Mixed-format shape: a K+V FullAttentionSpec group plus a key-only MLA index
     group are detected per engine group and kept as separate LMCache groups with
     the correct membership and per-group token packing."""
     caches = {

--- a/tests/v1/test_xpu_connector.py
+++ b/tests/v1/test_xpu_connector.py
@@ -813,7 +813,6 @@ def test_vllm_paged_connector_v2_to_gpu_bench(benchmark):
 
 def _create_metadata(use_mla, kv_caches, engine_kv_format):
     # First Party
-    from lmcache.v1.gpu_connector.utils import get_num_blocks
     from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 
     num_heads = 1 if use_mla else 8

--- a/tests/v1/test_xpu_connector.py
+++ b/tests/v1/test_xpu_connector.py
@@ -831,6 +831,5 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
         engine_kv_formats=[engine_kv_format] * len(kv_list),
-        num_blocks=get_num_blocks(kv_list, engine_kv_format),
     )
     return metadata

--- a/tests/v1/test_xpu_connector.py
+++ b/tests/v1/test_xpu_connector.py
@@ -830,7 +830,7 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
     kv_list = list(kv_caches.values())
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
-        engine_kv_format=engine_kv_format,
+        engine_kv_formats=[engine_kv_format] * len(kv_list),
         num_blocks=get_num_blocks(kv_list, engine_kv_format),
     )
     return metadata


### PR DESCRIPTION
Detect the Engine KV format per engine group (engine + server sides) and build each kernel group's shape_desc from per-layer formats for models that mix formats across groups. Per-layer formats are transient; contexts keep a single representative format for the not-yet-per-group consumers. No behavior change for existing models.