### PR TITLE
[Bug] fix(cpu): return None instead of busy-looping forever when use_hot=False and staging buffer is full (#2942)

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -774,6 +774,17 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         assert isinstance(self.memory_allocator, MixedMemoryAllocator)
 
+        if not self.use_hot:
+            # No hot cache means no eviction mechanism is available.
+            # When local_cpu=False, the CPU pool serves only as a staging
+            # buffer for disk I/O — we cannot evict from it.  Returning
+            # None avoids an infinite busy-wait loop (issue #2942).
+            logger.warning(
+                "Local cpu memory is under pressure and use_hot=False. "
+                "No eviction mechanism available — returning None."
+            )
+            return None
+
         evict_keys_count = 0
         num_attempts = 0
         while True:

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -653,6 +653,17 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_obj is not None or not eviction:
             return memory_obj
 
+        if not self.use_hot:
+            # No hot cache means no eviction mechanism is available.
+            # When local_cpu=False, the CPU pool serves only as a staging
+            # buffer for disk I/O — we cannot evict from it.  Returning
+            # None avoids an infinite busy-wait loop (issue #2942).
+            logger.warning(
+                "Local cpu memory is under pressure and use_hot=False. "
+                "No eviction mechanism available — returning None."
+            )
+            return None
+
         evict_keys_count = 0
         num_attempts = 0
         while True:


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #2942
Refs #3372

When `local_cpu=False` (i.e., `use_hot=False`), the CPU memory pool serves only as a staging buffer for disk I/O. The eviction path in `allocate()` is entirely gated by `if self.use_hot:`, so when `use_hot=False`, no eviction is ever attempted — the `while True` loop just calls `time.sleep(0.1)` and retries `memory_allocator.allocate()` forever, causing the engine to hang.

**Root cause**:
```python
while True:
    wait_other_requests = True
    if self.use_hot:              # ← skipped when use_hot=False
        evict_keys = self.cache_policy.get_evict_candidates(...)
        if evict_keys:
            wait_other_requests = False
            ...
    if wait_other_requests:        # ← always True when use_hot=False
        # sleeps 0.1s and retries → infinite loop
```

**Fix**: Return `None` immediately when `use_hot=False` and the initial allocation fails, since no eviction mechanism is available. The caller (`LocalDiskBackend.load_bytes_from_disk`) has an `assert memory_obj is not None` that will produce a clean error instead of an indefinite hang.

**Special notes for your reviewers**:
- The `if self.use_hot:` check inside the while loop is now redundant (since we return early without entering the loop), but it remains for defensive coding and a minimal diff
- This only affects the `use_hot=False` code path; the hot-cache eviction path is unchanged

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests