### PR TITLE
Read allocator sizes from a single locked snapshot in memcheck/usage reporting

### DIFF
--- a/lmcache/v1/distributed/memory_manager/gds_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/gds_l1_memory_manager.py
@@ -107,9 +107,10 @@ class GDSL1MemoryManager:
 
     def get_memory_usage(self) -> tuple[int, int]:
         """Return ``(used_bytes, total_bytes)`` of the slab."""
-        free_size = self._address_manager.get_free_size()
-        total_size = self._address_manager.get_heap_size()
-        return total_size - free_size, total_size
+        # Single locked snapshot so used/total can't be computed from reads
+        # taken across a concurrent sbrk() growth (see #3768).
+        snapshot = self._address_manager.get_size_snapshot()
+        return snapshot.allocated, snapshot.heap
 
     def get_l1_memory_desc(self) -> Optional[L1MemoryDesc]:
         """Return ``None``: the GDS L1 medium is the slab file, not a buffer.
@@ -133,19 +134,14 @@ class GDSL1MemoryManager:
         coalesced. Returns ``True`` when consistent, ``False`` otherwise.
         """
         clear = True
+        # Single locked snapshot so the consistency check can't compare sizes
+        # taken across a concurrent sbrk() growth (see #3768).
+        snapshot = self._address_manager.get_size_snapshot()
         logger.info("Checking memory allocator consistency")
-        logger.info(
-            " - Total allocated size: %s MB",
-            self._address_manager.total_allocated_size / 1048576,
-        )
+        logger.info(" - Total allocated size: %s MB", snapshot.allocated / 1048576)
+        logger.info(" - Total free size: %s MB", snapshot.free / 1048576)
 
-        total_free_size = self._address_manager.get_free_size()
-        logger.info(" - Total free size: %s MB", total_free_size / 1048576)
-
-        if (
-            total_free_size + self._address_manager.total_allocated_size
-            != self._address_manager.get_heap_size()
-        ):
+        if snapshot.free + snapshot.allocated != snapshot.heap:
             logger.error("Memory allocator size is inconsistent")
             logger.error("This implies a bug in the memory allocator")
             clear = False

--- a/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
@@ -194,10 +194,10 @@ class L1MemoryManager:
             )
 
         address_manager = get_address_manager(self._allocator)
-        free_size = address_manager.get_free_size()
-        total_size = address_manager.get_heap_size()
-        used_size = total_size - free_size
-        return used_size, total_size
+        # Single locked snapshot so used/total can't be computed from reads
+        # taken across a concurrent sbrk() growth (see #3768).
+        snapshot = address_manager.get_size_snapshot()
+        return snapshot.allocated, snapshot.heap
 
     def get_l1_memory_desc(self) -> L1MemoryDesc:
         """

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1242,6 +1242,26 @@ class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
         return shapes, dtypes
 
 
+@dataclass(frozen=True)
+class AddressSizeSnapshot:
+    """A consistent snapshot of an :class:`AddressManager`'s sizes.
+
+    The three values are captured atomically under the allocator lock, so they
+    all describe the same allocator state even when lazy ``sbrk()`` growth
+    happens concurrently. For a consistent allocator ``free + allocated ==
+    heap`` always holds.
+
+    Attributes:
+        free: Total free bytes in the address space.
+        allocated: Total allocated bytes in the address space.
+        heap: Total size of the address space in bytes.
+    """
+
+    free: int
+    allocated: int
+    heap: int
+
+
 class AddressManager:
     """
     Manages a virtual address space starting from 0 for memory allocation.
@@ -1545,6 +1565,28 @@ class AddressManager:
         """
         return self._size - self.total_allocated_size
 
+    @synchronized("_lock")
+    def get_size_snapshot(self) -> AddressSizeSnapshot:
+        """
+        Atomically read free, allocated, and heap sizes under the lock.
+
+        Reading these through separate ``get_free_size()`` / ``get_heap_size()``
+        calls plus a bare ``total_allocated_size`` access can interleave with
+        ``sbrk()`` address-space growth, mixing values from different allocator
+        states and producing false inconsistencies in ``memcheck()`` and
+        memory-usage reporting. Capturing all three under a single lock
+        acquisition guarantees they describe one coherent state.
+
+        Returns:
+            An :class:`AddressSizeSnapshot` with ``free``, ``allocated``, and
+            ``heap`` byte counts, where ``free + allocated == heap``.
+        """
+        allocated = self.total_allocated_size
+        heap = self._size
+        return AddressSizeSnapshot(
+            free=heap - allocated, allocated=allocated, heap=heap
+        )
+
     def check_consistency(self) -> bool:
         """
         Check if the address manager is consistent.
@@ -1805,22 +1847,17 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         Returns True is everything is fine, otherwise False.
         """
         clear = True
+        # Read free, allocated, and heap sizes from a single locked snapshot so
+        # concurrent lazy sbrk() growth can't make the consistency check compare
+        # values from different allocator states (see #3768).
+        snapshot = self.address_manager.get_size_snapshot()
         logger.info("Checking memory allocator consistency")
         logger.info(" - Total active allocations: %d", self.num_active_allocations)
-        logger.info(
-            " - Total allocated size: %f MB",
-            self.address_manager.total_allocated_size / 1048576,
-        )
-
-        # Check the real total free size
-        total_free_size = self.address_manager.get_free_size()
-        logger.info(" - Total free size: %f MB", total_free_size / 1048576)
+        logger.info(" - Total allocated size: %f MB", snapshot.allocated / 1048576)
+        logger.info(" - Total free size: %f MB", snapshot.free / 1048576)
 
         # Check if the numbers are consistent
-        if (
-            total_free_size + self.address_manager.total_allocated_size
-            != self.address_manager.get_heap_size()
-        ):
+        if snapshot.free + snapshot.allocated != snapshot.heap:
             logger.error("Memory allocator size is inconsistent")
             logger.error("This implies a bug in the memory allocator")
             clear = False

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1892,6 +1892,20 @@ class PagedAddressManager:
         """Get the total free size in bytes."""
         return len(self._allocator.free_blocks) * self._allocator.align_bytes
 
+    def get_size_snapshot(self) -> AddressSizeSnapshot:
+        """Return free, allocated, and heap sizes as a single snapshot.
+
+        Mirrors :meth:`AddressManager.get_size_snapshot` so callers (e.g.
+        ``L1MemoryManager.get_memory_usage``) can read a coherent
+        ``(free, allocated, heap)`` triple regardless of which address-manager
+        implementation backs the allocator. The paged address space has a fixed
+        ``heap`` size (no lazy ``sbrk`` growth), so a lock is unnecessary; the
+        free size is derived from the current free-block count in one read.
+        """
+        heap = self.get_heap_size()
+        free = self.get_free_size()
+        return AddressSizeSnapshot(free=free, allocated=heap - free, heap=heap)
+
 
 class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
     """

--- a/tests/v1/test_address_manager.py
+++ b/tests/v1/test_address_manager.py
@@ -5,6 +5,7 @@
 from typing import List, Tuple
 import concurrent.futures
 import threading
+import time
 
 # Third Party
 import pytest
@@ -1236,6 +1237,9 @@ class TestAddressSizeSnapshot:
         def grow():
             while not stop.is_set():
                 manager.sbrk(4096)
+                # Yield briefly so the grower does not starve the observer
+                # threads (and pin a core) in constrained CI environments.
+                time.sleep(0.001)
 
         def observe():
             for _ in range(20000):

--- a/tests/v1/test_address_manager.py
+++ b/tests/v1/test_address_manager.py
@@ -10,7 +10,7 @@ import threading
 import pytest
 
 # First Party
-from lmcache.v1.memory_management import AddressManager
+from lmcache.v1.memory_management import AddressManager, AddressSizeSnapshot
 
 
 class TestAddressManagerBasic:
@@ -1182,6 +1182,83 @@ class TestAddressManagerEdgeCases:
 
         assert manager.get_free_size() == size
         assert manager.total_allocated_size == 0
