### PR TITLE
feat(observability): per-tier (L2/L3/remote) cache-hit token metrics (#3752)

### DIFF
--- a/docs/source/production/observability/metrics.rst
+++ b/docs/source/production/observability/metrics.rst
@@ -46,6 +46,15 @@ Token Metrics
    * - ``lmcache:num_hit_tokens``
      - Counter
      - Total number of tokens hit in LMCache during retrieval.
+   * - ``lmcache:num_l2_hit_tokens``
+     - Counter
+     - Hit tokens served from the L2 (CPU RAM) tier during retrieval.
+   * - ``lmcache:num_l3_hit_tokens``
+     - Counter
+     - Hit tokens served from the L3 (local disk / NVMe) tier during retrieval.
+   * - ``lmcache:num_remote_hit_tokens``
+     - Counter
+     - Hit tokens served from a remote tier during retrieval.
    * - ``lmcache:num_stored_tokens``
      - Counter
      - Total number of tokens stored in LMCache.

--- a/lmcache/observability.py
+++ b/lmcache/observability.py
@@ -9,10 +9,12 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Mapping,
     Optional,
     Sequence,
     Union,
 )
+import enum
 import os
 import threading
 import time
@@ -34,6 +36,80 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+class CacheTier(enum.Enum):
+    """Storage tier a cache hit was served from."""
+
+    L2 = "L2"  # CPU RAM
+    L3 = "L3"  # local disk / NVMe / GDS / PD
+    REMOTE = "remote"  # remote backends (Redis, P2P, Maru, ...)
+
+
+_BACKEND_NAME_TO_TIER = {
+    "LocalCPUBackend": CacheTier.L2,
+    "LocalDiskBackend": CacheTier.L3,
+    "GdsBackend": CacheTier.L3,
+    "PDBackend": CacheTier.L3,
+}
+_warned_unknown_backends: set[str] = set()
+
+
+def backend_name_to_tier(backend_name: str) -> CacheTier:
+    """Map a storage-backend name to its cache tier.
+
+    Unknown names (for example config-named remote backends) map to
+    ``CacheTier.REMOTE`` so that metric classification never raises on the
+    retrieve hot path. Each unrecognized name is logged once at debug level.
+
+    Args:
+        backend_name: The storage backend's registered name (the
+            ``StorageManager.storage_backends`` key), such as ``LocalCPUBackend``.
+
+    Returns:
+        The :class:`CacheTier` the backend belongs to.
+    """
+    tier = _BACKEND_NAME_TO_TIER.get(backend_name)
+    if tier is None:
+        if backend_name not in _warned_unknown_backends:
+            _warned_unknown_backends.add(backend_name)
+            logger.debug(
+                "Unknown storage backend %s; counting its hits as the REMOTE tier",
+                backend_name,
+            )
+        return CacheTier.REMOTE
+    return tier
+
+
+def classify_hit_tokens_by_tier(
+    hit_records: list[tuple[str, int, int]],
+    last_failed_block_start: int | None,
+) -> dict[CacheTier, int]:
+    """Sum retrieved hit tokens per cache tier, honoring prefix truncation.
+
+    Each record is a ``(backend_name, start, end)`` triple describing a chunk
+    that was read from a backend. A record contributes ``end - start`` tokens to
+    its tier only if the chunk survives prefix truncation: when
+    ``last_failed_block_start`` is not ``None``, only chunks with
+    ``end <= last_failed_block_start`` are actually returned to the caller, so
+    chunks past that point are excluded (they would otherwise be overcounted).
+
+    Args:
+        hit_records: The ``(backend_name, start, end)`` triples for successfully
+            read chunks, in retrieval order.
+        last_failed_block_start: The start offset of the first chunk that failed
+            to be retrieved, or ``None`` if every chunk succeeded.
+
+    Returns:
+        A mapping from every :class:`CacheTier` to its retrieved hit-token count
+        (tiers with no hits map to ``0``).
+    """
+    result = {tier: 0 for tier in CacheTier}
+    for backend_name, start, end in hit_records:
+        if last_failed_block_start is not None and end > last_failed_block_start:
+            continue
+        result[backend_name_to_tier(backend_name)] += end - start
+    return result
+
+
 @dataclass
 class LMCacheStats:
     # Counter (Note that these are incremental values,
@@ -43,6 +119,9 @@ class LMCacheStats:
     interval_lookup_requests: int
     interval_requested_tokens: int
     interval_hit_tokens: int
+    interval_l2_hit_tokens: int
+    interval_l3_hit_tokens: int
+    interval_remote_hit_tokens: int
     interval_stored_tokens: int
     interval_lookup_tokens: int
     interval_lookup_hits: int
@@ -256,6 +335,9 @@ class LMCStatsMonitor:
         self.interval_lookup_requests = 0
         self.interval_requested_tokens = 0  # total requested tokens retrieve
         self.interval_hit_tokens = 0  # total hit tokens retrieve
+        self.interval_l2_hit_tokens = 0  # hit tokens served from L2 (CPU RAM)
+        self.interval_l3_hit_tokens = 0  # hit tokens served from L3 (local disk)
+        self.interval_remote_hit_tokens = 0  # hit tokens served from a remote tier
         self.interval_stored_tokens = 0  # total tokens tored in LMCache
         self.interval_lookup_tokens = 0  # total requested tokens lookup
         self.interval_lookup_hits = 0  # total hit tokens lookup
@@ -394,6 +476,18 @@ class LMCStatsMonitor:
         self.retrieve_request_id += 1
         self.set_current_retrieve_stats(retrieve_stats)
         return retrieve_stats
+
+    @thread_safe
+    def record_tier_hits(self, tier_hit_tokens: Mapping[CacheTier, int]) -> None:
+        """Accumulate per-tier hit-token counts from a single retrieve.
+
+        Args:
+            tier_hit_tokens: Hit-token counts keyed by :class:`CacheTier`. Missing
+                tiers are treated as zero.
+        """
+        self.interval_l2_hit_tokens += tier_hit_tokens.get(CacheTier.L2, 0)
+        self.interval_l3_hit_tokens += tier_hit_tokens.get(CacheTier.L3, 0)
+        self.interval_remote_hit_tokens += tier_hit_tokens.get(CacheTier.REMOTE, 0)
 
     @thread_safe
     def on_retrieve_finished(
@@ -601,6 +695,9 @@ class LMCStatsMonitor:
 
         self.interval_requested_tokens = 0
         self.interval_hit_tokens = 0
+        self.interval_l2_hit_tokens = 0
+        self.interval_l3_hit_tokens = 0
+        self.interval_remote_hit_tokens = 0
         self.interval_stored_tokens = 0
         self.interval_lookup_tokens = 0
         self.interval_lookup_hits = 0
@@ -773,6 +870,9 @@ class LMCStatsMonitor:
             interval_lookup_requests=self.interval_lookup_requests,
             interval_requested_tokens=self.interval_requested_tokens,
             interval_hit_tokens=self.interval_hit_tokens,
+            interval_l2_hit_tokens=self.interval_l2_hit_tokens,
+            interval_l3_hit_tokens=self.interval_l3_hit_tokens,
+            interval_remote_hit_tokens=self.interval_remote_hit_tokens,
             interval_stored_tokens=self.interval_stored_tokens,
             interval_lookup_tokens=self.interval_lookup_tokens,
             interval_lookup_hits=self.interval_lookup_hits,
@@ -959,6 +1059,24 @@ class PrometheusLogger:
         self.counter_num_hit_tokens = self._create_counter(
             name="lmcache:num_hit_tokens",
             documentation="Total number of tokens hit in lmcache",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_l2_hit_tokens = self._create_counter(
+            name="lmcache:num_l2_hit_tokens",
+            documentation="Total hit tokens served from the L2 (CPU RAM) tier",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_l3_hit_tokens = self._create_counter(
+            name="lmcache:num_l3_hit_tokens",
+            documentation="Total hit tokens served from the L3 (local disk) tier",
+            labelnames=labelnames,
+        )
+
+        self.counter_num_remote_hit_tokens = self._create_counter(
+            name="lmcache:num_remote_hit_tokens",
+            documentation="Total hit tokens served from a remote tier",
             labelnames=labelnames,
         )
 
@@ -1705,6 +1823,11 @@ class PrometheusLogger:
             self.counter_num_requested_tokens, stats.interval_requested_tokens
         )
         self._log_counter(self.counter_num_hit_tokens, stats.interval_hit_tokens)
+        self._log_counter(self.counter_num_l2_hit_tokens, stats.interval_l2_hit_tokens)
+        self._log_counter(self.counter_num_l3_hit_tokens, stats.interval_l3_hit_tokens)
+        self._log_counter(
+            self.counter_num_remote_hit_tokens, stats.interval_remote_hit_tokens
+        )
         self._log_counter(self.counter_num_stored_tokens, stats.interval_stored_tokens)
         self._log_counter(self.counter_num_lookup_tokens, stats.interval_lookup_tokens)
         self._log_counter(self.counter_num_lookup_hits, stats.interval_lookup_hits)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -30,7 +30,11 @@ import torch
 # First Party
 from lmcache import torch_dev, torch_device_type
 from lmcache.logging import init_logger
-from lmcache.observability import LMCacheStatsLogger, LMCStatsMonitor
+from lmcache.observability import (
+    LMCacheStatsLogger,
+    LMCStatsMonitor,
+    classify_hit_tokens_by_tier,
+)
 from lmcache.usage_context import InitializeUsageContext
 from lmcache.utils import (
     CacheEngineKey,
@@ -1746,6 +1750,9 @@ class LMCacheEngine:
             block_mapping = self.storage_manager.get_block_mapping(chunk_infos)
 
         last_failed_block_start = None
+        # (backend_name, start, end) per successfully read chunk, used to attribute
+        # hit tokens to their storage tier after prefix truncation below.
+        hit_records: list[tuple[str, int, int]] = []
         for location, blocks in block_mapping.items():
             keys = [key for key, _, _ in blocks]
             memory_objs = self.storage_manager.batched_get(
@@ -1771,6 +1778,7 @@ class LMCacheEngine:
                 tot_kv_size += memory_obj.get_size()
                 ret_mask[start:end] = True
                 used_keys.add(key)
+                hit_records.append((location, start, end))
 
             for (key, _, _), memory_obj in zip(blocks, memory_objs, strict=False):
                 if memory_obj is not None and key not in used_keys:
@@ -1806,6 +1814,10 @@ class LMCacheEngine:
                     else:
                         memory_obj.ref_count_down()
             reordered_chunks = kept_chunks
+
+        self.stats_monitor.record_tier_hits(
+            classify_hit_tokens_by_tier(hit_records, last_failed_block_start)
+        )
         return reordered_chunks, tot_kv_size
 
     def _broadcast_or_receive_memory_objs(

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -8,8 +8,11 @@ import pytest
 
 # First Party
 from lmcache.observability import (
+    CacheTier,
     LMCStatsMonitor,
     PrometheusLogger,
+    backend_name_to_tier,
+    classify_hit_tokens_by_tier,
 )
 
 
@@ -464,3 +467,74 @@ def test_prometheus_logger_reset_reinitializes_all_label_views(
         )
         == 0
     )
+
+
+# ---- per-tier hit-token metrics (#3752) ----
+
+
+def test_backend_name_to_tier():
+    assert backend_name_to_tier("LocalCPUBackend") is CacheTier.L2
+    for name in ("LocalDiskBackend", "GdsBackend", "PDBackend"):
+        assert backend_name_to_tier(name) is CacheTier.L3
+    # remote and any unrecognized backend fall back to REMOTE (never raises)
+    for name in ("RemoteBackend", "MaruBackend", "P2PBackend", "SomethingBrandNew"):
+        assert backend_name_to_tier(name) is CacheTier.REMOTE
+
+
+def test_classify_hit_tokens_by_tier_no_truncation():
+    records = [
+        ("LocalCPUBackend", 0, 3),
+        ("LocalDiskBackend", 3, 5),
+        ("RemoteBackend", 5, 6),
+    ]
+    assert classify_hit_tokens_by_tier(records, None) == {
+        CacheTier.L2: 3,
+        CacheTier.L3: 2,
+        CacheTier.REMOTE: 1,
+    }
+
+
+def test_classify_hit_tokens_by_tier_truncation_drops_suffix():
+    # last_failed_block_start=3 -> only chunks with end <= 3 are returned to the caller
+    records = [
+        ("LocalCPUBackend", 0, 3),
+        ("LocalDiskBackend", 3, 5),
+        ("RemoteBackend", 5, 6),
+    ]
+    assert classify_hit_tokens_by_tier(records, 3) == {
+        CacheTier.L2: 3,
+        CacheTier.L3: 0,
+        CacheTier.REMOTE: 0,
+    }
+
+
+def test_record_tier_hits_accumulates_and_clears(stats_monitor):
+    stats_monitor.record_tier_hits(
+        {CacheTier.L2: 10, CacheTier.L3: 4, CacheTier.REMOTE: 1}
+    )
+    stats_monitor.record_tier_hits({CacheTier.L2: 5})  # missing tiers treated as zero
+    stats = stats_monitor.get_stats_and_clear()
+    assert stats.interval_l2_hit_tokens == 15
+    assert stats.interval_l3_hit_tokens == 4
+    assert stats.interval_remote_hit_tokens == 1
+    # interval counters reset after read
+    cleared = stats_monitor.get_stats_and_clear()
+    assert cleared.interval_l2_hit_tokens == 0
+    assert cleared.interval_l3_hit_tokens == 0
+    assert cleared.interval_remote_hit_tokens == 0
+
+
+def test_per_tier_hit_counters_emitted(_cleanup_prometheus_logger):
+    LMCStatsMonitor.DestroyInstance()
+    monitor = LMCStatsMonitor.GetOrCreate()
+    monitor.record_tier_hits({CacheTier.L2: 7, CacheTier.L3: 3, CacheTier.REMOTE: 2})
+    stats = monitor.get_stats_and_clear()
+
+    prom = PrometheusLogger(_make_metadata())
+    prom.log_prometheus(stats)
+    labels = _sample_labels(prom)
+
+    assert REGISTRY.get_sample_value("lmcache:num_l2_hit_tokens_total", labels) == 7
+    assert REGISTRY.get_sample_value("lmcache:num_l3_hit_tokens_total", labels) == 3
+    assert REGISTRY.get_sample_value("lmcache:num_remote_hit_tokens_total", labels) == 2
+    LMCStatsMonitor.DestroyInstance()


### PR DESCRIPTION
## Summary

Addresses the per-tier hit-rate gap in #3752. Today `lmcache:num_hit_tokens` is a single aggregate, so operators can't tell whether a retrieve hit came from **L2** (CPU RAM), **L3** (local disk / NVMe), or a **remote** backend. This adds per-tier hit-token Prometheus counters:

- `lmcache:num_l2_hit_tokens`
- `lmcache:num_l3_hit_tokens`
- `lmcache:num_remote_hit_tokens`

Hit-rate per tier is then a PromQL expression over these and the existing request/token counters (no new gauge needed).

## What's included

- `CacheTier` enum + `backend_name_to_tier()` (LocalCPUBackend -> L2; LocalDiskBackend/GdsBackend/PDBackend -> L3; everything else -> REMOTE). Unknown/dynamically-named backends map to REMOTE with a one-time debug log, so metric classification never raises on the retrieve path.
- `classify_hit_tokens_by_tier()` attributes hit tokens to tiers **after** the prefix-truncation in `_process_tokens_internal`: a chunk dropped because a later block failed (`end > last_failed_block_start`) is not counted, matching the tokens actually returned to the caller.
- `LMCStatsMonitor.record_tier_hits()` + three interval counters, exported through `PrometheusLogger`.
- Wired into the sync retrieve path; `metrics.rst` updated.

These are separate counters (not a `tier` label), matching the existing `lmcache:*` metric convention in `PrometheusLogger`.

## Scope

This PR covers the **default sync retrieve path** (`enable_async_loading` defaults to `False`). The recording API (`record_tier_hits` + `classify_hit_tokens_by_tier`) is path-agnostic, so the async-loading path is a small follow-up (just a new call site). The issue's other asks — OTel spans, per-request JSONL trace, the TP>1 `/dev/shm` bridge, and latency decomposition — are separate follow-ups, kept out to keep this PR small and focused.

## Testing

Added CPU unit tests in `tests/test_observability.py`:
- `backend_name_to_tier` for every known backend + unknown -> REMOTE
- `classify_hit_tokens_by_tier`: no truncation, suffix-dropped, multi-tier
- `record_tier_hits` accumulation + clear-after-read
- per-tier Prometheus counters emitted (`REGISTRY` sample assertions)

```
$ ruff check lmcache/observability.py lmcache/v1/cache_engine.py tests/test_observability.py
All checks passed!
$ ruff format --check <same files>      # already formatted
```

The pure classification logic (tier mapping + truncation-aware counting) was verified locally against the reporter-style cases. The full `tests/test_observability.py` runs in CI (importing the `lmcache` package pulls torch / `c_ops`, which aren't available on my dev box).

## AI assistance

Developed with AI assistance (Claude); I reviewed every line, verified the wiring and the truncation correctness, and can defend the change. The commit carries a `Co-authored-by: Claude` trailer.

Closes #3752 is **not** claimed here — this implements the per-tier-metrics portion; happy to keep the issue open for the OTel/JSONL/async follow-ups, or split as you prefer.
