### PR TITLE
refactor: single-source the EngineKVFormat enum via engine_kv_format.def

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,12 @@ repos:
     entry: python tools/check_spdx_header.py
     language: python
     types: [python]
+  - id: gen-engine-kv-format
+    name: Generate EngineKVFormat from engine_kv_format.def
+    entry: python tools/gen_engine_kv_format.py
+    language: python
+    pass_filenames: false
+    files: ^(csrc/engine_kv_format\.def|tools/gen_engine_kv_format\.py|lmcache/_engine_kv_format\.py)$
   - id: ban-torch-device
     name: Ban direct torch device usage
     entry: >-

--- a/csrc/engine_kv_format.def
+++ b/csrc/engine_kv_format.def
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Single source of truth for the EngineKVFormat enum members.
+//
+// This is an X-macro list: it is intentionally NOT guarded (no #pragma once)
+// and contains no includes, so it can be #included multiple times with a
+// different definition of X(name, value):
+//
+//   - csrc/kv_transfer_types.h    -> generates the `enum class EngineKVFormat`
+//   - csrc/pybind.cpp             -> generates pybind11 .value() calls (CUDA)
+//   - csrc/sycl/pybind_sycl.cpp   -> generates pybind11 .value() calls (SYCL/XPU)
+//
+// Each consumer does:
+//     #define X(name, value) ...
+//     #include "engine_kv_format.def"   // "../engine_kv_format.def" from csrc/sycl/
+//     #undef X
+//
+// To add a new KV layout, add one X(...) line here (and nothing else on the
+// C++ side). Keep the integer values stable and contiguous.
+
+// used by: vLLM CROSS_LAYER mode
+X(NB_NL_TWO_BS_NH_HS, 0)
+
+// used by: vLLM non-MLA flash attention
+X(NL_X_TWO_NB_BS_NH_HS, 1)
+
+// used by: vLLM non-MLA flash infer
+X(NL_X_NB_TWO_BS_NH_HS, 2)
+
+// used by: vLLM MLA
+X(NL_X_NB_BS_HS, 3)
+
+// used by: SGLang MHA (flash attention and flash infer)
+X(TWO_X_NL_X_NBBS_NH_HS, 4)
+
+// used by: SGLang MLA
+X(NL_X_NBBS_ONE_HS, 5)
+
+// used by: vLLM non-MLA flash attention (HND layout)
+// physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
+X(NL_X_TWO_NB_NH_BS_HS, 6)
+
+// used by: vLLM non-MLA flash infer (HND layout)
+// physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
+X(NL_X_NB_TWO_NH_BS_HS, 7)
+
+// used by: TRT-LLM cross-layer (HND layout)
+// physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+X(NB_NL_TWO_NH_BS_HS, 8)
+
+// used by: SGLang MHA via the MP daemon path
+// physical shape per layer: [num_blocks, block_size, num_heads, head_size]
+X(TWO_X_NL_X_NB_BS_NH_HS, 9)
+
+// used by: vLLM non-MLA blocks-first attention with K/V fused into the trailing
+// dim. physical shape per layer: [num_blocks, num_heads, block_size, 2,
+// head_size] (recovered by splitting the fused trailing [block_size,
+// 2 * head_size]). Currently only reached via the host gather/scatter path,
+// not the device transfer kernels.
+X(NL_X_NB_NH_BS_TWO_HS, 10)

--- a/csrc/kv_transfer_types.h
+++ b/csrc/kv_transfer_types.h
@@ -39,78 +39,10 @@ kv_cache[0][0].shape = (C, D, E)
 The logic for identifying the format currently lives in
 `lmcache/v1/gpu_connector/utils.py`
 */
+// Members are single-sourced in engine_kv_format.def (see that file for the
+// per-format documentation). Each X(name, value) becomes an enum member.
 enum class EngineKVFormat : int {
-  NB_NL_TWO_BS_NH_HS = 0,
-  /*
-  used by:
-  - vLLM CROSS_LAYER mode
-  */
-
-  NL_X_TWO_NB_BS_NH_HS = 1,
-  /*
-  used by:
-  - vLLM non-MLA flash attention
-  */
-
-  NL_X_NB_TWO_BS_NH_HS = 2,
-  /*
-  used by:
-  - vLLM non-MLA flash infer
-  */
-
-  NL_X_NB_BS_HS = 3,
-  /*
-  used by:
-  - vLLM MLA
-  */
-
-  TWO_X_NL_X_NBBS_NH_HS = 4,
-  /*
-  used by:
-  - SGLang MHA (flash attention and flash infer)
-  */
-
-  NL_X_NBBS_ONE_HS = 5,
-  /*
-  used by:
-  - SGLang MLA
-  */
-
-  NL_X_TWO_NB_NH_BS_HS = 6,
-  /*
-  used by:
-  - vLLM non-MLA flash attention (HND layout)
-  physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
-  */
-
-  NL_X_NB_TWO_NH_BS_HS = 7,
-  /*
-  used by:
-  - vLLM non-MLA flash infer (HND layout)
-  physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
-  */
-
-  NB_NL_TWO_NH_BS_HS = 8,
-  /*
-  used by:
-  - TRT-LLM cross-layer (HND layout)
-  physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
-  */
-
-  TWO_X_NL_X_NB_BS_NH_HS = 9,
-  /*
-  used by:
-  - SGLang MHA via the MP daemon path
-  physical shape per layer: [num_blocks, block_size, num_heads, head_size]
-  */
-
-  NL_X_NB_NH_BS_TWO_HS = 10,
-  /*
-  used by:
-  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
-  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
-  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
-  Currently only reached via the host gather/scatter path, not the device
-  transfer kernels.
-  */
+#define X(name, value) name = value,
+#include "engine_kv_format.def"
+#undef X
 };

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -21,19 +21,14 @@ PYBIND11_MODULE(c_ops, m) {
       .value("H2D", TransferDirection::H2D)
       .value("D2H", TransferDirection::D2H)
       .export_values();
-  py::enum_<EngineKVFormat>(m, "EngineKVFormat")
-      .value("NB_NL_TWO_BS_NH_HS", EngineKVFormat::NB_NL_TWO_BS_NH_HS)
-      .value("NL_X_TWO_NB_BS_NH_HS", EngineKVFormat::NL_X_TWO_NB_BS_NH_HS)
-      .value("NL_X_NB_TWO_BS_NH_HS", EngineKVFormat::NL_X_NB_TWO_BS_NH_HS)
-      .value("NL_X_NB_BS_HS", EngineKVFormat::NL_X_NB_BS_HS)
-      .value("TWO_X_NL_X_NBBS_NH_HS", EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS)
-      .value("NL_X_NBBS_ONE_HS", EngineKVFormat::NL_X_NBBS_ONE_HS)
-      .value("NL_X_TWO_NB_NH_BS_HS", EngineKVFormat::NL_X_TWO_NB_NH_BS_HS)
-      .value("NL_X_NB_TWO_NH_BS_HS", EngineKVFormat::NL_X_NB_TWO_NH_BS_HS)
-      .value("NB_NL_TWO_NH_BS_HS", EngineKVFormat::NB_NL_TWO_NH_BS_HS)
-      .value("TWO_X_NL_X_NB_BS_NH_HS", EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
-      .value("NL_X_NB_NH_BS_TWO_HS", EngineKVFormat::NL_X_NB_NH_BS_TWO_HS)
-      .export_values();
+  // Members are single-sourced in engine_kv_format.def. The X macro's second
+  // parameter must NOT be named `value`: it would be substituted into the
+  // `.value(` call in the body. The numeric value is unused in this context.
+  auto engine_kv_format = py::enum_<EngineKVFormat>(m, "EngineKVFormat");
+#define X(name, val) engine_kv_format.value(#name, EngineKVFormat::name);
+#include "engine_kv_format.def"
+#undef X
+  engine_kv_format.export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),
         py::arg("slot_mapping"), py::arg("paged_memory_device"),

--- a/csrc/sycl/pybind_sycl.cpp
+++ b/csrc/sycl/pybind_sycl.cpp
@@ -16,19 +16,14 @@ PYBIND11_MODULE(xpu_ops, m) {
       .value("H2D", TransferDirection::H2D)
       .value("D2H", TransferDirection::D2H)
       .export_values();
-  py::enum_<EngineKVFormat>(m, "EngineKVFormat")
-      .value("NB_NL_TWO_BS_NH_HS", EngineKVFormat::NB_NL_TWO_BS_NH_HS)
-      .value("NL_X_TWO_NB_BS_NH_HS", EngineKVFormat::NL_X_TWO_NB_BS_NH_HS)
-      .value("NL_X_NB_TWO_BS_NH_HS", EngineKVFormat::NL_X_NB_TWO_BS_NH_HS)
-      .value("NL_X_NB_BS_HS", EngineKVFormat::NL_X_NB_BS_HS)
-      .value("TWO_X_NL_X_NBBS_NH_HS", EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS)
-      .value("NL_X_NBBS_ONE_HS", EngineKVFormat::NL_X_NBBS_ONE_HS)
-      .value("NL_X_TWO_NB_NH_BS_HS", EngineKVFormat::NL_X_TWO_NB_NH_BS_HS)
-      .value("NL_X_NB_TWO_NH_BS_HS", EngineKVFormat::NL_X_NB_TWO_NH_BS_HS)
-      .value("NB_NL_TWO_NH_BS_HS", EngineKVFormat::NB_NL_TWO_NH_BS_HS)
-      .value("TWO_X_NL_X_NB_BS_NH_HS", EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
-      .value("NL_X_NB_NH_BS_TWO_HS", EngineKVFormat::NL_X_NB_NH_BS_TWO_HS)
-      .export_values();
+  // Members are single-sourced in engine_kv_format.def. The X macro's second
+  // parameter must NOT be named `value`: it would be substituted into the
+  // `.value(` call in the body. The numeric value is unused in this context.
+  auto engine_kv_format = py::enum_<EngineKVFormat>(m, "EngineKVFormat");
+#define X(name, val) engine_kv_format.value(#name, EngineKVFormat::name);
+#include "../engine_kv_format.def"
+#undef X
+  engine_kv_format.export_values();
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),
         py::arg("slot_mapping"), py::arg("paged_memory_device"),

--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -96,10 +96,13 @@ kv_format/
 
 ## Adding a new format
 
-1. Add the enum value in `csrc/kv_transfer_types.h` (the single
-   backend-agnostic definition shared by every accelerator backend), then
-   register it in each backend's pybind module — `csrc/pybind.cpp` (CUDA)
-   and `csrc/sycl/pybind_sycl.cpp` (SYCL/XPU).
+1. Add one `X(NAME, VALUE)` line in `csrc/engine_kv_format.def` — the single
+   source of truth. The C++ `enum class` (`csrc/kv_transfer_types.h`) and both
+   pybind modules (`csrc/pybind.cpp`, `csrc/sycl/pybind_sycl.cpp`) generate
+   their members from it via the preprocessor; the Python fallback enum
+   (`lmcache/_engine_kv_format.py`) is regenerated from it by
+   `tools/gen_engine_kv_format.py` (run via the `gen-engine-kv-format`
+   pre-commit hook). No other enum definition needs editing.
 2. Add a branch in the engine's `detectors/<engine>.py` `discover()`. It keys
    off `(list_depth, tensor_ndim)` from `measure_list_depth_until_tensor`,
    returning `(format, kv)`; any reshape-via-hints (e.g. TRT-LLM's 4-D `view`'d

--- a/lmcache/_engine_kv_format.py
+++ b/lmcache/_engine_kv_format.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# AUTO-GENERATED FROM csrc/engine_kv_format.def -- DO NOT EDIT.
+# Regenerate with: python tools/gen_engine_kv_format.py
+# (or `pre-commit run gen-engine-kv-format --all-files`).
+#
+# This is the static, typed Python mirror of the C++ EngineKVFormat enum. The
+# members are single-sourced in csrc/engine_kv_format.def; edit that file (one
+# X(...) line) and regenerate, never edit this file by hand.
+
+# Standard
+from enum import IntEnum
+
+
+class EngineKVFormat(IntEnum):
+    """Enumeration of different engine KV cache memory layouts."""
+
+    # used by: vLLM CROSS_LAYER mode
+    NB_NL_TWO_BS_NH_HS = 0
+
+    # used by: vLLM non-MLA flash attention
+    NL_X_TWO_NB_BS_NH_HS = 1
+
+    # used by: vLLM non-MLA flash infer
+    NL_X_NB_TWO_BS_NH_HS = 2
+
+    # used by: vLLM MLA
+    NL_X_NB_BS_HS = 3
+
+    # used by: SGLang MHA (flash attention and flash infer)
+    TWO_X_NL_X_NBBS_NH_HS = 4
+
+    # used by: SGLang MLA
+    NL_X_NBBS_ONE_HS = 5
+
+    # used by: vLLM non-MLA flash attention (HND layout)
+    # physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
+    NL_X_TWO_NB_NH_BS_HS = 6
+
+    # used by: vLLM non-MLA flash infer (HND layout)
+    # physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
+    NL_X_NB_TWO_NH_BS_HS = 7
+
+    # used by: TRT-LLM cross-layer (HND layout)
+    # physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+    NB_NL_TWO_NH_BS_HS = 8
+
+    # used by: SGLang MHA via the MP daemon path
+    # physical shape per layer: [num_blocks, block_size, num_heads, head_size]
+    TWO_X_NL_X_NB_BS_NH_HS = 9
+
+    # used by: vLLM non-MLA blocks-first attention with K/V fused into the trailing
+    # dim. physical shape per layer: [num_blocks, num_heads, block_size, 2,
+    # head_size] (recovered by splitting the fused trailing [block_size,
+    # 2 * head_size]). Currently only reached via the host gather/scatter path,
+    # not the device transfer kernels.
+    NL_X_NB_NH_BS_TWO_HS = 10
+
+
+# Backward-compat alias for the pre-#3673 GPUKVFormat name.
+GPUKVFormat = EngineKVFormat

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -21,6 +21,7 @@ import torch
 
 # First Party
 from lmcache import torch_dev
+from lmcache._engine_kv_format import EngineKVFormat
 
 # Store the tensor objects in memory so that they can be accessed
 # outside the scope of this file
@@ -255,46 +256,6 @@ class TransferDirection(IntEnum):
 
     H2D = 0
     D2H = 1
-
-
-class EngineKVFormat(IntEnum):
-    """Enumeration of different engine KV cache memory layouts."""
-
-    # used by: vLLM CROSS_LAYER mode
-    NB_NL_TWO_BS_NH_HS = 0
-
-    # used by: vLLM non-MLA flash attention
-    NL_X_TWO_NB_BS_NH_HS = 1
-
-    # used by: vLLM non-MLA flash infer
-    NL_X_NB_TWO_BS_NH_HS = 2
-
-    # used by: vLLM MLA
-    NL_X_NB_BS_HS = 3
-
-    # used by: SGLang MHA (flash attention and flash infer)
-    TWO_X_NL_X_NBBS_NH_HS = 4
-
-    # used by: SGLang MLA
-    NL_X_NBBS_ONE_HS = 5
-
-    # used by: vLLM non-MLA flash attention (HND layout)
-    NL_X_TWO_NB_NH_BS_HS = 6
-
-    # used by: vLLM non-MLA flash infer (HND layout)
-    NL_X_NB_TWO_NH_BS_HS = 7
-
-    # used by: TRT-LLM cross-layer (HND layout)
-    NB_NL_TWO_NH_BS_HS = 8
-
-    # used by: SGLang MHA via the MP daemon path
-    TWO_X_NL_X_NB_BS_NH_HS = 9
-
-    # used by: vLLM non-MLA blocks-first attention with K/V fused into the
-    # trailing dim. Per-layer physical shape
-    # [num_blocks, num_heads, block_size, 2, head_size] -- the K/V "2" axis is
-    # second-to-last, recovered by splitting the fused [..., 2 * head_size].
-    NL_X_NB_NH_BS_TWO_HS = 10
 
 
 # Backward-compat alias

--- a/tests/test_gen_engine_kv_format.py
+++ b/tests/test_gen_engine_kv_format.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``tools/gen_engine_kv_format.py``.
+
+The generator renders ``lmcache/_engine_kv_format.py`` (the static, typed Python
+mirror of the C++ ``EngineKVFormat`` enum) from the X-macro spec in
+``csrc/engine_kv_format.def``. These tests exercise its public functions
+(``parse_members`` / ``render``) and verify the committed generated file is
+up to date -- all without a GPU or the compiled extension.
+"""
+
+# Standard
+from pathlib import Path
+from types import ModuleType
+import importlib.util
+
+# Third Party
+import pytest
+
+_GEN_PATH = Path(__file__).resolve().parent.parent / "tools" / "gen_engine_kv_format.py"
+
+
+def _load_generator() -> ModuleType:
+    """Load the standalone generator script as a module (it is not a package)."""
+    spec = importlib.util.spec_from_file_location("gen_engine_kv_format", _GEN_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load generator from {_GEN_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_generator()
+
+
+def test_parse_members_basic_order_and_values() -> None:
+    """Members are returned in file order with their integer values."""
+    members = gen.parse_members("X(A, 0)\nX(B, 1)\nX(C, 2)\n")
+    assert [(name, value) for name, value, _ in members] == [
+        ("A", 0),
+        ("B", 1),
+        ("C", 2),
+    ]
+
+
+def test_parse_members_attaches_preceding_comments() -> None:
+    """``//`` comment lines directly above an entry attach to it."""
+    members = gen.parse_members("// used by: foo\n// shape: bar\nX(A, 0)\n")
+    assert members[0][2] == ["used by: foo", "shape: bar"]
+
+
+def test_parse_members_blank_line_resets_comments() -> None:
+    """A blank line detaches a comment block from a following entry."""
+    members = gen.parse_members("// header\n\nX(A, 0)\n")
+    assert members[0][2] == []
+
+
+def test_parse_members_rejects_duplicate_value() -> None:
+    """Two members sharing an integer value is an error."""
+    with pytest.raises(ValueError):
+        gen.parse_members("X(A, 0)\nX(B, 0)\n")
+
+
+def test_parse_members_rejects_duplicate_name() -> None:
+    """Two members sharing a name is an error."""
+    with pytest.raises(ValueError):
+        gen.parse_members("X(A, 0)\nX(A, 1)\n")
+
+
+def test_parse_members_allows_trailing_comment() -> None:
+    """An inline ``// ...`` trailing comment on an ``X(...)`` line is tolerated."""
+    members = gen.parse_members("X(A, 0)  // inline note\n")
+    assert [(name, value) for name, value, _ in members] == [("A", 0)]
+
+
+def test_parse_members_rejects_no_members() -> None:
+    """A spec with no ``X(...)`` entries is an error."""
+    with pytest.raises(ValueError):
+        gen.parse_members("// only comments, no entries\n")
+
+
+def test_render_produces_valid_python_with_alias() -> None:
+    """Rendered output compiles and contains the enum, members, and alias."""
+    code = gen.render(gen.parse_members("// c\nX(A, 0)\nX(B, 1)\n"))
+    compile(code, "<generated>", "exec")  # raises SyntaxError if malformed
+    assert "class EngineKVFormat(IntEnum):" in code
+    assert "    A = 0" in code
+    assert "    B = 1" in code
+    assert "GPUKVFormat = EngineKVFormat" in code
+
+
+def test_committed_generated_file_is_up_to_date() -> None:
+    """The checked-in mirror matches a fresh regeneration from the .def."""
+    expected = gen.render(gen.parse_members(gen.DEF_PATH.read_text(encoding="utf-8")))
+    actual = gen.OUT_PATH.read_text(encoding="utf-8")
+    assert actual == expected, (
+        "lmcache/_engine_kv_format.py is stale; "
+        "run `python tools/gen_engine_kv_format.py` and commit the result."
+    )

--- a/tests/v1/test_c_ops_fallback_parity.py
+++ b/tests/v1/test_c_ops_fallback_parity.py
@@ -24,6 +24,7 @@ import re
 import pytest
 
 # First Party
+import lmcache._engine_kv_format as engine_kv_format
 import lmcache.python_ops_fallback as fallback
 
 try:
@@ -220,7 +221,12 @@ _shared_func_names = sorted(
     (set(_fallback_callables) & set(_c_ops_callables)) - _EXCLUDED_FUNCS
 )
 
-_fallback_enums = _public_enums(fallback)
+# Enums the fallback re-exports from the canonical lmcache._engine_kv_format
+# module (e.g. EngineKVFormat) are owned by that module, not by the fallback,
+# so discover them there too. Both that module and the compiled c_ops enum are
+# generated from csrc/engine_kv_format.def, so their parity holds by
+# construction; this check guards against a stale build or codegen.
+_fallback_enums = {**_public_enums(fallback), **_public_enums(engine_kv_format)}
 _c_ops_enums = _public_enums(c_ops) if HAS_C_OPS else {}
 _shared_enum_names = sorted(set(_fallback_enums) & set(_c_ops_enums))
 

--- a/tools/gen_engine_kv_format.py
+++ b/tools/gen_engine_kv_format.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the Python ``EngineKVFormat`` enum from the shared X-macro spec.
+
+The enum members are single-sourced in ``csrc/engine_kv_format.def`` (the same
+file the C++ ``enum class`` and the pybind11 registrations are generated from).
+This script renders a static, typed Python mirror at
+``lmcache/_engine_kv_format.py`` so that:
+
+- the pure-Python fallback (``lmcache.python_ops_fallback``) cannot drift from
+  the compiled ``EngineKVFormat``, and
+- static type checkers and IDEs see real enum members (a runtime ``IntEnum``
+  built by parsing the ``.def`` would not).
+
+Run directly (``python tools/gen_engine_kv_format.py``) or via the
+``gen-engine-kv-format`` pre-commit hook. The generated file is committed; CI
+re-runs this script and fails if the committed output is stale.
+"""
+
+# Standard
+from pathlib import Path
+import re
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEF_PATH = REPO_ROOT / "csrc" / "engine_kv_format.def"
+OUT_PATH = REPO_ROOT / "lmcache" / "_engine_kv_format.py"
+
+# Matches a single X-macro entry, e.g. ``X(NL_X_NB_BS_HS, 3)``, tolerating an
+# optional trailing ``// comment``.
+_MEMBER_RE = re.compile(r"^\s*X\(\s*(\w+)\s*,\s*(\d+)\s*\)\s*(?://.*)?$")
+# Matches a ``// ...`` doc comment line (carried over as a Python ``#`` comment).
+_COMMENT_RE = re.compile(r"^\s*//\s?(.*)$")
+
+_HEADER = """\
+# SPDX-License-Identifier: Apache-2.0
+#
+# AUTO-GENERATED FROM csrc/engine_kv_format.def -- DO NOT EDIT.
+# Regenerate with: python tools/gen_engine_kv_format.py
+# (or `pre-commit run gen-engine-kv-format --all-files`).
+#
+# This is the static, typed Python mirror of the C++ EngineKVFormat enum. The
+# members are single-sourced in csrc/engine_kv_format.def; edit that file (one
+# X(...) line) and regenerate, never edit this file by hand.
+
+# Standard
+from enum import IntEnum
+
+
+class EngineKVFormat(IntEnum):
+    \"\"\"Enumeration of different engine KV cache memory layouts.\"\"\"
+"""
+
+
+def parse_members(def_text: str) -> list[tuple[str, int, list[str]]]:
+    """Parse the ``.def`` into ordered ``(name, value, comment_lines)`` tuples.
+
+    Args:
+        def_text: Full text of ``csrc/engine_kv_format.def``.
+
+    Returns:
+        One tuple per ``X(...)`` entry, in file order. ``comment_lines`` holds
+        the ``//`` doc-comment lines immediately preceding the entry (the file
+        header block, terminated by a blank line, is not attached to any entry).
+
+    Raises:
+        ValueError: If no members are found, or a name or value is duplicated.
+    """
+    members: list[tuple[str, int, list[str]]] = []
+    seen_values: set[int] = set()
+    seen_names: set[str] = set()
+    pending_comments: list[str] = []
+    for line in def_text.splitlines():
+        member_match = _MEMBER_RE.match(line)
+        if member_match is not None:
+            name = member_match.group(1)
+            value = int(member_match.group(2))
+            if name in seen_names:
+                raise ValueError(f"Duplicate EngineKVFormat name {name}")
+            if value in seen_values:
+                raise ValueError(f"Duplicate EngineKVFormat value {value} for {name}")
+            seen_names.add(name)
+            seen_values.add(value)
+            members.append((name, value, pending_comments))
+            pending_comments = []
+            continue
+        comment_match = _COMMENT_RE.match(line)
+        if comment_match is not None:
+            pending_comments.append(comment_match.group(1).rstrip())
+        else:
+            # Blank line or other content resets the pending comment block, so
+            # only comments directly above an X(...) entry attach to it.
+            pending_comments = []
+    if not members:
+        raise ValueError(f"No X(...) members found in {DEF_PATH}")
+    return members
+
+
+def render(members: list[tuple[str, int, list[str]]]) -> str:
+    """Render the generated module text from parsed members.
+
+    Args:
+        members: Output of :func:`parse_members`.
+
+    Returns:
+        The full contents of ``lmcache/_engine_kv_format.py``.
+    """
+    lines: list[str] = [_HEADER.rstrip("\n")]
+    for name, value, comments in members:
+        lines.append("")
+        for comment in comments:
+            lines.append(f"    # {comment}" if comment else "    #")
+        lines.append(f"    {name} = {value}")
+    # Backward-compat alias (pre-#3673 name). Mirrors the GPUKVFormat alias
+    # registered in the pybind modules, so callers and the c_ops/fallback parity
+    # check see the same enum surface in both.
+    lines.append("")
+    lines.append("")
+    lines.append("# Backward-compat alias for the pre-#3673 GPUKVFormat name.")
+    lines.append("GPUKVFormat = EngineKVFormat")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    """Regenerate ``lmcache/_engine_kv_format.py`` from the ``.def`` spec.
+
+    Returns:
+        Process exit code (0 on success).
+    """
+    members = parse_members(DEF_PATH.read_text(encoding="utf-8"))
+    OUT_PATH.write_text(render(members), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #3674 (follow-up to #3676, per @hlin99's request to single-source the fallback enum).

`EngineKVFormat`'s members were hand-duplicated across **four** places that had to be kept in sync manually — the #3673 rename had to touch all of them:
- the C++ `enum class` — `csrc/kv_transfer_types.h`
- the CUDA pybind registration — `csrc/pybind.cpp`
- the SYCL pybind registration — `csrc/sycl/pybind_sycl.cpp`
- the pure-Python fallback enum — `lmcache/python_ops_fallback.py`

This makes **`csrc/engine_kv_format.def` the single source of truth** (an X-macro list). The C++ enum and both pybind `.value()` blocks generate their members from it via the preprocessor (`#include`); a pre-commit hook (`gen-engine-kv-format`) runs `tools/gen_engine_kv_format.py` to render a static, typed Python mirror (`lmcache/_engine_kv_format.py`) that the fallback imports. **Adding a KV layout is now a one-line edit to the `.def`.**

**Special notes for your reviewers**:

- **No behavioral change.** Enum names and values (0–10) are identical to `dev`; the `GPUKVFormat` back-compat alias is preserved. Verified `.def` == generated mirror == the previous hand-written enum.
- **Why codegen rather than parsing the `.def` at runtime (Python side):** the fallback references enum members by name in ~40 places and mypy is enforced — a dynamically-built `IntEnum` loses statically-known members and breaks type-checking. Generating a static module keeps it fully typed and ships normally (committed `.py`, **no packaging or build-system changes**). Enum parity between the compiled `c_ops` enum and the Python mirror then holds **by construction**.
- **No build-system change.** The C++ side is pure-preprocessor `#include` (hipify-safe; nothing generated before compile); only the Python mirror is generated, via pre-commit (freshness enforced in CI like `ruff-format`).
- **New pattern for LMCache.** No prior codegen in the repo; used a pre-commit codegen hook (closest in-ecosystem precedent: SGLang `code_gen.py`, vLLM `tools/generate_*.py`). Happy to adjust if you'd prefer a different mechanism.
- **`TransferDirection`** left hand-written (2 values, effectively never changes) — still guarded by the parity test. Can fold it in too if you'd like uniformity.
- **Design doc** `docs/design/v1/gpu_connector/layout-invariant.md` "Adding a new format" updated to the `.def` workflow (rebased on top of the recent `kv_format/` specs/detectors restructure).

**Testing** — built from source and run on **H100, CUDA 13.0**:

```bash
uv pip install -e . --no-build-isolation     # builds: .def #include compiles under nvcc 13 (sm_90, ninja)

pytest tests/v1/test_c_ops_fallback_parity.py            # 38 passed, 1 skipped
pytest tests/v1/test_mem_kernels.py tests/v1/test_gpu_connector.py   # passed
pytest tests/v1/test_python_ops_fallback.py              # passed
pytest tests/test_gen_engine_kv_format.py                # 9 passed (CPU-only)
pre-commit run --all-files                               # green
```

- **`test_c_ops_fallback_parity.py` (the key check):** `test_enum_parity[EngineKVFormat]`, `[GPUKVFormat]`, `[TransferDirection]`, plus `test_all_c_ops_enums_have_fallback` / `_callables_` / `_descriptors_` all pass → the **compiled `c_ops` enum equals the generated Python mirror**.
- **Runtime smoke:** `c_ops.EngineKVFormat.__members__` → 11 entries (0–10); `GPUKVFormat is EngineKVFormat` → `True`.
- **New `tests/test_gen_engine_kv_format.py`:** covers `parse_members` ordering/values, comment attachment, duplicate-value/duplicate-name & empty-spec rejection, trailing-comment tolerance, `render` output + the `GPUKVFormat` alias, and a freshness check that the committed mirror matches a fresh regeneration.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests


@hlin99 @maobaolong 

