### PR TITLE
docs: daily drift check — multi-process mode (2026-06-23)

### DIFF
--- a/docs/design/v1/multiprocess/raw_cuda_ipc.md
+++ b/docs/design/v1/multiprocess/raw_cuda_ipc.md
@@ -23,26 +23,31 @@ no direct CuPy/NumPy equivalent, but the size in bytes is enough.
 DLPack carries no dtype semantics for the bytes view; `view(dtype)` on
 the torch side restores them.
 
-## Subclass rather than separate type
+## Shared base rather than separate type
 
-`RawCudaIPCWrapper` is a **subclass** of `CudaIPCWrapper`, not a new
-class with its own ext code. This is load-bearing for the wire format:
+`RawCudaIPCWrapper` is a **sibling** of `CudaIPCWrapper`: both subclass
+the device-agnostic `DeviceIPCWrapper` base (see
+[`device_ipc_wrapper_design.md`](device_ipc_wrapper_design.md) for the
+full hierarchy). Sharing a single base is load-bearing for the wire
+format:
 
-- `KVCache = list[CudaIPCWrapper]` is the registered msgspec type for
+- `KVCache = list[DeviceIPCWrapper]` is the registered msgspec type for
   `REGISTER_KV_CACHE`. msgspec does **not** support unions of custom
-  ext-encoded types — adding a parallel class would force a wider
-  decoder type and break either round-trip or the existing
-  `CudaIPCWrapper` consumers.
+  ext-encoded types — adding a parallel class with its own ext code
+  would force a wider decoder type and break either round-trip or the
+  existing `DeviceIPCWrapper` consumers.
 - The customized serializer (`_CUSTOMERIZED_SERIALIZERS`) is keyed on
-  `CudaIPCWrapper` and dispatched by `isinstance`, so subclass instances
-  encode through the same path with **ext code 1**.
-- `Serialize` is `pickle.dumps(obj)`, which preserves subclass
-  identity. On the receiving side `Deserialize` reconstructs the
-  subclass and `to_tensor` dispatches to the override.
+  `DeviceIPCWrapper` and dispatched by `isinstance`, so every subclass
+  instance encodes through the same path with **ext code 1**.
+- `Serialize` is `pickle.dumps(obj)`, which preserves the concrete
+  subclass identity. On the receiving side `Deserialize` reconstructs
+  the concrete subclass and `to_tensor` dispatches to the correct
+  override.
 
 The receiving server therefore needs no per-type branching: a
-`list[CudaIPCWrapper]` arriving at `MPCacheServer.register_kv_cache`
-contains either kind, and `to_tensor()` does the right thing.
+`list[DeviceIPCWrapper]` arriving at `MPCacheServer.register_kv_cache`
+contains any mix of concrete wrappers, and `to_tensor()` does the
+right thing.
 
 ## Sender-side validation
 
@@ -66,5 +71,5 @@ CuPy/MemoryPointer's owner field.
 The wrapper does not try `_share_cuda_()` first. That would couple the
 two codepaths, and the failure mode is silent corruption (PyTorch
 returns a handle for a different region of memory than what the
-caller intended). Explicit subclassing keeps the choice at the call
-site.
+caller intended). Keeping `RawCudaIPCWrapper` as its own concrete
+sibling of `CudaIPCWrapper` keeps the choice at the call site.

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -354,7 +354,13 @@ methods:
 
 - ``reserve_write()`` / ``finish_write()`` -- Two-phase write into L1.
 - ``submit_prefetch_task()`` / ``query_prefetch_status()`` -- Async lookup +
-  L2 prefetch.
+  L2 prefetch. ``query_prefetch_status()`` is non-blocking and returns
+  ``None`` while the L2 prefetch is still in flight.
+- ``wait_prefetch_status()`` -- Blocking alternative to polling
+  ``query_prefetch_status()``: waits on a controller condition variable
+  until the prefetch result is published (or a timeout expires).
+  L1-only prefetches return immediately. Used by the
+  ``WAIT_PREFETCH_STATUS`` RPC to avoid busy-polling on the load path.
 - ``read_prefetched_results()`` / ``finish_read_prefetched()`` -- Read
   prefetched data from L1 with automatic lock management.
 


### PR DESCRIPTION
## Summary

