### PR TITLE
feat(shm): pin SHM and host buffers via cudaHostRegister when available

### DIFF
--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -414,6 +414,7 @@ def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:
 
 def free_pinned_numa_ptr(ptr: int, size: int | None = None) -> None:
     """Non-CUDA equivalent of freeing a previously allocated NUMA pointer."""
+
     # Release the tensor object for that pointer reference
     _tensor_registry.pop(ptr, None)
 
@@ -430,6 +431,7 @@ def alloc_pinned_ptr(size: int, device_id: int = 0) -> int:
 
 def free_pinned_ptr(ptr: int) -> None:
     """Non-CUDA equivalent of freeing a previously allocated pinned pointer."""
+
     # Release the tensor object for that pointer reference
     _tensor_registry.pop(ptr, None)
 

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -21,12 +21,14 @@ import torch
 
 # First Party
 from lmcache import torch_dev
+from lmcache.utils import try_pin_buffer, try_unpin_buffer
 
 # Store the tensor objects in memory so that they can be accessed
 # outside the scope of this file
 _tensor_registry: dict[int, torch.Tensor] = {}
 _shm_registry: dict[int, shared_memory.SharedMemory] = {}
 _buf_registry: dict[int, ctypes.Array] = {}
+_pinned_ptr_registry: dict[int, int] = {}  # ptr -> size, for cudaHostUnregister
 
 # Cached copy library for lmcache_memcpy_async (lazy-initialized)
 _copy_lib_NOT_LOADED = object()
@@ -400,6 +402,8 @@ def _alloc_page_aligned_pinned_view(size: int) -> Tuple[torch.Tensor, int]:
 def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:
     """Non-CUDA equivalent of allocating pinned memory with NUMA awareness.
     On XPU, uses pin_memory=True (SYCL USM host allocation) for fast transfers.
+    Attempts to pin the buffer via cudaHostRegister for async D2H;
+    if pinning fails, continues without pinning.
     Note: NUMA node selection is not supported on non-CUDA."""
 
     view, aligned_ptr = _alloc_page_aligned_pinned_view(size)
@@ -407,11 +411,22 @@ def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:
     # holding the view in the registry transitively keeps the underlying
     # memory alive.
     _tensor_registry[aligned_ptr] = view
+
+    # Try to pin the buffer for async D2H copies
+    if try_pin_buffer(aligned_ptr, size):
+        _pinned_ptr_registry[aligned_ptr] = size
+
     return aligned_ptr
 
 
 def free_pinned_numa_ptr(ptr: int, size: int | None = None) -> None:
-    """Non-CUDA equivalent of freeing a previously allocated NUMA pointer."""
+    """Non-CUDA equivalent of freeing a previously allocated NUMA pointer.
+    Unregisters pinned memory if it was pinned."""
+
+    # Unpin if previously registered
+    if ptr in _pinned_ptr_registry:
+        try_unpin_buffer(ptr)
+        _pinned_ptr_registry.pop(ptr, None)
 
     # Release the tensor object for that pointer reference
     _tensor_registry.pop(ptr, None)
@@ -420,15 +435,27 @@ def free_pinned_numa_ptr(ptr: int, size: int | None = None) -> None:
 def alloc_pinned_ptr(size: int, device_id: int = 0) -> int:
     """Non-CUDA equivalent of allocating pinned memory and returning pointer
     to it. On XPU, uses pin_memory=True (SYCL USM host allocation) for
-    fast DMA transfers. On other non-CUDA platforms, pinning is not supported."""
+    fast DMA transfers. Attempts to pin the buffer via cudaHostRegister
+    for async D2H; if pinning fails, continues without pinning."""
 
     view, aligned_ptr = _alloc_page_aligned_pinned_view(size)
     _tensor_registry[aligned_ptr] = view
+
+    # Try to pin the buffer for async D2H copies
+    if try_pin_buffer(aligned_ptr, size):
+        _pinned_ptr_registry[aligned_ptr] = size
+
     return aligned_ptr
 
 
 def free_pinned_ptr(ptr: int) -> None:
-    """Non-CUDA equivalent of freeing a previously allocated pinned pointer."""
+    """Non-CUDA equivalent of freeing a previously allocated pinned pointer.
+    Unregisters pinned memory if it was pinned."""
+
+    # Unpin if previously registered
+    if ptr in _pinned_ptr_registry:
+        try_unpin_buffer(ptr)
+        _pinned_ptr_registry.pop(ptr, None)
 
     # Release the tensor object for that pointer reference
     _tensor_registry.pop(ptr, None)
@@ -454,7 +481,9 @@ def batched_memcpy(src_ptrs: list[int], dst_ptrs: list[int], sizes: list[int]) -
 
 def alloc_shm_pinned_ptr(size: int, shm_name: str = "") -> int:
     """Non-CUDA equivalent of allocating shared memory pinned pointer.
-    Uses multiprocessing.shared_memory for cross-platform POSIX shm."""
+    Uses multiprocessing.shared_memory for cross-platform POSIX shm.
+    Attempts to pin the buffer via cudaHostRegister for async D2H;
+    if pinning fails, continues without pinning."""
 
     # Strip leading '/' for SharedMemory name
     name = shm_name.lstrip("/") if shm_name else None
@@ -479,12 +508,22 @@ def alloc_shm_pinned_ptr(size: int, shm_name: str = "") -> int:
     _tensor_registry[ptr] = tensor
     _buf_registry[ptr] = buf
     _shm_registry[ptr] = shm
+
+    # Try to pin the SHM buffer for async D2H copies
+    if try_pin_buffer(ptr, size):
+        _pinned_ptr_registry[ptr] = size
+
     return ptr
 
 
 def free_shm_pinned_ptr(ptr: int, size: int = 0, shm_name: str = "") -> None:
     """Non-CUDA equivalent of freeing a shared memory
-    pinned pointer."""
+    pinned pointer. Unregisters pinned memory if it was pinned."""
+
+    # Unpin if previously registered
+    if ptr in _pinned_ptr_registry:
+        try_unpin_buffer(ptr)
+        _pinned_ptr_registry.pop(ptr, None)
 
     # Release in order: tensor -> ctypes buf -> shm
     _tensor_registry.pop(ptr, None)

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -402,8 +402,6 @@ def _alloc_page_aligned_pinned_view(size: int) -> Tuple[torch.Tensor, int]:
 def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:
     """Non-CUDA equivalent of allocating pinned memory with NUMA awareness.
     On XPU, uses pin_memory=True (SYCL USM host allocation) for fast transfers.
-    Attempts to pin the buffer via cudaHostRegister for async D2H;
-    if pinning fails, continues without pinning.
     Note: NUMA node selection is not supported on non-CUDA."""
 
     view, aligned_ptr = _alloc_page_aligned_pinned_view(size)
@@ -411,23 +409,11 @@ def alloc_pinned_numa_ptr(size: int, numa_id: int = 0) -> int:
     # holding the view in the registry transitively keeps the underlying
     # memory alive.
     _tensor_registry[aligned_ptr] = view
-
-    # Try to pin the buffer for async D2H copies
-    if try_pin_buffer(aligned_ptr, size):
-        _pinned_ptr_registry[aligned_ptr] = size
-
     return aligned_ptr
 
 
 def free_pinned_numa_ptr(ptr: int, size: int | None = None) -> None:
-    """Non-CUDA equivalent of freeing a previously allocated NUMA pointer.
-    Unregisters pinned memory if it was pinned."""
-
-    # Unpin if previously registered
-    if ptr in _pinned_ptr_registry:
-        try_unpin_buffer(ptr)
-        _pinned_ptr_registry.pop(ptr, None)
-
+    """Non-CUDA equivalent of freeing a previously allocated NUMA pointer."""
     # Release the tensor object for that pointer reference
     _tensor_registry.pop(ptr, None)
 
@@ -435,28 +421,15 @@ def free_pinned_numa_ptr(ptr: int, size: int | None = None) -> None:
 def alloc_pinned_ptr(size: int, device_id: int = 0) -> int:
     """Non-CUDA equivalent of allocating pinned memory and returning pointer
     to it. On XPU, uses pin_memory=True (SYCL USM host allocation) for
-    fast DMA transfers. Attempts to pin the buffer via cudaHostRegister
-    for async D2H; if pinning fails, continues without pinning."""
+    fast DMA transfers. On other non-CUDA platforms, pinning is not supported."""
 
     view, aligned_ptr = _alloc_page_aligned_pinned_view(size)
     _tensor_registry[aligned_ptr] = view
-
-    # Try to pin the buffer for async D2H copies
-    if try_pin_buffer(aligned_ptr, size):
-        _pinned_ptr_registry[aligned_ptr] = size
-
     return aligned_ptr
 
 
 def free_pinned_ptr(ptr: int) -> None:
-    """Non-CUDA equivalent of freeing a previously allocated pinned pointer.
-    Unregisters pinned memory if it was pinned."""
-
-    # Unpin if previously registered
-    if ptr in _pinned_ptr_registry:
-        try_unpin_buffer(ptr)
-        _pinned_ptr_registry.pop(ptr, None)
-
+    """Non-CUDA equivalent of freeing a previously allocated pinned pointer."""
     # Release the tensor object for that pointer reference
     _tensor_registry.pop(ptr, None)
 

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -94,6 +94,77 @@ def check_interprocess_event_support() -> None:
         )
 
 
+def try_pin_buffer(ptr: int, size: int) -> bool:
+    """Try to pin a host buffer via cudaHostRegister for async D2H copies.
+
+    Args:
+        ptr: Raw host pointer (integer address) to pin.
+        size: Size of the buffer in bytes.
+
+    Returns:
+        True if the buffer was successfully pinned, False otherwise.
+    """
+    # First Party
+    from lmcache import torch_dev
+
+    if not torch_dev.is_available() or not hasattr(torch_dev, "cudart"):
+        return False
+    try:
+        # TODO: take torch_dev.cudart().cudaHostRegister as temp solution
+        # may abstract a function for ptr register for diff platforms
+        err = torch_dev.cudart().cudaHostRegister(ptr, size, 0)
+        if err == 0:
+            return True
+        logger.warning(
+            "cudaHostRegister failed (ptr=%d, size=%d, err=%s); "
+            "D2H copies will be synchronous",
+            ptr,
+            size,
+            err,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to pin buffer (ptr=%d, size=%d): %r; "
+            "D2H copies will be synchronous",
+            ptr,
+            size,
+            exc,
+        )
+    return False
+
+
+def try_unpin_buffer(ptr: int) -> bool:
+    """Try to unpin a host buffer via cudaHostUnregister.
+
+    Args:
+        ptr: Raw host pointer (integer address) to unpin.
+
+    Returns:
+        True if the buffer was successfully unpinned, False otherwise.
+    """
+    # First Party
+    from lmcache import torch_dev
+
+    try:
+        # TODO: take torch_dev.cudart().cudaHostUnregister as temp solution
+        # may abstract a function for ptr unregister for diff platforms
+        err = torch_dev.cudart().cudaHostUnregister(ptr)
+        if err == 0:
+            return True
+        logger.warning(
+            "cudaHostUnregister failed (ptr=%d, err=%s)",
+            ptr,
+            err,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to unpin buffer (ptr=%d): %r",
+            ptr,
+            exc,
+        )
+    return False
+
+
 # Math utility functions
 def cdiv(a: int, b: int) -> int:
     """Ceiling division."""

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -108,6 +108,9 @@ def try_pin_buffer(ptr: int, size: int) -> bool:
     from lmcache import torch_dev
 
     if not torch_dev.is_available() or not hasattr(torch_dev, "cudart"):
+        logger.warning(
+            "torch_dev does not have cudart... not able to pin memory by cudart"
+        )
         return False
     try:
         # TODO: take torch_dev.cudart().cudaHostRegister as temp solution
@@ -146,6 +149,9 @@ def try_unpin_buffer(ptr: int) -> bool:
     from lmcache import torch_dev
 
     if not torch_dev.is_available() or not hasattr(torch_dev, "cudart"):
+        logger.warning(
+            "torch_dev does not have cudart... not able to unpin memory by cudart"
+        )
         return False
 
     try:

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -145,6 +145,9 @@ def try_unpin_buffer(ptr: int) -> bool:
     # First Party
     from lmcache import torch_dev
 
+    if not torch_dev.is_available() or not hasattr(torch_dev, "cudart"):
+        return False
+
     try:
         # TODO: take torch_dev.cudart().cudaHostUnregister as temp solution
         # may abstract a function for ptr unregister for diff platforms

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -225,14 +225,12 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def close(self) -> None:
         if self._shm is None:
             return
+        self._unpin_shm_buffer()
         try:
-            self._unpin_shm_buffer()
+            self._shm.close()
         finally:
-            try:
-                self._shm.close()
-            finally:
-                self._shm = None
-                self._shm_buffer = None
+            self._shm = None
+            self._shm_buffer = None
 
     def _pin_shm_buffer(self) -> None:
         """Pin the SHM buffer as page-locked host memory via cudaHostRegister.

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -6,11 +6,15 @@ from dataclasses import dataclass
 from multiprocessing import shared_memory
 from multiprocessing.resource_tracker import unregister
 from typing import Any
+import ctypes
 
 # Third Party
 import torch
 
 # First Party
+from lmcache import torch_dev
+from lmcache.logging import init_logger
+from lmcache.utils import try_pin_buffer, try_unpin_buffer
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
@@ -18,6 +22,8 @@ from lmcache.v1.multiprocess.transfer_context.base import (
     EngineDrivenContext,
     EngineDrivenContextMetadata,
 )
+
+logger = init_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -92,6 +98,9 @@ class EngineDrivenContextShm(EngineDrivenContext):
         self._pool_size = pool_size
         self._shm: shared_memory.SharedMemory | None = None
         self._shm_buffer: memoryview | None = None
+        self._pinned = False
+        self._pinned_ptr = 0
+        self._pinned_size = 0
         try:
             self._shm = shared_memory.SharedMemory(
                 name=shm_name.lstrip("/"), create=False
@@ -101,6 +110,11 @@ class EngineDrivenContextShm(EngineDrivenContext):
             # unlink the segment when this worker exits.
             unregister(f"/{self._shm.name}", "shared_memory")
             self._shm_buffer = self._shm.buf
+            # pin memory is per process
+            # the shm might be pinned on lmcache server side already
+            # pin memory here is for worker side for fast DMA copy
+            self._pin_shm_buffer()
+            logger.info("SHM pinned=%s for shm_name=%s", self._pinned, self._shm_name)
         except Exception:
             self._shm = None
             self._shm_buffer = None
@@ -212,7 +226,42 @@ class EngineDrivenContextShm(EngineDrivenContext):
         if self._shm is None:
             return
         try:
-            self._shm.close()
+            self._unpin_shm_buffer()
         finally:
-            self._shm = None
-            self._shm_buffer = None
+            try:
+                self._shm.close()
+            finally:
+                self._shm = None
+                self._shm_buffer = None
+
+    def _pin_shm_buffer(self) -> None:
+        """Pin the SHM buffer as page-locked host memory via cudaHostRegister.
+
+        Enables faster async D2H CUDA copies to the SHM region. If pinning is
+        not available or fails, logs a warning and continues without pinning.
+        """
+        if self._shm_buffer is None or not torch_dev.is_available():
+            return
+        try:
+            ptr = ctypes.addressof(ctypes.c_char.from_buffer(self._shm_buffer))
+        except Exception as exc:
+            logger.warning(
+                "Failed to get pointer for shm_name=%s: %r; "
+                "D2H copies will be synchronous",
+                self._shm_name,
+                exc,
+            )
+            return
+        if try_pin_buffer(ptr, self._pool_size):
+            self._pinned = True
+            self._pinned_ptr = ptr
+            self._pinned_size = self._pool_size
+
+    def _unpin_shm_buffer(self) -> None:
+        """Unpin the SHM buffer if it was previously pinned via cudaHostRegister."""
+        if not self._pinned or self._pinned_ptr == 0:
+            return
+        try_unpin_buffer(self._pinned_ptr)
+        self._pinned = False
+        self._pinned_ptr = 0
+        self._pinned_size = 0


### PR DESCRIPTION
## Pin SHM and host buffers for async DMA

Pin SHM and pinned-host buffers via `cudaHostRegister` so that async
GPU→CPU DMA copies can proceed without stalling on the copy stream.
Pinning is best-effort: if CUDA is unavailable or `cudaHostRegister`
fails, the code continues with synchronous copies and logs a warning.

Because `cudaHostRegister` is per-process, the server and worker each
pin their own view of the SHM segment independently.

**`lmcache/utils.py`** — shared helpers:
- `try_pin_buffer(ptr, size)`: calls `cudaHostRegister`; returns `False`
  on any failure without raising.
- `try_unpin_buffer(ptr)`: calls `cudaHostUnregister`; same semantics.

**`transfer_context/shm.py`** (`EngineDrivenContextShm`):
- Pins the SHM pool on attach (`_pin_shm_buffer`); unpins in `close()`
  (`_unpin_shm_buffer`).

**`python_ops_fallback.py`**:
- `alloc_pinned_ptr` / `alloc_pinned_numa_ptr` / `alloc_shm_pinned_ptr`
  attempt to pin after allocation; corresponding `free_*` calls unpin
  before release. Tracked via a unified `_pinned_ptr_registry`.

> **Note:** The current use of `torch_dev.cudart().cudaHostRegister` is
> a temporary CUDA-specific abstraction. Once other device backends gain
> equivalent host-memory pinning capabilities, this should be generalized
> into a proper device-agnostic abstraction in `torch_dev`.