### PR TITLE
fix: prevent disk deadlock on memory allocation failure

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -444,43 +444,44 @@ class LocalDiskBackend(StorageBackendInterface):
 
         logger.debug(f"lookup_id: {lookup_id}; Prefetching {len(keys)} keys from disk.")
         for key in keys:
-            self.disk_lock.acquire()
-            assert key in self.dict, f"Key {key} not found in disk cache after pinning"
-
-            path = self.dict[key].path
-            dtype = self.dict[key].dtype
-            shape = self.dict[key].shape
-            fmt = self.dict[key].fmt
-
-            assert dtype is not None
-            assert shape is not None
-
-            # busy_loop=False prevents spinning on the event loop thread;
-            # if staging memory is exhausted the caller will get a logged
-            # error rather than a silent deadlock.
-            memory_obj = self.local_cpu_backend.allocate(
-                shape,
-                dtype,
-                fmt,
-                busy_loop=False,
-            )
-
-            if memory_obj is None:
-                logger.error(
-                    "Memory allocation failed during async disk load for key %s. "
-                    "CPU staging pool may be exhausted (unpin() not called after "
-                    "a previous retrieve). Returning partial results.",
-                    key,
+            with self.disk_lock:
+                assert key in self.dict, (
+                    f"Key {key} not found in disk cache after pinning"
                 )
-                return mem_objs
 
-            self.dict[key].pin()
+                path = self.dict[key].path
+                dtype = self.dict[key].dtype
+                shape = self.dict[key].shape
+                fmt = self.dict[key].fmt
 
-            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
-            # Update cache recency
-            self.cache_policy.update_on_hit(key, self.dict)
+                assert dtype is not None
+                assert shape is not None
 
-            self.disk_lock.release()
+                # busy_loop=False prevents spinning on the event loop thread;
+                # if staging memory is exhausted the caller will get a logged
+                # error rather than a silent deadlock.
+                memory_obj = self.local_cpu_backend.allocate(
+                    shape,
+                    dtype,
+                    fmt,
+                    busy_loop=False,
+                )
+
+                if memory_obj is None:
+                    logger.error(
+                        "Memory allocation failed during async disk load for key %s. "
+                        "CPU staging pool may be exhausted (unpin() not called after "
+                        "a previous retrieve). Returning partial results.",
+                        key,
+                    )
+                    return mem_objs
+
+                self.dict[key].pin()
+
+                # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
+                # Update cache recency
+                self.cache_policy.update_on_hit(key, self.dict)
+
             logger.debug(f"Prefetching {key} from disk.")
             memory_obj.pin()
             mem_objs.append(memory_obj)

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -471,10 +471,15 @@ class LocalDiskBackend(StorageBackendInterface):
                     logger.error(
                         "Memory allocation failed during async disk load for key %s. "
                         "CPU staging pool may be exhausted (unpin() not called after "
-                        "a previous retrieve). Returning partial results.",
+                        "a previous retrieve). Aborting and returning empty list.",
                         key,
                     )
-                    return mem_objs
+                    for m in mem_objs:
+                        m.unpin()
+                        m.ref_count_down()
+                    for k in keys[:len(mem_objs)]:
+                        self.dict[k].unpin()
+                    return []
 
                 self.dict[key].pin()
 

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -477,7 +477,7 @@ class LocalDiskBackend(StorageBackendInterface):
                     for m in mem_objs:
                         m.unpin()
                         m.ref_count_down()
-                    for k in keys[:len(mem_objs)]:
+                    for k in keys[: len(mem_objs)]:
                         self.dict[k].unpin()
                     return []
 

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -471,8 +471,9 @@ class TestGetBlockingCachePolicyUpdate:
         self, local_disk_backend: LocalDiskBackend, async_loop
     ) -> None:
         """Release disk_lock, unpin and decrement ref count."""
-        from unittest.mock import MagicMock
+        # Standard
         from typing import Any
+        from unittest.mock import MagicMock
 
         key1 = create_test_key(104)
         key2 = create_test_key(105)

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -470,8 +470,9 @@ class TestGetBlockingCachePolicyUpdate:
     def test_batched_get_non_blocking_lock_release_on_allocation_failure(
         self, local_disk_backend: LocalDiskBackend, async_loop
     ) -> None:
-        """Release disk_lock, unpin and decrement ref count for allocated objects and metadata on allocation failure."""
+        """Release disk_lock, unpin and decrement ref count."""
         from unittest.mock import MagicMock
+        from typing import Any
 
         key1 = create_test_key(104)
         key2 = create_test_key(105)
@@ -479,7 +480,7 @@ class TestGetBlockingCachePolicyUpdate:
         self._inject_key(local_disk_backend, key1, shape, torch.bfloat16)
         self._inject_key(local_disk_backend, key2, shape, torch.bfloat16)
 
-        allocated_objs = []
+        allocated_objs: list[Any] = []
         mock_obj = MagicMock()
 
         def mock_allocate(*args, **kwargs):
@@ -492,7 +493,9 @@ class TestGetBlockingCachePolicyUpdate:
         with patch.object(
             local_disk_backend.local_cpu_backend, "allocate", side_effect=mock_allocate
         ):
-            coro = local_disk_backend.batched_get_non_blocking("test_lookup", [key1, key2])
+            coro = local_disk_backend.batched_get_non_blocking(
+                "test_lookup", [key1, key2]
+            )
             results = async_loop.run_until_complete(coro)
 
         assert results == []

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -470,19 +470,38 @@ class TestGetBlockingCachePolicyUpdate:
     def test_batched_get_non_blocking_lock_release_on_allocation_failure(
         self, local_disk_backend: LocalDiskBackend, async_loop
     ) -> None:
-        """Release disk_lock when allocate returns None."""
-        key = create_test_key(104)
-        shape = torch.Size([28, 2, 256, 8, 128])
-        self._inject_key(local_disk_backend, key, shape, torch.bfloat16)
+        """Release disk_lock, unpin and decrement ref count for allocated objects and metadata on allocation failure."""
+        from unittest.mock import MagicMock
 
-        # Mock allocate returning None
+        key1 = create_test_key(104)
+        key2 = create_test_key(105)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        self._inject_key(local_disk_backend, key1, shape, torch.bfloat16)
+        self._inject_key(local_disk_backend, key2, shape, torch.bfloat16)
+
+        allocated_objs = []
+        mock_obj = MagicMock()
+
+        def mock_allocate(*args, **kwargs):
+            if len(allocated_objs) == 0:
+                allocated_objs.append(mock_obj)
+                return mock_obj
+            return None
+
+        # Mock allocate returning first obj and then None
         with patch.object(
-            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+            local_disk_backend.local_cpu_backend, "allocate", side_effect=mock_allocate
         ):
-            coro = local_disk_backend.batched_get_non_blocking("test_lookup", [key])
+            coro = local_disk_backend.batched_get_non_blocking("test_lookup", [key1, key2])
             results = async_loop.run_until_complete(coro)
 
         assert results == []
+        assert len(allocated_objs) == 1
+        mock_obj.pin.assert_called_once()
+        mock_obj.unpin.assert_called_once()
+        mock_obj.ref_count_down.assert_called_once()
+        assert local_disk_backend.dict[key1].pin_count == 0
+        assert local_disk_backend.dict[key2].pin_count == 0
         # Verify lock is released and can be acquired again without blocking
         assert not local_disk_backend.disk_lock.locked()
         local_disk_backend.local_cpu_backend.memory_allocator.close()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -466,3 +466,23 @@ class TestGetBlockingCachePolicyUpdate:
         assert result is None
         mock_update.assert_not_called()
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_batched_get_non_blocking_lock_release_on_allocation_failure(
+        self, local_disk_backend: LocalDiskBackend, async_loop
+    ) -> None:
+        """Release disk_lock when allocate returns None."""
+        key = create_test_key(104)
+        shape = torch.Size([28, 2, 256, 8, 128])
+        self._inject_key(local_disk_backend, key, shape, torch.bfloat16)
+
+        # Mock allocate returning None
+        with patch.object(
+            local_disk_backend.local_cpu_backend, "allocate", return_value=None
+        ):
+            coro = local_disk_backend.batched_get_non_blocking("test_lookup", [key])
+            results = async_loop.run_until_complete(coro)
+
+        assert results == []
+        # Verify lock is released and can be acquired again without blocking
+        assert not local_disk_backend.disk_lock.locked()
+        local_disk_backend.local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

the original code acquires  self.disk_lock  but returned early  without releasing lock when CPU memory allocation failed.

```
self.disk_lock.acquire() 
memory_obj = self.local_cpu_backend.allocate(...）
if memory_obj is None:
    return mem_objs
```


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
