### PR TITLE
Add built-in GCS remote storage connector

### DIFF
--- a/docs/source/developer_guide/extending_lmcache/remote_storage_plugins.rst
+++ b/docs/source/developer_guide/extending_lmcache/remote_storage_plugins.rst
@@ -2,7 +2,7 @@ Remote Storage Plugins
 ========================
 
 LMCache supports built-in remote storage connectors for Redis, InfiniStore,
-MooncakeStore, S3, Hugging Face Buckets, and more.
+MooncakeStore, S3, Google Cloud Storage, Hugging Face Buckets, and more.
 The remote storage plugin system provides the ability to add custom storage connectors through dynamic loading. This enables extending remote storage capabilities without modifying core code.
 
 .. note::
@@ -42,7 +42,7 @@ The framework extracts the *type* portion (everything before the first ``.``) to
 
 Using Built-in Connectors via Plugins
 -------------------------------------
-Built-in connectors (``fs``, ``mooncakestore``, ``hfbucket``, etc.) can be used
+Built-in connectors (``fs``, ``mooncakestore``, ``gcs``, ``hfbucket``, etc.) can be used
 directly via ``remote_storage_plugins`` without specifying ``module_path`` or
 ``class_name``. Their configuration is placed under ``extra_config``:
 
@@ -81,6 +81,16 @@ Built-in Hugging Face Buckets example:
     extra_config:
       remote_storage_plugin.hfbucket.bucket_handle: hf://buckets/my-org/lmcache-kv/prod
       remote_storage_plugin.hfbucket.token_env: HF_TOKEN
+
+Built-in Google Cloud Storage example:
+
+.. code-block:: yaml
+
+    remote_storage_plugins: ["gcs"]
+    extra_config:
+      remote_storage_plugin.gcs.bucket_uri: gs://my-lmcache-bucket/prod
+      remote_storage_plugin.gcs.project: my-gcp-project
+      remote_storage_plugin.gcs.credentials_path: /etc/gcp/service-account.json
 
 How to Integrate Custom Remote Storage with LMCache
 ---------------------------------------------------

--- a/docs/source/kv_cache/storage_backends/gcs.rst
+++ b/docs/source/kv_cache/storage_backends/gcs.rst
@@ -1,0 +1,107 @@
+Google Cloud Storage Backend
+============================
+
+The Google Cloud Storage (GCS) backend stores LMCache chunks in a GCS bucket
+using LMCache's built-in remote storage plugin framework. This is a persistent
+remote backend suited to warm and cold KV cache persistence rather than the
+lowest-latency hot tier.
+
+When to use it
+--------------
+
+Use the GCS backend when you want:
+
+* A managed object store for persistent KV cache data.
+* A built-in backend configured through ``remote_storage_plugins``.
+* Multiple named GCS-backed instances in one LMCache deployment.
+
+Avoid using it as the primary hot path for the lowest-latency cache lookups.
+Local CPU, local disk, and other lower-latency backends are a better fit for
+the hottest cache tier.
+
+
+Requirements and limitations
+----------------------------
+
+* LMCache uses the ``google-cloud-storage`` Python client for uploads,
+  downloads, listing, and deletes.
+* The phase-1 built-in release is intentionally conservative:
+
+  * Only full chunks are supported.
+  * Partial chunk uploads are rejected.
+  * Downloads are rejected when the stored object size does not match the
+    expected full LMCache chunk size.
+  * Chunk metadata is not stored alongside the GCS objects.
+
+
+Minimal configuration
+---------------------
+
+.. code-block:: yaml
+
+   chunk_size: 256
+   local_cpu: false
+   save_unfull_chunk: false
+   remote_serde: "naive"
+   blocking_timeout_secs: 10
+   remote_storage_plugins: ["gcs"]
+   extra_config:
+     remote_storage_plugin.gcs.bucket_uri: "gs://my-lmcache-bucket/prod"
+     remote_storage_plugin.gcs.project: "my-gcp-project"
+     remote_storage_plugin.gcs.credentials_path: "/etc/gcp/service-account.json"
+     remote_storage_plugin.gcs.metadata_cache_ttl_secs: 30
+
+
+Multiple instances
+------------------
+
+Use instance-qualified plugin names to configure more than one bucket-backed
+remote store in the same LMCache config.
+
+.. code-block:: yaml
+
+   remote_storage_plugins: ["gcs.us", "gcs.eu"]
+   extra_config:
+     remote_storage_plugin.gcs.us.bucket_uri: "gs://lmcache-us/prod"
+     remote_storage_plugin.gcs.us.project: "project-us"
+     remote_storage_plugin.gcs.eu.bucket_uri: "gs://lmcache-eu/prod"
+     remote_storage_plugin.gcs.eu.project: "project-eu"
+
+
+Configuration reference
+-----------------------
+
+All configuration keys live under
+``extra_config.remote_storage_plugin.<plugin_name>.*`` where ``plugin_name`` is
+either ``gcs`` or an instance-qualified name such as ``gcs.prod``.
+
+* ``bucket_uri`` (required): GCS bucket URI in ``gs://<bucket>[/<prefix>]``
+  format.
+* ``project`` (optional): GCP project override passed to the storage client.
+  Leave unset to rely on Application Default Credentials project resolution.
+* ``credentials_path`` (optional): Service-account JSON path passed to the
+  storage client. Leave unset to use Application Default Credentials.
+* ``metadata_cache_ttl_secs`` (optional, default ``30``): TTL for cached exact
+  existence and size metadata.
+
+
+Authentication
+--------------
+
+The connector works with either:
+
+* **Application Default Credentials (recommended):** omit
+  ``credentials_path`` and let the GCS client resolve credentials from the
+  runtime environment.
+* **Explicit service-account JSON:** set ``credentials_path`` when the LMCache
+  process must use a specific credential file.
+
+
+Notes
+-----
+
+* The backend stores objects under the configured GCS prefix using a reversible
+  encoding of LMCache keys, so ``list()`` returns LMCache key strings instead
+  of raw object names.
+* This built-in connector is non-MP only. MP GCS L2 adapter work is out of
+  scope for this release.

--- a/docs/source/kv_cache/storage_backends/index.rst
+++ b/docs/source/kv_cache/storage_backends/index.rst
@@ -15,6 +15,7 @@ Supported Backends
    eic
    fs
    gds
+   gcs
    hfbucket
    infinistore
    local_storage

--- a/lmcache/v1/storage_backend/connector/gcs_adapter.py
+++ b/lmcache/v1/storage_backend/connector/gcs_adapter.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.storage_backend.connector import (
+    ConnectorAdapter,
+    ConnectorContext,
+    extract_plugin_type,
+)
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+
+# Local
+from .gcs_connector import GCSConnector, resolve_gcs_connector_config
+
+logger = init_logger(__name__)
+
+PLUGIN_TYPE = "gcs"
+
+
+class GCSConnectorAdapter(ConnectorAdapter):
+    """Adapter for Google Cloud Storage remote connectors."""
+
+    def __init__(self) -> None:
+        super().__init__("plugin://")
+
+    def can_parse(self, url: str) -> bool:
+        """Match plugin URLs for the built-in ``gcs`` connector type."""
+        if not url.startswith(self.schema):
+            return False
+        plugin_name = url[len(self.schema) :]
+        return extract_plugin_type(plugin_name) == PLUGIN_TYPE
+
+    def create_connector(self, context: ConnectorContext) -> RemoteConnector:
+        """Create a configured ``GCSConnector`` for the given context."""
+        if context.config is None:
+            raise ValueError("config is required for GCSConnector")
+        if context.metadata is None:
+            raise ValueError("metadata is required for GCSConnector")
+
+        plugin_name = context.plugin_name or PLUGIN_TYPE
+        connector_config = resolve_gcs_connector_config(
+            context.config,
+            plugin_name=plugin_name,
+        )
+        logger.info(
+            "Creating GCS connector for plugin %s and bucket %s",
+            plugin_name,
+            connector_config.bucket_location.bucket_name,
+        )
+        return GCSConnector(
+            local_cpu_backend=context.local_cpu_backend,
+            config=context.config,
+            metadata=context.metadata,
+            connector_config=connector_config,
+        )

--- a/lmcache/v1/storage_backend/connector/gcs_connector.py
+++ b/lmcache/v1/storage_backend/connector/gcs_connector.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import Protocol
 from urllib.parse import quote, unquote
-import asyncio
 import builtins
 
 # First Party
@@ -196,7 +195,7 @@ class GCSConnector(RemoteConnector):
 
     async def exists(self, key: CacheEngineKey) -> bool:
         """Return whether a full LMCache chunk exists for ``key``."""
-        return await asyncio.to_thread(self.exists_sync, key)
+        return self.exists_sync(key)
 
     def exists_sync(self, key: CacheEngineKey) -> bool:
         """Synchronously return whether a full LMCache chunk exists."""
@@ -214,7 +213,7 @@ class GCSConnector(RemoteConnector):
 
     async def list(self) -> builtins.list[str]:
         """List LMCache keys currently stored under this connector prefix."""
-        return await asyncio.to_thread(self._list_sync)
+        return self._list_sync()
 
     async def close(self) -> None:
         """Release connector-local resources."""
@@ -227,7 +226,7 @@ class GCSConnector(RemoteConnector):
 
     async def ping(self) -> int:
         """Check access to the configured bucket."""
-        return await asyncio.to_thread(self._ping_sync)
+        return self._ping_sync()
 
     def support_batched_put(self) -> bool:
         """Report support for batched uploads."""
@@ -243,7 +242,18 @@ class GCSConnector(RemoteConnector):
             raise ValueError(
                 "keys and memory_objs must have the same length for batched_put"
             )
-        await asyncio.to_thread(self._batched_put_sync, keys, memory_objs)
+
+        upload_entries: builtins.list[tuple[str, bytes]] = []
+        try:
+            for key, memory_obj in zip(keys, memory_objs, strict=True):
+                key_str = key.to_string()
+                self._validate_full_chunk_for_upload(key_str, memory_obj)
+                upload_entries.append((key_str, bytes(memory_obj.byte_array)))
+
+            self._batched_put_sync(upload_entries)
+        finally:
+            for memory_obj in memory_objs:
+                memory_obj.ref_count_down()
 
     def support_batched_get(self) -> bool:
         """Report support for batch downloads."""
@@ -258,7 +268,7 @@ class GCSConnector(RemoteConnector):
             return []
 
         key_strings = [key.to_string() for key in keys]
-        object_sizes = await asyncio.to_thread(self._resolve_object_sizes, key_strings)
+        object_sizes = self._resolve_object_sizes(key_strings)
         results: builtins.list[MemoryObj | None] = [None] * len(keys)
 
         try:
@@ -277,8 +287,7 @@ class GCSConnector(RemoteConnector):
                     )
                     continue
 
