### PR TITLE
[Bugfix] controller: parse ROUTER payload as the last frame (#3628)

### DIFF
--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -62,6 +62,37 @@ logger = init_logger(__name__)
 # a control message.
 
 
+def parse_router_frames(frames: list[bytes]) -> tuple[bytes, bytes]:
+    """Split a ROUTER multipart message into ``(identity, payload)``.
+
+    A ROUTER socket prepends exactly one identity frame to whatever the peer
+    sent. The worker is a ``zmq.DEALER`` that sends ``[empty_delimiter,
+    payload]``, so the controller normally receives
+    ``[identity, empty_delimiter, payload]``. The payload is therefore always
+    the *last* frame -- which is exactly how the worker decodes replies
+    (``frames[-1]``). Relying on a fixed ``frames[2]`` index instead breaks
+    whenever the empty delimiter is absent (e.g. a ``[identity, payload]``
+    layout), surfacing as ``msgspec.ValidationError: Expected object, got int``
+    from decoding the wrong frame.
+
+    Args:
+        frames: The frames returned by ``recv_multipart`` on a ROUTER socket.
+
+    Returns:
+        A ``(identity, payload)`` tuple, where ``identity`` is the first frame
+        and ``payload`` is the last frame.
+
+    Raises:
+        ValueError: If fewer than 2 frames are present (a valid ROUTER message
+            needs at least an identity frame and a payload frame).
+    """
+    if len(frames) < 2:
+        raise ValueError(
+            f"Invalid ROUTER message format, expected >= 2 frames, got {len(frames)}"
+        )
+    return frames[0], frames[-1]
+
+
 class LMCacheControllerManager:
     def __init__(
         self,
@@ -353,26 +384,16 @@ class LMCacheControllerManager:
     async def handle_batched_req_request(self, socket) -> Optional[MsgBase]:
         """Handle requests on ROUTER socket.
 
-        ROUTER socket receives multi-part messages:
-        [identity, empty_frame, payload]
-        and must reply with the same identity frame.
+        ROUTER socket receives multi-part messages of the form
+        ``[identity, (empty_frame,) payload]`` (the empty delimiter is
+        optional) and must reply with the same identity frame.
         """
         while True:
             frames = await socket.recv_multipart()
             with SocketMetricsContext(self, SocketType.REPLY):
                 identity = None
                 try:
-                    # ROUTER socket: [identity, empty_frame, payload]
-                    if len(frames) < 3:
-                        logger.error(
-                            "Invalid ROUTER message format, expected >= 3 frames, "
-                            "got %d",
-                            len(frames),
-                        )
-                        continue
-                    identity = frames[0]
-                    # frames[1] is empty delimiter
-                    part = frames[2]
+                    identity, part = parse_router_frames(frames)
 
                     # Parse message based on format
                     if part.startswith(b"{"):
@@ -400,6 +421,7 @@ class LMCacheControllerManager:
                     msgspec.DecodeError,
                     msgspec.ValidationError,
                     zmq.ZMQError,
+                    ValueError,
                 ) as e:
                     logger.error("Error handling request message: %s", e, exc_info=True)
                     err_msg = ErrorMsg(error=str(e))
@@ -415,8 +437,9 @@ class LMCacheControllerManager:
         This runs on a separate socket to ensure heartbeats are processed
         without being blocked by other requests.
 
-        ROUTER socket receives multi-part messages:
-        [identity, empty_frame, payload]
+        ROUTER socket receives multi-part messages of the form
+        ``[identity, (empty_frame,) payload]`` (the empty delimiter is
+        optional).
         """
         logger.info("Heartbeat handler task started, waiting for heartbeat requests...")
         while True:
@@ -425,16 +448,7 @@ class LMCacheControllerManager:
             with SocketMetricsContext(self, SocketType.REPLY):
                 identity = None
                 try:
-                    # ROUTER socket: [identity, empty_frame, payload]
-                    if len(frames) < 3:
-                        logger.error(
-                            "Invalid heartbeat ROUTER message format, "
-                            "expected >= 3 frames, got %d",
-                            len(frames),
-                        )
-                        continue
-                    identity = frames[0]
-                    part = frames[2]
+                    identity, part = parse_router_frames(frames)
 
                     if part.startswith(b"{"):
                         msg_dict = json.loads(part)
@@ -463,6 +477,7 @@ class LMCacheControllerManager:
                     msgspec.DecodeError,
                     msgspec.ValidationError,
                     zmq.ZMQError,
+                    ValueError,
                 ) as e:
                     logger.error(
                         "Error handling heartbeat request: %s", e, exc_info=True

--- a/tests/v1/cache_controller/test_router_frames.py
+++ b/tests/v1/cache_controller/test_router_frames.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for ROUTER multipart frame parsing (issue #3628).
+
+The controller's ROUTER handlers used to read a fixed ``frames[2]`` and
+required ``>= 3`` frames. The worker is a ``zmq.DEALER`` that sends
+``[empty_delimiter, payload]`` and decodes replies with ``frames[-1]``, so the
+controller must treat the *last* frame as the payload and tolerate a
+``[identity, payload]`` layout. Indexing a fixed position instead surfaced as
+``msgspec.ValidationError: Expected object, got int`` (the empty delimiter /
+wrong frame decoded as the message) and intermittent
+``expected >= 3 frames, got 2`` rejections.
+"""
+
+# Third Party
+import msgspec
+import pytest
+
+# First Party
+from lmcache.v1.cache_controller.controller_manager import parse_router_frames
+from lmcache.v1.cache_controller.message import HeartbeatMsg, Msg
+
+
+def _heartbeat_payload() -> bytes:
+    msg = HeartbeatMsg(
+        instance_id="instance-0",
+        worker_id=0,
+        ip="127.0.0.1",
+        port=9000,
+        peer_init_url=None,
+    )
+    return msgspec.msgpack.encode(msg)
+
+
+def test_parse_three_frame_layout() -> None:
+    """``[identity, empty_delimiter, payload]`` (the common DEALER case)."""
+    payload = _heartbeat_payload()
+    identity, part = parse_router_frames([b"worker-id", b"", payload])
+    assert identity == b"worker-id"
+    assert part == payload
+    decoded = msgspec.msgpack.decode(part, type=Msg)
+    assert isinstance(decoded, HeartbeatMsg)
+    assert decoded.instance_id == "instance-0"
+
+
+def test_parse_two_frame_layout_without_delimiter() -> None:
+    """``[identity, payload]`` must decode the payload, not error out."""
+    payload = _heartbeat_payload()
+    identity, part = parse_router_frames([b"worker-id", payload])
+    assert identity == b"worker-id"
+    assert part == payload
+    decoded = msgspec.msgpack.decode(part, type=Msg)
+    assert isinstance(decoded, HeartbeatMsg)
+
+
+def test_parse_extra_frames_still_takes_last() -> None:
+    """The payload is always the last frame regardless of leading frames."""
+    payload = _heartbeat_payload()
+    identity, part = parse_router_frames([b"worker-id", b"", b"x", payload])
+    assert identity == b"worker-id"
+    assert part == payload
+
+
+def test_parse_too_few_frames_raises() -> None:
+    with pytest.raises(ValueError, match="expected >= 2 frames, got 1"):
+        parse_router_frames([b"only-payload"])


### PR DESCRIPTION
## Summary

Fixes #3628.

With `enableController: true` and `kvaware` routing, the controller manager intermittently fails to decode worker messages on the heartbeat and reply ROUTER sockets:

```
msgspec.ValidationError: Expected `object`, got `int`   (controller_manager.py, handle_heartbeat_request / handle_batched_req_request)
Invalid ROUTER message format, expected >= 3 frames, got 2
```

Full sync never completes and kvaware routing silently degrades to session routing.

## Root cause

The controller's two ROUTER handlers read a **fixed** `frames[2]` as the payload and required `len(frames) >= 3`:

```python
# ROUTER socket: [identity, empty_frame, payload]
if len(frames) < 3:
    ... continue
identity = frames[0]
part = frames[2]
```

The worker (`lmcache/v1/cache_controller/worker.py`) is a `zmq.DEALER` that sends `[empty_delimiter, payload]` and decodes replies with `frames[-1]`. A ROUTER prepends one identity frame, so the controller normally gets `[identity, empty_delimiter, payload]`. Indexing a fixed position is brittle and **asymmetric** with the worker's own `frames[-1]` convention: whenever the empty delimiter is absent (`[identity, payload]`), the controller either rejects the message (`got 2`) or decodes the wrong frame (the empty delimiter / a non-object → `Expected object, got int`).

## Fix

- Extract `parse_router_frames(frames) -> (identity, payload)` that takes the **last** frame as the payload (matching the worker) and accepts both the 2-frame `[identity, payload]` and 3-frame `[identity, empty, payload]` layouts, raising `ValueError` only when fewer than 2 frames are present.
- Route both ROUTER handlers through it. For the usual 3-frame message this is byte-for-byte identical to the old behavior (`frames[-1] == frames[2]`); the 2-frame case now decodes instead of erroring.

The PULL/PUSH batched-push path is unchanged — a PULL socket carries no identity frame, so iterating all frames there is already correct.

## Test

Adds `tests/v1/cache_controller/test_router_frames.py` with pure-Python regression tests (real `HeartbeatMsg` msgpack round-trip) covering the 3-frame, 2-frame, extra-frame, and too-few-frame cases.

Verified locally: `ruff check`, `ruff format --check`, `isort --check-only`, `codespell` all clean. (The function logic was also exercised directly to confirm payload selection and the `ValueError` guard.)