### PR TITLE
feat(valkey): add per-key TTL + partial-chunk validation to Valkey glide connector

### DIFF
--- a/docs/source/kv_cache/storage_backends/valkey.rst
+++ b/docs/source/kv_cache/storage_backends/valkey.rst
@@ -47,6 +47,12 @@ The following ``extra_config`` keys are supported:
    * - ``valkey_database``
      - None
      - Database ID (standalone mode only, ignored in cluster mode).
+   * - ``valkey_enable_ttl``
+     - ``false``
+     - Feature flag. When ``true``, every key is written with an expiry (see ``valkey_ttl_sec``) so Valkey/Redis ``volatile-*`` eviction policies can reclaim L2 cache keys once the node reaches ``maxmemory``. When ``false`` (default), keys are persisted without a TTL.
+   * - ``valkey_ttl_sec``
+     - ``86400``
+     - Key TTL in seconds, applied only when ``valkey_enable_ttl`` is ``true``. Must be a positive integer. If the flag is enabled but this key is omitted, it defaults to ``86400`` (24 hours).
    * - ``request_timeout``
      - ``5.0``
      - GLIDE request timeout in seconds. Also used as the Python-side Future timeout.
@@ -84,6 +90,25 @@ Standalone-mode Valkey Configuration with database
      valkey_username: "Your username"
      valkey_password: "Your password"
      valkey_database: 0
+
+Standalone-mode Valkey Configuration with key TTL (volatile eviction)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enable a per-key TTL so a node configured with a ``volatile-lru`` /
+``volatile-lfu`` eviction policy can reclaim L2 cache keys once it reaches
+``maxmemory``. Without a TTL such policies never evict the KV cache keys,
+which can choke the remote cache.
+
+.. code-block:: yaml
+
+   chunk_size: 256
+   remote_url: "valkey://<your host>:6379"
+   remote_serde: "naive"
+   extra_config:
+     valkey_username: "Your username"
+     valkey_password: "Your password"
+     valkey_enable_ttl: true
+     valkey_ttl_sec: 3600   # keys expire after 1 hour
 
 Cluster-mode
 ~~~~~~~~~~~~~~~~

--- a/lmcache/v1/storage_backend/connector/valkey_adapter.py
+++ b/lmcache/v1/storage_backend/connector/valkey_adapter.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.config_base import _to_bool
 from lmcache.v1.storage_backend.connector import (
     ConnectorAdapter,
     ConnectorContext,
@@ -20,6 +21,11 @@ class ValkeyConnectorAdapter(ConnectorAdapter):
     Uses the GLIDE sync client with a ThreadPoolExecutor for
     high-throughput KV cache transfer.  Supports both standalone
     (default) and cluster modes via ``valkey_mode`` config.
+
+    Like ``RESPConnectorAdapter``, this adapter uses single-key, fixed-size
+    storage with no per-chunk metadata, so partial/unfull chunks are not
+    supported: ``save_chunk_meta`` and ``save_unfull_chunk`` must both be
+    ``False``.
 
     Requires ``valkey-glide`` 2.3+.
     """
@@ -51,6 +57,17 @@ class ValkeyConnectorAdapter(ConnectorAdapter):
             else {}
         )
 
+        # Single-key fixed-size storage (like RESP) carries no per-chunk
+        # metadata, so partial/unfull chunks are unsupported. save_chunk_meta
+        # comes from free-form extra_config, so coerce it (a string like
+        # "false" would otherwise be truthy).
+        if _to_bool(extra_config.get("save_chunk_meta", False)):
+            raise ValueError("save_chunk_meta must be False for Valkey glide connector")
+        if config is not None and config.save_unfull_chunk:
+            raise ValueError(
+                "save_unfull_chunk must be False for Valkey glide connector"
+            )
+
         num_workers = int(
             extra_config.get(
                 "valkey_num_workers",
@@ -59,7 +76,7 @@ class ValkeyConnectorAdapter(ConnectorAdapter):
         )
         username = str(extra_config.get("valkey_username", ""))
         password = str(extra_config.get("valkey_password", ""))
-        tls_enable = bool(extra_config.get("tls_enable", False))
+        tls_enable = _to_bool(extra_config.get("tls_enable", False))
 
         # Timeouts
         request_timeout = float(

--- a/lmcache/v1/storage_backend/connector/valkey_adapter.py
+++ b/lmcache/v1/storage_backend/connector/valkey_adapter.py
@@ -22,6 +22,10 @@ class ValkeyConnectorAdapter(ConnectorAdapter):
     high-throughput KV cache transfer.  Supports both standalone
     (default) and cluster modes via ``valkey_mode`` config.
 
+    Optionally sets a per-key TTL (``valkey_enable_ttl`` + ``valkey_ttl_sec``) so
+    Valkey/Redis ``volatile-*`` eviction policies can reclaim L2 cache keys
+    under memory pressure.
+
     Like ``RESPConnectorAdapter``, this adapter uses single-key, fixed-size
     storage with no per-chunk metadata, so partial/unfull chunks are not
     supported: ``save_chunk_meta`` and ``save_unfull_chunk`` must both be
@@ -47,6 +51,7 @@ class ValkeyConnectorAdapter(ConnectorAdapter):
         from .valkey_connector import (
             DEFAULT_CONNECTION_TIMEOUT_SECS,
             DEFAULT_REQUEST_TIMEOUT_SECS,
+            DEFAULT_TTL_SECS,
             ValkeyConnector,
         )
 
@@ -108,12 +113,51 @@ class ValkeyConnectorAdapter(ConnectorAdapter):
                 )
                 database_id = None
 
+        # TTL feature flag (volatile-* eviction support).
+        #
+        # Without a TTL, keys are persisted indefinitely; a Valkey/Redis node
+        # using a ``volatile-lru``/``volatile-lfu`` eviction policy will never
+        # evict them and the L2 remote cache chokes once ``maxmemory`` is hit.
+        # Enabling ``valkey_enable_ttl`` makes every key expire after
+        # ``valkey_ttl_sec`` seconds so the eviction policy can reclaim memory.
+        ttl_seconds: Optional[int] = None
+        if _to_bool(extra_config.get("valkey_enable_ttl", False)):
+            raw_ttl = extra_config.get("valkey_ttl_sec", None)
+            if raw_ttl is None:
+                ttl_seconds = DEFAULT_TTL_SECS
+                logger.warning(
+                    "valkey_enable_ttl is enabled but valkey_ttl_sec is not set; "
+                    "defaulting key TTL to %d seconds.",
+                    ttl_seconds,
+                )
+            else:
+                # bool is a subclass of int, so a boolean (e.g. ``True``)
+                # would otherwise coerce to a 1-second TTL — reject it.
+                if isinstance(raw_ttl, bool):
+                    raise ValueError(
+                        f"valkey_ttl_sec must be a positive integer number of "
+                        f"seconds, got {raw_ttl!r}."
+                    )
+                try:
+                    ttl_seconds = int(float(raw_ttl))
+                except (ValueError, TypeError) as e:
+                    raise ValueError(
+                        f"valkey_ttl_sec must be a positive integer number of "
+                        f"seconds, got {raw_ttl!r}."
+                    ) from e
+                if ttl_seconds <= 0:
+                    raise ValueError(
+                        f"valkey_ttl_sec must be a positive number of seconds, "
+                        f"got {ttl_seconds}."
+                    )
+
         parsed_url = parse_remote_url(context.url)
         logger.info(
-            "Creating Valkey connector for %s:%d (mode=%s)",
+            "Creating Valkey connector for %s:%d (mode=%s, ttl_seconds=%s)",
             parsed_url.host,
             parsed_url.port,
             valkey_mode,
+            ttl_seconds,
         )
         return ValkeyConnector(
             host=parsed_url.host,
@@ -128,4 +172,5 @@ class ValkeyConnectorAdapter(ConnectorAdapter):
             tls_enable=tls_enable,
             cluster_mode=cluster_mode,
             database_id=database_id,
+            ttl_seconds=ttl_seconds,
         )

--- a/lmcache/v1/storage_backend/connector/valkey_connector.py
+++ b/lmcache/v1/storage_backend/connector/valkey_connector.py
@@ -238,11 +238,33 @@ class _ThreadWorkerPool:
             if result is None:
                 return False
             n = int(result)
+            if n != size:
+                # Fixed-size KV chunks must round-trip exactly. A short read
+                # signals a size mismatch / corrupt or stale-format entry;
+                # treat it as a miss rather than leaving stale tail bytes in
+                # buf[n:] and reporting success.
+                logger.warning(
+                    "Valkey GET size mismatch for key %s: read %d bytes, "
+                    "expected %d; treating as miss.",
+                    key_str,
+                    n,
+                    size,
+                )
+                return False
             buf[:n] = scratch_view[:n]
             return True
         else:
             data = client.get(key_str.encode())
             if data is None:
+                return False
+            if len(data) != buf.nbytes:
+                logger.warning(
+                    "Valkey GET size mismatch for key %s: read %d bytes, "
+                    "expected %d; treating as miss.",
+                    key_str,
+                    len(data),
+                    buf.nbytes,
+                )
                 return False
             buf[: len(data)] = data
             return True

--- a/lmcache/v1/storage_backend/connector/valkey_connector.py
+++ b/lmcache/v1/storage_backend/connector/valkey_connector.py
@@ -33,7 +33,7 @@ Requires ``valkey-glide`` with PRs #5492 (zero-copy SET) and #5493 (buffer GET).
 # Standard
 from concurrent.futures import Future, ThreadPoolExecutor
 from enum import IntEnum, auto
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 import asyncio
 import inspect
 import threading
@@ -46,12 +46,19 @@ from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
 from lmcache.v1.storage_backend.job_executor.pq_executor import AsyncPQExecutor
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
+if TYPE_CHECKING:
+    # Third Party
+    import glide_sync  # type: ignore[import-untyped]
+
 logger = init_logger(__name__)
 
 #: Default request timeout (seconds).
 DEFAULT_REQUEST_TIMEOUT_SECS: float = 5.0
 #: Default connection timeout (seconds).
 DEFAULT_CONNECTION_TIMEOUT_SECS: float = 10.0
+#: Default key TTL (seconds) used when the TTL feature flag is enabled but no
+#: explicit ``valkey_ttl_sec`` is configured (24 hours).
+DEFAULT_TTL_SECS: int = 86400
 
 
 class Priorities(IntEnum):
@@ -88,6 +95,10 @@ class _ThreadWorkerPool:
         tls_enable: Whether to use TLS for Valkey connections.
         cluster_mode: If True, use GlideClusterClient; else GlideClient.
         database_id: Database ID for standalone mode (ignored in cluster).
+        ttl_seconds: If set, every key is written with this expiry (in
+            seconds) so Valkey/Redis ``volatile-*`` eviction policies can
+            reclaim L2 cache keys under memory pressure. ``None`` (default)
+            disables TTL — keys are persisted without expiry.
     """
 
     def __init__(
@@ -102,6 +113,7 @@ class _ThreadWorkerPool:
         tls_enable: bool = False,
         cluster_mode: bool = False,
         database_id: Optional[int] = None,
+        ttl_seconds: Optional[int] = None,
     ):
         self.num_workers = num_workers
         self._host = host
@@ -114,6 +126,8 @@ class _ThreadWorkerPool:
         self._tls_enable = tls_enable
         self._cluster_mode = cluster_mode
         self._database_id = database_id
+        self._ttl_seconds = ttl_seconds
+        self._expiry_obj = None  # lazily built ExpirySet (see _do_set)
         self._local = threading.local()
         self._has_buffer_get: Optional[bool] = None
 
@@ -128,10 +142,11 @@ class _ThreadWorkerPool:
         mode_str = "cluster" if cluster_mode else "standalone"
         logger.info(
             "Valkey thread pool: %d threads, mode=%s, per-thread clients, "
-            "buffer_get=%s",
+            "buffer_get=%s, ttl_seconds=%s",
             num_workers,
             mode_str,
             self._has_buffer_get,
+            ttl_seconds,
         )
 
     def _get_client(self):  # type: ignore[no-untyped-def]
@@ -201,9 +216,35 @@ class _ThreadWorkerPool:
             )
         return bool(self._has_buffer_get)
 
+    def _build_expiry(self) -> "glide_sync.ExpirySet":
+        """Lazily build (and cache) the GLIDE ``ExpirySet`` for SET calls.
+
+        Built lazily so ``glide_sync`` is only imported on worker threads
+        (matching ``_get_client``). The resulting ``ExpirySet`` is an
+        immutable value object, so it is safe to share across threads; a
+        benign race during lazy init just rebuilds an equivalent object.
+        """
+        exp = self._expiry_obj
+        if exp is None:
+            if self._ttl_seconds is None:
+                raise ValueError("ttl_seconds must be set to build an ExpirySet")
+            # Third Party
+            import glide_sync  # type: ignore[import-untyped]
+
+            exp = glide_sync.ExpirySet(glide_sync.ExpiryType.SEC, self._ttl_seconds)
+            self._expiry_obj = exp
+        return exp
+
     def _do_set(self, key_str: str, data: bytes) -> None:
-        """SET a key (runs on a worker thread)."""
-        self._get_client().set(key_str.encode(), data)
+        """SET a key (runs on a worker thread).
+
+        When a TTL is configured (``ttl_seconds`` is not None), the key is
+        written with an expiry so that Valkey/Redis ``volatile-*`` eviction
+        policies can reclaim it once the node reaches ``maxmemory``. Without
+        a TTL the key is persisted indefinitely (legacy behavior).
+        """
+        expiry = self._build_expiry() if self._ttl_seconds is not None else None
+        self._get_client().set(key_str.encode(), data, expiry=expiry)
 
     def _get_scratch(self, size: int) -> bytearray:
         """Per-thread reusable staging buffer for buffer-GET (issue #6215).
@@ -336,6 +377,9 @@ class ValkeyConnector(RemoteConnector):
         tls_enable: Whether to use TLS for Valkey connections.
         cluster_mode: If True, use GlideClusterClient; else GlideClient.
         database_id: Database ID for standalone mode (ignored in cluster).
+        ttl_seconds: If set, keys are written with this expiry (seconds) so
+            ``volatile-*`` eviction policies can reclaim them. ``None``
+            (default) disables TTL.
     """
 
     def __init__(
@@ -352,6 +396,7 @@ class ValkeyConnector(RemoteConnector):
         tls_enable: bool = False,
         cluster_mode: bool = False,
         database_id: Optional[int] = None,
+        ttl_seconds: Optional[int] = None,
     ):
         super().__init__(local_cpu_backend.config, local_cpu_backend.metadata)
 
