### PR TITLE
[Bugfix][Examples] drop EngineArgs+asdict in rust_backend_offload and blend (#3438)

### DIFF
--- a/examples/blend_kv_v1/blend.py
+++ b/examples/blend_kv_v1/blend.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from dataclasses import asdict
 import argparse
 import contextlib
 import os
@@ -10,7 +9,6 @@ import time
 from transformers import AutoTokenizer
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
-from vllm.engine.arg_utils import EngineArgs
 
 # First Party
 from lmcache.integration.vllm.utils import ENGINE_NAME
@@ -65,7 +63,12 @@ def build_llm_with_lmcache(lmcache_connector: str, model: str):
         kv_role="kv_both",
     )
 
-    llm_args = EngineArgs(
+    # Pass kwargs directly to LLM() instead of routing through
+    # EngineArgs + asdict(). asdict() emits None for every unset EngineArgs
+    # field, and vLLM >= 0.20 / pydantic v2 rejects None for
+    # CompilationConfig fields like cudagraph_capture_sizes (list) and
+    # pass_config.fuse_minimax_qk_norm (bool). See issue #3438.
+    llm = LLM(
         model=model,
         kv_transfer_config=ktc,
         max_model_len=32648,
@@ -73,8 +76,6 @@ def build_llm_with_lmcache(lmcache_connector: str, model: str):
         enable_prefix_caching=False,
         enforce_eager=True,
     )
-
-    llm = LLM(**asdict(llm_args))
     try:
         yield llm
     finally:

--- a/examples/kv_cache_reuse/local_backends/rust_backend_offload.py
+++ b/examples/kv_cache_reuse/local_backends/rust_backend_offload.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from dataclasses import asdict
 import argparse
 import contextlib
 import json
@@ -11,7 +10,6 @@ import time
 # Third Party
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
-from vllm.engine.arg_utils import EngineArgs
 
 # First Party
 from lmcache.integration.vllm.utils import ENGINE_NAME
@@ -76,13 +74,18 @@ def build_llm_with_lmcache(lmcache_connector: str, model: str):
     )
     # Set GPU memory utilization to 0.5 for an A100 GPU with 40GB
     # memory. Update it accordingly for different GPU.
-    llm_args = EngineArgs(
+    #
+    # Pass kwargs directly to LLM() instead of routing through
+    # EngineArgs + asdict(). asdict() emits None for every unset EngineArgs
+    # field, and vLLM >= 0.20 / pydantic v2 rejects None for
+    # CompilationConfig fields like cudagraph_capture_sizes (list) and
+    # pass_config.fuse_minimax_qk_norm (bool). See issue #3438.
+    llm = LLM(
         model=model,
         kv_transfer_config=ktc,
         max_model_len=8000,
         gpu_memory_utilization=0.5,
     )
-    llm = LLM(**asdict(llm_args))
     try:
         yield llm
     finally:


### PR DESCRIPTION
## Summary

Follow-up to #3438 / #3441.

`examples/kv_cache_reuse/local_backends/offload.py` was fixed in #3441, but two sibling examples still build the LLM via `LLM(**asdict(EngineArgs(...)))`:

- `examples/kv_cache_reuse/local_backends/rust_backend_offload.py`
- `examples/blend_kv_v1/blend.py`

`dataclasses.asdict()` emits `None` for every unset `EngineArgs` field, and vLLM ≥ 0.20.1 (pydantic v2, strict validation) rejects `None` for `CompilationConfig` fields such as `cudagraph_capture_sizes` (expects `list`) and `pass_config.fuse_minimax_qk_norm` (expects `bool`). So both examples crash with a pydantic validation error on current vLLM.

## Fix

Pass the explicitly-set kwargs directly to `LLM()` (matching the convention #3441 established in `offload.py`) and drop the now-unused `EngineArgs` / `asdict` imports. No behavior change beyond not forwarding spurious `None`s.

Verified locally: `ruff check`, `ruff format --check`, `isort --check-only`, `codespell` clean on both files.