+
+
+class TestAddressSizeSnapshot:
+    """Test AddressManager.get_size_snapshot atomic size reads (#3768)."""
+
+    def test_snapshot_matches_individual_reads(self):
+        """Snapshot fields match the individual accessors on a quiescent
+        allocator."""
+        size = 4096 * 10
+        manager = AddressManager(size)
+        manager.allocate(4096 * 3)
+
+        snapshot = manager.get_size_snapshot()
+        assert isinstance(snapshot, AddressSizeSnapshot)
+        assert snapshot.heap == manager.get_heap_size()
+        assert snapshot.allocated == manager.total_allocated_size
+        assert snapshot.free == manager.get_free_size()
+
+    def test_snapshot_invariant_holds(self):
+        """free + allocated == heap holds within a single snapshot after
+        allocate / free / sbrk."""
+        size = 4096 * 10
+        manager = AddressManager(size)
+
+        addr, alloc_size = manager.allocate(4096 * 2)
+        snap = manager.get_size_snapshot()
+        assert snap.free + snap.allocated == snap.heap
+
+        manager.sbrk(4096 * 5)
+        snap = manager.get_size_snapshot()
+        assert snap.free + snap.allocated == snap.heap
+        assert snap.heap == size + 4096 * 5
+
+        manager.free(addr, alloc_size)
+        snap = manager.get_size_snapshot()
+        assert snap.free + snap.allocated == snap.heap
+        assert snap.allocated == 0
+
+    def test_snapshot_consistent_during_concurrent_sbrk(self):
+        """The snapshot invariant must never break even while sbrk() grows the
+        address space concurrently.
+
+        With the old split reads (get_free_size() then get_heap_size()) an
+        interleaved sbrk() could mix a stale free size with a newer heap size,
+        making memcheck() report a false inconsistency. The locked snapshot
+        rules that out.
+        """
+        manager = AddressManager(4096 * 4)
+        stop = threading.Event()
+        errors: list[str] = []
+
+        def grow():
+            while not stop.is_set():
+                manager.sbrk(4096)
+
+        def observe():
+            for _ in range(20000):
+                snap = manager.get_size_snapshot()
+                if snap.free + snap.allocated != snap.heap:
+                    errors.append(
+                        f"inconsistent snapshot: {snap.free} + "
+                        f"{snap.allocated} != {snap.heap}"
+                    )
+                    return
+
+        grower = threading.Thread(target=grow)
+        grower.start()
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+                futures = [ex.submit(observe) for _ in range(4)]
+                for f in concurrent.futures.as_completed(futures):
+                    f.result()
+        finally:
+            stop.set()
+            grower.join()
+
+        assert not errors, errors[0]
 
 
 def _no_overlap(allocations: List[Tuple[int, int]]) -> bool:


### PR DESCRIPTION
## Summary

Closes #3768.

`TensorMemoryAllocator.memcheck()` read free size, allocated size, and heap size through **separate** `AddressManager` calls:

```python
total_free_size = self.address_manager.get_free_size()
if (total_free_size + self.address_manager.total_allocated_size
        != self.address_manager.get_heap_size()):
    logger.error("Memory allocator size is inconsistent")
```

With lazy allocation, `sbrk()` can grow the address space **between** those reads, so the check compares a stale free size against a newer heap size and incorrectly logs `Memory allocator size is inconsistent` / returns `False` on a perfectly valid allocator. The same split-read pattern affected L1 memory-usage reporting, which derived `used`/`total` from separate address-manager reads.

## Fix

Add `AddressManager.get_size_snapshot()`, which captures `(free, allocated, heap)` atomically under the allocator's existing `_lock` and returns an `AddressSizeSnapshot`. All three values then describe one coherent state, so `free + allocated == heap` always holds for a consistent allocator regardless of concurrent `sbrk()` growth.

Routed through the snapshot:
- `TensorMemoryAllocator.memcheck`
- `gds_l1_memory_manager`: `memcheck` + `get_memory_usage`
- `l1_memory_manager`: `get_memory_usage`

All four sites operate on an `AddressManager` (verified: `TensorMemoryAllocator.address_manager`, GDS L1's `_address_manager`, and both branches of L1's `get_address_manager` — `pin_allocator.address_manager` and `LazyMemoryAllocator.get_address_manager()` — are `AddressManager` instances).

## Testing

Adds `TestAddressSizeSnapshot` to `tests/v1/test_address_manager.py`:
- snapshot fields match the individual accessors on a quiescent allocator;
- `free + allocated == heap` holds across allocate / free / sbrk;
- the invariant never breaks while a background thread grows the space via `sbrk()` (4 observer threads × 20k snapshots).

`ruff check`, `ruff format --check`, and `py_compile` pass on all changed files. (The allocator module imports `torch`, so the suite runs in CI; I additionally validated the snapshot arithmetic and concurrency guarantee with a standalone replica of the size bookkeeping.)