### PR TITLE
[good-first-issue] fix(mp): add background cleanup thread to SessionManager for expired session reclamation (#3562)

### DIFF
--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -163,8 +163,10 @@ class MPCacheServerContext:
 
     def close(self) -> None:
         """
-        Tear down the storage manager and the process-global GDS context.
+        Tear down the storage manager, session manager, and the
+        process-global GDS context.
         """
+        self._session_manager.stop_cleanup()
         self._storage_manager.close()
         # Tear down the GDS cuFile context (the shared slab + its handle).
         get_gds_context().close()

--- a/lmcache/v1/multiprocess/session.py
+++ b/lmcache/v1/multiprocess/session.py
@@ -14,8 +14,51 @@ import time
 from lmcache.logging import init_logger
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.token_hasher import TokenHasher
+from lmcache.v1.periodic_thread import (
+    PeriodicThread,
+    PeriodicThreadRegistry,
+    ThreadLevel,
+    ThreadRunSummary,
+)
 
 logger = init_logger(__name__)
+
+
+class SessionCleanupThread(PeriodicThread):
+    """Periodic background thread that removes expired sessions.
+
+    Runs in the background at a configurable interval and delegates
+    to SessionManager.cleanup_expired().
+    """
+
+    DEFAULT_INTERVAL = 60.0  # seconds between cleanup cycles
+    DEFAULT_INIT_WAIT = 30.0  # delay before first cleanup cycle
+
+    def __init__(
+        self,
+        session_manager: "SessionManager",
+        interval: float = DEFAULT_INTERVAL,
+    ):
+        super().__init__(
+            name="session-cleanup-thread",
+            interval=interval,
+            level=ThreadLevel.LOW,
+            init_wait=DEFAULT_INIT_WAIT,
+        )
+        self._session_manager = session_manager
+
+        # Register with the global periodic-thread registry
+        PeriodicThreadRegistry.get_instance().register(self)
+
+    def _execute(self) -> ThreadRunSummary:
+        """Run one cleanup cycle."""
+        removed = self._session_manager.cleanup_expired()
+        return ThreadRunSummary(
+            timestamp=time.time(),
+            success=True,
+            message=f"Cleaned up {removed} expired session(s)",
+            extra_info={"removed": str(removed)},
+        )
 
 
 @dataclass
@@ -121,12 +164,20 @@ class SessionManager:
     """Thread-safe manager for per-request sessions."""
 
     DEFAULT_SESSION_TTL = 600  # 10 minutes
+    DEFAULT_CLEANUP_INTERVAL = 60.0  # seconds between cleanup cycles
 
-    def __init__(self, hasher: TokenHasher, ttl: float = DEFAULT_SESSION_TTL):
+    def __init__(
+        self,
+        hasher: TokenHasher,
+        ttl: float = DEFAULT_SESSION_TTL,
+        cleanup_interval: float = DEFAULT_CLEANUP_INTERVAL,
+    ):
         self._hasher = hasher
         self._ttl = ttl
         self._sessions: dict[str, Session] = {}
         self._lock = threading.Lock()
+        self._cleanup_thread = SessionCleanupThread(self, interval=cleanup_interval)
+        self._cleanup_thread.start()
 
     def get_or_create(self, request_id: str) -> Session:
         """Get existing session or create a new one.
@@ -189,3 +240,13 @@ class SessionManager:
         """
         with self._lock:
             return len(self._sessions)
+
+    def stop_cleanup(self, timeout: float = 5.0) -> None:
+        """Stop the background cleanup thread.
+
+        Safe to call multiple times; subsequent calls are no-ops.
+
+        Args:
+            timeout: Maximum time to wait for thread termination in seconds.
+        """
+        self._cleanup_thread.stop(timeout=timeout)

--- a/tests/v1/multiprocess/test_session.py
+++ b/tests/v1/multiprocess/test_session.py
@@ -29,7 +29,9 @@ def session(hasher: TokenHasher) -> Session:
 @pytest.fixture
 def session_manager(hasher: TokenHasher) -> SessionManager:
     """A SessionManager with short TTL for testing expiry."""
-    return SessionManager(hasher, ttl=0.1)
+    mgr = SessionManager(hasher, ttl=0.1)
+    yield mgr
+    mgr.stop_cleanup()
 
 
 class TestSession:
@@ -302,33 +304,42 @@ class TestSessionManagerRemoveReturnsSession:
     def test_remove_returns_session_with_state(self, hasher: TokenHasher) -> None:
         """remove() should return the session with all accumulated state."""
         mgr = SessionManager(hasher, ttl=600)
-        session = mgr.get_or_create("req-1")
-        session.set_tokens(list(range(8)))
-        session.get_hashes(0, 8)
+        try:
+            session = mgr.get_or_create("req-1")
+            session.set_tokens(list(range(8)))
+            session.get_hashes(0, 8)
 
-        key = IPCCacheServerKey.from_token_ids(
-            model_name="model",
-            world_size=1,
-            worker_id=None,
-            token_ids=list(range(8)),
-            request_id="req-1",
-        )
-        session.lookup_ipc_key = key
+            key = IPCCacheServerKey.from_token_ids(
+                model_name="model",
+                world_size=1,
+                worker_id=None,
+                token_ids=list(range(8)),
+                request_id="req-1",
+            )
+            session.lookup_ipc_key = key
 
-        removed = mgr.remove("req-1")
-        assert removed is not None
-        assert removed.request_id == "req-1"
-        assert len(removed.get_hashes(0)) == 2
-        assert removed.lookup_ipc_key is key
+            removed = mgr.remove("req-1")
+            assert removed is not None
+            assert removed.request_id == "req-1"
+            assert len(removed.get_hashes(0)) == 2
+            assert removed.lookup_ipc_key is key
+        finally:
+            mgr.stop_cleanup()
 
     def test_remove_clears_from_manager(self, hasher: TokenHasher) -> None:
         """After remove(), the session should no longer be in the manager."""
         mgr = SessionManager(hasher, ttl=600)
-        mgr.get_or_create("req-1")
-        mgr.remove("req-1")
-        assert mgr.active_count() == 0
+        try:
+            mgr.get_or_create("req-1")
+            mgr.remove("req-1")
+            assert mgr.active_count() == 0
+        finally:
+            mgr.stop_cleanup()
 
     def test_remove_nonexistent_returns_none(self, hasher: TokenHasher) -> None:
         """remove() on a non-existent request_id should return None."""
         mgr = SessionManager(hasher, ttl=600)
-        assert mgr.remove("no-such-id") is None
+        try:
+            assert mgr.remove("no-such-id") is None
+        finally:
+            mgr.stop_cleanup()

--- a/tests/v1/multiprocess/test_unified_touch.py
+++ b/tests/v1/multiprocess/test_unified_touch.py
@@ -60,6 +60,14 @@ def hasher() -> TokenHasher:
     return TokenHasher(chunk_size=4, hash_algorithm="blake3")
 
 
+@pytest.fixture
+def session_mgr(hasher: TokenHasher) -> SessionManager:
+    """SessionManager with long TTL for testing, auto-cleaned up."""
+    mgr = SessionManager(hasher, ttl=600)
+    yield mgr
+    mgr.stop_cleanup()
+
+
 # =============================================================================
 # L1EvictionPolicy Bridge Tests
 # =============================================================================
@@ -192,9 +200,9 @@ class TestEndSessionTouchKeys:
     3. Handles edge cases (no session, no lookup key, empty hashes)
     """
 
-    def test_end_session_generates_correct_keys(self, hasher: TokenHasher):
+    def test_end_session_generates_correct_keys(self, hasher: TokenHasher, session_mgr: SessionManager):
         """end_session should generate ObjectKeys from session hashes and lookup key."""
-        mgr = SessionManager(hasher, ttl=600)
+        mgr = session_mgr
         session = mgr.get_or_create("req-1")
 
         tokens = list(range(12))  # 3 chunks of 4
@@ -215,9 +223,9 @@ class TestEndSessionTouchKeys:
         # With world_size=1 and worker_id=None, should have 3 keys
         assert len(obj_keys) == 3
 
-    def test_end_session_expands_keys_for_world_size(self, hasher: TokenHasher):
+    def test_end_session_expands_keys_for_world_size(self, hasher: TokenHasher, session_mgr: SessionManager):
         """end_session should expand keys for all workers when world_size > 1."""
-        mgr = SessionManager(hasher, ttl=600)
+        mgr = session_mgr
         session = mgr.get_or_create("req-1")
 
         tokens = list(range(8))  # 2 chunks of 4
@@ -243,16 +251,16 @@ class TestEndSessionTouchKeys:
         # 2 chunks * 2 workers = 4 keys
         assert len(obj_keys) == 4
 
-    def test_end_session_no_session_skips_touch(self, hasher: TokenHasher):
+    def test_end_session_no_session_skips_touch(self, hasher: TokenHasher, session_mgr: SessionManager):
         """end_session should skip touch when session doesn't exist."""
-        mgr = SessionManager(hasher, ttl=600)
+        mgr = session_mgr
         removed = mgr.remove("nonexistent")
         assert removed is None
         # No error should occur
 
-    def test_end_session_no_lookup_key_skips_touch(self, hasher: TokenHasher):
+    def test_end_session_no_lookup_key_skips_touch(self, hasher: TokenHasher, session_mgr: SessionManager):
         """end_session should skip touch when session has no lookup_ipc_key."""
-        mgr = SessionManager(hasher, ttl=600)
+        mgr = session_mgr
         session = mgr.get_or_create("req-1")
         session.set_tokens(list(range(8)))
         session.get_hashes(0, 8)
@@ -263,9 +271,9 @@ class TestEndSessionTouchKeys:
         assert removed.lookup_ipc_key is None
         # No error should occur
 
-    def test_end_session_empty_hashes_produces_no_keys(self, hasher: TokenHasher):
+    def test_end_session_empty_hashes_produces_no_keys(self, hasher: TokenHasher, session_mgr: SessionManager):
         """end_session should produce no keys when session has no computed hashes."""
-        mgr = SessionManager(hasher, ttl=600)
+        mgr = session_mgr
         session = mgr.get_or_create("req-1")
 
         ipc_key = make_ipc_key(
@@ -282,7 +290,7 @@ class TestEndSessionTouchKeys:
         obj_keys = ipc_key_to_object_keys(removed.lookup_ipc_key, chunk_hashes, [0])[0]
         assert len(obj_keys) == 0
 
-    def test_end_session_hashes_cover_retrieve_and_store(self, hasher: TokenHasher):
+    def test_end_session_hashes_cover_retrieve_and_store(self, hasher: TokenHasher, session_mgr: SessionManager):
         """Session hashes should cover both retrieve and store ranges.
 
         Simulates the typical flow:
@@ -291,7 +299,7 @@ class TestEndSessionTouchKeys:
         3. store calls session.get_hashes(hit_end, total)
         4. end_session uses session.get_hashes(0) to get all
         """
-        mgr = SessionManager(hasher, ttl=600)
+        mgr = session_mgr
         session = mgr.get_or_create("req-1")
 
         tokens = list(range(20))  # 5 chunks of 4


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #3562
Refs #3372

`SessionManager.cleanup_expired()` was defined but never called in production code — sessions that were never explicitly removed via `remove()` would accumulate in `_sessions` indefinitely, causing a slow memory leak.

This PR adds a `SessionCleanupThread` (subclass of `PeriodicThread`) that periodically calls `cleanup_expired()` at a configurable interval (default 60s, configurable via `cleanup_interval` constructor argument). The thread starts automatically in `SessionManager.__init__`, is registered with the global `PeriodicThreadRegistry`, and can be stopped via `SessionManager.stop_cleanup()`.

**Changes:**
- New `SessionCleanupThread` class in `session.py` — PeriodicThread subclass with LOW level
- `SessionManager.__init__` now starts the cleanup thread automatically
- `SessionManager.stop_cleanup(timeout)` for graceful teardown
- `MPCacheServerContext.close()` calls `stop_cleanup()` during shutdown
- Test fixtures updated to stop threads after each test

**Special notes for your reviewers**:
- The default interval (60s) and init_wait (30s) follow the pattern used by other PeriodicThreads in the codebase
- Thread level is LOW since a missed cleanup cycle is not critical — sessions will still be cleaned up on the next cycle
- Tested that existing SessionManager tests pass with the new thread lifecycle

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests