### PR TITLE
[Doc] Fix docstring parameter names that don't match signatures

### DIFF
--- a/lmcache/integration/vllm/vllm_v1_adapter.py
+++ b/lmcache/integration/vllm/vllm_v1_adapter.py
@@ -163,7 +163,6 @@ class RequestTracker:
                 local cache hit) and new tokens that will be scheduled.
             lmcache_cached_tokens (int): the number of tokens that are
                 cached in LMCache.
-            request_priority (int): the priority of the request
             skip_save (bool): whether the request cache should be saved
         """
         # vLLM 0.9.0 update: request.block_ids changed from list[int] to

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -443,7 +443,7 @@ class L1Manager:
             keys: The list of object keys to reserve write access for.
             is_temporary: The list of booleans indicating whether each key is
                 temporary.
-            shape_spec: The memory layout description for the objects to be
+            layout_desc: The memory layout description for the objects to be
                 allocated.
             mode (Literal["new", "update", "all"]): Reservation mode.
             - "new": Reserve only new objects that do not exist.

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -321,7 +321,7 @@ class KVLayerGroupsManager:
                 homogeneous models repeat one shared format.
             engine_group_infos: Engine KV cache group metadata, one info per
                 kernel group in kernel-group order, or empty.
-            lmcache_logical_chunk_size: Tokens per LMCache chunk
+            lmcache_tokens_per_chunk: Tokens per LMCache chunk
             separate_object_groups: When True (default), split kernel groups
                 into one object group per sliding-window size; when False, all
                 kernel groups share a single full-attention object group.

--- a/lmcache/v1/manager.py
+++ b/lmcache/v1/manager.py
@@ -65,7 +65,6 @@ class LMCacheManager:
         Args:
             config: LMCache engine configuration
             service_factory: Factory for creating service components
-            role: The role string ("scheduler" or "worker")
             connector: Reference to LMCacheConnectorV1Impl for internal
                        API server
         """


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Fixes four docstrings whose documented parameter names don't match the actual
function signatures (the project standard is that docstrings must match current
behavior). Docstring-only; no behavior change.

- `LMCacheManager.__init__` (`lmcache/v1/manager.py`) — remove stale `role` arg
  (no longer a parameter)
- `L1Manager.reserve_write` (`lmcache/v1/distributed/l1_manager.py`) —
  `shape_spec` → `layout_desc`
- `KVLayerGroupsManager.__init__` (`lmcache/v1/kv_layer_groups.py`) —
  `lmcache_logical_chunk_size` → `lmcache_tokens_per_chunk`
- `RequestTracker.from_new_request`
  (`lmcache/integration/vllm/vllm_v1_adapter.py`) — remove stale
  `request_priority` arg

**Special notes for your reviewers**:
`ruff check` / `ruff format --check` / `codespell --toml pyproject.toml` all pass
locally on the changed files.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
