### PR TITLE
[CLI] Output the model answer in `lmcache query engine`

### DIFF
--- a/lmcache/cli/commands/query/_request.py
+++ b/lmcache/cli/commands/query/_request.py
@@ -130,7 +130,8 @@ def _stream(
     chat: bool,
     max_tokens: int,
 ) -> dict[str, Any]:
-    """POST with ``stream: true``; parse SSE; return TTFT/TPOT and token metrics."""
+    """POST with ``stream: true``; parse SSE; return the completion text plus
+    TTFT/TPOT and token metrics."""
     payload = {
         **body,
         "stream": True,
@@ -214,6 +215,7 @@ def _stream(
         (decode_time / num_generated) if num_generated > 0 and decode_time > 0 else 0.0
     )
     return {
+        "answer": joined,
         "prompt_tokens": prompt_tokens,
         "output_tokens": num_generated,
         "ttft_ms": ttft_s * 1000.0,
@@ -283,14 +285,23 @@ class Request:
             "chat_first": self._chat_first,
         }
 
-    def send_request(self, prompt: str) -> dict[str, Any] | MetricMap:
-        """Send request and return stats."""
+    def send_request(self, prompt: str) -> tuple[str, MetricMap]:
+        """Send request and return the completion text and its metrics.
+
+        Args:
+            prompt: The fully expanded prompt to send to the engine.
+
+        Returns:
+            A ``(answer, metrics)`` tuple where ``answer`` is the model's
+            completion text and ``metrics`` is a :data:`MetricMap` of token
+            and latency stats keyed by metric id.
+        """
         request_data = self.build_request(prompt)
-        stats = {
-            "model": request_data["model"],
-            **self._query_with_fallback(request_data),
-        }
-        return {key: (_METRIC_NAMES.get(key, key), stats[key]) for key in stats}
+        result = self._query_with_fallback(request_data)
+        answer = str(result.pop("answer", ""))
+        stats = {"model": request_data["model"], **result}
+        metrics = {key: (_METRIC_NAMES.get(key, key), stats[key]) for key in stats}
+        return answer, metrics
 
     def _first_model_id(self) -> str:
         """Return the first model ID from ``GET /v1/models``."""

--- a/lmcache/cli/commands/query/engine_command.py
+++ b/lmcache/cli/commands/query/engine_command.py
@@ -86,11 +86,12 @@ class EngineCommand(BaseCommand):
                 completions_only=args.completions,
                 chat_first=args.chat_first,
             )
-            engine_stats = sender.send_request(prompt_builder.complete_prompt)
+            answer, engine_stats = sender.send_request(prompt_builder.complete_prompt)
 
             model_id = args.model or str(engine_stats["model"][1])
             metrics = self.create_metrics("Query Engine", args)
             metrics.add("model", "Model", model_id)
+            metrics.add("answer", "Answer", answer)
             prompt_name, prompt_value = engine_stats["prompt_tokens"]
             metrics.add("prompt_tokens", prompt_name, int(prompt_value))
             output_name, output_value = engine_stats["output_tokens"]

--- a/tests/cli/commands/test_query.py
+++ b/tests/cli/commands/test_query.py
@@ -15,7 +15,7 @@ from lmcache.cli.commands.query import QueryCommand
 def _engine_metric_map(
     model_id: str = "facebook/opt-125m",
 ) -> dict[str, tuple[str, object]]:
-    """Shape returned by :meth:`lmcache.cli.request.Request.send_request`."""
+    """Metric-map portion of :meth:`lmcache.cli.request.Request.send_request`."""
     return {
         "model": ("Model", model_id),
         "prompt_tokens": ("Input tokens", 10),
@@ -153,7 +153,7 @@ class TestQueryCommandExecute:
     ) -> None:
         """query_engine should call Request.send_request with the expanded prompt."""
         mock_instance = MagicMock()
-        mock_instance.send_request.return_value = _engine_metric_map()
+        mock_instance.send_request.return_value = ("Paris.", _engine_metric_map())
         mock_request_cls.return_value = mock_instance
 
         args = parser.parse_args(
@@ -185,6 +185,8 @@ class TestQueryCommandExecute:
         assert "facebook/opt-125m" in out
         assert "Input tokens" in out
         assert "Prompt tokens" not in out
+        assert "Answer" in out
+        assert "Paris." in out
 
     @patch("lmcache.cli.commands.query.engine_command.Request")
     def test_execute_uses_engine_model_when_cli_model_omitted(
@@ -196,8 +198,9 @@ class TestQueryCommandExecute:
     ) -> None:
         """With no ``--model``, the report uses the model id from engine stats."""
         mock_instance = MagicMock()
-        mock_instance.send_request.return_value = _engine_metric_map(
-            model_id="listed-model"
+        mock_instance.send_request.return_value = (
+            "answer",
+            _engine_metric_map(model_id="listed-model"),
         )
         mock_request_cls.return_value = mock_instance
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`lmcache query engine` streamed the model's completion text but then threw it away, printing only token/latency stats. So there was no way to see what the engine actually answered. This makes the command output the answer.

- `_stream` now returns the completion text (`answer`) alongside the existing metrics.
- `Request.send_request` returns a `(answer, metrics)` tuple instead of just the metric map; the answer is split out so it never leaks into the numeric metric loop.
- `EngineCommand` renders the answer as an `Answer` field, so it shows up in terminal, JSON, and `--output` file results next to the stats.

Example:
```
================= Query Engine =================
Model:                      MiniMaxAI/MiniMax-M3
Answer:                                    Paris
Input tokens:                                188
Output tokens:                                32
--------------- Latency Metrics ----------------
TTFT (ms):                                 25.32
...
```

**Special notes for your reviewers**:

Only the `query engine` path is touched; the metrics framework and other commands are unchanged. Verified end-to-end against a live OpenAI-compatible engine and via the unit tests.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests