### PR TITLE
feat(MP): add securityContext to crd(lmcache.lmcache.ai_lmcacheengines.yaml) and modify controller

### DIFF
--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -372,6 +372,14 @@ type LMCacheEngineSpec struct {
 	// +optional
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
+	// securityContext defines the container-level security context for the
+	// LMCache container.
+	//
+	// When unset, the operator preserves the existing default behavior and runs
+	// the container with privileged: true.
+	// +optional
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+
 	// podAnnotations are additional annotations added to pods.
 	// +optional
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -865,6 +865,11 @@ func (in *LMCacheEngineSpec) DeepCopyInto(out *LMCacheEngineSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.SecurityContext)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PodAnnotations != nil {
 		in, out := &in.PodAnnotations, &out.PodAnnotations

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -1499,6 +1499,201 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              securityContext:
+                description: |-
+                  securityContext defines the container-level security context for the
+                  LMCache container.
+
+                  When unset, the operator preserves the existing default behavior and runs
+                  the container with privileged: true.
+                properties:
+                  allowPrivilegeEscalation:
+                    description: |-
+                      AllowPrivilegeEscalation controls whether a process can gain more
+                      privileges than its parent process. This bool directly controls if
+                      the no_new_privs flag will be set on the container process.
+                      AllowPrivilegeEscalation is true always when the container is:
+                      1) run as Privileged
+                      2) has CAP_SYS_ADMIN
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                      overrides the pod's appArmorProfile.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile loaded on the node that should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must match the loaded name of the profile.
+                          Must be set if and only if type is "Localhost".
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of AppArmor profile will be applied.
+                          Valid options are:
+                            Localhost - a profile pre-loaded on the node.
+                            RuntimeDefault - the container runtime's default profile.
+                            Unconfined - no AppArmor enforcement.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  capabilities:
+                    description: |-
+                      The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container runtime.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  privileged:
+                    description: |-
+                      Run container in privileged mode.
+                      Processes in privileged containers are essentially equivalent to root on the host.
+                      Defaults to false.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  procMount:
+                    description: |-
+                      procMount denotes the type of proc mount to use for the containers.
+                      The default value is Default which uses the container runtime defaults for
+                      readonly paths and masked paths.
+                      This requires the ProcMountType feature flag to be enabled.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                  readOnlyRootFilesystem:
+                    description: |-
+                      Whether this container has a read-only root filesystem.
+                      Default is false.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: |-
+                      Indicates that the container must run as a non-root user.
+                      If true, the Kubelet will validate the image at runtime to ensure that it
+                      does not run as UID 0 (root) and fail to start the container if it does.
+                      If unset or false, no such validation will be performed.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: |-
+                      The SELinux context to be applied to the container.
+                      If unspecified, the container runtime will allocate a random SELinux context for each
+                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: |-
+                      The seccomp options to use by this container. If seccomp options are
+                      provided at both the pod & container level, the container options
+                      override the pod options.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile defined in a file on the node should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of seccomp profile will be applied.
+                          Valid options are:
+
+                          Localhost - a profile defined in a file on the node should be used.
+                          RuntimeDefault - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will be used.
+                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                          GMSA credential spec named by the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: |-
+                          HostProcess determines if a container should be run as a 'Host Process' container.
+                          All of a Pod's containers must have the same effective HostProcess value
+                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: |-
+                          The UserName in Windows to run the entrypoint of the container process.
+                          Defaults to the user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
               server:
                 description: server defines server configuration.
                 properties:

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -80,7 +80,15 @@ func buildDaemonSetCore(
 		rc := nvidiaRuntimeClass
 		runtimeClassName = &rc
 	}
-	privileged := true
+	containerSecurityContext := spec.SecurityContext
+	if containerSecurityContext == nil {
+		privileged := true
+		containerSecurityContext = &corev1.SecurityContext{
+			Privileged: &privileged,
+		}
+	} else {
+		containerSecurityContext = containerSecurityContext.DeepCopy()
+	}
 
 	serverPort := derefInt32(getServerPort(spec), 5555)
 	imgRepo := defaultImageRepo
