### PR TITLE
[Core] Batch store memory allocation in LMCacheEngine

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -477,8 +477,77 @@ class LMCacheEngine:
         if request_configs is not None and len(request_configs) != 0:
             assert isinstance(request_configs, dict)
 
+        force_store_wait = self.config.get_extra_config_value("force_store_wait", False)
+
         with store_stats.profile_process_tokens():
             prev_key = 0
+            pending_chunks: List[Tuple[int, int, CacheEngineKey]] = []
+            pending_shapes: Optional[list[torch.Size]] = None
+            pending_dtypes: Optional[list[torch.dtype]] = None
+
+            def flush_pending_chunks() -> bool:
+                nonlocal prev_key, pending_shapes, pending_dtypes
+                nonlocal tot_kv_size, tot_token_num
+
+                if not pending_chunks:
+                    return False
+
+                assert pending_shapes is not None
+                assert pending_dtypes is not None
+                allocated_objs, allocation_stopped = self._allocate_store_memory_objs(
+                    pending_shapes,
+                    pending_dtypes,
+                    len(pending_chunks),
+                    busy_loop=force_store_wait,
+                )
+
+                for (start, end, key), memory_obj in zip(
+                    pending_chunks,
+                    allocated_objs,
+                    strict=False,
+                ):
+                    starts.append(start)
+                    ends.append(end)
+                    keys.append(key)
+                    memory_objs.append(memory_obj)
+                    tot_kv_size += memory_obj.get_size()
+                    tot_token_num += end - start
+
+                    # Create KV event
+                    if self.kv_events_enabled:
+                        stored_event = CacheStoreEvent(
+                            block_hashes=[key.chunk_hash],
+                            parent_block_hash=None if start == 0 else prev_key,
+                            token_ids=[],
+                            block_size=end - start,
+                            lora_id=None,
+                            medium="cpu",
+                            lora_name=None,
+                        )
+                        if tokens is not None:
+                            stored_event.token_ids = convert_tokens_to_list(
+                                tokens,
+                                start,
+                                end,
+                            )
+                            if isinstance(tokens, torch.Tensor):
+                                stored_event.medium = tokens.device
+                        elif hashes is not None:
+                            stored_event.token_ids = hashes[start : end + 1]
+                        logger.debug(
+                            (
+                                "Added kv cache event '%s' to kv cache events queue"
+                                % stored_event
+                            )
+                        )
+                        self.kv_events.append(stored_event)
+                        prev_key = key.chunk_hash
+
+                pending_chunks.clear()
+                pending_shapes = None
+                pending_dtypes = None
+                return allocation_stopped
+
             for start, end, key in self.token_database.process_tokens(
                 tokens,
                 hashes,
@@ -492,60 +561,31 @@ class LMCacheEngine:
                 kv_shapes = self.metadata.get_shapes(num_tokens)
                 kv_dtypes = self.metadata.get_dtypes()
 
-                # TODO (Jiayi): should be batched in the future
-                memory_obj = self.storage_manager.allocate(
-                    kv_shapes,
-                    kv_dtypes,
-                    busy_loop=self.config.get_extra_config_value(
-                        "force_store_wait", False
-                    ),
-                    fmt=self.fmt,
-                )
-                if memory_obj is None:
+                if pending_shapes is not None and (
+                    kv_shapes != pending_shapes or kv_dtypes != pending_dtypes
+                ):
+                    if flush_pending_chunks():
+                        logger.warning(
+                            "Local cpu memory under pressure so"
+                            " choosing to store only "
+                            " %d total chunks of KV cache.",
+                            len(memory_objs),
+                        )
+                        break
+
+                if not pending_chunks:
+                    pending_shapes = kv_shapes
+                    pending_dtypes = kv_dtypes
+
+                pending_chunks.append((start, end, key))
+            else:
+                if flush_pending_chunks():
                     logger.warning(
                         "Local cpu memory under pressure so"
                         " choosing to store only "
                         " %d total chunks of KV cache.",
                         len(memory_objs),
                     )
-                    break
-
-                starts.append(start)
-                ends.append(end)
-                keys.append(key)
-                memory_objs.append(memory_obj)
-                tot_kv_size += memory_obj.get_size()
-                tot_token_num += num_tokens
-
-                # Create KV event
-                if self.kv_events_enabled:
-                    stored_event = CacheStoreEvent(
-                        block_hashes=[key.chunk_hash],
-                        parent_block_hash=None if start == 0 else prev_key,
-                        token_ids=[],
-                        block_size=num_tokens,
-                        lora_id=None,
-                        medium="cpu",
-                        lora_name=None,
-                    )
-                    if tokens is not None:
-                        stored_event.token_ids = convert_tokens_to_list(
-                            tokens,
-                            start,
-                            end,
-                        )
-                        if isinstance(tokens, torch.Tensor):
-                            stored_event.medium = tokens.device
-                    elif hashes is not None:
-                        stored_event.token_ids = hashes[start : end + 1]
-                    logger.debug(
-                        (
-                            "Added kv cache event '%s' to kv cache events queue"
-                            % stored_event
-                        )
-                    )
-                    self.kv_events.append(stored_event)
-                    prev_key = key.chunk_hash
 
         # memory_objs might be empty, directly return to avoid sending tokens
         if not memory_objs:
@@ -1634,6 +1674,68 @@ class LMCacheEngine:
             logger.error("Error closing storage_manager: %s", e)
 
         logger.info("LMCacheEngine closed.")
+
+    def _allocate_store_memory_objs(
+        self,
+        kv_shapes: list[torch.Size],
+        kv_dtypes: list[torch.dtype],
+        batch_size: int,
+        busy_loop: bool,
+    ) -> tuple[List[MemoryObj], bool]:
+        """Allocate store buffers, using the batched allocator as a fast path."""
+        assert self.storage_manager is not None
+
+        memory_objs = self.storage_manager.batched_allocate(
+            kv_shapes,
+            kv_dtypes,
+            batch_size=batch_size,
+            busy_loop=busy_loop,
+            eviction=False,
+            fmt=self.fmt,
+        )
+        if memory_objs is None:
+            return self._allocate_store_memory_objs_one_by_one(
+                kv_shapes,
+                kv_dtypes,
+                batch_size,
+                busy_loop,
+            )
+
+        allocated_objs: List[MemoryObj] = []
+        for memory_obj in memory_objs[:batch_size]:
+            if memory_obj is None:
+                break
+            allocated_objs.append(memory_obj)
+
+        for memory_obj in memory_objs[len(allocated_objs) :]:
+            if memory_obj is not None:
+                memory_obj.ref_count_down()
+
+        allocation_stopped = len(allocated_objs) < batch_size
+        return allocated_objs, allocation_stopped
+
+    def _allocate_store_memory_objs_one_by_one(
+        self,
+        kv_shapes: list[torch.Size],
+        kv_dtypes: list[torch.dtype],
+        batch_size: int,
+        busy_loop: bool,
+    ) -> tuple[List[MemoryObj], bool]:
+        """Allocate store buffers one at a time, preserving partial-store behavior."""
+        assert self.storage_manager is not None
+
+        memory_objs: List[MemoryObj] = []
+        for _ in range(batch_size):
+            memory_obj = self.storage_manager.allocate(
+                kv_shapes,
+                kv_dtypes,
+                busy_loop=busy_loop,
+                fmt=self.fmt,
+            )
+            if memory_obj is None:
+                return memory_objs, True
+            memory_objs.append(memory_obj)
+        return memory_objs, False
 
     def _async_process_tokens_internal(
         self,

--- a/tests/v1/test_cache_engine.py
+++ b/tests/v1/test_cache_engine.py
@@ -23,6 +23,7 @@ from lmcache.utils import (
 from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventStatus, EventType
+from lmcache.v1.token_database import ChunkedTokenDatabase
 
 # Local
 from .utils import (
@@ -1673,6 +1674,132 @@ def _make_mock_memory_obj(size: int = 1024) -> MagicMock:
     mock = MagicMock()
     mock.get_size.return_value = size
     return mock
+
+
+def _make_store_engine() -> tuple[LMCacheEngine, MagicMock, MagicMock]:
+    """Create a minimal engine and mocks for testing the public store() path."""
+    cfg = LMCacheEngineConfig.from_legacy(
+        chunk_size=4,
+        remote_url=None,
+        save_unfull_chunk=True,
+    )
+    metadata = dumb_metadata(kv_shape=(2, 2, 4, 1, 8))
+    metadata.chunk_size = 4
+
+    gpu_connector = MagicMock()
+    gpu_connector.batched_from_gpu.return_value = None
+
+    engine = LMCacheEngine(
+        cfg,
+        metadata,
+        ChunkedTokenDatabase(cfg, metadata),
+        gpu_connector,
+        mock_up_broadcast_fn,
+        mock_up_broadcast_object_fn,
+    )
+    storage_manager = MagicMock()
+    storage_manager.is_frozen.return_value = False
+    engine.storage_manager = storage_manager
+    return engine, storage_manager, gpu_connector
+
+
+def test_store_uses_batched_allocate_for_uniform_chunks() -> None:
+    """Store should batch allocations for contiguous equal-shape chunks."""
+    engine, storage_manager, gpu_connector = _make_store_engine()
+    memory_objs = [_make_mock_memory_obj(), _make_mock_memory_obj()]
+    storage_manager.batched_allocate.return_value = memory_objs
+
+    tokens = torch.arange(8)
+    kvcaches = MagicMock()
+    engine.store(tokens=tokens, kvcaches=kvcaches, slot_mapping=list(range(8)))
+
+    expected_shapes = engine.metadata.get_shapes(4)
+    expected_dtypes = engine.metadata.get_dtypes()
+    storage_manager.batched_allocate.assert_called_once_with(
+        expected_shapes,
+        expected_dtypes,
+        batch_size=2,
+        busy_loop=False,
+        eviction=False,
+        fmt=engine.fmt,
+    )
+    storage_manager.allocate.assert_not_called()
+    gpu_connector.batched_from_gpu.assert_called_once()
+    storage_manager.batched_put.assert_called_once()
+    assert storage_manager.batched_put.call_args.args[1] == memory_objs
+
+
+def test_store_falls_back_to_single_allocate_when_batched_allocate_fails() -> None:
+    """Store should preserve partial-store behavior when batch allocation fails."""
+    engine, storage_manager, gpu_connector = _make_store_engine()
+    memory_obj = _make_mock_memory_obj()
+    storage_manager.batched_allocate.return_value = None
+    storage_manager.allocate.side_effect = [memory_obj, None]
+
+    tokens = torch.arange(8)
+    kvcaches = MagicMock()
+    engine.store(tokens=tokens, kvcaches=kvcaches, slot_mapping=list(range(8)))
+
+    assert storage_manager.allocate.call_count == 2
+    gpu_connector.batched_from_gpu.assert_called_once_with(
+        [memory_obj],
+        [0],
+        [4],
+        kvcaches=kvcaches,
+        slot_mapping=list(range(8)),
+    )
+    storage_manager.batched_put.assert_called_once()
+    assert storage_manager.batched_put.call_args.args[1] == [memory_obj]
+
+
+def test_store_keeps_successful_prefix_from_partial_batched_allocate() -> None:
+    """Store should release objects after the first failed batch allocation slot."""
+    engine, storage_manager, gpu_connector = _make_store_engine()
+    kept_obj = _make_mock_memory_obj()
+    extra_obj = _make_mock_memory_obj()
+    storage_manager.batched_allocate.return_value = [
+        kept_obj,
+        None,
+        extra_obj,
+    ]
+
+    tokens = torch.arange(12)
+    kvcaches = MagicMock()
+    engine.store(tokens=tokens, kvcaches=kvcaches, slot_mapping=list(range(12)))
+
+    storage_manager.allocate.assert_not_called()
+    gpu_connector.batched_from_gpu.assert_called_once()
+    assert gpu_connector.batched_from_gpu.call_args.args[:3] == (
+        [kept_obj],
+        [0],
+        [4],
+    )
+    storage_manager.batched_put.assert_called_once()
+    assert storage_manager.batched_put.call_args.args[1] == [kept_obj]
+    extra_obj.ref_count_down.assert_called_once()
+
+
+def test_store_batches_only_chunks_with_matching_shapes() -> None:
+    """Store should flush a batch before a differently sized tail chunk."""
+    engine, storage_manager, _ = _make_store_engine()
+    memory_objs = [
+        [_make_mock_memory_obj(), _make_mock_memory_obj()],
+        [_make_mock_memory_obj()],
+    ]
+    storage_manager.batched_allocate.side_effect = memory_objs
+
+    tokens = torch.arange(10)
+    engine.store(tokens=tokens, kvcaches=MagicMock(), slot_mapping=list(range(10)))
+
+    assert storage_manager.batched_allocate.call_count == 2
+    first_call, second_call = storage_manager.batched_allocate.call_args_list
+    assert first_call.kwargs["batch_size"] == 2
+    assert first_call.args[0] == engine.metadata.get_shapes(4)
+    assert second_call.kwargs["batch_size"] == 1
+    assert second_call.args[0] == engine.metadata.get_shapes(2)
+    assert storage_manager.batched_put.call_args.args[1] == (
+        memory_objs[0] + memory_objs[1]
+    )
 
 
 def _make_mock_engine(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR optimizes the `LMCacheEngine.store()` hot path by batching memory allocation for consecutive chunks that share the same KV shape and dtype. Before this change, `store()` asked the storage manager to allocate one `MemoryObj` per processed chunk. That was simple, but it meant a normal prefill/store request with many full-sized chunks repeatedly paid the allocator call overhead even when every chunk had the same allocation shape.

The new flow keeps a small pending-chunk buffer inside `store()`. As tokens are processed into cache chunks, the engine groups adjacent chunks whose `metadata.get_shapes(num_tokens)` and `metadata.get_dtypes()` match. When the group ends, or when token processing finishes, the engine flushes the group through `StorageManager.batched_allocate()` with the group size. The rest of the store pipeline remains the same: successfully allocated memory objects are paired with their original `(start, end, key)` metadata, copied from GPU through `batched_from_gpu()`, and submitted to storage through `batched_put()`.

This keeps the optimization focused on allocation. It does not change how tokens are segmented, how keys are generated, how KV events are emitted, how GPU extraction works, or how storage backends receive the final objects. The order of `starts`, `ends`, `keys`, and `memory_objs` is still derived from the token-processing order, and differently shaped chunks are flushed separately so tail chunks and `save_unfull_chunk` behavior stay isolated from the full-chunk fast path.

The fallback behavior is also preserved. If `batched_allocate()` cannot allocate the group and returns `None`, the helper falls back to the previous one-by-one `allocate()` behavior. That matters because the existing single-allocation path owns eviction behavior and `force_store_wait` / `busy_loop` behavior. If a backend returns a partial list with a `None` inside it, the store path keeps only the successful prefix, releases any later allocated objects, and stops at the first failed slot. That matches the old partial-store semantics while avoiding unused `MemoryObj` leaks.

Reviewer map:

| Area | Key files | What to review |
| --- | --- | --- |
| Store batching | `lmcache/v1/cache_engine.py` | Pending chunk grouping, shape/dtype boundary flushes, and preservation of token-processing order. |
| Allocation helpers | `lmcache/v1/cache_engine.py` | Batch fast path, one-by-one fallback, partial-list cleanup, and `force_store_wait` propagation. |
| Regression tests | `tests/v1/test_cache_engine.py` | Public `store()` tests for uniform batches, batch failure fallback, partial batch cleanup, and differently sized tail chunks. |

The main contribution is reducing allocator overhead for the common case without making the store pipeline less predictable. For a run of `N` compatible chunks, the allocation path changes from `N` individual `allocate()` calls to one `batched_allocate(..., batch_size=N)` call. If the fast path is not available or cannot allocate, the code returns to the existing per-chunk behavior.

Optimization evidence:

I measured the store allocation path with a lightweight public-`store()` benchmark using a mocked storage manager and mocked GPU connector. This isolates the Python store-path overhead and allocator call pattern without mixing in real GPU transfer, disk I/O, or backend-specific allocator latency. The benchmark stores 256 tokens as 64 chunks with identical shape and dtype, runs 9 repeats after warmup, and reports the median store-call time.

The `origin/dev` baseline performs one `allocate()` call per chunk. This PR performs one `batched_allocate()` call for the whole compatible chunk group.

| Branch / path | Median `store()` time | `batched_allocate()` calls | `allocate()` calls |
| --- | ---: | ---: | ---: |
| `origin/dev` one-by-one allocation | 2246.809 us | 0 | 64 |
| This PR batch fast path | 1614.174 us | 1 | 0 |

In this isolated benchmark, the batched path reduces allocator calls from 64 to 1 and lowers median mocked `store()` time by about 28.2% (`1.39x` faster). This is not an end-to-end serving benchmark; it is intended to prove that the PR removes repeated allocation-call overhead on the exact hot path it changes.

**Special notes for your reviewers**:

- This PR does not change the public `LMCacheEngine.store()` API.
- The optimization is intentionally scoped to allocation. GPU copy, storage put, token database processing, and KV event construction are not redesigned.
- The batch fast path uses `eviction=False` for the initial attempt. If direct batch allocation fails, the fallback path calls the existing one-by-one `allocate()` method, preserving the previous eviction behavior.
- The implementation deliberately flushes before a shape/dtype change. This prevents full chunks and tail chunks from being allocated as if they had the same layout.

Validation performed:

- New focused store tests:
  - `test_store_uses_batched_allocate_for_uniform_chunks`
  - `test_store_falls_back_to_single_allocate_when_batched_allocate_fails`
  - `test_store_keeps_successful_prefix_from_partial_batched_allocate`
  - `test_store_batches_only_chunks_with_matching_shapes`
  - Result: `4 passed`
- Store hot-path regression subset:
  - Existing `test_paged_same_retrieve_store` nodes.
  - CPU and remote `test_paged_store_offset` nodes.
  - Existing `test_paged_store_kv_tensors_mask` nodes.
  - The four new batch allocation tests.
  - Result: `12 passed`
- Local-disk offset verification:
  - `test_paged_store_offset[cpu-False-local_disk-256]`
  - `test_paged_store_offset[cpu-True-local_disk-256]`
  - Result: `2 passed` 
- `pre-commit run --all-files`
  - Passed: SPDX, direct torch device check, isort, ruff, ruff-format, codespell, clang-format, mypy.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
