### PR TITLE
[good-first-issue] core: convert remaining f-string log calls to %-format across 11 files

### DIFF
--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -2013,7 +2013,7 @@ class LMCacheStatsLogger:
                 else:
                     logger.info("Stats logger thread terminated successfully")
             except Exception as e:
-                logger.error(f"Error waiting for stats logger thread: {e}")
+                logger.error("Error waiting for stats logger thread: %s", e)
         else:
             logger.info("Stats logger thread already stopped")
 

--- a/lmcache/usage_context.py
+++ b/lmcache/usage_context.py
@@ -354,7 +354,7 @@ class ContinuousUsageContext:
             self.interval_num_hit_tokens = 0
             self.interval_num_stored_tokens = 0
         except Exception as e:
-            logger.debug(f"Unable to send lmcache caching usage message: {e}")
+            logger.debug("Unable to send lmcache caching usage message: %s", e)
         try:
             histogram_data = self.list_to_histogram(
                 self.cache_lifespan_data, self.cache_lifespan_buckets
@@ -367,7 +367,7 @@ class ContinuousUsageContext:
                 logger.debug("caching lifespan message sent.")
             self.cache_lifespan_data = []
         except Exception as e:
-            logger.debug(f"Unable to send lmcache caching lifespan message: {e}")
+            logger.debug("Unable to send lmcache caching lifespan message: %s", e)
 
     def list_to_histogram(self, data: List[float], buckets: List[float]) -> dict:
         histogram, _ = np.histogram(data, bins=buckets)

--- a/lmcache/utils.py
+++ b/lmcache/utils.py
@@ -764,7 +764,7 @@ def start_loop_in_thread_with_exceptions(loop: asyncio.AbstractEventLoop):
     def loop_excepthook(loop, context):
         msg = context.get("message", "Unhandled exception in event loop")
         exc = context.get("exception")
-        logger.error(f"[asyncio] {msg}")
+        logger.error("[asyncio] %s", msg)
         if exc:
             traceback.print_exception(type(exc), exc, exc.__traceback__)
 

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -800,7 +800,7 @@ def _log_config(self):
             value = f"{value} GB"
         config_dict[name] = value
 
-    logger.info(f"LMCache Configuration: {config_dict}")
+    logger.info("LMCache Configuration: %s", config_dict)
     return self
 
 

--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -176,7 +176,7 @@ def _from_json(cls, json_str: str):
         config_dict = json.loads(json_str)
         return cls.from_dict(config_dict)
     except json.JSONDecodeError as e:
-        logger.error(f"Invalid JSON input: {e}")
+        logger.error("Invalid JSON input: %s", e)
         raise
 
 
@@ -195,7 +195,7 @@ def _resolve_config_aliases(
     for key, value in config_dict.items():
         if key in deprecated_configs:
             # Log deprecation warning
-            logger.warning(f"{deprecated_configs[key]} (source: {source})")
+            logger.warning("%s (source: %s)", deprecated_configs[key], source)
 
             # Map to new key if alias exists
             if key in config_aliases:
@@ -209,7 +209,7 @@ def _resolve_config_aliases(
             resolved[key] = value
         else:
             # Unknown configuration key
-            logger.warning(f"Unknown configuration key: {key} (source: {source})")
+            logger.warning("Unknown configuration key: %s (source: %s)", key, source)
 
     return resolved
 
@@ -521,7 +521,7 @@ def create_singleton_config(
                         _config_instance = config_class.from_env()
                     else:
                         config_file = os.environ[config_env_var]
-                        logger.info(f"Loading config file {config_file}")
+                        logger.info("Loading config file %s", config_file)
                         _config_instance = config_class.from_file(config_file)
                         # Update config from environment variables
                         _config_instance.update_config_from_env()

--- a/lmcache/v1/lookup_client/lmcache_lookup_client.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client.py
@@ -258,11 +258,11 @@ class LMCacheLookupServer:
                     response = lookup_result.to_bytes(4, "big")
                     self.transport.send_response(identity, response)
                 except json.JSONDecodeError as e:
-                    logger.error(f"Error decoding JSON in lookup request: {e}")
+                    logger.error("Error decoding JSON in lookup request: %s", e)
                 except UnicodeDecodeError as e:
-                    logger.error(f"Error decoding UTF-8 in lookup request: {e}")
+                    logger.error("Error decoding UTF-8 in lookup request: %s", e)
                 except Exception as e:
-                    logger.error(f"Error processing lookup request: {e}")
+                    logger.error("Error processing lookup request: %s", e)
 
         logger.info("lmcache lookup server started")
         self.thread = threading.Thread(

--- a/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
+++ b/lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py
@@ -88,7 +88,7 @@ class LMCacheBypassLookupClient(LookupClientInterface):
             return result
 
         except Exception as e:
-            logger.error(f"Error in bypass lookup: {e}")
+            logger.error("Error in bypass lookup: %s", e)
             return 0
 
     def supports_producer_reuse(self) -> bool:

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1806,15 +1806,15 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
         """
         clear = True
         logger.info("Checking memory allocator consistency")
-        logger.info(f" - Total active allocations: {self.num_active_allocations}")
+        logger.info(" - Total active allocations: %d", self.num_active_allocations)
         logger.info(
-            f" - Total allocated size: "
-            f"{self.address_manager.total_allocated_size / 1048576} MB"
+            " - Total allocated size: %f MB",
+            self.address_manager.total_allocated_size / 1048576,
         )
 
         # Check the real total free size
         total_free_size = self.address_manager.get_free_size()
-        logger.info(f" - Total free size: {total_free_size / 1048576} MB")
+        logger.info(" - Total free size: %f MB", total_free_size / 1048576)
 
         # Check if the numbers are consistent
         if (
@@ -2100,14 +2100,14 @@ class PagedTensorMemoryAllocator(MemoryAllocatorInterface):
         """
 
         logger.info("Checking memory allocator consistency")
-        logger.info(f" - Total active allocations: {self.num_active_allocations}")
+        logger.info(" - Total active allocations: %d", self.num_active_allocations)
         logger.info(
-            f" - Total allocated size: {self.total_allocated_size / 1048576} MB"
+            " - Total allocated size: %f MB", self.total_allocated_size / 1048576
         )
 
         # Check the real total free size
         total_free_size = len(self.free_blocks) * self.align_bytes
-        logger.info(f" - Total free size: {total_free_size / 1048576} MB")
+        logger.info(" - Total free size: %f MB", total_free_size / 1048576)
 
         # Check if the numbers are consistent
         if total_free_size + self.total_allocated_size != self.buffer.numel():

--- a/lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py
+++ b/lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py
@@ -98,7 +98,7 @@ class MPRuntimePluginLauncher:
             worker_count=1,
             worker_id=0,
         )
-        logger.info(f"MPRuntimePluginLauncher initialized with {wrapper}")
+        logger.info("MPRuntimePluginLauncher initialized with %s", wrapper)
 
     def launch_plugins(self) -> None:
         """Launch all configured plugins."""

--- a/lmcache/v1/rpc_utils.py
+++ b/lmcache/v1/rpc_utils.py
@@ -83,7 +83,7 @@ def close_zmq_socket(socket: zmq.asyncio.Socket, linger: int = 0) -> None:
         socket.setsockopt(zmq.LINGER, linger)  # type: ignore[attr-defined]
         socket.close()
     except Exception as e:
-        logger.error(f"Warning: Failed to close socket cleanly: {e}")
+        logger.error("Warning: Failed to close socket cleanly: %s", e)
 
 
 def get_ip():

--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -107,7 +107,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
             NONE_HASH = 0
             logger.info("Using default NONE_HASH=0 (vLLM not available)")
 
-        logger.info(f"Using hash algorithm: {hash_algorithm}")
+        logger.info("Using hash algorithm: %s", hash_algorithm)
         self.metadata = metadata
         # Whether only the first rank should save cache. This flag is also used
         # to control the logical world_size embedded into CacheEngineKey.
@@ -187,7 +187,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
         for name in names_to_try:
             try:
                 hash_func = get_hash_fn_by_name(name)
-                logger.info(f"Loaded '{name}' from {module_name}")
+                logger.info("Loaded '%s' from %s", name, module_name)
                 return hash_func
             except ValueError:
                 continue


### PR DESCRIPTION
**What this PR does / why we need it**:
Refs #3372

Converts f-string logger calls to lazy %-format across 11 files, so interpolation only runs when the log record is actually emitted. This follows the established pattern from #3424, #3784, and #3794.

**Files changed:**
- `lmcache/v1/config_base.py` — 4 calls
- `lmcache/v1/config.py` — 1 call
- `lmcache/v1/token_database.py` — 2 calls
- `lmcache/v1/rpc_utils.py` — 1 call
- `lmcache/v1/lookup_client/lmcache_lookup_client.py` — 3 calls
- `lmcache/v1/lookup_client/lmcache_lookup_client_bypass.py` — 1 call
- `lmcache/v1/memory_management.py` — 6 calls
- `lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py` — 1 call
- `lmcache/utils.py` — 1 call
- `lmcache/usage_context.py` — 2 calls
- `lmcache/observability.py` — 1 call

**Special notes for your reviewers**:
- No behavioral changes — only log-call formatting is updated
- Format specifiers chosen based on type annotations: %d for int, %s for str/objects, %f for floats
- These are the remaining f-string log calls not covered by PRs #3784, #3797, #3795

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
