### PR TITLE
docs: codify the log format-specifier convention in coding standards

### DIFF
--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -253,6 +253,12 @@ C++/CUDA files use clang-format (Google style, 80-col). Rust code uses `cargo fm
 - Use the project's `init_logger(__name__)` from `lmcache.logging`, not bare `logging.getLogger()`.
 - Operational logs (store/retrieve activity, background task progress) should be at `DEBUG` level, not `INFO`.
 - Log levels must be appropriate: do not use `WARNING` for conditions that are expected during normal concurrent operation (e.g., a key not found due to a benign race condition).
+- Use lazy `%`-formatting, not f-strings, in log calls so interpolation only runs when the record is emitted: `logger.info("instance %s", instance_id)`, not `logger.info(f"instance {instance_id}")`.
+- Pick the format specifier from the variable's **type annotation**, not from neighboring log calls:
+  - `int` (counts, numeric IDs) → `%d`
+  - everything else (`str`, `bool`, objects, exceptions) → `%s`
+  - floats use `%f` / `%.2f` as appropriate
+  - Watch ambiguous names: `instance_id` is a `str` in most modules (e.g. `cache_engine.py`, `config_base.py`) but an `int` GPU index in some multiprocess modules — check the annotation before choosing `%s` vs `%d`. Bools print as `1`/`0` under `%d`, so use `%s` when you want `True`/`False`.
 
 ### 7.5 Error Handling
 


### PR DESCRIPTION
## Summary

Closes #3785 (Direction A — the lightweight option proposed in the issue).

The issue notes that converting f-string log calls to `%`-format isn't a mechanical find-and-replace because the right specifier depends on the variable's type — and some names (`instance_id`) are `str` in most modules but `int` (GPU index) in a few multiprocess modules. It asks whether "`%d` for `int`, `%s` for everything else" is the right convention and offers to document it.

This PR documents exactly that, in `docs/coding_standards.md` §7.4 (Logging):

- Prefer lazy `%`-formatting over f-strings in log calls.
- Choose the specifier from the variable's **type annotation**, not neighboring calls: `%d` for `int`, `%s` for everything else (`str`/`bool`/objects/exceptions), `%f`/`%.2f` for floats.
- Calls out the `instance_id` str-vs-int ambiguity and the bool `%d`→`1`/`0` vs `%s`→`True`/`False` gotcha.

This gives the f-string→%-format conversions (e.g. #3794, my #3797) a single convention to follow.

## Testing

Docs-only change. `codespell --toml pyproject.toml docs/coding_standards.md` passes.

If maintainers prefer Direction B (unifying `instance_id`'s type) instead, happy to close this — but the convention is useful either way.