### PR TITLE
[Bench] Support --served-model-name in engine bench (alias vs HF path)

### DIFF
--- a/lmcache/cli/commands/bench/engine_bench/command.py
+++ b/lmcache/cli/commands/bench/engine_bench/command.py
@@ -86,7 +86,16 @@ def add_engine_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--model",
         default=None,
-        help="Model name (auto-detected from engine if omitted).",
+        help="Model name (auto-detected from engine if omitted). Used for "
+        "LMCache /status matching and tokenizer loading; pass the HF model "
+        "path when the engine runs with --served-model-name.",
+    )
+    parser.add_argument(
+        "--served-model-name",
+        default=None,
+        help="Model name used in vLLM OpenAI API requests when it differs "
+        "from --model (the engine's --served-model-name alias). "
+        "Defaults to --model.",
     )
     parser.add_argument(
         "--workload",
@@ -415,6 +424,7 @@ def _export_config(
     state = InteractiveState()
     state.set("engine_url", config.engine_url)
     state.set("model", config.model)
+    state.set("served_model_name", config.api_model)
     state.set("workload", config.workload)
     state.set("kv_cache_volume", config.kv_cache_volume_gb)
     state.set("tokens_per_gb_kvcache", config.tokens_per_gb_kvcache)
@@ -560,9 +570,11 @@ def run_engine_bench(command: "BaseCommand", args: argparse.Namespace) -> None:
     )
 
     # 3. Create request sender (callbacks wired after workload creation)
+    # Use api_model (the --served-model-name alias) for OpenAI API requests;
+    # config.model stays the HF path for LMCache /status + tokenizer. See #3809.
     request_sender = RequestSender(
         config.engine_url,
-        config.model,
+        config.api_model,
         ignore_eos=config.ignore_eos,
     )
 

--- a/lmcache/cli/commands/bench/engine_bench/config.py
+++ b/lmcache/cli/commands/bench/engine_bench/config.py
@@ -40,8 +40,15 @@ class EngineBenchConfig:
     export_json: bool
     quiet: bool
     ignore_eos: bool = False
+    # Name used to address the model in vLLM OpenAI API requests (the
+    # ``--served-model-name`` alias). ``model`` stays the HF path used for
+    # LMCache ``/status`` matching and tokenizer loading. Defaults to ``model``
+    # when the two are the same. See https://github.com/LMCache/LMCache/issues/3809.
+    api_model: str = ""
 
     def __post_init__(self) -> None:
+        if not self.api_model:
+            self.api_model = self.model
         if not self.engine_url:
             raise ValueError("engine_url must be non-empty")
         if self.kv_cache_volume_gb <= 0:
@@ -225,6 +232,12 @@ def parse_args_to_config(args: argparse.Namespace) -> EngineBenchConfig:
         A fully-resolved EngineBenchConfig.
     """
     model = args.model if args.model else auto_detect_model(args.engine_url)
+    # vLLM addresses the model by its --served-model-name alias in API
+    # requests, while LMCache /status matching and tokenizer loading use the HF
+    # model path (``model``). When they differ, --served-model-name selects the
+    # API name; it defaults to ``model`` for the common case where they match.
+    # See https://github.com/LMCache/LMCache/issues/3809.
+    api_model = getattr(args, "served_model_name", None) or model
 
     tokens_per_gb = args.tokens_per_gb_kvcache
     if tokens_per_gb is None:
@@ -239,6 +252,7 @@ def parse_args_to_config(args: argparse.Namespace) -> EngineBenchConfig:
     return EngineBenchConfig(
         engine_url=args.engine_url,
         model=model,
+        api_model=api_model,
         workload=args.workload,
         kv_cache_volume_gb=args.kv_cache_volume,
         tokens_per_gb_kvcache=tokens_per_gb,

--- a/lmcache/cli/commands/bench/engine_bench/interactive/schema.py
+++ b/lmcache/cli/commands/bench/engine_bench/interactive/schema.py
@@ -172,6 +172,18 @@ ALL_ITEMS: list[ConfigItem] = [
         phase=PHASE_GENERAL,
     ),
     ConfigItem(
+        key="served_model_name",
+        display_name="Served model name (API alias)",
+        description=(
+            "Model name used in OpenAI API requests when it differs from the "
+            "model above (the engine's --served-model-name alias). Leave empty "
+            "to reuse the model name."
+        ),
+        input_type="text",
+        default="",
+        phase=PHASE_GENERAL,
+    ),
+    ConfigItem(
         key="kv_cache_volume",
         display_name="KV cache volume (GB)",
         description="Target active KV cache size for the benchmark.",

--- a/tests/cli/commands/bench/engine_bench/test_config.py
+++ b/tests/cli/commands/bench/engine_bench/test_config.py
@@ -74,6 +74,15 @@ class TestEngineBenchConfig:
         assert self._make_config().ignore_eos is False
         assert self._make_config(ignore_eos=True).ignore_eos is True
 
+    def test_api_model_defaults_to_model(self) -> None:
+        # When no alias is given, API requests reuse the model name (#3809).
+        assert self._make_config(model="hf/path").api_model == "hf/path"
+
+    def test_api_model_independent_of_model(self) -> None:
+        cfg = self._make_config(model="hf/path", api_model="alias")
+        assert cfg.model == "hf/path"
+        assert cfg.api_model == "alias"
+
     def test_empty_engine_url(self) -> None:
         with pytest.raises(ValueError, match="engine_url must be non-empty"):
             self._make_config(engine_url="")
@@ -152,6 +161,21 @@ class TestParseArgsToConfig:
         cfg = parse_args_to_config(base_namespace)
         assert cfg.model == "auto-detected-model"
         mock_auto_detect.assert_called_once_with("http://localhost:8000")
+
+    def test_api_model_defaults_to_model_when_no_alias(self, base_namespace) -> None:
+        # Backward compatible: api_model mirrors model when not overridden (#3809).
+        cfg = parse_args_to_config(base_namespace)
+        assert cfg.model == "test-model"
+        assert cfg.api_model == "test-model"
+
+    def test_served_model_name_sets_api_model(self, base_namespace) -> None:
+        # --served-model-name selects the API name; --model stays the HF path
+        # used for LMCache /status matching + tokenizer loading (#3809).
+        base_namespace.model = "/llm/Kimi-K2.5"
+        base_namespace.served_model_name = "kimi-k2.5"
+        cfg = parse_args_to_config(base_namespace)
+        assert cfg.model == "/llm/Kimi-K2.5"
+        assert cfg.api_model == "kimi-k2.5"
 
     def test_no_tokens_per_gb_no_lmcache_url_raises(
         self,


### PR DESCRIPTION
## Summary

Fixes #3809.

`lmcache bench engine` used a single `--model` value for three incompatible
purposes:

| Purpose | Needs |
|---|---|
| Match LMCache `/status` entries | HF model path |
| vLLM OpenAI API request `model` field | the `--served-model-name` alias |
| Tokenizer loading | HF model path |

When the engine runs with `--served-model-name`, no single `--model` value
works — either `/status` matching fails (`Model 'kimi-k2.5' not found on LMCache
server`) or the API request 404s (`The model '/llm/...' does not exist`).

## Fix (bench-side, no protocol change)

- Add a `--served-model-name` flag and an `api_model` field on
  `EngineBenchConfig`.
- `--model` stays the **HF path** used for `/status` matching and tokenizer
  loading; `api_model` (the **alias**) is used only for the OpenAI API request
  in `RequestSender`.
- `api_model` defaults to `model`, so behaviour is unchanged when the flag is
  absent (backward compatible).
- The flag flows through the interactive and saved-config (`--config`) paths via
  the central `ALL_ITEMS` schema registry and is persisted on export.

So the reporter's case now works:

```
lmcache bench engine --engine-url ... --lmcache-url ... \
    --model /llm2/Moonshotai/Kimi-K2.5 --served-model-name kimi-k2.5
```

## Tests

`test_config.py`: `api_model` defaults to `model` (dataclass + parse path), and
`--served-model-name` sets `api_model` to the alias while `--model` stays the HF
path. Verified end-to-end against the real config module.

## Note

This is a focused bench-side fix. A more invasive alternative (per the issue) is
to propagate `served_model_name` through the KV-cache registration chain
(`REGISTER_KV_CACHE` / adapters / `report_status`) so `/status` exposes the alias
directly across vLLM/SGLang/TRT-LLM. Happy to pursue that instead if maintainers
prefer the server-side approach.