-                data = await asyncio.to_thread(
-                    self._gcs_client.download_blob,
+                data = self._gcs_client.download_blob(
                     self.bucket_name,
                     self._key_string_to_object_path(key_str),
                 )
@@ -352,7 +361,7 @@ class GCSConnector(RemoteConnector):
         """Asynchronously return the number of consecutive prefix hits."""
         del lookup_id
         del pin
-        return await asyncio.to_thread(self.batched_contains, keys)
+        return self.batched_contains(keys)
 
     def support_batched_get_non_blocking(self) -> bool:
         """Report support for non-blocking batch loads."""
@@ -411,20 +420,17 @@ class GCSConnector(RemoteConnector):
 
     def _batched_put_sync(
         self,
-        keys: Sequence[CacheEngineKey],
-        memory_objs: Sequence[MemoryObj],
+        upload_entries: Sequence[tuple[str, bytes]],
     ) -> None:
         """Upload all provided chunks."""
         self._ensure_bucket_for_writes()
         uploaded_key_strings: builtins.list[str] = []
         try:
-            for key, memory_obj in zip(keys, memory_objs, strict=True):
-                key_str = key.to_string()
-                self._validate_full_chunk_for_upload(key_str, memory_obj)
+            for key_str, payload in upload_entries:
                 self._gcs_client.upload_blob(
                     self.bucket_name,
                     self._key_string_to_object_path(key_str),
-                    bytes(memory_obj.byte_array),
+                    payload,
                 )
                 uploaded_key_strings.append(key_str)
                 self._set_cached_object_size(key_str, self.full_chunk_size_bytes)
@@ -581,7 +587,19 @@ class GCSConnector(RemoteConnector):
 
 
 def parse_gcs_bucket_handle(bucket_handle: str) -> GCSLocation:
-    """Parse ``gs://bucket[/prefix]`` into bucket name and object prefix."""
+    """Parse a GCS bucket handle into bucket and prefix components.
+
+    Args:
+        bucket_handle: Bucket handle in ``gs://<bucket>[/<prefix>]`` form.
+
+    Returns:
+        A :class:`GCSLocation` containing the bucket name and optional object
+        prefix.
+
+    Raises:
+        ValueError: If ``bucket_handle`` does not start with ``gs://`` or does
+            not include a bucket name.
+    """
     normalized_handle = bucket_handle.strip()
     if not normalized_handle.startswith(_GCS_HANDLE_PREFIX):
         raise ValueError("bucket_handle must start with 'gs://' for the gcs plugin")
@@ -601,7 +619,18 @@ def resolve_gcs_connector_config(
     config: LMCacheEngineConfig,
     plugin_name: str,
 ) -> GCSConnectorConfig:
-    """Resolve plugin-scoped configuration for the GCS connector."""
+    """Resolve the plugin-scoped configuration for a GCS connector.
+
+    Args:
+        config: Engine configuration containing ``extra_config`` overrides.
+        plugin_name: Fully-qualified remote storage plugin name.
+
+    Returns:
+        A :class:`GCSConnectorConfig` built from the plugin-specific settings.
+
+    Raises:
+        ValueError: If the required bucket handle setting is missing or invalid.
+    """
     extra_config = config.extra_config or {}
     config_prefix = f"remote_storage_plugin.{plugin_name}"
 
@@ -636,12 +665,26 @@ def resolve_gcs_connector_config(
 
 
 def encode_gcs_object_name(key_str: str) -> str:
-    """Encode a serialized LMCache key into a reversible GCS object name."""
+    """Encode a serialized LMCache key into a reversible GCS object name.
+
+    Args:
+        key_str: Serialized LMCache key string.
+
+    Returns:
+        A percent-encoded object name safe to use in GCS paths.
+    """
     return quote(key_str, safe="")
 
 
 def decode_gcs_object_name(object_name: str) -> str:
-    """Decode a reversible GCS object name back into an LMCache key string."""
+    """Decode a reversible GCS object name back into an LMCache key string.
+
+    Args:
+        object_name: Percent-encoded GCS object name.
+
+    Returns:
+        The decoded serialized LMCache key string.
+    """
     return unquote(object_name)
 
 

--- a/lmcache/v1/storage_backend/connector/gcs_connector.py
+++ b/lmcache/v1/storage_backend/connector/gcs_connector.py
@@ -1,0 +1,684 @@
+# SPDX-License-Identifier: Apache-2.0
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Sequence
+from copy import copy
+from dataclasses import dataclass
+from threading import Lock
+from typing import Protocol
+from urllib.parse import quote, unquote
+import asyncio
+import builtins
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+logger = init_logger(__name__)
+
+PLUGIN_TYPE = "gcs"
+_GCS_HANDLE_PREFIX = "gs://"
+
+
+@dataclass(frozen=True)
+class GCSLocation:
+    """Parsed Google Cloud Storage location."""
+
+    bucket_name: str
+    object_prefix: str
+
+
+@dataclass(frozen=True)
+class GCSConnectorConfig:
+    """Resolved GCS connector configuration."""
+
+    plugin_name: str
+    bucket_location: GCSLocation
+    project: str | None
+    credentials_path: str | None
+    create_bucket_if_missing: bool
+    metadata_cache_ttl_secs: float
+
+
+@dataclass(frozen=True)
+class _CachedObjectMetadata:
+    """Cached object size entry with expiration metadata."""
+
+    size_bytes: int
+    expires_at: float
+
+
+class GCSClientInterface(Protocol):
+    """Protocol for GCS client implementations used by the connector."""
+
+    def ensure_bucket(self, bucket_name: str) -> None:
+        """Ensure the bucket exists."""
+
+    def bucket_exists(self, bucket_name: str) -> bool:
+        """Return whether the bucket exists and is reachable."""
+
+    def get_blob_size(self, bucket_name: str, blob_name: str) -> int:
+        """Return blob size in bytes or ``0`` when missing."""
+
+    def list_blobs(self, bucket_name: str, prefix: str) -> list[str]:
+        """List blob names under ``prefix``."""
+
+    def upload_blob(self, bucket_name: str, blob_name: str, payload: bytes) -> None:
+        """Upload blob bytes."""
+
+    def download_blob(self, bucket_name: str, blob_name: str) -> bytes | None:
+        """Download blob bytes or ``None`` when missing."""
+
+    def delete_blob(self, bucket_name: str, blob_name: str) -> bool:
+        """Delete a blob. Return ``True`` when deleted or already absent."""
+
+
+class GCSClient(GCSClientInterface):
+    """Thin synchronous wrapper around ``google-cloud-storage``."""
+
+    def __init__(
+        self,
+        *,
+        project: str | None = None,
+        credentials_path: str | None = None,
+    ) -> None:
+        # Third Party
+        from google.cloud import storage
+
+        client_kwargs: dict[str, object] = {}
+        if project:
+            client_kwargs["project"] = project
+        if credentials_path:
+            # Third Party
+            from google.oauth2 import service_account
+
+            client_kwargs["credentials"] = (
+                service_account.Credentials.from_service_account_file(credentials_path)
+            )
+
+        self._client = storage.Client(**client_kwargs)
+
+    def ensure_bucket(self, bucket_name: str) -> None:
+        """Create the bucket when it does not already exist."""
+        if self._client.lookup_bucket(bucket_name) is not None:
+            return
+        self._client.create_bucket(bucket_name)
+
+    def bucket_exists(self, bucket_name: str) -> bool:
+        """Return whether the bucket currently exists."""
+        return self._client.lookup_bucket(bucket_name) is not None
+
+    def get_blob_size(self, bucket_name: str, blob_name: str) -> int:
+        """Return blob size in bytes or ``0`` when missing."""
+        blob = self._client.bucket(bucket_name).get_blob(blob_name)
+        if blob is None:
+            return 0
+        size = getattr(blob, "size", 0)
+        return int(size) if size is not None else 0
+
+    def list_blobs(self, bucket_name: str, prefix: str) -> list[str]:
+        """List blob names for the provided prefix."""
+        return [
+            blob.name for blob in self._client.list_blobs(bucket_name, prefix=prefix)
+        ]
+
+    def upload_blob(self, bucket_name: str, blob_name: str, payload: bytes) -> None:
+        """Upload blob bytes."""
+        blob = self._client.bucket(bucket_name).blob(blob_name)
+        blob.upload_from_string(payload, content_type="application/octet-stream")
+
+    def download_blob(self, bucket_name: str, blob_name: str) -> bytes | None:
+        """Download blob bytes or ``None`` when missing."""
+        blob = self._client.bucket(bucket_name).get_blob(blob_name)
+        if blob is None:
+            return None
+        return blob.download_as_bytes()
+
+    def delete_blob(self, bucket_name: str, blob_name: str) -> bool:
+        """Delete a blob and treat missing objects as success."""
+        try:
+            self._client.bucket(bucket_name).delete_blob(blob_name)
+        except Exception as exc:
+            if _is_not_found_error(exc):
+                return True
+            raise
+        return True
+
+
+class GCSConnector(RemoteConnector):
+    """LMCache remote connector backed by Google Cloud Storage."""
+
+    def __init__(
+        self,
+        local_cpu_backend: LocalCPUBackend,
+        config: LMCacheEngineConfig,
+        metadata: LMCacheMetadata,
+        connector_config: GCSConnectorConfig,
+        gcs_client: GCSClientInterface | None = None,
+    ) -> None:
+        """Initialize the GCS connector."""
+        normalized_config = _normalize_save_chunk_meta_config(config)
+        super().__init__(normalized_config, metadata)
+
+        if self.save_chunk_meta:
+            raise ValueError("save_chunk_meta must be False for gcs")
+        if config.save_unfull_chunk:
+            raise ValueError("save_unfull_chunk must be False for gcs")
+
+        self.local_cpu_backend = local_cpu_backend
+        self.plugin_name = connector_config.plugin_name
+        self.bucket_name = connector_config.bucket_location.bucket_name
+        self.object_prefix = connector_config.bucket_location.object_prefix
+        self.create_bucket_if_missing = connector_config.create_bucket_if_missing
+        self.metadata_cache_ttl_secs = connector_config.metadata_cache_ttl_secs
+
+        self._gcs_client = gcs_client or GCSClient(
+            project=connector_config.project,
+            credentials_path=connector_config.credentials_path,
+        )
+        self._metadata_cache: dict[str, _CachedObjectMetadata] = {}
+        self._metadata_cache_lock = Lock()
+        self._bucket_create_lock = Lock()
+        self._bucket_create_checked = False
+
+        logger.info(
+            "Initialized GCSConnector for bucket %s with prefix '%s'",
+            self.bucket_name,
+            self.object_prefix,
+        )
+
+    async def exists(self, key: CacheEngineKey) -> bool:
+        """Return whether a full LMCache chunk exists for ``key``."""
+        return await asyncio.to_thread(self.exists_sync, key)
+
+    def exists_sync(self, key: CacheEngineKey) -> bool:
+        """Synchronously return whether a full LMCache chunk exists."""
+        object_size = self._get_object_size_bytes(key.to_string())
+        return object_size == self.full_chunk_size_bytes
+
+    async def get(self, key: CacheEngineKey) -> MemoryObj | None:
+        """Retrieve the full chunk associated with ``key``."""
+        memory_objs = await self.batched_get([key])
+        return memory_objs[0]
+
+    async def put(self, key: CacheEngineKey, memory_obj: MemoryObj) -> None:
+        """Store a full chunk in GCS."""
+        await self.batched_put([key], [memory_obj])
+
+    async def list(self) -> builtins.list[str]:
+        """List LMCache keys currently stored under this connector prefix."""
+        return await asyncio.to_thread(self._list_sync)
+
+    async def close(self) -> None:
+        """Release connector-local resources."""
+        with self._metadata_cache_lock:
+            self._metadata_cache.clear()
+
+    def support_ping(self) -> bool:
+        """Report support for lightweight connectivity checks."""
+        return True
+
+    async def ping(self) -> int:
+        """Check access to the configured bucket."""
+        return await asyncio.to_thread(self._ping_sync)
+
+    def support_batched_put(self) -> bool:
+        """Report support for batched uploads."""
+        return True
+
+    async def batched_put(
+        self,
+        keys: builtins.list[CacheEngineKey],
+        memory_objs: builtins.list[MemoryObj],
+    ) -> None:
+        """Upload multiple full chunks in sequence."""
+        if len(keys) != len(memory_objs):
+            raise ValueError(
+                "keys and memory_objs must have the same length for batched_put"
+            )
+        await asyncio.to_thread(self._batched_put_sync, keys, memory_objs)
+
+    def support_batched_get(self) -> bool:
+        """Report support for batch downloads."""
+        return True
+
+    async def batched_get(
+        self,
+        keys: builtins.list[CacheEngineKey],
+    ) -> builtins.list[MemoryObj | None]:
+        """Download multiple chunks while preserving input order."""
+        if not keys:
+            return []
+
+        key_strings = [key.to_string() for key in keys]
+        object_sizes = await asyncio.to_thread(self._resolve_object_sizes, key_strings)
+        results: builtins.list[MemoryObj | None] = [None] * len(keys)
+
+        try:
+            for index, (key_str, object_size) in enumerate(
+                zip(key_strings, object_sizes, strict=False)
+            ):
+                if object_size == 0:
+                    continue
+                if object_size != self.full_chunk_size_bytes:
+                    logger.error(
+                        "Size mismatch for %s: GCS has %d bytes, expected %d bytes. "
+                        "Rejecting the load because gcs only supports full chunks.",
+                        key_str,
+                        object_size,
+                        self.full_chunk_size_bytes,
+                    )
+                    continue
+
+                data = await asyncio.to_thread(
+                    self._gcs_client.download_blob,
+                    self.bucket_name,
+                    self._key_string_to_object_path(key_str),
+                )
+                if data is None:
+                    self._set_cached_object_size(key_str, 0)
+                    continue
+                if len(data) != self.full_chunk_size_bytes:
+                    logger.error(
+                        "Downloaded object for %s has %d bytes, expected %d bytes. "
+                        "Rejecting the load because gcs only supports full chunks.",
+                        key_str,
+                        len(data),
+                        self.full_chunk_size_bytes,
+                    )
+                    self._set_cached_object_size(key_str, len(data))
+                    continue
+
+                memory_obj = self.local_cpu_backend.allocate(
+                    self.meta_shapes,
+                    self.meta_dtypes,
+                    self.meta_fmt,
+                )
+                if memory_obj is None:
+                    logger.debug("Memory allocation failed while downloading from gcs.")
+                    continue
+
+                try:
+                    buffer = memory_obj.byte_array.cast("B")
+                    if len(buffer) < len(data):
+                        raise RuntimeError(
+                            "Allocated buffer is smaller than downloaded gcs object"
+                        )
+                    buffer[: len(data)] = data
+                    results[index] = memory_obj
+                except Exception:
+                    memory_obj.ref_count_down()
+                    raise
+        except Exception:
+            for existing in results:
+                if existing is not None:
+                    existing.ref_count_down()
+            raise
+
+        return results
+
+    def support_batched_contains(self) -> bool:
+        """Report support for synchronous prefix contains checks."""
+        return True
+
+    def batched_contains(self, keys: builtins.list[CacheEngineKey]) -> int:
+        """Return the number of consecutive prefix keys that exist as full chunks."""
+        key_strings = [key.to_string() for key in keys]
+        object_sizes = self._resolve_object_sizes(key_strings)
+        hit_count = 0
+        for object_size in object_sizes:
+            if object_size != self.full_chunk_size_bytes:
+                return hit_count
+            hit_count += 1
+        return hit_count
+
+    def support_batched_async_contains(self) -> bool:
+        """Report support for async prefix contains checks."""
+        return True
+
+    async def batched_async_contains(
+        self,
+        lookup_id: str,
+        keys: builtins.list[CacheEngineKey],
+        pin: bool = False,
+    ) -> int:
+        """Asynchronously return the number of consecutive prefix hits."""
+        del lookup_id
+        del pin
+        return await asyncio.to_thread(self.batched_contains, keys)
+
+    def support_batched_get_non_blocking(self) -> bool:
+        """Report support for non-blocking batch loads."""
+        return True
+
+    async def batched_get_non_blocking(
+        self,
+        lookup_id: str,
+        keys: builtins.list[CacheEngineKey],
+    ) -> builtins.list[MemoryObj]:
+        """Return the successful prefix of ``batched_get`` results."""
+        del lookup_id
+        results = await self.batched_get(keys)
+        prefix_results: builtins.list[MemoryObj] = []
+        found_failure = False
+        for result in results:
+            if found_failure:
+                if result is not None:
+                    result.ref_count_down()
+                continue
+            if result is None:
+                found_failure = True
+                continue
+            prefix_results.append(result)
+        return prefix_results
+
+    def remove_sync(self, key: CacheEngineKey) -> bool:
+        """Synchronously remove a GCS object for ``key``."""
+        key_str = key.to_string()
+        try:
+            removed = self._gcs_client.delete_blob(
+                self.bucket_name,
+                self._key_string_to_object_path(key_str),
+            )
+        except Exception as exc:
+            logger.error("Failed to delete %s from gcs: %s", key_str, exc)
+            return False
+
+        if removed:
+            self._set_cached_object_size(key_str, 0)
+        return removed
+
+    def __repr__(self) -> str:
+        return (
+            f"<GCSConnector bucket_name={self.bucket_name} "
+            f"prefix={self.object_prefix!r}>"
+        )
+
+    def _ping_sync(self) -> int:
+        """Perform the synchronous bucket health check used by ``ping``."""
+        try:
+            return 0 if self._gcs_client.bucket_exists(self.bucket_name) else 1
+        except Exception as exc:
+            logger.warning("Failed to ping gcs bucket %s: %s", self.bucket_name, exc)
+            return 1
+
+    def _batched_put_sync(
+        self,
+        keys: Sequence[CacheEngineKey],
+        memory_objs: Sequence[MemoryObj],
+    ) -> None:
+        """Upload all provided chunks."""
+        self._ensure_bucket_for_writes()
+        uploaded_key_strings: builtins.list[str] = []
+        try:
+            for key, memory_obj in zip(keys, memory_objs, strict=True):
+                key_str = key.to_string()
+                self._validate_full_chunk_for_upload(key_str, memory_obj)
+                self._gcs_client.upload_blob(
+                    self.bucket_name,
+                    self._key_string_to_object_path(key_str),
+                    bytes(memory_obj.byte_array),
+                )
+                uploaded_key_strings.append(key_str)
+                self._set_cached_object_size(key_str, self.full_chunk_size_bytes)
+        except Exception:
+            if uploaded_key_strings:
+                refreshed_sizes = self._fetch_object_sizes_sync(uploaded_key_strings)
+                for key_str, size in refreshed_sizes.items():
+                    self._set_cached_object_size(key_str, size)
+            raise
+
+    def _ensure_bucket_for_writes(self) -> None:
+        """Create the bucket on demand when configured to do so."""
+        if not self.create_bucket_if_missing or self._bucket_create_checked:
+            return
+
+        with self._bucket_create_lock:
+            if self._bucket_create_checked:
+                return
+            self._gcs_client.ensure_bucket(self.bucket_name)
+            self._bucket_create_checked = True
+
+    def _validate_full_chunk_for_upload(
+        self,
+        key_str: str,
+        memory_obj: MemoryObj,
+    ) -> None:
+        """Reject partial or metadata-bearing uploads for the conservative MVP."""
+        physical_size = memory_obj.get_physical_size()
+        if physical_size != self.full_chunk_size_bytes:
+            raise ValueError(
+                f"Cannot upload {key_str}: chunk size {physical_size} bytes does not "
+                f"match expected full chunk size {self.full_chunk_size_bytes} bytes. "
+                "Partial/unfull chunks are not supported by gcs."
+            )
+
+    def _list_sync(self) -> builtins.list[str]:
+        """Return LMCache key strings discovered under the configured prefix."""
+        try:
+            blob_names = self._gcs_client.list_blobs(
+                self.bucket_name,
+                self.object_prefix,
+            )
+        except Exception as exc:
+            if _is_not_found_error(exc):
+                return []
+            raise
+
+        keys: builtins.list[str] = []
+        for blob_name in blob_names:
+            relative_path = self._relative_object_path(blob_name)
+            if relative_path is None or "/" in relative_path:
+                continue
+            key_str = decode_gcs_object_name(relative_path)
+            keys.append(key_str)
+            self._set_cached_object_size(
+                key_str,
+                self._gcs_client.get_blob_size(self.bucket_name, blob_name),
+            )
+        return keys
+
+    def _get_object_size_bytes(self, key_str: str) -> int:
+        """Return the cached or fetched size for a specific LMCache key string."""
+        cached_size = self._get_cached_object_size(key_str)
+        if cached_size is not None:
+            return cached_size
+
+        object_sizes = self._fetch_object_sizes_sync([key_str])
+        object_size = object_sizes.get(key_str, 0)
+        self._set_cached_object_size(key_str, object_size)
+        return object_size
+
+    def _resolve_object_sizes(self, key_strings: Sequence[str]) -> builtins.list[int]:
+        """Resolve cached and uncached object sizes while preserving order."""
+        cached_results: dict[str, int] = {}
+        uncached_key_strings: builtins.list[str] = []
+        for key_str in key_strings:
+            cached_size = self._get_cached_object_size(key_str)
+            if cached_size is None:
+                uncached_key_strings.append(key_str)
+            else:
+                cached_results[key_str] = cached_size
+
+        fetched_results = self._fetch_object_sizes_sync(uncached_key_strings)
+        for key_str, size in fetched_results.items():
+            self._set_cached_object_size(key_str, size)
+
+        return [
+            cached_results.get(key_str, fetched_results.get(key_str, 0))
+            for key_str in key_strings
+        ]
+
+    def _fetch_object_sizes_sync(
+        self,
+        key_strings: Sequence[str],
+    ) -> dict[str, int]:
+        """Fetch object sizes for the requested key strings."""
+        results: dict[str, int] = {}
+        for key_str in key_strings:
+            try:
+                results[key_str] = self._gcs_client.get_blob_size(
+                    self.bucket_name,
+                    self._key_string_to_object_path(key_str),
+                )
+            except Exception as exc:
+                if _is_not_found_error(exc):
+                    results[key_str] = 0
+                    continue
+                raise
+        return results
+
+    def _key_string_to_object_path(self, key_str: str) -> str:
+        """Convert an LMCache key string into the stored GCS object path."""
+        object_name = encode_gcs_object_name(key_str)
+        if not self.object_prefix:
+            return object_name
+        return f"{self.object_prefix}/{object_name}"
+
+    def _relative_object_path(self, object_path: str) -> str | None:
+        """Strip the configured prefix from an object path if it matches."""
+        if not self.object_prefix:
+            return object_path
+
+        prefix_with_separator = f"{self.object_prefix}/"
+        if object_path == self.object_prefix:
+            return None
+        if not object_path.startswith(prefix_with_separator):
+            return None
+        return object_path[len(prefix_with_separator) :]
+
+    def _get_cached_object_size(self, key_str: str) -> int | None:
+        """Return the non-expired cached object size for ``key_str``."""
+        # Standard
+        import time
+
+        with self._metadata_cache_lock:
+            cached_entry = self._metadata_cache.get(key_str)
+            if cached_entry is None:
+                return None
+            if cached_entry.expires_at < time.monotonic():
+                self._metadata_cache.pop(key_str, None)
+                return None
+            return cached_entry.size_bytes
+
+    def _set_cached_object_size(self, key_str: str, size_bytes: int) -> None:
+        """Cache the object size for ``key_str``."""
+        # Standard
+        import time
+
+        with self._metadata_cache_lock:
+            self._metadata_cache[key_str] = _CachedObjectMetadata(
+                size_bytes=size_bytes,
+                expires_at=time.monotonic() + self.metadata_cache_ttl_secs,
+            )
+
+
+def parse_gcs_bucket_handle(bucket_handle: str) -> GCSLocation:
+    """Parse ``gs://bucket[/prefix]`` into bucket name and object prefix."""
+    normalized_handle = bucket_handle.strip()
+    if not normalized_handle.startswith(_GCS_HANDLE_PREFIX):
+        raise ValueError("bucket_handle must start with 'gs://' for the gcs plugin")
+
+    path = normalized_handle[len(_GCS_HANDLE_PREFIX) :].strip("/")
+    path_parts = [part for part in path.split("/") if part]
+    if not path_parts:
+        raise ValueError("bucket_handle must be in the form 'gs://<bucket>[/<prefix>]'")
+
+    return GCSLocation(
+        bucket_name=path_parts[0],
+        object_prefix="/".join(path_parts[1:]),
+    )
+
+
+def resolve_gcs_connector_config(
+    config: LMCacheEngineConfig,
+    plugin_name: str,
+) -> GCSConnectorConfig:
+    """Resolve plugin-scoped configuration for the GCS connector."""
+    extra_config = config.extra_config or {}
+    config_prefix = f"remote_storage_plugin.{plugin_name}"
+
+    bucket_handle_obj = extra_config.get(f"{config_prefix}.bucket_handle")
+    if not isinstance(bucket_handle_obj, str) or not bucket_handle_obj:
+        raise ValueError(
+            f"GCS connector '{plugin_name}' requires '{config_prefix}.bucket_handle'"
+        )
+
+    project_obj = extra_config.get(f"{config_prefix}.project")
+    project = project_obj if isinstance(project_obj, str) and project_obj else None
+
+    credentials_path_obj = extra_config.get(f"{config_prefix}.credentials_path")
+    credentials_path = (
+        credentials_path_obj
+        if isinstance(credentials_path_obj, str) and credentials_path_obj
+        else None
+    )
+
+    return GCSConnectorConfig(
+        plugin_name=plugin_name,
+        bucket_location=parse_gcs_bucket_handle(bucket_handle_obj),
+        project=project,
+        credentials_path=credentials_path,
+        create_bucket_if_missing=_coerce_bool(
+            extra_config.get(f"{config_prefix}.create_bucket_if_missing", False)
+        ),
+        metadata_cache_ttl_secs=_coerce_float(
+            extra_config.get(f"{config_prefix}.metadata_cache_ttl_secs", 30.0)
+        ),
+    )
+
+
+def encode_gcs_object_name(key_str: str) -> str:
+    """Encode a serialized LMCache key into a reversible GCS object name."""
+    return quote(key_str, safe="")
+
+
+def decode_gcs_object_name(object_name: str) -> str:
+    """Decode a reversible GCS object name back into an LMCache key string."""
+    return unquote(object_name)
+
+
+def _normalize_save_chunk_meta_config(
+    config: LMCacheEngineConfig,
+) -> LMCacheEngineConfig:
+    """Clone config and default ``save_chunk_meta`` to ``False`` for gcs."""
+    if config.extra_config is not None and "save_chunk_meta" in config.extra_config:
+        return config
+
+    normalized_config = copy(config)
+    normalized_extra_config = (
+        dict(config.extra_config) if config.extra_config is not None else {}
+    )
+    normalized_extra_config["save_chunk_meta"] = False
+    normalized_config.extra_config = normalized_extra_config
+    return normalized_config
+
+
+def _coerce_bool(value: object) -> bool:
+    """Coerce common truthy config values into ``bool``."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _coerce_float(value: object) -> float:
+    """Coerce numeric config values into ``float``."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return float(value)
+    raise ValueError(f"Cannot coerce {value!r} to float")
+
+
+def _is_not_found_error(exc: Exception) -> bool:
+    """Best-effort detection for GCS not-found errors without a hard import."""
+    return exc.__class__.__name__ == "NotFound"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -47,3 +47,4 @@ httptools
 cachetools
 google-api-core
 google-cloud-bigtable
+google-cloud-storage

--- a/tests/v1/storage_backend/test_gcs_connector.py
+++ b/tests/v1/storage_backend/test_gcs_connector.py
@@ -352,6 +352,7 @@ def test_put_get_exists_list_and_remove_roundtrip(memory_allocator) -> None:
 
     try:
         asyncio.run(connector.put(key, memory_obj))
+        assert memory_obj.get_ref_count() == 0
         assert fake_client.ensure_bucket_calls == []
 
         assert connector.exists_sync(key) is True
@@ -368,7 +369,6 @@ def test_put_get_exists_list_and_remove_roundtrip(memory_allocator) -> None:
         assert connector.remove_sync(key) is True
         assert connector.exists_sync(key) is False
     finally:
-        memory_obj.ref_count_down()
         asyncio.run(connector.close())
         connector.local_cpu_backend.memory_allocator.close()
 
@@ -395,6 +395,7 @@ def test_batched_put_and_batched_get_preserve_order(memory_allocator) -> None:
 
     try:
         asyncio.run(connector.batched_put(keys, memory_objs))
+        assert [memory_obj.get_ref_count() for memory_obj in memory_objs] == [0, 0]
         assert fake_client.ensure_bucket_calls == ["test-bucket"]
 
         missing_key = create_test_key(12)
@@ -422,8 +423,6 @@ def test_batched_put_and_batched_get_preserve_order(memory_allocator) -> None:
             for result in prefix_hits:
                 result.ref_count_down()
     finally:
-        for memory_obj in memory_objs:
-            memory_obj.ref_count_down()
         asyncio.run(connector.close())
         connector.local_cpu_backend.memory_allocator.close()
 

--- a/tests/v1/storage_backend/test_gcs_connector.py
+++ b/tests/v1/storage_backend/test_gcs_connector.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+import asyncio
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.memory_management import MemoryFormat, MemoryObj
+from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.storage_backend.connector import ConnectorContext
+from lmcache.v1.storage_backend.connector.gcs_adapter import GCSConnectorAdapter
+from lmcache.v1.storage_backend.connector.gcs_connector import (
+    GCSConnector,
+    GCSConnectorConfig,
+    decode_gcs_object_name,
+    encode_gcs_object_name,
+    parse_gcs_bucket_handle,
+    resolve_gcs_connector_config,
+)
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.remote_backend import RemoteBackend
+
+
+@dataclass(frozen=True)
+class FakeBlobEntry:
+    """Small stand-in for GCS blob metadata."""
+
+    name: str
+    size: int
+
+
+class FakeGCSClient:
+    """In-memory GCS client used to unit test the connector."""
+
+    def __init__(
+        self,
+        *,
+        project: str | None = None,
+        credentials_path: str | None = None,
+    ) -> None:
+        del project
+        del credentials_path
+        self.storage: dict[str, bytes] = {}
+        self.ensure_bucket_calls: list[str] = []
+        self.bucket_exists_value = True
+        self.deleted_blob_names: list[str] = []
+
+    def ensure_bucket(self, bucket_name: str) -> None:
+        """Record bucket-ensure requests."""
+        self.ensure_bucket_calls.append(bucket_name)
+        self.bucket_exists_value = True
+
+    def bucket_exists(self, bucket_name: str) -> bool:
+        """Return whether the bucket exists."""
+        del bucket_name
+        return self.bucket_exists_value
+
+    def get_blob_size(self, bucket_name: str, blob_name: str) -> int:
+        """Return the stored size or ``0`` for missing blobs."""
+        del bucket_name
+        payload = self.storage.get(blob_name)
+        return 0 if payload is None else len(payload)
+
+    def list_blobs(self, bucket_name: str, prefix: str) -> list[str]:
+        """List stored blob names under the requested prefix."""
+        del bucket_name
+        prefix_with_separator = f"{prefix}/" if prefix else ""
+        return [
+            blob_name
+            for blob_name in sorted(self.storage)
+            if not prefix
+            or blob_name == prefix
+            or blob_name.startswith(prefix_with_separator)
+        ]
+
+    def upload_blob(self, bucket_name: str, blob_name: str, payload: bytes) -> None:
+        """Store uploaded bytes under their blob names."""
+        del bucket_name
+        self.storage[blob_name] = payload
+
+    def download_blob(self, bucket_name: str, blob_name: str) -> bytes | None:
+        """Return stored blob bytes."""
+        del bucket_name
+        return self.storage.get(blob_name)
+
+    def delete_blob(self, bucket_name: str, blob_name: str) -> bool:
+        """Remove stored objects."""
+        del bucket_name
+        self.deleted_blob_names.append(blob_name)
+        self.storage.pop(blob_name, None)
+        return True
+
+
+def create_test_metadata() -> LMCacheMetadata:
+    """Create LMCache metadata with a deterministic full chunk layout."""
+    return LMCacheMetadata(
+        model_name="test-model",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.bfloat16,
+        kv_shape=(4, 2, 256, 8, 128),
+    )
+
+
+def create_test_config(
+    extra_config: dict[str, object] | None = None,
+    *,
+    plugin_name: str = "gcs",
+    save_unfull_chunk: bool = False,
+) -> LMCacheEngineConfig:
+    """Create a plugin-based config for the GCS connector."""
+    return LMCacheEngineConfig.from_defaults(
+        chunk_size=256,
+        local_cpu=True,
+        max_local_cpu_size=0.1,
+        save_unfull_chunk=save_unfull_chunk,
+        lmcache_instance_id="test-gcs",
+        remote_storage_plugins=[plugin_name],
+        extra_config=extra_config or {},
+    )
+
+
+def create_test_key(key_id: int) -> CacheEngineKey:
+    """Create a deterministic cache key for unit tests."""
+    return CacheEngineKey(
+        model_name="test/model",
+        world_size=1,
+        worker_id=0,
+        chunk_hash=key_id,
+        dtype=torch.bfloat16,
+    )
+
+
+def create_connector(
+    memory_allocator,
+    *,
+    plugin_name: str = "gcs",
+    extra_config: dict[str, object] | None = None,
+    save_unfull_chunk: bool = False,
+    gcs_client: FakeGCSClient | None = None,
+) -> tuple[GCSConnector, FakeGCSClient, LMCacheMetadata]:
+    """Create a connector with an in-memory fake GCS client."""
+    metadata = create_test_metadata()
+    config_dict = {
+        f"remote_storage_plugin.{plugin_name}.bucket_handle": "gs://test-bucket/prod",
+        f"remote_storage_plugin.{plugin_name}.metadata_cache_ttl_secs": 30,
+    }
+    if extra_config is not None:
+        config_dict.update(extra_config)
+
+    config = create_test_config(
+        config_dict,
+        plugin_name=plugin_name,
+        save_unfull_chunk=save_unfull_chunk,
+    )
+    local_cpu_backend = LocalCPUBackend(
+        config,
+        metadata,
+        memory_allocator=memory_allocator,
+    )
+    client = gcs_client or FakeGCSClient()
+    connector = GCSConnector(
+        local_cpu_backend=local_cpu_backend,
+        config=config,
+        metadata=metadata,
+        connector_config=resolve_gcs_connector_config(config, plugin_name),
+        gcs_client=client,
+    )
+    return connector, client, metadata
+
+
+def create_full_chunk_memory_obj(
+    local_cpu_backend: LocalCPUBackend,
+    metadata: LMCacheMetadata,
+    fill_byte: int,
+) -> tuple[MemoryObj, bytes]:
+    """Allocate and initialize a full chunk memory object for upload tests."""
+    memory_obj = local_cpu_backend.allocate(
+        metadata.get_shapes(),
+        metadata.get_dtypes(),
+        MemoryFormat.KV_2LTD,
+    )
+    assert memory_obj is not None
+    byte_buffer = memoryview(memory_obj.byte_array).cast("B")
+    payload = bytes([fill_byte]) * len(byte_buffer)
+    byte_buffer[:] = payload
+    return memory_obj, payload
+
+
+def memory_obj_to_bytes(memory_obj: MemoryObj) -> bytes:
+    """Convert a test memory object to raw bytes."""
+    return memoryview(memory_obj.byte_array).cast("B").tobytes()
+
+
+@pytest.fixture
+def async_loop():
+    """Create an asyncio event loop running in a separate thread for testing."""
+    loop = asyncio.new_event_loop()
+
+    # Standard
+    import threading
+
+    # First Party
+    from lmcache.utils import start_loop_in_thread_with_exceptions
+
+    thread = threading.Thread(
+        target=start_loop_in_thread_with_exceptions,
+        args=(loop,),
+        name="test-async-loop",
+    )
+    thread.start()
+
+    yield loop
+
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5.0)
+
+
+@pytest.fixture
+def local_cpu_backend(memory_allocator):
+    """Create a LocalCPUBackend for testing."""
+    config = LMCacheEngineConfig.from_legacy(chunk_size=256)
+    metadata = create_test_metadata()
+    return LocalCPUBackend(config, metadata, memory_allocator=memory_allocator)
+
+
+@pytest.mark.parametrize(
+    ("bucket_handle", "bucket_name", "object_prefix"),
+    [
+        ("gs://my-bucket", "my-bucket", ""),
+        ("gs://my-bucket/prod/checkpoints", "my-bucket", "prod/checkpoints"),
+    ],
+)
+def test_parse_gcs_bucket_handle(
+    bucket_handle: str,
+    bucket_name: str,
+    object_prefix: str,
+) -> None:
+    """Bucket handles should split into bucket name and object prefix."""
+    location = parse_gcs_bucket_handle(bucket_handle)
+    assert location.bucket_name == bucket_name
+    assert location.object_prefix == object_prefix
+
+
+def test_gcs_object_name_encoding_is_reversible() -> None:
+    """Encoded object names should round-trip for LMCache keys."""
+    key_str = "model/name@1/2?x=y"
+    assert decode_gcs_object_name(encode_gcs_object_name(key_str)) == key_str
+
+
+def test_adapter_can_parse_plugin_urls() -> None:
+    """The adapter should match plugin URLs with and without instances."""
+    adapter = GCSConnectorAdapter()
+    assert adapter.can_parse("plugin://gcs")
+    assert adapter.can_parse("plugin://gcs.us")
+    assert not adapter.can_parse("plugin://fs")
+
+
+def test_resolve_gcs_connector_config_uses_full_plugin_name() -> None:
+    """Instance-specific plugin config should be resolved from the full name."""
+    config = create_test_config(
+        {
+            "remote_storage_plugin.gcs.us.bucket_handle": "gs://us-bucket/prod",
+            "remote_storage_plugin.gcs.us.project": "test-project",
+            "remote_storage_plugin.gcs.us.credentials_path": "/tmp/gcs-us.json",
+            "remote_storage_plugin.gcs.us.create_bucket_if_missing": True,
+            "remote_storage_plugin.gcs.us.metadata_cache_ttl_secs": 12,
+        },
+        plugin_name="gcs.us",
+    )
+
+    connector_config = resolve_gcs_connector_config(config, "gcs.us")
+
+    assert connector_config.plugin_name == "gcs.us"
+    assert connector_config.bucket_location.bucket_name == "us-bucket"
+    assert connector_config.bucket_location.object_prefix == "prod"
+    assert connector_config.project == "test-project"
+    assert connector_config.credentials_path == "/tmp/gcs-us.json"
+    assert connector_config.create_bucket_if_missing is True
+    assert connector_config.metadata_cache_ttl_secs == 12.0
+
+
+def test_adapter_create_connector_uses_plugin_scoped_config(monkeypatch) -> None:
+    """Adapter connector creation should pass through the resolved plugin config."""
+    created: dict[str, object] = {}
+
+    class DummyConnector:
+        """Capture adapter constructor arguments without invoking the real client."""
+
+        def __init__(
+            self,
+            local_cpu_backend: object,
+            config: LMCacheEngineConfig,
+            metadata: LMCacheMetadata,
+            connector_config: GCSConnectorConfig,
+        ) -> None:
+            created["local_cpu_backend"] = local_cpu_backend
+            created["config"] = config
+            created["metadata"] = metadata
+            created["connector_config"] = connector_config
+
+    config = create_test_config(
+        {
+            "remote_storage_plugin.gcs.prod.bucket_handle": "gs://test-bucket/prod",
+        },
+        plugin_name="gcs.prod",
+    )
+    metadata = create_test_metadata()
+    loop = asyncio.new_event_loop()
+    adapter = GCSConnectorAdapter()
+
+    monkeypatch.setattr(
+        "lmcache.v1.storage_backend.connector.gcs_adapter.GCSConnector",
+        DummyConnector,
+    )
+
+    connector = adapter.create_connector(
+        ConnectorContext(
+            url="plugin://gcs.prod",
+            loop=loop,
+            local_cpu_backend=None,
+            config=config,
+            metadata=metadata,
+            plugin_name="gcs.prod",
+        )
+    )
+
+    assert isinstance(connector, DummyConnector)
+    connector_config = created["connector_config"]
+    assert isinstance(connector_config, GCSConnectorConfig)
+    assert connector_config.plugin_name == "gcs.prod"
+    assert connector_config.bucket_location.object_prefix == "prod"
+
+
+def test_put_get_exists_list_and_remove_roundtrip(memory_allocator) -> None:
+    """Single-object operations should round-trip against the fake client."""
+    connector, fake_client, metadata = create_connector(memory_allocator)
+    key = create_test_key(1)
+    memory_obj, payload = create_full_chunk_memory_obj(
+        connector.local_cpu_backend,
+        metadata,
+        fill_byte=17,
+    )
+
+    try:
+        asyncio.run(connector.put(key, memory_obj))
+        assert fake_client.ensure_bucket_calls == []
+
+        assert connector.exists_sync(key) is True
+        assert asyncio.run(connector.exists(key)) is True
+        assert asyncio.run(connector.list()) == [key.to_string()]
+
+        loaded = asyncio.run(connector.get(key))
+        assert loaded is not None
+        try:
+            assert memory_obj_to_bytes(loaded) == payload
+        finally:
+            loaded.ref_count_down()
+
+        assert connector.remove_sync(key) is True
+        assert connector.exists_sync(key) is False
+    finally:
+        memory_obj.ref_count_down()
+        asyncio.run(connector.close())
+        connector.local_cpu_backend.memory_allocator.close()
+
+
+def test_batched_put_and_batched_get_preserve_order(memory_allocator) -> None:
+    """Batched operations should preserve result order and prefix semantics."""
+    connector, fake_client, metadata = create_connector(
+        memory_allocator,
+        extra_config={
+            "remote_storage_plugin.gcs.create_bucket_if_missing": True,
+        },
+    )
+    keys = [create_test_key(10), create_test_key(11)]
+    memory_objs_and_payloads = [
+        create_full_chunk_memory_obj(
+            connector.local_cpu_backend, metadata, fill_byte=33
+        ),
+        create_full_chunk_memory_obj(
+            connector.local_cpu_backend, metadata, fill_byte=44
+        ),
+    ]
+    memory_objs = [item[0] for item in memory_objs_and_payloads]
+    payloads = [item[1] for item in memory_objs_and_payloads]
+
+    try:
+        asyncio.run(connector.batched_put(keys, memory_objs))
+        assert fake_client.ensure_bucket_calls == ["test-bucket"]
+
+        missing_key = create_test_key(12)
+        results = asyncio.run(connector.batched_get([keys[0], missing_key, keys[1]]))
+        assert results[0] is not None
+        assert results[1] is None
+        assert results[2] is not None
+        try:
+            assert memory_obj_to_bytes(results[0]) == payloads[0]
+            assert memory_obj_to_bytes(results[2]) == payloads[1]
+        finally:
+            for result in results:
+                if result is not None:
+                    result.ref_count_down()
+
+        assert connector.batched_contains([keys[0], missing_key, keys[1]]) == 1
+
+        prefix_hits = asyncio.run(
+            connector.batched_get_non_blocking("lookup-1", [keys[0], missing_key])
+        )
+        try:
+            assert len(prefix_hits) == 1
+            assert memory_obj_to_bytes(prefix_hits[0]) == payloads[0]
+        finally:
+            for result in prefix_hits:
+                result.ref_count_down()
+    finally:
+        for memory_obj in memory_objs:
+            memory_obj.ref_count_down()
+        asyncio.run(connector.close())
+        connector.local_cpu_backend.memory_allocator.close()
+
+
+def test_partial_chunk_upload_is_rejected(memory_allocator) -> None:
+    """Partial chunks should be rejected by the conservative MVP."""
+    connector, _, _ = create_connector(memory_allocator)
+    key = create_test_key(20)
+    try:
+        memory_obj = MagicMock(spec=MemoryObj)
+        memory_obj.get_physical_size.return_value = connector.full_chunk_size_bytes - 1
+        with pytest.raises(ValueError, match="Partial/unfull chunks are not supported"):
+            asyncio.run(connector.put(key, memory_obj))
+    finally:
+        asyncio.run(connector.close())
+        connector.local_cpu_backend.memory_allocator.close()
+
+
+def test_size_mismatch_get_returns_none(memory_allocator) -> None:
+    """Loads should be rejected when the stored blob size is wrong."""
+    connector, fake_client, _ = create_connector(memory_allocator)
+    key = create_test_key(30)
+    object_path = connector._key_string_to_object_path(key.to_string())
+    fake_client.storage[object_path] = b"too-small"
+
+    try:
+        loaded = asyncio.run(connector.get(key))
+        assert loaded is None
+        assert connector.exists_sync(key) is False
+    finally:
+        asyncio.run(connector.close())
+        connector.local_cpu_backend.memory_allocator.close()
+
+
+def test_remote_backend_init_with_plugin_uses_builtin_gcs_adapter(
+    monkeypatch,
+    async_loop,
+    local_cpu_backend,
+) -> None:
+    """RemoteBackend should create the built-in GCS connector via plugin_name."""
+    fake_client = FakeGCSClient()
+    monkeypatch.setattr(
+        "lmcache.v1.storage_backend.connector.gcs_connector.GCSClient",
+        lambda project=None, credentials_path=None: fake_client,
+    )
+
+    config = create_test_config(
+        {
+            "remote_storage_plugin.gcs.bucket_handle": "gs://test-bucket/prod",
+        }
+    )
+    metadata = create_test_metadata()
+    backend = RemoteBackend(
+        config=config,
+        metadata=metadata,
+        loop=async_loop,
+        local_cpu_backend=local_cpu_backend,
+        dst_device="cpu",
+        plugin_name="gcs",
+    )
+
+    try:
+        assert backend.plugin_name == "gcs"
+        assert backend.remote_url == "plugin://gcs"
+        assert backend.connection is not None
+        assert backend.connection.__class__.__name__ == "InstrumentedRemoteConnector"
+        wrapped_connector = backend.connection.getWrappedConnector()
+        assert wrapped_connector.__class__.__name__ == "GCSConnector"
+    finally:
+        local_cpu_backend.memory_allocator.close()
+        backend.close()


### PR DESCRIPTION
## What this PR does / why we need it:

  This PR adds a built-in non-MP Google Cloud Storage (GCS) remote storage connector for LMCache via remote_storage_plugins=["gcs"].

 ## It includes:

  - a built-in GCSConnectorAdapter
  - a non-MP GCSConnector
  - dedicated unit tests for the GCS connector
  - user-facing GCS backend documentation
  - updates to the remote storage plugin docs for the new built-in connector

  This fills the gap of first-party GCS support in the existing remote storage connector architecture without expanding scope to MP GCS L2 adapter
  support.

 ## Special notes for your reviewers:

  - This PR targets the non-MP remote connector path only.
  - MP GCS L2 adapter support is intentionally left to a follow-up change.
  - The initial implementation is conservative and follows the tested full-chunk path.
  - Verification performed during development included:
      - ruff check
      - py_compile
      - NO_NATIVE_EXT=1 uv run python -m pytest -xvs tests/v1/storage_backend/test_gcs_connector.py
      - PYTHONPATH=. python3 -m pytest -q tests/v1/storage_backend/test_remote_storage_plugin.py -k "adapter_is_loaded or creates_connector or
        via_create_connector_function"

## If applicable:

  - [x] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
This pull request adds first-class support for Google Cloud Storage (GCS) as a built-in remote storage backend for LMCache. It introduces a new GCS connector, updates documentation to describe usage and configuration, and ensures GCS is available as a supported backend. The changes make it easy to persist KV cache data in GCS buckets using LMCache's plugin system.

**GCS Backend Support**

* Added a new `GCSConnectorAdapter` and related logic in `gcs_adapter.py` to enable GCS as a built-in remote storage backend via the LMCache plugin system. This adapter handles configuration, instantiation, and integration with the core connector framework.
* Added `google-cloud-storage` as a dependency in `requirements/common.txt` to support GCS operations.

**Documentation Updates**

* Created a new documentation page `gcs.rst` detailing how to configure, use, and authenticate the GCS backend, including example YAML configurations and limitations.
* Updated the remote storage plugins documentation to mention GCS as a built-in connector, provide example configuration, and list it alongside other supported backends. [[1]](diffhunk://#diff-f44ae18187f0940695ac80c2692bf5efeadc79f128d9d9eaa172d5197c2c05beL5-R5) [[2]](diffhunk://#diff-f44ae18187f0940695ac80c2692bf5efeadc79f128d9d9eaa172d5197c2c05beL45-R45) [[3]](diffhunk://#diff-f44ae18187f0940695ac80c2692bf5efeadc79f128d9d9eaa172d5197c2c05beR85-R94) [[4]](diffhunk://#diff-dc575ef961c9d4daff1ed87e0f9b8073495cb631bad3eadc1779519d61e5898eR18)
