### PR TITLE
raw-block: persist stable device identity in checkpoints

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -101,6 +101,13 @@ Rules:
 
 The on-device format is intentionally unchanged by the MP adapter work.
 
+Checkpoint payloads record a stable `device_id` rather than relying on
+`device_path`, which can change across reboot or when the same NVMe namespace is
+opened through `/dev/nvme*` versus `/dev/ng*`. Older checkpoints that do not
+contain `device_id` are accepted only when
+`allow_legacy_checkpoint_without_device_id=true`, and that option is intended
+only for one-time migration before writing a new checkpoint with `device_id`.
+
 Recovered keys are exposed to the shared L2 eviction policy on adapter startup,
 so reclaimed slots come from global L2 eviction or explicit `delete()` calls.
 
@@ -140,7 +147,8 @@ Important validation rules:
 - `load_checkpoint_on_init=false` starts with an empty in-memory index instead
   of loading the latest on-device metadata checkpoint
 - `allow_legacy_checkpoint_without_device_id=true` permits loading older
-  checkpoints that do not contain a `device_id`; use it only for migration
+  checkpoints that do not contain a `device_id`; use it only for migration and
+  disable it after a new checkpoint has been written
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
 
@@ -148,7 +156,9 @@ Important validation rules:
 
 The legacy `RustRawBlockBackend` now acts as a thin facade over `RawBlockCore`.
 It preserves non-MP behavior such as prefix-oriented contains/get semantics,
-while the MP adapter uses the core's full-bitmap lookup/load API.
+while the MP adapter uses the core's full-bitmap lookup/load API. The non-MP
+backend exposes the legacy checkpoint migration option through the
+`rust_raw_block.allow_legacy_checkpoint_without_device_id` extra config key.
 
 ## References
 

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -123,6 +123,7 @@ The MP adapter is configured through `--l2-adapter` JSON:
   "meta_checkpoint_interval_sec": 60,
   "meta_enable_periodic": true,
   "load_checkpoint_on_init": true,
+  "allow_legacy_checkpoint_without_device_id": false,
   "meta_verify_on_load": true,
   "num_store_workers": 2,
   "num_lookup_workers": 1,
@@ -138,6 +139,8 @@ Important validation rules:
 - `per_tp_device_paths` is rejected in MP mode
 - `load_checkpoint_on_init=false` starts with an empty in-memory index instead
   of loading the latest on-device metadata checkpoint
+- `allow_legacy_checkpoint_without_device_id=true` permits loading older
+  checkpoints that do not contain a `device_id`; use it only for migration
 - with `use_odirect=true`, MP L1 alignment must satisfy
   `l1_align_bytes >= block_align`
 

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -46,8 +46,11 @@ caller-provided load buffers during prefetch.
   per-TP device-path mappings in MP mode.
 - ``raw_block`` remains ``"type": "raw_block"`` for all supported engines.
 - ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
-  through ``RawBlockCore``. Slot reclamation is driven by the shared/global
-  L2 eviction controller or explicit ``delete()`` calls.
+  through ``RawBlockCore``. Checkpoint recovery validates a stable
+  ``device_id``: ``nvme:<wwid>`` for NVMe namespaces or
+  ``file:<st_dev>:<st_ino>:<st_size>`` for regular files. Slot reclamation is
+  driven by the shared/global L2 eviction controller or explicit ``delete()``
+  calls.
 - If ``use_odirect`` is enabled, the server's ``--l1-align-bytes`` should be
   at least ``block_align``.
 - ``persist_enabled`` must remain ``true`` for this adapter.

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -66,6 +66,22 @@ caller-provided load buffers during prefetch.
 - When ``use_uring_cmd=true``, ``use_odirect`` is ignored for NVMe namespace
   character devices.
 
+**Upgrade from checkpoints without device_id:**
+
+Raw-block checkpoint recovery validates a stable ``device_id`` so that metadata
+from one raw device is not applied to another device. Checkpoints written by
+older versions may not contain this field. When upgrading with an existing
+checkpoint that must be recovered, set
+``allow_legacy_checkpoint_without_device_id=true`` for the first startup only.
+After the legacy checkpoint is loaded and a new checkpoint is written, disable
+the option so future recovery requires stable device identity validation.
+
+If recovery is not required, set ``load_checkpoint_on_init=false`` to start with
+an empty in-memory index instead. The legacy non-MP ``rust_raw_block`` backend
+uses the extra config key
+``rust_raw_block.allow_legacy_checkpoint_without_device_id`` for the same
+migration behavior.
+
 **Configuration examples:**
 
 .. code-block:: bash

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -26,6 +26,9 @@ caller-provided load buffers during prefetch.
 - ``load_checkpoint_on_init``: Load an existing on-device metadata checkpoint
   during startup (default ``true``). Set to ``false`` to start with an empty
   in-memory index instead.
+- ``allow_legacy_checkpoint_without_device_id``: Allow loading legacy
+  checkpoints written before ``device_id`` was recorded (default ``false``).
+  Keep this disabled except during checkpoint migration.
 - ``enable_zero_copy``: Try aligned direct-buffer I/O when possible.
 - ``io_engine``: Rust raw-block I/O engine. Valid values are ``"posix"``
   (default synchronous ``pread``/``pwrite`` path), ``"io_uring"`` (direct Rust
@@ -47,7 +50,8 @@ caller-provided load buffers during prefetch.
 - ``raw_block`` remains ``"type": "raw_block"`` for all supported engines.
 - ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
   through ``RawBlockCore``. Checkpoint recovery validates a stable
-  ``device_id``: ``nvme:<wwid>`` for NVMe namespaces or
+  ``device_id`` unless ``allow_legacy_checkpoint_without_device_id`` is enabled
+  for migration of old checkpoints: ``nvme:<wwid>`` for NVMe namespaces or
   ``file:<st_dev>:<st_ino>:<st_size>`` for regular files. Slot reclamation is
   driven by the shared/global L2 eviction controller or explicit ``delete()``
   calls.

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -255,7 +255,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "- meta_enable_periodic (bool): enable periodic checkpointing "
             "(default true)\n"
             "- load_checkpoint_on_init (bool): load existing metadata checkpoint "
-            "on startup (default true)\n"
+            "on startup (default true; requires stable device_id)\n"
             "- meta_verify_on_load (bool): validate slot headers on recovery "
             "(default true)\n"
             "- enable_zero_copy (bool): use aligned direct buffers when possible "

--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -82,6 +82,7 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         meta_idle_quiet_ms: int = 100,
         meta_enable_periodic: bool = True,
         load_checkpoint_on_init: bool = True,
+        allow_legacy_checkpoint_without_device_id: bool = False,
         meta_verify_on_load: bool = True,
         enable_zero_copy: bool = True,
         io_engine: str = "posix",
@@ -108,6 +109,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_idle_quiet_ms: Quiet period before periodic checkpoints.
             meta_enable_periodic: Whether to run the checkpoint thread.
             load_checkpoint_on_init: Whether to load existing checkpoint metadata.
+            allow_legacy_checkpoint_without_device_id: Whether recovery accepts
+                checkpoints written before device_id was recorded.
             meta_verify_on_load: Whether recovery verifies slot headers.
             enable_zero_copy: Whether to use aligned direct-buffer I/O.
             io_engine: Raw-block I/O engine: ``"posix"`` or ``"io_uring"``.
@@ -132,6 +135,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
         self.meta_idle_quiet_ms = int(meta_idle_quiet_ms)
         self.meta_enable_periodic = bool(meta_enable_periodic)
         self.load_checkpoint_on_init = bool(load_checkpoint_on_init)
+        self.allow_legacy_checkpoint_without_device_id = bool(
+            allow_legacy_checkpoint_without_device_id
+        )
         self.meta_verify_on_load = bool(meta_verify_on_load)
         self.enable_zero_copy = bool(enable_zero_copy)
         self.io_engine = normalize_raw_block_io_engine(io_engine)
@@ -221,6 +227,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_idle_quiet_ms=int(d.get("meta_idle_quiet_ms", 100)),
             meta_enable_periodic=bool(d.get("meta_enable_periodic", True)),
             load_checkpoint_on_init=bool(d.get("load_checkpoint_on_init", True)),
+            allow_legacy_checkpoint_without_device_id=bool(
+                d.get("allow_legacy_checkpoint_without_device_id", False)
+            ),
             meta_verify_on_load=bool(d.get("meta_verify_on_load", True)),
             enable_zero_copy=bool(d.get("enable_zero_copy", True)),
             io_engine=io_engine,
@@ -256,6 +265,8 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             "(default true)\n"
             "- load_checkpoint_on_init (bool): load existing metadata checkpoint "
             "on startup (default true; requires stable device_id)\n"
+            "- allow_legacy_checkpoint_without_device_id (bool): allow loading "
+            "legacy checkpoints that do not record device_id (default false)\n"
             "- meta_verify_on_load (bool): validate slot headers on recovery "
             "(default true)\n"
             "- enable_zero_copy (bool): use aligned direct buffers when possible "
@@ -290,6 +301,9 @@ class RawBlockL2AdapterConfig(L2AdapterConfigBase):
             meta_idle_quiet_ms=self.meta_idle_quiet_ms,
             meta_enable_periodic=self.meta_enable_periodic,
             load_checkpoint_on_init=self.load_checkpoint_on_init,
+            allow_legacy_checkpoint_without_device_id=(
+                self.allow_legacy_checkpoint_without_device_id
+            ),
             meta_verify_on_load=self.meta_verify_on_load,
             io_engine=self.io_engine,
             iouring_queue_depth=self.iouring_queue_depth,

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -307,6 +307,12 @@ class RustRawBlockBackend(StoragePluginInterface):
             load_checkpoint_on_init=bool(
                 extra.get("rust_raw_block.load_checkpoint_on_init", True)
             ),
+            allow_legacy_checkpoint_without_device_id=bool(
+                extra.get(
+                    "rust_raw_block.allow_legacy_checkpoint_without_device_id",
+                    False,
+                )
+            ),
             meta_verify_on_load=bool(
                 extra.get("rust_raw_block.meta_verify_on_load", True)
             ),

--- a/lmcache/v1/storage_backend/raw_block/__init__.py
+++ b/lmcache/v1/storage_backend/raw_block/__init__.py
@@ -8,6 +8,7 @@ from lmcache.v1.storage_backend.raw_block.core import (
     RawBlockCoreConfig,
     RawBlockPutManyResult,
     normalize_raw_block_io_engine,
+    resolve_raw_block_device_id,
     round_up,
     validate_raw_block_io_options,
 )
@@ -36,6 +37,7 @@ __all__ = [
     "encode_object_key",
     "object_key_to_string",
     "normalize_raw_block_io_engine",
+    "resolve_raw_block_device_id",
     "round_up",
     "slot_identity_from_encoded_key",
     "validate_raw_block_io_options",

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -195,6 +195,7 @@ class RawBlockCoreConfig:
     meta_verify_on_load: bool
     max_data_transfer_size: int = 0
     load_checkpoint_on_init: bool = True
+    allow_legacy_checkpoint_without_device_id: bool = False
     io_engine: str = "posix"
     iouring_queue_depth: int = DEFAULT_IOURING_QUEUE_DEPTH
     use_uring_cmd: bool = False
@@ -267,6 +268,9 @@ class RawBlockCore:
         self.meta_idle_quiet_ms = int(config.meta_idle_quiet_ms)
         self.meta_enable_periodic = bool(config.meta_enable_periodic)
         self.load_checkpoint_on_init = bool(config.load_checkpoint_on_init)
+        self.allow_legacy_checkpoint_without_device_id = bool(
+            config.allow_legacy_checkpoint_without_device_id
+        )
         self.meta_verify_on_load = bool(config.meta_verify_on_load)
         self.io_engine = normalize_raw_block_io_engine(config.io_engine)
         self.iouring_queue_depth = int(config.iouring_queue_depth)
@@ -1765,9 +1769,20 @@ class RawBlockCore:
             return False
         checkpoint_device_id = data.get("device_id")
         if not checkpoint_device_id:
-            logger.warning("Device metadata missing device_id; ignoring metadata")
-            return False
-        if not self.device_id or str(checkpoint_device_id) != self.device_id:
+            if not self.allow_legacy_checkpoint_without_device_id:
+                logger.warning("Device metadata missing device_id; ignoring metadata")
+                return False
+            if not self.device_id:
+                logger.warning(
+                    "Legacy device metadata missing device_id, but current device "
+                    "has no stable device_id; ignoring metadata"
+                )
+                return False
+            logger.warning(
+                "Loading legacy device metadata without device_id; this should "
+                "only be used to migrate checkpoints written by older versions"
+            )
+        elif not self.device_id or str(checkpoint_device_id) != self.device_id:
             logger.warning("Device metadata device_id mismatch; ignoring metadata")
             return False
         if int(data.get("slot_bytes", self.slot_bytes)) != self.slot_bytes:

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -117,16 +117,17 @@ def _resolve_sysfs_queue_dir(device_path: str) -> Optional[str]:
     return None
 
 
-def _resolve_nvme_block_name(device_path: str) -> Optional[str]:
-    """Resolve the NVMe block namespace name for block or generic char paths."""
+def _resolve_nvme_block_name(device_path: str) -> Optional[tuple[str, Optional[str]]]:
+    """Resolve the NVMe block namespace name and optional partition suffix."""
     base_name = os.path.basename(os.path.realpath(device_path))
-    match = re.fullmatch(r"nvme\d+n\d+", base_name)
+    match = re.fullmatch(r"(nvme\d+n\d+)(p\d+)?", base_name)
     if match:
-        return base_name
+        block_name, partition_suffix = match.groups()
+        return block_name, partition_suffix
     match = re.fullmatch(r"ng(\d+)n(\d+)", base_name)
     if match:
         ctrl, nsid = match.groups()
-        return f"nvme{ctrl}n{nsid}"
+        return f"nvme{ctrl}n{nsid}", None
     return None
 
 
@@ -149,13 +150,27 @@ def resolve_raw_block_device_id(device_path: str) -> Optional[str]:
 
     Returns:
         ``nvme:<wwid>`` for NVMe namespaces with a sysfs WWID,
+        ``nvme:<wwid>:<partition_suffix>`` for NVMe partitions,
         ``file:<st_dev>:<st_ino>:<st_size>`` for regular files, or None when
         no supported stable identity can be resolved.
+
+    Notes:
+        NVMe generic character devices, such as ``/dev/ng0n1``, identify the
+        whole namespace and do not encode partition identity. They intentionally
+        resolve to ``nvme:<wwid>`` rather than matching partition block paths such
+        as ``/dev/nvme0n1p1``. Partition-aware ``io_uring_cmd`` would require a
+        separate logical device path and partition-offset handling.
     """
-    block_name = _resolve_nvme_block_name(device_path)
-    if block_name is not None:
+    nvme_block = _resolve_nvme_block_name(device_path)
+    if nvme_block is not None:
+        block_name, partition_suffix = nvme_block
         wwid = _read_sysfs_text(f"/sys/block/{block_name}/wwid")
-        return f"nvme:{wwid}" if wwid else None
+        if wwid is None:
+            return None
+        device_id = f"nvme:{wwid}"
+        if partition_suffix is not None:
+            return f"{device_id}:{partition_suffix}"
+        return device_id
 
     try:
         st = os.stat(os.path.realpath(device_path))

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -117,6 +117,55 @@ def _resolve_sysfs_queue_dir(device_path: str) -> Optional[str]:
     return None
 
 
+def _resolve_nvme_block_name(device_path: str) -> Optional[str]:
+    """Resolve the NVMe block namespace name for block or generic char paths."""
+    base_name = os.path.basename(os.path.realpath(device_path))
+    match = re.fullmatch(r"nvme\d+n\d+", base_name)
+    if match:
+        return base_name
+    match = re.fullmatch(r"ng(\d+)n(\d+)", base_name)
+    if match:
+        ctrl, nsid = match.groups()
+        return f"nvme{ctrl}n{nsid}"
+    return None
+
+
+def _read_sysfs_text(path: str) -> Optional[str]:
+    """Read a sysfs text value and return None on failure or empty content."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            value = f.read().strip()
+    except Exception:
+        return None
+    return value or None
+
+
+def resolve_raw_block_device_id(device_path: str) -> Optional[str]:
+    """Resolve a stable identity for a raw-block backing path.
+
+    Args:
+        device_path: NVMe block path, NVMe generic namespace character path,
+            or regular file path used for tests.
+
+    Returns:
+        ``nvme:<wwid>`` for NVMe namespaces with a sysfs WWID,
+        ``file:<st_dev>:<st_ino>:<st_size>`` for regular files, or None when
+        no supported stable identity can be resolved.
+    """
+    block_name = _resolve_nvme_block_name(device_path)
+    if block_name is not None:
+        wwid = _read_sysfs_text(f"/sys/block/{block_name}/wwid")
+        return f"nvme:{wwid}" if wwid else None
+
+    try:
+        st = os.stat(os.path.realpath(device_path))
+    except OSError:
+        return None
+    if stat.S_ISREG(st.st_mode):
+        return f"file:{st.st_dev}:{st.st_ino}:{st.st_size}"
+    return None
+
+
 def _read_sysfs_int(path: str) -> Optional[int]:
     """Read an integer value from sysfs and return None on failure."""
     try:
@@ -222,6 +271,7 @@ class RawBlockCore:
         self.io_engine = normalize_raw_block_io_engine(config.io_engine)
         self.iouring_queue_depth = int(config.iouring_queue_depth)
         self.use_uring_cmd = bool(config.use_uring_cmd)
+        self.device_id = resolve_raw_block_device_id(self.device_path)
         if self.use_uring_cmd and self.use_odirect:
             logger.warning(
                 "RawBlockCore: use_odirect is ignored for NVMe namespace "
@@ -253,6 +303,13 @@ class RawBlockCore:
         validate_raw_block_io_options(
             iouring_queue_depth=self.iouring_queue_depth,
         )
+        if not self.device_id and (
+            self.load_checkpoint_on_init or self.meta_enable_periodic
+        ):
+            raise ValueError(
+                "RawBlockCore metadata checkpointing requires a stable "
+                "device_id from NVMe WWID or regular-file identity"
+            )
         if self.use_uring_cmd and self.io_engine != "io_uring":
             raise ValueError("use_uring_cmd requires io_uring as io_engine")
         if self.use_uring_cmd:
@@ -911,6 +968,7 @@ class RawBlockCore:
                 "type": "RawBlockCore",
                 "key_namespace": self.key_namespace,
                 "device_path": self.device_path,
+                "device_id": self.device_id,
                 "block_align": self.block_align,
                 "header_bytes": self.header_bytes,
                 "slot_bytes": self.slot_bytes,
@@ -1571,7 +1629,7 @@ class RawBlockCore:
             dirty_total = self._meta_dirty_total
             snapshot = {
                 "version": 1,
-                "device_path": self.device_path,
+                "device_id": self.device_id,
                 "capacity_bytes": self.capacity_bytes,
                 "block_align": self.block_align,
                 "header_bytes": self.header_bytes,
@@ -1678,6 +1736,9 @@ class RawBlockCore:
         if not force and not idle_ok:
             return False
 
+        if not self.device_id:
+            raise RuntimeError("RawBlockCore metadata checkpoint requires device_id")
+
         snapshot, dirty_total_snapshot = self._snapshot_state()
         payload = json.dumps(snapshot, separators=(",", ":"), ensure_ascii=True).encode(
             "utf-8"
@@ -1702,9 +1763,12 @@ class RawBlockCore:
             return False
         if int(data.get("version", 0)) != 1:
             return False
-        checkpoint_device_path = data.get("device_path")
-        if checkpoint_device_path and checkpoint_device_path != self.device_path:
-            logger.warning("Device metadata device_path mismatch; ignoring metadata")
+        checkpoint_device_id = data.get("device_id")
+        if not checkpoint_device_id:
+            logger.warning("Device metadata missing device_id; ignoring metadata")
+            return False
+        if not self.device_id or str(checkpoint_device_id) != self.device_id:
+            logger.warning("Device metadata device_id mismatch; ignoring metadata")
             return False
         if int(data.get("slot_bytes", self.slot_bytes)) != self.slot_bytes:
             logger.warning("Device metadata slot_bytes mismatch; ignoring metadata")

--- a/tests/v1/distributed/test_raw_block_l2_adapter.py
+++ b/tests/v1/distributed/test_raw_block_l2_adapter.py
@@ -179,6 +179,15 @@ def test_raw_block_l2_adapter_config_accepts_io_engine_values(io_engine):
     assert config.io_engine == io_engine
 
 
+def test_raw_block_l2_adapter_config_passes_legacy_device_id_option():
+    config = RawBlockL2AdapterConfig.from_dict(
+        _config_dict(allow_legacy_checkpoint_without_device_id=True)
+    )
+
+    assert config.allow_legacy_checkpoint_without_device_id is True
+    assert config.to_core_config().allow_legacy_checkpoint_without_device_id is True
+
+
 def test_raw_block_l2_adapter_config_rejects_invalid_io_engine():
     with pytest.raises(ValueError, match="io_engine"):
         RawBlockL2AdapterConfig.from_dict(_config_dict(io_engine="uring"))

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 import pytest
 
 # First Party
-from lmcache.v1.storage_backend.raw_block import RawBlockCore, encode_object_key
+from lmcache.v1.storage_backend.raw_block import (
+    RawBlockCore,
+    encode_object_key,
+    resolve_raw_block_device_id,
+)
 from tests.v1.storage_backend.raw_block_test_utils import (
     make_empty_memory_obj,
     make_memory_obj,
@@ -101,6 +105,14 @@ def test_raw_block_core_delete_and_missing_load(tmp_path):
         core.close()
 
 
+def test_raw_block_core_requires_device_id_for_unsupported_checkpoint_path(tmp_path):
+    path = tmp_path / "missing_raw_block.bin"
+    config = make_raw_block_core_config(path)
+
+    with pytest.raises(ValueError, match="requires a stable device_id"):
+        RawBlockCore(config, key_namespace="object")
+
+
 def test_raw_block_core_recovers_checkpoint_from_temp_file(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -125,6 +137,41 @@ def test_raw_block_core_recovers_checkpoint_from_temp_file(tmp_path):
         recovered.close()
 
 
+def test_raw_block_device_id_resolves_nvme_namespace_paths(monkeypatch):
+    observed_paths: list[str] = []
+
+    def fake_read_sysfs_text(path: str) -> str:
+        observed_paths.append(path)
+        return "nvme.11111111-2222-3333-4444-555555555555"
+
+    monkeypatch.setattr(
+        "lmcache.v1.storage_backend.raw_block.core._read_sysfs_text",
+        fake_read_sysfs_text,
+    )
+
+    assert (
+        resolve_raw_block_device_id("/dev/nvme0n1")
+        == "nvme:nvme.11111111-2222-3333-4444-555555555555"
+    )
+    assert observed_paths[-1] == "/sys/block/nvme0n1/wwid"
+
+    assert (
+        resolve_raw_block_device_id("/dev/ng0n1")
+        == "nvme:nvme.11111111-2222-3333-4444-555555555555"
+    )
+    assert observed_paths[-1] == "/sys/block/nvme0n1/wwid"
+
+
+def test_raw_block_device_id_resolves_regular_file_identity(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    st = path.stat()
+
+    assert (
+        resolve_raw_block_device_id(str(path))
+        == f"file:{st.st_dev}:{st.st_ino}:{st.st_size}"
+    )
+
+
 def test_raw_block_core_rebuilds_missing_free_slots_from_checkpoint(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -144,7 +191,7 @@ def test_raw_block_core_rebuilds_missing_free_slots_from_checkpoint(tmp_path):
         applied = core.apply_loaded_state(
             {
                 "version": 1,
-                "device_path": str(path),
+                "device_id": core.device_id,
                 "capacity_bytes": core.capacity_bytes,
                 "block_align": core.block_align,
                 "header_bytes": core.header_bytes,
@@ -185,5 +232,84 @@ def test_raw_block_core_rebuilds_missing_free_slots_from_checkpoint(tmp_path):
             core.data_base_offset() + core.slot_bytes
         )
         assert core.report_status()["next_slot"] == 2
+    finally:
+        core.close()
+
+
+def test_raw_block_core_accepts_checkpoint_with_matching_device_id(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    config = make_raw_block_core_config(path)
+    core = RawBlockCore(config, key_namespace="object")
+
+    try:
+        core.device_id = "nvme:nvme.11111111-2222-3333-4444-555555555555"
+        applied = core.apply_loaded_state(
+            {
+                "version": 1,
+                "device_path": "/dev/ng0n1",
+                "device_id": "nvme:nvme.11111111-2222-3333-4444-555555555555",
+                "slot_bytes": core.slot_bytes,
+                "meta_total_bytes": core.meta_total_bytes,
+                "meta_magic": core.meta_magic_text,
+                "meta_version": core.meta_version,
+                "next_slot": 0,
+                "free_slots": [],
+                "entries": {},
+            }
+        )
+
+        assert applied is True
+    finally:
+        core.close()
+
+
+def test_raw_block_core_rejects_checkpoint_missing_device_id(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    config = make_raw_block_core_config(path)
+    core = RawBlockCore(config, key_namespace="object")
+
+    try:
+        applied = core.apply_loaded_state(
+            {
+                "version": 1,
+                "device_path": "/dev/ng0n1",
+                "slot_bytes": core.slot_bytes,
+                "meta_total_bytes": core.meta_total_bytes,
+                "meta_magic": core.meta_magic_text,
+                "meta_version": core.meta_version,
+                "next_slot": 0,
+                "free_slots": [],
+                "entries": {},
+            }
+        )
+
+        assert applied is False
+    finally:
+        core.close()
+
+
+def test_raw_block_core_rejects_checkpoint_with_different_device_id(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    config = make_raw_block_core_config(path)
+    core = RawBlockCore(config, key_namespace="object")
+
+    try:
+        core.device_id = "nvme:nvme.11111111-2222-3333-4444-555555555555"
+        applied = core.apply_loaded_state(
+            {
+                "version": 1,
+                "device_path": str(path),
+                "device_id": "nvme:nvme.aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "slot_bytes": core.slot_bytes,
+                "meta_total_bytes": core.meta_total_bytes,
+                "meta_magic": core.meta_magic_text,
+                "meta_version": core.meta_version,
+                "next_slot": 0,
+                "free_slots": [],
+                "entries": {},
+            }
+        )
+
+        assert applied is False
     finally:
         core.close()

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -3,6 +3,9 @@
 # Future
 from __future__ import annotations
 
+# Standard
+from dataclasses import replace
+
 # Third Party
 import pytest
 
@@ -284,6 +287,34 @@ def test_raw_block_core_rejects_checkpoint_missing_device_id(tmp_path):
         )
 
         assert applied is False
+    finally:
+        core.close()
+
+
+def test_raw_block_core_allows_legacy_checkpoint_missing_device_id(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    config = replace(
+        make_raw_block_core_config(path),
+        allow_legacy_checkpoint_without_device_id=True,
+    )
+    core = RawBlockCore(config, key_namespace="object")
+
+    try:
+        applied = core.apply_loaded_state(
+            {
+                "version": 1,
+                "device_path": "/dev/ng0n1",
+                "slot_bytes": core.slot_bytes,
+                "meta_total_bytes": core.meta_total_bytes,
+                "meta_magic": core.meta_magic_text,
+                "meta_version": core.meta_version,
+                "next_slot": 0,
+                "free_slots": [],
+                "entries": {},
+            }
+        )
+
+        assert applied is True
     finally:
         core.close()
 

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -164,6 +164,18 @@ def test_raw_block_device_id_resolves_nvme_namespace_paths(monkeypatch):
     )
     assert observed_paths[-1] == "/sys/block/nvme0n1/wwid"
 
+    assert (
+        resolve_raw_block_device_id("/dev/nvme0n1p1")
+        == "nvme:nvme.11111111-2222-3333-4444-555555555555:p1"
+    )
+    assert observed_paths[-1] == "/sys/block/nvme0n1/wwid"
+
+    assert (
+        resolve_raw_block_device_id("/dev/nvme0n1p2")
+        == "nvme:nvme.11111111-2222-3333-4444-555555555555:p2"
+    )
+    assert observed_paths[-1] == "/sys/block/nvme0n1/wwid"
+
 
 def test_raw_block_device_id_resolves_regular_file_identity(tmp_path):
     path = make_raw_block_file(tmp_path)

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -41,6 +41,7 @@ from lmcache.v1.storage_backend.raw_block import (
     RawBlockCoreConfig,
     RawBlockKeySpec,
     RawBlockPutManyResult,
+    resolve_raw_block_device_id,
 )
 
 
@@ -86,10 +87,12 @@ def _install_fake_raw_block_device(monkeypatch, *, size_bytes: int = 64 * 1024):
     )
 
 
-def _make_raw_block_core(*, use_odirect: bool = False) -> RawBlockCore:
+def _make_raw_block_core(
+    device_path: str, *, use_odirect: bool = False
+) -> RawBlockCore:
     return RawBlockCore(
         RawBlockCoreConfig(
-            device_path="/tmp/raw-block-boundary-test",
+            device_path=device_path,
             capacity_bytes=64 * 1024,
             block_align=4096,
             header_bytes=4096,
@@ -124,7 +127,7 @@ def _make_byte_obj(size: int) -> TensorMemoryObj:
     return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
 
 
-def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch):
+def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch, tmp_path):
     calls: list[dict[str, object]] = []
 
     class FakeRawBlockDevice:
@@ -149,10 +152,13 @@ def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch):
         "lmcache_rust_raw_block_io",
         types.SimpleNamespace(RawBlockDevice=FakeRawBlockDevice),
     )
+    device_path = tmp_path / "raw-block-engine-test"
+    device_path.touch()
+    device_path_str = str(device_path)
 
     core = RawBlockCore(
         RawBlockCoreConfig(
-            device_path="/tmp/raw-block-engine-test",
+            device_path=device_path_str,
             capacity_bytes=0,
             block_align=4096,
             header_bytes=4096,
@@ -175,7 +181,7 @@ def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch):
     try:
         assert calls == [
             {
-                "path": "/tmp/raw-block-engine-test",
+                "path": device_path_str,
                 "writable": True,
                 "use_odirect": False,
                 "alignment": 4096,
@@ -188,9 +194,13 @@ def test_raw_block_core_passes_io_engine_options_to_rust_binding(monkeypatch):
         core.close()
 
 
-def test_raw_block_core_non_odirect_rejects_payload_over_slot_capacity(monkeypatch):
+def test_raw_block_core_non_odirect_rejects_payload_over_slot_capacity(
+    monkeypatch, tmp_path
+):
     _install_fake_raw_block_device(monkeypatch)
-    core = _make_raw_block_core(use_odirect=False)
+    device_path = tmp_path / "raw-block-boundary-test"
+    device_path.touch()
+    core = _make_raw_block_core(str(device_path), use_odirect=False)
     try:
         payload_capacity = core.slot_bytes - core.header_bytes
         exact_key = RawBlockKeySpec(encoded="exact", slot_identity=1)
@@ -210,9 +220,11 @@ def test_raw_block_core_non_odirect_rejects_payload_over_slot_capacity(monkeypat
         core.close()
 
 
-def test_raw_block_core_odirect_prepare_payload_boundaries(monkeypatch):
+def test_raw_block_core_odirect_prepare_payload_boundaries(monkeypatch, tmp_path):
     _install_fake_raw_block_device(monkeypatch)
-    core = _make_raw_block_core(use_odirect=True)
+    device_path = tmp_path / "raw-block-boundary-test"
+    device_path.touch()
+    core = _make_raw_block_core(str(device_path), use_odirect=True)
     try:
         payload_capacity = core.slot_bytes - core.header_bytes
 
@@ -1455,6 +1467,7 @@ def test_rust_raw_block_backend_skips_invalid_checkpoint_entries(
                     "meta_total_bytes": backend.meta_total_bytes,
                     "meta_magic": backend.meta_magic_text,
                     "meta_version": backend.meta_version,
+                    "device_id": resolve_raw_block_device_id(dev_path),
                     "data_base_offset": backend.data_base_offset,
                     "next_slot": 0,
                     "free_slots": [],
@@ -1531,6 +1544,7 @@ def test_rust_raw_block_backend_recovers_legacy_key_dtype(
                     "meta_total_bytes": backend.meta_total_bytes,
                     "meta_magic": backend.meta_magic_text,
                     "meta_version": backend.meta_version,
+                    "device_id": resolve_raw_block_device_id(dev_path),
                     "data_base_offset": backend.data_base_offset,
                     "next_slot": 1,
                     "free_slots": [],
@@ -2332,7 +2346,7 @@ def _make_raw_block_backend(
 
 
 def test_rust_raw_block_backend_batched_submit_rolls_back_refs_on_dispatch_failure(
-    monkeypatch, memory_allocator, loop_in_thread
+    monkeypatch, memory_allocator, loop_in_thread, tmp_path
 ):
     """A dispatch failure rolls back every ref_count_up and clears put_tasks.
 
@@ -2342,8 +2356,10 @@ def test_rust_raw_block_backend_batched_submit_rolls_back_refs_on_dispatch_failu
     in-flight put-task set so nothing leaks.
     """
     _install_fake_raw_block_device(monkeypatch, size_bytes=64 * 1024 * 1024)
+    device_path = tmp_path / "plugin-rollback"
+    device_path.touch()
     backend = _make_raw_block_backend(
-        "/tmp/plugin-rollback", memory_allocator, loop_in_thread
+        str(device_path), memory_allocator, loop_in_thread
     )
     try:
         allocator = AdHocMemoryAllocator(device="cpu")
@@ -2378,12 +2394,14 @@ def test_rust_raw_block_backend_batched_submit_rolls_back_refs_on_dispatch_failu
 
 
 def test_rust_raw_block_backend_batched_submit_rolls_back_only_unscheduled_refs(
-    monkeypatch, memory_allocator, loop_in_thread
+    monkeypatch, memory_allocator, loop_in_thread, tmp_path
 ):
     """A partial per-key dispatch failure leaves scheduled task cleanup to task."""
     _install_fake_raw_block_device(monkeypatch, size_bytes=64 * 1024 * 1024)
+    device_path = tmp_path / "plugin-partial-rollback"
+    device_path.touch()
     backend = _make_raw_block_backend(
-        "/tmp/plugin-partial-rollback",
+        str(device_path),
         memory_allocator,
         loop_in_thread,
         io_engine="posix",


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Raw-block checkpoint recovery previously relied on the configured `device_path`
to identify checkpoint metadata. That is fragile because device paths can change
across reboot, and the same NVMe namespace may be opened as `/dev/nvme*` or
`/dev/ng*` depending on whether `io_uring_cmd` is used.

This PR adds a stable `device_id` to raw-block checkpoint metadata:
- NVMe namespaces use `nvme:<wwid>` from `/sys/block/<namespace>/wwid`
- regular files use `file:<st_dev>:<st_ino>:<st_size>`

Recovery now validates `device_id` instead of relying on `device_path`, so path
changes do not reject valid checkpoints. Unsupported paths fail fast when
checkpoint loading or periodic checkpointing is enabled.

For upgrade compatibility, this PR also adds an opt-in legacy migration switch:
- MP `raw_block`: `allow_legacy_checkpoint_without_device_id=true`
- non-MP `rust_raw_block`: `rust_raw_block.allow_legacy_checkpoint_without_device_id=true`

This option allows loading older checkpoints that were written before `device_id`
was recorded. It only applies when the checkpoint is missing `device_id`;
checkpoints with a mismatched `device_id` are still rejected. After the legacy
checkpoint is loaded and a new checkpoint is written, the option should be
disabled again.

**Special notes for your reviewers**:
`device_path` may still appear in diagnostics or legacy metadata, but recovery
validation uses stable `device_id`.

The legacy migration option is disabled by default and is intended only as a
one-time upgrade path for pre-`device_id` checkpoints.

**If applicable**:
- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

**Tested with**:

```bash
pytest -q tests/v1/storage_backend/test_rust_raw_block_backend.py \
tests/v1/storage_backend/test_raw_block_core.py
```