### PR TITLE
[CLI] Add `describe engine` command

### DIFF
--- a/docs/design/cli/commands/describe.md
+++ b/docs/design/cli/commands/describe.md
@@ -9,7 +9,8 @@ and entry point are all working. The next step (Phase 1 per
 [commands.md](../commands.md)) is to implement `lmcache describe kvcache`, which
 provides a rich status dashboard of a running LMCache KV cache service.
 
-`describe engine` is Phase 2 scope and stubbed but not implemented here.
+`describe engine` (Phase 2) is now implemented — see the
+[`describe engine`](#lmcache-describe-engine) section below.
 
 ---
 
@@ -142,18 +143,80 @@ L2 adapter sections are generated for each adapter in
 
 ---
 
+## `lmcache describe engine`
+
+`describe engine` is the engine-side counterpart to `describe kvcache`. Where
+`kvcache` inspects the LMCache service, `engine` inspects the **inference
+engine** (vLLM) that LMCache is paired with, reading only the engine's own HTTP
+surface.
+
+```bash
+$ lmcache describe engine --url http://localhost:8000
+
+================ Inference Engine ================
+Model:                  meta-llama/Llama-3.1-8B-Instruct
+Max context (tokens):   131072
+Status:                 OK
+Running requests:       3
+==================================================
+```
+
+```json
+{
+  "title": "Inference Engine",
+  "metrics": {
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "max_context": 131072,
+    "status": "OK",
+    "running_requests": 3
+  }
+}
+```
+
+### Data sources
+
+Unlike `kvcache` (a single `/status` call), `engine` composes three vLLM
+endpoints, so no LMCache-server cooperation is required:
+
+| Display label | Machine key | Source |
+|---|---|---|
+| Model | `model` | `/v1/models` → `data[0].id` |
+| Max context (tokens) | `max_context` | `/v1/models` → `data[0].max_model_len` |
+| Status | `status` | `/health` HTTP 200 → `"OK"` / `"UNHEALTHY"` |
+| Running requests | `running_requests` | `/metrics` → sum of `vllm:num_requests_running` series |
+
+`--url` defaults to `http://localhost:8000` (the engine default; `kvcache`
+defaults to `http://localhost:8080`).
+
+### Error handling
+
+| Condition | Behavior |
+|---|---|
+| `/v1/models` unreachable / errors | Print error to stderr, exit 1 (same as `kvcache`) |
+| `/health` not reachable or non-200 | `Status: UNHEALTHY` (does not fail the command) |
+| `/metrics` unreachable or metric absent | `Running requests: N/A` (best-effort; metric is informational) |
+| Empty model list | `Model` / `Max context` render as `N/A` |
+
+The `/health` and `/metrics` lookups are intentionally non-fatal: an engine that
+is up but has metrics disabled, or is momentarily unhealthy, still yields a
+useful report rather than a hard failure. Only the primary `/v1/models` fetch
+exits non-zero on failure.
+
+---
+
 ## Design Decisions
 
 ### 1. Sub-target as positional argument
 
 ```
 lmcache describe kvcache --url http://localhost:8000
-lmcache describe engine  --url http://localhost:8000   # (Phase 2)
+lmcache describe engine  --url http://localhost:8000
 ```
 
-Uses a positional `target` argument with `choices=["kvcache"]` (extend to
-`"engine"` in Phase 2). Matches the `describe {kvcache,engine}` pattern in
-[commands.md](../commands.md).
+Uses a positional `target` argument with `choices=["kvcache", "engine"]`,
+matching the `describe {kvcache,engine}` pattern in
+[commands.md](../commands.md). Each target resolves its own default `--url`
+(`8080` for `kvcache`, `8000` for `engine`) via the `DEFAULT_URLS` map.
 
 ### 2. `--url` points to the HTTP endpoint
 
@@ -332,14 +395,18 @@ class DescribeCommand(BaseCommand):
     help() → "Show detailed status of a running LMCache service."
 
     add_arguments(parser):
-        parser.add_argument("target", choices=["kvcache"],
+        parser.add_argument("target", choices=["kvcache", "engine"],
                             help="What to describe.")
-        parser.add_argument("--url", default="http://localhost:8080",
-                            help="LMCache HTTP server URL")
+        parser.add_argument("--url", default=None,
+                            help="Server URL (per-target default applied)")
 
     execute(args):
+        if args.url is None:
+            args.url = DEFAULT_URLS[args.target]
         if args.target == "kvcache":
             self._describe_kvcache(args)
+        elif args.target == "engine":
+            self._describe_engine(args)
 
     _describe_kvcache(args):
         1. Normalize URL (ensure http:// prefix)
@@ -407,10 +474,3 @@ ALL_COMMANDS: list[BaseCommand] = [
 3. **JSON output:** Verify machine keys are snake_case and values are raw types
    (not display-formatted strings), except `l1_used_gb` and `uptime` which include
    human-readable formatting.
-
----
-
-## Future Work (out of scope)
-
-- `describe engine` (Phase 2) — queries vLLM's `/v1/models` and `/health`
-  endpoints for model name, context length, running requests.

--- a/docs/source/cli/describe.rst
+++ b/docs/source/cli/describe.rst
@@ -2,8 +2,15 @@ lmcache describe
 ================
 
 The ``lmcache describe`` command shows the detailed status of a running
-LMCache service, including cache health, L1 storage, registered models, and
-L2 adapters.
+service. Two targets are supported:
+
+- ``kvcache`` — the LMCache KV cache service (health, L1 storage, registered
+  models, L2 adapters).
+- ``engine`` — the inference engine (vLLM) LMCache is paired with (model,
+  context window, health, in-flight requests).
+
+KV Cache Service (``kvcache``)
+------------------------------
 
 .. code-block:: bash
 
@@ -56,6 +63,54 @@ The output shows:
   KV tensor shape (symbolic and concrete), attention backend, and group geometry.
 - **L2 adapters** — type, health, backend, stored objects, and utilization.
 
+Inference Engine (``engine``)
+-----------------------------
+
+``describe engine`` inspects the vLLM inference engine instead of the LMCache
+service, reading only the engine's own HTTP endpoints (``/v1/models``,
+``/health``, ``/metrics``).
+
+.. code-block:: bash
+
+   lmcache describe engine --url http://localhost:8000
+
+.. code-block:: text
+
+   ================ Inference Engine ================
+   Model:                  meta-llama/Llama-3.1-8B-Instruct
+   Max context (tokens):   131072
+   Status:                 OK
+   Running requests:       3
+   ==================================================
+
+The output shows:
+
+- **Model** and **Max context** — the served model id and its maximum context
+  length, from ``/v1/models``.
+- **Status** — ``OK`` / ``UNHEALTHY`` from the engine's ``/health`` probe.
+- **Running requests** — in-flight requests, summed from the
+  ``vllm:num_requests_running`` metric. Shows ``N/A`` if metrics are disabled
+  or unreachable.
+
+Only the ``/v1/models`` fetch is required: if ``/health`` or ``/metrics`` is
+unavailable the command still reports what it can rather than failing.
+
+.. code-block:: bash
+
+   lmcache describe engine --url http://localhost:8000 --format json
+
+.. code-block:: json
+
+   {
+     "title": "Inference Engine",
+     "metrics": {
+       "model": "meta-llama/Llama-3.1-8B-Instruct",
+       "max_context": 131072,
+       "status": "OK",
+       "running_requests": 3
+     }
+   }
+
 Options
 -------
 
@@ -65,11 +120,11 @@ Options
 
    * - Flag
      - Description
-   * - ``kvcache``
-     - Target to describe (positional, required; currently only
-       ``kvcache`` is supported).
+   * - ``target``
+     - What to describe (positional, required): ``kvcache`` or ``engine``.
    * - ``--url``
-     - LMCache HTTP server URL (default: ``http://localhost:8080``).
+     - Server URL. Defaults per target: ``http://localhost:8080`` for
+       ``kvcache``, ``http://localhost:8000`` for ``engine``.
    * - ``--format``
      - Output format: ``terminal`` (default) or ``json``.
    * - ``--output PATH``

--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -13,6 +13,9 @@ import sys
 import urllib.error
 import urllib.request
 
+# Third Party
+from prometheus_client.parser import text_string_to_metric_families
+
 # First Party
 from lmcache.cli.commands.base import BaseCommand
 from lmcache.cli.metrics import Metrics
@@ -105,9 +108,6 @@ def fetch_running_requests(url: str, timeout: int = 10) -> int | None:
         unreachable or the metric is absent (e.g. metrics disabled or an
         unsupported engine version).
     """
-    # Third Party
-    from prometheus_client.parser import text_string_to_metric_families
-
     try:
         with urllib.request.urlopen(
             urllib.request.Request(url), timeout=timeout

--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -17,6 +17,12 @@ import urllib.request
 from lmcache.cli.commands.base import BaseCommand
 from lmcache.cli.metrics import Metrics
 
+# Default server URLs per describe target (ZMQ/HTTP semantics differ).
+DEFAULT_URLS: dict[str, str] = {
+    "kvcache": "http://localhost:8080",
+    "engine": "http://localhost:8000",
+}
+
 # -------------------------------------------------------------------
 # Shared helpers
 # -------------------------------------------------------------------
@@ -56,6 +62,73 @@ def fetch_json(url: str, timeout: int = 10) -> dict:
         raise DescribeError(f"Cannot connect to {url}: {exc.reason}") from exc
     except OSError as exc:
         raise DescribeError(f"Cannot connect to {url}: {exc}") from exc
+
+
+def fetch_health(url: str, timeout: int = 10) -> bool:
+    """Return whether *url* responds with HTTP 200.
+
+    A lightweight liveness probe for endpoints (e.g. the vLLM ``/health``
+    route) that return an empty body rather than JSON, so :func:`fetch_json`
+    cannot be used.
+
+    Args:
+        url: Full health-check URL to GET.
+        timeout: Socket timeout in seconds.
+
+    Returns:
+        ``True`` if the server responds with HTTP 200, ``False`` on any
+        non-200 status or connection error.
+    """
+    try:
+        with urllib.request.urlopen(
+            urllib.request.Request(url), timeout=timeout
+        ) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def fetch_running_requests(url: str, timeout: int = 10) -> int | None:
+    """Return the number of in-flight requests from a vLLM ``/metrics`` page.
+
+    Parses the Prometheus ``vllm:num_requests_running`` gauge, summing the
+    value across all reported series (e.g. one per model). This is best
+    effort: the metric is informational, so any failure to fetch or parse
+    degrades to ``None`` (rendered as ``N/A``) rather than raising.
+
+    Args:
+        url: Full ``/metrics`` URL to GET.
+        timeout: Socket timeout in seconds.
+
+    Returns:
+        The total running-request count, or ``None`` if the endpoint is
+        unreachable or the metric is absent (e.g. metrics disabled or an
+        unsupported engine version).
+    """
+    # Third Party
+    from prometheus_client.parser import text_string_to_metric_families
+
+    try:
+        with urllib.request.urlopen(
+            urllib.request.Request(url), timeout=timeout
+        ) as resp:
+            text = resp.read().decode()
+    except (urllib.error.URLError, OSError):
+        return None
+
+    total = 0.0
+    found = False
+    try:
+        for family in text_string_to_metric_families(text):
+            if family.name != "vllm:num_requests_running":
+                continue
+            for sample in family.samples:
+                total += sample.value
+                found = True
+    except ValueError:
+        # Malformed exposition text; treat as unavailable.
+        return None
+    return int(total) if found else None
 
 
 def fmt_bytes(n: int) -> str:
@@ -299,6 +372,56 @@ class KVCacheDescriber:
 
 
 # -------------------------------------------------------------------
+# Engine describer
+# -------------------------------------------------------------------
+
+
+class EngineDescriber:
+    """Builds the ``describe engine`` output from vLLM server responses.
+
+    Reads model identity and context window from the engine's
+    ``/v1/models`` response and combines them with a ``/health`` liveness
+    result to render a concise status view.
+    """
+
+    def __init__(
+        self,
+        metrics: Metrics,
+        models_data: dict,
+        is_healthy: bool,
+        running_requests: int | None,
+        base_url: str,
+    ) -> None:
+        self.metrics = metrics
+        self.models_data = models_data
+        self.is_healthy = is_healthy
+        self.running_requests = running_requests
+        self.base_url = base_url
+
+    def describe(self) -> None:
+        """Run all section builders and emit."""
+        self.add_overview()
+        self.metrics.emit()
+
+    def add_overview(self) -> None:
+        """Model identity, context window, health status, and load."""
+        model = self._first_model()
+        self.metrics.add("model", "Model", model.get("id") if model else None)
+        self.metrics.add(
+            "max_context",
+            "Max context (tokens)",
+            model.get("max_model_len") if model else None,
+        )
+        self.metrics.add("status", "Status", fmt_health(self.is_healthy))
+        self.metrics.add("running_requests", "Running requests", self.running_requests)
+
+    def _first_model(self) -> dict | None:
+        """Return the first model entry from a ``/v1/models`` response."""
+        data = self.models_data.get("data") or []
+        return data[0] if data else None
+
+
+# -------------------------------------------------------------------
 # Command
 # -------------------------------------------------------------------
 
@@ -315,18 +438,25 @@ class DescribeCommand(BaseCommand):
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "target",
-            choices=["kvcache"],
+            choices=["kvcache", "engine"],
             help="What to describe.",
         )
         parser.add_argument(
             "--url",
-            help="LMCache HTTP server URL (default to http://localhost:8080).",
-            default="http://localhost:8080",
+            default=None,
+            help=(
+                "Server URL (default: http://localhost:8080 for kvcache, "
+                "http://localhost:8000 for engine)."
+            ),
         )
 
     def execute(self, args: argparse.Namespace) -> None:
+        if getattr(args, "url", None) is None:
+            args.url = DEFAULT_URLS[args.target]
         if args.target == "kvcache":
             self._describe_kvcache(args)
+        elif args.target == "engine":
+            self._describe_engine(args)
 
     def _describe_kvcache(self, args: argparse.Namespace) -> None:
         base_url = normalize_url(args.url)
@@ -338,3 +468,18 @@ class DescribeCommand(BaseCommand):
 
         metrics = self.create_metrics("LMCache KV Cache Service", args, width=50)
         KVCacheDescriber(metrics, data, base_url).describe()
+
+    def _describe_engine(self, args: argparse.Namespace) -> None:
+        base_url = normalize_url(args.url)
+        try:
+            models = fetch_json(f"{base_url}/v1/models")
+        except DescribeError as exc:
+            print(str(exc), file=sys.stderr)
+            sys.exit(1)
+
+        is_healthy = fetch_health(f"{base_url}/health")
+        running_requests = fetch_running_requests(f"{base_url}/metrics")
+        metrics = self.create_metrics("Inference Engine", args, width=50)
+        EngineDescriber(
+            metrics, models, is_healthy, running_requests, base_url
+        ).describe()

--- a/tests/cli/test_describe.py
+++ b/tests/cli/test_describe.py
@@ -13,7 +13,9 @@ import pytest
 # First Party
 from lmcache.cli.commands.describe import (
     DescribeError,
+    fetch_health,
     fetch_json,
+    fetch_running_requests,
     fmt_health,
     normalize_url,
     safe_get,
@@ -383,3 +385,232 @@ class TestFetchJson:
                 fetch_json(f"http://127.0.0.1:{port}/status")
         finally:
             server.server_close()
+
+
+class TestFetchHealth:
+    def test_ok(self):
+        handler = type(
+            "_H",
+            (_MockHandler,),
+            {"response_body": b"", "response_code": 200},
+        )
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+        t = Thread(target=server.handle_request, daemon=True)
+        t.start()
+        try:
+            assert fetch_health(f"http://127.0.0.1:{port}/health") is True
+        finally:
+            server.server_close()
+
+    def test_non_200(self):
+        handler = type(
+            "_H",
+            (_MockHandler,),
+            {"response_body": b"", "response_code": 503},
+        )
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+        t = Thread(target=server.handle_request, daemon=True)
+        t.start()
+        try:
+            assert fetch_health(f"http://127.0.0.1:{port}/health") is False
+        finally:
+            server.server_close()
+
+    def test_connection_refused(self):
+        assert fetch_health("http://127.0.0.1:19999/health") is False
+
+
+class TestFetchRunningRequests:
+    def _serve(self, body: bytes, code: int = 200):
+        handler = type(
+            "_H",
+            (_MockHandler,),
+            {"response_body": body, "response_code": code},
+        )
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+        t = Thread(target=server.handle_request, daemon=True)
+        t.start()
+        return server, port
+
+    def test_single_series(self):
+        body = (
+            b"# HELP vllm:num_requests_running Number of running requests.\n"
+            b"# TYPE vllm:num_requests_running gauge\n"
+            b'vllm:num_requests_running{model_name="m"} 3.0\n'
+        )
+        server, port = self._serve(body)
+        try:
+            assert fetch_running_requests(f"http://127.0.0.1:{port}/metrics") == 3
+        finally:
+            server.server_close()
+
+    def test_sums_multiple_series(self):
+        body = (
+            b'vllm:num_requests_running{model_name="a"} 3.0\n'
+            b'vllm:num_requests_running{model_name="b"} 1.0\n'
+        )
+        server, port = self._serve(body)
+        try:
+            assert fetch_running_requests(f"http://127.0.0.1:{port}/metrics") == 4
+        finally:
+            server.server_close()
+
+    def test_metric_absent(self):
+        body = b"# only other metrics here\nvllm:num_requests_waiting 5.0\n"
+        server, port = self._serve(body)
+        try:
+            assert fetch_running_requests(f"http://127.0.0.1:{port}/metrics") is None
+        finally:
+            server.server_close()
+
+    def test_connection_refused(self):
+        assert fetch_running_requests("http://127.0.0.1:19999/metrics") is None
+
+
+# ---------------------------------------------------------------------------
+# describe engine
+# ---------------------------------------------------------------------------
+
+SAMPLE_MODELS = {
+    "object": "list",
+    "data": [
+        {
+            "id": "meta-llama/Llama-3.1-8B-Instruct",
+            "object": "model",
+            "owned_by": "vllm",
+            "max_model_len": 131072,
+        }
+    ],
+}
+
+
+class TestDescribeEngineFields:
+    """Test that ``_describe_engine`` extracts fields from a sample
+    ``/v1/models`` response plus a ``/health`` result."""
+
+    def _run(self, models, is_healthy):
+        """Execute ``describe engine`` with mocked HTTP and return metrics dict."""
+        # First Party
+        from lmcache.cli.commands.describe import DescribeCommand
+
+        cmd = DescribeCommand()
+
+        class FakeArgs:
+            target = "engine"
+            url = "http://localhost:8000"
+            format = "json"
+            output = None
+
+        with (
+            patch(
+                "lmcache.cli.commands.describe.fetch_json",
+                return_value=models,
+            ),
+            patch(
+                "lmcache.cli.commands.describe.fetch_health",
+                return_value=is_healthy,
+            ),
+            patch(
+                "lmcache.cli.commands.describe.fetch_running_requests",
+                return_value=3,
+            ),
+        ):
+            # Standard
+            import io
+
+            buf = io.StringIO()
+            with patch("sys.stdout", buf):
+                cmd.execute(FakeArgs())
+            return json.loads(buf.getvalue())
+
+    def test_field_extraction(self):
+        """Verify model, context, status, and running requests are populated."""
+        output = self._run(SAMPLE_MODELS, is_healthy=True)
+        assert output["title"] == "Inference Engine"
+        m = output["metrics"]
+        assert m["model"] == "meta-llama/Llama-3.1-8B-Instruct"
+        assert m["max_context"] == 131072
+        assert m["status"] == "OK"
+        assert m["running_requests"] == 3
+
+    def test_unhealthy(self):
+        """Verify status shows UNHEALTHY when /health is not OK."""
+        output = self._run(SAMPLE_MODELS, is_healthy=False)
+        assert output["metrics"]["status"] == "UNHEALTHY"
+
+    def test_missing_model(self):
+        """Verify empty model list renders model/context as None."""
+        output = self._run({"object": "list", "data": []}, is_healthy=True)
+        m = output["metrics"]
+        assert m["model"] is None
+        assert m["max_context"] is None
+
+
+class TestDescribeEngineDefaultUrl:
+    def test_engine_default_url(self):
+        """Verify url=None resolves to the engine default (localhost:8000)."""
+        # First Party
+        from lmcache.cli.commands.describe import DescribeCommand
+
+        cmd = DescribeCommand()
+
+        class FakeArgs:
+            target = "engine"
+            url = None
+            format = "json"
+            output = None
+
+        captured: dict[str, str] = {}
+
+        def fake_fetch(url, *args, **kwargs):
+            captured["url"] = url
+            return SAMPLE_MODELS
+
+        with (
+            patch(
+                "lmcache.cli.commands.describe.fetch_json",
+                side_effect=fake_fetch,
+            ),
+            patch(
+                "lmcache.cli.commands.describe.fetch_health",
+                return_value=True,
+            ),
+            patch(
+                "lmcache.cli.commands.describe.fetch_running_requests",
+                return_value=3,
+            ),
+        ):
+            # Standard
+            import io
+
+            buf = io.StringIO()
+            with patch("sys.stdout", buf):
+                cmd.execute(FakeArgs())
+
+        assert "8000" in captured["url"]
+
+
+class TestDescribeEngineErrors:
+    def test_error_exits_1(self):
+        """Verify sys.exit(1) when the engine cannot be reached."""
+        # First Party
+        from lmcache.cli.commands.describe import DescribeCommand
+
+        cmd = DescribeCommand()
+
+        class FakeArgs:
+            target = "engine"
+            url = "http://localhost:8000"
+            format = None
+            output = None
+
+        with patch(
+            "lmcache.cli.commands.describe.fetch_json",
+            side_effect=DescribeError("Cannot connect"),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd.execute(FakeArgs())
+            assert exc_info.value.code == 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `lmcache describe engine`, the engine-side counterpart to the existing
`lmcache describe kvcache`. It gives operators a one-shot status view of the
inference engine a running LMCache instance is paired with:

    $ lmcache describe engine --url http://localhost:8000

    ================ Inference Engine ================
    Model:                  meta-llama/Llama-3.1-8B-Instruct
    Max context (tokens):   131072
    Status:                 OK
    Running requests:       3
    ==================================================

Data is read from the engine's own HTTP surface — model identity and context
window from `/v1/models`, liveness from `/health`, and in-flight load from the
Prometheus `vllm:num_requests_running` gauge on `/metrics`. The running-requests
lookup is best-effort: if metrics are disabled or unreachable it degrades to
`N/A` rather than failing the command. Only the primary `/v1/models` fetch exits
non-zero on failure. `--url` defaults to `http://localhost:8000` (the engine
default) and supports `--format json` / `--output` like the other describe
targets.

Refs #3720

**notes**

- The new `EngineDescriber` mirrors the existing `KVCacheDescriber`
  section-builder pattern, and the engine tests mirror the kvcache tests in the
  same file, so the structure should look familiar.
- Docs updated alongside the code: the user guide (`docs/source/cli/describe.rst`)
  gains an `engine` section, and the design doc
  (`docs/design/cli/commands/describe.md`) now documents the implemented command
  (data sources, fields, JSON shape, error handling) instead of marking it as
  stubbed.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests


**Follow-up**

While adding this command I ended up hand-rolling another `normalize_url` +
`urlopen` try/except, the same boilerplate that's already duplicated across the
other client commands. Filed #3868 to track pulling it into a shared
`lmcache/cli/http.py`; intentionally left out of this PR to keep the scope to
`describe engine`.