### PR TITLE
feat(s3): opt-in per-cache_salt bucket isolation for multi-tenancy

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/s3_bucket_router.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_bucket_router.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure, dependency-free bucket routing for the S3 L2 adapter (multi-tenant isolation).
+
+Kept import-free (no awscrt / lmcache) so the routing logic is unit-testable in isolation and
+trivial to review. The adapter delegates here.
+"""
+from __future__ import annotations
+
+# Standard
+import base64
+import json
+import re
+
+_SANITIZE = re.compile(r"[^a-z0-9-]+")
+
+
+def sanitize_salt(salt: str) -> str:
+    """cache_salt → an S3-bucket-name-safe fragment (lowercase [a-z0-9-], trimmed)."""
+    return _SANITIZE.sub("-", (salt or "").lower()).strip("-")
+
+
+def salt_of_key(key_str: str) -> str:
+    """Extract the cache_salt from a stored object key.
+    Key format: ``<model>@<rank>@<group>@<hash>[@<cache_salt>]`` ('@' barred in model & salt)."""
+    parts = (key_str or "").split("@")
+    return parts[4] if len(parts) >= 5 else ""
+
+
+def resolve_bucket_host(
+    key_str: str,
+    *,
+    base_endpoint: str,
+    mode: str = "single",
+    template: str = "{base}-{salt}",
+) -> str:
+    """Virtual-hosted S3 Host for a key.
+
+    - mode 'single' (default = upstream behavior): always the configured base bucket.
+    - mode 'per_cache_salt': a *salted* key routes to its own bucket named by ``template``
+      (``{salt}`` = sanitized cache_salt, ``{base}`` = base bucket name). Unsalted keys, and any
+      salt that sanitizes to empty, fall back to the base bucket.
+
+    base_endpoint is virtual-hosted: ``<bucket>.s3.<region>.amazonaws.com``.
+    """
+    if mode != "per_cache_salt":
+        return base_endpoint
+    safe = sanitize_salt(salt_of_key(key_str))
+    if not safe:
+        return base_endpoint
+    base_bucket, _, suffix = base_endpoint.partition(".")
+    if not suffix:
+        return base_endpoint
+    bucket = template.format(salt=safe, base=base_bucket)
+    return f"{bucket}.{suffix}"
+
+
+# ---- per-bucket listing / eviction support ---------------------------------
+def bucket_hosts(
+    base_endpoint: str,
+    seen_salts: set[str],
+    mode: str = "single",
+    template: str = "{base}-{salt}",
+) -> list[str]:
+    """Ordered list of bucket Hosts the adapter must list for eviction: the base bucket plus
+    one per observed tenant salt (per_cache_salt mode). 'single' mode → just the base."""
+    if mode != "per_cache_salt":
+        return [base_endpoint]
+    base_bucket, _, suffix = base_endpoint.partition(".")
+    hosts = [base_endpoint]
+    for salt in sorted(s for s in seen_salts if s):
+        h = (template.format(salt=salt, base=base_bucket) + "." + suffix) if suffix else base_endpoint
+        if h not in hosts:
+            hosts.append(h)
+    return hosts
+
+
+def encode_cursor(bucket_idx: int, token: str | None) -> str:
+    """Encode a (bucket_index, in-bucket continuation token) pair into one opaque cursor."""
+    return base64.urlsafe_b64encode(json.dumps([bucket_idx, token]).encode()).decode()
+
+
+def decode_cursor(cursor: str | None) -> tuple[int, str | None]:
+    """Cross-bucket cursor → (bucket_index, in-bucket continuation token). None/garbage → (0, None)."""
+    if not cursor:
+        return 0, None
+    try:
+        i, tok = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+        return int(i), tok
+    except Exception:
+        return 0, None

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -24,6 +24,8 @@ import ctypes
 import threading
 import xml.etree.ElementTree as ET
 
+from . import s3_bucket_router as _bucket_router  # per-cache_salt bucket routing (PR feature)
+
 if TYPE_CHECKING:
     from lmcache.v1.distributed.internal_api import L1MemoryDesc
 
@@ -330,6 +332,14 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
     - max_capacity_gb (float): aggregate capacity used by
       ``get_usage()``; ``0`` disables aggregate eviction
       (``usage_fraction == -1.0``).
+    - s3_bucket_mode (str): ``"single"`` (default, upstream behavior — one
+      bucket) or ``"per_cache_salt"`` (route each ``cache_salt`` to its own
+      physical bucket for multi-tenant isolation on a shared box).
+    - s3_bucket_template (str): bucket-name format used in ``per_cache_salt``
+      mode; supports ``{salt}`` (sanitized cache_salt) and ``{base}`` (the
+      ``s3_endpoint``'s bucket name), e.g. ``"kv-cache-{salt}"`` or
+      ``"{base}-{salt}"``. Empty (default) → ``"{base}-{salt}"``. Unsalted KV
+      and ``"single"`` mode both use the ``s3_endpoint`` bucket unchanged.
     """
 
     def __init__(
@@ -343,6 +353,8 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         max_capacity_gb: float = 0.0,
+        s3_bucket_mode: str = "single",
+        s3_bucket_template: str = "",
     ):
         self.s3_endpoint = s3_endpoint
         self.s3_region = s3_region
