### PR TITLE
docs: daily drift check — multi-process mode (2026-06-26)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -205,10 +205,13 @@ Source: ``lmcache/v1/distributed/config.py``
      - Enable or disable lazy allocation for L1 memory.
        Pass ``--l1-use-lazy`` to enable (default) or
        ``--no-l1-use-lazy`` to explicitly disable.
-       Lazy allocation relies on ``cudart`` host-pinned memory, so on
-       non-CUDA backends (where ``lmcache.torch_dev`` exposes no
-       ``cudart`` attribute) it is automatically downgraded to eager
-       allocation with a logged warning, regardless of the flag value.
+       Lazy allocation requires host-memory pinning, which is provided per
+       platform by the ``DeviceExt`` backend attached to ``torch_dev`` (CUDA
+       uses ``cudaHostRegister`` via the torch ``cudart`` binding, with a
+       ``libcudart`` ``ctypes`` fallback). On backends where
+       ``torch_dev.ext.is_pin_supported`` is ``False`` it is automatically
+       downgraded to eager allocation with a logged warning, regardless of
+       the flag value.
    * - ``--l1-init-size-gb``
      - ``20``
      - Initial allocation size (GB) when using lazy allocation.


### PR DESCRIPTION
## Summary

Daily docs drift check on the multi-process surface. **One** new user-facing inconsistency found in `docs/source/`; nothing new in `docs/design/` beyond what is already pending review in the earlier drift-check PRs (#3879, #3863, #3840, #3817, #3774).

### `docs/source/` (user-facing — highest priority)

- **`docs/source/mp/configuration.rst`** — In the L1 configuration table, the `--l1-use-lazy` / `--no-l1-use-lazy` row still describes the auto-fallback in terms of the *old* detection mechanism:

  > Lazy allocation relies on ``cudart`` host-pinned memory, so on non-CUDA backends (where ``lmcache.torch_dev`` exposes no ``cudart`` attribute) it is automatically downgraded to eager allocation with a logged warning, regardless of the flag value.

  After [#3823](https://github.com/LMCache/LMCache/pull/3823) (`dc6df96`, landed 2026-06-26 — *refactor(platform): abstract pin memory behind DeviceExt and pin SHM for async D2H*), host-memory pinning is now provided per platform by a `PinMemoryBackend` attached as `torch_dev.ext` (`DeviceExt`). The fallback decision in `lmcache/v1/distributed/config.py` is gated on `torch_dev.ext.is_pin_supported`, not on a `cudart` attribute lookup, and the warning text no longer mentions `cudart`.

### `docs/design/`

No new drift on `docs/design/` beyond items already proposed in the open drift-check PRs:

- `raw_cuda_ipc.md` updates (`CudaIPCWrapper` → `DeviceIPCWrapper`, `custom_types.py` → `platform/cuda/ipc_wrapper.py`, `MPCacheServer` → `LMCacheDrivenTransferModule`) are queued in #3863 and #3840.
- The `ARCHITECTURE_MULTI_HARDWARE.md` diagram still annotates the memory-allocator layer with `.cudart() (hasattr)`, which is technically stale after #3823 (the allocators now go through `torch_dev.ext.pin_memory()` instead of probing `torch_dev.cudart()` directly). It was **intentionally left out of this PR** because: (1) the change requires reshaping an ASCII diagram on a high-level overview doc, and (2) the underlying CUDA implementation in `lmcache/v1/platform/cuda/pin_memory.py` still calls `torch.cuda.cudart()`, so the listing is misleading-by-omission rather than outright wrong. Flagging here so it can be picked up in a follow-up.

## Evidence

| Doc claim (current) | Code reality | Reference |
| --- | --- | --- |
| `docs/source/mp/configuration.rst:208-211` — "Lazy allocation relies on ``cudart`` host-pinned memory, so on non-CUDA backends (where ``lmcache.torch_dev`` exposes no ``cudart`` attribute) it is automatically downgraded to eager allocation…" | `LazyMemoryAllocator` pins via `torch_dev.ext.pin_memory(...)` (a `DeviceExt` capability backed by `PinMemoryBackend`). The auto-disable is gated on `torch_dev.ext.is_pin_supported`. | [`lmcache/v1/lazy_memory_allocator.py:199` @ 73bf76b](https://github.com/LMCache/LMCache/blob/73bf76b/lmcache/v1/lazy_memory_allocator.py#L199), [`lazy_memory_allocator.py:240` @ 73bf76b](https://github.com/LMCache/LMCache/blob/73bf76b/lmcache/v1/lazy_memory_allocator.py#L240), [`lmcache/v1/distributed/config.py:154-159` @ 73bf76b](https://github.com/LMCache/LMCache/blob/73bf76b/lmcache/v1/distributed/config.py#L154-L159) |
| (same claim) — "automatically downgraded to eager allocation **with a logged warning**" | Warning text is now generic — "LazyMemoryAllocator requires memory pinning which is not supported on the current backend. Disabling l1-use-lazy." | [`config.py:155-158` @ 73bf76b](https://github.com/LMCache/LMCache/blob/73bf76b/lmcache/v1/distributed/config.py#L155-L158) |
| `DeviceExt` / `PinMemoryBackend` are the new home of host-memory pinning | New files added by #3823 | [`lmcache/v1/platform/device_ext.py` @ 73bf76b](https://github.com/LMCache/LMCache/blob/73bf76b/lmcache/v1/platform/device_ext.py), [`lmcache/v1/platform/base_pin_memory.py` @ 73bf76b](https://github.com/LMCache/LMCache/blob/73bf76b/lmcache/v1/platform/base_pin_memory.py), [`lmcache/v1/platform/cuda/pin_memory.py` @ 73bf76b](https://github.com/LMCache/LMCache/blob/73bf76b/lmcache/v1/platform/cuda/pin_memory.py) |

## Proposed fix (applied in this PR)

Rewrite the affected paragraph in `docs/source/mp/configuration.rst` to:

- Describe lazy allocation as requiring host-memory pinning provided by `DeviceExt` per platform.
- Keep the cudart context, but move it to where it belongs — *as one specific backend* (CUDA uses `cudaHostRegister` via the torch `cudart` binding, with a `libcudart` `ctypes` fallback) — so that NVIDIA users can still recognize what backs the pin call.
- Replace the stale "`cudart` attribute" gate with the actual current check, `torch_dev.ext.is_pin_supported`.

Docs-only diff; no code is touched. Touches only `docs/source/mp/configuration.rst`.

## Notes

- Auto-generated by the daily LMCache docs drift-check routine; **human review required before merge**.
- This PR is marked **draft** and is not requesting maintainer reviewers automatically.
- Branch lives on the `ApostaC/LMCache` fork (`docs/drift-check-2026-06-26`) and targets upstream `dev`.

---
_Generated by the daily LMCache docs drift-check routine_

---
_Generated by [Claude Code](https://claude.ai/code/session_012rWFoqYAr2hLg52fMXXPch)_