### PR TITLE
[Refactor][CLI] share one HTTP helper across client commands (#3868)

### DIFF
--- a/docs/design/cli/framework-and-metrics.md
+++ b/docs/design/cli/framework-and-metrics.md
@@ -379,3 +379,26 @@ flag as needed.
 
 Commands print errors to stderr and return exit code 1. The dispatcher catches
 exceptions from `args.func(args)` and prints a clean error message.
+
+### Shared HTTP helper (`lmcache/cli/http.py`)
+
+Client commands that talk to an LMCache-side HTTP server share one module
+instead of each re-implementing the same `urllib` boilerplate (which had
+drifted across commands and coupled `ping` to `describe`). It provides:
+
+- `normalize_url(url)` — add an `http://` scheme if missing and strip trailing
+  slashes. (`describe` and `quota._helpers` re-export it for backward
+  compatibility.)
+- `DEFAULT_URLS` — default base URLs keyed by target (`kvcache`, `engine`).
+- `request_json(method, url, *, data=None, timeout=10.0)` — send a request with
+  an optional JSON body and return the parsed JSON response.
+- `CliHttpError` — raised by `request_json` on any HTTP/connection failure,
+  carrying `status` (`None` for connection-level errors), `reason`, and the
+  decoded error `body`.
+
+Each command keeps its own *presentation* of failures (e.g. `describe` raises
+`DescribeError`; `kvcache`/`quota` log and `sys.exit(1)`) by catching
+`CliHttpError` and mapping it; only the transport is shared. `ping` keeps its
+own status-based (non-JSON) probe but uses the shared `normalize_url` /
+`DEFAULT_URLS`. The bench `_normalize_url` (which also appends `/v1`) is left
+separate by design.

--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -10,11 +10,13 @@ Usage::
 import argparse
 import json
 import sys
-import urllib.error
-import urllib.request
 
 # First Party
 from lmcache.cli.commands.base import BaseCommand
+
+# ``normalize_url`` is imported (and thus still importable from this module
+# for backward compatibility); it now lives in the shared CLI HTTP module.
+from lmcache.cli.http import CliHttpError, normalize_url, request_json
 from lmcache.cli.metrics import Metrics
 
 # -------------------------------------------------------------------
@@ -26,36 +28,24 @@ class DescribeError(Exception):
     """Raised when the describe command cannot fetch or parse status data."""
 
 
-def normalize_url(url: str) -> str:
-    """Ensure *url* has an ``http://`` or ``https://`` scheme."""
-    if not url.startswith(("http://", "https://")):
-        url = f"http://{url}"
-    return url.rstrip("/")
-
-
 def fetch_json(url: str, timeout: int = 10) -> dict:
     """GET *url* and return the parsed JSON body.
 
     Raises:
         DescribeError: On network/HTTP errors.
     """
-    req = urllib.request.Request(url)
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as exc:
-        if exc.code == 503:
-            body = exc.read().decode()
+        return request_json("GET", url, timeout=timeout)
+    except CliHttpError as exc:
+        if exc.status == 503 and exc.body is not None:
             try:
-                detail = json.loads(body).get("error", body)
+                detail = json.loads(exc.body).get("error", exc.body)
             except (json.JSONDecodeError, AttributeError):
-                detail = body
+                detail = exc.body
             raise DescribeError(f"Server unhealthy: {detail}") from exc
-        raise DescribeError(f"HTTP {exc.code} from {url}: {exc.reason}") from exc
-    except urllib.error.URLError as exc:
+        if exc.status is not None:
+            raise DescribeError(f"HTTP {exc.status} from {url}: {exc.reason}") from exc
         raise DescribeError(f"Cannot connect to {url}: {exc.reason}") from exc
-    except OSError as exc:
-        raise DescribeError(f"Cannot connect to {url}: {exc}") from exc
 
 
 def fmt_bytes(n: int) -> str:

--- a/lmcache/cli/commands/kvcache.py
+++ b/lmcache/cli/commands/kvcache.py
@@ -10,11 +10,10 @@ from typing import Any, Optional
 import argparse
 import json
 import sys
-import urllib.error
-import urllib.request
 
 # First Party
 from lmcache.cli.commands.base import BaseCommand
+from lmcache.cli.http import CliHttpError, request_json
 from lmcache.logging import init_logger
 
 logger = init_logger(__name__)
@@ -36,26 +35,20 @@ def _http_request(
     Raises:
         SystemExit: On connection error or non-2xx HTTP response.
     """
-    body = None
-    headers: dict[str, str] = {}
-    if data is not None:
-        body = json.dumps(data).encode()
-        headers["Content-Type"] = "application/json"
-
-    req = urllib.request.Request(url, data=body, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as e:
-        try:
-            error_body = json.loads(e.read().decode())
-            msg = error_body.get("message") or error_body.get("error") or str(e)
-        except (json.JSONDecodeError, ValueError, OSError):
-            msg = str(e)
-        logger.error("Server error: %s", msg)
-        sys.exit(1)
-    except urllib.error.URLError as e:
-        logger.error("Cannot reach %s — is the server running? (%s)", url, e.reason)
+        return request_json(method, url, data=data, timeout=10)
+    except CliHttpError as exc:
+        if exc.status is not None:
+            msg = f"HTTP Error {exc.status}: {exc.reason}"
+            if exc.body is not None:
+                try:
+                    error_body = json.loads(exc.body)
+                    msg = error_body.get("message") or error_body.get("error") or msg
+                except (json.JSONDecodeError, ValueError, OSError):
+                    pass
+            logger.error("Server error: %s", msg)
+            sys.exit(1)
+        logger.error("Cannot reach %s — is the server running? (%s)", url, exc.reason)
         sys.exit(1)
 
 

--- a/lmcache/cli/commands/ping.py
+++ b/lmcache/cli/commands/ping.py
@@ -16,7 +16,7 @@ import urllib.request
 
 # First Party
 from lmcache.cli.commands.base import BaseCommand
-from lmcache.cli.commands.describe import normalize_url
+from lmcache.cli.http import DEFAULT_URLS, normalize_url
 
 # -------------------------------------------------------------------
 # Constants
@@ -25,11 +25,6 @@ from lmcache.cli.commands.describe import normalize_url
 HEALTH_ENDPOINTS: dict[str, str] = {
     "kvcache": "/healthcheck",
     "engine": "/health",
-}
-
-DEFAULT_URLS: dict[str, str] = {
-    "kvcache": "http://localhost:8080",
-    "engine": "http://localhost:8000",
 }
 
 TITLES: dict[str, str] = {

--- a/lmcache/cli/commands/quota/_helpers.py
+++ b/lmcache/cli/commands/quota/_helpers.py
@@ -5,24 +5,26 @@
 from typing import Any, Optional
 import json
 import sys
-import urllib.error
-import urllib.request
 
 # First Party
+# ``normalize_url`` is imported (and thus still importable from this module
+# for backward compatibility); it now lives in the shared CLI HTTP module.
+from lmcache.cli.http import CliHttpError, normalize_url, request_json
 from lmcache.logging import init_logger
 
 logger = init_logger(__name__)
 
+__all__ = [
+    "DEFAULT_SALT_SENTINEL",
+    "escape_salt",
+    "http_request",
+    "normalize_url",
+    "unescape_salt",
+]
+
 # The MP HTTP server uses "_default" as a sentinel for the empty-string
 # cache_salt (anonymous / un-salted traffic).
 DEFAULT_SALT_SENTINEL = "_default"
-
-
-def normalize_url(url: str) -> str:
-    """Ensure *url* has an ``http://`` or ``https://`` scheme."""
-    if not url.startswith(("http://", "https://")):
-        url = f"http://{url}"
-    return url.rstrip("/")
 
 
 def escape_salt(salt: str) -> str:
@@ -55,24 +57,18 @@ def http_request(
     Raises:
         SystemExit: On connection error or non-2xx HTTP response.
     """
-    body = None
-    headers: dict[str, str] = {}
-    if data is not None:
-        body = json.dumps(data).encode()
-        headers["Content-Type"] = "application/json"
-
-    req = urllib.request.Request(url, data=body, headers=headers, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as e:
-        try:
-            error_body = json.loads(e.read().decode())
-            msg = error_body.get("error") or error_body.get("message") or str(e)
-        except (json.JSONDecodeError, ValueError, OSError):
-            msg = str(e)
-        logger.error("Server error: %s", msg)
-        sys.exit(1)
-    except urllib.error.URLError as e:
-        logger.error("Cannot reach %s — is the server running? (%s)", url, e.reason)
+        return request_json(method, url, data=data, timeout=timeout)
+    except CliHttpError as exc:
+        if exc.status is not None:
+            msg = f"HTTP Error {exc.status}: {exc.reason}"
+            if exc.body is not None:
+                try:
+                    error_body = json.loads(exc.body)
+                    msg = error_body.get("error") or error_body.get("message") or msg
+                except (json.JSONDecodeError, ValueError, OSError):
+                    pass
+            logger.error("Server error: %s", msg)
+            sys.exit(1)
+        logger.error("Cannot reach %s — is the server running? (%s)", url, exc.reason)
         sys.exit(1)

--- a/lmcache/cli/http.py
+++ b/lmcache/cli/http.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared HTTP helpers for the ``lmcache`` CLI client commands.
+
+Centralizes URL normalization, the default server URLs, and a small
+JSON-over-HTTP request helper so individual commands don't re-implement (and
+drift on) the same ``urllib`` boilerplate. See issue #3868.
+"""
+
+# Standard
+from typing import Any, Optional
+import json
+import urllib.error
+import urllib.request
+
+# Default base URLs for the LMCache-side servers, keyed by CLI target.
+DEFAULT_URLS: dict[str, str] = {
+    "kvcache": "http://localhost:8080",
+    "engine": "http://localhost:8000",
+}
+
+
+def normalize_url(url: str) -> str:
+    """Ensure *url* has an ``http://`` or ``https://`` scheme.
+
+    Args:
+        url: A bare ``host[:port]`` or a full URL.
+
+    Returns:
+        The URL with a scheme and no trailing slashes.
+    """
+    if not url.startswith(("http://", "https://")):
+        url = f"http://{url}"
+    return url.rstrip("/")
+
+
+class CliHttpError(Exception):
+    """Raised by :func:`request_json` on any HTTP or connection failure.
+
+    Carries the structured failure details so each command can render its own
+    user-facing message and exit behavior.
+
+    Attributes:
+        url: The request URL.
+        status: The HTTP status code for an error response, or ``None`` for a
+            connection-level failure (DNS, connection refused, timeout).
+        reason: The HTTP reason phrase, or the connection error description.
+        body: The decoded error response body for HTTP errors, else ``None``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        url: str,
+        status: Optional[int] = None,
+        reason: str = "",
+        body: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.url = url
+        self.status = status
+        self.reason = reason
+        self.body = body
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    data: Optional[dict[str, Any]] = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Send an HTTP request with an optional JSON body and parse the response.
+
+    Args:
+        method: HTTP method (``GET``, ``POST``, ``PUT``, ``DELETE``).
+        url: Full request URL.
+        data: Optional object serialized as a JSON request body. When set, a
+            ``Content-Type: application/json`` header is added.
+        timeout: Socket timeout in seconds.
+
+    Returns:
+        The parsed JSON response object.
+
+    Raises:
+        CliHttpError: On any HTTP error status or connection-level failure.
+    """
+    body: Optional[bytes] = None
+    headers: dict[str, str] = {}
+    if data is not None:
+        body = json.dumps(data).encode()
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            err_body: Optional[str] = exc.read().decode()
+        except OSError:
+            err_body = None
+        raise CliHttpError(
+            f"HTTP {exc.code} from {url}: {exc.reason}",
+            url=url,
+            status=exc.code,
+            reason=str(exc.reason),
+            body=err_body,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise CliHttpError(
+            f"Cannot connect to {url}: {exc.reason}",
+            url=url,
+            reason=str(exc.reason),
+        ) from exc
+    except OSError as exc:
+        raise CliHttpError(
+            f"Cannot connect to {url}: {exc}",
+            url=url,
+            reason=str(exc),
+        ) from exc

--- a/tests/cli/test_http.py
+++ b/tests/cli/test_http.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the shared CLI HTTP helpers (issue #3868)."""
+
+# Standard
+from io import BytesIO
+import urllib.error
+import urllib.request
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.describe import normalize_url as describe_normalize_url
+from lmcache.cli.commands.ping import DEFAULT_URLS as ping_default_urls
+from lmcache.cli.commands.quota._helpers import normalize_url as quota_normalize_url
+from lmcache.cli.http import (
+    DEFAULT_URLS,
+    CliHttpError,
+    normalize_url,
+    request_json,
+)
+
+
+class _FakeResponse:
+    """Minimal context-manager response with a ``read()`` body."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class TestNormalizeUrl:
+    def test_adds_scheme(self) -> None:
+        assert normalize_url("localhost:8080") == "http://localhost:8080"
+
+    def test_keeps_scheme_and_strips_trailing_slashes(self) -> None:
+        assert normalize_url("https://host:443///") == "https://host:443"
+
+
+class TestDefaultUrls:
+    def test_targets(self) -> None:
+        assert DEFAULT_URLS["kvcache"] == "http://localhost:8080"
+        assert DEFAULT_URLS["engine"] == "http://localhost:8000"
+
+
+class TestRequestJson:
+    def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            urllib.request,
+            "urlopen",
+            lambda req, timeout=None: _FakeResponse(b'{"ok": true}'),
+        )
+        assert request_json("GET", "http://x/status") == {"ok": True}
+
+    def test_sets_json_body_and_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+
+        def _fake(req: urllib.request.Request, timeout: object = None) -> _FakeResponse:
+            captured["data"] = req.data
+            captured["ctype"] = req.get_header("Content-type")
+            captured["method"] = req.get_method()
+            return _FakeResponse(b"{}")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _fake)
+        request_json("POST", "http://x", data={"a": 1})
+        assert captured["data"] == b'{"a": 1}'
+        assert captured["ctype"] == "application/json"
+        assert captured["method"] == "POST"
+
+    def test_http_error_maps_to_clihttperror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(req: object, timeout: object = None) -> _FakeResponse:
+            raise urllib.error.HTTPError(
+                "http://x",
+                503,
+                "Service Unavailable",
+                {},  # type: ignore[arg-type]
+                BytesIO(b'{"error": "down"}'),
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", _raise)
+        with pytest.raises(CliHttpError) as ei:
+            request_json("GET", "http://x")
+        exc = ei.value
+        assert exc.status == 503
+        assert exc.reason == "Service Unavailable"
+        assert exc.body == '{"error": "down"}'
+
+    def test_connection_error_maps_to_clihttperror(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(req: object, timeout: object = None) -> _FakeResponse:
+            raise urllib.error.URLError("refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _raise)
+        with pytest.raises(CliHttpError) as ei:
+            request_json("GET", "http://x")
+        exc = ei.value
+        assert exc.status is None
+        assert "refused" in exc.reason
+
+
+class TestBackwardCompatReexports:
+    """The shared helpers must still be importable from their old homes."""
+
+    def test_describe_reexports_normalize_url(self) -> None:
+        assert describe_normalize_url is normalize_url
+
+    def test_quota_helpers_reexports_normalize_url(self) -> None:
+        assert quota_normalize_url is normalize_url
+
+    def test_ping_uses_shared_default_urls(self) -> None:
+        assert ping_default_urls is DEFAULT_URLS


### PR DESCRIPTION
## Summary

Fixes #3868.

The CLI client commands each re-implemented the same `urllib` boilerplate to talk to an LMCache-side HTTP server (URL normalization, `Request` + `urlopen`, JSON decode, error handling). The logic had drifted across commands, and `ping` imported `normalize_url` out of `describe` — coupling one command to another.

## Changes

New module **`lmcache/cli/http.py`**:
- `normalize_url(url)` — add an `http://` scheme if missing, strip trailing slashes.
- `DEFAULT_URLS` — default base URLs keyed by target (`kvcache`, `engine`).
- `request_json(method, url, *, data=None, timeout=10.0)` — JSON-over-HTTP transport.
- `CliHttpError` — structured failure (`status`, `reason`, `body`) raised by `request_json`.

Migrated `describe`, `ping`, `kvcache`, and `quota/_helpers` onto it. **Each command keeps its exact user-facing behavior** by catching `CliHttpError` and mapping it:
- `describe.fetch_json` still raises `DescribeError`, including the 503 `Server unhealthy: …` special case and the same connection/HTTP messages.
- `kvcache._http_request` / `quota.http_request` still `logger.error(...)` + `sys.exit(1)`, preserving their (different) error-key precedence and the `str(HTTPError)` fallback string.
- `ping` keeps its own status-based (non-JSON) probe + rtt timing, but now uses the shared `normalize_url`/`DEFAULT_URLS` — removing the `ping → describe` import.

`normalize_url` is re-exported from `describe` and `quota._helpers` for backward compatibility (existing imports and tests keep working). The bench `_normalize_url` (which also appends `/v1`) is intentionally left separate.

## Tests

`tests/cli/test_http.py`: `normalize_url`, `request_json` (success, JSON body/header/method, HTTP-error → `CliHttpError`, connection-error → `CliHttpError`), and the back-compat re-exports.

Also documented the helper in `docs/design/cli/framework-and-metrics.md`.

Verified locally: `ruff check` / `ruff format --check` / `isort` / `codespell` clean. Because `http.py` is stdlib-only, I exercised `request_json`, `describe.fetch_json` error mapping, and the `kvcache`/`quota` exit + precedence behavior directly to confirm byte-identical messages (full pytest runs in CI).