### PR TITLE
Fix: Reject unknown dtypes in standalone KV shape specs

### DIFF
--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -85,10 +85,15 @@ def parse_kvcache_shape_spec(spec_str: str) -> List[LayerGroupSpec]:
     - "(2,2,256,4,16):float16:2" (single group)
     - "(2,2,256,4,16):float16:2;(3,2,256,4,4):bfloat16:2" (two groups)
 
-    Note: The shape string (inside parentheses) is not parsed and kept as string
-    to support different Attention implementations with varying shapes.
+    Args:
+        spec_str: Semicolon-delimited layer group specifications.
 
-    Returns a list of LayerGroupSpec objects.
+    Returns:
+        The parsed layer group specifications.
+
+    Raises:
+        ValueError: If the specification is empty, malformed, or contains an
+            unsupported dtype or invalid number.
     """
     if not spec_str:
         raise ValueError("KV shape specification cannot be empty")
@@ -121,12 +126,19 @@ def parse_kvcache_shape_spec(spec_str: str) -> List[LayerGroupSpec]:
         dtype_str = parts[0].strip()
         layer_count_str = parts[1].strip()
 
+        dtype_key = dtype_str.lower()
+        if dtype_key not in dtype_map:
+            raise ValueError(
+                "Unrecognized dtype '%s' in group specification: %s. "
+                "Supported: %s" % (dtype_str, group_spec, list(dtype_map.keys()))
+            )
+
         try:
             # Parse shape tuple - support arbitrary dimensions
             shape_parts = shape_str.split(",")
             shape = tuple(int(part.strip()) for part in shape_parts)
             layer_count = int(layer_count_str)
-            dtype = dtype_map.get(dtype_str.strip().lower(), torch.float16)
+            dtype = dtype_map[dtype_key]
 
             # Create LayerGroupSpec with parsed shape
             groups.append(LayerGroupSpec(layer_count, shape, dtype))

--- a/lmcache/v1/standalone/__main__.py
+++ b/lmcache/v1/standalone/__main__.py
@@ -129,8 +129,8 @@ def parse_kvcache_shape_spec(spec_str: str) -> List[LayerGroupSpec]:
         dtype_key = dtype_str.lower()
         if dtype_key not in dtype_map:
             raise ValueError(
-                "Unrecognized dtype '%s' in group specification: %s. "
-                "Supported: %s" % (dtype_str, group_spec, list(dtype_map.keys()))
+                f"Unrecognized dtype '{dtype_str}' in group specification: "
+                f"{group_spec}. Supported: {list(dtype_map.keys())}"
             )
 
         try:

--- a/tests/v1/standalone/test_main.py
+++ b/tests/v1/standalone/test_main.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.standalone.__main__ import parse_kvcache_shape_spec
+
+
+def test_parse_kvcache_shape_spec_rejects_unknown_dtype() -> None:
+    with pytest.raises(ValueError, match="Unrecognized dtype"):
+        parse_kvcache_shape_spec("(2,2,256,4,16):float64:2")


### PR DESCRIPTION
**What this PR does / why we need it**:

The standalone KV-cache shape parser previously defaulted unknown dtypes to `float16`. As a result, typos or unsupported dtype values could silently initialize the cache with an unintended dtype.

This PR:

- explicitly rejects unknown dtypes and reports the supported values
- aligns the standalone parser behavior with the shared KV shape parser
- corrects the parser docstring
- adds a regression test for unsupported dtypes

**Special notes for your reviewers**:

Validation performed remotely:

- Regression test failed before the fix with `DID NOT RAISE ValueError`
- `pytest tests/v1/standalone/test_main.py -q`: passed
- `pre-commit run --all-files`: passed
- Pre-commit hooks explicitly run against the new test file: passed

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
