### PR TITLE
feat: add PerfStepTimer debug instrumentation to KV cache store/retrieve pipeline

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -16,7 +16,7 @@ import zmq
 # First Party
 from lmcache.integration.request_telemetry.factory import RequestTelemetryFactory
 from lmcache.integration.vllm.utils import vllm_layout_hints
-from lmcache.store_timer import StoreTimer
+from lmcache.perf_step_timer import PerfStepTimer
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
@@ -1070,7 +1070,7 @@ class LMCacheMPWorkerAdapter:
             },
         )
 
-        self._store_timer = StoreTimer(prefix="adapter")
+        self._store_timer = PerfStepTimer(prefix="adapter")
 
     @property
     def is_healthy(self) -> bool:

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -16,6 +16,7 @@ import zmq
 # First Party
 from lmcache.integration.request_telemetry.factory import RequestTelemetryFactory
 from lmcache.integration.vllm.utils import vllm_layout_hints
+from lmcache.store_timer import StoreTimer
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
@@ -1069,6 +1070,8 @@ class LMCacheMPWorkerAdapter:
             },
         )
 
+        self._store_timer = StoreTimer(prefix="adapter")
+
     @property
     def is_healthy(self) -> bool:
         """Whether the LMCache server is healthy.
@@ -1266,6 +1269,7 @@ class LMCacheMPWorkerAdapter:
                 model inference step
             cache_salt: Per-user isolation salt.
         """
+        self._store_timer.mark(f"vllm_store_{request_id}", "vllm_enter")
         self._ensure_heartbeat_started()
 
         if not self.is_healthy:
@@ -1293,6 +1297,8 @@ class LMCacheMPWorkerAdapter:
             event,
             self.blocks_in_chunk,
         )
+        self._store_timer.mark(f"vllm_store_{request_id}", "vllm_return")
+        self._store_timer.emit(f"vllm_store_{request_id}")
         self.store_futures[request_id] = future
         self.store_events[request_id] = event
 
@@ -1318,6 +1324,7 @@ class LMCacheMPWorkerAdapter:
                 model inference step
             cache_salt: Per-user isolation salt.
         """
+        self._store_timer.mark(f"vllm_retrieve_{request_id}", "vllm_enter")
         self._ensure_heartbeat_started()
 
         if not self.is_healthy:
@@ -1348,6 +1355,8 @@ class LMCacheMPWorkerAdapter:
             self.blocks_in_chunk,
             skip_first_n_tokens=op.skip_first_n_tokens,
         )
+        self._store_timer.mark(f"vllm_retrieve_{request_id}", "vllm_return")
+        self._store_timer.emit(f"vllm_retrieve_{request_id}")
         self.retrieve_futures[request_id] = (future, op.flat_block_ids)
         self.retrieve_events[request_id] = event
 

--- a/lmcache/perf_step_timer.py
+++ b/lmcache/perf_step_timer.py
@@ -169,14 +169,14 @@ class PerfStepTimer:
             prev_step, prev_t = entries[i - 1]
             curr_step, curr_t = entries[i]
             delta_ms = (curr_t - prev_t) * 1000
-            parts.append(f"{prev_step} -> {curr_step}={delta_ms:.3f}ms")
+            parts.append("%s -> %s=%.3fms" % (prev_step, curr_step, delta_ms))
 
         total_ms = (entries[-1][1] - entries[0][1]) * 1000
-        parts.append(f"total={total_ms:.3f}ms")
+        parts.append("total=%.3fms" % total_ms)
 
         logger.debug(
             "[PERF-STEP-TIMING] %sname=%s %s",
-            f"prefix={self._prefix} " if self._prefix else "",
+            "prefix=%s " % self._prefix if self._prefix else "",
             name,
             " ".join(parts),
         )

--- a/lmcache/perf_step_timer.py
+++ b/lmcache/perf_step_timer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Lightweight store-path timing utility for multiprocess transfer contexts."""
+"""Step-based timing utility for performance debugging."""
 
 # Standard
 import logging
@@ -12,7 +12,7 @@ from lmcache.utils import init_logger
 logger = init_logger(__name__)
 
 
