### PR TITLE
Fix race condition in `memcheck()` during `LazyMemoryAllocator` expansion

### DIFF
--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1555,6 +1555,22 @@ class AddressManager:
         """
         return self._size - self.total_allocated_size
 
+    @synchronized("_lock")
+    def size_snapshot(self) -> tuple[int, int]:
+        """
+        Return a consistent (heap_size, allocated_size) snapshot under the lock.
+
+        Taking heap_size and allocated_size in a single critical section prevents
+        sbrk() from interleaving between the two reads, which would otherwise
+        cause memcheck() to observe a transient inconsistency during lazy
+        expansion even when the allocator is healthy.
+
+        Returns:
+            A tuple (heap_size, allocated_size).
+        """
+        return self._size, self.total_allocated_size
+
+    @synchronized("_lock")
     def check_consistency(self) -> bool:
         """
         Check if the address manager is consistent.
@@ -1822,15 +1838,14 @@ class TensorMemoryAllocator(MemoryAllocatorInterface):
             self.address_manager.total_allocated_size / 1048576,
         )
 
-        # Check the real total free size
-        total_free_size = self.address_manager.get_free_size()
+        # Take a consistent snapshot under the lock so that a concurrent sbrk()
+        # cannot interleave between the two reads and produce a false positive.
+        heap_size, allocated_size = self.address_manager.size_snapshot()
+        total_free_size = heap_size - allocated_size
         logger.info(" - Total free size: %f MB", total_free_size / 1048576)
 
         # Check if the numbers are consistent
-        if (
-            total_free_size + self.address_manager.total_allocated_size
-            != self.address_manager.get_heap_size()
-        ):
+        if total_free_size + allocated_size != heap_size:
             logger.error("Memory allocator size is inconsistent")
             logger.error("This implies a bug in the memory allocator")
             clear = False


### PR DESCRIPTION
### Problem
Fix #3834

`TensorMemoryAllocator.memcheck()` reads `AddressManager._size` twice through two separate unprotected calls (`get_free_size()` then `get_heap_size()`). During lazy expansion, the background thread can call `sbrk()` — which holds `_lock` — between those two reads, causing the check to observe `old_size != new_size` and incorrectly report the allocator as unhealthy.

### Fix

**`AddressManager.size_snapshot()`** — new `@synchronized("_lock")` method that returns `(_size, total_allocated_size)` in a single critical section, ensuring the two values are always consistent.

**`AddressManager.check_consistency()`** — add `@synchronized("_lock")` so the free-list traversal and size comparison are also protected against concurrent `sbrk()`.

**`TensorMemoryAllocator.memcheck()`** — replace the two separate reads with a single `size_snapshot()` call. Check 1 (`free + allocated == heap`) remains logically a tautology, but the lock prevents any future refactor of `get_free_size()` from re-introducing the race silently.

### Testing

Verified that inserting the following two debug sleeps makes the race fire on
every run without the fix, and disappear with it:

```python
# lazy_memory_allocator.py — _commit_expansion()
import time; time.sleep(0.01)  # delay sbrk until memcheck has read get_free_size()

# memory_management.py — memcheck(), between get_free_size() and get_heap_size()
import time; time.sleep(0.01)  # keep window open for sbrk to fire
```

### Performance

No impact on the hot path. `memcheck()` is only called from the `/status` monitoring endpoint and explicit `clear()` operations — never from `allocate()` or `free()`. `_lock` is already acquired on every `allocate()` and `free()` call; the two additional acquisitions in `memcheck()` add negligible overhead.
