### PR TITLE
docs: daily drift check — multi-process mode (2026-06-22)

### DIFF
--- a/docs/source/developer_guide/cli.rst
+++ b/docs/source/developer_guide/cli.rst
@@ -3,28 +3,46 @@ Extending the CLI
 
 This guide explains how to add new subcommands to the ``lmcache`` CLI.
 
+.. note::
+
+   For the full extension guide -- including N-level nested subcommands
+   via ``CompositeCommand`` and the auto-discovery rules -- see
+   :doc:`/extension/cli`.
+
 Architecture Overview
 ---------------------
 
-The CLI uses explicit command registration:
+The CLI uses **auto-discovery** of subcommand classes:
 
 1. Each command is a class inheriting from ``BaseCommand``.
-2. Commands are instantiated and listed in a central ``ALL_COMMANDS`` registry.
-3. At startup, the entry point iterates ``ALL_COMMANDS`` and calls
+2. Commands live in their own module (or sub-package) under
+   ``lmcache/cli/commands/``. They are picked up at startup by
+   ``discover_subclasses()`` (in
+   ``lmcache/v1/utils/subclass_discovery.py``) and exposed via
+   ``ALL_COMMANDS`` in ``commands/__init__.py``.
+3. The entry point iterates ``ALL_COMMANDS`` and calls
    ``cmd.register(subparsers)`` to wire up argparse.
+
+No manual registration is required -- creating the module is enough.
+Helper modules whose names start with an underscore (e.g.
+``_helpers.py``) are excluded from discovery.
 
 ``BaseCommand`` is an abstract class with a small set of required methods
 (name, help, argument registration, and execute). Forgetting any of them
-raises ``TypeError`` at instantiation time.
+raises ``TypeError`` at instantiation time. Commands that only group
+sub-subcommands inherit from ``CompositeCommand`` instead -- see
+:doc:`/extension/cli` for that pattern.
 
 Step-by-Step: Adding a New Command
 -----------------------------------
 
-**Step 1.** Create a new command class that subclasses ``BaseCommand``:
+**Step 1.** Create a new module under ``lmcache/cli/commands/`` and
+define a class that subclasses ``BaseCommand``:
 
 .. code-block:: python
 
    # SPDX-License-Identifier: Apache-2.0
+   # lmcache/cli/commands/describe.py
    import argparse
 
    from lmcache.cli.commands.base import BaseCommand
@@ -48,18 +66,13 @@ Step-by-Step: Adding a New Command
            metrics.add("chunks", "Cached chunks", 1024)
            metrics.emit()
 
-**Step 2.** Add an instance of it to the ``ALL_COMMANDS`` registry:
+**Step 2.** That's it -- the command is discovered automatically. No
+edits to ``commands/__init__.py`` are required.
+``lmcache describe --url http://localhost:8000`` is now available.
 
-.. code-block:: python
-
-   from lmcache.cli.commands.describe import DescribeCommand
-
-   ALL_COMMANDS: list[BaseCommand] = [
-       # ... existing commands ...
-       DescribeCommand(),   # add here
-   ]
-
-That's it --- ``lmcache describe --url http://localhost:8000`` is now available.
+For nested subcommands (e.g. ``lmcache tool cache-simulator simulate``),
+follow the ``CompositeCommand`` pattern documented in
+:doc:`/extension/cli`.
 
 Using the Metrics System
 ------------------------

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -416,6 +416,23 @@ On the vLLM side, specify the LMCache server host and port via the
         --kv-transfer-config \
         '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "127.0.0.1", "lmcache.mp.port": 6000}}'
 
+To target multiple LMCache servers from a single vLLM deployment, pass a
+list (or comma-separated string) of server URLs via
+``lmcache.mp.server_urls``. When set, ``server_urls`` takes precedence
+over the single-server ``host`` / ``port`` keys; vLLM's world size must
+be divisible by the number of servers, and each worker connects only to
+its locally-assigned server (global ranks are sliced into contiguous
+blocks, one block per server). Multi-server mode currently supports
+tensor parallelism only -- pipeline parallelism (``pp_size > 1``) and
+data parallelism (``dp_size > 1``) are rejected with a clear error.
+
+.. code-block:: bash
+
+    vllm serve Qwen/Qwen3-14B \
+        --tensor-parallel-size 4 \
+        --kv-transfer-config \
+        '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.server_urls": "tcp://host1:6667,tcp://host2:6667"}}'
+
 ``LMCacheMPConnector`` reads the following keys from
 ``kv_connector_extra_config``:
 
@@ -432,12 +449,24 @@ All connector-level options are passed through
    * - Key
      - Default
      - Description
+   * - ``lmcache.mp.server_urls``
+     - *(unset)*
+     - Multi-server deployment: list (or comma-separated string) of
+       ``<transport>://<host>:<port>`` URLs, e.g.
+       ``"tcp://host1:6667,tcp://host2:6667"``. When set, takes
+       precedence over ``lmcache.mp.host`` / ``lmcache.mp.port``; the
+       vLLM world size must be divisible by the number of servers, and
+       each worker connects to its locally-assigned server.
    * - ``lmcache.mp.host``
      - ``tcp://localhost``
-     - Host (with ZMQ transport prefix) of the LMCache MP server.
+     - Single-server deployment: host (with ZMQ transport prefix) of
+       the LMCache MP server. Ignored when ``lmcache.mp.server_urls``
+       is set.
    * - ``lmcache.mp.port``
      - ``5555``
-     - Port of the LMCache MP server. Must match the server's ``--port``.
+     - Single-server deployment: port of the LMCache MP server. Must
+       match the server's ``--port``. Ignored when
+       ``lmcache.mp.server_urls`` is set.
    * - ``lmcache.mp.mq_timeout``
      - ``300.0``
      - Timeout (seconds) for blocking message-queue requests, including


### PR DESCRIPTION
## Summary

The daily docs-drift-check routine found **two** new inconsistencies between `docs/source/` and the multi-process code that landed on `dev` today.

### Drift items found and fixed

**`docs/source/` (user-facing, highest priority)**

| # | Doc | Drift |
|---|---|---|
| 1 | [`docs/source/mp/configuration.rst`](https://github.com/LMCache/LMCache/blob/4751788/docs/source/mp/configuration.rst#L407-L458) — *vLLM Client Configuration* / *Connector `extra_config` Keys* | The "Connector `extra_config` Keys" table documents only `lmcache.mp.host` / `lmcache.mp.port` for picking the LMCache server. After [#3248 (`c0c613e`)](https://github.com/LMCache/LMCache/commit/c0c613e59f062b3800673e8f15419a24fd36bfd4), `LMCacheMPConnector.__init__` first reads [`lmcache.mp.server_urls`](https://github.com/LMCache/LMCache/blob/4751788/lmcache/integration/vllm/lmcache_mp_connector.py#L525-L545) (list or comma-separated string) and only falls back to the single-server `host`/`port` pair when `server_urls` is unset. The new key is also subject to runtime constraints — `world_size` must be divisible by `n_servers`, and multi-server mode rejects `pp_size > 1` / `dp_size > 1` ([`lmcache_mp_connector.py:550-577`](https://github.com/LMCache/LMCache/blob/4751788/lmcache/integration/vllm/lmcache_mp_connector.py#L550-L577)). **Fix:** added a `lmcache.mp.server_urls` row to the table (with the new "takes precedence over host/port" semantics), updated the `host` and `port` rows to call out that they apply to single-server deployments, and added a short narrative + example showing the multi-server invocation. |
| 2 | [`docs/source/developer_guide/cli.rst`](https://github.com/LMCache/LMCache/blob/4751788/docs/source/developer_guide/cli.rst) — *Architecture Overview* / *Step-by-Step* | The guide still tells contributors that they must "add an instance to the central `ALL_COMMANDS` registry" (Step 2). After [#3678 (`15b38e7`)](https://github.com/LMCache/LMCache/commit/15b38e7edfa18eaa20d297c796fba1cf63cf2dc1), `commands/__init__.py` builds `ALL_COMMANDS` automatically via [`discover_subclasses()`](https://github.com/LMCache/LMCache/blob/4751788/lmcache/cli/commands/__init__.py#L15-L38), so no manual edit is required and the walkthrough is wrong. The new [`docs/source/extension/cli.rst`](https://github.com/LMCache/LMCache/blob/4751788/docs/source/extension/cli.rst) added by [#3719 (`e09972c`)](https://github.com/LMCache/LMCache/commit/e09972c8abe988f142d264aa57a190cce7ad603f) covers the new mechanism in depth, but the developer-guide page (which is still in the toctree at `docs/source/developer_guide/index.rst`) was not refreshed. **Fix:** rewrote *Architecture Overview* and *Step-by-Step* to describe `discover_subclasses()`-based auto-discovery, dropped the obsolete `ALL_COMMANDS` step, and pointed readers to `extension/cli.rst` for the full `CompositeCommand` (N-level nested subcommands) guide. The "Using the Metrics System" section is unchanged — it still matches `BaseCommand.create_metrics()`.

**`docs/design/` (secondary)**

- No new drift this run. `docs/design/cli/commands.md` was already refreshed as part of #3678, and `docs/design/cli/commands/describe.md` correctly marks `describe engine` as Phase 2 / not yet implemented (consistent with `lmcache/cli/commands/describe.py`).

### Items intentionally not duplicated

The two earlier items still on `dev` — the stale `P2P_LOOKUP_AND_LOCK` row in `docs/source/mp/index.rst` and the missing `--p2p-*` flags section in `docs/source/mp/configuration.rst` — are already covered by the still-open draft PR [#3774 (2026-06-21)](https://github.com/LMCache/LMCache/pull/3774). They are deliberately omitted here to avoid duplication.

### Proposed fix

Applied in this PR's diff — see the file changes tab. Both touched files are under `docs/source/`. No code is touched.

### Notes

- Auto-generated by the daily drift-check routine. **Needs human review before merge.** Not marked Ready for review.
- Branched from current `dev` tip `4751788` and contains a single commit signed off as `ApostaC <yihua98@uchicago.edu>` for DCO.
- No code-level concerns flagged this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjY5dP7JXzAAmocVSZYCPy)_