### PR TITLE
Add CLI command tree inspector

### DIFF
--- a/docs/design/cli/commands/describe.md
+++ b/docs/design/cli/commands/describe.md
@@ -435,18 +435,10 @@ def _fmt_used_gb(used_bytes: int, ratio: float) -> str:
     """Format as 'XX.XX (YY.Y%)'."""
 ```
 
-### Modify: `lmcache/cli/commands/__init__.py`
+### Command discovery
 
-Add import and registry entry:
-
-```python
-from lmcache.cli.commands.describe import DescribeCommand
-
-ALL_COMMANDS: list[BaseCommand] = [
-    MockCommand(),
-    DescribeCommand(),
-]
-```
+`DescribeCommand` is auto-discovered from `lmcache/cli/commands/describe.py`.
+No import or registry edit in `lmcache/cli/commands/__init__.py` is required.
 
 ### Patterns to follow
 

--- a/docs/design/cli/commands/ping.md
+++ b/docs/design/cli/commands/ping.md
@@ -186,17 +186,10 @@ def ping(url: str, timeout: int = 10) -> tuple[str, float, str | None]:
 Reuses `normalize_url()` from `describe.py` (import it, or move to a shared
 `lmcache/cli/utils.py` if preferred).
 
-### Modify: `lmcache/cli/commands/__init__.py`
+### Command discovery
 
-```python
-from lmcache.cli.commands.ping import PingCommand
-
-ALL_COMMANDS: list[BaseCommand] = [
-    MockCommand(),
-    DescribeCommand(),
-    PingCommand(),
-]
-```
+`PingCommand` is auto-discovered from `lmcache/cli/commands/ping.py`. No import
+or registry edit in `lmcache/cli/commands/__init__.py` is required.
 
 ---
 

--- a/docs/design/cli/framework-and-metrics.md
+++ b/docs/design/cli/framework-and-metrics.md
@@ -11,14 +11,17 @@ of the [CLI design](commands.md), minus the actual server/ping/describe commands
 
 ---
 
-## 1. Explicit Command Registration
+## 1. Plugin-Style Command Discovery
 
 ### Goal
 
 Adding a new subcommand (e.g., `lmcache describe`) requires:
 
-1. Creating a new file in `lmcache/cli/commands/` with a `BaseCommand` subclass.
-2. Adding one import + one entry to `ALL_COMMANDS` in `commands/__init__.py`.
+1. Creating a new file or package in `lmcache/cli/commands/`.
+2. Defining a concrete `BaseCommand` subclass in that module.
+3. Letting startup auto-discovery collect and register the command.
+
+No import or manual `ALL_COMMANDS` edit is required.
 
 ### Mechanism
 
@@ -40,33 +43,29 @@ class MyCommand(BaseCommand):
         ...  # command logic
 ```
 
-```python
-# lmcache/cli/commands/__init__.py  (add import + list entry)
-from lmcache.cli.commands.my_cmd import MyCommand
-
-ALL_COMMANDS: list[BaseCommand] = [
-    ...,
-    MyCommand(),
-]
-```
-
 `BaseCommand` enforces that all four abstract methods (`name`, `help`,
 `add_arguments`, `execute`) are implemented — instantiation fails otherwise.
 The concrete `register()` method (inherited, not typically overridden) wires
 everything up automatically.
 
+`CompositeCommand` is a `BaseCommand` subclass for command groups. It scans the
+package where the concrete group is defined, discovers child `BaseCommand`
+subclasses, and registers them as nested subparsers.
+
 ### How command discovery works
 
 1. `lmcache <cmd> ...` invokes `main()` in `main.py`.
 2. `main.py` imports `ALL_COMMANDS` from `commands/__init__.py`.
-3. At import time, `__init__.py` imports each command class and instantiates
-   it into the `ALL_COMMANDS` list.  Instantiation validates that all abstract
-   methods are implemented (`TypeError` on failure).
+3. At import time, `commands/__init__.py` calls `discover_subclasses()` on its
+   own package. The helper walks direct submodules with `pkgutil.iter_modules`,
+   imports them, and yields concrete `BaseCommand` subclasses.
 4. `main.py` iterates `ALL_COMMANDS` and calls `cmd.register(subparsers)`.
 5. `BaseCommand.register()` creates an argparse subparser (using `name()` and
    `help()`), calls `add_arguments()` to wire up flags, and sets
    `parser.set_defaults(func=self.execute)`.
-6. After parsing, `main.py` dispatches via `args.func(args)`, which calls the
+6. `CompositeCommand.register()` repeats discovery inside its own package to
+   register nested child commands.
+7. After parsing, `main.py` dispatches via `args.func(args)`, which calls the
    matched command's `execute()`.
 
 ### How to add a new subcommand
@@ -90,18 +89,20 @@ class DescribeCommand(BaseCommand):
         ...  # implementation
 ```
 
-**Step 2.** Register it in `lmcache/cli/commands/__init__.py`:
+**Step 2.** Done. The command is automatically discovered:
 
-```python
-from lmcache.cli.commands.describe import DescribeCommand
-
-ALL_COMMANDS: list[BaseCommand] = [
-    MockCommand(),
-    DescribeCommand(),   # <-- add here
-]
+```bash
+lmcache describe --url http://localhost:8000
 ```
 
-That's it — `lmcache describe --url http://localhost:8000` is now available.
+Use the command-tree inspector to confirm discovery:
+
+```bash
+lmcache tool list-commands --format json
+```
+
+The output includes every discovered command path, including nested
+`CompositeCommand` groups and their leaf commands.
 
 ### File layout
 
@@ -116,9 +117,12 @@ lmcache/cli/
 │   ├── handler.py       # StreamHandler, FileHandler
 │   └── formatter.py     # TerminalFormatter, JsonFormatter
 ├── commands/
-│   ├── __init__.py      # ALL_COMMANDS registry
-│   ├── base.py          # BaseCommand ABC
-│   └── mock.py          # lmcache mock  (example command)
+│   ├── __init__.py      # Auto-discovers ALL_COMMANDS
+│   ├── base.py          # BaseCommand ABC + CompositeCommand
+│   ├── mock.py          # lmcache mock  (example command)
+│   └── tool/            # lmcache tool (CompositeCommand)
+│       ├── __init__.py
+│       └── list_commands.py
 └── corpora/             # built-in prompt corpora (future)
 ```
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -70,7 +70,7 @@ Available Commands
    * - :doc:`trace`
      - Inspect and replay storage-level trace files.
    * - :doc:`tool`
-     - Run offline analysis tools (e.g. the cache simulator).
+     - Run offline analysis tools and inspect the auto-discovered command tree.
 
 Output Formats
 --------------
@@ -105,4 +105,3 @@ See :doc:`/developer_guide/cli` for details.
    quota
    trace
    tool
-

--- a/docs/source/cli/tool.rst
+++ b/docs/source/cli/tool.rst
@@ -8,7 +8,7 @@ LMCache.
 
    lmcache tool <tool-name> <action> [options]
 
-Currently one tool is available: ``cache-simulator``.
+Currently two tools are available: ``cache-simulator`` and ``list-commands``.
 
 .. note::
 
@@ -51,3 +51,18 @@ Each action has its own flags. Run the built-in help for the full list:
    lmcache tool cache-simulator simulate --help
    lmcache tool cache-simulator sweep --help
    lmcache tool cache-simulator gen-dataset --help
+
+list-commands
+-------------
+
+Inspect the CLI command tree that LMCache discovered at startup:
+
+.. code-block:: bash
+
+   lmcache tool list-commands
+   lmcache tool list-commands --format json
+
+The command reports each path, command name, help text, command type
+(``group`` or ``command``), and depth. This is useful when adding or debugging
+plugin-style CLI extensions because it shows which ``BaseCommand`` and
+``CompositeCommand`` classes were registered without manual registry edits.

--- a/docs/source/developer_guide/cli.rst
+++ b/docs/source/developer_guide/cli.rst
@@ -128,11 +128,12 @@ creates the recursive nesting without any special configuration.
        │       └── engine_bench/__init__.py → EngineBenchCommand (leaf)
        └── tool/__init__.py → ToolCommand (composite)
            └── ToolCommand.register() discovers:
-               └── cache_simulator/__init__.py → CacheSimulatorCommand (composite)
-                   └── CacheSimulatorCommand.register() discovers:
-                       ├── simulate_command.py     → SimulateCommand (leaf)
-                       ├── sweep_command.py        → SweepCommand (leaf)
-                       └── gen_dataset_command.py  → GenDatasetCommand (leaf)
+               ├── cache_simulator/__init__.py → CacheSimulatorCommand (composite)
+               │   └── CacheSimulatorCommand.register() discovers:
+               │       ├── simulate_command.py     → SimulateCommand (leaf)
+               │       ├── sweep_command.py        → SweepCommand (leaf)
+               │       └── gen_dataset_command.py  → GenDatasetCommand (leaf)
+               └── list_commands.py → ListCommandsCommand (leaf)
 
 Directory Layout
 ----------------
@@ -152,6 +153,7 @@ Directory Layout
    │   └── ...
    └── tool/                  # Level-2 composite command
        ├── __init__.py         # ToolCommand(CompositeCommand)
+       ├── list_commands.py    # Level-2 leaf: ``lmcache tool list-commands``
        └── cache_simulator/    # Level-3 composite command
            ├── __init__.py     # CacheSimulatorCommand(CompositeCommand)
            ├── simulate_command.py   # Level-3 leaf: ``lmcache tool cache-simulator simulate``
@@ -302,8 +304,8 @@ Level 2: Adding a Subcommand to an Existing Group
 ---------------------------------------------------
 
 If a ``CompositeCommand`` group already exists (e.g. ``bench``, ``quota``,
-``trace``), you can extend it by simply adding **one new file** — no other
-changes are required.
+``trace``, ``tool``), you can extend it by simply adding **one new file**
+— no other changes are required.
 
 For example, to add a new ``lmcache bench l2`` subcommand under the
 existing ``bench`` group:
@@ -354,6 +356,22 @@ imports to add, no ``__init__.py`` edits in the parent.
 
    - It does **not** start with ``_``.
    - It contains a concrete ``BaseCommand`` subclass.
+
+Inspecting Discovered Commands
+------------------------------
+
+Run the built-in command tree inspector to see what the auto-discovery path
+registered:
+
+.. code-block:: bash
+
+   lmcache tool list-commands
+   lmcache tool list-commands --format json
+
+The command reports each path, command name, help text, command type
+(``group`` or ``command``), and depth. This is useful when adding or debugging
+plugin-style CLI extensions because it shows which ``BaseCommand`` and
+``CompositeCommand`` classes were registered without manual registry edits.
 
 Level N: Arbitrary Nesting
 --------------------------
@@ -465,7 +483,7 @@ command authors just build metrics and call ``emit()``:
        # Trigger all handlers
        metrics.emit()
 
-The ``--format`` and ``--output`` flags are added automatically by
+The ``--format``, ``--output``, and ``--quiet`` flags are added automatically by
 ``BaseCommand.register()`` — subcommands do not need to add them manually.
 
 Summary

--- a/lmcache/cli/commands/base.py
+++ b/lmcache/cli/commands/base.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import abc
 import argparse
 import sys
+from collections.abc import Mapping
+from types import MappingProxyType
 
 # First Party
 from lmcache.cli.metrics import (
@@ -151,6 +153,15 @@ class CompositeCommand(BaseCommand):
 
     def add_arguments(self, _parser: argparse.ArgumentParser) -> None:
         """No top-level arguments; all args are registered by subcommands."""
+
+    def subcommands(self) -> Mapping[str, BaseCommand]:
+        """Return auto-discovered child commands by command name.
+
+        Returns:
+            Read-only mapping from child command name to command instance. The
+            mapping is empty until :meth:`register` discovers child commands.
+        """
+        return MappingProxyType(getattr(self, "_subcmds", {}))
 
     def register(self, subparsers: argparse._SubParsersAction) -> None:
         """Register this command and auto-discover all sub-subcommands.

--- a/lmcache/cli/commands/tool/list_commands.py
+++ b/lmcache/cli/commands/tool/list_commands.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``lmcache tool list-commands`` - list discovered CLI commands."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Iterable
+import argparse
+
+# First Party
+from lmcache.cli.commands.base import BaseCommand, CompositeCommand
+
+
+def _command_type(command: BaseCommand) -> str:
+    """Return the command kind shown in CLI output.
+
+    Args:
+        command: Command instance to classify.
+
+    Returns:
+        ``"group"`` for composite commands, otherwise ``"command"``.
+    """
+    if isinstance(command, CompositeCommand):
+        return "group"
+    return "command"
+
+
+def _iter_command_entries(
+    commands: Iterable[BaseCommand],
+    prefix: tuple[str, ...] = ("lmcache",),
+) -> Iterable[dict[str, object]]:
+    """Yield command metadata for a command tree.
+
+    Args:
+        commands: Commands at the current tree level.
+        prefix: CLI path tokens before the current level.
+
+    Yields:
+        Dictionaries containing stable command metadata.
+    """
+    for command in commands:
+        path_tokens = (*prefix, command.name())
+        yield {
+            "path": " ".join(path_tokens),
+            "name": command.name(),
+            "help": command.help(),
+            "type": _command_type(command),
+            "depth": len(path_tokens) - 1,
+        }
+        if isinstance(command, CompositeCommand):
+            yield from _iter_command_entries(
+                command.subcommands().values(),
+                path_tokens,
+            )
+
+
+def collect_command_entries() -> list[dict[str, object]]:
+    """Collect metadata for all auto-discovered LMCache CLI commands.
+
+    Returns:
+        Command entries sorted by CLI path for deterministic output.
+    """
+    # Deferred import avoids a circular dependency while command modules are
+    # being imported by the auto-discovery path.
+    # First Party
+    from lmcache.cli.commands import ALL_COMMANDS
+
+    return sorted(
+        _iter_command_entries(ALL_COMMANDS),
+        key=lambda entry: str(entry["path"]),
+    )
+
+
+class ListCommandsCommand(BaseCommand):
+    """List the command tree discovered by the LMCache CLI."""
+
+    def name(self) -> str:
+        """Return the subcommand name.
+
+        Returns:
+            The string ``"list-commands"``.
+        """
+        return "list-commands"
+
+    def help(self) -> str:
+        """Return short help text.
+
+        Returns:
+            Help string shown by ``lmcache tool -h``.
+        """
+        return "List auto-discovered CLI commands."
+
+    def add_arguments(self, _parser: argparse.ArgumentParser) -> None:
+        """Add command-specific arguments.
+
+        Args:
+            _parser: The ``ArgumentParser`` for this subcommand.
+        """
+
+    def execute(self, args: argparse.Namespace) -> None:
+        """List all discovered CLI commands.
+
+        Args:
+            args: Parsed CLI arguments.
+        """
+        entries = collect_command_entries()
+        metrics = self.create_metrics("LMCache CLI Commands", args)
+        metrics.add("command_count", "Command count", len(entries))
+        for index, entry in enumerate(entries):
+            section = metrics.add_list_section(
+                "commands",
+                f"command_{index}",
+                str(entry["path"]),
+            )
+            section.add("path", "Path", entry["path"])
+            section.add("name", "Name", entry["name"])
+            section.add("help", "Help", entry["help"])
+            section.add("type", "Type", entry["type"])
+            section.add("depth", "Depth", entry["depth"])
+        metrics.emit()

--- a/lmcache/cli/main.py
+++ b/lmcache/cli/main.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """LMCache CLI entry point.
 
-Subcommands are explicitly registered in
-``lmcache.cli.commands.ALL_COMMANDS``.
+Subcommands are auto-discovered into ``lmcache.cli.commands.ALL_COMMANDS``
+and registered with the root argparse parser at startup.
 """
 
 # Standard

--- a/tests/cli/commands/tool/__init__.py
+++ b/tests/cli/commands/tool/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache tool`` commands."""

--- a/tests/cli/commands/tool/test_list_commands.py
+++ b/tests/cli/commands/tool/test_list_commands.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``lmcache tool list-commands``."""
+
+# Standard
+from unittest.mock import patch
+import io
+import json
+
+# First Party
+from lmcache.cli.main import main
+
+
+def _run_cli_json(argv: list[str]) -> dict:
+    stdout = io.StringIO()
+    with patch("sys.argv", argv), patch("sys.stdout", stdout):
+        main()
+    return json.loads(stdout.getvalue())
+
+
+def test_list_commands_reports_discovered_command_tree() -> None:
+    """The command lists top-level and nested auto-discovered commands."""
+    output = _run_cli_json(
+        ["lmcache", "tool", "list-commands", "--format", "json"],
+    )
+
+    assert output["title"] == "LMCache CLI Commands"
+    metrics = output["metrics"]
+    commands = metrics["commands"]
+    paths = {entry["path"] for entry in commands}
+
+    assert metrics["command_count"] == len(commands)
+    assert "lmcache ping" in paths
+    assert "lmcache tool" in paths
+    assert "lmcache tool list-commands" in paths
+
+
+def test_list_commands_reports_stable_command_fields() -> None:
+    """Each command entry exposes stable fields for docs and tooling."""
+    output = _run_cli_json(
+        ["lmcache", "tool", "list-commands", "--format", "json"],
+    )
+    commands = output["metrics"]["commands"]
+
+    list_commands = next(
+        entry for entry in commands if entry["path"] == "lmcache tool list-commands"
+    )
+
+    assert list_commands["name"] == "list-commands"
+    assert list_commands["type"] == "command"
+    assert list_commands["depth"] == 2
+    assert list_commands["help"]
+
+    tool = next(entry for entry in commands if entry["path"] == "lmcache tool")
+    assert tool["name"] == "tool"
+    assert tool["type"] == "group"
+    assert tool["depth"] == 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `lmcache tool list-commands`, a small CLI command that prints the auto-discovered LMCache CLI command tree. This makes the plugin-style `BaseCommand` / `CompositeCommand` architecture easier to inspect and helps contributors verify that new commands are discovered without manual registration.

Also updates stale CLI docs/design notes that still described the old manual `ALL_COMMANDS` registration flow.

Fixes #3720.

**Special notes for your reviewers**:

The new command is nested under `lmcache tool` and uses the existing metrics output path, so it supports `--format`, `--output`, and `--quiet`.

Validation run locally:
- `pytest -q --confcutdir=tests/cli tests/cli/commands/tool/test_list_commands.py`
- `ruff check lmcache/cli/commands/base.py lmcache/cli/commands/tool/list_commands.py lmcache/cli/main.py tests/cli/commands/tool/test_list_commands.py tests/cli/commands/tool/__init__.py`
- `ruff format --check lmcache/cli/commands/base.py lmcache/cli/commands/tool/list_commands.py lmcache/cli/main.py tests/cli/commands/tool/test_list_commands.py tests/cli/commands/tool/__init__.py`
- `git diff --check`

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests