### PR TITLE
[Bugfix] Fix AssertionError in request_finished when LMCacheEngine is None

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -1845,17 +1845,19 @@ class LMCacheConnectorV1Impl:
 
         # Cleanup if request was aborted
         if request.status == RequestStatus.FINISHED_ABORTED:
-            # Notify storage backends of aborted requests
-            assert self.lmcache_engine is not None
-            sm = self.lmcache_engine.storage_manager
-            if sm is not None:
-                sm.cancel_request(request.request_id)
+            # Notify storage backends of aborted requests.
+            # lmcache_engine may be None on the scheduler side when
+            # enable_scheduler_bypass_lookup is disabled.
+            if self.lmcache_engine is not None:
+                sm = self.lmcache_engine.storage_manager
+                if sm is not None:
+                    sm.cancel_request(request.request_id)
 
             if self.async_loading:
                 # Cancel any ongoing async lookup and prefetch tasks on workers
                 lookup_id = request.request_id
-                assert self.lookup_client is not None
-                self.lookup_client.cancel_lookup(lookup_id)  # type: ignore[attr-defined]
+                if self.lookup_client is not None:
+                    self.lookup_client.cancel_lookup(lookup_id)  # type: ignore[attr-defined]
 
         params = (
             request.kv_transfer_params

--- a/tests/v1/test_v1_adapter_none_engine.py
+++ b/tests/v1/test_v1_adapter_none_engine.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from types import SimpleNamespace
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm")
+
+# Third Party
+from vllm.v1.request import RequestStatus
+
+# First Party
+from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
+
+
+class _FakeParent:
+    def __init__(self, metadata=None):
+        self._connector_metadata = metadata
+
+    def _get_connector_metadata(self):
+        return self._connector_metadata
+
+
+class _FakeManager:
+    def __init__(self, engine=None):
+        self.lmcache_engine = engine
+        self.lmcache_engine_metadata = None
+        self.lookup_client = None
+
+
+def test_request_finished_with_none_engine() -> None:
+    """Aborted request must not crash when lmcache_engine is None.
+
+    On the scheduler side, when ``enable_scheduler_bypass_lookup`` is
+    disabled, the service factory returns ``None`` for the engine.
+    The original code had ``assert self.lmcache_engine is not None``
+    which killed the EngineCore process on any request abort.
+    """
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector._parent = _FakeParent()  # type: ignore[assignment]
+    connector._manager = _FakeManager(engine=None)  # type: ignore[assignment]
+    connector.config = SimpleNamespace(
+        get_extra_config_value=lambda key, default: default
+    )
+    connector.async_loading = False
+
+    request = SimpleNamespace(
+        request_id="req-aborted",
+        status=RequestStatus.FINISHED_ABORTED,
+    )
+
+    res, params = connector.request_finished(request, [1, 2, 3])
+    assert res is False
+    assert params is None
+
+
+def test_request_finished_with_none_engine_and_async_loading() -> None:
+    """Aborted request with async_loading must not crash when
+    both lmcache_engine and lookup_client are None.
+
+    This exercises the second guard (``lookup_client is not None``)
+    in the abort cleanup path.
+    """
+    connector = LMCacheConnectorV1Impl.__new__(LMCacheConnectorV1Impl)
+    connector._parent = _FakeParent()  # type: ignore[assignment]
+    connector._manager = _FakeManager(engine=None)  # type: ignore[assignment]
+    connector.config = SimpleNamespace(
+        get_extra_config_value=lambda key, default: default
+    )
+    connector.async_loading = True
+
+    request = SimpleNamespace(
+        request_id="req-aborted-async",
+        status=RequestStatus.FINISHED_ABORTED,
+    )
+
+    res, params = connector.request_finished(request, [1, 2, 3])
+    assert res is False
+    assert params is None

--- a/tests/v1/test_v1_adapter_none_engine.py
+++ b/tests/v1/test_v1_adapter_none_engine.py
@@ -17,18 +17,18 @@ from lmcache.integration.vllm.vllm_v1_adapter import LMCacheConnectorV1Impl
 
 
 class _FakeParent:
-    def __init__(self, metadata=None):
+    def __init__(self, metadata: Optional[Any] = None) -> None:
         self._connector_metadata = metadata
 
-    def _get_connector_metadata(self):
+    def _get_connector_metadata(self) -> Optional[Any]:
         return self._connector_metadata
 
 
 class _FakeManager:
-    def __init__(self, engine=None):
+    def __init__(self, engine: Optional[Any] = None) -> None:
         self.lmcache_engine = engine
-        self.lmcache_engine_metadata = None
-        self.lookup_client = None
+        self.lmcache_engine_metadata: Optional[Any] = None
+        self.lookup_client: Optional[Any] = None
 
 
 def test_request_finished_with_none_engine() -> None:

--- a/tests/v1/test_v1_adapter_none_engine.py
+++ b/tests/v1/test_v1_adapter_none_engine.py
@@ -2,6 +2,7 @@
 
 # Standard
 from types import SimpleNamespace
+from typing import Any, Optional
 
 # Third Party
 import pytest


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a fatal `AssertionError` crash in the vLLM EngineCore process when a request is aborted and the scheduler-side `LMCacheEngine` is `None`.

On the scheduler side, when `enable_scheduler_bypass_lookup` is disabled, the [service factory returns `None`](https://github.com/LMCache/LMCache/blob/dev/lmcache/integration/vllm/vllm_service_factory.py#L167-L179) for the engine. This is expected — the scheduler doesn't need a full engine in this configuration.

However, `request_finished()` in `vllm_v1_adapter.py` contained two hard assertions that assumed the engine and lookup client are always present:

```python
assert self.lmcache_engine is not None   # line 1849
assert self.lookup_client is not None     # line 1857
```

When any request was aborted (e.g., client disconnect, timeout), the abort path hit these assertions and crashed the entire EngineCore process, killing all in-flight requests.

**Root cause traceback:**
```
EngineCore → scheduler._connector_finished()
  → lmcache_connector.request_finished()
    → vllm_v1_adapter.request_finished()
      → assert self.lmcache_engine is not None  ← AssertionError
```

**Fix:** Replace the two `assert` statements with conditional guards (`if ... is not None`), consistent with how `get_kv_events()` already handles a `None` engine in the same class.

**Special notes for your reviewers**:

- The fix is minimal and scoped to the abort cleanup path in `request_finished()`.
- The `get_kv_events()` method (same class, line 1888) already uses the guarded pattern (`if self.lmcache_engine is not None`), so this change brings `request_finished` in line with existing conventions.
- No behavior change when the engine is present — the cleanup logic runs identically.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
