### PR TITLE
core: convert f-string log calls in system_detection.py to %-format

### DIFF
--- a/lmcache/v1/system_detection.py
+++ b/lmcache/v1/system_detection.py
@@ -43,11 +43,11 @@ class SystemMemoryDetector:
             available_gb = memory.available / (1024**3)
 
             system = platform.system()
-            logger.info(f"{system} system available memory: {available_gb:.2f} GB")
+            logger.info("%s system available memory: %.2f GB", system, available_gb)
             return available_gb
 
         except Exception as e:
-            logger.warning(f"Failed to get system available memory using psutil: {e}")
+            logger.warning("Failed to get system available memory using psutil: %s", e)
             return 0.0
 
 
@@ -106,5 +106,5 @@ class NUMADetector:
 
             return NUMAMapping(gpu_to_numa_mapping={device_index: numa_node})
         except Exception as e:
-            logger.warning(f"Failed to auto read NUMA mapping from system: {e}")
+            logger.warning("Failed to auto read NUMA mapping from system: %s", e)
             return None


### PR DESCRIPTION
## Summary

Closes #3794.

Converts the three f-string `logger` calls in `lmcache/v1/system_detection.py` to lazy `%`-format so interpolation only runs when the record is actually emitted — matching the convention already used elsewhere (e.g. `lmcache/v1/cache_engine.py`).

- `logger.info(f"{system} system available memory: {available_gb:.2f} GB")` → `logger.info("%s system available memory: %.2f GB", system, available_gb)`
- `logger.warning(f"Failed to get system available memory using psutil: {e}")` → `%s` for the exception
- `logger.warning(f"Failed to auto read NUMA mapping from system: {e}")` → `%s` for the exception

Type-aware specifiers per the convention in #3785: `%.2f` for the float memory value, `%s` for `system` (str) and exceptions.

## Testing

- `ruff format` / `ruff check` pass.
- `python -m py_compile` passes.
- No remaining f-string `logger` calls in the file.