### PR TITLE
[MP][Coordinator] Warm-prefetch KV from L2 into L1

### DIFF
--- a/docs/design/v1/mp_coordinator/l2_prefetch.md
+++ b/docs/design/v1/mp_coordinator/l2_prefetch.md
@@ -1,0 +1,104 @@
+# Coordinator-Controlled L2→L1 Prefetch
+
+## Why
+
+An operator or scheduler that knows a node will soon serve a particular prompt
+(a traffic shift, a known-hot shared prefix) needs a way to **pre-warm** that
+node's L1 from L2 before the requests land. The coordinator already pushes L2
+*evict* and *resync* to nodes; this adds the symmetric *prefetch* control.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Cl as client / scheduler
+    participant Co as coordinator
+    participant M as mp server
+
+    Cl->>Co: POST /l2/prefetch {instance_id, model_name, world_size, token_ids, cache_salt}
+    Co->>M: POST /l2/prefetch (tokens forwarded verbatim)
+    M-->>Co: {request_id, chunks, status: "submitted"}
+    Co-->>Cl: {instance_id, request_id, chunks, status}
+    loop until completed
+        Cl->>Co: GET /l2/prefetch/{instance_id}/{request_id}
+        Co->>M: GET /l2/prefetch/{request_id}
+        M-->>Co: {status: pending | completed}
+        Co-->>Cl: (relayed verbatim)
+    end
+```
+
+A client names **one** registered MP server and a **token sequence** (plus the
+model/world_size and tenant salt). The coordinator resolves the target's
+address from the registry, `POST`s to its `/l2/prefetch`, and relays the
+server's `request_id` back. The client then polls
+`GET /l2/prefetch/{instance_id}/{request_id}` on the coordinator, which proxies
+the server's status. The warm holds **no read-lock** — completion is reported
+reactively and releases nothing; see `docs/design/v1/multiprocess/l2_apis.md`
+for the warm-prefetch lifecycle (retain-permanent, no-lock load). There is no
+background polling on either side: the submit and status calls are quick and
+the client drives completion on demand.
+
+## Components
+
+- **`schemas.py`** — `PrefetchRequest {instance_id, model_name, world_size,
+  token_ids, cache_salt}` and `PrefetchResponse {instance_id, request_id,
+  chunks, status}`.
+- **`l2/prefetch_manager.py`** — `L2PrefetchManager`. `submit_prefetch` awaits
+  the target's `POST /l2/prefetch` and returns its reply; `get_status` proxies
+  `GET /l2/prefetch/{request_id}` and relays `(status_code, body)`. No
+  fire-and-forget tasks — both calls are quick.
+- **`http_apis/l2_api.py`** — `POST /l2/prefetch` and
+  `GET /l2/prefetch/{instance_id}/{request_id}`. Each resolves the target via
+  `registry.get(instance_id)` (**404** if unknown) and uses the shared outbound
+  `httpx.AsyncClient` on `app.state.outbound_client`; a transport error to the
+  target surfaces as **502**.
+
+## Wiring (`app.py`)
+
+`create_app` instantiates `L2PrefetchManager` and puts it on
+`app.state.prefetch_manager`. The lifespan stashes the outbound client on
+`app.state.outbound_client` (it previously reached only the background loops)
+so request handlers can issue outbound calls.
+
+## Failure modes
+
+- **Unknown `instance_id`** → 404 (synchronous, before any outbound call).
+- **Target unreachable / non-2xx submit** → 502 from the coordinator (the
+  caller learns the submit failed, unlike a fire-and-forget dispatch).
+- **Target has no layout for `(model_name, world_size)`** → the server returns
+  409, surfaced to the caller via the 502/proxy path.
+- **Client abandons polling** → the server's job lingers as a small handle
+  entry (no lock held, no L1 pinned) until polled or swept — see the no-lock
+  lifecycle in `l2_apis.md`.
+
+## Scope
+
+The coordinator only routes submit + status; it does not track which keys a
+node already holds or retry. Completion is observed via the status endpoint
+(the warm acquires no read-lock, so it emits no `SM_READ_PREFETCHED_FINISHED`;
+the load itself still surfaces through the controller's
+`L2_PREFETCH_LOAD_COMPLETED` event).
+
+### Single-node vs. multi-node
+
+One `instance_id` is **one node's** MP server, and its L1 is shared with that
+node's workers via intra-node CUDA IPC — so it holds only the KV shards for the
+`global_rank`s served on that node. Concretely:
+
+- **Single-node deployment** (all `world_size` workers on one box, e.g. TP=8 on
+  one node): one instance holds every shard. A single `POST /l2/prefetch`
+  warms the whole model's KV for the prompt. **This is the supported case.**
+- **Multi-node deployment** (TP/PP spanning nodes): each node holds only its
+  slice. A single dispatch warms one node; the caller must warm *each* node's
+  `instance_id` to cover the full model. The MP server's all-rank fan-out also
+  loads foreign-rank keys that no local worker reads — harmless (best-effort:
+  they occupy L1 as unread, retained-but-unlocked entries that eviction
+  reclaims under pressure), but not optimal.
+
+**Coordinating multi-node fan-out — choosing the right set of `instance_id`s
+and restricting each to its local ranks — is deferred to the KV cache
+directory** (separate PR). The directory is the component that knows which node
+holds which shard; this endpoint is the per-node primitive it will drive.
+Restricting the fan-out to local ranks is intentionally *not* done here because
+the MP server does not yet track which `global_rank`s it serves — that per-node
+rank topology is directory-owned infrastructure.

--- a/docs/design/v1/multiprocess/l2_apis.md
+++ b/docs/design/v1/multiprocess/l2_apis.md
@@ -2,22 +2,117 @@
 
 ## Overview
 
-Two HTTP endpoints, both auto-discovered out of
+HTTP endpoints auto-discovered out of
 `lmcache/v1/multiprocess/http_apis/l2_api.py`:
 
 - `DELETE /l2` — delete the KV cache for a caller-supplied list of
   keys (the keys are addresses; the cached bytes are what gets removed).
 - `GET /l2/keys` — paginate keys currently resident in L2, optionally
   filtered by `model_name`.
+- `POST /l2/prefetch` — submit a **warm** L1 load of a token sequence's
+  chunks from L2. The caller sends `token_ids`, not keys; returns a
+  `request_id`.
+- `GET /l2/prefetch/{request_id}` — poll a submitted warm prefetch; status is
+  reported reactively and completion releases nothing (the warm holds no lock).
 
-Both endpoints operate on the **primary** L2 adapter — the first
-adapter configured in the storage manager's adapter list. There is no
-adapter selector on the wire. A deployment that wants these endpoints
-to target a specific adapter must configure that adapter first.
+`DELETE /l2` and `GET /l2/keys` operate on the **primary** L2 adapter —
+the first adapter configured in the storage manager's adapter list (an
+optional `?adapter=<type_name>` selector targets another). `POST
+/l2/prefetch` coalesces across **all** configured L2 adapters via the
+prefetch controller, so it has no adapter selector.
 
 These endpoints serve operator + admin workflows: "purge this user's
-keys," "show me what's resident in L2," "garbage-collect orphans after
-a deployment rename." They are NOT in the hot-path read/write flow.
+keys," "show me what's resident in L2," "pre-warm this node before a
+traffic shift." They are NOT in the hot-path read/write flow.
+
+### Warm prefetch (`POST /l2/prefetch`)
+
+Body: `{"model_name": str, "world_size": int, "token_ids": [int, ...],
+"cache_salt": str}`. The caller describes content by **tokens**, never by
+internal cache keys — a key is a content hash plus a per-rank layout bitmap,
+which callers cannot construct. The server hashes the tokens
+(`ctx.token_hasher.compute_chunk_hashes`) and expands each chunk across the
+node's ranks (`ipc_key_to_object_keys` with `worker_id=None`), exactly as the
+lookup path does. `model_name` / `world_size` also select the registered
+`MemoryLayoutDesc` (`ctx.layout_desc_registry.find`) for the L1 write buffers.
+
+`POST` returns **202** `{"request_id", "chunks", "status": "submitted"}` (or
+`{"chunks": 0, "status": "noop"}` when the sequence is shorter than one chunk);
+**409** if no layout is registered for `(model_name, world_size)` (the model
+has not allocated KV cache on this node yet); **400** if the token count
+exceeds the cap or `cache_salt` violates its invariants. The submit is
+non-blocking — the load runs in the `PrefetchController`'s thread.
+
+`GET /l2/prefetch/{request_id}` reports `{"status": "pending"}` or
+`{"status": "completed", "found_keys", "total_keys"}`, and **404** for an
+unknown id. The poll that first observes completion drops the job
+(exactly-once) — the warm holds no read-lock, so there is nothing to release —
+so a later poll for the same id is 404.
+
+`found_keys`/`total_keys` count only chunks **this request loaded from L2**;
+chunks already resident in L1 are skipped at `reserve_write` and not counted, so
+a partially-resident warm undercounts by the resident chunk count (a cold
+request loads and counts everything). Not counting the resident chunks is
+deliberate: an already-resident entry may be a transient temporary from another
+lookup, so claiming it as warmed could mislead.
+
+The warm submits with the gap-tolerant `TrimPolicy.SPARSE`, **not** the default
+`PREFIX`. This matters because the warm skips the L1-hit `reserve_read`, so the
+controller sees an already-resident chunk only as "not reserved" — indistinguishable
+from an L2 miss. Under `PREFIX` (`count_leading_ones`) a resident **leading**
+chunk would read as a gap at index 0 and trim the entire remainder, so warming a
+sequence whose prefix is already cached would load **nothing**. `SPARSE` keeps
+every not-yet-resident key regardless of gaps, so the trailing chunks still load.
+The trade-off: on a genuine mid-sequence L2 *miss* `SPARSE` also loads the
+post-gap chunks, which a contiguous-prefix lookup cannot reuse — harmless
+best-effort waste (the extra keys are retained-but-unlocked and evictable). The
+fully correct alternative (bridge only the resident prefix, still stop at real
+L2 gaps) would need the warm to feed an L1-residency probe into the prefix; that
+is deferred.
+
+> Keeping key construction server-side is deliberate: hashing scheme,
+> `chunk_size`, and per-rank layout are all engine-context concerns the caller
+> (and even the coordinator) does not have. The coordinator forwards
+> `token_ids` verbatim.
+
+**Node scope.** One MP server is one node; its L1 is shared with that node's
+workers via intra-node CUDA IPC, so it holds only the shards for the
+`global_rank`s served locally. Warming a single node fully covers a
+**single-node** deployment (all `world_size` workers on one box). On a
+**multi-node** deployment each node holds only its slice — the caller must warm
+each node, and the all-rank fan-out here also loads foreign-rank keys that no
+local worker reads (harmless best-effort waste). Fleet-wide fan-out and
+local-rank restriction are owned by the (separate) KV cache directory; this
+endpoint is the per-node primitive.
+
+State lives in a `WarmPrefetchJobs` table
+(`lmcache/v1/multiprocess/warm_prefetch.py`) on `app.state`: `submit` starts
+the prefetch and registers its handle under a `request_id`; `poll` reports
+status and, on completion, drops the job. The table is **handle-only** — the
+warm holds no lock, so there is nothing to release and no keys need to be kept
+around for a release step. There is **no server-side polling loop** — the
+caller drives completion via the status endpoint, and every `StorageManager`
+call here is non-blocking (the load runs in the controller's thread), so no
+asyncio is involved.
+
+A warm prefetch differs from the lookup-path prefetch through
+`PrefetchMode.WARM` (threaded `StorageManager.submit_prefetch_task` →
+`PrefetchController`), which is **warm-only** and redefines the load to:
+
+1. **Retain (permanent), not temporary.** Loaded chunks survive instead of
+   being deleted when a read-lock is released — and since there is no read-lock
+   here (below), without forced retention they would never persist.
+2. **Acquire no read-lock.** A lookup-path prefetch read-locks the loaded and
+   already-resident keys to pin them for the imminent TP reader; a warm has no
+   such reader, so it transitions loaded keys to *ready* via `finish_write`
+   (not `finish_write_and_reserve_read`), and `submit_prefetch_task` skips the
+   L1-hit `reserve_read` pass entirely. The chunks are left resident, retained,
+   unlocked, evictable, and re-lookupable — a later lookup takes its own lock.
+
+A job whose status is never polled to completion lingers in the table (and in
+the controller's small completed-result bookkeeping). Since **no lock is held,
+no L1 is pinned** — only a dict entry leaks; a TTL sweep that queries stale
+handles to drop them is a possible future addition.
 
 ---
 

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -269,3 +269,56 @@ L2 endpoint summary
    * - ``GET``
      - ``/l2/status``
      - Total usage and per-salt breakdown.
+   * - ``POST``
+     - ``/l2/prefetch``
+     - Submit a warm prefetch of a token sequence on one server; returns a ``request_id``.
+   * - ``GET``
+     - ``/l2/prefetch/{instance_id}/{request_id}``
+     - Poll a submitted warm prefetch (``pending`` / ``completed``).
+
+Warm prefetch (pre-loading L1 from L2)
+--------------------------------------
+
+Pre-warm one MP server's L1 with the KV for a known prompt **before** the
+requests arrive, so the first request hits L1 instead of paying the L2 fetch
+inline -- useful when you know a workload is about to be routed to a node (a
+traffic shift, a hot shared system prompt).
+
+You describe the content by **token ids** -- the unit the cache speaks -- never
+by internal cache keys, which you cannot construct (a key is a content hash
+plus a per-rank layout bitmap). The coordinator forwards the request to the
+named server, which hashes the tokens, expands them across the node's ranks,
+loads the chunks from L2 into L1, and **retains** them so a later lookup hits.
+
+The submit returns a ``request_id``; poll the status endpoint until
+``completed``. The warm acquires no lock -- the poll simply reports progress
+and clears the server-side job once the load finishes.
+
+.. code-block:: bash
+
+    # Submit: warm tenant "user-a"'s prompt on server "server-1"
+    curl -s -X POST http://localhost:9300/l2/prefetch \
+        -H 'Content-Type: application/json' \
+        -d '{
+            "instance_id": "server-1",
+            "model_name": "Qwen/Qwen3-8B",
+            "world_size": 1,
+            "token_ids": [101, 102, 103, "..."],
+            "cache_salt": "user-a"
+        }'
+    # -> {"instance_id": "server-1", "request_id": "abc123", "chunks": 12, "status": "submitted"}
+
+    # Poll until completed
+    curl -s http://localhost:9300/l2/prefetch/server-1/abc123
+    # -> {"status": "pending"}      # load still running
+    # -> {"status": "completed", "found_keys": 12, "total_keys": 12}
+
+A few rules of thumb:
+
+- ``token_ids`` must match what was stored (same tokenizer / special tokens)
+  and contain at least one full ``chunk_size`` of tokens -- only complete
+  chunks are warmed (a shorter sequence returns ``status: "noop"``).
+- ``world_size`` selects the server's KV layout and the per-rank fan-out
+  (``1`` for a single-GPU, TP=1 deployment).
+- **Single-node scope**: one ``instance_id`` warms only that node's shards.
+  For a model sharded across multiple nodes, warm each node's instance.

--- a/docs/source/mp/http_api.rst
+++ b/docs/source/mp/http_api.rst
@@ -163,6 +163,13 @@ compatibility with the vLLM-embedded API server.
      - ``/l2/keys``
      - Paginate keys currently resident in one L2 adapter (optionally
        filtered by ``model_name``).
+   * - POST
+     - ``/l2/prefetch``
+     - Warm a node's L1 by loading a token sequence's chunks from L2 ahead
+       of traffic; returns a ``request_id``.
+   * - GET
+     - ``/l2/prefetch/{request_id}``
+     - Poll a submitted warm prefetch (``pending`` / ``completed``).
 
 **Quota management**
 
@@ -592,6 +599,13 @@ Three endpoints — ``GET /l2/adapters``, ``DELETE /l2``, and
 backends, purge keys from one, and enumerate what is currently
 resident.
 
+A further pair — ``POST /l2/prefetch`` and
+``GET /l2/prefetch/{request_id}`` — lets an operator (or the
+coordinator) **pre-warm** a node's L1 from L2 ahead of traffic and poll
+the load to completion; they are documented at the end of this section.
+The coordinator exposes an ``instance_id``-routed variant of both — see
+:doc:`coordinator`.
+
 ``DELETE /l2`` and ``GET /l2/keys`` accept an optional
 ``?adapter=<type_name>`` query parameter to target a specific adapter.
 Omit the selector to target the **primary** (first-configured)
@@ -818,6 +832,123 @@ cause keys to appear, disappear, or shift between pages.
       next=$(echo "$page" | jq -r '.next_page_token // empty')
       [ -z "$next" ] && break
     done
+
+``POST /l2/prefetch``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Warm one node's L1 by loading a token sequence's chunks from L2 **ahead** of
+the requests that will use them, so the first request hits L1 instead of
+paying the L2 fetch inline. Useful when a workload is about to be routed to a
+node (a traffic shift, a hot shared system prompt).
+
+The caller describes content by **token ids**, never by internal cache keys (a
+key is a content hash plus a per-rank layout bitmap, which callers cannot
+construct). The server hashes the tokens, expands each chunk across the node's
+ranks, and submits a *warm* prefetch: loaded chunks are **retained**
+(permanent) and left **unlocked** — there is no downstream reader to pin them
+for, so a later real lookup takes its own lock. The call returns immediately;
+the load runs in the storage manager's own thread. It coalesces across all
+configured L2 adapters, so there is no ``?adapter=`` selector.
+
+**Request body:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 68
+
+   * - Field
+     - Type
+     - Description
+   * - ``model_name``
+     - string
+     - The served model id, exactly as registered (e.g. ``Qwen/Qwen3-8B``).
+   * - ``world_size``
+     - int
+     - The value vLLM registered for the node's KV layout and rank fan-out
+       (``1`` for a single-GPU, TP=1 deployment).
+   * - ``token_ids``
+     - list[int]
+     - The prompt token ids. Must use the same tokenizer / special-token
+       settings as the store, and contain at least one full ``chunk_size`` of
+       tokens — only complete chunks are warmed.
+   * - ``cache_salt``
+     - string
+     - Per-tenant key isolation; must match the store (default ``""``).
+
+**Response** (``202 Accepted``):
+
+.. code-block:: json
+
+    {"request_id": "abc123", "chunks": 12, "status": "submitted"}
+
+When the sequence is shorter than one chunk, nothing is submitted and there is
+no ``request_id`` to poll:
+
+.. code-block:: json
+
+    {"chunks": 0, "status": "noop"}
+
+**HTTP status codes:**
+
+- ``202``: submitted (or a ``noop`` as above).
+- ``400``: ``token_ids`` exceeds the per-request cap, or ``cache_salt``
+  violates its invariants.
+- ``409``: no layout registered for ``(model_name, world_size)`` — the model
+  has not allocated KV cache on this node yet (start vLLM first).
+- ``422``: request body fails field-level validation.
+- ``503``: engine not initialized.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s -X POST http://localhost:8080/l2/prefetch \
+        -H 'Content-Type: application/json' \
+        -d '{"model_name": "Qwen/Qwen3-8B", "world_size": 1,
+             "token_ids": [101, 102, 103], "cache_salt": "user-a"}'
+    # -> {"request_id": "abc123", "chunks": 1, "status": "submitted"}
+
+``GET /l2/prefetch/{request_id}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Poll a submitted warm prefetch. The warm holds no lock, so the poll only
+reports progress; the first poll that observes completion drops the job
+(exactly-once), so a later poll for the same id returns ``404``.
+
+**Response** (``200 OK``) while the load runs:
+
+.. code-block:: json
+
+    {"status": "pending"}
+
+…and once complete:
+
+.. code-block:: json
+
+    {"status": "completed", "found_keys": 12, "total_keys": 12}
+
+``found_keys`` / ``total_keys`` count only chunks **loaded from L2** by this
+request; chunks already resident in L1 are skipped at ``reserve_write`` and not
+counted, so a partially-resident warm undercounts by the resident chunk count
+(a cold request loads and counts everything). The warm uses the gap-tolerant
+``SPARSE`` trim policy, so an already-resident chunk does not stop the rest from
+loading — it loads every not-yet-resident chunk and reports that count. Not
+counting the resident chunks is deliberate: an already-present entry may be a
+transient temporary from another lookup, so claiming it as warmed could mislead.
+
+**HTTP status codes:**
+
+- ``200``: status reported (``pending`` or ``completed``).
+- ``404``: unknown ``request_id`` — already completed-and-consumed, or never
+  submitted.
+- ``503``: engine not initialized.
+
+**Example:**
+
+.. code-block:: bash
+
+    curl -s http://localhost:8080/l2/prefetch/abc123
+    # -> {"status": "completed", "found_keys": 1, "total_keys": 1}
 
 .. _mp-http-quota-api:
 

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -34,23 +34,15 @@ class TrimPolicy(enum.Enum):
 
 
 class PrefetchMode(enum.Enum):
-    """The intent of a prefetch, selecting the whole load discipline per request.
+    """The intent of a prefetch request.
 
-    The two modes are not independent knobs but one discriminant: each bundles a
-    retention decision *and* a locking decision, because both follow from whether
-    there is an imminent consumer for the loaded keys.
+    ``LOOKUP`` -- prefetch for an imminent reader: loaded keys are pinned for
+    the requesting workers, and whether they persist or are dropped after use
+    follows the configured prefetch policy.
 
-    ``LOOKUP`` -- load for an imminent reader (the lookup path). Retention defers
-    to the configured :class:`PrefetchPolicy` (the global ``prefetch_policy``
-    config decides temporary vs. retained), and loaded/already-resident keys are
-    **read-locked** to pin them for the requesting workers until they finish.
-
-    ``WARM`` -- speculative pre-warm (the coordinator-driven warm prefetch). There
-    is no imminent reader, so loaded keys are forced **permanent** and
-    transitioned write-locked -> ready via ``finish_write`` -- i.e. **no read
-    lock is acquired**. The object is immediately resident, unlocked, and
-    evictable; a warm holds nothing to release, and completion is observed by
-    querying the prefetch handle. A later real lookup takes its own lock.
+    ``WARM`` -- speculative pre-warm with no imminent reader: loaded keys are
+    retained and left unpinned (immediately resident and evictable), so a later
+    lookup can hit them.
     """
 
     LOOKUP = enum.auto()

--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -33,6 +33,30 @@ class TrimPolicy(enum.Enum):
     SPARSE = enum.auto()
 
 
+class PrefetchMode(enum.Enum):
+    """The intent of a prefetch, selecting the whole load discipline per request.
+
+    The two modes are not independent knobs but one discriminant: each bundles a
+    retention decision *and* a locking decision, because both follow from whether
+    there is an imminent consumer for the loaded keys.
+
+    ``LOOKUP`` -- load for an imminent reader (the lookup path). Retention defers
+    to the configured :class:`PrefetchPolicy` (the global ``prefetch_policy``
+    config decides temporary vs. retained), and loaded/already-resident keys are
+    **read-locked** to pin them for the requesting workers until they finish.
+
+    ``WARM`` -- speculative pre-warm (the coordinator-driven warm prefetch). There
+    is no imminent reader, so loaded keys are forced **permanent** and
+    transitioned write-locked -> ready via ``finish_write`` -- i.e. **no read
+    lock is acquired**. The object is immediately resident, unlocked, and
+    evictable; a warm holds nothing to release, and completion is observed by
+    querying the prefetch handle. A later real lookup takes its own lock.
+    """
+
+    LOOKUP = enum.auto()
+    WARM = enum.auto()
+
+
 @dataclass(frozen=True)
 class ObjectKey:
     """

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -28,6 +28,7 @@ from lmcache.v1.distributed.api import (
     AttnWindowDesc,
     MemoryLayoutDesc,
     ObjectKey,
+    PrefetchMode,
     TrimPolicy,
 )
 from lmcache.v1.distributed.error import L1Error
@@ -147,6 +148,10 @@ class InFlightPrefetchRequest:
     attn_desc: AttnWindowDesc = DEFAULT_ATTN_WINDOW_DESC
     """Cross-chunk attention windows of all object groups, in object-group
     order."""
+    mode: PrefetchMode = PrefetchMode.LOOKUP
+    """The prefetch intent (see :class:`PrefetchMode`).  ``WARM`` forces all
+    loaded keys permanent and acquires no read lock; ``LOOKUP`` defers
+    retention to the policy and read-locks loaded keys."""
 
     # Lookup phase: adapter_idx -> task_id (removed as results arrive)
     pending_lookup_tasks: dict[int, L2TaskId] = field(default_factory=dict)
@@ -239,6 +244,7 @@ class PrefetchController(StorageControllerInterface):
                 int,
                 TrimPolicy,
                 AttnWindowDesc,
+                PrefetchMode,
             ]
         ] = []
 
@@ -258,6 +264,7 @@ class PrefetchController(StorageControllerInterface):
                 int,
                 TrimPolicy,
                 AttnWindowDesc,
+                PrefetchMode,
             ]
         ] = []
         self._next_request_id: PrefetchRequestId = 0
@@ -342,6 +349,7 @@ class PrefetchController(StorageControllerInterface):
         extra_count: int = 0,
         policy: TrimPolicy = TrimPolicy.PREFIX,
         attn_desc: AttnWindowDesc = DEFAULT_ATTN_WINDOW_DESC,
+        mode: PrefetchMode = PrefetchMode.LOOKUP,
     ) -> PrefetchRequestId:
         """
         Submit a prefetch request for the given keys.
@@ -370,6 +378,10 @@ class PrefetchController(StorageControllerInterface):
                 :class:`TrimPolicy`).  Defaults to ``PREFIX``.
             attn_desc: Cross-chunk attention windows of all object groups, in
                 object-group order.
+            mode: The prefetch intent (see :class:`PrefetchMode`).  ``WARM``
+                forces every loaded key permanent and acquires no read lock;
+                ``LOOKUP`` defers retention to the configured
+                :class:`PrefetchPolicy` and read-locks loaded keys.
 
         Returns:
             A request ID for tracking via query_prefetch_result.
@@ -378,7 +390,7 @@ class PrefetchController(StorageControllerInterface):
             request_id = self._next_request_id
             self._next_request_id += 1
             self._submission_queue.append(
-                (request_id, keys, layout_desc, extra_count, policy, attn_desc)
+                (request_id, keys, layout_desc, extra_count, policy, attn_desc, mode)
             )
         self._submission_efd.notify()
         return request_id
@@ -762,12 +774,12 @@ class PrefetchController(StorageControllerInterface):
         while (
             self._pending_queue and len(self._in_flight_requests) < self._max_in_flight
         ):
-            request_id, keys, layout_desc, extra_count, policy, attn_desc = (
+            request_id, keys, layout_desc, extra_count, policy, attn_desc, mode = (
                 self._pending_queue.pop(0)
             )
             self._status_pending_count -= 1
             self._start_lookup_phase(
-                request_id, keys, layout_desc, extra_count, policy, attn_desc
+                request_id, keys, layout_desc, extra_count, policy, attn_desc, mode
             )
 
     # =========================================================================
@@ -782,6 +794,7 @@ class PrefetchController(StorageControllerInterface):
         extra_count: int = 0,
         policy: TrimPolicy = TrimPolicy.PREFIX,
         attn_desc: AttnWindowDesc = DEFAULT_ATTN_WINDOW_DESC,
+        mode: PrefetchMode = PrefetchMode.LOOKUP,
     ) -> None:
         """Submit lookup_and_lock to all live (non-draining) adapters for a
         new request."""
@@ -809,6 +822,7 @@ class PrefetchController(StorageControllerInterface):
             extra_count=extra_count,
             policy=policy,
             attn_desc=attn_desc,
+            mode=mode,
             pending_lookup_tasks=pending_lookup_tasks,
         )
         self._in_flight_requests[request_id] = request
@@ -878,9 +892,15 @@ class PrefetchController(StorageControllerInterface):
         keys_to_reserve = merged_bitmap.gather(request.keys)
         l1_mgr = self._l1_manager
 
-        retentions = self._policy.select_l1_retentions(
-            keys_to_reserve,
-        )
+        # WARM overrides the configured policy to keep every loaded key
+        # permanent (used by the warm prefetch); LOOKUP defers to the
+        # configured PrefetchPolicy.
+        if request.mode is PrefetchMode.WARM:
+            retentions = [True] * len(keys_to_reserve)
+        else:
+            retentions = self._policy.select_l1_retentions(
+                keys_to_reserve,
+            )
         write_results = l1_mgr.reserve_write(
             keys=keys_to_reserve,
             is_temporary=[not r for r in retentions],
@@ -1125,12 +1145,19 @@ class PrefetchController(StorageControllerInterface):
 
         l1_mgr = self._l1_manager
 
-        # Transition loaded keys: write-locked -> read-locked
-        # Use extra_count so that all TP workers each get their own read lock.
+        # Transition loaded keys out of write-locked state.
         if loaded_keys:
-            l1_mgr.finish_write_and_reserve_read(
-                loaded_keys, extra_count=request.extra_count
-            )
+            if request.mode is PrefetchMode.WARM:
+                # Warm prefetch: ready, NO read lock. The object is immediately
+                # resident, unlocked, and evictable -- nothing to release later;
+                # completion is observed by querying the handle.
+                l1_mgr.finish_write(loaded_keys)
+            else:
+                # write-locked -> read-locked; extra_count so each TP worker
+                # gets its own read lock.
+                l1_mgr.finish_write_and_reserve_read(
+                    loaded_keys, extra_count=request.extra_count
+                )
 
         # Clean up failed keys
         if failed_keys:

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -892,9 +892,7 @@ class PrefetchController(StorageControllerInterface):
         keys_to_reserve = merged_bitmap.gather(request.keys)
         l1_mgr = self._l1_manager
 
-        # WARM overrides the configured policy to keep every loaded key
-        # permanent (used by the warm prefetch); LOOKUP defers to the
-        # configured PrefetchPolicy.
+        # WARM retains every loaded key; LOOKUP follows the configured policy.
         if request.mode is PrefetchMode.WARM:
             retentions = [True] * len(keys_to_reserve)
         else:
@@ -1148,9 +1146,7 @@ class PrefetchController(StorageControllerInterface):
         # Transition loaded keys out of write-locked state.
         if loaded_keys:
             if request.mode is PrefetchMode.WARM:
-                # Warm prefetch: ready, NO read lock. The object is immediately
-                # resident, unlocked, and evictable -- nothing to release later;
-                # completion is observed by querying the handle.
+                # Warm: make ready, pin nothing.
                 l1_mgr.finish_write(loaded_keys)
             else:
                 # write-locked -> read-locked; extra_count so each TP worker

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -421,27 +421,18 @@ class StorageManager:
                 ``SPARSE`` keeps every found key (gap-tolerant).
             attn_desc: Cross-chunk attention windows of all object groups, in
                 object-group order.
-            skip_l2: If True, do not submit to L2. For ``LOOKUP`` this returns
-                the already-resident L1 hit set only; for ``WARM`` (which does
-                not probe L1) it is a no-op that returns an empty handle.
+            skip_l2: If True, do not load from L2. For ``LOOKUP`` only
+                already-resident L1 keys are returned; for ``WARM`` nothing is
+                loaded and an empty handle is returned.
             mode: The prefetch intent (see :class:`PrefetchMode`).  ``WARM``
-                is the speculative pre-warm path: every key loaded from L2 is
-                retained (permanent) regardless of the configured prefetch
-                policy, and **no read lock** is taken (this method skips the
-                L1-hit ``reserve_read`` entirely).  ``LOOKUP`` (default) loads
-                for an imminent reader: retention defers to the policy and
-                found/loaded keys are read-locked.
+                retains loaded keys and pins none; ``LOOKUP`` (default) pins
+                them for an imminent reader and follows the policy.
 
         Returns:
             PrefetchHandle to track the task.
         """
         if mode is PrefetchMode.WARM:
-            # Warm prefetch path: acquire NO read lock. Skip the L1-hit
-            # reserve_read entirely and hand all keys to the controller, which
-            # loads L2 misses and transitions them to *ready* via finish_write
-            # (no lock); keys already resident in L1 are skipped by
-            # reserve_write. The handle reports the L2-loaded set via
-            # query_prefetch_status; there is nothing to release.
+            # Warm path: load all keys, pin none. skip_l2 makes it a no-op.
             prefetch_request_id = -1
             if not skip_l2 and keys and self._l2_adapters:
                 prefetch_request_id = self._prefetch_controller.submit_prefetch_request(

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -18,6 +18,7 @@ from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
     PrefetchHandle,
+    PrefetchMode,
     TrimPolicy,
 )
 from lmcache.v1.distributed.config import EvictionConfig, StorageManagerConfig
@@ -403,6 +404,7 @@ class StorageManager:
         policy: TrimPolicy = TrimPolicy.PREFIX,
         attn_desc: AttnWindowDesc = DEFAULT_ATTN_WINDOW_DESC,
         skip_l2: bool = False,
+        mode: PrefetchMode = PrefetchMode.LOOKUP,
     ) -> PrefetchHandle:
         """Prefetch objects into L1 asynchronously.
 
@@ -419,11 +421,47 @@ class StorageManager:
                 ``SPARSE`` keeps every found key (gap-tolerant).
             attn_desc: Cross-chunk attention windows of all object groups, in
                 object-group order.
-            skip_l2: If True, only check L1 and return without submitting to L2.
+            skip_l2: If True, do not submit to L2. For ``LOOKUP`` this returns
+                the already-resident L1 hit set only; for ``WARM`` (which does
+                not probe L1) it is a no-op that returns an empty handle.
+            mode: The prefetch intent (see :class:`PrefetchMode`).  ``WARM``
+                is the speculative pre-warm path: every key loaded from L2 is
+                retained (permanent) regardless of the configured prefetch
+                policy, and **no read lock** is taken (this method skips the
+                L1-hit ``reserve_read`` entirely).  ``LOOKUP`` (default) loads
+                for an imminent reader: retention defers to the policy and
+                found/loaded keys are read-locked.
 
         Returns:
             PrefetchHandle to track the task.
         """
+        if mode is PrefetchMode.WARM:
+            # Warm prefetch path: acquire NO read lock. Skip the L1-hit
+            # reserve_read entirely and hand all keys to the controller, which
+            # loads L2 misses and transitions them to *ready* via finish_write
+            # (no lock); keys already resident in L1 are skipped by
+            # reserve_write. The handle reports the L2-loaded set via
+            # query_prefetch_status; there is nothing to release.
+            prefetch_request_id = -1
+            if not skip_l2 and keys and self._l2_adapters:
+                prefetch_request_id = self._prefetch_controller.submit_prefetch_request(
+                    keys,
+                    layout_desc,
+                    extra_count=extra_count,
+                    policy=policy,
+                    mode=mode,
+                )
+            return PrefetchHandle(
+                prefetch_request_id=prefetch_request_id,
+                external_request_id=external_request_id,
+                l1_found_indices=(),
+                total_requested_keys=len(keys),
+                submit_time=time.monotonic(),
+                l2_orig_indices=(
+                    tuple(range(len(keys))) if prefetch_request_id != -1 else ()
+                ),
+            )
+
         # NOTE: now we only have L1, so the prefetch is essentially checking how many
         # objects are already in L1, and adding read locks to them.
 
@@ -465,6 +503,7 @@ class StorageManager:
                     extra_count=extra_count,
                     policy=TrimPolicy.SPARSE,
                     attn_desc=attn_desc,
+                    mode=mode,
                 )
             return PrefetchHandle(
                 prefetch_request_id=prefetch_request_id,
@@ -530,6 +569,7 @@ class StorageManager:
                 extra_count=extra_count,
                 attn_desc=attn_desc,
                 policy=policy,
+                mode=mode,
             )
             # The controller indexes its result bitmap over remaining_keys
             # (0-based); map those local indices back to original positions.

--- a/lmcache/v1/mp_coordinator/app.py
+++ b/lmcache/v1/mp_coordinator/app.py
@@ -35,6 +35,7 @@ from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
 from lmcache.v1.mp_coordinator.l2.eviction_manager import (
     L2EvictionManager,
 )
+from lmcache.v1.mp_coordinator.l2.prefetch_manager import L2PrefetchManager
 from lmcache.v1.mp_coordinator.l2.resync_manager import L2ResyncManager
 from lmcache.v1.mp_coordinator.l2.usage_manager import L2UsageManager
 from lmcache.v1.mp_coordinator.registry import InstanceRegistry
@@ -87,6 +88,7 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         eviction_manager=eviction_manager,
         page_size=config.resync_page_size,
     )
+    prefetch_manager = L2PrefetchManager()
     blend_directory = GlobalBlendMatcher(
         chunk_size=config.blend_chunk_size, probe_stride=config.blend_probe_stride
     )
@@ -121,6 +123,9 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
         # calls (eviction dispatch + startup resync). Created inside
         # the lifespan so it binds to the running event loop.
         outbound_client = httpx.AsyncClient(timeout=30.0)
+        # Stash on app.state so request handlers (e.g. POST /l2/prefetch) can
+        # issue outbound calls; background loops capture it directly.
+        app.state.outbound_client = outbound_client
         health_task = None
         eviction_task = None
         resync_task = None
@@ -152,6 +157,7 @@ def create_app(config: MPCoordinatorConfig) -> FastAPI:
     app.state.usage_manager = usage_manager
     app.state.eviction_manager = eviction_manager
     app.state.resync_manager = resync_manager
+    app.state.prefetch_manager = prefetch_manager
     app.state.blend_directory = blend_directory
 
     apis_path = Path(__file__).parent / "http_apis"

--- a/lmcache/v1/mp_coordinator/http_apis/l2_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/l2_api.py
@@ -6,19 +6,24 @@ status queries (quota + usage) for per-``cache_salt`` L2 data.
 """
 
 # Third Party
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
+import httpx
 
 # First Party
 from lmcache.v1.distributed.quota_manager import QuotaManager
 from lmcache.v1.mp_coordinator.l2.eviction_manager import (
     L2EvictionManager,
 )
+from lmcache.v1.mp_coordinator.l2.prefetch_manager import L2PrefetchManager
 from lmcache.v1.mp_coordinator.l2.usage_manager import L2UsageManager
+from lmcache.v1.mp_coordinator.registry import InstanceRegistry
 from lmcache.v1.mp_coordinator.schemas import (
     EventType,
     L2StatusListResponse,
     L2StatusResponse,
+    PrefetchRequest,
+    PrefetchResponse,
     QuotaResponse,
     ReportUsageRequest,
     ReportUsageResponse,
@@ -63,6 +68,34 @@ def _eviction_manager(request: Request) -> L2EvictionManager:
     if mgr is None:
         raise RuntimeError("eviction manager not initialized")
     return mgr
+
+
+def _prefetch_manager(request: Request) -> L2PrefetchManager:
+    """Return the shared :class:`L2PrefetchManager` from ``app.state``."""
+    mgr = getattr(request.app.state, "prefetch_manager", None)
+    if mgr is None:
+        raise RuntimeError("prefetch manager not initialized")
+    return mgr
+
+
+def _registry(request: Request) -> InstanceRegistry:
+    """Return the shared :class:`InstanceRegistry` from ``app.state``."""
+    registry = getattr(request.app.state, "registry", None)
+    if registry is None:
+        raise RuntimeError("registry not initialized")
+    return registry
+
+
+def _outbound_client(request: Request) -> httpx.AsyncClient:
+    """Return the shared outbound :class:`httpx.AsyncClient` from ``app.state``.
+
+    Created in the app lifespan so it binds to the running event loop. Raises
+    ``RuntimeError`` if accessed outside the lifespan (e.g. in a bare app).
+    """
+    client = getattr(request.app.state, "outbound_client", None)
+    if client is None:
+        raise RuntimeError("outbound client not initialized")
+    return client
 
 
 # -- Quota writes ------------------------------------------------------------
@@ -141,6 +174,104 @@ async def report_events(
             tracker.record_evicted(ok)
             ctrl.on_remove(ok)
     return ReportUsageResponse(recorded=len(body.events))
+
+
+# -- Prefetch dispatch -------------------------------------------------------
+
+
+@router.post("/l2/prefetch")
+async def request_prefetch(body: PrefetchRequest, request: Request) -> PrefetchResponse:
+    """Submit a warm prefetch of a token sequence on one MP server.
+
+    Resolves ``body.instance_id`` in the registry and ``POST``s to that
+    server's ``/l2/prefetch``, which submits the load and returns a
+    ``request_id`` (the load runs in the server's storage-manager thread).
+    Poll ``GET /l2/prefetch/{instance_id}/{request_id}`` for completion.
+
+    Args:
+        body: Target instance, model/world_size, the token_ids to warm, and
+            the per-tenant cache_salt.
+
+    Returns:
+        ``PrefetchResponse`` carrying the server's ``request_id`` (empty when
+        the sequence was shorter than one chunk -- ``status`` ``"noop"``).
+
+    Raises:
+        HTTPException: 404 if ``instance_id`` is not registered; 502 if the
+            target server is unreachable or rejects the submit.
+    """
+    target = _registry(request).get(body.instance_id)
+    if target is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no MP server registered with instance_id={body.instance_id!r}",
+        )
+
+    try:
+        result = await _prefetch_manager(request).submit_prefetch(
+            target=target,
+            http_client=_outbound_client(request),
+            model_name=body.model_name,
+            world_size=body.world_size,
+            token_ids=body.token_ids,
+            cache_salt=body.cache_salt,
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"prefetch submit to {body.instance_id!r} failed: {exc}",
+        ) from None
+
+    return PrefetchResponse(
+        instance_id=body.instance_id,
+        request_id=result.get("request_id", ""),
+        chunks=result.get("chunks", 0),
+        status=result.get("status", "submitted"),
+    )
+
+
+@router.get("/l2/prefetch/{instance_id}/{request_id}")
+async def get_prefetch_status(
+    instance_id: str, request_id: str, request: Request
+) -> JSONResponse:
+    """Proxy a warm-prefetch status poll to the owning MP server.
+
+    The warm holds no lock, so this poll only reports progress; the first poll
+    that observes completion drops the job on the server (exactly-once). Poll
+    until ``"completed"``.
+
+    Args:
+        instance_id: The MP server the prefetch was submitted to.
+        request_id: The id returned by ``POST /l2/prefetch``.
+
+    Returns:
+        The server's status body relayed verbatim with its status code (200
+        ``pending`` / ``completed``, or 404 for an unknown id).
+
+    Raises:
+        HTTPException: 404 if ``instance_id`` is not registered; 502 if the
+            target server is unreachable.
+    """
+    target = _registry(request).get(instance_id)
+    if target is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no MP server registered with instance_id={instance_id!r}",
+        )
+
+    try:
+        code, payload = await _prefetch_manager(request).get_status(
+            target=target,
+            http_client=_outbound_client(request),
+            request_id=request_id,
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"prefetch status from {instance_id!r} failed: {exc}",
+        ) from None
+
+    return JSONResponse(status_code=code, content=payload)
 
 
 # -- Combined status queries -------------------------------------------------

--- a/lmcache/v1/mp_coordinator/l2/prefetch_manager.py
+++ b/lmcache/v1/mp_coordinator/l2/prefetch_manager.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator-side warm-prefetch dispatch.
+
+Forwards a client's warm-prefetch request to one named MP server and proxies
+its status. The MP server's ``POST /l2/prefetch`` submits the load and returns
+a ``request_id`` immediately (the load runs in the server's storage-manager
+thread); the coordinator relays that id back to the client, which then polls
+``GET /l2/prefetch/{instance_id}/{request_id}`` on the coordinator until the
+server reports completion. There is no background polling on either side -- the
+submit and status calls are quick and the client drives completion on demand.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any
+
+# Third Party
+import httpx
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.mp_coordinator.registry import MPInstance
+
+logger = init_logger(__name__)
+
+
+class L2PrefetchManager:
+    """Submit warm-prefetch requests to MP servers and proxy their status."""
+
+    async def submit_prefetch(
+        self,
+        target: MPInstance,
+        http_client: httpx.AsyncClient,
+        model_name: str,
+        world_size: int,
+        token_ids: list[int],
+        cache_salt: str,
+    ) -> dict[str, Any]:
+        """``POST /l2/prefetch`` to ``target`` and return its JSON reply.
+
+        Args:
+            target: The MP server to warm.
+            http_client: Shared async client for outbound coordinator calls.
+            model_name: Model whose layout the target uses to allocate L1.
+            world_size: World size selecting the layout and per-rank fan-out.
+            token_ids: Prompt tokens whose complete chunks should be warmed.
+            cache_salt: Per-tenant isolation salt applied to the produced keys.
+
+        Returns:
+            The server's reply, e.g. ``{"request_id", "chunks", "status"}`` or
+            ``{"chunks": 0, "status": "noop"}``.
+
+        Raises:
+            httpx.HTTPError: If the target is unreachable or returns non-2xx.
+        """
+        url = f"http://{target.ip}:{target.http_port}/l2/prefetch"
+        body = {
+            "model_name": model_name,
+            "world_size": world_size,
+            "token_ids": token_ids,
+            "cache_salt": cache_salt,
+        }
+        resp = await http_client.post(url, json=body)
+        resp.raise_for_status()
+        logger.info(
+            "Prefetch submitted to %s: %d tokens", target.instance_id, len(token_ids)
+        )
+        return resp.json()
+
+    async def get_status(
+        self,
+        target: MPInstance,
+        http_client: httpx.AsyncClient,
+        request_id: str,
+    ) -> tuple[int, dict[str, Any]]:
+        """Proxy ``GET /l2/prefetch/{request_id}`` on ``target``.
+
+        Args:
+            target: The MP server holding the job.
+            http_client: Shared async client for outbound coordinator calls.
+            request_id: The id returned by :meth:`submit_prefetch`.
+
+        Returns:
+            ``(status_code, body)`` from the server (e.g. 200 with a status
+            body, or 404 for an unknown id), relayed verbatim to the caller.
+
+        Raises:
+            httpx.HTTPError: If the target is unreachable (transport error).
+        """
+        url = f"http://{target.ip}:{target.http_port}/l2/prefetch/{request_id}"
+        resp = await http_client.get(url)
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {"detail": resp.text}
+        return resp.status_code, body

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -336,3 +336,47 @@ class BlendMatchResponse(BaseModel):
     """
 
     matches: list[GlobalMatchModel]
+
+
+class PrefetchRequest(BaseModel):
+    """Body of ``POST /l2/prefetch`` on the coordinator.
+
+    Asks the coordinator to warm one MP server's L1 with the chunks of a token
+    sequence. The caller describes content by ``token_ids`` -- the unit the
+    cache speaks -- not by internal cache keys, which it cannot construct. The
+    coordinator forwards the request verbatim to that server's own
+    ``POST /l2/prefetch``, which hashes the tokens and expands them into the
+    per-rank keys.
+
+    Attributes:
+        instance_id: Identifier of the target MP server (must be registered).
+        model_name: Model whose layout the target uses to allocate L1 buffers.
+        world_size: World size selecting the layout and the per-rank fan-out.
+        token_ids: Prompt tokens whose complete chunks should be warmed.
+        cache_salt: Per-tenant isolation salt applied to the produced keys.
+    """
+
+    instance_id: str
+    model_name: str
+    world_size: int = Field(ge=1)
+    token_ids: list[int] = Field(default_factory=list)
+    cache_salt: str = ""
+
+
+class PrefetchResponse(BaseModel):
+    """Reply to ``POST /l2/prefetch`` on the coordinator.
+
+    Attributes:
+        instance_id: The target MP server the prefetch was submitted to.
+        request_id: The server's job id to poll via
+            ``GET /l2/prefetch/{instance_id}/{request_id}``. Empty when
+            ``status`` is ``"noop"`` (nothing to warm).
+        chunks: Number of whole chunks submitted to warm.
+        status: ``"submitted"`` (a job is in flight) or ``"noop"`` (the
+            sequence was shorter than one chunk).
+    """
+
+    instance_id: str
+    request_id: str = ""
+    chunks: int = 0
+    status: str

--- a/lmcache/v1/mp_observability/trace/codecs.py
+++ b/lmcache/v1/mp_observability/trace/codecs.py
@@ -32,6 +32,7 @@ from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
     PrefetchHandle,
+    PrefetchMode,
     TrimPolicy,
 )
 
@@ -245,6 +246,14 @@ def _dec_trim_policy(name: str) -> TrimPolicy:
     return TrimPolicy[name]
 
 
+def _enc_prefetch_mode(m: PrefetchMode) -> str:
+    return m.name
+
+
+def _dec_prefetch_mode(name: str) -> PrefetchMode:
+    return PrefetchMode[name]
+
+
 def _enc_attn_window(d: AttnWindowDesc) -> list[int]:
     return list(d.num_chunks_in_sw)
 
@@ -296,6 +305,10 @@ register_codec(
 register_codec(
     TrimPolicy,
     TypeCodec(tag="TrimPolicy", encode=_enc_trim_policy, decode=_dec_trim_policy),
+)
+register_codec(
+    PrefetchMode,
+    TypeCodec(tag="PrefetchMode", encode=_enc_prefetch_mode, decode=_dec_prefetch_mode),
 )
 register_codec(
     set,

--- a/lmcache/v1/multiprocess/http_apis/l2_api.py
+++ b/lmcache/v1/multiprocess/http_apis/l2_api.py
@@ -13,6 +13,18 @@ Three endpoints:
   keys currently locked by in-flight store/load tasks (S3) are skipped
   so deletion never corrupts an active transfer.
 
+- ``POST /l2/prefetch`` — submit a warm prefetch of a token sequence's
+  chunks from L2 into L1. The caller sends ``token_ids`` (not keys); the
+  server hashes them, expands them across the node's ranks, submits a retain
+  prefetch that loads them **unlocked** (no read lock), and returns a
+  ``request_id`` immediately. The loaded chunks are retained (permanent) and
+  immediately a normal, evictable L1 entry. Coalesces across all configured
+  L2 adapters (no selector).
+
+- ``GET /l2/prefetch/{request_id}`` — poll a submitted warm prefetch
+  (``pending`` / ``completed``). Reactive: the caller drives completion;
+  there is no server-side polling loop and nothing to release.
+
 - ``GET /l2/keys`` — paginate keys resident in the selected adapter,
   optionally filtered by ``model_name``. Returns 501 when the selected
   adapter does not implement listing (in v1 only ``S3L2Adapter`` does).
@@ -38,7 +50,13 @@ import asyncio
 from fastapi import APIRouter, HTTPException, Query, Request
 
 # First Party
-from lmcache.v1.distributed.api import EncodedObjectKey
+from lmcache.v1.distributed.api import EncodedObjectKey, ipc_key_to_object_keys
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+from lmcache.v1.multiprocess.warm_prefetch import (
+    COMPLETED,
+    UNKNOWN,
+    WarmPrefetchJobs,
+)
 
 router = APIRouter()
 
@@ -49,6 +67,21 @@ _DEFAULT_PAGE_SIZE = 500
 # target. Keeps the request body bounded and prevents a single call
 # from monopolizing the adapter's I/O loop for an unbounded interval.
 _MAX_DELETE_BATCH = 10_000
+# Hard cap on how many token ids a single ``POST /l2/prefetch`` request may
+# carry. Keeps the request body bounded and the synchronous hashing /
+# key-construction work in the handler proportionate.
+_MAX_PREFETCH_TOKENS = 1_000_000
+
+
+def _get_engine(request: Request) -> Any:
+    """Resolve the shared engine (``MPCacheServer``) or raise ``HTTPException``.
+
+    Raises ``HTTPException(503)`` when the engine isn't initialized yet.
+    """
+    engine = getattr(request.app.state, "engine", None)
+    if engine is None:
+        raise HTTPException(status_code=503, detail="engine not initialized")
+    return engine
 
 
 def _get_storage_manager(request: Request) -> Any:
@@ -59,10 +92,20 @@ def _get_storage_manager(request: Request) -> Any:
     which FastAPI turns into a ``{"detail": "engine not initialized"}``
     JSON response.
     """
-    engine = getattr(request.app.state, "engine", None)
-    if engine is None:
-        raise HTTPException(status_code=503, detail="engine not initialized")
-    return engine.storage_manager
+    return _get_engine(request).storage_manager
+
+
+def _warm_jobs(request: Request) -> WarmPrefetchJobs:
+    """Return the per-app warm-prefetch job table, created lazily.
+
+    Holds the in-flight ``submit`` handles so a later status poll can report
+    completion. The warm holds no lock, so there is nothing to release.
+    """
+    jobs = getattr(request.app.state, "warm_prefetch_jobs", None)
+    if jobs is None:
+        jobs = WarmPrefetchJobs()
+        request.app.state.warm_prefetch_jobs = jobs
+    return jobs
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +126,27 @@ class DeleteRequest:
     """
 
     keys: list[EncodedObjectKey]
+
+
+@dataclass(frozen=True)
+class PrefetchRequest:
+    """Wire body for :py:func:`prefetch_to_l1`.
+
+    Callers describe content by ``token_ids`` -- the same unit the lookup
+    path speaks -- never by internal cache keys, which they cannot construct
+    (a key is a content hash plus a per-rank layout bitmap). The server hashes
+    the tokens and expands them into the per-rank :class:`ObjectKey`s itself.
+
+    ``model_name`` / ``world_size`` select the registered
+    :class:`MemoryLayoutDesc` and the rank fan-out; ``cache_salt`` isolates
+    the keys per tenant. FastAPI validates field types (422); the token cap
+    and ``cache_salt`` invariants raise ``HTTPException(400)`` in the handler.
+    """
+
+    model_name: str
+    world_size: int
+    token_ids: list[int]
+    cache_salt: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +252,120 @@ async def delete_from_l2(
         return response
     response["ok"] = True
     return response
+
+
+@router.post("/l2/prefetch", response_model=None, status_code=202)
+async def prefetch_to_l1(
+    body: PrefetchRequest,
+    request: Request,
+) -> dict[str, object]:
+    """Submit a warm prefetch of a token sequence's chunks from L2 into L1.
+
+    Hashes ``body.token_ids`` into chunk keys (the same path the lookup handler
+    uses), expands them across the node's ranks, and submits a retain prefetch
+    that loads them **unlocked** (no read lock). Returns immediately with a
+    ``request_id``; the load runs in the storage manager's own thread. Poll
+    ``GET /l2/prefetch/{request_id}`` to observe completion. The loaded chunks
+    are resident, retained, and immediately re-lookupable/evictable -- there is
+    no lock to release and no server-side polling loop. Coalesces across all
+    configured L2 adapters, so there is no ``?adapter=`` selector (unlike
+    ``DELETE /l2``).
+
+    Body: ``{"model_name", "world_size", "token_ids": [int, ...], "cache_salt"}``.
+
+    Responses:
+        202: ``{"request_id", "chunks", "status": "submitted"}``, or
+            ``{"chunks": 0, "status": "noop"}`` when the sequence is shorter
+            than one chunk (nothing submitted; no ``request_id`` to poll).
+        400: token count exceeds ``_MAX_PREFETCH_TOKENS`` or ``cache_salt``
+            violates its invariants.
+        409: no layout registered for ``(model_name, world_size)`` -- the
+            model has not allocated KV cache on this node yet.
+        422: request body fails field-level validation.
+        503: engine not initialized.
+    """
+    if len(body.token_ids) > _MAX_PREFETCH_TOKENS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"too many token_ids in a single request "
+                f"(limit={_MAX_PREFETCH_TOKENS}, got={len(body.token_ids)})"
+            ),
+        )
+
+    ctx = _get_engine(request).context
+    layout_desc = ctx.layout_desc_registry.find(body.model_name, body.world_size)
+    if layout_desc is None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"no layout registered for model_name={body.model_name!r} "
+                f"world_size={body.world_size}; the model has not allocated "
+                f"KV cache on this node yet"
+            ),
+        )
+
+    # worker_id=None expands each chunk to one key per rank, warming the whole
+    # node's L1 (mirrors how the lookup path fans a chunk across workers).
+    try:
+        ipc_key = IPCCacheServerKey(
+            model_name=body.model_name,
+            world_size=body.world_size,
+            worker_id=None,
+            token_ids=tuple(body.token_ids),
+            start=0,
+            end=len(body.token_ids),
+            request_id="",
+            cache_salt=body.cache_salt,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+    chunk_hashes = ctx.token_hasher.compute_chunk_hashes(list(body.token_ids))
+    if not chunk_hashes:
+        # Fewer than one full chunk of tokens -- nothing to warm.
+        return {"chunks": 0, "status": "noop"}
+
+    obj_keys = ipc_key_to_object_keys(ipc_key, chunk_hashes, [0])[0]
+    request_id = _warm_jobs(request).submit(ctx.storage_manager, obj_keys, layout_desc)
+    return {
+        "request_id": request_id,
+        "chunks": len(chunk_hashes),
+        "status": "submitted",
+    }
+
+
+@router.get("/l2/prefetch/{request_id}", response_model=None)
+async def prefetch_status(request_id: str, request: Request) -> dict[str, object]:
+    """Report a warm-prefetch job's status and finalize it on completion.
+
+    The first poll that observes completion drops the job (and pops the
+    controller's result bookkeeping), so a later poll for the same id returns
+    404 (exactly-once). The warm holds no lock, so there is nothing to release.
+
+    Responses:
+        200: ``{"status": "pending"}`` while the load runs, or
+            ``{"status": "completed", "found_keys", "total_keys"}`` once done.
+        404: unknown ``request_id`` (already completed-and-consumed, or never
+            submitted).
+        503: engine not initialized.
+    """
+    status = _warm_jobs(request).poll(_get_storage_manager(request), request_id)
+    if status.state == UNKNOWN:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"unknown prefetch request_id={request_id!r} "
+                f"(already completed or never submitted)"
+            ),
+        )
+    if status.state == COMPLETED:
+        return {
+            "status": COMPLETED,
+            "found_keys": status.found_keys,
+            "total_keys": status.total_keys,
+        }
+    return {"status": status.state}
 
 
 @router.get("/l2/keys", response_model=None)

--- a/lmcache/v1/multiprocess/warm_prefetch.py
+++ b/lmcache/v1/multiprocess/warm_prefetch.py
@@ -2,26 +2,16 @@
 """Warm-prefetch job table for the MP server.
 
 A *warm* prefetch loads a caller-supplied set of keys from L2 into L1 and leaves
-them resident, **retained, and unlocked** so a subsequent real lookup hits L1.
-It uses ``PrefetchMode.WARM``, which loads keys permanently and **without a
-read lock** -- there is no downstream reader to pin them for, so nothing has to
-be released. It also submits with the gap-tolerant ``TrimPolicy.SPARSE`` so an
-already-resident chunk does not stop the rest from loading: because the warm
-skips the L1-hit ``reserve_read``, ``PREFIX`` would read a resident leading
-chunk as a gap and trim everything after it, loading nothing.
+them resident, retained, and unpinned, so a subsequent real lookup hits L1. It
+loads every requested key not already in L1, and pins nothing -- there is no
+downstream reader to pin for.
 
-Because nothing is locked, this table only needs the prefetch **handle** per
-job (not the keys): ``submit`` starts the load and registers
-``request_id -> handle``; ``poll`` reports status by querying that handle.
-There is **no background polling** -- the caller drives completion reactively
-via the HTTP status endpoint, and every ``StorageManager`` call here is
-non-blocking (the L2 load runs in the ``PrefetchController``'s own thread), so
-no asyncio is involved.
-
-A job whose status is never polled to completion lingers in the table (and
-leaves the controller's small completed-result entry until popped); since no
-lock is held there is no pinned L1. A future TTL sweep can call
-``query_prefetch_status`` on stale handles to drop them.
+The table tracks in-flight warm prefetches: ``submit`` starts one and returns an
+opaque request id; ``poll`` reports its status (pending, then completed) and
+drops it once the load finishes. Status is observed reactively by the caller --
+there is no background polling -- and these calls do not block. A job whose
+status is never polled to completion simply lingers until a later cleanup drops
+it; since nothing is pinned, no L1 is held.
 """
 
 # Standard

--- a/lmcache/v1/multiprocess/warm_prefetch.py
+++ b/lmcache/v1/multiprocess/warm_prefetch.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Warm-prefetch job table for the MP server.
+
+A *warm* prefetch loads a caller-supplied set of keys from L2 into L1 and leaves
+them resident, **retained, and unlocked** so a subsequent real lookup hits L1.
+It uses ``PrefetchMode.WARM``, which loads keys permanently and **without a
+read lock** -- there is no downstream reader to pin them for, so nothing has to
+be released. It also submits with the gap-tolerant ``TrimPolicy.SPARSE`` so an
+already-resident chunk does not stop the rest from loading: because the warm
+skips the L1-hit ``reserve_read``, ``PREFIX`` would read a resident leading
+chunk as a gap and trim everything after it, loading nothing.
+
+Because nothing is locked, this table only needs the prefetch **handle** per
+job (not the keys): ``submit`` starts the load and registers
+``request_id -> handle``; ``poll`` reports status by querying that handle.
+There is **no background polling** -- the caller drives completion reactively
+via the HTTP status endpoint, and every ``StorageManager`` call here is
+non-blocking (the L2 load runs in the ``PrefetchController``'s own thread), so
+no asyncio is involved.
+
+A job whose status is never polled to completion lingers in the table (and
+leaves the controller's small completed-result entry until popped); since no
+lock is held there is no pinned L1. A future TTL sweep can call
+``query_prefetch_status`` on stale handles to drop them.
+"""
+
+# Standard
+from dataclasses import dataclass
+import threading
+import uuid
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.api import (
+    MemoryLayoutDesc,
+    ObjectKey,
+    PrefetchHandle,
+    PrefetchMode,
+    TrimPolicy,
+)
+from lmcache.v1.distributed.storage_manager import StorageManager
+
+logger = init_logger(__name__)
+
+# Job states reported by :meth:`WarmPrefetchJobs.poll`.
+PENDING = "pending"
+COMPLETED = "completed"
+UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class WarmStatus:
+    """Outcome of a status poll.
+
+    Attributes:
+        state: ``"pending"`` (load still running), ``"completed"`` (loaded), or
+            ``"unknown"`` (no such request id -- already completed-and-consumed,
+            or never submitted).
+        found_keys: Keys loaded into L1 (only meaningful when ``completed``).
+        total_keys: Keys originally requested (only meaningful when
+            ``completed``).
+    """
+
+    state: str
+    found_keys: int = 0
+    total_keys: int = 0
+
+
+class WarmPrefetchJobs:
+    """Thread-safe table of in-flight warm-prefetch jobs (``request_id ->
+    handle``).
+
+    ``submit`` starts a no-lock retain prefetch and returns an opaque request
+    id; ``poll`` reports progress and, on completion, drops the job
+    (exactly-once: a subsequent poll for the same id returns ``UNKNOWN``).
+    Since the warm holds no read lock, there is nothing to release on
+    completion.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty table."""
+        self._lock = threading.Lock()
+        self._jobs: dict[str, PrefetchHandle] = {}
+
+    def submit(
+        self,
+        storage_manager: StorageManager,
+        keys: list[ObjectKey],
+        layout_desc: MemoryLayoutDesc,
+    ) -> str:
+        """Start a no-lock retain prefetch and register its handle.
+
+        Args:
+            storage_manager: The MP server's storage manager.
+            keys: Object keys to load from L2 into L1.
+            layout_desc: Memory layout for the L1 write buffers.
+
+        Returns:
+            An opaque request id to pass to :meth:`poll`.
+        """
+        handle = storage_manager.submit_prefetch_task(
+            keys,
+            layout_desc,
+            mode=PrefetchMode.WARM,
+            policy=TrimPolicy.SPARSE,
+        )
+        request_id = uuid.uuid4().hex
+        with self._lock:
+            self._jobs[request_id] = handle
+        return request_id
+
+    def poll(
+        self,
+        storage_manager: StorageManager,
+        request_id: str,
+    ) -> WarmStatus:
+        """Report a job's status; drop it once the load completes.
+
+        Args:
+            storage_manager: The MP server's storage manager.
+            request_id: The id returned by :meth:`submit`.
+
+        Returns:
+            A :class:`WarmStatus`. The first poll that observes completion drops
+            the job (and pops the controller's result bookkeeping), so later
+            polls for the same id return ``UNKNOWN``.
+        """
+        with self._lock:
+            handle = self._jobs.get(request_id)
+        if handle is None:
+            return WarmStatus(state=UNKNOWN)
+
+        found = storage_manager.query_prefetch_status(handle)
+        if found is None:
+            return WarmStatus(state=PENDING)
+
+        with self._lock:
+            self._jobs.pop(request_id, None)
+        found_keys = found.popcount()
+        logger.info(
+            "Warm prefetch %s completed: %d/%d keys loaded into L1",
+            request_id,
+            found_keys,
+            handle.total_requested_keys,
+        )
+        return WarmStatus(
+            state=COMPLETED,
+            found_keys=found_keys,
+            total_keys=handle.total_requested_keys,
+        )

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -632,32 +632,30 @@ class TestStorageManagerL2Prefetch:
         sm.close()
 
     def test_warm_skip_l2_is_noop(self, l2_storage_manager_config, basic_layout):
-        """``mode=WARM`` + ``skip_l2=True`` submits nothing and returns an empty
-        handle.
+        """``mode=WARM`` + ``skip_l2=True`` submits no controller request.
 
         Regression: the WARM branch must honor ``skip_l2`` (it previously
-        ignored it, issuing L2 lookup/load work and mutating L1).
+        ignored it, issuing L2 lookup/load work and mutating L1). The returned
+        :class:`PrefetchHandle` is the public signal — no request id to track
+        and no L2-sourced indices; since the controller is the only path that
+        loads from L2, this also means L1 is left untouched.
         """
         sm = StorageManager(l2_storage_manager_config)
         keys = [make_object_key(i) for i in range(3)]
 
-        # Populate L2, then clear L1 so any erroneous L2 load would be visible.
+        # Put the keys in L2 so a non-skip warm would have something to load,
+        # then clear L1 so a load would be the only way they could reappear.
         self._write_keys_and_wait_for_l2(sm, keys, basic_layout)
-        time.sleep(0.05)
         sm.clear()
-        used, _ = sm._l1_manager.get_memory_usage()
-        assert used == 0
 
         handle = sm.submit_prefetch_task(
             keys, basic_layout, mode=PrefetchMode.WARM, skip_l2=True
         )
 
-        # No controller request submitted, nothing to track.
+        # skip_l2 honored: the controller was never asked.
         assert handle.prefetch_request_id == -1
         assert handle.l2_orig_indices == ()
-        # L1 untouched — no L2 load happened.
-        used, _ = sm._l1_manager.get_memory_usage()
-        assert used == 0, f"skip_l2 should load nothing, but {used} bytes used"
+        assert handle.total_requested_keys == len(keys)
 
         sm.close()
 

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -11,7 +11,12 @@ import pytest
 import torch
 
 # First Party
-from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey, TrimPolicy
+from lmcache.v1.distributed.api import (
+    MemoryLayoutDesc,
+    ObjectKey,
+    PrefetchMode,
+    TrimPolicy,
+)
 from lmcache.v1.distributed.config import (
     EvictionConfig,
     L1ManagerConfig,
@@ -623,6 +628,36 @@ class TestStorageManagerL2Prefetch:
 
         assert hit_count is not None, "Prefetch should complete"
         assert hit_count == 0, f"Expected 0 hits, got {hit_count}"
+
+        sm.close()
+
+    def test_warm_skip_l2_is_noop(self, l2_storage_manager_config, basic_layout):
+        """``mode=WARM`` + ``skip_l2=True`` submits nothing and returns an empty
+        handle.
+
+        Regression: the WARM branch must honor ``skip_l2`` (it previously
+        ignored it, issuing L2 lookup/load work and mutating L1).
+        """
+        sm = StorageManager(l2_storage_manager_config)
+        keys = [make_object_key(i) for i in range(3)]
+
+        # Populate L2, then clear L1 so any erroneous L2 load would be visible.
+        self._write_keys_and_wait_for_l2(sm, keys, basic_layout)
+        time.sleep(0.05)
+        sm.clear()
+        used, _ = sm._l1_manager.get_memory_usage()
+        assert used == 0
+
+        handle = sm.submit_prefetch_task(
+            keys, basic_layout, mode=PrefetchMode.WARM, skip_l2=True
+        )
+
+        # No controller request submitted, nothing to track.
+        assert handle.prefetch_request_id == -1
+        assert handle.l2_orig_indices == ()
+        # L1 untouched — no L2 load happened.
+        used, _ = sm._l1_manager.get_memory_usage()
+        assert used == 0, f"skip_l2 should load nothing, but {used} bytes used"
 
         sm.close()
 

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -19,7 +19,12 @@ import torch
 
 # First Party
 from lmcache.native_storage_ops import Bitmap
-from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey, TrimPolicy
+from lmcache.v1.distributed.api import (
+    MemoryLayoutDesc,
+    ObjectKey,
+    PrefetchMode,
+    TrimPolicy,
+)
 from lmcache.v1.distributed.config import L1ManagerConfig, L1MemoryManagerConfig
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.l1_manager import L1Manager
@@ -1362,3 +1367,134 @@ class TestWaitPrefetchResult:
         assert time.monotonic() - start >= 0.2
 
         ctrl.stop()
+
+
+# =============================================================================
+# Retention Policy
+# =============================================================================
+
+
+class TestPrefetchMode:
+    """``mode=WARM`` (the warm path) loads keys **permanent** and
+    **without a read lock**, vs ``LOOKUP`` which read-locks temporary
+    objects that vanish on release.
+
+    Both tests use ``DefaultPrefetchPolicy`` so the only difference is the
+    per-request ``mode`` argument.
+    """
+
+    def test_warm_loads_unlocked_and_permanent(self, l1_manager):
+        """WARM loads keys permanent and with NO read lock: immediately ready
+        (reserve_read SUCCEEDS), holding no lock (unsafe_read NOT_READABLE), and
+        not deleted on a reserve_read/finish_read cycle (permanent, not temp)."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout, mode=PrefetchMode.WARM)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 3
+
+        # No warming lock: unsafe_read (which needs an active read lock) reports
+        # NOT_READABLE even though the keys are present and ready.
+        unsafe = l1_manager.unsafe_read(keys)
+        for key in keys:
+            assert unsafe[key][0] == L1Error.KEY_NOT_READABLE
+
+        # They are ready and re-lookupable: reserve_read SUCCEEDS...
+        read_results = l1_manager.reserve_read(keys)
+        for key in keys:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        # ...and releasing that probe lock does NOT delete them (permanent).
+        l1_manager.finish_read(keys)
+        again = l1_manager.reserve_read(keys)
+        for key in keys:
+            assert again[key][0] == L1Error.SUCCESS
+
+        l1_manager.finish_read(keys)
+        l1_manager.delete(keys)
+        ctrl.stop()
+        adapter.close()
+
+    def test_warm_sparse_skips_write_locked_prefix_and_loads_later_keys(
+        self, l1_manager
+    ):
+        """SPARSE WARM does not let a write-locked earlier key suppress later
+        keys that can be reserved and loaded."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        existing = l1_manager.reserve_write(
+            [keys[0]], is_temporary=[False], layout_desc=layout, mode="new"
+        )
+        assert existing[keys[0]][0] == L1Error.SUCCESS
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(
+            keys,
+            layout,
+            policy=TrimPolicy.SPARSE,
+            mode=PrefetchMode.WARM,
+        )
+        result = wait_for_prefetch_result_bitmap(ctrl, req_id)
+        assert result is not None
+        assert result.get_indices_list() == [1, 2]
+
+        l1_manager.finish_write([keys[0]])
+        read_results = l1_manager.reserve_read(keys[1:])
+        for key in keys[1:]:
+            assert read_results[key][0] == L1Error.SUCCESS
+
+        l1_manager.finish_read(keys[1:])
+        l1_manager.delete(keys)
+        ctrl.stop()
+        adapter.close()
+
+    def test_default_deletes_keys_after_finish_read(self, l1_manager):
+        """LOOKUP defers to ``DefaultPrefetchPolicy`` (temporary), so
+        the keys are deleted from L1 once the read-lock is released."""
+        adapter = make_adapter()
+        layout = make_layout()
+        keys = [make_object_key(i) for i in range(3)]
+        store_keys_in_l2(adapter, keys, layout)
+
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+
+        req_id = ctrl.submit_prefetch_request(keys, layout)
+        result = wait_for_prefetch_result(ctrl, req_id)
+        assert result == 3
+
+        # Releasing the read-lock deletes the temporary objects, so a
+        # subsequent lookup (reserve_read) misses with KEY_NOT_EXIST.
+        l1_manager.finish_read(keys)
+        read_results = l1_manager.reserve_read(keys)
+        for key in keys:
+            assert read_results[key][0] == L1Error.KEY_NOT_EXIST
+
+        ctrl.stop()
+        adapter.close()

--- a/tests/v1/mp_coordinator/test_l2_api.py
+++ b/tests/v1/mp_coordinator/test_l2_api.py
@@ -3,6 +3,7 @@
 
 # Third Party
 from fastapi.testclient import TestClient
+import httpx
 
 # First Party
 from lmcache.v1.mp_coordinator.app import create_app
@@ -289,3 +290,76 @@ def test_default_salt_sentinel():
         assert data["quota_exists"] is True
         assert abs(data["quota_limit_gb"] - 3.0) < 1e-6
         assert abs(data["usage_gb"] - 500 / 1024**3) < 1e-12
+
+
+# -- Prefetch dispatch -------------------------------------------------------
+
+
+def _prefetch_body(instance_id: str, salt: str = "alice") -> dict:
+    return {
+        "instance_id": instance_id,
+        "model_name": "m",
+        "world_size": 1,
+        "token_ids": [1, 2, 3, 4],
+        "cache_salt": salt,
+    }
+
+
+def _mock_mp_server() -> httpx.AsyncClient:
+    """An outbound client that emulates the target MP server's prefetch API."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/l2/prefetch":
+            return httpx.Response(
+                202, json={"request_id": "abc", "chunks": 2, "status": "submitted"}
+            )
+        if request.method == "GET" and request.url.path == "/l2/prefetch/abc":
+            return httpx.Response(
+                200, json={"status": "completed", "found_keys": 2, "total_keys": 2}
+            )
+        return httpx.Response(404, json={"detail": "not found"})
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_prefetch_unknown_instance_returns_404():
+    """Targeting an unregistered instance must 404 (before any dispatch)."""
+    with _client() as client:
+        resp = client.post("/l2/prefetch", json=_prefetch_body("does-not-exist"))
+        assert resp.status_code == 404
+
+
+def test_prefetch_submit_then_status_proxy():
+    """A registered target: submit relays the server's request_id, and the
+    status GET proxies the server's completion body."""
+    with _client() as client:
+        client.post(
+            "/instances",
+            json={"instance_id": "mp-1", "ip": "127.0.0.1", "http_port": 8080},
+        )
+        # Replace the lifespan's real outbound client with a mock MP server.
+        client.app.state.outbound_client = _mock_mp_server()
+
+        resp = client.post("/l2/prefetch", json=_prefetch_body("mp-1"))
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {
+            "instance_id": "mp-1",
+            "request_id": "abc",
+            "chunks": 2,
+            "status": "submitted",
+        }
+
+        status = client.get("/l2/prefetch/mp-1/abc")
+        assert status.status_code == 200, status.text
+        assert status.json() == {
+            "status": "completed",
+            "found_keys": 2,
+            "total_keys": 2,
+        }
+
+
+def test_prefetch_status_unknown_instance_returns_404():
+    """Status for an unregistered instance must 404."""
+    with _client() as client:
+        resp = client.get("/l2/prefetch/does-not-exist/abc")
+        assert resp.status_code == 404

--- a/tests/v1/mp_coordinator/test_prefetch_manager.py
+++ b/tests/v1/mp_coordinator/test_prefetch_manager.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the coordinator warm-prefetch manager (submit + status proxy)."""
+
+# Standard
+import json as _json
+import time
+
+# Third Party
+import httpx
+import pytest
+
+# First Party
+from lmcache.v1.mp_coordinator.l2.prefetch_manager import L2PrefetchManager
+from lmcache.v1.mp_coordinator.registry import MPInstance
+
+
+def _instance(instance_id: str, ip: str = "10.0.0.1", port: int = 8000) -> MPInstance:
+    now = time.time()
+    return MPInstance(
+        instance_id=instance_id,
+        ip=ip,
+        http_port=port,
+        registration_time=now,
+        last_heartbeat_time=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_prefetch_posts_body_and_returns_reply():
+    """submit_prefetch POSTs /l2/prefetch with the token body and returns the
+    server's JSON reply verbatim."""
+    mgr = L2PrefetchManager()
+    target = _instance("mp-1", ip="10.0.0.7", port=8765)
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["json"] = (request.read() or b"").decode()
+        return httpx.Response(
+            202, json={"request_id": "abc", "chunks": 2, "status": "submitted"}
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await mgr.submit_prefetch(
+            target=target,
+            http_client=client,
+            model_name="m",
+            world_size=2,
+            token_ids=[1, 2, 3, 4],
+            cache_salt="alice",
+        )
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://10.0.0.7:8765/l2/prefetch"
+    assert _json.loads(captured["json"]) == {
+        "model_name": "m",
+        "world_size": 2,
+        "token_ids": [1, 2, 3, 4],
+        "cache_salt": "alice",
+    }
+    assert result == {"request_id": "abc", "chunks": 2, "status": "submitted"}
+
+
+@pytest.mark.asyncio
+async def test_submit_prefetch_raises_on_http_error():
+    """A non-2xx submit surfaces as an httpx error for the caller to map."""
+    mgr = L2PrefetchManager()
+    target = _instance("mp-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(httpx.HTTPError):
+            await mgr.submit_prefetch(
+                target=target,
+                http_client=client,
+                model_name="m",
+                world_size=1,
+                token_ids=[1, 2],
+                cache_salt="",
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_status_proxies_code_and_body():
+    """get_status returns the server's (status_code, body) verbatim."""
+    mgr = L2PrefetchManager()
+    target = _instance("mp-1", ip="10.0.0.7", port=8765)
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200, json={"status": "completed", "found_keys": 4, "total_keys": 4}
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        code, body = await mgr.get_status(
+            target=target, http_client=client, request_id="abc"
+        )
+
+    assert captured["url"] == "http://10.0.0.7:8765/l2/prefetch/abc"
+    assert code == 200
+    assert body == {"status": "completed", "found_keys": 4, "total_keys": 4}
+
+
+@pytest.mark.asyncio
+async def test_get_status_relays_404():
+    """An unknown id on the server is relayed as a 404 (not raised)."""
+    mgr = L2PrefetchManager()
+    target = _instance("mp-1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "unknown"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        code, body = await mgr.get_status(
+            target=target, http_client=client, request_id="x"
+        )
+
+    assert code == 404
+    assert body == {"detail": "unknown"}

--- a/tests/v1/multiprocess/http_apis/test_l2_api.py
+++ b/tests/v1/multiprocess/http_apis/test_l2_api.py
@@ -452,3 +452,186 @@ class TestListEndpoint:
         client = TestClient(_make_app(sm))
         resp = client.get("/l2/keys", params={"page_token": "garbage"})
         assert resp.status_code == 400
+
+
+# =============================================================================
+# Prefetch (warm L1 from L2)
+# =============================================================================
+
+
+@dataclass
+class _FakeLayoutRegistry:
+    """Minimal layout registry: ``find`` returns ``layout`` and records calls."""
+
+    layout: Optional[object] = None
+    find_calls: list[tuple[str, int]] = field(default_factory=list)
+
+    def find(self, model_name: str, world_size: int) -> Optional[object]:
+        self.find_calls.append((model_name, world_size))
+        return self.layout
+
+
+class _PrefetchHandle:
+    """Minimal stand-in for ``PrefetchHandle`` (only the queried field)."""
+
+    def __init__(self, total: int) -> None:
+        self.total_requested_keys = total
+
+
+class _PrefetchBitmap:
+    """Stands in for the found-key Bitmap; ``popcount`` is the loaded count."""
+
+    def __init__(self, n: int) -> None:
+        self._n = n
+
+    def popcount(self) -> int:
+        return self._n
+
+
+@dataclass
+class _PrefetchStorageManager:
+    """Records ``submit_prefetch_task`` calls and serves canned poll results."""
+
+    submit_calls: list[dict] = field(default_factory=list)
+
+    def submit_prefetch_task(
+        self,
+        keys,
+        layout_desc,
+        mode=None,
+        **_,
+    ) -> _PrefetchHandle:
+        self.submit_calls.append({"keys": list(keys), "mode": mode})
+        return _PrefetchHandle(len(keys))
+
+    def query_prefetch_status(self, handle) -> _PrefetchBitmap:
+        # Report all keys loaded.
+        return _PrefetchBitmap(handle.total_requested_keys)
+
+
+@dataclass
+class _FakeTokenHasher:
+    """Hashes ``chunk_size`` tokens into one opaque chunk hash each."""
+
+    chunk_size: int = 4
+
+    def compute_chunk_hashes(self, token_ids: list[int]) -> list[bytes]:
+        n = len(token_ids) // self.chunk_size
+        return [i.to_bytes(4, "big") for i in range(n)]
+
+
+@dataclass
+class _FakeContext:
+    layout_desc_registry: _FakeLayoutRegistry
+    storage_manager: _PrefetchStorageManager
+    token_hasher: _FakeTokenHasher = field(default_factory=_FakeTokenHasher)
+
+
+class _PrefetchEngine:
+    def __init__(self, ctx: _FakeContext):
+        self.context = ctx
+        self.storage_manager = ctx.storage_manager
+
+
+def _make_prefetch_app(ctx: Optional[_FakeContext]) -> FastAPI:
+    app = FastAPI()
+    app.include_router(l2_keys_router)
+    if ctx is not None:
+        app.state.engine = _PrefetchEngine(ctx)
+    return app
+
+
+def _ctx(layout: Optional[object]) -> _FakeContext:
+    return _FakeContext(
+        layout_desc_registry=_FakeLayoutRegistry(layout=layout),
+        storage_manager=_PrefetchStorageManager(),
+    )
+
+
+def _prefetch_body(token_ids: list[int], world_size: int = 2, salt: str = "") -> dict:
+    return {
+        "model_name": "m",
+        "world_size": world_size,
+        "token_ids": token_ids,
+        "cache_salt": salt,
+    }
+
+
+class TestPrefetchEndpoint:
+    def test_submit_returns_request_id_and_resolves_layout(self):
+        ctx = _ctx(layout=object())
+        client = TestClient(_make_prefetch_app(ctx))
+
+        # 8 tokens at chunk_size 4 -> 2 chunks.
+        resp = client.post(
+            "/l2/prefetch",
+            json=_prefetch_body([1, 2, 3, 4, 5, 6, 7, 8], world_size=2),
+        )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body["status"] == "submitted"
+        assert body["chunks"] == 2
+        assert body["request_id"]  # non-empty id to poll
+        # Layout was resolved for the requested (model_name, world_size).
+        assert ("m", 2) in ctx.layout_desc_registry.find_calls
+
+    def test_status_poll_completes_then_404(self):
+        # The fake reports the load done on the first poll: status completes
+        # (releasing the lock), and a second poll for the same id is 404.
+        ctx = _ctx(layout=object())
+        client = TestClient(_make_prefetch_app(ctx))
+
+        rid = client.post(
+            "/l2/prefetch", json=_prefetch_body([1, 2, 3, 4, 5, 6, 7, 8], world_size=2)
+        ).json()["request_id"]
+
+        resp = client.get(f"/l2/prefetch/{rid}")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "completed"
+        # 2 chunks x world_size 2 = 4 per-rank keys warmed.
+        assert body["found_keys"] == 4
+        assert body["total_keys"] == 4
+
+        # Exactly-once: the job was consumed by the completing poll.
+        assert client.get(f"/l2/prefetch/{rid}").status_code == 404
+
+    def test_status_unknown_request_id_404(self):
+        ctx = _ctx(layout=object())
+        client = TestClient(_make_prefetch_app(ctx))
+        assert client.get("/l2/prefetch/nope").status_code == 404
+
+    def test_short_sequence_is_noop(self):
+        # Fewer than one full chunk -> nothing submitted, no request_id.
+        ctx = _ctx(layout=object())
+        client = TestClient(_make_prefetch_app(ctx))
+
+        resp = client.post("/l2/prefetch", json=_prefetch_body([1, 2]))
+        assert resp.status_code == 202, resp.text
+        assert resp.json() == {"chunks": 0, "status": "noop"}
+
+    def test_409_when_layout_not_registered(self):
+        ctx = _ctx(layout=None)
+        client = TestClient(_make_prefetch_app(ctx))
+
+        resp = client.post(
+            "/l2/prefetch",
+            json=_prefetch_body([1, 2, 3, 4], world_size=99),
+        )
+        assert resp.status_code == 409
+
+    def test_400_on_invalid_cache_salt(self):
+        ctx = _ctx(layout=object())
+        client = TestClient(_make_prefetch_app(ctx))
+
+        # "@" is forbidden in cache_salt (ObjectKey/IPC key invariant).
+        resp = client.post(
+            "/l2/prefetch",
+            json=_prefetch_body([1, 2, 3, 4], salt="bad@salt"),
+        )
+        assert resp.status_code == 400
+
+    def test_503_when_engine_not_initialized(self):
+        client = TestClient(_make_prefetch_app(None))
+        resp = client.post("/l2/prefetch", json=_prefetch_body([1, 2, 3, 4]))
+        assert resp.status_code == 503

--- a/tests/v1/multiprocess/test_warm_prefetch.py
+++ b/tests/v1/multiprocess/test_warm_prefetch.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the warm-prefetch job table (:mod:`warm_prefetch`).
+
+Fakes the ``StorageManager``, so no real engine/CUDA/L2 is needed. Verifies the
+no-lock contract: ``submit`` uses ``PrefetchMode.WARM`` (the no-lock warm
+path), status is polled reactively, and completion releases **nothing** (no
+``finish_read`` — the warm holds no lock).
+"""
+
+# Standard
+from dataclasses import dataclass
+from typing import Optional
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey, PrefetchMode, TrimPolicy
+from lmcache.v1.multiprocess.warm_prefetch import (
+    COMPLETED,
+    PENDING,
+    UNKNOWN,
+    WarmPrefetchJobs,
+)
+
+
+def _key(i: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(i),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+class _FakeHandle:
+    def __init__(self, total: int) -> None:
+        self.total_requested_keys = total
+
+
+class _FakeBitmap:
+    """Stands in for the found-key ``Bitmap``; ``popcount`` is the found count."""
+
+    def __init__(self, n: int) -> None:
+        self._n = n
+
+    def popcount(self) -> int:
+        return self._n
+
+
+@dataclass
+class _FakeStorageManager:
+    found: int = 0
+    delay_polls: int = 0
+
+    submit_args: Optional[dict] = None
+    finish_called: bool = False
+    _polls: int = 0
+    _total: int = 0
+
+    def submit_prefetch_task(self, keys, layout_desc, mode=None, policy=None, **_):
+        self._total = len(keys)
+        self.submit_args = {"keys": list(keys), "mode": mode, "policy": policy}
+        return _FakeHandle(self._total)
+
+    def query_prefetch_status(self, handle):
+        if self._polls < self.delay_polls:
+            self._polls += 1
+            return None
+        return _FakeBitmap(self.found)
+
+    def finish_read_prefetched(self, keys, extra_count: int = 0) -> None:
+        # Must never be called: the warm holds no lock.
+        self.finish_called = True
+
+
+def test_submit_uses_retain_and_poll_completes_without_release():
+    """submit goes through the WARM (no-lock) path; the caller polls
+    (pending → completed); completion releases nothing and consumes the job."""
+    keys = [_key(0), _key(1)]
+    sm = _FakeStorageManager(found=2, delay_polls=2)
+    jobs = WarmPrefetchJobs()
+
+    request_id = jobs.submit(sm, keys, layout_desc=object())
+    assert sm.submit_args is not None
+    assert sm.submit_args["mode"] is PrefetchMode.WARM
+    assert sm.submit_args["policy"] is TrimPolicy.SPARSE
+
+    # Pending while the load runs (reactive poll; no background loop).
+    assert jobs.poll(sm, request_id).state == PENDING
+    assert jobs.poll(sm, request_id).state == PENDING
+
+    status = jobs.poll(sm, request_id)
+    assert status.state == COMPLETED
+    assert status.found_keys == 2
+    assert status.total_keys == 2
+    # No lock was held, so nothing is released.
+    assert sm.finish_called is False
+
+    # Exactly-once: the completing poll consumed the job.
+    assert jobs.poll(sm, request_id).state == UNKNOWN
+
+
+def test_poll_unknown_request_id():
+    """Polling an id that was never submitted returns UNKNOWN."""
+    sm = _FakeStorageManager()
+    jobs = WarmPrefetchJobs()
+    assert jobs.poll(sm, "does-not-exist").state == UNKNOWN
+    assert sm.finish_called is False


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a coordinator-controlled *warm prefetch*. A client POSTs a token sequence + a target node to the coordinator, which dispatches to that MP server's new `POST /l2/prefetch`. The server hashes the tokens into per-rank keys and loads those chunks from L2 into L1 — leaving them **resident, retained, and unlocked** — so a later request for that prefix hits L1 instead of paying the L2 fetch inline. Useful for pre-warming a node ahead of a known or shifting workload.

Key pieces:
- **`PrefetchMode.WARM`** (a warm-only prefetch intent) threaded through `StorageManager.submit_prefetch_task` → `PrefetchController`. It redefines the load to *retain (permanent)* **and acquire no read lock**: a warm has no imminent consumer to pin for, so loaded keys transition write-locked → ready via `finish_write` (not `finish_write_and_reserve_read`), and the L1-hit `reserve_read` pass is skipped entirely. The chunks are left resident, unlocked, evictable, and re-lookupable — a later real lookup takes its own lock.
- MP-server **`POST /l2/prefetch`** (token-based; key construction stays server-side) returning a `request_id`, and **`GET /l2/prefetch/{request_id}`** for status. State lives in a `WarmPrefetchJobs` handle table on `app.state`. Status is a **reactive query** — there is no server-side poll loop and nothing to release (no lock), so completion is observed on demand. It reports `found_keys`/`total_keys` (the chunks this request loaded from L2).
- Warm loads use the gap-tolerant **`TrimPolicy.SPARSE`** so an already-resident leading chunk doesn't stop the rest from loading. (The default `PREFIX` would trim everything past the first resident chunk, because the warm skips the L1-hit pass and a resident chunk reads as a gap.)
- Coordinator **`POST /l2/prefetch`** + **`GET /l2/prefetch/{instance_id}/{request_id}`** via `L2PrefetchManager`, which proxies the submit and relays status from the named instance (404 for an unknown instance, 502 if unreachable).

**Special notes for your reviewers**:

- **No lock by design.** A warm has no downstream reader, so it holds no read lock — nothing to release, no abandonment leak, no pinned L1. The job table is handle-only; an unpolled job lingers only as a small dict entry (no pinned memory) until polled or dropped by a future TTL sweep.
- Token-based by design: callers can't build internal content keys (chunk hash + per-rank layout bitmap), so they send `token_ids` and the server reconstructs keys via the same path as lookup.
- `found_keys`/`total_keys` count only chunks *loaded from L2* by this request; chunks already resident in L1 are skipped at `reserve_write` and not counted — deliberate, since an already-resident entry may be a transient temporary from another lookup, so claiming it as warmed could mislead. Documented in the API reference and design doc.
- `skip_l2=True` is honored for `WARM` (returns an empty handle without touching L2), with a regression test.
- Scope is single-node (one `instance_id` = one node's shards); multi-node fan-out is deferred to a future KV-cache-directory PR (called out in the design doc).
- Validated end-to-end on GPU (real coordinator + MP server over HTTP, FS L2 + GPU L1): a cold warm loads all chunks, retained and unlocked (`reserve_read` SUCCEEDS, `unsafe_read` NOT_READABLE), re-lookupable; and a partial-residency warm loads the remaining chunks under `SPARSE`.

**If applicable**:

- [x] this PR contains user facing changes — docs added (`docs/source/mp/coordinator.rst`, `docs/source/mp/http_api.rst`) plus design docs and a runnable example
- [x] this PR contains unit tests
