### PR TITLE
[feat][cb] enable cb compartible with vllm hma

### DIFF
--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -430,6 +430,9 @@ class KVLayerGroupsManager:
         self._lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
         self._separate_object_groups = separate_object_groups
 
+        # When True, sliding-window groups store/transfer FULL per-chunk KV
+        self._full_sw_kv = False
+
         logger.info(
             "KV layer groups: ---\n%s\n---",
             "\n".join(repr(g) for g in self._kernel_groups),
@@ -526,6 +529,14 @@ class KVLayerGroupsManager:
         sw_size = self.get_subchunk_sw_size_tokens(kernel_group_idx)
         return group.calculate_slots(sw_size)
 
+    def enable_full_sw_kv(self) -> None:
+        """Store/transfer the FULL per-chunk KV for sliding-window groups.
+
+        Keeps every block so a chunk stays valid when reused at any position
+        (default windowing keeps only each chunk's last sub-chunk window).
+        """
+        self._full_sw_kv = True
+
     def get_subchunk_sw_size_tokens(self, kernel_group_idx: int) -> int:
         """Return the sub-chunk sliding window size of a given kernel group.
         The size is measured in the number of tokens.
@@ -542,6 +553,10 @@ class KVLayerGroupsManager:
             window models.
         """
         sw_size_tokens = self._kernel_groups[kernel_group_idx].sw_size_tokens
+        # full_sw_kv: report the full chunk as the window so store/transfer keep
+        # every block (chunk stays valid for reuse at any position).
+        if self._full_sw_kv:
+            return self._lmcache_tokens_per_chunk
         if sw_size_tokens == -1 or sw_size_tokens >= self._lmcache_tokens_per_chunk:
             return self._lmcache_tokens_per_chunk
         return sw_size_tokens
@@ -558,6 +573,10 @@ class KVLayerGroupsManager:
             With object-group separation disabled (the default), the result
             has a single full-attention entry.
         """
+        if self._full_sw_kv:
+            # full_sw_kv: every group reports full attention, no cross-chunk
+            # window skipping (mirrors get_subchunk_sw_size_tokens).
+            return AttnWindowDesc(num_chunks_in_sw=[-1] * len(self._object_groups))
         return AttnWindowDesc(
             num_chunks_in_sw=[
                 w if w >= 1 else -1

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -180,9 +180,11 @@ class MPCacheServerContext:
         chunk_size: int = 256,
         hash_algorithm: str = "blake3",
         separate_object_groups: bool = True,
+        full_sw_kv: bool = False,
     ) -> None:
         self._chunk_size = chunk_size
         self._separate_object_groups = separate_object_groups
+        self._full_sw_kv = full_sw_kv
 
         # Initialize the process-global GDS context.
         # No-op when GDS L1 is disabled (config is None).
@@ -218,6 +220,11 @@ class MPCacheServerContext:
     def separate_object_groups(self) -> bool:
         """Whether to split kernel groups into per-sliding-window object groups."""
         return self._separate_object_groups
+
+    @property
+    def full_sw_kv(self) -> bool:
+        """Whether sliding-window groups cache full per-chunk KV (no window cutting)."""
+        return self._full_sw_kv
 
     @property
     def storage_manager(self) -> StorageManager:

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1552,9 +1552,23 @@ class BlendV3Module(InstanceLivenessTarget):
             check_interprocess_event_support()
             event = torch_dev.Event(interprocess=True)
 
-            # One staged block-id tensor per engine (kernel) group, indexed by
-            # group. A single shared mapping corrupts all but group 0 under HMA
+            # One staged block-id tensor per engine group, indexed by group.
             block_ids_per_group_gpu = gpu_context.stage_block_ids(gpu_block_ids)
+
+            # Resolve each kernel group's block table + block size once. Select
+            # by engine_group_idx (kernel groups may share one, e.g. MiniMax-M3).
+            kgm = gpu_context.kv_layer_groups_manager
+            resolved_groups: list[tuple[torch.Tensor, int]] = []
+            for group_idx in range(num_groups):
+                eg_idx = kgm.kernel_groups[group_idx].engine_group_idx
+                if eg_idx >= len(block_ids_per_group_gpu):
+                    eg_idx = 0
+                resolved_groups.append(
+                    (
+                        block_ids_per_group_gpu[eg_idx],
+                        kgm.kernel_groups[group_idx].tokens_per_block,
+                    )
+                )
 
             self._event_bus.publish_on_stream(
                 gpu_context.cupy_stream,
@@ -1589,8 +1603,11 @@ class BlendV3Module(InstanceLivenessTarget):
                     # Per-token scatter handles any cur_st; just bound the
                     # matched range to the allocated slots.
                     pairs: list[tuple[CBMatchResult, Any]] = []
-                    num_slots = (
-                        int(block_ids_per_group_gpu[0].numel()) * tokens_per_block
+                    # Bound by the smallest group: under HMA the sliding group
+                    # has fewer blocks than the full group, so [0] isn't safe.
+                    num_slots = min(
+                        int(block_ids.numel()) * group_bs
+                        for block_ids, group_bs in resolved_groups
                     )
                     for r, memory_obj in zip(cb_match_result, memory_objs, strict=True):
                         if r.cur_ed > num_slots:
@@ -1675,26 +1692,8 @@ class BlendV3Module(InstanceLivenessTarget):
                                 ]
                             )
                             for group_idx in range(num_groups):
-                                # Index the per-engine-group block table by the
-                                # kernel group's engine_group_idx: kernel groups can
-                                # share one engine group (e.g. MiniMax-M3), so the
-                                # kernel index would target the wrong group.
-                                eg_idx = (
-                                    gpu_context.kv_layer_groups_manager.kernel_groups[
-                                        group_idx
-                                    ].engine_group_idx
-                                )
-                                if eg_idx >= len(block_ids_per_group_gpu):
-                                    eg_idx = 0
-                                group_block_ids = block_ids_per_group_gpu[eg_idx]
-                                # Per-group block size: groups can differ in
-                                # tokens_per_block, so slot_mapping / page_buffer_size
-                                # / the transfer block_size all use this group's value.
-                                group_bs = (
-                                    gpu_context.kv_layer_groups_manager.kernel_groups[
-                                        group_idx
-                                    ].tokens_per_block
-                                )
+                                # This group's block table + size (resolved above).
+                                group_block_ids, group_bs = resolved_groups[group_idx]
                                 page_buffer_size = gpu_context.num_blocks * group_bs
                                 slot_mapping = group_block_ids[
                                     pos // group_bs

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1436,7 +1436,7 @@ class BlendV3Module(InstanceLivenessTarget):
         self,
         key: IPCCacheServerKey,
         cb_match_result: list[CBMatchResult],
-        gpu_block_ids: list[int],
+        gpu_block_ids: list[list[int]],
         instance_id: int,
         event_ipc_handle: bytes,
     ) -> tuple[bytes, bool]:
@@ -1453,7 +1453,9 @@ class BlendV3Module(InstanceLivenessTarget):
             key (IPCCacheServerKey): The request key.
             cb_match_result (list[CBMatchResult]): Matched ranges to scatter
                 (prefix-hit and shifted), any order.
-            gpu_block_ids (list[int]): This request's full paged block table.
+            gpu_block_ids (list[list[int]]): This request's paged block table
+                per engine (kernel) group; single-group models pass [[...]].
+                Mirrors the engine RETRIEVE/STORE per-group block-id contract.
             instance_id (int): Target KV-cache instance.
             event_ipc_handle (bytes): IPC handle to the forward's CUDA event.
 
@@ -1550,8 +1552,9 @@ class BlendV3Module(InstanceLivenessTarget):
             check_interprocess_event_support()
             event = torch_dev.Event(interprocess=True)
 
-            # Staged once (single group), sliced per chunk inside the loop.
-            all_block_ids_gpu = gpu_context.stage_block_ids([gpu_block_ids])[0]
+            # One staged block-id tensor per engine (kernel) group, indexed by
+            # group. A single shared mapping corrupts all but group 0 under HMA
+            block_ids_per_group_gpu = gpu_context.stage_block_ids(gpu_block_ids)
 
             self._event_bus.publish_on_stream(
                 gpu_context.cupy_stream,
@@ -1586,7 +1589,9 @@ class BlendV3Module(InstanceLivenessTarget):
                     # Per-token scatter handles any cur_st; just bound the
                     # matched range to the allocated slots.
                     pairs: list[tuple[CBMatchResult, Any]] = []
-                    num_slots = int(all_block_ids_gpu.numel()) * tokens_per_block
+                    num_slots = (
+                        int(block_ids_per_group_gpu[0].numel()) * tokens_per_block
+                    )
                     for r, memory_obj in zip(cb_match_result, memory_objs, strict=True):
                         if r.cur_ed > num_slots:
                             logger.warning(
@@ -1658,7 +1663,6 @@ class BlendV3Module(InstanceLivenessTarget):
 
                             # (c) Per-token slot scatter: partial vLLM blocks
                             # shared with recomputed tokens stay disjoint.
-                            bs = tokens_per_block
                             pos = torch.cat(
                                 [
                                     torch.arange(
@@ -1670,11 +1674,22 @@ class BlendV3Module(InstanceLivenessTarget):
                                     for (r, _) in batch
                                 ]
                             )
-                            slot_mapping = all_block_ids_gpu[pos // bs] * bs + (
-                                pos % bs
-                            )
-                            page_buffer_size = gpu_context.num_blocks * bs
                             for group_idx in range(num_groups):
+                                # Per-group block table and block size: groups can differ in
+                                # tokens_per_block, so slot_mapping / page_buffer_size / the
+                                # transfer block_size all use this group's value (a global one
+                                # would index the block table out of bounds).
+                                group_block_ids = block_ids_per_group_gpu[group_idx]
+                                group_bs = (
+                                    gpu_context.kv_layer_groups_manager.kernel_groups[
+                                        group_idx
+                                    ].tokens_per_block
+                                )
+                                page_buffer_size = gpu_context.num_blocks * group_bs
+                                slot_mapping = (
+                                    group_block_ids[pos // group_bs] * group_bs
+                                    + (pos % group_bs)
+                                )
                                 tmp_buffers = [
                                     gpu_context.get_temp_kernel_group_buffer(
                                         slot_idx, group_idx
@@ -1690,7 +1705,7 @@ class BlendV3Module(InstanceLivenessTarget):
                                     page_buffer_size,
                                     lmc_ops.TransferDirection.H2D,
                                     gpu_context.get_engine_kv_format(group_idx),
-                                    block_size=bs,
+                                    block_size=group_bs,
                                     head_size=rope_state.head_size,
                                 )
 

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1679,9 +1679,11 @@ class BlendV3Module(InstanceLivenessTarget):
                                 # kernel group's engine_group_idx: kernel groups can
                                 # share one engine group (e.g. MiniMax-M3), so the
                                 # kernel index would target the wrong group.
-                                eg_idx = gpu_context.kv_layer_groups_manager.kernel_groups[
-                                    group_idx
-                                ].engine_group_idx
+                                eg_idx = (
+                                    gpu_context.kv_layer_groups_manager.kernel_groups[
+                                        group_idx
+                                    ].engine_group_idx
+                                )
                                 if eg_idx >= len(block_ids_per_group_gpu):
                                     eg_idx = 0
                                 group_block_ids = block_ids_per_group_gpu[eg_idx]
@@ -1694,10 +1696,9 @@ class BlendV3Module(InstanceLivenessTarget):
                                     ].tokens_per_block
                                 )
                                 page_buffer_size = gpu_context.num_blocks * group_bs
-                                slot_mapping = (
-                                    group_block_ids[pos // group_bs] * group_bs
-                                    + (pos % group_bs)
-                                )
+                                slot_mapping = group_block_ids[
+                                    pos // group_bs
+                                ] * group_bs + (pos % group_bs)
                                 tmp_buffers = [
                                     gpu_context.get_temp_kernel_group_buffer(
                                         slot_idx, group_idx

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1675,11 +1675,19 @@ class BlendV3Module(InstanceLivenessTarget):
                                 ]
                             )
                             for group_idx in range(num_groups):
-                                # Per-group block table and block size: groups can differ in
-                                # tokens_per_block, so slot_mapping / page_buffer_size / the
-                                # transfer block_size all use this group's value (a global one
-                                # would index the block table out of bounds).
-                                group_block_ids = block_ids_per_group_gpu[group_idx]
+                                # Index the per-engine-group block table by the
+                                # kernel group's engine_group_idx: kernel groups can
+                                # share one engine group (e.g. MiniMax-M3), so the
+                                # kernel index would target the wrong group.
+                                eg_idx = gpu_context.kv_layer_groups_manager.kernel_groups[
+                                    group_idx
+                                ].engine_group_idx
+                                if eg_idx >= len(block_ids_per_group_gpu):
+                                    eg_idx = 0
+                                group_block_ids = block_ids_per_group_gpu[eg_idx]
+                                # Per-group block size: groups can differ in
+                                # tokens_per_block, so slot_mapping / page_buffer_size
+                                # / the transfer block_size all use this group's value.
                                 group_bs = (
                                     gpu_context.kv_layer_groups_manager.kernel_groups[
                                         group_idx

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -669,6 +669,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             engine_group_infos=engine_group_infos,
             engine_type=engine_type,
             separate_object_groups=self._ctx.separate_object_groups,
+            full_sw_kv=self._ctx.full_sw_kv,
         )
         layout_desc = get_layout_desc(
             cache_context, self._ctx.chunk_size, object_group_id=0

--- a/lmcache/v1/multiprocess/protocols/blend_v3.py
+++ b/lmcache/v1/multiprocess/protocols/blend_v3.py
@@ -39,12 +39,13 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Retrieve pre-computed chunks into the request's paged blocks.
         # Payload: (key, cb_match_result, gpu_block_ids, instance_id,
         #           event_ipc_handle).
-        # Returns: (event_ipc_handle: bytes, success: bool).
+
+        # gpu_block_ids is per engine group (list[list[int]]).
         "CB_RETRIEVE_PRE_COMPUTED_V3": ProtocolDefinition(
             payload_classes=[
                 IPCCacheServerKey,
                 list[CBMatchResult],
-                list[int],
+                list[list[int]],
                 int,
                 bytes,
             ],

--- a/lmcache/v1/multiprocess/protocols/blend_v3.py
+++ b/lmcache/v1/multiprocess/protocols/blend_v3.py
@@ -39,7 +39,6 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Retrieve pre-computed chunks into the request's paged blocks.
         # Payload: (key, cb_match_result, gpu_block_ids, instance_id,
         #           event_ipc_handle).
-
         # gpu_block_ids is per engine group (list[list[int]]).
         "CB_RETRIEVE_PRE_COMPUTED_V3": ProtocolDefinition(
             payload_classes=[

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -344,11 +344,15 @@ def run_cache_server(
                 )
                 mem_cfg.shm_name = ""
 
+    # blend engine: single object group + full per-chunk SWA KV
+    is_blend = mp_config.engine_type == "blend"
+
     ctx = MPCacheServerContext(
         storage_manager_config=storage_manager_config,
         chunk_size=mp_config.chunk_size,
         hash_algorithm=mp_config.hash_algorithm,
-        separate_object_groups=mp_config.separate_object_groups,
+        separate_object_groups=mp_config.separate_object_groups and not is_blend,
+        full_sw_kv=is_blend,
     )
 
     modules = _build_modules(ctx, mp_config, coordinator_config)

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -162,6 +162,7 @@ def create_cache_context(
     engine_group_infos: "Sequence[EngineGroupInfo]" = (),
     engine_type: EngineType = EngineType.VLLM,
     separate_object_groups: bool = True,
+    full_sw_kv: bool = False,
 ) -> BaseCacheContext:
     """Create the appropriate cache context for *kv_caches*.
 
@@ -187,6 +188,10 @@ def create_cache_context(
         separate_object_groups: When True (default), split kernel groups into
             one object group per sliding-window size; when False, a single
             full-attention object group.
+        full_sw_kv: When True, sliding-window groups store/transfer full
+            per-chunk KV (no sub-chunk window cutting) so chunks stay valid for
+            reuse at any position; see
+            :meth:`KVLayerGroupsManager.enable_full_sw_kv`.
 
     Returns:
         A concrete cache context instance.
@@ -207,4 +212,5 @@ def create_cache_context(
         engine_group_infos,
         engine_type,
         separate_object_groups,
+        full_sw_kv,
     )

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -71,6 +71,7 @@ class CPUCacheContext(BaseCacheContext):
         engine_group_infos: "Sequence[EngineGroupInfo]" = (),
         engine_type: EngineType = EngineType.VLLM,
         separate_object_groups: bool = True,
+        full_sw_kv: bool = False,
     ) -> None:
         if not kv_caches:
             raise ValueError(
@@ -109,6 +110,11 @@ class CPUCacheContext(BaseCacheContext):
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
             separate_object_groups=separate_object_groups,
         )
+        # Set full_sw_kv before the temp buffer / object groups are sized so
+        # both use the full (un-windowed) per-chunk geometry (mirrors
+        # GPUCacheContext).
+        if full_sw_kv:
+            kv_layer_groups_manager.enable_full_sw_kv()
 
         # Pre-allocated block IDs buffer (CPU).
         _MAX_BLOCK_IDS = 1_000_000

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -354,6 +354,7 @@ class GPUCacheContext(BaseCacheContext):
         engine_group_infos: Sequence[EngineGroupInfo] = (),
         engine_type: EngineType = EngineType.VLLM,
         separate_object_groups: bool = True,
+        full_sw_kv: bool = False,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
         kv_caches_norm, engine_kv_formats = normalize_and_discover_per_layer_formats(
@@ -372,6 +373,10 @@ class GPUCacheContext(BaseCacheContext):
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
             separate_object_groups=separate_object_groups,
         )
+        # Set full_sw_kv before the temp buffer / object groups are built so
+        # both are sized for the full (un-windowed) per-chunk geometry.
+        if full_sw_kv:
+            kv_layer_groups_manager.enable_full_sw_kv()
 
         # Pre-allocated GPU buffer for block IDs (up to 1M elements).
         # The caller copies block_ids into this buffer before launching the

--- a/tests/v1/multiprocess/test_lmcache_driven_layout_registry.py
+++ b/tests/v1/multiprocess/test_lmcache_driven_layout_registry.py
@@ -94,6 +94,7 @@ def test_unregister_one_shared_gpu_layout_keeps_registry_until_last_instance(
         engine_group_infos: object = (),
         engine_type: object = None,
         separate_object_groups: bool = False,
+        full_sw_kv: bool = False,
     ) -> _FakeGPUContext:
         """Return a fake cache context without touching CUDA or wrappers."""
         return _FakeGPUContext()

--- a/tests/v1/platform/test_cache_context_dispatch.py
+++ b/tests/v1/platform/test_cache_context_dispatch.py
@@ -58,6 +58,7 @@ class _FakeContext(BaseCacheContext):
         engine_group_infos: Any,
         engine_type: Any,
         separate_object_groups: bool = True,
+        full_sw_kv: bool = False,
     ) -> None:
         # Skip ``BaseCacheContext.__init__`` -- it requires real
         # KVLayerGroupsManager / shape descriptors that are out of
@@ -68,6 +69,7 @@ class _FakeContext(BaseCacheContext):
         self.engine_group_infos = engine_group_infos
         self.engine_type = engine_type
         self.separate_object_groups = separate_object_groups
+        self.full_sw_kv = full_sw_kv
 
     # ------------------------------------------------------------------
     # Abstract stubs -- never called from these tests.


### PR DESCRIPTION
**What this PR does / why we need it**:
enable blend server with  vLLM's hybrid KV-cache manager (HMA) on multi-group SWA models. Fixed via three changes, all gated on `engine_type == "blend"` (standard prefix-caching unaffected):

1. **Per-group scatter** — `cb_retrieve_pre_computed` takes per-group block tables (`list[list[int]]`) and builds slot_mapping per group.
2. **Single object group** — force `separate_object_groups=False`. CB's scatter is single-group; the default split leaves group 1 unfilled.
3. **Full per-chunk SWA KV** — enable `full_sw_kv`. Sub-chunk window-cut caches are valid only at a chunk's original position, but CacheBlend reuses chunks at arbitrary positions. Threaded into `GPUCacheContext` before buffer/group sizing via `enable_full_sw_kv()` (overrides `get_subchunk_sw_size_tokens`, `get_attn_desc`).

**Special notes for your reviewers**:

- All three key off `engine_type == "blend"`; standard path keeps SWA windowing and object-group separation, so store/transfer volume and prefix-caching semantics are unchanged.
 

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests