### PR TITLE
cleanup: move type-only IPCCacheServerKey import under TYPE_CHECKING

### DIFF
--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -8,6 +8,7 @@ Could be implemented by native code in the future
 
 # Standard
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 import enum
 
 # Third Party
@@ -15,7 +16,10 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 
 logger = init_logger(__name__)
 
@@ -271,7 +275,7 @@ class PrefetchHandle:
 
 
 def ipc_key_to_object_keys(
-    ipc_key: IPCCacheServerKey,
+    ipc_key: "IPCCacheServerKey",
     chunk_hashes: list[bytes],
     object_group_ids: list[int],
 ) -> list[list[ObjectKey]]:


### PR DESCRIPTION
## Summary

Addresses #3730 — the example explicitly cited in the issue.

In `lmcache/v1/distributed/api.py`, `IPCCacheServerKey` is imported at module level but used **only** as the `ipc_key` parameter annotation of `ipc_key_to_object_keys` (the other two occurrences are a docstring and a comment). It is never instantiated, called, subclassed, or used with `isinstance` at runtime.

Move it under a `typing.TYPE_CHECKING` guard and quote the annotation, dropping an unnecessary import-time dependency on `lmcache.v1.multiprocess.custom_types`.

## Why quote the annotation

The repo does **not** use `from __future__ import annotations`, so function annotations are evaluated at definition time. With the import moved under `TYPE_CHECKING`, the name is absent at runtime, so the annotation is quoted to keep it lazy. This matches the existing convention — e.g. `cache_engine.py` imports `HealthMonitor` under `TYPE_CHECKING` and writes `health_monitor: "HealthMonitor"`.

## Testing

- `ruff check`, `ruff format --check`, `isort --check-only`, and `py_compile` all pass.
- No runtime behavior change: `IPCCacheServerKey` had no runtime use; `ipc_key_to_object_keys.__annotations__['ipc_key']` is now the string `"IPCCacheServerKey"`.

Per the issue, the same pattern applies in other modules; this PR keeps scope to the cited example and can be followed up file-by-file.