### PR TITLE
fix(memory): cache ctypes ubyte-array types to stop heap-type leak

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -4,7 +4,7 @@ from collections import deque
 from contextlib import nullcontext
 from dataclasses import dataclass
 from enum import Enum, auto
-from functools import wraps
+from functools import cache, wraps
 from typing import Any, List, Optional, Tuple, Union
 import abc
 import ctypes
@@ -41,11 +41,11 @@ logger = init_logger(__name__)
 #
 # Caching by length is safe: the `from_address(addr)` instance never owns the
 # underlying buffer, only the metadata (length, item-type), and that metadata
-# depends solely on `N`.
-_UBYTE_ARRAY_TYPE_CACHE: dict[int, type] = {}
-
-
-def _get_cached_ubyte_array_type(num_bytes: int) -> type:
+# depends solely on `N`. ``functools.cache`` provides a thread-safe unbounded
+# memoization primitive, so concurrent first-time accesses for the same `N`
+# cannot race to create distinct heap types.
+@cache
+def _get_cached_ubyte_array_type(num_bytes: int) -> type[ctypes.Array[ctypes.c_ubyte]]:
     """Return a cached ``ctypes.c_ubyte * num_bytes`` array type.
 
     Args:
@@ -55,11 +55,7 @@ def _get_cached_ubyte_array_type(num_bytes: int) -> type:
         The cached ``ctypes.Array`` subclass for the given length. Subsequent
         calls with the same ``num_bytes`` return the same type object.
     """
-    arr_type = _UBYTE_ARRAY_TYPE_CACHE.get(num_bytes)
-    if arr_type is None:
-        arr_type = ctypes.c_ubyte * num_bytes
-        _UBYTE_ARRAY_TYPE_CACHE[num_bytes] = arr_type
-    return arr_type
+    return ctypes.c_ubyte * num_bytes
 
 
 # Helper functions for thread safety
@@ -875,9 +871,7 @@ class TensorMemoryObj(MemoryObj):
         # https://github.com/LMCache/LMCache/issues/3767.
         arr_type = _get_cached_ubyte_array_type(num_bytes)
         ubyte_ptr = ctypes.cast(ptr, ctypes.POINTER(ctypes.c_ubyte))
-        byte_array = arr_type.from_address(
-            ctypes.addressof(ubyte_ptr.contents)
-        )
+        byte_array = arr_type.from_address(ctypes.addressof(ubyte_ptr.contents))
         return memoryview(byte_array)
 
     @property

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -29,6 +29,39 @@ import lmcache.c_ops as lmc_ops
 logger = init_logger(__name__)
 
 
+# Cache for ctypes ubyte-array types keyed by length.
+#
+# ctypes does not cache `(c_ubyte * N)` array types -- each call to the `*`
+# operator builds a fresh heap type via PyCArrayType_from_ctype. The heap
+# type metadata stays alive forever (held by the type system), so calling
+# `(ctypes.c_ubyte * N).from_address(...)` on every TensorMemoryObj.byte_array
+# access leaks ~1-2 kB per call. Under long-running remote-backend put/get
+# workloads this is the dominant source of monotonic anonymous-memory growth
+# (see https://github.com/LMCache/LMCache/issues/3767).
+#
+# Caching by length is safe: the `from_address(addr)` instance never owns the
+# underlying buffer, only the metadata (length, item-type), and that metadata
+# depends solely on `N`.
+_UBYTE_ARRAY_TYPE_CACHE: dict[int, type] = {}
+
+
+def _get_cached_ubyte_array_type(num_bytes: int) -> type:
+    """Return a cached ``ctypes.c_ubyte * num_bytes`` array type.
+
+    Args:
+        num_bytes: The length of the array type in bytes.
+
+    Returns:
+        The cached ``ctypes.Array`` subclass for the given length. Subsequent
+        calls with the same ``num_bytes`` return the same type object.
+    """
+    arr_type = _UBYTE_ARRAY_TYPE_CACHE.get(num_bytes)
+    if arr_type is None:
+        arr_type = ctypes.c_ubyte * num_bytes
+        _UBYTE_ARRAY_TYPE_CACHE[num_bytes] = arr_type
+    return arr_type
+
+
 # Helper functions for thread safety
 def synchronized(lock_attr_name):
     """
@@ -834,8 +867,15 @@ class TensorMemoryObj(MemoryObj):
         # the metadata length.
         num_bytes = self.get_size()
         ptr = self.raw_data.data_ptr()
+        # ctypes does not cache (c_ubyte * N) array types -- each `*` builds a
+        # fresh heap type. With this property accessed once per remote put/get,
+        # uncached creation leaks ~1-2 kB per call (heap-type metadata is held
+        # by the type system and never reclaimed). Cache the array type per
+        # size so steady-state usage reuses a fixed set of types. See
+        # https://github.com/LMCache/LMCache/issues/3767.
+        arr_type = _get_cached_ubyte_array_type(num_bytes)
         ubyte_ptr = ctypes.cast(ptr, ctypes.POINTER(ctypes.c_ubyte))
-        byte_array = (ctypes.c_ubyte * num_bytes).from_address(
+        byte_array = arr_type.from_address(
             ctypes.addressof(ubyte_ptr.contents)
         )
         return memoryview(byte_array)

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -320,10 +320,7 @@ def test_byte_array_caches_ctypes_array_type():
        logical byte length).
     """
     # First Party
-    from lmcache.v1.memory_management import (
-        _UBYTE_ARRAY_TYPE_CACHE,
-        _get_cached_ubyte_array_type,
-    )
+    from lmcache.v1.memory_management import _get_cached_ubyte_array_type
 
     # Direct helper contract.
     t1 = _get_cached_ubyte_array_type(1024)
@@ -331,8 +328,6 @@ def test_byte_array_caches_ctypes_array_type():
     t3 = _get_cached_ubyte_array_type(2048)
     assert t1 is t2, "same length must map to the same cached array type"
     assert t1 is not t3, "different lengths must not share a cached array type"
-    assert _UBYTE_ARRAY_TYPE_CACHE[1024] is t1
-    assert _UBYTE_ARRAY_TYPE_CACHE[2048] is t3
 
     # Property-level contract: repeated TensorMemoryObj.byte_array accesses
     # must not create new heap types.
@@ -345,11 +340,11 @@ def test_byte_array_caches_ctypes_array_type():
         # Prime the cache with this object's size (and any other state the
         # allocate path warmed up) so we measure only repeated-access growth.
         _ = obj.byte_array
-        before = len(_UBYTE_ARRAY_TYPE_CACHE)
+        before = _get_cached_ubyte_array_type.cache_info().currsize
         for _ in range(50):
             mv = obj.byte_array
             assert isinstance(mv, memoryview)
-        after = len(_UBYTE_ARRAY_TYPE_CACHE)
+        after = _get_cached_ubyte_array_type.cache_info().currsize
         assert after == before, (
             f"byte_array leaked array types across 50 repeated accesses: "
             f"cache grew from {before} to {after}"

--- a/tests/v1/test_memory_management.py
+++ b/tests/v1/test_memory_management.py
@@ -301,6 +301,64 @@ def test_mixed_alloc(alloc_cls):
     allocator.close()
 
 
+def test_byte_array_caches_ctypes_array_type():
+    """``TensorMemoryObj.byte_array`` must reuse the ctypes array type per length.
+
+    Regression for https://github.com/LMCache/LMCache/issues/3767.
+
+    ``ctypes`` does not cache ``(c_ubyte * N)`` array types: every ``*`` call
+    builds a fresh heap type whose metadata stays alive forever. On the remote
+    backend put/get path ``byte_array`` is accessed once per chunk, so without
+    caching every call permanently leaks ~1-2 kB of heap-type metadata. Long
+    timed-trace replays then see monotonic anonymous-memory growth that
+    eventually triggers an OOM kill.
+
+    Verify two contracts:
+    1. Repeated ``byte_array`` accesses with the same logical size return
+       memoryviews backed by the same underlying ctypes array type.
+    2. Different sizes hit different cached types (the cache is keyed on the
+       logical byte length).
+    """
+    # First Party
+    from lmcache.v1.memory_management import (
+        _UBYTE_ARRAY_TYPE_CACHE,
+        _get_cached_ubyte_array_type,
+    )
+
+    # Direct helper contract.
+    t1 = _get_cached_ubyte_array_type(1024)
+    t2 = _get_cached_ubyte_array_type(1024)
+    t3 = _get_cached_ubyte_array_type(2048)
+    assert t1 is t2, "same length must map to the same cached array type"
+    assert t1 is not t3, "different lengths must not share a cached array type"
+    assert _UBYTE_ARRAY_TYPE_CACHE[1024] is t1
+    assert _UBYTE_ARRAY_TYPE_CACHE[2048] is t3
+
+    # Property-level contract: repeated TensorMemoryObj.byte_array accesses
+    # must not create new heap types.
+    total_size = 1 << 22
+    allocator = MixedMemoryAllocator(total_size)
+    shape = torch.Size([4096])
+    obj = allocator.allocate(shape, torch.uint8)
+    assert isinstance(obj, TensorMemoryObj)
+    try:
+        # Prime the cache with this object's size (and any other state the
+        # allocate path warmed up) so we measure only repeated-access growth.
+        _ = obj.byte_array
+        before = len(_UBYTE_ARRAY_TYPE_CACHE)
+        for _ in range(50):
+            mv = obj.byte_array
+            assert isinstance(mv, memoryview)
+        after = len(_UBYTE_ARRAY_TYPE_CACHE)
+        assert after == before, (
+            f"byte_array leaked array types across 50 repeated accesses: "
+            f"cache grew from {before} to {after}"
+        )
+    finally:
+        obj.ref_count_down()
+        allocator.close()
+
+
 def test_memory_obj_metadata_to_and_from_dict():
     shape1 = torch.Size([128, 10])
     dtype1 = torch.float


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #3767.

`TensorMemoryObj.byte_array` builds a fresh `(ctypes.c_ubyte * num_bytes)`
array type on every call. `ctypes` does **not** cache these array types
(unlike pointer types, which use `_pointer_type_cache`); each `*` call goes
through `PyCArrayType_from_ctype` and produces a brand-new heap type whose
metadata is held by the type system forever. The remote-backend put/get path
accesses `byte_array` once per chunk transfer (`lm_connector.py:72,118`,
`memory_management.py:838`), so every remote put/get permanently leaks
~1-2 kB of heap-type metadata.

Over a long timed-trace replay this manifests as the symptom in #3767:
- `Shmem` stays bounded (the up-front pinned CPU pool sized by
  `LMCACHE_MAX_LOCAL_CPU_SIZE`)
- `RssAnon` grows monotonically
- The host eventually OOM-kills the EngineCore process

The fix caches the array type per length in a module-level dict and reuses
it on every access. The cached `from_address(addr)` instance never owns the
underlying buffer, only the metadata (length, item-type), so caching by `N`
is sound.

**Special notes for your reviewers**:

Reproduction harness (not part of this PR; available on request) drives
`LMCacheEngine` directly with `LMCACHE_CACHE_POLICY=LFU`,
`remote_url="lm://..."`, `remote_serde="naive"`, 1 GB pool, 768 tokens/iter,
2000 iters. Steady state begins around iter 600 once the CPU pool is full
and ref counts have settled.

| Run | RssAnon iter 800 → iter 1999 | steady-state slope |
|----|----|----|
| baseline (LFU, before fix)  | +14576 kB | ~12 kB / iter |
| in-tree fix (LFU, after fix) | **+1736 kB** | **~1.5 kB / iter** (~88% reduction) |

The residual ~1.5 kB / iter is unrelated background churn (transient
`threading.Condition` objects, prometheus value buffers); it does not grow
without bound and is independent of LMCache code paths.

I considered three alternatives before settling on the cache:
1. `memoryview(self.raw_data)` directly — clean but `raw_data` may carry
   alignment padding (e.g. from `batched_allocate`); the existing comment
   in `byte_array` explicitly notes the size has to be the logical
   `get_size()`, not `raw_data` length.
2. `memoryview(self.raw_data.contiguous().numpy())` — would force CPU-only
   semantics and pay a numpy dtype-view cost on the hot put/get path.
3. Cache the array type per length (this PR) — minimal, preserves existing
   semantics, ~5 lines of net change.

Two adjacent issues found while bisecting #3767, neither of which is the
root cause and both worth filing as separate PRs:

- `LRUCachePolicy.chunk_hash_to_init_timestamp` never shrinks
  (`update_on_force_evict` is `pass`); affects users running
  `LMCACHE_CACHE_POLICY=LRU`. The reporter uses `LFU`, so this is unrelated
  to #3767.
- `LFUCachePolicy.get_evict_candidates` removes keys from `key_to_freq` /
  `freq_to_keys` before the caller commits to evicting them. The
  `continue` / `break` paths in
  `LocalCPUBackend.batched_allocate` (lines 800, 813) can leave the
  `hot_cache` entry in place while LFU state is gone, orphaning the
  underlying `MemoryObj`. Only triggers on the layerwise / batched
  allocation path; the non-layerwise put path used by the issue reporter
  does not hit it.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
