### PR TITLE
feat(cli): add CSV output format for metrics

### DIFF
--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -779,7 +779,7 @@ Options
    * - ``--format FORMAT``
      - ``terminal``
      - Stdout output format for the final metrics summary. Available:
-       ``terminal``, ``json``.
+       ``terminal``, ``json``, ``csv``.
    * - ``--output PATH``
      - *(unset)*
      - Save the final metrics summary to a file at PATH (format chosen

--- a/docs/source/cli/describe.rst
+++ b/docs/source/cli/describe.rst
@@ -71,7 +71,7 @@ Options
    * - ``--url``
      - LMCache HTTP server URL (default: ``http://localhost:8080``).
    * - ``--format``
-     - Output format: ``terminal`` (default) or ``json``.
+     - Output format: ``terminal`` (default), ``json``, or ``csv``.
    * - ``--output PATH``
      - Save metrics to a file (format follows ``--format``).
    * - ``-q`` / ``--quiet``

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -77,13 +77,26 @@ Output Formats
 
 Commands that produce metrics share three common flags:
 
-* ``--format {terminal,json}`` — stdout format (default: ``terminal``).
+* ``--format {terminal,json,csv}`` — stdout format (default: ``terminal``).
 * ``--output PATH`` — also write metrics to a file (uses ``--format``).
 * ``-q`` / ``--quiet`` — suppress stdout; rely on the exit code.
 
 The terminal output uses human-readable labels (e.g. ``"Round trip time
 (ms)"``), while JSON uses machine-readable keys (e.g.
 ``"round_trip_time_ms"``).
+
+``csv`` renders the same metrics as a flat ``section,index,key,label,value``
+table — one row per metric — so output loads directly into a spreadsheet or
+dataframe. This is handy for comparing ``lmcache bench`` runs or appending
+periodic snapshots to a single file:
+
+.. code-block:: bash
+
+   # Append a benchmark summary to a results file for later comparison
+   lmcache bench engine --output results.csv --format csv
+
+   # Filter one nested group from a status report without a JSON parser
+   lmcache describe kvcache --format csv | grep '^models,'
 
 Adding New Commands
 -------------------

--- a/docs/source/cli/kvcache.rst
+++ b/docs/source/cli/kvcache.rst
@@ -20,7 +20,7 @@ server.
 
    options:
      -h, --help       show this help message and exit
-     --format FORMAT  Stdout output format (default: terminal). Available: terminal, json.
+     --format FORMAT  Stdout output format (default: terminal). Available: terminal, json, csv.
      --output PATH    Save metrics to a file at PATH (format chosen by --format).
      -q, --quiet      Suppress stdout output. Exit code only.
 
@@ -78,7 +78,7 @@ Options
      - URL of the LMCache MP HTTP server (e.g. ``http://localhost:8000``).
    * - ``--format``
      - No
-     - Output format: ``terminal`` (default) or ``json``.
+     - Output format: ``terminal`` (default), ``json``, or ``csv``.
    * - ``--output``
      - No
      - Save output to a file (uses the format chosen by ``--format``).

--- a/docs/source/cli/ping.rst
+++ b/docs/source/cli/ping.rst
@@ -37,7 +37,7 @@ Options
      - Server URL. Defaults to ``http://localhost:8080`` for ``kvcache``,
        ``http://localhost:8000`` for ``engine``.
    * - ``--format``
-     - Output format: ``terminal`` (default) or ``json``.
+     - Output format: ``terminal`` (default), ``json``, or ``csv``.
    * - ``--output PATH``
      - Save metrics to a file (format follows ``--format``).
    * - ``-q`` / ``--quiet``

--- a/docs/source/cli/query.rst
+++ b/docs/source/cli/query.rst
@@ -81,7 +81,7 @@ Options
        ``/v1/completions``.
    * - ``--format``
      - No
-     - Output format: ``terminal`` (default) or ``json``.
+     - Output format: ``terminal`` (default), ``json``, or ``csv``.
    * - ``--output PATH``
      - No
      - Save metrics to a file (format follows ``--format``).

--- a/docs/source/cli/quota.rst
+++ b/docs/source/cli/quota.rst
@@ -67,7 +67,7 @@ Create or update a quota for a given ``cache_salt``.
      - LMCache HTTP server URL (default: ``http://localhost:8080``).
    * - ``--format``
      - No
-     - Output format: ``terminal`` (default) or ``json``.
+     - Output format: ``terminal`` (default), ``json``, or ``csv``.
    * - ``--output``
      - No
      - Save output to a file (uses the format chosen by ``--format``).
@@ -114,7 +114,7 @@ Show the current quota limit and live usage for a specific ``cache_salt``.
      - LMCache HTTP server URL (default: ``http://localhost:8080``).
    * - ``--format``
      - No
-     - Output format: ``terminal`` (default) or ``json``.
+     - Output format: ``terminal`` (default), ``json``, or ``csv``.
    * - ``--output``
      - No
      - Save output to a file.
@@ -189,7 +189,7 @@ List all registered quotas along with their current usage.
      - LMCache HTTP server URL (default: ``http://localhost:8080``).
    * - ``--format``
      - No
-     - Output format: ``terminal`` (default) or ``json``.
+     - Output format: ``terminal`` (default), ``json``, or ``csv``.
    * - ``--output``
      - No
      - Save output to a file.
@@ -236,7 +236,7 @@ evicted (effective limit drops to 0).
      - LMCache HTTP server URL (default: ``http://localhost:8080``).
    * - ``--format``
      - No
-     - Output format: ``terminal`` (default) or ``json``.
+     - Output format: ``terminal`` (default), ``json``, or ``csv``.
    * - ``--output``
      - No
      - Save output to a file.

--- a/docs/source/developer_guide/cli.rst
+++ b/docs/source/developer_guide/cli.rst
@@ -68,7 +68,10 @@ The metrics system uses a **handler + formatter** architecture:
 
 - **Metrics** — the collector. Holds sections and entries.
 - **Handler** — the destination (stdout, file, etc.).
-- **Formatter** — the rendering (ASCII table, JSON, etc.).
+- **Formatter** — the rendering. Built-in formats are ``terminal`` (ASCII
+  table), ``json`` (nested document), and ``csv`` (flat one-row-per-metric
+  table). Register a new one with the ``@register_formatter("name")``
+  decorator in ``lmcache/cli/metrics/formatter.py``.
 
 ``BaseCommand.create_metrics()`` sets up default handlers automatically, so
 command authors just build metrics and call ``emit()``:

--- a/lmcache/cli/commands/base.py
+++ b/lmcache/cli/commands/base.py
@@ -236,7 +236,9 @@ def _add_output_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         default=None,
         metavar="FORMAT",
-        help=("Stdout output format (default: terminal). Available: terminal, json."),
+        help=(
+            "Stdout output format (default: terminal). Available: terminal, json, csv."
+        ),
     )
     parser.add_argument(
         "--output",

--- a/lmcache/cli/metrics/formatter.py
+++ b/lmcache/cli/metrics/formatter.py
@@ -8,7 +8,9 @@ Formatters are attached to handlers, separating rendering from destination.
 # Standard
 from typing import Any
 import abc
+import csv
 import inspect
+import io
 import json
 
 # First Party
@@ -169,3 +171,81 @@ class JsonFormatter(MetricsFormatter):
             sections_to_dict(title, sections),
             indent=self._indent,
         )
+
+
+def _locate_section(
+    section: Section,
+    group_counts: dict[str, int],
+) -> tuple[str, str]:
+    """Return the ``(section, index)`` cells for *section*.
+
+    Advances *group_counts* in place so each section in a list group is
+    assigned the next index (0, 1, ...).
+
+    Args:
+        section: The section being rendered.
+        group_counts: Mutable map of list-group name to the next index to
+            assign; updated as a side effect for list-group sections.
+
+    Returns:
+        A ``(section_name, index)`` pair of CSV cells. Both are empty for
+        the unnamed top-level section; ``index`` is empty for named
+        non-list sections.
+    """
+    if section.key is None:
+        return "", ""
+    if section.list_group is not None:
+        index = group_counts.get(section.list_group, 0)
+        group_counts[section.list_group] = index + 1
+        return section.list_group, str(index)
+    return section.key, ""
+
+
+@register_formatter("csv")
+class CsvFormatter(MetricsFormatter):
+    """Renders metrics as a CSV in long tidy form.
+
+    Emits a header row followed by one row per metric, using a fixed
+    five-column schema:
+    * ``section`` — machine key of the owning section, or empty for
+      top-level (flat) metrics.
+    * ``index`` — zero-based position of the section within its list
+      group (e.g. ``models`` 0, 1, ...), or empty for non-list sections.
+      This keeps otherwise-identical repeated sections distinguishable.
+    * ``key`` / ``label`` — the metric's machine key and human label.
+    * ``value`` — the raw value; ``None`` renders as an empty field.
+
+    Every metric becomes one flat row regardless of how deeply the source
+    sections are nested, so the output loads directly into spreadsheets
+    or a dataframe. The ``title`` argument is accepted only to satisfy the
+    ``MetricsFormatter`` interface; it is not rendered, since CSV models a
+    single flat table with no natural slot for a presentational header.
+    """
+
+    _HEADER = ("section", "index", "key", "label", "value")
+
+    def format(self, title: str, sections: list[Section]) -> str:
+        """Render metrics as long-form CSV.
+
+        Args:
+            title: The report title. Unused — see the class docstring for
+                why the title is not part of the tabular output.
+            sections: Ordered list of ``Section`` objects.
+
+        Returns:
+            CSV text: a header row followed by one row per metric. Rows
+            are ``\\n``-terminated with no trailing newline, matching the
+            other formatters.
+        """
+        buffer = io.StringIO()
+        writer = csv.writer(buffer, lineterminator="\n")
+        writer.writerow(self._HEADER)
+
+        group_counts: dict[str, int] = {}
+        for section in sections:
+            location = _locate_section(section, group_counts)
+            for key, label, value in section.entries:
+                cell = "" if value is None else value
+                writer.writerow([*location, key, label, cell])
+
+        return buffer.getvalue().rstrip("\n")

--- a/tests/cli/test_formatter.py
+++ b/tests/cli/test_formatter.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the CLI metrics formatters, focused on ``CsvFormatter``."""
+
+# Standard
+import csv
+import io
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.metrics.formatter import (
+    CsvFormatter,
+    get_formatter,
+)
+from lmcache.cli.metrics.section import Section
+
+
+def _flat_section(entries: list[tuple[str, str, object]]) -> Section:
+    """Build the unnamed top-level section holding *entries*."""
+    section = Section(None, None)
+    for key, label, value in entries:
+        section.add(key, label, value)
+    return section
+
+
+def _parse(text: str) -> list[list[str]]:
+    """Parse formatter CSV output back into rows."""
+    return list(csv.reader(io.StringIO(text)))
+
+
+class TestCsvFormatterRegistration:
+    def test_lookup_returns_csv_formatter(self):
+        assert isinstance(get_formatter("csv"), CsvFormatter)
+
+    def test_ignores_unrelated_kwargs(self):
+        # ``BaseCommand.create_metrics`` forwards ``width``; the CSV
+        # formatter must accept being constructed without using it.
+        assert isinstance(get_formatter("csv", width=80), CsvFormatter)
+
+
+class TestCsvFormatterOutput:
+    def test_header_is_always_first_row(self):
+        rows = _parse(CsvFormatter().format("Title", []))
+        assert rows == [["section", "index", "key", "label", "value"]]
+
+    def test_flat_metrics_have_empty_section_and_index(self):
+        sections = [_flat_section([("health", "Health", "Healthy")])]
+        rows = _parse(CsvFormatter().format("Describe", sections))
+        assert rows[1] == ["", "", "health", "Health", "Healthy"]
+
+    def test_named_section_uses_key_and_empty_index(self):
+        section = Section("limits", "Limits")
+        section.add("limit_gb", "Limit (GB)", 40)
+        rows = _parse(CsvFormatter().format("Quota", [section]))
+        assert rows[1] == ["limits", "", "limit_gb", "Limit (GB)", "40"]
+
+    def test_list_group_sections_get_incrementing_indices(self):
+        model0 = Section("model_0", "Model 0", list_group="models")
+        model0.add("model", "Model", "llama")
+        model1 = Section("model_1", "Model 1", list_group="models")
+        model1.add("model", "Model", "mistral")
+        rows = _parse(CsvFormatter().format("Describe", [model0, model1]))
+        assert rows[1] == ["models", "0", "model", "Model", "llama"]
+        assert rows[2] == ["models", "1", "model", "Model", "mistral"]
+
+    def test_none_value_renders_as_empty_field(self):
+        sections = [_flat_section([("l1_capacity_gb", "L1 capacity (GB)", None)])]
+        rows = _parse(CsvFormatter().format("Describe", sections))
+        assert rows[1] == ["", "", "l1_capacity_gb", "L1 capacity (GB)", ""]
+
+    def test_value_with_comma_is_quoted_and_round_trips(self):
+        sections = [_flat_section([("gpu_ids", "GPU IDs", "0, 1")])]
+        text = CsvFormatter().format("Describe", sections)
+        # Raw output must quote the comma so the cell stays intact...
+        assert '"0, 1"' in text
+        # ...and parsing back must recover the original value unchanged.
+        assert _parse(text)[1][4] == "0, 1"
+
+    def test_no_trailing_newline(self):
+        sections = [_flat_section([("status", "Status", "OK")])]
+        assert not CsvFormatter().format("Describe", sections).endswith("\n")
+
+
+def test_unknown_format_raises_value_error():
+    with pytest.raises(ValueError, match="csv"):
+        get_formatter("does-not-exist")


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a third CLI output format, `csv`, alongside `terminal` and `json`. It
registers a `CsvFormatter` through the existing `@register_formatter`
registry, so every metric-producing command (`bench`, `describe`, `ping`,
`query`, `quota`) supports `--format csv` with no changes at the call sites.

The format renders metrics in long/"tidy" form with a fixed
`section,index,key,label,value` schema — one row per metric. This adds a
capability the existing formats don't cover: tabular output that loads
directly into a spreadsheet or dataframe. It's most useful for comparing
`lmcache bench` runs (append each summary to one CSV, then diff/pivot) and
for slicing nested status reports with plain text tools. A per-list-group
`index` column keeps repeated sections (e.g. multiple models or L2
adapters) distinguishable, so the output is lossless; the stdlib `csv`
module handles quoting/escaping, so no new dependency is introduced.

**Special notes for your reviewers**:

- Scope is intentionally CSV-only. The formatter layer previously had no
  direct unit tests, so `tests/cli/test_formatter.py` is new and covers
  `CsvFormatter` plus the shared `get_formatter`/registry path. I did not
  add tests for the pre-existing `terminal`/`json` formatters — that's
  outside this change and better as a focused follow-up; happy to open an
  issue for it.
- The report title is deliberately omitted from CSV output (a flat table
  has no slot for a presentational header); the `format(title, ...)`
  parameter is kept only to satisfy the `MetricsFormatter` interface.
- Docs: updated every English CLI page that enumerates the formats plus the
  developer guide; left the `zh_CN/**.po` catalogs to the translation
  automation.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
