### PR TITLE
[Core] Add TTLLock batch operations for L1 read locks

### DIFF
--- a/csrc/storage_manager/pybind.cpp
+++ b/csrc/storage_manager/pybind.cpp
@@ -37,8 +37,13 @@ PYBIND11_MODULE(native_storage_ops, m) {
       .def("lock", &TTLLock::lock,
            "Increment the lock counter by 1 and update the TTL. "
            "If the previous TTL has expired, reset counter to 1.")
+      .def("lock_count", &TTLLock::lock_count, py::arg("count"),
+           "Increment the lock counter by count and update the TTL. "
+           "If the previous TTL has expired, reset counter to count.")
       .def("unlock", &TTLLock::unlock,
            "Decrement the lock counter by 1 (minimum 0).")
+      .def("unlock_count", &TTLLock::unlock_count, py::arg("count"),
+           "Decrement the lock counter by count (minimum 0).")
       .def("is_locked", &TTLLock::is_locked,
            "Check if the lock is held (counter > 0 and TTL not expired).")
       .def("reset", &TTLLock::reset,

--- a/csrc/storage_manager/ttl_lock.cpp
+++ b/csrc/storage_manager/ttl_lock.cpp
@@ -2,6 +2,10 @@
 
 #include "ttl_lock.h"
 
+#include <limits>
+#include <stdexcept>
+#include <thread>
+
 namespace lmcache {
 namespace storage_manager {
 
@@ -10,32 +14,49 @@ TTLLock::TTLLock(uint32_t ttl_sec)
       expiration_ms_(0),
       ttl_ms_(static_cast<int64_t>(ttl_sec) * 1000) {}
 
-void TTLLock::lock() {
+void TTLLock::lock() { lock_count(1); }
+
+void TTLLock::lock_count(int64_t count) {
+  if (count <= 0) {
+    throw std::invalid_argument("TTLLock::lock_count count must be positive");
+  }
+
   int64_t current_time = now_ms();
   int64_t new_expiration = current_time + ttl_ms_;
 
   // Use compare-and-swap loop to handle the TTL expiration case
   while (true) {
-    int64_t old_expiration = expiration_ms_.load(std::memory_order_acquire);
     int64_t old_counter = counter_.load(std::memory_order_acquire);
+    int64_t old_expiration = expiration_ms_.load(std::memory_order_acquire);
+
+    if (old_counter < 0) {
+      // Another thread is resetting an expired counter. Retry until the
+      // reset publishes a non-negative count.
+      std::this_thread::yield();
+      continue;
+    }
 
     // Check if TTL has expired
     bool expired = (current_time >= old_expiration);
 
     if (expired) {
-      // TTL expired, try to reset counter to 1 and set new expiration
-      // First, try to update the expiration
-      if (expiration_ms_.compare_exchange_strong(old_expiration, new_expiration,
-                                                 std::memory_order_seq_cst)) {
-        // Successfully updated expiration, now set counter to 1
-        counter_.store(1, std::memory_order_seq_cst);
+      // TTL expired: claim reset ownership by moving the non-negative counter
+      // to a sentinel value. This prevents concurrent lock_count() calls from
+      // incrementing a stale counter that would then be overwritten.
+      if (counter_.compare_exchange_strong(old_counter, -1,
+                                           std::memory_order_seq_cst)) {
+        expiration_ms_.store(new_expiration, std::memory_order_seq_cst);
+        counter_.store(count, std::memory_order_seq_cst);
         return;
       }
-      // Another thread updated expiration, retry
+      // Another thread modified the counter, retry
       continue;
     } else {
       // TTL not expired, try to increment counter
-      if (counter_.compare_exchange_strong(old_counter, old_counter + 1,
+      if (old_counter > std::numeric_limits<int64_t>::max() - count) {
+        throw std::overflow_error("TTLLock::lock_count counter overflow");
+      }
+      if (counter_.compare_exchange_strong(old_counter, old_counter + count,
                                            std::memory_order_seq_cst)) {
         // Successfully incremented counter, update expiration
         expiration_ms_.store(new_expiration, std::memory_order_seq_cst);
@@ -47,17 +68,30 @@ void TTLLock::lock() {
   }
 }
 
-void TTLLock::unlock() {
+void TTLLock::unlock() { unlock_count(1); }
+
+void TTLLock::unlock_count(int64_t count) {
+  if (count <= 0) {
+    throw std::invalid_argument("TTLLock::unlock_count count must be positive");
+  }
+
   // Use compare-and-swap loop to ensure we don't go below 0
   while (true) {
     int64_t old_counter = counter_.load(std::memory_order_acquire);
+
+    if (old_counter < 0) {
+      // A lock_count() call is resetting an expired counter.
+      std::this_thread::yield();
+      continue;
+    }
 
     if (old_counter <= 0) {
       // Already at 0, nothing to do
       return;
     }
 
-    if (counter_.compare_exchange_strong(old_counter, old_counter - 1,
+    int64_t new_counter = old_counter > count ? old_counter - count : 0;
+    if (counter_.compare_exchange_strong(old_counter, new_counter,
                                          std::memory_order_seq_cst)) {
       return;
     }

--- a/csrc/storage_manager/ttl_lock.h
+++ b/csrc/storage_manager/ttl_lock.h
@@ -40,11 +40,36 @@ class TTLLock {
   void lock();
 
   /**
+   * @brief Increment the lock counter by count and update the TTL.
+   *
+   * If the previous TTL has expired, the counter is reset to count.
+   * Otherwise, the counter is incremented by count.
+   * The TTL is always refreshed to the current time + TTL duration.
+   *
+   * @param count Number of lock counts to acquire. Must be positive.
+   *
+   * @throws std::invalid_argument if count is not positive.
+   * @throws std::overflow_error if the counter would overflow.
+   */
+  void lock_count(int64_t count);
+
+  /**
    * @brief Decrement the lock counter by 1.
    *
    * The counter will not go below 0.
    */
   void unlock();
+
+  /**
+   * @brief Decrement the lock counter by count.
+   *
+   * The counter will not go below 0.
+   *
+   * @param count Number of lock counts to release. Must be positive.
+   *
+   * @throws std::invalid_argument if count is not positive.
+   */
+  void unlock_count(int64_t count);
 
   /**
    * @brief Check if the lock is currently held.

--- a/lmcache/native_storage_ops.pyi
+++ b/lmcache/native_storage_ops.pyi
@@ -32,8 +32,34 @@ class TTLLock:
         """
         ...
 
+    def lock_count(self, count: int) -> None:
+        """
+        Increment the lock counter by count and update the TTL.
+        If the previous TTL has expired, reset counter to count.
+
+        Args:
+            count: Number of lock counts to acquire. Must be positive.
+
+        Raises:
+            ValueError: If count is not positive.
+            OverflowError: If the counter would exceed int64 capacity.
+        """
+        ...
+
     def unlock(self) -> None:
         """Decrement the lock counter by 1 (minimum 0)."""
+        ...
+
+    def unlock_count(self, count: int) -> None:
+        """
+        Decrement the lock counter by count (minimum 0).
+
+        Args:
+            count: Number of lock counts to release. Must be positive.
+
+        Raises:
+            ValueError: If count is not positive.
+        """
         ...
 
     def is_locked(self) -> bool:

--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -274,11 +274,7 @@ class L1Manager:
                 ret[key] = (L1Error.KEY_NOT_READABLE, None)
                 continue
 
-            # TODO(perf): support a count argument in
-            # TTLLock.lock() to avoid Python for-loop
-            # overhead (TTLLock is C++ std::atomic).
-            for _ in range(total):
-                entry.read_lock.lock()
+            entry.read_lock.lock_count(total)
             ret[key] = (L1Error.SUCCESS, entry.memory_obj)
             successful_keys.append(key)
 
@@ -395,11 +391,7 @@ class L1Manager:
                 ret[key] = L1Error.KEY_IN_WRONG_STATE
                 continue
 
-            # TODO(perf): support a count argument in
-            # TTLLock.unlock() to avoid Python for-loop
-            # overhead (TTLLock is C++ std::atomic).
-            for _ in range(total):
-                entry.read_lock.unlock()
+            entry.read_lock.unlock_count(total)
             if entry.is_temporary and not entry.read_lock.is_locked():
                 # NOTE: temporary objects shouldn't have write-locks
                 need_to_free.append(entry.memory_obj)
@@ -643,8 +635,7 @@ class L1Manager:
                 continue
 
             entry.write_lock.unlock()
-            for _ in range(total):
-                entry.read_lock.lock()
+            entry.read_lock.lock_count(total)
             ret[key] = (L1Error.SUCCESS, entry.memory_obj)
             successful_keys.append(key)
 

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -150,6 +150,29 @@ def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: in
     return ObjectKey(chunk_hash=hash_bytes, model_name=model_name, kv_rank=kv_rank)
 
 
+class RecordingReadLock:
+    """Read-lock test double that records batch calls from L1Manager."""
+
+    def __init__(self, locked: bool = False) -> None:
+        self.locked = locked
+        self.lock_count_calls: list[int] = []
+        self.unlock_count_calls: list[int] = []
+
+    def lock_count(self, count: int) -> None:
+        """Record a batch lock acquisition."""
+        self.lock_count_calls.append(count)
+        self.locked = True
+
+    def unlock_count(self, count: int) -> None:
+        """Record a batch lock release."""
+        self.unlock_count_calls.append(count)
+        self.locked = False
+
+    def is_locked(self) -> bool:
+        """Return whether this test double is locked."""
+        return self.locked
+
+
 # =============================================================================
 # Tests for L1Manager.reserve_read()
 # =============================================================================
@@ -311,6 +334,28 @@ class TestReserveRead:
         state = manager.get_object_state(key)
         assert state is not None
         assert not state.read_lock.is_locked()
+
+        manager.close()
+
+    def test_reserve_read_uses_batch_lock_count(
+        self, basic_l1_config, basic_layout
+    ) -> None:
+        """reserve_read should acquire all extra counts in one TTLLock call."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+        state = manager.get_object_state(key)
+        assert state is not None
+        read_lock = RecordingReadLock()
+        state.read_lock = read_lock  # type: ignore[assignment]
+
+        result = manager.reserve_read([key], extra_count=2)
+
+        assert result[key][0] == L1Error.SUCCESS
+        assert read_lock.lock_count_calls == [3]
+        assert read_lock.unlock_count_calls == []
 
         manager.close()
 
@@ -701,6 +746,28 @@ class TestFinishRead:
 
         manager.close()
 
+    def test_finish_read_uses_batch_unlock_count(
+        self, basic_l1_config, basic_layout
+    ) -> None:
+        """finish_read should release all extra counts in one TTLLock call."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        manager.reserve_write([key], [False], basic_layout)
+        manager.finish_write([key])
+        state = manager.get_object_state(key)
+        assert state is not None
+        read_lock = RecordingReadLock(locked=True)
+        state.read_lock = read_lock  # type: ignore[assignment]
+
+        result = manager.finish_read([key], extra_count=2)
+
+        assert result[key] == L1Error.SUCCESS
+        assert read_lock.lock_count_calls == []
+        assert read_lock.unlock_count_calls == [3]
+
+        manager.close()
+
     def test_finish_read_extra_count_partial_release(
         self, basic_l1_config, basic_layout
     ):
@@ -1072,6 +1139,27 @@ class TestFinishWriteAndReserveRead:
 
         # Clean up read lock
         manager.finish_read([key])
+        manager.close()
+
+    def test_transition_uses_batch_lock_count(
+        self, basic_l1_config, basic_layout
+    ) -> None:
+        """finish_write_and_reserve_read should acquire read locks in one call."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        manager.reserve_write([key], [False], basic_layout)
+        state = manager.get_object_state(key)
+        assert state is not None
+        read_lock = RecordingReadLock()
+        state.read_lock = read_lock  # type: ignore[assignment]
+
+        result = manager.finish_write_and_reserve_read([key], extra_count=2)
+
+        assert result[key][0] == L1Error.SUCCESS
+        assert read_lock.lock_count_calls == [3]
+        assert read_lock.unlock_count_calls == []
+
         manager.close()
 
     def test_key_not_exist(self, basic_l1_config, basic_layout):

--- a/tests/v1/native_storage_ops/test_ttl_lock.py
+++ b/tests/v1/native_storage_ops/test_ttl_lock.py
@@ -106,6 +106,56 @@ class TestTTLLockBasicSemantics:
         lock.lock()
         assert lock.is_locked()
 
+    def test_lock_count_increments_counter_by_count(self) -> None:
+        """Test that lock_count() acquires multiple lock counts at once."""
+        lock = TTLLock()
+
+        lock.lock_count(3)
+        assert lock.is_locked()
+
+        lock.unlock()
+        assert lock.is_locked()
+
+        lock.unlock_count(2)
+        assert not lock.is_locked()
+
+    def test_lock_count_rejects_non_positive_count(self) -> None:
+        """Test that lock_count() requires a positive count."""
+        lock = TTLLock()
+
+        with pytest.raises(ValueError):
+            lock.lock_count(0)
+
+        with pytest.raises(ValueError):
+            lock.lock_count(-1)
+
+    def test_unlock_count_rejects_non_positive_count(self) -> None:
+        """Test that unlock_count() requires a positive count."""
+        lock = TTLLock()
+
+        with pytest.raises(ValueError):
+            lock.unlock_count(0)
+
+        with pytest.raises(ValueError):
+            lock.unlock_count(-1)
+
+    def test_unlock_count_does_not_go_below_zero(self) -> None:
+        """Test that unlock_count() clamps the counter at zero."""
+        lock = TTLLock()
+
+        lock.lock_count(2)
+        lock.unlock_count(3)
+
+        assert not lock.is_locked()
+
+    def test_lock_count_rejects_counter_overflow(self) -> None:
+        """Test that lock_count() rejects counters beyond int64 capacity."""
+        lock = TTLLock()
+
+        lock.lock_count((2**63) - 1)
+        with pytest.raises(OverflowError):
+            lock.lock_count(1)
+
 
 class TestTTLLockTTLSemantics:
     """Test TTL (Time-To-Live) semantics of TTLLock."""
@@ -163,6 +213,23 @@ class TestTTLLockTTLSemantics:
         assert lock.is_locked()
 
         # Verify counter was reset by unlocking once
+        lock.unlock()
+        assert not lock.is_locked()
+
+    def test_lock_count_after_ttl_expired_resets_counter_to_count(self) -> None:
+        """Test lock_count() resets expired counters to the requested count."""
+        lock = TTLLock(ttl_second=1)
+
+        lock.lock_count(3)
+        time.sleep(1.5)
+        assert not lock.is_locked()
+
+        lock.lock_count(2)
+        assert lock.is_locked()
+
+        lock.unlock()
+        assert lock.is_locked()
+
         lock.unlock()
         assert not lock.is_locked()
 
@@ -252,6 +319,80 @@ class TestTTLLockThreadSafety:
             t.join()
 
         # Should be at 0
+        assert not lock.is_locked()
+
+    def test_concurrent_lock_count_operations(self) -> None:
+        """Test that concurrent lock_count() operations are thread-safe."""
+        lock = TTLLock()
+        num_threads = 50
+        count_per_thread = 20
+
+        def do_lock_count() -> None:
+            lock.lock_count(count_per_thread)
+
+        threads = [threading.Thread(target=do_lock_count) for _ in range(num_threads)]
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        remaining = 0
+        while lock.is_locked():
+            lock.unlock()
+            remaining += 1
+
+        assert remaining == num_threads * count_per_thread
+
+    def test_concurrent_lock_count_after_expiration_preserves_all_counts(self) -> None:
+        """Test expired counter reset does not lose concurrent lock_count calls."""
+        lock = TTLLock(ttl_second=1)
+        num_threads = 50
+        count_per_thread = 3
+
+        lock.lock_count(10)
+        time.sleep(1.5)
+        assert not lock.is_locked()
+
+        def do_lock_count() -> None:
+            lock.lock_count(count_per_thread)
+
+        threads = [threading.Thread(target=do_lock_count) for _ in range(num_threads)]
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        remaining = 0
+        while lock.is_locked():
+            lock.unlock()
+            remaining += 1
+
+        assert remaining == num_threads * count_per_thread
+
+    def test_concurrent_unlock_count_operations(self) -> None:
+        """Test that concurrent unlock_count() operations are thread-safe."""
+        lock = TTLLock()
+        total_locks = 1000
+        num_threads = 50
+        count_per_thread = total_locks // num_threads
+
+        lock.lock_count(total_locks)
+
+        def do_unlock_count() -> None:
+            lock.unlock_count(count_per_thread)
+
+        threads = [threading.Thread(target=do_unlock_count) for _ in range(num_threads)]
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
         assert not lock.is_locked()
 
     def test_concurrent_lock_unlock(self):


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR optimizes read-lock accounting in the distributed L1 manager by adding native count-based operations to `TTLLock`. The current L1 manager already supports reserving and releasing more than one read count for a key through `extra_count`, but it implements that behavior with Python loops that repeatedly call the C++ `TTLLock.lock()` / `TTLLock.unlock()` methods. That means each key can cross the Python/C++ boundary `1 + extra_count` times even though the underlying operation is just atomic counter arithmetic.

The new `TTLLock.lock_count(count)` and `TTLLock.unlock_count(count)` APIs move that repeated work into native code. Existing `lock()` and `unlock()` remain available and now delegate to the count-based versions with `count=1`, so existing callers keep the same behavior. The L1 manager uses the new batch operations in `reserve_read`, `finish_read`, and `finish_write_and_reserve_read`, reducing repeated native calls while preserving the same logical read-lock counts and state transitions.

The native implementation keeps the existing TTL semantics intact. If a lock has expired, `lock_count(count)` resets the stale counter to the requested count and refreshes the expiration time. If the lock is still active, it atomically increments the current counter and refreshes the TTL. `unlock_count(count)` preserves the old unlock behavior by clamping the counter at zero instead of allowing underflow. The implementation also validates non-positive counts and rejects counter overflow explicitly, which makes misuse fail clearly rather than corrupting the counter.

Reviewer map:

| Area | Key files | What to review |
| --- | --- | --- |
| Native API | `csrc/storage_manager/ttl_lock.{h,cpp}` | Count validation, overflow handling, expired-TTL reset semantics, and thread-safety around the temporary reset sentinel. |
| Python exposure | `csrc/storage_manager/pybind.cpp`, `lmcache/native_storage_ops.pyi` | Python binding names, argument handling, and documented exception behavior. |
| L1 manager hot path | `lmcache/v1/distributed/l1_manager.py` | Replacement of Python loops with one `lock_count()` / `unlock_count()` call per successful key. |
| Tests | `tests/v1/native_storage_ops/test_ttl_lock.py`, `tests/v1/distributed/test_l1_manager.py` | Coverage for native semantics, invalid inputs, overflow, TTL expiry, concurrency, and L1 state transitions. |

The practical contribution is narrow but important: the PR removes avoidable interpreter overhead from a distributed-cache hot path without changing the public L1 manager API. The old per-count behavior is still represented exactly by the new count-based operations, and the tests assert both the native lock semantics and that the L1 manager actually uses the new batch methods.

Optimization evidence:

I measured the exact operation this PR optimizes: acquiring and releasing multiple read-lock counts from Python. The old path performs `count` Python calls to `lock()` followed by `count` Python calls to `unlock()`. The new path performs one `lock_count(count)` call followed by one `unlock_count(count)` call. The benchmark uses `TTLLock` directly, runs 20,000 iterations per repeat, reports the median of 7 repeats, and measures one acquire+release cycle in microseconds.

| Read-lock count | Old Python loop median | New batch API median | Speedup |
| --- | ---: | ---: | ---: |
| 8 | 3.116 us | 0.392 us | 7.96x |
| 32 | 11.913 us | 0.388 us | 30.72x |
| 128 | 46.706 us | 0.388 us | 120.37x |

The speedup scales with `count` because the old path pays Python/C++ call overhead once per count, while the new path pays it once per key. This benchmark intentionally isolates lock accounting overhead; it does not claim an end-to-end distributed-cache throughput number.

**Special notes for your reviewers**:

- This is a performance PR, not an API redesign. The only new public surface is the optional `TTLLock.lock_count()` / `TTLLock.unlock_count()` native binding.
- The old single-count methods remain supported. `lock()` is equivalent to `lock_count(1)`, and `unlock()` is equivalent to `unlock_count(1)`.
- `unlock_count()` intentionally clamps at zero, matching the previous repeated-`unlock()` behavior.
- `lock_count()` raises on invalid count and counter overflow. That behavior is documented in the C++ header and Python stub.

Validation performed:

- `pytest -q tests/v1/native_storage_ops/test_ttl_lock.py tests/v1/distributed/test_l1_manager.py`
  - Result: `108 passed`
  - This covers native `TTLLock` behavior and the distributed L1 manager paths changed by this PR.
- `pre-commit run --all-files`
  - Passed: SPDX, direct torch device check, isort, ruff, ruff-format, codespell, clang-format, mypy.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