@@ -276,13 +284,11 @@ func buildDaemonSetCore(
 							Ports:           containerPorts,
 							Env:             envVars,
 							Resources:       ComputeResources(spec),
-							SecurityContext: &corev1.SecurityContext{
-								Privileged: &privileged,
-							},
-							VolumeMounts:   volumeMounts,
-							StartupProbe:   startupProbe,
-							LivenessProbe:  livenessProbe,
-							ReadinessProbe: readinessProbe,
+							SecurityContext: containerSecurityContext,
+							VolumeMounts:    volumeMounts,
+							StartupProbe:    startupProbe,
+							LivenessProbe:   livenessProbe,
+							ReadinessProbe:  readinessProbe,
 						},
 					},
 					Volumes: volumes,

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -535,6 +535,9 @@ func TestBuildDaemonSet_Minimal(t *testing.T) {
 	if c.ImagePullPolicy != corev1.PullIfNotPresent {
 		t.Fatalf("expected PullIfNotPresent, got %s", c.ImagePullPolicy)
 	}
+	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
+		t.Fatal("expected default securityContext.privileged=true when spec.securityContext is unset")
+	}
 
 	// Should have probes
 	if c.StartupProbe == nil {
@@ -585,6 +588,40 @@ func TestBuildDaemonSet_Minimal(t *testing.T) {
 	// Should have 3 ports (server + http + metrics) by default
 	if len(c.Ports) != 3 {
 		t.Fatalf("expected 3 container ports, got %d", len(c.Ports))
+	}
+}
+
+func TestBuildDaemonSet_CustomSecurityContext(t *testing.T) {
+	engine := minimalEngine()
+	runAsNonRoot := true
+	privileged := false
+	runAsUser := int64(1000)
+	engine.Spec.SecurityContext = &corev1.SecurityContext{
+		RunAsNonRoot: &runAsNonRoot,
+		Privileged:   &privileged,
+		RunAsUser:    &runAsUser,
+	}
+
+	ds := BuildDaemonSet(engine)
+	c := ds.Spec.Template.Spec.Containers[0]
+
+	if c.SecurityContext == nil {
+		t.Fatal("expected securityContext to be set")
+	}
+	if c.SecurityContext.Privileged == nil || *c.SecurityContext.Privileged {
+		t.Fatal("expected privileged=false from spec.securityContext")
+	}
+	if c.SecurityContext.RunAsNonRoot == nil || !*c.SecurityContext.RunAsNonRoot {
+		t.Fatal("expected runAsNonRoot=true from spec.securityContext")
+	}
+	if c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 1000 {
+		t.Fatal("expected runAsUser=1000 from spec.securityContext")
+	}
+
+	// Ensure a DeepCopy is used so later spec mutations do not alter the built DaemonSet.
+	*engine.Spec.SecurityContext.Privileged = true
+	if c.SecurityContext.Privileged == nil || *c.SecurityContext.Privileged {
+		t.Fatal("built daemonset securityContext should not be affected by later spec mutations")
 	}
 }
 


### PR DESCRIPTION
## Summary
When running the `lmcache-server` DaemonSet Pod together with a vLLM Pod for IPC communication, we encountered a `cudaErrorMapBufferObjectFailed` error.

After investigation, we found that the vLLM Pod was running as the non-root `nobody` user for security reasons, while the `lmcache-server` DaemonSet Pod was running as `root`. Because of this user mismatch, the `lmcache-server` Pod could not properly read or write the IPC-related files created by the vLLM Pod.

To address this, this PR adds support for configuring `securityContext` when deploying the `lmcacheengines` CRD, so that the LMCache server Pod can run with the appropriate user settings for IPC communication.

## Details

The issue occurred when the `lmcache-server` DaemonSet Pod and the vLLM Pod were running with different users while communicating through IPC.

The vLLM Pod was running as the non-root `nobody` user for security reasons, and IPC-related files were created under `/dev/shm` with the following ownership and permissions:

```text
-rw------- 1 nobody nogroup 81920 cuda.shm.fffe.223.1
-rw------- 1 nobody nogroup 81920 cuda.shm.fffe.224.1
-rw------- 1 nobody nogroup 81920 cuda.shm.fffe.225.1
-rw------- 1 nobody nogroup 81920 cuda.shm.fffe.226.1
-rw------- 1 nobody nogroup 64424509440 lmcache_l1_pool_1
-rw------- 1 nobody nogroup 80064 torch_547_3673712610_0
-rw------- 1 nobody nogroup 80064 torch_548_3790871826_0
-rw------- 1 nobody nogroup 80064 torch_549_88063950_0
-rw------- 1 nobody nogroup 80064 torch_550_2061898546_0
```

Although these files were visible from the `lmcache-server` Pod through the shared `hostPath` mount for `/dev/shm`, the `lmcache-server` Pod was running as `root` and could not properly access the IPC files created by the vLLM Pod. As a result, LMCache failed during `REGISTER_KV_CACHE` while trying to unwrap the CUDA IPC handle:

```text
torch.AcceleratorError: CUDA error: mapping of buffer object failed
```

To resolve this, this PR adds security context-related fields to the `LMCacheEngine` CRD. It also updates the controller logic that watches the `LMCacheEngine` resource so that the configured `securityContext` is applied when creating the `lmcache-server` DaemonSet.

With this change, users can configure the `lmcache-server` Pod to run with the appropriate user and group settings required to access IPC-related files created by the vLLM Pod.