### PR TITLE
docs(coding-standards): add log format specifier convention

### DIFF
--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -374,3 +374,19 @@ Use this checklist before submitting a PR or during review:
 - [ ] Thread safety maintained for shared state
 - [ ] No unnecessary memory copies in hot paths
 - [ ] CUDA/GPU resources properly managed
+
+### 7.7 Log Format Specifiers
+
+Use the correct `printf`-style format specifier based on the **type annotation**, not neighboring log calls:
+
+| Type | Specifier | Example |
+|------|-----------|---------|
+| `int` (counts, numeric IDs) | `%d` | `logger.info("Retrieved %d chunks", chunk_count)` |
+| `str` (string IDs, names) | `%s` | `logger.info("Dropped instance %s", instance_id)` |
+| `bool` | `%s` (prints `True`/`False`) | `logger.info("Cache hit: %s", hit)` |
+| `float` | `%s` or `%r` | `logger.info("Score: %s", score)` |
+| Objects / exceptions | `%s` (calls `__str__`) | `logger.info("Error: %s", exc)` |
+
+**Why this matters**: `instance_id` is typed as `str` in the cache engine layer (UUID) and `int` in the multiprocess layer (GPU/worker index). A mechanical f-string→`%`-style conversion can silently pick the wrong specifier unless the type annotation is checked. Always verify the type before choosing `%d` vs `%s`.
+
+**Naming note**: When a variable represents a GPU/worker index number, prefer `gpu_instance_id` or `worker_id` over bare `instance_id` to distinguish it from the string `instance_id` used in the engine layer.

--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -269,8 +269,24 @@ C++/CUDA files use clang-format (Google style, 80-col). Rust code uses `cargo fm
 - CUDA/GPU resources must be properly managed (allocated, freed, synchronized).
 - No unnecessary memory copies or allocations in hot paths.
 
----
+### 7.7 Log Format Specifiers
 
+Use the correct `printf`-style format specifier based on the **type annotation**, not neighboring log calls:
+
+| Type | Specifier | Example |
+|------|-----------|---------|
+| `int` (counts, numeric IDs) | `%d` | `logger.info("Retrieved %d chunks", chunk_count)` |
+| `str` (string IDs, names) | `%s` | `logger.info("Dropped instance %s", instance_id)` |
+| `bool` | `%s` (prints `True`/`False`) | `logger.info("Cache hit: %s", hit)` |
+| `float` | `%s` or `%r` | `logger.info("Score: %s", score)` |
+| Objects / exceptions | `%s` (calls `__str__`) | `logger.info("Error: %s", exc)` |
+
+**Why this matters**: `instance_id` is typed as `str` in the cache engine layer (UUID) and `int` in the multiprocess layer (GPU/worker index). A mechanical f-string→`%`-style conversion can silently pick the wrong specifier unless the type annotation is checked. Always verify the type before choosing `%d` vs `%s`.
+
+**Naming note**: When a variable represents a GPU/worker index number, prefer `gpu_instance_id` or `worker_id` over bare `instance_id` to distinguish it from the string `instance_id` used in the engine layer.
+
+
+---
 ## 8. Thread Safety
 
 - All shared state access must be protected by appropriate locks.
@@ -374,19 +390,3 @@ Use this checklist before submitting a PR or during review:
 - [ ] Thread safety maintained for shared state
 - [ ] No unnecessary memory copies in hot paths
 - [ ] CUDA/GPU resources properly managed
-
-### 7.7 Log Format Specifiers
-
-Use the correct `printf`-style format specifier based on the **type annotation**, not neighboring log calls:
-
-| Type | Specifier | Example |
-|------|-----------|---------|
-| `int` (counts, numeric IDs) | `%d` | `logger.info("Retrieved %d chunks", chunk_count)` |
-| `str` (string IDs, names) | `%s` | `logger.info("Dropped instance %s", instance_id)` |
-| `bool` | `%s` (prints `True`/`False`) | `logger.info("Cache hit: %s", hit)` |
-| `float` | `%s` or `%r` | `logger.info("Score: %s", score)` |
-| Objects / exceptions | `%s` (calls `__str__`) | `logger.info("Error: %s", exc)` |
-
-**Why this matters**: `instance_id` is typed as `str` in the cache engine layer (UUID) and `int` in the multiprocess layer (GPU/worker index). A mechanical f-string→`%`-style conversion can silently pick the wrong specifier unless the type annotation is checked. Always verify the type before choosing `%d` vs `%s`.
-
-**Naming note**: When a variable represents a GPU/worker index number, prefer `gpu_instance_id` or `worker_id` over bare `instance_id` to distinguish it from the string `instance_id` used in the engine layer.


### PR DESCRIPTION
Adds a new subsection (7.7) to `docs/coding_standards.md` documenting the printf-style format specifier convention for logging calls:

| Type | Specifier |
|------|-----------|
| `int` (counts, numeric IDs) | `%d` |
| `str` (string IDs, names) | `%s` |
| `bool` | `%s` |
| `float` | `%s` or `%r` |
| Objects / exceptions | `%s` |

Also clarifies that when `instance_id` is used as an `int` (GPU/worker index in the multiprocess layer), prefer more descriptive names like `gpu_instance_id` or `worker_id` to avoid confusion with the `str` `instance_id` in the engine layer.

Refs #3785