@@ -353,6 +365,16 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.max_capacity_gb = max_capacity_gb
+        # Multi-tenant per-cache_salt bucket isolation (opt-in; default
+        # reproduces exact single-bucket upstream behavior).
+        #   s3_bucket_mode: "single" (default) or "per_cache_salt".
+        #   s3_bucket_template: bucket-name format for per_cache_salt mode;
+        #     supports {salt} (sanitized cache_salt) and {base} (the
+        #     s3_endpoint's bucket name), e.g. "kv-cache-{salt}".
+        if s3_bucket_mode not in ("single", "per_cache_salt"):
+            raise ValueError("s3_bucket_mode must be 'single' or 'per_cache_salt'")
+        self.s3_bucket_mode = s3_bucket_mode
+        self.s3_bucket_template = s3_bucket_template
 
     @classmethod
     def from_dict(cls, d: dict) -> "S3L2AdapterConfig":
@@ -397,6 +419,8 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
             aws_access_key_id=_opt_str("aws_access_key_id"),
             aws_secret_access_key=_opt_str("aws_secret_access_key"),
             max_capacity_gb=float(max_cap),
+            s3_bucket_mode=d.get("s3_bucket_mode", "single"),
+            s3_bucket_template=(_opt_str("s3_bucket_template") or ""),
         )
         cfg.eviction_config = cls._parse_eviction_config(d)
         return cfg
@@ -455,6 +479,18 @@ class S3L2Adapter(L2AdapterInterface):
         self._endpoint = endpoint
         self._region = config.s3_region
         self._enable_s3express = config.s3_enable_s3express
+        # per-cache_salt bucket routing (multi-tenant isolation)
+        self._bucket_mode = config.s3_bucket_mode
+        self._bucket_template = config.s3_bucket_template or "{base}-{salt}"
+        self._base_bucket = endpoint.split(".", 1)[0]
+        self._host_suffix = endpoint.partition(".")[2]  # s3.<region>.amazonaws.com
+        self._seen_salts: set[str] = set()  # salts observed → buckets to list for eviction
+        self._ensured_buckets: set[str] = set()  # tenant buckets provisioned this process
+        self._mgmt_s3 = None  # lazy boto3 client for bucket create/lifecycle (control plane)
+        # Auto-provision a tenant bucket on first use (+ TTL). Disable to require
+        # buckets to be pre-created by an onboarding hook.
+        self._auto_create_bucket = config.s3_bucket_mode == "per_cache_salt"
+        self._bucket_ttl_days = 30
 
         # awscrt client setup (mirrors s3_connector.py:103-153)
         event_loop_group = io.EventLoopGroup(config.s3_num_io_threads)
@@ -748,11 +784,39 @@ class S3L2Adapter(L2AdapterInterface):
                     "S3 connection disabled (circuit-broken); listing unavailable"
                 )
 
