### PR TITLE
[Operator] Add configurable hostNetwork field to LMCacheEngine CRD

### DIFF
--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -388,6 +388,13 @@ type LMCacheEngineSpec struct {
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
+	// hostNetwork runs the pod in the host's network namespace. When true the
+	// operator also sets dnsPolicy to ClusterFirstWithHostNet so cluster DNS
+	// still works. Default: false.
+	// +optional
+	// +kubebuilder:default=false
+	HostNetwork *bool `json:"hostNetwork,omitempty"`
+
 	// extraArgs are additional CLI flags appended to the server command.
 	// They are appended last and can override any auto-generated flag.
 	// +optional

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -880,6 +880,11 @@ func (in *LMCacheEngineSpec) DeepCopyInto(out *LMCacheEngineSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.HostNetwork != nil {
+		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ExtraArgs != nil {
 		in, out := &in.ExtraArgs, &out.ExtraArgs
 		*out = make([]string, len(*in))

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -1216,6 +1216,13 @@ spec:
                 - nvidia
                 - amd
                 type: string
+              hostNetwork:
+                default: false
+                description: |-
+                  hostNetwork runs the pod in the host's network namespace. When true the
+                  operator also sets dnsPolicy to ClusterFirstWithHostNet so cluster DNS
+                  still works. Default: false.
+                type: boolean
               image:
                 description: image defines the container image to use.
                 properties:

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -257,8 +257,8 @@ func buildDaemonSetCore(
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					HostIPC:     true,
-					HostNetwork: derefBool(spec.HostNetwork, false),
+					HostIPC:            true,
+					HostNetwork:        derefBool(spec.HostNetwork, false),
 					RuntimeClassName:   runtimeClassName,
 					ServiceAccountName: spec.ServiceAccountName,
 					PriorityClassName:  spec.PriorityClassName,

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -257,7 +257,8 @@ func buildDaemonSetCore(
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					HostIPC:            true,
+					HostIPC:     true,
+					HostNetwork: derefBool(spec.HostNetwork, false),
 					RuntimeClassName:   runtimeClassName,
 					ServiceAccountName: spec.ServiceAccountName,
 					PriorityClassName:  spec.PriorityClassName,
@@ -288,6 +289,10 @@ func buildDaemonSetCore(
 				},
 			},
 		},
+	}
+
+	if derefBool(spec.HostNetwork, false) {
+		ds.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 
 	return ds

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -1136,6 +1136,22 @@ func TestBuildDaemonSet_GPUVendorAMD(t *testing.T) {
 	}
 }
 
+func TestBuildDaemonSet_HostNetworkEnabled(t *testing.T) {
+	engine := minimalEngine()
+	engine.Spec.HostNetwork = ptr(true)
+	engine.SetDefaults()
+
+	ds := BuildDaemonSet(engine)
+	podSpec := ds.Spec.Template.Spec
+
+	if !podSpec.HostNetwork {
+		t.Fatal("expected HostNetwork=true")
+	}
+	if podSpec.DNSPolicy != corev1.DNSClusterFirstWithHostNet {
+		t.Fatalf("expected DNSPolicy=ClusterFirstWithHostNet, got %s", podSpec.DNSPolicy)
+	}
+}
+
 // hasEnvAll reports whether envs contains an env var named name set to the
 // literal "all" (the value the GPU passthrough vars are always set to).
 func hasEnvAll(envs []corev1.EnvVar, name string) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an optional `hostNetwork` field (`*bool`, default `false`) to the `LMCacheEngineSpec` CRD. When set to `true`, the engine DaemonSet pods run in the host's network namespace — useful for environments where host networking is required for performance or connectivity.

The operator automatically sets `dnsPolicy: ClusterFirstWithHostNet` when `hostNetwork` is enabled so that cluster DNS resolution continues to work.

**Changes:**
- `api/v1alpha1/lmcacheengine_types.go` — new `HostNetwork *bool` field with `+kubebuilder:default=false`
- `internal/resources/daemonset.go` — wire `HostNetwork` + conditional `DNSPolicy` in `buildDaemonSetCore()`
- `internal/resources/resources_test.go` — test for `HostNetwork=true` asserting both `HostNetwork` and `DNSPolicy`
- CRD manifest + deepcopy regenerated via `make manifests generate`

**Special notes for your reviewers**:

- `hostNetwork` is only applied to the LMCacheEngine DaemonSet, not to CacheBlendEngine or webhook-injected vLLM pods.
- The existing `HostNetwork=false` assertion in `TestBuildDaemonSet_Minimal` already covers the default case.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests