### PR TITLE
NIXL: Add NIXL INFINIA plugin for OBJ

### DIFF
--- a/docs/source/kv_cache/storage_backends/nixl.rst
+++ b/docs/source/kv_cache/storage_backends/nixl.rst
@@ -49,7 +49,7 @@ Key settings:
 
 - ``nixl_path``: directory (or list of directories) under which the storage files will be saved (e.g. /mnt/nixl/). Needed for NIXL backends that store to file. When using a list of paths with ``path_sharding``, paths will be selected based on the sharding strategy.
 
-- ``nixl_buffer_device``: dictates where the memory managed by NIXL should be on. "cpu" or "cuda" is supported for "GDS", "GDS_MT", and "OBJ" backends - for "POSIX", "HF3FS", "AZURE_BLOB" & "DOCA_MEMOS", must be "cpu". In CPU mode, NIXL shares ``LocalCPUBackend``'s pinned buffer; ``LocalCPUBackend`` is always created when ``nixl_buffer_device: cpu``, regardless of the ``local_cpu`` setting. ``local_cpu: false`` still suppresses hot-cache promotions — the backend acts as a staging buffer only, mirroring how ``local_disk`` already uses ``LocalCPUBackend``.
+- ``nixl_buffer_device``: dictates where the memory managed by NIXL should be on. "cpu" or "cuda" is supported for "GDS", "GDS_MT", "OBJ" and "INFINIA" backends - for "POSIX", "HF3FS", "AZURE_BLOB" & "DOCA_MEMOS", must be "cpu". In CPU mode, NIXL shares ``LocalCPUBackend``'s pinned buffer; ``LocalCPUBackend`` is always created when ``nixl_buffer_device: cpu``, regardless of the ``local_cpu`` setting. ``local_cpu: false`` still suppresses hot-cache promotions — the backend acts as a staging buffer only, mirroring how ``local_disk`` already uses ``LocalCPUBackend``.
 
 - ``nixl_backend``: configuration of which nixl backend to use for storage.
 
@@ -74,7 +74,7 @@ Key settings:
 
 .. note::
 
-    Supported backends are: ["GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ", "AZURE_BLOB", "DOCA_MEMOS"].
+    Supported backends are: ["GDS", "GDS_MT", "POSIX", "HF3FS", "OBJ", "AZURE_BLOB", "DOCA_MEMOS", "INFINIA"].
 
     Backend specific params should be provided via ``extra_config.nixl_backend_params``. Please refer to NIXL documentation for specifics.
 
@@ -150,6 +150,24 @@ Example ``lmcache-config.yaml`` for AZURE_BLOB backend to offload using Azure Bl
         account_url: https://<your_azure_storage_account_name>.blob.core.windows.net
         container_name: <your_container_name>
 
+Example ``lmcache-config.yaml`` for INFINIA backend to offload using DDN's Infinia Storage API:
+
+.. code-block:: yaml
+
+    chunk_size: 256
+    nixl_buffer_device: cpu
+    max_local_cpu_size: 1  # GiB
+    extra_config:
+      enable_nixl_storage: true
+      nixl_backend: AZURE_BLOB
+      nixl_pool_size: 64
+      nixl_path: /mnt/nixl/cache/
+      nixl_backend_params:
+        cluster: <your_cluster_name>
+        tenant: <your_tenant_name>
+        subtenant: <your_subtenant_name>
+        dataset: <your_dataset_name>
+
 Per-Worker Endpoint Distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -194,7 +212,7 @@ In order to use dynamic mode, extra_config.nixl_pool_size should be set to 0.
 Restrictions
 ^^^^^^^^^^^^
 
-- Dynamic mode is supported for object backends ("OBJ", "AZURE_BLOB", "DOCA_MEMOS") and file backends ("POSIX", "GDS", "GDS_MT", "HF3FS").
+- Dynamic mode is supported for object backends ("OBJ", "AZURE_BLOB", "DOCA_MEMOS", "INFINIA") and file backends ("POSIX", "GDS", "GDS_MT", "HF3FS").
 - save_unfull_chunk must be set to False.
 
 Example ``lmcache-config.yaml`` for OBJ backend with dynamic mode:
@@ -268,3 +286,22 @@ model/chunk debug information) and uniqueness is probabilistic at 128 bits.
       nixl_pool_size: 64
       nixl_backend_params:
         # refer to NIXL DOCA_MEMOS plugin docs for connection params
+
+Example ``lmcache-config.yaml`` for INFINIA backend to offload using DDN's Infinia Storage API:
+
+.. code-block:: yaml
+
+    chunk_size: 256
+    nixl_buffer_device: cpu
+    max_local_cpu_size: 1  # GiB
+    extra_config:
+      enable_nixl_storage: true
+      nixl_backend: AZURE_BLOB
+      nixl_pool_size: 0
+      nixl_path: /mnt/nixl/cache/
+      nixl_backend_params:
+        cluster: <your_cluster_name>
+        tenant: <your_tenant_name>
+        subtenant: <your_subtenant_name>
+        dataset: <your_dataset_name>
+

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -121,7 +121,7 @@ class NixlStorageConfig:
     @staticmethod
     def validate_nixl_backend(backend: str, device: str) -> bool:
         device = device.split(":", 1)[0]
-        if backend in ("GDS", "GDS_MT", "OBJ"):
+        if backend in ("GDS", "GDS_MT", "OBJ", "INFINIA"):
             return device == "cpu" or device == "cuda"
         elif backend in ("POSIX", "HF3FS", "AZURE_BLOB", "DOCA_MEMOS"):
             return device == "cpu"
@@ -475,12 +475,16 @@ class NixlStorageAgent(ABC):
         self.init_mem_handlers(device, buffer_ptr, buffer_size, page_size, device_id)
 
     def init_mem_handlers(self, device, buffer_ptr, buffer_size, page_size, device_id):
-        # Break the registration into page size chunks to ensure the maximum buffer size
-        # of the underlying plugin is not exceeded
-        reg_list = [
-            (base_addr, page_size, device_id, "")
-            for base_addr in range(buffer_ptr, buffer_ptr + buffer_size, page_size)
-        ]
+        if self.backend != "INFINIA":
+            # Break the registration into page size chunks to ensure the maximum buffer size
+            # of the underlying plugin is not exceeded
+            reg_list = [
+                (base_addr, page_size, device_id, "")
+                for base_addr in range(buffer_ptr, buffer_ptr + buffer_size, page_size)
+            ]
+        else:
+            # register the whole memory by one registerMem call for INFINIA
+            reg_list = [(buffer_ptr, buffer_size, device_id, "")]
         xfer_desc = [
             (base_addr, page_size, device_id)
             for base_addr in range(buffer_ptr, buffer_ptr + buffer_size, page_size)
@@ -641,7 +645,7 @@ class NixlDynamicStorageAgent(NixlStorageAgent):
             allocator, device, backend, backend_params, enable_prog_thread, sync_mode
         )
 
-        if backend in ("OBJ", "AZURE_BLOB", "DOCA_MEMOS"):
+        if backend in ("OBJ", "AZURE_BLOB", "DOCA_MEMOS", "INFINIA"):
             self.mem_type = "OBJ"
         else:
             self.mem_type = "FILE"
@@ -1068,7 +1072,7 @@ class NixlStaticStorageBackend(NixlStorageBackend):
                 create_dirs=True,
             )
             return NixlFilePool(size, sharder, use_direct_io)
-        elif backend in ("OBJ", "AZURE_BLOB", "DOCA_MEMOS"):
+        elif backend in ("OBJ", "AZURE_BLOB", "DOCA_MEMOS", "INFINIA"):
             return NixlObjectPool(size, b128=(backend == "DOCA_MEMOS"))
         else:
             raise ValueError(f"Unsupported NIXL backend: {backend}")

--- a/lmcache/v1/storage_backend/nixl_storage_backend.py
+++ b/lmcache/v1/storage_backend/nixl_storage_backend.py
@@ -476,8 +476,8 @@ class NixlStorageAgent(ABC):
 
     def init_mem_handlers(self, device, buffer_ptr, buffer_size, page_size, device_id):
         if self.backend != "INFINIA":
-            # Break the registration into page size chunks to ensure the maximum buffer size
-            # of the underlying plugin is not exceeded
+            # Break the registration into page size chunks to ensure the
+            # maximum buffer size of the underlying plugin is not exceeded
             reg_list = [
                 (base_addr, page_size, device_id, "")
                 for base_addr in range(buffer_ptr, buffer_ptr + buffer_size, page_size)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR helps to enable the Infinia NIXL plugin for the object storage. This plugin was added since NIXL 1.3.0

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
