### PR TITLE
refactor(platform): auto-discover DeviceIPCWrapper subclasses under platform/<device>/

### DIFF
--- a/docs/design/v1/multiprocess/device_ipc_wrapper_design.md
+++ b/docs/design/v1/multiprocess/device_ipc_wrapper_design.md
@@ -29,7 +29,8 @@ All of them live behind a single msgspec ext code 1 and a single `KVCache = list
 
 ## What the base class owns
 
-`DeviceIPCWrapper` (in `custom_types.py`) provides the parts that every transport shares:
+`DeviceIPCWrapper` (in `platform/base_ipc_wrapper.py`) provides the parts that every
+transport shares:
 
 - **Interface fields** — `dtype`, `shape`, `stride`, `storage_offset`, `device_uuid`. Subclasses populate these in `__init__`; the base uses them for equality and the receiving side uses them to rebuild the logical view.
 - **Device discovery** — `_get_device_uuid`, `_discover_devices`,`_get_device_index_from_uuid`. These are `@classmethod`s (not static) and route through the `torch_dev` abstraction, so they work across device backends, and a subclass can override `_get_device_uuid` if its backend needs a different identity source.
@@ -53,12 +54,21 @@ All of them live behind a single msgspec ext code 1 and a single `KVCache = list
 
 ## Platform registration
 
-The factory lookup (`platform/_registry.py`) keys on `tensor.device.type`, so the integration adapter never has an if/elif chain. Each platform sub-package self-registers at import time:
+The factory lookup (`platform/_registry.py`) keys on `tensor.device.type`, so
+the integration adapter never has an if/elif chain.  Concrete wrappers are
+discovered automatically at runtime — no static `register_kv_wrapper` calls
+needed:
 
-```text
-platform/cuda/__init__.py  ->  register_kv_wrapper("cuda", CudaIPCWrapper)
-platform/cpu/__init__.py   ->  register_kv_wrapper("cpu",  migrate_to_shm_and_wrap)
-```
+- Each concrete subclass sets a ``device_type`` ClassVar (e.g. ``"cuda"``)
+  and exposes a ``wrap`` factory classmethod.
+- :func:`~lmcache.v1.platform._registry._discover_wrappers_once` scans
+  ``lmcache.v1.platform`` two levels deep for ``DeviceIPCWrapper`` subclasses
+  on first use, indexes them by ``device_type``, and skips any subclass where
+  ``_is_default_wrapper`` is ``False`` (so ``RawCudaIPCWrapper`` coexists with
+  ``CudaIPCWrapper`` without colliding).
+- Adding a new accelerator backend only requires shipping a sub-package under
+  ``platform/<device>/`` with a ``DeviceIPCWrapper`` subclass — zero changes
+  to the dispatcher or the registry.
 
 ## Backward compatibility
 

--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -402,7 +402,7 @@ def run_server_bench(
         shm_names: list[str] = []
         if use_gpu:
             # First Party
-            from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
+            from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
 
             allocated = _allocate_gpu_kv_cache(groups=layer_groups)
             log(

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -30,12 +30,12 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import (
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.multiprocess.custom_types import (
-    CudaIPCWrapper,
     IPCCacheServerKey,
     KVCache,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType
+from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
 
 logger = init_logger(__name__)
 

--- a/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
+++ b/lmcache/integration/tensorrt_llm/tensorrt_mp_adapter.py
@@ -36,10 +36,10 @@ from lmcache.logging import init_logger
 from lmcache.utils import EngineType, check_interprocess_event_support
 from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
-    RawCudaIPCWrapper,
 )
 from lmcache.v1.multiprocess.mq import MessageQueueClient, MessagingFuture
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+from lmcache.v1.platform.cuda.ipc_wrapper import RawCudaIPCWrapper
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -42,7 +42,7 @@ def assert_contiguous(tensor: torch.Tensor) -> None:
     LMCache transfer kernels assume logical and physical views match for
     coalesced memory accesses. Used at boundaries where we receive a
     tensor we can't or shouldn't permute (e.g. raw CUDA-IPC reconstruction
-    in :class:`~lmcache.v1.multiprocess.custom_types.RawCudaIPCWrapper`).
+    in :class:`~lmcache.v1.platform.cuda.ipc_wrapper.RawCudaIPCWrapper`).
 
     Raises:
         ValueError: If *tensor* has a nonzero storage offset, or is

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -2,15 +2,15 @@
 # Standard
 from dataclasses import dataclass, field
 from typing import Any, Callable
-import pickle
-import threading
 
 # Third Party
 import msgspec
 import torch
 
 # First Party
-from lmcache import torch_dev, torch_device_type
+from lmcache.v1.platform.base_ipc_wrapper import (  # noqa: E402,F401
+    DeviceIPCWrapper,
+)
 
 """
 Defines the types and the customized encoder/decoders for inter-process
@@ -21,230 +21,6 @@ Key Types:
   - Contains token_ids, start, end, request_id (all required)
   - Converted to ObjectKey for storage operations via ipc_key_to_object_keys()
 """
-
-
-class DeviceIPCWrapper:
-    """Base class for KV-cache IPC wrapper.
-
-    Holds the device-agnostic mechanism shared by all transports: the
-    interface fields (``dtype``/``shape``/``stride``/``storage_offset``/
-    ``device_uuid``), UUID<->ordinal discovery via the ``torch_dev``
-    abstraction, equality, and pickle-based (de)serialization.
-
-    Every wire-level wrapper subclasses this so they share the single
-    msgspec ext code (1) registered for ``DeviceIPCWrapper``: pickle
-    preserves the concrete subclass identity across the wire so
-    ``to_tensor`` dispatches correctly on the receiving side.
-
-    Subclasses implement ``__init__`` (populate the interface fields from a
-    tensor) and ``to_tensor`` (reconstruct the tensor from the handle).
-    """
-
-    _discovered_device_mapping: dict[str, int] = {}
-    _device_mapping_lock = threading.Lock()
-
-    @classmethod
-    def _get_device_uuid(cls, device_index: int) -> str:
-        """Get the UUID of a device given its index."""
-        return str(torch_dev.get_device_properties(device_index).uuid)
-
-    @classmethod
-    def _discover_devices(cls):
-        """Discover all available accelerator devices and map their UUIDs
-        to the physical device ordinals.
-        """
-        if not torch_dev.is_available():
-            return
-
-        num_devices = torch_dev.device_count()
-        with DeviceIPCWrapper._device_mapping_lock:
-            if DeviceIPCWrapper._discovered_device_mapping:
-                return  # Already discovered
-
-            for i in range(num_devices):
-                device_uuid = cls._get_device_uuid(i)
-                DeviceIPCWrapper._discovered_device_mapping[device_uuid] = i
-
-    @classmethod
-    def _get_device_index_from_uuid(cls, device_uuid: str) -> int:
-        """Get the physical device ordinal from its UUID."""
-        cls._discover_devices()
-
-        with DeviceIPCWrapper._device_mapping_lock:
-            device_index = DeviceIPCWrapper._discovered_device_mapping.get(
-                device_uuid, None
-            )
-
-        if device_index is None:
-            raise RuntimeError(
-                f"Device UUID {device_uuid} not found in the discovered "
-                "devices. Please make sure the process can see all the "
-                "accelerator devices"
-            )
-        return device_index
-
-    def to_tensor(self) -> torch.Tensor:
-        """Reconstruct the tensor in this process from the IPC handle.
-
-        Subclasses implement the transport-specific reconstruction.
-        """
-        raise NotImplementedError
-
-    def __eq__(self, other):
-        if type(self) is not type(other):
-            return False
-        return (
-            self.handle == other.handle
-            and self.dtype == other.dtype
-            and self.shape == other.shape
-            and self.stride == other.stride
-            and self.storage_offset == other.storage_offset
-            and self.device_uuid == other.device_uuid
-        )
-
-    @staticmethod
-    def Serialize(obj: "DeviceIPCWrapper") -> bytes:
-        return pickle.dumps(obj)
-
-    @staticmethod
-    def Deserialize(data: bytes) -> "DeviceIPCWrapper":
-        return pickle.loads(data)
-
-
-class CudaIPCWrapper(DeviceIPCWrapper):
-    def __init__(self, tensor: torch.Tensor):
-        # First Party
-        from lmcache.v1.gpu_connector.kv_format.contiguity import (
-            attempt_permute_to_contiguous_view,
-        )
-
-        # Permute any non-contiguous view (e.g. vLLM's NHD-over-HND) so the
-        # shape/stride we encode across IPC reflects the physical layout.
-        # Offset is preserved by the wrapper's storage_offset field.
-        tensor = attempt_permute_to_contiguous_view(tensor)
-
-        storage = tensor.untyped_storage()
-        handle = storage._share_cuda_()
-
-        self.handle = handle
-        self.dtype = tensor.dtype
-        self.shape = tuple(tensor.shape)
-        self.stride = tuple(tensor.stride())
-        self.storage_offset = int(tensor.storage_offset())
-
-        device_index = tensor.device.index
-        self.device_uuid = self._get_device_uuid(device_index)
-
-    def to_tensor(self) -> torch.Tensor:
-        """
-        Note:
-            This function may break if the accelerator is not initialized.
-            We should call `torch_dev.init()` before using this function
-            (guarded by hasattr since not all backends expose init()).
-        """
-        device_index = self._get_device_index_from_uuid(self.device_uuid)
-
-        storage = torch.UntypedStorage._new_shared_cuda(  # noqa: SLF001
-            device_index, *self.handle[1:]
-        )
-
-        t = torch.empty(
-            (), device=f"{torch_device_type}:{device_index}", dtype=self.dtype
-        )
-        t.set_(storage, self.storage_offset, self.shape, self.stride)
-        return t
-
-
-class RawCudaIPCWrapper(DeviceIPCWrapper):
-    """IPC wrapper for CUDA tensors allocated outside PyTorch's caching
-    allocator.
-
-    PyTorch's ``UntypedStorage._share_cuda_()`` only works for tensors
-    backed by its own caching allocator. TRT-LLM publishes its KV pool
-    via ``at::for_blob`` over a ``cudaMalloc``'d buffer, which raises in
-    ``_share_cuda_()``. This subclass bypasses that path: it calls
-    ``cudaIpcGetMemHandle`` on the raw data pointer, then reconstructs
-    the tensor on the receiving side via ``cudaIpcOpenMemHandle`` plus
-    a CuPy ``UnownedMemory`` → DLPack → ``torch`` round-trip.
-
-    Sharing the ``DeviceIPCWrapper`` base (rather than introducing a
-    parallel class with its own msgspec ext code) is load-bearing —
-    msgspec does not support unions of custom ext-encoded types. With a
-    common base, ``KVCache = list[DeviceIPCWrapper]`` type-checks, the
-    single ext code 1 round-trips every wrapper, and pickle preserves
-    the concrete subclass identity through the wire so ``to_tensor``
-    dispatches correctly.
-    """
-
-    def __init__(self, tensor: torch.Tensor) -> None:
-        # First Party
-        from lmcache.v1.gpu_connector.utils import assert_contiguous
-
-        assert_contiguous(tensor)
-
-        try:
-            # Third Party
-            from cuda.bindings import runtime as cudart
-        except ImportError:
-            # Third Party
-            from cuda import cudart
-
-        data_ptr = tensor.data_ptr()
-        err, ipc_handle = cudart.cudaIpcGetMemHandle(data_ptr)
-        if err != cudart.cudaError_t.cudaSuccess:
-            raise RuntimeError(
-                f"cudaIpcGetMemHandle failed: {err} (ptr=0x{data_ptr:x})"
-            )
-
-        # Store only what's needed for reconstruction.
-        self._ipc_handle_reserved = bytes(ipc_handle.reserved)
-        self._nbytes = tensor.untyped_storage().nbytes()
-
-        # DeviceIPCWrapper interface fields. ``handle`` is unused —
-        # ``to_tensor`` is overridden to bypass it — but kept (None) so
-        # the base-class equality check has a value to compare.
-        self.handle = None
-        self.dtype = tensor.dtype
-        self.shape = tuple(tensor.shape)
-        self.stride = tuple(tensor.stride())
-        self.storage_offset = int(tensor.storage_offset())
-
-        device_index = tensor.device.index
-        self.device_uuid = self._get_device_uuid(device_index)
-
-    def to_tensor(self) -> torch.Tensor:
-        """Reconstruct the tensor in this process via raw CUDA IPC."""
-        # Third Party
-        import cupy
-
-        try:
-            # Third Party
-            from cuda.bindings import runtime as cudart
-        except ImportError:
-            # Third Party
-            from cuda import cudart
-
-        device_index = self._get_device_index_from_uuid(self.device_uuid)
-
-        handle = cudart.cudaIpcMemHandle_t()
-        handle.reserved = self._ipc_handle_reserved
-        err, ptr = cudart.cudaIpcOpenMemHandle(
-            handle, cudart.cudaIpcMemLazyEnablePeerAccess
-        )
-        if err != cudart.cudaError_t.cudaSuccess:
-            raise RuntimeError(f"cudaIpcOpenMemHandle failed: {err}")
-
-        # Wrap as a flat ``uint8`` CuPy array, DLPack to torch, then view
-        # as the original dtype/shape. ``uint8`` avoids dtype-conversion
-        # gaps (bfloat16, fp8 have no direct CuPy/NumPy equivalent without
-        # ml_dtypes).
-        with cupy.cuda.Device(device_index):
-            mem = cupy.cuda.UnownedMemory(ptr, self._nbytes, owner=self)
-            memptr = cupy.cuda.MemoryPointer(mem, 0)
-            cp_flat = cupy.ndarray(self._nbytes, dtype=cupy.uint8, memptr=memptr)
-
-        raw = torch.from_dlpack(cp_flat)
-        return raw.view(self.dtype).reshape(self.shape)
 
 
 @dataclass(order=True, frozen=True)
@@ -432,6 +208,17 @@ class CBUnifiedLookupResult:
     non_prefix_segments: list[CBMatchResult]
     segmented_prefix_segments: list[CBMatchResult] = field(default_factory=list)
 
+
+# ------------------------------------------------------------------
+# Backward-compatibility re-exports: the canonical home for
+# ``CudaIPCWrapper`` / ``RawCudaIPCWrapper`` is now
+# ``lmcache.v1.platform.cuda.ipc_wrapper``.
+# ------------------------------------------------------------------
+# First Party
+from lmcache.v1.platform.cuda.ipc_wrapper import (  # noqa: E402,F401
+    CudaIPCWrapper,
+    RawCudaIPCWrapper,
+)
 
 _CUSTOMERIZED_SERIALIZERS = {
     DeviceIPCWrapper: CustomizedSerdeConfig(

--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -209,17 +209,6 @@ class CBUnifiedLookupResult:
     segmented_prefix_segments: list[CBMatchResult] = field(default_factory=list)
 
 
-# ------------------------------------------------------------------
-# Backward-compatibility re-exports: the canonical home for
-# ``CudaIPCWrapper`` / ``RawCudaIPCWrapper`` is now
-# ``lmcache.v1.platform.cuda.ipc_wrapper``.
-# ------------------------------------------------------------------
-# First Party
-from lmcache.v1.platform.cuda.ipc_wrapper import (  # noqa: E402,F401
-    CudaIPCWrapper,
-    RawCudaIPCWrapper,
-)
-
 _CUSTOMERIZED_SERIALIZERS = {
     DeviceIPCWrapper: CustomizedSerdeConfig(
         serializer=DeviceIPCWrapper.Serialize,

--- a/lmcache/v1/platform/_registry.py
+++ b/lmcache/v1/platform/_registry.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 # Standard
 from typing import Any, Callable, Dict
+import threading
 
 # First Party
 from lmcache.logging import init_logger
@@ -46,8 +47,12 @@ _KV_WRAPPER_FACTORIES: Dict[str, Callable[..., Any]] = {}
 # Missing entry == always available.
 _AVAILABILITY: Dict[str, Callable[[], bool]] = {}
 
-# Guard so discovery only runs once (lazy init).
+# Guard so discovery only runs once (lazy init).  The lock plus the
+# double-checked flag below keep the first concurrent caller from
+# racing a second one through the scan and emitting duplicate
+# "multiple wrappers claim device_type=..." warnings.
 _WRAPPERS_DISCOVERED: bool = False
+_DISCOVERY_LOCK = threading.Lock()
 
 
 def _discover_wrappers_once() -> None:
@@ -67,22 +72,29 @@ def _discover_wrappers_once() -> None:
     *device_type* trigger a warning; the first one wins.
     """
     global _WRAPPERS_DISCOVERED
+    # Fast path: avoid the lock once discovery is done (the common case).
     if _WRAPPERS_DISCOVERED:
         return
 
-    # First Party
-    from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
-    from lmcache.v1.utils.subclass_discovery import discover_subclasses
-    import lmcache.v1.platform as platform_pkg
+    with _DISCOVERY_LOCK:
+        # Re-check under the lock: another thread may have run the
+        # scan while we were waiting.
+        if _WRAPPERS_DISCOVERED:
+            return
 
-    for cls in discover_subclasses(
-        platform_pkg,
-        DeviceIPCWrapper,  # type: ignore[type-abstract]
-        levels=[2, 2],
-    ):
-        _register_discovered_wrapper(cls)
+        # First Party
+        from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
+        from lmcache.v1.utils.subclass_discovery import discover_subclasses
+        import lmcache.v1.platform as platform_pkg
 
-    _WRAPPERS_DISCOVERED = True
+        for cls in discover_subclasses(
+            platform_pkg,
+            DeviceIPCWrapper,  # type: ignore[type-abstract]
+            levels=[2, 2],
+        ):
+            _register_discovered_wrapper(cls)
+
+        _WRAPPERS_DISCOVERED = True
 
 
 def _register_discovered_wrapper(cls: type) -> None:

--- a/lmcache/v1/platform/_registry.py
+++ b/lmcache/v1/platform/_registry.py
@@ -2,15 +2,20 @@
 """Platform backend registry.
 
 Each accelerator sub-package (``platform/cuda``, ``platform/cpu``,
-future ``platform/xpu`` ...) registers a concrete factory for the
-KV-cache IPC wrapper consumed by the multiprocess adapter.
+future ``platform/xpu`` ...) ships a concrete
+:class:`~lmcache.v1.platform.base_ipc_wrapper.DeviceIPCWrapper`
+subclass with a ``device_type`` ClassVar and a ``wrap`` factory
+classmethod.  :func:`_discover_wrappers_once` scans the ``platform``
+package for those subclasses at run-time and populates the factory
+table -- no static ``register_kv_wrapper`` calls needed.
 
 The :func:`get_kv_wrapper_factory` lookup keys on
 ``tensor.device.type`` so the call site in
 :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` stays free
-of any if/elif chain. Adding a new accelerator therefore requires
+of any if/elif chain.  Adding a new accelerator therefore requires
 *zero* changes to the dispatcher; it only needs to ship its own
-sub-package and register the right callable at import time.
+sub-package with a ``DeviceIPCWrapper`` subclass that sets
+``device_type`` and ``wrap``.
 """
 
 # Future
@@ -19,20 +24,99 @@ from __future__ import annotations
 # Standard
 from typing import Any, Callable, Dict
 
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
 # Public sentinel used by callers who want the always-available
 # fall-back regardless of the running ``torch_device_type``.
 DEFAULT_BACKEND: str = "cpu"
 
 
-# KV-cache IPC wrapper factory per device type. Concrete sub-packages
-# self-register here (CUDA -> ``CudaIPCWrapper``, CPU -> POSIX-SHM
-# wrapper) so :func:`get_kv_wrapper_factory` can dispatch by
-# ``tensor.device.type`` without any if/elif chain in the call site.
+# KV-cache IPC wrapper factory per device type.  Populated lazily on
+# first :func:`get_kv_wrapper_factory` call by scanning the
+# ``platform`` package for
+# :class:`~lmcache.v1.platform.base_ipc_wrapper.DeviceIPCWrapper`
+# subclasses.  Tests substitute entries via
+# :func:`snapshot` / :func:`restore`.
 _KV_WRAPPER_FACTORIES: Dict[str, Callable[..., Any]] = {}
 
 # Per-backend availability predicate (e.g. CUDA's ``is_available``).
 # Missing entry == always available.
 _AVAILABILITY: Dict[str, Callable[[], bool]] = {}
+
+# Guard so discovery only runs once (lazy init).
+_WRAPPERS_DISCOVERED: bool = False
+
+
+def _discover_wrappers_once() -> None:
+    """Populate :data:`_KV_WRAPPER_FACTORIES` on first use.
+
+    Walks ``lmcache.v1.platform`` two levels deep for
+    :class:`~lmcache.v1.platform.base_ipc_wrapper.DeviceIPCWrapper`
+    subclasses.  Each subclass is indexed by its *device_type*
+    ClassVar, and its *wrap* factory is stored as the KV-wrapper
+    factory — but only when ``_is_default_wrapper`` is ``True``
+    (so e.g. :class:`~lmcache.v1.platform.cuda.ipc_wrapper.RawCudaIPCWrapper`
+    is skipped in favour of
+    :class:`~lmcache.v1.platform.cuda.ipc_wrapper.CudaIPCWrapper`).
+
+    Subclasses with an empty *device_type* or ``_is_default_wrapper ==
+    False`` are skipped.  Multiple subclasses claiming the same
+    *device_type* trigger a warning; the first one wins.
+    """
+    global _WRAPPERS_DISCOVERED
+    if _WRAPPERS_DISCOVERED:
+        return
+
+    # First Party
+    from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
+    from lmcache.v1.utils.subclass_discovery import discover_subclasses
+    import lmcache.v1.platform as platform_pkg
+
+    for cls in discover_subclasses(
+        platform_pkg,
+        DeviceIPCWrapper,  # type: ignore[type-abstract]
+        levels=[2, 2],
+    ):
+        _register_discovered_wrapper(cls)
+
+    _WRAPPERS_DISCOVERED = True
+
+
+def _register_discovered_wrapper(cls: type) -> None:
+    """Index *cls* in :data:`_KV_WRAPPER_FACTORIES` by its device_type.
+
+    Only registers when ``_is_default_wrapper`` is ``True`` so sibling
+    subclasses (e.g. ``RawCudaIPCWrapper`` vs ``CudaIPCWrapper``) can
+    share a ``device_type`` without colliding.
+    """
+    if not getattr(cls, "_is_default_wrapper", False):
+        return
+
+    device_type: str = getattr(cls, "device_type", "")
+    if not device_type:
+        logger.warning(
+            "Skipping %s: empty device_type ClassVar; concrete "
+            "DeviceIPCWrapper subclasses must override it.",
+            cls.__name__,
+        )
+        return
+
+    factory = getattr(cls, "wrap", cls)
+    existing = _KV_WRAPPER_FACTORIES.get(device_type)
+    if existing is not None and existing is not factory:
+        logger.warning(
+            "Multiple KV-wrapper classes claim device_type=%r "
+            "(%s vs %s); keeping the first.",
+            device_type,
+            getattr(existing, "__name__", str(existing)),
+            cls.__name__,
+        )
+        return
+
+    _KV_WRAPPER_FACTORIES[device_type] = factory
 
 
 def register_availability(device_type: str, predicate: Callable[[], bool]) -> None:
@@ -48,6 +132,11 @@ def register_availability(device_type: str, predicate: Callable[[], bool]) -> No
 
 def register_kv_wrapper(device_type: str, factory: Callable[..., Any]) -> None:
     """Register a KV-cache IPC wrapper factory for ``device_type``.
+
+    This is the manual registration path kept for backward
+    compatibility.  New backends should instead set ``device_type``
+    and ``wrap`` on their :class:`DeviceIPCWrapper` subclass and let
+    :func:`_discover_wrappers_once` handle registration.
 
     Args:
         device_type: The device type string (e.g., ``"cuda"``).
@@ -79,10 +168,10 @@ def is_available(device_type: str) -> bool:
 def get_kv_wrapper_factory(device_type: str) -> Callable[..., Any]:
     """Pick the KV-cache wrapper factory for ``device_type``.
 
-    A missing entry means the caller is asking for a backend that
-    nobody registered (typically because the relevant sub-package was
-    not imported), which is a programming error and deserves an
-    explicit failure.
+    Triggers lazy auto-discovery on first call (see
+    :func:`_discover_wrappers_once`).  A missing entry means no
+    :class:`~lmcache.v1.platform.base_ipc_wrapper.DeviceIPCWrapper`
+    subclass declared *device_type* for the requested backend.
 
     Args:
         device_type: The device type string (e.g., ``"cuda"``).
@@ -93,6 +182,7 @@ def get_kv_wrapper_factory(device_type: str) -> Callable[..., Any]:
     Raises:
         ValueError: If no factory is registered for the device type.
     """
+    _discover_wrappers_once()
     factory = _KV_WRAPPER_FACTORIES.get(device_type)
     if factory is None:
         raise ValueError(

--- a/lmcache/v1/platform/_registry.py
+++ b/lmcache/v1/platform/_registry.py
@@ -203,30 +203,60 @@ def get_kv_wrapper_factory(device_type: str) -> Callable[..., Any]:
     return factory
 
 
-def snapshot() -> Dict[str, Dict[str, Callable[..., Any]]]:
+def snapshot() -> Dict[str, Any]:
     """Return a deep-copy of the registry tables.
 
     Test suites use this to install backend overrides without leaking
     state across tests; pair with :func:`restore` in a ``finally`` /
     fixture teardown clause.
 
+    The lazy-discovery flag is captured alongside the tables: if a test
+    snapshots *before* discovery runs and restores *after*, the next
+    caller still re-runs discovery and picks up the auto-registered
+    backends, instead of seeing a stale "already discovered, table is
+    empty" view.
+
     Returns:
-        A dict with keys ``"kv_wrapper"`` and ``"availability"``, each
-        mapping device-type strings to their registered callables.
+        A dict with keys ``"kv_wrapper"``, ``"availability"`` and
+        ``"discovered"``.
     """
     return {
         "kv_wrapper": dict(_KV_WRAPPER_FACTORIES),
         "availability": dict(_AVAILABILITY),
+        "discovered": _WRAPPERS_DISCOVERED,
     }
 
 
-def restore(state: Dict[str, Dict[str, Callable[..., Any]]]) -> None:
+def restore(state: Dict[str, Any]) -> None:
     """Restore registry tables to a previously :func:`snapshot`-ed state.
 
     Args:
         state: A snapshot dict as returned by :func:`snapshot`.
     """
+    global _WRAPPERS_DISCOVERED
     _KV_WRAPPER_FACTORIES.clear()
     _KV_WRAPPER_FACTORIES.update(state.get("kv_wrapper", {}))
     _AVAILABILITY.clear()
     _AVAILABILITY.update(state.get("availability", {}))
+    _WRAPPERS_DISCOVERED = bool(state.get("discovered", False))
+
+
+def reset_for_tests() -> None:
+    """Wipe registry tables and force re-discovery on next access.
+
+    Intended **only** for test fixtures: clears every registered KV
+    wrapper / availability predicate and flips
+    :data:`_WRAPPERS_DISCOVERED` back to ``False`` so the next
+    :func:`get_kv_wrapper_factory` call re-runs the
+    :func:`_discover_wrappers_once` scan and re-populates the table
+    from the live ``platform`` sub-packages.
+
+    This is the recommended replacement for callers that previously
+    hand-mutated module-private globals; pair with an ``autouse``
+    pytest fixture to guarantee every test starts and ends with a
+    clean slate (see ``tests/v1/multiprocess/conftest.py``).
+    """
+    global _WRAPPERS_DISCOVERED
+    _KV_WRAPPER_FACTORIES.clear()
+    _AVAILABILITY.clear()
+    _WRAPPERS_DISCOVERED = False

--- a/lmcache/v1/platform/base_ipc_wrapper.py
+++ b/lmcache/v1/platform/base_ipc_wrapper.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Base class for device IPC wrappers.
+
+:class:`DeviceIPCWrapper` is the abstract base for KV-cache IPC wrapper
+implementations.  Every concrete wrapper (e.g. :class:`~.cpu.shm.CpuShmTensorWrapper`,
+:class:`~.cuda.ipc_wrapper.CudaIPCWrapper`) subclasses it so they share
+the single msgspec ext code (1) -- pickle preserves the concrete
+subclass identity across the wire so ``to_tensor`` dispatches correctly
+on the receiving side.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import ClassVar
+import pickle
+import threading
+
+# Third Party
+import torch
+
+# First Party
+from lmcache import torch_dev
+
+
+class DeviceIPCWrapper:
+    """Base class for KV-cache IPC wrapper.
+
+    Holds the device-agnostic mechanism shared by all transports: the
+    interface fields (``dtype``/``shape``/``stride``/``storage_offset``/
+    ``device_uuid``), UUID<->ordinal discovery via the ``torch_dev``
+    abstraction, equality, and pickle-based (de)serialization.
+
+    Every wire-level wrapper subclasses this so they share the single
+    msgspec ext code (1) registered for ``DeviceIPCWrapper``: pickle
+    preserves the concrete subclass identity across the wire so
+    ``to_tensor`` dispatches correctly on the receiving side.
+
+    Subclasses implement ``__init__`` (populate the interface fields from a
+    tensor) and ``to_tensor`` (reconstruct the tensor from the handle).
+    """
+
+    #: Set ``True`` on the subclass that should be used as the default
+    #: factory for a given ``device_type``.  Auto-discovery
+    #: (:func:`~lmcache.v1.platform._registry._discover_wrappers_once`)
+    #: skips subclasses where this is ``False``.
+    _is_default_wrapper: ClassVar[bool] = False
+
+    _discovered_device_mapping: dict[str, int] = {}
+    _device_mapping_lock = threading.Lock()
+
+    @classmethod
+    def _get_device_uuid(cls, device_index: int) -> str:
+        """Get the UUID of a device given its index."""
+        return str(torch_dev.get_device_properties(device_index).uuid)
+
+    @classmethod
+    def _discover_devices(cls):
+        """Discover all available accelerator devices and map their UUIDs
+        to the physical device ordinals.
+        """
+        if not torch_dev.is_available():
+            return
+
+        num_devices = torch_dev.device_count()
+        with DeviceIPCWrapper._device_mapping_lock:
+            if DeviceIPCWrapper._discovered_device_mapping:
+                return  # Already discovered
+
+            for i in range(num_devices):
+                device_uuid = cls._get_device_uuid(i)
+                DeviceIPCWrapper._discovered_device_mapping[device_uuid] = i
+
+    @classmethod
+    def _get_device_index_from_uuid(cls, device_uuid: str) -> int:
+        """Get the physical device ordinal from its UUID."""
+        cls._discover_devices()
+
+        with DeviceIPCWrapper._device_mapping_lock:
+            device_index = DeviceIPCWrapper._discovered_device_mapping.get(
+                device_uuid, None
+            )
+
+        if device_index is None:
+            raise RuntimeError(
+                f"Device UUID {device_uuid} not found in the discovered "
+                "devices. Please make sure the process can see all the "
+                "accelerator devices"
+            )
+        return device_index
+
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the tensor in this process from the IPC handle.
+
+        Subclasses implement the transport-specific reconstruction.
+        """
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+        return (
+            self.handle == other.handle
+            and self.dtype == other.dtype
+            and self.shape == other.shape
+            and self.stride == other.stride
+            and self.storage_offset == other.storage_offset
+            and self.device_uuid == other.device_uuid
+        )
+
+    @staticmethod
+    def Serialize(obj: "DeviceIPCWrapper") -> bytes:
+        return pickle.dumps(obj)
+
+    @staticmethod
+    def Deserialize(data: bytes) -> "DeviceIPCWrapper":
+        return pickle.loads(data)

--- a/lmcache/v1/platform/base_ipc_wrapper.py
+++ b/lmcache/v1/platform/base_ipc_wrapper.py
@@ -13,7 +13,7 @@ on the receiving side.
 from __future__ import annotations
 
 # Standard
-from typing import ClassVar
+from typing import Any, ClassVar, Tuple
 import pickle
 import threading
 
@@ -47,6 +47,19 @@ class DeviceIPCWrapper:
     #: skips subclasses where this is ``False``.
     _is_default_wrapper: ClassVar[bool] = False
 
+    # Interface fields populated by each concrete subclass's
+    # ``__init__``.  Declared here so the base-class ``__eq__`` (and
+    # type-checkers) can see them; ``handle`` is intentionally typed as
+    # ``Any`` because each backend stores a different opaque payload
+    # (``tuple`` for CUDA shared-storage IPC, ``None`` for the SHM /
+    # raw-CUDA paths that override ``to_tensor``).
+    handle: Any
+    dtype: torch.dtype
+    shape: Tuple[int, ...]
+    stride: Tuple[int, ...]
+    storage_offset: int
+    device_uuid: str
+
     _discovered_device_mapping: dict[str, int] = {}
     _device_mapping_lock = threading.Lock()
 
@@ -56,7 +69,7 @@ class DeviceIPCWrapper:
         return str(torch_dev.get_device_properties(device_index).uuid)
 
     @classmethod
-    def _discover_devices(cls):
+    def _discover_devices(cls) -> None:
         """Discover all available accelerator devices and map their UUIDs
         to the physical device ordinals.
         """
@@ -97,7 +110,14 @@ class DeviceIPCWrapper:
         """
         raise NotImplementedError
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        # ``isinstance`` first so type-checkers can narrow ``other`` to
+        # ``DeviceIPCWrapper`` before we touch its attributes; the
+        # exact-type check that follows then enforces that, e.g., a
+        # ``CudaIPCWrapper`` is never considered equal to a
+        # ``RawCudaIPCWrapper`` even though they share a base class.
+        if not isinstance(other, DeviceIPCWrapper):
+            return False
         if type(self) is not type(other):
             return False
         return (
@@ -111,8 +131,30 @@ class DeviceIPCWrapper:
 
     @staticmethod
     def Serialize(obj: "DeviceIPCWrapper") -> bytes:
+        """Pickle ``obj`` for the multiprocess wire.
+
+        Pickle (rather than msgspec) is used so the concrete subclass
+        identity round-trips: every wrapper shares the single msgspec
+        ext code (1), and the receiver relies on the unpickled type to
+        dispatch ``to_tensor`` correctly.
+
+        Args:
+            obj: The wrapper instance to serialize.
+
+        Returns:
+            The pickled bytes payload.
+        """
         return pickle.dumps(obj)
 
     @staticmethod
     def Deserialize(data: bytes) -> "DeviceIPCWrapper":
+        """Inverse of :meth:`Serialize`.
+
+        Args:
+            data: The pickled bytes payload produced by :meth:`Serialize`.
+
+        Returns:
+            The reconstructed wrapper instance, with its concrete
+            subclass identity preserved.
+        """
         return pickle.loads(data)

--- a/lmcache/v1/platform/base_ipc_wrapper.py
+++ b/lmcache/v1/platform/base_ipc_wrapper.py
@@ -13,7 +13,7 @@ on the receiving side.
 from __future__ import annotations
 
 # Standard
-from typing import Any, ClassVar, Tuple
+from typing import Any, Tuple
 import pickle
 import threading
 
@@ -39,13 +39,13 @@ class DeviceIPCWrapper:
 
     Subclasses implement ``__init__`` (populate the interface fields from a
     tensor) and ``to_tensor`` (reconstruct the tensor from the handle).
-    """
 
-    #: Set ``True`` on the subclass that should be used as the default
-    #: factory for a given ``device_type``.  Auto-discovery
-    #: (:func:`~lmcache.v1.platform._registry._discover_wrappers_once`)
-    #: skips subclasses where this is ``False``.
-    _is_default_wrapper: ClassVar[bool] = False
+    Concrete subclasses set ``_is_default_wrapper = True`` (a ``ClassVar``)
+    to mark themselves as the default factory for their ``device_type``;
+    auto-discovery in :mod:`lmcache.v1.platform._registry` reads it via
+    ``getattr(cls, "_is_default_wrapper", False)`` so the attribute is
+    intentionally not declared on the base class.
+    """
 
     # Interface fields populated by each concrete subclass's
     # ``__init__``.  Declared here so the base-class ``__eq__`` (and

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -1,35 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """CPU-specific platform primitives.
 
-Importing this package self-registers the POSIX-SHM KV-cache wrapper
-factory with :mod:`lmcache.v1.platform._registry`, so the dispatch
-in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
-pick the right wrapper based on ``tensor.device.type`` without any
-if/elif chain.
+:class:`~lmcache.v1.platform.cpu.shm.CpuShmTensorWrapper` carries a
+``device_type`` ClassVar and a ``wrap`` factory classmethod, which
+:func:`~lmcache.v1.platform._registry._discover_wrappers_once` picks
+up at run-time -- no static ``register_kv_wrapper`` needed.
 """
-
-# Standard
-from typing import Any
-
-# Third Party
-import torch
-
-# First Party
-from lmcache.v1.platform._registry import register_kv_wrapper
-
-
-def _kv_wrapper_factory(tensor: torch.Tensor) -> Any:
-    """Indirect-dispatch wrapper.
-
-    Defers loading :mod:`lmcache.v1.platform.cpu.shm` (which pulls in
-    ``multiprocess.custom_types``) until first use, so importing this
-    package during ``lmcache/__init__.py``'s bootstrap does not race
-    other imports that touch ``torch_dev``.
-    """
-    # First Party
-    from lmcache.v1.platform.cpu.shm import migrate_to_shm_and_wrap
-
-    return migrate_to_shm_and_wrap(tensor)
-
-
-register_kv_wrapper("cpu", _kv_wrapper_factory)

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -85,10 +85,20 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
 
     @classmethod
     def wrap(cls, tensor: torch.Tensor) -> "CpuShmTensorWrapper":
-        """Factory classmethod for auto-registration via
+        """Factory used by
         :func:`~lmcache.v1.platform._registry._discover_wrappers_once`.
 
-        Delegates to :func:`migrate_to_shm_and_wrap`."""
+        Delegates to :func:`migrate_to_shm_and_wrap`, which migrates the
+        tensor's storage to a POSIX SHM segment so the LMCache mp server
+        can map the same physical pages.
+
+        Args:
+            tensor: A contiguous CPU tensor to migrate and wrap.
+
+        Returns:
+            A new :class:`CpuShmTensorWrapper` referencing the SHM
+            segment that now backs ``tensor``.
+        """
         return migrate_to_shm_and_wrap(tensor)
 
     def __init__(self, tensor: torch.Tensor, shm_name: str) -> None:

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -15,6 +15,7 @@ any if/elif chain.
 from __future__ import annotations
 
 # Standard
+from typing import ClassVar
 import ctypes
 import itertools
 import os
@@ -26,13 +27,13 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.multiprocess.custom_types import DeviceIPCWrapper
 from lmcache.v1.multiprocess.posix_shm import (
     shm_create_readwrite,
     shm_map_readwrite,
     shm_munmap,
     shm_unlink,
 )
+from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
 
 logger = init_logger(__name__)
 
@@ -70,9 +71,25 @@ class CpuShmTensorWrapper(DeviceIPCWrapper):
     so ``to_tensor`` dispatches correctly on both sides.
     """
 
+    #: ``torch.device.type`` this wrapper handles (used by auto-discovery
+    #: in :func:`~lmcache.v1.platform._registry._discover_wrappers_once`).
+    device_type: ClassVar[str] = "cpu"
+
+    #: Marked ``True`` so auto-discovery picks this as the default
+    #: factory for ``"cpu"``.
+    _is_default_wrapper: ClassVar[bool] = True
+
     # POSIX shared-memory name (``/lmcache_...``) -- leading ``/`` is
     # required by ``shm_open(3)`` on both Linux and macOS.
     SHM_NAME_PREFIX = "/lmcache_kv_"
+
+    @classmethod
+    def wrap(cls, tensor: torch.Tensor) -> "CpuShmTensorWrapper":
+        """Factory classmethod for auto-registration via
+        :func:`~lmcache.v1.platform._registry._discover_wrappers_once`.
+
+        Delegates to :func:`migrate_to_shm_and_wrap`."""
+        return migrate_to_shm_and_wrap(tensor)
 
     def __init__(self, tensor: torch.Tensor, shm_name: str) -> None:
         if tensor.device.type != "cpu":

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -1,35 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """CUDA-specific platform primitives.
 
-Importing this package self-registers a CUDA KV-cache wrapper
-factory with :mod:`lmcache.v1.platform._registry`, so the dispatch
-in :mod:`lmcache.integration.vllm.vllm_multi_process_adapter` can
-locate it by ``tensor.device.type``.
+:class:`~lmcache.v1.platform.cuda.ipc_wrapper.CudaIPCWrapper` carries
+a ``device_type`` ClassVar and a ``wrap`` factory classmethod, which
+:func:`~lmcache.v1.platform._registry._discover_wrappers_once` picks
+up at run-time -- no static ``register_kv_wrapper`` needed.
+
+The CUDA availability predicate is still registered statically here
+so callers can check ``is_available("cuda")`` at import time.
 """
 
-# Standard
-from typing import Any
-
-# Third Party
-import torch
-
 # First Party
-from lmcache.v1.platform._registry import (
-    register_availability,
-    register_kv_wrapper,
-)
-
-
-def _kv_wrapper_factory(tensor: torch.Tensor) -> Any:
-    """Indirect-dispatch wrapper.
-
-    Re-imports :class:`CudaIPCWrapper` on every call so test suites
-    that swap the symbol still see their override take effect.
-    """
-    # First Party
-    from lmcache.v1.multiprocess.custom_types import CudaIPCWrapper
-
-    return CudaIPCWrapper(tensor)
+from lmcache.v1.platform._registry import register_availability
 
 
 def _cuda_is_available() -> bool:
@@ -41,4 +23,3 @@ def _cuda_is_available() -> bool:
 
 
 register_availability("cuda", _cuda_is_available)
-register_kv_wrapper("cuda", _kv_wrapper_factory)

--- a/lmcache/v1/platform/cuda/ipc_wrapper.py
+++ b/lmcache/v1/platform/cuda/ipc_wrapper.py
@@ -36,11 +36,19 @@ class CudaIPCWrapper(DeviceIPCWrapper):
 
     @classmethod
     def wrap(cls, tensor: torch.Tensor) -> "CudaIPCWrapper":
-        """Factory for auto-registration via
-        :func:`~lmcache.v1.platform._registry._discover_wrappers_once`."""
+        """Factory used by
+        :func:`~lmcache.v1.platform._registry._discover_wrappers_once`.
+
+        Args:
+            tensor: A CUDA tensor backed by PyTorch's caching allocator.
+
+        Returns:
+            A new :class:`CudaIPCWrapper` wrapping ``tensor`` for the
+            multiprocess wire.
+        """
         return cls(tensor)
 
-    def __init__(self, tensor: torch.Tensor):
+    def __init__(self, tensor: torch.Tensor) -> None:
         # First Party
         from lmcache.v1.gpu_connector.kv_format.contiguity import (
             attempt_permute_to_contiguous_view,

--- a/lmcache/v1/platform/cuda/ipc_wrapper.py
+++ b/lmcache/v1/platform/cuda/ipc_wrapper.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA IPC wrapper implementations.
+
+:class:`CudaIPCWrapper` handles tensors backed by PyTorch's caching
+allocator (vLLM default).  :class:`RawCudaIPCWrapper` handles tensors
+allocated outside PyTorch (e.g. TRT-LLM's ``cudaMalloc``'d pool).
+
+Both carry ``device_type = "cuda"`` so
+:func:`~lmcache.v1.platform._registry._discover_wrappers_once` can
+index them; :class:`RawCudaIPCWrapper` sets ``_is_default_wrapper =
+False`` so only :class:`CudaIPCWrapper` auto-registers as the default
+factory.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import ClassVar
+
+# Third Party
+import torch
+
+# First Party
+from lmcache import torch_device_type
+from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
+
+
+class CudaIPCWrapper(DeviceIPCWrapper):
+    #: ``torch.device.type`` this wrapper handles (used by auto-discovery).
+    device_type: ClassVar[str] = "cuda"
+
+    #: Marked ``True`` so auto-discovery picks this as the default
+    #: factory for ``"cuda"``.
+    _is_default_wrapper: ClassVar[bool] = True
+
+    @classmethod
+    def wrap(cls, tensor: torch.Tensor) -> "CudaIPCWrapper":
+        """Factory for auto-registration via
+        :func:`~lmcache.v1.platform._registry._discover_wrappers_once`."""
+        return cls(tensor)
+
+    def __init__(self, tensor: torch.Tensor):
+        # First Party
+        from lmcache.v1.gpu_connector.kv_format.contiguity import (
+            attempt_permute_to_contiguous_view,
+        )
+
+        # Permute any non-contiguous view (e.g. vLLM's NHD-over-HND) so the
+        # shape/stride we encode across IPC reflects the physical layout.
+        # Offset is preserved by the wrapper's storage_offset field.
+        tensor = attempt_permute_to_contiguous_view(tensor)
+
+        storage = tensor.untyped_storage()
+        handle = storage._share_cuda_()
+
+        self.handle = handle
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+
+        device_index = tensor.device.index
+        self.device_uuid = self._get_device_uuid(device_index)
+
+    def to_tensor(self) -> torch.Tensor:
+        """
+        Note:
+            This function may break if the accelerator is not initialized.
+            We should call ``torch_dev.init()`` before using this function
+            (guarded by hasattr since not all backends expose init()).
+        """
+        device_index = self._get_device_index_from_uuid(self.device_uuid)
+
+        storage = torch.UntypedStorage._new_shared_cuda(  # noqa: SLF001
+            device_index, *self.handle[1:]
+        )
+
+        t = torch.empty(
+            (), device=f"{torch_device_type}:{device_index}", dtype=self.dtype
+        )
+        t.set_(storage, self.storage_offset, self.shape, self.stride)
+        return t
+
+
+class RawCudaIPCWrapper(DeviceIPCWrapper):
+    """IPC wrapper for CUDA tensors allocated outside PyTorch's caching
+    allocator.
+
+    PyTorch's ``UntypedStorage._share_cuda_()`` only works for tensors
+    backed by its own caching allocator. TRT-LLM publishes its KV pool
+    via ``at::for_blob`` over a ``cudaMalloc``'d buffer, which raises in
+    ``_share_cuda_()``. This subclass bypasses that path: it calls
+    ``cudaIpcGetMemHandle`` on the raw data pointer, then reconstructs
+    the tensor on the receiving side via ``cudaIpcOpenMemHandle`` plus
+    a CuPy ``UnownedMemory`` → DLPack → ``torch`` round-trip.
+
+    Sharing the ``DeviceIPCWrapper`` base (rather than introducing a
+    parallel class with its own msgspec ext code) is load-bearing —
+    msgspec does not support unions of custom ext-encoded types. With a
+    common base, ``KVCache = list[DeviceIPCWrapper]`` type-checks, the
+    single ext code 1 round-trips every wrapper, and pickle preserves
+    the concrete subclass identity through the wire so ``to_tensor``
+    dispatches correctly.
+    """
+
+    #: Same ``torch.device.type`` as ``CudaIPCWrapper``, but
+    #: ``_is_default_wrapper = False`` so auto-discovery skips this
+    #: class — callers (TRT-LLM adapter) instantiate it directly.
+    device_type: ClassVar[str] = "cuda"
+    _is_default_wrapper: ClassVar[bool] = False
+
+    def __init__(self, tensor: torch.Tensor) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector.utils import assert_contiguous
+
+        assert_contiguous(tensor)
+
+        try:
+            # Third Party
+            from cuda.bindings import runtime as cudart
+        except ImportError:
+            # Third Party
+            from cuda import cudart
+
+        data_ptr = tensor.data_ptr()
+        err, ipc_handle = cudart.cudaIpcGetMemHandle(data_ptr)
+        if err != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(
+                f"cudaIpcGetMemHandle failed: {err} (ptr=0x{data_ptr:x})"
+            )
+
+        # Store only what's needed for reconstruction.
+        self._ipc_handle_reserved = bytes(ipc_handle.reserved)
+        self._nbytes = tensor.untyped_storage().nbytes()
+
+        # DeviceIPCWrapper interface fields. ``handle`` is unused —
+        # ``to_tensor`` is overridden to bypass it — but kept (None) so
+        # the base-class equality check has a value to compare.
+        self.handle = None
+        self.dtype = tensor.dtype
+        self.shape = tuple(tensor.shape)
+        self.stride = tuple(tensor.stride())
+        self.storage_offset = int(tensor.storage_offset())
+
+        device_index = tensor.device.index
+        self.device_uuid = self._get_device_uuid(device_index)
+
+    def to_tensor(self) -> torch.Tensor:
+        """Reconstruct the tensor in this process via raw CUDA IPC."""
+        # Third Party
+        import cupy
+
+        try:
+            # Third Party
+            from cuda.bindings import runtime as cudart
+        except ImportError:
+            # Third Party
+            from cuda import cudart
+
+        device_index = self._get_device_index_from_uuid(self.device_uuid)
+
+        handle = cudart.cudaIpcMemHandle_t()
+        handle.reserved = self._ipc_handle_reserved
+        err, ptr = cudart.cudaIpcOpenMemHandle(
+            handle, cudart.cudaIpcMemLazyEnablePeerAccess
+        )
+        if err != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"cudaIpcOpenMemHandle failed: {err}")
+
+        # Wrap as a flat ``uint8`` CuPy array, DLPack to torch, then view
+        # as the original dtype/shape. ``uint8`` avoids dtype-conversion
+        # gaps (bfloat16, fp8 have no direct CuPy/NumPy equivalent without
+        # ml_dtypes).
+        with cupy.cuda.Device(device_index):
+            mem = cupy.cuda.UnownedMemory(ptr, self._nbytes, owner=self)
+            memptr = cupy.cuda.MemoryPointer(mem, 0)
+            cp_flat = cupy.ndarray(self._nbytes, dtype=cupy.uint8, memptr=memptr)
+
+        raw = torch.from_dlpack(cp_flat)
+        return raw.view(self.dtype).reshape(self.shape)

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -21,7 +21,6 @@ from lmcache.v1.distributed.config import (
 from lmcache.v1.mp_observability.config import DEFAULT_OBSERVABILITY_CONFIG
 from lmcache.v1.multiprocess.config import MPServerConfig
 from lmcache.v1.multiprocess.custom_types import (
-    CudaIPCWrapper,
     IPCCacheServerKey,
     KVCache,
 )
@@ -31,6 +30,7 @@ from lmcache.v1.multiprocess.protocol import (
     get_response_class,
 )
 from lmcache.v1.multiprocess.server import run_cache_server
+from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
 
 # Configuration constants
 SERVER_HOST = "localhost"

--- a/tests/v1/multiprocess/test_custom_types.py
+++ b/tests/v1/multiprocess/test_custom_types.py
@@ -11,11 +11,11 @@ import torch
 # First Party
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
-    CudaIPCWrapper,
     IPCCacheServerKey,
     get_customized_decoder,
     get_customized_encoder,
 )
+from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
 
 
 def test_ipc_cache_engine_key_serialization():

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -382,7 +382,12 @@ def test_create_transfer_context_handle_mode_unsupported_device_raises(
     snapshot = platform_registry.snapshot()
     try:
         # Drop every registered factory so 'cpu' can never be resolved.
-        platform_registry.restore({"kv_wrapper": {}, "availability": {}})
+        # Pass ``discovered=True`` so the lazy discovery pass does not
+        # immediately re-register the auto-discovered backends and
+        # defeat the empty-table fixture.
+        platform_registry.restore(
+            {"kv_wrapper": {}, "availability": {}, "discovered": True}
+        )
         with pytest.raises(ValueError, match="not supported for device type"):
             create_transfer_context(
                 {"layer_0": torch.randn(2, 2)}, mode="lmcache_driven"

--- a/tests/v1/multiprocess/test_mq.py
+++ b/tests/v1/multiprocess/test_mq.py
@@ -15,7 +15,6 @@ import zmq
 from lmcache.utils import EngineType
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
-    CudaIPCWrapper,
     IPCCacheServerKey,
 )
 from lmcache.v1.multiprocess.mq import (
@@ -29,6 +28,7 @@ from lmcache.v1.multiprocess.protocol import (
     get_payload_classes,
 )
 from lmcache.v1.multiprocess.server import add_handler_helper
+from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
 
 # Test helpers
 from tests.v1.multiprocess import test_mq_handler_helpers

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -364,8 +364,8 @@ class TestRawCudaIPCWrapperType:
         # First Party
         from lmcache.v1.multiprocess.custom_types import (
             DeviceIPCWrapper,
-            RawCudaIPCWrapper,
         )
+        from lmcache.v1.platform.cuda.ipc_wrapper import RawCudaIPCWrapper
 
         assert issubclass(RawCudaIPCWrapper, DeviceIPCWrapper)
 
@@ -377,8 +377,8 @@ class TestRawCudaIPCWrapperType:
         from lmcache.v1.multiprocess.custom_types import (
             DeviceIPCWrapper,
             KVCache,
-            RawCudaIPCWrapper,
         )
+        from lmcache.v1.platform.cuda.ipc_wrapper import RawCudaIPCWrapper
 
         assert KVCache == list[DeviceIPCWrapper]
         # Static check substitute: a concrete wrapper fits the list type.


### PR DESCRIPTION

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Move every concrete DeviceIPCWrapper next to its accelerator code under
platform/<device>/ and replace the static if/elif dispatch with runtime
subclass discovery (same pattern as cache_context.py). Adding a new
backend now only requires shipping a DeviceIPCWrapper subclass with
device_type and wrap() — no edits to the dispatcher.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