The daily docs-drift-check routine found **two** new doc-only inconsistencies between LMCache docs and the multi-process code merged onto `dev` since the 2026-06-22 drift-check PR ([#3817](https://github.com/LMCache/LMCache/pull/3817)). Both are addressed in this PR.

### Drift items found and fixed

**`docs/source/` (user-facing, highest priority)**

| # | Doc | Drift |
|---|---|---|
| 1 | [`docs/source/mp/index.rst`](https://github.com/LMCache/LMCache/blob/176cc33/docs/source/mp/index.rst#L347-L359) — *Distributed Storage / StorageManager* | The "Key methods" list mentions `submit_prefetch_task()` / `query_prefetch_status()` for "Async lookup + L2 prefetch", but after [#3704 (`a312a7f`)](https://github.com/LMCache/LMCache/commit/a312a7f6a846cc1504eaac3471e1257d204c0c7c) `StorageManager` also exposes [`wait_prefetch_status()`](https://github.com/LMCache/LMCache/blob/176cc33/lmcache/v1/distributed/storage_manager.py#L610-L635) — the blocking variant that the new [`WAIT_PREFETCH_STATUS`](https://github.com/LMCache/LMCache/blob/176cc33/lmcache/v1/multiprocess/modules/lookup.py#L128-L129) RPC handler delegates to. The RPC entry was added to the *RequestType* table in the same PR, but the corresponding StorageManager-level entry on the same page was missed. **Fix:** added a `wait_prefetch_status()` bullet next to the existing `query_prefetch_status()` line and noted that `query_prefetch_status()` is non-blocking. |

**`docs/design/` (secondary)**

| # | Doc | Drift |
|---|---|---|
| 2 | [`docs/design/v1/multiprocess/raw_cuda_ipc.md`](https://github.com/LMCache/LMCache/blob/176cc33/docs/design/v1/multiprocess/raw_cuda_ipc.md#L26-L45) — *Subclass rather than separate type* | The section claims `RawCudaIPCWrapper` is a **subclass** of `CudaIPCWrapper`, that `KVCache = list[CudaIPCWrapper]` is the registered msgspec type, and that `_CUSTOMERIZED_SERIALIZERS` is keyed on `CudaIPCWrapper`. After [#3703 (`b2d804e`)](https://github.com/LMCache/LMCache/commit/b2d804e98118036a190274bea010d3f42e507504) both wrappers are **siblings** under a new `DeviceIPCWrapper` base: [`RawCudaIPCWrapper(DeviceIPCWrapper)`](https://github.com/LMCache/LMCache/blob/176cc33/lmcache/v1/multiprocess/custom_types.py#L158), the registered wire type is [`KVCache = list[DeviceIPCWrapper]`](https://github.com/LMCache/LMCache/blob/176cc33/lmcache/v1/multiprocess/custom_types.py#L344), and the [serializer is keyed on `DeviceIPCWrapper`](https://github.com/LMCache/LMCache/blob/176cc33/lmcache/v1/multiprocess/custom_types.py#L436-L439). The new sibling design is described in [`device_ipc_wrapper_design.md`](https://github.com/LMCache/LMCache/blob/176cc33/docs/design/v1/multiprocess/device_ipc_wrapper_design.md) added by the same PR. **Fix:** rewrote the section to reflect the sibling relationship, updated every type reference from `CudaIPCWrapper` → `DeviceIPCWrapper`, cross-linked the new `device_ipc_wrapper_design.md`, and adjusted the "Why no `_share_cuda_` fallback" wording (which still said "explicit subclassing"). |

### Items intentionally not duplicated

- The `lmcache.mp.server_urls` documentation gap and the `developer_guide/cli.rst` auto-discovery refresh are already covered by the still-open draft PR [#3817 (2026-06-22)](https://github.com/LMCache/LMCache/pull/3817).
- The stale `P2P_LOOKUP_AND_LOCK` row in `docs/source/mp/index.rst` and the missing `--p2p-*` flags section in `docs/source/mp/configuration.rst` are already covered by the still-open draft PR [#3774 (2026-06-21)](https://github.com/LMCache/LMCache/pull/3774).

### Other PRs reviewed this run (no doc drift)

- [#3221 (`ec1156e`)](https://github.com/LMCache/LMCache/commit/ec1156ea31d390f84201bcea8f1bbcf5ff8ba175) "HiddenStateStore" — ships its own user-facing doc (`docs/source/non_kv_cache/hidden_states.rst`) and design doc (`docs/design/v1/hidden_state_store.md`). Config keys `enable_hidden_state_cache`, `max_hidden_state_cpu_size`, `hidden_state_layers` are all documented there. Not MP-mode specific.
- [#3745 (`389b9cf`)](https://github.com/LMCache/LMCache/commit/389b9cfcb5cec502dbba6b5d13725bf2e024610d) "Add bitmap operations" — internal C++/Python module, ships its own `docs/design/v1/distributed/bitmap_ops/README.md`. No user-facing or MP doc impact.
- [#3784 (`176cc33`)](https://github.com/LMCache/LMCache/commit/176cc333) and [#3542 (`0c4873c`)](https://github.com/LMCache/LMCache/commit/0c4873c) are pure log-format and README-wording polish; no surface-level claims affected.

### Proposed fix

Applied in this PR's diff — see the file changes tab. Both touched files are docs only.

### Notes

- Auto-generated by the daily drift-check routine. **Needs human review before merge.** Not marked Ready for review.
- Branched from current `dev` tip `176cc33` and contains a single commit signed off as `ApostaC <yihua98@uchicago.edu>` to satisfy DCO.
- No code-level concerns flagged this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGcfHW2Fb9VovJVdrp5VxB)_