### PR TITLE
fix: bounds-check S3L2Adapter GET to prevent writing past MemoryObj (#3831)

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -870,9 +870,16 @@ class S3L2Adapter(L2AdapterInterface):
     def _get_request(self, key_str: str, mem_obj: MemoryObj):
         req = self._make_request("GET", key_str)
         data_ptr = mem_obj.data_ptr
+        buf_size = mem_obj.get_size()
+        overflow = {"hit": False}
 
         def on_body(chunk, offset, **kwargs):
-            # Write chunk into the caller-provided MemoryObj buffer.
+            # Write chunk into the caller-provided MemoryObj buffer, dropping
+            # any bytes past its bounds so an oversized S3 object can't write
+            # out of bounds; on_done fails the request if that happens (#3831).
+            if offset < 0 or offset + len(chunk) > buf_size:
+                overflow["hit"] = True
+                return
             ctypes.memmove(data_ptr + offset, chunk, len(chunk))
 
         def on_done(error=None, status_code=None, **kwargs):
@@ -880,6 +887,11 @@ class S3L2Adapter(L2AdapterInterface):
             if error or not ok:
                 raise RuntimeError(
                     f"S3 GET failed for {key_str}: {error or status_code}"
+                )
+            if overflow["hit"]:
+                raise RuntimeError(
+                    f"S3 GET for {key_str} returned more data than the "
+                    f"{buf_size}-byte destination buffer"
                 )
 
         s3_req = s3.S3Request(
@@ -1201,6 +1213,15 @@ class S3L2Adapter(L2AdapterInterface):
         for i, (key, obj) in enumerate(zip(keys, objects, strict=True)):
             try:
                 key_str = _object_key_to_string(key)
+                with self._lock:
+                    cached_size = self._object_size_cache.get(key_str)
+                if cached_size is not None and cached_size != obj.get_size():
+                    logger.error(
+                        f"Size mismatch for {key_str}: S3 has {cached_size} "
+                        f"bytes, but the destination expects {obj.get_size()} "
+                        f"bytes; skipping load to avoid writing past the buffer."
+                    )
+                    continue
                 s3_req = self._get_request(key_str, obj)
                 futures.append(asyncio.wrap_future(s3_req.finished_future))
                 launched_indices.append(i)

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -519,6 +519,47 @@ class TestStoreLookupLoad:
         assert adapter.query_lookup_and_lock_result(tid) is not None
         assert adapter.query_lookup_and_lock_result(tid) is None
 
+    def test_load_rejects_oversized_after_lookup(self, adapter):
+        """A cached object larger than the destination buffer is rejected
+        before the GET (size mismatch), so the load reports a miss and never
+        writes past the MemoryObj bounds (#3831).
+        """
+        key = create_object_key(7)
+        adapter.submit_store_task([key], [create_memory_obj(size=32, fill_value=2.0)])
+        wait_for_event_fd(adapter.get_store_event_fd())
+        adapter.pop_completed_store_tasks()
+
+        # Lookup caches the oversized object length.
+        tid = adapter.submit_lookup_and_lock_task([key])
+        wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+        adapter.query_lookup_and_lock_result(tid)
+
+        # Load into a smaller 16-element (64-byte) buffer.
+        dst = create_memory_obj(size=16, fill_value=0.0)
+        tid = adapter.submit_load_task([key], [dst])
+        assert wait_for_event_fd(adapter.get_load_event_fd())
+        bm = adapter.query_load_result(tid)
+        assert bm is not None and bm.test(0) is False
+        assert torch.allclose(dst.tensor, torch.zeros(16))
+
+    def test_load_rejects_oversized_without_lookup(self, adapter):
+        """With no cached size (no prior lookup) the GET is issued, so the
+        on_body guard must drop the oversized response and fail the load
+        instead of writing past the MemoryObj bounds (#3831).
+        """
+        key = create_object_key(8)
+        # 32-element (128-byte) object placed directly in the backend so the
+        # adapter has no cached size and issues the GET.
+        big = create_memory_obj(size=32, fill_value=2.0)
+        _BACKEND.put(_object_key_to_string(key), bytes(big.byte_array))
+
+        dst = create_memory_obj(size=16, fill_value=0.0)
+        tid = adapter.submit_load_task([key], [dst])
+        assert wait_for_event_fd(adapter.get_load_event_fd())
+        bm = adapter.query_load_result(tid)
+        assert bm is not None and bm.test(0) is False
+        assert torch.allclose(dst.tensor, torch.zeros(16))
+
 
 # =============================================================================
 # Eviction (delete + locking)


### PR DESCRIPTION
`S3L2Adapter._get_request`'s body callback `memmove`'d S3 chunks into the destination `MemoryObj` without checking the write stayed in bounds, so a response larger than the local layout expects could write past the buffer. The non-MP `S3Connector.get` already guards this with an object-size check; the L2 adapter cached the HEAD `Content-Length` but only treated it as an existence signal.

The fix compares the cached size against the destination `get_size()` before issuing the GET (same shape as `S3Connector.get`) and drops out-of-bounds bytes in the body callback as a backstop, with `on_done` failing the request so the load reports a miss rather than corrupting memory.

Two regression tests cover both paths -- rejected via the cached size after a lookup, and via the body-callback guard with no cached size.

Fixes #3831.