### PR TITLE
[operator] replace privileged:true with unconfined profiles

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/mp/operator.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/mp/operator.po
@@ -98,8 +98,8 @@ msgid "Prerequisites"
 msgstr "先决条件"
 
 #: ../../source/mp/operator.rst:41
-msgid "Kubernetes 1.20+"
-msgstr "Kubernetes 1.20+"
+msgid "Kubernetes 1.30+ (``securityContext.appArmorProfile`` used for CUDA IPC is not available before 1.30)"
+msgstr "Kubernetes 1.30+（``securityContext.appArmorProfile`` 用于 CUDA IPC，1.30 以下版本不支持此字段）"
 
 #: ../../source/mp/operator.rst:42
 msgid "``kubectl`` configured to access your cluster"

--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -38,7 +38,7 @@ eliminates:
 Prerequisites
 -------------
 
-- Kubernetes 1.20+
+- Kubernetes 1.30+ (``securityContext.appArmorProfile`` used for CUDA IPC is not available before 1.30)
 - ``kubectl`` configured to access your cluster
 - (Optional) `Prometheus Operator <https://github.com/prometheus-operator/prometheus-operator>`_
   for ServiceMonitor support

--- a/operator/AGENTS.md
+++ b/operator/AGENTS.md
@@ -101,8 +101,7 @@ Both names point at the same image; only the hostnames differ.
 
 - **PodSecurity admission**: test namespaces are pre-labeled
   `pod-security.kubernetes.io/enforce=privileged` so the operator's
-  DaemonSet (which sets `hostIPC=true` + `privileged=true`) is accepted
-  at admission time. Harmless on clusters that don't enforce PodSecurity.
+  DaemonSet (which sets `hostIPC=true`) is accepted at admission time. Harmless on clusters that don't enforce PodSecurity.
 - **SCC (Security Context Constraints)**: M1 smokes never wait for
   DaemonSet pods to schedule, so SCC isn't a blocker. If you need pods
   to actually run later (M2/M3 GPU tier), grant the LMCache

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -155,13 +155,13 @@ The operator always injects these into the pod spec:
 
 - **`hostIPC: true`** — **required for CUDA IPC between LMCache and vLLM.** LMCache uses `CudaIPCWrapper` which calls PyTorch's `_share_cuda_()` to get a GPU driver-level IPC handle. The handle is serialized and sent over ZMQ TCP. The receiving process reconstructs the tensor via `cudaIpcOpenMemHandle` at the driver level. This call requires both processes to share the same IPC namespace — without `hostIPC: true`, `cudaIpcOpenMemHandle` fails with `cudaErrorMapBufferObjectFailed`. **Both the LMCache pods and vLLM pods must have `hostIPC: true`.**
 - **`runtimeClassName: nvidia`** — uses the NVIDIA container runtime, which injects the host's NVIDIA driver libraries and device files into the container. This is required for CUDA to function inside the pod.
-- **`privileged: true`** (security context) — **required for GPU visibility without explicit GPU resource requests.** LMCache needs access to all GPUs on the node for CUDA IPC and custom data transfer kernels, but it must not claim any GPUs via `nvidia.com/gpu` resource requests (otherwise those GPUs would be unavailable to the serving engine). The combination of `runtimeClassName: nvidia` + `privileged: true` + `NVIDIA_VISIBLE_DEVICES=all` allows the container to see all GPUs without consuming device plugin resources. This means the serving engine (e.g., vLLM) can still request all GPUs on the node.
+- **`seccompProfile: Unconfined` + `appArmorProfile: Unconfined`** (engine container only, Kubernetes 1.30+) — **required on the CUDA IPC receiving/opening side.** `cudaIpcOpenMemHandle` invokes NVIDIA kernel driver ioctls and driver-mediated cross-process GPU memory mapping that can be blocked by the default seccomp/AppArmor profiles. The operator sets these profiles only on the LMCache/CacheBlend engine container because, in the operator-managed flow, it is the **opener** (`cudaIpcOpenMemHandle`); the vLLM container is the **creator** (`cudaIpcGetMemHandle`/`_share_cuda_()` on its own memory) and has not historically required elevated profiles for that operation. This replaces the previous `privileged: true` approach, narrowing the attack surface while preserving CUDA IPC functionality.
 - **`NVIDIA_VISIBLE_DEVICES=all`** and **`NVIDIA_DRIVER_CAPABILITIES=all`** — env vars that instruct the NVIDIA container runtime to expose all GPUs and all driver capabilities to the container.
 - **`--host 0.0.0.0`** — always passed as a container arg. The server defaults to `--host localhost` which only binds to loopback; the server must bind to all interfaces so the node-local Service can route traffic to it.
 - **No `hostNetwork`** — the operator does **not** use `hostNetwork`. Instead, it creates a ClusterIP Service with `internalTrafficPolicy=Local`. kube-proxy ensures that traffic to the service is routed only to the LMCache pod on the same node. This avoids occupying host ports and reduces the privileged surface area.
 - **No `/dev/shm` emptyDir mount** — the operator intentionally does *not* mount an emptyDir at `/dev/shm`. With `hostIPC: true`, the container already sees the host's `/dev/shm`. Mounting an emptyDir would shadow the host's `/dev/shm` with a private tmpfs, breaking CUDA IPC (`cudaIpcOpenMemHandle` fails because IPC handles written by one pod are invisible to others). If your workload needs a larger `/dev/shm` for non-IPC purposes, add it via `spec.volumes` / `spec.volumeMounts`.
 
-> **Security implications:** The LMCache pods run with `privileged: true` and `hostIPC: true`. This exposes the host's IPC namespace and grants full device access to the container. This is required for GPU visibility and CUDA IPC. Only deploy in trusted environments. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace — the `baseline` and `restricted` profiles reject these settings.
+> **Security implications:** The LMCache pods run with `hostIPC: true` and `seccomp`/`AppArmor` profiles set to `Unconfined`. `hostIPC` exposes the host's IPC namespace (required for CUDA IPC). Disabling seccomp and AppArmor allows the NVIDIA driver ioctls needed for `cudaIpcOpenMemHandle`. Containers do **not** run as `privileged: true`. Only deploy in trusted environments. Clusters using Pod Security Standards must allow the `privileged` PSS profile for the LMCache namespace because `hostIPC: true` is rejected by `baseline` and `restricted`.
 
 ---
 
@@ -327,7 +327,7 @@ OnEvent(LMCacheEngine create/update/delete):
    - memoryLimit = ceil(memoryRequest * 1.5) Gi
    - containerArgs from all spec fields
 3. RECONCILE DaemonSet (CreateOrUpdate, ownerRef)
-   - Always inject: hostIPC, runtimeClassName: nvidia, privileged: true, --host 0.0.0.0
+   - Always inject: hostIPC, runtimeClassName: nvidia, seccompProfile/appArmorProfile: Unconfined, --host 0.0.0.0
 4. RECONCILE node-local lookup Service (internalTrafficPolicy=Local)
 5. RECONCILE headless Service for metrics
 6. RECONCILE connection ConfigMap
@@ -394,7 +394,7 @@ l2Backend, scheduling, overrides, imagePullSecrets) and adds:
 DaemonSet running `lmcache server --engine-type blend` (plus
 `--l1-align-bytes 16777216`), a node-local lookup Service, a metrics Service, and
 a `<name>-connection` ConfigMap. **GPU model is identical to `LMCacheEngine`**:
-`privileged` + `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` +
+`seccompProfile/appArmorProfile: Unconfined` + `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` +
 `hostIPC: true`, with **no `nvidia.com/gpu` device-plugin claim** — the engine
 *shares* the vLLM GPU rather than reserving one, because the blend server scatters
 re-RoPE'd KV directly into vLLM's paged KV over **same-device CUDA IPC**. The
@@ -461,7 +461,7 @@ user-supplied `--flag=value`.
 - **`make deploy`, not `make run`** — `make run` sets `ENABLE_WEBHOOKS=false` and
   installs no `MutatingWebhookConfiguration`; it is controller-only. The webhook
   needs the operator running as an in-cluster pod.
-- **Pod Security Standards** — the injected `hostIPC`/`privileged` is rejected by
+- **Pod Security Standards** — the injected `hostIPC: true` is rejected by
   the `baseline`/`restricted` profiles, so the engine's and the vLLM pod's
   namespaces must be labeled `pod-security.kubernetes.io/enforce=privileged`.
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -6,7 +6,7 @@ See [DESIGN.md](DESIGN.md) for architecture details, reconciliation logic, and C
 
 ## Prerequisites
 
-- Kubernetes 1.20+
+- Kubernetes 1.30+ (`securityContext.appArmorProfile` used for CUDA IPC is not available before 1.30)
 - `kubectl` configured to access your cluster
 - For NVIDIA GPUs (default): NVIDIA GPU Operator with the `nvidia` RuntimeClass available on GPU nodes
 - For AMD GPUs: set `spec.gpuVendor: amd` in your `LMCacheEngine` (see [AMD GPUs (ROCm)](#amd-gpus-rocm) below)
@@ -14,7 +14,7 @@ See [DESIGN.md](DESIGN.md) for architecture details, reconciliation logic, and C
 - (CacheBlend only) [cert-manager](https://cert-manager.io) for the injection webhook's serving cert — see [CacheBlend](#cacheblend) below
 
 > [!IMPORTANT]
-> By default the operator runs LMCache pods with `runtimeClassName: nvidia` and `privileged: true` to gain GPU visibility without consuming GPU resources via the device plugin. This allows the serving engine (e.g., vLLM) to claim all GPUs on the node. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace.
+> By default the operator runs LMCache pods with `runtimeClassName: nvidia`, `hostIPC: true`, and `seccomp`/`AppArmor` set to `Unconfined` (instead of `privileged: true`) to gain GPU visibility without consuming GPU resources via the device plugin. This allows the serving engine (e.g., vLLM) to claim all GPUs on the node. Clusters using Pod Security Standards must allow the `privileged` PSS profile for the LMCache namespace (required by `hostIPC: true`).
 >
 > On AMD ROCm clusters, `spec.gpuVendor: amd` omits `runtimeClassName` and skips NVIDIA-specific env vars.
 
@@ -53,7 +53,7 @@ The minimal CR just needs `l1.sizeGB`. Apply the sample (a fully-commented field
 kubectl apply -f config/samples/lmcache_v1alpha1_lmcacheengine.yaml
 ```
 
-The operator automatically handles `hostIPC`, GPU visibility (`runtimeClassName: nvidia`, `privileged: true`), node-local service routing, resource sizing, and Prometheus metrics — see [DESIGN.md](DESIGN.md) for details.
+The operator automatically handles `hostIPC`, GPU visibility (`runtimeClassName: nvidia`, `seccomp`/`AppArmor` Unconfined), node-local service routing, resource sizing, and Prometheus metrics — see [DESIGN.md](DESIGN.md) for details.
 
 ### 3. Connect vLLM to LMCache
 
@@ -139,7 +139,7 @@ image ENTRYPOINT — a `sh -c` wrapper is skipped). Editable samples:
 > (`kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml`).
 > If Pod Security Standards are enforced, label the engine's and the vLLM pod's
 > namespaces `pod-security.kubernetes.io/enforce=privileged` — the webhook injects
-> `hostIPC`/`privileged`, which `baseline`/`restricted` reject.
+> `hostIPC: true`, which `baseline`/`restricted` reject.
 
 > [!IMPORTANT]
 > CacheBlend is still in early stage development and under heavy testing. Its

--- a/operator/api/v1alpha1/cacheblendengine_types.go
+++ b/operator/api/v1alpha1/cacheblendengine_types.go
@@ -95,7 +95,7 @@ type InjectionSpec struct {
 type CacheBlendEngineSpec struct {
 	// gpuVendor selects the GPU vendor. "nvidia" (default) requires the NVIDIA
 	// GPU Operator's "nvidia" RuntimeClass; "amd" runs on the default container
-	// runtime with privileged: true.
+	// runtime with seccomp/AppArmor Unconfined security context.
 	// +optional
 	// +kubebuilder:default="nvidia"
 	// +kubebuilder:validation:Enum=nvidia;amd

--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -299,7 +299,7 @@ type CoordinatorConnectionSpec struct {
 type LMCacheEngineSpec struct {
 	// gpuVendor selects the GPU vendor. "nvidia" (default) requires the NVIDIA
 	// GPU Operator's "nvidia" RuntimeClass; "amd" runs on the default container
-	// runtime with privileged: true.
+	// runtime with seccomp/AppArmor Unconfined security context.
 	// +optional
 	// +kubebuilder:default="nvidia"
 	// +kubebuilder:validation:Enum=nvidia;amd

--- a/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
@@ -1232,7 +1232,7 @@ spec:
                 description: |-
                   gpuVendor selects the GPU vendor. "nvidia" (default) requires the NVIDIA
                   GPU Operator's "nvidia" RuntimeClass; "amd" runs on the default container
-                  runtime with privileged: true.
+                  runtime with seccomp/AppArmor Unconfined security context.
                 enum:
                 - nvidia
                 - amd

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -1211,7 +1211,7 @@ spec:
                 description: |-
                   gpuVendor selects the GPU vendor. "nvidia" (default) requires the NVIDIA
                   GPU Operator's "nvidia" RuntimeClass; "amd" runs on the default container
-                  runtime with privileged: true.
+                  runtime with seccomp/AppArmor Unconfined security context.
                 enum:
                 - nvidia
                 - amd

--- a/operator/config/samples/vllm_cacheblend_deployment.yaml
+++ b/operator/config/samples/vllm_cacheblend_deployment.yaml
@@ -13,7 +13,7 @@
 #   1. A CacheBlendEngine named below exists IN THIS NAMESPACE and is reconciled
 #      (its `<name>-connection` ConfigMap exists — the webhook reads it).
 #   2. This namespace is labeled pod-security.kubernetes.io/enforce=privileged
-#      (the injected hostIPC/privileged is rejected by baseline/restricted PSS).
+#      (the injected hostIPC=true is rejected by baseline/restricted PSS).
 #   3. The vLLM container launches via the image ENTRYPOINT (["vllm","serve"])
 #      with args ONLY. Do NOT use `command: ["/bin/sh","-c", ...]` — a command
 #      override makes the webhook SKIP injection (appended args can't reach

--- a/operator/internal/resources/cacheblend_engine.go
+++ b/operator/internal/resources/cacheblend_engine.go
@@ -109,7 +109,7 @@ func BuildCBEngineArgs(spec *lmcachev1alpha1.CacheBlendEngineSpec) []string {
 
 // BuildCBEngineDaemonSet constructs the DaemonSet for the blend_v3 engine of the
 // given CacheBlendEngine. It reuses the shared GPU/security pod-template
-// scaffolding (hostIPC, runtimeClassName=nvidia, privileged, NVIDIA_VISIBLE_DEVICES=all,
+// scaffolding (hostIPC, runtimeClassName=nvidia, seccomp/AppArmor Unconfined, NVIDIA_VISIBLE_DEVICES=all,
 // CPU+memory-only resources with no nvidia.com/gpu claim) so the engine shares the
 // node's GPU via CUDA IPC, and adds the blend-specific server args.
 func BuildCBEngineDaemonSet(engine *lmcachev1alpha1.CacheBlendEngine) *appsv1.DaemonSet {

--- a/operator/internal/resources/cacheblend_engine_test.go
+++ b/operator/internal/resources/cacheblend_engine_test.go
@@ -125,9 +125,15 @@ func TestBuildCBEngineDaemonSet_GPUAndSecurity(t *testing.T) {
 	}
 	c := podSpec.Containers[0]
 
-	// privileged: true.
-	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
-		t.Fatal("expected privileged=true")
+	// seccomp + AppArmor Unconfined instead of privileged: true.
+	if c.SecurityContext == nil ||
+		c.SecurityContext.SeccompProfile == nil ||
+		c.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeUnconfined {
+		t.Fatal("expected seccompProfile=Unconfined")
+	}
+	if c.SecurityContext.AppArmorProfile == nil ||
+		c.SecurityContext.AppArmorProfile.Type != corev1.AppArmorProfileTypeUnconfined {
+		t.Fatal("expected appArmorProfile=Unconfined")
 	}
 
 	// NVIDIA env exposes all GPUs without a device-plugin claim.
@@ -204,7 +210,7 @@ func TestBuildCBEngineDaemonSet_AMDNoRuntimeClass(t *testing.T) {
 	if podSpec.RuntimeClassName != nil {
 		t.Fatalf("expected nil RuntimeClassName for AMD, got %q", *podSpec.RuntimeClassName)
 	}
-	// Still privileged + hostIPC.
+	// Still seccomp/AppArmor Unconfined + hostIPC.
 	if !podSpec.HostIPC {
 		t.Fatal("expected HostIPC=true even for AMD")
 	}

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -51,9 +51,9 @@ func BuildDaemonSet(engine *lmcachev1alpha1.LMCacheEngine) *appsv1.DaemonSet {
 
 // buildDaemonSetCore constructs the DaemonSet shared by the LMCacheEngine and
 // CacheBlendEngine controllers. It is the single source of truth for the
-// GPU/security pod-template scaffolding (hostIPC, runtimeClassName, privileged,
-// NVIDIA_VISIBLE_DEVICES, resources without a device-plugin GPU claim) so those
-// settings cannot drift between the two engines.
+// GPU/security pod-template scaffolding (hostIPC, runtimeClassName,
+// NVIDIA_VISIBLE_DEVICES, seccomp/AppArmor profiles, resources without a
+// device-plugin GPU claim) so those settings cannot drift between the two engines.
 //
 // Parameters:
 //   - name, namespace: the owning object's identity, used for labels and metadata.
@@ -80,8 +80,6 @@ func buildDaemonSetCore(
 		rc := nvidiaRuntimeClass
 		runtimeClassName = &rc
 	}
-	privileged := true
-
 	serverPort := derefInt32(getServerPort(spec), 5555)
 	imgRepo := defaultImageRepo
 	imgTag := "latest"
@@ -277,7 +275,12 @@ func buildDaemonSetCore(
 							Env:             envVars,
 							Resources:       ComputeResources(spec),
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: &privileged,
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeUnconfined,
+								},
+								AppArmorProfile: &corev1.AppArmorProfile{
+									Type: corev1.AppArmorProfileTypeUnconfined,
+								},
 							},
 							VolumeMounts:   volumeMounts,
 							StartupProbe:   startupProbe,

--- a/operator/test/e2e/crd_smoke_test.go
+++ b/operator/test/e2e/crd_smoke_test.go
@@ -160,7 +160,7 @@ var _ = Describe("LMCacheEngine smoke (no-GPU)", Ordered, func() {
 })
 
 // assertDaemonSetShape verifies the operator's auto-injected pod-level
-// settings: hostIPC, runtimeClassName=nvidia, container privileged
+// settings: hostIPC, runtimeClassName=nvidia, seccomp/AppArmor Unconfined
 // security context, --host 0.0.0.0 always present in container args,
 // and the absence of any /dev/shm volume mount that would shadow the
 // host's /dev/shm and break CUDA IPC.
@@ -174,8 +174,10 @@ func assertDaemonSetShape(ds *appsv1.DaemonSet, expectedServerPort int32) {
 
 	c := pod.Containers[0]
 	Expect(c.SecurityContext).NotTo(BeNil(), "container.securityContext must be set")
-	Expect(c.SecurityContext.Privileged).NotTo(BeNil())
-	Expect(*c.SecurityContext.Privileged).To(BeTrue(), "container.privileged must be true")
+	Expect(c.SecurityContext.SeccompProfile).NotTo(BeNil(), "container.seccompProfile must be set")
+	Expect(c.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeUnconfined), "container.seccompProfile must be Unconfined")
+	Expect(c.SecurityContext.AppArmorProfile).NotTo(BeNil(), "container.appArmorProfile must be set")
+	Expect(c.SecurityContext.AppArmorProfile.Type).To(Equal(corev1.AppArmorProfileTypeUnconfined), "container.appArmorProfile must be Unconfined")
 	Expect(c.Args).To(ContainElements("--host", "0.0.0.0"))
 	Expect(argValue(c.Args, "--port")).To(Equal(fmt.Sprintf("%d", expectedServerPort)))
 

--- a/operator/test/e2e/smoke_helpers_test.go
+++ b/operator/test/e2e/smoke_helpers_test.go
@@ -53,12 +53,12 @@ var nsCounter atomic.Int64
 // each spec gets per-test isolation without relying on package state.
 //
 // The namespace is pre-labeled with the `privileged` PodSecurity profile
-// because the LMCache DaemonSet's pod template sets hostIPC=true and
-// privileged=true. On clusters that enforce PodSecurity admission (OCP
-// in particular), a `restricted` namespace would reject the DaemonSet at
-// creation time, which the smokes need to succeed even though they never
-// wait for pods to schedule. The label is a no-op on clusters that don't
-// enforce PodSecurity.
+// because the LMCache DaemonSet's pod template sets hostIPC=true, which
+// is rejected by the `baseline` and `restricted` profiles. On clusters
+// that enforce PodSecurity admission (OCP in particular), a `restricted`
+// namespace would reject the DaemonSet at creation time, which the smokes
+// need to succeed even though they never wait for pods to schedule. The
+// label is a no-op on clusters that don't enforce PodSecurity.
 func createTestNamespace(ctx context.Context) string {
 	GinkgoHelper()
 	name := uniqueNamespaceName()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR removes `privileged: true` from operator-managed LMCache and CacheBlend engine DaemonSets. Instead, the engine container now uses `seccompProfile: Unconfined` and `appArmorProfile: Unconfined`, which is the narrower privilege surface needed for CUDA IPC receiving/opening via cudaIpcOpenMemHandle.

**Special notes for your reviewers**:

Kubernetes 1.30+ is required for the new securityContext.appArmorProfile field. Clusters older than 1.30 would need the legacy AppArmor annotation path, should we add support for legacy k8s version?

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
