### PR TITLE
convert f-string log calls to %-format in system_detection.py

### DIFF
--- a/lmcache/v1/system_detection.py
+++ b/lmcache/v1/system_detection.py
@@ -43,11 +43,11 @@ class SystemMemoryDetector:
             available_gb = memory.available / (1024**3)
 
             system = platform.system()
-            logger.info(f"{system} system available memory: {available_gb:.2f} GB")
+            logger.info("%s system available memory: %.2f GB", system, available_gb)
             return available_gb
 
         except Exception as e:
-            logger.warning(f"Failed to get system available memory using psutil: {e}")
+            logger.warning("Failed to get system available memory using psutil: %s", e)
             return 0.0
 
 
@@ -106,5 +106,5 @@ class NUMADetector:
 
             return NUMAMapping(gpu_to_numa_mapping={device_index: numa_node})
         except Exception as e:
-            logger.warning(f"Failed to auto read NUMA mapping from system: {e}")
+            logger.warning("Failed to auto read NUMA mapping from system: %s", e)
             return None


### PR DESCRIPTION
Picked this up as a good-first-issue. Converted the f-string logger calls in lmcache/v1/system_detection.py to lazy %-format (per ruff G004), so messages are only built when the log actually emits. Format style only, no behavior change.

Fixes #3794 