-        fut = asyncio.run_coroutine_threadsafe(
-            self._execute_list(prefix, max_keys, cursor),
-            self._loop,
-        )
-        entries, next_token = fut.result(timeout=30.0)
+        if self._bucket_mode != "per_cache_salt":
+            fut = asyncio.run_coroutine_threadsafe(
+                self._execute_list(prefix, max_keys, cursor),
+                self._loop,
+            )
+            entries, next_token = fut.result(timeout=30.0)
+        else:
+            # Per-tenant buckets: list the base + every observed tenant bucket,
+            # paginating across them with a composite cursor
+            # (bucket_index, in-bucket-token). Deletes the eviction controller
+            # issues route back to the right bucket via _make_request.
+            hosts = _bucket_router.bucket_hosts(
+                self._endpoint, self._seen_salts, self._bucket_mode, self._bucket_template
+            )
+            idx, token = _bucket_router.decode_cursor(cursor)
+            entries, next_token = [], None
+            while idx < len(hosts):
+                fut = asyncio.run_coroutine_threadsafe(
+                    self._execute_list(prefix, max_keys, token, host=hosts[idx]),
+                    self._loop,
+                )
+                e, t = fut.result(timeout=30.0)
+                entries.extend(e)
+                if t:  # this bucket has more pages → resume here next call
+                    next_token = _bucket_router.encode_cursor(idx, t)
+                    break
+                idx += 1  # bucket exhausted → advance
+                token = None
+                if entries:  # return what we have; resume at the next bucket next call
+                    next_token = (
+                        _bucket_router.encode_cursor(idx, None) if idx < len(hosts) else None
+                    )
+                    break
         page_entries = tuple(
             KeyEntry(key=k.to_encoded_object_key(), size_bytes=sz) for k, sz in entries
         )
@@ -831,11 +895,68 @@ class S3L2Adapter(L2AdapterInterface):
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
+    # ---- Multi-tenant per-cache_salt bucket routing (PR feature) ----------
+    # Pure routing logic lives in s3_bucket_router (dependency-free + unit-tested).
+    def _endpoint_for_key(self, key_str: str) -> str:
+        host = _bucket_router.resolve_bucket_host(
+            key_str,
+            base_endpoint=self._endpoint,
+            mode=self._bucket_mode,
+            template=self._bucket_template,
+        )
+        if host != self._endpoint:
+            # remember which tenant buckets we've written to, for per-bucket
+            # eviction/listing.
+            self._seen_salts.add(
+                _bucket_router.sanitize_salt(_bucket_router.salt_of_key(key_str))
+            )
+            if self._auto_create_bucket:
+                self._ensure_bucket(host)
+        return host
+
+    def _ensure_bucket(self, host: str) -> None:
+        """Provision a tenant bucket (idempotent, once per process) + a TTL
+        lifecycle, so per_cache_salt routing works without a separate
+        onboarding step. Control-plane only — uses boto3 (not the CRT data
+        client). Failures are logged, not raised: a missing bucket surfaces
+        later as a normal PUT error rather than killing the request path."""
+        bucket = host.split(".", 1)[0]
+        if bucket in self._ensured_buckets:
+            return
+        self._ensured_buckets.add(bucket)
+        try:
+            import boto3
+            from botocore.exceptions import ClientError
+
+            if self._mgmt_s3 is None:
+                self._mgmt_s3 = boto3.client("s3", region_name=self._region)
+            try:
+                self._mgmt_s3.create_bucket(
+                    Bucket=bucket,
+                    CreateBucketConfiguration={"LocationConstraint": self._region},
+                )
+                logger.info("Auto-provisioned tenant KV bucket %s", bucket)
+            except ClientError as e:
+                code = e.response.get("Error", {}).get("Code", "")
+                if code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+                    raise
+            self._mgmt_s3.put_bucket_lifecycle_configuration(
+                Bucket=bucket,
+                LifecycleConfiguration={"Rules": [{
+                    "ID": "kv-cache-ttl", "Filter": {"Prefix": ""}, "Status": "Enabled",
+                    "Expiration": {"Days": self._bucket_ttl_days},
+                }]},
+            )
+        except Exception:
+            logger.warning(
+                "Failed to auto-provision tenant bucket %s", bucket, exc_info=True
+            )
+
     def _make_request(
         self, method: str, key_str: str, *, body_stream=None, extra_headers=None
     ):
         headers = HttpHeaders()
-        headers.add("Host", self._endpoint)
+        headers.add("Host", self._endpoint_for_key(key_str))
         if extra_headers:
             for k, v in extra_headers:
                 headers.add(k, v)
@@ -959,8 +1080,9 @@ class S3L2Adapter(L2AdapterInterface):
         prefix: Optional[str],
         max_keys: int,
         continuation_token: Optional[str],
+        host: Optional[str] = None,
     ):
-        """Build a ListObjectsV2 request.
+        """Build a ListObjectsV2 request against ``host`` (default: the base bucket).
 
         Returns ``(s3_req, body_chunks, captured)``. The caller awaits
         ``s3_req.finished_future`` and assembles the XML from
@@ -979,7 +1101,7 @@ class S3L2Adapter(L2AdapterInterface):
         path = "/?" + urlencode(params, quote_via=url_quote)
 
         headers = HttpHeaders()
-        headers.add("Host", self._endpoint)
+        headers.add("Host", host or self._endpoint)
         req = HttpRequest("GET", path, headers)
 
         body_chunks: list[bytes] = []
@@ -1235,10 +1357,11 @@ class S3L2Adapter(L2AdapterInterface):
         prefix: Optional[str],
         max_keys: int,
         continuation_token: Optional[str],
+        host: Optional[str] = None,
     ) -> tuple[list[tuple[ObjectKey, int]], Optional[str]]:
-        """Issue one ``ListObjectsV2`` call and parse the response."""
+        """Issue one ``ListObjectsV2`` call against ``host`` and parse the response."""
         s3_req, body_chunks, _captured = self._list_request(
-            prefix, max_keys, continuation_token
+            prefix, max_keys, continuation_token, host=host
         )
         await asyncio.wrap_future(s3_req.finished_future)
         return _parse_list_response_xml(b"".join(body_chunks))

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -375,6 +375,15 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
             raise ValueError("s3_bucket_mode must be 'single' or 'per_cache_salt'")
         self.s3_bucket_mode = s3_bucket_mode
         self.s3_bucket_template = s3_bucket_template
+        # Fail fast on a malformed template (unknown placeholder / bad spec) at
+        # config time rather than on the first PUT in per_cache_salt mode.
+        if s3_bucket_mode == "per_cache_salt":
+            try:
+                (s3_bucket_template or "{base}-{salt}").format(salt="x", base="x")
+            except (KeyError, ValueError, IndexError) as e:
+                raise ValueError(
+                    f"invalid s3_bucket_template {s3_bucket_template!r}: {e}"
+                ) from e
 
     @classmethod
     def from_dict(cls, d: dict) -> "S3L2AdapterConfig":
@@ -486,6 +495,7 @@ class S3L2Adapter(L2AdapterInterface):
         self._host_suffix = endpoint.partition(".")[2]  # s3.<region>.amazonaws.com
         self._seen_salts: set[str] = set()  # salts observed → buckets to list for eviction
         self._ensured_buckets: set[str] = set()  # tenant buckets provisioned this process
+        self._bucket_creation_lock = threading.Lock()  # serialize provisioning
         self._mgmt_s3 = None  # lazy boto3 client for bucket create/lifecycle (control plane)
         # Auto-provision a tenant bucket on first use (+ TTL). Disable to require
         # buckets to be pre-created by an onboarding hook.
@@ -801,8 +811,13 @@ class S3L2Adapter(L2AdapterInterface):
             idx, token = _bucket_router.decode_cursor(cursor)
             entries, next_token = [], None
             while idx < len(hosts):
+                # Request only the remaining page budget so many small tenant
+                # buckets aggregate into one full page instead of forcing a
+                # round-trip per (mostly-empty) bucket.
                 fut = asyncio.run_coroutine_threadsafe(
-                    self._execute_list(prefix, max_keys, token, host=hosts[idx]),
+                    self._execute_list(
+                        prefix, max_keys - len(entries), token, host=hosts[idx]
+                    ),
                     self._loop,
                 )
                 e, t = fut.result(timeout=30.0)
@@ -810,11 +825,12 @@ class S3L2Adapter(L2AdapterInterface):
                 if t:  # this bucket has more pages → resume here next call
                     next_token = _bucket_router.encode_cursor(idx, t)
                     break
-                idx += 1  # bucket exhausted → advance
+                idx += 1  # bucket exhausted → continue into the next bucket
                 token = None
-                if entries:  # return what we have; resume at the next bucket next call
+                if len(entries) >= max_keys:  # page full → resume at next bucket
                     next_token = (
-                        _bucket_router.encode_cursor(idx, None) if idx < len(hosts) else None
+                        _bucket_router.encode_cursor(idx, None)
+                        if idx < len(hosts) else None
                     )
                     break
         page_entries = tuple(
@@ -906,10 +922,11 @@ class S3L2Adapter(L2AdapterInterface):
         )
         if host != self._endpoint:
             # remember which tenant buckets we've written to, for per-bucket
-            # eviction/listing.
-            self._seen_salts.add(
-                _bucket_router.sanitize_salt(_bucket_router.salt_of_key(key_str))
-            )
+            # eviction/listing (mutated from request threads → hold the lock).
+            with self._lock:
+                self._seen_salts.add(
+                    _bucket_router.sanitize_salt(_bucket_router.salt_of_key(key_str))
+                )
             if self._auto_create_bucket:
                 self._ensure_bucket(host)
         return host
@@ -919,38 +936,64 @@ class S3L2Adapter(L2AdapterInterface):
         lifecycle, so per_cache_salt routing works without a separate
         onboarding step. Control-plane only — uses boto3 (not the CRT data
         client). Failures are logged, not raised: a missing bucket surfaces
-        later as a normal PUT error rather than killing the request path."""
-        bucket = host.split(".", 1)[0]
-        if bucket in self._ensured_buckets:
-            return
-        self._ensured_buckets.add(bucket)
-        try:
-            import boto3
-            from botocore.exceptions import ClientError
+        later as a normal PUT error rather than killing the request path.
 
-            if self._mgmt_s3 is None:
-                self._mgmt_s3 = boto3.client("s3", region_name=self._region)
+        Thread-safe: the bucket is only recorded in ``_ensured_buckets`` after
+        a successful create+lifecycle, and provisioning is serialized by
+        ``_bucket_creation_lock`` so concurrent writers to a new tenant don't
+        race (a fast-path check avoids taking the lock once provisioned)."""
+        bucket = host.split(".", 1)[0]
+        with self._lock:
+            if bucket in self._ensured_buckets:
+                return
+        with self._bucket_creation_lock:
+            with self._lock:  # re-check: another thread may have finished while we waited
+                if bucket in self._ensured_buckets:
+                    return
             try:
-                self._mgmt_s3.create_bucket(
+                import boto3
+                from botocore.exceptions import ClientError
+
+                if self._mgmt_s3 is None:
+                    self._mgmt_s3 = boto3.client(
+                        "s3",
+                        region_name=self._region,
+                        aws_access_key_id=self._config.aws_access_key_id,
+                        aws_secret_access_key=self._config.aws_secret_access_key,
+                    )
+                try:
+                    # us-east-1 is the S3 default region and rejects an explicit
+                    # LocationConstraint; every other region requires it.
+                    if self._region == "us-east-1":
+                        self._mgmt_s3.create_bucket(Bucket=bucket)
+                    else:
+                        self._mgmt_s3.create_bucket(
+                            Bucket=bucket,
+                            CreateBucketConfiguration={
+                                "LocationConstraint": self._region
+                            },
+                        )
+                    logger.info("Auto-provisioned tenant KV bucket %s", bucket)
+                except ClientError as e:
+                    code = e.response.get("Error", {}).get("Code", "")
+                    if code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+                        raise
+                self._mgmt_s3.put_bucket_lifecycle_configuration(
                     Bucket=bucket,
-                    CreateBucketConfiguration={"LocationConstraint": self._region},
+                    LifecycleConfiguration={"Rules": [{
+                        "ID": "kv-cache-ttl", "Filter": {"Prefix": ""},
+                        "Status": "Enabled",
+                        "Expiration": {"Days": self._bucket_ttl_days},
+                    }]},
                 )
-                logger.info("Auto-provisioned tenant KV bucket %s", bucket)
-            except ClientError as e:
-                code = e.response.get("Error", {}).get("Code", "")
-                if code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
-                    raise
-            self._mgmt_s3.put_bucket_lifecycle_configuration(
-                Bucket=bucket,
-                LifecycleConfiguration={"Rules": [{
-                    "ID": "kv-cache-ttl", "Filter": {"Prefix": ""}, "Status": "Enabled",
-                    "Expiration": {"Days": self._bucket_ttl_days},
-                }]},
-            )
-        except Exception:
-            logger.warning(
-                "Failed to auto-provision tenant bucket %s", bucket, exc_info=True
-            )
+                # Only mark provisioned after success, so a failed create isn't
+                # cached as "done" (a later write would then 404 forever).
+                with self._lock:
+                    self._ensured_buckets.add(bucket)
+            except Exception:
+                logger.warning(
+                    "Failed to auto-provision tenant bucket %s", bucket, exc_info=True
+                )
 
     def _make_request(
         self, method: str, key_str: str, *, body_stream=None, extra_headers=None

--- a/tests/v1/distributed/test_s3_bucket_router.py
+++ b/tests/v1/distributed/test_s3_bucket_router.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the per-cache_salt S3 bucket router (no awscrt/lmcache deps needed)."""
+from lmcache.v1.distributed.l2_adapters import s3_bucket_router as r
+
+BASE = "kv-cache.s3.us-east-1.amazonaws.com"
+
+
+def test_sanitize():
+    assert r.sanitize_salt("tenant:a") == "tenant-a"
+    assert r.sanitize_salt("ORG:Big_Co!") == "org-big-co"
+    assert r.sanitize_salt("") == ""
+    assert r.sanitize_salt("user:42/x") == "user-42-x"
+
+
+def test_salt_of_key():
+    assert r.salt_of_key("model@01@00@deadbeef@tenant:a") == "tenant:a"
+    assert r.salt_of_key("model@01@00@deadbeef") == ""          # unsalted
+    assert r.salt_of_key("") == ""
+
+
+def test_single_mode_is_upstream():
+    # default mode never changes the host (PR-safe default)
+    assert r.resolve_bucket_host("m@1@0@h@tenant:a", base_endpoint=BASE) == BASE
+    assert r.resolve_bucket_host("m@1@0@h", base_endpoint=BASE) == BASE
+
+
+def test_per_salt_routes_to_own_bucket():
+    h = r.resolve_bucket_host("m@1@0@h@tenant:a", base_endpoint=BASE,
+                              mode="per_cache_salt", template="kv-cache-{salt}")
+    assert h == "kv-cache-tenant-a.s3.us-east-1.amazonaws.com"
+
+
+def test_per_salt_distinct_tenants_distinct_buckets():
+    a = r.resolve_bucket_host("m@1@0@h@tenant:a", base_endpoint=BASE, mode="per_cache_salt",
+                              template="kv-cache-{salt}")
+    b = r.resolve_bucket_host("m@1@0@h@tenant:b", base_endpoint=BASE, mode="per_cache_salt",
+                              template="kv-cache-{salt}")
+    assert a != b
+    assert "tenant-a" in a and "tenant-b" in b
+
+
+def test_per_salt_unsalted_uses_base():
+    # unsalted KV must never leak into a tenant bucket
+    assert r.resolve_bucket_host("m@1@0@h", base_endpoint=BASE, mode="per_cache_salt",
+                                 template="kv-cache-{salt}") == BASE
+
+
+def test_base_template_placeholder():
+    h = r.resolve_bucket_host("m@1@0@h@tenant:9", base_endpoint=BASE, mode="per_cache_salt",
+                              template="{base}-{salt}")
+    assert h == "kv-cache-tenant-9.s3.us-east-1.amazonaws.com"
+
+
+def test_bucket_hosts_single():
+    assert r.bucket_hosts(BASE, {"tenant-1"}, mode="single") == [BASE]
+
+
+def test_bucket_hosts_per_salt():
+    hosts = r.bucket_hosts(BASE, {"tenant-a", "tenant-b"}, mode="per_cache_salt",
+                           template="kv-cache-{salt}")
+    assert hosts[0] == BASE
+    assert any("tenant-a" in h for h in hosts) and any("tenant-b" in h for h in hosts)
+    assert len(hosts) == 3
+
+
+def test_cursor_roundtrip():
+    for i, tok in [(0, None), (2, "abc=="), (5, "x/y+z")]:
+        assert r.decode_cursor(r.encode_cursor(i, tok)) == (i, tok)
+    assert r.decode_cursor(None) == (0, None)
+    assert r.decode_cursor("garbage!!") == (0, None)


### PR DESCRIPTION
## Summary

Opt-in **per-`cache_salt` S3 bucket isolation** for the S3 L2 adapter: route each tenant's KV to its **own physical S3 bucket**, keyed by `cache_salt`. On a shared multi-tenant inference box, no two tenants share a bucket — one tenant's writes never consume or evict another's cache, and there is no cross-tenant read path. Default behavior is **unchanged** (single bucket); the feature is entirely opt-in.

## Motivation

Today the S3 backend is single-bucket: every tenant's KV lands in one bucket and `cache_salt` only prefixes the object key. For multi-tenant serving that means **shared capacity** (one tenant can fill or LRU-evict another's entries) and a shared blast radius. Physical per-tenant buckets give hard isolation plus independent lifecycle/capacity per tenant.

## Design (default-safe)

Two new optional `S3L2AdapterConfig` fields, both defaulting to **exact current behavior**:

- `s3_bucket_mode`: `"single"` (default) | `"per_cache_salt"`
- `s3_bucket_template`: bucket-name format for per-salt mode; supports `{salt}` (sanitized `cache_salt`) and `{base}` (the configured bucket name), e.g. `"kv-cache-{salt}"` or `"{base}-{salt}"`.

In `per_cache_salt` mode:

- **Routing** — `_make_request` (PUT/GET/HEAD/DELETE) sets the virtual-hosted `Host` per key. The CRT `S3Client` is **region-bound, not bucket-bound**, so a single client serves all tenant buckets — only the per-request `Host` changes. Unsalted keys and `single` mode keep the configured bucket.
- **Listing / eviction** — `list_l2_keys` iterates the base bucket plus every observed tenant bucket with a composite cursor, so the eviction controller sees keys across all tenant buckets and issued deletes route back to the correct bucket.
- **Provisioning** — the first write to a tenant bucket idempotently creates it (plus a configurable lifecycle TTL) via boto3; failures are logged, not raised. Can be turned off to require buckets be pre-created by an onboarding hook.

The routing logic lives in a new **dependency-free** module `s3_bucket_router.py` (no `awscrt` / `lmcache` imports) so it is unit-testable and reviewable in isolation.

## Tests

- `tests/v1/distributed/test_s3_bucket_router.py` — 10 unit cases: sanitize, `single`-mode no-op, per-salt routing, distinct tenants → distinct buckets, unsalted → base, `{base}`/`{salt}` placeholders, cross-bucket listing, cursor roundtrip.
- **Validated end-to-end** on a multi-replica 8×GPU box (vLLM + LMCache MP, S3 L2), not just unit tests:
  - **Isolation** — two tenants → two separate buckets, `0` objects leaked into the base/other bucket.
  - **Read reuse** — identical prompt twice under one tenant → cold prefill then a full KV cache hit (the load path works through per-tenant routing).
  - **Provisioning** — tenant buckets auto-created with the lifecycle TTL on first write.
  - **Eviction** — under sustained load the L2 eviction controller crossed its watermark and evicted (deleted) from the per-tenant bucket; footprint stayed bounded by the cap.
  - `single` mode is byte-for-byte unchanged (covered by the existing `test_s3_l2_adapter.py`).

## Notes

Draft for now — happy to take feedback on the config surface and on whether auto-provisioning belongs in the adapter or in a separate onboarding hook.
