### PR TITLE
[Perf][MP] Collapse object-group KV transfer into one GIL-released native call & fix affinity-pool rank routing

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -1062,20 +1062,18 @@ void single_layer_kv_transfer_sgl(
  * @param host_buffer_alignments the alignment (i.e., cudaHostRegister
  * granularity) requirement of the host buffer. Must be power of two.
  */
-void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
-                          TransferDirection direction,
-                          size_t host_buffer_offset,
-                          size_t host_buffer_alignments) {
-  // Check that host_buffer_alignments is power of two
-  TORCH_CHECK((host_buffer_alignments & (host_buffer_alignments - 1)) == 0,
-              "host_buffer_alignments must be power of two");
-
+// Enqueue one alignment-aware asynchronous copy on the given stream. The copy
+// is split into smaller copies so each stays within a single host-buffer
+// alignment window (cudaHostRegister granularity), matching the host buffer's
+// registration layout. Shared by lmcache_memcpy_async, its batched variant, and
+// the object-group transfer executor so they all produce byte-for-byte
+// identical stream work.
+void lmcache_memcpy_async_one(uintptr_t dest, uintptr_t src, size_t nbytes,
+                              cudaMemcpyKind kind, size_t host_buffer_offset,
+                              size_t host_buffer_alignments,
+                              cudaStream_t stream) {
   size_t offset = 0;
   const size_t mask = host_buffer_alignments - 1;
-  cudaMemcpyKind kind = (direction == TransferDirection::H2D)
-                            ? cudaMemcpyHostToDevice
-                            : cudaMemcpyDeviceToHost;
-  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   while (offset < nbytes) {
     size_t current_src = src + offset;
@@ -1094,5 +1092,68 @@ void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
                                     max_nbytes, kind, stream));
 
     offset += max_nbytes;
+  }
+}
+
+void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
+                          TransferDirection direction,
+                          size_t host_buffer_offset,
+                          size_t host_buffer_alignments) {
+  // Check that host_buffer_alignments is power of two
+  TORCH_CHECK((host_buffer_alignments & (host_buffer_alignments - 1)) == 0,
+              "host_buffer_alignments must be power of two");
+
+  cudaMemcpyKind kind = (direction == TransferDirection::H2D)
+                            ? cudaMemcpyHostToDevice
+                            : cudaMemcpyDeviceToHost;
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  lmcache_memcpy_async_one(dest, src, nbytes, kind, host_buffer_offset,
+                           host_buffer_alignments, stream);
+}
+
+/**
+ * Batched variant of lmcache_memcpy_async.
+ *
+ * Enqueue a list of asynchronous copies on the current CUDA stream within a
+ * single GIL release (the release is configured at the pybind layer). The
+ * stream work is identical to calling lmcache_memcpy_async once per element,
+ * but the orchestrating Python thread only releases and re-acquires the GIL
+ * once for the whole batch instead of once per copy -- this removes the
+ * per-copy GIL handoff points that otherwise let sibling threads starve it.
+ *
+ * Element i copies nbytes[i] bytes from srcs[i] to dests[i], using
+ * host_buffer_offsets[i] for the host-side alignment window. All copies share
+ * one direction and one host_buffer_alignments value.
+ *
+ * @param dests Destination pointers (device or host), one per copy.
+ * @param srcs Source pointers (device or host), one per copy.
+ * @param nbytes Number of bytes to copy, one per copy.
+ * @param direction H2D or D2H (applies to every copy).
+ * @param host_buffer_offsets Per-copy virtual offset in the lmcache memory
+ *   allocator (the host side of each copy).
+ * @param host_buffer_alignments Alignment (cudaHostRegister granularity)
+ *   requirement of the host buffers. Must be a power of two.
+ */
+void lmcache_memcpy_async_batched(
+    const std::vector<uintptr_t>& dests, const std::vector<uintptr_t>& srcs,
+    const std::vector<size_t>& nbytes, TransferDirection direction,
+    const std::vector<size_t>& host_buffer_offsets,
+    size_t host_buffer_alignments) {
+  TORCH_CHECK((host_buffer_alignments & (host_buffer_alignments - 1)) == 0,
+              "host_buffer_alignments must be power of two");
+  const size_t n = dests.size();
+  TORCH_CHECK(
+      srcs.size() == n && nbytes.size() == n && host_buffer_offsets.size() == n,
+      "lmcache_memcpy_async_batched expects dests, srcs, nbytes, and "
+      "host_buffer_offsets of equal length");
+
+  cudaMemcpyKind kind = (direction == TransferDirection::H2D)
+                            ? cudaMemcpyHostToDevice
+                            : cudaMemcpyDeviceToHost;
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  for (size_t i = 0; i < n; ++i) {
+    lmcache_memcpy_async_one(dests[i], srcs[i], nbytes[i], kind,
+                             host_buffer_offsets[i], host_buffer_alignments,
+                             stream);
   }
 }

--- a/csrc/mem_kernels.cuh
+++ b/csrc/mem_kernels.cuh
@@ -6,6 +6,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/util/Exception.h>
+#include <vector>
 #include "kv_transfer_types.h"
 
 void multi_layer_kv_transfer(
@@ -40,6 +41,20 @@ void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
                           TransferDirection direction,
                           size_t host_buffer_offset,
                           size_t host_buffer_alignments);
+
+// Enqueue one alignment-aware async copy on `stream`. Shared building block for
+// the single/batched memcpy entry points and the object-group transfer
+// executor (mp_mem_kernels.cu).
+void lmcache_memcpy_async_one(uintptr_t dest, uintptr_t src, size_t nbytes,
+                              cudaMemcpyKind kind, size_t host_buffer_offset,
+                              size_t host_buffer_alignments,
+                              cudaStream_t stream);
+
+void lmcache_memcpy_async_batched(
+    const std::vector<uintptr_t>& dests, const std::vector<uintptr_t>& srcs,
+    const std::vector<size_t>& nbytes, TransferDirection direction,
+    const std::vector<size_t>& host_buffer_offsets,
+    size_t host_buffer_alignments);
 
 // deprecated / unused except in unit tests
 void load_and_reshape_flash(torch::Tensor& key_value, torch::Tensor& key_cache,

--- a/csrc/mp_mem_kernels.cu
+++ b/csrc/mp_mem_kernels.cu
@@ -296,19 +296,22 @@ __global__ void multi_layer_block_transfer_kernel(
                   static_cast<int>(engine_kv_format));                  \
   }
 
+// Pointer-based launch core. Takes raw device addresses + scalars instead of
+// torch::Tensors and an explicit `stream`, so callers can issue many launches
+// back-to-back without per-launch tensor marshalling and without re-setting the
+// CUDA device guard each time. The caller MUST have an active device guard for
+// the target device (set once) before calling this.
 template <typename ScalarType>
-void multi_layer_block_kv_transfer_templated(
-    const torch::Tensor& paged_buffer_ptrs_tensor,
-    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
-    const torch::Device& device, TransferDirection direction,
-    PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
-    EngineKVFormat engine_kv_format, int skip_prefix_n_blocks) {
+void multi_layer_block_kv_transfer_ptr_templated(
+    uintptr_t paged_buffer_ptrs_addr, const int64_t* lmcache_objects_ptrs,
+    int num_objects, uintptr_t block_ids_addr, int total_blocks,
+    TransferDirection direction, const PageBufferShapeDesc& shape_desc,
+    int lmcache_chunk_size, EngineKVFormat engine_kv_format,
+    int skip_prefix_n_blocks, cudaStream_t stream) {
   // --- Validation ---
-  int num_objects = static_cast<int>(lmcache_objects_ptrs.size());
   TORCH_CHECK(num_objects >= 1 && num_objects <= 4,
               "Expected 1-4 LMCache objects, got ", num_objects);
 
-  int total_blocks = block_ids.size(0);
   TORCH_CHECK(total_blocks % num_objects == 0, "block_ids length (",
               total_blocks, ") must be divisible by num_objects (", num_objects,
               ")");
@@ -331,13 +334,11 @@ void multi_layer_block_kv_transfer_templated(
 
   // --- Build paged buffer pointer array ---
   ScalarType** paged_buffer_ptrs =
-      reinterpret_cast<ScalarType**>(paged_buffer_ptrs_tensor.data_ptr());
+      reinterpret_cast<ScalarType**>(paged_buffer_ptrs_addr);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device);
-  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-
-  // --- block_ids is a GPU int64 tensor, read directly ---
-  const int64_t* block_ids_ptr = block_ids.data_ptr<int64_t>();
+  // --- block_ids is a GPU int64 array, read directly ---
+  const int64_t* block_ids_ptr =
+      reinterpret_cast<const int64_t*>(block_ids_addr);
 
   // --- Grid and block dimensions ---
   int elements_per_head = shape_desc.hs * shape_desc.element_size /
@@ -355,8 +356,55 @@ void multi_layer_block_kv_transfer_templated(
   }
 }
 
+template <typename ScalarType>
+void multi_layer_block_kv_transfer_templated(
+    const torch::Tensor& paged_buffer_ptrs_tensor,
+    std::vector<int64_t> lmcache_objects_ptrs, const torch::Tensor& block_ids,
+    const torch::Device& device, TransferDirection direction,
+    PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+    EngineKVFormat engine_kv_format, int skip_prefix_n_blocks) {
+  const at::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  multi_layer_block_kv_transfer_ptr_templated<ScalarType>(
+      reinterpret_cast<uintptr_t>(paged_buffer_ptrs_tensor.data_ptr()),
+      lmcache_objects_ptrs.data(),
+      static_cast<int>(lmcache_objects_ptrs.size()),
+      reinterpret_cast<uintptr_t>(block_ids.data_ptr<int64_t>()),
+      static_cast<int>(block_ids.size(0)), direction, shape_desc,
+      lmcache_chunk_size, engine_kv_format, skip_prefix_n_blocks, stream);
+}
+
 #undef DISPATCH_FORMAT
 #undef LAUNCH_KERNEL
+
+// Dispatch the pointer-based launch on the working dtype (matching the
+// vectorization choice in multi_layer_block_kv_transfer below).
+void launch_block_kv_transfer_ptr(
+    uintptr_t paged_buffer_ptrs_addr, const int64_t* lmcache_objects_ptrs,
+    int num_objects, uintptr_t block_ids_addr, int total_blocks,
+    TransferDirection direction, const PageBufferShapeDesc& shape_desc,
+    int lmcache_chunk_size, EngineKVFormat engine_kv_format,
+    int skip_prefix_n_blocks, cudaStream_t stream) {
+  int head_bytes = shape_desc.hs * shape_desc.element_size;
+  TORCH_CHECK(head_bytes % sizeof(uint16_t) == 0, "head_size * element_size (",
+              head_bytes, ") must be divisible by 2 for vectorized access");
+  if (head_bytes % sizeof(uint4) == 0) {
+    multi_layer_block_kv_transfer_ptr_templated<uint4>(
+        paged_buffer_ptrs_addr, lmcache_objects_ptrs, num_objects,
+        block_ids_addr, total_blocks, direction, shape_desc, lmcache_chunk_size,
+        engine_kv_format, skip_prefix_n_blocks, stream);
+  } else if (head_bytes % sizeof(uint32_t) == 0) {
+    multi_layer_block_kv_transfer_ptr_templated<uint32_t>(
+        paged_buffer_ptrs_addr, lmcache_objects_ptrs, num_objects,
+        block_ids_addr, total_blocks, direction, shape_desc, lmcache_chunk_size,
+        engine_kv_format, skip_prefix_n_blocks, stream);
+  } else {
+    multi_layer_block_kv_transfer_ptr_templated<uint16_t>(
+        paged_buffer_ptrs_addr, lmcache_objects_ptrs, num_objects,
+        block_ids_addr, total_blocks, direction, shape_desc, lmcache_chunk_size,
+        engine_kv_format, skip_prefix_n_blocks, stream);
+  }
+}
 
 }  // namespace
 
@@ -388,3 +436,58 @@ void multi_layer_block_kv_transfer(
 }
 
 #undef LAUNCH_TEMPLATED
+
+void execute_object_group_transfer(
+    TransferDirection direction, const torch::Device& device,
+    size_t host_buffer_alignment,
+    const std::vector<KernelGroupSpec>& kernel_group_specs,
+    const std::vector<BatchStep>& batch_steps) {
+  // Set the device guard and resolve the stream once for the whole plan; every
+  // staging copy and kernel launch below is enqueued on this stream in order.
+  const at::cuda::OptionalCUDAGuard device_guard(device);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const bool is_h2d = (direction == TransferDirection::H2D);
+  const cudaMemcpyKind kind =
+      is_h2d ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToHost;
+
+  const auto do_staging = [&](const std::vector<StagingCopy>& staging) {
+    for (const auto& copy : staging) {
+      lmcache_memcpy_async_one(copy.dest, copy.src, copy.nbytes, kind,
+                               copy.host_offset, host_buffer_alignment, stream);
+    }
+  };
+
+  for (const auto& step : batch_steps) {
+    // H2D stages CPU->GPU temp buffers before the kernel reads them; D2H stages
+    // GPU->CPU after the kernel writes them. The per-step ordering must be
+    // preserved because temp buffers are reused across steps.
+    if (is_h2d) {
+      do_staging(step.staging);
+    }
+    for (const auto& launch : step.launches) {
+      TORCH_CHECK(
+          launch.group_idx >= 0 &&
+              launch.group_idx < static_cast<int>(kernel_group_specs.size()),
+          "LaunchVar.group_idx out of range: ", launch.group_idx);
+      const KernelGroupSpec& group = kernel_group_specs[launch.group_idx];
+      TORCH_CHECK(
+          launch.num_objects >= 1 &&
+              launch.num_objects <=
+                  static_cast<int>(group.lmcache_objects_ptrs.size()),
+          "LaunchVar.num_objects (", launch.num_objects,
+          ") exceeds available temp buffers (",
+          group.lmcache_objects_ptrs.size(), ")");
+      const uintptr_t block_ids_addr =
+          group.block_ids_base +
+          static_cast<uintptr_t>(launch.block_ids_offset) * sizeof(int64_t);
+      launch_block_kv_transfer_ptr(
+          group.paged_buffer_ptrs, group.lmcache_objects_ptrs.data(),
+          launch.num_objects, block_ids_addr, launch.total_blocks, direction,
+          group.shape_desc, group.lmcache_chunk_size, group.engine_kv_format,
+          launch.skip_prefix_n_blocks, stream);
+    }
+    if (!is_h2d) {
+      do_staging(step.staging);
+    }
+  }
+}

--- a/csrc/mp_mem_kernels.cuh
+++ b/csrc/mp_mem_kernels.cuh
@@ -5,6 +5,7 @@
 #include "mem_kernels.cuh"  // TransferDirection, EngineKVFormat
 
 #include <c10/cuda/CUDAGuard.h>
+#include <cstdint>
 #include <vector>
 
 struct PageBufferShapeDesc {
@@ -65,6 +66,73 @@ struct MemoryObj4 {
   ScalarType* objects[4];
   int num_objects;  // 0 - 4
 };
+
+// ---------------------------------------------------------------------------
+// Object-group transfer plan.
+//
+// A whole object group's transfer (all staging copies + all kernel launches) is
+// described as a plan on the Python side, then executed in a single native call
+// (execute_object_group_transfer) that releases the GIL once for the entire
+// burst instead of once per copy/launch. See the design in
+// docs/design/v1/multiprocess/modules/ and lmcache_driven_transfer.py.
+// ---------------------------------------------------------------------------
+
+// One asynchronous host<->device copy. `host_offset` is the host-side virtual
+// offset in the lmcache allocator (source for H2D, destination for D2H).
+struct StagingCopy {
+  uintptr_t dest;
+  uintptr_t src;
+  size_t nbytes;
+  size_t host_offset;
+};
+
+// One kernel launch within a batch step. The batch-invariant arguments live in
+// the referenced KernelGroupSpec; only these vary per (batch, kernel group).
+struct LaunchVar {
+  int group_idx;             // index into the plan's kernel_group_specs
+  int64_t block_ids_offset;  // element offset into the group's block_ids_base
+  int total_blocks;          // number of block ids for this launch
+  int num_objects;           // chunks in this batch (1-4)
+  int skip_prefix_n_blocks;
+};
+
+// One batch: its staging copies and kernel launches. For H2D the staging runs
+// before the launches, for D2H after; the executor preserves this ordering.
+struct BatchStep {
+  std::vector<StagingCopy> staging;
+  std::vector<LaunchVar> launches;
+};
+
+// Per-kernel-group invariants, resolved once on the Python side.
+struct KernelGroupSpec {
+  uintptr_t paged_buffer_ptrs;                // device ptr-array base address
+  std::vector<int64_t> lmcache_objects_ptrs;  // temp GPU buffer ptr per slot
+  PageBufferShapeDesc shape_desc;
+  int lmcache_chunk_size;
+  EngineKVFormat engine_kv_format;
+  uintptr_t block_ids_base;  // device int64* base; sliced via block_ids_offset
+};
+
+/**
+ * Execute one object group's transfer plan on the current CUDA stream.
+ *
+ * Enqueues every staging copy and kernel launch described by `batch_steps`
+ * within a single GIL release (configured at the pybind layer), eliminating the
+ * per-copy/per-launch GIL handoffs of the equivalent Python loop. The device
+ * guard and stream are set once for the whole plan.
+ *
+ * @param direction            H2D (retrieve) or D2H (store), applied to all ops
+ * @param device               CUDA device of the transfer
+ * @param host_buffer_alignment Host buffer alignment for staging copies
+ *                              (power of two)
+ * @param kernel_group_specs   Per-kernel-group invariants
+ * @param batch_steps          Ordered per-batch staging + launch work
+ */
+void execute_object_group_transfer(
+    TransferDirection direction, const torch::Device& device,
+    size_t host_buffer_alignment,
+    const std::vector<KernelGroupSpec>& kernel_group_specs,
+    const std::vector<BatchStep>& batch_steps);
 
 /**
  * Block-level multi-layer KV transfer between vLLM paged buffers and

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -55,6 +55,11 @@ PYBIND11_MODULE(c_ops, m) {
   m.def("reshape_and_cache_back_flash", &reshape_and_cache_back_flash);
   m.def("lmcache_memcpy_async", &lmcache_memcpy_async,
         py::call_guard<py::gil_scoped_release>());
+  m.def("lmcache_memcpy_async_batched", &lmcache_memcpy_async_batched,
+        py::arg("dests"), py::arg("srcs"), py::arg("nbytes"),
+        py::arg("direction"), py::arg("host_buffer_offsets"),
+        py::arg("host_buffer_alignments"),
+        py::call_guard<py::gil_scoped_release>());
   m.def("encode_fast_new", &encode_cuda_new);
   m.def("decode_fast_new", &decode_cuda_new);
   m.def("decode_fast_prefsum", &decode_cuda_prefsum);
@@ -100,6 +105,51 @@ PYBIND11_MODULE(c_ops, m) {
       .def_readwrite("element_size", &PageBufferShapeDesc::element_size)
       .def_readwrite("block_stride_elems",
                      &PageBufferShapeDesc::block_stride_elems);
+  // Object-group transfer plan types (see mp_mem_kernels.cuh). Built on the
+  // Python side and consumed by execute_object_group_transfer.
+  py::class_<StagingCopy>(m, "StagingCopy")
+      .def(py::init([](uintptr_t dest, uintptr_t src, size_t nbytes,
+                       size_t host_offset) {
+             return StagingCopy{dest, src, nbytes, host_offset};
+           }),
+           py::arg("dest"), py::arg("src"), py::arg("nbytes"),
+           py::arg("host_offset"));
+  py::class_<LaunchVar>(m, "LaunchVar")
+      .def(py::init([](int group_idx, int64_t block_ids_offset,
+                       int total_blocks, int num_objects,
+                       int skip_prefix_n_blocks) {
+             return LaunchVar{group_idx, block_ids_offset, total_blocks,
+                              num_objects, skip_prefix_n_blocks};
+           }),
+           py::arg("group_idx"), py::arg("block_ids_offset"),
+           py::arg("total_blocks"), py::arg("num_objects"),
+           py::arg("skip_prefix_n_blocks"));
+  py::class_<BatchStep>(m, "BatchStep")
+      .def(py::init([](std::vector<StagingCopy> staging,
+                       std::vector<LaunchVar> launches) {
+             return BatchStep{std::move(staging), std::move(launches)};
+           }),
+           py::arg("staging"), py::arg("launches"));
+  py::class_<KernelGroupSpec>(m, "KernelGroupSpec")
+      .def(py::init([](uintptr_t paged_buffer_ptrs,
+                       std::vector<int64_t> lmcache_objects_ptrs,
+                       PageBufferShapeDesc shape_desc, int lmcache_chunk_size,
+                       EngineKVFormat engine_kv_format,
+                       uintptr_t block_ids_base) {
+             return KernelGroupSpec{paged_buffer_ptrs,
+                                    std::move(lmcache_objects_ptrs),
+                                    shape_desc,
+                                    lmcache_chunk_size,
+                                    engine_kv_format,
+                                    block_ids_base};
+           }),
+           py::arg("paged_buffer_ptrs"), py::arg("lmcache_objects_ptrs"),
+           py::arg("shape_desc"), py::arg("lmcache_chunk_size"),
+           py::arg("engine_kv_format"), py::arg("block_ids_base"));
+  m.def("execute_object_group_transfer", &execute_object_group_transfer,
+        py::arg("direction"), py::arg("device"),
+        py::arg("host_buffer_alignment"), py::arg("kernel_group_specs"),
+        py::arg("batch_steps"), py::call_guard<py::gil_scoped_release>());
   m.def("record_event_on_stream", &record_event_on_stream,
         py::arg("cuda_stream_ptr"), py::arg("event_type_name"),
         py::arg("session_id"), py::arg("str_metadata"), py::arg("int_metadata"),

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -599,6 +599,11 @@ class LMCacheMPSchedulerAdapter:
         )
         assert len(server_urls) >= 1, "At least one server url required"
         self._server_urls: list[str] = list(server_urls)
+        # The scheduler issues only non-affinity requests (e.g. LOOKUP), so it
+        # leaves its DEALER identity opaque. It must NOT claim a dense-rank
+        # identity: that namespace belongs to the worker adapters, and reusing a
+        # rank here would collide with the same-rank worker on the server's
+        # ROUTER socket (which requires unique identities per peer).
         self.mq_clients: dict[str, MessageQueueClient] = {
             url: MessageQueueClient(url, context) for url in self._server_urls
         }
@@ -1097,7 +1102,23 @@ class LMCacheMPWorkerAdapter:
                 self._mp_transfer_mode = None
         else:
             self._mp_transfer_mode = None
-        self.mq_client = MessageQueueClient(server_url, context)
+        # Stamp this worker's physical rank onto the DEALER identity so the
+        # server's affinity pool routes its STORE / RETRIEVE to a dedicated
+        # thread -- one rank per thread -- instead of hashing an opaque identity
+        # onto a shared slot. This is the client that issues the GPU-bound
+        # (affinity-routed) requests.
+        #
+        # Use ``vllm_worker_id`` (the physical rank, unique per worker process /
+        # GPU), NOT ``kv_worker_id``: for MLA models the latter collapses to 0
+        # across all TP ranks (kv_worker_id = vllm_worker_id // tp_size), which
+        # would give every worker the identity b"0" and collide them on the
+        # server's ROUTER socket (only one peer keeps the identity; the rest
+        # never receive replies and time out). The affinity unit we want is the
+        # physical GPU/worker anyway -- each has its own server-side transfer
+        # context and temp buffer.
+        self.mq_client = MessageQueueClient(
+            server_url, context, routing_key=parallel_strategy.vllm_worker_id
+        )
         self._mq_timeout = mq_timeout
 
         # Instance id for GPU worker. uuid4-derived (OS entropy) rather
@@ -1105,7 +1126,9 @@ class LMCacheMPWorkerAdapter:
         # Masked to 63 bits to stay signed-int64-safe for any msgpack peer.
         self.instance_id: int = uuid.uuid4().int & ((1 << 63) - 1)
         logger.info(
-            "LMCache MP worker adapter created with instance_id=%d",
+            "LMCache MP worker adapter created: vllm_worker_id=%d "
+            "(affinity routing_key), instance_id=%d",
+            parallel_strategy.vllm_worker_id,
             self.instance_id,
         )
 

--- a/lmcache/v1/gpu_connector/gpu_ops.py
+++ b/lmcache/v1/gpu_connector/gpu_ops.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+# Standard
+from typing import Sequence
+
 # Third Party
 import torch
 
@@ -7,6 +10,12 @@ from lmcache.v1.gpu_connector.gds_context import SlabDirection, get_gds_context
 from lmcache.v1.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.memory_management import GDSMemoryObject, MemoryObj
 import lmcache.c_ops as lmc_ops
+
+# Whether the loaded native extension exposes the batched async-copy entry
+# point. Older c_ops builds only have the per-object ``lmcache_memcpy_async``;
+# the batched helpers below fall back to it so the Python side works against
+# either build (the GIL win only materializes once the extension is rebuilt).
+_HAS_BATCHED_MEMCPY_ASYNC = hasattr(lmc_ops, "lmcache_memcpy_async_batched")
 
 
 # Helper functions
@@ -90,3 +99,259 @@ def lmcache_memcpy_async_d2h(
         dst_tensor.view(torch.uint8)[:mem_obj_size].copy_(
             gpu_buffer.view(torch.uint8), non_blocking=True
         )
+
+
+def _issue_lazy_memcpy_async_batched(
+    dests: list[int],
+    srcs: list[int],
+    sizes: list[int],
+    direction: "lmc_ops.TransferDirection",
+    host_offsets: list[int],
+) -> None:
+    """Issue the accumulated lazy-allocator copies on the current CUDA stream.
+
+    When the native extension exposes ``lmcache_memcpy_async_batched`` the whole
+    list is issued in one call, releasing the GIL once for the batch instead of
+    once per copy. Otherwise it falls back to one ``lmcache_memcpy_async`` per
+    copy so the helper works against older extension builds.
+
+    ``dests`` and ``srcs`` are already ordered for ``direction`` (the host side
+    is the source for H2D and the destination for D2H); ``host_offsets`` is the
+    host buffer offset of each copy regardless of direction.
+
+    Args:
+        dests: Destination pointers, one per copy.
+        srcs: Source pointers, one per copy.
+        sizes: Byte counts, one per copy.
+        direction: H2D or D2H, applied to every copy.
+        host_offsets: Per-copy host-buffer offset in the lmcache allocator.
+    """
+    if not dests:
+        return
+    if _HAS_BATCHED_MEMCPY_ASYNC:
+        lmc_ops.lmcache_memcpy_async_batched(
+            dests,
+            srcs,
+            sizes,
+            direction,
+            host_offsets,
+            LazyMemoryAllocator.PIN_CHUNK_SIZE,
+        )
+        return
+    for dest, src, size, host_offset in zip(
+        dests, srcs, sizes, host_offsets, strict=True
+    ):
+        lmc_ops.lmcache_memcpy_async(
+            dest,
+            src,
+            size,
+            direction,
+            host_offset,
+            LazyMemoryAllocator.PIN_CHUNK_SIZE,
+        )
+
+
+def lmcache_memcpy_async_h2d_batched(
+    memory_objs: Sequence[MemoryObj],
+    gpu_buffers: Sequence[torch.Tensor],
+) -> None:
+    """Stage a batch of memory objects into GPU buffers (H2D) in one call.
+
+    Equivalent to calling :func:`lmcache_memcpy_async_h2d` once per
+    ``(memory_obj, gpu_buffer)`` pair, except every copy that uses the
+    lazy-allocator native path is issued through a single
+    ``lmc_ops.lmcache_memcpy_async_batched`` call. That collapses the per-chunk
+    GIL release/re-acquire handoffs into a single handoff for the whole batch,
+    removing the dominant source of GIL contention between the per-instance
+    transfer worker threads. GDS- and plain-tensor-backed objects still copy one
+    at a time, since they do not use the native staging path.
+
+    This function is non-blocking and won't do stream synchronization.
+
+    Args:
+        memory_objs: The memory objects to copy from, one per chunk in the
+            batch. Must not contain None.
+        gpu_buffers: The GPU buffers to copy into, aligned element-wise with
+            ``memory_objs``.
+
+    Raises:
+        ValueError: If the two sequences differ in length, if a memory object
+            has not been allocated (``raw_tensor`` is None), or if a memory
+            object's size does not match its GPU buffer.
+    """
+    if len(memory_objs) != len(gpu_buffers):
+        raise ValueError(
+            "memory_objs and gpu_buffers must have the same length, got "
+            f"{len(memory_objs)} and {len(gpu_buffers)}"
+        )
+
+    dests: list[int] = []
+    srcs: list[int] = []
+    sizes: list[int] = []
+    host_offsets: list[int] = []
+    for memory_obj, gpu_buffer in zip(memory_objs, gpu_buffers, strict=True):
+        if isinstance(memory_obj, GDSMemoryObject) or not isinstance(
+            memory_obj.parent(), LazyMemoryAllocator
+        ):
+            # Non-lazy objects do not use the native staging path.
+            lmcache_memcpy_async_h2d(memory_obj, gpu_buffer)
+            continue
+        src_tensor = memory_obj.raw_tensor
+        if src_tensor is None:
+            raise ValueError(
+                "memory_obj.raw_tensor is None; ensure the MemoryObj has been "
+                "allocated."
+            )
+        mem_obj_size = memory_obj.get_size()
+        if mem_obj_size != gpu_buffer.nbytes:
+            raise ValueError(
+                f"Size mismatch: memory_obj nbytes={mem_obj_size}, "
+                f"gpu_buffer nbytes={gpu_buffer.nbytes}"
+            )
+        dests.append(gpu_buffer.data_ptr())
+        srcs.append(memory_obj.data_ptr)
+        sizes.append(mem_obj_size)
+        host_offsets.append(memory_obj.meta.address)
+
+    _issue_lazy_memcpy_async_batched(
+        dests, srcs, sizes, lmc_ops.TransferDirection.H2D, host_offsets
+    )
+
+
+def objects_all_lazy(memory_objs: Sequence[MemoryObj | None]) -> bool:
+    """Return True if every non-None object uses the lazy-allocator path.
+
+    The native object-group transfer executor can only stage lazy-allocator
+    objects (raw host pointer + alignment window). GDS- and plain-tensor-backed
+    objects need their own copy mechanisms, so a group containing any of them
+    must fall back to the per-object Python path. None entries are ignored (they
+    only occur for D2H, where the batch is skipped anyway).
+
+    Args:
+        memory_objs: The memory objects of an object group.
+
+    Returns:
+        True if every non-None object is lazy-allocator-backed.
+    """
+    for memory_obj in memory_objs:
+        if memory_obj is None:
+            continue
+        if isinstance(memory_obj, GDSMemoryObject) or not isinstance(
+            memory_obj.parent(), LazyMemoryAllocator
+        ):
+            return False
+    return True
+
+
+def build_staging_copies(
+    memory_objs: Sequence[MemoryObj],
+    gpu_buffers: Sequence[torch.Tensor],
+    is_h2d: bool,
+) -> list["lmc_ops.StagingCopy"]:
+    """Build native ``StagingCopy`` descriptors for one batch of lazy objects.
+
+    The H2D/D2H direction decides which side is source vs. destination; the host
+    side is always the lazy memory object. Callers must ensure every object is
+    lazy-allocator-backed (see :func:`objects_all_lazy`).
+
+    Args:
+        memory_objs: Lazy-allocator memory objects, one per chunk in the batch.
+        gpu_buffers: GPU staging buffers, aligned element-wise with
+            ``memory_objs``.
+        is_h2d: True for retrieve (CPU->GPU), False for store (GPU->CPU).
+
+    Returns:
+        One ``lmc_ops.StagingCopy`` per object, in input order.
+
+    Raises:
+        ValueError: If an object has not been allocated (``raw_tensor`` is None)
+            or its size does not match its GPU buffer.
+    """
+    copies: list["lmc_ops.StagingCopy"] = []
+    for memory_obj, gpu_buffer in zip(memory_objs, gpu_buffers, strict=True):
+        if memory_obj.raw_tensor is None:
+            raise ValueError(
+                "memory_obj.raw_tensor is None; ensure the MemoryObj has been "
+                "allocated."
+            )
+        mem_obj_size = memory_obj.get_size()
+        if mem_obj_size != gpu_buffer.nbytes:
+            raise ValueError(
+                f"Size mismatch: memory_obj nbytes={mem_obj_size}, "
+                f"gpu_buffer nbytes={gpu_buffer.nbytes}"
+            )
+        host_ptr = memory_obj.data_ptr
+        gpu_ptr = gpu_buffer.data_ptr()
+        host_offset = memory_obj.meta.address
+        if is_h2d:
+            copies.append(
+                lmc_ops.StagingCopy(gpu_ptr, host_ptr, mem_obj_size, host_offset)
+            )
+        else:
+            copies.append(
+                lmc_ops.StagingCopy(host_ptr, gpu_ptr, mem_obj_size, host_offset)
+            )
+    return copies
+
+
+def lmcache_memcpy_async_d2h_batched(
+    gpu_buffers: Sequence[torch.Tensor],
+    memory_objs: Sequence[MemoryObj],
+) -> None:
+    """Copy a batch of GPU buffers back into memory objects (D2H) in one call.
+
+    The D2H counterpart of :func:`lmcache_memcpy_async_h2d_batched`: copies that
+    use the lazy-allocator native path are issued through a single
+    ``lmc_ops.lmcache_memcpy_async_batched`` call, collapsing the per-chunk GIL
+    handoffs into one. GDS- and plain-tensor-backed objects still copy one at a
+    time.
+
+    This function is non-blocking and won't do stream synchronization.
+
+    Args:
+        gpu_buffers: The GPU buffers to copy from, one per chunk in the batch.
+        memory_objs: The memory objects to copy into, aligned element-wise with
+            ``gpu_buffers``. Must not contain None.
+
+    Raises:
+        ValueError: If the two sequences differ in length, if a memory object
+            has not been allocated (``raw_tensor`` is None), or if a memory
+            object's size does not match its GPU buffer.
+    """
+    if len(memory_objs) != len(gpu_buffers):
+        raise ValueError(
+            "gpu_buffers and memory_objs must have the same length, got "
+            f"{len(gpu_buffers)} and {len(memory_objs)}"
+        )
+
+    dests: list[int] = []
+    srcs: list[int] = []
+    sizes: list[int] = []
+    host_offsets: list[int] = []
+    for gpu_buffer, memory_obj in zip(gpu_buffers, memory_objs, strict=True):
+        if isinstance(memory_obj, GDSMemoryObject) or not isinstance(
+            memory_obj.parent(), LazyMemoryAllocator
+        ):
+            # Non-lazy objects do not use the native staging path.
+            lmcache_memcpy_async_d2h(gpu_buffer, memory_obj)
+            continue
+        dst_tensor = memory_obj.raw_tensor
+        if dst_tensor is None:
+            raise ValueError(
+                "memory_obj.raw_tensor is None; ensure the MemoryObj has been "
+                "allocated."
+            )
+        mem_obj_size = memory_obj.get_size()
+        if mem_obj_size != gpu_buffer.nbytes:
+            raise ValueError(
+                f"Size mismatch: memory_obj nbytes={mem_obj_size}, "
+                f"gpu_buffer nbytes={gpu_buffer.nbytes}"
+            )
+        dests.append(memory_obj.data_ptr)
+        srcs.append(gpu_buffer.data_ptr())
+        sizes.append(mem_obj_size)
+        host_offsets.append(memory_obj.meta.address)
+
+    _issue_lazy_memcpy_async_batched(
+        dests, srcs, sizes, lmc_ops.TransferDirection.D2H, host_offsets
+    )

--- a/lmcache/v1/multiprocess/affinity_pool.py
+++ b/lmcache/v1/multiprocess/affinity_pool.py
@@ -9,6 +9,12 @@ worker, tasks execute sequentially in FIFO order.
 This is used for GPU-bound request handlers (STORE / RETRIEVE) so that all
 operations for a given vLLM instance land on one thread, eliminating the need
 for per-instance locks on the shared temporary GPU buffer.
+
+For one worker per instance, callers should pass a *dense* ``affinity_key``
+(a rank index ``0..world_size-1``) and size the pool with
+``max_workers >= world_size``: then ``affinity_key % num_workers`` is a 1:1
+mapping. A hashed or sparse key gives no such guarantee -- distinct keys can
+collide onto one worker while others sit idle (see ``_maybe_warn_collision``).
 """
 
 # Standard
@@ -41,6 +47,14 @@ class AffinityThreadPool:
         self._num_workers = max_workers
         self._queues: list[queue.Queue] = [queue.Queue() for _ in range(max_workers)]
         self._threads: list[threading.Thread] = []
+        # Collision tracking: maps a worker slot to the first affinity key
+        # routed there, so we can warn once when two distinct keys (clients)
+        # land on the same slot and get serialized onto one thread. Guarded by
+        # ``_collision_lock`` since submit() may be called from multiple
+        # threads.
+        self._collision_lock = threading.Lock()
+        self._slot_first_key: dict[int, int] = {}
+        self._collision_warned = False
         for i in range(max_workers):
             t = threading.Thread(
                 target=self._worker,
@@ -82,12 +96,53 @@ class AffinityThreadPool:
     def submit(self, fn, *args, affinity_key: int = 0, **kwargs) -> Future:
         """Submit *fn* for execution on the worker determined by *affinity_key*.
 
+        For an even one-key-per-worker spread, pass a dense ``affinity_key``
+        (e.g. a rank index ``0..world_size-1``) and size the pool with
+        ``max_workers >= world_size``. Sparse or hashed keys may collide onto a
+        shared worker even when idle workers exist; the first such collision is
+        logged once at WARNING level.
+
         Returns a :class:`concurrent.futures.Future`.
         """
         future: Future = Future()
         slot = affinity_key % self._num_workers
+        self._maybe_warn_collision(slot, affinity_key)
         self._queues[slot].put((future, fn, args, kwargs))
         return future
+
+    def _maybe_warn_collision(self, slot: int, affinity_key: int) -> None:
+        """Log once if a second distinct key is routed to an occupied slot.
+
+        A collision means two clients share one worker thread (their tasks are
+        serialized) while other workers may sit idle -- usually because the
+        pool has fewer workers than distinct clients, or because keys are not
+        dense. Only the first collision is logged to avoid log spam.
+
+        Args:
+            slot: The worker slot ``affinity_key`` mapped to.
+            affinity_key: The routing key for the current submission.
+        """
+        if self._collision_warned:
+            return
+        with self._collision_lock:
+            if self._collision_warned:
+                return
+            existing = self._slot_first_key.get(slot)
+            if existing is None:
+                self._slot_first_key[slot] = affinity_key
+            elif existing != affinity_key:
+                self._collision_warned = True
+                logger.warning(
+                    "AffinityThreadPool: affinity keys %d and %d both map to "
+                    "worker slot %d of %d -- these clients share one thread and "
+                    "are serialized. Increase the worker count (e.g. "
+                    "--max-gpu-workers) to >= the number of distinct clients "
+                    "for one worker per client.",
+                    existing,
+                    affinity_key,
+                    slot,
+                    self._num_workers,
+                )
 
     def shutdown(self, wait: bool = True) -> None:
         """Shut down the pool.

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -324,7 +324,7 @@ def _run_object_group_transfer_plan(
                 [buffer.data_ptr() for buffer in temp_buffers],
                 cache_context.get_shape_desc(kernel_group_id),
                 cache_context.get_slots_per_chunk_in_sw(kernel_group_id),
-                cache_context.engine_kv_format,
+                cache_context.get_engine_kv_format(kernel_group_id),
                 block_ids_tensor.data_ptr(),
             )
         )
@@ -336,7 +336,7 @@ def _run_object_group_transfer_plan(
     ]
     keep_alive.extend(object_group_buffers)
 
-    sw_size_chunks = kv_groups_manager.get_sw_size_chunks(object_group_id)
+    sw_size_chunks = object_group.sw_size_chunks
     num_objects_to_skip = 0
     if sw_size_chunks >= 1 and is_h2d:
         num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -24,9 +24,12 @@ from lmcache.v1.distributed.api import (
     ObjectKey,
 )
 from lmcache.v1.gpu_connector.gpu_ops import (
-    lmcache_memcpy_async_d2h,
-    lmcache_memcpy_async_h2d,
+    build_staging_copies,
+    lmcache_memcpy_async_d2h_batched,
+    lmcache_memcpy_async_h2d_batched,
+    objects_all_lazy,
 )
+from lmcache.v1.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
@@ -51,6 +54,13 @@ from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
+
+# Whether the native extension can execute a whole object-group transfer plan in
+# one GIL-released call. Older c_ops builds lack it; transfer_kv_per_object_group
+# then falls back to the per-op Python path.
+_CAN_PLAN_OBJECT_GROUP_TRANSFER = hasattr(
+    lmc_ops, "execute_object_group_transfer"
+)
 
 
 def get_layout_desc(
@@ -230,6 +240,185 @@ def _recalculate_blocks_to_skip(
     return full_windows_to_skip * blocks_per_window + max(0, tail_blocks_to_skip)
 
 
+def _run_object_group_transfer_plan(
+    cache_context: BaseCacheContext,
+    block_ids_gpu: list[torch.Tensor],
+    memory_objs: Sequence[MemoryObj | None],
+    object_group_id: int,
+    batch_size: int,
+    skip_first_n_tokens: int,
+    direction: "lmc_ops.TransferDirection",
+) -> None:
+    """Plan and execute one object group's transfer in a single native call.
+
+    This is the fast path of :func:`transfer_kv_per_object_group`: it runs the
+    same batched-iteration / skip logic, but instead of issuing each staging
+    copy and kernel launch immediately (each a GIL release/re-acquire), it
+    resolves every argument to plain pointers/scalars (the "planner", GIL held
+    throughout) and hands the whole plan to ``execute_object_group_transfer``,
+    which issues all of it on the stream within a single GIL release.
+
+    Requires every object to be lazy-allocator-backed; the caller gates this
+    with :func:`objects_all_lazy`.
+
+    Args:
+        cache_context: The GPU cache context containing the KV cache information.
+        block_ids_gpu: GPU block IDs, indexed by LMCache KV group index.
+        memory_objs: The MemoryObj instances to copy. None entries are only
+            valid for D2H (the batch is skipped); H2D raises.
+        object_group_id: Index of the object group being copied.
+        batch_size: Number of memory objects per batched copy.
+        skip_first_n_tokens: Tokens to skip writing at the start of the range.
+        direction: H2D (retrieve) or D2H (store).
+
+    Raises:
+        ValueError: If a None entry is found in memory_objs when direction is
+            H2D, or if an object's size does not match its GPU staging buffer.
+    """
+    lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
+    kv_groups_manager = cache_context.kv_layer_groups_manager
+    object_group = kv_groups_manager.object_groups[object_group_id]
+    kernel_group_ids = object_group.kernel_group_indices
+    is_h2d = direction == lmc_ops.TransferDirection.H2D
+    max_batch_size = cache_context.max_batch_size
+
+    # Keep every tensor whose data_ptr the native call dereferences referenced
+    # for the duration of this function. (The underlying storage is owned by the
+    # cache context / caller and outlives the async copies; this is belt-and-
+    # suspenders against the temporary view objects being collected early.)
+    keep_alive: list[torch.Tensor] = []
+
+    # --- Per-kernel-group invariants, resolved once (vs. every batch before) ---
+    kernel_group_specs: list["lmc_ops.KernelGroupSpec"] = []
+    spec_index_by_kg: dict[int, int] = {}
+    blocks_per_chunk_by_kg: dict[int, int] = {}
+    blocks_per_window_by_kg: dict[int, int] = {}
+    for kernel_group_id in kernel_group_ids:
+        blocks_per_chunk = cache_context.calculate_num_blocks(
+            lmcache_chunk_size, kernel_group_id
+        )
+        tokens_per_window = min(
+            lmcache_chunk_size,
+            kv_groups_manager.get_subchunk_sw_size_tokens(kernel_group_id),
+        )
+        blocks_per_window = cache_context.calculate_num_blocks(
+            tokens_per_window, kernel_group_id
+        )
+        blocks_per_chunk_by_kg[kernel_group_id] = blocks_per_chunk
+        blocks_per_window_by_kg[kernel_group_id] = blocks_per_window
+
+        paged_ptrs = cache_context.get_kernel_group_kv_pointers(kernel_group_id)
+        block_ids_tensor = block_ids_gpu[kernel_group_id]
+        temp_buffers = [
+            cache_context.get_temp_kernel_group_buffer(slot, kernel_group_id)
+            for slot in range(max_batch_size)
+        ]
+        keep_alive.append(paged_ptrs)
+        keep_alive.append(block_ids_tensor)
+        keep_alive.extend(temp_buffers)
+
+        spec_index_by_kg[kernel_group_id] = len(kernel_group_specs)
+        kernel_group_specs.append(
+            lmc_ops.KernelGroupSpec(
+                paged_ptrs.data_ptr(),
+                [buffer.data_ptr() for buffer in temp_buffers],
+                cache_context.get_shape_desc(kernel_group_id),
+                cache_context.get_slots_per_chunk_in_sw(kernel_group_id),
+                cache_context.engine_kv_format,
+                block_ids_tensor.data_ptr(),
+            )
+        )
+
+    # Temp object-group staging buffers (reused per batch slot, like above).
+    object_group_buffers = [
+        cache_context.get_temp_object_group_buffer(slot, object_group_id)
+        for slot in range(max_batch_size)
+    ]
+    keep_alive.extend(object_group_buffers)
+
+    sw_size_chunks = kv_groups_manager.get_sw_size_chunks(object_group_id)
+    num_objects_to_skip = 0
+    if sw_size_chunks >= 1 and is_h2d:
+        num_objects_to_skip = max(0, len(memory_objs) - sw_size_chunks)
+        logger.debug(
+            "Detected sliding window for object group %d: "
+            "skipping the first %d objects in the batch",
+            object_group_id,
+            num_objects_to_skip,
+        )
+
+    # --- Walk the batches in order, emitting staging + launch work per step ---
+    batch_steps: list["lmc_ops.BatchStep"] = []
+    for start_object_idx, memory_object_batch in batched_iteration_with_skip(
+        memory_objs, batch_size, skip_count=num_objects_to_skip
+    ):
+        if any(mo is None for mo in memory_object_batch):
+            if is_h2d:
+                raise ValueError(
+                    "MemoryObj is None for some objects in the batch, cannot "
+                    "perform H2D copy. memory_object_batch: "
+                    f"{memory_object_batch}"
+                )
+            else:
+                continue
+
+        batch_len = len(memory_object_batch)
+        batch_start_token = start_object_idx * lmcache_chunk_size
+        batch_end_token = batch_start_token + batch_len * lmcache_chunk_size
+
+        effective_start = max(batch_start_token, skip_first_n_tokens)
+        if effective_start >= batch_end_token:
+            continue
+
+        skip_tokens_in_chunk = effective_start - batch_start_token
+
+        staging = build_staging_copies(
+            memory_object_batch,
+            object_group_buffers[:batch_len],
+            is_h2d,
+        )
+
+        launches: list["lmc_ops.LaunchVar"] = []
+        for kernel_group_id in kernel_group_ids:
+            blocks_per_chunk = blocks_per_chunk_by_kg[kernel_group_id]
+            blocks_per_window = blocks_per_window_by_kg[kernel_group_id]
+
+            start_block_pos = start_object_idx * blocks_per_window
+            end_block_pos = (start_object_idx + batch_len) * blocks_per_window
+
+            orig_skip_blocks = cache_context.calculate_num_blocks(
+                skip_tokens_in_chunk, kernel_group_id
+            )
+            recalculated_skip_blocks = _recalculate_blocks_to_skip(
+                blocks_per_chunk,
+                blocks_per_window,
+                orig_skip_blocks,
+            )
+
+            launches.append(
+                lmc_ops.LaunchVar(
+                    spec_index_by_kg[kernel_group_id],
+                    start_block_pos,
+                    end_block_pos - start_block_pos,
+                    batch_len,
+                    recalculated_skip_blocks,
+                )
+            )
+
+        batch_steps.append(lmc_ops.BatchStep(staging, launches))
+
+    if not batch_steps:
+        return
+
+    lmc_ops.execute_object_group_transfer(
+        direction,
+        cache_context.device,
+        LazyMemoryAllocator.PIN_CHUNK_SIZE,
+        kernel_group_specs,
+        batch_steps,
+    )
+
+
 def transfer_kv_per_object_group(
     cache_context: BaseCacheContext,
     block_ids_gpu: list[torch.Tensor],
@@ -264,7 +453,25 @@ def transfer_kv_per_object_group(
     Note:
         This function expects the caller to stage the block ids (list[list[int]])
         into GPU tensors and pass them in as `block_ids_gpu`.
+
+        When the native extension supports it and every object is
+        lazy-allocator-backed, the whole group is issued through a single
+        ``execute_object_group_transfer`` call (one GIL release for all staging
+        copies and kernel launches). Otherwise it falls back to the per-op
+        Python path below (GDS / plain-tensor objects, or an older c_ops build).
     """
+    if _CAN_PLAN_OBJECT_GROUP_TRANSFER and objects_all_lazy(memory_objs):
+        _run_object_group_transfer_plan(
+            cache_context,
+            block_ids_gpu,
+            memory_objs,
+            object_group_id,
+            batch_size,
+            skip_first_n_tokens,
+            direction,
+        )
+        return
+
     lmcache_chunk_size = cache_context.lmcache_tokens_per_chunk
     kv_groups_manager = cache_context.kv_layer_groups_manager
     object_group = kv_groups_manager.object_groups[object_group_id]
@@ -306,15 +513,19 @@ def transfer_kv_per_object_group(
 
         skip_tokens_in_chunk = effective_start - batch_start_token
 
-        # For H2D, copy from CPU to GPU tmp buffers before the kernel launch
+        # For H2D, copy from CPU to GPU tmp buffers before the kernel launch.
+        # Issue the whole batch in one native call so the GIL is released once
+        # for all chunks, not once per chunk (see lmcache_memcpy_async_h2d_batched).
         if is_h2d:
-            for chunk_idx, memory_obj in enumerate(memory_object_batch):
-                lmcache_memcpy_async_h2d(
-                    memory_obj,
+            lmcache_memcpy_async_h2d_batched(
+                memory_object_batch,
+                [
                     cache_context.get_temp_object_group_buffer(
                         chunk_idx, object_group_id
-                    ),
-                )
+                    )
+                    for chunk_idx in range(batch_len)
+                ],
+            )
 
         # Do paged KV copy
         for kernel_group_id in kernel_group_ids:
@@ -372,15 +583,19 @@ def transfer_kv_per_object_group(
                 recalculated_skip_blocks,
             )
 
-        # For D2H, copy from GPU tmp buffers to CPU after the kernel launch
+        # For D2H, copy from GPU tmp buffers to CPU after the kernel launch.
+        # Issue the whole batch in one native call so the GIL is released once
+        # for all chunks, not once per chunk (see lmcache_memcpy_async_d2h_batched).
         if not is_h2d:
-            for chunk_idx, memory_obj in enumerate(memory_object_batch):
-                lmcache_memcpy_async_d2h(
+            lmcache_memcpy_async_d2h_batched(
+                [
                     cache_context.get_temp_object_group_buffer(
                         chunk_idx, object_group_id
-                    ),
-                    memory_obj,
-                )
+                    )
+                    for chunk_idx in range(batch_len)
+                ],
+                memory_object_batch,
+            )
 
 
 @dataclass

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -42,6 +42,32 @@ RequestUID = int
 
 
 # Helper functions
+def _affinity_key_from_identity(identity: bytes) -> int:
+    """Derive an affinity-routing key from a zmq client identity.
+
+    Clients that participate in affinity routing (vLLM workers) set their
+    DEALER identity to their dense rank index (``kv_worker_id``) encoded as a
+    decimal byte string -- e.g. ``b"4"``. Returning that integer directly makes
+    ``affinity_key % num_workers`` a 1:1 mapping whenever the pool has at least
+    ``world_size`` workers, so each rank gets its own worker thread instead of
+    colliding under a hash.
+
+    Any other client (no identity set, or a non-integer identity) falls back to
+    hashing the identity bytes, preserving the previous routing behavior.
+
+    Args:
+        identity: The raw zmq ROUTER identity frame for the requesting client.
+
+    Returns:
+        The dense rank when ``identity`` is a decimal integer, otherwise
+        ``hash(identity)``.
+    """
+    try:
+        return int(identity)
+    except (ValueError, TypeError):
+        return hash(identity)
+
+
 def encode_request_uid(uid: RequestUID) -> bytes:
     return msgspec.msgpack.encode(uid)
 
@@ -264,10 +290,34 @@ class MessageQueueClient:
         request_type: RequestType
         request_payloads: list[Any]
 
-    def __init__(self, server_url: str, context: zmq.Context):
+    def __init__(
+        self,
+        server_url: str,
+        context: zmq.Context,
+        routing_key: int | None = None,
+    ):
+        """Create a client connected to a :class:`MessageQueueServer`.
+
+        Args:
+            server_url: The ``tcp://host:port`` URL the server is bound to.
+            context: The shared zmq context.
+            routing_key: This client's dense rank index (``kv_worker_id``,
+                in ``[0, world_size)``) for the server it connects to. When
+                provided, it is stamped onto the DEALER identity so the
+                server's affinity pool routes this client's blocking requests
+                (STORE / RETRIEVE) to a dedicated worker thread -- one rank
+                per thread -- instead of hashing an opaque identity onto a
+                shared slot. Must be unique among the clients connecting to a
+                single server. When ``None``, zmq assigns an opaque identity
+                and the server falls back to hash-based routing.
+        """
         # Socket
         self.ctx = context
         self.socket = self.ctx.socket(zmq.DEALER)
+        # Stamp the dense rank as the ROUTER identity before connecting so the
+        # server can route on it (see _affinity_key_from_identity).
+        if routing_key is not None:
+            self.socket.setsockopt(zmq.IDENTITY, str(routing_key).encode())
         self.socket.connect(server_url)
 
         # Input queue
@@ -554,7 +604,7 @@ class MessageQueueServer:
             prefix_frames (list[bytes]): The prefix frames to send back.
                 prefix_frames[0] is the zmq identity used as affinity key.
         """
-        affinity_key = hash(prefix_frames[0])
+        affinity_key = _affinity_key_from_identity(prefix_frames[0])
         future = handler_entry(payloads, affinity_key=affinity_key)
 
         def _notify_response(fut: Future):


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes two sources of GIL contention between the per-instance KV-transfer
worker threads in the multiprocess (MP) server. Both surfaced as throughput loss
under concurrent transfers: the hot path issued many small pybind calls that each
release/re-acquire the GIL (giving sibling threads a chance to starve the
orchestrating thread), and the server's affinity pool could serialize distinct
clients onto a single worker thread while others sat idle.

**1. Collapse a whole object-group transfer into one GIL-released native call**

The KV transfer for an object group previously issued each staging memcpy and
each kernel launch through its own pybind call, releasing and re-acquiring the
GIL on every op. This PR resolves the entire transfer (all staging copies + all
kernel launches) into a plan on the Python side (GIL held throughout), then hands
it to a single new native entry point `execute_object_group_transfer`, which
issues the whole burst on the CUDA stream inside one GIL release.

- New native plan types and executor (`StagingCopy`, `LaunchVar`, `BatchStep`,
  `KernelGroupSpec`, `execute_object_group_transfer`) in
  csrc/mp_mem_kernels.{cu,cuh} and csrc/pybind.cpp.
- Extracted a shared `lmcache_memcpy_async_one` building block and a
  pointer-based launch core (`multi_layer_block_kv_transfer_ptr_templated` /
  `launch_block_kv_transfer_ptr`) so launches can be issued back-to-back without
  per-launch tensor marshalling and with the CUDA device guard / stream resolved
  once for the whole plan.
- Added `lmcache_memcpy_async_batched` so the staging copies alone can also be
  batched into one GIL release (used by the fallback path).
- Python side: `_run_object_group_transfer_plan` plus the planner/helpers in
  lmcache/v1/gpu_connector/gpu_ops.py (`build_staging_copies`, `objects_all_lazy`,
  `lmcache_memcpy_async_h2d_batched`, `lmcache_memcpy_async_d2h_batched`).

**2. Fix affinity-pool assignment (dense rank routing instead of hashing)**

The server routes GPU-bound requests (STORE / RETRIEVE) to a worker thread via
`affinity_key % num_workers`, where the key was `hash(zmq_identity)`. With opaque
hashed identities, distinct vLLM workers could collide onto the same worker thread
(and be serialized) while other threads sat idle — defeating the one-thread-per-
instance design.

- Workers now stamp their physical rank onto the DEALER identity
  (`MessageQueueClient(routing_key=...)`), and the server derives the affinity
  key by parsing that decimal identity (`_affinity_key_from_identity`), giving a
  1:1 rank→thread mapping when `max_workers >= world_size`. Non-integer / unset
  identities (e.g. the scheduler's LOOKUP client) fall back to the previous
  hash-based routing.
- Uses `vllm_worker_id` (physical rank, unique per worker/GPU), **not**
  `kv_worker_id`, which collapses to 0 across TP ranks for MLA models and would
  collide every worker onto identity `b"0"` on the server's ROUTER socket.
- Added a one-time WARNING in `AffinityThreadPool` when two distinct keys map to
  the same slot, so misconfiguration (fewer workers than clients) is visible.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
