### PR TITLE
[p2p][bugfix] fix coordinator server disconnected error

### DIFF
--- a/docs/source/cli/coordinator.rst
+++ b/docs/source/cli/coordinator.rst
@@ -57,6 +57,12 @@ Options
    * - ``--blend-probe-stride N``
      - Positions between CacheBlend match probes; ``1`` probes every offset
        for full recall (default: ``1``).
+   * - ``--timeout-keep-alive SECS``
+     - Seconds the HTTP server keeps idle connections open before closing
+       them. Must be greater than the MP servers' heartbeat interval
+       (default ``5``), otherwise heartbeat requests may hit a closing
+       connection and fail with ``Server disconnected without sending a
+       response`` (default: ``10``).
 
 Configuration
 -------------
@@ -65,9 +71,9 @@ Every flag is optional. Unset flags fall back to the
 ``LMCACHE_MP_COORDINATOR_*`` environment variables (``HOST``, ``PORT``,
 ``INSTANCE_TIMEOUT``, ``HEALTH_CHECK_INTERVAL``, ``EVICTION_CHECK_INTERVAL``,
 ``EVICTION_RATIO``, ``TRIGGER_WATERMARK``, ``BLEND_CHUNK_SIZE``,
-``BLEND_PROBE_STRIDE``), and then to the built-in defaults. A supplied flag
-always overrides the matching env-derived value, so env-only deployments keep
-working unchanged.
+``BLEND_PROBE_STRIDE``, ``TIMEOUT_KEEP_ALIVE``), and then to the built-in
+defaults. A supplied flag always overrides the matching env-derived value, so
+env-only deployments keep working unchanged.
 
 A second set of env-only knobs controls the startup L2 resync —
 ``LMCACHE_MP_COORDINATOR_ENABLE_STARTUP_RESYNC`` (default ``True``),

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -23,9 +23,9 @@ Expected log output:
 
 The CLI accepts ``--host``, ``--port``, ``--instance-timeout``,
 ``--health-check-interval``, ``--eviction-check-interval``,
-``--eviction-ratio``, ``--trigger-watermark``, ``--blend-chunk-size``, and
-``--blend-probe-stride``; any flag overrides the matching environment variable
-below. See :doc:`/cli/coordinator` for details.
+``--eviction-ratio``, ``--trigger-watermark``, ``--blend-chunk-size``,
+``--blend-probe-stride``, and ``--timeout-keep-alive``; any flag overrides the
+matching environment variable below. See :doc:`/cli/coordinator` for details.
 Equivalently, the coordinator can still be launched as a module with
 ``python3 -m lmcache.v1.mp_coordinator``.
 
@@ -73,6 +73,13 @@ variables:
      - ``1``
      - Positions between CacheBlend match probes. ``1`` probes every offset
        for full recall.
+   * - ``LMCACHE_MP_COORDINATOR_TIMEOUT_KEEP_ALIVE``
+     - ``10``
+     - Seconds the HTTP server keeps idle connections open before closing
+       them. Must be greater than the MP servers' heartbeat interval
+       (default ``5``), otherwise heartbeat requests may hit a closing
+       connection and fail with ``Server disconnected without sending a
+       response``.
    * - ``LMCACHE_MP_COORDINATOR_ENABLE_STARTUP_RESYNC``
      - ``True``
      - When ``True``, the coordinator runs a one-shot L2 resync on

--- a/lmcache/cli/commands/coordinator.py
+++ b/lmcache/cli/commands/coordinator.py
@@ -119,6 +119,15 @@ class CoordinatorCommand(BaseCommand):
                 "offset for full recall (default: 1)."
             ),
         )
+        parser.add_argument(
+            "--timeout-keep-alive",
+            type=int,
+            default=None,
+            help=(
+                "Seconds the HTTP server keeps idle connections open "
+                "before closing them (default: 10)."
+            ),
+        )
 
     def execute(self, args: argparse.Namespace) -> None:
         """Build the coordinator config and serve the app with uvicorn.
@@ -165,6 +174,7 @@ class CoordinatorCommand(BaseCommand):
                 ("trigger_watermark", args.trigger_watermark),
                 ("blend_chunk_size", args.blend_chunk_size),
                 ("blend_probe_stride", args.blend_probe_stride),
+                ("timeout_keep_alive", args.timeout_keep_alive),
             )
             if value is not None
         }
@@ -172,4 +182,10 @@ class CoordinatorCommand(BaseCommand):
             config = dataclasses.replace(config, **overrides)
 
         app = create_app(config)
-        uvicorn.run(app, host=config.host, port=config.port, log_level="info")
+        uvicorn.run(
+            app,
+            host=config.host,
+            port=config.port,
+            log_level="info",
+            timeout_keep_alive=config.timeout_keep_alive,
+        )

--- a/lmcache/v1/mp_coordinator/__main__.py
+++ b/lmcache/v1/mp_coordinator/__main__.py
@@ -21,7 +21,13 @@ def main() -> None:
     """Build the coordinator app from the environment and serve it."""
     config = MPCoordinatorConfig.from_env()
     app = create_app(config)
-    uvicorn.run(app, host=config.host, port=config.port, log_level="info")
+    uvicorn.run(
+        app,
+        host=config.host,
+        port=config.port,
+        log_level="info",
+        timeout_keep_alive=config.timeout_keep_alive,
+    )
 
 
 if __name__ == "__main__":

--- a/lmcache/v1/mp_coordinator/config.py
+++ b/lmcache/v1/mp_coordinator/config.py
@@ -50,6 +50,9 @@ class MPCoordinatorConfig:
             server before giving up.
         resync_page_size: ``page_size`` forwarded to ``GET /l2/keys``
             during resync.
+        timeout_keep_alive: Seconds the HTTP server keeps idle connections
+            open before closing them. Must be greater than the heartbeat
+            interval of MP servers to avoid race-condition disconnects.
     """
 
     host: str = "0.0.0.0"
@@ -65,6 +68,7 @@ class MPCoordinatorConfig:
     resync_poll_interval: float = 1.0
     resync_max_wait: float = 60.0
     resync_page_size: int = 1000
+    timeout_keep_alive: int = 10
 
     def __post_init__(self) -> None:
         """Validate timing parameters.
@@ -94,6 +98,8 @@ class MPCoordinatorConfig:
             raise ValueError("blend_chunk_size must be positive")
         if self.blend_probe_stride < 1:
             raise ValueError("blend_probe_stride must be positive")
+        if self.timeout_keep_alive <= 0:
+            raise ValueError("timeout_keep_alive must be positive")
 
     @classmethod
     def from_env(cls) -> "MPCoordinatorConfig":
@@ -150,4 +156,7 @@ class MPCoordinatorConfig:
             ),
             resync_max_wait=_num("RESYNC_MAX_WAIT", cls.resync_max_wait, float),
             resync_page_size=int(_num("RESYNC_PAGE_SIZE", cls.resync_page_size, int)),
+            timeout_keep_alive=int(
+                _num("TIMEOUT_KEEP_ALIVE", cls.timeout_keep_alive, int)
+            ),
         )

--- a/tests/cli/commands/test_coordinator.py
+++ b/tests/cli/commands/test_coordinator.py
@@ -58,18 +58,22 @@ class TestCoordinatorCommandArguments:
                 "512",
                 "--blend-probe-stride",
                 "2",
+                "--timeout-keep-alive",
+                "15",
             ]
         )
         assert args.host == "127.0.0.1"
         assert args.port == 9999
         assert args.blend_chunk_size == 512
         assert args.blend_probe_stride == 2
+        assert args.timeout_keep_alive == 15
 
     def test_flags_default_to_none(self, parser):
         """Unset flags default to None so env/config defaults win."""
         args = parser.parse_args(["coordinator"])
         assert args.blend_chunk_size is None
         assert args.blend_probe_stride is None
+        assert args.timeout_keep_alive is None
 
 
 class TestCoordinatorCommandExecute:
@@ -88,6 +92,7 @@ class TestCoordinatorCommandExecute:
             trigger_watermark=None,
             blend_chunk_size=512,
             blend_probe_stride=2,
+            timeout_keep_alive=None,
         )
 
         captured = {}


### PR DESCRIPTION
When the coordinator's uvicorn keep-alive timeout (default `5s`) equals the MP server's heartbeat interval (also `5s`), a race condition causes intermittent Server disconnected without sending a response errors. The server may close the idle connection at the exact moment the client sends its next heartbeat.

Fix: Add a configurable timeout_keep_alive parameter (default `10s`) to the coordinator's uvicorn server, ensuring idle connections stay open longer than the heartbeat interval.

the error log is as follows:
<img width="1587" height="174" alt="Clipboard_Screenshot_1782388224" src="https://github.com/user-attachments/assets/ab9c4e97-1f4f-4e7d-adb5-ce88d05bf99d" />
