### PR TITLE
[Feat] s3 l2: support path-style addressing and key prefix (#3344)

### DIFF
--- a/docs/design/v1/multiprocess/l2_apis.md
+++ b/docs/design/v1/multiprocess/l2_apis.md
@@ -263,8 +263,9 @@ Costs:
 ### Filtering
 
 The only supported filter is **`model_name`**, pushed down as
-`prefix=<flattened_model_name>@`. Flattening (`/` → `_`) is applied
-so the prefix matches the form `_format_safe_path` stored on S3.
+`prefix=<key_prefix><flattened_model_name>@`, where `<key_prefix>` is the
+optional configured `s3_prefix` (empty by default). Flattening (`/` → `_`)
+is applied so the prefix matches the form `_format_object_path` stores on S3.
 `cache_salt` is intentionally NOT a filter parameter — it sits at the
 *end* of the key and can't be expressed as an S3 prefix, so filtering
 it would only narrow client-side without reducing the RTTs. If a
@@ -292,10 +293,24 @@ parser skips entries it can't decode.
 ### `/` in `model_name` is stored verbatim
 
 The adapter stores objects under their literal `_object_key_to_string`
-output — no path-flattening. `_format_safe_path` only URL-encodes the
-HTTP path (`/` stays as `/` in the URL, `@` becomes `%40`). S3 accepts
+output — no path-flattening. `_format_object_path` only URL-encodes the
+HTTP path (`/` stays as `/` in the URL, `@` becomes `%40`), optionally
+prepending the configured `s3_prefix` and, for path-style addressing
+(`s3_bucket` set), the bucket as the leading path segment. S3 accepts
 `/` in object keys as a legal character (it's only the AWS console
 that treats `/` as a virtual-folder delimiter — purely cosmetic).
+
+### Addressing styles (virtual-hosted vs path-style)
+
+By default the adapter uses **virtual-hosted** addressing: the bucket is
+part of the host (`s3_endpoint="s3://<bucket>.<host>"`), and the object
+path is `/<object>`. Setting **`s3_bucket`** switches to **path-style**
+addressing: `s3_endpoint` is the bare host, `Host:` is that host, and the
+bucket rides as the first path segment (`/<bucket>/<object>`). Path-style
+is required by most self-hosted / S3-compatible endpoints (MinIO, Dell ECS)
+that cannot resolve a bucket folded into a custom host. `s3_prefix` nests
+all objects under a sub-directory in either style. The resolution lives in
+`_compute_s3_addressing`.
 
 Round-trip example:
 

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -117,12 +117,20 @@ def _string_to_object_key(name: str) -> ObjectKey:
 
 def _parse_list_response_xml(
     body: bytes,
+    key_prefix: str = "",
 ) -> tuple[list[tuple[ObjectKey, int]], Optional[str]]:
     """Parse a ListObjectsV2 XML response into ``(entries, next_token)``.
 
     Entries this adapter can't parse (foreign objects in the bucket)
     are skipped silently. ``next_token`` is ``None`` when the listing
     is not truncated.
+
+    Args:
+        body: The raw ListObjectsV2 XML response.
+        key_prefix: The configured object-name prefix (e.g. ``'myprefix/'``).
+            S3 returns keys with this prefix attached; it is stripped before
+            decoding so the listing yields the original object names. Keys that
+            do not carry the prefix are treated as foreign and skipped.
 
     Raises:
         ValueError: the response body is not valid XML.
@@ -144,8 +152,14 @@ def _parse_list_response_xml(
         size_elem = contents.find("Size")
         if key_elem is None or key_elem.text is None:
             continue
+        name = key_elem.text
+        if key_prefix:
+            if not name.startswith(key_prefix):
+                # Outside this adapter's prefix namespace — foreign object.
+                continue
+            name = name[len(key_prefix) :]
         try:
-            obj_key = _string_to_object_key(key_elem.text)
+            obj_key = _string_to_object_key(name)
         except ValueError as exc:
             logger.debug(
                 "Skipping unparsable S3 object %r in listing: %s", key_elem.text, exc
@@ -191,9 +205,60 @@ def _object_key_to_string(key: ObjectKey) -> str:
     return base
 
 
-def _format_safe_path(key_str: str) -> str:
-    """URL-encode the object name to form a safe HTTP path."""
-    return "/" + url_quote(key_str)
+def _compute_s3_addressing(
+    endpoint: str, bucket: Optional[str], prefix: Optional[str]
+) -> tuple[str, str, str]:
+    """Resolve the S3 host, bucket path segment, and object-name prefix.
+
+    Two addressing styles are supported:
+
+    - **Virtual-hosted** (``bucket`` unset): the bucket is part of the host,
+      e.g. ``endpoint='s3://<bucket>.<host>'``. Requests target
+      ``Host: <bucket>.<host>`` with object path ``/<object>``.
+    - **Path-style** (``bucket`` set): the bucket is the first path segment,
+      e.g. ``endpoint='s3://<host>'`` with ``bucket='<bucket>'``. Requests
+      target ``Host: <host>`` with object path ``/<bucket>/<object>``. This is
+      required by most self-hosted / S3-compatible endpoints (MinIO, Dell ECS),
+      which cannot resolve a bucket folded into a custom host.
+
+    ``prefix`` (optional) nests every object under a sub-directory and applies
+    to both styles, so the object path becomes ``.../<prefix>/<object>``.
+
+    Args:
+        endpoint: The configured ``s3_endpoint`` (with or without the
+            ``s3://`` scheme).
+        bucket: Optional bucket name for path-style addressing.
+        prefix: Optional key prefix (sub-directory) for stored objects.
+
+    Returns:
+        ``(host, bucket_path, key_prefix)`` where ``host`` is the bare host for
+        the ``Host`` header, ``bucket_path`` is ``''`` or ``'/<bucket>'``
+        (URL-encoded, no trailing slash), and ``key_prefix`` is ``''`` or
+        ``'<prefix>/'`` (raw, trailing slash) to prepend to object names.
+    """
+    host = endpoint
+    if host.startswith("s3://"):
+        host = host[len("s3://") :]
+    host = host.rstrip("/")
+
+    bucket_path = ""
+    if bucket:
+        bucket_path = "/" + url_quote(bucket.strip("/"), safe="/")
+
+    key_prefix = ""
+    if prefix:
+        key_prefix = prefix.strip("/") + "/"
+
+    return host, bucket_path, key_prefix
+
+
+def _format_object_path(bucket_path: str, key_prefix: str, key_str: str) -> str:
+    """Build the request path for an object given addressing components.
+
+    The object name is URL-encoded; ``bucket_path`` and ``key_prefix`` slashes
+    are preserved so path-style and prefixed layouts stay valid.
+    """
+    return bucket_path + "/" + url_quote(key_prefix + key_str)
 
 
 def _make_credentials_provider(
@@ -312,11 +377,21 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
     """Config for the S3 L2 adapter.
 
     Fields:
-    - s3_endpoint (str, required): bucket URL using **virtual-hosted**
-      style; accepts either ``"s3://<bucket>.<host>"`` or the bare
-      ``"<bucket>.<host>"`` form. The bucket name must be part of the
-      host because requests are signed and routed against this Host
-      header (path-style addressing is not supported).
+    - s3_endpoint (str, required): bucket/host URL, with or without the
+      ``s3://`` scheme. Two addressing styles are supported:
+      * **Virtual-hosted** (default, ``s3_bucket`` unset): the bucket is
+        part of the host, e.g. ``"s3://<bucket>.<host>"``.
+      * **Path-style** (``s3_bucket`` set): the endpoint is the bare host,
+        e.g. ``"s3://<host>"``, and the bucket is sent as the first path
+        segment. Required by most self-hosted / S3-compatible endpoints
+        (MinIO, Dell ECS) that cannot resolve a bucket folded into a custom
+        host.
+    - s3_bucket (str, optional): bucket name for path-style addressing.
+      When set, requests target ``Host: <host>`` with path
+      ``/<bucket>/<object>``.
+    - s3_prefix (str, optional): key prefix (sub-directory) under which all
+      objects are stored, e.g. ``"lmcache"`` → ``.../<prefix>/<object>``.
+      Applies to both addressing styles.
     - s3_region (str, required): AWS region used for SigV4.
     - s3_num_io_threads (int): CRT IO threads.
     - s3_prefer_http2 (bool): ALPN negotiate to HTTP/2.
@@ -336,6 +411,8 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
         self,
         s3_endpoint: str,
         s3_region: str,
+        s3_bucket: Optional[str] = None,
+        s3_prefix: Optional[str] = None,
         s3_num_io_threads: int = 64,
         s3_prefer_http2: bool = True,
         s3_enable_s3express: bool = False,
@@ -345,6 +422,8 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
         max_capacity_gb: float = 0.0,
     ):
         self.s3_endpoint = s3_endpoint
+        self.s3_bucket = s3_bucket
+        self.s3_prefix = s3_prefix
         self.s3_region = s3_region
         self.s3_num_io_threads = s3_num_io_threads
         self.s3_prefer_http2 = s3_prefer_http2
@@ -389,6 +468,8 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
 
         cfg = cls(
             s3_endpoint=endpoint,
+            s3_bucket=_opt_str("s3_bucket"),
+            s3_prefix=_opt_str("s3_prefix"),
             s3_region=region,
             s3_num_io_threads=_int("s3_num_io_threads", 64),
             s3_prefer_http2=_bool("s3_prefer_http2", True),
@@ -405,8 +486,12 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
     def help(cls) -> str:
         return (
             "S3 L2 adapter config fields:\n"
-            "- s3_endpoint (str, required): virtual-hosted bucket URL "
-            "('s3://<bucket>.<host>' or '<bucket>.<host>')\n"
+            "- s3_endpoint (str, required): bucket/host URL. Virtual-hosted "
+            "('s3://<bucket>.<host>') by default, or the bare host "
+            "('s3://<host>') when s3_bucket is set for path-style addressing\n"
+            "- s3_bucket (str): bucket name for path-style addressing "
+            "(self-hosted S3 such as MinIO / Dell ECS)\n"
+            "- s3_prefix (str): key prefix (sub-directory) for stored objects\n"
             "- s3_region (str, required): AWS region for SigV4\n"
             "- s3_num_io_threads (int): CRT IO threads (default 64)\n"
             "- s3_prefer_http2 (bool): try HTTP/2 via ALPN (default true)\n"
@@ -449,10 +534,12 @@ class S3L2Adapter(L2AdapterInterface):
         super().__init__(max_capacity_bytes=int(config.max_capacity_gb * (1024**3)))
         self._config = config
 
-        endpoint = config.s3_endpoint
-        if endpoint.startswith("s3://"):
-            endpoint = endpoint[len("s3://") :]
-        self._endpoint = endpoint
+        # Resolve host / bucket-path / object-prefix for the configured
+        # addressing style (virtual-hosted by default, path-style when
+        # ``s3_bucket`` is set). See ``_compute_s3_addressing``.
+        self._endpoint, self._bucket_path, self._key_prefix = _compute_s3_addressing(
+            config.s3_endpoint, config.s3_bucket, config.s3_prefix
+        )
         self._region = config.s3_region
         self._enable_s3express = config.s3_enable_s3express
 
@@ -841,7 +928,7 @@ class S3L2Adapter(L2AdapterInterface):
                 headers.add(k, v)
         return HttpRequest(
             method,
-            _format_safe_path(key_str),
+            _format_object_path(self._bucket_path, self._key_prefix, key_str),
             headers,
             body_stream=body_stream,
         )
@@ -970,13 +1057,16 @@ class S3L2Adapter(L2AdapterInterface):
             ("list-type", "2"),
             ("max-keys", str(max_keys)),
         ]
-        if prefix:
-            params.append(("prefix", prefix))
+        # Restrict the listing to this adapter's object-name prefix so a
+        # shared/path-style bucket only returns our keys.
+        effective_prefix = self._key_prefix + (prefix or "")
+        if effective_prefix:
+            params.append(("prefix", effective_prefix))
         if continuation_token:
             params.append(("continuation-token", continuation_token))
         # urlencode handles percent-escaping of values (continuation
         # tokens are typically base64 with ``+``/``/``/``=`` chars).
-        path = "/?" + urlencode(params, quote_via=url_quote)
+        path = self._bucket_path + "/?" + urlencode(params, quote_via=url_quote)
 
         headers = HttpHeaders()
         headers.add("Host", self._endpoint)
@@ -1241,7 +1331,7 @@ class S3L2Adapter(L2AdapterInterface):
             prefix, max_keys, continuation_token
         )
         await asyncio.wrap_future(s3_req.finished_future)
-        return _parse_list_response_xml(b"".join(body_chunks))
+        return _parse_list_response_xml(b"".join(body_chunks), self._key_prefix)
 
     async def _execute_delete(
         self, keys: list[ObjectKey]

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -8,6 +8,7 @@ routes PUT/GET/HEAD/DELETE against a shared dict.  No network required.
 
 # Standard
 from concurrent.futures import Future as ConcurrentFuture
+from urllib.parse import quote as url_quote
 import select
 import threading
 import time
@@ -900,3 +901,130 @@ class TestS3L2AdapterListKeys:
             page.entries[0].key
             == create_object_key(0, model_name="m").to_encoded_object_key()
         )
+
+
+# =============================================================================
+# Addressing: virtual-hosted vs path-style + key prefix (issue #3344)
+# =============================================================================
+
+
+class TestS3Addressing:
+    def test_virtual_hosted_default(self) -> None:
+        host, bucket_path, key_prefix = s3mod._compute_s3_addressing(
+            "s3://my-bucket.s3.example.com", None, None
+        )
+        assert host == "my-bucket.s3.example.com"
+        assert bucket_path == ""
+        assert key_prefix == ""
+
+    def test_path_style_with_bucket(self) -> None:
+        host, bucket_path, key_prefix = s3mod._compute_s3_addressing(
+            "s3://minio.internal:9000", "my-bucket", None
+        )
+        assert host == "minio.internal:9000"
+        assert bucket_path == "/my-bucket"
+        assert key_prefix == ""
+
+    def test_prefix_is_normalized(self) -> None:
+        host, bucket_path, key_prefix = s3mod._compute_s3_addressing(
+            "s3://host", "bkt", "/lmcache/kv/"
+        )
+        assert host == "host"
+        assert bucket_path == "/bkt"
+        assert key_prefix == "lmcache/kv/"
+
+    def test_scheme_optional_and_trailing_slash_stripped(self) -> None:
+        host, _, _ = s3mod._compute_s3_addressing("host.example.com/", None, None)
+        assert host == "host.example.com"
+
+    def test_format_object_path_virtual_host_matches_legacy(self) -> None:
+        # No bucket/prefix: byte-identical to the previous "/" + quote(key).
+        assert s3mod._format_object_path("", "", "a@b@c@d") == "/a%40b%40c%40d"
+
+    def test_format_object_path_path_style_with_prefix(self) -> None:
+        path = s3mod._format_object_path("/bkt", "pre/", "a@b@c@d")
+        assert path == "/bkt/pre/a%40b%40c%40d"
+
+
+class TestS3ListPrefixStripping:
+    def test_parse_strips_key_prefix(self) -> None:
+        key = create_object_key(7)
+        name = _object_key_to_string(key)
+        xml = (
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            "<ListBucketResult>"
+            f"<Contents><Key>pre/{name}</Key><Size>123</Size></Contents>"
+            "</ListBucketResult>"
+        ).encode()
+        entries, token = s3mod._parse_list_response_xml(xml, "pre/")
+        assert token is None
+        assert len(entries) == 1
+        parsed_key, size = entries[0]
+        assert _object_key_to_string(parsed_key) == name
+        assert size == 123
+
+    def test_parse_skips_objects_outside_prefix(self) -> None:
+        key = create_object_key(7)
+        name = _object_key_to_string(key)
+        xml = (
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            "<ListBucketResult>"
+            f"<Contents><Key>{name}</Key><Size>123</Size></Contents>"
+            "</ListBucketResult>"
+        ).encode()
+        # The object lacks the configured prefix → foreign, skipped.
+        entries, _ = s3mod._parse_list_response_xml(xml, "pre/")
+        assert entries == []
+
+
+def _make_path_style_adapter() -> S3L2Adapter:
+    config = S3L2AdapterConfig(
+        s3_endpoint="s3://minio.internal:9000",
+        s3_bucket="kvbucket",
+        s3_prefix="lmcache",
+        s3_region="us-east-1",
+        s3_prefer_http2=False,
+        s3_num_io_threads=1,
+        max_capacity_gb=0.001,
+    )
+    return S3L2Adapter(config)
+
+
+class TestS3PathStyleRequests:
+    def test_make_request_uses_path_style_and_prefix(self) -> None:
+        adapter = _make_path_style_adapter()
+        try:
+            key_str = _object_key_to_string(create_object_key(1))
+            req = adapter._make_request("PUT", key_str)
+            assert req.path == f"/kvbucket/lmcache/{url_quote(key_str)}"
+            assert req.headers.get("Host") == "minio.internal:9000"
+        finally:
+            adapter.close()
+
+    def test_roundtrip_path_style_and_prefix(self) -> None:
+        # Store/lookup/load must round-trip with path-style + prefix keys.
+        adapter = _make_path_style_adapter()
+        try:
+            key = create_object_key(1)
+            obj = create_memory_obj(fill_value=2.5)
+
+            tid = adapter.submit_store_task([key], [obj])
+            assert wait_for_event_fd(adapter.get_store_event_fd())
+            assert adapter.pop_completed_store_tasks()[tid].is_successful()
+
+            # The object is stored under the bucket + prefix namespace.
+            assert _BACKEND.contains(f"kvbucket/lmcache/{_object_key_to_string(key)}")
+
+            tid = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
+            assert wait_for_event_fd(adapter.get_lookup_and_lock_event_fd())
+            bm = adapter.query_lookup_and_lock_result(tid)
+            assert bm is not None and bm.test(0) is True
+
+            dst = create_memory_obj(fill_value=0.0)
+            tid = adapter.submit_load_task([key], [dst])
+            assert wait_for_event_fd(adapter.get_load_event_fd())
+            bm = adapter.query_load_result(tid)
+            assert bm is not None and bm.test(0) is True
+            assert torch.allclose(dst.tensor, torch.full((16,), 2.5))
+        finally:
+            adapter.close()


### PR DESCRIPTION
## Summary

Fixes #3344.

The S3 L2 adapter (`s3_l2_adapter.py`) only supported **virtual-hosted** addressing — the bucket had to be folded into the host (`s3://<bucket>.<host>`), and object requests went to `Host: <bucket>.<host>` with path `/<object>`. Self-hosted / S3-compatible endpoints such as **Dell ECS** and **MinIO** expose a bare host and require the bucket as the first path segment, so they could not be used as an L2 backend. There was also no way to store objects under a sub-directory of a shared bucket (the issue also asked for a prefix).

## Changes

Two optional config fields on `S3L2AdapterConfig`:

- **`s3_bucket`** — when set, switches to **path-style** addressing: requests target `Host: <host>` (from `s3_endpoint`) with object path `/<bucket>/<object>`.
- **`s3_prefix`** — nests all objects under a sub-directory (`/<prefix>/<object>`), in either addressing style.

Implementation:
- A pure helper `_compute_s3_addressing(endpoint, bucket, prefix) -> (host, bucket_path, key_prefix)` centralizes resolution; `_format_object_path()` builds object paths.
- `_make_request` (HEAD/GET/PUT/DELETE) uses the resolved bucket path + key prefix.
- `ListObjectsV2` prepends the bucket path and folds the key prefix into the `prefix=` filter; `_parse_list_response_xml` strips the prefix before decoding object names (non-prefixed/foreign objects are skipped).
- **Default behavior (virtual-hosted, no prefix) is byte-for-byte unchanged** — `_format_object_path("", "", key) == "/" + quote(key)`.

Updated the L2 design doc (`docs/design/v1/multiprocess/l2_apis.md`) with an addressing section and the renamed helper.

## Tests

- `TestS3Addressing` — virtual-hosted vs path-style, prefix normalization, scheme/trailing-slash handling, and legacy-equivalence of `_format_object_path`.
- `TestS3ListPrefixStripping` — list parser strips the configured prefix and skips foreign objects.
- `TestS3PathStyleRequests` — `_make_request` produces `/<bucket>/<prefix>/<obj>` with `Host: <host>`, plus a path-style + prefix **store → lookup → load** round-trip through the in-memory fake backend.

Verified locally: `ruff check`, `ruff format --check`, `isort --check-only`, `codespell` clean; the addressing/`_format_object_path` logic was exercised standalone (awscrt/torch aren't installed locally, so the pytest suite runs in CI).