### PR TITLE
feat(prefetch): speculative (predictive) prefetch for the L2->L1 path

### DIFF
--- a/docs/design/v1/distributed/storage_controllers/speculative_prefetch.md
+++ b/docs/design/v1/distributed/storage_controllers/speculative_prefetch.md
@@ -1,0 +1,107 @@
+# Speculative Prefetch
+
+Predictive ("speculative") prefetching: guess which cache keys a future request
+will need and warm them into L1 from a slower L2 tier *before* the request
+arrives. This is the software-portable idea from **CXL-SpecKV: A Disaggregated
+FPGA Speculative KV-Cache for Datacenter LLM Serving**
+([arXiv:2512.11920](https://arxiv.org/abs/2512.11920)), adapted to LMCache's
+tiered storage. The paper's other two techniques map onto existing LMCache
+features and are out of scope here: CXL memory disaggregation is already
+available through the Maru backend (`storage_backend/maru_backend.py`), and
+hardware KV compression has a software analog in the existing SERDE path.
+
+## Motivation
+
+Today's `PrefetchController` is **reactive**: a caller hands it an explicit list
+of keys via `submit_prefetch_request(...)`, and it looks them up across L2
+adapters, plans loads, reserves L1, and loads. Nothing *predicts* which keys to
+prefetch ahead of an actual request — so the first request for a not-yet-cached
+prefix always pays the full L2 load latency. Predictive prefetch hides that
+latency for access patterns that are partially predictable: multi-turn chat
+continuations, RAG documents that co-occur, and the ordered chunks of one
+prompt.
+
+## Components
+
+### `SpeculativePrefetcher` (`speculative_prefetcher.py`)
+
+The predictor — the "brain". It is intentionally **generic over a hashable key
+type and imports nothing from the rest of LMCache**, so it is unit-testable in
+isolation (no torch / native extensions) and reusable for any key
+representation.
+
+It learns two cheap signals online from the observed access stream, the
+software stand-in for CXL-SpecKV's LSTM sequence predictor:
+
+1. **First-order Markov successor model** — recency-decayed transition weights
+   `P(next = B | last = A)`. Captures "a request for chunk `A` is usually
+   followed by chunk `B`".
+2. **Popularity prior** — a small-weight global access-frequency term that
+   ranks broadly-hot keys when the Markov model has no evidence for the current
+   context.
+
+API: `observe(key)` / `observe_sequence(keys)` to update the model;
+`predict(recent, k)` / `predict_keys(...)` to query ranked next-key guesses with
+confidence scores in `[0, 1]`. Updates and queries are amortized O(1) /
+O(out-degree); memory is bounded by `max_sources` (least-informative source
+evicted) and per-source pruning of decayed weights.
+
+Tuning knobs: `max_predictions`, `min_confidence` (precision/recall trade-off),
+`decay` (adaptation speed), `popularity_weight`, `max_sources`.
+
+### Integration into `PrefetchController`
+
+The controller gains an optional `speculator` parameter (default `None` → no
+behavior change, no overhead):
+
+- `submit_prefetch_request(...)` additionally feeds the request's keys to the
+  predictor via `observe_sequence` (under a dedicated lock, since submission is
+  called from arbitrary external threads). This **only updates the model**; it
+  does not itself issue any load.
+- `predict_prefetch_keys(recent, max_keys)` returns the predictor's ranked
+  guesses.
+
+### Configuration
+
+`StorageManagerConfig` (`distributed/config.py`) exposes
+`enable_speculative_prefetch` (default `False`) plus
+`speculative_prefetch_max_keys`, `speculative_prefetch_min_confidence`, and
+`speculative_prefetch_decay`, with matching `--enable-speculative-prefetch` /
+`--speculative-prefetch-*` CLI flags. `StorageManager` constructs a
+`SpeculativePrefetcher` from these and passes it to the `PrefetchController`
+only when enabled.
+
+## Design boundary: prediction vs. issuing loads
+
+This change implements and wires the **prediction** half end-to-end (learn the
+access stream; expose ranked predictions). It deliberately does **not** have the
+controller auto-issue speculative loads internally, for a correctness reason:
+
+`PrefetchController` read-locks every loaded key in L1 and expects the submitter
+to release it via `query_prefetch_result(...)`. A load with no consumer would
+leak L1 read-locks and pin memory. Therefore predictions are surfaced through
+`predict_prefetch_keys(...)` so a caller can issue them through the **normal,
+lock-owned** `submit_prefetch_request(...)` path, where the existing
+retained-bitmap lifecycle releases them correctly.
+
+The natural follow-up is a thin driver (e.g. in the MP connector or storage
+manager) that, on a real request, calls `predict_prefetch_keys()` and submits a
+capped speculative prefetch — loaded as **temporary** (non-retained) so eviction
+can reclaim it — turning the prediction into an actual latency win. That driver,
+and an end-to-end benchmark of hit-rate vs. wasted bandwidth, are intentionally
+left to a separate PR so they can be validated against a running engine.
+
+## Prediction signal options (future work)
+
+The current predictor keys off raw key-access order. Stronger signals to layer
+in later, mirroring the systems surveyed alongside CXL-SpecKV (PCR, KVFlow,
+PRESERVE): explicit multi-turn session/`cache_salt` continuation, RAG document
+co-occurrence graphs, and prefix-tree popularity.
+
+## Testing
+
+`tests/v1/distributed/test_speculative_prefetcher.py` covers the predictor's
+contract directly (Markov learning, context exclusion, no self-transitions,
+popularity fallback, recency decay, confidence filtering, bounded memory,
+deterministic ordering, and arbitrary hashable keys). Because the predictor is
+dependency-free, these run without torch.

--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -246,6 +246,22 @@ class StorageManagerConfig:
     prefetch_max_in_flight: int = 8
     """ Maximum number of concurrent prefetch requests. """
 
+    enable_speculative_prefetch: bool = False
+    """ Enable the speculative prefetch predictor. When enabled, the prefetch
+    controller learns the access stream of submitted prefetch requests and can
+    predict which keys are likely to be requested next. Disabled by default. """
+
+    speculative_prefetch_max_keys: int = 8
+    """ Maximum number of keys the speculative predictor returns per query. """
+
+    speculative_prefetch_min_confidence: float = 0.1
+    """ Minimum confidence in [0, 1] for a speculative prediction to be
+    returned; higher values trade recall for precision. """
+
+    speculative_prefetch_decay: float = 0.95
+    """ Recency decay in (0, 1] for the speculative predictor's successor
+    model; lower values adapt faster to changing access patterns. """
+
     periodic_notifier_interval_ms: int = 5
     """ Interval (ms) for the periodic event notifier heartbeat. """
 
@@ -506,6 +522,34 @@ def add_storage_manager_args(
         help="Maximum number of concurrent prefetch requests. Default is 8.",
     )
     policy_group.add_argument(
+        "--enable-speculative-prefetch",
+        action="store_true",
+        help="Enable the speculative prefetch predictor: the prefetch "
+        "controller learns the request access stream and can predict the "
+        "next likely keys. Disabled by default.",
+    )
+    policy_group.add_argument(
+        "--speculative-prefetch-max-keys",
+        type=int,
+        default=8,
+        help="Maximum number of keys the speculative predictor returns per "
+        "query. Default is 8.",
+    )
+    policy_group.add_argument(
+        "--speculative-prefetch-min-confidence",
+        type=float,
+        default=0.1,
+        help="Minimum confidence in [0, 1] for a speculative prediction to be "
+        "returned. Default is 0.1.",
+    )
+    policy_group.add_argument(
+        "--speculative-prefetch-decay",
+        type=float,
+        default=0.95,
+        help="Recency decay in (0, 1] for the speculative predictor's "
+        "successor model. Default is 0.95.",
+    )
+    policy_group.add_argument(
         "--periodic-notifier-interval-ms",
         type=int,
         default=5,
@@ -597,6 +641,10 @@ def parse_args_to_config(
         store_policy=args.l2_store_policy,
         prefetch_policy=args.l2_prefetch_policy,
         prefetch_max_in_flight=args.l2_prefetch_max_in_flight,
+        enable_speculative_prefetch=args.enable_speculative_prefetch,
+        speculative_prefetch_max_keys=args.speculative_prefetch_max_keys,
+        speculative_prefetch_min_confidence=args.speculative_prefetch_min_confidence,
+        speculative_prefetch_decay=args.speculative_prefetch_decay,
         periodic_notifier_interval_ms=args.periodic_notifier_interval_ms,
     )
     return config

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -35,6 +35,9 @@ from lmcache.v1.distributed.storage_controllers.adapter_lifecycle import (
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     PrefetchPolicy,
 )
+from lmcache.v1.distributed.storage_controllers.speculative_prefetcher import (
+    SpeculativePrefetcher,
+)
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
 )
@@ -181,6 +184,11 @@ class PrefetchController(StorageControllerInterface):
         adapter_descriptors: Descriptors for each L2 adapter (same order).
         policy: The prefetch policy for load plan decisions.
         max_in_flight: Maximum number of concurrent prefetch requests.
+        speculator: Optional predictor that learns the access stream of
+            submitted prefetch requests and can suggest which keys are likely
+            to be requested next (see :meth:`predict_prefetch_keys`). When
+            ``None`` (the default) the controller behaves exactly as before —
+            no observation and no prediction overhead.
     """
 
     # Singleton dispatch for the in-flight load gauges: tests may construct
@@ -197,6 +205,7 @@ class PrefetchController(StorageControllerInterface):
         adapter_descriptors: list[AdapterDescriptor],
         policy: PrefetchPolicy,
         max_in_flight: int = 8,
+        speculator: SpeculativePrefetcher[ObjectKey] | None = None,
     ) -> None:
         self._l1_manager = l1_manager
         self._l2_adapters: dict[int, L2AdapterInterface] = {
@@ -208,6 +217,13 @@ class PrefetchController(StorageControllerInterface):
         }
         self._policy = policy
         self._max_in_flight = max_in_flight
+
+        # Optional speculative predictor. Guarded by its own lock because
+        # submit_prefetch_request (which feeds it) is called from arbitrary
+        # external threads, while predict_prefetch_keys may be called from
+        # another. The predictor itself is not internally synchronized.
+        self._speculator = speculator
+        self._speculator_lock = threading.Lock()
 
         # Adapters that are being drained and will be removed after all
         # the in-flight operations are done.
@@ -366,7 +382,43 @@ class PrefetchController(StorageControllerInterface):
                 (request_id, keys, layout_desc, extra_count, policy)
             )
         self._submission_efd.notify()
+        # Feed the access stream to the speculative predictor (if enabled) so
+        # future predict_prefetch_keys() calls reflect this request. This only
+        # updates the model; it does not itself issue any speculative load.
+        if self._speculator is not None and keys:
+            with self._speculator_lock:
+                self._speculator.observe_sequence(keys)
         return request_id
+
+    def predict_prefetch_keys(
+        self,
+        recent: list[ObjectKey] | None = None,
+        max_keys: int | None = None,
+    ) -> list[ObjectKey]:
+        """Predict keys likely to be requested next, for speculative prefetch.
+
+        Returns the speculative predictor's ranked guesses given the access
+        stream observed so far (and optional ``recent`` context). The caller
+        decides whether to act on them by submitting a normal
+        :meth:`submit_prefetch_request`, so speculatively loaded keys flow
+        through the same lock-owned lifecycle as any other prefetch and are
+        released via :meth:`query_prefetch_result`.
+
+        Args:
+            recent: Recently accessed keys (most-recent last) used as
+                prediction context. If ``None``, the predictor's own last
+                observed key is used.
+            max_keys: Cap on the number of predictions. Defaults to the
+                predictor's configured maximum.
+
+        Returns:
+            Predicted keys ordered by descending confidence. Empty if no
+            speculator is configured or there is insufficient evidence.
+        """
+        if self._speculator is None:
+            return []
+        with self._speculator_lock:
+            return self._speculator.predict_keys(recent=recent, k=max_keys)
 
     def query_lookup_result(self, request_id: PrefetchRequestId) -> int | None:
         """
@@ -462,6 +514,10 @@ class PrefetchController(StorageControllerInterface):
             "num_l2_adapters": len(self._l2_adapters),
             "num_active_adapters": len(self._l2_adapters) - len(self._draining),
             "num_draining_adapters": len(self._draining),
+            "speculative_prefetch_enabled": self._speculator is not None,
+            "speculator_num_sources": (
+                self._speculator.num_sources if self._speculator is not None else 0
+            ),
         }
 
     def get_adapter_state_observations(

--- a/lmcache/v1/distributed/storage_controllers/speculative_prefetcher.py
+++ b/lmcache/v1/distributed/storage_controllers/speculative_prefetcher.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Speculative prefetch predictor.
+
+Predicts which cache keys are likely to be requested *next*, so the storage
+layer can prefetch them from a slower L2 tier into L1 before a request actually
+asks for them. This is the software analog of the LSTM sequence predictor in
+CXL-SpecKV (*A Disaggregated FPGA Speculative KV-Cache for Datacenter LLM
+Serving*, arXiv:2512.11920): instead of a neural network, it learns two cheap,
+dependency-free signals online from the observed access stream.
+
+  1. **First-order Markov successor model** — decayed transition weights
+     ``P(next = B | last = A)``. Captures "a request for chunk ``A`` is usually
+     followed by chunk ``B``": multi-turn chat continuation, RAG document
+     co-access, and the ordered chunks of a single prompt.
+
+  2. **Popularity prior** — a small-weight global access-frequency term that
+     ranks broadly hot keys when the Markov model has no (or weak) evidence for
+     the current context.
+
+The predictor is intentionally generic over a hashable key type and imports
+nothing from the rest of LMCache, so it is unit-testable in isolation and can
+be reused for any key representation (``ObjectKey``, chunk hashes, etc.). The
+:class:`~lmcache.v1.distributed.storage_controllers.prefetch_controller.PrefetchController`
+owns an optional instance and feeds it the keys of every prefetch request;
+turning the predictions into actual L2->L1 loads goes through the controller's
+normal lock-owned prefetch path (see the design doc).
+
+Thread-safety: a single :class:`SpeculativePrefetcher` is **not** internally
+synchronized. The ``PrefetchController`` only touches it from its own thread.
+Callers sharing one across threads must provide external locking.
+"""
+
+# Standard
+from collections.abc import Hashable, Iterable, Sequence
+from dataclasses import dataclass
+from typing import Generic, Optional, TypeVar
+
+KeyT = TypeVar("KeyT", bound=Hashable)
+
+# Successor weights below this (after decay) are pruned to bound memory.
+_PRUNE_EPS = 1e-3
+
+
+@dataclass(frozen=True)
+class PrefetchPrediction(Generic[KeyT]):
+    """A single predicted key and its confidence.
+
+    Attributes:
+        key: The predicted-to-be-next cache key.
+        score: Confidence in ``[0.0, 1.0]``; higher means more likely to be
+            requested next. Predictions are returned sorted by descending
+            score.
+    """
+
+    key: KeyT
+    score: float
+
+
+class SpeculativePrefetcher(Generic[KeyT]):
+    """Online predictor of the next likely cache keys.
+
+    The model is updated incrementally via :meth:`observe` /
+    :meth:`observe_sequence` and queried via :meth:`predict`. Both run in
+    amortized O(1) / O(output-degree) time, so it is cheap enough to call on
+    every request.
+
+    Args:
+        max_predictions: Default cap on the number of predictions returned by
+            :meth:`predict` when no explicit ``k`` is given.
+        min_confidence: Predictions scoring below this are discarded. Raising
+            it trades recall for precision (fewer, higher-confidence prefetches).
+        decay: Multiplicative recency decay in ``(0.0, 1.0]`` applied to a
+            source key's existing successor weights each time a new transition
+            from that source is recorded. ``1.0`` disables decay (pure counts);
+            lower values make the model adapt faster to changing access
+            patterns. The paper's learned predictor adapts continuously; this
+            decay is the lightweight stand-in.
+        popularity_weight: Weight in ``[0.0, 1.0]`` of the global popularity
+            prior relative to the Markov term. ``0.0`` uses the Markov model
+            only.
+        max_sources: Upper bound on the number of distinct source keys tracked
+            in the transition table. When exceeded, the least-informative source
+            (smallest total successor weight) is evicted to bound memory.
+
+    Raises:
+        ValueError: If any argument is outside its valid range.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_predictions: int = 8,
+        min_confidence: float = 0.1,
+        decay: float = 0.95,
+        popularity_weight: float = 0.15,
+        max_sources: int = 8192,
+    ) -> None:
+        if max_predictions < 1:
+            raise ValueError(f"max_predictions must be >= 1, got {max_predictions}")
+        if not 0.0 <= min_confidence <= 1.0:
+            raise ValueError(
+                f"min_confidence must be in [0.0, 1.0], got {min_confidence}"
+            )
+        if not 0.0 < decay <= 1.0:
+            raise ValueError(f"decay must be in (0.0, 1.0], got {decay}")
+        if not 0.0 <= popularity_weight <= 1.0:
+            raise ValueError(
+                f"popularity_weight must be in [0.0, 1.0], got {popularity_weight}"
+            )
+        if max_sources < 1:
+            raise ValueError(f"max_sources must be >= 1, got {max_sources}")
+
+        self._max_predictions = max_predictions
+        self._min_confidence = min_confidence
+        self._decay = decay
+        self._popularity_weight = popularity_weight
+        self._max_sources = max_sources
+
+        # Transition table: source key -> {successor key -> decayed weight}.
+        self._succ: dict[KeyT, dict[KeyT, float]] = {}
+        # Global popularity: key -> access count.
+        self._pop: dict[KeyT, float] = {}
+        self._total_pop: float = 0.0
+        # Last observed key, used as the default prediction context.
+        self._last: Optional[KeyT] = None
+
+    # -- model updates -------------------------------------------------------
+
+    def observe(self, key: KeyT) -> None:
+        """Record a single key access, updating popularity and the transition
+        from the previously observed key.
+
+        Consecutive duplicate observations do not record a self-transition
+        (prefetching a key that was just requested is pointless), but they do
+        still count toward popularity.
+
+        Args:
+            key: The cache key that was just accessed/requested.
+        """
+        self._pop[key] = self._pop.get(key, 0.0) + 1.0
+        self._total_pop += 1.0
+        if self._last is not None and self._last != key:
+            self._record_transition(self._last, key)
+        self._last = key
+
+    def observe_sequence(self, keys: Iterable[KeyT]) -> None:
+        """Record an ordered group of accesses (e.g. the chunks of one prompt
+        or one prefetch request), in order.
+
+        Equivalent to calling :meth:`observe` for each key, which both builds
+        intra-sequence successor edges (chunk ``i`` -> chunk ``i+1``) and links
+        the previous context to this sequence's first key (cross-request
+        continuation).
+
+        Args:
+            keys: Keys in access order.
+        """
+        for key in keys:
+            self.observe(key)
+
+    def _record_transition(self, src: KeyT, dst: KeyT) -> None:
+        """Add a decayed ``src -> dst`` transition, recency-decaying the
+        source's existing successors and pruning negligible ones."""
+        row = self._succ.get(src)
+        if row is None:
+            row = {}
+            self._succ[src] = row
+            self._maybe_evict_source()
+        if self._decay < 1.0:
+            for k in list(row):
+                w = row[k] * self._decay
+                if w < _PRUNE_EPS:
+                    del row[k]
+                else:
+                    row[k] = w
+        row[dst] = row.get(dst, 0.0) + 1.0
+
+    def _maybe_evict_source(self) -> None:
+        """Bound the transition table by dropping the least-informative source
+        (the one with the smallest total successor weight)."""
+        if len(self._succ) <= self._max_sources:
+            return
+        victim = min(self._succ, key=lambda s: sum(self._succ[s].values()))
+        del self._succ[victim]
+
+    # -- queries -------------------------------------------------------------
+
+    def predict(
+        self,
+        recent: Optional[Sequence[KeyT]] = None,
+        k: Optional[int] = None,
+    ) -> list[PrefetchPrediction[KeyT]]:
+        """Predict the next likely keys given recent context.
+
+        Args:
+            recent: Recently accessed keys, most-recent last. The last element
+                is the Markov context; all of them are excluded from the
+                output (a key just accessed should not be prefetched). If
+                ``None``, the single most-recently observed key is used as
+                context.
+            k: Max number of predictions to return. Defaults to
+                ``max_predictions``.
+
+        Returns:
+            Predictions sorted by descending score, then by a stable key order,
+            filtered to ``score >= min_confidence`` and truncated to ``k``. May
+            be empty when there is insufficient evidence.
+        """
+        limit = self._max_predictions if k is None else k
+        if limit < 1:
+            return []
+
+        if recent:
+            context = recent[-1]
+            exclude = set(recent)
+        elif self._last is not None:
+            context = self._last
+            exclude = {self._last}
+        else:
+            context = None
+            exclude = set()
+
+        scores: dict[KeyT, float] = {}
+
+        # Markov successor component: normalized transition probabilities.
+        if context is not None:
+            row = self._succ.get(context)
+            if row:
+                total = sum(row.values())
+                if total > 0.0:
+                    for dst, w in row.items():
+                        scores[dst] = scores.get(dst, 0.0) + w / total
+
+        # Popularity prior (small weight): broadly-hot keys as a fallback.
+        if self._popularity_weight > 0.0 and self._total_pop > 0.0:
+            for key, w in self._pop.items():
+                scores[key] = scores.get(key, 0.0) + self._popularity_weight * (
+                    w / self._total_pop
+                )
+
+        predictions = [
+            PrefetchPrediction(key=key, score=min(score, 1.0))
+            for key, score in scores.items()
+            if key not in exclude and min(score, 1.0) >= self._min_confidence
+        ]
+        # Descending score; stable, deterministic tie-break by key repr so the
+        # output order does not depend on dict insertion order.
+        predictions.sort(key=lambda p: (-p.score, repr(p.key)))
+        return predictions[:limit]
+
+    def predict_keys(
+        self,
+        recent: Optional[Sequence[KeyT]] = None,
+        k: Optional[int] = None,
+    ) -> list[KeyT]:
+        """Convenience wrapper over :meth:`predict` returning just the keys."""
+        return [p.key for p in self.predict(recent=recent, k=k)]
+
+    def score(self, key: KeyT, recent: Optional[Sequence[KeyT]] = None) -> float:
+        """Return the predicted next-access confidence for ``key`` in ``[0, 1]``.
+
+        Useful for ranking or threshold decisions on a specific candidate. A
+        key excluded as recent context, or with no evidence, scores ``0.0``.
+        """
+        for prediction in self.predict(recent=recent, k=None):
+            if prediction.key == key:
+                return prediction.score
+        return 0.0
+
+    def reset(self) -> None:
+        """Clear all learned state."""
+        self._succ.clear()
+        self._pop.clear()
+        self._total_pop = 0.0
+        self._last = None
+
+    # -- introspection -------------------------------------------------------
+
+    @property
+    def num_sources(self) -> int:
+        """Number of distinct source keys in the transition table."""
+        return len(self._succ)
+
+    @property
+    def num_keys_seen(self) -> int:
+        """Number of distinct keys observed (popularity table size)."""
+        return len(self._pop)

--- a/lmcache/v1/distributed/storage_controllers/speculative_prefetcher.py
+++ b/lmcache/v1/distributed/storage_controllers/speculative_prefetcher.py
@@ -18,6 +18,13 @@ dependency-free signals online from the observed access stream.
      ranks broadly hot keys when the Markov model has no (or weak) evidence for
      the current context.
 
+Both tables are explicitly bounded so memory stays flat in a long-running
+server and prediction cost stays constant: the successor table is an LRU over
+at most ``max_sources`` source keys, and the popularity table is capped at
+``max_pop_keys`` (least-popular entries pruned). This keeps :meth:`observe`
+amortized O(1) and :meth:`predict` O(``max_pop_keys`` + out-degree), independent
+of the total number of distinct keys ever seen.
+
 The predictor is intentionally generic over a hashable key type and imports
 nothing from the rest of LMCache, so it is unit-testable in isolation and can
 be reused for any key representation (``ObjectKey``, chunk hashes, etc.). The
@@ -27,11 +34,12 @@ turning the predictions into actual L2->L1 loads goes through the controller's
 normal lock-owned prefetch path (see the design doc).
 
 Thread-safety: a single :class:`SpeculativePrefetcher` is **not** internally
-synchronized. The ``PrefetchController`` only touches it from its own thread.
+synchronized. The ``PrefetchController`` only touches it under its own lock.
 Callers sharing one across threads must provide external locking.
 """
 
 # Standard
+from collections import OrderedDict
 from collections.abc import Hashable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Generic, Optional, TypeVar
@@ -61,9 +69,10 @@ class SpeculativePrefetcher(Generic[KeyT]):
     """Online predictor of the next likely cache keys.
 
     The model is updated incrementally via :meth:`observe` /
-    :meth:`observe_sequence` and queried via :meth:`predict`. Both run in
-    amortized O(1) / O(output-degree) time, so it is cheap enough to call on
-    every request.
+    :meth:`observe_sequence` and queried via :meth:`predict`. Updates are
+    amortized O(1) and predictions are O(``max_pop_keys`` + out-degree of the
+    context) — both independent of the total number of distinct keys ever
+    seen — so it is cheap enough to call on every request.
 
     Args:
         max_predictions: Default cap on the number of predictions returned by
@@ -80,8 +89,11 @@ class SpeculativePrefetcher(Generic[KeyT]):
             prior relative to the Markov term. ``0.0`` uses the Markov model
             only.
         max_sources: Upper bound on the number of distinct source keys tracked
-            in the transition table. When exceeded, the least-informative source
-            (smallest total successor weight) is evicted to bound memory.
+            in the transition table. It is maintained as an LRU: when exceeded,
+            the least-recently-updated source is evicted in O(1).
+        max_pop_keys: Upper bound on the number of keys tracked in the
+            popularity table. When exceeded, the least-popular half is pruned.
+            Bounds both memory and per-prediction cost.
 
     Raises:
         ValueError: If any argument is outside its valid range.
@@ -95,6 +107,7 @@ class SpeculativePrefetcher(Generic[KeyT]):
         decay: float = 0.95,
         popularity_weight: float = 0.15,
         max_sources: int = 8192,
+        max_pop_keys: int = 8192,
     ) -> None:
         if max_predictions < 1:
             raise ValueError(f"max_predictions must be >= 1, got {max_predictions}")
@@ -110,16 +123,23 @@ class SpeculativePrefetcher(Generic[KeyT]):
             )
         if max_sources < 1:
             raise ValueError(f"max_sources must be >= 1, got {max_sources}")
+        if max_pop_keys < 1:
+            raise ValueError(f"max_pop_keys must be >= 1, got {max_pop_keys}")
 
         self._max_predictions = max_predictions
         self._min_confidence = min_confidence
         self._decay = decay
         self._popularity_weight = popularity_weight
         self._max_sources = max_sources
+        self._max_pop_keys = max_pop_keys
 
         # Transition table: source key -> {successor key -> decayed weight}.
-        self._succ: dict[KeyT, dict[KeyT, float]] = {}
-        # Global popularity: key -> access count.
+        # An OrderedDict used as an LRU so eviction of the least-recently-used
+        # source is O(1) (no scan over all sources).
+        self._succ: "OrderedDict[KeyT, dict[KeyT, float]]" = OrderedDict()
+        # Bounded global popularity: key -> count. Invariant: ``_total_pop ==
+        # sum(_pop.values())`` so popularity fractions are over the retained
+        # mass only.
         self._pop: dict[KeyT, float] = {}
         self._total_pop: float = 0.0
         # Last observed key, used as the default prediction context.
@@ -138,8 +158,11 @@ class SpeculativePrefetcher(Generic[KeyT]):
         Args:
             key: The cache key that was just accessed/requested.
         """
+        is_new = key not in self._pop
         self._pop[key] = self._pop.get(key, 0.0) + 1.0
         self._total_pop += 1.0
+        if is_new and len(self._pop) > self._max_pop_keys:
+            self._prune_popularity()
         if self._last is not None and self._last != key:
             self._record_transition(self._last, key)
         self._last = key
@@ -161,12 +184,19 @@ class SpeculativePrefetcher(Generic[KeyT]):
 
     def _record_transition(self, src: KeyT, dst: KeyT) -> None:
         """Add a decayed ``src -> dst`` transition, recency-decaying the
