### PR TITLE
Move IPCCacheServerKey import under TYPE_CHECKING in distributed/api.py

### DIFF
--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -9,13 +9,16 @@ Could be implemented by native code in the future
 # Standard
 from dataclasses import dataclass
 import enum
+from typing import TYPE_CHECKING
 
 # Third Party
 import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+
+if TYPE_CHECKING:
+    from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 
 logger = init_logger(__name__)
 
@@ -271,7 +274,7 @@ class PrefetchHandle:
 
 
 def ipc_key_to_object_keys(
-    ipc_key: IPCCacheServerKey,
+    ipc_key: "IPCCacheServerKey",
     chunk_hashes: list[bytes],
     object_group_ids: list[int],
 ) -> list[list[ObjectKey]]:


### PR DESCRIPTION
Moves the IPCCacheServerKey import under a TYPE_CHECKING guard in lmcache/v1/distributed/api.py.

The import was only used for the type annotation on ipc_key in ipc_key_to_object_keys, not at runtime. Moving it under TYPE_CHECKING reduces unnecessary import-time dependencies. The annotation is updated to a string literal to avoid a NameError at runtime.

Closes #3730