### PR TITLE
[Bugfix] Pin nixl backend directly so only one CUDA variant installs

### DIFF
--- a/requirements/cuda12_core.txt
+++ b/requirements/cuda12_core.txt
@@ -2,5 +2,8 @@
 # LMCACHE_CUDA_MAJOR=12. The cu13 default lives in cuda13_core.txt.
 
 cupy-cuda12x
-# nixl on PyPI is a meta-package that pulls nixl-cu12 (CUDA-only).
-nixl; python_version < "3.13"
+# Depend on nixl-cu12 directly: it provides the top-level `nixl` namespace.
+# The `nixl` meta-package lists both nixl-cu12 and nixl-cu13 as unconditional
+# (unmarked) deps, so it drags the cu13 backend in too; pinning the backend
+# package avoids that double install.
+nixl-cu12; python_version < "3.13"

--- a/requirements/cuda13_core.txt
+++ b/requirements/cuda13_core.txt
@@ -3,5 +3,8 @@
 # The cu12 analogue lives in cuda12_core.txt.
 
 cupy-cuda13x
-# nixl meta-package pulls nixl-cu13 and exposes the top-level `nixl` namespace.
-nixl>=1.1.0; python_version < "3.13"
+# Depend on nixl-cu13 directly: it provides the top-level `nixl` namespace.
+# The `nixl` meta-package lists both nixl-cu12 and nixl-cu13 as unconditional
+# (unmarked) deps, so it drags the cu12 backend in too; pinning the backend
+# package avoids that double install.
+nixl-cu13>=1.1.0; python_version < "3.13"


### PR DESCRIPTION
**What this PR does / why we need it**:

In a CUDA 13 environment, `pip install lmcache` was installing **both** `nixl-cu12` and `nixl-cu13` (and likewise the cu12 build would drag in `nixl-cu13`).

Root cause: the requirements files depended on the **`nixl` meta-package** on PyPI, whose `requires_dist` lists both backends *without environment markers*:

```
nixl-cu12==X         <- no marker, always installed
nixl-cu13==X         <- no marker, always installed
nixl-cu12==X; extra == "cu12"
nixl-cu13==X; extra == "cu13"
```

Because the two base deps have no markers, `pip install nixl` unconditionally pulls in both CUDA backends; the `[cu12]`/`[cu13]` extras only *add* a backend back, they can't suppress the other.

The fix is to depend on the concrete backend package directly. `nixl-cu13` (and `nixl-cu12`) provide the same top-level `nixl` import namespace and only depend on `torch`/`numpy`, so no cross-backend gets pulled:

- `requirements/cuda13_core.txt`: `nixl>=1.1.0` → `nixl-cu13>=1.1.0`
- `requirements/cuda12_core.txt`: `nixl` → `nixl-cu12`

This matches what `docker/Dockerfile` already does (it installs `nixl-cu${CUDA_MAJOR}` directly) — only the PyPI `install_requires` path was still going through the broken meta-package.

**Special notes for your reviewers**:

After this change, a CUDA 13 `pip install lmcache` pulls only `nixl-cu13`, and the cu12 build only `nixl-cu12`.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
