### PR TITLE
[core] Add AMD hipFile backend for the GDS L1 tier (MP mode)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -223,10 +223,23 @@ GDS L1 Tier
 Source: ``lmcache/v1/distributed/config.py``
 
 Opt-in. Setting ``--gds-l1-path`` switches the L1 medium from pinned DRAM to
-an NVMe slab file accessed via GPUDirect Storage (cuFile DMA). The CPU
-pinned-DRAM tier is then disabled, and ``--l1-size-gb`` sizes the slab.
-Disable byte-array L2 adapters when this is on (the GDS tier exposes no L1
-memory buffer for them to register).
+an NVMe slab file accessed via GPUDirect Storage DMA. The CPU pinned-DRAM tier
+is then disabled, and ``--l1-size-gb`` sizes the slab. Disable byte-array L2
+adapters when this is on (the GDS tier exposes no L1 memory buffer for them to
+register).
+
+The DMA path is selected automatically by platform: **cuFile**
+(``libcufile.so``) on NVIDIA and **hipFile** (``libhipfile.so``,
+`ROCm/hipFile <https://github.com/ROCm/hipFile>`_) on AMD ROCm. The same
+flags apply to both; no configuration change is needed to switch vendors.
+
+.. note::
+
+   AMD hipFile requires ROCm >= 7.2.0. The zero-copy GPUDirect fast path
+   additionally needs a kernel built with ``CONFIG_PCI_P2PDMA``,
+   ``amdgpu-dkms >= 30.20.1``, and the slab on a local NVMe ext4/xfs
+   filesystem; where those are unavailable hipFile transparently falls back to
+   a host-bounce compatibility path (correct, but not zero-copy).
 
 .. list-table::
    :header-rows: 1

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -164,9 +164,10 @@ class GdsL1Config:
     """Configuration for the GDS slab-file L1 tier.
 
     When present on :class:`L1ManagerConfig`, the L1 medium becomes an NVMe
-    slab file accessed via cuFile DMA instead of pinned DRAM (mutually
-    exclusive with the pinned-DRAM tier in ``memory_config``). Carries the
-    slab location, capacity, and DMA mode.
+    slab file accessed via GPUDirect Storage DMA (cuFile on NVIDIA, hipFile on
+    AMD ROCm) instead of pinned DRAM (mutually exclusive with the pinned-DRAM
+    tier in ``memory_config``). Carries the slab location, capacity, and DMA
+    mode.
     """
 
     file_location: str
@@ -181,7 +182,7 @@ class GdsL1Config:
     """Open the slab with ``O_DIRECT`` (required for the GDS DMA fast path)."""
 
     align_bytes: int = 4096
-    """Allocation alignment; cuFile/O_DIRECT require 4 KiB."""
+    """Allocation alignment; cuFile/hipFile and O_DIRECT require 4 KiB."""
 
 
 @dataclass
@@ -402,9 +403,10 @@ def add_storage_manager_args(
     gds_group = parser.add_argument_group(
         "GDS L1 tier",
         "Configuration for the GDS slab-file L1 tier. Setting --gds-l1-path "
-        "makes the L1 medium an NVMe slab accessed via cuFile DMA instead of "
-        "pinned DRAM; --l1-size-gb then sizes the slab. Disable byte-array L2 "
-        "adapters when this is on.",
+        "makes the L1 medium an NVMe slab accessed via GPUDirect Storage DMA "
+        "(cuFile on NVIDIA, hipFile on AMD ROCm) instead of pinned DRAM; "
+        "--l1-size-gb then sizes the slab. Disable byte-array L2 adapters when "
+        "this is on.",
     )
     gds_group.add_argument(
         "--gds-l1-path",

--- a/lmcache/v1/gpu_connector/_cufile_async.py
+++ b/lmcache/v1/gpu_connector/_cufile_async.py
@@ -124,6 +124,30 @@ def _check(err: "CUfileError", op: str) -> None:
         )
 
 
+# --- Handle registration -------------------------------------------
+
+
+def register_handle(fd: int) -> Any:
+    """Register an open fd with cuFile and return the ``CUfileHandle_t``.
+
+    Opens the cuFile driver on first use. The returned handle is accepted
+    directly as the first argument of ``cuFileReadAsync`` / ``cuFileWriteAsync``.
+    """
+    _ensure_driver_open()
+    # Third Party
+    from cufile.bindings import cuFileHandleRegister
+
+    return cuFileHandleRegister(fd)
+
+
+def deregister_handle(handle: Any) -> None:
+    """Reverse of :func:`register_handle` (``cuFileHandleDeregister``)."""
+    # Third Party
+    from cufile.bindings import cuFileHandleDeregister
+
+    cuFileHandleDeregister(handle)
+
+
 # --- Buffer / stream registration ----------------------------------
 
 
@@ -257,10 +281,6 @@ class AsyncHandle:
         fallocate_size: Optional[int] = None,
         mode: int = 0o644,
     ) -> None:
-        _ensure_driver_open()
-        # Third Party
-        from cufile.bindings import cuFileHandleRegister
-
         flags = os.O_DIRECT
         if writable:
             flags |= os.O_CREAT | os.O_RDWR
@@ -272,7 +292,7 @@ class AsyncHandle:
         try:
             if fallocate_size is not None and writable:
                 os.posix_fallocate(self._fd, 0, fallocate_size)
-            self._handle = cuFileHandleRegister(self._fd)
+            self._handle = register_handle(self._fd)
         except Exception:
             os.close(self._fd)
             raise
@@ -366,11 +386,8 @@ class AsyncHandle:
         """Deregister the cuFile handle and close the fd."""
         if self._fd < 0:
             return
-        # Third Party
-        from cufile.bindings import cuFileHandleDeregister
-
         try:
-            cuFileHandleDeregister(self._handle)
+            deregister_handle(self._handle)
         finally:
             try:
                 os.close(self._fd)

--- a/lmcache/v1/gpu_connector/_gds_async.py
+++ b/lmcache/v1/gpu_connector/_gds_async.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform dispatch for the GDS async backend.
+
+Re-exports the GDSContext-facing surface from the cuFile wrapper on NVIDIA
+(:mod:`lmcache.v1.gpu_connector._cufile_async`) or the hipFile wrapper on AMD
+ROCm (:mod:`lmcache.v1.gpu_connector._hipfile_async`). Both modules expose an
+identical API -- :class:`AsyncHandle`, :class:`Submission`, and the
+``register_*`` / ``deregister_*`` / ``close_driver`` functions -- so
+:mod:`lmcache.v1.gpu_connector.gds_context` imports this shim as ``ca`` and is
+platform-agnostic.
+
+Selection is by ``torch.version.hip``: a ROCm torch build reports a non-None
+HIP version. Importing this shim does not dlopen any GPU IO driver; both
+backends bind ``libcufile``/``libhipfile`` lazily on first use.
+"""
+
+# Third Party
+import torch
+
+if torch.version.hip is not None:
+    # First Party
+    from lmcache.v1.gpu_connector._hipfile_async import (
+        AsyncHandle as AsyncHandle,
+        Submission as Submission,
+        close_driver as close_driver,
+        deregister_buffer as deregister_buffer,
+        deregister_handle as deregister_handle,
+        deregister_stream as deregister_stream,
+        register_buffer as register_buffer,
+        register_handle as register_handle,
+        register_stream as register_stream,
+    )
+else:
+    # First Party
+    from lmcache.v1.gpu_connector._cufile_async import (
+        AsyncHandle as AsyncHandle,
+        Submission as Submission,
+        close_driver as close_driver,
+        deregister_buffer as deregister_buffer,
+        deregister_handle as deregister_handle,
+        deregister_stream as deregister_stream,
+        register_buffer as register_buffer,
+        register_handle as register_handle,
+        register_stream as register_stream,
+    )

--- a/lmcache/v1/gpu_connector/_gds_async.py
+++ b/lmcache/v1/gpu_connector/_gds_async.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Platform dispatch for the GDS async backend.
 
-Re-exports the GDSContext-facing surface from the cuFile wrapper on NVIDIA
-(:mod:`lmcache.v1.gpu_connector._cufile_async`) or the hipFile wrapper on AMD
-ROCm (:mod:`lmcache.v1.gpu_connector._hipfile_async`). Both modules expose an
-identical API -- :class:`AsyncHandle`, :class:`Submission`, and the
-``register_*`` / ``deregister_*`` / ``close_driver`` functions -- so
+Selects the GDSContext-facing backend by platform -- the cuFile wrapper
+(:mod:`lmcache.v1.gpu_connector._cufile_async`) on NVIDIA, or the hipFile
+wrapper (:mod:`lmcache.v1.gpu_connector._hipfile_async`) on AMD ROCm. Both
+modules expose an identical API -- :class:`AsyncHandle`, :class:`Submission`,
+and the ``register_*`` / ``deregister_*`` / ``close_driver`` functions -- so
 :mod:`lmcache.v1.gpu_connector.gds_context` imports this shim as ``ca`` and is
 platform-agnostic.
 
@@ -19,27 +19,19 @@ import torch
 
 if torch.version.hip is not None:
     # First Party
-    from lmcache.v1.gpu_connector._hipfile_async import (
-        AsyncHandle as AsyncHandle,
-        Submission as Submission,
-        close_driver as close_driver,
-        deregister_buffer as deregister_buffer,
-        deregister_handle as deregister_handle,
-        deregister_stream as deregister_stream,
-        register_buffer as register_buffer,
-        register_handle as register_handle,
-        register_stream as register_stream,
-    )
+    from lmcache.v1.gpu_connector import _hipfile_async as _backend
 else:
     # First Party
-    from lmcache.v1.gpu_connector._cufile_async import (
-        AsyncHandle as AsyncHandle,
-        Submission as Submission,
-        close_driver as close_driver,
-        deregister_buffer as deregister_buffer,
-        deregister_handle as deregister_handle,
-        deregister_stream as deregister_stream,
-        register_buffer as register_buffer,
-        register_handle as register_handle,
-        register_stream as register_stream,
-    )
+    from lmcache.v1.gpu_connector import _cufile_async as _backend
+
+# Re-export the selected backend's surface under stable names so callers
+# (and test monkeypatches) target this module.
+AsyncHandle = _backend.AsyncHandle
+Submission = _backend.Submission
+close_driver = _backend.close_driver
+register_handle = _backend.register_handle
+deregister_handle = _backend.deregister_handle
+register_buffer = _backend.register_buffer
+deregister_buffer = _backend.deregister_buffer
+register_stream = _backend.register_stream
+deregister_stream = _backend.deregister_stream

--- a/lmcache/v1/gpu_connector/_gds_async.py
+++ b/lmcache/v1/gpu_connector/_gds_async.py
@@ -14,10 +14,19 @@ HIP version. Importing this shim does not dlopen any GPU IO driver; both
 backends bind ``libcufile``/``libhipfile`` lazily on first use.
 """
 
+# Standard
+from typing import TYPE_CHECKING
+
 # Third Party
 import torch
 
-if torch.version.hip is not None:
+# A static type checker analyzes the TYPE_CHECKING branch only (one ``_backend``
+# binding, so no ``no-redef``); at runtime the ``elif``/``else`` pick the real
+# backend by platform.
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.gpu_connector import _cufile_async as _backend
+elif torch.version.hip is not None:
     # First Party
     from lmcache.v1.gpu_connector import _hipfile_async as _backend
 else:

