### PR TITLE
Fix/translation reuse job

### DIFF
--- a/.github/workflows/translate_doc_zh.yml
+++ b/.github/workflows/translate_doc_zh.yml
@@ -47,10 +47,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Only reuse the automation branch while its PR is still open. A
-          # closed (un-merged) PR's branch holds stale translations that would
-          # otherwise overwrite human edits already merged to dev, so in that
-          # case fall back to dev as the translation base.
+          # Reuse the automation branch only while its PR is open; a closed PR's
+          # branch is stale and would overwrite human edits merged to dev.
           open_prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
             --head automation/update-chinese-docs --state open \
             --json number --jq 'length' || echo 0)

--- a/.github/workflows/translate_doc_zh.yml
+++ b/.github/workflows/translate_doc_zh.yml
@@ -44,9 +44,22 @@ jobs:
           pip install -r requirements/docs.txt
 
       - name: Reuse translations from open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if git fetch origin automation/update-chinese-docs 2>/dev/null; then
+          # Only reuse the automation branch while its PR is still open. A
+          # closed (un-merged) PR's branch holds stale translations that would
+          # otherwise overwrite human edits already merged to dev, so in that
+          # case fall back to dev as the translation base.
+          open_prs=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --head automation/update-chinese-docs --state open \
+            --json number --jq 'length' || echo 0)
+          if [ "${open_prs:-0}" -gt 0 ] && \
+             git fetch origin automation/update-chinese-docs 2>/dev/null; then
+            echo "Open translation PR found; reusing its translations."
             git checkout FETCH_HEAD -- docs/source/locale/zh_CN/LC_MESSAGES/ || true
+          else
+            echo "No open translation PR; using dev as the translation base."
           fi
 
       - name: Update gettext catalogs


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
The weekly Chinese-translation workflow reused the automation/update-chinese-docs branch by checking it out over the working tree — regardless of whether that branch's PR was still open. When a translation PR is closed without merging, its branch is outdated and the next scheduled run restored that stale branch over dev, silently overwriting human-reviewed translations.

This happened in practice: hand-reviewed translations merged in #3744  were overwritten by #3811 , because the previous bot PR (#3733) had been closed but its branch was still reused.

This PR updates the script so the scheduled translation job reuses the automation branch only while its PR is open. If the PR is closed/merged (or none exists), it falls back to dev as the translation base.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
