### PR TITLE
Move IPC cache key import under TYPE_CHECKING

### DIFF
--- a/lmcache/v1/distributed/api.py
+++ b/lmcache/v1/distributed/api.py
@@ -9,13 +9,16 @@ Could be implemented by native code in the future
 # Standard
 from dataclasses import dataclass
 import enum
+from typing import TYPE_CHECKING
 
 # Third Party
 import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+
+if TYPE_CHECKING:
+    from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 
 logger = init_logger(__name__)
 
@@ -314,7 +317,7 @@ class PrefetchHandle:
 
 
 def ipc_key_to_object_keys(
-    ipc_key: IPCCacheServerKey,
+    ipc_key: "IPCCacheServerKey",
     chunk_hashes: list[bytes],
     object_group_ids: list[int],
 ) -> list[list[ObjectKey]]:


### PR DESCRIPTION
## Summary

- Move the `IPCCacheServerKey` import in `lmcache/v1/distributed/api.py` under `TYPE_CHECKING`
- Quote the `ipc_key` annotation so the type remains available to type checkers without requiring the runtime import

## Why

`IPCCacheServerKey` is only used as a type annotation in this module. Avoiding the runtime import keeps the distributed API module from importing multiprocess custom types unless type checking is active.

Fixes LMCache/LMCache#3730.

## Validation

- `python3 -m py_compile lmcache/v1/distributed/api.py`
- Static AST check confirmed the `custom_types` import only appears under `if TYPE_CHECKING` and the `ipc_key` annotation is quoted

Note: full runtime import and ruff checks were not run locally because this environment is missing `torch` and `ruff`.