--- a/lmcache/v1/gpu_connector/_hipfile_async.py
+++ b/lmcache/v1/gpu_connector/_hipfile_async.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal ctypes wrapper around the hipFile async C API (AMD ROCm).
+
+AMD analog of :mod:`lmcache.v1.gpu_connector._cufile_async`. hipFile
+(``ROCm/hipFile``, "AMD Infinity Storage") is the ROCm GPUDirect-Storage
+library; its async surface mirrors cuFile 1:1 (``hipFileReadAsync`` +
+``hipFileStreamRegister`` + batched submit + single ``hipStreamSynchronize``),
+so this module exposes the same primitives and the **same Python surface** as
+the cuFile wrapper -- :class:`GDSContext` talks to either through the
+:mod:`lmcache.v1.gpu_connector._gds_async` dispatch shim.
+
+Surface (identical to ``_cufile_async``):
+
+- :func:`register_buffer` / :func:`deregister_buffer` — wrap
+  ``hipFileBufRegister`` / ``hipFileBufDeregister`` on a torch tensor.
+- :func:`register_stream` / :func:`deregister_stream` — wrap
+  ``hipFileStreamRegister`` / ``hipFileStreamDeregister`` on a raw HIP
+  stream handle.
+- :func:`register_handle` / :func:`deregister_handle` — wrap
+  ``hipFileHandleRegister`` / ``hipFileHandleDeregister`` on an fd.
+- :class:`AsyncHandle` — opens a file with ``O_DIRECT`` (required by
+  hipFile) and registers the hipFile handle. ``read_async`` /
+  ``write_async`` enqueue an async IO on a stream and return a
+  :class:`Submission`. Callers run ``hipStreamSynchronize`` once to drain a
+  batch; :meth:`Submission.bytes_done` returns the actual byte count.
+
+Unlike cuFile (which ships an ``nvidia.cufile`` Python binding), hipFile has
+no Python package, so every symbol -- driver lifecycle, handle/buffer
+registration, and the ``hipFileError_t`` / ``hipFileDescr_t`` structs -- is
+bound directly from ``libhipfile.so`` via ctypes here. Requires ROCm >= 7.2.0.
+"""
+
+# Standard
+from typing import Any, Optional
+import ctypes
+import os
+
+# Third Party
+import torch
+
+# ``libhipfile.so`` is dlopened lazily (see ``_lib``) so importing this module
+# on a CPU-only / NVIDIA host -- it is transitively pulled in by the GDS
+# dispatch shim during CLI command discovery -- does not require the ROCm GPU
+# IO driver to be present. This mirrors the lazy ``import cufile`` in the cuFile
+# wrapper.
+
+_LIBHIPFILE_SONAME = "libhipfile.so"
+
+# hipFile handle type for a POSIX fd (hipfile.h: ``hipFileHandleTypeOpaqueFD``).
+_HIPFILE_HANDLE_TYPE_OPAQUE_FD = 1
+
+# hipFileStreamRegister flags (hipfile.h): buffer offset, file offset, and size
+# are all fixed at submission time (HIPFILE_STREAM_FIXED_* = 0x1|0x2|0x4). Same
+# 0x7 the cuFile wrapper uses. PAGE_ALIGNED_INPUTS (0x8) is omitted -- transfer
+# sizes are not always 4 KiB.
+_STREAM_REGISTER_FLAGS = 0x7
+
+# hipFileSuccess (hipfile.h ``hipFileOpError``).
+_HIPFILE_SUCCESS = 0
+
+
+class _HipFileError(ctypes.Structure):
+    """ctypes mirror of ``hipFileError_t`` (hipfile.h).
+
+    Two ints: ``err`` is the ``hipFileOpError_t`` status (0 == success);
+    ``hip_drv_err`` carries the underlying ``hipError_t`` when ``err`` indicates
+    a GPU-driver failure.
+    """
+
+    _fields_ = [("err", ctypes.c_int), ("hip_drv_err", ctypes.c_int)]
+
+
+class _HipFileHandleUnion(ctypes.Union):
+    """ctypes mirror of the ``hipFileDescr_t.handle`` union (fd or Win32 HANDLE)."""
+
+    _fields_ = [("fd", ctypes.c_int), ("hFile", ctypes.c_void_p)]
+
+
+class _HipFileDescr(ctypes.Structure):
+    """ctypes mirror of ``hipFileDescr_t`` (hipfile.h)."""
+
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("handle", _HipFileHandleUnion),
+        ("fs_ops", ctypes.c_void_p),
+    ]
+
+
+_lib_handle: Optional[ctypes.CDLL] = None
+
+
+def _declare_signatures(lib: ctypes.CDLL) -> None:
+    """Set argtypes/restype on the libhipfile symbols. Idempotent."""
+    if getattr(lib.hipFileReadAsync, "argtypes", None):
+        return
+
+    lib.hipFileDriverOpen.argtypes = []
+    lib.hipFileDriverOpen.restype = _HipFileError
+
+    lib.hipFileDriverClose.argtypes = []
+    lib.hipFileDriverClose.restype = _HipFileError
+
+    lib.hipFileHandleRegister.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p),  # hipFileHandle_t *fh
+        ctypes.POINTER(_HipFileDescr),  # hipFileDescr_t *descr
+    ]
+    lib.hipFileHandleRegister.restype = _HipFileError
+
+    lib.hipFileHandleDeregister.argtypes = [ctypes.c_void_p]  # hipFileHandle_t fh
+    lib.hipFileHandleDeregister.restype = None  # void
+
+    lib.hipFileBufRegister.argtypes = [
+        ctypes.c_void_p,  # const void *buffer_base
+        ctypes.c_size_t,  # size_t length
+        ctypes.c_int,  # int flags
+    ]
+    lib.hipFileBufRegister.restype = _HipFileError
+
+    lib.hipFileBufDeregister.argtypes = [ctypes.c_void_p]  # const void *buffer_base
+    lib.hipFileBufDeregister.restype = _HipFileError
+
+    lib.hipFileReadAsync.argtypes = [
+        ctypes.c_void_p,  # hipFileHandle_t fh
+        ctypes.c_void_p,  # void *buffer_base
+        ctypes.POINTER(ctypes.c_size_t),  # size_t *size_p
+        ctypes.POINTER(ctypes.c_int64),  # hoff_t *file_offset_p
+        ctypes.POINTER(ctypes.c_int64),  # hoff_t *buffer_offset_p
+        ctypes.POINTER(ctypes.c_int64),  # ssize_t *bytes_read_p
+        ctypes.c_void_p,  # hipStream_t stream
+    ]
+    lib.hipFileReadAsync.restype = _HipFileError
+
+    lib.hipFileWriteAsync.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.POINTER(ctypes.c_int64),
+        ctypes.c_void_p,
+    ]
+    lib.hipFileWriteAsync.restype = _HipFileError
+
+    lib.hipFileStreamRegister.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    lib.hipFileStreamRegister.restype = _HipFileError
+
+    lib.hipFileStreamDeregister.argtypes = [ctypes.c_void_p]
+    lib.hipFileStreamDeregister.restype = _HipFileError
+
+    lib.hipFileGetOpErrorString.argtypes = [ctypes.c_int]
+    lib.hipFileGetOpErrorString.restype = ctypes.c_char_p
+
+
+_driver_opened = False
+
+
+def _lib() -> ctypes.CDLL:
+    """dlopen ``libhipfile.so`` once and declare signatures. Idempotent."""
+    global _lib_handle
+    if _lib_handle is None:
+        _lib_handle = ctypes.CDLL(_LIBHIPFILE_SONAME)
+        _declare_signatures(_lib_handle)
+    return _lib_handle
+
+
+def _ensure_driver_open() -> None:
+    """Idempotently open the hipFile driver."""
+    global _driver_opened
+    if _driver_opened:
+        return
+    lib = _lib()
+    _check(lib.hipFileDriverOpen(), "hipFileDriverOpen")
+    _driver_opened = True
+
+
+def close_driver() -> None:
+    """Close the hipFile driver. Optional — useful in tests."""
+    global _driver_opened
+    if not _driver_opened:
+        return
+    lib = _lib()
+    try:
+        _check(lib.hipFileDriverClose(), "hipFileDriverClose")
+    finally:
+        _driver_opened = False
+
+
+def _op_error_string(err_code: int) -> str:
+    """Return the human-readable name for a ``hipFileOpError_t`` value."""
+    raw = _lib().hipFileGetOpErrorString(ctypes.c_int(abs(err_code)))
+    return raw.decode() if raw is not None else "unknown"
+
+
+def _check(err: "_HipFileError", op: str) -> None:
+    """Convert a non-zero ``hipFileError_t`` into a Python exception."""
+    if err.err != _HIPFILE_SUCCESS:
+        raise RuntimeError(
+            f"{op} failed: hipFileError(err={err.err} [{_op_error_string(err.err)}], "
+            f"hip_drv_err={err.hip_drv_err})"
+        )
+
+
+# --- Handle registration -------------------------------------------
+
+
+def register_handle(fd: int) -> int:
+    """Register an open fd with hipFile and return the ``hipFileHandle_t``.
+
+    Opens the hipFile driver on first use. The returned handle is the raw
+    ``void *`` value (as an int), accepted directly as the first argument of
+    ``hipFileReadAsync`` / ``hipFileWriteAsync``.
+    """
+    _ensure_driver_open()
+    lib = _lib()
+    handle = ctypes.c_void_p()
+    descr = _HipFileDescr()
+    descr.type = _HIPFILE_HANDLE_TYPE_OPAQUE_FD
+    descr.handle.fd = fd
+    descr.fs_ops = None
+    _check(
+        lib.hipFileHandleRegister(ctypes.byref(handle), ctypes.byref(descr)),
+        "hipFileHandleRegister",
+    )
+    return handle.value if handle.value is not None else 0
+
+
+def deregister_handle(handle: int) -> None:
+    """Reverse of :func:`register_handle` (``hipFileHandleDeregister``)."""
+    _lib().hipFileHandleDeregister(ctypes.c_void_p(handle))
+
+
+# --- Buffer / stream registration ----------------------------------
+
+
+def register_buffer(buf: torch.Tensor) -> None:
+    """Register a device tensor with hipFile for GPUDirect Storage DMA.
+
+    Must be called before any ``read_async`` / ``write_async`` whose
+    ``buf_base`` falls inside this tensor's allocation. Implicitly opens the
+    hipFile driver on first use.
+    """
+    if not buf.is_cuda:
+        raise ValueError("register_buffer: tensor must be on the GPU")
+    _ensure_driver_open()
+    lib = _lib()
+    nbytes = buf.numel() * buf.element_size()
+    _check(
+        lib.hipFileBufRegister(
+            ctypes.c_void_p(buf.data_ptr()),
+            ctypes.c_size_t(nbytes),
+            ctypes.c_int(0),
+        ),
+        "hipFileBufRegister",
+    )
+
+
+def deregister_buffer(buf: torch.Tensor) -> None:
+    """Reverse of :func:`register_buffer`."""
+    _check(
+        _lib().hipFileBufDeregister(ctypes.c_void_p(buf.data_ptr())),
+        "hipFileBufDeregister",
+    )
+
+
+def register_stream(raw_stream: int) -> None:
+    """Register a HIP stream with hipFile.
+
+    ``raw_stream`` is the integer ``hipStream_t`` handle — get it via
+    ``torch_dev.current_stream().cuda_stream`` (torch reports the HIP stream
+    through the same attribute on ROCm).
+
+    Optional for correctness (``read_async`` / ``write_async`` also take the
+    stream per call). Registered with the FIXED_* flags (0x7): hipFile still
+    reads the size/offset pointers at stream-execution time -- so their storage
+    must stay alive and unchanged until completion (see ``Submission``) -- but
+    promising the values are fixed at submission lets hipFile skip per-op setup.
+    """
+    _ensure_driver_open()
+    _check(
+        _lib().hipFileStreamRegister(
+            ctypes.c_void_p(raw_stream), _STREAM_REGISTER_FLAGS
+        ),
+        "hipFileStreamRegister",
+    )
+
+
+def deregister_stream(raw_stream: int) -> None:
+    """Reverse of :func:`register_stream`."""
+    _check(
+        _lib().hipFileStreamDeregister(ctypes.c_void_p(raw_stream)),
+        "hipFileStreamDeregister",
+    )
+
+
+# --- AsyncHandle + Submission --------------------------------------
+
+
+class Submission:
+    """One in-flight ``hipFileReadAsync`` / ``hipFileWriteAsync``.
+
+    Holds the host-side ``size_p`` / ``file_offset_p`` / ``buf_offset_p`` /
+    ``bytes_done_p`` storage that hipFile writes into asynchronously. These
+    ctypes objects MUST stay alive until the stream actually executes the op —
+    keep the :class:`Submission` reference (or stash it in a list) until after
+    the stream sync.
+    """
+
+    __slots__ = ("_size", "_file_offset", "_buf_offset", "_bytes_done")
+
+    def __init__(
+        self,
+        size: int,
+        file_offset: int,
+        buf_offset: int,
+    ) -> None:
+        self._size = ctypes.c_size_t(size)
+        self._file_offset = ctypes.c_int64(file_offset)
+        self._buf_offset = ctypes.c_int64(buf_offset)
+        self._bytes_done = ctypes.c_int64(0)
+
+    @property
+    def bytes_done(self) -> int:
+        """Bytes actually transferred. Valid only AFTER the stream sync."""
+        return self._bytes_done.value
+
+
+class AsyncHandle:
+    """Open file + hipFile handle wrapper.
+
+    Opens with ``O_DIRECT`` (required for hipFile's GPUDirect Storage fast
+    path). Optionally pre-allocates the file via ``posix_fallocate``.
+    """
+
+    __slots__ = ("_fd", "_handle", "path", "writable")
+
+    def __init__(
+        self,
+        path: str,
+        writable: bool = False,
+        fallocate_size: Optional[int] = None,
+        mode: int = 0o644,
+    ) -> None:
+        flags = os.O_DIRECT
+        if writable:
+            flags |= os.O_CREAT | os.O_RDWR
+        else:
+            flags |= os.O_RDONLY
+        self.path = path
+        self.writable = writable
+        self._fd = os.open(path, flags, mode)
+        try:
+            if fallocate_size is not None and writable:
+                os.posix_fallocate(self._fd, 0, fallocate_size)
+            self._handle = register_handle(self._fd)
+        except Exception:
+            os.close(self._fd)
+            raise
+
+    @classmethod
+    def from_fd(
+        cls,
+        fd: int,
+        handle: Any,
+        path: str,
+        writable: bool = False,
+    ) -> "AsyncHandle":
+        """Wrap an already-opened fd and registered hipFile handle.
+
+        For callers that open + register the file themselves (e.g. a slab that
+        must be created, truncated, and ``posix_fallocate``d before
+        ``hipFileHandleRegister``) and just need an ``AsyncHandle`` around the
+        result.
+        """
+        obj = cls.__new__(cls)
+        obj._fd = fd
+        obj._handle = handle
+        obj.path = path
+        obj.writable = writable
+        return obj
+
+    @property
+    def fd(self) -> int:
+        return self._fd
+
+    def read_async(
+        self,
+        buf_base: int,
+        size: int,
+        file_offset: int,
+        buf_offset: int,
+        raw_stream: int,
+    ) -> Submission:
+        """Enqueue a ``hipFileReadAsync`` on the stream.
+
+        ``buf_base`` is the registered base pointer (e.g. ``buf.data_ptr()``).
+        ``buf_offset`` is the byte offset within that registration that the data
+        should land at.
+        """
+        sub = Submission(size=size, file_offset=file_offset, buf_offset=buf_offset)
+        _check(
+            _lib().hipFileReadAsync(
+                ctypes.c_void_p(self._handle),
+                ctypes.c_void_p(buf_base),
+                ctypes.byref(sub._size),
+                ctypes.byref(sub._file_offset),
+                ctypes.byref(sub._buf_offset),
+                ctypes.byref(sub._bytes_done),
+                ctypes.c_void_p(raw_stream),
+            ),
+            "hipFileReadAsync",
+        )
+        return sub
+
+    def write_async(
+        self,
+        buf_base: int,
+        size: int,
+        file_offset: int,
+        buf_offset: int,
+        raw_stream: int,
+    ) -> Submission:
+        """Enqueue a ``hipFileWriteAsync`` on the stream."""
+        sub = Submission(size=size, file_offset=file_offset, buf_offset=buf_offset)
+        _check(
+            _lib().hipFileWriteAsync(
+                ctypes.c_void_p(self._handle),
+                ctypes.c_void_p(buf_base),
+                ctypes.byref(sub._size),
+                ctypes.byref(sub._file_offset),
+                ctypes.byref(sub._buf_offset),
+                ctypes.byref(sub._bytes_done),
+                ctypes.c_void_p(raw_stream),
+            ),
+            "hipFileWriteAsync",
+        )
+        return sub
+
+    def close(self) -> None:
+        """Deregister the hipFile handle and close the fd."""
+        if self._fd < 0:
+            return
+        try:
+            deregister_handle(self._handle)
+        finally:
+            try:
+                os.close(self._fd)
+            finally:
+                self._fd = -1
+
+    def __enter__(self) -> "AsyncHandle":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/lmcache/v1/gpu_connector/_hipfile_async.py
+++ b/lmcache/v1/gpu_connector/_hipfile_async.py
@@ -34,6 +34,7 @@ bound directly from ``libhipfile.so`` via ctypes here. Requires ROCm >= 7.2.0.
 from typing import Any, Optional
 import ctypes
 import os
+import threading
 
 # Third Party
 import torch
@@ -86,6 +87,10 @@ class _HipFileDescr(ctypes.Structure):
     ]
 
 
+# Guards the one-time dlopen + driver open/close below. Only the init/teardown
+# transitions are serialized; the per-DMA fast path (``_lib()`` once loaded)
+# never touches the lock.
+_init_lock = threading.Lock()
 _lib_handle: Optional[ctypes.CDLL] = None
 
 
@@ -155,34 +160,61 @@ _driver_opened = False
 
 
 def _lib() -> ctypes.CDLL:
-    """dlopen ``libhipfile.so`` once and declare signatures. Idempotent."""
+    """dlopen ``libhipfile.so`` once and declare signatures. Idempotent.
+
+    Thread-safe via double-checked locking: the common case (already loaded)
+    returns without taking ``_init_lock``, so the per-DMA path stays lock-free.
+
+    Returns:
+        The process-global ``libhipfile.so`` handle.
+    """
     global _lib_handle
-    if _lib_handle is None:
-        _lib_handle = ctypes.CDLL(_LIBHIPFILE_SONAME)
-        _declare_signatures(_lib_handle)
+    if _lib_handle is not None:
+        return _lib_handle
+    with _init_lock:
+        if _lib_handle is None:
+            handle = ctypes.CDLL(_LIBHIPFILE_SONAME)
+            _declare_signatures(handle)
+            _lib_handle = handle
     return _lib_handle
 
 
 def _ensure_driver_open() -> None:
-    """Idempotently open the hipFile driver."""
+    """Idempotently open the hipFile driver (thread-safe).
+
+    Raises:
+        RuntimeError: If ``hipFileDriverOpen`` reports a non-success status.
+    """
     global _driver_opened
     if _driver_opened:
         return
+    # ``_lib()`` does its own locking; call it before taking ``_init_lock`` so
+    # the (non-reentrant) lock is never acquired twice on the same thread.
     lib = _lib()
-    _check(lib.hipFileDriverOpen(), "hipFileDriverOpen")
-    _driver_opened = True
+    with _init_lock:
+        if _driver_opened:
+            return
+        _check(lib.hipFileDriverOpen(), "hipFileDriverOpen")
+        _driver_opened = True
 
 
 def close_driver() -> None:
-    """Close the hipFile driver. Optional — useful in tests."""
+    """Close the hipFile driver (thread-safe). Optional — useful in tests.
+
+    Raises:
+        RuntimeError: If ``hipFileDriverClose`` reports a non-success status.
+    """
     global _driver_opened
     if not _driver_opened:
         return
     lib = _lib()
-    try:
-        _check(lib.hipFileDriverClose(), "hipFileDriverClose")
-    finally:
-        _driver_opened = False
+    with _init_lock:
+        if not _driver_opened:
+            return
+        try:
+            _check(lib.hipFileDriverClose(), "hipFileDriverClose")
+        finally:
+            _driver_opened = False
 
 
 def _op_error_string(err_code: int) -> str:
@@ -209,6 +241,16 @@ def register_handle(fd: int) -> int:
     Opens the hipFile driver on first use. The returned handle is the raw
     ``void *`` value (as an int), accepted directly as the first argument of
     ``hipFileReadAsync`` / ``hipFileWriteAsync``.
+
+    Args:
+        fd: An open file descriptor for the slab (opened with ``O_DIRECT`` for
+            the GDS fast path).
+
+    Returns:
+        The registered ``hipFileHandle_t`` as an integer.
+
+    Raises:
+        RuntimeError: If ``hipFileHandleRegister`` reports a non-success status.
     """
     _ensure_driver_open()
     lib = _lib()
@@ -225,7 +267,11 @@ def register_handle(fd: int) -> int:
 
 
 def deregister_handle(handle: int) -> None:
-    """Reverse of :func:`register_handle` (``hipFileHandleDeregister``)."""
+    """Reverse of :func:`register_handle` (``hipFileHandleDeregister``).
+
+    Args:
+        handle: The ``hipFileHandle_t`` (as an int) from :func:`register_handle`.
+    """
     _lib().hipFileHandleDeregister(ctypes.c_void_p(handle))
 
 
@@ -238,6 +284,13 @@ def register_buffer(buf: torch.Tensor) -> None:
     Must be called before any ``read_async`` / ``write_async`` whose
     ``buf_base`` falls inside this tensor's allocation. Implicitly opens the
     hipFile driver on first use.
+
+    Args:
+        buf: A GPU (HIP device) tensor to register for DMA.
+
+    Raises:
+        ValueError: If ``buf`` is not on the GPU.
+        RuntimeError: If ``hipFileBufRegister`` reports a non-success status.
     """
     if not buf.is_cuda:
         raise ValueError("register_buffer: tensor must be on the GPU")
@@ -255,7 +308,14 @@ def register_buffer(buf: torch.Tensor) -> None:
 
 
 def deregister_buffer(buf: torch.Tensor) -> None:
-    """Reverse of :func:`register_buffer`."""
+    """Reverse of :func:`register_buffer`.
+
+    Args:
+        buf: A tensor previously passed to :func:`register_buffer`.
+
+    Raises:
+        RuntimeError: If ``hipFileBufDeregister`` reports a non-success status.
+    """
     _check(
         _lib().hipFileBufDeregister(ctypes.c_void_p(buf.data_ptr())),
         "hipFileBufDeregister",
@@ -274,6 +334,12 @@ def register_stream(raw_stream: int) -> None:
     reads the size/offset pointers at stream-execution time -- so their storage
     must stay alive and unchanged until completion (see ``Submission``) -- but
     promising the values are fixed at submission lets hipFile skip per-op setup.
+
+    Args:
+        raw_stream: The integer ``hipStream_t`` handle to register.
+
+    Raises:
+        RuntimeError: If ``hipFileStreamRegister`` reports a non-success status.
     """
     _ensure_driver_open()
     _check(
@@ -285,7 +351,14 @@ def register_stream(raw_stream: int) -> None:
 
 
 def deregister_stream(raw_stream: int) -> None:
-    """Reverse of :func:`register_stream`."""
+    """Reverse of :func:`register_stream`.
+
+    Args:
+        raw_stream: The ``hipStream_t`` handle passed to :func:`register_stream`.
+
+    Raises:
+        RuntimeError: If ``hipFileStreamDeregister`` reports a non-success status.
+    """
     _check(
         _lib().hipFileStreamDeregister(ctypes.c_void_p(raw_stream)),
         "hipFileStreamDeregister",
@@ -450,5 +523,10 @@ class AsyncHandle:
     def __enter__(self) -> "AsyncHandle":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[Any],
+    ) -> None:
         self.close()

--- a/lmcache/v1/gpu_connector/gds_context.py
+++ b/lmcache/v1/gpu_connector/gds_context.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Process-global cuFile data path for the GDS L1 tier.
+"""Process-global GPUDirect Storage data path for the GDS L1 tier.
 
-One :class:`GDSContext` per worker process owns the slab file, its cuFile
-handle, the registered GPU staging buffers, and the stream-ordered cuFile
-submissions. Created once at startup by :func:`initialize_gds_context`,
-reached via :func:`get_gds_context`. :meth:`GDSContext.register_gpu_buffer`
-registers a staging buffer; :meth:`GDSContext.transfer_async` moves a chunk
-between that buffer and the slab. No POSIX fallback -- if cuFile is
-unavailable, construction fails loudly. The slab is cleared on init, so it
-does not survive a restart (GDS L1 is treated like DRAM).
+The actual GPU<->slab DMA goes through the platform GDS library -- cuFile on
+NVIDIA, hipFile on AMD ROCm -- reached via the :mod:`_gds_async` dispatch shim
+(imported here as ``ca``), so this module is platform-agnostic.
+
+One :class:`GDSContext` per worker process owns the slab file, its GDS handle,
+the registered GPU staging buffers, and the stream-ordered GDS submissions.
+Created once at startup by :func:`initialize_gds_context`, reached via
+:func:`get_gds_context`. :meth:`GDSContext.register_gpu_buffer` registers a
+staging buffer; :meth:`GDSContext.transfer_async` moves a chunk between that
+buffer and the slab. No POSIX fallback -- if the GDS library is unavailable,
+construction fails loudly. The slab is cleared on init, so it does not survive
+a restart (GDS L1 is treated like DRAM).
 """
 
 # Standard
@@ -34,10 +38,11 @@ logger = init_logger(__name__)
 
 _SLAB_FILENAME = "lmcache_gds_slab.bin"
 _CUFILE_ALIGNMENT = 4096
-# A single cuFileBufRegister/DMA is capped at 16 MiB; larger buffers and chunks
-# are registered and transferred in <=16 MiB regions.
+# A single GDS buffer registration / DMA is capped at 16 MiB (both cuFile and
+# hipFile); larger buffers and chunks are registered and transferred in
+# <=16 MiB regions.
 _MAX_CUFILE_REGION = 16 * 1024 * 1024
-# cuFile submissions to accumulate before recording a completion event and
+# GDS submissions to accumulate before recording a completion event and
 # draining finished ones (keeps the live submission set bounded).
 _SUBMISSION_CHECKPOINT_EVERY = 64
 
@@ -53,7 +58,7 @@ class SlabDirection(enum.Enum):
 
 @dataclass
 class _StreamSubmissions:
-    """Per-stream cuFile submissions, kept alive until their DMA has run.
+    """Per-stream GDS submissions, kept alive until their DMA has run.
 
     Submissions accumulate in ``uncommitted``, move to ``inflight`` behind a
     CUDA event on the stream, and drop once it completes. Per-stream because an
@@ -68,10 +73,10 @@ class _StreamSubmissions:
 
 
 class GDSContext:
-    """Per-process cuFile context owning the slab file and its DMA path.
+    """Per-process GDS context owning the slab file and its DMA path.
 
     The singleton always exists but is inert until :meth:`initialize` creates
-    the slab and registers the cuFile handle (flipping :attr:`initialized`).
+    the slab and registers the GDS handle (flipping :attr:`initialized`).
     While off, ``register_gpu_buffer`` is a no-op.
     """
 
@@ -89,7 +94,7 @@ class GDSContext:
         # ``_submissions_lock`` (see ``_record_submission``).
         self._submissions_lock = threading.Lock()
         self._submissions: dict[int, _StreamSubmissions] = {}
-        # Registry of cuFile-registered GPU regions and the CUDA streams they run on
+        # Registry of GDS-registered GPU regions and the streams they run on
         self._registry_lock = threading.Lock()
         self._buffers: list[torch.Tensor] = []
         self._base_ptrs: list[int] = []
@@ -97,7 +102,7 @@ class GDSContext:
         self._registered_streams: set[int] = set()  # maintained for close()
 
     def initialize(self, config: GdsL1Config) -> None:
-        """Create + clear the slab and register it with cuFile.
+        """Create + clear the slab and register it with the GDS library.
 
         Args:
             config: GDS tier config. ``size_in_bytes`` sizes the preallocated
@@ -106,7 +111,8 @@ class GDSContext:
                 ``use_direct_io`` opens it with ``O_DIRECT``.
 
         Raises:
-            Exception: Whatever ``cufile`` raises if GDS is unavailable.
+            Exception: Whatever the GDS library (cuFile/hipFile) raises if GDS
+                is unavailable.
         """
         self._slab_size = (config.size_in_bytes + _CUFILE_ALIGNMENT - 1) & ~(
             _CUFILE_ALIGNMENT - 1
@@ -124,10 +130,10 @@ class GDSContext:
     # --- Public API ---------------------------------------------------
 
     def register_gpu_buffer(self, buffer: torch.Tensor) -> None:
-        """Register a staging buffer (and its CUDA stream) with cuFile.
+        """Register a staging buffer (and its stream) with the GDS library.
 
-        Registered as contiguous <=16 MiB regions (the cuFileBufRegister cap);
-        :meth:`transfer_async` splits transfers at these boundaries.
+        Registered as contiguous <=16 MiB regions (the GDS buffer-registration
+        cap); :meth:`transfer_async` splits transfers at these boundaries.
 
         Args:
             buffer: Contiguous CUDA staging buffer, 4 KiB-aligned in size.
@@ -186,7 +192,7 @@ class GDSContext:
         """DMA a chunk between ``gpu_buffer`` and its slab region.
 
         ``READ`` pulls slab -> ``gpu_buffer``; ``WRITE`` pushes the reverse.
-        Split at registered-region boundaries (each cuFile DMA must stay within
+        Split at registered-region boundaries (each GDS DMA must stay within
         one <=16 MiB region), so any chunk size works. Stream-ordered, no sync.
 
         Args:
@@ -209,7 +215,7 @@ class GDSContext:
             pos += seg_len
 
     def close(self) -> None:
-        """Sync the stream, deregister cuFile state, and close the slab handle."""
+        """Sync the stream, deregister GDS state, and close the slab handle."""
         if self._buffers:
             torch_dev.synchronize(device=self._buffers[0].device)
         with self._submissions_lock:
@@ -242,7 +248,7 @@ class GDSContext:
     # --- Internal -----------------------------------------------------
 
     def _open_and_register_slab(self, use_direct_io: bool) -> None:
-        """Create, truncate, preallocate the slab file and register it with cuFile.
+        """Create, truncate, preallocate the slab file and register it with GDS.
 
         Args:
             use_direct_io: Open with ``O_DIRECT`` (required for the GDS fast path).
@@ -268,7 +274,7 @@ class GDSContext:
             fd, handle, self._slab_path, writable=True
         )
         logger.info(
-            "GDSContext: slab created at %s (%.1f GiB, O_DIRECT=%s), cuFile "
+            "GDSContext: slab created at %s (%.1f GiB, O_DIRECT=%s), GDS "
             "handle registered",
             self._slab_path,
             self._slab_size / (1 << 30),
@@ -276,7 +282,7 @@ class GDSContext:
         )
 
     def _register_region_locked(self, buffer: torch.Tensor) -> None:
-        """cuFile-register one <=16 MiB region (caller holds the lock)."""
+        """GDS-register one <=16 MiB region (caller holds the lock)."""
         nbytes = buffer.numel() * buffer.element_size()
         base = buffer.data_ptr()
         ca.register_buffer(buffer)
@@ -285,7 +291,7 @@ class GDSContext:
         self._base_ptrs.insert(idx, base)
         self._nbytes.insert(idx, nbytes)
         logger.info(
-            "GDSContext: registered %d bytes at 0x%x via cuFile "
+            "GDSContext: registered %d bytes at 0x%x via GDS "
             "(total registrations: %d)",
             nbytes,
             base,
@@ -293,7 +299,7 @@ class GDSContext:
         )
 
     def _deregister_region_locked(self, buffer: torch.Tensor) -> None:
-        """Deregister one region with cuFile (caller holds the lock).
+        """Deregister one region with the GDS library (caller holds the lock).
 
         Args:
             buffer: A staging-buffer slot previously registered.
@@ -329,7 +335,7 @@ class GDSContext:
     def _slab_read(
         self, slab_offset: int, size: int, dev_offset: int, buf_base: int
     ) -> None:
-        """Submit one ``cuFileReadAsync`` against the slab handle (stream-ordered)."""
+        """Submit one async GDS read against the slab handle (stream-ordered)."""
         if self._slab_handle is None:
             raise RuntimeError("GDSContext._slab_read: slab handle not open")
         stream_handle = torch_dev.current_stream().cuda_stream
@@ -341,7 +347,7 @@ class GDSContext:
     def _slab_write(
         self, slab_offset: int, size: int, dev_offset: int, buf_base: int
     ) -> None:
-        """Submit one ``cuFileWriteAsync`` against the slab handle (stream-ordered)."""
+        """Submit one async GDS write against the slab handle (stream-ordered)."""
         if self._slab_handle is None:
             raise RuntimeError("GDSContext._slab_write: slab handle not open")
         stream_handle = torch_dev.current_stream().cuda_stream

--- a/lmcache/v1/gpu_connector/gds_context.py
+++ b/lmcache/v1/gpu_connector/gds_context.py
@@ -27,7 +27,7 @@ import torch
 from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.v1.distributed.config import GdsL1Config
-from lmcache.v1.gpu_connector import _cufile_async as ca
+from lmcache.v1.gpu_connector import _gds_async as ca
 from lmcache.v1.memory_management import GDSMemoryObject
 
 logger = init_logger(__name__)
@@ -260,10 +260,7 @@ class GDSContext:
             flags |= os.O_DIRECT
         fd = os.open(self._slab_path, flags)
         try:
-            # Third Party
-            from cufile.bindings import cuFileHandleRegister
-
-            handle = cuFileHandleRegister(fd)
+            handle = ca.register_handle(fd)
         except Exception:
             os.close(fd)
             raise

--- a/lmcache/v1/gpu_connector/gds_context.py
+++ b/lmcache/v1/gpu_connector/gds_context.py
@@ -291,8 +291,7 @@ class GDSContext:
         self._base_ptrs.insert(idx, base)
         self._nbytes.insert(idx, nbytes)
         logger.info(
-            "GDSContext: registered %d bytes at 0x%x via GDS "
-            "(total registrations: %d)",
+            "GDSContext: registered %d bytes at 0x%x via GDS (total registrations: %d)",
             nbytes,
             base,
             len(self._buffers),

--- a/tests/v1/gpu_connector/test_gds_context.py
+++ b/tests/v1/gpu_connector/test_gds_context.py
@@ -5,8 +5,8 @@ Most tests are pure (no cuFile): they exercise the public interface
 (singleton/no-op semantics, the <=16 MiB region split observed at the ``ca``
 cuFile seam, and the registered-region mapping driven through
 :meth:`GDSContext.transfer_async`). The ``test_gds_*_roundtrip`` tests
-exercise the real cuFile DMA path and are skipped unless CUDA + nvidia-fs
-(real GDS) are present.
+exercise the real GDS DMA path (cuFile on NVIDIA, hipFile on AMD ROCm) and are
+skipped unless that stack is present (see :func:`_gds_available`).
 """
 
 # Standard
@@ -23,7 +23,7 @@ from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.distributed.config import GdsL1Config
 from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.memory_manager import GDSL1MemoryManager
-from lmcache.v1.gpu_connector import _cufile_async as ca
+from lmcache.v1.gpu_connector import _gds_async as ca
 from lmcache.v1.gpu_connector.gds_context import (
     GDSContext,
     SlabDirection,
@@ -37,9 +37,32 @@ def _fake_stream(handle: int):
     return SimpleNamespace(cuda_stream=handle, synchronize=lambda: None)
 
 
+def _gds_available() -> bool:
+    """Whether a real GPUDirect Storage stack is present for the roundtrip tests.
+
+    NVIDIA: CUDA plus the nvidia-fs kernel module (``/proc/driver/nvidia-fs``).
+    AMD ROCm: a loadable ``libhipfile.so`` (the hipFile GPU IO library). When
+    the GDS-capable driver/filesystem is absent hipFile still round-trips
+    correctly via its host-bounce fallback, so library loadability is a
+    sufficient gate for the correctness checks below.
+    """
+    if not torch.cuda.is_available():
+        return False
+    if torch.version.hip is not None:
+        # Standard
+        import ctypes
+
+        try:
+            ctypes.CDLL("libhipfile.so")
+        except OSError:
+            return False
+        return True
+    return os.path.exists("/proc/driver/nvidia-fs/stats")
+
+
 requires_gds = pytest.mark.skipif(
-    not (torch.cuda.is_available() and os.path.exists("/proc/driver/nvidia-fs/stats")),
-    reason="needs CUDA + nvidia-fs (real GPUDirect Storage)",
+    not _gds_available(),
+    reason="needs CUDA + nvidia-fs or ROCm + libhipfile.so (real GPUDirect Storage)",
 )
 
 

--- a/tests/v1/gpu_connector/test_hipfile_async.py
+++ b/tests/v1/gpu_connector/test_hipfile_async.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the hipFile async wrapper (``_hipfile_async``).
+
+These are pure: ``libhipfile.so`` is never dlopened. A fake lib (see
+:class:`_FakeLib`) is substituted at the ``_lib`` seam, so the tests exercise
+the Python logic of the ctypes wrapper -- ``hipFileDescr_t`` construction, the
+stream-register flag value, error decoding, :class:`Submission` lifetime, and
+which symbol each call dispatches to -- without a GPU or the ROCm GPU IO
+driver. The ctypes ABI itself (struct field offsets, argtype marshalling) is
+covered by the on-hardware roundtrip tests in ``test_gds_context.py``.
+"""
+
+# Standard
+from types import SimpleNamespace
+import ctypes
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.gpu_connector import _hipfile_async as ha
+
+
+def _ok() -> ha._HipFileError:
+    """A success ``hipFileError_t`` (err == hipFileSuccess)."""
+    return ha._HipFileError(err=ha._HIPFILE_SUCCESS, hip_drv_err=0)
+
+
+def _err(code: int = 5001) -> ha._HipFileError:
+    """A failure ``hipFileError_t``."""
+    return ha._HipFileError(err=code, hip_drv_err=0)
+
+
+class _FakeLib:
+    """Stand-in for the ``libhipfile.so`` CDLL.
+
+    Each hipFile symbol records its positional args in :attr:`calls` and returns
+    a success ``hipFileError_t`` by default. Tests override individual symbols
+    (e.g. to populate an out-param or force an error) by assigning attributes.
+    """
+
+    def __init__(self) -> None:
+        self.calls: dict[str, tuple] = {}
+
+    def __getattr__(self, name: str):
+        # Any hipFile* symbol not explicitly overridden records its args and
+        # succeeds. ``__getattr__`` only fires for names not set in __dict__.
+        def _record(*args):
+            self.calls[name] = args
+            if name == "hipFileGetOpErrorString":
+                return b"hipFileFakeError"
+            return _ok()
+
+        return _record
+
+
+@pytest.fixture(autouse=True)
+def _fake_lib(monkeypatch) -> _FakeLib:
+    """Replace the ``_lib`` seam with a fake and reset module driver state."""
+    lib = _FakeLib()
+    monkeypatch.setattr(ha, "_lib", lambda: lib)
+    monkeypatch.setattr(ha, "_driver_opened", False)
+    return lib
+
+
+def _fake_gpu_tensor(ptr: int = 0x1000, nbytes: int = 4096):
+    """A duck-typed stand-in for a CUDA ``torch.Tensor`` (no GPU needed)."""
+    return SimpleNamespace(
+        is_cuda=True,
+        data_ptr=lambda: ptr,
+        numel=lambda: nbytes,
+        element_size=lambda: 1,
+    )
+
+
+class TestCheck:
+    def test_success_is_noop(self):
+        ha._check(_ok(), "op")
+
+    def test_nonzero_raises_with_code_and_name(self, _fake_lib):
+        with pytest.raises(RuntimeError) as exc:
+            ha._check(_err(5002), "hipFileDriverOpen")
+        msg = str(exc.value)
+        assert "hipFileDriverOpen" in msg
+        assert "5002" in msg
+        # The op-error string is resolved through the lib.
+        assert "hipFileFakeError" in msg
+
+
+class TestDriverLifecycle:
+    def test_ensure_open_calls_driver_open_once(self, _fake_lib):
+        ha._ensure_driver_open()
+        ha._ensure_driver_open()
+        # Recorded means it was called; idempotency guarded by _driver_opened.
+        assert "hipFileDriverOpen" in _fake_lib.calls
+        assert ha._driver_opened is True
+
+    def test_close_driver_when_open(self, _fake_lib):
+        ha._ensure_driver_open()
+        ha.close_driver()
+        assert "hipFileDriverClose" in _fake_lib.calls
+        assert ha._driver_opened is False
+
+    def test_close_driver_noop_when_closed(self, _fake_lib):
+        ha.close_driver()
+        assert "hipFileDriverClose" not in _fake_lib.calls
+
+
+class TestRegisterHandle:
+    def test_builds_opaque_fd_descr_and_returns_handle(self, _fake_lib):
+        captured = {}
+
+        def _register(fh_ref, descr_ref):
+            descr = descr_ref._obj
+            captured["type"] = descr.type
+            captured["fd"] = descr.handle.fd
+            # Populate the out-param like the real driver would.
+            fh_ref._obj.value = 0xDEADBEEF
+            return _ok()
+
+        _fake_lib.hipFileHandleRegister = _register
+        handle = ha.register_handle(42)
+        assert handle == 0xDEADBEEF
+        assert captured["type"] == ha._HIPFILE_HANDLE_TYPE_OPAQUE_FD
+        assert captured["fd"] == 42
+
+    def test_register_handle_opens_driver(self, _fake_lib):
+        ha.register_handle(7)
+        assert "hipFileDriverOpen" in _fake_lib.calls
+
+    def test_deregister_handle_dispatches(self, _fake_lib):
+        ha.deregister_handle(0x1234)
+        assert "hipFileHandleDeregister" in _fake_lib.calls
+
+
+class TestBufferRegistration:
+    def test_rejects_non_gpu_tensor(self):
+        cpu = SimpleNamespace(is_cuda=False)
+        with pytest.raises(ValueError):
+            ha.register_buffer(cpu)
+
+    def test_register_buffer_passes_size(self, _fake_lib):
+        ha.register_buffer(_fake_gpu_tensor(ptr=0x2000, nbytes=8192))
+        base, length, flags = _fake_lib.calls["hipFileBufRegister"]
+        assert base.value == 0x2000
+        assert length.value == 8192
+
+    def test_deregister_buffer_dispatches(self, _fake_lib):
+        ha.deregister_buffer(_fake_gpu_tensor(ptr=0x2000))
+        (base,) = _fake_lib.calls["hipFileBufDeregister"]
+        assert base.value == 0x2000
+
+
+class TestStreamRegistration:
+    def test_register_stream_uses_fixed_flags(self, _fake_lib):
+        ha.register_stream(0xABC)
+        stream, flags = _fake_lib.calls["hipFileStreamRegister"]
+        assert stream.value == 0xABC
+        # FIXED_BUF_OFFSET | FIXED_FILE_OFFSET | FIXED_FILE_SIZE.
+        assert flags == 0x7
+
+    def test_deregister_stream_dispatches(self, _fake_lib):
+        ha.register_stream(0xABC)
+        ha.deregister_stream(0xABC)
+        (stream,) = _fake_lib.calls["hipFileStreamDeregister"]
+        assert stream.value == 0xABC
+
+
+class TestSubmission:
+    def test_bytes_done_defaults_zero_then_reflects_driver(self):
+        sub = ha.Submission(size=4096, file_offset=0, buf_offset=0)
+        assert sub.bytes_done == 0
+        sub._bytes_done.value = 4096
+        assert sub.bytes_done == 4096
+
+
+class TestAsyncHandleIO:
+    def _handle(self) -> ha.AsyncHandle:
+        return ha.AsyncHandle.from_fd(fd=5, handle=0xFEED, path="/slab", writable=True)
+
+    def test_read_async_dispatches_and_returns_submission(self, _fake_lib):
+        def _read(fh, buf, size_p, foff_p, boff_p, bytes_p, stream):
+            # Driver reports the byte count into the caller's storage.
+            bytes_p._obj.value = 4096
+            _fake_lib.calls["hipFileReadAsync"] = (fh, buf, stream)
+            return _ok()
+
+        _fake_lib.hipFileReadAsync = _read
+        h = self._handle()
+        sub = h.read_async(
+            buf_base=0x3000, size=4096, file_offset=0, buf_offset=0, raw_stream=0x9
+        )
+        fh, buf, stream = _fake_lib.calls["hipFileReadAsync"]
+        assert fh.value == 0xFEED
+        assert buf.value == 0x3000
+        assert stream.value == 0x9
+        assert sub.bytes_done == 4096
+
+    def test_write_async_dispatches(self, _fake_lib):
+        h = self._handle()
+        sub = h.write_async(
+            buf_base=0x3000, size=2048, file_offset=512, buf_offset=0, raw_stream=0x9
+        )
+        assert "hipFileWriteAsync" in _fake_lib.calls
+        assert isinstance(sub, ha.Submission)
+
+    def test_io_error_raises(self, _fake_lib):
+        _fake_lib.hipFileWriteAsync = lambda *a: _err(5023)
+        h = self._handle()
+        with pytest.raises(RuntimeError) as exc:
+            h.write_async(
+                buf_base=0x3000, size=2048, file_offset=0, buf_offset=0, raw_stream=0x9
+            )
+        assert "hipFileWriteAsync" in str(exc.value)
+
+
+class TestStructLayout:
+    """Guard the ctypes structs against the hipfile.h C ABI (LP64)."""
+
+    def test_error_struct_size(self):
+        assert ctypes.sizeof(ha._HipFileError) == 8
+
+    def test_descr_struct_layout(self):
+        assert ctypes.sizeof(ha._HipFileDescr) == 24
+        assert ha._HipFileDescr.type.offset == 0
+        assert ha._HipFileDescr.handle.offset == 8
+        assert ha._HipFileDescr.fs_ops.offset == 16


### PR DESCRIPTION
**What this PR does / why we need it**:

The GDS L1 slab-file tier added in #3589 reaches storage via NVIDIA cuFile (ctypes against `libcufile.so`). This PR adds the AMD ROCm analog, [ROCm/hipFile](https://github.com/ROCm/hipFile) ("AMD Infinity Storage"), so the GDS L1 tier works on AMD GPUs. hipFile mirrors the cuFile async surface 1:1 (every symbol the tier uses has a `hipFile*` equivalent since ROCm 7.2.0), so this is a backend mirror rather than a redesign.

Changes:
- **`_hipfile_async.py`** (new) — ctypes wrapper over `libhipfile.so` mirroring `_cufile_async`'s surface (`register_buffer`/`register_stream`/`register_handle`/`AsyncHandle`/`Submission`). hipFile ships no Python binding, so the driver lifecycle, handle/buffer/stream registration, and the `hipFileError_t` / `hipFileDescr_t` structs are bound directly via ctypes.
- **`_gds_async.py`** (new) — dispatch shim that re-exports the cuFile or hipFile backend based on `torch.version.hip`. `gds_context` imports it as `ca` and is now platform-agnostic.
- **`_cufile_async.py`** — factored `cuFileHandleRegister`/`Deregister` into `register_handle`/`deregister_handle` so both backends expose an identical surface. No behavior change on NVIDIA.
- **`gds_context.py`** — registers the slab handle through the dispatch shim instead of importing `cufile.bindings` directly.

**Special notes for your reviewers**:

- The cuFile path is functionally unchanged; the only refactor is moving handle (de)registration behind `register_handle`/`deregister_handle`, which the existing `AsyncHandle` now also uses.
- The `requires_gds` guard in `test_gds_context.py` was generalized to `_gds_available()` (CUDA + nvidia-fs, **or** ROCm + a loadable `libhipfile.so`). The existing roundtrip tests are backend-agnostic and exercise hipFile on AMD unchanged.
- hipFile must be built with `amdclang++` and C++20 (`std::bit_cast`); only Ubuntu 24.04 / el9 / openSUSE packages are published today.

**Validation** — built `libhipfile.so` from source and ran on two AMD nodes:

| | MI350X (gfx950, ROCm 7.2) | MI300X (gfx942) |
|---|---|---|
| `test_hipfile_async.py` | 19/19 pass | 19/19 pass |
| GDS roundtrip (write/read, two-stream, >16 MiB split) | 3/3 pass | 3/3 pass |
| hipFile mode | compat | compat |

The roundtrips run the full `GDSContext → _gds_async → _hipfile_async → libhipfile.so → GPU↔slab` path including a position-dependent pattern across the 16 MiB region boundary, confirming data integrity on both architectures. Both nodes ran in hipFile **compat mode**; the zero-copy P2PDMA fast path is pending bare-metal hardware with `CONFIG_PCI_P2PDMA` + `amdgpu-dkms >= 30.20.1` + a local ext4/xfs NVMe.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests