### PR TITLE
[Refactor] Dispatch transfers per group EngineKVFormat (MiniMaxM3 2/2)

### DIFF
--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -118,7 +118,7 @@ def create_engine_group_infos_from_vllm(
     # First Party
     from lmcache.utils import EngineType
     from lmcache.v1.gpu_connector.utils import (
-        normalize_and_discover_per_group_formats,
+        normalize_and_discover_per_layer_formats,
     )
     from lmcache.v1.kv_layer_groups import (
         EXCLUDED_ENGINE_GROUP,
@@ -144,7 +144,7 @@ def create_engine_group_infos_from_vllm(
     layer_index_groups = [
         [layer_to_idx[name] for name in group.layer_names] for group in vllm_groups
     ]
-    normalized_kv_caches, engine_kv_formats = normalize_and_discover_per_group_formats(
+    normalized_kv_caches, engine_kv_formats = normalize_and_discover_per_layer_formats(
         per_layer_discoverable_kv_caches,
         layer_index_groups,
         EngineType.VLLM,

--- a/lmcache/integration/vllm/kv_cache_groups.py
+++ b/lmcache/integration/vllm/kv_cache_groups.py
@@ -118,21 +118,12 @@ def create_engine_group_infos_from_vllm(
     # First Party
     from lmcache.utils import EngineType
     from lmcache.v1.gpu_connector.utils import (
-        get_num_layers,
-        normalize_kv_and_discover_format,
+        normalize_and_discover_per_group_formats,
     )
     from lmcache.v1.kv_layer_groups import (
         EXCLUDED_ENGINE_GROUP,
         group_layers_by_identity,
     )
-
-    # Inspect the real registered tensors for physical layout and dtype.
-    engine_kv_format, normalized_kv_caches = normalize_kv_and_discover_format(
-        list(kv_caches.values()),
-        EngineType.VLLM,
-        layout_hints=layout_hints,
-    )
-    num_layers = get_num_layers(normalized_kv_caches, engine_kv_format)
 
     # vLLM-specific field access (confined to this function): map each
     # registered KV tensor to its vLLM engine KV cache group index. vLLM places
@@ -140,12 +131,26 @@ def create_engine_group_infos_from_vllm(
     # have disjoint block-id spaces and must not share an LMCache group. ``None``
     # means a single (non-hybrid) group, i.e. every layer shares one block-id
     # space.
+    per_layer_discoverable_kv_caches = list(kv_caches.values())
     layer_to_idx = {name: idx for idx, name in enumerate(kv_caches.keys())}
     vllm_groups = (
         getattr(kv_cache_config, "kv_cache_groups", ()) or ()
         if kv_cache_config is not None
         else ()
     )
+
+    # Detect the Engine KV format of each registered tensor: per engine group
+    # when they mix formats (e.g. MiniMax-M3), one shared format otherwise.
+    layer_index_groups = [
+        [layer_to_idx[name] for name in group.layer_names] for group in vllm_groups
+    ]
+    normalized_kv_caches, engine_kv_formats = normalize_and_discover_per_group_formats(
+        per_layer_discoverable_kv_caches,
+        layer_index_groups,
+        EngineType.VLLM,
+        layout_hints,
+    )
+    num_layers = len(engine_kv_formats)
     # Layers absent from every engine group's ``layer_names`` are cross-layer
     # KV-sharing layers (e.g. google/gemma-4-E4B-it): vLLM aliases them to a
     # target owner's KV tensor, so the owner's group already covers them. Tag
@@ -183,8 +188,7 @@ def create_engine_group_infos_from_vllm(
         )
         for identity, indices in group_layers_by_identity(
             normalized_kv_caches,
-            engine_kv_format,
-            num_layers,
+            engine_kv_formats,
             per_layer_group_idx,
         )
     ]

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -28,7 +28,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_layers,
     get_page_buffer_size,
     get_tokens_per_layer,
-    normalize_and_discover_per_group_formats,
+    normalize_and_discover_per_layer_formats,
     normalize_kv_and_discover_format,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -467,7 +467,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         # This legacy in-process connector has no engine group metadata, so all
         # layers form one (non-hybrid) group with a single shared format.
         no_engine_groups: list[list[int]] = []
-        self.kvcaches, engine_kv_formats = normalize_and_discover_per_group_formats(
+        self.kvcaches, engine_kv_formats = normalize_and_discover_per_layer_formats(
             self.kvcaches, no_engine_groups, EngineType.VLLM, self.layout_hints
         )
         self.engine_kv_format = engine_kv_formats[0]

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -28,6 +28,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_layers,
     get_page_buffer_size,
     get_tokens_per_layer,
+    normalize_and_discover_per_group_formats,
     normalize_kv_and_discover_format,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
@@ -463,9 +464,13 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.init:
             return
 
-        self.engine_kv_format, self.kvcaches = normalize_kv_and_discover_format(
-            self.kvcaches, EngineType.VLLM, layout_hints=self.layout_hints
+        # This legacy in-process connector has no engine group metadata, so all
+        # layers form one (non-hybrid) group with a single shared format.
+        no_engine_groups: list[list[int]] = []
+        self.kvcaches, engine_kv_formats = normalize_and_discover_per_group_formats(
+            self.kvcaches, no_engine_groups, EngineType.VLLM, self.layout_hints
         )
+        self.engine_kv_format = engine_kv_formats[0]
         self.num_blocks = get_num_blocks(self.kvcaches, self.engine_kv_format)
         self.block_size = get_block_size(self.kvcaches, self.engine_kv_format)
         self.page_buffer_size = self.num_blocks * self.block_size
@@ -474,7 +479,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         if self.metadata.kv_layer_groups_manager is None:
             self.metadata.kv_layer_groups_manager = KVLayerGroupsManager(
                 self.kvcaches,
-                engine_kv_format=self.engine_kv_format,
+                engine_kv_formats=engine_kv_formats,
                 num_blocks=self.num_blocks,
             )
         klg_manager = self.metadata.kv_layer_groups_manager

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -7,6 +7,7 @@
 # callers keep working unchanged.
 # mypy: disable-error-code="union-attr,call-overload"
 # Standard
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Optional, Union
 
 # Third Party
@@ -221,6 +222,102 @@ def normalize_kv_and_discover_format(
         storage with the input but may be a permuted view.
     """
     return detect_format(kv_caches, serving_engine, layout_hints)
+
+
+def _detect_whole_list_format(
+    per_layer_caches: "Sequence[DiscoverableKVCache]",
+    serving_engine: EngineType,
+    layout_hints: "LayoutHints | None",
+) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
+    """Detect the whole list as one format and repeat it for every layer.
+
+    The canonical single-format path -- used when there are no engine groups or
+    when every group resolved to the same format. Kept identical to the
+    pre-per-group behavior so uniform models stay byte-for-byte unchanged.
+    """
+    # detect_format's detector does isinstance(.., list) and indexes by layer, so
+    # hand it a concrete list (a tuple would skip the fused branch and misdetect).
+    kv_caches = list(per_layer_caches)
+    engine_kv_format, normalized = detect_format(
+        kv_caches, serving_engine, layout_hints
+    )
+    return normalized, [engine_kv_format] * get_num_layers(normalized, engine_kv_format)
+
+
+def normalize_and_discover_per_group_formats(
+    per_layer_discoverable_kv_caches: "Sequence[DiscoverableKVCache]",
+    layer_index_groups: "Sequence[Sequence[int]]",
+    serving_engine: EngineType,
+    layout_hints: "LayoutHints | None" = None,
+) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
+    """Normalize per-layer KV caches and discover one Engine KV format per layer.
+
+    Engines that place differently-formatted layers in different groups -- e.g.
+    MiniMax-M3's K+V main cache (``kv_size=2``) alongside its key-only MLA index
+    cache (``kv_size=1``) -- need each group detected on its own tensors;
+    detecting the whole list at once would collapse to a single format and
+    mis-shape one group. When the groups resolve to differing formats, each group
+    is detected independently and a per-layer format list is returned. Otherwise
+    (no groups, or every group the same format -- every model supported today)
+    the whole list is detected once and the single shared format is repeated for
+    every layer, leaving behavior byte-for-byte unchanged.
+
+    Args:
+        per_layer_discoverable_kv_caches: One KV cache entry per layer (the
+            layer-indexable sequence every call site already builds). A bare
+            fused tensor is intentionally not accepted: per-group detection is
+            inherently per-layer, and ``list()`` on a single tensor would shred
+            it into dim-0 slices.
+        layer_index_groups: Layer indices of each engine group (one inner
+            sequence per group). Empty means a single non-hybrid group.
+        serving_engine: Which serving engine produced the caches.
+        layout_hints: See :class:`LayoutHints`.
+
+    Returns:
+        ``(normalized_kv_caches, engine_kv_formats)``. ``engine_kv_formats`` holds
+        one format per layer (its length is the layer count), ready for
+        :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
+    """
+    # No engine groups: one shared format for every layer.
+    if not layer_index_groups:
+        return _detect_whole_list_format(
+            per_layer_discoverable_kv_caches, serving_engine, layout_hints
+        )
+
+    # Detect each engine group on its own tensors. The loop mutates this copy,
+    # never the input, so the whole-list fallback below still detects on the
+    # original (pristine) entries.
+    normalized_per_layer = list(per_layer_discoverable_kv_caches)
+    per_layer_format: list[Optional["lmc_ops.EngineKVFormat"]] = [None] * len(
+        normalized_per_layer
+    )
+    seen_formats: set[int] = set()
+    for indices in layer_index_groups:
+        group_format, normalized_sub = detect_format(
+            [normalized_per_layer[i] for i in indices],
+            serving_engine,
+            layout_hints,
+        )
+        seen_formats.add(int(group_format))
+        for sub_idx, layer_idx in enumerate(indices):
+            normalized_per_layer[layer_idx] = normalized_sub[sub_idx]
+            per_layer_format[layer_idx] = group_format
+
+    # Groups all resolved to one format: identical to the no-groups case, so take
+    # the same canonical whole-list path rather than trusting the per-group
+    # assembly to match it (keeps uniform models byte-for-byte unchanged).
+    if len(seen_formats) == 1:
+        return _detect_whole_list_format(
+            per_layer_discoverable_kv_caches, serving_engine, layout_hints
+        )
+
+    # Heterogeneous (e.g. MiniMax-M3): return the per-layer formats. Layers in no
+    # group (cross-layer KV sharing) keep their tensor and are skipped downstream;
+    # fill their slot with any detected format so every layer has one.
+    shared = next(fmt for fmt in per_layer_format if fmt is not None)
+    return normalized_per_layer, [
+        fmt if fmt is not None else shared for fmt in per_layer_format
+    ]
 
 
 def get_num_layers(

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -230,35 +230,25 @@ def normalize_and_discover_per_layer_formats(
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None" = None,
 ) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
-    """Normalize the KV caches and discover one Engine KV format per layer.
+    """Normalize the KV caches and return one Engine KV format per layer.
 
-    Engines that place differently-formatted layers in different groups -- e.g.
-    MiniMax-M3's K+V main cache (``kv_size=2``) alongside its key-only MLA index
-    cache (``kv_size=1``) -- need each group detected on its own tensors;
-    detecting the whole list at once would collapse to a single format and
-    mis-shape one group. Each engine group is therefore detected independently and
-    the per-group results are assembled into a per-layer list.
-
-    With no engine groups, one synthetic group spanning every layer is used, which
-    is exactly the old whole-list detection. Normalization
-    (:func:`attempt_permute_to_contiguous_view` plus the detector reshape) is
-    per-tensor, so the assembled per-layer result is byte-for-byte identical to
-    detecting the whole list at once -- uniform models stay unchanged without a
-    separate code path.
+    Reports each layer's own format, so models whose layers do not all share one
+    format -- e.g. MiniMax-M3's K+V main cache (``kv_size=2``) alongside its
+    key-only MLA index cache (``kv_size=1``) -- get a correct per-layer format
+    rather than a single model-wide one.
 
     Args:
-        kv_caches: The registered KV caches. Per-group detection applies only to a
-            layer-indexable ``list`` (one entry per layer); a single fused tensor
-            is single-format by construction and is detected directly.
+        kv_caches: The registered KV caches: a per-layer list, or a single fused
+            tensor for cross-layer formats.
         layer_index_groups: Layer indices of each engine group (one inner
             sequence per group). Empty means a single non-hybrid group.
         serving_engine: Which serving engine produced the caches.
         layout_hints: See :class:`LayoutHints`.
 
     Returns:
-        ``(normalized_kv_caches, engine_kv_formats)``. ``engine_kv_formats`` holds
-        one format per layer (its length is the layer count), ready for
-        :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
+        ``(normalized_kv_caches, engine_kv_formats)``: the canonical KV cache
+        structure and one format per layer (length equals the layer count),
+        ready for :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
     """
     # A single fused tensor is single-format by construction and cannot be indexed
     # by layer; detect it directly and repeat the format for every layer.

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -225,19 +225,17 @@ def normalize_kv_and_discover_format(
 
 
 def _detect_whole_list_format(
-    per_layer_caches: "Sequence[DiscoverableKVCache]",
+    kv_caches: "DiscoverableKVCache",
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None",
 ) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
-    """Detect the whole list as one format and repeat it for every layer.
+    """Detect the whole structure as one format and repeat it for every layer.
 
-    The canonical single-format path -- used when there are no engine groups or
-    when every group resolved to the same format. Kept identical to the
-    pre-per-group behavior so uniform models stay byte-for-byte unchanged.
+    The canonical single-format path -- used when there are no engine groups, the
+    caches are a single fused tensor, or every group resolved to the same format.
+    Kept identical to the pre-per-group behavior so uniform models stay
+    byte-for-byte unchanged.
     """
-    # detect_format's detector does isinstance(.., list) and indexes by layer, so
-    # hand it a concrete list (a tuple would skip the fused branch and misdetect).
-    kv_caches = list(per_layer_caches)
     engine_kv_format, normalized = detect_format(
         kv_caches, serving_engine, layout_hints
     )
@@ -245,7 +243,7 @@ def _detect_whole_list_format(
 
 
 def normalize_and_discover_per_group_formats(
-    per_layer_discoverable_kv_caches: "Sequence[DiscoverableKVCache]",
+    kv_caches: "DiscoverableKVCache",
     layer_index_groups: "Sequence[Sequence[int]]",
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None" = None,
@@ -258,16 +256,15 @@ def normalize_and_discover_per_group_formats(
     detecting the whole list at once would collapse to a single format and
     mis-shape one group. When the groups resolve to differing formats, each group
     is detected independently and a per-layer format list is returned. Otherwise
-    (no groups, or every group the same format -- every model supported today)
-    the whole list is detected once and the single shared format is repeated for
-    every layer, leaving behavior byte-for-byte unchanged.
+    (no groups, a single fused tensor, or every group the same format -- every
+    model supported today) the whole structure is detected once and the single
+    shared format is repeated for every layer, leaving behavior byte-for-byte
+    unchanged.
 
     Args:
-        per_layer_discoverable_kv_caches: One KV cache entry per layer (the
-            layer-indexable sequence every call site already builds). A bare
-            fused tensor is intentionally not accepted: per-group detection is
-            inherently per-layer, and ``list()`` on a single tensor would shred
-            it into dim-0 slices.
+        kv_caches: The registered KV caches. Per-group detection applies only to a
+            layer-indexable ``list`` (one entry per layer); a single fused tensor
+            is single-format by construction and takes the whole-list path.
         layer_index_groups: Layer indices of each engine group (one inner
             sequence per group). Empty means a single non-hybrid group.
         serving_engine: Which serving engine produced the caches.
@@ -278,16 +275,16 @@ def normalize_and_discover_per_group_formats(
         one format per layer (its length is the layer count), ready for
         :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
     """
-    # No engine groups: one shared format for every layer.
-    if not layer_index_groups:
-        return _detect_whole_list_format(
-            per_layer_discoverable_kv_caches, serving_engine, layout_hints
-        )
+    # Per-group detection is inherently per-layer, so it applies only to a
+    # layer-indexable list. No groups, or a single fused tensor, means one shared
+    # format for every layer via the canonical whole-list path.
+    if not layer_index_groups or not isinstance(kv_caches, list):
+        return _detect_whole_list_format(kv_caches, serving_engine, layout_hints)
 
-    # Detect each engine group on its own tensors. The loop mutates this copy,
-    # never the input, so the whole-list fallback below still detects on the
-    # original (pristine) entries.
-    normalized_per_layer = list(per_layer_discoverable_kv_caches)
+    # Private writable copy: the loop scatters each group's normalized tensors in
+    # by layer index. The input is never mutated, so the whole-list fallback below
+    # still detects on the original (pristine) entries.
+    normalized_per_layer = list(kv_caches)
     per_layer_format: list[Optional["lmc_ops.EngineKVFormat"]] = [None] * len(
         normalized_per_layer
     )
@@ -307,9 +304,7 @@ def normalize_and_discover_per_group_formats(
     # the same canonical whole-list path rather than trusting the per-group
     # assembly to match it (keeps uniform models byte-for-byte unchanged).
     if len(seen_formats) == 1:
-        return _detect_whole_list_format(
-            per_layer_discoverable_kv_caches, serving_engine, layout_hints
-        )
+        return _detect_whole_list_format(kv_caches, serving_engine, layout_hints)
 
     # Heterogeneous (e.g. MiniMax-M3): return the per-layer formats. Layers in no
     # group (cross-layer KV sharing) keep their tensor and are skipped downstream;

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -224,47 +224,32 @@ def normalize_kv_and_discover_format(
     return detect_format(kv_caches, serving_engine, layout_hints)
 
 
-def _detect_whole_list_format(
-    kv_caches: "DiscoverableKVCache",
-    serving_engine: EngineType,
-    layout_hints: "LayoutHints | None",
-) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
-    """Detect the whole structure as one format and repeat it for every layer.
-
-    The canonical single-format path -- used when there are no engine groups, the
-    caches are a single fused tensor, or every group resolved to the same format.
-    Kept identical to the pre-per-group behavior so uniform models stay
-    byte-for-byte unchanged.
-    """
-    engine_kv_format, normalized = detect_format(
-        kv_caches, serving_engine, layout_hints
-    )
-    return normalized, [engine_kv_format] * get_num_layers(normalized, engine_kv_format)
-
-
 def normalize_and_discover_per_group_formats(
     kv_caches: "DiscoverableKVCache",
     layer_index_groups: "Sequence[Sequence[int]]",
     serving_engine: EngineType,
     layout_hints: "LayoutHints | None" = None,
 ) -> "tuple[DiscoverableKVCache, list[lmc_ops.EngineKVFormat]]":
-    """Normalize per-layer KV caches and discover one Engine KV format per layer.
+    """Normalize the KV caches and discover one Engine KV format per layer.
 
     Engines that place differently-formatted layers in different groups -- e.g.
     MiniMax-M3's K+V main cache (``kv_size=2``) alongside its key-only MLA index
     cache (``kv_size=1``) -- need each group detected on its own tensors;
     detecting the whole list at once would collapse to a single format and
-    mis-shape one group. When the groups resolve to differing formats, each group
-    is detected independently and a per-layer format list is returned. Otherwise
-    (no groups, a single fused tensor, or every group the same format -- every
-    model supported today) the whole structure is detected once and the single
-    shared format is repeated for every layer, leaving behavior byte-for-byte
-    unchanged.
+    mis-shape one group. Each engine group is therefore detected independently and
+    the per-group results are scattered back into a per-layer list.
+
+    With no engine groups, one synthetic group spanning every layer is used, which
+    is exactly the old whole-list detection. Normalization
+    (:func:`attempt_permute_to_contiguous_view` plus the detector reshape) is
+    per-tensor, so the assembled per-layer result is byte-for-byte identical to
+    detecting the whole list at once -- uniform models stay unchanged without a
+    separate code path.
 
     Args:
         kv_caches: The registered KV caches. Per-group detection applies only to a
             layer-indexable ``list`` (one entry per layer); a single fused tensor
-            is single-format by construction and takes the whole-list path.
+            is single-format by construction and is detected directly.
         layer_index_groups: Layer indices of each engine group (one inner
             sequence per group). Empty means a single non-hybrid group.
         serving_engine: Which serving engine produced the caches.
@@ -275,40 +260,37 @@ def normalize_and_discover_per_group_formats(
         one format per layer (its length is the layer count), ready for
         :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
     """
-    # Per-group detection is inherently per-layer, so it applies only to a
-    # layer-indexable list. No groups, or a single fused tensor, means one shared
-    # format for every layer via the canonical whole-list path.
-    if not layer_index_groups or not isinstance(kv_caches, list):
-        return _detect_whole_list_format(kv_caches, serving_engine, layout_hints)
+    # A single fused tensor is single-format by construction and cannot be indexed
+    # by layer; detect it directly and repeat the format for every layer.
+    if not isinstance(kv_caches, list):
+        engine_kv_format, normalized = detect_format(
+            kv_caches, serving_engine, layout_hints
+        )
+        return normalized, [engine_kv_format] * get_num_layers(
+            normalized, engine_kv_format
+        )
 
-    # Private writable copy: the loop scatters each group's normalized tensors in
-    # by layer index. The input is never mutated, so the whole-list fallback below
-    # still detects on the original (pristine) entries.
+    # Detect each engine group on its own tensors; with no groups, one synthetic
+    # group spans every layer (== whole-list detection). The loop reads the
+    # pristine input and scatters normalized tensors into a private copy by layer
+    # index, so the input is never mutated.
+    groups = layer_index_groups or [range(len(kv_caches))]
     normalized_per_layer = list(kv_caches)
     per_layer_format: list[Optional["lmc_ops.EngineKVFormat"]] = [None] * len(
         normalized_per_layer
     )
-    seen_formats: set[int] = set()
-    for indices in layer_index_groups:
+    for indices in groups:
         group_format, normalized_sub = detect_format(
-            [normalized_per_layer[i] for i in indices],
+            [kv_caches[i] for i in indices],
             serving_engine,
             layout_hints,
         )
-        seen_formats.add(int(group_format))
         for sub_idx, layer_idx in enumerate(indices):
             normalized_per_layer[layer_idx] = normalized_sub[sub_idx]
             per_layer_format[layer_idx] = group_format
 
-    # Groups all resolved to one format: identical to the no-groups case, so take
-    # the same canonical whole-list path rather than trusting the per-group
-    # assembly to match it (keeps uniform models byte-for-byte unchanged).
-    if len(seen_formats) == 1:
-        return _detect_whole_list_format(kv_caches, serving_engine, layout_hints)
-
-    # Heterogeneous (e.g. MiniMax-M3): return the per-layer formats. Layers in no
-    # group (cross-layer KV sharing) keep their tensor and are skipped downstream;
-    # fill their slot with any detected format so every layer has one.
+    # Layers in no group (cross-layer KV sharing) keep their tensor and are skipped
+    # downstream; fill their slot with any detected format so every layer has one.
     shared = next(fmt for fmt in per_layer_format if fmt is not None)
     return normalized_per_layer, [
         fmt if fmt is not None else shared for fmt in per_layer_format

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -224,7 +224,7 @@ def normalize_kv_and_discover_format(
     return detect_format(kv_caches, serving_engine, layout_hints)
 
 
-def normalize_and_discover_per_group_formats(
+def normalize_and_discover_per_layer_formats(
     kv_caches: "DiscoverableKVCache",
     layer_index_groups: "Sequence[Sequence[int]]",
     serving_engine: EngineType,
@@ -237,7 +237,7 @@ def normalize_and_discover_per_group_formats(
     cache (``kv_size=1``) -- need each group detected on its own tensors;
     detecting the whole list at once would collapse to a single format and
     mis-shape one group. Each engine group is therefore detected independently and
-    the per-group results are scattered back into a per-layer list.
+    the per-group results are assembled into a per-layer list.
 
     With no engine groups, one synthetic group spanning every layer is used, which
     is exactly the old whole-list detection. Normalization
@@ -271,14 +271,11 @@ def normalize_and_discover_per_group_formats(
         )
 
     # Detect each engine group on its own tensors; with no groups, one synthetic
-    # group spans every layer (== whole-list detection). The loop reads the
-    # pristine input and scatters normalized tensors into a private copy by layer
-    # index, so the input is never mutated.
+    # group spans every layer (== whole-list detection). Normalization is
+    # per-tensor, so assembling the per-group results matches detecting the whole
+    # list -- uniform models are unchanged.
     groups = layer_index_groups or [range(len(kv_caches))]
-    normalized_per_layer = list(kv_caches)
-    per_layer_format: list[Optional["lmc_ops.EngineKVFormat"]] = [None] * len(
-        normalized_per_layer
-    )
+    detected: dict[int, tuple[DiscoverableKVCache, "lmc_ops.EngineKVFormat"]] = {}
     for indices in groups:
         group_format, normalized_sub = detect_format(
             [kv_caches[i] for i in indices],
@@ -286,15 +283,20 @@ def normalize_and_discover_per_group_formats(
             layout_hints,
         )
         for sub_idx, layer_idx in enumerate(indices):
-            normalized_per_layer[layer_idx] = normalized_sub[sub_idx]
-            per_layer_format[layer_idx] = group_format
+            detected[layer_idx] = (normalized_sub[sub_idx], group_format)
 
-    # Layers in no group (cross-layer KV sharing) keep their tensor and are skipped
-    # downstream; fill their slot with any detected format so every layer has one.
-    shared = next(fmt for fmt in per_layer_format if fmt is not None)
-    return normalized_per_layer, [
-        fmt if fmt is not None else shared for fmt in per_layer_format
+    # A layer in no group (cross-layer KV sharing) keeps its own tensor and is
+    # skipped downstream; give it any detected format so every layer has one.
+    fallback_format = next(fmt for _, fmt in detected.values())
+    normalized_per_layer = [
+        detected[i][0] if i in detected else kv_caches[i]
+        for i in range(len(kv_caches))
     ]
+    engine_kv_formats = [
+        detected[i][1] if i in detected else fallback_format
+        for i in range(len(kv_caches))
+    ]
+    return normalized_per_layer, engine_kv_formats
 
 
 def get_num_layers(

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -183,6 +183,12 @@ class KernelGroupInfo:
     """Torch dtype of the KV cache tensors for this group. Used for
     kernel template instantiation; see class docstring for why we keep
     this alongside ``shape_desc.element_size``."""
+    engine_kv_format: "lmc_ops.EngineKVFormat"
+    """Engine KV format of this group's layers (every layer in a group shares
+    one format). The per-group transfer path reads this instead of the cache
+    context's single representative format, so a model that mixes formats across
+    engine groups -- e.g. MiniMax-M3's K+V main cache and key-only MLA index
+    cache -- dispatches each group with its own format."""
     tokens_per_block: int = 0
     """Logical engine tokens covered by one paged chunk (one engine block
     ID) of this group, as declared by the engine's KV cache spec at
@@ -401,6 +407,7 @@ class KVLayerGroupsManager:
                     layer_indices=indices,
                     shape_desc=shape_desc,
                     dtype=dt,
+                    engine_kv_format=group_format,
                     tokens_per_block=tokens_per_block,
                     engine_group_idx=engine_group_idx,
                     sw_size_tokens=sw_size_tokens,
@@ -751,6 +758,15 @@ def parse_kvcache_shape_spec(
                 "Shape must be a 5-tuple (kv_size,nb,bs,nh,hs): %s" % group_spec
             )
         kv_size, nb, bs, nh, hs = shape
+        # The shape spec fixes a canonical per-layer layout (kv_size, nb, bs, nh,
+        # hs), so recover the matching Engine KV format from kv_size (1 => key-only
+        # MLA, otherwise K+V) -- the spec carries no format enum, but the kernel
+        # group needs one just like the detected path.
+        engine_kv_format = (
+            lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
+            if kv_size == 1
+            else lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+        )
         shape_desc = lmc_ops.PageBufferShapeDesc()
         shape_desc.kv_size = kv_size
         shape_desc.nl = layer_count
@@ -767,6 +783,7 @@ def parse_kvcache_shape_spec(
                 layer_indices=indices,
                 shape_desc=shape_desc,
                 dtype=dtype,
+                engine_kv_format=engine_kv_format,
             )
         )
         layer_offset += layer_count

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -74,19 +74,13 @@ def group_layers_by_identity(
 ) -> list[tuple[LayerGroupIdentity, list[int]]]:
     """Partition layer indices by :data:`LayerGroupIdentity`.
 
-    This helper is shared by vLLM-side LMCache group inflation and server-side
-    ``KernelGroupInfo`` construction so both sides agree on group order.
-
     Args:
-        kv_caches: Registered KV cache structure inspected for per-layer shape
-            and dtype.
-        engine_kv_formats: One Engine KV format per registered tensor, each
-            returned by :func:`normalize_kv_and_discover_format` and used to read
-            heads/sizes/``kv_size``. Its length is the layer count. Homogeneous
-            models repeat one shared format; a model that mixes formats across
-            engine groups -- e.g. MiniMax-M3's K+V main cache (``kv_size=2``) plus
-            its key-only MLA index cache (``kv_size=1``) -- supplies the differing
-            per-layer formats.
+        kv_caches: Registered KV cache structure, one entry per layer.
+        engine_kv_formats: One Engine KV format per registered tensor; its length
+            is the layer count. Homogeneous models repeat one shared format; a
+            model that mixes formats across engine groups -- e.g. MiniMax-M3's K+V
+            main cache (``kv_size=2``) plus its key-only MLA index cache
+            (``kv_size=1``) -- supplies the differing per-layer formats.
         per_layer_engine_group_idx: Optional engine block group id per layer.
             When ``None`` every layer is treated as block group 0 (non-hybrid);
             when present, layers from different engine block groups never share an
@@ -96,8 +90,7 @@ def group_layers_by_identity(
 
     Returns:
         A list of ``(identity, layer_indices)`` pairs sorted by each group's
-        first layer index, so the group order is deterministic and identical on
-        both the vLLM and server sides.
+        first layer index, so the group order is deterministic.
 
     Raises:
         ValueError: If ``per_layer_engine_group_idx`` is given but its length
@@ -299,17 +292,9 @@ class KVLayerGroupsManager:
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         lmcache_tokens_per_chunk: int = 256,
     ) -> None:
-        """Partition layers into groups keyed by
-        :data:`LayerGroupIdentity`.
+        """Partition the layers into kernel groups for this set of KV caches.
 
-        For each layer ``i`` in ``kv_caches``, read
-        ``(kv_size, num_heads, head_size, dtype)`` via the format-aware
-        accessors in ``utils.py``. Layers with identical identities are
-        bucketed together; each bucket becomes one
-        :class:`KernelGroupInfo`.
-
-        Groups are emitted in the order of their first-appearing layer,
-        so group indices are deterministic across runs.
+        Group order is deterministic across runs.
 
         Args:
             kv_caches: KV cache structure accepted by

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -69,8 +69,7 @@ EXCLUDED_ENGINE_GROUP = -1
 
 def group_layers_by_identity(
     kv_caches: "DiscoverableKVCache",
-    engine_kv_format: "lmc_ops.EngineKVFormat",
-    num_layers: int,
+    engine_kv_formats: "Sequence[lmc_ops.EngineKVFormat]",
     per_layer_engine_group_idx: Sequence[int] | None = None,
 ) -> list[tuple[LayerGroupIdentity, list[int]]]:
     """Partition layer indices by :data:`LayerGroupIdentity`.
@@ -81,21 +80,28 @@ def group_layers_by_identity(
     Args:
         kv_caches: Registered KV cache structure inspected for per-layer shape
             and dtype.
-        engine_kv_format: Format descriptor returned by
-            :func:`normalize_kv_and_discover_format`, used to read heads/sizes.
-        num_layers: Number of registered KV tensors to partition.
-        per_layer_engine_group_idx: Optional per-registered-index engine
-            block group id. When ``None`` every layer is treated as block group
-            0 (non-hybrid); when present, layers from different engine block
-            groups never share an identity even if their tensor shapes match.
-            Layers whose value is ``EXCLUDED_ENGINE_GROUP`` are left out of all
-            groups (e.g. cross-layer KV-sharing layers whose KV lives in their
-            target owner's blocks).
+        engine_kv_formats: One Engine KV format per registered tensor, each
+            returned by :func:`normalize_kv_and_discover_format` and used to read
+            heads/sizes/``kv_size``. Its length is the layer count. Homogeneous
+            models repeat one shared format; a model that mixes formats across
+            engine groups -- e.g. MiniMax-M3's K+V main cache (``kv_size=2``) plus
+            its key-only MLA index cache (``kv_size=1``) -- supplies the differing
+            per-layer formats.
+        per_layer_engine_group_idx: Optional engine block group id per layer.
+            When ``None`` every layer is treated as block group 0 (non-hybrid);
+            when present, layers from different engine block groups never share an
+            identity even if their tensor shapes match. Layers whose value is
+            ``EXCLUDED_ENGINE_GROUP`` are left out of all groups (e.g. cross-layer
+            KV-sharing layers whose KV lives in their target owner's blocks).
 
     Returns:
         A list of ``(identity, layer_indices)`` pairs sorted by each group's
         first layer index, so the group order is deterministic and identical on
         both the vLLM and server sides.
+
+    Raises:
+        ValueError: If ``per_layer_engine_group_idx`` is given but its length
+            does not match ``engine_kv_formats``.
     """
     # First Party
     from lmcache.v1.gpu_connector.utils import (
@@ -106,8 +112,16 @@ def group_layers_by_identity(
         is_mla,
     )
 
-    mla = is_mla(engine_kv_format)
-    kv_size = 1 if mla else 2
+    num_layers = len(engine_kv_formats)
+    if (
+        per_layer_engine_group_idx is not None
+        and len(per_layer_engine_group_idx) != num_layers
+    ):
+        raise ValueError(
+            f"per_layer_engine_group_idx has {len(per_layer_engine_group_idx)} "
+            f"entries but engine_kv_formats has {num_layers} layers"
+        )
+
     groups_dict: dict[LayerGroupIdentity, list[int]] = defaultdict(list)
     for idx in range(num_layers):
         engine_group_idx = (
@@ -119,10 +133,13 @@ def group_layers_by_identity(
         # KV-sharing layers, whose KV lives in their target owner's blocks).
         if engine_group_idx == EXCLUDED_ENGINE_GROUP:
             continue
-        nh = 1 if mla else get_num_heads(kv_caches, engine_kv_format, idx)
-        hs = get_head_size(kv_caches, engine_kv_format, idx)
-        dt = get_dtype(kv_caches, engine_kv_format, idx)
-        bs = get_block_size(kv_caches, engine_kv_format, idx)
+        layer_format = engine_kv_formats[idx]
+        mla = is_mla(layer_format)
+        kv_size = 1 if mla else 2
+        nh = 1 if mla else get_num_heads(kv_caches, layer_format, idx)
+        hs = get_head_size(kv_caches, layer_format, idx)
+        dt = get_dtype(kv_caches, layer_format, idx)
+        bs = get_block_size(kv_caches, layer_format, idx)
 
         identity = LayerGroupIdentity(
             kv_size=kv_size,
@@ -277,7 +294,7 @@ class KVLayerGroupsManager:
     def __init__(
         self,
         kv_caches: "DiscoverableKVCache",
-        engine_kv_format: "lmc_ops.EngineKVFormat",
+        engine_kv_formats: "Sequence[lmc_ops.EngineKVFormat]",
         num_blocks: int,
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         lmcache_tokens_per_chunk: int = 256,
@@ -296,9 +313,13 @@ class KVLayerGroupsManager:
 
         Args:
             kv_caches: KV cache structure accepted by
-                :func:`normalize_kv_and_discover_format`.
-            engine_kv_format: Format returned by
-                :func:`normalize_kv_and_discover_format`.
+                :func:`normalize_and_discover_per_group_formats`.
+            engine_kv_formats: One Engine KV format per layer (its length is the
+                layer count), from
+                :func:`normalize_and_discover_per_group_formats`. A model that
+                mixes formats across engine groups (e.g. MiniMax-M3) supplies the
+                differing per-layer formats so each group is shaped with its own;
+                homogeneous models repeat one shared format.
             num_blocks: Number of paged blocks in the device KV cache.
             engine_group_infos: Engine KV cache group metadata, one info per
                 kernel group in kernel-group order, or empty.
@@ -308,7 +329,6 @@ class KVLayerGroupsManager:
         # lmcache.v1.gpu_connector.__init__ → metadata → kv_layer_groups.
         # First Party
         from lmcache.v1.gpu_connector.utils import (
-            get_num_layers,
             make_page_buffer_shape_desc,
             resolve_block_stride_and_log_layout,
         )
@@ -317,7 +337,7 @@ class KVLayerGroupsManager:
         self._kernel_groups: list[KernelGroupInfo] = []
         self._object_groups: list[ObjectGroupInfo] = []
 
-        num_layers = get_num_layers(kv_caches, engine_kv_format)
+        num_layers = len(engine_kv_formats)
         if num_layers == 0:
             logger.debug("No KV caches available, skipping KV layer groups building")
             return
@@ -325,9 +345,8 @@ class KVLayerGroupsManager:
         per_layer_engine_group_idx = get_engine_group_indices(
             engine_group_infos, num_layers
         )
-
         groups_by_identity = group_layers_by_identity(
-            kv_caches, engine_kv_format, num_layers, per_layer_engine_group_idx
+            kv_caches, engine_kv_formats, per_layer_engine_group_idx
         )
 
         # Engine group infos are produced by the same group_layers_by_identity
@@ -345,15 +364,20 @@ class KVLayerGroupsManager:
         for group_idx, ((_, _, _, bs, engine_group_idx, dt), indices) in enumerate(
             groups_by_identity
         ):
+            # Layers are bucketed by geometry derived from their format, so in
+            # practice every layer in a group shares one format; use the first
+            # layer's. (Promoting format into the identity to make this provable
+            # is a follow-up.)
+            group_format = engine_kv_formats[indices[0]]
             block_stride_elems = resolve_block_stride_and_log_layout(
                 kv_caches,
-                engine_kv_format,
+                group_format,
                 layer_idx=indices[0],
                 group_idx=group_idx,
             )
             shape_desc = make_page_buffer_shape_desc(
                 kv_caches,
-                engine_kv_format,
+                group_format,
                 layer_idx=indices[0],
                 num_layers_in_group=len(indices),
                 num_blocks=num_blocks,

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -313,10 +313,10 @@ class KVLayerGroupsManager:
 
         Args:
             kv_caches: KV cache structure accepted by
-                :func:`normalize_and_discover_per_group_formats`.
+                :func:`normalize_and_discover_per_layer_formats`.
             engine_kv_formats: One Engine KV format per layer (its length is the
                 layer count), from
-                :func:`normalize_and_discover_per_group_formats`. A model that
+                :func:`normalize_and_discover_per_layer_formats`. A model that
                 mixes formats across engine groups (e.g. MiniMax-M3) supplies the
                 differing per-layer formats so each group is shaped with its own;
                 homogeneous models repeat one shared format.

--- a/lmcache/v1/multiprocess/group_view.py
+++ b/lmcache/v1/multiprocess/group_view.py
@@ -105,6 +105,33 @@ def _engine_group_id_per_view(
     return tuple(group.engine_group_id for group in groups)
 
 
+def engine_group_layer_indices(
+    groups: Sequence[EngineGroupInfo],
+) -> list[list[int]]:
+    """Return each engine group's layer indices, ordered by engine group id.
+
+    Several ``EngineGroupInfo`` may share one ``engine_group_id`` (when one
+    engine group is split by transfer identity); their ``layer_indices`` are
+    unioned. The result feeds per-engine-group KV format detection so the server
+    reconstructs the same per-layer formats the engine side produced.
+
+    Args:
+        groups: The LMCache KV groups, in protocol order.
+
+    Returns:
+        One sorted ``list[int]`` of layer indices per engine group, indexed by
+        engine group id (dense from 0). Empty when ``groups`` is empty (a single
+        non-hybrid group with no per-group split).
+    """
+    if not groups:
+        return []
+    num_groups = max(group.engine_group_id for group in groups) + 1
+    per_group: list[list[int]] = [[] for _ in range(num_groups)]
+    for group in groups:
+        per_group[group.engine_group_id].extend(group.layer_indices)
+    return [sorted(indices) for indices in per_group]
+
+
 def expand_engine_block_ids(
     groups: Sequence[EngineGroupInfo],
     engine_side_block_ids: Sequence[Sequence[int]] | Sequence[int],

--- a/lmcache/v1/multiprocess/group_view.py
+++ b/lmcache/v1/multiprocess/group_view.py
@@ -110,10 +110,8 @@ def engine_group_layer_indices(
 ) -> list[list[int]]:
     """Return each engine group's layer indices, ordered by engine group id.
 
-    Several ``EngineGroupInfo`` may share one ``engine_group_id`` (when one
-    engine group is split by transfer identity); their ``layer_indices`` are
-    unioned. The result feeds per-engine-group KV format detection so the server
-    reconstructs the same per-layer formats the engine side produced.
+    Several ``EngineGroupInfo`` may share one ``engine_group_id``; their
+    ``layer_indices`` are unioned into that group's entry.
 
     Args:
         groups: The LMCache KV groups, in protocol order.

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -367,7 +367,7 @@ def transfer_kv_per_object_group(
                 direction,
                 cache_context.get_shape_desc(kernel_group_id),
                 group_lmcache_chunk_size,
-                cache_context.engine_kv_format,
+                cache_context.get_engine_kv_format(kernel_group_id),
                 recalculated_skip_blocks,
             )
 

--- a/lmcache/v1/platform/base_cache_context.py
+++ b/lmcache/v1/platform/base_cache_context.py
@@ -200,6 +200,15 @@ class BaseCacheContext(ABC):
         """Returns the PageBufferShapeDesc for *group_idx*."""
         return self.kv_layer_groups_manager.get_shape_desc(group_idx)
 
+    def get_engine_kv_format(self, group_idx: int) -> "lmc_ops.EngineKVFormat":
+        """Returns the Engine KV format of kernel *group_idx*.
+
+        The per-group format -- read by the transfer path so a model mixing
+        formats across groups (e.g. MiniMax-M3) dispatches each group with its
+        own, instead of the context's single representative ``engine_kv_format``.
+        """
+        return self.kv_layer_groups_manager.kv_layer_groups[group_idx].engine_kv_format
+
     def get_slots_per_chunk_in_sw(self, kernel_group_idx: int) -> int:
         """Returns the number of slots per lmcache chunk for D/H
         transfer."""
@@ -270,7 +279,7 @@ class BaseCacheContext(ABC):
         """Returns the engine KV shape with actual numeric values."""
         group = self.kv_layer_groups_manager.kv_layer_groups[0]
         return get_concrete_engine_kv_shape_from_shape_desc(
-            group.shape_desc, self.engine_kv_format
+            group.shape_desc, group.engine_kv_format
         )
 
     # ------------------------------------------------------------------

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -33,7 +33,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
-    normalize_and_discover_per_group_formats,
+    normalize_and_discover_per_layer_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
@@ -99,7 +99,7 @@ class CPUCacheContext(BaseCacheContext):
         (
             kv_caches_normalized,
             engine_kv_formats,
-        ) = normalize_and_discover_per_group_formats(
+        ) = normalize_and_discover_per_layer_formats(
             unwrapped,
             engine_group_layer_indices(engine_group_infos),
             engine_type,

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -33,10 +33,11 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
-    normalize_kv_and_discover_format,
+    normalize_and_discover_per_group_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.group_view import engine_group_layer_indices
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 from lmcache.v1.platform.cpu.stub_cpu_device import StubStream
 
@@ -92,21 +93,28 @@ class CPUCacheContext(BaseCacheContext):
         # GPUCacheContext uses, so we don't need to hand-roll any
         # PageBufferShapeDesc here. ``layout_hints`` / ``engine_type``
         # are forwarded so the signature matches GPUCacheContext.
+        # Detect each engine group's format from the registered tensors so a
+        # model mixing formats across groups (e.g. MiniMax-M3) groups and shapes
+        # correctly. Homogeneous models yield one shared format for every layer.
         (
-            engine_kv_format,
             kv_caches_normalized,
-        ) = normalize_kv_and_discover_format(
+            engine_kv_formats,
+        ) = normalize_and_discover_per_group_formats(
             unwrapped,
+            engine_group_layer_indices(engine_group_infos),
             engine_type,
-            layout_hints=layout_hints,
+            layout_hints,
         )
         kv_caches_list: list[torch.Tensor] = list(kv_caches_normalized)
+        # Representative format for context-wide, format-only queries (identical
+        # to the single detected format for every homogeneous model).
+        engine_kv_format = engine_kv_formats[0]
         is_mla_val = is_mla(engine_kv_format)
         num_layers_val = get_num_layers(kv_caches_list, engine_kv_format)
         num_blocks_val = get_num_blocks(kv_caches_list, engine_kv_format)
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_list,
-            engine_kv_format=engine_kv_format,
+            engine_kv_formats=engine_kv_formats,
             num_blocks=num_blocks_val,
             engine_group_infos=engine_group_infos,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -407,7 +407,7 @@ class GPUCacheContext(BaseCacheContext):
         self.group_kv_pointers_: list[torch.Tensor] = []
         for group in self.kv_layer_groups_manager_.kv_layer_groups:
             ptrs = get_group_data_ptrs(
-                self.kv_caches_, self.engine_kv_format, group.layer_indices
+                self.kv_caches_, group.engine_kv_format, group.layer_indices
             )
             self.group_kv_pointers_.append(list_to_gpu_tensor(ptrs, self.device_))
 

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -32,7 +32,7 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
-    normalize_and_discover_per_group_formats,
+    normalize_and_discover_per_layer_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
@@ -362,7 +362,7 @@ class GPUCacheContext(BaseCacheContext):
         # Detect each engine group's format from the registered tensors so a
         # model mixing formats across groups (e.g. MiniMax-M3) groups and shapes
         # correctly. Homogeneous models yield one shared format for every layer.
-        kv_caches_norm, engine_kv_formats = normalize_and_discover_per_group_formats(
+        kv_caches_norm, engine_kv_formats = normalize_and_discover_per_layer_formats(
             unwrapped,
             engine_group_layer_indices(engine_group_infos),
             engine_type,

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -32,11 +32,14 @@ from lmcache.v1.gpu_connector.utils import (
     get_num_blocks,
     get_num_layers,
     is_mla,
-    normalize_kv_and_discover_format,
+    normalize_and_discover_per_group_formats,
 )
 from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.multiprocess.custom_types import KVCache
-from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.group_view import (
+    EngineGroupInfo,
+    engine_group_layer_indices,
+)
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 
 logger = init_logger(__name__)
@@ -356,11 +359,18 @@ class GPUCacheContext(BaseCacheContext):
         engine_type: EngineType = EngineType.VLLM,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
-        engine_kv_format, kv_caches_norm = normalize_kv_and_discover_format(
+        # Detect each engine group's format from the registered tensors so a
+        # model mixing formats across groups (e.g. MiniMax-M3) groups and shapes
+        # correctly. Homogeneous models yield one shared format for every layer.
+        kv_caches_norm, engine_kv_formats = normalize_and_discover_per_group_formats(
             unwrapped,
+            engine_group_layer_indices(engine_group_infos),
             engine_type,
-            layout_hints=layout_hints,
+            layout_hints,
         )
+        # Representative format for context-wide, format-only queries (identical
+        # to the single detected format for every homogeneous model).
+        engine_kv_format = engine_kv_formats[0]
         self.device_ = get_device(kv_caches_norm)
         is_mla_val = is_mla(engine_kv_format)
         num_layers_val = get_num_layers(kv_caches_norm, engine_kv_format)
@@ -368,7 +378,7 @@ class GPUCacheContext(BaseCacheContext):
 
         kv_layer_groups_manager = KVLayerGroupsManager(
             kv_caches_norm,
-            engine_kv_format=engine_kv_format,
+            engine_kv_formats=engine_kv_formats,
             num_blocks=num_blocks_val,
             engine_group_infos=engine_group_infos,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/tests/v1/platform/test_gpu_cache_context.py
+++ b/tests/v1/platform/test_gpu_cache_context.py
@@ -99,7 +99,7 @@ def _build_manager(
     """Build a real :class:`KVLayerGroupsManager` from synthetic tensors."""
     return KVLayerGroupsManager(
         tensors,
-        engine_kv_format=engine_kv_format,
+        engine_kv_formats=[engine_kv_format] * len(tensors),
         num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
         lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,

--- a/tests/v1/test_gpu_connector.py
+++ b/tests/v1/test_gpu_connector.py
@@ -955,7 +955,7 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
     kv_list = list(kv_caches.values())
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
-        engine_kv_format=engine_kv_format,
+        engine_kv_formats=[engine_kv_format] * len(kv_list),
         num_blocks=get_num_blocks(kv_list, engine_kv_format),
     )
     return metadata

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -43,7 +43,7 @@ def _build_manager(
 
     return KVLayerGroupsManager(
         tensors,
-        engine_kv_format=lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        engine_kv_formats=[lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS] * len(tensors),
         num_blocks=num_blocks,
         engine_group_infos=engine_group_infos,
     )
@@ -71,6 +71,39 @@ class TestKVLayerGroupsManager:
         assert group.shape_desc.nb == 32
         assert group.shape_desc.bs == 256
         assert group.dtype == torch.float16
+
+    def test_build_mixed_formats_per_group(self):
+        """MiniMax-M3 shape: a K+V group and a key-only MLA group are shaped
+        with their own per-layer formats (kv_size 2 and 1), not one shared
+        format -- the server-side per-group path."""
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        tensors = [
+            torch.randn(2, 32, 256, 8, 64, dtype=torch.bfloat16),  # K+V (rank-5)
+            torch.randn(32, 256, 128, dtype=torch.bfloat16),  # MLA key-only (rank-3)
+        ]
+        manager = KVLayerGroupsManager(
+            tensors,
+            engine_kv_formats=[
+                lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+                lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
+            ],
+            num_blocks=32,
+            engine_group_infos=[
+                EngineGroupInfo(0, (0,)),
+                EngineGroupInfo(1, (1,)),
+            ],
+        )
+
+        groups = manager.kernel_groups
+        assert len(groups) == 2
+        by_group = {g.engine_group_idx: g for g in groups}
+        assert by_group[0].shape_desc.kv_size == 2  # K+V main cache
+        assert by_group[0].shape_desc.nh == 8
+        assert by_group[1].shape_desc.kv_size == 1  # key-only MLA index cache
+        assert by_group[1].shape_desc.nh == 1
+        assert by_group[1].shape_desc.hs == 128
 
     def test_build_multiple_layers_same_shape(self):
         tensors = [

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -104,6 +104,12 @@ class TestKVLayerGroupsManager:
         assert by_group[1].shape_desc.kv_size == 1  # key-only MLA index cache
         assert by_group[1].shape_desc.nh == 1
         assert by_group[1].shape_desc.hs == 128
+        # Each kernel group persists its own format for the transfer path.
+        assert (
+            by_group[0].engine_kv_format
+            == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+        )
+        assert by_group[1].engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
 
     def test_build_multiple_layers_same_shape(self):
         tensors = [
@@ -243,6 +249,19 @@ class TestParseKvcacheShapeSpec:
         assert g.shape_desc.nl == 32
         assert g.dtype == torch.float16
         assert g.layer_indices == list(range(32))
+        # The shape spec carries no format enum; kv_size=2 recovers the K+V one.
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        assert g.engine_kv_format == lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS
+
+    def test_single_group_mla_recovers_key_only_format(self):
+        """kv_size=1 recovers the key-only MLA format (no enum in the spec)."""
+        # First Party
+        import lmcache.c_ops as lmc_ops
+
+        groups = parse_kvcache_shape_spec("(1,1024,16,1,128):bfloat16:8")
+        assert groups[0].engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
 
     def test_multiple_groups(self):
         """Test parsing multiple groups separated by semicolons."""

--- a/tests/v1/test_vllm_kv_cache_groups.py
+++ b/tests/v1/test_vllm_kv_cache_groups.py
@@ -44,6 +44,13 @@ class FullAttentionSpec:
 
 
 @dataclass
+class MLAAttentionSpec:
+    """Key-only, one-vector-per-token spec (e.g. MiniMax-M3's index cache)."""
+
+    block_size: int
+
+
+@dataclass
 class UniformTypeKVCacheSpecs:
     block_size: int
     kv_cache_specs: "dict[str, object]" = field(default_factory=dict)
@@ -62,6 +69,11 @@ class MockKVCacheConfig:
 
 def _same_shape_caches(names: list[str]) -> dict[str, torch.Tensor]:
     return {n: torch.randn(2, 32, 16, 8, 64, dtype=torch.float16) for n in names}
+
+
+def _mla_caches(names: list[str]) -> dict[str, torch.Tensor]:
+    """Key-only rank-3 caches (num_blocks, block_size, head_size), MLA layout."""
+    return {n: torch.randn(32, 16, 128, dtype=torch.bfloat16) for n in names}
 
 
 def test_conversion_defaults_to_single_group_without_config():
@@ -220,4 +232,79 @@ def test_conversion_mixed_window_layers_in_one_group_rejected():
                 kv_cache_groups=[MockKVCacheGroup(["layer.0", "layer.1"], uniform_spec)]
             ),
             _same_shape_caches(["layer.0", "layer.1"]),
+        )
+
+
+def test_conversion_mixed_kv_and_mla_groups():
+    """MiniMax-M3 shape: a K+V FullAttentionSpec group plus a key-only MLA index
+    group are detected per engine group and kept as separate LMCache groups with
+    the correct membership and per-group token packing."""
+    caches = {
+        **_same_shape_caches(["main.0", "main.1"]),
+        **_mla_caches(["idx.0", "idx.1"]),
+    }
+    spec = create_engine_group_infos_from_vllm(
+        MockKVCacheConfig(
+            kv_cache_groups=[
+                MockKVCacheGroup(
+                    ["main.0", "main.1"], FullAttentionSpec(block_size=16)
+                ),
+                MockKVCacheGroup(["idx.0", "idx.1"], MLAAttentionSpec(block_size=128)),
+            ]
+        ),
+        caches,
+    )
+
+    assert num_engine_groups(spec) == 2
+    assert [group.engine_group_id for group in spec] == [0, 1]
+    assert [group.layer_indices for group in spec] == [(0, 1), (2, 3)]
+    assert [group.tokens_per_block for group in spec] == [16, 128]
+
+
+def test_group_layers_by_identity_uses_per_layer_format():
+    """A per-layer Engine KV format gives the K+V layer kv_size=2 and the MLA
+    layer kv_size=1, splitting them into separate identities -- the per-group
+    distinction the single global format cannot express."""
+    # First Party
+    from lmcache.v1.kv_layer_groups import group_layers_by_identity
+    import lmcache.c_ops as lmc_ops
+
+    kv_caches = [
+        torch.randn(2, 32, 16, 8, 64, dtype=torch.bfloat16),  # K+V (rank-5)
+        torch.randn(32, 16, 128, dtype=torch.bfloat16),  # MLA key-only (rank-3)
+    ]
+    per_layer_format = [
+        lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS,
+        lmc_ops.EngineKVFormat.NL_X_NB_BS_HS,
+    ]
+    groups = group_layers_by_identity(
+        kv_caches,
+        per_layer_format,
+        per_layer_engine_group_idx=[0, 1],
+    )
+
+    kv_size_by_group = {
+        identity.engine_group_idx: identity.kv_size for identity, _ in groups
+    }
+    num_heads_by_group = {
+        identity.engine_group_idx: identity.num_heads for identity, _ in groups
+    }
+    assert kv_size_by_group == {0: 2, 1: 1}
+    # The MLA group collapses heads to 1; the K+V group keeps its head count.
+    assert num_heads_by_group == {0: 8, 1: 1}
+
+
+def test_group_layers_by_identity_rejects_group_idx_length_mismatch():
+    """per_layer_engine_group_idx must hold one entry per layer."""
+    # First Party
+    from lmcache.v1.kv_layer_groups import group_layers_by_identity
+    import lmcache.c_ops as lmc_ops
+
+    kv_caches = [torch.randn(2, 32, 16, 8, 64, dtype=torch.bfloat16)]
+    # One layer (one format) but two engine-group ids.
+    with pytest.raises(ValueError, match="per_layer_engine_group_idx"):
+        group_layers_by_identity(
+            kv_caches,
+            [lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS],
+            per_layer_engine_group_idx=[0, 1],
         )

--- a/tests/v1/test_xpu_connector.py
+++ b/tests/v1/test_xpu_connector.py
@@ -830,7 +830,7 @@ def _create_metadata(use_mla, kv_caches, engine_kv_format):
     kv_list = list(kv_caches.values())
     metadata.kv_layer_groups_manager = KVLayerGroupsManager(
         kv_list,
-        engine_kv_format=engine_kv_format,
+        engine_kv_formats=[engine_kv_format] * len(kv_list),
         num_blocks=get_num_blocks(kv_list, engine_kv_format),
     )
     return metadata


### PR DESCRIPTION
Persist the format per kernel group (KernelGroupInfo.engine_kv_format, set from the value PR A already computes) and switch the per-group consumers from the context's single representative to group.engine_kv_format: multi_layer_block_kv_transfer, get_group_data_ptrs, the base_cache_context shape-desc path, and is_mla where per-group. Supply the format in parse_kvcache_shape_spec. Route M3 through the MP connector (non-MP stays single-format). Adds the M3 end-to-end store/retrieve correctness test. Enables MiniMax-M3; GPU/M3-verified.