### PR TITLE
[Feat] fs l2: capacity-aware eviction

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/l2_eviction.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_eviction.md
@@ -197,7 +197,7 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 | `MockL2Adapter`            | ✓        | ✓           | stored, deleted     |
 | `NixlStoreL2Adapter`       | ✓ (skips pinned) | ✓ (pool-based) | stored, deleted |
 | `RawBlockL2Adapter`        | ✓ (skips locked) | ✓ | stored, accessed, deleted |
-| `FSL2Adapter`              | no-op    | `(-1, -1)`  | none                |
+| `FSL2Adapter`              | ✓ (skips locked, POSIX-safe unlink) | ✓ (requires `max_capacity_gb`) | stored, accessed, deleted |
 | `NativeConnectorL2Adapter` | ✓ (via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, deleted |
 
 **Note on `NativeConnectorL2Adapter`:** Eviction support requires two things:
@@ -208,6 +208,32 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 2. The adapter must be configured with `max_capacity_gb > 0` to enable client-side
    size tracking for `get_usage()`. Without it, `get_usage()` returns `(-1, -1)` and
    the eviction controller will not trigger.
+
+**Note on `FSL2Adapter`:** Eviction is enabled by setting `max_capacity_gb > 0`;
+with the default `0` the adapter stays unbounded and fully stateless (its legacy
+behaviour) — no per-key tracking, no listener notifications. When enabled:
+
+- **Accounting** is tracked per key in an in-memory map guarded by the adapter
+  lock, so a store is counted exactly once even under a concurrent store of the
+  same key or a re-store of an already-resident key. A key found on disk but not
+  yet tracked (e.g. left by a prior run with recovery off) is accounted on the
+  next store.
+- **Locking.** A per-key refcount pins keys against eviction: `lookup_and_lock`
+  locks the hit keys (released by `submit_unlock`) and a store locks its batch
+  for the duration of the write. `delete()` skips any key with a positive
+  refcount, so a key cannot be evicted between a lookup and its load, or while it
+  is being written. POSIX also keeps an already-open file readable through its
+  descriptor and the load path treats a vanished file as a miss, so even an
+  unlocked delete that races a load never corrupts data.
+- **delete()** runs synchronously on the eviction-controller thread and
+  `unlink`s each victim file. If `unlink` hard-fails the file is still on disk,
+  so its size is restored to accounting and no delete is reported.
+- **Recovery.** On startup, `recover_on_start` (default `true`) scans `base_path`
+  so files left by a previous run count toward usage and are replayed to the
+  eviction policy when it registers; the replay targets only eviction-policy
+  listeners, so non-eviction listeners (e.g. the coordinator event reporter) are
+  not sent the warm cache as fresh store events. Set it to `false` to skip the
+  scan for very large directories.
 
 Example configuration with eviction enabled:
 

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -11,6 +11,7 @@ name encodes all key fields so it can be reversed on startup.
 from __future__ import annotations
 
 # Standard
+from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 import asyncio
@@ -20,6 +21,7 @@ import threading
 if TYPE_CHECKING:
     from lmcache.v1.distributed.internal_api import (
         L1MemoryDesc,
+        L2AdapterListener,
     )
 
 # Third Party
@@ -179,6 +181,8 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
         relative_tmp_dir: Optional[str] = None,
         read_ahead_size: Optional[int] = None,
         use_odirect: bool = False,
+        max_capacity_gb: float = 0,
+        recover_on_start: bool = True,
     ):
         """Initialize FSL2AdapterConfig.
 
@@ -193,11 +197,22 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
                 using O_DIRECT for both reads and writes.
                 Requires buffer sizes aligned to the
                 filesystem block size.
+            max_capacity_gb: Maximum L2 capacity in GB. When
+                greater than 0 the adapter reports usage and
+                participates in L2 eviction; ``0`` (default)
+                disables eviction (unbounded, legacy behaviour).
+            recover_on_start: When True (default) and capacity
+                is bounded, scan ``base_path`` at startup so
+                files left by a previous run count toward usage
+                and can be evicted. Disable for very large
+                directories where the startup scan is costly.
         """
         self.base_path = base_path
         self.relative_tmp_dir = relative_tmp_dir
         self.read_ahead_size = read_ahead_size
         self.use_odirect = use_odirect
+        self.max_capacity_gb = max_capacity_gb
+        self.recover_on_start = recover_on_start
 
     @classmethod
     def from_dict(cls, d: dict) -> "FSL2AdapterConfig":
@@ -215,11 +230,19 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
         use_odirect = d.get("use_odirect", False)
         if not isinstance(use_odirect, bool):
             raise ValueError("use_odirect must be a boolean")
+        max_capacity_gb = d.get("max_capacity_gb", 0)
+        if not isinstance(max_capacity_gb, (int, float)) or max_capacity_gb < 0:
+            raise ValueError("max_capacity_gb must be a non-negative number")
+        recover_on_start = d.get("recover_on_start", True)
+        if not isinstance(recover_on_start, bool):
+            raise ValueError("recover_on_start must be a boolean")
         return cls(
             base_path=base_path,
             relative_tmp_dir=relative_tmp_dir,
             read_ahead_size=read_ahead_size,
             use_odirect=use_odirect,
+            max_capacity_gb=float(max_capacity_gb),
+            recover_on_start=recover_on_start,
         )
 
     @classmethod
@@ -235,7 +258,13 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
             "readahead by reading this many bytes first "
             "(optional)\n"
             "- use_odirect (bool): bypass page cache "
-            "via O_DIRECT (optional, default false)"
+            "via O_DIRECT (optional, default false)\n"
+            "- max_capacity_gb (float): max L2 capacity "
+            "in GB for usage tracking / eviction "
+            "(optional, default 0 = disabled)\n"
+            "- recover_on_start (bool): scan base_path at "
+            "startup to account for pre-existing files "
+            "(optional, default true)"
         )
 
 
