### PR TITLE
docs: daily drift check — multi-process mode (2026-06-25)

### DIFF
--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -77,7 +77,7 @@ High-Level Architecture
          |
          |--- L1Manager (l1_manager.py)
          |       |--- L1MemoryManager (CPU DRAM) or
-         |       |    GDSL1MemoryManager (NVMe slab via cuFile)
+         |       |    GDSL1MemoryManager (NVMe slab via cuFile / hipFile)
          |       |--- TTLLock per object (read/write)
          |
          |--- StoreController  -----> L2 Adapter(s) (async L1->L2 push)
@@ -383,9 +383,12 @@ tiers selected at startup (both satisfy ``L1ManagerProtocol``):
   ``--l1-size-gb``.
 - ``GDSL1MemoryManager`` -- an NVMe slab file when ``--gds-l1-path`` is set.
   The bytes live on disk; reads/writes DMA directly between the GPU staging
-  buffer and the slab via cuFile, driven by the process-global ``GDSContext``
-  (``gpu_connector/gds_context.py``) and dispatched from ``gpu_ops``. The CPU
-  tier is disabled in this mode.
+  buffer and the slab, driven by the process-global ``GDSContext``
+  (``gpu_connector/gds_context.py``) and dispatched from ``gpu_ops``. The DMA
+  backend is selected by platform via ``gpu_connector/_gds_async.py`` --
+  cuFile (``libcufile.so``) on NVIDIA and hipFile (``libhipfile.so``) on AMD
+  ROCm; see the *GDS L1 Tier* section of :doc:`configuration` for the
+  vendor-specific requirements. The CPU tier is disabled in this mode.
 
 L2 Adapters
 ~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Daily docs drift check on the multi-process surface. One inconsistency found in `docs/source/`, none in `docs/design/` beyond what is already pending review in earlier drift PRs (#3863, #3840, #3817, #3774).

### `docs/source/`

- **`docs/source/mp/index.rst`** — `GDSL1MemoryManager` is described as DMA'ing "via cuFile" in two places: the high-level architecture diagram around line 80 and the L1 manager prose section around line 386. After [#3843](https://github.com/LMCache/LMCache/pull/3843) (`b823176`, landed 2026-06-24) added an AMD hipFile backend for the GDS L1 tier, the GDS async path now dispatches to **cuFile on NVIDIA or hipFile on AMD ROCm** based on `torch.version.hip`. `docs/source/mp/configuration.rst` (GDS L1 Tier section) was updated as part of that PR; the index page was not.

### `docs/design/`

No drift left over after accounting for the open drift-check PRs:

- The `custom_types.py` → `platform/cuda/ipc_wrapper.py` rename in `docs/design/v1/multiprocess/raw_cuda_ipc.md` and the `MPCacheServer.register_kv_cache` → `LMCacheDrivenTransferModule.register_kv_cache` rename are already proposed in #3863.
- The `CudaIPCWrapper` → `DeviceIPCWrapper` shift is already proposed in #3840.
- `docs/design/v1/multiprocess/device_ipc_wrapper_design.md` was updated in the same commit that landed the auto-discovery refactor ([#3829](https://github.com/LMCache/LMCache/pull/3829)).
- The remaining `custom_types.py` reference in `docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md:799` is still correct — `IPCCacheServerKey` lives in `lmcache/v1/multiprocess/custom_types.py`; only the IPC wrapper classes moved out.

## Evidence

| Doc claim (current) | Code reality | Permalink |
| --- | --- | --- |
| `docs/source/mp/index.rst:80` – `GDSL1MemoryManager (NVMe slab via cuFile)` | DMA backend selected by platform: cuFile on NVIDIA, hipFile on AMD ROCm | [`_gds_async.py:1-34` @ 4aafa30](https://github.com/LMCache/LMCache/blob/4aafa30eeb39823f2071423f3ea0fbb23ddc4755/lmcache/v1/gpu_connector/_gds_async.py#L1-L34) |
| `docs/source/mp/index.rst:386` – "the slab via cuFile, driven by the process-global ``GDSContext``" | Same — `_gds_async.py` picks `_cufile_async` (NVIDIA) or `_hipfile_async` (AMD ROCm) | [`_gds_async.py:26-34` @ 4aafa30](https://github.com/LMCache/LMCache/blob/4aafa30eeb39823f2071423f3ea0fbb23ddc4755/lmcache/v1/gpu_connector/_gds_async.py#L26-L34) |
| Cross-check: `docs/source/mp/configuration.rst:239` already says "**cuFile** … on NVIDIA and **hipFile** … on AMD ROCm" for the same tier | Matches code | [`configuration.rst` @ 4aafa30](https://github.com/LMCache/LMCache/blob/4aafa30eeb39823f2071423f3ea0fbb23ddc4755/docs/source/mp/configuration.rst#L239-L242) |

## Proposed fix (applied in this PR)

- Update the architecture-diagram line to read `GDSL1MemoryManager (NVMe slab via cuFile / hipFile)`.
- Expand the L1 manager prose to mention that the DMA backend is selected by platform via `gpu_connector/_gds_async.py` (cuFile / `libcufile.so` on NVIDIA, hipFile / `libhipfile.so` on AMD ROCm), and link to the *GDS L1 Tier* section in `configuration.rst` for the vendor-specific requirements (ROCm ≥ 7.2.0, kernel `CONFIG_PCI_P2PDMA`, NVMe ext4/xfs, etc.).

Docs-only diff; no code changes. Touches only `docs/source/mp/index.rst`.

## Notes

- Auto-generated by the daily LMCache docs drift-check routine; **human review required before merge**.
- This PR is marked **draft** and is not requesting maintainer reviewers automatically.
- Branch lives on the `ApostaC/LMCache` fork (`docs/drift-check-2026-06-25`) and targets upstream `dev`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvBJNioHc8d38Za9ftyuvQ)_