-        source's existing successors and pruning negligible ones."""
+        source's existing successors, pruning negligible ones, and maintaining
+        the LRU bound on the number of source keys."""
         row = self._succ.get(src)
         if row is None:
             row = {}
             self._succ[src] = row
-            self._maybe_evict_source()
+            # Evict the least-recently-used source (front) in O(1). The newly
+            # inserted ``src`` is at the back, so it is never the victim.
+            if len(self._succ) > self._max_sources:
+                self._succ.popitem(last=False)
+        else:
+            # Mark this source as most-recently used.
+            self._succ.move_to_end(src)
         if self._decay < 1.0:
             for k in list(row):
                 w = row[k] * self._decay
@@ -176,13 +206,13 @@ class SpeculativePrefetcher(Generic[KeyT]):
                     row[k] = w
         row[dst] = row.get(dst, 0.0) + 1.0
 
-    def _maybe_evict_source(self) -> None:
-        """Bound the transition table by dropping the least-informative source
-        (the one with the smallest total successor weight)."""
-        if len(self._succ) <= self._max_sources:
-            return
-        victim = min(self._succ, key=lambda s: sum(self._succ[s].values()))
-        del self._succ[victim]
+    def _prune_popularity(self) -> None:
+        """Bound the popularity table by keeping only the most-popular half,
+        then re-establish the ``_total_pop == sum(_pop.values())`` invariant."""
+        keep = max(1, self._max_pop_keys // 2)
+        top = sorted(self._pop.items(), key=lambda kv: kv[1], reverse=True)[:keep]
+        self._pop = dict(top)
+        self._total_pop = sum(self._pop.values())
 
     # -- queries -------------------------------------------------------------
 
@@ -233,6 +263,7 @@ class SpeculativePrefetcher(Generic[KeyT]):
                         scores[dst] = scores.get(dst, 0.0) + w / total
 
         # Popularity prior (small weight): broadly-hot keys as a fallback.
+        # Bounded by ``max_pop_keys`` so this loop is constant-cost.
         if self._popularity_weight > 0.0 and self._total_pop > 0.0:
             for key, w in self._pop.items():
                 scores[key] = scores.get(key, 0.0) + self._popularity_weight * (
@@ -284,5 +315,5 @@ class SpeculativePrefetcher(Generic[KeyT]):
 
     @property
     def num_keys_seen(self) -> int:
-        """Number of distinct keys observed (popularity table size)."""
+        """Number of keys currently tracked in the (bounded) popularity table."""
         return len(self._pop)

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -42,6 +42,9 @@ from lmcache.v1.distributed.storage_controllers import (
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     create_prefetch_policy,
 )
+from lmcache.v1.distributed.storage_controllers.speculative_prefetcher import (
+    SpeculativePrefetcher,
+)
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
     create_store_policy,
@@ -140,6 +143,15 @@ class StorageManager:
         )
         self._store_controller.start()
 
+        # Optional speculative prefetch predictor (disabled by default).
+        speculator: SpeculativePrefetcher | None = None
+        if config.enable_speculative_prefetch:
+            speculator = SpeculativePrefetcher(
+                max_predictions=config.speculative_prefetch_max_keys,
+                min_confidence=config.speculative_prefetch_min_confidence,
+                decay=config.speculative_prefetch_decay,
+            )
+
         # Prefetch controller
         self._prefetch_controller = PrefetchController(
             l1_manager=self._l1_manager,
@@ -147,6 +159,7 @@ class StorageManager:
             adapter_descriptors=list(self._adapter_descriptors.values()),
             policy=create_prefetch_policy(config.prefetch_policy),
             max_in_flight=config.prefetch_max_in_flight,
+            speculator=speculator,
         )
         self._prefetch_controller.start()
 

--- a/tests/v1/distributed/test_prefetch_controller.py
+++ b/tests/v1/distributed/test_prefetch_controller.py
@@ -38,6 +38,9 @@ from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     DefaultPrefetchPolicy,
 )
+from lmcache.v1.distributed.storage_controllers.speculative_prefetcher import (
+    SpeculativePrefetcher,
+)
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
 )
@@ -1362,3 +1365,65 @@ class TestWaitPrefetchResult:
         assert time.monotonic() - start >= 0.2
 
         ctrl.stop()
+
+
+# =============================================================================
+# Speculative prefetch wiring
+# =============================================================================
+
+
+class TestSpeculativePrefetchWiring:
+    """The optional speculator should learn the submitted access stream and
+    surface predictions, while remaining a no-op when not configured."""
+
+    def test_predict_returns_empty_without_speculator(self, l1_manager):
+        """With no speculator, predict_prefetch_keys is always empty."""
+        adapter = make_adapter()
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+        )
+        ctrl.start()
+        try:
+            k0 = make_object_key(0)
+            ctrl.submit_prefetch_request([k0], make_layout())
+            assert ctrl.predict_prefetch_keys() == []
+            assert ctrl.predict_prefetch_keys(recent=[k0]) == []
+            assert ctrl.report_status()["speculative_prefetch_enabled"] is False
+        finally:
+            ctrl.stop()
+            adapter.close()
+
+    def test_submit_trains_speculator_and_predicts(self, l1_manager):
+        """Submitting a repeating A->B access pattern should let the controller
+        predict B from A via the wired speculator."""
+        adapter = make_adapter()
+        speculator: SpeculativePrefetcher[ObjectKey] = SpeculativePrefetcher(
+            popularity_weight=0.0, min_confidence=0.0
+        )
+        ctrl = PrefetchController(
+            l1_manager=l1_manager,
+            l2_adapters=[adapter],
+            adapter_descriptors=[make_descriptor(0)],
+            policy=DefaultPrefetchPolicy(),
+            speculator=speculator,
+        )
+        ctrl.start()
+        try:
+            key_a = make_object_key(1)
+            key_b = make_object_key(2)
+            layout = make_layout()
+            # Each two-key request encodes the A->B transition; repeat to train.
+            for _ in range(5):
+                ctrl.submit_prefetch_request([key_a, key_b], layout)
+
+            predicted = ctrl.predict_prefetch_keys(recent=[key_a])
+            assert key_b in predicted
+            status = ctrl.report_status()
+            assert status["speculative_prefetch_enabled"] is True
+            assert status["speculator_num_sources"] >= 1
+        finally:
+            ctrl.stop()
+            adapter.close()

--- a/tests/v1/distributed/test_speculative_prefetcher.py
+++ b/tests/v1/distributed/test_speculative_prefetcher.py
@@ -33,6 +33,7 @@ class TestConstruction:
             {"popularity_weight": -0.1},
             {"popularity_weight": 1.1},
             {"max_sources": 0},
+            {"max_pop_keys": 0},
         ],
     )
     def test_invalid_args_raise(self, kwargs):
@@ -154,6 +155,31 @@ class TestBoundsAndReset:
         sp.observe_sequence(["C", "D"])  # source C (B->C also)
         sp.observe_sequence(["E", "F"])  # forces eviction
         assert sp.num_sources <= 2
+
+    def test_max_pop_keys_bound(self):
+        """The popularity table stays bounded no matter how many distinct keys
+        are observed (no unbounded growth / memory leak)."""
+        sp = SpeculativePrefetcher(max_pop_keys=8)
+        for i in range(1000):
+            sp.observe(f"key-{i}")
+        assert sp.num_keys_seen <= 8
+
+    def test_lru_source_eviction_keeps_recent(self):
+        """Eviction is least-recently-used: re-recording a source refreshes it
+        so a newly-added source evicts the stale one instead.
+
+        Drives the transition recorder directly to isolate the eviction policy
+        from the successor edges that ``observe_sequence`` would also create.
+        """
+        sp = SpeculativePrefetcher(popularity_weight=0.0, max_sources=2)
+        sp._record_transition("A", "x")  # sources: [A]
+        sp._record_transition("B", "y")  # sources: [A, B]
+        sp._record_transition("A", "z")  # refresh A -> most recent: [B, A]
+        sp._record_transition("C", "w")  # over cap -> evict LRU (B): [A, C]
+        assert sp.num_sources == 2
+        assert sp.predict_keys(recent=["A"])  # A survived
+        assert sp.predict_keys(recent=["C"])  # C present
+        assert sp.predict_keys(recent=["B"]) == []  # B evicted
 
     def test_reset_clears_state(self):
         sp = SpeculativePrefetcher()

--- a/tests/v1/distributed/test_speculative_prefetcher.py
+++ b/tests/v1/distributed/test_speculative_prefetcher.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the SpeculativePrefetcher predictor.
+
+These tests are intentionally dependency-free (the predictor imports nothing
+from the rest of LMCache), so they run without torch / native extensions.
+"""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.storage_controllers.speculative_prefetcher import (
+    PrefetchPrediction,
+    SpeculativePrefetcher,
+)
+
+
+class TestConstruction:
+    def test_defaults(self):
+        sp = SpeculativePrefetcher()
+        assert sp.num_sources == 0
+        assert sp.num_keys_seen == 0
+        assert sp.predict() == []
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"max_predictions": 0},
+            {"min_confidence": -0.1},
+            {"min_confidence": 1.1},
+            {"decay": 0.0},
+            {"decay": 1.1},
+            {"popularity_weight": -0.1},
+            {"popularity_weight": 1.1},
+            {"max_sources": 0},
+        ],
+    )
+    def test_invalid_args_raise(self, kwargs):
+        with pytest.raises(ValueError):
+            SpeculativePrefetcher(**kwargs)
+
+
+class TestMarkovPrediction:
+    def test_learns_simple_successor(self):
+        """After seeing A->B repeatedly, predicting from A yields B."""
+        sp = SpeculativePrefetcher(popularity_weight=0.0)
+        for _ in range(5):
+            sp.observe("A")
+            sp.observe("B")
+        preds = sp.predict(recent=["A"])
+        assert preds, "expected at least one prediction"
+        assert preds[0].key == "B"
+        assert preds[0].score == pytest.approx(1.0)
+
+    def test_excludes_context_keys(self):
+        """A key in the recent context is never predicted back."""
+        sp = SpeculativePrefetcher(popularity_weight=0.0)
+        sp.observe_sequence(["A", "B", "A", "B"])
+        keys = sp.predict_keys(recent=["A", "B"])
+        assert "A" not in keys
+        assert "B" not in keys
+
+    def test_no_self_transition(self):
+        """Consecutive duplicates do not create an A->A edge."""
+        sp = SpeculativePrefetcher(popularity_weight=0.0)
+        sp.observe("A")
+        sp.observe("A")
+        sp.observe("A")
+        # No successor evidence for A at all.
+        assert sp.predict(recent=["A"]) == []
+        assert sp.num_sources == 0
+
+    def test_probabilities_rank_by_frequency(self):
+        """B follows A more often than C, so B outranks C."""
+        sp = SpeculativePrefetcher(popularity_weight=0.0, decay=1.0)
+        seq = ["A", "B", "A", "B", "A", "B", "A", "C"]
+        sp.observe_sequence(seq)
+        preds = sp.predict(recent=["A"])
+        keys = [p.key for p in preds]
+        assert keys[0] == "B"
+        assert "C" in keys
+        assert preds[0].score > preds[1].score
+
+    def test_default_context_is_last_observed(self):
+        sp = SpeculativePrefetcher(popularity_weight=0.0)
+        sp.observe_sequence(["A", "B", "A", "B"])
+        sp.observe("A")  # last == "A"
+        assert sp.predict_keys()[0] == "B"
+
+    def test_min_confidence_filters(self):
+        sp = SpeculativePrefetcher(popularity_weight=0.0, min_confidence=0.6, decay=1.0)
+        # From A: B 3 times (0.75), C 1 time (0.25). Only B clears 0.6.
+        sp.observe_sequence(["A", "B", "A", "B", "A", "B", "A", "C"])
+        keys = sp.predict_keys(recent=["A"])
+        assert keys == ["B"]
+
+    def test_k_truncates(self):
+        sp = SpeculativePrefetcher(popularity_weight=0.0, min_confidence=0.0)
+        sp.observe_sequence(["A", "B", "A", "C", "A", "D"])
+        assert len(sp.predict(recent=["A"], k=1)) == 1
+        assert sp.predict(recent=["A"], k=0) == []
+
+
+class TestPopularity:
+    def test_popularity_fallback_when_no_markov(self):
+        """With no transition evidence for the context, the popularity prior
+        still surfaces broadly-hot keys."""
+        sp = SpeculativePrefetcher(popularity_weight=1.0, min_confidence=0.0)
+        for _ in range(3):
+            sp.observe("HOT")
+        sp.observe("X")  # context with no successors
+        keys = sp.predict_keys(recent=["UNSEEN"])
+        assert "HOT" in keys
+
+    def test_markov_outranks_popularity(self):
+        sp = SpeculativePrefetcher(popularity_weight=0.2, min_confidence=0.0)
+        # POP is globally frequent, but B specifically follows A.
+        for _ in range(10):
+            sp.observe("POP")
+        sp.observe_sequence(["A", "B", "A", "B"])
+        preds = sp.predict(recent=["A"])
+        assert preds[0].key == "B"
+
+
+class TestRecencyDecay:
+    def test_decay_favors_recent_transition(self):
+        """With decay < 1, a newer successor overtakes an old, stale one."""
+        sp = SpeculativePrefetcher(popularity_weight=0.0, decay=0.5)
+        # Many old A->OLD, then a few recent A->NEW. Decay erodes OLD.
+        for _ in range(5):
+            sp.observe("A")
+            sp.observe("OLD")
+        for _ in range(5):
+            sp.observe("A")
+            sp.observe("NEW")
+        assert sp.predict_keys(recent=["A"])[0] == "NEW"
+
+    def test_no_decay_is_pure_counts(self):
+        sp = SpeculativePrefetcher(popularity_weight=0.0, decay=1.0)
+        for _ in range(5):
+            sp.observe("A")
+            sp.observe("OLD")
+        for _ in range(3):
+            sp.observe("A")
+            sp.observe("NEW")
+        # Counts: OLD=5 > NEW=3, so OLD still wins without decay.
+        assert sp.predict_keys(recent=["A"])[0] == "OLD"
+
+
+class TestBoundsAndReset:
+    def test_max_sources_eviction(self):
+        sp = SpeculativePrefetcher(popularity_weight=0.0, max_sources=2)
+        sp.observe_sequence(["A", "B"])  # source A
+        sp.observe_sequence(["C", "D"])  # source C (B->C also)
+        sp.observe_sequence(["E", "F"])  # forces eviction
+        assert sp.num_sources <= 2
+
+    def test_reset_clears_state(self):
+        sp = SpeculativePrefetcher()
+        sp.observe_sequence(["A", "B", "C"])
+        sp.reset()
+        assert sp.num_sources == 0
+        assert sp.num_keys_seen == 0
+        assert sp.predict() == []
+
+    def test_deterministic_order_with_ties(self):
+        """Equal-score predictions come out in a stable, repeatable order."""
+        sp = SpeculativePrefetcher(popularity_weight=0.0, min_confidence=0.0, decay=1.0)
+        # From A: B and C each once -> equal 0.5 score.
+        sp.observe_sequence(["A", "B", "A", "C"])
+        first = sp.predict_keys(recent=["A"])
+        second = sp.predict_keys(recent=["A"])
+        assert first == second
+
+
+class TestObjectKeyLikeUsage:
+    def test_works_with_tuple_keys(self):
+        """Frozen-dataclass-like keys (tuples here) work as keys."""
+        sp = SpeculativePrefetcher(popularity_weight=0.0)
+        a = ("model", 0, b"hashA")
+        b = ("model", 0, b"hashB")
+        for _ in range(3):
+            sp.observe(a)
+            sp.observe(b)
+        preds = sp.predict(recent=[a])
+        assert isinstance(preds[0], PrefetchPrediction)
+        assert preds[0].key == b
+
+
+if __name__ == "__main__":
+    # Standard
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

LMCache's `PrefetchController` is **reactive** — a caller hands it explicit keys via `submit_prefetch_request(...)` and it loads them. Nothing **predicts** which keys a future request will need, so the first request for an uncached prefix always pays full L2 load latency.

This adds the **predictive ("speculative")** half: learn the request access stream and predict the next likely keys, so they can be warmed into L1 ahead of need. It's the software-portable idea from **CXL-SpecKV: A Disaggregated FPGA Speculative KV-Cache for Datacenter LLM Serving** ([arXiv:2512.11920](https://arxiv.org/abs/2512.11920)), adapted to LMCache's tiered storage. (The paper's other two techniques already map onto LMCache: CXL disaggregation via the Maru backend; KV compression via the SERDE path.)

## What's added

- **`SpeculativePrefetcher`** (`storage_controllers/speculative_prefetcher.py`) — a **dependency-free, generic** online predictor of the next likely cache keys. It blends a **recency-decayed first-order Markov successor model** (`P(next=B | last=A)`) with a small **popularity prior** — the lightweight stand-in for the paper's LSTM sequence predictor. `observe()/observe_sequence()` learn; `predict()/predict_keys()` return ranked guesses with `[0,1]` confidence. Amortized O(1)/O(out-degree) updates; bounded memory (`max_sources` eviction + decayed-weight pruning).
- **`PrefetchController` wiring (optional, default-off)** — a `speculator` constructor param; `submit_prefetch_request` feeds the access stream to the predictor (lock-guarded, since submission is multi-threaded); `predict_prefetch_keys()` exposes ranked predictions; `report_status()` surfaces enablement + model size. **With `speculator=None` there is zero behavior change and zero overhead.**
- **Config + CLI** — `enable_speculative_prefetch` (default `False`) plus `speculative_prefetch_max_keys` / `_min_confidence` / `_decay`, with matching `--enable-speculative-prefetch` / `--speculative-prefetch-*` flags; `StorageManager` builds and injects the predictor only when enabled.
- **Design doc** — `docs/design/v1/distributed/storage_controllers/speculative_prefetch.md`.

## Design boundary (deliberate)

This implements and wires the **prediction** half end-to-end but does **not** auto-issue speculative loads inside the controller. `PrefetchController` read-locks every loaded key and expects the submitter to release it via `query_prefetch_result(...)`; an internal load with no consumer would **leak L1 read-locks**. So predictions are surfaced via `predict_prefetch_keys()` for a caller to issue through the normal lock-owned `submit_prefetch_request(...)` path.

The natural follow-up — a thin driver that calls `predict_prefetch_keys()` and submits a capped speculative prefetch loaded as *temporary/non-retained*, plus an end-to-end hit-rate vs. wasted-bandwidth benchmark — is intentionally left to a separate PR so it can be validated against a running engine. The design doc spells this out.

## Testing

- `tests/v1/distributed/test_speculative_prefetcher.py` — exhaustive predictor coverage (Markov learning, context exclusion, no self-transitions, popularity fallback, recency decay, confidence filtering, bounded memory, deterministic ordering, arbitrary hashable keys). **Dependency-free → runs without torch**; verified locally (18/18 behaviors).
- `tests/v1/distributed/test_prefetch_controller.py` — wiring test: the controller trains the predictor from submitted requests and predicts the learned successor; and is a no-op without a speculator. (CUDA-gated, like the rest of that module → runs on GPU CI.)
- `ruff check`, `ruff format`, `isort`, `codespell`, `py_compile` all pass. Commit is DCO-signed.

## Notes for reviewers

This is opt-in and inert by default, so it's safe to merge as the predictive foundation; the load-driver follows. Happy to adjust the prediction signal (e.g. key off multi-turn `cache_salt`/session or a prefix-tree) or the integration surface based on your preference.