### PR TITLE
[Refactor]: Consolidate all grouping queries on EngineKVFormat (also fixes SGLang tests)

### DIFF
--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Physical KV-cache memory layout an engine hands to LMCache, plus the
+// classification predicates over it. Vendor-header-free, so every backend and
+// the Python facade (lmc_ops) share one definition. Detection (raw layout ->
+// format) lives in lmcache/v1/gpu_connector/kv_format.
+
+/*
+Symbol Reference:
+NL: number of layers
+NB: number of blocks/pages
+BS: block/page size
+NBBS: block/page buffer size = NB * BS
+NH: number of heads
+HS: head size
+TWO: 2
+ONE: 1
+
+_ means a dimension within the same tensor
+_X_ means a dimension across a list
+
+A_X_B_X_C_D_E means:
+kv_cache: List[List[torch.Tensor]]
+len(kv_cache) = A
+len(kv_cache[0]) = B
+kv_cache[0][0].shape = (C, D, E)
+*/
+enum class EngineKVFormat : int {
+  NB_NL_TWO_BS_NH_HS = 0,
+  /*
+  used by:
+  - vLLM CROSS_LAYER mode
+  */
+
+  NL_X_TWO_NB_BS_NH_HS = 1,
+  /*
+  used by:
+  - vLLM non-MLA flash attention
+  */
+
+  NL_X_NB_TWO_BS_NH_HS = 2,
+  /*
+  used by:
+  - vLLM non-MLA flash infer
+  */
+
+  NL_X_NB_BS_HS = 3,
+  /*
+  used by:
+  - vLLM MLA
+  */
+
+  TWO_X_NL_X_NBBS_NH_HS = 4,
+  /*
+  used by:
+  - SGLang MHA (flash attention and flash infer)
+  */
+
+  NL_X_NBBS_ONE_HS = 5,
+  /*
+  used by:
+  - SGLang MLA
+  */
+
+  NL_X_TWO_NB_NH_BS_HS = 6,
+  /*
+  used by:
+  - vLLM non-MLA flash attention (HND layout)
+  physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
+  */
+
+  NL_X_NB_TWO_NH_BS_HS = 7,
+  /*
+  used by:
+  - vLLM non-MLA flash infer (HND layout)
+  physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
+  */
+
+  NB_NL_TWO_NH_BS_HS = 8,
+  /*
+  used by:
+  - TRT-LLM cross-layer (HND layout)
+  physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
+  */
+
+  TWO_X_NL_X_NB_BS_NH_HS = 9,
+  /*
+  used by:
+  - SGLang MHA via the MP daemon path
+  physical shape per layer: [num_blocks, block_size, num_heads, head_size]
+  */
+
+  NL_X_NB_NH_BS_TWO_HS = 10,
+  /*
+  used by:
+  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
+  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
+  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
+  Currently only reached via the host gather/scatter path, not the device
+  transfer kernels.
+  */
+};
+
+// __host__ __device__ under CUDA/HIP so the kernels can call these; the guard
+// keeps the header vendor-runtime-free.
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  #define LMC_KV_FORMAT_HD __host__ __device__
+#else
+  #define LMC_KV_FORMAT_HD
+#endif
+
+// Structural shape of the normalized kv_caches: exactly one is true per format.
+
+// All layers in one fused tensor.
+LMC_KV_FORMAT_HD constexpr bool is_cross_layer(EngineKVFormat f) {
+  return f == EngineKVFormat::NB_NL_TWO_BS_NH_HS ||
+         f == EngineKVFormat::NB_NL_TWO_NH_BS_HS;
+}
+
+// Keys and values in two separate top-level lists: [key_layers, value_layers].
+LMC_KV_FORMAT_HD constexpr bool is_kv_list(EngineKVFormat f) {
+  return f == EngineKVFormat::TWO_X_NL_X_NBBS_NH_HS ||
+         f == EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS;
+}
+
+// One list entry per layer: kv_caches[layer_idx] is that layer's tensor.
+LMC_KV_FORMAT_HD constexpr bool is_layer_list(EngineKVFormat f) {
+  return f == EngineKVFormat::NL_X_TWO_NB_BS_NH_HS ||
+         f == EngineKVFormat::NL_X_NB_TWO_BS_NH_HS ||
+         f == EngineKVFormat::NL_X_NB_BS_HS ||
+         f == EngineKVFormat::NL_X_NBBS_ONE_HS ||
+         f == EngineKVFormat::NL_X_TWO_NB_NH_BS_HS ||
+         f == EngineKVFormat::NL_X_NB_TWO_NH_BS_HS ||
+         f == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS;
+}
+
+// Multi-head Latent Attention: a single latent KV head (no separate K/V split).
+LMC_KV_FORMAT_HD constexpr bool is_mla(EngineKVFormat f) {
+  return f == EngineKVFormat::NL_X_NB_BS_HS ||   // vLLM MLA
+         f == EngineKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
+}

--- a/csrc/kv_transfer_types.h
+++ b/csrc/kv_transfer_types.h
@@ -2,115 +2,12 @@
 
 #pragma once
 
-// Backend-agnostic descriptors for KV-cache transfers.
-//
-// These enums describe *what* is being transferred (the direction of a
-// host/device copy and the physical KV-cache memory layout) and carry no
-// accelerator-specific dependency. They are intentionally free of any
-// <torch/...>, <ATen/...> or vendor runtime headers so that every backend
-// (CUDA, ROCm, MUSA, SYCL/XPU, ...) can share a single definition instead of
-// redeclaring them in each accelerator-coupled kernel header.
+// Backend-agnostic transfer descriptors, free of any vendor runtime headers so
+// every backend (CUDA, ROCm, MUSA, SYCL/XPU, ...) shares one definition.
+
+#include "engine_kv_format.h"  // EngineKVFormat + its classification predicates
 
 enum class TransferDirection : int {
   H2D = 0,
   D2H = 1,
-};
-
-/*
-Symbol Reference:
-NL: number of layers
-NB: number of blocks/pages
-BS: block/page size
-NBBS: block/page buffer size = NB * BS
-NH: number of heads
-HS: head size
-TWO: 2
-ONE: 1
-
-_ means a dimension within the same tensor
-_X_ means a dimension across a list
-
-A_X_B_X_C_D_E means:
-kv_cache: List[List[torch.Tensor]]
-len(kv_cache) = A
-len(kv_cache[0]) = B
-kv_cache[0][0].shape = (C, D, E)
-
-The logic for identifying the format currently lives in
-`lmcache/v1/gpu_connector/utils.py`
-*/
-enum class EngineKVFormat : int {
-  NB_NL_TWO_BS_NH_HS = 0,
-  /*
-  used by:
-  - vLLM CROSS_LAYER mode
-  */
-
-  NL_X_TWO_NB_BS_NH_HS = 1,
-  /*
-  used by:
-  - vLLM non-MLA flash attention
-  */
-
-  NL_X_NB_TWO_BS_NH_HS = 2,
-  /*
-  used by:
-  - vLLM non-MLA flash infer
-  */
-
-  NL_X_NB_BS_HS = 3,
-  /*
-  used by:
-  - vLLM MLA
-  */
-
-  TWO_X_NL_X_NBBS_NH_HS = 4,
-  /*
-  used by:
-  - SGLang MHA (flash attention and flash infer)
-  */
-
-  NL_X_NBBS_ONE_HS = 5,
-  /*
-  used by:
-  - SGLang MLA
-  */
-
-  NL_X_TWO_NB_NH_BS_HS = 6,
-  /*
-  used by:
-  - vLLM non-MLA flash attention (HND layout)
-  physical shape per layer: [2, num_blocks, num_heads, block_size, head_size]
-  */
-
-  NL_X_NB_TWO_NH_BS_HS = 7,
-  /*
-  used by:
-  - vLLM non-MLA flash infer (HND layout)
-  physical shape per layer: [num_blocks, 2, num_heads, block_size, head_size]
-  */
-
-  NB_NL_TWO_NH_BS_HS = 8,
-  /*
-  used by:
-  - TRT-LLM cross-layer (HND layout)
-  physical shape: [num_blocks, num_layers, 2, num_heads, block_size, head_size]
-  */
-
-  TWO_X_NL_X_NB_BS_NH_HS = 9,
-  /*
-  used by:
-  - SGLang MHA via the MP daemon path
-  physical shape per layer: [num_blocks, block_size, num_heads, head_size]
-  */
-
-  NL_X_NB_NH_BS_TWO_HS = 10,
-  /*
-  used by:
-  - vLLM non-MLA blocks-first attention with K/V fused into the trailing dim
-  physical shape per layer: [num_blocks, num_heads, block_size, 2, head_size]
-  (recovered by splitting the fused trailing [block_size, 2 * head_size]).
-  Currently only reached via the host gather/scatter path, not the device
-  transfer kernels.
-  */
 };

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -28,13 +28,6 @@
 
 namespace lmc {
 
-// inline helper to check MLA (callable from device and host)
-__host__ __device__ __forceinline__ bool is_mla(
-    const EngineKVFormat engine_kv_format) {
-  return engine_kv_format == EngineKVFormat::NL_X_NB_BS_HS ||   // vllm MLA
-         engine_kv_format == EngineKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
-}
-
 // inline helper to check HND layout (callable from device and host)
 __host__ __device__ __forceinline__ bool is_hnd(
     const EngineKVFormat engine_kv_format) {
@@ -550,7 +543,7 @@ void multi_layer_kv_transfer_templated(
   lmc::check_block_size(engine_kv_format, block_size);
   lmc::check_head_size(engine_kv_format, head_size_xword);
 
-  int k_or_v_size = lmc::is_mla(engine_kv_format) ? 1 : 2;
+  int k_or_v_size = ::is_mla(engine_kv_format) ? 1 : 2;
 
   dim3 grid(num_transfer_tokens, num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));
@@ -690,7 +683,7 @@ void multi_layer_kv_transfer_unilateral(
     const torch::Tensor& slot_mapping,    // [num_tokens],
     const torch::Device& paged_memory_device, const int page_buffer_size,
     const TransferDirection direction, const EngineKVFormat engine_kv_format) {
-  const bool use_mla = lmc::is_mla(engine_kv_format);
+  const bool use_mla = ::is_mla(engine_kv_format);
   // MLA case collapses back to multi_layer_kv_transfer
   // (vLLM and SGLang indexing are compatible)
   if (use_mla) {
@@ -789,7 +782,7 @@ void single_layer_kv_transfer(
   int head_size_in_64bit;
   int block_size;
 
-  const bool use_mla = lmc::is_mla(engine_kv_format);
+  const bool use_mla = ::is_mla(engine_kv_format);
   const bool hnd_layout = lmc::is_hnd(engine_kv_format);
 
   if (use_mla) {

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -34,6 +34,19 @@ PYBIND11_MODULE(c_ops, m) {
       .value("TWO_X_NL_X_NB_BS_NH_HS", EngineKVFormat::TWO_X_NL_X_NB_BS_NH_HS)
       .value("NL_X_NB_NH_BS_TWO_HS", EngineKVFormat::NL_X_NB_NH_BS_TWO_HS)
       .export_values();
+  // Format classification, shared with the device kernels (engine_kv_format.h).
+  m.def(
+      "is_cross_layer", [](EngineKVFormat f) { return is_cross_layer(f); },
+      py::arg("engine_kv_format"));
+  m.def(
+      "is_kv_list", [](EngineKVFormat f) { return is_kv_list(f); },
+      py::arg("engine_kv_format"));
+  m.def(
+      "is_layer_list", [](EngineKVFormat f) { return is_layer_list(f); },
+      py::arg("engine_kv_format"));
+  m.def(
+      "is_mla", [](EngineKVFormat f) { return is_mla(f); },
+      py::arg("engine_kv_format"));
   m.def("multi_layer_kv_transfer", &multi_layer_kv_transfer,
         py::arg("key_value"), py::arg("key_value_ptrs"),
         py::arg("slot_mapping"), py::arg("paged_memory_device"),

--- a/csrc/sycl/mem_kernels_sycl.cpp
+++ b/csrc/sycl/mem_kernels_sycl.cpp
@@ -62,11 +62,6 @@ inline int round_up_to_sg(int n) {
 // ---------------------------------------------------------------------------
 namespace lmc {
 
-inline bool is_mla(const EngineKVFormat engine_kv_format) {
-  return engine_kv_format == EngineKVFormat::NL_X_NB_BS_HS ||   // vLLM MLA
-         engine_kv_format == EngineKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
-}
-
 template <EngineKVFormat format>
 inline int64_t page_buffer_offset(const int k_or_v, const int token_idx,
                                   const int scalar_offset,
@@ -402,7 +397,7 @@ void multi_layer_kv_transfer_templated(
   int elements_per_xword = sizeof(T) / key_value.element_size();
   int num_xwords = num_origin_elements / elements_per_xword;
 
-  int k_or_v_size = lmc::is_mla(engine_kv_format) ? 1 : 2;
+  int k_or_v_size = ::is_mla(engine_kv_format) ? 1 : 2;
 
   // Round up to a sub-group multiple so every sub-group is full.
   int wg_size = round_up_to_sg(std::min(num_xwords, MAX_WG_SIZE));
@@ -523,7 +518,7 @@ void multi_layer_kv_transfer_unilateral(
     const torch::Tensor& slot_mapping, const torch::Device& paged_memory_device,
     const int page_buffer_size, const TransferDirection direction,
     const EngineKVFormat engine_kv_format) {
-  const bool use_mla = lmc::is_mla(engine_kv_format);
+  const bool use_mla = ::is_mla(engine_kv_format);
   // MLA case collapses back to multi_layer_kv_transfer
   if (use_mla) {
     return multi_layer_kv_transfer(key_value, key_value_ptrs, slot_mapping,
@@ -646,7 +641,7 @@ void single_layer_kv_transfer(torch::Tensor& lmc_key_value_cache,
   int head_size_in_64bit;
   int block_size;
 
-  const bool use_mla = lmc::is_mla(engine_kv_format);
+  const bool use_mla = ::is_mla(engine_kv_format);
 
   if (use_mla) {
     num_heads = 1;

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -758,20 +758,53 @@ def multi_layer_kv_transfer_unilateral(
                 key_value[kv_idx, layer_id, valid_mask_kv, :] = gathered.to(kv_device)
 
 
-def _is_cross_layer_format(engine_kv_format: EngineKVFormat) -> bool:
-    """Return True when a KV format uses a single cross-layer tensor."""
+# Pure-Python mirrors of the c_ops predicates (csrc/engine_kv_format.h); the
+# parity test pins these to the same names and signatures.
+def is_cross_layer(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when all layers live in one fused tensor."""
     return int(engine_kv_format) in (
         int(EngineKVFormat.NB_NL_TWO_BS_NH_HS),
         int(EngineKVFormat.NB_NL_TWO_NH_BS_HS),
     )
 
 
-def _is_sglang_mha_format(engine_kv_format: EngineKVFormat) -> bool:
-    """Return True when a KV format uses SGLang MHA layout (2*NL tensors)."""
+def is_kv_list(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when keys and values are two separate top-level lists."""
     return int(engine_kv_format) in (
         int(EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS),
         int(EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS),
     )
+
+
+def is_layer_list(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when the structure is one list entry per layer."""
+    return int(engine_kv_format) in (
+        int(EngineKVFormat.NL_X_TWO_NB_BS_NH_HS),
+        int(EngineKVFormat.NL_X_NB_TWO_BS_NH_HS),
+        int(EngineKVFormat.NL_X_NB_BS_HS),
+        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
+        int(EngineKVFormat.NL_X_TWO_NB_NH_BS_HS),
+        int(EngineKVFormat.NL_X_NB_TWO_NH_BS_HS),
+        int(EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
+    )
+
+
+def is_mla(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when a KV format uses MLA paged layout."""
+    return int(engine_kv_format) in (
+        int(EngineKVFormat.NL_X_NB_BS_HS),
+        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
+    )
+
+
+def _is_cross_layer_format(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when a KV format uses a single cross-layer tensor."""
+    return is_cross_layer(engine_kv_format)
+
+
+def _is_sglang_mha_format(engine_kv_format: EngineKVFormat) -> bool:
+    """Return True when a KV format uses SGLang MHA layout (2*NL tensors)."""
+    return is_kv_list(engine_kv_format)
 
 
 def _is_hnd_format(engine_kv_format: EngineKVFormat) -> bool:
@@ -785,10 +818,7 @@ def _is_hnd_format(engine_kv_format: EngineKVFormat) -> bool:
 
 def _is_mla_format(engine_kv_format: EngineKVFormat) -> bool:
     """Return True when a KV format uses MLA paged layout."""
-    return int(engine_kv_format) in (
-        int(EngineKVFormat.NL_X_NB_BS_HS),
-        int(EngineKVFormat.NL_X_NBBS_ONE_HS),
-    )
+    return is_mla(engine_kv_format)
 
 
 _ELEMENT_SIZE_TO_DTYPE: dict[int, torch.dtype] = {

--- a/lmcache/v1/gpu_connector/kv_format/specs/base.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/base.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Per-format geometry interface for GPU KV caches.
 
-Each :class:`KVFormatSpec` describes one ``EngineKVFormat``: static facts
-(MLA/HND/cross-layer) plus methods that read geometry off a normalized
-``kv_caches``. The enum is the single source of truth for which formats exist;
-engine identity lives only in detection. The format -> spec table is in
-``registry.py``.
+Each :class:`KVFormatSpec` holds the geometry accessors for one
+``EngineKVFormat`` -- methods that read shape off a normalized ``kv_caches``.
+The format's static facts (MLA and the structural shape) live on the
+``EngineKVFormat`` enum itself (``csrc/engine_kv_format.h``, read via
+``lmc_ops``), shared with the device kernels. The enum is the single source of
+truth for which formats exist; engine identity lives only in detection. The
+format -> spec table is in ``registry.py``.
 """
 
 # Standard
@@ -78,8 +80,11 @@ class KVFormatSpec(ABC):
     since one format may come from many (engine, backend) pairs.
 
     Class attributes: ``engine_kv_format`` (the format this describes, its
-    identity), ``is_mla`` / ``is_hnd`` / ``is_cross_layer`` (layout flags), and
-    ``attention_backends`` (diagnostic labels; first is the representative).
+    identity) and ``attention_backends`` (diagnostic labels; first is the
+    representative). The format's static facts -- ``is_mla`` and the structural
+    shape ``is_cross_layer`` / ``is_kv_list`` / ``is_layer_list`` -- live on the
+    ``EngineKVFormat`` itself (``csrc/engine_kv_format.h``, read via ``lmc_ops``),
+    shared with the device kernels.
 
     Method usage by mode -- every spec is consumed through the ``get_*``
     facade in ``gpu_connector.utils``:
@@ -101,9 +106,6 @@ class KVFormatSpec(ABC):
     """
 
     engine_kv_format: ClassVar["lmc_ops.EngineKVFormat"]
-    is_mla: ClassVar[bool] = False
-    is_hnd: ClassVar[bool] = False
-    is_cross_layer: ClassVar[bool] = False
     attention_backends: ClassVar[tuple[str, ...]] = ()
 
     def __init__(self, kv_caches: DiscoverableKVCache) -> None:

--- a/lmcache/v1/gpu_connector/kv_format/specs/nb_nl_two_bs_nh_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nb_nl_two_bs_nh_hs.py
@@ -20,7 +20,6 @@ import lmcache.c_ops as lmc_ops
 
 class NB_NL_TWO_BS_NH_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS
-    is_cross_layer = True
     attention_backends = ("vLLM CROSS_LAYER",)
 
     def num_layers(self) -> int:

--- a/lmcache/v1/gpu_connector/kv_format/specs/nb_nl_two_nh_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nb_nl_two_nh_bs_hs.py
@@ -21,8 +21,6 @@ import lmcache.c_ops as lmc_ops
 
 class NB_NL_TWO_NH_BS_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS
-    is_cross_layer = True
-    is_hnd = True
     attention_backends = ("TRT-LLM cross-layer (HND layout)",)
 
     def num_layers(self) -> int:

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_bs_hs.py
@@ -20,7 +20,6 @@ import lmcache.c_ops as lmc_ops
 
 class NL_X_NB_BS_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_BS_HS
-    is_mla = True
     attention_backends = ("vLLM MLA",)
 
     def num_layers(self) -> int:

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_nh_bs_two_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_nh_bs_two_hs.py
@@ -23,7 +23,6 @@ import lmcache.c_ops as lmc_ops
 
 class NL_X_NB_NH_BS_TWO_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS
-    is_hnd = True
     attention_backends = ("vLLM non-MLA blocks-first, fused K/V",)
 
     def num_layers(self) -> int:

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_two_nh_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nb_two_nh_bs_hs.py
@@ -22,7 +22,6 @@ import lmcache.c_ops as lmc_ops
 
 class NL_X_NB_TWO_NH_BS_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS
-    is_hnd = True
     attention_backends = ("vLLM non-MLA flash infer (HND layout)",)
 
     def num_layers(self) -> int:

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nbbs_one_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_nbbs_one_hs.py
@@ -21,7 +21,6 @@ import lmcache.c_ops as lmc_ops
 
 class NL_X_NBBS_ONE_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS
-    is_mla = True
     attention_backends = ("SGLang MLA",)
 
     def num_layers(self) -> int:

--- a/lmcache/v1/gpu_connector/kv_format/specs/nl_x_two_nb_nh_bs_hs.py
+++ b/lmcache/v1/gpu_connector/kv_format/specs/nl_x_two_nb_nh_bs_hs.py
@@ -21,7 +21,6 @@ import lmcache.c_ops as lmc_ops
 
 class NL_X_TWO_NB_NH_BS_HS_Spec(KVFormatSpec):
     engine_kv_format = lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS
-    is_hnd = True
     attention_backends = ("vLLM non-MLA flash attention (HND layout)",)
 
     def num_layers(self) -> int:

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -86,25 +86,9 @@ def assert_layerwise_gpu_connector(gpu_connector: "GPUConnectorInterface"):
     assert isinstance(gpu_connector, valid_connectors)
 
 
-def is_cross_layer_format(engine_kv_format: "lmc_ops.EngineKVFormat") -> bool:
-    """Return ``True`` if *engine_kv_format* stores all layers in one tensor.
-
-    Cross-layer formats -- ``NB_NL_TWO_BS_NH_HS`` (vLLM, NHD) and
-    ``NB_NL_TWO_NH_BS_HS`` (TRT-LLM, HND) -- are represented as a single
-    bare :class:`torch.Tensor` rather than a list-of-tensors keyed by
-    layer index.
-    """
-    return get_spec_class(engine_kv_format).is_cross_layer
-
-
-def is_hnd(engine_kv_format: "lmc_ops.EngineKVFormat") -> bool:
-    """Return ``True`` if the Engine KV Format uses an HND physical layout."""
-    return get_spec_class(engine_kv_format).is_hnd
-
-
 def is_mla(engine_kv_format: "lmc_ops.EngineKVFormat") -> bool:
     """Return ``True`` for a Multi-head Latent Attention (MLA) layout."""
-    return get_spec_class(engine_kv_format).is_mla
+    return lmc_ops.is_mla(engine_kv_format)
 
 
 def get_engine_kv_shape_description(engine_kv_format: "lmc_ops.EngineKVFormat") -> str:
@@ -250,20 +234,22 @@ def normalize_and_discover_per_layer_formats(
         structure and one format per layer (length equals the layer count),
         ready for :func:`lmcache.v1.kv_layer_groups.group_layers_by_identity`.
     """
-    # A single fused tensor is single-format by construction and cannot be indexed
-    # by layer; detect it directly and repeat the format for every layer.
-    if not isinstance(kv_caches, list):
-        engine_kv_format, normalized = detect_format(
-            kv_caches, serving_engine, layout_hints
-        )
-        return normalized, [engine_kv_format] * get_num_layers(
-            normalized, engine_kv_format
+
+    # Detect the whole structure once. A format that isn't a per-layer list (a
+    # cross-layer tensor, or a K/V-split) is single-format -- return it whole.
+    whole_format, whole_normalized = detect_format(
+        kv_caches, serving_engine, layout_hints
+    )
+    if not lmc_ops.is_layer_list(whole_format):
+        return whole_normalized, [whole_format] * get_num_layers(
+            whole_normalized, whole_format
         )
 
+    # Per-layer list: re-detect per engine group, split by tensor shape so a group
+    # that mixes layouts gets the right format per layer.
     groups = layer_index_groups or [range(len(kv_caches))]
     detected: dict[int, tuple[DiscoverableKVCache, "lmc_ops.EngineKVFormat"]] = {}
     for indices in groups:
-        # One engine group can still mix layouts
         layers_by_shape: dict[Hashable, list[int]] = {}
         for i in indices:
             shape = getattr(kv_caches[i], "shape", None)
@@ -538,20 +524,14 @@ def resolve_block_stride_and_log_layout(
         # - SGL MHA: outer list is K/V (length 2), inner list is
         #   per-layer; K & V share shape/stride by construction.
         # - Other formats: ``kv_caches`` is already a per-layer list.
-        if engine_kv_format in (
-            lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS,
-            lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS,
-        ):
+        if lmc_ops.is_cross_layer(engine_kv_format):
             if not isinstance(kv_caches, torch.Tensor):
                 raise TypeError(
                     "Cross-layer EngineKVFormat expects a single backing "
                     f"torch.Tensor, got {type(kv_caches).__name__}."
                 )
             return kv_caches
-        if engine_kv_format in (
-            lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS,
-            lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
-        ):
+        if lmc_ops.is_kv_list(engine_kv_format):
             return kv_caches[0][layer_idx]  # type: ignore[index,return-value]
         return kv_caches[layer_idx]  # type: ignore[index,return-value]
 

--- a/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
@@ -77,7 +77,6 @@ def test_accessors():
     # get_dtype is on the register_kv_caches -> group_layers_by_identity path,
     # so it must recognize this format too.
     assert U.get_dtype(norm, fmt) == _raw_blocks_first_caches()[0].dtype
-    assert U.is_hnd(fmt) is True
     assert not U.is_mla(fmt)
 
 

--- a/tests/v1/gpu_connector/test_kv_format_classification.py
+++ b/tests/v1/gpu_connector/test_kv_format_classification.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Golden tests for the ``EngineKVFormat`` classification predicates.
+
+The structural shape (``is_cross_layer`` / ``is_kv_list`` / ``is_layer_list``)
+and the ``is_mla`` modifier are defined once in ``csrc/engine_kv_format.h`` and
+read via ``lmc_ops``, shared with the device kernels. This file pins each
+format's classification and enforces that the three structural flags partition
+every format (exactly one is true), so a new format or an edit cannot silently
+break the contract the per-layer detection relies on.
+"""
+
+# First Party
+import lmcache.c_ops as lmc_ops
+
+F = lmc_ops.EngineKVFormat
+
+# (is_cross_layer, is_kv_list, is_layer_list, is_mla) per format.
+EXPECTED = {
+    F.NB_NL_TWO_BS_NH_HS: (True, False, False, False),
+    F.NB_NL_TWO_NH_BS_HS: (True, False, False, False),
+    F.TWO_X_NL_X_NBBS_NH_HS: (False, True, False, False),
+    F.TWO_X_NL_X_NB_BS_NH_HS: (False, True, False, False),
+    F.NL_X_TWO_NB_BS_NH_HS: (False, False, True, False),
+    F.NL_X_NB_TWO_BS_NH_HS: (False, False, True, False),
+    F.NL_X_TWO_NB_NH_BS_HS: (False, False, True, False),
+    F.NL_X_NB_TWO_NH_BS_HS: (False, False, True, False),
+    F.NL_X_NB_NH_BS_TWO_HS: (False, False, True, False),
+    F.NL_X_NB_BS_HS: (False, False, True, True),
+    F.NL_X_NBBS_ONE_HS: (False, False, True, True),
+}
+
+
+def _all_formats():
+    return [v for v in vars(F).values() if isinstance(v, F)]
+
+
+def test_classification_matches_golden():
+    for fmt, expected in EXPECTED.items():
+        got = (
+            lmc_ops.is_cross_layer(fmt),
+            lmc_ops.is_kv_list(fmt),
+            lmc_ops.is_layer_list(fmt),
+            lmc_ops.is_mla(fmt),
+        )
+        assert got == expected, f"{fmt}: got {got}, expected {expected}"
+
+
+def test_every_format_is_pinned():
+    # A new EngineKVFormat must be added to EXPECTED (and classified) deliberately.
+    assert set(_all_formats()) == set(EXPECTED)
+
+
+def test_structural_flags_partition_every_format():
+    # Exactly one structural shape is true for every format.
+    for fmt in _all_formats():
+        structural = (
+            lmc_ops.is_cross_layer(fmt),
+            lmc_ops.is_kv_list(fmt),
+            lmc_ops.is_layer_list(fmt),
+        )
+        assert sum(structural) == 1, f"{fmt}: structural flags {structural}"

--- a/tests/v1/gpu_connector/test_kv_format_specs.py
+++ b/tests/v1/gpu_connector/test_kv_format_specs.py
@@ -57,9 +57,6 @@ def _build(name: str):
 _RAISE = object()
 GOLDEN = {
     "NB_NL_TWO_BS_NH_HS": dict(
-        is_mla=False,
-        is_hnd=False,
-        is_cross_layer=True,
         shape_desc="[NB, NL, 2, BS, NH, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -73,9 +70,6 @@ GOLDEN = {
         concrete="[7, 5, 2, 3, 2, 4]",
     ),
     "NB_NL_TWO_NH_BS_HS": dict(
-        is_mla=False,
-        is_hnd=True,
-        is_cross_layer=True,
         shape_desc="[NB, NL, 2, NH, BS, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -89,9 +83,6 @@ GOLDEN = {
         concrete="[7, 5, 2, 2, 3, 4]",
     ),
     "NL_X_TWO_NB_BS_NH_HS": dict(
-        is_mla=False,
-        is_hnd=False,
-        is_cross_layer=False,
         shape_desc="NL x [2, NB, BS, NH, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -105,9 +96,6 @@ GOLDEN = {
         concrete="5 x [2, 7, 3, 2, 4]",
     ),
     "NL_X_NB_TWO_BS_NH_HS": dict(
-        is_mla=False,
-        is_hnd=False,
-        is_cross_layer=False,
         shape_desc="NL x [NB, 2, BS, NH, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -121,9 +109,6 @@ GOLDEN = {
         concrete="5 x [7, 2, 3, 2, 4]",
     ),
     "NL_X_TWO_NB_NH_BS_HS": dict(
-        is_mla=False,
-        is_hnd=True,
-        is_cross_layer=False,
         shape_desc="NL x [2, NB, NH, BS, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -137,9 +122,6 @@ GOLDEN = {
         concrete="5 x [2, 7, 2, 3, 4]",
     ),
     "NL_X_NB_TWO_NH_BS_HS": dict(
-        is_mla=False,
-        is_hnd=True,
-        is_cross_layer=False,
         shape_desc="NL x [NB, 2, NH, BS, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -153,9 +135,6 @@ GOLDEN = {
         concrete="5 x [7, 2, 2, 3, 4]",
     ),
     "NL_X_NB_BS_HS": dict(
-        is_mla=True,
-        is_hnd=False,
-        is_cross_layer=False,
         shape_desc="NL x [NB, BS, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -169,9 +148,6 @@ GOLDEN = {
         concrete="5 x [7, 3, 4]",
     ),
     "TWO_X_NL_X_NBBS_NH_HS": dict(
-        is_mla=False,
-        is_hnd=False,
-        is_cross_layer=False,
         shape_desc="2 x NL x [PBS, NH, HS]",
         num_layers=NL,
         num_blocks=_RAISE,
@@ -185,9 +161,6 @@ GOLDEN = {
         concrete="2 x 5 x [21, 2, 4]",
     ),
     "TWO_X_NL_X_NB_BS_NH_HS": dict(
-        is_mla=False,
-        is_hnd=False,
-        is_cross_layer=False,
         shape_desc="2 x NL x [NB, BS, NH, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -201,9 +174,6 @@ GOLDEN = {
         concrete="2 x 5 x [7, 3, 2, 4]",
     ),
     "NL_X_NBBS_ONE_HS": dict(
-        is_mla=True,
-        is_hnd=False,
-        is_cross_layer=False,
         shape_desc="NL x [PBS, 1, HS]",
         num_layers=NL,
         num_blocks=_RAISE,
@@ -217,9 +187,6 @@ GOLDEN = {
         concrete="5 x [21, 1, 4]",
     ),
     "NL_X_NB_NH_BS_TWO_HS": dict(
-        is_mla=False,
-        is_hnd=True,
-        is_cross_layer=False,
         shape_desc="NL x [NB, NH, BS, 2, HS]",
         num_layers=NL,
         num_blocks=NB,
@@ -245,11 +212,9 @@ def case(request):
 
 
 def test_static_metadata(case):
+    # The format's static layout flags are pinned in test_kv_format_classification
+    # (read via lmc_ops); here we only freeze the symbolic shape.
     name, fmt, gold = case
-    cls = get_spec_class(fmt)
-    assert cls.is_mla == gold["is_mla"], name
-    assert cls.is_hnd == gold["is_hnd"], name
-    assert cls.is_cross_layer == gold["is_cross_layer"], name
     assert describe_shape(fmt) == gold["shape_desc"], name
 
 
@@ -288,9 +253,9 @@ def test_data_ptrs_shape(case):
     kv = _build(name)
     spec = get_spec(kv, fmt)
     ptrs = spec.data_ptrs(list(range(NL)))
-    if gold["is_cross_layer"]:
+    if lmc_ops.is_cross_layer(fmt):
         assert len(ptrs) == 1, name  # single base pointer
-    elif name.startswith("TWO_X_NL_X"):
+    elif lmc_ops.is_kv_list(fmt):
         assert len(ptrs) == 2 * NL, name  # K's then V's
     else:
         assert len(ptrs) == NL, name  # one per layer

--- a/tests/v1/gpu_connector/test_normalize_per_layer_formats.py
+++ b/tests/v1/gpu_connector/test_normalize_per_layer_formats.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``normalize_and_discover_per_layer_formats``.
+
+Uniform models return the whole normalized structure (so a format that isn't a
+per-layer list -- a cross-layer fused tensor, or a ``[keys, values]`` K/V-split
+-- stays intact); mixed models report each engine group's own per-layer format.
+The K/V-split path is the SGLang regression: it must not be sliced per layer.
+"""
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import normalize_and_discover_per_layer_formats
+import lmcache.c_ops as lmc_ops
+
+NB, NL, BS, NH, HS = 7, 5, 3, 2, 4
+DT = torch.float16
+F = lmc_ops.EngineKVFormat
+
+# The vLLM CPU-HND safeguard forces HND regardless of hint on a CPU host; bypass
+# it so the hint-driven NHD branch is exercised on any host.
+_VLLM_DEV = "lmcache.v1.gpu_connector.kv_format.detectors.vllm.torch_device_type"
+
+
+def _t(*shape: int) -> torch.Tensor:
+    return torch.zeros(shape, dtype=DT)
+
+
+def test_sglang_kv_list_uniform():
+    # Regression: a flat list of 2*NL tensors that detection regroups into a
+    # length-2 [key_layers, value_layers]. ``is_layer_list`` is False for the
+    # K/V-split format, so it is returned whole -- never sliced per layer.
+    flat = [_t(NB * BS, NH, HS) for _ in range(2 * NL)]
+    normalized, formats = normalize_and_discover_per_layer_formats(
+        flat, (), EngineType.SGLANG, {"tokens_per_block": BS}
+    )
+    assert len(normalized) == 2 and len(normalized[0]) == NL
+    assert tuple(normalized[0][0].shape) == (NB, BS, NH, HS)
+    assert formats == [F.TWO_X_NL_X_NB_BS_NH_HS] * NL
+
+
+def test_vllm_layer_list_uniform(monkeypatch):
+    # Per-layer-list format, every layer the same: whole list back, format per layer.
+    monkeypatch.setattr(_VLLM_DEV, "cuda")
+    kv = [_t(2, NB, BS, NH, HS) for _ in range(NL)]
+    normalized, formats = normalize_and_discover_per_layer_formats(
+        kv, (), EngineType.VLLM, {"kv_layout": "NHD"}
+    )
+    assert len(normalized) == NL
+    assert formats == [F.NL_X_TWO_NB_BS_NH_HS] * NL
+
+
+def test_vllm_heterogeneous_groups(monkeypatch):
+    # Mixed-format model: a full K/V group beside a key-only MLA index group.
+    monkeypatch.setattr(_VLLM_DEV, "cuda")
+    kv = [_t(2, NB, BS, NH, HS) for _ in range(3)] + [_t(NB, BS, HS) for _ in range(2)]
+    normalized, formats = normalize_and_discover_per_layer_formats(
+        kv, [[0, 1, 2], [3, 4]], EngineType.VLLM, {"kv_layout": "NHD"}
+    )
+    assert len(normalized) == 5
+    assert formats[:3] == [F.NL_X_TWO_NB_BS_NH_HS] * 3
+    assert formats[3:] == [F.NL_X_NB_BS_HS] * 2

--- a/tests/v1/test_trtllm_integration.py
+++ b/tests/v1/test_trtllm_integration.py
@@ -75,23 +75,6 @@ class TestGPUKVFormatEnum:
 
         assert hasattr(lmc_ops.EngineKVFormat, "NB_NL_TWO_NH_BS_HS")
 
-    def test_is_cross_layer_format(self) -> None:
-        # First Party
-        from lmcache.v1.gpu_connector.utils import is_cross_layer_format
-        import lmcache.c_ops as lmc_ops
-
-        assert is_cross_layer_format(lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS)
-        assert is_cross_layer_format(lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS)
-        assert not is_cross_layer_format(lmc_ops.EngineKVFormat.NL_X_NB_BS_HS)
-
-    def test_is_hnd(self) -> None:
-        # First Party
-        from lmcache.v1.gpu_connector.utils import is_hnd
-        import lmcache.c_ops as lmc_ops
-
-        assert is_hnd(lmc_ops.EngineKVFormat.NB_NL_TWO_NH_BS_HS)
-        assert not is_hnd(lmc_ops.EngineKVFormat.NB_NL_TWO_BS_NH_HS)
-
 
 @pytest.mark.skipif(not _has_lmc_ops(), reason="lmcache C ops not built")
 class TestNormalizeTRTLLM:


### PR DESCRIPTION
## What

The structural shape of a normalized `kv_caches` (cross-layer / K/V-split / per-layer-list) and the MLA modifier were classified in two drifting places: a Python `KVFormatSpec` ClassVar per spec, and hand-rolled `is_mla` helpers duplicated across `mem_kernels.cu` and `mem_kernels_sycl.cpp`. Detection branched on these via an ad-hoc per-layer slice that assumed one normalized entry per registered tensor, which broke SGLang's K/V-split `[keys, values]` layout with an `IndexError` at registration.

This moves the classification to a single source of truth on the `EngineKVFormat` itself, and the SGLang fix falls out of it.

## Changes

- New `csrc/engine_kv_format.h` holds the enum (split out of `kv_transfer_types.h`) plus `constexpr` `is_cross_layer` / `is_kv_list` / `is_layer_list` / `is_mla`, guarded `__host__ __device__` so the device kernels share them. pybind exposes them via `lmc_ops`; the duplicate `is_mla` is removed from the CUDA and SYCL kernels.
- `KVFormatSpec` and the specs drop their flag ClassVars; the `gpu_connector` facades read `lmc_ops`.
- `normalize_and_discover_per_layer_formats` front-loads on `is_layer_list_format`: a format that isn't a per-layer list is returned whole, so the K/V-split layout is never sliced — the SGLang fix is now a property of the format, not a special case. `_pick_layout_probe_tensor` reads the predicates too.

## Not in scope

`is_hnd` is intentionally left out: its live consumer is the CUDA `check_head_size` path (2 formats) and it had drifted from the Python specs (4 formats), so unifying it risks kernel behavior and needs a separate audited change. The dead Python `is_hnd` facade is removed.

## Tests

Golden classification + partition invariant over every format (via `lmc_ops`), and a per-layer regression covering the SGLang K/V-split, uniform, and mixed-format cases. Full kv_format / kv-layer-groups / kernel suites pass against a local CUDA rebuild.
