### PR TITLE
[p2p] add tcp transfer channel

### DIFF
--- a/docs/design/v1/distributed/transfer_channel/overall.md
+++ b/docs/design/v1/distributed/transfer_channel/overall.md
@@ -15,8 +15,9 @@ a handshake, and can then read arbitrary `(offset, size)` regions out of the
 remote peer's L1 buffer into its own. Only **reads** are supported today (a peer
 pulls data from a remote; it never pushes).
 
-The abstraction is transport-agnostic; the only implementation today is
-[`nixl`](#nixl-implementation) (RDMA/UCX via the NIXL bindings).
+The abstraction is transport-agnostic; two implementations are provided:
+[`nixl`](#nixl-implementation) (RDMA/UCX via the NIXL bindings) and
+[`tcp`](#tcp-implementation) (plain TCP sockets, no special hardware required).
 
 ## Architecture Overview
 
@@ -157,6 +158,107 @@ points:
   hanging forever. The server's `_serve_loop` polls with a 1 s timeout so it can
   observe shutdown.
 
+## tcp implementation
+
+`impl/tcp_impl.py` implements the abstraction over plain TCP sockets. It
+self-registers under the type name `"tcp"` at import time. This implementation
+requires **no special hardware** (no RDMA NIC, no NIXL library) and works on any
+network that supports TCP, making it suitable for development environments,
+commodity hardware, or cross-datacenter scenarios where RDMA is unavailable.
+
+### Design overview
+
+Unlike the nixl implementation which separates the control plane (ZMQ handshake)
+from the data plane (RDMA transfer), the TCP implementation uses a **single TCP
+connection** for both handshake and data transfer per client-server pair.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                  TCP Transfer Channel                         │
+├─────────────────────────────────────────────────────────────┤
+│  Handshake: 8-byte magic exchange ("LMTCP001")              │
+│  Data transfer: binary protocol over the same TCP socket    │
+│  → copies data through kernel TCP stack                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Wire protocol
+
+The protocol uses a simple binary framing with little-endian integers:
+
+**Handshake:**
+- Client sends 8-byte magic `LMTCP001`
+- Server echoes the same 8-byte magic
+
+**Read Request** (client → server):
+```
+[4B msg_type=1] [4B request_id] [4B num_entries]
+For each entry:
+  [8B offset (int64)] [8B size (int64)]
+```
+
+**Read Response** (server → client):
+```
+[4B msg_type=2] [4B request_id] [4B num_entries] [4B mask_byte_count]
+[N bytes success_mask (packed bits)]
+For each successful entry:
+  [raw bytes of entry.size]
+```
+
+### Key differences from nixl
+
+| Aspect | nixl | tcp |
+|--------|------|-----|
+| Data plane | RDMA (zero-copy, kernel bypass) | TCP socket + `memmove` |
+| Control plane | ZMQ REP/REQ (separate socket) | Same TCP connection |
+| Hardware | RDMA NIC + NIXL library | None (standard TCP) |
+| Latency | μs-level | ms-level |
+| CPU overhead | Minimal (DMA offload) | Higher (data copy + syscalls) |
+| Passive client creation | Yes (bidirectional after one handshake) | No (each direction requires its own connection) |
+| Address translation | Page-index math (`offset/align → index list`) | Identity (`offset, size` passed directly) |
+
+### Notable implementation points
+
+- **Server threading model.** The server uses a `ThreadPoolExecutor` (up to 16
+  threads) to handle concurrent client connections. Each client gets a dedicated
+  handler thread that serves read requests in a loop until the connection closes.
+- **Client async model.** `submit_read` is non-blocking: it serializes the
+  request and sends it over the socket, then returns immediately. A background
+  `_recv_loop` thread receives responses and writes data directly into L1 memory
+  via `ctypes.memmove`.
+- **Connection lifecycle.** A single persistent TCP connection is maintained per
+  peer. If the connection drops, all pending tasks are marked as failed. The
+  P2P L2 adapter's timeout mechanism will then treat these as load failures.
+- **Socket tuning.** `TCP_NODELAY` is set to avoid Nagle buffering latency.
+  Send/receive buffers are set to 4 MB for better throughput on large transfers.
+- **No page-index translation.** Unlike nixl which maps `(offset, size)` to a
+  list of page indices in a prepped descriptor list, the TCP implementation
+  passes `(offset, size)` directly in the wire protocol. The server reads from
+  `L1_base_ptr + offset` and the client writes to `L1_base_ptr + offset`.
+- **No third-party dependencies.** The implementation uses only Python standard
+  library modules (`socket`, `struct`, `threading`, `ctypes`).
+
+### Usage
+
+```python
+initialize_transfer_channel_context(
+    "tcp",
+    l1_memory_desc=l1_memory_desc,
+    listen_url="0.0.0.0:7600",
+    advertise_url="192.168.1.100:7600",
+)
+```
+
+No additional `**kwargs` are required (unlike nixl which accepts `backends`).
+
+### When to use tcp vs nixl
+
+- **Use `tcp`** when: no RDMA hardware is available, developing/testing locally,
+  or the transfer latency is not on the critical path (e.g. large prefetch
+  windows that hide the transfer time).
+- **Use `nixl`** when: RDMA hardware is available and low-latency, high-throughput
+  P2P transfer is required (production inference serving).
+
 ## Extending: add a new transfer channel implementation
 
 Implementations live under `impl/` and **self-register a factory** with the
@@ -214,6 +316,8 @@ is the public creation entry point.
 - Integration tests for the nixl implementation (guarded by
   `pytest.importorskip("nixl")`, public interface only):
   `tests/v1/distributed/transfer_channel/test_nixl_impl.py`.
+- Integration tests for the tcp implementation (no special dependencies):
+  `tests/v1/distributed/transfer_channel/test_tcp_impl.py`.
 
 ## Related
 

--- a/docs/source/mp/p2p.rst
+++ b/docs/source/mp/p2p.rst
@@ -14,14 +14,16 @@ from scratch when the same prefix arrives on a different node.
 **Peer-to-peer (P2P) KV cache sharing turns the per-node caches into one
 logical cache.** When a node looks up a prefix that is not in its own memory,
 it can read that prefix's KV directly from the memory of the peer node that
-holds it, over the datacenter network using RDMA. The result is a much higher
-effective cache hit rate across the fleet, without any central storage tier in
-the hot path.
+holds it, over the datacenter network. The result is a much higher effective
+cache hit rate across the fleet, without any central storage tier in the hot
+path.
 
-The transfer is a one-sided RDMA read from the requesting node into its own L1
-buffer; the node that owns the data is not interrupted to serve it. On an
-RDMA-capable network (InfiniBand / RoCE) this is dramatically faster than
-recomputing the prefix or round-tripping through a shared object store.
+The transfer is performed by a pluggable **transfer engine**. The default
+(``nixl``) uses one-sided RDMA reads — the node that owns the data is not
+interrupted to serve it. On an RDMA-capable network (InfiniBand / RoCE) this
+is dramatically faster than recomputing the prefix or round-tripping through a
+shared object store. For environments without RDMA hardware, a ``tcp`` engine
+is also available that transfers data over plain TCP sockets.
 
 How it works
 ------------
@@ -36,14 +38,16 @@ P2P involves three pieces:
 * **LMCache server** — each server runs a P2P controller that periodically asks
   the coordinator for the current peer list and, for every live peer, opens a
   connection used to look up and read that peer's KV.
-* **Transfer channel** — the RDMA layer that performs the actual remote memory
-  reads. Each server registers its L1 buffer once at startup so peers can read
-  from it.
+* **Transfer channel** — the transport layer that performs the actual remote
+  memory reads. Each server registers its L1 buffer once at startup so peers
+  can read from it. The default engine (``nixl``) uses RDMA; the ``tcp`` engine
+  uses plain TCP sockets.
 
 On a cache miss, a node asks the peer that owns the prefix to *lock and locate*
-it, receives the remote addresses, RDMA-reads the KV into its own L1, and serves
-the request from there. Peers are discovered and connected automatically as
-they join, and disconnected automatically as they leave — no static peer lists.
+it, receives the remote addresses, reads the KV into its own L1 (via RDMA or
+TCP depending on the configured engine), and serves the request from there.
+Peers are discovered and connected automatically as they join, and disconnected
+automatically as they leave — no static peer lists.
 
 Requirements
 ------------
@@ -52,10 +56,11 @@ Requirements
   started with ``--p2p-advertise-url`` but no ``--coordinator-url`` refuses to
   start.
 * **An RDMA-capable network** (InfiniBand / RoCE) is strongly recommended for
-  production performance. By default P2P uses the ``nixl`` transfer engine,
-  which is shipped with LMCache, so there is nothing extra to install.
+  production performance when using the default ``nixl`` engine. The ``tcp``
+  engine works on any network but has higher latency and CPU overhead. Both
+  engines are shipped with LMCache — there is nothing extra to install.
 * **A single, contiguous L1 region.** The transfer channel registers the whole
-  L1 buffer for RDMA, so P2P is incompatible with the GDS L1 tier
+  L1 buffer, so P2P is incompatible with the GDS L1 tier
   (``--gds-l1-path``) and the Device-DAX L1 tier (``--l1-devdax-path``); the
   server refuses to start in those configurations.
 
@@ -93,11 +98,12 @@ heartbeat interval doubles as the peer-discovery poll interval. See
 
 .. tip::
 
-   Increase the L1 buffer alignment to at least 64 KB
-   (``--l1-align-bytes 65536``) on servers that participate in P2P. A larger
-   alignment lets the transfer channel issue bigger, better-aligned RDMA reads
-   and noticeably improves transfer performance. The default (4 KB) is fine for
-   non-P2P deployments.
+   When using the ``nixl`` engine, increase the L1 buffer alignment to at least
+   64 KB (``--l1-align-bytes 65536``) on servers that participate in P2P. A
+   larger alignment lets the transfer channel issue bigger, better-aligned RDMA
+   reads and noticeably improves transfer performance. The ``tcp`` engine does
+   not require large alignment but still benefits from it for internal buffer
+   management. The default (4 KB) is fine for non-P2P deployments.
 
 Transfer engine backends
 ------------------------
@@ -113,11 +119,22 @@ selected per server with ``--p2p-transfer-engine``.
      - Description
    * - ``nixl`` (default)
      - RDMA-based transport, shipped with LMCache. Runs over InfiniBand / RoCE
-       fabrics.
+       fabrics. Provides the lowest latency and highest throughput via
+       zero-copy, kernel-bypass RDMA reads.
+   * - ``tcp``
+     - Plain TCP socket transport. No special hardware required — works on any
+       network. Data is copied through the kernel TCP stack, so latency and CPU
+       overhead are higher than ``nixl``. Suitable for development, testing, or
+       environments without RDMA.
 
-``nixl`` is the only backend available today. The transfer engine is a
-pluggable abstraction, so additional backends can be added in the future
-without changing the rest of the P2P stack.
+The transfer engine is a pluggable abstraction; additional backends can be
+added in the future without changing the rest of the P2P stack.
+
+.. tip::
+
+   Use ``--p2p-transfer-engine tcp`` when RDMA hardware is unavailable or when
+   running single-node tests over loopback. Switch to ``nixl`` (the default)
+   for production deployments on RDMA-capable networks.
 
 Running a multi-node deployment
 -------------------------------

--- a/lmcache/v1/distributed/transfer_channel/impl/__init__.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/__init__.py
@@ -7,3 +7,4 @@ self-registers its factory via ``register_transfer_channel_factory``.
 
 # First Party
 from lmcache.v1.distributed.transfer_channel.impl import nixl_impl  # noqa: F401
+from lmcache.v1.distributed.transfer_channel.impl import tcp_impl  # noqa: F401

--- a/lmcache/v1/distributed/transfer_channel/impl/tcp_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/tcp_impl.py
@@ -22,7 +22,6 @@ from concurrent.futures import ThreadPoolExecutor
 from ctypes import c_char
 from dataclasses import dataclass
 from typing import Optional
-import ctypes
 import socket
 import struct
 import threading
@@ -181,6 +180,10 @@ class TcpTransferChannelServer(TransferChannelServer):
         self._l1_memory_desc = l1_memory_desc
         self._running = True
 
+        # Track active client sockets so we can close them on shutdown
+        self._client_sockets: set[socket.socket] = set()
+        self._client_sockets_lock = threading.Lock()
+
         host, port = _parse_url(listen_url)
         self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -206,8 +209,12 @@ class TcpTransferChannelServer(TransferChannelServer):
         """Accept incoming connections and dispatch to handler threads."""
         while self._running:
             try:
+                # TODO(chunxiaozheng): use a more efficient method to accept
+                #  and handle connections
                 client_sock, addr = self._server_socket.accept()
                 _set_socket_options(client_sock)
+                with self._client_sockets_lock:
+                    self._client_sockets.add(client_sock)
                 self._executor.submit(self._handle_client, client_sock, addr)
             except socket.timeout:
                 continue
@@ -251,6 +258,8 @@ class TcpTransferChannelServer(TransferChannelServer):
             if self._running:
                 logger.exception("Error handling client %s", addr)
         finally:
+            with self._client_sockets_lock:
+                self._client_sockets.discard(client_sock)
             client_sock.close()
 
     def _serve_read_request(
@@ -290,12 +299,22 @@ class TcpTransferChannelServer(TransferChannelServer):
             # Read directly from L1 shared memory
             src_addr = ptr + offset
             buf = (c_char * size).from_address(src_addr)
-            _send_all(client_sock, bytes(buf))
+            _send_all(client_sock, memoryview(buf))
 
     def close(self) -> None:
         """Stop accepting connections and shut down handler threads."""
         self._running = False
         self._server_socket.close()
+
+        # Close all active client sockets to unblock handler threads
+        with self._client_sockets_lock:
+            for sock in self._client_sockets:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            self._client_sockets.clear()
+
         if self._accept_thread.is_alive():
             self._accept_thread.join(timeout=5)
         self._executor.shutdown(wait=False)
@@ -403,17 +422,17 @@ class TcpTransferChannelClient(TransferChannelClient):
             try:
                 _send_all(self._socket, req.encode())
             except (OSError, ConnectionError) as e:
-                # Mark task as failed
-                with self._lock:
-                    self._tasks[task_id] = (
-                        len(remote_addresses),
-                        TransferChannelReadResult(
-                            finished=True,
-                            succeeded_mask=[False] * len(remote_addresses),
-                        ),
-                    )
-                    self._task_local_addrs.pop(task_id, None)
+                # TODO(chunxiaozheng): should we add some recovery logic here?
                 logger.warning("Failed to send read request: %s", e)
+                # The socket is no longer usable after a send failure;
+                # mark all pending tasks as failed and close.
+                self._mark_all_failed()
+                self._closed = True
+                try:
+                    self._socket.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                self._socket.close()
 
         return task_id
 
@@ -469,10 +488,19 @@ class TcpTransferChannelClient(TransferChannelClient):
                     # Determine size from local address
                     if i < len(local_addrs):
                         size = local_addrs[i].size
-                        data = _recv_exact(self._socket, size)
-                        # Write to local L1 memory
+                        # Receive directly into L1 memory (zero intermediate copy)
                         dst_addr = self._l1_ptr + local_addrs[i].offset
-                        ctypes.memmove(dst_addr, data, size)
+                        dst_buf = (c_char * size).from_address(dst_addr)
+                        view = memoryview(dst_buf)
+                        remaining = size
+                        while remaining > 0:
+                            nbytes = self._socket.recv_into(view)
+                            if nbytes == 0:
+                                raise ConnectionError(
+                                    f"Connection closed while expecting {size} bytes"
+                                )
+                            view = view[nbytes:]
+                            remaining -= nbytes
                     else:
                         # Shouldn't happen, but handle gracefully
                         logger.warning(

--- a/lmcache/v1/distributed/transfer_channel/impl/tcp_impl.py
+++ b/lmcache/v1/distributed/transfer_channel/impl/tcp_impl.py
@@ -1,0 +1,701 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TCP-backed implementation of the transfer channel abstraction.
+
+This implementation uses plain TCP sockets for data transfer between peers.
+It does not require RDMA hardware and is suitable for environments without
+specialized networking (e.g. development, cross-datacenter, or commodity
+hardware).
+
+Architecture:
+- Server: Listens for incoming TCP connections. Each connection is handled
+  in a dedicated thread. Clients send read requests (remote offsets/sizes),
+  and the server responds with the raw bytes from its L1 shared memory.
+- Client: Maintains a persistent TCP connection to a peer's server. Read
+  requests are submitted asynchronously and fulfilled by a background
+  receiver thread.
+- Context: Owns the server, manages client connections, and provides
+  address translation.
+"""
+
+# Standard
+from concurrent.futures import ThreadPoolExecutor
+from ctypes import c_char
+from dataclasses import dataclass
+from typing import Optional
+import ctypes
+import socket
+import struct
+import threading
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.transfer_channel.abstract import (
+    TransferChannelClient,
+    TransferChannelContext,
+    TransferChannelServer,
+)
+from lmcache.v1.distributed.transfer_channel.api import (
+    TransferChannelAddress,
+    TransferChannelReadResult,
+)
+from lmcache.v1.distributed.transfer_channel.factory import (
+    register_transfer_channel_factory,
+)
+
+logger = init_logger(__name__)
+
+# Protocol constants
+_HANDSHAKE_MAGIC = b"LMTCP001"
+_MSG_TYPE_READ_REQ = 1
+_MSG_TYPE_READ_RESP = 2
+
+# Default connection timeout (seconds)
+_CONNECT_TIMEOUT_S = 30.0
+
+# Maximum number of concurrent server handler threads
+_MAX_SERVER_THREADS = 16
+
+# Socket buffer sizes (4 MB for better throughput on large transfers)
+_SOCKET_BUF_SIZE = 4 * 1024 * 1024
+
+
+############################################################
+# Helper functions
+############################################################
+def _parse_url(url: str) -> tuple[str, int]:
+    """Parse a ``host:port`` (optionally ``tcp://host:port``) into (host, port)."""
+    stripped = url.split("://", 1)[-1]
+    host, _, port = stripped.rpartition(":")
+    if not host or not port:
+        raise ValueError(f"Invalid transfer channel url: {url!r} (expected host:port)")
+    return host, int(port)
+
+
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Receive exactly ``n`` bytes from ``sock``, raising on premature close."""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError(
+                f"Connection closed while expecting {n} bytes "
+                f"(received {len(buf)} so far)"
+            )
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _send_all(sock: socket.socket, data: bytes | memoryview) -> None:
+    """Send all bytes, handling partial sends."""
+    sock.sendall(data)
+
+
+def _set_socket_options(sock: socket.socket) -> None:
+    """Apply common socket options for performance."""
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, _SOCKET_BUF_SIZE)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, _SOCKET_BUF_SIZE)
+
+
+############################################################
+# Wire protocol structures
+############################################################
+@dataclass
+class _ReadRequest:
+    """A batch read request sent from client to server.
+
+    Wire format:
+        [4 bytes] msg_type = _MSG_TYPE_READ_REQ
+        [4 bytes] request_id
+        [4 bytes] num_entries
+        For each entry:
+            [8 bytes] offset (int64, little-endian)
+            [8 bytes] size (int64, little-endian)
+    """
+
+    request_id: int
+    entries: list[tuple[int, int]]  # (offset, size)
+
+    def encode(self) -> bytes:
+        """Serialize to wire format."""
+        header = struct.pack(
+            "<III", _MSG_TYPE_READ_REQ, self.request_id, len(self.entries)
+        )
+        body = b"".join(
+            struct.pack("<qq", offset, size) for offset, size in self.entries
+        )
+        return header + body
+
+    @staticmethod
+    def decode_from_socket(
+        sock: socket.socket, request_id: int, num_entries: int
+    ) -> "_ReadRequest":
+        """Decode entries from socket after header has been read."""
+        entry_data = _recv_exact(sock, num_entries * 16)
+        entries = []
+        for i in range(num_entries):
+            offset, size = struct.unpack_from("<qq", entry_data, i * 16)
+            entries.append((offset, size))
+        return _ReadRequest(request_id=request_id, entries=entries)
+
+
+@dataclass
+class _ReadResponse:
+    """A batch read response sent from server to client.
+
+    Wire format:
+        [4 bytes] msg_type = _MSG_TYPE_READ_RESP
+        [4 bytes] request_id
+        [4 bytes] num_entries
+        [4 bytes] success_mask_bytes (ceil(num_entries / 8))
+        [N bytes] success_mask (packed bits)
+        For each successful entry:
+            [raw bytes] data of entry.size bytes
+    """
+
+    request_id: int
+    success_mask: list[bool]
+    # data is sent inline, not stored here for the server side
+
+
+############################################################
+# Server
+############################################################
+class TcpTransferChannelServer(TransferChannelServer):
+    """TCP server that serves read requests from peer clients.
+
+    Each connected client gets a dedicated handler thread. The server reads
+    requests from the client, fetches the requested byte ranges from the
+    local L1 shared memory, and sends the data back.
+    """
+
+    def __init__(
+        self,
+        listen_url: str,
+        advertise_url: str,
+        l1_memory_desc: L1MemoryDesc,
+    ) -> None:
+        self._listen_url = listen_url
+        self._advertise_url = advertise_url
+        self._l1_memory_desc = l1_memory_desc
+        self._running = True
+
+        host, port = _parse_url(listen_url)
+        self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server_socket.bind((host, port))
+        self._server_socket.listen(32)
+        self._server_socket.settimeout(1.0)
+
+        self._executor = ThreadPoolExecutor(
+            max_workers=_MAX_SERVER_THREADS,
+            thread_name_prefix="tc-tcp-handler",
+        )
+        self._accept_thread = threading.Thread(
+            target=self._accept_loop, name="tc-tcp-accept", daemon=True
+        )
+        self._accept_thread.start()
+        logger.info(
+            "TCP transfer channel server listening on %s (advertise: %s)",
+            listen_url,
+            advertise_url,
+        )
+
+    def _accept_loop(self) -> None:
+        """Accept incoming connections and dispatch to handler threads."""
+        while self._running:
+            try:
+                client_sock, addr = self._server_socket.accept()
+                _set_socket_options(client_sock)
+                self._executor.submit(self._handle_client, client_sock, addr)
+            except socket.timeout:
+                continue
+            except OSError:
+                if self._running:
+                    logger.exception("Error accepting TCP connection")
+                break
+
+    def _handle_client(self, client_sock: socket.socket, addr: tuple[str, int]) -> None:
+        """Handle a single client connection, serving read requests until close."""
+        try:
+            # Perform handshake: expect magic bytes from client
+            magic = _recv_exact(client_sock, len(_HANDSHAKE_MAGIC))
+            if magic != _HANDSHAKE_MAGIC:
+                logger.warning("Invalid handshake magic from %s: %r", addr, magic)
+                return
+
+            # Send magic back as acknowledgement
+            _send_all(client_sock, _HANDSHAKE_MAGIC)
+
+            # Serve read requests in a loop
+            while self._running:
+                try:
+                    header_data = _recv_exact(client_sock, 12)
+                except ConnectionError:
+                    break
+
+                msg_type, request_id, num_entries = struct.unpack("<III", header_data)
+                if msg_type != _MSG_TYPE_READ_REQ:
+                    logger.warning("Unexpected message type %d from %s", msg_type, addr)
+                    break
+
+                req = _ReadRequest.decode_from_socket(
+                    client_sock, request_id, num_entries
+                )
+                self._serve_read_request(client_sock, req)
+
+        except ConnectionError:
+            logger.debug("Client %s disconnected", addr)
+        except Exception:
+            if self._running:
+                logger.exception("Error handling client %s", addr)
+        finally:
+            client_sock.close()
+
+    def _serve_read_request(
+        self, client_sock: socket.socket, req: _ReadRequest
+    ) -> None:
+        """Read the requested byte ranges from L1 memory and send them back."""
+        ptr = self._l1_memory_desc.ptr
+        mem_size = self._l1_memory_desc.size
+        num_entries = len(req.entries)
+
+        # Determine which entries are valid
+        success_mask = []
+        for offset, size in req.entries:
+            valid = offset >= 0 and size > 0 and offset + size <= mem_size
+            success_mask.append(valid)
+
+        # Build response header
+        mask_byte_count = (num_entries + 7) // 8
+        mask_bytes = bytearray(mask_byte_count)
+        for i, ok in enumerate(success_mask):
+            if ok:
+                mask_bytes[i // 8] |= 1 << (i % 8)
+
+        resp_header = struct.pack(
+            "<IIII",
+            _MSG_TYPE_READ_RESP,
+            req.request_id,
+            num_entries,
+            mask_byte_count,
+        )
+        _send_all(client_sock, resp_header + bytes(mask_bytes))
+
+        # Send data for each successful entry
+        for i, (offset, size) in enumerate(req.entries):
+            if not success_mask[i]:
+                continue
+            # Read directly from L1 shared memory
+            src_addr = ptr + offset
+            buf = (c_char * size).from_address(src_addr)
+            _send_all(client_sock, bytes(buf))
+
+    def close(self) -> None:
+        """Stop accepting connections and shut down handler threads."""
+        self._running = False
+        self._server_socket.close()
+        if self._accept_thread.is_alive():
+            self._accept_thread.join(timeout=5)
+        self._executor.shutdown(wait=False)
+
+
+############################################################
+# Client
+############################################################
+class TcpTransferChannelClient(TransferChannelClient):
+    """TCP client that reads data from a remote peer's L1 memory.
+
+    Maintains a persistent TCP connection to the peer's server. Read requests
+    are submitted and responses are received on the same connection. A
+    background receiver thread processes incoming responses and marks tasks
+    as complete.
+    """
+
+    def __init__(self, transfer_channel_server_url: str) -> None:
+        self._server_url = transfer_channel_server_url
+        self._closed = False
+
+        self._task_counter = 0
+        self._lock = threading.Lock()
+        # task_id -> (num_entries, result or None if pending)
+        self._tasks: dict[int, tuple[int, Optional[TransferChannelReadResult]]] = {}
+        # task_id -> list of (local_offset, size) for writing received data
+        self._task_local_addrs: dict[int, list[TransferChannelAddress]] = {}
+        # L1 memory descriptor (set by context after creation)
+        self._l1_ptr: int = 0
+        self._l1_size: int = 0
+
+        # Connect to the server
+        host, port = _parse_url(transfer_channel_server_url)
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.settimeout(_CONNECT_TIMEOUT_S)
+        self._socket.connect((host, port))
+        _set_socket_options(self._socket)
+
+        # Perform handshake
+        _send_all(self._socket, _HANDSHAKE_MAGIC)
+        ack = _recv_exact(self._socket, len(_HANDSHAKE_MAGIC))
+        if ack != _HANDSHAKE_MAGIC:
+            self._socket.close()
+            raise ConnectionError(
+                f"Handshake failed with {transfer_channel_server_url}: "
+                f"expected {_HANDSHAKE_MAGIC!r}, got {ack!r}"
+            )
+
+        # Switch to non-blocking for the send path; the receiver thread
+        # uses blocking recv.
+        self._socket.settimeout(None)
+
+        # Send lock to serialize write access to the socket
+        self._send_lock = threading.Lock()
+
+        # Start receiver thread
+        self._recv_thread = threading.Thread(
+            target=self._recv_loop, name="tc-tcp-recv", daemon=True
+        )
+        self._recv_thread.start()
+
+    def set_l1_memory(self, ptr: int, size: int) -> None:
+        """Set the local L1 memory pointer and size for writing received data.
+
+        Args:
+            ptr: Base address of the local L1 shared memory.
+            size: Total size of the L1 memory region.
+        """
+        self._l1_ptr = ptr
+        self._l1_size = size
+
+    def submit_read(
+        self,
+        local_addresses: list[TransferChannelAddress],
+        remote_addresses: list[TransferChannelAddress],
+    ) -> int:
+        """Submit a read request to fetch data from the remote peer.
+
+        Args:
+            local_addresses: Where to write the received data in local L1.
+            remote_addresses: Where to read from in the remote peer's L1.
+
+        Returns:
+            A task ID for tracking the read status.
+        """
+        if len(local_addresses) != len(remote_addresses):
+            raise ValueError(
+                "local_addresses and remote_addresses must have equal length "
+                f"({len(local_addresses)} != {len(remote_addresses)})"
+            )
+
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Client is closed")
+            task_id = self._task_counter
+            self._task_counter += 1
+            self._tasks[task_id] = (len(remote_addresses), None)
+            self._task_local_addrs[task_id] = list(local_addresses)
+
+        # Build and send the read request
+        entries = [(addr.offset, addr.size) for addr in remote_addresses]
+        req = _ReadRequest(request_id=task_id, entries=entries)
+
+        with self._send_lock:
+            try:
+                _send_all(self._socket, req.encode())
+            except (OSError, ConnectionError) as e:
+                # Mark task as failed
+                with self._lock:
+                    self._tasks[task_id] = (
+                        len(remote_addresses),
+                        TransferChannelReadResult(
+                            finished=True,
+                            succeeded_mask=[False] * len(remote_addresses),
+                        ),
+                    )
+                    self._task_local_addrs.pop(task_id, None)
+                logger.warning("Failed to send read request: %s", e)
+
+        return task_id
+
+    def query_read_status(self, task_id: int) -> TransferChannelReadResult:
+        """Query the status of a previously submitted read.
+
+        Args:
+            task_id: The task ID returned by submit_read.
+
+        Returns:
+            The read result (finished=False if still in progress).
+        """
+        with self._lock:
+            if task_id not in self._tasks:
+                raise KeyError(f"Unknown read task id: {task_id}")
+            num_entries, result = self._tasks[task_id]
+            if result is None:
+                return TransferChannelReadResult(finished=False, succeeded_mask=[])
+            # Remove completed task
+            del self._tasks[task_id]
+            self._task_local_addrs.pop(task_id, None)
+            return result
+
+    def _recv_loop(self) -> None:
+        """Background thread that receives responses from the server."""
+        while not self._closed:
+            try:
+                # Read response header: msg_type(4) + request_id(4) +
+                # num_entries(4) + mask_byte_count(4)
+                header_data = _recv_exact(self._socket, 16)
+                msg_type, request_id, num_entries, mask_byte_count = struct.unpack(
+                    "<IIII", header_data
+                )
+
+                if msg_type != _MSG_TYPE_READ_RESP:
+                    logger.warning("Unexpected response message type: %d", msg_type)
+                    break
+
+                # Read success mask
+                mask_bytes = _recv_exact(self._socket, mask_byte_count)
+                success_mask = []
+                for i in range(num_entries):
+                    bit = (mask_bytes[i // 8] >> (i % 8)) & 1
+                    success_mask.append(bool(bit))
+
+                # Read data for successful entries and write to local L1
+                with self._lock:
+                    local_addrs = self._task_local_addrs.get(request_id, [])
+
+                for i in range(num_entries):
+                    if not success_mask[i]:
+                        continue
+                    # Determine size from local address
+                    if i < len(local_addrs):
+                        size = local_addrs[i].size
+                        data = _recv_exact(self._socket, size)
+                        # Write to local L1 memory
+                        dst_addr = self._l1_ptr + local_addrs[i].offset
+                        ctypes.memmove(dst_addr, data, size)
+                    else:
+                        # Shouldn't happen, but handle gracefully
+                        logger.warning(
+                            "Response entry %d has no local address for task %d",
+                            i,
+                            request_id,
+                        )
+                        break
+
+                # Mark task as complete
+                with self._lock:
+                    if request_id in self._tasks:
+                        self._tasks[request_id] = (
+                            num_entries,
+                            TransferChannelReadResult(
+                                finished=True, succeeded_mask=success_mask
+                            ),
+                        )
+
+            except ConnectionError:
+                if not self._closed:
+                    logger.debug("TCP transfer channel connection closed")
+                self._mark_all_failed()
+                break
+            except Exception:
+                if not self._closed:
+                    logger.exception("Error in TCP transfer channel recv loop")
+                self._mark_all_failed()
+                break
+
+    def _mark_all_failed(self) -> None:
+        """Mark all pending tasks as failed (connection lost)."""
+        with self._lock:
+            for task_id, (num_entries, result) in list(self._tasks.items()):
+                if result is None:
+                    self._tasks[task_id] = (
+                        num_entries,
+                        TransferChannelReadResult(
+                            finished=True,
+                            succeeded_mask=[False] * num_entries,
+                        ),
+                    )
+
+    def close(self) -> None:
+        """Close the connection and stop the receiver thread."""
+        self._closed = True
+        try:
+            self._socket.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        self._socket.close()
+        if self._recv_thread.is_alive():
+            self._recv_thread.join(timeout=5)
+
+
+############################################################
+# Context
+############################################################
+class TcpTransferChannelContext(TransferChannelContext):
+    """Owns the TCP server and manages client connections to peers.
+
+    Unlike NIXL which uses RDMA for zero-copy transfers, this implementation
+    copies data over TCP sockets. It is simpler and works on any network but
+    has higher latency and CPU overhead.
+    """
+
+    def __init__(
+        self,
+        l1_memory_desc: L1MemoryDesc,
+        listen_url: str,
+        advertise_url: str,
+    ) -> None:
+        """Create the TCP transfer channel context.
+
+        Args:
+            l1_memory_desc: Describes the local L1 memory region.
+            listen_url: The ``host:port`` to bind the server on.
+            advertise_url: The ``host:port`` advertised to peers.
+        """
+        self._l1_memory_desc = l1_memory_desc
+        self._listen_url = listen_url
+        self._advertise_url = advertise_url
+
+        self._clients: dict[str, TcpTransferChannelClient] = {}
+        self._lock = threading.Lock()
+
+        # Start the server
+        self._server = TcpTransferChannelServer(
+            listen_url=listen_url,
+            advertise_url=advertise_url,
+            l1_memory_desc=l1_memory_desc,
+        )
+
+    ############################################################
+    # Address translation
+    ############################################################
+    def get_transfer_channel_address(
+        self,
+        lmcache_addresses: list[tuple[int, int]],
+    ) -> list[TransferChannelAddress]:
+        """Translate (offset, size) L1 addresses into TransferChannelAddress.
+
+        For TCP, the address is simply the offset and size within the L1
+        memory region (no page-granular translation needed).
+
+        Args:
+            lmcache_addresses: List of (offset, size) tuples.
+
+        Returns:
+            List of TransferChannelAddress objects.
+        """
+        size = self._l1_memory_desc.size
+        out = []
+        for offset, obj_size in lmcache_addresses:
+            if offset < 0 or offset + obj_size > size:
+                raise ValueError(
+                    f"Object [{offset:#x}, {offset + obj_size:#x}) is outside the "
+                    f"registered L1 region [0x0, {size:#x})"
+                )
+            out.append(TransferChannelAddress(offset=offset, size=obj_size))
+        return out
+
+    ############################################################
+    # Server / client management
+    ############################################################
+    def get_transfer_channel_server(self) -> TcpTransferChannelServer:
+        """Return the TCP transfer channel server."""
+        return self._server
+
+    def get_transfer_channel_client(
+        self,
+        peer_advertise_url: str,
+    ) -> TcpTransferChannelClient:
+        """Get or create a client connected to the specified peer.
+
+        Args:
+            peer_advertise_url: The ``host:port`` of the peer's server.
+
+        Returns:
+            A connected TcpTransferChannelClient.
+        """
+        with self._lock:
+            client = self._clients.get(peer_advertise_url)
+            if client is not None:
+                return client
+
+        # Create a new client connection
+        client = TcpTransferChannelClient(peer_advertise_url)
+        client.set_l1_memory(self._l1_memory_desc.ptr, self._l1_memory_desc.size)
+
+        with self._lock:
+            # Check again in case another thread created it concurrently
+            existing = self._clients.get(peer_advertise_url)
+            if existing is not None:
+                client.close()
+                return existing
+            self._clients[peer_advertise_url] = client
+
+        logger.debug("Created TCP transfer channel client for %s", peer_advertise_url)
+        return client
+
+    def remove_transfer_channel_client(self, peer_advertise_url: str) -> None:
+        """Remove and close the client for the specified peer.
+
+        Args:
+            peer_advertise_url: The ``host:port`` of the peer.
+        """
+        with self._lock:
+            client = self._clients.pop(peer_advertise_url, None)
+        if client is None:
+            return
+        try:
+            client.close()
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Error closing TCP transfer channel client for %s",
+                peer_advertise_url,
+            )
+
+    def get_num_connected_clients(self) -> int:
+        """Return the number of currently connected clients."""
+        with self._lock:
+            return len(self._clients)
+
+    def close(self) -> None:
+        """Shut down the server and all clients."""
+        with self._lock:
+            clients = list(self._clients.values())
+            self._clients.clear()
+
+        self._server.close()
+        for client in clients:
+            try:
+                client.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+############################################################
+# Factory registration
+############################################################
+def create_tcp_transfer_channel_context(
+    l1_memory_desc: L1MemoryDesc,
+    listen_url: str,
+    advertise_url: str,
+    **kwargs,
+) -> TcpTransferChannelContext:
+    """Create a ``TcpTransferChannelContext``.
+
+    Args:
+        l1_memory_desc: Describes the L1 memory region.
+        listen_url: ``host:port`` this peer's server binds to.
+        advertise_url: ``host:port`` this peer advertises as its identity.
+        **kwargs: Unused; accepted for interface compatibility.
+
+    Returns:
+        A new ``TcpTransferChannelContext`` instance.
+    """
+    return TcpTransferChannelContext(
+        l1_memory_desc=l1_memory_desc,
+        listen_url=listen_url,
+        advertise_url=advertise_url,
+    )
+
+
+register_transfer_channel_factory("tcp", create_tcp_transfer_channel_context)

--- a/tests/v1/distributed/transfer_channel/test_tcp_impl.py
+++ b/tests/v1/distributed/transfer_channel/test_tcp_impl.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Integration tests for the TCP-backed transfer channel implementation.
+
+Tests are written against the public contracts documented in
+``transfer_channel/abstract.py`` and ``transfer_channel/api.py`` (the
+``TransferChannelContext`` / ``TransferChannelServer`` / ``TransferChannelClient``
+interfaces). They use only public methods and do not access private fields.
+
+Unlike the nixl implementation, TCP does not require special hardware or
+third-party libraries, so these tests run unconditionally.
+
+Most tests share a single module-scoped context-pair to avoid paying the
+connection setup cost for every test. The reads are self-verifying -- each
+reads fresh remote data into its target region and checks that region -- so a
+reused buffer and connection do not affect their outcome. Tests that must
+observe a pristine connection state use their own function-scoped pair.
+"""
+
+# Standard
+import itertools
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.transfer_channel.api import (
+    TransferChannelAddress,
+)
+from lmcache.v1.distributed.transfer_channel.impl.tcp_impl import (
+    TcpTransferChannelContext,
+)
+
+_ALIGN = 256
+_BUF_SIZE = 4096
+
+# Each context must bind to a distinct port so multiple pairs can coexist in one
+# process without clashing.
+_port_counter = itertools.count(18900)
+
+
+def _next_url() -> str:
+    return f"127.0.0.1:{next(_port_counter)}"
+
+
+def _make_context_pair():
+    """Create two contexts backed by two distinct CPU buffers.
+
+    ``buf_b`` holds a known byte pattern so transfers can be content-verified;
+    ``buf_a`` starts zeroed. Returns ``(ctx_a, buf_a, url_a, ctx_b, buf_b, url_b)``.
+    """
+    buf_a = torch.zeros(_BUF_SIZE, dtype=torch.uint8)
+    buf_b = torch.arange(0, 256, dtype=torch.uint8).repeat(_BUF_SIZE // 256)
+    desc_a = L1MemoryDesc(ptr=buf_a.data_ptr(), size=buf_a.numel(), align_bytes=_ALIGN)
+    desc_b = L1MemoryDesc(ptr=buf_b.data_ptr(), size=buf_b.numel(), align_bytes=_ALIGN)
+
+    url_a, url_b = _next_url(), _next_url()
+    ctx_a = TcpTransferChannelContext(desc_a, listen_url=url_a, advertise_url=url_a)
+    ctx_b = TcpTransferChannelContext(desc_b, listen_url=url_b, advertise_url=url_b)
+    return ctx_a, buf_a, url_a, ctx_b, buf_b, url_b
+
+
+@pytest.fixture(scope="module")
+def shared_contexts():
+    """A single context-pair reused across connection-state-insensitive tests."""
+    ctx_a, buf_a, url_a, ctx_b, buf_b, url_b = _make_context_pair()
+    try:
+        yield ctx_a, buf_a, url_a, ctx_b, buf_b, url_b
+    finally:
+        ctx_a.close()
+        ctx_b.close()
+
+
+@pytest.fixture
+def fresh_contexts():
+    """A brand-new context-pair for tests that need pristine connection state."""
+    ctx_a, buf_a, url_a, ctx_b, buf_b, url_b = _make_context_pair()
+    try:
+        yield ctx_a, buf_a, url_a, ctx_b, buf_b, url_b
+    finally:
+        ctx_a.close()
+        ctx_b.close()
+
+
+def _wait_finished(client, task_id, timeout_s=5.0):
+    """Poll query_read_status until the task reports finished (or timeout)."""
+    deadline = time.monotonic() + timeout_s
+    result = client.query_read_status(task_id)
+    while not result.is_finished() and time.monotonic() < deadline:
+        time.sleep(0.01)
+        result = client.query_read_status(task_id)
+    return result
+
+
+# =========================================================
+# Address translation (get_transfer_channel_address)
+# =========================================================
+class TestAddressTranslation:
+    """Tests for get_transfer_channel_address."""
+
+    def test_returns_matching_offsets_and_sizes(self, shared_contexts):
+        ctx_a, _, _, _, _, _ = shared_contexts
+        addrs = ctx_a.get_transfer_channel_address([(0, 512), (1024, 256)])
+        assert len(addrs) == 2
+        assert (addrs[0].offset, addrs[0].size) == (0, 512)
+        assert (addrs[1].offset, addrs[1].size) == (1024, 256)
+
+    def test_out_of_region_raises_value_error(self, shared_contexts):
+        ctx_a, _, _, _, _, _ = shared_contexts
+        with pytest.raises(ValueError):
+            ctx_a.get_transfer_channel_address([(_BUF_SIZE, 256)])
+        with pytest.raises(ValueError):
+            ctx_a.get_transfer_channel_address([(_BUF_SIZE - 128, 256)])
+
+    def test_negative_offset_raises_value_error(self, shared_contexts):
+        ctx_a, _, _, _, _, _ = shared_contexts
+        with pytest.raises(ValueError):
+            ctx_a.get_transfer_channel_address([(-1, 256)])
+
+    def test_zero_size_at_valid_offset(self, shared_contexts):
+        """Zero-size objects should still be translatable (edge case)."""
+        ctx_a, _, _, _, _, _ = shared_contexts
+        # This depends on implementation; TCP passes through directly
+        # A zero-size read is technically valid (no data to transfer)
+        addrs = ctx_a.get_transfer_channel_address([(0, 0)])
+        assert len(addrs) == 1
+        assert addrs[0].offset == 0
+        assert addrs[0].size == 0
+
+    def test_multiple_addresses_at_boundary(self, shared_contexts):
+        """Addresses exactly at the end of the region should be valid."""
+        ctx_a, _, _, _, _, _ = shared_contexts
+        addrs = ctx_a.get_transfer_channel_address([(_BUF_SIZE - 256, 256)])
+        assert len(addrs) == 1
+        assert addrs[0].offset == _BUF_SIZE - 256
+        assert addrs[0].size == 256
+
+
+# =========================================================
+# End-to-end read (submit_read / query_read_status)
+# =========================================================
+class TestEndToEndRead:
+    """Tests for the full read path: submit_read + query_read_status."""
+
+    def test_read_copies_remote_data_into_local_buffer(self, shared_contexts):
+        ctx_a, buf_a, _, ctx_b, buf_b, url_b = shared_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+
+        local = ctx_a.get_transfer_channel_address([(0, 512)])
+        remote = ctx_b.get_transfer_channel_address([(0, 512)])
+        task_id = client.submit_read(local, remote)
+
+        result = _wait_finished(client, task_id)
+        assert result.is_finished() is True
+        assert result.succeeded_mask == [True] * len(remote)
+        assert torch.equal(buf_a[:512], buf_b[:512])
+
+    def test_read_into_offset_region(self, shared_contexts):
+        ctx_a, buf_a, _, ctx_b, buf_b, url_b = shared_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+
+        # Read remote [0, 256) into local [1024, 1280).
+        local = ctx_a.get_transfer_channel_address([(1024, 256)])
+        remote = ctx_b.get_transfer_channel_address([(0, 256)])
+        task_id = client.submit_read(local, remote)
+
+        result = _wait_finished(client, task_id)
+        assert result.is_finished() is True
+        assert torch.equal(buf_a[1024:1280], buf_b[0:256])
+
+    def test_read_multiple_entries_in_one_batch(self, shared_contexts):
+        """A single submit_read with multiple entries should transfer all."""
+        ctx_a, buf_a, _, ctx_b, buf_b, url_b = shared_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+
+        # Read two disjoint regions in one batch
+        local = ctx_a.get_transfer_channel_address([(2048, 256), (2304, 256)])
+        remote = ctx_b.get_transfer_channel_address([(256, 256), (512, 256)])
+        task_id = client.submit_read(local, remote)
+
+        result = _wait_finished(client, task_id)
+        assert result.is_finished() is True
+        assert result.succeeded_mask == [True, True]
+        assert torch.equal(buf_a[2048:2304], buf_b[256:512])
+        assert torch.equal(buf_a[2304:2560], buf_b[512:768])
+
+    def test_read_full_buffer(self, shared_contexts):
+        """Reading the entire buffer should work."""
+        ctx_a, buf_a, _, ctx_b, buf_b, url_b = shared_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+
+        local = ctx_a.get_transfer_channel_address([(0, _BUF_SIZE)])
+        remote = ctx_b.get_transfer_channel_address([(0, _BUF_SIZE)])
+        task_id = client.submit_read(local, remote)
+
+        result = _wait_finished(client, task_id)
+        assert result.is_finished() is True
+        assert result.succeeded_mask == [True]
+        assert torch.equal(buf_a[:_BUF_SIZE], buf_b[:_BUF_SIZE])
+
+    def test_multiple_sequential_reads(self, shared_contexts):
+        """Multiple sequential reads on the same client should all succeed."""
+        ctx_a, buf_a, _, ctx_b, buf_b, url_b = shared_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+
+        for i in range(5):
+            offset = i * 256
+            local = ctx_a.get_transfer_channel_address([(offset, 256)])
+            remote = ctx_b.get_transfer_channel_address([(offset, 256)])
+            task_id = client.submit_read(local, remote)
+
+            result = _wait_finished(client, task_id)
+            assert result.is_finished() is True
+            assert result.succeeded_mask == [True]
+            assert torch.equal(
+                buf_a[offset : offset + 256], buf_b[offset : offset + 256]
+            )
+
+    def test_submit_read_mismatched_lengths_raises_value_error(self, shared_contexts):
+        ctx_a, _, _, ctx_b, _, url_b = shared_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+        local = ctx_a.get_transfer_channel_address([(0, 256)])
+        remote = ctx_b.get_transfer_channel_address([(0, 256), (256, 256)])
+        with pytest.raises(ValueError):
+            client.submit_read(local, remote)
+
+    def test_query_unknown_task_id_raises_key_error(self, shared_contexts):
+        ctx_a, _, _, _, _, url_b = shared_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+        with pytest.raises(KeyError):
+            client.query_read_status(99999)
+
+
+# =========================================================
+# Client / server management
+# =========================================================
+class TestClientServerManagement:
+    """Tests for client creation, removal, and server access."""
+
+    def test_get_client_is_idempotent(self, shared_contexts):
+        ctx_a, _, _, _, _, url_b = shared_contexts
+        first = ctx_a.get_transfer_channel_client(url_b)
+        second = ctx_a.get_transfer_channel_client(url_b)
+        assert first is second
+
+    def test_remove_unknown_client_is_noop(self, fresh_contexts):
+        """Removing a peer with no registered client does nothing and does not raise."""
+        ctx_a, _, _, _, _, _ = fresh_contexts
+        ctx_a.remove_transfer_channel_client("10.255.255.1:65000")
+        assert ctx_a.get_num_connected_clients() == 0
+
+    def test_remove_client_after_connect(self, fresh_contexts):
+        """A live client obtained via get_transfer_channel_client can be removed."""
+        ctx_a, _, _, _, _, url_b = fresh_contexts
+        ctx_a.get_transfer_channel_client(url_b)
+        assert ctx_a.get_num_connected_clients() == 1
+
+        ctx_a.remove_transfer_channel_client(url_b)
+        assert ctx_a.get_num_connected_clients() == 0
+
+    def test_reconnect_after_remove(self, fresh_contexts):
+        """After removing a client, a new one can be created for the same peer."""
+        ctx_a, buf_a, _, ctx_b, buf_b, url_b = fresh_contexts
+        ctx_a.get_transfer_channel_client(url_b)
+        ctx_a.remove_transfer_channel_client(url_b)
+        assert ctx_a.get_num_connected_clients() == 0
+
+        # Reconnect and verify data transfer still works
+        client = ctx_a.get_transfer_channel_client(url_b)
+        assert ctx_a.get_num_connected_clients() == 1
+
+        local = ctx_a.get_transfer_channel_address([(0, 256)])
+        remote = ctx_b.get_transfer_channel_address([(0, 256)])
+        task_id = client.submit_read(local, remote)
+
+        result = _wait_finished(client, task_id)
+        assert result.is_finished() is True
+        assert result.succeeded_mask == [True]
+        assert torch.equal(buf_a[:256], buf_b[:256])
+
+    def test_connecting_does_not_register_reverse_client(self, fresh_contexts):
+        """TCP connections are unidirectional: A connecting to B does not give B
+        a client to A (unlike nixl's passive client creation)."""
+        ctx_a, _, _, ctx_b, _, url_b = fresh_contexts
+        assert ctx_a.get_num_connected_clients() == 0
+        assert ctx_b.get_num_connected_clients() == 0
+
+        ctx_a.get_transfer_channel_client(url_b)
+
+        # A has a client to B, but B does NOT have a reverse client to A
+        assert ctx_a.get_num_connected_clients() == 1
+        assert ctx_b.get_num_connected_clients() == 0
+
+    def test_server_is_available_from_context(self, shared_contexts):
+        ctx_a, _, _, _, _, _ = shared_contexts
+        assert ctx_a.get_transfer_channel_server() is not None
+
+    def test_close_cleans_up_all_clients(self, fresh_contexts):
+        """Closing the context should clean up all clients."""
+        ctx_a, _, _, _, _, url_b = fresh_contexts
+        ctx_a.get_transfer_channel_client(url_b)
+        assert ctx_a.get_num_connected_clients() == 1
+
+        ctx_a.close()
+        assert ctx_a.get_num_connected_clients() == 0
+
+
+# =========================================================
+# Bidirectional reads (both sides read from each other)
+# =========================================================
+class TestBidirectionalReads:
+    """Tests that both peers can read from each other (with separate connections)."""
+
+    def test_both_peers_can_read_from_each_other(self, fresh_contexts):
+        """Both A and B can read from each other using separate client connections."""
+        ctx_a, buf_a, url_a, ctx_b, buf_b, url_b = fresh_contexts
+
+        # Write a known pattern into buf_a for B to read
+        buf_a[:256] = torch.arange(0, 256, dtype=torch.uint8)
+
+        # A reads from B
+        client_a_to_b = ctx_a.get_transfer_channel_client(url_b)
+        local_a = ctx_a.get_transfer_channel_address([(256, 256)])
+        remote_b = ctx_b.get_transfer_channel_address([(0, 256)])
+        task_id_1 = client_a_to_b.submit_read(local_a, remote_b)
+
+        result_1 = _wait_finished(client_a_to_b, task_id_1)
+        assert result_1.is_finished() is True
+        assert result_1.succeeded_mask == [True]
+        assert torch.equal(buf_a[256:512], buf_b[0:256])
+
+        # B reads from A
+        client_b_to_a = ctx_b.get_transfer_channel_client(url_a)
+        local_b = ctx_b.get_transfer_channel_address([(256, 256)])
+        remote_a = ctx_a.get_transfer_channel_address([(0, 256)])
+        task_id_2 = client_b_to_a.submit_read(local_b, remote_a)
+
+        result_2 = _wait_finished(client_b_to_a, task_id_2)
+        assert result_2.is_finished() is True
+        assert result_2.succeeded_mask == [True]
+        assert torch.equal(buf_b[256:512], buf_a[0:256])
+
+
+# =========================================================
+# Concurrent reads
+# =========================================================
+class TestConcurrentReads:
+    """Tests for concurrent read operations."""
+
+    def test_multiple_concurrent_reads(self, shared_contexts):
+        """Multiple reads submitted without waiting should all complete."""
+        ctx_a, buf_a, _, ctx_b, buf_b, url_b = shared_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+
+        task_ids = []
+        for i in range(4):
+            offset = i * 256
+            local = ctx_a.get_transfer_channel_address([(offset, 256)])
+            remote = ctx_b.get_transfer_channel_address([(offset, 256)])
+            task_id = client.submit_read(local, remote)
+            task_ids.append((task_id, offset))
+
+        # Wait for all to complete
+        for task_id, offset in task_ids:
+            result = _wait_finished(client, task_id)
+            assert result.is_finished() is True
+            assert result.succeeded_mask == [True]
+            assert torch.equal(
+                buf_a[offset : offset + 256], buf_b[offset : offset + 256]
+            )
+
+
+# =========================================================
+# Error handling
+# =========================================================
+class TestErrorHandling:
+    """Tests for error conditions and edge cases."""
+
+    def test_connect_to_nonexistent_server_raises(self):
+        """Connecting to a port with no server should raise."""
+        buf = torch.zeros(_BUF_SIZE, dtype=torch.uint8)
+        desc = L1MemoryDesc(ptr=buf.data_ptr(), size=buf.numel(), align_bytes=_ALIGN)
+        url = _next_url()
+        ctx = TcpTransferChannelContext(desc, listen_url=url, advertise_url=url)
+        try:
+            # Use a port that is very unlikely to have a server
+            bad_url = "127.0.0.1:1"
+            with pytest.raises((ConnectionRefusedError, OSError)):
+                ctx.get_transfer_channel_client(bad_url)
+        finally:
+            ctx.close()
+
+    def test_read_after_server_close_marks_task_failed(self, fresh_contexts):
+        """If the server closes, eventually new reads should fail gracefully."""
+        ctx_a, buf_a, _, ctx_b, buf_b, url_b = fresh_contexts
+        client = ctx_a.get_transfer_channel_client(url_b)
+
+        # Verify the connection works first
+        local = ctx_a.get_transfer_channel_address([(0, 256)])
+        remote = ctx_b.get_transfer_channel_address([(0, 256)])
+        task_id = client.submit_read(local, remote)
+        result = _wait_finished(client, task_id)
+        assert result.is_finished() is True
+        assert result.succeeded_mask == [True]
+
+        # Close the server side
+        ctx_b.close()
+
+        # Wait until the client's recv loop detects the broken connection.
+        # We poll by submitting reads until one fails, with a deadline.
+        deadline = time.monotonic() + 5.0
+        saw_failure = False
+        while time.monotonic() < deadline:
+            time.sleep(0.2)
+            local_n = ctx_a.get_transfer_channel_address([(256, 256)])
+            remote_n = [TransferChannelAddress(offset=256, size=256)]
+            tid = client.submit_read(local_n, remote_n)
+            res = _wait_finished(client, tid, timeout_s=2.0)
+            if res.is_finished() and res.succeeded_mask == [False]:
+                saw_failure = True
+                break
+
+        assert saw_failure, "Expected at least one read to fail after server close"


### PR DESCRIPTION
add `tcp` transfer channel for p2p, I tested in 2 * H20, the configs are as follows:
# DEPLOY
- machine 1:
1. step 1: start coordinator 
```
lmcache coordinator --host 0.0.0.0 --port 9300
```
2. step 2: start lmcache server
```
lmcache server \
    --host xxx \
    --port 16666 \
    --prometheus-port 9009 \
    --chunk-size 256 \
    --l1-size-gb 3 \
    --eviction-policy LRU \
    --max-workers 1 \
    --p2p-transfer-engine tcp \
    --p2p-advertise-url xxx:17777 \
    --coordinator-url http://xxx:9300 \
    --coordinator-advertise-ip xxx
```
3. step3: start vllm
```
LOG_DIR=/data1/mp/logs/
MODEL_PATH="/data1/deepseek/DeepSeek-V2-Lite-Chat/"
KV_TRANSFER_CONFIG='{"kv_connector":"LMCacheMPConnector","kv_connector_module_path":"lmcache.integration.vllm.lmcache_mp_connector","kv_role":"kv_both","kv_connector_extra_config":{"lmcache.mp.port":16666, "lmcache.mp.host":"tcp://xxx","lmcache.mp.heartbeat_interval":20, "lmcache.mp.heartbeat_init_wait":30}}'

/usr/bin/python3 -m vllm.entrypoints.cli.main serve $MODEL_PATH \
    -tp 2 \
    --load-format dummy \
    --trust-remote-code \
    --served-model-name lmcache_test \
    --gpu_memory_utilization 0.85 \
    --max-num-seqs 64 \
    --enforce-eager --max-model-len 81920 \
    --port 8002 \
    --kv-transfer-config "$KV_TRANSFER_CONFIG" \
    > $LOG_DIR/vllm_server.log 2>&1 &
```

- machine 2
only start lmcache server and vllm. 

# TEST
1. send a curl request to machine 1, and we can see the log:
<img width="1587" height="46" alt="Clipboard_Screenshot_1782385772" src="https://github.com/user-attachments/assets/dbff85e3-0edb-45cb-a65e-1291d467d7bb" />
2. send the same request to machine 2, and we can see the log:
<img width="1578" height="129" alt="Clipboard_Screenshot_1782385946" src="https://github.com/user-attachments/assets/4072cf7e-83d9-4fdc-81d3-57c06d24e08c" />
get kvcache from machine 1
 