### PR TITLE
[Fix][FS] Align native FS object key format

### DIFF
--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -9,6 +9,17 @@
 namespace lmcache {
 namespace connector {
 
+namespace {
+
+constexpr size_t kUnsaltedKeyFieldCount = 4;
+constexpr size_t kSaltedKeyFieldCount = 5;
+
+// Conservative reserve() slack for fixed filename formatting bytes not covered
+// by field sizes: '@' separators, the "0x" rank prefix, and ".data".
+constexpr size_t kFilenameFormattingReserveSlack = 32;
+
+}  // namespace
+
 // ---------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------
@@ -27,22 +38,23 @@ std::string FSConnector::replace_all(const std::string& str,
 
 std::string FSConnector::key_to_filename(const std::string& key) {
   // Input key format (from _object_key_to_string):
-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+  //   Unsalted:
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
+  //   Salted  :
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
+  //   @<cache_salt>
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+  //   Unsalted:
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>.data
   //   Salted  :
-  //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
-  //
-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
-  // format, so existing cache directories remain valid.
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>@<cache_salt>.data
   //
   // NOTE: both model_name and cache_salt are forbidden from containing
   // '@' (invariant enforced on the Python side), so splitting on '@'
   // is unambiguous — no marker, no rsplit.
 
-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
+  // Split on '@' — must yield 4 (unsalted) or 5 (salted) fields.
   std::vector<std::string> parts;
   size_t start = 0;
   for (size_t pos = 0; pos <= key.size(); ++pos) {
@@ -51,29 +63,34 @@ std::string FSConnector::key_to_filename(const std::string& key) {
       start = pos + 1;
     }
   }
-  if (parts.size() != 3 && parts.size() != 4) {
+  if (parts.size() != kUnsaltedKeyFieldCount &&
+      parts.size() != kSaltedKeyFieldCount) {
     throw std::runtime_error(
-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
+        "FSConnector: malformed key (expected 4 or 5 '@'-separated fields): " +
         key);
   }
 
   const std::string& model_name = parts[0];
   const std::string& kv_rank_hex = parts[1];
-  const std::string& chunk_hash = parts[2];
-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+  const std::string& object_group_id = parts[2];
+  const std::string& chunk_hash = parts[3];
+  const std::string cache_salt =
+      parts.size() == kSaltedKeyFieldCount ? parts[4] : std::string();
 
   // Replace '/' with '-SEP-' for filesystem safety
   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
 
-  // Emit filename. Salt is appended at the tail so the unsalted shape
-  // matches what older builds wrote to disk.
+  // Emit filename in the same field order as the Python filesystem adapter.
   std::string result;
   result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
-                 cache_salt.size() + 32);
+                 object_group_id.size() + cache_salt.size() +
+                 kFilenameFormattingReserveSlack);
   result += safe_model;
   result += KEY_SEP;
   result += "0x";
   result += kv_rank_hex;
+  result += KEY_SEP;
+  result += object_group_id;
   result += KEY_SEP;
   result += chunk_hash;
   if (!cache_salt.empty()) {

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -52,12 +52,17 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   // Build the filesystem-safe filename from a serialized key string.
   //
   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
+  //   Unsalted:
+  //   "{model}@{kv_rank:08x}@{object_group_id:x}@{hash.hex()}"
+  //   Salted  :
+  //   "{model}@{kv_rank:08x}@{object_group_id:x}@{hash.hex()}"
+  //   "@{cache_salt}"
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
+  //   Unsalted:
+  //   "{safe_model}@{kv_rank:#010x}@{object_group_id:x}@{hash.hex()}.data"
+  //   Salted  :
+  //   "{safe_model}@{kv_rank:#010x}@{object_group_id:x}@{hash.hex()}@{cache_salt}.data"
   //
   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
   // gains a '0x' prefix, and '.data' is appended. Both model_name and


### PR DESCRIPTION
**What this PR does / why we need it**:

The native C++ filesystem connector still parsed the pre-`object_group_id` key shape, while Python native serialization and the Python filesystem adapter now use `object_group_id` as a required field. This made salted `fs_native` keys malformed on the C++ side and left the C++ filename comments out of sync with the active format.

- Update `FSConnector::key_to_filename` to accept the current 4-field unsalted and 5-field salted key shapes:
  ```text
  <model>@<kv_rank>@<object_group_id>@<chunk_hash>
  <model>@<kv_rank>@<object_group_id>@<chunk_hash>@<cache_salt>
  ```
- Preserve the same field order when emitting filesystem filenames so native FS matches `fs_l2_adapter.py`.
- Update the C++ header/source comments to document the current Python-compatible object key and filename formats.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests