### PR TITLE
[Bug] fix(disk): wrap async_save_bytes_to_disk write in try/except to prevent MemoryObj leak on I/O failure (#3533)

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -539,7 +539,14 @@ class LocalDiskBackend(StorageBackendInterface):
         self.stats_monitor.update_local_storage_usage(self.usage)
 
         # TODO(Jiayi): need to add ref count in disk memory object
-        self.write_file(buffer, path)
+        try:
+            self.write_file(buffer, path)
+        except Exception:
+            # Ensure ref_count_down runs on failure to prevent MemoryObj
+            # leak and self-deadlock (see issue #3533).
+            memory_obj.ref_count_down()
+            self.disk_worker.remove_put_task(key)
+            raise
 
         # ref count down here because there's a ref_count_up in
         # `submit_put_task` above.


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #3533
Refs #3372

When `async_save_bytes_to_disk` encounters an I/O exception (disk full, NFS timeout, O_DIRECT alignment failure, etc.), `ref_count_down()` was skipped because it lives after the `write_file()` call. This causes a MemoryObj leak with non-zero refcount:

1. `write_file()` raises → execution jumps past `ref_count_down()`
2. MemoryObj leaks with `ref_count > 0`
3. Python GC eventually collects → `__del__` → `parent_allocator.free(self)` → `AddressManager.free()` acquires `self._lock`
4. If another thread holds `AddressManager._lock` in `batched_allocate()` → **self-deadlock**

**Fix**: Wrap `write_file()` in `try/except` so that `ref_count_down()` and `remove_put_task()` are guaranteed to execute on any I/O failure before the exception is re-raised.

**Root cause chain** (from issue):
```
disk full / IO error
  → write_file() raises (local_disk_backend.py:542)
  → ref_count_down() skipped (local_disk_backend.py:555)
  → MemoryObj leaks: ref_count > 0
  → GC collects → __del__ → parent_allocator.free(self)
  → AddressManager.free() acquires self._lock
  → if batched_allocate() already holds _lock → self-deadlock
```

**Special notes for your reviewers**:
- Minimal change: only the exception path is affected; the normal (happy) path is identical to before
- `ref_count_down()` and `remove_put_task()` are called in the except block to prevent both the memory leak and the put-task tracking leak

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests