### PR TITLE
fix(token_database): avoid unfold crash on sub-separator-length sequences

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -471,6 +471,9 @@ class SegmentTokenDatabase(TokenDatabase):
 
         if self.sep_len == 0 or len(tokens) < self.sep_len:
             yield tokens
+            # `tokens.unfold(0, self.sep_len, 1)` below raises when
+            # `len(tokens) < self.sep_len`, so this branch must return early.
+            return
 
         # Unfold into sliding windows
         # shape: (num_tokens-sep_len+1, sep_len)

--- a/tests/v1/test_token_database.py
+++ b/tests/v1/test_token_database.py
@@ -135,6 +135,55 @@ def test_segment_token_database(prefix_length, chunk_lengths):
         # print(ed, ends[i])
 
 
+class _StubTokenizer:
+    """Minimal stand-in for a HF tokenizer.
+
+    Lets ``SegmentTokenDatabase`` be constructed without downloading a model;
+    only ``encode`` is used by ``SegmentTokenDatabase.__init__``.
+    """
+
+    def __init__(self, sep_ids: list[int]) -> None:
+        self._sep_ids = sep_ids
+
+    def encode(self, text: str) -> list[int]:
+        return self._sep_ids
+
+
+class _StubAutoTokenizer:
+    """Stand-in for ``transformers.AutoTokenizer`` that never hits the network."""
+
+    @staticmethod
+    def from_pretrained(model_name: str) -> _StubTokenizer:
+        # __init__ drops the first encoded token, so the effective separator
+        # becomes [9, 9, 9] (sep_len == 3).
+        return _StubTokenizer([0, 9, 9, 9])
+
+
+def test_segment_split_handles_sequence_shorter_than_separator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sequence shorter than the separator yields one segment, not a crash.
+
+    Regression test: ``_fast_split_by_subtensor`` used to fall through to
+    ``tensor.unfold(0, sep_len, 1)`` for such inputs, which raises a
+    RuntimeError when ``len(tokens) < sep_len``.
+    """
+    monkeypatch.setattr("lmcache.v1.token_database.AutoTokenizer", _StubAutoTokenizer)
+
+    cfg = LMCacheEngineConfig.from_legacy(blend_special_str=" # # ")
+    metadata = dumb_metadata_with_model_name("dummy-model")
+    db = SegmentTokenDatabase(cfg, metadata)
+    assert db.sep_len == 3
+
+    # Two tokens: shorter than the 3-token separator.
+    short_tokens = torch.tensor([11, 12], dtype=torch.long)
+    results = list(db.process_tokens(tokens=short_tokens, make_key=False))
+
+    assert len(results) == 1
+    start, end, _ = results[0]
+    assert (start, end) == (0, 2)
+
+
 def test_process_tokens_returns_int_keys_for_bytes_hash_func() -> None:
     """process_tokens must produce int chunk_hash keys even when the underlying
     hash function returns bytes (e.g. sha256_cbor). This ensures downstream


### PR DESCRIPTION
SegmentTokenDatabase._fast_split_by_subtensor yields the whole input when the token sequence is shorter than the separator, but then fell through to tensor.unfold(0, sep_len, 1), which raises a RuntimeError whenever len(tokens) < sep_len. Add an early return so such inputs are handled cleanly.

Add a network-free regression test (stubbed tokenizer) covering the sub-separator-length case.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

`SegmentTokenDatabase._fast_split_by_subtensor` yields the whole input when the
token sequence is shorter than the separator (`len(tokens) < sep_len`), but then
falls through to `tensor.unfold(0, sep_len, 1)`, which raises:

    RuntimeError: maximum size for tensor at dimension 0 is N but size is sep_len

So any blend request whose total token count is smaller than the separator
crashes the worker. This adds an early `return` in that branch so such inputs are
returned as a single segment, which is the intended behavior.

**Special notes for your reviewers**:

The new test constructs a SegmentTokenDatabase with a stubbed tokenizer, so it
runs without network / HF credentials (unlike the existing
`test_segment_token_database`, which is HF-gated). It asserts that a
sub-separator-length input yields exactly one segment without raising.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