@@ -253,7 +282,9 @@ class FSL2Adapter(L2AdapterInterface):
     """
 
     def __init__(self, config: FSL2AdapterConfig):
-        super().__init__()
+        super().__init__(
+            max_capacity_bytes=int(config.max_capacity_gb * (1024**3)),
+        )
         self._config = config
         base = config.base_path
         self._base_path = Path(base)
@@ -293,6 +324,28 @@ class FSL2Adapter(L2AdapterInterface):
         self._completed_load_tasks: dict[L2TaskId, Bitmap] = {}
         self._lock = threading.Lock()
 
+        # Capacity / eviction bookkeeping. ``_sizes`` is the authoritative
+        # per-key byte map guarded by ``_lock``. It makes store-side
+        # ``_notify_keys_stored`` fire exactly once per key (even under
+        # concurrent stores of the same key) and supplies delete sizes
+        # without an extra stat. ``_recovered`` holds files found at
+        # startup so each eviction listener can be seeded when it
+        # registers (listeners attach after ``__init__``).
+        self._sizes: dict[ObjectKey, int] = {}
+        self._recovered: tuple[list[ObjectKey], list[int]] = ([], [])
+        # Refcount lock per key (guarded by ``_lock``). A key with a positive
+        # count is being looked-up/loaded or actively stored and must not be
+        # evicted; ``delete`` skips such keys. Only used when eviction is on.
+        self._locked_keys: dict[ObjectKey, int] = defaultdict(int)
+        if config.max_capacity_gb > 0 and not self.supports_global_eviction:
+            logger.warning(
+                "FSL2Adapter max_capacity_gb=%s rounds down to 0 bytes; "
+                "eviction stays disabled. Use a larger capacity.",
+                config.max_capacity_gb,
+            )
+        if self.supports_global_eviction and config.recover_on_start:
+            self._recover_existing_files()
+
         # Background asyncio event loop
         self._loop = asyncio.new_event_loop()
         self._loop_thread = threading.Thread(target=self._run_event_loop, daemon=True)
@@ -320,6 +373,35 @@ class FSL2Adapter(L2AdapterInterface):
 
     def get_load_event_fd(self) -> int:
         return self._load_efd.fileno()
+
+    # ------------------------------------------------------------------
+    # Listener Interface
+    # ------------------------------------------------------------------
+
+    def register_listener(self, listener: "L2AdapterListener") -> None:
+        """Register a listener, seeding eviction policies with recovered keys.
+
+        Listeners attach after ``__init__``, so any files recovered at
+        startup (see :meth:`_recover_existing_files`) are replayed here so
+        the eviction policy learns about pre-existing objects and can evict
+        them. The replay only targets eviction-policy listeners: other
+        listeners (e.g. the coordinator event reporter) must not receive
+        recovered files as fresh store events, which would double-report the
+        warm cache to the fleet on every restart. The replay happens *before*
+        the base class adds the listener to its notify list, so a concurrent
+        store cannot deliver a live event to the listener before it is seeded.
+
+        Args:
+            listener: The L2 adapter listener to register.
+        """
+        # Local import avoids a module-load cycle through the adapter package.
+        # First Party
+        from lmcache.v1.distributed.eviction import L2EvictionPolicy
+
+        recovered_keys, recovered_sizes = self._recovered
+        if recovered_keys and isinstance(listener, L2EvictionPolicy):
+            listener.on_l2_keys_stored(recovered_keys, recovered_sizes)
+        super().register_listener(listener)
 
     # ------------------------------------------------------------------
     # Store Interface
@@ -375,9 +457,16 @@ class FSL2Adapter(L2AdapterInterface):
             return self._completed_lookup_tasks.pop(task_id, None)
 
     def submit_unlock(self, keys: list[ObjectKey]) -> None:
-        # No-op: FS adapter has no eviction, so locking
-        # between lookup and load is unnecessary.
-        pass
+        """Release the eviction lock taken by ``submit_lookup_and_lock_task``.
+
+        Decrements the per-key refcount so a key that is no longer being
+        loaded becomes eligible for eviction again. A no-op for keys that
+        were never locked (e.g. when eviction is disabled).
+
+        Args:
+            keys: The keys to unlock.
+        """
+        self._unlock_keys(keys)
 
     # ------------------------------------------------------------------
     # Load Interface
@@ -407,12 +496,16 @@ class FSL2Adapter(L2AdapterInterface):
 
     def report_status(self) -> dict:
         """Return a status dict for the FS L2 adapter."""
+        usage = self.get_usage()
         return {
             "is_healthy": self._loop_thread.is_alive(),
             "type": "FSL2Adapter",
             "base_path": str(self._base_path),
             "use_odirect": self._use_odirect,
             "event_loop_alive": self._loop_thread.is_alive(),
+            "max_capacity_bytes": usage.total_capacity_bytes,
+            "total_bytes_used": usage.total_bytes_used,
+            "usage_fraction": usage.usage_fraction,
         }
 
     # ------------------------------------------------------------------
@@ -420,14 +513,67 @@ class FSL2Adapter(L2AdapterInterface):
     # ------------------------------------------------------------------
 
     def delete(self, keys: list[ObjectKey]) -> None:
-        # Not implemented for the filesystem adapter.
-        pass
+        """Delete objects from disk and update eviction accounting.
 
-    # ``get_usage()`` is inherited from ``L2AdapterInterface``. The FS
-    # adapter declares no max capacity (default 0) so ``supports_global_eviction``
-    # returns ``False`` and ``usage_fraction == -1.0`` — the eviction
-    # controller treats this as "no eviction signal" and skips the
-    # adapter entirely.
+        Called synchronously by the L2 eviction controller with the
+        policy-selected victim keys. Each evictable key's file is unlinked
+        and ``_notify_keys_deleted`` is fired so base byte accounting and
+        the eviction policy stay consistent. Sizes come from the in-memory
+        ``_sizes`` map (populated on store / recovery), so no stat is
+        needed. Keys absent from ``_sizes`` are skipped.
+
+        A key whose eviction refcount is positive (it is being looked-up,
+        loaded, or actively stored) is left untouched; the controller will
+        retry it on a later cycle. If ``unlink`` hard-fails (a non-missing
+        OSError, e.g. a read-only mount) the file is still on disk, so its
+        size is restored to ``_sizes`` and no delete is reported, keeping
+        accounting in step with reality.
+
+        Concurrency: this runs on the eviction-controller thread while
+        loads run on the event-loop thread. POSIX keeps an unlinked file
+        readable through any descriptor a load already opened, and the
+        load path treats a vanished file as a miss
+        (``FileNotFoundError``), so a delete concurrent with a load never
+        corrupts data.
+
+        Args:
+            keys: The keys of the objects to delete.
+        """
+        # Pop sizes for evictable keys, skipping locked (in-flight) keys.
+        popped: list[tuple[ObjectKey, int]] = []
+        with self._lock:
+            for key in keys:
+                if self._locked_keys.get(key, 0) > 0:
+                    continue
+                size = self._sizes.pop(key, None)
+                if size is None:
+                    continue
+                popped.append((key, size))
+
+        deleted_keys: list[ObjectKey] = []
+        deleted_sizes: list[int] = []
+        restore: list[tuple[ObjectKey, int]] = []
+        for key, size in popped:
+            path = self._key_to_path(key)
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass  # already gone -- treat as deleted
+            except OSError:
+                # File still on disk: keep it accounted, do not report it.
+                logger.exception("FSL2Adapter failed to unlink %s", path)
+                restore.append((key, size))
+                continue
+            deleted_keys.append(key)
+            deleted_sizes.append(size)
+
+        if restore:
+            with self._lock:
+                for key, size in restore:
+                    self._sizes.setdefault(key, size)
+
+        if deleted_keys:
+            self._notify_keys_deleted(deleted_keys, deleted_sizes)
 
     # ------------------------------------------------------------------
     # Cleanup
@@ -473,6 +619,75 @@ class FSL2Adapter(L2AdapterInterface):
         tid = self._next_task_id
         self._next_task_id += 1
         return tid
+
+    def _lock_keys(self, keys: list[ObjectKey]) -> None:
+        """Increment the eviction-lock refcount for *keys* (under ``_lock``)."""
+        with self._lock:
+            for key in keys:
+                self._locked_keys[key] += 1
+
+    def _unlock_keys(self, keys: list[ObjectKey]) -> None:
+        """Decrement the eviction-lock refcount for *keys* (under ``_lock``).
+
+        Keys whose count reaches zero are removed so the map only holds
+        currently-locked keys.
+        """
+        with self._lock:
+            for key in keys:
+                count = self._locked_keys.get(key, 0)
+                if count <= 1:
+                    self._locked_keys.pop(key, None)
+                else:
+                    self._locked_keys[key] = count - 1
+
+    def _recover_existing_files(self) -> None:
+        """Account for KV files left in ``base_path`` by a previous run.
+
+        Rebuilds byte accounting so ``usage_fraction`` and the capacity
+        bound reflect pre-existing files, and stashes the recovered
+        keys/sizes in ``_recovered`` so each eviction listener is seeded
+        when it registers (listeners attach after ``__init__``, so a plain
+        ``_notify_keys_stored`` here would reach no listener). Files that
+        do not parse as a valid :class:`ObjectKey` (foreign files, the
+        temp sub-dir) are skipped.
+        """
+        keys: list[ObjectKey] = []
+        sizes: list[int] = []
+        try:
+            with os.scandir(self._base_path) as it:
+                for entry in it:
+                    # ``follow_symlinks=False`` so a symlink named like a key
+                    # is not counted at its target's size (and later unlinked
+                    # as just the link, diverging accounting from disk).
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+                    key = _filename_to_object_key(entry.name)
+                    if key is None:
+                        continue
+                    try:
+                        size = entry.stat(follow_symlinks=False).st_size
+                    except OSError:
+                        continue
+                    keys.append(key)
+                    sizes.append(size)
+                    self._sizes[key] = size
+        except OSError:
+            logger.exception(
+                "FSL2Adapter recovery scan failed for %s",
+                self._base_path,
+            )
+            return
+        if keys:
+            # Apply base byte accounting now; listeners (none registered
+            # yet) are seeded later in ``register_listener``.
+            self._notify_keys_stored(keys, sizes)
+            self._recovered = (keys, sizes)
+            logger.info(
+                "FSL2Adapter recovered %d existing objects (%d bytes) from %s",
+                len(keys),
+                sum(sizes),
+                self._base_path,
+            )
 
     def _key_to_path(self, key: ObjectKey) -> Path:
         return self._base_path / _object_key_to_filename(key)
@@ -578,14 +793,63 @@ class FSL2Adapter(L2AdapterInterface):
         objects: list[MemoryObj],
         task_id: L2TaskId,
     ) -> None:
+        evicting = self.supports_global_eviction
+        # Lock the batch so eviction cannot drop a key while it is being
+        # stored (closes the store-vs-delete race). Released in ``finally``.
+        if evicting:
+            self._lock_keys(keys)
+        try:
+            success, bytes_written, accounted = await self._write_objects(
+                keys, objects, task_id
+            )
+            # Account candidates exactly once, only when eviction is enabled.
+            # With eviction disabled the adapter stays stateless (its historic
+            # behaviour) and avoids unbounded ``_sizes`` growth.
+            if evicting and accounted:
+                self._account_stored(accounted)
+        finally:
+            if evicting:
+                self._unlock_keys(keys)
+
+        with self._lock:
+            self._completed_store_tasks[task_id] = L2StoreResult(success, bytes_written)
+        self._store_efd.notify()
+
+    async def _write_objects(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+        task_id: L2TaskId,
+    ) -> tuple[bool, int, list[tuple[ObjectKey, int]]]:
+        """Write each object to disk.
+
+        Returns ``(success, bytes_written, accounted)`` where ``accounted``
+        holds ``(key, size)`` pairs that should be added to usage tracking:
+        freshly written keys, plus keys already on disk but untracked (e.g.
+        left by a prior run when recovery was off), so usage converges to
+        disk reality.
+
+        Args:
+            keys: The object keys to store.
+            objects: The memory objects to store, aligned with ``keys``.
+            task_id: The store task id (for logging).
+        """
         success = True
         bytes_written = 0
+        accounted: list[tuple[ObjectKey, int]] = []
+        evicting = self.supports_global_eviction
         try:
             for key, obj in zip(keys, objects, strict=True):
                 file_path, tmp_path = self._key_to_file_and_tmp_path(key)
 
-                # Skip if already stored on disk
+                # Skip if already stored on disk.
                 if await aiofiles.os.path.exists(file_path):
+                    if evicting and key not in self._sizes:
+                        try:
+                            st = await aiofiles.os.stat(file_path)
+                            accounted.append((key, st.st_size))
+                        except OSError:
+                            pass
                     continue
                 buf = obj.byte_array
                 size = len(buf)
@@ -597,10 +861,8 @@ class FSL2Adapter(L2AdapterInterface):
                         aligned = self._os_disk_bs > 0 and size % self._os_disk_bs == 0
                         if not aligned:
                             logger.warning(
-                                "Cannot use O_DIRECT for "
-                                "writing size %d, not "
-                                "aligned to block size "
-                                "%d.",
+                                "Cannot use O_DIRECT for writing size %d, "
+                                "not aligned to block size %d.",
                                 size,
                                 self._os_disk_bs,
                             )
@@ -619,6 +881,7 @@ class FSL2Adapter(L2AdapterInterface):
 
                     await aiofiles.os.replace(tmp_path, file_path)
                     bytes_written += size
+                    accounted.append((key, size))
                     logger.debug(
                         "FSL2Adapter stored key %s (%d bytes)",
                         file_path.name,
@@ -633,15 +896,30 @@ class FSL2Adapter(L2AdapterInterface):
                         await aiofiles.os.unlink(tmp_path)
                     success = False
         except Exception:
-            logger.exception(
-                "FSL2Adapter store task %s failed",
-                task_id,
-            )
+            logger.exception("FSL2Adapter store task %s failed", task_id)
             success = False
+        return success, bytes_written, accounted
 
+    def _account_stored(self, accounted: list[tuple[ObjectKey, int]]) -> None:
+        """Add not-yet-tracked ``(key, size)`` pairs to usage accounting.
+
+        Counts each key exactly once -- a concurrent store of the same key,
+        a recovered key, or an already-accounted key is skipped so
+        ``usage_fraction`` does not drift upward.
+
+        Args:
+            accounted: Candidate ``(key, size)`` pairs to account.
+        """
+        newly_keys: list[ObjectKey] = []
+        newly_sizes: list[int] = []
         with self._lock:
-            self._completed_store_tasks[task_id] = L2StoreResult(success, bytes_written)
-        self._store_efd.notify()
+            for k, sz in accounted:
+                if k not in self._sizes:
+                    self._sizes[k] = sz
+                    newly_keys.append(k)
+                    newly_sizes.append(sz)
+        if newly_keys:
+            self._notify_keys_stored(newly_keys, newly_sizes)
 
     # ---- lookup ---------------------------------------------------------
 
@@ -655,6 +933,15 @@ class FSL2Adapter(L2AdapterInterface):
             if not await self._key_exists_on_disk(key):
                 continue
             bitmap.set(i)
+
+        # Lock the hit keys so eviction cannot delete them between this
+        # lookup and the load that follows. The caller releases them via
+        # ``submit_unlock``. Locking is published before the result so a
+        # delete racing the lookup observes the lock.
+        if self.supports_global_eviction:
+            hit_keys = bitmap.gather(keys)
+            if hit_keys:
+                self._lock_keys(hit_keys)
 
         with self._lock:
             self._completed_lookup_tasks[task_id] = bitmap
@@ -742,6 +1029,14 @@ class FSL2Adapter(L2AdapterInterface):
                     file_path,
                 )
                 continue
+
+        # Touch successfully loaded keys so the LRU eviction policy keeps
+        # them warm. Skipped entirely when eviction is disabled to keep the
+        # load path free of bookkeeping. No byte impact on access.
+        if self.supports_global_eviction:
+            hit_keys = bitmap.gather(keys)
+            if hit_keys:
+                self._notify_keys_accessed(hit_keys)
 
         with self._lock:
             self._completed_load_tasks[task_id] = bitmap

--- a/tests/v1/distributed/test_fs_l2_adapter_eviction.py
+++ b/tests/v1/distributed/test_fs_l2_adapter_eviction.py
@@ -1,0 +1,558 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for capacity-aware eviction in the ``fs`` L2 adapter.
+
+The ``fs`` adapter participates in the shared L2 eviction framework like
+``native_connector``: it declares a capacity, reports usage via the base
+``_notify_keys_*`` helpers, and implements ``delete`` to unlink files.
+These tests verify the consistency guarantees that wiring relies on:
+
+* byte accounting tracks store/delete exactly once per key (no double
+  count under dedup),
+* ``delete`` removes files, frees accounting, and notifies listeners,
+* load touches keys so an LRU policy keeps them warm,
+* startup recovery accounts for and seeds pre-existing files,
+* a real LRU policy drives end-to-end eviction of the right victims, and
+* deleting a file concurrently with a read never corrupts data (POSIX).
+"""
+
+# Standard
+from pathlib import Path
+import os
+import select
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import EvictionConfig
+from lmcache.v1.distributed.eviction import L2EvictionPolicy
+from lmcache.v1.distributed.eviction_policy import CreateEvictionPolicy
+from lmcache.v1.distributed.internal_api import L2StoreResult
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    FSL2Adapter,
+    FSL2AdapterConfig,
+    _object_key_to_filename,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObj,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd
+
+# Bytes per element of the float32 payloads used below.
+_F32 = 4
+
+# The fs adapter ignores the layout descriptor in lookup, so an empty one
+# is sufficient to drive ``submit_lookup_and_lock_task`` in tests.
+_EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
+
+
+def _gb(num_bytes: int) -> float:
+    """Convert a byte budget to the GB unit the config expects."""
+    return num_bytes / (1024**3)
+
+
+def create_object_key(chunk_id: int, model_name: str = "test_model") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
+        model_name=model_name,
+        kv_rank=0,
+    )
+
+
+def create_memory_obj(num_elems: int = 256, fill_value: float = 1.0) -> TensorMemoryObj:
+    """A float32 ``TensorMemoryObj`` of ``num_elems * 4`` bytes."""
+    raw_data = torch.empty(num_elems, dtype=torch.float32)
+    raw_data.fill_(fill_value)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([num_elems]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=num_elems * _F32,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+def wait_for_event_fd(event_fd: int, timeout: float = 5.0) -> bool:
+    poll = select.poll()
+    poll.register(event_fd, select.POLLIN)
+    events = poll.poll(timeout * 1000)
+    if events:
+        try:
+            consume_fd(event_fd)
+        except BlockingIOError:
+            pass
+        return True
+    return False
+
+
+def store_blocking(
+    adapter: FSL2Adapter,
+    keys: list[ObjectKey],
+    objs: list[MemoryObj],
+    timeout: float = 5.0,
+) -> L2StoreResult:
+    """Submit a store task and block until it completes."""
+    task_id = adapter.submit_store_task(keys, objs)
+    assert wait_for_event_fd(adapter.get_store_event_fd(), timeout)
+    completed = adapter.pop_completed_store_tasks()
+    assert task_id in completed
+    return completed[task_id]
+
+
+def load_blocking(
+    adapter: FSL2Adapter,
+    keys: list[ObjectKey],
+    objs: list[MemoryObj],
+    timeout: float = 5.0,
+) -> Bitmap:
+    """Submit a load task and block until it completes; return the bitmap."""
+    task_id = adapter.submit_load_task(keys, objs)
+    assert wait_for_event_fd(adapter.get_load_event_fd(), timeout)
+    bitmap = adapter.query_load_result(task_id)
+    assert bitmap is not None
+    return bitmap
+
+
+def lookup_lock_blocking(
+    adapter: FSL2Adapter,
+    keys: list[ObjectKey],
+    timeout: float = 5.0,
+) -> Bitmap:
+    """Submit a lookup-and-lock task and block until it completes."""
+    task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
+    assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout)
+    bitmap = adapter.query_lookup_and_lock_result(task_id)
+    assert bitmap is not None
+    return bitmap
+
+
+class RecordingListener:
+    """L2 adapter listener that records every callback invocation."""
+
+    def __init__(self) -> None:
+        self.stored: list[tuple[list[ObjectKey], list[int]]] = []
+        self.accessed: list[list[ObjectKey]] = []
+        self.deleted: list[list[ObjectKey]] = []
+
+    def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+        self.stored.append((list(keys), list(sizes)))
+
+    def on_l2_keys_accessed(self, keys: list[ObjectKey]) -> None:
+        self.accessed.append(list(keys))
+
+    def on_l2_keys_deleted(self, keys: list[ObjectKey]) -> None:
+        self.deleted.append(list(keys))
+
+
+@pytest.fixture
+def make_adapter(tmp_path):
+    """Factory that builds adapters and closes them at teardown."""
+    created: list[FSL2Adapter] = []
+
+    def _make(**kwargs) -> FSL2Adapter:
+        kwargs.setdefault("base_path", str(tmp_path / "fsl2"))
+        adapter = FSL2Adapter(FSL2AdapterConfig(**kwargs))
+        created.append(adapter)
+        return adapter
+
+    yield _make
+
+    for adapter in created:
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_from_dict_defaults(self):
+        cfg = FSL2AdapterConfig.from_dict({"base_path": "/tmp/x"})
+        assert cfg.max_capacity_gb == 0
+        assert cfg.recover_on_start is True
+
+    def test_from_dict_capacity_and_recover(self):
+        cfg = FSL2AdapterConfig.from_dict(
+            {"base_path": "/tmp/x", "max_capacity_gb": 2, "recover_on_start": False}
+        )
+        assert cfg.max_capacity_gb == 2.0
+        assert cfg.recover_on_start is False
+
+    def test_from_dict_negative_capacity_raises(self):
+        with pytest.raises(ValueError, match="max_capacity_gb"):
+            FSL2AdapterConfig.from_dict({"base_path": "/tmp/x", "max_capacity_gb": -1})
+
+    def test_from_dict_invalid_capacity_type_raises(self):
+        with pytest.raises(ValueError, match="max_capacity_gb"):
+            FSL2AdapterConfig.from_dict(
+                {"base_path": "/tmp/x", "max_capacity_gb": "big"}
+            )
+
+    def test_from_dict_invalid_recover_type_raises(self):
+        with pytest.raises(ValueError, match="recover_on_start"):
+            FSL2AdapterConfig.from_dict(
+                {"base_path": "/tmp/x", "recover_on_start": "yes"}
+            )
+
+    def test_help_mentions_capacity(self):
+        assert "max_capacity_gb" in FSL2AdapterConfig.help()
+
+
+# ---------------------------------------------------------------------------
+# Capacity reporting
+# ---------------------------------------------------------------------------
+
+
+class TestCapacityReporting:
+    def test_no_capacity_disables_eviction(self, make_adapter):
+        adapter = make_adapter()
+        assert adapter.supports_global_eviction is False
+        assert adapter.get_usage().usage_fraction == -1.0
+
+    def test_capacity_enables_eviction(self, make_adapter):
+        adapter = make_adapter(max_capacity_gb=_gb(4096))
+        assert adapter.supports_global_eviction is True
+        assert adapter.get_usage().total_capacity_bytes > 0
+
+
+# ---------------------------------------------------------------------------
+# Usage accounting
+# ---------------------------------------------------------------------------
+
+
+class TestUsageAccounting:
+    def test_store_increases_usage(self, make_adapter):
+        adapter = make_adapter(max_capacity_gb=_gb(1 << 20))
+        keys = [create_object_key(i) for i in range(3)]
+        objs = [create_memory_obj(256) for _ in range(3)]
+        result = store_blocking(adapter, keys, objs)
+        assert result.is_successful()
+
+        expected = sum(len(o.byte_array) for o in objs)
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == expected
+        assert usage.usage_fraction == pytest.approx(
+            expected / usage.total_capacity_bytes
+        )
+
+    def test_dedup_does_not_double_count(self, make_adapter):
+        adapter = make_adapter(max_capacity_gb=_gb(1 << 20))
+        key = create_object_key(0)
+        size = len(create_memory_obj(256).byte_array)
+
+        store_blocking(adapter, [key], [create_memory_obj(256)])
+        assert adapter.get_usage().total_bytes_used == size
+
+        # Re-storing the same key skips the write (already on disk) and
+        # must not inflate accounting.
+        store_blocking(adapter, [key], [create_memory_obj(256)])
+        assert adapter.get_usage().total_bytes_used == size
+
+    def test_delete_decreases_usage_and_removes_files(self, tmp_path, make_adapter):
+        base = tmp_path / "fsl2"
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        keys = [create_object_key(i) for i in range(3)]
+        objs = [create_memory_obj(256) for _ in range(3)]
+        store_blocking(adapter, keys, objs)
+        size = len(objs[0].byte_array)
+
+        adapter.delete([keys[0], keys[2]])
+
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == size  # only keys[1] remains
+        assert not (base / _object_key_to_filename(keys[0])).exists()
+        assert (base / _object_key_to_filename(keys[1])).exists()
+        assert not (base / _object_key_to_filename(keys[2])).exists()
+
+    def test_delete_unknown_key_is_noop(self, make_adapter):
+        adapter = make_adapter(max_capacity_gb=_gb(1 << 20))
+        # Never stored -- delete must not raise or drive accounting negative.
+        adapter.delete([create_object_key(99)])
+        assert adapter.get_usage().total_bytes_used == 0
+
+    def test_no_capacity_store_stays_stateless(self, make_adapter):
+        # With eviction disabled (max_capacity_gb=0, the default) the store
+        # path must not accumulate per-key accounting -- the fs adapter keeps
+        # its historic stateless, zero-overhead behaviour.
+        adapter = make_adapter()  # capacity 0
+        keys = [create_object_key(i) for i in range(3)]
+        objs = [create_memory_obj(256) for _ in range(3)]
+        store_blocking(adapter, keys, objs)
+
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == 0
+        assert usage.usage_fraction == -1.0
+
+
+# ---------------------------------------------------------------------------
+# Listener notifications
+# ---------------------------------------------------------------------------
+
+
+class TestListenerNotifications:
+    def test_store_notifies_listener_once(self, make_adapter):
+        adapter = make_adapter(max_capacity_gb=_gb(1 << 20))
+        listener = RecordingListener()
+        adapter.register_listener(listener)
+
+        key = create_object_key(0)
+        store_blocking(adapter, [key], [create_memory_obj(256)])
+        store_blocking(adapter, [key], [create_memory_obj(256)])  # dedup
+
+        flat = [k for batch, _ in listener.stored for k in batch]
+        assert flat.count(key) == 1
+
+    def test_load_notifies_accessed_for_hits_only(self, make_adapter):
+        adapter = make_adapter(max_capacity_gb=_gb(1 << 20))
+        listener = RecordingListener()
+        adapter.register_listener(listener)
+
+        stored_key = create_object_key(0)
+        missing_key = create_object_key(1)
+        store_blocking(adapter, [stored_key], [create_memory_obj(256)])
+
+        dst = [create_memory_obj(256), create_memory_obj(256)]
+        load_blocking(adapter, [stored_key, missing_key], dst)
+
+        accessed = [k for batch in listener.accessed for k in batch]
+        assert stored_key in accessed
+        assert missing_key not in accessed
+
+    def test_delete_notifies_deleted(self, make_adapter):
+        adapter = make_adapter(max_capacity_gb=_gb(1 << 20))
+        listener = RecordingListener()
+        adapter.register_listener(listener)
+
+        key = create_object_key(0)
+        store_blocking(adapter, [key], [create_memory_obj(256)])
+        adapter.delete([key])
+
+        deleted = [k for batch in listener.deleted for k in batch]
+        assert deleted == [key]
+
+
+# ---------------------------------------------------------------------------
+# Startup recovery
+# ---------------------------------------------------------------------------
+
+
+def _seed_file(base_dir: Path, key: ObjectKey, num_bytes: int) -> None:
+    base_dir.mkdir(parents=True, exist_ok=True)
+    (base_dir / _object_key_to_filename(key)).write_bytes(b"\xab" * num_bytes)
+
+
+class TestRecovery:
+    def test_recovery_accounts_existing_files(self, tmp_path, make_adapter):
+        base = tmp_path / "fsl2"
+        keys = [create_object_key(i) for i in range(2)]
+        for key in keys:
+            _seed_file(base, key, 1024)
+
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        assert adapter.get_usage().total_bytes_used == 2048
+
+    def test_recovery_seeds_eviction_policy(self, tmp_path, make_adapter):
+        base = tmp_path / "fsl2"
+        key = create_object_key(0)
+        _seed_file(base, key, 1024)
+
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        policy = CreateEvictionPolicy(EvictionConfig(eviction_policy="LRU"))
+        adapter.register_listener(L2EvictionPolicy(policy))
+
+        # The recovered file is known to the policy and is evictable.
+        actions = policy.get_eviction_actions(1.0)
+        evictable = [k for action in actions for k in action.keys]
+        assert key in evictable
+
+    def test_recovery_does_not_seed_non_eviction_listener(self, tmp_path, make_adapter):
+        # A non-eviction listener (e.g. the coordinator event reporter) must
+        # NOT receive recovered files as fresh store events, which would
+        # double-report the warm cache to the fleet on every restart.
+        base = tmp_path / "fsl2"
+        _seed_file(base, create_object_key(0), 1024)
+
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        listener = RecordingListener()
+        adapter.register_listener(listener)
+
+        assert listener.stored == []
+
+    def test_recovery_skips_foreign_files(self, tmp_path, make_adapter):
+        base = tmp_path / "fsl2"
+        key = create_object_key(0)
+        _seed_file(base, key, 1024)
+        (base / "not-a-kv-file.txt").write_bytes(b"junk")
+        (base / "malformed.data").write_bytes(b"junk")
+
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        # Only the one valid file counts.
+        assert adapter.get_usage().total_bytes_used == 1024
+
+    def test_recover_on_start_false_skips_scan(self, tmp_path, make_adapter):
+        base = tmp_path / "fsl2"
+        _seed_file(base, create_object_key(0), 1024)
+
+        adapter = make_adapter(
+            base_path=str(base),
+            max_capacity_gb=_gb(1 << 20),
+            recover_on_start=False,
+        )
+        assert adapter.get_usage().total_bytes_used == 0
+
+    def test_no_capacity_skips_recovery(self, tmp_path, make_adapter):
+        base = tmp_path / "fsl2"
+        _seed_file(base, create_object_key(0), 1024)
+
+        adapter = make_adapter(base_path=str(base))  # cap 0
+        # Eviction disabled -> no usage signal, no recovery cost.
+        assert adapter.get_usage().usage_fraction == -1.0
+        assert adapter.get_usage().total_bytes_used == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end eviction with a real LRU policy
+# ---------------------------------------------------------------------------
+
+
+class TestLRUEvictionIntegration:
+    def test_lru_evicts_least_recently_used_victims(self, tmp_path, make_adapter):
+        base = tmp_path / "fsl2"
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        policy = CreateEvictionPolicy(EvictionConfig(eviction_policy="LRU"))
+        adapter.register_listener(L2EvictionPolicy(policy))
+
+        keys = [create_object_key(i) for i in range(5)]
+        for key in keys:
+            store_blocking(adapter, [key], [create_memory_obj(256)])
+
+        # Touch keys[0] via a load so it becomes most-recently-used and
+        # must survive eviction even though it was stored first.
+        load_blocking(adapter, [keys[0]], [create_memory_obj(256)])
+
+        before = adapter.get_usage().total_bytes_used
+        actions = policy.get_eviction_actions(0.4)
+        victims = [k for action in actions for k in action.keys]
+        assert victims, "LRU should select victims to evict"
+        assert keys[0] not in victims  # protected by the recent load
+
+        adapter.delete(victims)
+
+        # Accounting dropped, victim files gone, survivors intact.
+        per_obj = len(create_memory_obj(256).byte_array)
+        usage = adapter.get_usage()
+        assert usage.total_bytes_used == before - per_obj * len(victims)
+        for victim in victims:
+            assert not (base / _object_key_to_filename(victim)).exists()
+        assert (base / _object_key_to_filename(keys[0])).exists()
+
+        # keys[0] still loads with the correct payload.
+        dst = create_memory_obj(256, fill_value=0.0)
+        bitmap = load_blocking(adapter, [keys[0]], [dst])
+        assert bitmap.test(0)
+        assert torch.equal(dst.raw_data, torch.ones(256, dtype=torch.float32))
+
+
+# ---------------------------------------------------------------------------
+# POSIX delete-during-read safety
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionLocking:
+    def test_locked_key_survives_eviction_then_unlock_frees_it(
+        self, tmp_path, make_adapter
+    ):
+        base = tmp_path / "fsl2"
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        key = create_object_key(0)
+        store_blocking(adapter, [key], [create_memory_obj(256)])
+        size = len(create_memory_obj(256).byte_array)
+
+        # lookup_and_lock pins the key; a concurrent eviction must skip it.
+        assert lookup_lock_blocking(adapter, [key]).test(0)
+        adapter.delete([key])
+        assert adapter.get_usage().total_bytes_used == size
+        assert (base / _object_key_to_filename(key)).exists()
+
+        # After unlock the key is evictable again.
+        adapter.submit_unlock([key])
+        adapter.delete([key])
+        assert adapter.get_usage().total_bytes_used == 0
+        assert not (base / _object_key_to_filename(key)).exists()
+
+    def test_store_in_progress_lock_is_balanced(self, tmp_path, make_adapter):
+        # After a completed store the key holds no residual lock, so it is
+        # immediately evictable (the store lock is released in finally).
+        base = tmp_path / "fsl2"
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        key = create_object_key(0)
+        store_blocking(adapter, [key], [create_memory_obj(256)])
+
+        adapter.delete([key])
+        assert adapter.get_usage().total_bytes_used == 0
+
+
+class TestHardening:
+    def test_store_accounts_preexisting_untracked_file(self, tmp_path, make_adapter):
+        # recover_on_start=False leaves a prior-run file untracked; a later
+        # store of that key must account it so usage/eviction include it.
+        base = tmp_path / "fsl2"
+        key = create_object_key(0)
+        _seed_file(base, key, 1024)
+        adapter = make_adapter(
+            base_path=str(base),
+            max_capacity_gb=_gb(1 << 20),
+            recover_on_start=False,
+        )
+        assert adapter.get_usage().total_bytes_used == 0  # not tracked yet
+
+        store_blocking(adapter, [key], [create_memory_obj(256)])  # exists -> skip
+        assert adapter.get_usage().total_bytes_used == 1024  # accounted at disk size
+
+    def test_recovery_skips_symlink(self, tmp_path, make_adapter):
+        base = tmp_path / "fsl2"
+        _seed_file(base, create_object_key(0), 1024)  # one real 1024B file
+        # A symlink named like a valid key pointing at a larger external file.
+        target = tmp_path / "external_blob"
+        target.write_bytes(b"\x00" * 4096)
+        os.symlink(target, base / _object_key_to_filename(create_object_key(1)))
+
+        adapter = make_adapter(base_path=str(base), max_capacity_gb=_gb(1 << 20))
+        # Only the real file is counted; the symlink target is not.
+        assert adapter.get_usage().total_bytes_used == 1024
+
+
+class TestDeleteSafety:
+    def test_load_after_delete_is_miss(self, make_adapter):
+        adapter = make_adapter(max_capacity_gb=_gb(1 << 20))
+        key = create_object_key(0)
+        store_blocking(adapter, [key], [create_memory_obj(256)])
+        adapter.delete([key])
+
+        bitmap = load_blocking(adapter, [key], [create_memory_obj(256)])
+        assert not bitmap.test(0)  # miss, no exception, no corruption
+
+    def test_open_descriptor_survives_unlink(self, tmp_path):
+        """The POSIX property delete() relies on: an already-open fd keeps
+        reading a file's data after it is unlinked."""
+        path = tmp_path / "probe.bin"
+        payload = b"\xcd" * 4096
+        path.write_bytes(payload)
+
+        fd = os.open(str(path), os.O_RDONLY)
+        try:
+            os.unlink(path)  # concurrent eviction
+            assert not path.exists()
+            assert os.read(fd, len(payload)) == payload  # still readable
+        finally:
+            os.close(fd)


### PR DESCRIPTION
**What this PR does / why we need it**:

The pure-Python `fs` L2 adapter could not be capacity-bounded: `delete()` was a
no-op and `max_capacity_bytes` stayed `0`, so it never joined the L2 eviction
framework. Under disk-space pressure its `base_path` grows until the device
fills, at which point every store fails and the cache silently stops admitting
new content — sustained hit rate collapses. This PR wires `fs` into the existing
per-adapter eviction framework (mirroring `native_connector`): set
`max_capacity_gb > 0` and the adapter reports usage, touches keys on load for
LRU recency, and evicts via `delete()`. Victim selection and the LRU policy are
unchanged framework code — the adapter only declares capacity, reports usage,
and unlinks.

**Special notes for your reviewers**:

- **Defaults / config**: two new `fs` config keys — `max_capacity_gb` (default
  `0` = unbounded, fully backward-compatible legacy behaviour) and
  `recover_on_start` (default `true`). Eviction engages only when
  `max_capacity_gb > 0`.
- **Exactly-once accounting**: an in-memory per-key size map guarded by the
  adapter lock makes a store count once even under a concurrent store of the
  same key or a re-store of an already-resident key, and supplies delete sizes
  without an extra `stat`.
- **Crash/race safety**: `delete()` runs synchronously on the eviction-controller
  thread and `unlink`s victim files. POSIX keeps an already-open file readable
  through its descriptor, and the load path treats a vanished file as a miss, so
  a delete racing a load never corrupts data — no lock protocol is needed and
  `submit_unlock` stays a no-op. A test exercises this POSIX property directly.
- **Startup recovery**: with capacity set, `recover_on_start` scans `base_path`
  so files from a previous run count toward usage and are replayed to the
  eviction policy when it registers (listeners attach after `__init__`). Set it
  to `false` to skip the scan on very large directories. Known v1 limitation:
  recovered keys are seeded with current-time recency (true age is not restored).
- **Tests**: 23 new tests — config validation, usage accounting, dedup-once,
  delete, load-accessed notification, recovery + listener seeding, end-to-end
  eviction with a real `LRU` policy (a load protects the MRU key from eviction),
  and the POSIX delete-during-read property. No SLF on production internals; the
  tests assert via the public `get_usage()` / listener surface (a couple read the
  adapter's own `_base_path` to check files on disk).

**If applicable**:

- [x] this PR contains user facing changes - docs added (l2_eviction design-doc Adapter Support Matrix + an `FSL2Adapter` note)
- [x] this PR contains unit tests
