### PR TITLE
[Bugfix] trtllm: cap kernel object batch at 4 to match c_ops limit (#3889)

### DIFF
--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -1933,7 +1933,14 @@ class SGLangLayerwiseGPUConnector(GPUConnectorInterface):
         return torch.Size([num_tokens, 2, self.hidden_dim_size])
 
 
-_TRTLLM_KERNEL_BATCH_SIZE = 32
+# The ``multi_layer_block_kv_transfer`` kernel packs object pointers into a
+# fixed ``MemoryObj4`` struct (``csrc/mp_mem_kernels.cuh``) and hard-rejects any
+# call with more than 4 objects (``TORCH_CHECK(num_objects <= 4, ...)`` in
+# ``csrc/mp_mem_kernels.cu``). The Python batch stride must therefore never
+# exceed this cap, otherwise stores/loads spanning more than 4 chunks raise
+# ``RuntimeError: Expected 1-4 LMCache objects, got <N>``.
+_MULTI_LAYER_KERNEL_MAX_OBJECTS = 4
+_TRTLLM_KERNEL_BATCH_SIZE = _MULTI_LAYER_KERNEL_MAX_OBJECTS
 
 
 class TRTLLMGPUConnector(GPUConnectorInterface):

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -416,34 +416,28 @@ class TestTRTLLMBatchedTransferCap:
             <= gpu_connectors._MULTI_LAYER_KERNEL_MAX_OBJECTS
         )
 
-    def test_batched_transfer_never_exceeds_kernel_cap(
+    def test_batched_to_gpu_never_exceeds_kernel_cap(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Standard
+        from unittest.mock import MagicMock
         import contextlib
 
         # First Party
         from lmcache.v1.gpu_connector import gpu_connectors
         from lmcache.v1.gpu_connector.gpu_connectors import TRTLLMGPUConnector
-
-        # Build without __init__ to avoid creating real CUDA streams.
-        connector = object.__new__(TRTLLMGPUConnector)
-        connector.device = torch.device("cpu")
-        connector.chunk_size = 256
-        connector.paged_buffer_ptrs = None
-        connector.shape_desc = None
-        connector._kv_format = None
-        connector._batch_size = gpu_connectors._TRTLLM_KERNEL_BATCH_SIZE
-
-        # One block per chunk is enough to exercise the batching stride.
-        monkeypatch.setattr(
-            connector, "_get_chunk_block_ids", lambda block_ids, start: [start]
+        from lmcache.v1.memory_management import (
+            MemoryFormat,
+            MemoryObj,
+            MemoryObjMetadata,
+            TensorMemoryObj,
         )
-        monkeypatch.setattr(connector, "_stage_block_ids", lambda ids: ids)
+
+        # CPU-only test: the transfer streams and the kernel are the only GPU
+        # bits, so stub them and exercise everything else for real.
+        monkeypatch.setattr(torch.cuda, "Stream", lambda **kwargs: MagicMock())
         monkeypatch.setattr(
-            gpu_connectors.torch.cuda,
-            "stream",
-            lambda stream: contextlib.nullcontext(),
+            torch.cuda, "stream", lambda stream: contextlib.nullcontext()
         )
 
         objects_per_call: list[int] = []
@@ -455,38 +449,46 @@ class TestTRTLLMBatchedTransferCap:
             gpu_connectors.lmc_ops, "multi_layer_block_kv_transfer", _record
         )
 
-        class _FakeTensor:
-            def __init__(self, ptr: int) -> None:
-                self._ptr = ptr
+        num_kv_heads, head_dim, tokens_per_block = 2, 64, 16
+        num_layers, chunk_size = 4, 256
+        connector = TRTLLMGPUConnector(
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            hidden_dim_size=num_kv_heads * head_dim,
+            num_layers=num_layers,
+            chunk_size=chunk_size,
+            dtype=torch.bfloat16,
+            device=torch.device("cpu"),
+        )
 
-            def data_ptr(self) -> int:
-                return self._ptr
+        # Register the TRT-LLM pool via the public API. flat dim is
+        # num_kv_heads * tokens_per_block * head_dim.
+        flat = num_kv_heads * tokens_per_block * head_dim
+        pool = torch.zeros(4, num_layers, 2, flat, dtype=torch.bfloat16)
+        connector.register_kv_caches(pool)
 
-        class _FakeMemoryObj:
-            def __init__(self, ptr: int) -> None:
-                self.tensor = _FakeTensor(ptr)
+        def _cpu_memory_obj() -> TensorMemoryObj:
+            raw = torch.zeros(16, dtype=torch.float32)
+            meta = MemoryObjMetadata(
+                shape=torch.Size([16]),
+                dtype=torch.float32,
+                address=0,
+                phy_size=16 * 4,
+                fmt=MemoryFormat.KV_2LTD,
+                ref_count=1,
+            )
+            return TensorMemoryObj(raw, meta, parent_allocator=None)
 
         num_chunks = 9  # > 4 chunks: the failing case before the fix.
-        memory_objs = [_FakeMemoryObj(ptr=i + 1) for i in range(num_chunks)]
-        starts = list(range(num_chunks))
+        blocks_per_chunk = chunk_size // tokens_per_block
+        memory_objs: list[MemoryObj] = [_cpu_memory_obj() for _ in range(num_chunks)]
+        starts = [i * chunk_size for i in range(num_chunks)]
+        ends = [start + chunk_size for start in starts]
+        block_ids = list(range(num_chunks * blocks_per_chunk))
 
-        connector._batched_transfer(
-            memory_objs,
-            starts,
-            block_ids=[],
-            direction=lmc_ops_transfer_direction(),
-            stream=None,
-        )
+        connector.batched_to_gpu(memory_objs, starts, ends, block_ids=block_ids)
 
         assert objects_per_call, "kernel was never invoked"
         assert max(objects_per_call) <= 4
         # Every chunk must still be transferred exactly once.
         assert sum(objects_per_call) == num_chunks
-
-
-def lmc_ops_transfer_direction() -> object:
-    """Return any TransferDirection value (direction is opaque to the stub)."""
-    # First Party
-    import lmcache.c_ops as lmc_ops
-
-    return lmc_ops.TransferDirection.D2H

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -392,3 +392,101 @@ class TestRawCudaIPCWrapperType:
         registry = custom_types._CUSTOMERIZED_SERIALIZERS  # noqa: PLC2701
         assert custom_types.DeviceIPCWrapper in registry
         assert registry[custom_types.DeviceIPCWrapper].code == 1
+
+
+@pytest.mark.skipif(not _has_lmc_ops(), reason="lmcache C ops not built")
+class TestTRTLLMBatchedTransferCap:
+    """Regression for #3889.
+
+    ``multi_layer_block_kv_transfer`` hard-rejects calls carrying more than 4
+    LMCache objects, so the Python batch stride must never exceed that cap.
+    Before the fix the stride was 32, which raised
+    ``RuntimeError: Expected 1-4 LMCache objects, got <N>`` for any prompt
+    spanning more than 4 chunks. This test does not need a GPU: it stubs the
+    kernel call and only checks how many object pointers each call receives.
+    """
+
+    def test_kernel_batch_size_within_cap(self) -> None:
+        # First Party
+        from lmcache.v1.gpu_connector import gpu_connectors
+
+        assert gpu_connectors._MULTI_LAYER_KERNEL_MAX_OBJECTS == 4
+        assert (
+            gpu_connectors._TRTLLM_KERNEL_BATCH_SIZE
+            <= gpu_connectors._MULTI_LAYER_KERNEL_MAX_OBJECTS
+        )
+
+    def test_batched_transfer_never_exceeds_kernel_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Standard
+        import contextlib
+
+        # First Party
+        from lmcache.v1.gpu_connector import gpu_connectors
+        from lmcache.v1.gpu_connector.gpu_connectors import TRTLLMGPUConnector
+
+        # Build without __init__ to avoid creating real CUDA streams.
+        connector = object.__new__(TRTLLMGPUConnector)
+        connector.device = torch.device("cpu")
+        connector.chunk_size = 256
+        connector.paged_buffer_ptrs = None
+        connector.shape_desc = None
+        connector._kv_format = None
+        connector._batch_size = gpu_connectors._TRTLLM_KERNEL_BATCH_SIZE
+
+        # One block per chunk is enough to exercise the batching stride.
+        monkeypatch.setattr(
+            connector, "_get_chunk_block_ids", lambda block_ids, start: [start]
+        )
+        monkeypatch.setattr(connector, "_stage_block_ids", lambda ids: ids)
+        monkeypatch.setattr(
+            gpu_connectors.torch.cuda,
+            "stream",
+            lambda stream: contextlib.nullcontext(),
+        )
+
+        objects_per_call: list[int] = []
+
+        def _record(paged_ptrs, ptrs, *args, **kwargs) -> None:
+            objects_per_call.append(len(ptrs))
+
+        monkeypatch.setattr(
+            gpu_connectors.lmc_ops, "multi_layer_block_kv_transfer", _record
+        )
+
+        class _FakeTensor:
+            def __init__(self, ptr: int) -> None:
+                self._ptr = ptr
+
+            def data_ptr(self) -> int:
+                return self._ptr
+
+        class _FakeMemoryObj:
+            def __init__(self, ptr: int) -> None:
+                self.tensor = _FakeTensor(ptr)
+
+        num_chunks = 9  # > 4 chunks: the failing case before the fix.
+        memory_objs = [_FakeMemoryObj(ptr=i + 1) for i in range(num_chunks)]
+        starts = list(range(num_chunks))
+
+        connector._batched_transfer(
+            memory_objs,
+            starts,
+            block_ids=[],
+            direction=lmc_ops_transfer_direction(),
+            stream=None,
+        )
+
+        assert objects_per_call, "kernel was never invoked"
+        assert max(objects_per_call) <= 4
+        # Every chunk must still be transferred exactly once.
+        assert sum(objects_per_call) == num_chunks
+
+
+def lmc_ops_transfer_direction() -> object:
+    """Return any TransferDirection value (direction is opaque to the stub)."""
+    # First Party
+    import lmcache.c_ops as lmc_ops
+
+    return lmc_ops.TransferDirection.D2H


### PR DESCRIPTION
## Summary

Fixes #3889.

The TRT-LLM GPU connector (`TRTLLMGPUConnector._batched_transfer`) batched KV transfers in groups of `_TRTLLM_KERNEL_BATCH_SIZE = 32` object pointers per `lmc_ops.multi_layer_block_kv_transfer` call. The c_ops kernel packs pointers into a fixed `MemoryObj4` struct (`csrc/mp_mem_kernels.cuh`) and **hard-rejects any call with more than 4 objects**:

```cpp
// csrc/mp_mem_kernels.cu
TORCH_CHECK(num_objects >= 1 && num_objects <= 4,
            "Expected 1-4 LMCache objects, got ", num_objects);
```

So any store/load spanning more than 4 chunks (~>1024 tokens at `chunk_size=256`) raised `RuntimeError: Expected 1-4 LMCache objects, got <N>` and killed the TRT-LLM executor loop. Short prompts (≤4 chunks) never tripped it, which is why the existing E2E tests pass.

## Fix

- Introduce a named constant `_MULTI_LAYER_KERNEL_MAX_OBJECTS = 4` documenting the kernel ABI cap, and set the batch stride to it. `_batched_transfer` already loops with this stride, so the only effect is more (smaller) kernel launches — no semantic change. The kernel has no larger batched variant; 4 is a genuine ABI ceiling.

## Test

- Adds `TestTRTLLMBatchedTransferCap` — a **GPU-free** regression test that stubs the kernel call and drives `_batched_transfer` with 9 chunks (the failing >4-chunk case), asserting no single kernel invocation ever receives more than 4 object pointers while every chunk is still transferred exactly once.

Verified locally: `ruff check`, `ruff format --check`, `isort --check-only`, `codespell` all clean.