### PR TITLE
[Core] Support VLM-aware cache identity for vLLM MP CacheBlend

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -46,7 +46,12 @@ from lmcache.integration.vllm.kv_cache_group_edits import (
 from lmcache.integration.vllm.kv_cache_groups import (
     create_engine_group_infos_from_vllm,
 )
-from lmcache.integration.vllm.utils import mla_enabled, vllm_layout_hints
+from lmcache.integration.vllm.utils import (
+    extract_mm_features,
+    mla_enabled,
+    try_get_mm_aware_token_ids,
+    vllm_layout_hints,
+)
 from lmcache.utils import init_logger as lmcache_init_logger
 from lmcache.v1.multiprocess.group_view import slice_block_ids_per_group
 
@@ -93,6 +98,7 @@ if TYPE_CHECKING:
         PromMetricT,
     )
     from vllm.forward_context import ForwardContext
+    from vllm.multimodal.inputs import PlaceholderRange
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
@@ -186,6 +192,15 @@ class LMCacheMPRequestTracker:
     # Read-only list to track the token ids
     all_token_ids: ConstantList[int]
 
+    # VLM-aware token ids used only for LMCache keys, CacheBlend matching,
+    # lookup locks, and cache observability.
+    cache_token_ids: list[int] | None
+
+    # Multimodal identity metadata used to refresh cache_token_ids when vLLM
+    # appends generated tokens to all_token_ids after tracker construction.
+    mm_hashes: list[str]
+    mm_positions: list["PlaceholderRange"]
+
     # Block ids will be updated at update_states_after_alloc and
     # during generation. Keyed by engine_group_idx; non-HMA models use 0.
     allocated_block_ids: dict[int, list[int]] = field(default_factory=dict)
@@ -212,6 +227,8 @@ class LMCacheMPRequestTracker:
         self.request_id = request.request_id
         self.cache_salt: str = request.cache_salt or ""
         self.all_token_ids = request.all_token_ids
+        self.mm_hashes, self.mm_positions = extract_mm_features(request)
+        self.cache_token_ids = self._build_cache_token_ids()
         self.allocated_block_ids = {}
         self.num_stored_tokens = 0
         self.num_vllm_hit_tokens = 0
@@ -268,6 +285,21 @@ class LMCacheMPRequestTracker:
             for engine_group_idx, blocks in self.allocated_block_ids.items()
         }
 
+    def get_cache_token_ids(self) -> list[int] | None:
+        """Return VLM-aware cache token ids aligned to current raw tokens.
+
+        vLLM may append generated tokens to ``all_token_ids`` after tracker
+        construction. Generated tokens are not covered by multimodal
+        placeholders, but they still need to be present in LMCache keys if a
+        later store spans them.
+
+        Returns:
+            The refreshed cache token id list, or ``None`` when multimodal
+            metadata cannot safely form a cache identity.
+        """
+        self.cache_token_ids = self._build_cache_token_ids()
+        return self.cache_token_ids
+
     ####
     # For debugging
     ####
@@ -285,6 +317,9 @@ class LMCacheMPRequestTracker:
 
     def __str__(self) -> str:
         return self.__repr__()
+
+    def _build_cache_token_ids(self) -> list[int] | None:
+        return try_get_mm_aware_token_ids(self)
 
 
 @dataclass
@@ -359,6 +394,9 @@ class LMCacheMPRequestMetadata:
         num_chunks = num_staging_tokens // lmcache_tokens_per_chunk
 
         if num_chunks >= 1:
+            token_ids = tracker.get_cache_token_ids()
+            if token_ids is None:
+                return None
             start_token_idx = tracker.num_stored_tokens
             end_token_idx = start_token_idx + num_chunks * lmcache_tokens_per_chunk
             block_ids = slice_block_ids_per_group(
@@ -367,9 +405,8 @@ class LMCacheMPRequestMetadata:
                 start_token_idx,
                 end_token_idx,
             )
-            token_ids = list(tracker.all_token_ids)
             op = LoadStoreOp(
-                token_ids=token_ids,
+                token_ids=list(token_ids),
                 block_ids=block_ids,
                 start=start_token_idx,
                 end=end_token_idx,
@@ -428,13 +465,15 @@ class LMCacheMPRequestMetadata:
             "number of LMCache hit tokens. "
         )
         if end_token_idx > start_token_idx:
+            token_ids = tracker.get_cache_token_ids()
+            if token_ids is None:
+                return None
             block_ids = slice_block_ids_per_group(
                 tracker.allocated_block_ids,
                 group_tokens_per_block,
                 start_token_idx,
                 end_token_idx,
             )
-            token_ids = list(tracker.all_token_ids)
 
             # Compute how many tokens at the start of the retrieve range
             # overlap with APC-shared blocks. The server must skip writing
@@ -444,7 +483,7 @@ class LMCacheMPRequestMetadata:
             skip_first_n_tokens = tracker.num_vllm_hit_tokens - start_token_idx
 
             op = LoadStoreOp(
-                token_ids=token_ids,
+                token_ids=list(token_ids),
                 block_ids=block_ids,
                 start=start_token_idx,
                 end=end_token_idx,
@@ -907,10 +946,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         # TODO: support loading KV for preempted requests in the future
         if request.status == RequestStatus.PREEMPTED:
             return 0, False
+        cache_token_ids = tracker.get_cache_token_ids()
+        if cache_token_ids is None:
+            return 0, False
 
         self.scheduler_adapter.maybe_submit_lookup_request(
             request.request_id,
-            token_ids=list(request.all_token_ids),
+            token_ids=list(cache_token_ids),
             cache_salt=tracker.cache_salt,
         )
 
@@ -1010,18 +1052,20 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                     free_end = tracker.num_vllm_hit_tokens
 
                 if free_end > 0:
-                    self.scheduler_adapter.free_lookup_locks(
-                        token_ids=list(tracker.all_token_ids),
-                        start=0,
-                        end=free_end,
-                        request_id=request.request_id,
-                        cache_salt=tracker.cache_salt,
-                    )
-                    logger.debug(
-                        "Free locks of tokens %d-%d since it is cached by vLLM.",
-                        0,
-                        free_end,
-                    )
+                    cache_token_ids = tracker.get_cache_token_ids()
+                    if cache_token_ids is not None:
+                        self.scheduler_adapter.free_lookup_locks(
+                            token_ids=list(cache_token_ids),
+                            start=0,
+                            end=free_end,
+                            request_id=request.request_id,
+                            cache_salt=tracker.cache_salt,
+                        )
+                        logger.debug(
+                            "Free locks of tokens %d-%d since it is cached by vLLM.",
+                            0,
+                            free_end,
+                        )
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
@@ -1267,6 +1311,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             tracker = self.request_trackers.get(new_request.req_id)
             if tracker is None:
                 continue
+            cache_token_ids = tracker.get_cache_token_ids()
+            if cache_token_ids is None:
+                continue
             primary_block_ids = tracker.allocated_block_ids.get(0, [])
             num_blocks = len(primary_block_ids)
             total_tokens = num_blocks * self._group_tokens_per_block[0]
@@ -1274,7 +1321,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 RequestAllocationRecord(
                     req_id=new_request.req_id,
                     new_block_ids=list(primary_block_ids),
-                    new_token_ids=list(tracker.all_token_ids[:total_tokens]),
+                    new_token_ids=list(cache_token_ids[:total_tokens]),
                 )
             )
 
@@ -1292,6 +1339,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             tracker = self.request_trackers.get(request_id)
             if tracker is None:
                 continue
+            cache_token_ids = tracker.get_cache_token_ids()
+            if cache_token_ids is None:
+                continue
             # The new blocks sit at the end of the request's block list.
             # Compute the token range they cover.
             total_blocks = len(tracker.allocated_block_ids.get(0, []))
@@ -1299,7 +1349,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             tokens_per_block = self._group_tokens_per_block[0]
             start_token = (total_blocks - num_new_blocks) * tokens_per_block
             end_token = total_blocks * tokens_per_block
-            new_token_ids = list(tracker.all_token_ids[start_token:end_token])
+            new_token_ids = list(cache_token_ids[start_token:end_token])
             records.append(
                 RequestAllocationRecord(
                     req_id=request_id,

--- a/lmcache/integration/vllm/tests/test_mm_hash_utils.py
+++ b/lmcache/integration/vllm/tests/test_mm_hash_utils.py
@@ -3,12 +3,19 @@
 import dataclasses
 
 # Third Party
+import pytest
 import torch
 
 # First Party
 from lmcache.integration.vllm.utils import (
+    apply_mm_hashes_to_token_list,
     apply_mm_hashes_to_token_ids,
     hex_hash_to_int16,
+    hex_hash_to_int64,
+    get_mm_aware_token_ids,
+    has_unsafe_mm_metadata,
+    mm_token_surrogate_id,
+    try_get_mm_aware_token_ids,
 )
 
 
@@ -18,12 +25,42 @@ class DummyPlaceholderRange:
     length: int
 
 
+@dataclasses.dataclass(frozen=True)
+class DummyMMFeature:
+    identifier: str
+    mm_position: DummyPlaceholderRange
+
+
+@dataclasses.dataclass
+class DummyRequest:
+    all_token_ids: list[int]
+    mm_features: list[DummyMMFeature] | None = None
+    mm_hashes: list[str] | None = None
+    mm_positions: list[DummyPlaceholderRange] | None = None
+
+
+def test_hex_hash_to_int64_accepts_hex_and_non_hex() -> None:
+    assert hex_hash_to_int64("0000") >= 2**62
+    assert hex_hash_to_int64("0x0001") >= 2**62
+    assert hex_hash_to_int64("0x0001") != 1
+    assert hex_hash_to_int64("0x10000") > 0xFFFF
+    assert hex_hash_to_int64("0xffffffffffffffff") >= 2**62
+
+    s = "chatcmpl-a2a48871c4aad192-image-0"
+    v1 = hex_hash_to_int64(s)
+    v2 = hex_hash_to_int64(s)
+    assert isinstance(v1, int)
+    assert 2**62 <= v1 < 2**63
+    assert v1 == v2
+
+
 def test_hex_hash_to_int16_accepts_hex_and_non_hex() -> None:
-    # Hex behavior preserved (with and without 0x prefix).
-    assert hex_hash_to_int16("0000") == 0
-    assert hex_hash_to_int16("ffff") == 0xFFFF
-    assert hex_hash_to_int16("0xFFFF") == 0xFFFF
-    assert hex_hash_to_int16("0x0001") == 1
+    # Hex strings are still accepted, but no longer map directly into the text
+    # token namespace.
+    assert hex_hash_to_int16("0000") == (hex_hash_to_int64("0000") & 0xFFFF)
+    assert hex_hash_to_int16("ffff") == (hex_hash_to_int64("ffff") & 0xFFFF)
+    assert hex_hash_to_int16("0xFFFF") == (hex_hash_to_int64("0xFFFF") & 0xFFFF)
+    assert hex_hash_to_int16("0x0001") != 1
 
     # Non-hex identifiers must not raise and must be deterministic.
     s = "chatcmpl-a2a48871c4aad192-image-0"
@@ -32,26 +69,18 @@ def test_hex_hash_to_int16_accepts_hex_and_non_hex() -> None:
     assert isinstance(v1, int)
     assert 0 <= v1 <= 0xFFFF
     assert v1 == v2
+    assert v1 == (hex_hash_to_int64(s) & 0xFFFF)
 
 
-def test_hex_hash_to_int16_hex_variants_whitespace_and_truncation() -> None:
-    # Whitespace should be ignored and case should not matter.
-    assert hex_hash_to_int16(" FfFf ") == 0xFFFF
-    assert hex_hash_to_int16("\n0x00aB\t") == 0x00AB
-
-    # Long hex should be truncated to 16 bits via masking.
-    assert hex_hash_to_int16("123456") == 0x3456
-    assert hex_hash_to_int16("0x123456") == 0x3456
+def test_hex_hash_to_int16_normalizes_whitespace() -> None:
+    assert hex_hash_to_int16(" FfFf ") == hex_hash_to_int16("FfFf")
+    assert hex_hash_to_int16("\n0x00aB\t") == hex_hash_to_int16("0x00aB")
 
 
-def test_hex_hash_to_int16_empty_and_invalid_hex_are_safe_and_deterministic() -> None:
-    # Empty (or effectively empty) values should not raise.
-    for s in ("", "   ", "0x"):
-        v1 = hex_hash_to_int16(s)
-        v2 = hex_hash_to_int16(s)
-        assert isinstance(v1, int)
-        assert 0 <= v1 <= 0xFFFF
-        assert v1 == v2
+def test_hex_hash_to_int16_rejects_empty_identifiers() -> None:
+    for s in ("", "   "):
+        with pytest.raises(ValueError):
+            hex_hash_to_int16(s)
 
     # Invalid "hex-looking" strings must fall back to hashing.
     for s in ("0xGG", "deadbeeg", "0x12xz"):
@@ -63,13 +92,17 @@ def test_hex_hash_to_int16_empty_and_invalid_hex_are_safe_and_deterministic() ->
 
 
 def test_hex_hash_to_int16_non_string_inputs_are_safe() -> None:
-    # Be defensive: callers may pass None or other non-string types.
-    for val in (None, 0, 12345, 3.14, b"deadbeef"):
+    with pytest.raises(ValueError):
+        hex_hash_to_int16(None)
+
+    # Be defensive: callers may pass other non-string identifier types.
+    for val in (0, 12345, 3.14, b"deadbeef"):
         v1 = hex_hash_to_int16(val)  # type: ignore[arg-type]
         v2 = hex_hash_to_int16(val)  # type: ignore[arg-type]
         assert isinstance(v1, int)
         assert 0 <= v1 <= 0xFFFF
         assert v1 == v2
+        assert v1 == (hex_hash_to_int64(val) & 0xFFFF)
 
 
 def test_apply_mm_hashes_to_token_ids_handles_non_hex_mm_hash() -> None:
@@ -78,8 +111,10 @@ def test_apply_mm_hashes_to_token_ids_handles_non_hex_mm_hash() -> None:
     mm_positions = [DummyPlaceholderRange(offset=2, length=4)]
 
     out = apply_mm_hashes_to_token_ids(token_ids.clone(), mm_hashes, mm_positions)
-    expected_val = hex_hash_to_int16(mm_hashes[0])
-    assert out[2:6].tolist() == [expected_val] * 4
+    expected_vals = [mm_token_surrogate_id(mm_hashes[0], i) for i in range(4)]
+    assert out[2:6].tolist() == expected_vals
+    assert all(x >= 2**62 for x in expected_vals)
+    assert len(set(expected_vals)) == 4
 
 
 def test_apply_mm_hashes_to_token_ids_out_of_bounds_is_safe() -> None:
@@ -91,22 +126,209 @@ def test_apply_mm_hashes_to_token_ids_out_of_bounds_is_safe() -> None:
     assert out.tolist() == token_ids.tolist()
 
 
-def test_apply_mm_hashes_to_token_ids_multiple_placeholders_and_length_mismatch() -> (
-    None
-):
+def test_apply_mm_hashes_to_token_ids_multiple_placeholders() -> None:
     token_ids = torch.zeros(12, dtype=torch.long)
-    mm_hashes = ["deadbeef", "chatcmpl-a2a48871c4aad192-image-0", "EXTRA_HASH_IGNORED"]
+    mm_hashes = ["deadbeef", "chatcmpl-a2a48871c4aad192-image-0"]
     mm_positions = [
         DummyPlaceholderRange(offset=0, length=3),
         DummyPlaceholderRange(offset=5, length=4),
     ]
 
     out = apply_mm_hashes_to_token_ids(token_ids.clone(), mm_hashes, mm_positions)
-    v0 = hex_hash_to_int16(mm_hashes[0])
-    v1 = hex_hash_to_int16(mm_hashes[1])
+    v0 = [mm_token_surrogate_id(mm_hashes[0], i) for i in range(3)]
+    v1 = [mm_token_surrogate_id(mm_hashes[1], i) for i in range(4)]
 
-    assert out[0:3].tolist() == [v0] * 3
-    assert out[5:9].tolist() == [v1] * 4
-    # Other regions remain unchanged.
-    assert out[3:5].tolist() == [0, 0]
-    assert out[9:12].tolist() == [0, 0, 0]
+    assert out[0:3].tolist() == v0
+    assert out[5:9].tolist() == v1
+    assert out[3:5].tolist() != [0, 0]
+    assert out[9:12].tolist() != [0, 0, 0]
+    assert all(x >= 2**62 for x in out[3:5].tolist())
+    assert all(x >= 2**62 for x in out[9:12].tolist())
+
+
+def test_apply_mm_hashes_to_token_ids_fails_closed_on_length_mismatch() -> None:
+    token_ids = torch.arange(0, 8, dtype=torch.long)
+    mm_hashes = ["image-a", "image-b"]
+    mm_positions = [DummyPlaceholderRange(offset=1, length=2)]
+
+    out = apply_mm_hashes_to_token_ids(token_ids.clone(), mm_hashes, mm_positions)
+
+    assert out is None
+
+
+def test_apply_mm_hashes_to_token_list_returns_rewritten_copy() -> None:
+    token_ids = [10, 11, 12, 13, 14]
+    mm_hashes = ["0x10000"]
+    mm_positions = [DummyPlaceholderRange(offset=1, length=3)]
+
+    out = apply_mm_hashes_to_token_list(token_ids, mm_hashes, mm_positions)
+
+    assert token_ids == [10, 11, 12, 13, 14]
+    assert out is not None
+    assert out[:4] == [
+        10,
+        mm_token_surrogate_id("0x10000", 0),
+        mm_token_surrogate_id("0x10000", 1),
+        mm_token_surrogate_id("0x10000", 2),
+    ]
+    assert out[4] != 14
+    assert out[4] >= 2**62
+
+
+def test_apply_mm_hashes_salts_text_after_placeholder() -> None:
+    token_ids = [10, 11, 12, 13, 14, 15]
+    mm_positions = [DummyPlaceholderRange(offset=1, length=2)]
+
+    image_a = apply_mm_hashes_to_token_list(token_ids, ["image-a"], mm_positions)
+    image_b = apply_mm_hashes_to_token_list(token_ids, ["image-b"], mm_positions)
+
+    assert image_a is not None
+    assert image_b is not None
+    assert image_a[0] == image_b[0] == 10
+    assert image_a[1:3] != image_b[1:3]
+    assert image_a[3:] != token_ids[3:]
+    assert image_b[3:] != token_ids[3:]
+    assert image_a[3:] != image_b[3:]
+
+
+def test_mm_token_surrogate_id_is_position_and_namespace_safe() -> None:
+    same_offset = mm_token_surrogate_id("image-a", 3)
+    assert same_offset == mm_token_surrogate_id("image-a", 3)
+    assert same_offset != mm_token_surrogate_id("image-a", 4)
+    assert same_offset != mm_token_surrogate_id("image-b", 3)
+    assert same_offset >= 2**62
+    assert same_offset != 3
+
+
+def test_get_mm_aware_token_ids_text_only_returns_copy() -> None:
+    request = DummyRequest(all_token_ids=[1, 2, 3])
+
+    out = get_mm_aware_token_ids(request)
+
+    assert out == [1, 2, 3]
+    assert out is not request.all_token_ids
+
+
+def test_get_mm_aware_token_ids_uses_mm_features() -> None:
+    request = DummyRequest(
+        all_token_ids=[1, 2, 3, 4, 5],
+        mm_features=[
+            DummyMMFeature(
+                identifier="0x10000",
+                mm_position=DummyPlaceholderRange(offset=2, length=2),
+            )
+        ],
+    )
+
+    out = get_mm_aware_token_ids(request)
+
+    assert out[:4] == [
+        1,
+        2,
+        mm_token_surrogate_id("0x10000", 0),
+        mm_token_surrogate_id("0x10000", 1),
+    ]
+    assert out[4] != 5
+    assert out[4] >= 2**62
+
+
+def test_get_mm_aware_token_ids_uses_legacy_fields() -> None:
+    request = DummyRequest(
+        all_token_ids=[1, 2, 3, 4, 5, 6],
+        mm_hashes=["image-a", "image-b"],
+        mm_positions=[
+            DummyPlaceholderRange(offset=1, length=2),
+            DummyPlaceholderRange(offset=4, length=5),
+        ],
+    )
+
+    out = get_mm_aware_token_ids(request)
+
+    assert out[:3] == [
+        1,
+        mm_token_surrogate_id("image-a", 0),
+        mm_token_surrogate_id("image-a", 1),
+    ]
+    assert out[3] != 4
+    assert out[3] >= 2**62
+    assert out[4:] == [
+        mm_token_surrogate_id("image-b", 0),
+        mm_token_surrogate_id("image-b", 1),
+    ]
+    assert request.all_token_ids == [1, 2, 3, 4, 5, 6]
+
+
+def test_get_mm_aware_token_ids_fails_closed_on_empty_identifier() -> None:
+    request = DummyRequest(
+        all_token_ids=[1, 2, 3, 4],
+        mm_features=[
+            DummyMMFeature(
+                identifier="",
+                mm_position=DummyPlaceholderRange(offset=1, length=2),
+            )
+        ],
+    )
+
+    assert try_get_mm_aware_token_ids(request) is None
+    assert has_unsafe_mm_metadata(request)
+
+
+def test_get_mm_aware_token_ids_fails_closed_on_invalid_span() -> None:
+    request = DummyRequest(
+        all_token_ids=[1, 2, 3, 4],
+        mm_features=[
+            DummyMMFeature(
+                identifier="image-a",
+                mm_position=DummyPlaceholderRange(offset=-1, length=2),
+            )
+        ],
+    )
+
+    assert try_get_mm_aware_token_ids(request) is None
+    assert has_unsafe_mm_metadata(request)
+
+
+def test_try_get_mm_aware_token_ids_rejects_missing_positions() -> None:
+    request = DummyRequest(
+        all_token_ids=[1, 2, 3, 4],
+        mm_hashes=["image-a"],
+        mm_positions=None,
+    )
+
+    assert try_get_mm_aware_token_ids(request) is None
+    assert has_unsafe_mm_metadata(request)
+
+
+def test_try_get_mm_aware_token_ids_rejects_missing_hashes() -> None:
+    request = DummyRequest(
+        all_token_ids=[1, 2, 3, 4],
+        mm_hashes=None,
+        mm_positions=[DummyPlaceholderRange(offset=1, length=2)],
+    )
+
+    assert try_get_mm_aware_token_ids(request) is None
+    assert has_unsafe_mm_metadata(request)
+
+
+def test_try_get_mm_aware_token_ids_rejects_empty_legacy_hashes_with_positions() -> (
+    None
+):
+    request = DummyRequest(
+        all_token_ids=[1, 2, 3, 4],
+        mm_hashes=[],
+        mm_positions=[DummyPlaceholderRange(offset=1, length=2)],
+    )
+
+    assert try_get_mm_aware_token_ids(request) is None
+    assert has_unsafe_mm_metadata(request)
+
+
+def test_get_mm_aware_token_ids_raises_for_unsafe_mm_metadata() -> None:
+    request = DummyRequest(
+        all_token_ids=[1, 2, 3, 4],
+        mm_hashes=["image-a"],
+        mm_positions=None,
+    )
+
+    with pytest.raises(ValueError):
+        get_mm_aware_token_ids(request)

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Literal, Optional, Tuple
+from collections.abc import Sequence
 import hashlib
 import os
-import string
 import threading
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
@@ -27,7 +27,7 @@ logger = init_logger(__name__)
 ENGINE_NAME = "vllm-instance"
 
 # Thread-safe singleton storage
-_config_instance: Optional[LMCacheEngineConfig] = None
+_config_instance: LMCacheEngineConfig | None = None
 _config_lock = threading.Lock()
 
 
@@ -140,50 +140,276 @@ def create_lmcache_ec_config() -> LMCacheEngineConfig:
     return load_ec_engine_config(base_config=lmcache_get_or_create_config())
 
 
-def hex_hash_to_int16(s: str) -> int:
+_MM_SURROGATE_NAMESPACE_BIT = 1 << 62
+_MM_SURROGATE_VALUE_MASK = _MM_SURROGATE_NAMESPACE_BIT - 1
+_MM_SURROGATE_DOMAIN = b"LMCache:mm-token:v1"
+_MM_TEXT_SURROGATE_DOMAIN = b"LMCache:mm-conditioned-text:v1"
+_MM_CONTEXT_DOMAIN = b"LMCache:mm-context:v1"
+
+
+def _normalize_mm_identifier(value: object) -> str | None:
+    """Normalize a multimodal identifier, returning ``None`` if unusable."""
+    if value is None:
+        return None
+    value_str = str(value).strip()
+    if not value_str:
+        return None
+    return value_str
+
+
+def hex_hash_to_int64(value: object) -> int:
+    """Convert a multimodal identifier into a namespace-safe surrogate.
+
+    Args:
+        value: Identifier supplied by vLLM.
+
+    Returns:
+        A deterministic integer in the signed-int64-safe multimodal namespace
+        ``2**62 <= value < 2**63``. This is equivalent to
+        ``mm_token_surrogate_id(value, 0)`` and exists for compatibility with
+        older helper call sites.
+
+    Raises:
+        ValueError: If ``value`` is missing or empty.
     """
-    Convert a hash identifier into a 16-bit integer.
+    return mm_token_surrogate_id(value, 0)
 
-    Historically, LMCache expected multimodal identifiers to be hex strings.
-    In practice (e.g., OpenAI-style multimodal requests), identifiers may be
-    arbitrary strings like `chatcmpl-...-image-0`. This function therefore:
-      - Parses hex strings (optionally prefixed with `0x`) as before, or
-      - Falls back to a stable string hash (SHA-256) when the input is not hex.
+
+def mm_token_surrogate_id(identifier: object, local_offset: int) -> int:
+    """Build a VLM cache-token surrogate for one placeholder position.
+
+    Args:
+        identifier: Stable multimodal identifier supplied by vLLM.
+        local_offset: Token offset inside this placeholder span.
+
+    Returns:
+        A deterministic positive int64 value in LMCache's multimodal surrogate
+        namespace. The same identifier and local offset produce the same value;
+        different identifiers or local offsets produce different values with
+        cryptographic-hash collision probability.
+
+    Raises:
+        ValueError: If ``identifier`` is missing/empty or ``local_offset`` is
+            negative.
     """
-    # Be defensive: vLLM may pass non-string identifiers.
-    s = "" if s is None else str(s)
-    s_stripped = s.strip()
+    normalized = _normalize_mm_identifier(identifier)
+    if normalized is None:
+        raise ValueError("multimodal identifier is missing or empty")
+    if local_offset < 0:
+        raise ValueError("local_offset must be non-negative")
 
-    # Fast-path: pure hex (optionally 0x-prefixed).
-    hex_part = s_stripped[2:] if s_stripped.lower().startswith("0x") else s_stripped
-    if hex_part and all(c in string.hexdigits for c in hex_part):
-        try:
-            return int(hex_part, 16) & 0xFFFF
-        except ValueError:
-            # Extremely unlikely (e.g., oversized/odd formatting); fall back to hashing.
-            pass
+    identifier_bytes = normalized.encode("utf-8")
+    h = hashlib.sha256()
+    h.update(_MM_SURROGATE_DOMAIN)
+    h.update(len(identifier_bytes).to_bytes(8, byteorder="big", signed=False))
+    h.update(identifier_bytes)
+    h.update(local_offset.to_bytes(8, byteorder="big", signed=False))
+    raw = int.from_bytes(h.digest()[:8], byteorder="big", signed=False)
+    return _MM_SURROGATE_NAMESPACE_BIT | (raw & _MM_SURROGATE_VALUE_MASK)
 
-    # Fallback: stable 16-bit value derived from the full identifier string.
-    digest = hashlib.sha256(s_stripped.encode("utf-8")).digest()
-    return int.from_bytes(digest[:2], byteorder="big", signed=False)
+
+def _mm_context_salt(identifiers: Sequence[str]) -> bytes:
+    h = hashlib.sha256()
+    h.update(_MM_CONTEXT_DOMAIN)
+    for identifier in identifiers:
+        identifier_bytes = identifier.encode("utf-8")
+        h.update(len(identifier_bytes).to_bytes(8, byteorder="big", signed=False))
+        h.update(identifier_bytes)
+    return h.digest()
+
+
+def _mm_text_surrogate_id(context_salt: bytes, token_id: int, position: int) -> int:
+    h = hashlib.sha256()
+    h.update(_MM_TEXT_SURROGATE_DOMAIN)
+    h.update(context_salt)
+    h.update(int(token_id).to_bytes(8, byteorder="big", signed=True))
+    h.update(position.to_bytes(8, byteorder="big", signed=False))
+    raw = int.from_bytes(h.digest()[:8], byteorder="big", signed=False)
+    return _MM_SURROGATE_NAMESPACE_BIT | (raw & _MM_SURROGATE_VALUE_MASK)
+
+
+def hex_hash_to_int16(value: object) -> int:
+    """Convert a multimodal identifier into a compatibility 16-bit value.
+
+    Args:
+        value: Identifier supplied by vLLM.
+
+    Returns:
+        The low 16 bits of :func:`hex_hash_to_int64`.
+    """
+    return hex_hash_to_int64(value) & 0xFFFF
+
+
+def _rewrite_mm_cache_token_list(
+    token_ids: list[int],
+    mm_hashes: Sequence[object],
+    mm_positions: Sequence["PlaceholderRange"],
+) -> list[int] | None:
+    if len(mm_hashes) != len(mm_positions):
+        return None
+
+    entries: list[tuple[int, int, str]] = []
+    for hash_str, placeholder in zip(mm_hashes, mm_positions, strict=False):
+        normalized = _normalize_mm_identifier(hash_str)
+        if normalized is None:
+            return None
+        start, length = placeholder.offset, placeholder.length
+        if start < 0 or length < 0:
+            return None
+        if start >= len(token_ids) or length == 0:
+            continue
+        end = min(start + length, len(token_ids))
+        if end > start:
+            entries.append((start, end, normalized))
+
+    if not entries:
+        return list(token_ids)
+
+    entries.sort(key=lambda item: item[0])
+    active_identifiers: list[str] = []
+    rewritten = list(token_ids)
+    cursor = 0
+    for start, end, identifier in entries:
+        if active_identifiers:
+            context_salt = _mm_context_salt(active_identifiers)
+            for pos in range(cursor, start):
+                rewritten[pos] = _mm_text_surrogate_id(
+                    context_salt, rewritten[pos], pos
+                )
+        for pos in range(start, end):
+            rewritten[pos] = mm_token_surrogate_id(identifier, pos - start)
+        active_identifiers.append(identifier)
+        cursor = end
+
+    if active_identifiers:
+        context_salt = _mm_context_salt(active_identifiers)
+        for pos in range(cursor, len(rewritten)):
+            rewritten[pos] = _mm_text_surrogate_id(context_salt, rewritten[pos], pos)
+
+    return rewritten
 
 
 def apply_mm_hashes_to_token_ids(
     token_ids: torch.Tensor,
-    mm_hashes: list[str],
-    mm_positions: list["PlaceholderRange"],
-) -> torch.Tensor:
+    mm_hashes: Sequence[object],
+    mm_positions: Sequence["PlaceholderRange"],
+) -> torch.Tensor | None:
+    """Rewrite multimodal cache identity tokens in place.
+
+    Args:
+        token_ids: Token tensor to rewrite. The tensor must be able to hold
+            signed int64-safe surrogate ids.
+        mm_hashes: Multimodal identifiers parallel to ``mm_positions``.
+        mm_positions: Placeholder spans to rewrite.
+
+    Returns:
+        The same tensor object, rewritten in place, or ``None`` when the
+        multimodal metadata is unsafe to use for cache identity. Placeholder
+        spans use per-position media surrogate ids; following text tokens are
+        salted with the preceding multimodal context so sparse CacheBlend chunks
+        do not cross-match across different media.
     """
-    Overwrite token_ids in-place for multimodal placeholders using
-    efficient slice assignments.
+    rewritten = _rewrite_mm_cache_token_list(
+        token_ids.tolist(), mm_hashes, mm_positions
+    )
+    if rewritten is None:
+        return None
+    token_ids[:] = torch.tensor(
+        rewritten, dtype=token_ids.dtype, device=token_ids.device
+    )
+    return token_ids
+
+
+def apply_mm_hashes_to_token_list(
+    token_ids: list[int],
+    mm_hashes: Sequence[object],
+    mm_positions: Sequence["PlaceholderRange"],
+) -> list[int] | None:
+    """Return cache token ids with multimodal-aware identity rewriting.
+
+    Args:
+        token_ids: Raw token ids from vLLM.
+        mm_hashes: Multimodal identifiers parallel to ``mm_positions``.
+        mm_positions: Placeholder spans to rewrite.
+
+    Returns:
+        A new list where placeholder spans contain stable int64-safe
+        multimodal surrogate ids and following text tokens are salted with
+        preceding multimodal context. The input list is not modified. Returns
+        ``None`` when the multimodal metadata is unsafe to use for cache
+        identity.
     """
-    n = token_ids.size(0)
-    for hash_str, placeholder in zip(mm_hashes, mm_positions, strict=False):
-        start, length = placeholder.offset, placeholder.length
-        if start >= n:
-            continue
-        end = min(start + length, n)
-        token_ids[start:end] = hex_hash_to_int16(hash_str)
+    return _rewrite_mm_cache_token_list(token_ids, mm_hashes, mm_positions)
+
+
+def has_mm_metadata(request: "Request") -> bool:
+    """Return whether the request carries any multimodal metadata fields.
+
+    Args:
+        request: vLLM request-like object that may expose ``mm_features`` or
+            legacy ``mm_hashes`` / ``mm_positions`` fields.
+
+    Returns:
+        ``True`` when multimodal metadata is present, otherwise ``False``.
+    """
+    if getattr(request, "mm_features", None):
+        return True
+    return bool(
+        getattr(request, "mm_hashes", None) or getattr(request, "mm_positions", None)
+    )
+
+
+def try_get_mm_aware_token_ids(request: "Request") -> list[int] | None:
+    """Return safe cache token ids, or ``None`` when VLM identity is unsafe.
+
+    Args:
+        request: vLLM request exposing ``all_token_ids`` and optionally
+            ``mm_features`` or legacy ``mm_hashes`` / ``mm_positions``.
+
+    Returns:
+        A new token-id list suitable for LMCache cache keys and CacheBlend
+        matching. Returns ``None`` if the request carries multimodal metadata
+        but LMCache cannot safely rewrite the placeholder spans.
+    """
+    token_ids = list(request.all_token_ids)
+    mm_hashes, mm_positions = extract_mm_features(request)
+    if not mm_hashes or not mm_positions:
+        return None if has_mm_metadata(request) else token_ids
+    return apply_mm_hashes_to_token_list(token_ids, mm_hashes, mm_positions)
+
+
+def has_unsafe_mm_metadata(request: "Request") -> bool:
+    """Return whether multimodal metadata cannot form safe cache keys.
+
+    Args:
+        request: vLLM request-like object exposing ``all_token_ids`` and
+            optional multimodal metadata fields.
+
+    Returns:
+        ``True`` when multimodal metadata is present but cannot be safely
+        rewritten into cache-token ids, otherwise ``False``.
+    """
+    return has_mm_metadata(request) and try_get_mm_aware_token_ids(request) is None
+
+
+def get_mm_aware_token_ids(request: "Request") -> list[int]:
+    """Return request token ids with multimodal placeholders rewritten.
+
+    Args:
+        request: vLLM request exposing ``all_token_ids`` and optionally
+            ``mm_features`` or legacy ``mm_hashes`` / ``mm_positions``.
+
+    Returns:
+        A new token-id list suitable for LMCache cache keys and CacheBlend
+        matching.
+
+    Raises:
+        ValueError: If the request contains multimodal metadata that cannot be
+            safely rewritten.
+    """
+    token_ids = try_get_mm_aware_token_ids(request)
+    if token_ids is None:
+        raise ValueError("unsafe multimodal cache identity metadata")
     return token_ids
 
 
@@ -285,7 +511,7 @@ def create_lmcache_metadata(
 
 def extract_mm_features(
     request: "Request", modify: bool = False
-) -> Tuple[list[str], list["PlaceholderRange"]]:
+) -> tuple[list[str], list["PlaceholderRange"]]:
     """
     Normalize multimodal information from a Request into parallel lists.
 
@@ -316,11 +542,19 @@ def extract_mm_features(
             *((f.identifier, f.mm_position) for f in request.mm_features), strict=False
         )
         return (list(mm_hashes), list(mm_positions))
-    elif getattr(request, "mm_hashes", None):
+    elif hasattr(request, "mm_hashes") or hasattr(request, "mm_positions"):
+        mm_hashes = getattr(request, "mm_hashes", None)
+        mm_positions = getattr(request, "mm_positions", None)
         if modify:
-            return (request.mm_hashes.copy(), request.mm_positions.copy())
+            return (
+                mm_hashes.copy() if mm_hashes is not None else [],
+                mm_positions.copy() if mm_positions is not None else [],
+            )
         else:
-            return (request.mm_hashes, request.mm_positions)
+            return (
+                mm_hashes if mm_hashes is not None else [],
+                mm_positions if mm_positions is not None else [],
+            )
     else:
         return ([], [])
 
@@ -339,7 +573,7 @@ def get_size_bytes(shapes: list[torch.Size], kv_dtypes: list[torch.dtype]):
     )
 
 
-def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> Tuple[int, int]:
+def calculate_local_rank_and_world_size(vllm_config: "VllmConfig") -> tuple[int, int]:
     """
     Calculate the local worker id and local world size.
 

--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -32,9 +32,10 @@ from lmcache import utils
 from lmcache.banner import print_banner_once
 from lmcache.integration.vllm.utils import (
     ENGINE_NAME,
-    apply_mm_hashes_to_token_ids,
     extract_mm_features,
+    has_mm_metadata,
     lmcache_get_or_create_config,
+    try_get_mm_aware_token_ids,
 )
 from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
 from lmcache.logging import init_logger
@@ -294,6 +295,8 @@ class ReqMeta:
     disagg_spec: Optional[DisaggSpec] = None
     # the configs of the request
     request_configs: Optional[dict] = None
+    # True when the request must not write raw-token KV into LMCache.
+    skip_lmcache_store: bool = False
 
     @staticmethod
     def from_request_tracker(
@@ -338,6 +341,7 @@ class ReqMeta:
         # NOTE(vladnosiv): for disagg, you cannot skip saving, as saving is a transfer
         # Check if request_configs has lmcache.skip_save set to True
         request_skip = (tracker.request_configs or {}).get("lmcache.skip_save", False)
+        skip_cache_for_mm = bool(tracker.mm_hashes or tracker.mm_positions)
 
         skip_save = tracker.disagg_spec is None and (
             tracker.skip_save
@@ -363,24 +367,14 @@ class ReqMeta:
             num_tokens_to_save = input_token_len
 
         # If we need to save, update the number of saved tokens
-        if not skip_save:
+        if not skip_save and not skip_cache_for_mm:
             tracker.num_saved_tokens = num_tokens_to_save
-        save_spec = SaveSpec(skip_leading_tokens, not skip_save)
+        save_spec = SaveSpec(
+            skip_leading_tokens, not skip_save and not skip_cache_for_mm
+        )
 
         # Calculate the token ids and slot mappings for load and save
         token_ids = input_token_ids[:num_tokens_to_save]
-
-        # If the request has multimodal hashes, apply them to the token ids
-        if tracker.mm_hashes:
-            # TODO: Optimize this
-            token_ids = torch.tensor(token_ids)
-            assert tracker.mm_positions is not None, (
-                "tracker got mm_hashes but no mm_positions"
-            )
-            apply_mm_hashes_to_token_ids(
-                token_ids, tracker.mm_hashes, tracker.mm_positions
-            )
-            token_ids = token_ids.tolist()
 
         num_blocks = len(tracker.allocated_block_ids)
 
@@ -433,6 +427,7 @@ class ReqMeta:
             load_spec=load_spec,
             disagg_spec=tracker.disagg_spec,
             request_configs=tracker.request_configs,
+            skip_lmcache_store=skip_cache_for_mm,
         )
 
 
@@ -1032,6 +1027,9 @@ class LMCacheConnectorV1Impl:
         is_first = True
 
         for request in connector_metadata.requests:
+            if getattr(request, "skip_lmcache_store", False):
+                continue
+
             save_spec = request.save_spec
             if (
                 save_spec is None or not save_spec.can_save
@@ -1115,6 +1113,9 @@ class LMCacheConnectorV1Impl:
 
         if self.use_layerwise:
             for request in connector_metadata.requests:
+                if getattr(request, "skip_lmcache_store", False):
+                    self.lmcache_engine.lookup_unpin(request.req_id)
+                    continue
                 layerwise_storer = self._layerwise_save_storers.pop(
                     request.req_id, None
                 )
@@ -1135,6 +1136,9 @@ class LMCacheConnectorV1Impl:
         for request in connector_metadata.requests:
             # unpin the kv caches according to req_id
             self.lmcache_engine.lookup_unpin(request.req_id)
+
+            if getattr(request, "skip_lmcache_store", False):
+                continue
 
             save_spec = request.save_spec
             if (
@@ -1378,6 +1382,8 @@ class LMCacheConnectorV1Impl:
             self.lookup_client, "supports_producer_reuse"
         ):
             return 0
+        if has_mm_metadata(request):
+            return 0
 
         req_id = request.request_id
 
@@ -1397,17 +1403,10 @@ class LMCacheConnectorV1Impl:
             logger.debug(f"Looking up cache for the first time for request {req_id}!")
             self._requests_priority[req_id] = getattr(request, "priority", 0)
 
-            # token_ids = request.prompt_token_ids
             # all token ids covers the preemption case
-            token_ids = request.all_token_ids
-
-            # If the request has multimodal hashes, apply them to the token ids
-            mm_hashes, mm_positions = extract_mm_features(request)
-            if mm_hashes and mm_positions:
-                # TODO(Jiayi): Optimize this
-                token_ids = torch.tensor(request.prompt_token_ids)
-                apply_mm_hashes_to_token_ids(token_ids, mm_hashes, mm_positions)
-                token_ids = token_ids.tolist()
+            token_ids = try_get_mm_aware_token_ids(request)
+            if token_ids is None:
+                return 0
 
             request_configs = extract_request_configs(request.sampling_params)
             if self.skip_last_n_tokens > 0:

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -13,7 +13,7 @@ It is **opt-in**: with no coordinator URL configured the blend module receives
 """
 
 # Standard
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from queue import Empty, Queue
@@ -22,7 +22,7 @@ import threading
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.mp_coordinator.schemas import encode_tokens
+from lmcache.v1.mp_coordinator.schemas import encode_tokens_u64
 
 logger = init_logger(__name__)
 
@@ -30,7 +30,7 @@ logger = init_logger(__name__)
 PENDING = object()
 
 # (method, path, json_body) -> json_dict
-_RequestFn = Callable[[str, str, dict], dict]
+_RequestFn = Callable[[str, str, Mapping[str, object]], dict[str, object]]
 
 
 @dataclass
@@ -54,7 +54,7 @@ class _PublishItem:
 
     method: str
     path: str
-    payload: dict
+    payload: dict[str, object]
 
 
 @dataclass
@@ -113,7 +113,9 @@ class BlendCoordinatorClient:
             client = httpx.Client(timeout=request_timeout)
             base = base_url.rstrip("/")
 
-            def _http_request(method: str, path: str, payload: dict) -> dict:
+            def _http_request(
+                method: str, path: str, payload: Mapping[str, object]
+            ) -> dict[str, object]:
                 resp = client.request(method, f"{base}{path}", json=payload)
                 resp.raise_for_status()
                 return resp.json()
@@ -136,7 +138,7 @@ class BlendCoordinatorClient:
         )
         self._worker.start()
 
-    def enqueue_register(self, ranges: list[dict]) -> None:
+    def enqueue_register(self, ranges: list[dict[str, object]]) -> None:
         """Queue a best-effort register of stored ranges.
 
         Args:
@@ -260,7 +262,7 @@ class BlendCoordinatorClient:
                 "/blend/match",
                 {
                     "model_scope": item.model_scope,
-                    "tokens_b64": encode_tokens(item.tokens),
+                    "tokens_u64_b64": encode_tokens_u64(item.tokens),
                 },
             )
             matches = [

--- a/lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py
+++ b/lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py
@@ -24,7 +24,6 @@ from lmcache.v1.mp_coordinator.schemas import (
     BlendMatchRequest,
     BlendMatchResponse,
     GlobalMatchModel,
-    decode_tokens,
 )
 
 logger = init_logger(__name__)
@@ -90,15 +89,17 @@ def evict_fingerprints(body: BlendEvictRequest, request: Request) -> BlendEvictR
 def match_fingerprints(body: BlendMatchRequest, request: Request) -> BlendMatchResponse:
     """Match a request's rolling-hash array against the directory.
 
-    The request tokens arrive base64-packed (``tokens_b64``); they are decoded
-    to a ``uint64`` array and handed straight to the matcher.
+    The request tokens arrive base64-packed as either the current
+    ``tokens_u64_b64`` little-endian ``uint64`` buffer or the legacy
+    ``tokens_b64`` little-endian ``uint32`` buffer. They are decoded to a
+    ``uint64`` array and handed straight to the matcher.
 
     Returns:
         Matched chunks (``object_key`` / ``old_st`` / ``cur_st``), ascending by
         ``cur_st``.
     """
     directory = _directory(request)
-    matches = directory.match(body.model_scope, decode_tokens(body.tokens_b64))
+    matches = directory.match(body.model_scope, body.decoded_tokens())
     return BlendMatchResponse(
         matches=[
             GlobalMatchModel(object_key=m.object_key, old_st=m.old_st, cur_st=m.cur_st)

--- a/lmcache/v1/mp_coordinator/schemas.py
+++ b/lmcache/v1/mp_coordinator/schemas.py
@@ -13,7 +13,13 @@ from typing import Annotated
 import base64
 
 # Third Party
-from pydantic import BaseModel, Field, StringConstraints, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    model_validator,
+    StringConstraints,
+    field_validator,
+)
 import numpy as np
 
 # First Party
@@ -23,8 +29,8 @@ from lmcache.v1.distributed.api import EncodedObjectKey  # noqa: F401  re-export
 def encode_tokens(tokens: "list[int] | np.ndarray") -> str:
     """Encode token ids into a compact base64 wire string.
 
-    Token ids fit in ``uint32``, so a little-endian ``uint32`` buffer is far
-    smaller than a JSON integer list and decodes in one ``np.frombuffer`` call.
+    Legacy compatibility helper for the original ``tokens_b64`` field, which
+    uses a little-endian ``uint32`` buffer.
 
     Args:
         tokens: Token ids (a ``list[int]`` or any array castable to ``uint32``).
@@ -43,8 +49,7 @@ def decode_tokens(tokens_b64: str) -> np.ndarray:
         tokens_b64: Base64 of a little-endian ``uint32`` token buffer.
 
     Returns:
-        A ``uint64`` array of token ids (widened so it feeds the hashers
-        directly).
+        A ``uint64`` array of token ids, widened after decode.
 
     Raises:
         ValueError: If ``tokens_b64`` is not valid base64 or not a multiple of
@@ -60,6 +65,47 @@ def decode_tokens(tokens_b64: str) -> np.ndarray:
             "(malformed uint32 token buffer)"
         )
     return np.frombuffer(raw, dtype="<u4").astype(np.uint64)
+
+
+def encode_tokens_u64(tokens: "list[int] | np.ndarray") -> str:
+    """Encode token ids into the current uint64 CacheBlend match field.
+
+    CacheBlend token ids may include signed-int64-safe multimodal surrogate
+    values, so the new wire format uses a little-endian ``uint64`` buffer.
+
+    Args:
+        tokens: Token ids (a ``list[int]`` or any array castable to ``uint64``).
+
+    Returns:
+        Base64 of the little-endian ``uint64`` token buffer.
+    """
+    arr = np.ascontiguousarray(np.asarray(tokens, dtype="<u8"))
+    return base64.b64encode(arr.tobytes()).decode("ascii")
+
+
+def decode_tokens_u64(tokens_u64_b64: str) -> np.ndarray:
+    """Decode a base64 token string produced by :func:`encode_tokens_u64`.
+
+    Args:
+        tokens_u64_b64: Base64 of a little-endian ``uint64`` token buffer.
+
+    Returns:
+        A ``uint64`` array of token ids.
+
+    Raises:
+        ValueError: If ``tokens_u64_b64`` is not valid base64 or not a multiple
+            of 8 bytes.
+    """
+    try:
+        raw = base64.b64decode(tokens_u64_b64, validate=True)
+    except Exception as exc:
+        raise ValueError(f"tokens_u64_b64 is not valid base64: {exc}") from exc
+    if len(raw) % 8 != 0:
+        raise ValueError(
+            f"tokens_u64_b64 byte length {len(raw)} is not a multiple of 8 "
+            "(malformed uint64 token buffer)"
+        )
+    return np.frombuffer(raw, dtype="<u8")
 
 
 class RegisterRequest(BaseModel):
@@ -284,33 +330,61 @@ class BlendMatchRequest(BaseModel):
 
     Attributes:
         model_scope: Scope to match within.
-        tokens_b64: The request tokens, packed via :func:`encode_tokens`
-            (base64 little-endian ``uint32``).
+        tokens_u64_b64: The current request token field, packed via
+            :func:`encode_tokens_u64` (base64 little-endian ``uint64``).
+        tokens_b64: Legacy request token field, packed via
+            :func:`encode_tokens` (base64 little-endian ``uint32``).
     """
 
     model_scope: str
-    tokens_b64: str = ""
+    tokens_u64_b64: str | None = None
+    tokens_b64: str | None = None
 
-    @field_validator("tokens_b64")
+    @model_validator(mode="after")
+    def _validate_exactly_one_token_payload(self) -> "BlendMatchRequest":
+        """Require exactly one token payload field."""
+        if self.tokens_u64_b64 is not None and self.tokens_b64 is not None:
+            raise ValueError("send only one of tokens_u64_b64 or tokens_b64")
+        if self.tokens_u64_b64 is None and self.tokens_b64 is None:
+            raise ValueError("one of tokens_u64_b64 or tokens_b64 is required")
+        return self
+
+    def decoded_tokens(self) -> np.ndarray:
+        """Decode the request token payload as ``uint64`` tokens."""
+        if self.tokens_u64_b64 is not None:
+            return decode_tokens_u64(self.tokens_u64_b64)
+        assert self.tokens_b64 is not None
+        return decode_tokens(self.tokens_b64)
+
+    @field_validator("tokens_u64_b64")
     @classmethod
-    def _validate_tokens_b64(cls, value: str) -> str:
+    def _validate_tokens_u64_b64(cls, value: str | None) -> str | None:
         """Reject a malformed token buffer at request validation.
 
-        Without this, ``decode_tokens`` would raise ``ValueError`` inside the
-        route handler, which FastAPI surfaces as a 500 (server error) for what
-        is really bad client input. Validating here returns a 422 instead.
+        Without this, decoding would raise ``ValueError`` inside the route
+        handler, which FastAPI surfaces as a 500 (server error) for what is
+        really bad client input. Validating here returns a 422 instead.
 
         Args:
-            value: The base64 ``tokens_b64`` field.
+            value: The base64 ``tokens_u64_b64`` field.
 
         Returns:
             The unchanged value once it is confirmed decodable.
 
         Raises:
             ValueError: If ``value`` is not valid base64 or not a whole number
-                of ``uint32`` tokens (surfaced by FastAPI as 422).
+                of ``uint64`` tokens (surfaced by FastAPI as 422).
         """
-        decode_tokens(value)
+        if value is not None:
+            decode_tokens_u64(value)
+        return value
+
+    @field_validator("tokens_b64")
+    @classmethod
+    def _validate_tokens_b64(cls, value: str | None) -> str | None:
+        """Reject a malformed legacy uint32 token buffer."""
+        if value is not None:
+            decode_tokens(value)
         return value
 
 

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -784,7 +784,17 @@ class BlendV3Module(InstanceLivenessTarget):
             )
             return None, world_size
 
-        chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(list(key.token_ids))
+        try:
+            chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(
+                list(key.token_ids)
+            )
+        except ValueError as exc:
+            logger.warning(
+                "Skipping CacheBlend lookup for request %s: %s",
+                key.request_id,
+                exc,
+            )
+            return None, world_size
         if not chunk_hashes:
             return None, world_size
 
@@ -1157,6 +1167,18 @@ class BlendV3Module(InstanceLivenessTarget):
             tuple[bytes, bool]: The underlying ``LMCacheDrivenTransfer.store`` result
             (event handle, success).
         """
+        try:
+            self._ctx.token_hasher.ensure_token_ids_supported(
+                list(key.token_ids)[key.start : key.end]
+            )
+        except ValueError as exc:
+            logger.warning(
+                "Skipping CacheBlend store for request %s: %s",
+                key.request_id,
+                exc,
+            )
+            return event_ipc_handle, False
+
         result = self._transfer_module.store(
             key, instance_id, gpu_block_ids, event_ipc_handle
         )
@@ -1170,10 +1192,18 @@ class BlendV3Module(InstanceLivenessTarget):
         # not-yet-committed and drop the whole group as stale.
         try:
             session = self._ctx.session_manager.get_or_create(key.request_id)
-            chunk_hashes = [
-                TokenHasher.hash_to_bytes(h)
-                for h in session.get_hashes(key.start, key.end)
-            ]
+            try:
+                chunk_hashes = [
+                    TokenHasher.hash_to_bytes(h)
+                    for h in session.get_hashes(key.start, key.end)
+                ]
+            except ValueError as exc:
+                logger.warning(
+                    "Skipping CacheBlend fingerprint registration for request %s: %s",
+                    key.request_id,
+                    exc,
+                )
+                return result
             if not chunk_hashes:
                 return result
             tokens_in_range = list(key.token_ids)[key.start : key.end]

--- a/lmcache/v1/multiprocess/modules/lookup.py
+++ b/lmcache/v1/multiprocess/modules/lookup.py
@@ -259,7 +259,17 @@ class LookupModule:
 
         extra_count = compute_extra_count(tp_size, world_size)
 
-        chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(list(key.token_ids))
+        try:
+            chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(
+                list(key.token_ids)
+            )
+        except ValueError as exc:
+            logger.warning(
+                "Skipping lookup for request %s: %s",
+                key.request_id,
+                exc,
+            )
+            chunk_hashes = []
         if not chunk_hashes:
             self._register_prefetch_job(
                 _PrefetchJob(
@@ -479,9 +489,17 @@ class LookupModule:
             tp_size: Tensor-parallel size for MLA
                 multi-reader locking.
         """
-        chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(
-            list(key.token_ids), start=key.start, end=key.end
-        )
+        try:
+            chunk_hashes = self._ctx.token_hasher.compute_chunk_hashes(
+                list(key.token_ids), start=key.start, end=key.end
+            )
+        except ValueError as exc:
+            logger.warning(
+                "Skipping lookup-lock release for request %s: %s",
+                key.request_id,
+                exc,
+            )
+            return
         if not chunk_hashes:
             return
         # Release across every object group, mirroring lookup, which locks keys

--- a/lmcache/v1/multiprocess/token_hasher.py
+++ b/lmcache/v1/multiprocess/token_hasher.py
@@ -34,6 +34,8 @@ def _make_blake3_hash_func() -> Callable:
     # Third Party
     import blake3 as _blake3
 
+    extended_token_marker = b"LMC-u64"
+
     def blake3_hash(args):
         prefix_hash, tokens, _ = args
         h = _blake3.blake3()
@@ -44,8 +46,16 @@ def _make_blake3_hash_func() -> Callable:
             h.update(prefix_hash.to_bytes(8, byteorder="big", signed=True))
         else:
             h.update(bytes(prefix_hash))
-        # Serialize token IDs in one batch
-        h.update(struct.pack(f">{len(tokens)}I", *tokens))
+        # Preserve the original 32-bit encoding for normal text tokens so
+        # existing text-only cache keys stay stable. Use an explicit marker plus
+        # uint64 packing only when multimodal surrogate ids exceed uint32.
+        if not tokens:
+            h.update(struct.pack(">0I"))
+        elif min(tokens) >= 0 and max(tokens) <= 0xFFFFFFFF:
+            h.update(struct.pack(f">{len(tokens)}I", *tokens))
+        else:
+            h.update(extended_token_marker)
+            h.update(struct.pack(f">{len(tokens)}Q", *tokens))
         return h.digest()  # 32 bytes
 
     return blake3_hash
@@ -180,11 +190,31 @@ class TokenHasher:
         logger.info("Computed NONE_HASH=%s using hash function", none_hash)
         return none_hash
 
+    def ensure_token_ids_supported(self, tokens: list[int]) -> None:
+        """Raise if the configured hash algorithm cannot encode these tokens.
+
+        Args:
+            tokens: Token ids to validate before hashing.
+
+        Raises:
+            ValueError: If the configured hash algorithm cannot safely encode
+                token ids outside the uint32 range.
+        """
+        if self.hash_algorithm_name == "blake3" or not tokens:
+            return
+
+        if min(tokens) < 0 or max(tokens) > 0xFFFFFFFF:
+            raise ValueError(
+                "uint64 token ids require blake3 hash_algorithm; "
+                f"got {self.hash_algorithm_name}"
+            )
+
     def hash_tokens(self, tokens: list[int], prefix_hash: Any = None) -> Any:
         """Hash one chunk with rolling prefix.
 
         Returns int or bytes depending on hash_func.
         """
+        self.ensure_token_ids_supported(tokens)
         if prefix_hash is None:
             prefix_hash = self.none_hash
         return self.hash_func((prefix_hash, tuple(tokens), None))

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -7,7 +7,7 @@ end-to-end against the actual directory without a network or server.
 """
 
 # Standard
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 import time
 
 # Third Party
@@ -22,7 +22,7 @@ from lmcache.v1.mp_coordinator.blend_directory import (
     GlobalBlendMatcher,
     StoreRange,
 )
-from lmcache.v1.mp_coordinator.schemas import decode_tokens
+from lmcache.v1.mp_coordinator.schemas import decode_tokens_u64
 
 CHUNK = 3
 SCOPE = "model-a"
@@ -30,10 +30,12 @@ SCOPE = "model-a"
 
 def _matcher_request(
     matcher: GlobalBlendMatcher,
-) -> Callable[[str, str, dict], dict]:
+) -> Callable[[str, str, Mapping[str, object]], dict[str, object]]:
     """request_fn that drives a real matcher, mirroring the coordinator router."""
 
-    def request(method: str, path: str, payload: dict) -> dict:
+    def request(
+        method: str, path: str, payload: Mapping[str, object]
+    ) -> dict[str, object]:
         if method == "POST" and path == "/blend/fingerprints":
             ranges = [
                 StoreRange(
@@ -50,7 +52,7 @@ def _matcher_request(
             return {"removed": matcher.remove(keys) if keys else 0}
         if method == "POST" and path == "/blend/match":
             matches = matcher.match(
-                payload["model_scope"], decode_tokens(payload["tokens_b64"])
+                payload["model_scope"], decode_tokens_u64(payload["tokens_u64_b64"])
             )
             return {
                 "matches": [
@@ -63,7 +65,23 @@ def _matcher_request(
     return request
 
 
-def _range(prefix: str, tokens: list[int]) -> dict:
+def _recording_matcher_request(
+    matcher: GlobalBlendMatcher,
+    seen_payloads: list[Mapping[str, object]],
+) -> Callable[[str, str, Mapping[str, object]], dict[str, object]]:
+    request = _matcher_request(matcher)
+
+    def recording_request(
+        method: str, path: str, payload: Mapping[str, object]
+    ) -> dict[str, object]:
+        if method == "POST" and path == "/blend/match":
+            seen_payloads.append(payload)
+        return request(method, path, payload)
+
+    return recording_request
+
+
+def _range(prefix: str, tokens: list[int]) -> dict[str, object]:
     n_chunks = len(tokens) // CHUNK
     return {
         "model_scope": SCOPE,
@@ -101,6 +119,28 @@ def test_match_after_register():
             ("K0", 0, 0),
             ("K1", 3, 3),
         ]
+    finally:
+        client.close()
+
+
+def test_match_client_sends_uint64_tokens_b64() -> None:
+    m = GlobalBlendMatcher(chunk_size=CHUNK)
+    doc = [1, 2**40 + 7, 3]
+    m.register([_store_range("K", doc)])
+    seen_payloads: list[Mapping[str, object]] = []
+    client = BlendCoordinatorClient(
+        request_fn=_recording_matcher_request(m, seen_payloads)
+    )
+    try:
+        client.submit_match("r1", SCOPE, doc)
+        _wait_match(client, "r1")
+
+        assert seen_payloads
+        payload = seen_payloads[0]
+        assert "tokens_b64" not in payload
+        assert "tokens_u64_b64" in payload
+        assert isinstance(payload["tokens_u64_b64"], str)
+        assert decode_tokens_u64(payload["tokens_u64_b64"]).tolist() == doc
     finally:
         client.close()
 

--- a/tests/v1/mp_coordinator/test_blend_directory.py
+++ b/tests/v1/mp_coordinator/test_blend_directory.py
@@ -2,6 +2,7 @@
 """Tests for the coordinator global CacheBlend fingerprint directory."""
 
 # Standard
+import base64
 import threading
 
 # Third Party
@@ -12,7 +13,13 @@ from lmcache.v1.mp_coordinator.blend_directory import (
     GlobalBlendMatcher,
     StoreRange,
 )
-from lmcache.v1.mp_coordinator.schemas import decode_tokens, encode_tokens
+from lmcache.v1.mp_coordinator.schemas import (
+    decode_tokens,
+    decode_tokens_u64,
+    encode_tokens,
+    encode_tokens_u64,
+)
+from lmcache.integration.vllm.utils import mm_token_surrogate_id
 
 CHUNK = 3
 SCOPE = "model-a"
@@ -76,6 +83,37 @@ class TestRegisterMatch:
         m = GlobalBlendMatcher(chunk_size=CHUNK)
         m.register([store_range("K", [1, 2, 3])])
         assert m.match(SCOPE, [7, 8, 9]) == []
+
+    def test_vlm_surrogate_identity_distinguishes_images(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        same_image_tokens = [
+            101,
+            mm_token_surrogate_id("image-a", 0),
+            mm_token_surrogate_id("image-a", 1),
+        ]
+        different_image_tokens = [
+            101,
+            mm_token_surrogate_id("image-b", 0),
+            mm_token_surrogate_id("image-b", 1),
+        ]
+
+        assert m.register([store_range("IMG", same_image_tokens)]) == 1
+
+        same_matches = m.match(SCOPE, same_image_tokens)
+        assert [(x.object_key, x.old_st, x.cur_st) for x in same_matches] == [
+            ("IMG0", 0, 0)
+        ]
+        assert m.match(SCOPE, different_image_tokens) == []
+
+    def test_vlm_surrogate_identity_distinguishes_offsets_within_image(self) -> None:
+        m = GlobalBlendMatcher(chunk_size=CHUNK)
+        image_tokens = [mm_token_surrogate_id("image-a", i) for i in range(9)]
+        shifted_image_tokens = image_tokens[3:6]
+
+        assert m.register([store_range("IMG", image_tokens[:3])]) == 1
+
+        assert m.match(SCOPE, image_tokens[:3])[0].object_key == "IMG0"
+        assert m.match(SCOPE, shifted_image_tokens) == []
 
 
 class TestIdempotencyEviction:
@@ -233,27 +271,29 @@ class TestConcurrency:
 
 class TestTokenCodec:
     def test_round_trip(self) -> None:
+        tokens = [0, 1, 2, 65535, 2**31, 2**32 - 1, 2**32 + 7, 2**63 - 1]
+        decoded = decode_tokens_u64(encode_tokens_u64(tokens))
+        assert decoded.tolist() == tokens
+
+    def test_legacy_u32_round_trip(self) -> None:
         tokens = [0, 1, 2, 65535, 2**31, 2**32 - 1]
         decoded = decode_tokens(encode_tokens(tokens))
         assert decoded.tolist() == tokens
 
     def test_empty(self) -> None:
-        assert decode_tokens(encode_tokens([])).tolist() == []
+        assert decode_tokens_u64(encode_tokens_u64([])).tolist() == []
 
     def test_decoded_feeds_match(self) -> None:
         m = GlobalBlendMatcher(chunk_size=CHUNK)
         doc = [1, 2, 3, 4, 5, 6]
         m.register([store_range("K", doc)])
-        out = m.match(SCOPE, decode_tokens(encode_tokens(doc)))
+        out = m.match(SCOPE, decode_tokens_u64(encode_tokens_u64(doc)))
         assert [x.object_key for x in out] == ["K0", "K1"]
 
     def test_malformed_base64_raises(self) -> None:
         with pytest.raises(ValueError):
-            decode_tokens("not valid base64 !!!")
+            decode_tokens_u64("not valid base64 !!!")
 
     def test_bad_byte_length_raises(self) -> None:
-        # Standard
-        import base64
-
         with pytest.raises(ValueError):
-            decode_tokens(base64.b64encode(b"abc").decode())  # 3 bytes, not /4
+            decode_tokens_u64(base64.b64encode(b"abcd").decode())  # 4 bytes, not /8

--- a/tests/v1/mp_coordinator/test_blend_directory_api.py
+++ b/tests/v1/mp_coordinator/test_blend_directory_api.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the /blend fingerprint directory REST endpoints."""
 
+# Standard
+import base64
+
 # Third Party
 from fastapi.testclient import TestClient
 
 # First Party
 from lmcache.v1.mp_coordinator.app import create_app
 from lmcache.v1.mp_coordinator.config import MPCoordinatorConfig
-from lmcache.v1.mp_coordinator.schemas import encode_tokens
+from lmcache.v1.mp_coordinator.schemas import encode_tokens, encode_tokens_u64
 
 CHUNK = 3
 SCOPE = "model-a"
@@ -18,7 +21,7 @@ def _client() -> TestClient:
     return TestClient(create_app(config))
 
 
-def _range(prefix: str, tokens: list[int]) -> dict:
+def _range(prefix: str, tokens: list[int]) -> dict[str, object]:
     n_chunks = len(tokens) // CHUNK
     return {
         "model_scope": SCOPE,
@@ -37,7 +40,7 @@ def test_publish_then_match():
 
         out = client.post(
             "/blend/match",
-            json={"model_scope": SCOPE, "tokens_b64": encode_tokens(doc)},
+            json={"model_scope": SCOPE, "tokens_u64_b64": encode_tokens_u64(doc)},
         ).json()["matches"]
         assert [(m["object_key"], m["old_st"], m["cur_st"]) for m in out] == [
             ("K0", 0, 0),
@@ -49,7 +52,10 @@ def test_match_miss_returns_empty():
     with _client() as client:
         out = client.post(
             "/blend/match",
-            json={"model_scope": SCOPE, "tokens_b64": encode_tokens([7, 8, 9])},
+            json={
+                "model_scope": SCOPE,
+                "tokens_u64_b64": encode_tokens_u64([7, 8, 9]),
+            },
         ).json()
         assert out == {"matches": []}
 
@@ -64,7 +70,7 @@ def test_remove_evicts():
         assert resp.json() == {"removed": 2}
         out = client.post(
             "/blend/match",
-            json={"model_scope": SCOPE, "tokens_b64": encode_tokens(doc)},
+            json={"model_scope": SCOPE, "tokens_u64_b64": encode_tokens_u64(doc)},
         ).json()
         assert out == {"matches": []}
 
@@ -87,15 +93,46 @@ def test_match_malformed_tokens_b64_returns_422():
         )
         assert resp.status_code == 422
 
-        # Valid base64 but not a whole number of uint32 tokens (3 bytes).
-        # Standard
-        import base64
-
+        # Valid base64 but not a whole number of uint64 tokens (4 bytes).
         resp = client.post(
             "/blend/match",
             json={
                 "model_scope": SCOPE,
-                "tokens_b64": base64.b64encode(b"\x01\x02\x03").decode("ascii"),
+                "tokens_u64_b64": base64.b64encode(b"\x01\x02\x03\x04").decode("ascii"),
+            },
+        )
+        assert resp.status_code == 422
+
+
+def test_match_missing_token_payload_returns_422() -> None:
+    """A missing token payload is a client error, not an unhandled 500."""
+    with _client() as client:
+        resp = client.post("/blend/match", json={"model_scope": SCOPE})
+        assert resp.status_code == 422
+
+
+def test_match_accepts_legacy_uint32_tokens_b64() -> None:
+    """The old uint32 field remains readable for rolling upgrade safety."""
+    with _client() as client:
+        doc = [1, 2, 3]
+        client.post("/blend/fingerprints", json={"ranges": [_range("K", doc)]})
+        resp = client.post(
+            "/blend/match",
+            json={"model_scope": SCOPE, "tokens_b64": encode_tokens(doc)},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["matches"][0]["object_key"] == "K0"
+
+
+def test_match_rejects_ambiguous_token_payloads() -> None:
+    """Clients must not send both legacy and uint64 token payload fields."""
+    with _client() as client:
+        resp = client.post(
+            "/blend/match",
+            json={
+                "model_scope": SCOPE,
+                "tokens_b64": encode_tokens([1, 2, 3]),
+                "tokens_u64_b64": encode_tokens_u64([1, 2, 3]),
             },
         )
         assert resp.status_code == 422

--- a/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
+++ b/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
@@ -126,6 +126,40 @@ def test_fingerprint_worker_stops_on_signal():
     assert not worker.is_alive()
 
 
+def test_store_skips_uint64_tokens_when_hasher_cannot_hash_them():
+    """Non-blake3 hash configs cannot safely hash VLM uint64 surrogate ids."""
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+    from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
+    from lmcache.v1.multiprocess.token_hasher import TokenHasher
+
+    hasher = TokenHasher.__new__(TokenHasher)
+    hasher.chunk_size = 4
+    hasher.hash_algorithm_name = "builtin"
+    hasher.hash_func = hash
+    hasher.none_hash = 0
+
+    eng = v3_mod.BlendV3Module.__new__(v3_mod.BlendV3Module)
+    eng._ctx = SimpleNamespace(token_hasher=hasher)
+    eng._transfer_module = MagicMock()
+    eng._transfer_module.store.side_effect = AssertionError(
+        "store should skip before resolving uint64 cache token ids"
+    )
+
+    key = IPCCacheServerKey.from_token_ids(
+        "model",
+        world_size=1,
+        worker_id=0,
+        token_ids=[1, 2**62 + 7, 3, 4],
+        start=0,
+        end=4,
+        request_id="req-vlm",
+    )
+
+    assert eng.store(key, 1, [[1]], b"producer-event") == (b"producer-event", False)
+    eng._transfer_module.store.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # L2: obj_keys cache lifecycle
 # ---------------------------------------------------------------------------

--- a/tests/v1/multiprocess/test_optimized_lookup_v3.py
+++ b/tests/v1/multiprocess/test_optimized_lookup_v3.py
@@ -27,6 +27,10 @@ import numpy as np
 import pytest
 
 # First Party
+from lmcache.integration.vllm.utils import (
+    apply_mm_hashes_to_token_list,
+    mm_token_surrogate_id,
+)
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.multiprocess.custom_types import CBMatchResult
 from lmcache.v1.multiprocess.modules.blend_v3 import BlendTokenRangeMatcherV3
@@ -70,6 +74,12 @@ class OptimalLookupResult:
     prefix_hits: list[CBMatchResult]  # chain walk; old_st == cur_st, contiguous from 0
     cb_aligned: list[CBMatchResult]  # matcher hit; old_st == cur_st, past chain break
     cb_shifted: list[CBMatchResult]  # matcher hit; old_st != cur_st
+
+
+@dataclass(frozen=True)
+class DummyPlaceholderRange:
+    offset: int
+    length: int
 
 
 def _simulate_chain_walk(
@@ -370,6 +380,67 @@ def _chunk(seed: int) -> list[int]:
 # ---------------------------------------------------------------------------
 # Test cases
 # ---------------------------------------------------------------------------
+
+
+def test_vlm_surrogate_identity_distinguishes_images() -> None:
+    """Large multimodal surrogate ids are part of the V3 matcher identity."""
+    matcher = BlendTokenRangeMatcherV3(chunk_size=3)
+    same_image_tokens = [
+        101,
+        mm_token_surrogate_id("image-a", 0),
+        mm_token_surrogate_id("image-a", 1),
+    ]
+    different_image_tokens = [
+        101,
+        mm_token_surrogate_id("image-b", 0),
+        mm_token_surrogate_id("image-b", 1),
+    ]
+    shifted_image_tokens = [
+        101,
+        mm_token_surrogate_id("image-a", 3),
+        mm_token_surrogate_id("image-a", 4),
+    ]
+    chunk_hash = b"image-a-chunk"
+
+    matcher.on_new_token_hashes(same_image_tokens, [chunk_hash])
+
+    same_matches = matcher.match_sub_sequence(same_image_tokens)
+    assert [(x.hash, x.old_st, x.cur_st) for x in same_matches] == [(chunk_hash, 0, 0)]
+    assert matcher.match_sub_sequence(different_image_tokens) == []
+    assert matcher.match_sub_sequence(shifted_image_tokens) == []
+
+
+def test_vlm_identity_salts_text_chunks_after_placeholder() -> None:
+    """Sparse matcher must not reuse post-image text chunks across images."""
+    chunk_size = 4
+    matcher = BlendTokenRangeMatcherV3(chunk_size=chunk_size)
+    raw_tokens = [
+        101,
+        102,
+        103,
+        104,
+        201,
+        202,
+        203,
+        204,
+    ]
+    placeholder = [DummyPlaceholderRange(offset=1, length=2)]
+
+    image_a_tokens = apply_mm_hashes_to_token_list(raw_tokens, ["image-a"], placeholder)
+    image_b_tokens = apply_mm_hashes_to_token_list(raw_tokens, ["image-b"], placeholder)
+
+    assert image_a_tokens is not None
+    assert image_b_tokens is not None
+    assert image_a_tokens[4:8] != image_b_tokens[4:8]
+
+    matcher.on_new_token_hashes(image_a_tokens, [b"image-a-0", b"image-a-1"])
+
+    assert matcher.match_sub_sequence(image_b_tokens) == []
+    same_matches = matcher.match_sub_sequence(image_a_tokens)
+    assert [(x.hash, x.old_st, x.cur_st) for x in same_matches] == [
+        (b"image-a-0", 0, 0),
+        (b"image-a-1", 4, 4),
+    ]
 
 
 class TestOptimizedLookupEquivalence:

--- a/tests/v1/multiprocess/test_token_hasher.py
+++ b/tests/v1/multiprocess/test_token_hasher.py
@@ -77,6 +77,24 @@ class TestTokenHasher:
         h2 = hasher.hash_tokens([5, 6, 7, 8])
         assert h1 != h2
 
+    def test_hash_tokens_accepts_uint64_token_ids(self, hasher: TokenHasher) -> None:
+        """Multimodal cache surrogate ids can exceed the uint32 token range."""
+        h1 = hasher.hash_tokens([2**32 + 7, 2, 3, 4])
+        h2 = hasher.hash_tokens([2**32 + 8, 2, 3, 4])
+
+        assert isinstance(h1, bytes)
+        assert h1 != h2
+
+    def test_hash_tokens_rejects_uint64_for_non_blake3(self) -> None:
+        hasher = TokenHasher.__new__(TokenHasher)
+        hasher.chunk_size = 4
+        hasher.hash_algorithm_name = "builtin"
+        hasher.hash_func = hash
+        hasher.none_hash = 0
+
+        with pytest.raises(ValueError, match="uint64 token ids require blake3"):
+            hasher.hash_tokens([2**32 + 7, 2, 3, 4])
+
     def test_hash_tokens_with_prefix(self, hasher: TokenHasher) -> None:
         """Rolling hash: same tokens with different prefix produces different hash."""
         h_no_prefix = hasher.hash_tokens([1, 2, 3, 4])

--- a/tests/v1/test_vllm_mp_connector_mm_hash.py
+++ b/tests/v1/test_vllm_mp_connector_mm_hash.py
@@ -1,0 +1,497 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+from dataclasses import dataclass
+import enum
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+_MISSING = object()
+_CONNECTOR_MODULE = "lmcache.integration.vllm.lmcache_mp_connector"
+_CONNECTOR_PACKAGE = "lmcache.integration.vllm"
+_CONNECTOR_ATTR = "lmcache_mp_connector"
+_PatchedAttr = tuple[types.ModuleType, str, object]
+
+
+def _set_stub_attr(
+    module: types.ModuleType,
+    name: str,
+    value: object,
+    patched_attrs: list[_PatchedAttr],
+) -> None:
+    patched_attrs.append((module, name, getattr(module, name, _MISSING)))
+    setattr(module, name, value)
+
+
+def _install_vllm_stubs() -> tuple[list[str], list[_PatchedAttr], bool]:
+    modules = [
+        "vllm",
+        "vllm.config",
+        "vllm.distributed",
+        "vllm.distributed.kv_transfer",
+        "vllm.distributed.kv_transfer.kv_connector",
+        "vllm.distributed.kv_transfer.kv_connector.v1",
+        "vllm.distributed.kv_transfer.kv_connector.v1.base",
+        "vllm.v1",
+        "vllm.v1.attention",
+        "vllm.v1.attention.backend",
+        "vllm.v1.core",
+        "vllm.v1.core.sched",
+        "vllm.v1.core.sched.output",
+        "vllm.v1.kv_cache_interface",
+        "vllm.v1.outputs",
+        "vllm.v1.request",
+        "vllm.v1.utils",
+    ]
+    created_modules: list[str] = []
+    patched_attrs: list[_PatchedAttr] = []
+    connector_was_loaded = _CONNECTOR_MODULE in sys.modules
+    for name in modules:
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+            created_modules.append(name)
+
+    class KVConnectorBaseV1:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+    class KVConnectorMetadata:
+        pass
+
+    class KVConnectorRole(enum.Enum):
+        SCHEDULER = "scheduler"
+        WORKER = "worker"
+
+    class SupportsHMA:
+        pass
+
+    class RequestStatus(enum.Enum):
+        WAITING = "waiting"
+        PREEMPTED = "preempted"
+
+    class ConstantList(list[int]):
+        pass
+
+    class KVCacheConfig:
+        pass
+
+    class KVCacheSpec:
+        pass
+
+    class KVCacheSpecKind(enum.Enum):
+        FULL_ATTENTION = "full_attention"
+        SLIDING_WINDOW = "sliding_window"
+        CHUNKED_LOCAL_ATTENTION = "chunked_local_attention"
+        SINK_FULL_ATTENTION = "sink_full_attention"
+        CROSS_ATTENTION = "cross_attention"
+        MAMBA = "mamba"
+
+    def get_kv_cache_spec_kind(spec: object) -> KVCacheSpecKind:
+        return KVCacheSpecKind.FULL_ATTENTION
+
+    base_mod = sys.modules["vllm.distributed.kv_transfer.kv_connector.v1.base"]
+    _set_stub_attr(base_mod, "KVConnectorBase_V1", KVConnectorBaseV1, patched_attrs)
+    _set_stub_attr(base_mod, "KVConnectorMetadata", KVConnectorMetadata, patched_attrs)
+    _set_stub_attr(base_mod, "KVConnectorRole", KVConnectorRole, patched_attrs)
+    _set_stub_attr(base_mod, "SupportsHMA", SupportsHMA, patched_attrs)
+    _set_stub_attr(sys.modules["vllm.config"], "VllmConfig", object, patched_attrs)
+    _set_stub_attr(
+        sys.modules["vllm.v1.attention.backend"],
+        "AttentionMetadata",
+        object,
+        patched_attrs,
+    )
+    _set_stub_attr(
+        sys.modules["vllm.v1.core.sched.output"],
+        "SchedulerOutput",
+        object,
+        patched_attrs,
+    )
+    kv_interface_mod = sys.modules["vllm.v1.kv_cache_interface"]
+    _set_stub_attr(kv_interface_mod, "KVCacheConfig", KVCacheConfig, patched_attrs)
+    _set_stub_attr(kv_interface_mod, "KVCacheSpec", KVCacheSpec, patched_attrs)
+    _set_stub_attr(kv_interface_mod, "KVCacheSpecKind", KVCacheSpecKind, patched_attrs)
+    _set_stub_attr(
+        kv_interface_mod,
+        "get_kv_cache_spec_kind",
+        get_kv_cache_spec_kind,
+        patched_attrs,
+    )
+    _set_stub_attr(
+        sys.modules["vllm.v1.outputs"], "KVConnectorOutput", object, patched_attrs
+    )
+    _set_stub_attr(
+        sys.modules["vllm.v1.request"], "RequestStatus", RequestStatus, patched_attrs
+    )
+    _set_stub_attr(
+        sys.modules["vllm.v1.utils"], "ConstantList", ConstantList, patched_attrs
+    )
+    return created_modules, patched_attrs, connector_was_loaded
+
+
+def _restore_vllm_stubs(
+    state: tuple[list[str], list[_PatchedAttr], bool],
+) -> None:
+    created_modules, patched_attrs, connector_was_loaded = state
+    if not connector_was_loaded:
+        sys.modules.pop(_CONNECTOR_MODULE, None)
+        connector_package = sys.modules.get(_CONNECTOR_PACKAGE)
+        if connector_package is not None and hasattr(
+            connector_package, _CONNECTOR_ATTR
+        ):
+            delattr(connector_package, _CONNECTOR_ATTR)
+    for module, name, old_value in reversed(patched_attrs):
+        if old_value is _MISSING:
+            delattr(module, name)
+        else:
+            setattr(module, name, old_value)
+    for name in reversed(created_modules):
+        sys.modules.pop(name, None)
+
+
+_VLLM_STUB_STATE = _install_vllm_stubs()
+try:
+    # Third Party
+    from vllm.v1.request import RequestStatus  # noqa: E402
+
+    # First Party
+    from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+        LMCacheMPConnector,
+        LMCacheMPRequestMetadata,
+        LMCacheMPRequestState,
+        LMCacheMPRequestTracker,
+    )
+    from lmcache.integration.vllm.utils import mm_token_surrogate_id  # noqa: E402
+finally:
+    _restore_vllm_stubs(_VLLM_STUB_STATE)
+
+
+@dataclass(frozen=True)
+class DummyPlaceholderRange:
+    offset: int
+    length: int
+
+
+@dataclass(frozen=True)
+class DummyMMFeature:
+    identifier: str
+    mm_position: DummyPlaceholderRange
+
+
+@dataclass
+class DummyRequest:
+    request_id: str = "req-1"
+    all_token_ids: list[int] | None = None
+    cache_salt: str = ""
+    status: RequestStatus = RequestStatus.WAITING
+    mm_features: list[DummyMMFeature] | None = None
+    mm_hashes: list[str] | None = None
+    mm_positions: list[DummyPlaceholderRange] | None = None
+
+    def __post_init__(self) -> None:
+        if self.all_token_ids is None:
+            self.all_token_ids = [10, 11, 12, 13, 14, 15, 16, 17]
+
+
+class FakeSchedulerAdapter:
+    def __init__(self, lookup_result: int = 0) -> None:
+        self.lmcache_tokens_per_chunk = 4
+        self.lookup_result = lookup_result
+        self.lookup_calls: list[tuple[str, list[int], str]] = []
+        self.cleanup_calls: list[str] = []
+        self.free_lock_calls: list[dict[str, object]] = []
+        self.allocation_reports: list[list[object]] = []
+
+    def maybe_submit_lookup_request(
+        self, request_id: str, token_ids: list[int], cache_salt: str = ""
+    ) -> None:
+        self.lookup_calls.append((request_id, token_ids, cache_salt))
+
+    def check_lookup_result(self, request_id: str) -> int:
+        return self.lookup_result
+
+    def cleanup_lookup_result(self, request_id: str) -> None:
+        self.cleanup_calls.append(request_id)
+
+    def free_lookup_locks(
+        self,
+        token_ids: list[int],
+        start: int,
+        end: int,
+        request_id: str,
+        cache_salt: str = "",
+    ) -> None:
+        self.free_lock_calls.append(
+            {
+                "token_ids": token_ids,
+                "start": start,
+                "end": end,
+                "request_id": request_id,
+                "cache_salt": cache_salt,
+            }
+        )
+
+    def report_block_allocations(self, records: list[object]) -> None:
+        self.allocation_reports.append(records)
+
+
+def _vlm_request(request_id: str = "req-vlm") -> DummyRequest:
+    return DummyRequest(
+        request_id=request_id,
+        all_token_ids=[10, 11, 12, 13, 14, 15, 16, 17],
+        cache_salt="tenant-a",
+        mm_features=[
+            DummyMMFeature(
+                identifier="0x10000",
+                mm_position=DummyPlaceholderRange(offset=2, length=3),
+            )
+        ],
+    )
+
+
+def _connector(fake_adapter: FakeSchedulerAdapter) -> LMCacheMPConnector:
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    connector.scheduler_adapter = fake_adapter
+    connector.request_trackers = {}
+    connector._group_tokens_per_block = [4]
+    connector._hit_alignment_tokens = 4
+    return connector
+
+
+def test_mp_request_tracker_keeps_raw_tokens_and_cache_tokens_text_only() -> None:
+    request = DummyRequest(all_token_ids=[1, 2, 3])
+
+    tracker = LMCacheMPRequestTracker(request)
+
+    assert list(tracker.all_token_ids) == [1, 2, 3]
+    assert tracker.cache_token_ids == [1, 2, 3]
+    assert tracker.cache_token_ids is not tracker.all_token_ids
+
+
+def test_mp_request_tracker_rewrites_vlm_cache_token_ids_only() -> None:
+    request = _vlm_request()
+
+    tracker = LMCacheMPRequestTracker(request)
+
+    assert list(tracker.all_token_ids) == [10, 11, 12, 13, 14, 15, 16, 17]
+    assert tracker.cache_token_ids is not None
+    assert tracker.cache_token_ids[:5] == [
+        10,
+        11,
+        mm_token_surrogate_id("0x10000", 0),
+        mm_token_surrogate_id("0x10000", 1),
+        mm_token_surrogate_id("0x10000", 2),
+    ]
+    assert tracker.cache_token_ids[5:] != [15, 16, 17]
+    assert all(token >= 2**62 for token in tracker.cache_token_ids[5:])
+
+
+def test_mp_request_tracker_fails_closed_on_empty_mm_identifier() -> None:
+    request = DummyRequest(
+        all_token_ids=[10, 11, 12, 13],
+        mm_features=[
+            DummyMMFeature(
+                identifier="",
+                mm_position=DummyPlaceholderRange(offset=1, length=2),
+            )
+        ],
+    )
+
+    tracker = LMCacheMPRequestTracker(request)
+
+    assert tracker.cache_token_ids is None
+
+
+def test_store_metadata_skips_unsafe_vlm_identity() -> None:
+    request = DummyRequest(
+        all_token_ids=[10, 11, 12, 13],
+        mm_features=[
+            DummyMMFeature(
+                identifier="",
+                mm_position=DummyPlaceholderRange(offset=1, length=2),
+            )
+        ],
+    )
+    tracker = LMCacheMPRequestTracker(request)
+    tracker.allocated_block_ids = {0: [100]}
+    tracker.num_scheduled_tokens = 4
+
+    meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+        tracker,
+        lmcache_tokens_per_chunk=4,
+        group_tokens_per_block=[4],
+    )
+
+    assert meta is None
+    assert tracker.num_stored_tokens == 0
+
+
+def test_retrieve_metadata_skips_unsafe_vlm_identity() -> None:
+    request = DummyRequest(
+        all_token_ids=[10, 11, 12, 13],
+        mm_features=[
+            DummyMMFeature(
+                identifier="",
+                mm_position=DummyPlaceholderRange(offset=1, length=2),
+            )
+        ],
+    )
+    tracker = LMCacheMPRequestTracker(request)
+    tracker.allocated_block_ids = {0: [100]}
+    tracker.num_lmcache_hit_tokens = 4
+    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
+
+    meta = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+        tracker,
+        lmcache_tokens_per_chunk=4,
+        group_tokens_per_block=[4],
+    )
+
+    assert meta is None
+
+
+def test_lookup_skips_unsafe_vlm_identity() -> None:
+    fake_adapter = FakeSchedulerAdapter(lookup_result=8)
+    connector = _connector(fake_adapter)
+    request = DummyRequest(
+        all_token_ids=[10, 11, 12, 13],
+        mm_features=[
+            DummyMMFeature(
+                identifier="",
+                mm_position=DummyPlaceholderRange(offset=1, length=2),
+            )
+        ],
+    )
+
+    assert connector.get_num_new_matched_tokens(request, num_computed_tokens=0) == (
+        0,
+        False,
+    )
+    assert fake_adapter.lookup_calls == []
+
+
+def test_store_metadata_uses_cache_token_ids() -> None:
+    tracker = LMCacheMPRequestTracker(_vlm_request())
+    tracker.allocated_block_ids = {0: [100, 101]}
+    tracker.num_scheduled_tokens = 8
+
+    meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+        tracker,
+        lmcache_tokens_per_chunk=4,
+        group_tokens_per_block=[4],
+    )
+
+    assert meta is not None
+    assert meta.op.token_ids == tracker.cache_token_ids
+    assert meta.op.token_ids != list(tracker.all_token_ids)
+
+
+def test_store_metadata_refreshes_cache_token_ids_after_raw_tokens_grow() -> None:
+    request = _vlm_request()
+    tracker = LMCacheMPRequestTracker(request)
+    request.all_token_ids.extend([18, 19, 20, 21])
+    tracker.allocated_block_ids = {0: [100, 101, 102]}
+    tracker.num_scheduled_tokens = 12
+
+    meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+        tracker,
+        lmcache_tokens_per_chunk=4,
+        group_tokens_per_block=[4],
+    )
+
+    assert meta is not None
+    assert meta.op.token_ids == tracker.cache_token_ids
+    assert meta.op.token_ids[-4:] != [18, 19, 20, 21]
+    assert all(token >= 2**62 for token in meta.op.token_ids[-4:])
+
+
+def test_retrieve_metadata_uses_cache_token_ids() -> None:
+    tracker = LMCacheMPRequestTracker(_vlm_request())
+    tracker.allocated_block_ids = {0: [100, 101]}
+    tracker.num_vllm_hit_tokens = 0
+    tracker.num_lmcache_hit_tokens = 8
+    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
+
+    meta = LMCacheMPRequestMetadata.GetRetrieveMetadata(
+        tracker,
+        lmcache_tokens_per_chunk=4,
+        group_tokens_per_block=[4],
+    )
+
+    assert meta is not None
+    assert meta.op.token_ids == tracker.cache_token_ids
+    assert meta.op.token_ids != list(tracker.all_token_ids)
+
+
+def test_lookup_submits_cache_token_ids() -> None:
+    fake_adapter = FakeSchedulerAdapter(lookup_result=0)
+    connector = _connector(fake_adapter)
+    request = _vlm_request()
+
+    connector.get_num_new_matched_tokens(request, num_computed_tokens=0)
+
+    tracker = connector.request_trackers[request.request_id]
+    assert fake_adapter.lookup_calls == [
+        (request.request_id, tracker.cache_token_ids, "tenant-a")
+    ]
+
+
+def test_free_lookup_locks_use_cache_token_ids() -> None:
+    fake_adapter = FakeSchedulerAdapter(lookup_result=8)
+    connector = _connector(fake_adapter)
+    request = _vlm_request()
+
+    connector.get_num_new_matched_tokens(request, num_computed_tokens=8)
+    tracker = connector.request_trackers[request.request_id]
+    tracker.allocated_block_ids = {0: [100, 101]}
+    connector.update_state_after_alloc(request, MagicMock(), num_external_tokens=0)
+
+    assert fake_adapter.free_lock_calls == [
+        {
+            "token_ids": tracker.cache_token_ids,
+            "start": 0,
+            "end": 8,
+            "request_id": request.request_id,
+            "cache_salt": "tenant-a",
+        }
+    ]
+
+
+def test_new_request_allocation_telemetry_uses_cache_token_ids() -> None:
+    fake_adapter = FakeSchedulerAdapter()
+    connector = _connector(fake_adapter)
+    tracker = LMCacheMPRequestTracker(_vlm_request("req-new"))
+    tracker.allocated_block_ids = {0: [100, 101]}
+    connector.request_trackers[tracker.request_id] = tracker
+    scheduler_output = SimpleNamespace(
+        scheduled_new_reqs=[SimpleNamespace(req_id=tracker.request_id)],
+        scheduled_cached_reqs=SimpleNamespace(req_ids=[], new_block_ids=[]),
+    )
+
+    connector._report_block_allocation_deltas(scheduler_output)
+
+    [records] = fake_adapter.allocation_reports
+    assert records[0].new_block_ids == [100, 101]
+    assert records[0].new_token_ids == tracker.cache_token_ids
+
+
+def test_cached_request_allocation_telemetry_uses_cache_token_ids() -> None:
+    fake_adapter = FakeSchedulerAdapter()
+    connector = _connector(fake_adapter)
+    tracker = LMCacheMPRequestTracker(_vlm_request("req-cached"))
+    tracker.allocated_block_ids = {0: [100, 101]}
+    connector.request_trackers[tracker.request_id] = tracker
+    scheduler_output = SimpleNamespace(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[tracker.request_id],
+            new_block_ids=[([101],)],
+        ),
+    )
+
+    connector._report_block_allocation_deltas(scheduler_output)
+
+    [records] = fake_adapter.allocation_reports
+    assert records[0].new_block_ids == [101]
+    assert records[0].new_token_ids == tracker.cache_token_ids[4:8]

--- a/tests/v1/test_vllm_v1_adapter_mm_hash.py
+++ b/tests/v1/test_vllm_v1_adapter_mm_hash.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+"""VLM cache identity safety tests for the non-MP vLLM v1 adapter."""
+
+# Standard
+from dataclasses import dataclass
+from types import SimpleNamespace
+import enum
+import sys
+import types
+
+# Third Party
+import torch
+
+_MISSING = object()
+_ADAPTER_MODULE = "lmcache.integration.vllm.vllm_v1_adapter"
+_ADAPTER_PACKAGE = "lmcache.integration.vllm"
+_ADAPTER_ATTR = "vllm_v1_adapter"
+_PatchedAttr = tuple[types.ModuleType, str, object]
+
+
+def _set_stub_attr(
+    module: types.ModuleType,
+    name: str,
+    value: object,
+    patched_attrs: list[_PatchedAttr],
+) -> None:
+    patched_attrs.append((module, name, getattr(module, name, _MISSING)))
+    setattr(module, name, value)
+
+
+def _install_vllm_stubs() -> tuple[list[str], list[_PatchedAttr], bool]:
+    modules = [
+        "vllm",
+        "vllm.config",
+        "vllm.distributed",
+        "vllm.distributed.kv_transfer",
+        "vllm.distributed.kv_transfer.kv_connector",
+        "vllm.distributed.kv_transfer.kv_connector.v1",
+        "vllm.distributed.kv_transfer.kv_connector.v1.base",
+        "vllm.distributed.parallel_state",
+        "vllm.sampling_params",
+        "vllm.v1",
+        "vllm.v1.core",
+        "vllm.v1.core.sched",
+        "vllm.v1.core.sched.output",
+        "vllm.v1.request",
+        "vllm.version",
+    ]
+    created_modules: list[str] = []
+    patched_attrs: list[_PatchedAttr] = []
+    adapter_was_loaded = _ADAPTER_MODULE in sys.modules
+    for name in modules:
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+            created_modules.append(name)
+
+    class KVConnectorBaseV1:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+    class KVConnectorMetadata:
+        pass
+
+    class KVConnectorRole(enum.Enum):
+        SCHEDULER = "scheduler"
+        WORKER = "worker"
+
+    class RequestStatus(enum.Enum):
+        WAITING = "waiting"
+        FINISHED_ABORTED = "finished_aborted"
+
+    class SchedulerOutput:
+        pass
+
+    class SamplingParams:
+        pass
+
+    _set_stub_attr(sys.modules["vllm.config"], "VllmConfig", object, patched_attrs)
+    base_mod = sys.modules["vllm.distributed.kv_transfer.kv_connector.v1.base"]
+    _set_stub_attr(base_mod, "KVConnectorBase_V1", KVConnectorBaseV1, patched_attrs)
+    _set_stub_attr(base_mod, "KVConnectorMetadata", KVConnectorMetadata, patched_attrs)
+    _set_stub_attr(base_mod, "KVConnectorRole", KVConnectorRole, patched_attrs)
+    _set_stub_attr(
+        sys.modules["vllm.distributed.parallel_state"],
+        "get_pp_group",
+        lambda: None,
+        patched_attrs,
+    )
+    _set_stub_attr(
+        sys.modules["vllm.sampling_params"],
+        "SamplingParams",
+        SamplingParams,
+        patched_attrs,
+    )
+    _set_stub_attr(
+        sys.modules["vllm.v1.core.sched.output"],
+        "SchedulerOutput",
+        SchedulerOutput,
+        patched_attrs,
+    )
+    _set_stub_attr(
+        sys.modules["vllm.v1.request"], "RequestStatus", RequestStatus, patched_attrs
+    )
+    _set_stub_attr(sys.modules["vllm.version"], "__version__", "0.0.0", patched_attrs)
+    return created_modules, patched_attrs, adapter_was_loaded
+
+
+def _restore_vllm_stubs(
+    state: tuple[list[str], list[_PatchedAttr], bool],
+) -> None:
+    created_modules, patched_attrs, adapter_was_loaded = state
+    if not adapter_was_loaded:
+        sys.modules.pop(_ADAPTER_MODULE, None)
+        adapter_package = sys.modules.get(_ADAPTER_PACKAGE)
+        if adapter_package is not None and hasattr(adapter_package, _ADAPTER_ATTR):
+            delattr(adapter_package, _ADAPTER_ATTR)
+    for module, name, old_value in reversed(patched_attrs):
+        if old_value is _MISSING:
+            delattr(module, name)
+        else:
+            setattr(module, name, old_value)
+    for name in reversed(created_modules):
+        sys.modules.pop(name, None)
+
+
+_VLLM_STUB_STATE = _install_vllm_stubs()
+try:
+    # First Party
+    from lmcache.integration.vllm.vllm_v1_adapter import (  # noqa: E402
+        LMCacheConnectorMetadata,
+        LMCacheConnectorV1Impl,
+        ReqMeta,
+        RequestTracker,
+    )
+finally:
+    _restore_vllm_stubs(_VLLM_STUB_STATE)
+
+# First Party
+
+
+@dataclass(frozen=True)
+class DummyPlaceholderRange:
+    offset: int
+    length: int
+
+
+@dataclass(frozen=True)
+class DummyMMFeature:
+    identifier: str
+    mm_position: DummyPlaceholderRange
+
+
+@dataclass
+class DummyRequest:
+    request_id: str = "req-vlm"
+    all_token_ids: list[int] | None = None
+    prompt_token_ids: list[int] | None = None
+    sampling_params: object | None = None
+    num_tokens: int = 0
+    mm_features: list[DummyMMFeature] | None = None
+
+    def __post_init__(self) -> None:
+        if self.all_token_ids is None:
+            self.all_token_ids = [10, 11, 12, 13]
+        if self.prompt_token_ids is None:
+            self.prompt_token_ids = list(self.all_token_ids)
+        if self.num_tokens == 0:
+            self.num_tokens = len(self.all_token_ids)
+
+
+class NoLookupConnector(LMCacheConnectorV1Impl):
+    def __init__(self) -> None:
+        self.kv_role = "kv_consumer"
+
+    @property
+    def lookup_client(self) -> object:
+        raise AssertionError("VLM requests should skip non-MP cache lookup")
+
+    @property
+    def config(self) -> object:
+        raise AssertionError("VLM requests should return before reading config")
+
+
+class FakeLMCacheEngine:
+    def __init__(self) -> None:
+        self.store_calls: list[list[int]] = []
+        self.store_layer_calls: list[list[int]] = []
+        self.unpinned: list[str] = []
+
+    def lookup_unpin(self, req_id: str) -> None:
+        self.unpinned.append(req_id)
+
+    def store(
+        self,
+        token_ids: list[int],
+        **kwargs: object,
+    ) -> None:
+        self.store_calls.append(token_ids)
+
+    def store_layer(
+        self,
+        token_ids: list[int],
+        **kwargs: object,
+    ):
+        self.store_layer_calls.append(token_ids)
+        yield None
+
+
+class ProducerConnector(LMCacheConnectorV1Impl):
+    def __init__(
+        self,
+        engine: FakeLMCacheEngine,
+        requests: list[ReqMeta],
+        *,
+        use_layerwise: bool = False,
+    ) -> None:
+        self.kv_role = "kv_producer"
+        self._engine = engine
+        self.kv_caches = {"layer": object()}
+        self.device = "cpu"
+        self.use_layerwise = use_layerwise
+        self._config = SimpleNamespace(pd_bidirectional=False)
+        self._lmcache_chunk_size = 4
+        metadata = LMCacheConnectorMetadata(requests=requests)
+        self._parent = SimpleNamespace(
+            _connector_metadata=metadata,
+            _get_connector_metadata=lambda: metadata,
+        )
+        self._layerwise_save_storers = {}
+
+    @property
+    def lmcache_engine(self) -> FakeLMCacheEngine:
+        return self._engine
+
+    @property
+    def config(self) -> object:
+        return self._config
+
+
+def _vlm_request(identifier: str = "image-a") -> DummyRequest:
+    return DummyRequest(
+        all_token_ids=[10, 11, 12, 13],
+        mm_features=[
+            DummyMMFeature(
+                identifier=identifier,
+                mm_position=DummyPlaceholderRange(offset=1, length=2),
+            )
+        ],
+        sampling_params=SimpleNamespace(extra_args=None),
+    )
+
+
+def test_req_meta_keeps_raw_tokens_for_vlm_requests() -> None:
+    tracker = RequestTracker(
+        req_id="req-vlm",
+        prompt_len=4,
+        token_ids=[10, 11, 12, 13],
+        allocated_block_ids=[100],
+        mm_hashes=["image-a"],
+        mm_positions=[DummyPlaceholderRange(offset=1, length=2)],
+    )
+
+    meta = ReqMeta.from_request_tracker(
+        tracker,
+        block_size=4,
+        lmcache_chunk_size=4,
+        discard_partial_chunks=True,
+    )
+
+    assert meta is not None
+    assert meta.token_ids == [10, 11, 12, 13]
+    assert all(token < 2**32 for token in meta.token_ids)
+    assert meta.slot_mapping.tolist() == [400, 401, 402, 403]
+
+
+def test_req_meta_skips_save_for_vlm_requests() -> None:
+    tracker = RequestTracker(
+        req_id="req-vlm",
+        prompt_len=4,
+        token_ids=[10, 11, 12, 13],
+        allocated_block_ids=[100],
+        mm_hashes=["image-a"],
+        mm_positions=[DummyPlaceholderRange(offset=1, length=2)],
+    )
+
+    meta = ReqMeta.from_request_tracker(
+        tracker,
+        block_size=4,
+        lmcache_chunk_size=4,
+        discard_partial_chunks=True,
+    )
+
+    assert meta is not None
+    assert meta.save_spec is not None
+    assert not meta.save_spec.can_save
+    assert tracker.num_saved_tokens == 0
+
+
+def test_non_mp_lookup_skips_vlm_requests() -> None:
+    connector = NoLookupConnector()
+
+    ret = connector.get_num_new_matched_tokens(_vlm_request(), num_computed_tokens=0)
+
+    assert ret == 0
+
+
+def test_non_mp_kv_producer_skips_vlm_store() -> None:
+    tracker = RequestTracker(
+        req_id="req-vlm",
+        prompt_len=4,
+        token_ids=[10, 11, 12, 13],
+        allocated_block_ids=[100],
+        mm_hashes=["image-a"],
+        mm_positions=[DummyPlaceholderRange(offset=1, length=2)],
+    )
+    meta = ReqMeta.from_request_tracker(
+        tracker,
+        block_size=4,
+        lmcache_chunk_size=4,
+        discard_partial_chunks=True,
+    )
+    assert meta is not None
+
+    engine = FakeLMCacheEngine()
+    connector = ProducerConnector(engine, [meta])
+    wait_globals = connector.wait_for_save.__globals__
+    old_get_pp_group = wait_globals["get_pp_group"]
+    wait_globals["get_pp_group"] = lambda: SimpleNamespace(is_last_rank=True)
+
+    try:
+        connector.wait_for_save()
+    finally:
+        wait_globals["get_pp_group"] = old_get_pp_group
+
+    assert engine.unpinned == ["req-vlm"]
+    assert engine.store_calls == []
+
+
+def test_non_mp_layerwise_kv_producer_skips_vlm_store_layer() -> None:
+    tracker = RequestTracker(
+        req_id="req-vlm",
+        prompt_len=4,
+        token_ids=[10, 11, 12, 13],
+        allocated_block_ids=[100],
+        mm_hashes=["image-a"],
+        mm_positions=[DummyPlaceholderRange(offset=1, length=2)],
+    )
+    meta = ReqMeta.from_request_tracker(
+        tracker,
+        block_size=4,
+        lmcache_chunk_size=4,
+        discard_partial_chunks=True,
+    )
+    assert meta is not None
+
+    engine = FakeLMCacheEngine()
+    connector = ProducerConnector(engine, [meta], use_layerwise=True)
+
+    connector.save_kv_layer("layer", torch.zeros(1), None)
+
+    assert engine.store_layer_calls == []
+    assert connector._layerwise_save_storers == {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR completes VLM-aware cache identity support for vLLM MP CacheBlend.

Today, MP CacheBlend can match chunks by token ids without knowing that a VLM placeholder stands for image or video content. That can make two prompts with the same text but different multimodal inputs look identical to CacheBlend. This PR gives the MP CacheBlend path a separate cache-token view that includes stable multimodal identity while keeping the raw vLLM token ids available for model execution.

Refs #2988

Summary:

- Adds shared vLLM helpers that derive VLM-aware cache token ids from `all_token_ids` plus `mm_features`, or legacy `mm_hashes` / `mm_positions`. The helpers fail closed when a request contains multimodal metadata but that metadata is incomplete or unsafe.
- Uses a dual-token view in the MP request tracker: raw vLLM token ids stay available for vLLM/model execution, while `cache_token_ids` are used for CacheBlend identity.
- Routes MP CacheBlend lookup, store, retrieve, free-lock cleanup, and L0 allocation telemetry through `cache_token_ids`.
- Gives multimodal placeholders position-aware surrogate ids and salts text after multimodal spans, so sparse/non-prefix CacheBlend chunks do not cross-match across different media.
- Adds a `tokens_u64_b64` coordinator match payload for little-endian uint64 tokens while keeping legacy `tokens_b64` as little-endian uint32 for older clients. New clients send `tokens_u64_b64`.
- Keeps non-MP vLLM V1 VLM caching fail-closed for now: VLM lookup returns no match and VLM store paths skip LMCache writes, which avoids raw-token cache pollution outside the MP CacheBlend path.
- Adds local BlendV3 and coordinator tests for VLM identity, uint64 token transport, same-media hits, different-media misses, and fail-closed cases.

Implementation map:

| Area | Change |
| --- | --- |
| vLLM integration | Builds VLM-aware `cache_token_ids` from raw tokens plus multimodal metadata. |
| MP connector | Keeps raw `all_token_ids` for vLLM execution and sends `cache_token_ids` to CacheBlend lookup/store/retrieve/free-lock/telemetry. |
| Cache identity | Uses signed-int64 surrogate ids for multimodal placeholders and salts later text tokens with multimodal context. |
| Coordinator | Adds `tokens_u64_b64` for uint64 match payloads and keeps legacy `tokens_b64` for uint32 clients. |
| Non-MP V1 | Fails closed for VLM lookup/store to avoid raw-token cache pollution. |

Scope:

This PR targets vLLM MP CacheBlend, specifically the BlendV3 CacheBlend path and the MP coordinator match path used by it. It does not add SGLang VLM support, does not add a new VLM-specific blending/recompute algorithm, and does not claim general VLM support for every MP engine path. Legacy Blend and default MP transfer paths are outside this PR's support boundary.

Coordinator compatibility note:

The current coordinator match payload for new clients is `tokens_u64_b64` (little-endian uint64). The legacy `tokens_b64` field remains accepted as little-endian uint32. Deployments that rely on VLM surrogate ids should upgrade the MP CacheBlend client and coordinator together so match requests use the uint64 field.

Validation:

- `pytest -q lmcache/integration/vllm/tests/test_mm_hash_utils.py tests/v1/test_vllm_mp_connector_mm_hash.py tests/v1/test_vllm_v1_adapter_mm_hash.py tests/v1/multiprocess/test_token_hasher.py tests/v1/multiprocess/test_blend_v3_load_store_opts.py tests/v1/multiprocess/test_optimized_lookup_v3.py tests/v1/mp_coordinator/test_blend_client.py tests/v1/mp_coordinator/test_blend_directory.py tests/v1/mp_coordinator/test_blend_directory_api.py`
- `ruff check $(git diff --name-only dev..HEAD -- '*.py')`
- `git diff --check dev..HEAD`

Reviewer focus:

- Is signed-int64 multimodal surrogate identity acceptable for CacheBlend keys?
- Is `tokens_u64_b64` the right coordinator field shape for the uint64 match payload while keeping legacy `tokens_b64`?
- Should this PR close the vLLM MP CacheBlend portion of #2988, or should #2988 stay open for other backends, non-MP paths, or full VLM e2e coverage?

**Special notes for your reviewers**:

The implementation keeps raw vLLM token ids separate from CacheBlend identity tokens. This is intentional: surrogate ids are cache keys, not model tokens.

For non-MP vLLM V1 VLM requests, this PR chooses fail-closed behavior rather than raw-token caching. That path can be enabled later with the same dual-view model if needed.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests