### PR TITLE
Optimize resource cleanup for TRT-LLM multi-process adapter

### DIFF
--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -45,6 +45,9 @@ logger = init_logger(__name__)
 
 DEFAULT_SERVER_URL = "ipc:///tmp/lmcache.sock"
 DEFAULT_MQ_TIMEOUT: float = 300.0
+# Best-effort unregister budget in destructor cleanup; do not block exit on the
+# full business MQ timeout.
+DEFAULT_CLEANUP_UNREGISTER_TIMEOUT: float = 5.0
 
 
 def _get_server_url(llm_args: "TorchLlmArgs") -> str:
@@ -93,6 +96,7 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         self._mq_timeout = float(
             os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
         )
+        self._closed = False
 
         future = _send_request(self._mq_client, RequestType.GET_CHUNK_SIZE, [])
         self._chunk_size = future.result(timeout=self._mq_timeout)
@@ -272,6 +276,36 @@ class LMCacheMPKvConnectorScheduler(KvCacheConnectorScheduler):
         """No-op — block IDs are captured in :meth:`build_connector_meta`."""
         pass
 
+    def _cleanup(self) -> None:
+        """Release scheduler resources during connector destruction.
+
+        This method is idempotent and tolerates partial initialization if
+        ``__init__`` failed before all attributes were set.
+        """
+        if getattr(self, "_closed", False):
+            return
+        self._closed = True
+
+        mq_client = getattr(self, "_mq_client", None)
+        if mq_client is not None:
+            try:
+                mq_client.close()
+            except Exception as e:
+                logger.warning("LMCache MP scheduler: failed to close MQ client: %s", e)
+
+        zmq_context = getattr(self, "_zmq_context", None)
+        if zmq_context is not None:
+            try:
+                zmq_context.destroy(linger=0)
+            except Exception as e:
+                logger.warning(
+                    "LMCache MP scheduler: failed to destroy ZMQ context: %s", e
+                )
+
+    def __del__(self) -> None:
+        """Destructor to ensure resources are cleaned up."""
+        self._cleanup()
+
 
 class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
     """TRT-LLM worker that routes store/retrieve to an LMCache MP server."""
@@ -287,6 +321,7 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
         self._mq_timeout = float(
             os.environ.get("LMCACHE_MQ_TIMEOUT", DEFAULT_MQ_TIMEOUT)
         )
+        self._closed = False
 
         self._instance_id = os.getpid()
         self._registered = False
@@ -486,3 +521,60 @@ class LMCacheMPKvConnectorWorker(KvCacheConnectorWorker):
     ) -> Tuple[List[int], List[int]]:
         """All operations are synchronous — nothing is ever pending."""
         return [], []
+
+    def _cleanup(self) -> None:
+        """Release worker resources during connector destruction.
+
+        This method is idempotent and tolerates partial initialization if
+        ``__init__`` failed before all attributes were set. If the worker is
+        registered, it best-effort sends UNREGISTER_KV_CACHE with a short
+        timeout, then closes the MQ client and destroys the ZMQ context.
+        """
+        if getattr(self, "_closed", False):
+            return
+        self._closed = True
+
+        mq_client = getattr(self, "_mq_client", None)
+        if getattr(self, "_registered", False) and mq_client is not None:
+            instance_id = getattr(self, "_instance_id", None)
+            unregister_timeout = DEFAULT_CLEANUP_UNREGISTER_TIMEOUT
+            if instance_id is not None:
+                try:
+                    future = _send_request(
+                        mq_client,
+                        RequestType.UNREGISTER_KV_CACHE,
+                        [instance_id],
+                    )
+                    future.result(timeout=unregister_timeout)
+                except TimeoutError:
+                    logger.warning(
+                        "LMCache MP worker: KV cache unregistration timed out "
+                        "after %ss",
+                        unregister_timeout,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "LMCache MP worker: failed to unregister KV cache: %s",
+                        e,
+                        exc_info=True,
+                    )
+            self._registered = False
+
+        if mq_client is not None:
+            try:
+                mq_client.close()
+            except Exception as e:
+                logger.warning("LMCache MP worker: failed to close MQ client: %s", e)
+
+        zmq_context = getattr(self, "_zmq_context", None)
+        if zmq_context is not None:
+            try:
+                zmq_context.destroy(linger=0)
+            except Exception as e:
+                logger.warning(
+                    "LMCache MP worker: failed to destroy ZMQ context: %s", e
+                )
+
+    def __del__(self) -> None:
+        """Destructor to ensure resources are cleaned up."""
+        self._cleanup()

--- a/tests/v1/test_trtllm_mp_adapter.py
+++ b/tests/v1/test_trtllm_mp_adapter.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the multi-process TensorRT-LLM adapter cleanup logic."""
+
+# Standard
+from typing import Any
+from unittest.mock import MagicMock
+import importlib
+import sys
+import types
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.multiprocess.protocol import RequestType
+
+_ADAPTER_MODULE = "lmcache.integration.tensorrt_llm.tensorrt_mp_adapter"
+_PARENT_MODULE = "lmcache.integration.tensorrt_llm"
+_PARENT_PACKAGE = "lmcache.integration"
+
+
+def _build_tensorrt_llm_stub_modules() -> dict[str, types.ModuleType]:
+    """Build fake ``tensorrt_llm`` modules for adapter import under test."""
+    module_names = [
+        "tensorrt_llm",
+        "tensorrt_llm._torch",
+        "tensorrt_llm._torch.pyexecutor",
+        "tensorrt_llm._torch.pyexecutor.connectors",
+        "tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector",
+        "tensorrt_llm.bindings",
+        "tensorrt_llm.bindings.internal",
+        "tensorrt_llm.bindings.internal.batch_manager",
+        "tensorrt_llm.llmapi",
+        "tensorrt_llm.llmapi.llm_args",
+    ]
+    modules = {name: types.ModuleType(name) for name in module_names}
+    modules["tensorrt_llm"].mpi_rank = lambda: 0  # type: ignore[attr-defined]
+
+    class MockKvCacheConnector:
+        """Mock TRT-LLM KV cache connector base class."""
+
+        def __init__(self, llm_args: Any) -> None:
+            self._llm_args = llm_args
+            self._metadata = None
+
+    kv_cache_connector_module = modules[
+        "tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector"
+    ]
+    kv_cache_connector_module.KvCacheConnectorScheduler = (  # type: ignore[attr-defined]
+        MockKvCacheConnector
+    )
+    kv_cache_connector_module.KvCacheConnectorWorker = (  # type: ignore[attr-defined]
+        MockKvCacheConnector
+    )
+    kv_cache_connector_module.SchedulerOutput = MagicMock  # type: ignore[attr-defined]
+
+    modules["tensorrt_llm.bindings.internal.batch_manager"].LlmRequest = (  # type: ignore[attr-defined]
+        MagicMock
+    )
+    modules["tensorrt_llm.llmapi.llm_args"].TorchLlmArgs = MagicMock  # type: ignore[attr-defined]
+    return modules
+
+
+@pytest.fixture
+def adapter_mod(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Import the adapter under stubbed ``tensorrt_llm`` modules.
+
+    Returns:
+        Any: The imported TensorRT-LLM MP adapter module.
+    """
+    for name, module in _build_tensorrt_llm_stub_modules().items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    parent_pkg = importlib.import_module(_PARENT_PACKAGE)
+    monkeypatch.delattr(parent_pkg, "tensorrt_llm", raising=False)
+    monkeypatch.delitem(sys.modules, _ADAPTER_MODULE, raising=False)
+    monkeypatch.delitem(sys.modules, _PARENT_MODULE, raising=False)
+
+    return importlib.import_module(_ADAPTER_MODULE)
+
+
+def test_worker_cleanup_unregisters_registered_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    adapter_mod: Any,
+) -> None:
+    """Test LMCacheMPKvConnectorWorker cleanup when registered."""
+    mq_client = MagicMock(name="mq_client")
+    zmq_context = MagicMock(name="zmq_context")
+    future = MagicMock(name="future")
+    send_mock = MagicMock(name="_send_request", return_value=future)
+    monkeypatch.setattr(adapter_mod, "_send_request", send_mock)
+
+    worker = adapter_mod.LMCacheMPKvConnectorWorker.__new__(
+        adapter_mod.LMCacheMPKvConnectorWorker
+    )
+    worker._closed = False
+    worker._registered = True
+    worker._instance_id = 123
+    worker._mq_client = mq_client
+    worker._zmq_context = zmq_context
+    worker.__del__()
+
+    send_mock.assert_called_once_with(
+        mq_client,
+        RequestType.UNREGISTER_KV_CACHE,
+        [123],
+    )
+    future.result.assert_called_once_with(
+        timeout=adapter_mod.DEFAULT_CLEANUP_UNREGISTER_TIMEOUT
+    )
+    mq_client.close.assert_called_once()
+    zmq_context.destroy.assert_called_once_with(linger=0)
+
+    send_mock.reset_mock()
+    worker.__del__()
+    send_mock.assert_not_called()
+
+
+def test_worker_cleanup_unregistered_does_not_unregister(
+    monkeypatch: pytest.MonkeyPatch,
+    adapter_mod: Any,
+) -> None:
+    """Test LMCacheMPKvConnectorWorker cleanup when unregistered."""
+    mq_client = MagicMock(name="mq_client")
+    zmq_context = MagicMock(name="zmq_context")
+    send_mock = MagicMock(name="_send_request")
+    monkeypatch.setattr(adapter_mod, "_send_request", send_mock)
+
+    worker = adapter_mod.LMCacheMPKvConnectorWorker.__new__(
+        adapter_mod.LMCacheMPKvConnectorWorker
+    )
+    worker._closed = False
+    worker._registered = False
+    worker._mq_client = mq_client
+    worker._zmq_context = zmq_context
+    worker.__del__()
+
+    send_mock.assert_not_called()
+    mq_client.close.assert_called_once()
+    zmq_context.destroy.assert_called_once_with(linger=0)
+
+
+def test_cleanup_handles_partial_init(adapter_mod: Any) -> None:
+    """_cleanup() must not raise when __init__ failed before all attrs exist."""
+    scheduler = adapter_mod.LMCacheMPKvConnectorScheduler.__new__(
+        adapter_mod.LMCacheMPKvConnectorScheduler
+    )
+    scheduler._zmq_context = MagicMock(name="zmq_context")
+    scheduler._cleanup()
+    scheduler._zmq_context.destroy.assert_called_once_with(linger=0)
+
+    worker = adapter_mod.LMCacheMPKvConnectorWorker.__new__(
+        adapter_mod.LMCacheMPKvConnectorWorker
+    )
+    worker._cleanup()


### PR DESCRIPTION
 

**What this PR does / why we need it**:

Although TRT-LLM does not explicitly call any teardown API, running cleanup in `__del__` when the connector is destroyed ensures client-side resources (ZMQ) are released and the worker sends  UNREGISTER_KV_CACHE promptly. 

Without this, the MP server may retain stale registrations for up to the registration grace period (default 3600s), since the TRT-LLM adapter does not send heartbeat pings.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
