### PR TITLE
Share CLI HTTP helpers

### DIFF
--- a/lmcache/cli/commands/describe.py
+++ b/lmcache/cli/commands/describe.py
@@ -8,13 +8,16 @@ Usage::
 
 # Standard
 import argparse
-import json
 import sys
-import urllib.error
-import urllib.request
 
 # First Party
 from lmcache.cli.commands.base import BaseCommand
+from lmcache.cli.http import (
+    CLIHTTPError,
+    DEFAULT_URLS,
+    fetch_json as _fetch_json,
+    normalize_url,
+)
 from lmcache.cli.metrics import Metrics
 
 # -------------------------------------------------------------------
@@ -26,36 +29,16 @@ class DescribeError(Exception):
     """Raised when the describe command cannot fetch or parse status data."""
 
 
-def normalize_url(url: str) -> str:
-    """Ensure *url* has an ``http://`` or ``https://`` scheme."""
-    if not url.startswith(("http://", "https://")):
-        url = f"http://{url}"
-    return url.rstrip("/")
-
-
 def fetch_json(url: str, timeout: int = 10) -> dict:
     """GET *url* and return the parsed JSON body.
 
     Raises:
         DescribeError: On network/HTTP errors.
     """
-    req = urllib.request.Request(url)
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as exc:
-        if exc.code == 503:
-            body = exc.read().decode()
-            try:
-                detail = json.loads(body).get("error", body)
-            except (json.JSONDecodeError, AttributeError):
-                detail = body
-            raise DescribeError(f"Server unhealthy: {detail}") from exc
-        raise DescribeError(f"HTTP {exc.code} from {url}: {exc.reason}") from exc
-    except urllib.error.URLError as exc:
-        raise DescribeError(f"Cannot connect to {url}: {exc.reason}") from exc
-    except OSError as exc:
-        raise DescribeError(f"Cannot connect to {url}: {exc}") from exc
+        return _fetch_json(url, timeout=timeout)
+    except CLIHTTPError as exc:
+        raise DescribeError(str(exc)) from exc
 
 
 def fmt_bytes(n: int) -> str:
@@ -321,7 +304,7 @@ class DescribeCommand(BaseCommand):
         parser.add_argument(
             "--url",
             help="LMCache HTTP server URL (default to http://localhost:8080).",
-            default="http://localhost:8080",
+            default=DEFAULT_URLS["kvcache"],
         )
 
     def execute(self, args: argparse.Namespace) -> None:

--- a/lmcache/cli/commands/ping.py
+++ b/lmcache/cli/commands/ping.py
@@ -16,7 +16,7 @@ import urllib.request
 
 # First Party
 from lmcache.cli.commands.base import BaseCommand
-from lmcache.cli.commands.describe import normalize_url
+from lmcache.cli.http import DEFAULT_URLS, normalize_url
 
 # -------------------------------------------------------------------
 # Constants
@@ -25,11 +25,6 @@ from lmcache.cli.commands.describe import normalize_url
 HEALTH_ENDPOINTS: dict[str, str] = {
     "kvcache": "/healthcheck",
     "engine": "/health",
-}
-
-DEFAULT_URLS: dict[str, str] = {
-    "kvcache": "http://localhost:8080",
-    "engine": "http://localhost:8000",
 }
 
 TITLES: dict[str, str] = {

--- a/lmcache/cli/http.py
+++ b/lmcache/cli/http.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared HTTP helpers for CLI commands."""
+
+# Standard
+from typing import Any
+import json
+import urllib.error
+import urllib.request
+
+DEFAULT_URLS: dict[str, str] = {
+    "kvcache": "http://localhost:8080",
+    "engine": "http://localhost:8000",
+}
+
+
+class CLIHTTPError(Exception):
+    """Raised when a CLI HTTP request fails."""
+
+
+def normalize_url(url: str) -> str:
+    """Ensure *url* has an ``http://`` or ``https://`` scheme."""
+    if not url.startswith(("http://", "https://")):
+        url = f"http://{url}"
+    return url.rstrip("/")
+
+
+def fetch_json(url: str, timeout: int = 10) -> dict[str, Any]:
+    """GET *url* and return the parsed JSON body.
+
+    Raises:
+        CLIHTTPError: On network/HTTP errors.
+    """
+    req = urllib.request.Request(url)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 503:
+            body = exc.read().decode()
+            try:
+                detail = json.loads(body).get("error", body)
+            except (json.JSONDecodeError, AttributeError):
+                detail = body
+            raise CLIHTTPError(f"Server unhealthy: {detail}") from exc
+        raise CLIHTTPError(f"HTTP {exc.code} from {url}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise CLIHTTPError(f"Cannot connect to {url}: {exc.reason}") from exc
+    except OSError as exc:
+        raise CLIHTTPError(f"Cannot connect to {url}: {exc}") from exc


### PR DESCRIPTION
## Summary
- Add `lmcache.cli.http` with shared CLI default URLs, URL normalization, and JSON GET fetching.
- Update `describe` to use the shared HTTP helper while preserving `DescribeError`, `fetch_json`, and existing error messages.
- Update `ping` to use the shared default URLs and URL normalization.

Fixes #3868

## Tests
- `ruff format lmcache/cli/http.py lmcache/cli/commands/describe.py lmcache/cli/commands/ping.py`
- `ruff check lmcache/cli/http.py lmcache/cli/commands/describe.py lmcache/cli/commands/ping.py`
- `PYTHONPATH=. pytest --confcutdir=tests/cli tests/cli/test_describe.py tests/cli/test_ping.py -q`