### PR TITLE
Move L2 adapter type-only imports under TYPE_CHECKING

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py
@@ -27,13 +27,14 @@ import threading
 
 if TYPE_CHECKING:
     # First Party
+    from lmcache.native_storage_ops import Bitmap
+    from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
     from lmcache.v1.distributed.internal_api import L1MemoryDesc
+    from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+    from lmcache.v1.memory_management import MemoryObj
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.native_storage_ops import Bitmap
-from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
-from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     AdapterUsage,
     L2AdapterInterface,
@@ -46,7 +47,6 @@ from lmcache.v1.distributed.l2_adapters.config import (
 from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
-from lmcache.v1.memory_management import MemoryObj
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py
@@ -20,12 +20,14 @@ import threading
 import time
 
 if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
     from lmcache.v1.distributed.internal_api import L1MemoryDesc
+    from lmcache.v1.memory_management import MemoryObj
 
 # First Party
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
-from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import (
     L2AdapterInterface,
@@ -38,7 +40,6 @@ from lmcache.v1.distributed.l2_adapters.config import (
 from lmcache.v1.distributed.l2_adapters.factory import (
     register_l2_adapter_factory,
 )
-from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.platform import create_event_notifier
 from lmcache.v1.storage_backend.connector.hfbucket_connector import (
     HFBucketClient,

--- a/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py
@@ -12,6 +12,8 @@ import threading
 import time
 
 if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
     from lmcache.v1.distributed.internal_api import (
         L1MemoryDesc,
     )
@@ -19,7 +21,6 @@ if TYPE_CHECKING:
 # First Party
 from lmcache.logging import init_logger
 from lmcache.native_storage_ops import Bitmap
-from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
 from lmcache.v1.distributed.internal_api import L2StoreResult
 from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
 from lmcache.v1.distributed.l2_adapters.config import (


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #3730.

This PR continues the type-only import cleanup for LMCache distributed L2 adapters. PR #3800 covers the issue example in `lmcache/v1/distributed/api.py`, so this PR keeps scope to adjacent L2 adapter files only.

Moved imports that are used only for type annotations under `TYPE_CHECKING` in:

- `lmcache/v1/distributed/l2_adapters/base.py`
- `lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py`
- `lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py`
- `lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py`

Runtime imports are kept where they are needed at runtime, such as `Bitmap`, `L2StoreResult`, `MemoryObj`, and `TensorMemoryObj`.

**Special notes for your reviewers**:

This is an import-only cleanup. The affected files already use `from __future__ import annotations`, so no annotation stringification is needed.

Validation run locally:

- `.venv/bin/ruff check --select TC001,TC002,TC003,TC005 lmcache/v1/distributed/l2_adapters/base.py lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py`
- `.venv/bin/ruff check lmcache/v1/distributed/l2_adapters/base.py lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py lmcache/v1/distributed/l2_adapters/mock_l2_adapter.py`
- `.venv/bin/pytest -q tests/v1/distributed/test_mock_l2_adapter.py`
- `.venv/bin/pytest -q tests/v1/distributed/test_hfbucket_l2_adapter.py`

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests