### PR TITLE
feat: add configurable disk_io_threads for local disk and GDS backends

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -322,6 +322,31 @@ Settings for P2P (peer-to-peer) backend timeout behavior. These configurations a
      - 10000
      - Timeout in milliseconds for socket send operations
 
+Disk I/O Backend Configurations
+---------------------------------
+
+Settings shared by disk-based storage backends (local disk and GDS). These configurations are specified through ``extra_config``.
+
+.. code-block:: yaml
+
+    extra_config:
+      use_odirect: true
+      disk_io_threads: 8
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Configuration Key
+     - Default
+     - Description
+   * - use_odirect
+     - false
+     - Enable O_DIRECT for disk I/O, bypassing the kernel page cache. Recommended when most local CPU memory is already used for KV cache offloading.
+   * - disk_io_threads
+     - 4
+     - Number of worker threads in the disk I/O thread pool. Applies to both the local disk backend and the GDS backend. Increase for higher parallelism on fast NVMe drives. (Replaces the deprecated ``gds_io_threads`` key.)
+
 Nixl (as a storage backend) Configurations
 ------------------------------------------
 

--- a/docs/source/kv_cache/storage_backends/local_storage.rst
+++ b/docs/source/kv_cache/storage_backends/local_storage.rst
@@ -30,7 +30,8 @@ Two ways to configure LMCache Disk Offloading:
 
     # Disable page cache
     # This should be turned on for better performance if most local CPU memory is used
-    export LMCACHE_EXTRA_CONFIG='{'use_odirect': True}'
+    # Optionally tune the number of I/O worker threads (default: 4)
+    export LMCACHE_EXTRA_CONFIG='{"use_odirect": true, "disk_io_threads": 8}'
 
 **2. Configuration File**:
 
@@ -47,7 +48,10 @@ Passed in through ``LMCACHE_CONFIG_FILE=your-lmcache-config.yaml``
 
     # Disable page cache
     # This should be turned on for better performance if most local CPU memory is used
-    extra_config: {'use_odirect': True}
+    # Optionally tune the number of I/O worker threads (default: 4)
+    extra_config:
+      use_odirect: true
+      disk_io_threads: 8
 
 
 Multi-Path (Multi-Device) Disk Offloading
@@ -143,7 +147,7 @@ The following diagram shows the overall architecture of the Local Disk Backend:
             end
             
             subgraph Worker["<b>LocalDiskWorker</b>"]
-                PQ["<b>Priority Queue Executor (4 workers)</b>"]
+                PQ["<b>Priority Queue Executor (configurable workers, default 4)</b>"]
                 P0["<b>Priority 0: PREFETCH</b>"]
                 P1["<b>Priority 1: DELETE</b>"]
                 P2["<b>Priority 2: PUT</b>"]
@@ -172,7 +176,7 @@ The following diagram shows the overall architecture of the Local Disk Backend:
 
 - **Metadata Dictionary**: Maps each ``CacheEngineKey`` to its disk metadata (file path, size, shape, dtype, pin status)
 - **Cache Policy**: Configurable eviction policy (LRU, LFU, FIFO, or MRU) that tracks access patterns and decides which entries to evict when space is needed
-- **LocalDiskWorker**: Async task executor with priority queue - prefetch tasks run first (priority 0), then deletes (priority 1), then saves (priority 2)
+- **LocalDiskWorker**: Async task executor with priority queue - prefetch tasks run first (priority 0), then deletes (priority 1), then saves (priority 2). The number of I/O worker threads is configurable via ``extra_config.disk_io_threads`` (default: 4).
 - **Local Disk**: Filesystem where KV cache chunks are stored as individual ``.pt`` files
 
 

--- a/docs/source/kv_cache/storage_backends/weka.rst
+++ b/docs/source/kv_cache/storage_backends/weka.rst
@@ -28,7 +28,7 @@ Ways to configure LMCache WEKA Offloading
     # CPU can get in the way of GPUDirect operations
     export LMCACHE_LOCAL_CPU=False
     # GDS I/O Threads
-    export LMCACHE_EXTRA_CONFIG='{"gds_io_threads": 32}'
+    export LMCACHE_EXTRA_CONFIG='{"disk_io_threads": 32}'
 
 **2. Configuration File**:
 
@@ -48,7 +48,7 @@ Example ``config.yaml``:
     gds_buffer_size: 8192
     # GDS I/O Threads
     extra_config:
-      gds_io_threads: 32
+      disk_io_threads: 32
 
 GDS Buffer Size Explanation
 ---------------------------
@@ -110,7 +110,7 @@ Create a an lmcache configuration file called: ``weka-offload.yaml``
     gds_path: "/mnt/weka/cache"
     gds_buffer_size: 8192
     extra_config:
-      gds_io_threads: 32
+      disk_io_threads: 32
 
 If you don't want to use a config file, uncomment the first three environment variables
 and then comment out the ``LMCACHE_CONFIG_FILE`` below:
@@ -121,7 +121,7 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
     # LMCACHE_CHUNK_SIZE=256 \
     # LMCACHE_GDS_PATH="/mnt/weka/cache" \
     # LMCACHE_GDS_BUFFER_SIZE=8192 \
-    # LMCACHE_EXTRA_CONFIG='{"gds_io_threads": 32}' \
+    # LMCACHE_EXTRA_CONFIG='{"disk_io_threads": 32}' \
     LMCACHE_CONFIG_FILE="weka-offload.yaml" \
     vllm serve \
         meta-llama/Llama-3.1-8B-Instruct \

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -271,9 +271,14 @@ class GdsBackend(AllocatorBackendInterface):
         if self.use_thread_pool:
             thread_count = _DEFAULT_THREAD_COUNT
             if config.extra_config is not None:
-                thread_count = config.extra_config.get(
-                    "gds_io_threads", _DEFAULT_THREAD_COUNT
-                )
+                if "disk_io_threads" in config.extra_config:
+                    thread_count = config.extra_config["disk_io_threads"]
+                elif "gds_io_threads" in config.extra_config:
+                    logger.warning(
+                        "extra_config.gds_io_threads is deprecated; "
+                        "use disk_io_threads instead."
+                    )
+                    thread_count = config.extra_config["gds_io_threads"]
             self._thread_pool = ThreadPoolExecutor(
                 max_workers=thread_count, thread_name_prefix="gds-io"
             )

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -35,18 +35,21 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+_DEFAULT_THREAD_COUNT = 4
+
 
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
 class LocalDiskWorker:
-    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+    def __init__(
+        self, loop: asyncio.AbstractEventLoop, max_workers: int = _DEFAULT_THREAD_COUNT
+    ) -> None:
         self.put_lock = threading.Lock()
         self.put_tasks: List[CacheEngineKey] = []
 
         self.prefetch_lock = threading.Lock()
         self.prefetch_tasks: dict[CacheEngineKey, Future] = {}
 
-        # TODO(Jiayi): make executor and its parameters configurable
-        self.executor = AsyncPQThreadPoolExecutor(loop, max_workers=4)
+        self.executor = AsyncPQThreadPoolExecutor(loop, max_workers=max_workers)
         self.loop = loop
         self._closed = False
 
@@ -151,7 +154,10 @@ class LocalDiskBackend(StorageBackendInterface):
             self.use_odirect = config.extra_config.get("use_odirect", False)
         logger.info("Using O_DIRECT for disk I/O: %s", self.use_odirect)
 
-        self.disk_worker = LocalDiskWorker(loop)
+        thread_count = config.get_extra_config_value(
+            "disk_io_threads", _DEFAULT_THREAD_COUNT
+        )
+        self.disk_worker = LocalDiskWorker(loop, max_workers=thread_count)
 
         # TODO(Jiayi): We need a disk space allocator to avoid fragmentation
         # and hide the following details away from the backend.


### PR DESCRIPTION
The I/O thread pool size was hardcoded at 4 in LocalDiskBackend and read from gds_io_threads in GdsBackend. Consolidate both behind a single extra_config key, disk_io_threads (default 4).

- LocalDiskBackend: add _DEFAULT_THREAD_COUNT constant, accept max_workers in LocalDiskWorker, read disk_io_threads from extra_config.
- GdsBackend: read disk_io_threads, fall back to deprecated gds_io_threads with a warning.
- Docs: add "Disk I/O Backend Configurations" section to configurations.rst, update local_storage.rst and weka.rst.

Generated with [Devin](https://devin.ai)

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
