### PR TITLE
docs: daily drift check — multi-process mode (2026-06-24)

### DIFF
--- a/docs/design/v1/multiprocess/raw_cuda_ipc.md
+++ b/docs/design/v1/multiprocess/raw_cuda_ipc.md
@@ -2,7 +2,7 @@
 
 ## Why a second wrapper
 
-The default `CudaIPCWrapper` in `custom_types.py` calls
+The default `CudaIPCWrapper` in `platform/cuda/ipc_wrapper.py` calls
 `tensor.untyped_storage()._share_cuda_()` to publish the storage over
 CUDA IPC. That path only works when the storage is owned by PyTorch's
 caching allocator. TRT-LLM's KV pool is published via
@@ -28,21 +28,22 @@ the torch side restores them.
 `RawCudaIPCWrapper` is a **subclass** of `CudaIPCWrapper`, not a new
 class with its own ext code. This is load-bearing for the wire format:
 
-- `KVCache = list[CudaIPCWrapper]` is the registered msgspec type for
+- `KVCache = list[DeviceIPCWrapper]` is the registered msgspec type for
   `REGISTER_KV_CACHE`. msgspec does **not** support unions of custom
   ext-encoded types — adding a parallel class would force a wider
   decoder type and break either round-trip or the existing
-  `CudaIPCWrapper` consumers.
+  `DeviceIPCWrapper` consumers.
 - The customized serializer (`_CUSTOMERIZED_SERIALIZERS`) is keyed on
-  `CudaIPCWrapper` and dispatched by `isinstance`, so subclass instances
+  `DeviceIPCWrapper` and dispatched by `isinstance`, so subclass instances
   encode through the same path with **ext code 1**.
 - `Serialize` is `pickle.dumps(obj)`, which preserves subclass
   identity. On the receiving side `Deserialize` reconstructs the
   subclass and `to_tensor` dispatches to the override.
 
 The receiving server therefore needs no per-type branching: a
-`list[CudaIPCWrapper]` arriving at `MPCacheServer.register_kv_cache`
-contains either kind, and `to_tensor()` does the right thing.
+`list[DeviceIPCWrapper]` arriving at
+`LMCacheDrivenTransferModule.register_kv_cache` contains either kind, and
+`to_tensor()` does the right thing.
 
 ## Sender-side validation
 

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -554,7 +554,7 @@ Adding a new request type
 1. Add a new member to ``RequestType`` in ``protocols/base.py``.
 2. Create a ``ProtocolDefinition`` in the appropriate ``protocols/*.py`` file
    (``engine``, ``controller``, ``observability``, ``debug``, ``blend``,
-   ``blend_v2``, or ``blend_v3``) and add the request name to that
+   ``blend_v2``, ``blend_v3``, or ``p2p``) and add the request name to that
    module's ``REQUEST_NAMES``.
 3. Implement the handler method on the appropriate ``EngineModule``
    (e.g. ``LookupModule``, ``LMCacheDrivenTransferModule``, ``BlendV3Module``) and


### PR DESCRIPTION
## Summary

Auto-generated by the **daily multi-process docs drift check** routine. Today's pass found 2 inconsistencies between the docs and the current code on `dev` (tip `26cd499`):

### `docs/source/` (user-facing)

- **`docs/source/mp/index.rst`** — In the "Adding a new request type" how-to, the list of `protocols/*.py` modules is missing `p2p`. The `p2p` protocol module was added in **#3728** (`8f680ec`, 2026-06-18) and now ships alongside `engine`, `controller`, `observability`, `debug`, `blend`, `blend_v2`, and `blend_v3`.

### `docs/design/`

- **`docs/design/v1/multiprocess/raw_cuda_ipc.md`** — Multiple stale references after the `DeviceIPCWrapper` refactor in **#3703** and the auto-discovery follow-up in **#3829** (`3e1bc02`):
  - `CudaIPCWrapper in custom_types.py` → now lives at `platform/cuda/ipc_wrapper.py`.
  - `KVCache = list[CudaIPCWrapper]` → the registered msgspec type is now `KVCache = list[DeviceIPCWrapper]`.
  - `_CUSTOMERIZED_SERIALIZERS … keyed on CudaIPCWrapper` → now keyed on `DeviceIPCWrapper`.
  - Receiver "`list[CudaIPCWrapper]` arriving at `MPCacheServer.register_kv_cache`" → after the engine-module split, the handler is on `LMCacheDrivenTransferModule.register_kv_cache`, and the payload type is `list[DeviceIPCWrapper]`.

## Evidence

| Doc claim | Doc location | Current code |
|---|---|---|
| `CudaIPCWrapper in custom_types.py` | [`raw_cuda_ipc.md` L5](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/docs/design/v1/multiprocess/raw_cuda_ipc.md#L5) | [`lmcache/v1/platform/cuda/ipc_wrapper.py`](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/lmcache/v1/platform/cuda/ipc_wrapper.py) |
| `KVCache = list[CudaIPCWrapper]` | [`raw_cuda_ipc.md` L31](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/docs/design/v1/multiprocess/raw_cuda_ipc.md#L31) | [`custom_types.py` L120](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/lmcache/v1/multiprocess/custom_types.py#L120) — `KVCache = list[DeviceIPCWrapper]` |
| `_CUSTOMERIZED_SERIALIZERS` keyed on `CudaIPCWrapper` | [`raw_cuda_ipc.md` L37](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/docs/design/v1/multiprocess/raw_cuda_ipc.md#L37) | [`custom_types.py` L212-218](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/lmcache/v1/multiprocess/custom_types.py#L212-L218) — keyed on `DeviceIPCWrapper` |
| `MPCacheServer.register_kv_cache(...)` receives `list[CudaIPCWrapper]` | [`raw_cuda_ipc.md` L44](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/docs/design/v1/multiprocess/raw_cuda_ipc.md#L44) | [`modules/lmcache_driven_transfer.py` L623](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py#L623) — `LMCacheDrivenTransferModule.register_kv_cache(... kv_caches: KVCache ...)`; `KVCache = list[DeviceIPCWrapper]` |
| Protocol modules listed as `engine/controller/observability/debug/blend/blend_v2/blend_v3` | [`docs/source/mp/index.rst` L555-557](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/docs/source/mp/index.rst#L555-L557) | [`lmcache/v1/multiprocess/protocols/p2p.py`](https://github.com/LMCache/LMCache/blob/26cd49937aba3e24f753be203bce66b841a35f85/lmcache/v1/multiprocess/protocols/p2p.py) exists (added by #3728) |

## Proposed fix

Applied in the diff:

- Update the four stale references in `raw_cuda_ipc.md` to point at `platform/cuda/ipc_wrapper.py` / `DeviceIPCWrapper` / `LMCacheDrivenTransferModule.register_kv_cache`.
- Append `p2p` to the protocol-module list in `docs/source/mp/index.rst`.

Docs-only. No code changes.

## Notes

- Auto-generated by the **daily drift-check routine** (focus: multi-process mode). **Human review required before merge.**
- Marked **draft** intentionally. Please don't merge until a maintainer has eyeballed the wording.
- Sign-off (`Signed-off-by: ApostaC <yihua98@uchicago.edu>`) is on the commit so the DCO check passes.
- No code drift was flagged — only docs.

---
_Generated by [Claude Code](https://claude.ai/code/session_012zbnGRvRLxCwzLWTR1gThz)_