-class StoreTimer:
+class PerfStepTimer:
     """Thread-safe timing utility supporting multiple named groups.
 
     Only records timestamps when debug logging is enabled — zero overhead in
@@ -21,7 +21,7 @@ class StoreTimer:
     time.perf_counter() call.
 
     A single timer instance can track multiple independent *names* (e.g.
-    different store paths or sub-operations), each with its own ordered
+    different paths or sub-operations), each with its own ordered
     sequence of (step, time) entries.  Safe for concurrent use from multiple
     threads.
 
@@ -31,14 +31,14 @@ class StoreTimer:
 
     Usage::
 
-        timer = StoreTimer(prefix="req-42")
+        timer = PerfStepTimer(prefix="req-42")
 
         # Thread A — GPU IPC path
         timer.mark("gpu_ipc", "copy_start")
         timer.mark("gpu_ipc", "copy_done")
         timer.mark("gpu_ipc", "kv_releasable")
         timer.emit("gpu_ipc")
-        # [STORE-TIMING] prefix=req-42 name=gpu_ipc
+        # [PERF-STEP-TIMING] prefix=req-42 name=gpu_ipc
         #   copy_start -> copy_done=3.089ms copy_done ->
         #   kv_releasable=2.228ms total=5.317ms
 
@@ -93,7 +93,7 @@ class StoreTimer:
             self._groups.setdefault(name, []).append((step, t))
 
     def emit(self, name: str) -> None:
-        """Emit a ``[STORE-TIMING]`` debug log line for a specific name group.
+        """Emit a ``[PERF-STEP-TIMING]`` debug log line for a specific name group.
 
         The output shows the **delta** between each pair of adjacent steps,
         plus the total time from first to last step.
@@ -125,7 +125,7 @@ class StoreTimer:
         parts.append(f"total={total_ms:.3f}ms")
 
         logger.debug(
-            "[STORE-TIMING] %sname=%s %s",
+            "[PERF-STEP-TIMING] %sname=%s %s",
             f"prefix={self._prefix} " if self._prefix else "",
             name,
             " ".join(parts),

--- a/lmcache/perf_step_timer.py
+++ b/lmcache/perf_step_timer.py
@@ -29,6 +29,13 @@ class PerfStepTimer:
     not absolute time from t0, making it easy to identify which step is the
     bottleneck.
 
+    **TTL-based auto-emit:** To prevent ``_groups`` from leaking when a caller
+    calls ``mark()`` without ever calling ``emit()``, each group carries a
+    *last-mark timestamp*.  On every ``mark()`` call, groups whose last mark
+    occurred more than *ttl* seconds ago are automatically emitted and removed
+    — producing the same ``[PERF-STEP-TIMING]`` log output as an explicit
+    ``emit()`` call, so no timing data is silently lost.
+
     Usage::
 
         timer = PerfStepTimer(prefix="req-42")
@@ -51,21 +58,27 @@ class PerfStepTimer:
     Args:
         prefix: Optional prefix prepended to all log lines for easier
             grep / filtering (e.g. request id).
+        ttl: Seconds of inactivity after which a group is automatically
+            emitted and removed.  Defaults to ``5.0``.
     """
 
-    __slots__ = ("_enabled", "_prefix", "_groups", "_lock")
+    __slots__ = ("_enabled", "_prefix", "_groups", "_lock", "_ttl", "_last_mark")
 
-    def __init__(self, prefix: str = "") -> None:
+    def __init__(self, prefix: str = "", ttl: float = 5.0) -> None:
         """Initialize the timer.
 
         Args:
             prefix: Optional prefix for log output (e.g. request id).
+            ttl: Seconds after the last ``mark()`` call before a group is
+                automatically emitted.  Defaults to ``5.0``.
         """
         self._enabled = logger.isEnabledFor(logging.DEBUG)
         if not self._enabled:
             return
         self._prefix = prefix
+        self._ttl = ttl
         self._groups: dict[str, list[tuple[str, float]]] = {}
+        self._last_mark: dict[str, float] = {}
         self._lock = threading.Lock()
 
     @property
