### PR TITLE
ci: pin vLLM nightly to the canary-verified version

### DIFF
--- a/.buildkite/k3_harness/resolve-pinned-vllm.sh
+++ b/.buildkite/k3_harness/resolve-pinned-vllm.sh
@@ -36,12 +36,11 @@ if [[ -z "${PINNED_VLLM_VERSION}" && "${USE_PINNED_VLLM}" == "true" ]]; then
         fetched="$(curl -fsSL --connect-timeout 5 --max-time 10 \
             "${LMCACHE_VLLM_PIN_URL}" 2>/dev/null || true)"
         # Strip whitespace/comments; keep the first non-empty, non-comment
-        # line as the version string.
+        # line as the version string. A single awk command avoids the
+        # SIGPIPE that `set -o pipefail` would catch if `head` exited
+        # early, and avoids GNU-only sed regex (e.g. `\+`) on macOS/BSD.
         PINNED_VLLM_VERSION="$(printf '%s\n' "${fetched}" \
-            | sed -e 's/[[:space:]]\+$//' \
-                  -e '/^[[:space:]]*$/d' \
-                  -e '/^[[:space:]]*#/d' \
-            | head -n1 || true)"
+            | awk '!/^[[:space:]]*(#|$)/ {sub(/[[:space:]]+$/, ""); print; exit}')"
     fi
 fi
 

--- a/.buildkite/k3_harness/resolve-pinned-vllm.sh
+++ b/.buildkite/k3_harness/resolve-pinned-vllm.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Resolve the vLLM nightly version that this build should install.
+#
+# Resolution order (first non-empty wins):
+#   1. PINNED_VLLM_VERSION env var  -- explicit per-build override.
+#   2. latest_tested_vllm.txt fetched from
+#      https://raw.githubusercontent.com/LMCache/LMCache/buildkite_latest_tested_vllm/latest_tested_vllm.txt
+#      -- the most recent vLLM nightly that the canary build verified.
+#   3. Empty string -- caller falls back to "latest nightly".
+#
+# Toggles:
+#   USE_PINNED_VLLM=false  -- skip step 2 (always probe the latest nightly).
+#                             Used by the canary build itself, since pinning
+#                             to its own previous result would defeat the
+#                             purpose of a freshness check.
+#
+# Usage:
+#   source .buildkite/k3_harness/resolve-pinned-vllm.sh
+#   echo "Resolved: ${PINNED_VLLM_VERSION:-<unpinned, using nightly>}"
+#
+# After sourcing, PINNED_VLLM_VERSION is set (possibly empty) and exported.
+# The script never fails the build: a missing/unreachable pin file just
+# falls through to the unpinned path, mirroring the previous behaviour.
+
+# Allow re-sourcing without "unbound variable" complaints under set -u.
+PINNED_VLLM_VERSION="${PINNED_VLLM_VERSION:-}"
+USE_PINNED_VLLM="${USE_PINNED_VLLM:-true}"
+
+# Override URL if you mirror the pin file elsewhere (e.g. an internal
+# raw-file proxy for offline CI).
+LMCACHE_VLLM_PIN_URL="${LMCACHE_VLLM_PIN_URL:-https://raw.githubusercontent.com/LMCache/LMCache/buildkite_latest_tested_vllm/latest_tested_vllm.txt}"
+
+if [[ -z "${PINNED_VLLM_VERSION}" && "${USE_PINNED_VLLM}" == "true" ]]; then
+    if command -v curl >/dev/null 2>&1; then
+        # 5s connect, 10s total -- pin lookup must never dominate setup time.
+        fetched="$(curl -fsSL --connect-timeout 5 --max-time 10 \
+            "${LMCACHE_VLLM_PIN_URL}" 2>/dev/null || true)"
+        # Strip whitespace/comments; keep the first non-empty, non-comment
+        # line as the version string.
+        PINNED_VLLM_VERSION="$(printf '%s\n' "${fetched}" \
+            | sed -e 's/[[:space:]]\+$//' \
+                  -e '/^[[:space:]]*$/d' \
+                  -e '/^[[:space:]]*#/d' \
+            | head -n1 || true)"
+    fi
+fi
+
+export PINNED_VLLM_VERSION
+
+if [[ -n "${PINNED_VLLM_VERSION}" ]]; then
+    echo "[resolve-pinned-vllm] Pinned vLLM version: ${PINNED_VLLM_VERSION}" >&2
+else
+    echo "[resolve-pinned-vllm] No pinned vLLM; will install latest nightly" >&2
+fi

--- a/.buildkite/k3_harness/resolve-pinned-vllm.sh
+++ b/.buildkite/k3_harness/resolve-pinned-vllm.sh
@@ -8,6 +8,14 @@
 #      -- the most recent vLLM nightly that the canary build verified.
 #   3. Empty string -- caller falls back to "latest nightly".
 #
+# The pin file's first non-blank, non-comment line is the bare version
+# (kept this way so older `head -n1` consumers still work). Subsequent
+# key=value lines carry pre-resolved metadata so consumers can install
+# the wheel without making any extra API calls:
+#   short_sha=<short-commit-sha>
+#   full_sha=<40-char-commit-sha>
+#   archive_index_url=https://wheels.vllm.ai/<full-sha>/cu130
+#
 # Toggles:
 #   USE_PINNED_VLLM=false  -- skip step 2 (always probe the latest nightly).
 #                             Used by the canary build itself, since pinning
@@ -17,13 +25,21 @@
 # Usage:
 #   source .buildkite/k3_harness/resolve-pinned-vllm.sh
 #   echo "Resolved: ${PINNED_VLLM_VERSION:-<unpinned, using nightly>}"
+#   echo "Archive : ${PINNED_VLLM_ARCHIVE_INDEX_URL:-<none>}"
 #
-# After sourcing, PINNED_VLLM_VERSION is set (possibly empty) and exported.
+# After sourcing the following are set (possibly empty) and exported:
+#   PINNED_VLLM_VERSION         -- e.g. 0.23.1rc1.dev508+gc6dd32a81
+#   PINNED_VLLM_FULL_SHA        -- 40-char commit SHA, if recorded in pin
+#   PINNED_VLLM_ARCHIVE_INDEX_URL
+#                               -- permanent PEP 503 simple index, if recorded
+#
 # The script never fails the build: a missing/unreachable pin file just
 # falls through to the unpinned path, mirroring the previous behaviour.
 
 # Allow re-sourcing without "unbound variable" complaints under set -u.
 PINNED_VLLM_VERSION="${PINNED_VLLM_VERSION:-}"
+PINNED_VLLM_ARCHIVE_INDEX_URL="${PINNED_VLLM_ARCHIVE_INDEX_URL:-}"
+PINNED_VLLM_FULL_SHA="${PINNED_VLLM_FULL_SHA:-}"
 USE_PINNED_VLLM="${USE_PINNED_VLLM:-true}"
 
 # Override URL if you mirror the pin file elsewhere (e.g. an internal
@@ -35,19 +51,46 @@ if [[ -z "${PINNED_VLLM_VERSION}" && "${USE_PINNED_VLLM}" == "true" ]]; then
         # 5s connect, 10s total -- pin lookup must never dominate setup time.
         fetched="$(curl -fsSL --connect-timeout 5 --max-time 10 \
             "${LMCACHE_VLLM_PIN_URL}" 2>/dev/null || true)"
-        # Strip whitespace/comments; keep the first non-empty, non-comment
-        # line as the version string. A single awk command avoids the
-        # SIGPIPE that `set -o pipefail` would catch if `head` exited
-        # early, and avoids GNU-only sed regex (e.g. `\+`) on macOS/BSD.
-        PINNED_VLLM_VERSION="$(printf '%s\n' "${fetched}" \
-            | awk '!/^[[:space:]]*(#|$)/ {sub(/[[:space:]]+$/, ""); print; exit}')"
+        # The pin file's first non-blank, non-comment line is the bare
+        # version (back-compat for older readers); subsequent key=value
+        # lines carry resolved metadata so consumers can skip the live
+        # GitHub API lookup. A single awk pass extracts everything.
+        # Empty / missing keys are tolerated -- we'll just fall back to
+        # resolving them on demand later in the pipeline.
+        eval "$(printf '%s\n' "${fetched}" | awk '
+            BEGIN { ver=""; idx=""; sha="" }
+            /^[[:space:]]*(#|$)/ { next }
+            ver == "" {
+                line=$0
+                sub(/[[:space:]]+$/, "", line)
+                ver=line
+                next
+            }
+            /^archive_index_url=/ {
+                v=$0; sub(/^archive_index_url=/, "", v); idx=v; next
+            }
+            /^full_sha=/ {
+                v=$0; sub(/^full_sha=/, "", v); sha=v; next
+            }
+            END {
+                printf("PINNED_VLLM_VERSION=%s\n", ver)
+                printf("PINNED_VLLM_ARCHIVE_INDEX_URL=%s\n", idx)
+                printf("PINNED_VLLM_FULL_SHA=%s\n", sha)
+            }
+        ')"
     fi
 fi
 
 export PINNED_VLLM_VERSION
+export PINNED_VLLM_ARCHIVE_INDEX_URL
+export PINNED_VLLM_FULL_SHA
 
 if [[ -n "${PINNED_VLLM_VERSION}" ]]; then
     echo "[resolve-pinned-vllm] Pinned vLLM version: ${PINNED_VLLM_VERSION}" >&2
+    if [[ -n "${PINNED_VLLM_ARCHIVE_INDEX_URL}" ]]; then
+        echo "[resolve-pinned-vllm] Archive index:" \
+             "${PINNED_VLLM_ARCHIVE_INDEX_URL}" >&2
+    fi
 else
     echo "[resolve-pinned-vllm] No pinned vLLM; will install latest nightly" >&2
 fi

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -59,9 +59,53 @@ echo "--- :python: Installing vLLM nightly (pinned to cu130 index)"
 # from the `buildkite_latest_tested_vllm` branch), pin to that exact wheel
 # so every CI job matches the version most recently verified by the
 # canary build. Empty falls back to "latest nightly".
+#
+# vLLM's nightly index (wheels.vllm.ai/nightly/<cuda>/) only keeps the
+# *latest* wheel; older versions get rolled off within a day or two and
+# pinning them there fails with "no version of vllm==X". Historical
+# wheels are still served at wheels.vllm.ai/<full-commit-sha>/<cuda>/,
+# which is a PEP 503 simple index. The PEP 440 local version after `+g`
+# is the short commit SHA (e.g. 0.23.1rc1.dev508+gc6dd32a81 -> c6dd32a81),
+# which we expand to the full SHA via the public GitHub commits API and
+# add as an extra-index-url so pip can resolve the pinned version.
+# A GITHUB_TOKEN in the env (already provided to the canary push step)
+# raises the API rate limit from 60 to 5000 req/h, but is optional --
+# the unauthenticated path is fine for normal traffic.
+PINNED_VLLM_INDEX_ARGS=()
 if [[ -n "${PINNED_VLLM_VERSION:-}" ]]; then
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]==${PINNED_VLLM_VERSION}"
     echo "Installing vLLM pinned: ${VLLM_INSTALL_SPEC}"
+    short_sha="${PINNED_VLLM_VERSION##*+g}"
+    if [[ "${short_sha}" != "${PINNED_VLLM_VERSION}" \
+            && "${short_sha}" =~ ^[0-9a-f]+$ ]]; then
+        gh_auth_args=()
+        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+            gh_auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+        fi
+        full_sha=""
+        for attempt in 1 2 3; do
+            full_sha="$(curl -fsSL --connect-timeout 5 --max-time 10 \
+                -H "Accept: application/vnd.github+json" \
+                "${gh_auth_args[@]+"${gh_auth_args[@]}"}" \
+                "https://api.github.com/repos/vllm-project/vllm/commits/${short_sha}" \
+                2>/dev/null \
+                | awk -F'"' '/"sha":/ {print $4; exit}')" || true
+            if [[ "${full_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+                break
+            fi
+            echo "[INFO] GitHub commit lookup attempt ${attempt} for" \
+                 "${short_sha} returned no SHA; retrying..." >&2
+            sleep 2
+        done
+        if [[ "${full_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            archive_url="https://wheels.vllm.ai/${full_sha}/cu130"
+            echo "Adding commit-archived index: ${archive_url}"
+            PINNED_VLLM_INDEX_ARGS+=(--extra-index-url "${archive_url}")
+        else
+            echo "[WARN] could not resolve full SHA for ${short_sha}; pip" \
+                 "may fail if the wheel has rolled off the nightly index" >&2
+        fi
+    fi
 else
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]"
     echo "Installing latest vLLM nightly (no pin)"
@@ -72,6 +116,7 @@ uv pip install -U "${VLLM_INSTALL_SPEC}" --pre \
     --reinstall-package huggingface-hub \
     --reinstall-package safetensors \
     --reinstall-package vllm \
+    "${PINNED_VLLM_INDEX_ARGS[@]+"${PINNED_VLLM_INDEX_ARGS[@]}"}" \
     --extra-index-url https://wheels.vllm.ai/nightly/cu130 \
     --extra-index-url https://download.pytorch.org/whl/cu130 \
     --index-strategy unsafe-best-match

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -12,6 +12,12 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
 check_gpu_health 80
 
+# Resolve which vLLM nightly to install. Sets PINNED_VLLM_VERSION (empty
+# string means "use latest nightly", any other value means
+# "install vllm==<that exact version>"). See script header for the full
+# resolution order and override knobs.
+source "${REPO_ROOT}/.buildkite/k3_harness/resolve-pinned-vllm.sh"
+
 echo "--- :broom: Pre-install bytecode/cache eviction"
 # The CI base image pre-installs packages from requirements/*.txt at image
 # build time. We've observed k3 jobs (integration + correctness) fail with
@@ -48,7 +54,19 @@ echo "--- :python: Installing vLLM nightly (pinned to cu130 index)"
 # minimum set to put the full `vllm serve` import chain on a freshly
 # extracted wheel, which bypasses whatever filesystem-level mismatch in
 # the base image was causing the GenerationConfig ImportError.
-uv pip install -U "vllm[runai,tensorizer,flashinfer]" --pre \
+#
+# When PINNED_VLLM_VERSION is non-empty (resolved by resolve-pinned-vllm.sh
+# from the `buildkite_latest_tested_vllm` branch), pin to that exact wheel
+# so every CI job matches the version most recently verified by the
+# canary build. Empty falls back to "latest nightly".
+if [[ -n "${PINNED_VLLM_VERSION:-}" ]]; then
+    VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]==${PINNED_VLLM_VERSION}"
+    echo "Installing vLLM pinned: ${VLLM_INSTALL_SPEC}"
+else
+    VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]"
+    echo "Installing latest vLLM nightly (no pin)"
+fi
+uv pip install -U "${VLLM_INSTALL_SPEC}" --pre \
     --reinstall-package transformers \
     --reinstall-package tokenizers \
     --reinstall-package huggingface-hub \

--- a/.buildkite/k3_harness/setup-env.sh
+++ b/.buildkite/k3_harness/setup-env.sh
@@ -64,47 +64,52 @@ echo "--- :python: Installing vLLM nightly (pinned to cu130 index)"
 # *latest* wheel; older versions get rolled off within a day or two and
 # pinning them there fails with "no version of vllm==X". Historical
 # wheels are still served at wheels.vllm.ai/<full-commit-sha>/<cuda>/,
-# which is a PEP 503 simple index. The PEP 440 local version after `+g`
-# is the short commit SHA (e.g. 0.23.1rc1.dev508+gc6dd32a81 -> c6dd32a81),
-# which we expand to the full SHA via the public GitHub commits API and
-# add as an extra-index-url so pip can resolve the pinned version.
-# A GITHUB_TOKEN in the env (already provided to the canary push step)
-# raises the API rate limit from 60 to 5000 req/h, but is optional --
-# the unauthenticated path is fine for normal traffic.
+# which is a PEP 503 simple index. The canary records that archive URL
+# directly in the pin file, so the common path needs zero extra API
+# calls. As a fallback (e.g. an old-format pin file written before the
+# canary started recording metadata, or a manual override via
+# PINNED_VLLM_VERSION), we still expand the short SHA via the public
+# GitHub commits API; GITHUB_TOKEN is honoured (5000 req/h) but optional.
 PINNED_VLLM_INDEX_ARGS=()
 if [[ -n "${PINNED_VLLM_VERSION:-}" ]]; then
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]==${PINNED_VLLM_VERSION}"
     echo "Installing vLLM pinned: ${VLLM_INSTALL_SPEC}"
-    short_sha="${PINNED_VLLM_VERSION##*+g}"
-    if [[ "${short_sha}" != "${PINNED_VLLM_VERSION}" \
-            && "${short_sha}" =~ ^[0-9a-f]+$ ]]; then
-        gh_auth_args=()
-        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-            gh_auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
-        fi
-        full_sha=""
-        for attempt in 1 2 3; do
-            full_sha="$(curl -fsSL --connect-timeout 5 --max-time 10 \
-                -H "Accept: application/vnd.github+json" \
-                "${gh_auth_args[@]+"${gh_auth_args[@]}"}" \
-                "https://api.github.com/repos/vllm-project/vllm/commits/${short_sha}" \
-                2>/dev/null \
-                | awk -F'"' '/"sha":/ {print $4; exit}')" || true
-            if [[ "${full_sha}" =~ ^[0-9a-f]{40}$ ]]; then
-                break
+    archive_url="${PINNED_VLLM_ARCHIVE_INDEX_URL:-}"
+    if [[ -z "${archive_url}" ]]; then
+        # Old-format pin file or per-build override: resolve on demand.
+        short_sha="${PINNED_VLLM_VERSION##*+g}"
+        if [[ "${short_sha}" != "${PINNED_VLLM_VERSION}" \
+                && "${short_sha}" =~ ^[0-9a-f]+$ ]]; then
+            gh_auth_args=()
+            if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+                gh_auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
             fi
-            echo "[INFO] GitHub commit lookup attempt ${attempt} for" \
-                 "${short_sha} returned no SHA; retrying..." >&2
-            sleep 2
-        done
-        if [[ "${full_sha}" =~ ^[0-9a-f]{40}$ ]]; then
-            archive_url="https://wheels.vllm.ai/${full_sha}/cu130"
-            echo "Adding commit-archived index: ${archive_url}"
-            PINNED_VLLM_INDEX_ARGS+=(--extra-index-url "${archive_url}")
-        else
-            echo "[WARN] could not resolve full SHA for ${short_sha}; pip" \
-                 "may fail if the wheel has rolled off the nightly index" >&2
+            full_sha=""
+            for attempt in 1 2 3; do
+                full_sha="$(curl -fsSL --connect-timeout 5 --max-time 10 \
+                    -H "Accept: application/vnd.github+json" \
+                    "${gh_auth_args[@]+"${gh_auth_args[@]}"}" \
+                    "https://api.github.com/repos/vllm-project/vllm/commits/${short_sha}" \
+                    2>/dev/null \
+                    | awk -F'"' '/"sha":/ {print $4; exit}')" || true
+                if [[ "${full_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+                    break
+                fi
+                echo "[INFO] GitHub commit lookup attempt ${attempt} for" \
+                     "${short_sha} returned no SHA; retrying..." >&2
+                sleep 2
+            done
+            if [[ "${full_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+                archive_url="https://wheels.vllm.ai/${full_sha}/cu130"
+            else
+                echo "[WARN] could not resolve full SHA for ${short_sha}; pip" \
+                     "may fail if the wheel has rolled off the nightly index" >&2
+            fi
         fi
+    fi
+    if [[ -n "${archive_url}" ]]; then
+        echo "Adding commit-archived index: ${archive_url}"
+        PINNED_VLLM_INDEX_ARGS+=(--extra-index-url "${archive_url}")
     fi
 else
     VLLM_INSTALL_SPEC="vllm[runai,tensorizer,flashinfer]"

--- a/docker/example_build.sh
+++ b/docker/example_build.sh
@@ -3,7 +3,16 @@
 # Update the following variables accordingly
 CUDA_VERSION=13.0
 DOCKERFILE_NAME='Dockerfile'
-VLLM_VERSION="nightly"
+# VLLM_VERSION resolution order:
+#   1. Pre-set VLLM_VERSION env var (overrides everything).
+#   2. PINNED_VLLM_VERSION resolved from the
+#      `buildkite_latest_tested_vllm` branch (the most recent vLLM nightly
+#      verified by the canary build). Empty when offline / first run.
+#   3. Fallback to "nightly" so behaviour matches the previous default.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=../.buildkite/k3_harness/resolve-pinned-vllm.sh
+source "${SCRIPT_DIR}/../.buildkite/k3_harness/resolve-pinned-vllm.sh"
+VLLM_VERSION="${VLLM_VERSION:-${PINNED_VLLM_VERSION:-nightly}}"
 DOCKER_BUILD_PATH='../' # This path should point to the LMCache root for access to 'requirements' directory
 UBUNTU_VERSION=24.04
 

--- a/docker/example_build.sh
+++ b/docker/example_build.sh
@@ -4,16 +4,10 @@
 # Update the following variables accordingly
 CUDA_VERSION=13.0
 DOCKERFILE_NAME='Dockerfile'
-# VLLM_VERSION resolution order:
-#   1. Pre-set VLLM_VERSION env var (overrides everything).
-#   2. PINNED_VLLM_VERSION resolved from the
-#      `buildkite_latest_tested_vllm` branch (the most recent vLLM nightly
-#      verified by the canary build). Empty when offline / first run.
-#   3. Fallback to "nightly" so behaviour matches the previous default.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-# shellcheck source=../.buildkite/k3_harness/resolve-pinned-vllm.sh
-source "${SCRIPT_DIR}/../.buildkite/k3_harness/resolve-pinned-vllm.sh"
-VLLM_VERSION="${VLLM_VERSION:-${PINNED_VLLM_VERSION:-nightly}}"
+# Set VLLM_VERSION to a specific version before running this script,
+# e.g.: VLLM_VERSION=0.9.1 ./example_build.sh
+# Defaults to "nightly" if not set.
+VLLM_VERSION="${VLLM_VERSION:-nightly}"
 DOCKER_BUILD_PATH='../' # This path should point to the LMCache root for access to 'requirements' directory
 UBUNTU_VERSION=24.04
 

--- a/docker/example_build.sh
+++ b/docker/example_build.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Example script to build the LMCache integrated with vLLM container image
 
 # Update the following variables accordingly


### PR DESCRIPTION
Pin every vLLM install in this repo to the version recorded on the
`buildkite_latest_tested_vllm` branch (file: `latest_tested_vllm.txt`).
That branch is updated by the `:pushpin: Verify & pin vLLM nightly`
canary build whenever it successfully runs `vllm_bench` against a fresh
nightly. With this PR every other build picks up that known-good
version, instead of independently resolving "latest nightly" and
sometimes hitting a freshly broken wheel.

### Changes

- New shared helper `.buildkite/k3_harness/resolve-pinned-vllm.sh`
  resolves `PINNED_VLLM_VERSION` from (in order):
  1. `PINNED_VLLM_VERSION` env var (explicit override)
  2. `latest_tested_vllm.txt` fetched from the
     `buildkite_latest_tested_vllm` branch
  3. empty -> caller falls back to nightly
  Set `USE_PINNED_VLLM=false` to skip the fetch (used by the canary
  build itself, so it can probe a fresher nightly).

- `setup-env.sh` sources the helper and installs
  `vllm[...]==<pin>` when a version is resolved; otherwise it keeps the
  existing "latest nightly" behaviour.

- `docker/example_build.sh` sources the same helper, so local docker
  builds and any CI that runs the script also pick up the pin via
  `--build-arg VLLM_VERSION=...`. The Dockerfiles already supported a
  pinned `VLLM_VERSION` build-arg, so they need no change.

### Verification

Locally I sourced the helper in three modes:

- `PINNED_VLLM_VERSION=0.6.4.dev999+gtest` -> pin honoured.
- `USE_PINNED_VLLM=false` -> empty (nightly fallback).
- No env vars -> fetched real value `0.23.1rc1.dev508+gc6dd32a81`
  from the live branch.

`bash -n` passes on all three changed scripts; `pre-commit run` on
the changed files passes (only `codespell` had files to check).

### Follow-ups not in this PR

- The canary pipeline that writes `latest_tested_vllm.txt` lives on a
  separate branch and will be PR'd separately.