### PR TITLE
[Examples] Add Dynamo + LMCache MP integration recipe (aggregated + disaggregated)

### DIFF
--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -1,0 +1,65 @@
+# Dynamo + LMCache MP integration
+
+Recipes for running [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) vLLM
+serving with KV cache offloaded to an **LMCache multiprocess (mp) server**, in
+both **aggregated** and **disaggregated** modes.
+
+In mp mode LMCache runs as an out-of-process cache engine. vLLM workers attach
+to it through the `LMCacheMPConnector` and share KV tensors over CUDA IPC, so
+`sharedMemory` is disabled (LMCache owns `/dev/shm`) and `hostIPC` is enabled.
+
+## Layout
+
+| Path | What it is |
+|------|------------|
+| [`deploy/lmcache_engine.yaml`](deploy/lmcache_engine.yaml) | `LMCacheEngine` CR for the shared MP server. Apply **before** the workers. |
+| [`deploy/agg_lmcache_mp.yaml`](deploy/agg_lmcache_mp.yaml) | Kubernetes `DynamoGraphDeployment`, aggregated (single worker). |
+| [`deploy/disagg_lmcache_mp.yaml`](deploy/disagg_lmcache_mp.yaml) | Kubernetes `DynamoGraphDeployment`, disaggregated (prefill + decode workers). |
+| [`launch/agg_lmcache_mp.sh`](launch/agg_lmcache_mp.sh) | Local single-node launch script, aggregated (1 GPU). |
+| [`launch/disagg_lmcache_mp.sh`](launch/disagg_lmcache_mp.sh) | Local single-node launch script, disaggregated (2 GPUs). |
+
+## The LMCacheEngine (shared prerequisite)
+
+[`deploy/lmcache_engine.yaml`](deploy/lmcache_engine.yaml) declares the MP
+server that both the aggregated and disaggregated workers attach to. The
+LMCache operator reconciles the CR into:
+
+- a per-node **manager DaemonSet** pod (the LMCache server that holds the CPU
+  KV pool), and
+- a **ConfigMap** named `<metadata.name>-connection` (i.e. `lmcache-mp-connection`),
+  which the vLLM workers mount at `/etc/lmcache` and read as
+  `--kv-transfer-config`.
+
+It must live in the **same namespace** as the workers (`default`) so the
+connection ConfigMap is created where the workers can mount it.
+
+**Version pinning**: the server's bundled lmcache must be wire-compatible with
+the worker's. The worker image `vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.3`
+ships lmcache `0.4.4` (vLLM `0.20.1`), and the recipe pairs it with the
+guide-validated server build `nightly-2026-04-25` (lmcache `0.4.5.dev31`, a
+pre-stable build wire-compatible with that worker). Replace `my-tag` in each
+manifest accordingly.
+
+## Usage
+
+The `deploy/` manifests are applied with `kubectl` against a cluster that
+already has the Dynamo platform and the LMCache operator installed. Apply the
+`LMCacheEngine` first, then one of the worker manifests:
+
+```bash
+kubectl apply -n default -f deploy/lmcache_engine.yaml
+kubectl apply -n default -f deploy/disagg_lmcache_mp.yaml   # or agg_lmcache_mp.yaml
+```
+
+See the [Kubernetes deployment guide](../../docs/source/mp/deployment.rst) for
+the full step-by-step (platform install, operator, namespace, HF token Secret,
+then `kubectl apply`).
+
+The `launch/` scripts are the single-node local equivalents. They run **inside
+the Dynamo `vllm-runtime` container** and source Dynamo's
+`examples/common/{gpu_utils,launch_utils}.sh` helpers, so run them from a Dynamo
+checkout (or copy them into `examples/backends/vllm/launch/`).
+
+> The deploy manifests pin the worker image to `my-tag` and the
+> `LMCacheEngine` image separately; keep the two wire-compatible (see the
+> validated pairings in the deployment guide).

