### PR TITLE
docs: daily drift check — multi-process mode (2026-06-28)

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -451,8 +451,10 @@ pass ``lmcache.mp.host`` / ``lmcache.mp.port`` in
 
 **CPU-only (no GPU)** -- the server runs with a ``StubCPUDevice`` and shares
 KV tensors with vLLM over POSIX shared memory. Start ``lmcache server``
-normally, then set ``lmcache.mp.mp_transfer_mode=engine_driven`` on the vLLM
-side to enable the zero-copy SHM path.
+normally, then set ``lmcache.mp.mp_transfer_mode=lmcache_driven`` on the vLLM
+side to enable the zero-copy SHM handle path (the default ``auto`` routing
+maps non-CUDA devices to ``engine_driven``, which uses the worker-side
+gather/scatter copy path instead).
 
 **Docker** -- see :doc:`../production/docker_deployment`.
 

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -472,10 +472,12 @@ All connector-level options are passed through
    * - ``lmcache.mp.mp_transfer_mode``
      - ``auto``
      - Routing mode for the worker -> server transfer context. One of
-       ``auto`` (CUDA -> engine_driven, others -> lmcache_driven),
-       ``engine_driven`` (force IPC / SHM zero-copy), or
-       ``lmcache_driven`` (force worker-side gather/scatter copy).
-       Overrides the ``LMCACHE_MP_TRANSFER_MODE`` env var when set.
+       ``auto`` (CUDA -> lmcache_driven, others -> engine_driven),
+       ``lmcache_driven`` (force the IPC / SHM zero-copy handle path —
+       LMCache server pulls data via device handles), or
+       ``engine_driven`` (force the worker-side gather/scatter copy
+       path). Overrides the ``LMCACHE_MP_TRANSFER_MODE`` env var when
+       set.
 
 Environment Variables
 ---------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily docs drift check on the multi-process surface. **Two** user-facing inconsistencies found in `docs/source/`; both stem from the same pre-rename description of `mp_transfer_mode` that survived [#3679 (`714bd7a`)](https://github.com/LMCache/LMCache/commit/714bd7a58af23f13fcafd0731d9f78ba8b0a05bc) (rename + class swap on 2026-06-16). Nothing new in `docs/design/` beyond items already pending review in the earlier drift-check PRs (#3915, #3900, #3879, #3863, #3840, #3817, #3774).

### Drift items found and fixed

**`docs/source/` (user-facing — highest priority)**

| # | Doc | Drift |
|---|---|---|
| 1 | [`docs/source/mp/configuration.rst`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/source/mp/configuration.rst#L472-L478) — *Connector `extra_config` Keys* | The `lmcache.mp.mp_transfer_mode` row claims `auto` routes `CUDA -> engine_driven` and `others -> lmcache_driven`, and that `engine_driven` is the IPC / SHM zero-copy path while `lmcache_driven` is the worker-side gather/scatter path. After [#3679 (`714bd7a`)](https://github.com/LMCache/LMCache/commit/714bd7a58af23f13fcafd0731d9f78ba8b0a05bc) the contexts were swapped — `MPTransferMode` and `create_transfer_context` ([`worker_transfer.py:45-60`](https://github.com/LMCache/LMCache/blob/2d500a1/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L45-L60), [`worker_transfer.py:516-563`](https://github.com/LMCache/LMCache/blob/2d500a1/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L516-L563)) now route `CUDA -> LMCACHE_DRIVEN` / others `-> ENGINE_DRIVEN`, with `LMCacheDrivenTransferContext` being the IPC / SHM zero-copy handle path ([`worker_transfer.py:221-228`](https://github.com/LMCache/LMCache/blob/2d500a1/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L221-L228) — *"the serving engine provides device handles (IPC for CUDA, SHM wrappers for CPU with CUDA-IPC-like semantics) and the LMCache server performs direct device-side data transfer"*) and `EngineDrivenTransferContext` being the worker-side gather/scatter copy path ([`worker_transfer.py:314-320`](https://github.com/LMCache/LMCache/blob/2d500a1/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L314-L320) — *"the engine (worker side) owns the data movement: the worker adapter gathers/packs KV into CPU buffers, commits via message-queue"*). The `ExtraConfigDefault.mp_transfer_mode` comment in [`vllm_multi_process_adapter.py:56-62`](https://github.com/LMCache/LMCache/blob/2d500a1/lmcache/integration/vllm/vllm_multi_process_adapter.py#L56-L62) agrees. Other pages already match the code: [`docs/source/cli/bench.rst:747-756`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/source/cli/bench.rst#L747-L756), [`docs/source/cli/bench.rst:801-803`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/source/cli/bench.rst#L801-L803), [`docs/source/mp/deployment.rst:226-240`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/source/mp/deployment.rst#L226-L240), [`docs/design/cli/commands.md:202-203`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/design/cli/commands.md#L202-L203). **Fix:** rewrite the row so the `auto` routing and the two forced modes match the code; reuse the bench.rst / deployment.rst wording for consistency. |
| 2 | [`docs/source/getting_started/quickstart.rst`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/source/getting_started/quickstart.rst#L451-L457) — *Common variations / CPU-only* | The "CPU-only (no GPU)" tip tells users to set `lmcache.mp.mp_transfer_mode=engine_driven` *"to enable the zero-copy SHM path"*. With the current code that recommendation produces the **opposite** of what it claims: `engine_driven` is the worker-side gather/scatter copy path. The zero-copy SHM handle path on CPU is `lmcache_driven` (per [`worker_transfer.py:222-227`](https://github.com/LMCache/LMCache/blob/2d500a1/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L222-L227) and the consistent guidance in [`docs/source/cli/bench.rst:801-803`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/source/cli/bench.rst#L801-L803): *"By default --mode cpu uses the engine-driven gather/scatter path … To use the zero-copy SHM handle path instead, pass --transfer-mode lmcache_driven"*). Note also that the `auto` default already maps non-CUDA devices to `engine_driven`, so the override is only necessary to switch *away* from gather/scatter, not *into* it. **Fix:** swap the recommended mode to `lmcache_driven` and add a one-line note about what `auto` does on non-CUDA so readers don't think the recipe is redundant.

**`docs/design/`**

No new drift this run. The mp_transfer_mode descriptions in [`docs/design/cli/commands.md`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/design/cli/commands.md#L202-L203) and [`docs/design/v1/multiprocess/engine_driven_transfer_design.md`](https://github.com/LMCache/LMCache/blob/2d500a1/docs/design/v1/multiprocess/engine_driven_transfer_design.md#L7-L17) already match the post-#3679 code.

### Items intentionally not duplicated

These items remain queued in earlier still-open drift-check PRs and are deliberately omitted to avoid duplicate diffs:

- `docs/source/mp/operator.rst` — Connection-injection webhook section (#3915, 2026-06-27).
- `docs/source/mp/configuration.rst` — `--l1-use-lazy` cudart / `DeviceExt` fallback note (#3900, 2026-06-26).
- `docs/source/mp/index.rst` — GDS L1 cuFile / hipFile (#3879, 2026-06-25).
- `docs/source/mp/index.rst` — `p2p` protocol module in *Adding a new request type* + `docs/design/v1/multiprocess/raw_cuda_ipc.md` rewrap (#3863, 2026-06-24).
- `docs/source/mp/index.rst` — `wait_prefetch_status()` StorageManager entry + `raw_cuda_ipc.md` (#3840, 2026-06-23).
- `docs/source/mp/configuration.rst` — `lmcache.mp.server_urls` row + multi-server example (#3817, 2026-06-22). The developer-guide half of #3817 was superseded by #3851 ([`218b54e`](https://github.com/LMCache/LMCache/commit/218b54e1)).
- `docs/source/mp/index.rst` — `P2P_LOOKUP_AND_LOCK` row + `--p2p-*` flags section in `mp/configuration.rst` (#3774, 2026-06-21).

### Other PRs reviewed this run (no doc drift)

- [#3870 (`2d500a1`)](https://github.com/LMCache/LMCache/commit/2d500a161763e75519e835e7877914391355a872) "[Docs] update cli docs" — itself a documentation update; adds an *Auto-Discovery Mechanism* section to `docs/source/developer_guide/cli.rst`. Consistent with `lmcache/cli/commands/__init__.py` and `lmcache/v1/utils/subclass_discovery.py`. No drift.
- [#3570 (`1720917`)](https://github.com/LMCache/LMCache/commit/1720917e2df9b5ac1847b43543c7671cb86dcaf9) "feat: add thread to clean up expired sessions for SessionManager" — internal addition of a `PeriodicThread` cleaner to `SessionManager`. No CLI flag, no public API change, no user-facing surface. `docs/source/mp/index.rst` and `docs/design/v1/multiprocess/engine_driven_transfer_design.md` mention `SessionManager` only as a component name; both remain accurate.
- [#3920 (`7b05254`)](https://github.com/LMCache/LMCache/commit/7b05254cefa6e9ddd5d7c4e07ade50a30ad96a16) "[CI] Supports timer trigger test vllm and record" — CI-only. No doc impact.

**Special notes for your reviewers**:

- Auto-generated by the daily LMCache docs drift-check routine; **human review required before merge**.
- This PR is marked **draft** and is not requesting maintainer reviewers automatically.
- Branch lives on the `ApostaC/LMCache` fork (`docs/drift-check-2026-06-28`) and targets upstream `dev`.
- Single commit signed off as `ApostaC <yihua98@uchicago.edu>` for DCO.
- No code-level concerns flagged this run.
- The same drift exists in the auto-generated Chinese translations (`docs/source/locale/zh_CN/LC_MESSAGES/mp/configuration.po`, `getting_started/quickstart.po`). Leaving those for the next translation sweep since they should re-derive from the English source.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by the daily LMCache docs drift-check routine_

---
_Generated by [Claude Code](https://claude.ai/code/session_0146xNziVzeeo3Sms9FvofH9)_