### PR TITLE
docs: daily drift check — multi-process mode (2026-06-27)

### DIFF
--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -103,7 +103,13 @@ Connecting vLLM
 ---------------
 
 The operator creates a ConfigMap named ``<engine-name>-connection`` containing
-the ``kv-transfer-config`` JSON.  Mount it in your vLLM Deployment:
+the ``kv-transfer-config`` JSON.  You can either let the operator's mutating
+webhook inject it for you (recommended -- keeps your vLLM manifest clean) or
+mount it by hand.  See :ref:`mp-operator-connection-injection` below for the
+webhook flow; the rest of this section describes the manual mount that is its
+equivalent.
+
+Mount it in your vLLM Deployment:
 
 .. code-block:: yaml
 
@@ -163,6 +169,127 @@ Key requirements for vLLM pods:
   inline.  The ConfigMap name is always ``<LMCacheEngine name>-connection``.
 - **No hostNetwork needed** -- The operator's node-local Service handles
   routing via ``internalTrafficPolicy=Local``.
+
+.. _mp-operator-connection-injection:
+
+Connection Injection (Webhook)
+-------------------------------
+
+Hand-wiring the ConfigMap mount and the ``$(cat ...)`` argument substitution
+above is repetitive across vLLM Deployments.  A **mutating admission webhook**
+shipped with the operator can do it for you so the vLLM manifest stays clean.
+It mirrors the CacheBlend webhook (see :ref:`mp-operator-cacheblend`) with an
+``lmcache-`` annotation/label discriminator so the two injectors never
+cross-fire on the same pod.
+
+When invoked on an opted-in pod whose ``<engine>-connection`` ConfigMap exists,
+the webhook mutates the pod at admission time to add:
+
+- ``--kv-transfer-config <JSON>`` -- the ``LMCacheMPConnector`` config, read
+  verbatim from the engine's ``<engine>-connection`` ConfigMap and inlined onto
+  the vLLM container's ``args`` (no volume mount needed);
+- ``hostIPC: true`` on the pod spec (CUDA IPC with the node-local server);
+- ``PYTHONHASHSEED=0`` on the vLLM container env, **set-if-absent** -- it
+  preserves a value you already set.
+
+Unlike the CacheBlend injector it does **not** consult the engine CR: the
+entire connector config lives in the connection ConfigMap, and
+``LMCacheEngine`` has no injection sub-spec.  It fails open
+(``failurePolicy: Ignore``) and is idempotent (re-admitted pods carrying the
+``lmcache.ai/lmcache-injected`` stamp are allowed unchanged).
+
+Prerequisites
+~~~~~~~~~~~~~
+
+- **cert-manager** + ``make deploy`` (not ``make run``, which is
+  controller-only and disables the webhook via ``ENABLE_WEBHOOKS=false``) --
+  same as the CacheBlend webhook; install once per cluster (see
+  :ref:`mp-operator-cacheblend` "Additional Prerequisites").
+- **Pod Security Standards** -- the injected ``hostIPC`` is rejected by the
+  ``baseline`` / ``restricted`` PSS profiles, so the vLLM pod's namespace must
+  be labeled ``pod-security.kubernetes.io/enforce=privileged``.
+- **Engine reconciled in the same namespace** -- the webhook reads the
+  ``<engine>-connection`` ConfigMap directly, so the ``LMCacheEngine`` must
+  already exist in the vLLM pod's namespace.
+
+Opting a vLLM Pod In
+~~~~~~~~~~~~~~~~~~~~
+
+Add the opt-in label and the engine-binding annotation to the pod template, and
+launch vLLM via the image **ENTRYPOINT** (args only) -- a
+``command: ["/bin/sh", "-c", ...]`` wrapper is skipped (the webhook stamps
+``lmcache.ai/lmcache-skip-reason=command-override`` because appended args would
+not reach ``vllm serve``):
+
+.. code-block:: yaml
+
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: vllm-lmcache
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: vllm-lmcache
+      template:
+        metadata:
+          labels:
+            app: vllm-lmcache
+            lmcache.ai/lmcache-inject: "true"        # opt-in (webhook objectSelector)
+          annotations:
+            lmcache.ai/lmcache-engine: "my-cache"    # bind to the engine (same namespace)
+            # Optional -- name the vLLM container if it is not the first one:
+            # lmcache.ai/lmcache-container: "vllm"
+        spec:
+          runtimeClassName: nvidia
+          # Do NOT set hostIPC here or mount an emptyDir at /dev/shm -- the
+          # webhook injects hostIPC=true; an emptyDir would shadow the host's
+          # /dev/shm and break cudaIpcOpenMemHandle.
+          containers:
+            - name: vllm
+              image: lmcache/vllm-openai:latest
+              # Args-only launch (image ENTRYPOINT is ["vllm", "serve"]). The
+              # webhook appends --kv-transfer-config; do NOT add it yourself
+              # (a user-supplied one stamps skip-reason=kv-transfer-config-present).
+              args: ["<your-model>", "--port", "8000", "--gpu-memory-utilization", "0.8"]
+              ports:
+                - name: http
+                  containerPort: 8000
+              resources:
+                limits:
+                  nvidia.com/gpu: "1"
+
+A ready-to-edit manifest lives at
+``operator/config/samples/vllm_lmcache_deployment.yaml``.
+
+Verifying Injection
+~~~~~~~~~~~~~~~~~~~
+
+The webhook mutates **Pods**, not the Deployment, so inspect a pod (not the
+Deployment spec):
+
+.. code-block:: bash
+
+    kubectl get pod -l app=vllm-lmcache -o yaml | \
+      grep -E "hostIPC|kv-transfer-config|lmcache-injected|lmcache-skip-reason"
+
+If nothing was injected, check the pod's ``lmcache.ai/lmcache-skip-reason``
+annotation:
+
+- ``command-override`` -- the pod uses a ``sh -c`` wrapper, so injected args
+  would not reach ``vllm serve``.
+- ``kv-transfer-config-present`` -- the user already supplied
+  ``--kv-transfer-config``; the webhook does not clobber it.
+- ``engine-not-found`` -- the ``<engine>-connection`` ConfigMap is missing
+  (engine not yet reconciled, or wrong namespace, or wrong name).
+- ``target-container-not-found`` -- the
+  ``lmcache.ai/lmcache-container`` annotation names a container the pod does
+  not have.
+
+With ``failurePolicy: Ignore`` a webhook / cert problem also leaves the pod
+un-mutated silently -- confirm the operator pod is ``Running`` and the
+``MutatingWebhookConfiguration`` exists.
 
 Verifying the Deployment
 ------------------------
@@ -611,6 +738,8 @@ Override Auto-Computed Resources
           cpu: "8"
         limits:
           memory: "100Gi"
+
+.. _mp-operator-cacheblend:
 
 CacheBlend
 ----------


### PR DESCRIPTION
## Summary

Daily docs drift check on the multi-process surface. **One** new user-facing inconsistency in `docs/source/`; nothing new in `docs/design/` beyond what is already pending review in the earlier drift-check PRs (#3900, #3879, #3863, #3840, #3817, #3774).

### `docs/source/` (user-facing — highest priority)

- **`docs/source/mp/operator.rst`** — The "Connecting vLLM" section still presents the **manual `sh -c` + ConfigMap-mount** wiring as the only way to feed `--kv-transfer-config` into a vLLM pod. After [#3822](https://github.com/LMCache/LMCache/pull/3822) (`8aceebe`, landed 2026-06-26 — *[operator][feat] Auto-inject LMCacheEngine connection into vLLM pods via webhook*) the operator now ships a **mutating admission webhook** (`LMCachePodInjector`, registered at `/mutate-lmcache--v1-pod`) that injects `--kv-transfer-config <inline JSON>`, `hostIPC=true`, and `PYTHONHASHSEED=0` (set-if-absent) onto opted-in vLLM pods at admission time. The operator README and the new sample (`operator/config/samples/vllm_lmcache_deployment.yaml`) describe this fully; the MP operator page does not mention it anywhere outside the CacheBlend webhook section.

  The previous 06-26 drift-check PR (#3900) was opened at 16:14 UTC on 2026-06-26, *before* the webhook PR was merged at 19:16 UTC the same day, so this is genuinely new since the last routine run.

### `docs/design/`

No new drift on `docs/design/` beyond items already proposed in the open drift-check PRs (#3900 / #3879 / #3863 / #3840 / #3817 / #3774). Other recent landings reviewed and confirmed clean:

- [#3730 → #3736](https://github.com/LMCache/LMCache/pull/3736) (`6a57f42`) — `TYPE_CHECKING` reshuffle of l2 adapter imports. Internal-only, no doc impact.
- [#3800](https://github.com/LMCache/LMCache/pull/3800) (`2cdaa96`) — `IPCCacheServerKey` import moved under `TYPE_CHECKING`. The symbol itself still lives in `lmcache/v1/multiprocess/custom_types.py`, so the `docs/design/v1/distributed/l2_adapters/l2_per_user_quota.md:799` reference is still correct (this matches the note already in #3863).
- [#3836](https://github.com/LMCache/LMCache/pull/3836) (`31df26d`) — Valkey GLIDE per-key TTL + partial-chunk validation. Ships its own `docs/source/kv_cache/storage_backends/valkey.rst` update. The MP-mode L2 RESP adapter (`docs/source/mp/l2_storage/resp.rst`) is a separate code path (`RESPConnector`, not `ValkeyConnector`), so no cross-doc drift.
- [#3906](https://github.com/LMCache/LMCache/pull/3906) (`c4b527a`) — Welcome-page polish + zh_CN translation refresh. Only adds a dark-mode hero image and a new "Updates" line linking to two external blog posts; no internal claims to drift.
- [#3851](https://github.com/LMCache/LMCache/pull/3851) (`218b54e`) — Direct rewrite of `docs/source/developer_guide/cli.rst` for the auto-discovery framework. **Note:** this is the same file the still-open drift-check PR #3817 (2026-06-22) was proposing to fix; #3817 is now superseded for the developer-guide half of its diff. The remaining half (the `lmcache.mp.server_urls` row in `mp/configuration.rst`) is still relevant and unaddressed.

## Evidence

| Doc claim (current) | Code reality | Reference |
| --- | --- | --- |
| `docs/source/mp/operator.rst` "Connecting vLLM" presents a manual `sh -c` + ConfigMap-mount as the only wiring, with no mention of a webhook for the LMCacheEngine connection. | A new `LMCachePodInjector` mutating webhook auto-injects `--kv-transfer-config <inline JSON>`, `hostIPC=true`, and `PYTHONHASHSEED=0` (set-if-absent) on pods carrying the `lmcache.ai/lmcache-inject: "true"` label and the `lmcache.ai/lmcache-engine: "<engine>"` annotation. | [`operator/internal/webhook/lmcache_pod_injector.go` @ 6a57f42](https://github.com/LMCache/LMCache/blob/6a57f42b8d3bebd56edd9e9d9c3670d668740dd1/operator/internal/webhook/lmcache_pod_injector.go), [`vllm_lmcache_deployment.yaml` @ 6a57f42](https://github.com/LMCache/LMCache/blob/6a57f42b8d3bebd56edd9e9d9c3670d668740dd1/operator/config/samples/vllm_lmcache_deployment.yaml), [`operator/README.md#connection-injection` @ 6a57f42](https://github.com/LMCache/LMCache/blob/6a57f42b8d3bebd56edd9e9d9c3670d668740dd1/operator/README.md#connection-injection) |
| Webhook reads the engine's `<engine>-connection` ConfigMap directly; **no engine CR is consulted** (unlike CacheBlend). | The injector calls `prepareInjection(..., engineName, namespace, nil)` and does not look up the CR. | [`lmcache_pod_injector.go:90-100` @ 6a57f42](https://github.com/LMCache/LMCache/blob/6a57f42b8d3bebd56edd9e9d9c3670d668740dd1/operator/internal/webhook/lmcache_pod_injector.go#L90-L100) |
| Skip reasons stamped on `lmcache.ai/lmcache-skip-reason`: `command-override`, `kv-transfer-config-present`, `engine-not-found`, `target-container-not-found`. | Confirmed by the keys and the shared `prepareInjection` / `gate` helpers. | [`lmcache_pod_injector.go:30-58` @ 6a57f42](https://github.com/LMCache/LMCache/blob/6a57f42b8d3bebd56edd9e9d9c3670d668740dd1/operator/internal/webhook/lmcache_pod_injector.go#L30-L58), [`operator/internal/webhook/pod_inject_common.go` @ 6a57f42](https://github.com/LMCache/LMCache/blob/6a57f42b8d3bebd56edd9e9d9c3670d668740dd1/operator/internal/webhook/pod_inject_common.go) |
| `failurePolicy: Ignore`, idempotent (`lmcache.ai/lmcache-injected` stamp on re-admission). | Asserted on the kubebuilder webhook marker and in the handler's idempotency-gate. | [`lmcache_pod_injector.go:60` @ 6a57f42](https://github.com/LMCache/LMCache/blob/6a57f42b8d3bebd56edd9e9d9c3670d668740dd1/operator/internal/webhook/lmcache_pod_injector.go#L60) |

## Proposed fix (applied in this PR)

In `docs/source/mp/operator.rst`:

- Add a **"Connection Injection (Webhook)"** section between the existing "Connecting vLLM" (manual mount) and "Verifying the Deployment", labeled `mp-operator-connection-injection`.
- Describe the three injected mutations (`--kv-transfer-config`, `hostIPC`, `PYTHONHASHSEED=0` set-if-absent), the opt-in label + bind annotation, the `args`-only launch requirement, and the four skip-reason values stamped on `lmcache.ai/lmcache-skip-reason`.
- Mirror the CacheBlend webhook layout (prerequisites / opt-in / verification) so users following one section can navigate the other without surprise.
- Cross-link in both directions: the manual "Connecting vLLM" section now points to the webhook flow at the top, and the new section references the CacheBlend section by `:ref:` (also adds a `mp-operator-cacheblend` label needed for that ref).
- Point to the ready-to-edit sample at `operator/config/samples/vllm_lmcache_deployment.yaml`.

Docs-only diff; no code is touched. Touches only `docs/source/mp/operator.rst`.

## Notes

- Auto-generated by the daily LMCache docs drift-check routine; **human review required before merge.**
- This PR is marked **draft** and is not requesting maintainer reviewers automatically.
- Branch lives on the `ApostaC/LMCache` fork (`docs/drift-check-2026-06-27`) and targets upstream `dev`.

---
_Generated by the daily LMCache docs drift-check routine_

---
_Generated by [Claude Code](https://claude.ai/code/session_016eTjQk1B3mb5pzea9St1PM)_