### PR TITLE
fix(xpu): Use two-stage transfer to prevent GPU hang on XPU devices

### DIFF
--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -190,17 +190,39 @@ class VLLMPagedMemXPUConnectorV2(GPUConnectorInterface):
         vllm_cached = kwargs.get("vllm_cached_tokens", 0)
         skip_prefix_n_tokens = min(end - start, max(0, vllm_cached - start))
 
-        lmc_ops.multi_layer_kv_transfer(
-            memory_obj.tensor,
-            kv_cache_pointers,
-            slot_mapping[start:end],
-            self.device,
-            self.page_buffer_size,
-            lmc_ops.TransferDirection.H2D,
-            self.engine_kv_format,
-            self.block_size,
-            skip_prefix_n_tokens,
-        )
+        if self.gpu_buffer is None or end - start != self.gpu_buffer.shape[2]:
+            lmc_ops.multi_layer_kv_transfer(
+                memory_obj.tensor,
+                kv_cache_pointers,
+                slot_mapping[start:end],
+                self.device,
+                self.page_buffer_size,
+                lmc_ops.TransferDirection.H2D,
+                self.engine_kv_format,
+                self.block_size,
+                skip_prefix_n_tokens,
+            )
+        else:
+            # memobj -> gpu_buffer -> kvcaches
+            # Stage the host-resident memory object into the device
+            # intermediate buffer first, then run the XPU transfer kernel
+            # reading from that device buffer. The SYCL kernel can only
+            # safely access device (USM) memory; reading the host pool
+            # tensor directly causes a GPU hang / DEVICE_LOST on XPU.
+            assert self.gpu_buffer.device == self.device
+            tmp_gpu_buffer = self.gpu_buffer[:, :, : end - start, :]
+            tmp_gpu_buffer.copy_(memory_obj.tensor, non_blocking=True)
+            lmc_ops.multi_layer_kv_transfer(
+                tmp_gpu_buffer,
+                kv_cache_pointers,
+                slot_mapping[start:end],
+                self.device,
+                self.page_buffer_size,
+                lmc_ops.TransferDirection.H2D,
+                self.engine_kv_format,
+                self.block_size,
+                skip_prefix_n_tokens,
+            )
 
     @_lmcache_nvtx_annotate
     def from_gpu(self, memory_obj: MemoryObj, start: int, end: int, **kwargs):


### PR DESCRIPTION
The SYCL kernel on Intel XPU can only safely access device (USM) memory. Direct access to host pool tensors causes GPU hang / DEVICE_LOST.

This change adds a two-stage transfer path when gpu_buffer is available:
1. Stage host memory to device intermediate buffer
2. Run XPU transfer kernel reading from device buffer

Falls back to direct transfer when gpu_buffer is unavailable or size mismatches.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