@@ -373,6 +418,7 @@ class ValkeyConnector(RemoteConnector):
             tls_enable=tls_enable,
             cluster_mode=cluster_mode,
             database_id=database_id,
+            ttl_seconds=ttl_seconds,
         )
         self._pq_executor = AsyncPQExecutor(loop)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,8 +156,17 @@ class MockSyncGlideClient:
     def set(self, key: bytes, value) -> None:
         self._store[key] = bytes(value)
 
-    def get(self, key: bytes):
-        return self._store.get(key)
+    def get(self, key: bytes, buffer=None):
+        data = self._store.get(key)
+        if buffer is None:
+            return data
+        # Mirror glide's native buffer-GET: write into the caller's buffer and
+        # return the number of bytes read (an int count), or None on miss.
+        if data is None:
+            return None
+        n = len(data)
+        buffer[:n] = data
+        return n
 
     def exists(self, keys: list[bytes]) -> int:
         return sum(1 for k in keys if k in self._store)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,9 +152,13 @@ class MockSyncGlideClient:
     """In-memory mock of a synchronous Glide (Valkey) client."""
 
     _store: dict[bytes, bytes] = {}
+    #: Records the ``expiry`` argument from the most recent ``set`` call so
+    #: tests can assert TTL behavior. ``None`` means no expiry was passed.
+    last_expiry = None
 
-    def set(self, key: bytes, value) -> None:
+    def set(self, key: bytes, value, expiry=None) -> None:
         self._store[key] = bytes(value)
+        type(self).last_expiry = expiry
 
     def get(self, key: bytes, buffer=None):
         data = self._store.get(key)
@@ -174,6 +178,7 @@ class MockSyncGlideClient:
     @classmethod
     def reset_store(cls) -> None:
         cls._store.clear()
+        cls.last_expiry = None
 
 
 class MockRedis:

--- a/tests/v1/storage_backend/test_valkey_connector.py
+++ b/tests/v1/storage_backend/test_valkey_connector.py
@@ -29,6 +29,13 @@ from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.connector import CreateConnector
 
+# Captured at import time (before the autouse mock_thread_worker_pool fixture
+# patches valkey_connector._ThreadWorkerPool) so tests can exercise the real
+# worker-pool methods directly.
+from lmcache.v1.storage_backend.connector.valkey_connector import (  # noqa: E402
+    _ThreadWorkerPool as _RealThreadWorkerPool,
+)
+
 # Local
 from ...conftest import MockSyncGlideClient
 from ..utils import (
@@ -50,6 +57,12 @@ class MockThreadWorkerPool:
     # Class-level record of the last __init__ kwargs for config assertions.
     last_init_kwargs: dict = {}
 
+    #: When True, ``_do_get_into`` mirrors the real buffer-GET branch: it stages
+    #: into a scratch buffer and relies on the client returning an int byte
+    #: count (``n = int(result)``), exercising the same control flow as the real
+    #: ``_ThreadWorkerPool``. Default False uses the simpler legacy GET branch.
+    simulate_buffer_get: bool = False
+
     def __init__(self, *args, **kwargs):
         MockThreadWorkerPool.last_init_kwargs = {
             "args": args,
@@ -66,11 +79,26 @@ class MockThreadWorkerPool:
         self._client.set(key_str.encode(), bytes(data))
 
     def _do_get_into(self, key_str: str, buf: memoryview) -> bool:
-        """GET a key into a buffer."""
+        """GET a key into a buffer.
+
+        Mirrors the real ``_ThreadWorkerPool._do_get_into``: when
+        ``simulate_buffer_get`` is set, take the buffer-GET branch (stage into
+        a scratch buffer, rely on an int byte count); otherwise use the legacy
+        GET branch that returns the full bytes.
+        """
+        flat = buf.cast("B") if buf.format != "B" else buf
+        if type(self).simulate_buffer_get:
+            size = flat.nbytes
+            scratch = memoryview(bytearray(size))
+            result = self._client.get(key_str.encode(), buffer=scratch)
+            if result is None:
+                return False
+            n = int(result)
+            flat[:n] = scratch[:n]
+            return True
         data = self._client.get(key_str.encode())
         if data is None:
             return False
-        flat = buf.cast("B") if buf.format != "B" else buf
         flat[: len(data)] = data
         return True
 
@@ -148,6 +176,7 @@ def mock_thread_worker_pool():
     glide_sync or a real Valkey server."""
     MockSyncGlideClient.reset_store()
     MockThreadWorkerPool.last_init_kwargs = {}
+    MockThreadWorkerPool.simulate_buffer_get = False
     with patch(
         "lmcache.v1.storage_backend.connector.valkey_connector._ThreadWorkerPool",
         MockThreadWorkerPool,
@@ -808,6 +837,231 @@ def test_valkey_tls_config(local_backend, autorelease_v1):
 
         init_info = MockThreadWorkerPool.last_init_kwargs
         assert init_info["kwargs"].get("tls_enable") is True
+
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+# ── Partial-chunk restriction (single-key fixed-size storage) ───────────
+
+
+def test_valkey_rejects_save_unfull_chunk(local_backend, autorelease_v1):
+    """Valkey uses single-key fixed-size storage with no per-chunk metadata,
+    so partial/unfull chunks are not allowed (same as RESP)."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={"valkey_num_workers": 2},
+    )
+    # Force the partial-chunk flag on after construction so we exercise the
+    # adapter's guard rather than any config auto-adjust logic.
+    config.save_unfull_chunk = True
+
+    try:
+        with pytest.raises(ValueError, match="save_unfull_chunk must be False"):
+            autorelease_v1(
+                CreateConnector(
+                    "valkey://nopartial.local:6379",
+                    async_loop,
+                    local_backend,
+                    config,
+                )
+            )
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+def test_valkey_rejects_save_chunk_meta(local_backend, autorelease_v1):
+    """Valkey does not persist per-chunk metadata, so save_chunk_meta must be
+    False (same as RESP)."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "save_chunk_meta": True,
+        },
+    )
+
+    try:
+        with pytest.raises(ValueError, match="save_chunk_meta must be False"):
+            autorelease_v1(
+                CreateConnector(
+                    "valkey://nometa.local:6379",
+                    async_loop,
+                    local_backend,
+                    config,
+                )
+            )
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+@pytest.mark.parametrize(
+    "raw_value,should_reject",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("false", False),
+        ("0", False),
+    ],
+)
+def test_valkey_save_chunk_meta_string_coercion(
+    local_backend, autorelease_v1, raw_value, should_reject
+):
+    """save_chunk_meta from free-form extra_config may be a string; it must be
+    coerced (a bare truthiness check would treat "false" as True)."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "save_chunk_meta": raw_value,
+        },
+    )
+
+    try:
+        if should_reject:
+            with pytest.raises(ValueError, match="save_chunk_meta must be False"):
+                autorelease_v1(
+                    CreateConnector(
+                        "valkey://strmeta.local:6379",
+                        async_loop,
+                        local_backend,
+                        config,
+                    )
+                )
+        else:
+            autorelease_v1(
+                CreateConnector(
+                    "valkey://strmeta.local:6379",
+                    async_loop,
+                    local_backend,
+                    config,
+                )
+            )
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [("true", True), ("True", True), ("1", True), ("false", False), ("0", False)],
+)
+def test_valkey_tls_enable_string_coercion(
+    local_backend, autorelease_v1, raw_value, expected
+):
+    """tls_enable from free-form extra_config may be a string; it must be
+    coerced (a bare bool("false") would wrongly enable TLS)."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={"valkey_num_workers": 2, "tls_enable": raw_value}
+    )
+
+    try:
+        autorelease_v1(
+            CreateConnector(
+                "valkey://tlsstr.local:6380",
+                async_loop,
+                local_backend,
+                config,
+            )
+        )
+        init_info = MockThreadWorkerPool.last_init_kwargs
+        assert init_info["kwargs"].get("tls_enable") is expected
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+def test_valkey_do_get_into_rejects_short_read():
+    """_do_get_into must not silently accept a short read: fixed-size chunks
+    require an exact round-trip, so a partial fill is treated as a miss
+    (returns False) instead of leaving stale tail bytes in the buffer."""
+    # Standard
+    from types import SimpleNamespace
+
+    class _FakeClient:
+        def __init__(self, payload: bytes):
+            self._payload = payload
+
+        def get(self, key, buffer=None):
+            if buffer is not None:
+                n = len(self._payload)
+                buffer[:n] = self._payload
+                return n
+            return self._payload
+
+    def _make_self(payload, has_buffer_get):
+        return SimpleNamespace(
+            _get_client=lambda: _FakeClient(payload),
+            _has_buffer_get=has_buffer_get,
+            _get_scratch=lambda size: bytearray(size),
+        )
+
+    expected = 8
+
+    # Short read (buffer-get path) → treated as miss
+    buf = memoryview(bytearray(expected))
+    fake = _make_self(b"\xaa" * 4, has_buffer_get=True)
+    assert _RealThreadWorkerPool._do_get_into(fake, "k", buf) is False
+
+    # Short read (non-buffer path) → treated as miss
+    buf = memoryview(bytearray(expected))
+    fake = _make_self(b"\xaa" * 4, has_buffer_get=False)
+    assert _RealThreadWorkerPool._do_get_into(fake, "k", buf) is False
+
+    # Exact read (buffer-get path) → hit, buffer fully populated
+    buf = memoryview(bytearray(expected))
+    fake = _make_self(b"\xbb" * expected, has_buffer_get=True)
+    assert _RealThreadWorkerPool._do_get_into(fake, "k", buf) is True
+    assert bytes(buf) == b"\xbb" * expected
+
+    # Exact read (non-buffer path) → hit, buffer fully populated
+    buf = memoryview(bytearray(expected))
+    fake = _make_self(b"\xcc" * expected, has_buffer_get=False)
+    assert _RealThreadWorkerPool._do_get_into(fake, "k", buf) is True
+    assert bytes(buf) == b"\xcc" * expected
+
+
+@pytest.mark.parametrize("simulate_buffer_get", [False, True])
+def test_valkey_get_round_trip_both_get_modes(
+    valkey_url, local_backend, valkey_config, autorelease_v1, simulate_buffer_get
+):
+    """get/batched_get must round-trip correctly on both worker-pool GET paths:
+    the legacy GET (returns full bytes) and the buffer-GET branch (returns an
+    int byte count). This closes the gap where the mock only exercised the
+    non-buffer branch, leaving the connector's buffer-GET handling untested."""
+    MockThreadWorkerPool.simulate_buffer_get = simulate_buffer_get
+    async_loop, async_thread = init_asyncio_loop()
+
+    try:
+        connector = autorelease_v1(
+            CreateConnector(valkey_url, async_loop, local_backend, valkey_config)
+        )
+
+        # Single get round-trip
+        key = dumb_cache_engine_key()
+        mem = _create_test_memory_obj(local_backend, seed=7)
+        asyncio.run_coroutine_threadsafe(connector.put(key, mem), async_loop).result()
+        retrieved = asyncio.run_coroutine_threadsafe(
+            connector.get(key), async_loop
+        ).result()
+        assert retrieved is not None
+        check_mem_obj_equal([retrieved], [mem])
+
+        # Batched get round-trip
+        keys = [dumb_cache_engine_key(i) for i in range(3)]
+        mems = [_create_test_memory_obj(local_backend, seed=100 + i) for i in range(3)]
+        asyncio.run_coroutine_threadsafe(
+            connector.batched_put(keys, mems), async_loop
+        ).result()
+        retrieved_batch = asyncio.run_coroutine_threadsafe(
+            connector.batched_get(keys), async_loop
+        ).result()
+        assert all(r is not None for r in retrieved_batch)
+        check_mem_obj_equal(retrieved_batch, mems)
 
     finally:
         close_asyncio_loop(async_loop, async_thread)

--- a/tests/v1/storage_backend/test_valkey_connector.py
+++ b/tests/v1/storage_backend/test_valkey_connector.py
@@ -71,12 +71,16 @@ class MockThreadWorkerPool:
         self.num_workers = kwargs.get("num_workers", 8)
         if len(args) > 2 and isinstance(args[2], int):
             self.num_workers = args[2]
+        self._ttl_seconds = kwargs.get("ttl_seconds", None)
         self._client = MockSyncGlideClient()
         self._executor = ThreadPoolExecutor(max_workers=self.num_workers)
 
     def _do_set(self, key_str: str, data: bytes) -> None:
-        """SET a key."""
-        self._client.set(key_str.encode(), bytes(data))
+        """SET a key, mirroring the real pool's TTL handling."""
+        # ("EX", ttl) is a stand-in for glide_sync.ExpirySet, which isn't
+        # importable in the test env.
+        expiry = ("EX", self._ttl_seconds) if self._ttl_seconds is not None else None
+        self._client.set(key_str.encode(), bytes(data), expiry=expiry)
 
     def _do_get_into(self, key_str: str, buf: memoryview) -> bool:
         """GET a key into a buffer.
@@ -814,6 +818,36 @@ def test_valkey_cluster_mode_config(local_backend, autorelease_v1):
         close_asyncio_loop(async_loop, async_thread)
 
 
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [("true", True), ("True", True), ("1", True), ("false", False), ("0", False)],
+)
+def test_valkey_tls_enable_string_coercion(
+    local_backend, autorelease_v1, raw_value, expected
+):
+    """tls_enable from free-form extra_config may be a string; it must be
+    coerced (a bare bool("false") would wrongly enable TLS)."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={"valkey_num_workers": 2, "tls_enable": raw_value}
+    )
+
+    try:
+        autorelease_v1(
+            CreateConnector(
+                "valkey://tlsstr.local:6380",
+                async_loop,
+                local_backend,
+                config,
+            )
+        )
+        init_info = MockThreadWorkerPool.last_init_kwargs
+        assert init_info["kwargs"].get("tls_enable") is expected
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
 def test_valkey_tls_config(local_backend, autorelease_v1):
     """Test that tls_enable is passed through to the pool."""
     async_loop, async_thread = init_asyncio_loop()
@@ -842,7 +876,241 @@ def test_valkey_tls_config(local_backend, autorelease_v1):
         close_asyncio_loop(async_loop, async_thread)
 
 
-# ── Partial-chunk restriction (single-key fixed-size storage) ───────────
+# ── TTL feature flag (volatile-* eviction support) ──────────────────────
+
+
+def test_valkey_ttl_sec_disabled_by_default(local_backend, autorelease_v1):
+    """By default (no valkey_enable_ttl) no TTL is passed to the pool."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(extra_config={"valkey_num_workers": 2})
+
+    try:
+        autorelease_v1(
+            CreateConnector(
+                "valkey://ttl.local:6379", async_loop, local_backend, config
+            )
+        )
+        init_info = MockThreadWorkerPool.last_init_kwargs
+        assert init_info["kwargs"].get("ttl_seconds") is None
+
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+def test_valkey_ttl_sec_enabled_passthrough(local_backend, autorelease_v1):
+    """valkey_enable_ttl + valkey_ttl_sec flow through to the pool as ttl_seconds."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "valkey_enable_ttl": True,
+            "valkey_ttl_sec": 3600,
+        }
+    )
+
+    try:
+        autorelease_v1(
+            CreateConnector(
+                "valkey://ttl.local:6379", async_loop, local_backend, config
+            )
+        )
+        init_info = MockThreadWorkerPool.last_init_kwargs
+        assert init_info["kwargs"].get("ttl_seconds") == 3600
+
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+def test_valkey_ttl_sec_enabled_without_value_uses_default(
+    local_backend, autorelease_v1
+):
+    """Enabling the flag without valkey_ttl_sec falls back to DEFAULT_TTL_SECS."""
+    # First Party
+    from lmcache.v1.storage_backend.connector.valkey_connector import (
+        DEFAULT_TTL_SECS,
+    )
+
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "valkey_enable_ttl": True,
+        }
+    )
+
+    try:
+        autorelease_v1(
+            CreateConnector(
+                "valkey://ttl.local:6379", async_loop, local_backend, config
+            )
+        )
+        init_info = MockThreadWorkerPool.last_init_kwargs
+        assert init_info["kwargs"].get("ttl_seconds") == DEFAULT_TTL_SECS
+
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+@pytest.mark.parametrize("raw_ttl", [0, -1, -100, "-100", "0.5", "-0.5"])
+def test_valkey_ttl_sec_invalid_value_raises(raw_ttl, local_backend, autorelease_v1):
+    """A non-positive valkey_ttl_sec is rejected when the flag is enabled.
+
+    Covers zero, negative ints/strings, and sub-second values that truncate
+    to zero.
+    """
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "valkey_enable_ttl": True,
+            "valkey_ttl_sec": raw_ttl,
+        }
+    )
+
+    try:
+        with pytest.raises(ValueError, match="valkey_ttl_sec must be a positive"):
+            CreateConnector(
+                "valkey://ttl.local:6379", async_loop, local_backend, config
+            )
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+@pytest.mark.parametrize(
+    "raw_ttl,expected",
+    [("1800", 1800), ("1800.0", 1800), (1800.0, 1800), (1800, 1800)],
+)
+def test_valkey_ttl_sec_numeric_coercion(
+    raw_ttl, expected, local_backend, autorelease_v1
+):
+    """valkey_ttl_sec may arrive as an int/float or an int/float-like string
+    from free-form extra_config; all coerce to a positive int TTL."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "valkey_enable_ttl": True,
+            "valkey_ttl_sec": raw_ttl,
+        }
+    )
+
+    try:
+        autorelease_v1(
+            CreateConnector(
+                "valkey://ttl.local:6379", async_loop, local_backend, config
+            )
+        )
+        init_info = MockThreadWorkerPool.last_init_kwargs
+        assert init_info["kwargs"].get("ttl_seconds") == expected
+
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+def test_valkey_ttl_sec_non_numeric_raises(local_backend, autorelease_v1):
+    """A non-numeric valkey_ttl_sec is rejected with a clear ValueError."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "valkey_enable_ttl": True,
+            "valkey_ttl_sec": "not-a-number",
+        }
+    )
+
+    try:
+        with pytest.raises(ValueError, match="valkey_ttl_sec must be a positive"):
+            CreateConnector(
+                "valkey://ttl.local:6379", async_loop, local_backend, config
+            )
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+@pytest.mark.parametrize("raw_ttl", [True, False])
+def test_valkey_ttl_sec_bool_raises(raw_ttl, local_backend, autorelease_v1):
+    """A boolean valkey_ttl_sec is rejected (bool is an int subclass, so it
+    would otherwise silently coerce to a 1-second TTL)."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "valkey_enable_ttl": True,
+            "valkey_ttl_sec": raw_ttl,
+        }
+    )
+
+    try:
+        with pytest.raises(ValueError, match="valkey_ttl_sec must be a positive"):
+            CreateConnector(
+                "valkey://ttl.local:6379", async_loop, local_backend, config
+            )
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+def test_valkey_ttl_sec_applied_on_put(local_backend, autorelease_v1):
+    """When TTL is enabled, SET carries an expiry; otherwise it does not."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    config = LMCacheEngineConfig.from_defaults(
+        extra_config={
+            "valkey_num_workers": 2,
+            "valkey_enable_ttl": True,
+            "valkey_ttl_sec": 1800,
+        }
+    )
+
+    try:
+        connector = autorelease_v1(
+            CreateConnector(
+                "valkey://ttl.local:6379", async_loop, local_backend, config
+            )
+        )
+
+        key = dumb_cache_engine_key()
+        memory_obj = _create_test_memory_obj(local_backend, seed=11)
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result()
+
+        # The mock client records the expiry passed to the last SET.
+        assert MockSyncGlideClient.last_expiry == ("EX", 1800)
+
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
+
+
+def test_valkey_no_ttl_on_put_when_disabled(
+    valkey_url, local_backend, valkey_config, autorelease_v1
+):
+    """With TTL disabled, SET passes no expiry (legacy behavior)."""
+    async_loop, async_thread = init_asyncio_loop()
+
+    try:
+        connector = autorelease_v1(
+            CreateConnector(valkey_url, async_loop, local_backend, valkey_config)
+        )
+
+        key = dumb_cache_engine_key()
+        memory_obj = _create_test_memory_obj(local_backend, seed=12)
+        future = asyncio.run_coroutine_threadsafe(
+            connector.put(key, memory_obj), async_loop
+        )
+        future.result()
+
+        assert MockSyncGlideClient.last_expiry is None
+
+    finally:
+        close_asyncio_loop(async_loop, async_thread)
 
 
 def test_valkey_rejects_save_unfull_chunk(local_backend, autorelease_v1):
@@ -941,36 +1209,6 @@ def test_valkey_save_chunk_meta_string_coercion(
                     config,
                 )
             )
-    finally:
-        close_asyncio_loop(async_loop, async_thread)
-
-
-@pytest.mark.parametrize(
-    "raw_value,expected",
-    [("true", True), ("True", True), ("1", True), ("false", False), ("0", False)],
-)
-def test_valkey_tls_enable_string_coercion(
-    local_backend, autorelease_v1, raw_value, expected
-):
-    """tls_enable from free-form extra_config may be a string; it must be
-    coerced (a bare bool("false") would wrongly enable TLS)."""
-    async_loop, async_thread = init_asyncio_loop()
-
-    config = LMCacheEngineConfig.from_defaults(
-        extra_config={"valkey_num_workers": 2, "tls_enable": raw_value}
-    )
-
-    try:
-        autorelease_v1(
-            CreateConnector(
-                "valkey://tlsstr.local:6380",
-                async_loop,
-                local_backend,
-                config,
-            )
-        )
-        init_info = MockThreadWorkerPool.last_init_kwargs
-        assert init_info["kwargs"].get("tls_enable") is expected
     finally:
         close_asyncio_loop(async_loop, async_thread)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Two related improvements to the Valkey GLIDE connector (`valkey://`), stacked as separate commits:

1. **Optional per-key TTL (feature-flagged).** Today the connector writes keys with no expiry. A Valkey/Redis node configured with a `volatile-lru` / `volatile-lfu` eviction policy only evicts keys that have a TTL, so it never reclaims the KV-cache keys and the L2 remote cache chokes once it hits `maxmemory`. This adds an opt-in TTL so the eviction policy can reclaim memory under pressure. Two new `extra_config` keys:
   - `valkey_enable_ttl` (bool, default `false`) — feature flag.
   - `valkey_ttl_sec` (int seconds, default `86400` when enabled but unset) — per-key TTL; must be positive.

   When enabled, keys are written via `glide_sync.ExpirySet(ExpiryType.SEC, ttl)` (built lazily and cached; the immutable `ExpirySet` is safe to share across worker threads). The no-TTL path is unchanged, so existing deployments are unaffected until they opt in.

2. **Reject partial / unfull chunks.** The connector uses single-key, fixed-size storage (same scheme as `RESPConnector`) with no per-chunk metadata, so partial/unfull chunks cannot be represented or verified on read. The adapter now asserts `save_chunk_meta` and `save_unfull_chunk` are both `False`, mirroring `RESPConnectorAdapter`. Also coerces free-form `extra_config` booleans via `_to_bool` (so a string like `"false"` parses correctly — `bool("false")` is truthy), applied to `save_chunk_meta` and the existing `tls_enable` read.

**Special notes for your reviewers**:

- The two changes are independent commits; happy to split into separate PRs if preferred.
- TTL default behavior is unchanged (feature off). With TTL on, a key can expire between a positive `contains`/`batched_async_contains` and the subsequent `get`; this degrades gracefully to a cache miss / shorter consecutive prefix (handled in `_batched_get_non_blocking`), with no stale data.
- All commits are DCO signed-off.

**If applicable**:

- [x] this PR contains user facing changes - docs added (`docs/source/kv_cache/storage_backends/valkey.rst`)
- [x] this PR contains unit tests
