### PR TITLE
Fix free_lookup_locks missing cache_salt in the _0201 connector copy (follow-up to #3771)

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -879,6 +879,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
                         start=0,
                         end=free_end,
                         request_id=request.request_id,
+                        cache_salt=tracker.cache_salt,
                     )
                     logger.debug(
                         "Free locks of tokens %d-%d since it is cached by vLLM.",


### PR DESCRIPTION
## Summary

Follow-up to #3770 / #3771.

#3771 fixed the missing `cache_salt` on the `free_lookup_locks` call in `lmcache_mp_connector.py`, but the **same bug still exists in the `_0201` connector copy** (`lmcache/integration/vllm/lmcache_mp_connector_0201.py`), which #3771 didn't touch. This PR fixes that remaining copy.

Same root cause as #3770: the lookup is submitted with `cache_salt=tracker.cache_salt`, so the server builds its `ObjectKey` with that salt; the matching `free_lookup_locks` call omitted it (defaulting to `""`), constructing a different key, so the server couldn't locate/release the lock — leaving KV chunks read-locked until TTL in multi-tenant (per-request salt) deployments.

```diff
                         start=0,
                         end=free_end,
                         request_id=request.request_id,
+                        cache_salt=tracker.cache_salt,
                     )
```

## Notes

- This PR originally also patched `lmcache_mp_connector.py`; after rebasing onto `dev` (which now contains #3771), that change is dropped automatically and only the still-needed `_0201.py` fix remains.
- `lmcache_mp_connector_0180.py` has no `cache_salt` support on either the lookup or free path, so it has no key mismatch and is intentionally left unchanged.
- Mirrors the upstream vLLM fix (vllm-project/vllm#44097).