@@ -80,6 +93,10 @@ class PerfStepTimer:
         no lock, no dict access.  Thread-safe.  The same (name, step) pair
         can be recorded multiple times (reentrant) — each occurrence is kept.
 
+        As a side effect, any *other* groups whose last ``mark()`` occurred
+        more than ``ttl`` seconds ago are automatically emitted and removed
+        from ``_groups`` to prevent memory leaks.
+
         Args:
             name: Group name identifying the operation or path (e.g.
                 ``"gpu_ipc"``, ``"shm"``, ``"pickle"``).
@@ -89,8 +106,18 @@ class PerfStepTimer:
         if not self._enabled:
             return
         t = time.perf_counter()
+        stale_groups_to_log: list[tuple[str, list[tuple[str, float]]]] = []
         with self._lock:
             self._groups.setdefault(name, []).append((step, t))
+            self._last_mark[name] = t
+            for group_name, last_ts in list(self._last_mark.items()):
+                if group_name != name and (t - last_ts) > self._ttl:
+                    entries = self._groups.pop(group_name, None)
+                    self._last_mark.pop(group_name, None)
+                    if entries is not None and len(entries) >= 2:
+                        stale_groups_to_log.append((group_name, list(entries)))
+        for stale_name, entries in stale_groups_to_log:
+            self._log_entries(stale_name, entries)
 
     def emit(self, name: str) -> None:
         """Emit a ``[PERF-STEP-TIMING]`` debug log line for a specific name group.
@@ -108,12 +135,35 @@ class PerfStepTimer:
             return
         with self._lock:
             entries = self._groups.pop(name, None)
+            self._last_mark.pop(name, None)
             if entries is None or len(entries) < 2:
                 return
             # snapshot under lock
             entries = list(entries)
 
-        # Build delta pairs: step_a -> step_b=<delta>ms
+        self._log_entries(name, entries)
+
+    def emit_all(self) -> None:
+        """Emit timing lines for all recorded name groups.
+
+        Early-returns when debug logging is disabled.
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            names = list(self._groups.keys())
+        for name in names:
+            self.emit(name)
+
+    def _log_entries(self, name: str, entries: list[tuple[str, float]]) -> None:
+        """Format and log timing entries for a group.
+
+        The caller must ensure ``len(entries) >= 2``.
+
+        Args:
+            name: The group name being logged.
+            entries: Ordered list of ``(step, timestamp)`` pairs.
+        """
         parts = []
         for i in range(1, len(entries)):
             prev_step, prev_t = entries[i - 1]
@@ -130,15 +180,3 @@ class PerfStepTimer:
             name,
             " ".join(parts),
         )
-
-    def emit_all(self) -> None:
-        """Emit timing lines for all recorded name groups.
-
-        Early-returns when debug logging is disabled.
-        """
-        if not self._enabled:
-            return
-        with self._lock:
-            names = list(self._groups.keys())
-        for name in names:
-            self.emit(name)

--- a/lmcache/store_timer.py
+++ b/lmcache/store_timer.py
@@ -68,6 +68,11 @@ class StoreTimer:
         self._groups: dict[str, list[tuple[str, float]]] = {}
         self._lock = threading.Lock()
 
+    @property
+    def is_enabled(self) -> bool:
+        """Whether the timer is enabled."""
+        return self._enabled
+
     def mark(self, name: str, step: str) -> None:
         """Record a step under a named group.
 

--- a/lmcache/store_timer.py
+++ b/lmcache/store_timer.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight store-path timing utility for multiprocess transfer contexts."""
+
+# Standard
+import logging
+import threading
+import time
+
+# First Party
+from lmcache.utils import init_logger
+
+logger = init_logger(__name__)
+
+
+class StoreTimer:
+    """Thread-safe timing utility supporting multiple named groups.
+
+    Only records timestamps when debug logging is enabled — zero overhead in
+    production.  All public methods (mark, emit) early-return immediately
+    when not at DEBUG level, avoiding any lock acquisition, dict lookup, or
+    time.perf_counter() call.
+
+    A single timer instance can track multiple independent *names* (e.g.
+    different store paths or sub-operations), each with its own ordered
+    sequence of (step, time) entries.  Safe for concurrent use from multiple
+    threads.
+
+    The log output shows **elapsed time between adjacent steps** (delta),
+    not absolute time from t0, making it easy to identify which step is the
+    bottleneck.
+
+    Usage::
+
+        timer = StoreTimer(prefix="req-42")
+
+        # Thread A — GPU IPC path
+        timer.mark("gpu_ipc", "copy_start")
+        timer.mark("gpu_ipc", "copy_done")
+        timer.mark("gpu_ipc", "kv_releasable")
+        timer.emit("gpu_ipc")
+        # [STORE-TIMING] prefix=req-42 name=gpu_ipc
+        #   copy_start -> copy_done=3.089ms copy_done ->
+        #   kv_releasable=2.228ms total=5.317ms
+
+        # Thread B — SHM path (can run concurrently)
+        timer.mark("shm", "serialize_start")
+        timer.mark("shm", "serialize_done")
+        timer.mark("shm", "write_complete")
+        timer.emit("shm")
+
+    Args:
+        prefix: Optional prefix prepended to all log lines for easier
+            grep / filtering (e.g. request id).
+    """
+
+    __slots__ = ("_enabled", "_prefix", "_groups", "_lock")
+
+    def __init__(self, prefix: str = "") -> None:
+        """Initialize the timer.
+
+        Args:
+            prefix: Optional prefix for log output (e.g. request id).
+        """
+        self._enabled = logger.isEnabledFor(logging.DEBUG)
+        if not self._enabled:
+            return
+        self._prefix = prefix
+        self._groups: dict[str, list[tuple[str, float]]] = {}
+        self._lock = threading.Lock()
+
+    def mark(self, name: str, step: str) -> None:
+        """Record a step under a named group.
+
+        Early-returns when debug logging is disabled — no perf_counter call,
+        no lock, no dict access.  Thread-safe.  The same (name, step) pair
+        can be recorded multiple times (reentrant) — each occurrence is kept.
+
+        Args:
+            name: Group name identifying the operation or path (e.g.
+                ``"gpu_ipc"``, ``"shm"``, ``"pickle"``).
+            step: Step name describing what just completed (e.g.
+                ``"copy_start"``, ``"copy_done"``).
+        """
+        if not self._enabled:
+            return
+        t = time.perf_counter()
+        with self._lock:
+            self._groups.setdefault(name, []).append((step, t))
+
+    def emit(self, name: str) -> None:
+        """Emit a ``[STORE-TIMING]`` debug log line for a specific name group.
+
+        The output shows the **delta** between each pair of adjacent steps,
+        plus the total time from first to last step.
+
+        Early-returns when debug logging is disabled.  If *name* has not been
+        recorded or has fewer than 2 steps, this is a no-op.
+
+        Args:
+            name: The group name to emit timing for.
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            entries = self._groups.pop(name, None)
+            if entries is None or len(entries) < 2:
+                return
+            # snapshot under lock
+            entries = list(entries)
+
+        # Build delta pairs: step_a -> step_b=<delta>ms
+        parts = []
+        for i in range(1, len(entries)):
+            prev_step, prev_t = entries[i - 1]
+            curr_step, curr_t = entries[i]
+            delta_ms = (curr_t - prev_t) * 1000
+            parts.append(f"{prev_step} -> {curr_step}={delta_ms:.3f}ms")
+
+        total_ms = (entries[-1][1] - entries[0][1]) * 1000
+        parts.append(f"total={total_ms:.3f}ms")
+
+        logger.debug(
+            "[STORE-TIMING] %sname=%s %s",
+            f"prefix={self._prefix} " if self._prefix else "",
+            name,
+            " ".join(parts),
+        )
+
+    def emit_all(self) -> None:
+        """Emit timing lines for all recorded name groups.
+
+        Early-returns when debug logging is disabled.
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            names = list(self._groups.keys())
+        for name in names:
+            self.emit(name)

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -896,7 +896,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                         "finish_write",
                         list(all_dict.keys()),
                     )
-                    if self._store_timer._enabled:
+                    if self._store_timer.is_enabled:
                         _timer = self._store_timer
                         _tname = timer_name
 
@@ -1084,7 +1084,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                         "finish_read_prefetched",
                         prefetched_keys,
                     )
-                    if self._store_timer._enabled:
+                    if self._store_timer.is_enabled:
                         _timer = self._store_timer
                         _tname = timer_name
 

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -14,7 +14,7 @@ import torch
 # First Party
 from lmcache import torch_dev, torch_device_type
 from lmcache.logging import init_logger
-from lmcache.store_timer import StoreTimer
+from lmcache.perf_step_timer import PerfStepTimer
 from lmcache.utils import (
     EngineType,
     _lmcache_nvtx_annotate,
@@ -448,7 +448,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         )
         self._device_host_func_dispatcher.start()
 
-        self._store_timer = StoreTimer(prefix="lmcache_driven")
+        self._store_timer = PerfStepTimer(prefix="lmcache_driven")
 
     @property
     def context(self) -> MPCacheServerContext:

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -14,6 +14,7 @@ import torch
 # First Party
 from lmcache import torch_dev, torch_device_type
 from lmcache.logging import init_logger
+from lmcache.store_timer import StoreTimer
 from lmcache.utils import (
     EngineType,
     _lmcache_nvtx_annotate,
@@ -447,6 +448,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         )
         self._device_host_func_dispatcher.start()
 
+        self._store_timer = StoreTimer(prefix="lmcache_driven")
+
     @property
     def context(self) -> MPCacheServerContext:
         """Return the shared engine context. Exposed for testing only."""
@@ -743,6 +746,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             store completed without such a failure.
         """
         st = time.perf_counter()
+        timer_name = f"lmcache_driven_{key.request_id}"
+        self._store_timer.mark(timer_name, "ipc_server_enter")
 
         entry = self.get_and_touch_context_entry(instance_id)
         if entry is None:
@@ -811,6 +816,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 cache_context.device, event_ipc_handle
             )
             vllm_event.wait(stream=cache_context.stream)
+            self._store_timer.mark(timer_name, "kv_sync")
 
             # CPU-synchronous sentinel: a GPU store is about to be enqueued.
             # Must be published via publish() (not publish_on_stream) so the
@@ -880,6 +886,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 return event.ipc_handle(), False
             finally:
                 event.record()
+                self._store_timer.mark(timer_name, "ipc_server_return")
                 # Fail closed: commit the reserved objects only when every chunk
                 # copied successfully; otherwise the whole store is skipped.
                 stored_count = len(all_dict) if store_succeeded else 0
@@ -889,6 +896,17 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                         "finish_write",
                         list(all_dict.keys()),
                     )
+                    if self._store_timer._enabled:
+                        _timer = self._store_timer
+                        _tname = timer_name
+
+                        def _on_store_copy_done(_unused: None) -> None:
+                            _timer.mark(_tname, "ipc_copy_done")
+                            _timer.emit(_tname)
+
+                        cache_context.cupy_stream.launch_host_func(
+                            _on_store_copy_done, None
+                        )
                 else:
                     total_bytes = 0
                 self._ctx.event_bus.publish_on_stream(
@@ -947,6 +965,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             ValueError: If no GPU context is registered for the given instance ID.
         """
         st = time.perf_counter()
+        timer_name = f"lmcache_driven_retrieve_{key.request_id}"
+        self._store_timer.mark(timer_name, "ipc_server_enter")
 
         entry = self.get_and_touch_context_entry(instance_id)
         if entry is None:
@@ -1057,12 +1077,24 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 return event.ipc_handle(), False
             finally:
                 event.record()
+                self._store_timer.mark(timer_name, "ipc_server_return")
                 if prefetched_keys:
                     submit_callback_to_stream(
                         cache_context.cupy_stream,
                         "finish_read_prefetched",
                         prefetched_keys,
                     )
+                    if self._store_timer._enabled:
+                        _timer = self._store_timer
+                        _tname = timer_name
+
+                        def _on_retrieve_copy_done(_unused: None) -> None:
+                            _timer.mark(_tname, "ipc_copy_done")
+                            _timer.emit(_tname)
+
+                        cache_context.cupy_stream.launch_host_func(
+                            _on_retrieve_copy_done, None
+                        )
                 self._ctx.event_bus.publish_on_stream(
                     cache_context.cupy_stream,
                     Event(

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -13,7 +13,7 @@ import torch
 
 # First Party
 from lmcache import torch_dev
-from lmcache.store_timer import StoreTimer
+from lmcache.perf_step_timer import PerfStepTimer
 from lmcache.utils import EngineType, init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints, is_mla
@@ -324,7 +324,7 @@ class EngineDrivenTransferContext(TransferContext):
         self._engine_driven_context: EngineDrivenContext | None = None
         self._layout_hints: LayoutHints | None = None
         self._engine_kv_format: Any = None
-        self._store_timer = StoreTimer(prefix="engine_driven")
+        self._store_timer = PerfStepTimer(prefix="engine_driven")
 
     def register(
         self,

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -13,6 +13,7 @@ import torch
 
 # First Party
 from lmcache import torch_dev
+from lmcache.store_timer import StoreTimer
 from lmcache.utils import EngineType, init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints, is_mla
@@ -323,6 +324,7 @@ class EngineDrivenTransferContext(TransferContext):
         self._engine_driven_context: EngineDrivenContext | None = None
         self._layout_hints: LayoutHints | None = None
         self._engine_kv_format: Any = None
+        self._store_timer = StoreTimer(prefix="engine_driven")
 
     def register(
         self,
@@ -426,7 +428,10 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_store()."
             )
 
+        timer_name = f"engine_driven_store_{_request_id}"
+        self._store_timer.mark(timer_name, "enter")
         torch_dev.synchronize()
+        self._store_timer.mark(timer_name, "kv_sync")
         result = self._engine_driven_context.prepare_store(key, instance_id)
         out_buffers, chunk_indices = result if result is not None else (None, None)
         # All chunks already in cache — nothing to gather or commit.
@@ -446,7 +451,10 @@ class EngineDrivenTransferContext(TransferContext):
         if out_buffers is not None:
             # SHM path uses async device->CPU copies; complete them before commit.
             torch_dev.synchronize()
+        self._store_timer.mark(timer_name, "worker_copy")
         ok = self._engine_driven_context.commit_store(key, instance_id, cpu_chunks)
+        self._store_timer.mark(timer_name, "worker_ctx_return")
+        self._store_timer.emit(timer_name)
 
         future = MessagingFuture()
         future.set_result(ok)
@@ -469,7 +477,10 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_retrieve()."
             )
 
+        timer_name = f"engine_driven_retrieve_{_request_id}"
+        self._store_timer.mark(timer_name, "enter")
         src_buffers = self._engine_driven_context.prepare_retrieve(key, instance_id)
+        self._store_timer.mark(timer_name, "kv_sync")
         ok = src_buffers is not None
         if src_buffers is not None:
             try:
@@ -488,7 +499,10 @@ class EngineDrivenTransferContext(TransferContext):
             # SHM path: ensure all device writes are complete before releasing
             # the SHM slot (server may immediately reuse it after commit_retrieve).
             torch_dev.synchronize()
+        self._store_timer.mark(timer_name, "worker_copy")
         self._engine_driven_context.commit_retrieve(key, instance_id)
+        self._store_timer.mark(timer_name, "worker_ctx_return")
+        self._store_timer.emit(timer_name)
 
         future: MessagingFuture[bool] = MessagingFuture()
         future.set_result(ok)


### PR DESCRIPTION
Introduce a lightweight StoreTimer utility that records per-step latencies across the multiprocess KV transfer paths (adapter, lmcache-driven, engine-driven). All timing logic is gated behind DEBUG log level with zero overhead in production (no lock, no perf_counter call, no dict access when disabled).

Instrumented checkpoints:
- Adapter: vllm_enter → vllm_return
- LMCache-driven: ipc_server_enter → kv_sync → ipc_server_return → ipc_copy_done
- Engine-driven: enter → kv_sync → worker_copy → worker_ctx_return

The ipc_copy_done mark uses a conditional stream host callback (launch_host_func) only when DEBUG is enabled, ensuring no extra callback is registered in production.
