### PR TITLE
[fix] `LMCacheMPConnector` crashes under `MultiConnector` in PD setups

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1101,7 +1101,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # Notify LMCache to end the session for this request
         self.scheduler_adapter.end_session(request.request_id)
 
-        return True, return_params
+        return True, (return_params or None)
 
     def request_finished_all_groups(
         self,


### PR DESCRIPTION
 
### Description 
 Under `MultiConnector` for PD disaggregation, requests crashed with `RuntimeError: Only one connector can produce KV transfer params`. In a Nixl PD flow every request carries `kv_transfer_params`, but `request_finished` returned an empty-but-non-`None` dict, registering the MP connector as a second producer alongside `NixlConnector`.
 
###Fix:
Collapse empty params to `None`:
```python
return True, (return_params or None)
```
`NixlConnector` owns the PD handoff; `LMCacheMPConnector` stays offload-only. Behavior unchanged when LMCache reports actual stats.
 
**Testing:** Verified in a 1P1D cluster — previously-crashing requests now complete, with `kv_transfer_params: null` and confirmed NIXL transfer between nodes.
 