--- a/examples/dynamo_integration/deploy/agg_lmcache_mp.yaml
+++ b/examples/dynamo_integration/deploy/agg_lmcache_mp.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg-lmcache
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      sharedMemory:
+        disabled: true
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+            - name: PYTHONHASHSEED
+              value: "0"
+          volumeMounts:
+            - name: kv-transfer-config
+              mountPath: /etc/lmcache
+              readOnly: true
+          command:
+            - /bin/sh
+            - -c
+            - exec python3 -m dynamo.vllm "$@" --kv-transfer-config "$(cat /etc/lmcache/kv-transfer-config.json)"
+            - --
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disable-hybrid-kv-cache-manager
+        volumes:
+          - name: kv-transfer-config
+            configMap:
+              name: lmcache-mp-connection   # = <LMCacheEngine.metadata.name>-connection
+
+        # Required for CUDA IPC between vLLM and LMCache
+        hostIPC: true

--- a/examples/dynamo_integration/deploy/agg_lmcache_mp.yaml
+++ b/examples/dynamo_integration/deploy/agg_lmcache_mp.yaml
@@ -31,8 +31,6 @@ spec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
-          securityContext:
-            runAsUser: 0
           env:
             - name: PYTHONHASHSEED
               value: "0"

--- a/examples/dynamo_integration/deploy/agg_lmcache_mp.yaml
+++ b/examples/dynamo_integration/deploy/agg_lmcache_mp.yaml
@@ -32,7 +32,6 @@ spec:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
           securityContext:
-            privileged: true
             runAsUser: 0
           env:
             - name: PYTHONHASHSEED

--- a/examples/dynamo_integration/deploy/disagg_lmcache_mp.yaml
+++ b/examples/dynamo_integration/deploy/disagg_lmcache_mp.yaml
@@ -34,8 +34,6 @@ spec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
-          securityContext:
-            runAsUser: 0
           env:
             - name: PYTHONHASHSEED
               value: "0"
@@ -75,8 +73,6 @@ spec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
-          securityContext:
-            runAsUser: 0
           env:
             - name: PYTHONHASHSEED
               value: "0"

--- a/examples/dynamo_integration/deploy/disagg_lmcache_mp.yaml
+++ b/examples/dynamo_integration/deploy/disagg_lmcache_mp.yaml
@@ -35,7 +35,6 @@ spec:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
           securityContext:
-            privileged: true
             runAsUser: 0
           env:
             - name: PYTHONHASHSEED
@@ -77,7 +76,6 @@ spec:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
           securityContext:
-            privileged: true
             runAsUser: 0
           env:
             - name: PYTHONHASHSEED

--- a/examples/dynamo_integration/deploy/disagg_lmcache_mp.yaml
+++ b/examples/dynamo_integration/deploy/disagg_lmcache_mp.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-lmcache
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      # mp mode: LMCache owns /dev/shm
+      sharedMemory:
+        disabled: true
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        # mp mode: CUDA IPC between vLLM and the LMCache process
+        hostIPC: true
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+            - name: PYTHONHASHSEED
+              value: "0"
+          volumeMounts:
+            - name: kv-transfer-config
+              mountPath: /etc/lmcache
+              readOnly: true
+          command:
+            - /bin/sh
+            - -c
+            - exec python3 -m dynamo.vllm "$@" --kv-transfer-config "$(cat /etc/lmcache/kv-transfer-config.json)"
+            - --
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - decode
+            - --disable-hybrid-kv-cache-manager
+        volumes:
+          - name: kv-transfer-config
+            configMap:
+              name: lmcache-mp-connection   # = <LMCacheEngine.metadata.name>-connection
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      sharedMemory:
+        disabled: true
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        hostIPC: true
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+            - name: PYTHONHASHSEED
+              value: "0"
+          volumeMounts:
+            - name: kv-transfer-config
+              mountPath: /etc/lmcache
+              readOnly: true
+          command:
+            - /bin/sh
+            - -c
+            - exec python3 -m dynamo.vllm "$@" --kv-transfer-config "$(cat /etc/lmcache/kv-transfer-config.json)"
+            - --
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --disaggregation-mode
+            - prefill
+            - --disable-hybrid-kv-cache-manager
+        volumes:
+          - name: kv-transfer-config
+            configMap:
+              name: lmcache-mp-connection   # = <LMCacheEngine.metadata.name>-connection

--- a/examples/dynamo_integration/deploy/lmcache_engine.yaml
+++ b/examples/dynamo_integration/deploy/lmcache_engine.yaml
@@ -1,0 +1,13 @@
+apiVersion: lmcache.lmcache.ai/v1alpha1
+kind: LMCacheEngine
+metadata:
+  name: lmcache-mp   # produces the "lmcache-mp-connection" ConfigMap the workers mount
+  namespace: default   # must match the namespace the workers are deployed into
+spec:
+  image:
+    repository: lmcache/vllm-openai
+    tag: my-tag
+    pullPolicy: IfNotPresent
+  # L1 (CPU RAM) cache size -- bump for production workloads.
+  l1:
+    sizeGB: 16

--- a/examples/dynamo_integration/launch/agg_lmcache_mp.sh
+++ b/examples/dynamo_integration/launch/agg_lmcache_mp.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+# Explicitly unset PROMETHEUS_MULTIPROC_DIR to let Dynamo manage it internally
+unset PROMETHEUS_MULTIPROC_DIR
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL="Qwen/Qwen3-0.6B"
+
+# ---- Tunable (override via env vars) ----
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
+
+# Default KV cache cap from profiling (2x safety over min=560 MiB); ~3.8 GiB peak VRAM
+# Profiler/test framework overrides via env
+: "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=1119388000}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+
+print_launch_banner "Launching Aggregated Serving (1 GPU) + LMCache" "$MODEL" "$HTTP_PORT"
+
+# Start the LMCache MP server (out-of-process cache engine).
+lmcache server \
+  --l1-size-gb "${LMCACHE_L1_SIZE_GB:-16}" --eviction-policy LRU \
+  --port "$LMCACHE_PORT" --http-port "$LMCACHE_HTTP_PORT" &
+
+# Wait until the server's HTTP admin endpoint is healthy before launching workers.
+for _ in $(seq 1 60); do
+  curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 || {
+  echo "lmcache server failed to become healthy on :$LMCACHE_HTTP_PORT" >&2
+  exit 1
+}
+
+python -m dynamo.frontend &
+
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+  python -m dynamo.vllm --model "$MODEL" --enforce-eager \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+  $GPU_MEM_ARGS \
+  --disable-hybrid-kv-cache-manager \
+  --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT}}" &
+
+# Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit

--- a/examples/dynamo_integration/launch/agg_lmcache_mp.sh
+++ b/examples/dynamo_integration/launch/agg_lmcache_mp.sh
@@ -43,10 +43,10 @@ curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 || {
   exit 1
 }
 
-python -m dynamo.frontend &
+python3 -m dynamo.frontend &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
-  python -m dynamo.vllm --model "$MODEL" --enforce-eager \
+  python3 -m dynamo.vllm --model "$MODEL" --enforce-eager \
   --max-model-len "$MAX_MODEL_LEN" \
   --max-num-seqs "$MAX_CONCURRENT_SEQS" \
   $GPU_MEM_ARGS \

--- a/examples/dynamo_integration/launch/agg_lmcache_mp.sh
+++ b/examples/dynamo_integration/launch/agg_lmcache_mp.sh
@@ -32,9 +32,14 @@ print_launch_banner "Launching Aggregated Serving (1 GPU) + LMCache" "$MODEL" "$
 lmcache server \
   --l1-size-gb "${LMCACHE_L1_SIZE_GB:-16}" --eviction-policy LRU \
   --port "$LMCACHE_PORT" --http-port "$LMCACHE_HTTP_PORT" &
+SERVER_PID=$!
 
 # Wait until the server's HTTP admin endpoint is healthy before launching workers.
 for _ in $(seq 1 60); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "LMCache server process died unexpectedly" >&2
+    exit 1
+  fi
   curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 && break
   sleep 1
 done

--- a/examples/dynamo_integration/launch/disagg_lmcache_mp.sh
+++ b/examples/dynamo_integration/launch/disagg_lmcache_mp.sh
@@ -34,9 +34,14 @@ print_launch_banner "Launching Disaggregated Serving (2 GPUs) + LMCache" "$MODEL
 lmcache server \
   --l1-size-gb "${LMCACHE_L1_SIZE_GB:-16}" --eviction-policy LRU \
   --port "$LMCACHE_PORT" --http-port "$LMCACHE_HTTP_PORT" &
+SERVER_PID=$!
 
 # Wait until the server's HTTP admin endpoint is healthy before launching workers.
 for _ in $(seq 1 60); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "LMCache server process died unexpectedly" >&2
+    exit 1
+  fi
   curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 && break
   sleep 1
 done

--- a/examples/dynamo_integration/launch/disagg_lmcache_mp.sh
+++ b/examples/dynamo_integration/launch/disagg_lmcache_mp.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+# Explicitly unset PROMETHEUS_MULTIPROC_DIR to let Dynamo manage it internally
+unset PROMETHEUS_MULTIPROC_DIR
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL="Qwen/Qwen3-0.6B"
+
+# ---- Tunable (override via env vars) ----
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
+
+# KV cache cap for predictable launches; profiler/test framework overrides via
+# env. Applied per worker process (prefill and decode each get the same value,
+# on their own GPU).
+: "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=1119388000}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+LMCACHE_PORT="${LMCACHE_PORT:-5555}"
+LMCACHE_HTTP_PORT="${LMCACHE_HTTP_PORT:-8080}"
+
+print_launch_banner "Launching Disaggregated Serving (2 GPUs) + LMCache" "$MODEL" "$HTTP_PORT"
+
+# Start the single LMCache mp server (out-of-process cache engine) shared by the
+# prefill and decode workers.
+lmcache server \
+  --l1-size-gb "${LMCACHE_L1_SIZE_GB:-16}" --eviction-policy LRU \
+  --port "$LMCACHE_PORT" --http-port "$LMCACHE_HTTP_PORT" &
+
+# Wait until the server's HTTP admin endpoint is healthy before launching workers.
+for _ in $(seq 1 60); do
+  curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 || {
+  echo "lmcache server failed to become healthy on :$LMCACHE_HTTP_PORT" >&2
+  exit 1
+}
+
+# run ingress
+# dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
+python -m dynamo.frontend &
+
+# run decode worker on GPU 0
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
+  --model "$MODEL" --enforce-eager \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+  $GPU_MEM_ARGS \
+  --disaggregation-mode decode \
+  --disable-hybrid-kv-cache-manager \
+  --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT}}" &
+
+# run prefill worker on GPU 1
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
+CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
+  --model "$MODEL" --enforce-eager \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+  $GPU_MEM_ARGS \
+  --disaggregation-mode prefill \
+  --disable-hybrid-kv-cache-manager \
+  --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":$LMCACHE_PORT}}" &
+
+# Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
+wait_any_exit

--- a/examples/dynamo_integration/launch/disagg_lmcache_mp.sh
+++ b/examples/dynamo_integration/launch/disagg_lmcache_mp.sh
@@ -47,7 +47,7 @@ curl -sf "http://localhost:$LMCACHE_HTTP_PORT/healthcheck" >/dev/null 2>&1 || {
 
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
-python -m dynamo.frontend &
+python3 -m dynamo.frontend &
 
 # run decode worker on GPU 0
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
This PR adds examples/dynamo_integration/, a recipe for running [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) vLLM serving with the KV cache offloaded to an LMCache multiprocess (MP) server, in both aggregated and disaggregated modes.This PR adds examples/dynamo_integration/, a recipe for running NVIDIA Dynamo vLLM serving with the KV cache offloaded to an LMCache multiprocess (MP) server, in both aggregated and disaggregated modes.

It builds on two PRs by @Shaoting-Feng : the Dynamo deploy example ([ai-dynamo/dynamo#10185](https://github.com/ai-dynamo/dynamo/pull/10185)) and the LMCache aggregated guide ([LMCache/LMCache#3500](https://github.com/LMCache/LMCache/pull/3500)).

The aggregated files mirror those, and the disaggregated counterparts (prefill + decode workers sharing one MP server) are added on top. Per Feng's advice to validate this in LMCache before opening it on the Dynamo repo, I'm landing it here first.


The structure is as follows:
```
examples/dynamo_integration/
├── README.md
├── deploy/                    # Kubernetes DynamoGraphDeployment manifests
│   ├── lmcache_engine.yaml    # shared LMCacheEngine (the MP server)
│   ├── agg_lmcache_mp.yaml
│   └── disagg_lmcache_mp.yaml
└── launch/                    # local single-node launch scripts
    ├── agg_lmcache_mp.sh
    └── disagg_lmcache_mp.sh
```

**Special notes for your reviewers**:
I verified the disaggregated MP integration end-to-end on Dynamo 1.2.0 Kubernetes with the NGC vllm-runtime images. A warm request reports cached_tokens > 0, and the MP server records lookup hits. The committed manifests are the generalized (Qwen3-0.6B, my-tag) form of that setup. Advice welcome if anything is missing. cc @Shaoting-Feng 

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
