### PR TITLE
feat(mp): add CacheGen serde for filesystem L2

### DIFF
--- a/docs/source/mp/cachegen.rst
+++ b/docs/source/mp/cachegen.rst
@@ -1,8 +1,61 @@
 CacheGen
 ========
 
-.. note::
+Multiprocess mode can store L2 objects with CacheGen compression by
+configuring an L2 adapter serde:
 
-   CacheGen KV cache compression for multiprocess mode is **not implemented
-   yet** (coming soon). The original in-process implementation is preserved in
-   the Legacy section: :doc:`/kv_cache_optimizations/compression/index`.
+.. code-block:: json
+
+   {
+     "type": "fs",
+     "base_path": "/tmp/lmcache",
+     "serde": {
+       "type": "cachegen",
+       "model_name": "mistralai/Mistral-7B-Instruct-v0.2",
+       "chunk_size": 256,
+       "dtype": "bfloat16",
+       "num_heads": 8,
+       "head_size": 128
+     }
+   }
+
+Required serde fields:
+
+``model_name``
+   Model identifier used to select CacheGen quantization settings.
+
+``chunk_size``
+   Maximum number of tokens in each cached KV object.
+
+``dtype``
+   Destination KV dtype on load, for example ``bfloat16``.
+
+``num_heads``
+   Number of KV heads in the MP KV layout.
+
+``head_size``
+   Per-head KV dimension. ``num_heads * head_size`` must equal the MP
+   layout's hidden dimension.
+
+Optional serde fields:
+
+``max_workers``
+   Thread-pool size for asynchronous encode/decode work. The default is ``1``.
+
+CacheGen uses LMCache's existing CacheGen kernels, so encode/decode requires a
+backend where those kernels are available. CPU-only environments can parse the
+config but cannot run CacheGen encode/decode.
+
+CacheGen serialized payloads use LMCache's existing CacheGen bytestream format.
+Only enable this serde for L2 storage you trust; do not decode CacheGen objects
+written by untrusted users or systems.
+
+On load, LMCache uses the exact stored byte length when the L2 adapter can
+report it; the filesystem adapter reports this from the object file size. This
+matters for CacheGen because the encoded payload is variable-sized. Adapters
+that cannot report exact sizes fall back to the serializer's conservative
+estimate; the destination KV object still uses the original KV shape and
+``dtype``.
+
+For algorithm background and legacy in-process configuration, see
+:doc:`/kv_cache_optimizations/compression/cachegen`.

--- a/docs/source/mp/serde.rst
+++ b/docs/source/mp/serde.rst
@@ -52,6 +52,11 @@ serde factory.
    * - ``type``
      - Description
      - Config fields
+   * - ``cachegen``
+     - Encode KV tensors with CacheGen's variable-size bytestream format;
+       decode back to the configured KV dtype on load.
+     - ``model_name``, ``chunk_size``, ``dtype``, ``num_heads``,
+       ``head_size``; optional ``max_workers``.
    * - ``fp8``
      - Quantize each element to 8-bit float; dequantize on load.
        Lossy but highly compressible.

--- a/lmcache/v1/distributed/l2_adapters/base.py
+++ b/lmcache/v1/distributed/l2_adapters/base.py
@@ -354,6 +354,21 @@ class L2AdapterInterface(ABC):
         """Register a listener to receive L2 adapter events."""
         self._listeners.append(listener)
 
+    def get_object_sizes(self, keys: list[ObjectKey]) -> dict[ObjectKey, int]:
+        """Return known stored byte sizes for ``keys``.
+
+        This method is advisory and non-blocking. Adapters return only
+        keys whose exact stored byte length is cheaply available; missing
+        keys mean "unknown", not necessarily "absent".
+
+        Args:
+            keys: Object keys to query.
+
+        Returns:
+            Mapping from keys to exact stored byte sizes in bytes.
+        """
+        return {}
+
     def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
         """Update byte accounting and notify listeners that ``keys`` were
         stored. ``sizes[i]`` is the byte size of ``keys[i]``.

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -415,6 +415,25 @@ class FSL2Adapter(L2AdapterInterface):
             "event_loop_alive": self._loop_thread.is_alive(),
         }
 
+    def get_object_sizes(self, keys: list[ObjectKey]) -> dict[ObjectKey, int]:
+        """Return file sizes for keys currently present on disk.
+
+        Args:
+            keys: Object keys to query.
+
+        Returns:
+            Mapping from keys to exact file sizes in bytes. Missing files
+            are omitted from the result.
+        """
+        sizes: dict[ObjectKey, int] = {}
+        for key in keys:
+            path = self._key_to_path(key)
+            try:
+                sizes[key] = path.stat().st_size
+            except OSError:
+                continue
+        return sizes
+
     # ------------------------------------------------------------------
     # Eviction Interface
     # ------------------------------------------------------------------

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -51,6 +51,9 @@ def clone_tensor_memory_obj(obj: MemoryObj) -> TensorMemoryObj:
         metadata=copy.deepcopy(obj.metadata),
         parent_allocator=None,
     )
+    obj_size = obj.get_size()
+    if obj_size != new_obj.get_size():
+        new_obj.set_used_size(obj_size)
 
     return new_obj
 
@@ -327,6 +330,23 @@ class MockL2Adapter(L2AdapterInterface):
         """
         with self._lock:
             return key in self._memory_objects
+
+    def get_object_sizes(self, keys: list[ObjectKey]) -> dict[ObjectKey, int]:
+        """Return logical byte sizes for objects stored in the mock adapter.
+
+        Args:
+            keys: Object keys to query.
+
+        Returns:
+            Mapping from keys to stored logical byte sizes. Missing keys
+            are omitted from the result.
+        """
+        with self._lock:
+            return {
+                key: self._memory_objects[key].get_size()
+                for key in keys
+                if key in self._memory_objects
+            }
 
     ##################
     # Helper functions

--- a/lmcache/v1/distributed/l2_adapters/serde_wrapper.py
+++ b/lmcache/v1/distributed/l2_adapters/serde_wrapper.py
@@ -35,6 +35,9 @@ import enum
 import select
 import threading
 
+# Third Party
+import torch
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
@@ -252,7 +255,7 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
             wrapped_id = self._next_task_id
             self._next_task_id += 1
 
-        temp_keys, temp_objs = self._alloc_temp_buffers(keys, objects)
+        temp_keys, temp_objs = self._alloc_load_temp_buffers(keys, objects)
         if temp_objs is None:
             logger.warning(
                 "Serde wrapper: temp alloc failed for load task %d",
@@ -581,41 +584,136 @@ class SerdeL2AdapterWrapper(L2AdapterInterface):
         keys: list[ObjectKey],
         objects: list[MemoryObj],
     ) -> tuple[list[ObjectKey], list[MemoryObj] | None]:
-        """Reserve one temp byte buffer per input key. All-or-nothing:
-        any single failure releases the partial successes and returns
-        ``(temp_keys, None)``.
+        """Reserve estimate-sized temp byte buffers for store.
 
         Args:
             keys: Original logical keys; used only to derive temp keys.
-            objects: Source (store) or destination (load) MemoryObjs.
-                All entries must share a single ``(shape, dtype)`` — the
-                caller (store/prefetch controller) is responsible for
-                shape-grouping before submission.
+            objects: Source MemoryObjs. All entries must share a single
+                ``(shape, dtype)`` — the caller (store controller) is
+                responsible for shape-grouping before submission.
+
+        Returns:
+            ``(temp_keys, temp_objs)`` on success, or ``(temp_keys, None)``
+            after releasing partial reservations on allocation failure.
         """
         shape_0 = objects[0].get_shapes()
         dtype_0 = objects[0].get_dtypes()
-        temp_keys = [make_temp_key(k) for k in keys]
         layout = serialized_layout_desc(
             MemoryLayoutDesc(shapes=shape_0, dtypes=dtype_0), self._serde
         )
-        results = self._l1_manager.reserve_write(
-            keys=temp_keys,
-            is_temporary=[True] * len(temp_keys),
-            layout_desc=layout,
-            mode="new",
+        return self._reserve_temp_buffers(keys, [layout] * len(keys))
+
+    def _alloc_load_temp_buffers(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> tuple[list[ObjectKey], list[MemoryObj] | None]:
+        """Reserve load temp buffers, preferring exact stored byte sizes.
+
+        Args:
+            keys: Logical L2 object keys to load.
+            objects: Destination MemoryObjs. All entries must share a
+                single ``(shape, dtype)`` — the caller (prefetch controller)
+                is responsible for shape-grouping before submission.
+
+        Returns:
+            ``(temp_keys, temp_objs)`` on success, or ``(temp_keys, None)``
+            after releasing partial reservations on allocation failure.
+        """
+        shape_0 = objects[0].get_shapes()
+        dtype_0 = objects[0].get_dtypes()
+        estimate_layout = serialized_layout_desc(
+            MemoryLayoutDesc(shapes=shape_0, dtypes=dtype_0), self._serde
         )
-        # First pass: collect every key whose reserve_write succeeded.
-        # We must scan the full list (not bail on the first failure)
-        # so a mixed-success result still releases all reserved keys.
-        successful_temp_keys: list[ObjectKey] = []
-        for temp_key in temp_keys:
-            r = results.get(temp_key)
-            if r is not None and r[0] == L1Error.SUCCESS:
-                successful_temp_keys.append(temp_key)
-        if len(successful_temp_keys) != len(temp_keys):
-            self._release_write_temps(successful_temp_keys)
+        known_sizes = self._inner.get_object_sizes(keys)
+        layouts: list[MemoryLayoutDesc] = []
+        exact_sizes: list[int | None] = []
+        for key in keys:
+            size = known_sizes.get(key)
+            if size is not None and size >= 0:
+                layouts.append(
+                    MemoryLayoutDesc(
+                        shapes=[torch.Size([max(size, 1)])],
+                        dtypes=[torch.uint8],
+                    )
+                )
+                exact_sizes.append(size)
+            else:
+                layouts.append(estimate_layout)
+                exact_sizes.append(None)
+
+        temp_keys, temp_objs = self._reserve_temp_buffers(keys, layouts)
+        if temp_objs is None:
             return temp_keys, None
-        temp_objs = [results[tk][1] for tk in temp_keys]
+        for temp_obj, exact_size in zip(temp_objs, exact_sizes, strict=True):
+            if exact_size is not None:
+                temp_obj.set_used_size(exact_size)
+        return temp_keys, temp_objs
+
+    def _reserve_temp_buffers(
+        self,
+        keys: list[ObjectKey],
+        layouts: list[MemoryLayoutDesc],
+    ) -> tuple[list[ObjectKey], list[MemoryObj] | None]:
+        """Reserve one temp byte buffer per input key.
+
+        All-or-nothing: any single failure releases the partial successes
+        and returns ``(temp_keys, None)``.
+
+        Args:
+            keys: Original logical keys; used only to derive temp keys.
+            layouts: Per-key temp byte-buffer layouts. Length must match
+                ``keys``.
+
+        Returns:
+            ``(temp_keys, temp_objs)`` when every reservation succeeds,
+            otherwise ``(temp_keys, None)``.
+        """
+        if len(keys) != len(layouts):
+            raise ValueError("keys and layouts must have the same length")
+        temp_keys = [make_temp_key(k) for k in keys]
+        if not temp_keys:
+            return temp_keys, []
+
+        first_layout = layouts[0]
+        if all(layout == first_layout for layout in layouts):
+            results = self._l1_manager.reserve_write(
+                keys=temp_keys,
+                is_temporary=[True] * len(temp_keys),
+                layout_desc=first_layout,
+                mode="new",
+            )
+            batched_successful_temp_keys: list[ObjectKey] = []
+            batched_temp_objs: list[MemoryObj] = []
+            allocation_failed = False
+            for temp_key in temp_keys:
+                r = results.get(temp_key)
+                if r is None or r[0] != L1Error.SUCCESS or r[1] is None:
+                    allocation_failed = True
+                    continue
+                batched_successful_temp_keys.append(temp_key)
+                batched_temp_objs.append(r[1])
+            if allocation_failed:
+                self._release_write_temps(batched_successful_temp_keys)
+                return temp_keys, None
+            return temp_keys, batched_temp_objs
+
+        successful_temp_keys: list[ObjectKey] = []
+        temp_objs: list[MemoryObj] = []
+
+        for temp_key, layout in zip(temp_keys, layouts, strict=True):
+            results = self._l1_manager.reserve_write(
+                keys=[temp_key],
+                is_temporary=[True],
+                layout_desc=layout,
+                mode="new",
+            )
+            r = results.get(temp_key)
+            if r is None or r[0] != L1Error.SUCCESS or r[1] is None:
+                self._release_write_temps(successful_temp_keys)
+                return temp_keys, None
+            successful_temp_keys.append(temp_key)
+            temp_objs.append(r[1])
         return temp_keys, temp_objs
 
     def _release_write_temps(self, temp_keys: list[ObjectKey]) -> None:

--- a/lmcache/v1/distributed/serde/__init__.py
+++ b/lmcache/v1/distributed/serde/__init__.py
@@ -31,8 +31,37 @@ from lmcache.v1.distributed.serde.utils import (
     serialized_layout_desc,
 )
 
+
+def _create_cachegen_serde(kwargs: dict[str, object]) -> SerdeProcessor:
+    # First Party
+    from lmcache.v1.distributed.serde.cachegen import (  # noqa: PLC0415
+        _create_cachegen_serde as create_cachegen_serde,
+    )
+
+    return create_cachegen_serde(kwargs)
+
+
+register_serde_factory("cachegen", _create_cachegen_serde)
+
+
+def __getattr__(name: str) -> object:
+    if name in {"CacheGenMpDeserializer", "CacheGenMpSerializer"}:
+        # First Party
+        from lmcache.v1.distributed.serde.cachegen import (  # noqa: PLC0415
+            CacheGenMpDeserializer,
+            CacheGenMpSerializer,
+        )
+
+        globals()["CacheGenMpDeserializer"] = CacheGenMpDeserializer
+        globals()["CacheGenMpSerializer"] = CacheGenMpSerializer
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "AsyncSerdeProcessor",
+    "CacheGenMpDeserializer",
+    "CacheGenMpSerializer",
     "Deserializer",
     "Fp8QuantizationDeserializer",
     "Fp8QuantizationSerializer",

--- a/lmcache/v1/distributed/serde/cachegen.py
+++ b/lmcache/v1/distributed/serde/cachegen.py
@@ -1,0 +1,539 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CacheGen serde for multiprocess distributed L2 adapters."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any
+import math
+
+# Third Party
+import torch
+
+# First Party
+from lmcache import torch_device_type
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.distributed.serde.async_processor import AsyncSerdeProcessor
+from lmcache.v1.distributed.serde.base import Deserializer, SerdeProcessor, Serializer
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
+
+
+def _parse_required_str(kwargs: dict[str, object], name: str) -> str:
+    value = kwargs.get(name)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"cachegen serde requires non-empty {name!r}")
+    return value
+
+
+def _parse_positive_int(
+    kwargs: dict[str, object],
+    name: str,
+    default: int | None = None,
+) -> int:
+    value = kwargs.get(name, default)
+    if isinstance(value, bool) or value is None:
+        raise ValueError(f"cachegen serde requires positive integer {name!r}")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, float) and value.is_integer():
+        parsed = int(value)
+    else:
+        raise ValueError(f"cachegen serde requires positive integer {name!r}")
+    if parsed <= 0:
+        raise ValueError(f"cachegen serde requires positive integer {name!r}")
+    return parsed
+
+
+def _parse_dtype(kwargs: dict[str, object]) -> torch.dtype:
+    dtype_name = _parse_required_str(kwargs, "dtype")
+    dtype = getattr(torch, dtype_name, None)
+    if not isinstance(dtype, torch.dtype):
+        raise ValueError(f"Unknown torch dtype: {dtype_name!r}")
+    return dtype
+
+
+def _metadata(model_name: str, dtype: torch.dtype) -> LMCacheMetadata:
+    return LMCacheMetadata(
+        model_name=model_name,
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=dtype,
+        kv_shape=None,  # type: ignore[arg-type]
+    )
+
+
+def mp_layout_to_cachegen_tensor(
+    tensor: torch.Tensor,
+    *,
+    num_heads: int,
+    head_size: int,
+    chunk_size: int,
+) -> torch.Tensor:
+    """Convert MP KV layout to CacheGen KV layout.
+
+    Args:
+        tensor: MP-layout tensor with shape
+            ``[2, num_layers, num_tokens, hidden_dim]``.
+        num_heads: Number of KV heads.
+        head_size: Per-head KV dimension.
+        chunk_size: Maximum supported token count.
+
+    Returns:
+        CacheGen-layout tensor with shape
+        ``[num_layers, 2, num_tokens, num_heads, head_size]``.
+
+    Raises:
+        ValueError: If the tensor shape is not a valid MP KV layout.
+    """
+    if tensor.ndim != 4:
+        raise ValueError(
+            "CacheGen MP layout expects shape [2, num_layers, num_tokens, hidden_dim]"
+        )
+    if tensor.shape[0] != 2:
+        raise ValueError("CacheGen MP layout expects K/V dimension size 2")
+    if tensor.shape[2] > chunk_size:
+        raise ValueError(
+            f"CacheGen MP layout got {tensor.shape[2]} tokens, "
+            f"exceeding chunk_size {chunk_size}"
+        )
+    hidden_dim = int(tensor.shape[3])
+    expected_hidden_dim = num_heads * head_size
+    if hidden_dim != expected_hidden_dim:
+        raise ValueError(
+            f"CacheGen MP layout hidden_dim {hidden_dim} does not match "
+            f"num_heads * head_size {expected_hidden_dim}"
+        )
+    return tensor.reshape(
+        2,
+        int(tensor.shape[1]),
+        int(tensor.shape[2]),
+        num_heads,
+        head_size,
+    ).permute(1, 0, 2, 3, 4)
+
+
+def cachegen_layout_to_mp_tensor(
+    tensor: torch.Tensor,
+    dst_shape: torch.Size,
+    *,
+    num_heads: int,
+    head_size: int,
+) -> torch.Tensor:
+    """Convert CacheGen KV layout to MP KV layout.
+
+    Args:
+        tensor: CacheGen-layout tensor with shape
+            ``[num_layers, 2, num_tokens, num_heads, head_size]``.
+        dst_shape: Target MP shape ``[2, num_layers, num_tokens, hidden_dim]``.
+        num_heads: Number of KV heads.
+        head_size: Per-head KV dimension.
+
+    Returns:
+        MP-layout tensor with shape ``dst_shape``.
+
+    Raises:
+        ValueError: If the decoded tensor and target shape are inconsistent.
+    """
+    if len(dst_shape) != 4:
+        raise ValueError(
+            "CacheGen MP destination expects shape "
+            "[2, num_layers, num_tokens, hidden_dim]"
+        )
+    if dst_shape[0] != 2:
+        raise ValueError("CacheGen MP destination expects K/V dimension size 2")
+    expected_hidden_dim = num_heads * head_size
+    if int(dst_shape[3]) != expected_hidden_dim:
+        raise ValueError(
+            f"CacheGen MP destination hidden_dim {int(dst_shape[3])} does not "
+            f"match num_heads * head_size {expected_hidden_dim}"
+        )
+    expected_cachegen_shape = torch.Size(
+        [int(dst_shape[1]), 2, int(dst_shape[2]), num_heads, head_size]
+    )
+    if tensor.shape != expected_cachegen_shape:
+        raise ValueError(
+            f"CacheGen decoded shape {tuple(tensor.shape)} does not match "
+            f"destination-derived shape {tuple(expected_cachegen_shape)}"
+        )
+    return tensor.permute(1, 0, 2, 3, 4).reshape(dst_shape)
+
+
+def _cachegen_gpu_max_tokens_per_chunk() -> int:
+    # First Party
+    from lmcache.storage_backend.serde.cachegen_basics import (  # noqa: PLC0415
+        CACHEGEN_GPU_MAX_TOKENS_PER_CHUNK,
+    )
+
+    return int(CACHEGEN_GPU_MAX_TOKENS_PER_CHUNK)
+
+
+def _create_inner_serializer(
+    model_name: str,
+    chunk_size: int,
+    dtype: torch.dtype,
+) -> Any:
+    # First Party
+    from lmcache.storage_backend.serde.cachegen_encoder import (  # noqa: PLC0415
+        CacheGenSerializer,
+    )
+
+    config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
+    return CacheGenSerializer(config, _metadata(model_name, dtype))
+
+
+def _create_inner_deserializer(
+    model_name: str,
+    chunk_size: int,
+    dtype: torch.dtype,
+) -> Any:
+    # First Party
+    from lmcache.storage_backend.serde.cachegen_decoder import (  # noqa: PLC0415
+        CacheGenDeserializer,
+    )
+
+    config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
+    return CacheGenDeserializer(config, _metadata(model_name, dtype), dtype)
+
+
+class CacheGenMpSerializer(Serializer):
+    """Serialize KV tensors to CacheGen bytes for MP distributed L2 storage."""
+
+    def __init__(
+        self,
+        model_name: str,
+        chunk_size: int,
+        num_heads: int | None = None,
+        head_size: int | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        """Create a CacheGen MP serializer.
+
+        Args:
+            model_name: Model identifier used by CacheGen to select codec bins.
+            chunk_size: Maximum number of tokens in one serialized KV object.
+            num_heads: Number of KV heads in MP ``[2, L, T, D]`` tensors.
+            head_size: Per-head KV dimension in MP ``[2, L, T, D]`` tensors.
+            dtype: Source KV dtype used for CacheGen metadata.
+        """
+        self._model_name = model_name
+        self._chunk_size = chunk_size
+        self._num_heads = num_heads
+        self._head_size = head_size
+        self._inner = _create_inner_serializer(
+            model_name=model_name,
+            chunk_size=chunk_size,
+            dtype=dtype,
+        )
+        self._cachegen_config = self._inner.cachegen_config
+
+    def serialize(self, src: MemoryObj, dst: MemoryObj) -> int:
+        """Encode ``src.tensor`` into ``dst`` and return bytes written.
+
+        Args:
+            src: Source MemoryObj containing an MP ``[2, L, T, D]`` tensor
+                or a CacheGen-shaped ``[L, 2, T, H, HS]`` tensor.
+            dst: Destination byte-buffer MemoryObj.
+
+        Returns:
+            Number of bytes written into ``dst``.
+
+        Raises:
+            ValueError: If tensors are missing, the source shape is invalid,
+                or the destination buffer is too small.
+        """
+        src_tensor = src.tensor
+        dst_tensor = dst.tensor
+        if src_tensor is None:
+            raise ValueError("CacheGenMpSerializer requires src.tensor")
+        if dst_tensor is None:
+            raise ValueError("CacheGenMpSerializer requires dst.tensor")
+        cachegen_tensor = self._to_cachegen_tensor(src_tensor)
+
+        encode_tensor = (
+            cachegen_tensor
+            if cachegen_tensor.device.type == torch_device_type
+            else cachegen_tensor.to(torch_device_type)
+        )
+        blob = self._inner.to_bytes(encode_tensor)
+        n = len(blob)
+        dst_view = dst_tensor.flatten().view(torch.uint8)
+        if dst_view.numel() < n:
+            raise ValueError(
+                f"CacheGenMpSerializer destination capacity {dst_view.numel()} "
+                f"is smaller than payload {n}"
+            )
+        dst_view[:n].copy_(torch.frombuffer(bytearray(blob), dtype=torch.uint8))
+        return n
+
+    def estimate_serialized_size(self, layout_desc: MemoryLayoutDesc) -> int:
+        """Return a conservative CacheGen payload capacity.
+
+        Args:
+            layout_desc: Source KV memory layout.
+
+        Returns:
+            Upper-bound byte capacity for the encoded CacheGen payload.
+        """
+        total = 0
+        for shape, dtype in zip(layout_desc.shapes, layout_desc.dtypes, strict=True):
+            total += self._estimate_layout_size(shape, dtype)
+        return int(total)
+
+    def _estimate_layout_size(self, shape: torch.Size, dtype: torch.dtype) -> int:
+        cachegen_shape = self._cachegen_shape_for_layout(shape)
+        if cachegen_shape is None:
+            return math.prod(shape) * dtype.itemsize
+
+        num_layers, kv_dim, num_tokens, num_heads, head_size = (
+            int(cachegen_shape[0]),
+            int(cachegen_shape[1]),
+            int(cachegen_shape[2]),
+            int(cachegen_shape[3]),
+            int(cachegen_shape[4]),
+        )
+        n_channels = num_heads * head_size
+        source_bytes = math.prod(shape) * dtype.itemsize
+        max_bins = max(
+            [spec.bins for spec in self._cachegen_config.kspecs]
+            + [spec.bins for spec in self._cachegen_config.vspecs]
+        )
+        cdf_bytes = kv_dim * num_layers * n_channels * (max_bins + 1) * 2
+        max_tensors_bytes = kv_dim * num_layers * num_tokens * 4
+        max_tokens_per_chunk = _cachegen_gpu_max_tokens_per_chunk()
+        num_chunks = max(1, math.ceil(num_tokens / max_tokens_per_chunk))
+        bytestream_bytes = (
+            num_chunks * kv_dim * num_layers * n_channels * max_tokens_per_chunk
+        )
+        length_bytes = num_chunks * kv_dim * num_layers * n_channels * 4
+        pickle_overhead_bytes = 4 << 20
+        return max(source_bytes, bytestream_bytes) + (
+            cdf_bytes
+            + max_tensors_bytes
+            + length_bytes
+            + (pickle_overhead_bytes * num_chunks)
+        )
+
+    def _cachegen_shape_for_layout(self, shape: torch.Size) -> torch.Size | None:
+        if len(shape) == 5 and shape[1] == 2:
+            return shape
+        if len(shape) == 4 and shape[0] == 2:
+            self._require_mp_head_config()
+            assert self._num_heads is not None
+            assert self._head_size is not None
+            hidden_dim = int(shape[3])
+            expected_hidden_dim = self._num_heads * self._head_size
+            if hidden_dim != expected_hidden_dim:
+                raise ValueError(
+                    f"CacheGen MP layout hidden_dim {hidden_dim} does not match "
+                    f"num_heads * head_size {expected_hidden_dim}"
+                )
+            return torch.Size(
+                [int(shape[1]), 2, int(shape[2]), self._num_heads, self._head_size]
+            )
+        return None
+
+    def _to_cachegen_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.ndim == 5:
+            self._validate_cachegen_tensor(tensor)
+            return tensor
+        if tensor.ndim == 4:
+            return self._mp_to_cachegen_tensor(tensor)
+        raise ValueError(
+            "CacheGenMpSerializer expects MP shape [2, num_layers, num_tokens, "
+            "hidden_dim] or CacheGen shape [num_layers, 2, num_tokens, "
+            "num_heads, head_size]"
+        )
+
+    def _mp_to_cachegen_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
+        self._require_mp_head_config()
+        assert self._num_heads is not None
+        assert self._head_size is not None
+        return mp_layout_to_cachegen_tensor(
+            tensor,
+            num_heads=self._num_heads,
+            head_size=self._head_size,
+            chunk_size=self._chunk_size,
+        )
+
+    def _validate_cachegen_tensor(self, tensor: torch.Tensor) -> None:
+        if tensor.shape[1] != 2:
+            raise ValueError("CacheGenMpSerializer expects K/V dimension size 2")
+        if tensor.shape[2] > self._chunk_size:
+            raise ValueError(
+                f"CacheGenMpSerializer got {tensor.shape[2]} tokens, "
+                f"exceeding chunk_size {self._chunk_size}"
+            )
+        if self._num_heads is not None and tensor.shape[3] != self._num_heads:
+            raise ValueError(
+                f"CacheGenMpSerializer got {tensor.shape[3]} heads, "
+                f"expected {self._num_heads}"
+            )
+        if self._head_size is not None and tensor.shape[4] != self._head_size:
+            raise ValueError(
+                f"CacheGenMpSerializer got head_size {tensor.shape[4]}, "
+                f"expected {self._head_size}"
+            )
+
+    def _require_mp_head_config(self) -> None:
+        if self._num_heads is None or self._head_size is None:
+            raise ValueError(
+                "CacheGen MP layout requires num_heads and head_size for "
+                "[2, num_layers, num_tokens, hidden_dim] tensors"
+            )
+
+
+class CacheGenMpDeserializer(Deserializer):
+    """Deserialize CacheGen bytes back into caller-provided KV tensors."""
+
+    def __init__(
+        self,
+        model_name: str,
+        chunk_size: int,
+        dtype: torch.dtype,
+        num_heads: int | None = None,
+        head_size: int | None = None,
+    ) -> None:
+        """Create a CacheGen MP deserializer.
+
+        Args:
+            model_name: Model identifier used by CacheGen to select codec bins.
+            chunk_size: Maximum number of tokens in one serialized KV object.
+            dtype: Expected destination KV dtype.
+            num_heads: Number of KV heads in MP ``[2, L, T, D]`` tensors.
+            head_size: Per-head KV dimension in MP ``[2, L, T, D]`` tensors.
+        """
+        self._dtype = dtype
+        self._chunk_size = chunk_size
+        self._num_heads = num_heads
+        self._head_size = head_size
+        self._inner = _create_inner_deserializer(
+            model_name=model_name,
+            chunk_size=chunk_size,
+            dtype=dtype,
+        )
+
+    def deserialize(self, src: MemoryObj, dst: MemoryObj) -> None:
+        """Decode CacheGen bytes from ``src`` into ``dst.tensor``.
+
+        Args:
+            src: Source serialized byte-buffer MemoryObj.
+            dst: Destination KV MemoryObj.
+
+        Raises:
+            ValueError: If destination tensor is missing, dtype mismatches,
+                source bytes are unavailable, or decoded element count does
+                not match the destination.
+        """
+        dst_tensor = dst.tensor
+        if dst_tensor is None:
+            raise ValueError("CacheGenMpDeserializer requires dst.tensor")
+        if dst_tensor.dtype != self._dtype:
+            raise ValueError(
+                f"CacheGenMpDeserializer configured dtype {self._dtype} "
+                f"does not match destination dtype {dst_tensor.dtype}"
+            )
+
+        blob = self._src_bytes(src)
+        decoded = self._inner.from_bytes(blob)
+        if decoded.numel() != dst_tensor.numel():
+            raise ValueError(
+                f"CacheGenMpDeserializer decoded {decoded.numel()} elements, "
+                f"destination expects {dst_tensor.numel()}"
+            )
+        decoded = self._to_destination_layout(decoded, dst_tensor).to(
+            device=dst_tensor.device,
+            dtype=dst_tensor.dtype,
+        )
+        dst_tensor.copy_(decoded)
+
+    def _to_destination_layout(
+        self,
+        decoded: torch.Tensor,
+        dst_tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        if dst_tensor.ndim == 5:
+            if decoded.shape != dst_tensor.shape:
+                decoded = decoded.reshape(dst_tensor.shape)
+            return decoded
+        if dst_tensor.ndim == 4:
+            return self._cachegen_to_mp_tensor(decoded, dst_tensor)
+        raise ValueError(
+            "CacheGenMpDeserializer expects MP shape [2, num_layers, num_tokens, "
+            "hidden_dim] or CacheGen shape [num_layers, 2, num_tokens, "
+            "num_heads, head_size]"
+        )
+
+    def _cachegen_to_mp_tensor(
+        self,
+        decoded: torch.Tensor,
+        dst_tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        self._require_mp_head_config()
+        assert self._num_heads is not None
+        assert self._head_size is not None
+        if decoded.ndim != 5:
+            raise ValueError(
+                "CacheGenMpDeserializer decoded tensor must have shape "
+                "[num_layers, 2, num_tokens, num_heads, head_size]"
+            )
+        return cachegen_layout_to_mp_tensor(
+            decoded,
+            dst_tensor.shape,
+            num_heads=self._num_heads,
+            head_size=self._head_size,
+        )
+
+    def _require_mp_head_config(self) -> None:
+        if self._num_heads is None or self._head_size is None:
+            raise ValueError(
+                "CacheGen MP layout requires num_heads and head_size for "
+                "[2, num_layers, num_tokens, hidden_dim] tensors"
+            )
+
+    def _src_bytes(self, src: MemoryObj) -> bytes:
+        try:
+            return memoryview(src.byte_array).cast("B").tobytes()
+        except Exception:
+            src_tensor = src.tensor
+            if src_tensor is None:
+                raise ValueError("CacheGenMpDeserializer requires src bytes") from None
+            n = src.get_size()
+            return (
+                src_tensor.flatten()
+                .view(torch.uint8)[:n]
+                .detach()
+                .cpu()
+                .numpy()
+                .tobytes()
+            )
+
+
+def _create_cachegen_serde(kwargs: dict[str, object]) -> SerdeProcessor:
+    model_name = _parse_required_str(kwargs, "model_name")
+    chunk_size = _parse_positive_int(kwargs, "chunk_size")
+    dtype = _parse_dtype(kwargs)
+    num_heads = _parse_positive_int(kwargs, "num_heads")
+    head_size = _parse_positive_int(kwargs, "head_size")
+    max_workers = _parse_positive_int(kwargs, "max_workers", default=1)
+    return AsyncSerdeProcessor(
+        CacheGenMpSerializer(
+            model_name=model_name,
+            chunk_size=chunk_size,
+            num_heads=num_heads,
+            head_size=head_size,
+            dtype=dtype,
+        ),
+        CacheGenMpDeserializer(
+            model_name=model_name,
+            chunk_size=chunk_size,
+            dtype=dtype,
+            num_heads=num_heads,
+            head_size=head_size,
+        ),
+        max_workers=max_workers,
+    )

--- a/tests/v1/distributed/serde/test_cachegen.py
+++ b/tests/v1/distributed/serde/test_cachegen.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MP CacheGen distributed serde."""
+
+# Standard
+from dataclasses import dataclass
+from typing import cast
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache import torch_device_type
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.distributed.serde.cachegen import (
+    CacheGenMpDeserializer,
+    CacheGenMpSerializer,
+    cachegen_layout_to_mp_tensor,
+    mp_layout_to_cachegen_tensor,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+_GPU_AVAILABLE = torch_device_type == "cuda" or torch_device_type == "xpu"
+
+
+@dataclass
+class _FakeMemoryObj:
+    """Small MemoryObj test double exposing tensor and byte access."""
+
+    tensor: torch.Tensor
+
+    def get_size(self) -> int:
+        """Return the tensor size in bytes."""
+        return int(self.tensor.numel() * self.tensor.element_size())
+
+    @property
+    def byte_array(self) -> memoryview:
+        """Return a byte view of the CPU tensor contents."""
+        return memoryview(self.tensor.cpu().numpy())
+
+
+def _obj(tensor: torch.Tensor) -> MemoryObj:
+    """Cast a fake object into the MemoryObj protocol used by serde tests."""
+    return cast(MemoryObj, _FakeMemoryObj(tensor=tensor))
+
+
+def _kv_tensor(num_tokens: int, device: str) -> torch.Tensor:
+    """Create a CacheGen-shaped KV tensor for tests."""
+    torch.manual_seed(123)
+    return torch.rand(
+        32,
+        2,
+        num_tokens,
+        8,
+        128,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+
+def _mp_kv_tensor(num_tokens: int) -> torch.Tensor:
+    """Create an MP-shaped KV tensor for tests."""
+    return torch.arange(
+        2 * 32 * num_tokens * 8 * 128,
+        dtype=torch.float32,
+    ).reshape(2, 32, num_tokens, 8 * 128)
+
+
+def test_estimate_serialized_size_includes_cachegen_metadata_overhead() -> None:
+    """The CacheGen estimate includes metadata overhead beyond raw KV bytes."""
+    serializer = CacheGenMpSerializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=16,
+    )
+    layout = MemoryLayoutDesc(
+        shapes=[torch.Size([32, 2, 16, 8, 128])],
+        dtypes=[torch.bfloat16],
+    )
+    raw_bytes = (
+        32 * 2 * 16 * 8 * 128 * torch.empty((), dtype=torch.bfloat16).element_size()
+    )
+    estimate = serializer.estimate_serialized_size(layout)
+
+    assert estimate >= raw_bytes
+    assert estimate > raw_bytes
+
+
+def test_estimate_serialized_size_handles_mp_layout_with_metadata_overhead() -> None:
+    """MP layout estimates include CacheGen overhead after shape conversion."""
+    serializer = CacheGenMpSerializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=16,
+        num_heads=8,
+        head_size=128,
+    )
+    layout = MemoryLayoutDesc(
+        shapes=[torch.Size([2, 32, 16, 8 * 128])],
+        dtypes=[torch.bfloat16],
+    )
+    raw_bytes = 2 * 32 * 16 * 8 * 128 * torch.empty((), dtype=torch.bfloat16).itemsize
+
+    estimate = serializer.estimate_serialized_size(layout)
+
+    assert estimate >= raw_bytes
+    assert estimate > raw_bytes
+
+
+def test_estimate_serialized_size_rejects_mp_hidden_dim_mismatch() -> None:
+    """MP layout estimation rejects inconsistent head metadata."""
+    serializer = CacheGenMpSerializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=16,
+        num_heads=4,
+        head_size=128,
+    )
+    layout = MemoryLayoutDesc(
+        shapes=[torch.Size([2, 32, 16, 8 * 128])],
+        dtypes=[torch.bfloat16],
+    )
+
+    with pytest.raises(ValueError, match="hidden_dim"):
+        serializer.estimate_serialized_size(layout)
+
+
+def test_serialize_rejects_missing_tensor() -> None:
+    """Serialization requires a source tensor."""
+    serializer = CacheGenMpSerializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=16,
+    )
+    bad = cast(MemoryObj, _FakeMemoryObj(tensor=None))  # type: ignore[arg-type]
+    dst = _obj(torch.zeros(1024, dtype=torch.uint8))
+    with pytest.raises(ValueError, match="src.tensor"):
+        serializer.serialize(bad, dst)
+
+
+def test_mp_layout_to_cachegen_tensor_converts_dimension_order() -> None:
+    """MP [2, L, T, D] tensors convert to CacheGen [L, 2, T, H, HS]."""
+    src_tensor = _mp_kv_tensor(16)
+    expected = src_tensor.view(2, 32, 16, 8, 128).permute(1, 0, 2, 3, 4)
+
+    got = mp_layout_to_cachegen_tensor(
+        src_tensor,
+        num_heads=8,
+        head_size=128,
+        chunk_size=16,
+    )
+
+    assert torch.equal(got, expected)
+
+
+def test_cachegen_layout_to_mp_tensor_converts_dimension_order() -> None:
+    """CacheGen [L, 2, T, H, HS] tensors convert to MP [2, L, T, D]."""
+    mp_tensor = _mp_kv_tensor(16)
+    cachegen_tensor = mp_tensor.view(2, 32, 16, 8, 128).permute(1, 0, 2, 3, 4)
+
+    got = cachegen_layout_to_mp_tensor(
+        cachegen_tensor,
+        mp_tensor.shape,
+        num_heads=8,
+        head_size=128,
+    )
+
+    assert torch.equal(got, mp_tensor)
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="No GPU backend for CacheGen kernels")
+def test_cachegen_mp_serde_round_trip_cpu_l1_shape_and_dtype() -> None:
+    """CacheGen MP serde supports CPU L1 tensors around GPU kernels."""
+    chunk_size = 16
+    serializer = CacheGenMpSerializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=chunk_size,
+    )
+    deserializer = CacheGenMpDeserializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=chunk_size,
+        dtype=torch.bfloat16,
+    )
+    src_tensor = _kv_tensor(chunk_size, "cpu")
+    src = _obj(src_tensor)
+    layout = MemoryLayoutDesc(shapes=[src_tensor.shape], dtypes=[src_tensor.dtype])
+    dst = _obj(
+        torch.zeros(serializer.estimate_serialized_size(layout), dtype=torch.uint8)
+    )
+
+    n = serializer.serialize(src, dst)
+    dst_tensor = dst.tensor
+    assert dst_tensor is not None
+    assert 0 < n <= dst_tensor.numel()
+
+    encoded = _obj(dst_tensor[:n].clone())
+    out = _obj(torch.zeros_like(src_tensor))
+    deserializer.deserialize(encoded, out)
+    out_tensor = out.tensor
+    assert out_tensor is not None
+    assert out_tensor.shape == src_tensor.shape
+    assert out_tensor.dtype == torch.bfloat16
+    assert out_tensor.mean() != 0
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="No GPU backend for CacheGen kernels")
+def test_cachegen_mp_serde_round_trip_mp_layout_cpu_l1_shape_and_dtype() -> None:
+    """CacheGen MP serde preserves MP destination shape around GPU kernels."""
+    chunk_size = 16
+    serializer = CacheGenMpSerializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=chunk_size,
+        num_heads=8,
+        head_size=128,
+    )
+    deserializer = CacheGenMpDeserializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=chunk_size,
+        dtype=torch.bfloat16,
+        num_heads=8,
+        head_size=128,
+    )
+    src_tensor = _mp_kv_tensor(chunk_size).to(torch.bfloat16)
+    src = _obj(src_tensor)
+    layout = MemoryLayoutDesc(shapes=[src_tensor.shape], dtypes=[src_tensor.dtype])
+    dst = _obj(
+        torch.zeros(serializer.estimate_serialized_size(layout), dtype=torch.uint8)
+    )
+
+    n = serializer.serialize(src, dst)
+    dst_tensor = dst.tensor
+    assert dst_tensor is not None
+    assert 0 < n <= dst_tensor.numel()
+
+    encoded = _obj(dst_tensor[:n].clone())
+    out = _obj(torch.zeros_like(src_tensor))
+    deserializer.deserialize(encoded, out)
+    out_tensor = out.tensor
+    assert out_tensor is not None
+    assert out_tensor.shape == src_tensor.shape
+    assert out_tensor.dtype == torch.bfloat16
+    assert out_tensor.mean() != 0
+
+
+def test_mp_cachegen_layout_helpers_round_trip() -> None:
+    """MP layout survives conversion to CacheGen layout and back."""
+    src_tensor = _mp_kv_tensor(16)
+    cachegen_tensor = mp_layout_to_cachegen_tensor(
+        src_tensor,
+        num_heads=8,
+        head_size=128,
+        chunk_size=16,
+    )
+    out_tensor = cachegen_layout_to_mp_tensor(
+        cachegen_tensor,
+        src_tensor.shape,
+        num_heads=8,
+        head_size=128,
+    )
+
+    assert torch.equal(out_tensor, src_tensor)
+
+
+def test_deserialize_rejects_configured_dtype_mismatch() -> None:
+    """Deserialize validates the configured dtype against the destination."""
+    deserializer = CacheGenMpDeserializer(
+        model_name="mistralai/Mistral-7B-Instruct-v0.2",
+        chunk_size=16,
+        dtype=torch.float16,
+    )
+    src = _obj(torch.zeros(1, dtype=torch.uint8))
+    dst = _obj(torch.zeros(32, 2, 16, 8, 128, dtype=torch.bfloat16))
+    with pytest.raises(ValueError, match="configured dtype"):
+        deserializer.deserialize(src, dst)

--- a/tests/v1/distributed/serde/test_factory.py
+++ b/tests/v1/distributed/serde/test_factory.py
@@ -72,6 +72,112 @@ def test_create_fp8_accepts_float_max_workers() -> None:
         processor.close()
 
 
+def test_cachegen_is_registered_by_default() -> None:
+    """The built-in CacheGen serde is available without extra setup."""
+    assert "cachegen" in get_registered_serde_types()
+
+
+def test_create_cachegen_missing_required_kwargs_raises() -> None:
+    """CacheGen serde rejects configs missing required fields."""
+    with pytest.raises(ValueError, match="model_name"):
+        create_serde_processor(SerdeConfig(type="cachegen"))
+    with pytest.raises(ValueError, match="chunk_size"):
+        create_serde_processor(
+            SerdeConfig(
+                type="cachegen",
+                kwargs={"model_name": "mistralai/Mistral-7B-Instruct-v0.2"},
+            )
+        )
+    with pytest.raises(ValueError, match="dtype"):
+        create_serde_processor(
+            SerdeConfig(
+                type="cachegen",
+                kwargs={
+                    "model_name": "mistralai/Mistral-7B-Instruct-v0.2",
+                    "chunk_size": 256,
+                },
+            )
+        )
+    with pytest.raises(ValueError, match="num_heads"):
+        create_serde_processor(
+            SerdeConfig(
+                type="cachegen",
+                kwargs={
+                    "model_name": "mistralai/Mistral-7B-Instruct-v0.2",
+                    "chunk_size": 256,
+                    "dtype": "bfloat16",
+                },
+            )
+        )
+    with pytest.raises(ValueError, match="head_size"):
+        create_serde_processor(
+            SerdeConfig(
+                type="cachegen",
+                kwargs={
+                    "model_name": "mistralai/Mistral-7B-Instruct-v0.2",
+                    "chunk_size": 256,
+                    "dtype": "bfloat16",
+                    "num_heads": 8,
+                },
+            )
+        )
+
+
+def test_create_cachegen_unknown_dtype_raises() -> None:
+    """CacheGen serde rejects unknown torch dtype names."""
+    with pytest.raises(ValueError, match="Unknown torch dtype"):
+        create_serde_processor(
+            SerdeConfig(
+                type="cachegen",
+                kwargs={
+                    "model_name": "mistralai/Mistral-7B-Instruct-v0.2",
+                    "chunk_size": 256,
+                    "dtype": "not_a_dtype",
+                },
+            )
+        )
+
+
+def _cachegen_kwargs(**overrides: object) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "model_name": "mistralai/Mistral-7B-Instruct-v0.2",
+        "chunk_size": 256,
+        "dtype": "bfloat16",
+        "num_heads": 8,
+        "head_size": 128,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("chunk_size", 0),
+        ("chunk_size", 1.5),
+        ("chunk_size", True),
+        ("num_heads", 0),
+        ("num_heads", 1.5),
+        ("num_heads", True),
+        ("head_size", 0),
+        ("head_size", 1.5),
+        ("head_size", True),
+        ("max_workers", 0),
+        ("max_workers", 1.5),
+        ("max_workers", True),
+    ],
+)
+def test_create_cachegen_rejects_invalid_positive_integer_fields(
+    field: str,
+    value: object,
+) -> None:
+    """CacheGen serde rejects non-positive and non-integral integer fields."""
+    with pytest.raises(ValueError, match=field):
+        create_serde_processor(
+            SerdeConfig(type="cachegen", kwargs=_cachegen_kwargs(**{field: value}))
+        )
+
+
 def test_register_serde_factory_dispatch() -> None:
     """A custom factory is dispatched by its registered name."""
 

--- a/tests/v1/distributed/serde/test_variable_size_payload.py
+++ b/tests/v1/distributed/serde/test_variable_size_payload.py
@@ -1,0 +1,570 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for variable-size distributed serde payload handling."""
+
+# Standard
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+import os
+import shutil
+import tempfile
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.l1_manager import L1Manager
+from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    FSL2Adapter,
+    FSL2AdapterConfig,
+)
+from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+    MockL2Adapter,
+    MockL2AdapterConfig,
+)
+from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
+    NativeConnectorL2Adapter,
+)
+from lmcache.v1.distributed.l2_adapters.serde_wrapper import SerdeL2AdapterWrapper
+from lmcache.v1.distributed.serde import (
+    AsyncSerdeProcessor,
+    Deserializer,
+    SerdeConfig,
+    Serializer,
+    register_serde_factory,
+)
+from lmcache.v1.memory_management import MemoryObj, MemoryObjMetadata, TensorMemoryObj
+from lmcache.v1.platform import create_event_notifier
+
+
+def _key(i: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(i),
+        model_name="test-model",
+        kv_rank=0,
+    )
+
+
+def _byte_obj(n: int) -> MemoryObj:
+    raw = torch.arange(n, dtype=torch.uint8)
+    return TensorMemoryObj(
+        raw_data=raw,
+        metadata=MemoryObjMetadata(
+            shape=torch.Size([n]),
+            dtype=torch.uint8,
+            address=-1,
+            phy_size=n,
+            ref_count=1,
+            shapes=[torch.Size([n])],
+            dtypes=[torch.uint8],
+        ),
+        parent_allocator=None,
+    )
+
+
+def _wait_for_store_result(adapter: L2AdapterInterface, task_id: int) -> None:
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        completed = adapter.pop_completed_store_tasks()
+        if task_id in completed:
+            assert completed[task_id].is_successful()
+            return
+        time.sleep(0.05)
+    raise AssertionError("store task did not complete")
+
+
+def _wait_for_condition(
+    predicate: Callable[[], bool],
+    timeout: float = 10.0,
+    poll_interval: float = 0.05,
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll_interval)
+    return False
+
+
+def _wait_for_prefetch(sm: Any, handle: Any) -> int | None:
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        result = sm.query_prefetch_status(handle)
+        if result is not None:
+            return result.count_leading_ones()
+        time.sleep(0.05)
+    return None
+
+
+def _assert_temp_keys_match_originals(
+    temp_keys: list[ObjectKey],
+    original_keys: list[ObjectKey],
+) -> None:
+    assert len(temp_keys) == len(original_keys)
+    for temp_key, original_key in zip(temp_keys, original_keys, strict=True):
+        assert temp_key.model_name == original_key.model_name
+        assert temp_key.kv_rank == original_key.kv_rank
+        assert temp_key.object_group_id == original_key.object_group_id
+        assert temp_key.cache_salt == original_key.cache_salt
+        assert temp_key.chunk_hash.startswith(original_key.chunk_hash)
+        assert len(temp_key.chunk_hash) == len(original_key.chunk_hash) + 16
+
+
+def _import_storage_manager_deps() -> tuple[type, type, type, type, type, type]:
+    try:
+        # First Party
+        from lmcache.v1.distributed.config import (
+            EvictionConfig,
+            L1ManagerConfig,
+            L1MemoryManagerConfig,
+            StorageManagerConfig,
+        )
+        from lmcache.v1.distributed.l2_adapters.config import L2AdaptersConfig
+        from lmcache.v1.distributed.storage_manager import StorageManager
+    except ImportError as exc:
+        pytest.skip(f"StorageManager native dependencies are unavailable: {exc}")
+
+    return (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+        L2AdaptersConfig,
+        StorageManager,
+    )
+
+
+class _PrefixSerializer(Serializer):
+    """Write a small prefix to exercise variable-size serialized payloads."""
+
+    def serialize(self, src: MemoryObj, dst: MemoryObj) -> int:
+        """Copy only the first eight source bytes into ``dst``.
+
+        Args:
+            src: Source object containing a tensor.
+            dst: Destination byte-buffer object.
+
+        Returns:
+            The number of bytes written.
+
+        Raises:
+            ValueError: If either object does not expose a tensor.
+        """
+        if src.tensor is None or dst.tensor is None:
+            raise ValueError("test serializer requires tensors")
+        payload = src.tensor.flatten().view(torch.uint8)[:8].clone()
+        dst.tensor.flatten()[: payload.numel()].copy_(payload)
+        return int(payload.numel())
+
+    def estimate_serialized_size(self, layout_desc: MemoryLayoutDesc) -> int:
+        """Return an intentionally larger upper bound for the serialized buffer.
+
+        Args:
+            layout_desc: Source layout description. Unused by this test serde.
+
+        Returns:
+            A fixed 64-byte estimate.
+        """
+        return 64
+
+
+class _PrefixDeserializer(Deserializer):
+    """Restore the stored prefix and leave the remainder zeroed."""
+
+    def deserialize(self, src: MemoryObj, dst: MemoryObj) -> None:
+        """Copy all serialized bytes from ``src`` into the start of ``dst``.
+
+        Args:
+            src: Source serialized byte buffer.
+            dst: Destination object containing the original layout.
+
+        Raises:
+            ValueError: If either object does not expose a tensor.
+        """
+        if src.tensor is None or dst.tensor is None:
+            raise ValueError("test deserializer requires tensors")
+        dst.tensor.flatten().zero_()
+        dst.tensor.flatten().view(torch.uint8)[: src.get_size()].copy_(
+            src.tensor.flatten().view(torch.uint8)[: src.get_size()]
+        )
+
+
+def _create_prefix_serde(kwargs: dict[str, object]) -> AsyncSerdeProcessor:
+    """Create the variable-size test serde processor."""
+    return AsyncSerdeProcessor(_PrefixSerializer(), _PrefixDeserializer())
+
+
+class _EmptySerializer(Serializer):
+    """Write an empty payload to exercise exact zero-size L2 loads."""
+
+    def serialize(self, src: MemoryObj, dst: MemoryObj) -> int:
+        """Return zero bytes written.
+
+        Args:
+            src: Source object. Unused by this test serde.
+            dst: Destination byte-buffer object. Unused by this test serde.
+
+        Returns:
+            Zero bytes written.
+        """
+        return 0
+
+    def estimate_serialized_size(self, layout_desc: MemoryLayoutDesc) -> int:
+        """Return a non-zero estimate for an empty actual payload.
+
+        Args:
+            layout_desc: Source layout description. Unused by this test serde.
+
+        Returns:
+            A fixed 64-byte estimate.
+        """
+        return 64
+
+
+def _create_empty_serde(kwargs: dict[str, object]) -> AsyncSerdeProcessor:
+    """Create the empty-payload test serde processor."""
+    return AsyncSerdeProcessor(_EmptySerializer(), _PrefixDeserializer())
+
+
+try:
+    register_serde_factory("test-prefix-variable-size", _create_prefix_serde)
+except ValueError:
+    pass
+
+try:
+    register_serde_factory("test-empty-variable-size", _create_empty_serde)
+except ValueError:
+    pass
+
+
+def test_fs_adapter_get_object_sizes_reports_file_lengths(tmp_path: Path) -> None:
+    cfg = FSL2AdapterConfig(base_path=str(tmp_path))
+    adapter = FSL2Adapter(cfg)
+    try:
+        key = _key(1)
+        task_id = adapter.submit_store_task([key], [_byte_obj(5)])
+        _wait_for_store_result(adapter, task_id)
+        assert adapter.get_object_sizes([key, _key(2)]) == {key: 5}
+    finally:
+        adapter.close()
+
+
+def test_mock_adapter_get_object_sizes_reports_stored_logical_sizes() -> None:
+    adapter = MockL2Adapter(MockL2AdapterConfig(max_size_gb=1, mock_bandwidth_gb=1))
+    try:
+        key = _key(1)
+        obj = _byte_obj(32)
+        obj.set_used_size(7)
+        task_id = adapter.submit_store_task([key], [obj])
+        _wait_for_store_result(adapter, task_id)
+        assert adapter.get_object_sizes([key, _key(2)]) == {key: 7}
+    finally:
+        adapter.close()
+
+
+def _byte_size(layout_desc: MemoryLayoutDesc) -> int:
+    return sum(
+        int(shape.numel()) * dtype.itemsize
+        for shape, dtype in zip(layout_desc.shapes, layout_desc.dtypes, strict=True)
+    )
+
+
+def test_serde_wrapper_store_batches_equal_temp_layout_reservations() -> None:
+    """Store uses one batched temp reservation for identical serialized layouts."""
+
+    class _CountingL1Manager:
+        def __init__(self) -> None:
+            self.reserve_calls: list[
+                tuple[list[ObjectKey], list[bool], MemoryLayoutDesc, str]
+            ] = []
+            self.finished_write_read_keys: list[ObjectKey] = []
+            self.finished_read_keys: list[ObjectKey] = []
+
+        def reserve_write(
+            self,
+            keys: list[ObjectKey],
+            is_temporary: list[bool],
+            layout_desc: MemoryLayoutDesc,
+            mode: str = "all",
+        ) -> dict[ObjectKey, tuple[L1Error, MemoryObj | None]]:
+            self.reserve_calls.append(
+                (list(keys), list(is_temporary), layout_desc, mode)
+            )
+            return {
+                key: (L1Error.SUCCESS, _byte_obj(_byte_size(layout_desc)))
+                for key in keys
+            }
+
+        def finish_write(self, keys: list[ObjectKey]) -> None:
+            pass
+
+        def finish_write_and_reserve_read(self, keys: list[ObjectKey]) -> None:
+            self.finished_write_read_keys.extend(keys)
+
+        def finish_read(self, keys: list[ObjectKey]) -> None:
+            self.finished_read_keys.extend(keys)
+
+        def delete(self, keys: list[ObjectKey]) -> None:
+            pass
+
+    fake_l1 = _CountingL1Manager()
+    inner = MockL2Adapter(MockL2AdapterConfig(max_size_gb=1, mock_bandwidth_gb=1))
+    serde = AsyncSerdeProcessor(_PrefixSerializer(), _PrefixDeserializer())
+    wrapper = SerdeL2AdapterWrapper(inner, serde, cast(L1Manager, fake_l1))
+    try:
+        keys = [_key(20), _key(21), _key(22)]
+        task_id = wrapper.submit_store_task(keys, [_byte_obj(16) for _ in keys])
+        _wait_for_store_result(wrapper, task_id)
+
+        assert len(fake_l1.reserve_calls) == 1
+        reserve_keys, is_temporary, reserve_layout, mode = fake_l1.reserve_calls[0]
+        _assert_temp_keys_match_originals(reserve_keys, keys)
+        assert is_temporary == [True] * len(keys)
+        assert reserve_layout == MemoryLayoutDesc(
+            shapes=[torch.Size([64])],
+            dtypes=[torch.uint8],
+        )
+        assert mode == "new"
+        assert fake_l1.finished_write_read_keys == reserve_keys
+        assert fake_l1.finished_read_keys == reserve_keys
+    finally:
+        wrapper.close()
+
+
+def test_serde_wrapper_store_releases_all_temp_reservations_on_failure() -> None:
+    """Batched temp reservation failures release every successful temp key."""
+
+    class _PartialFailureL1Manager:
+        def __init__(self) -> None:
+            self.reserved_keys: list[ObjectKey] = []
+            self.finished_keys: list[ObjectKey] = []
+            self.deleted_keys: list[ObjectKey] = []
+
+        def reserve_write(
+            self,
+            keys: list[ObjectKey],
+            is_temporary: list[bool],
+            layout_desc: MemoryLayoutDesc,
+            mode: str = "all",
+        ) -> dict[ObjectKey, tuple[L1Error, MemoryObj | None]]:
+            self.reserved_keys = list(keys)
+            return {
+                key: (
+                    (L1Error.OUT_OF_MEMORY, None)
+                    if index == 1
+                    else (L1Error.SUCCESS, _byte_obj(1))
+                )
+                for index, key in enumerate(keys)
+            }
+
+        def finish_write(self, keys: list[ObjectKey]) -> None:
+            self.finished_keys.extend(keys)
+
+        def finish_write_and_reserve_read(self, keys: list[ObjectKey]) -> None:
+            pass
+
+        def finish_read(self, keys: list[ObjectKey]) -> None:
+            pass
+
+        def delete(self, keys: list[ObjectKey]) -> None:
+            self.deleted_keys.extend(keys)
+
+    fake_l1 = _PartialFailureL1Manager()
+    inner = MockL2Adapter(MockL2AdapterConfig(max_size_gb=1, mock_bandwidth_gb=1))
+    serde = AsyncSerdeProcessor(_PrefixSerializer(), _PrefixDeserializer())
+    wrapper = SerdeL2AdapterWrapper(inner, serde, cast(L1Manager, fake_l1))
+    try:
+        keys = [_key(30), _key(31), _key(32)]
+        task_id = wrapper.submit_store_task(keys, [_byte_obj(16) for _ in keys])
+        completed = wrapper.pop_completed_store_tasks()
+
+        assert task_id in completed
+        assert not completed[task_id].is_successful()
+        _assert_temp_keys_match_originals(fake_l1.reserved_keys, keys)
+        released_keys = [fake_l1.reserved_keys[0], fake_l1.reserved_keys[2]]
+        assert fake_l1.finished_keys == released_keys
+        assert fake_l1.deleted_keys == released_keys
+    finally:
+        wrapper.close()
+
+
+def test_native_adapter_does_not_report_advisory_object_sizes() -> None:
+    class _NativeClient:
+        def __init__(self) -> None:
+            self._notifier = create_event_notifier()
+            self._next_future_id = 0
+            self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+
+        def event_fd(self) -> int:
+            return self._notifier.fileno()
+
+        def submit_batch_set(
+            self,
+            keys: list[str],
+            memoryviews: list[memoryview],
+        ) -> int:
+            future_id = self._next_future_id
+            self._next_future_id += 1
+            self._completions.append((future_id, True, "", [True] * len(keys)))
+            self._notifier.notify()
+            return future_id
+
+        def drain_completions(
+            self,
+        ) -> list[tuple[int, bool, str, list[bool] | None]]:
+            completions = self._completions
+            self._completions = []
+            self._notifier.consume()
+            return completions
+
+        def close(self) -> None:
+            self._notifier.close()
+
+    adapter = NativeConnectorL2Adapter(_NativeClient())
+    try:
+        key = _key(3)
+        task_id = adapter.submit_store_task([key], [_byte_obj(9)])
+        _wait_for_store_result(adapter, task_id)
+        assert adapter.get_object_sizes([key]) == {}
+    finally:
+        adapter.close()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_fs_serde_load_uses_actual_stored_payload_size() -> None:
+    (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+        L2AdaptersConfig,
+        StorageManager,
+    ) = _import_storage_manager_deps()
+
+    disk_path = tempfile.mkdtemp(prefix="lmcache_variable_size_")
+    sm: Any | None = None
+    try:
+        fs_cfg = FSL2AdapterConfig(base_path=disk_path)
+        fs_cfg.serde_config = SerdeConfig(type="test-prefix-variable-size")
+        sm = StorageManager(
+            StorageManagerConfig(
+                l1_manager_config=L1ManagerConfig(
+                    memory_config=L1MemoryManagerConfig(
+                        size_in_bytes=512 << 20,
+                        use_lazy=True,
+                        init_size_in_bytes=128 << 20,
+                    ),
+                ),
+                eviction_config=EvictionConfig(eviction_policy="LRU"),
+                l2_adapter_config=L2AdaptersConfig(adapters=[fs_cfg]),  # type: ignore[list-item]
+            )
+        )
+        key = _key(10)
+        layout = MemoryLayoutDesc(
+            shapes=[torch.Size([16])],
+            dtypes=[torch.uint8],
+        )
+
+        reserved = sm.reserve_write([key], layout, mode="new")
+        assert key in reserved
+        tensor = reserved[key].tensor
+        assert tensor is not None
+        tensor.copy_(torch.arange(16, dtype=torch.uint8))
+        sm.finish_write([key])
+
+        assert _wait_for_condition(
+            lambda: any(
+                entry.is_file() and not entry.name.endswith(".tmp")
+                for entry in os.scandir(disk_path)
+            )
+        )
+        stored_files = [entry for entry in os.scandir(disk_path) if entry.is_file()]
+        assert len(stored_files) == 1
+        assert stored_files[0].stat().st_size == 8
+
+        sm.clear(force=True)
+        handle = sm.submit_prefetch_task([key], layout)
+        assert _wait_for_prefetch(sm, handle) == 1
+        with sm.read_prefetched_results([key]) as mem_objs:
+            assert mem_objs is not None
+            assert mem_objs[0].tensor is not None
+            got = mem_objs[0].tensor.flatten().view(torch.uint8)
+            assert torch.equal(got[:8].cpu(), torch.arange(8, dtype=torch.uint8))
+            assert torch.equal(got[8:].cpu(), torch.zeros(8, dtype=torch.uint8))
+        sm.finish_read_prefetched([key])
+    finally:
+        if sm is not None:
+            sm.close()
+        shutil.rmtree(disk_path, ignore_errors=True)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_fs_serde_load_uses_exact_zero_stored_payload_size() -> None:
+    (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+        L2AdaptersConfig,
+        StorageManager,
+    ) = _import_storage_manager_deps()
+
+    disk_path = tempfile.mkdtemp(prefix="lmcache_zero_size_")
+    sm: Any | None = None
+    try:
+        fs_cfg = FSL2AdapterConfig(base_path=disk_path)
+        fs_cfg.serde_config = SerdeConfig(type="test-empty-variable-size")
+        sm = StorageManager(
+            StorageManagerConfig(
+                l1_manager_config=L1ManagerConfig(
+                    memory_config=L1MemoryManagerConfig(
+                        size_in_bytes=512 << 20,
+                        use_lazy=True,
+                        init_size_in_bytes=128 << 20,
+                    ),
+                ),
+                eviction_config=EvictionConfig(eviction_policy="LRU"),
+                l2_adapter_config=L2AdaptersConfig(adapters=[fs_cfg]),  # type: ignore[list-item]
+            )
+        )
+        key = _key(11)
+        layout = MemoryLayoutDesc(
+            shapes=[torch.Size([16])],
+            dtypes=[torch.uint8],
+        )
+
+        reserved = sm.reserve_write([key], layout, mode="new")
+        assert key in reserved
+        tensor = reserved[key].tensor
+        assert tensor is not None
+        tensor.copy_(torch.arange(16, dtype=torch.uint8))
+        sm.finish_write([key])
+
+        assert _wait_for_condition(
+            lambda: any(
+                entry.is_file() and not entry.name.endswith(".tmp")
+                for entry in os.scandir(disk_path)
+            )
+        )
+        stored_files = [entry for entry in os.scandir(disk_path) if entry.is_file()]
+        assert len(stored_files) == 1
+        assert stored_files[0].stat().st_size == 0
+
+        sm.clear(force=True)
+        handle = sm.submit_prefetch_task([key], layout)
+        assert _wait_for_prefetch(sm, handle) == 1
+        with sm.read_prefetched_results([key]) as mem_objs:
+            assert mem_objs is not None
+            assert mem_objs[0].tensor is not None
+            got = mem_objs[0].tensor.flatten().view(torch.uint8)
+            assert torch.equal(got.cpu(), torch.zeros(16, dtype=torch.uint8))
+        sm.finish_read_prefetched([key])
+    finally:
+        if sm is not None:
+            sm.close()
+        shutil.rmtree(disk_path, ignore_errors=True)


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #2923.

This PR adds CacheGen as a multiprocess-mode L2 adapter serde for filesystem-backed L2 storage.

CacheGen writes variable-size encoded bytestreams. On load, the MP serde wrapper needs the actual stored payload size instead of the serializer's conservative estimate; otherwise an inner adapter can reject the read because the expected byte count does not match the bytes stored on disk. This PR adds an advisory `L2AdapterInterface.get_object_sizes()` hook and uses it when an adapter can cheaply report exact stored sizes.

It also adapts CacheGen to the actual MP KV layout. MP stores KV tensors as `[2, num_layers, num_tokens, hidden_dim]`, while the legacy CacheGen codec expects `[num_layers, 2, num_tokens, num_heads, head_size]`. The new serde converts between those layouts on store/load and validates `num_heads * head_size == hidden_dim`.

| Area | Change | Why it matters |
| --- | --- | --- |
| CacheGen serde | Register `serde.type="cachegen"` using LMCache's existing CacheGen encoder/decoder | Enables CacheGen compression through the MP L2 serde path |
| MP layout support | Convert MP `[2, L, T, D]` tensors to CacheGen `[L, 2, T, H, HS]`, and convert back on load | Makes the serde work with the actual MP KV buffer layout instead of only legacy CacheGen-shaped tensors |
| Config validation | Require `num_heads` and `head_size` for CacheGen serde config | Prevents silent layout mismatch and lets the serde split/restore the hidden dimension correctly |
| Size estimation | Estimate CacheGen buffer capacity for both CacheGen layout and MP layout; reject inconsistent MP head metadata early | Keeps store allocation conservative while surfacing bad config before encode/decode |
| Variable-size loads | Use exact stored byte sizes from adapters when available, including zero-byte payloads | Allows variable-size CacheGen bytestreams to load without expecting the conservative estimate size |
| L2 adapters | Add exact-size reporting for filesystem and mock adapters | Filesystem can report file size; mock preserves logical stored size for tests |
| Import behavior | Lazily import CacheGen internals from the serde package registration path | Avoids pulling legacy CacheGen/transformer dependencies when users only import or use other serde types |
| Docs/tests | Update MP serde docs and add layout, factory, exact-size, and round-trip tests | Documents required config and covers the main correctness paths |

**Special notes for your reviewers**:

Scope is intentionally limited to MP serde plus filesystem/mock exact-size support. Native connector exact-size reporting is left out because locally tracked sizes are not authoritative for pre-existing remote data or duplicate stores.

Store still uses a conservative CacheGen size estimate to reserve the serialized temp buffer. Load uses exact stored size when the adapter provides it; adapters that cannot report exact sizes fall back to the estimate.

CacheGen serde config now requires `num_heads` and `head_size` in addition to `model_name`, `chunk_size`, and `dtype`.

CacheGen bytestreams should only be decoded from trusted L2 storage.

This branch was also checked against the latest `origin/dev` after the amend; the local merge simulation completed with no conflicts.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Testing:

- `pytest -q tests/v1/distributed/serde/test_cachegen.py tests/v1/distributed/serde/test_factory.py tests/v1/distributed/serde/test_variable_size_payload.py` (`40 passed, 2 skipped`)
- `pre-commit run --files docs/source/mp/cachegen.rst docs/source/mp/serde.rst lmcache/v1/distributed/serde/__init__.py lmcache/v1/distributed/serde/cachegen.py tests/v1/distributed/serde/test_cachegen.py tests/v1/distributed/serde/test_factory.py tests/v1/distributed/serde/test_variable_size_payload.py` (passed)
- `git merge --no-commit --no-ff origin/dev` from the pushed PR head (passed, `UNMERGED_COUNT=0`)

Not run locally:

- `cd docs && make clean html` because this environment does not have `sphinx-build` installed.
