### PR TITLE
feat(operator): make engine DaemonSet privileged mode optional

### DIFF
--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -318,8 +318,8 @@ L2 Storage
      - List of L2 backends (``type`` + ``config``).
        See :doc:`l2_storage/index`.
 
-GPU Vendor
-~~~~~~~~~~
+GPU & Security
+~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -331,7 +331,16 @@ GPU Vendor
    * - ``gpuVendor``
      - ``nvidia``
      - GPU vendor: ``nvidia`` (uses the ``nvidia`` RuntimeClass) or ``amd``
-       (runs on the default runtime with ``privileged: true``).
+       (runs on the default runtime).
+   * - ``privileged``
+     - ``false``
+     - Run the engine container in privileged mode. On most clusters
+       ``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all`` already
+       grant GPU visibility without it; set ``true`` only where the engine
+       cannot otherwise see the GPUs. Required for ``gpuVendor: amd`` (no
+       RuntimeClass device injection, so privileged is the only path to
+       ``/dev/kfd``/``/dev/dri``). Enabling it requires the namespace to allow
+       the ``privileged`` Pod Security Standard.
 
 Scheduling
 ~~~~~~~~~~
@@ -626,9 +635,10 @@ It has two halves the operator runs together:
 
 - a GPU-resident CacheBlend V3 engine (``lmcache server --engine-type blend``),
   deployed as a DaemonSet with the **same GPU model as** ``LMCacheEngine``
-  (``privileged`` + ``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all``
-  + ``hostIPC``, and **no** ``nvidia.com/gpu`` claim) so it shares the vLLM GPU
-  for same-device CUDA IPC; and
+  (``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all`` + ``hostIPC``,
+  plus ``privileged`` when ``spec.privileged`` is set, and **no**
+  ``nvidia.com/gpu`` claim) so it shares the vLLM GPU for same-device CUDA IPC;
+  and
 - the vLLM-side plugin, injected into opted-in pods by the webhook.
 
 Additional Prerequisites
@@ -1082,6 +1092,10 @@ resources from other processes on the same host.
 - Clusters using Pod Security Standards must allow the ``privileged`` profile
   for the LMCache namespace -- the ``baseline`` and ``restricted`` profiles
   reject ``hostIPC``.
+- ``spec.privileged`` defaults to ``false``. When enabled (required for
+  ``gpuVendor: amd``), the engine container additionally runs privileged,
+  granting it full device access -- enable it only where GPU visibility
+  requires it.
 
 Development
 -----------

--- a/operator/AGENTS.md
+++ b/operator/AGENTS.md
@@ -101,8 +101,11 @@ Both names point at the same image; only the hostnames differ.
 
 - **PodSecurity admission**: test namespaces are pre-labeled
   `pod-security.kubernetes.io/enforce=privileged` so the operator's
-  DaemonSet (which sets `hostIPC=true` + `privileged=true`) is accepted
-  at admission time. Harmless on clusters that don't enforce PodSecurity.
+  DaemonSet (which always sets `hostIPC=true`, and `privileged=true` only
+  when `spec.privileged` is enabled) is accepted at admission time.
+  `hostIPC=true` alone is rejected by the `baseline`/`restricted` profiles,
+  so the label is required regardless of `privileged`. Harmless on clusters
+  that don't enforce PodSecurity.
 - **SCC (Security Context Constraints)**: M1 smokes never wait for
   DaemonSet pods to schedule, so SCC isn't a blocker. If you need pods
   to actually run later (M2/M3 GPU tier), grant the LMCache

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -143,6 +143,12 @@ spec:
   serviceAccountName: string
   priorityClassName: string
 
+  # -- Security --
+  privileged: bool            # default: false; run the engine container in
+                              # privileged mode. Needed only on clusters where
+                              # the engine cannot see the node GPUs otherwise
+                              # (see "Auto-managed Pod Settings" below).
+
   # -- Extra CLI flags --
   extraArgs: []string         # appended last, can override any auto-generated flag
 ```
@@ -155,13 +161,13 @@ The operator always injects these into the pod spec:
 
 - **`hostIPC: true`** — **required for CUDA IPC between LMCache and vLLM.** LMCache uses `CudaIPCWrapper` which calls PyTorch's `_share_cuda_()` to get a GPU driver-level IPC handle. The handle is serialized and sent over ZMQ TCP. The receiving process reconstructs the tensor via `cudaIpcOpenMemHandle` at the driver level. This call requires both processes to share the same IPC namespace — without `hostIPC: true`, `cudaIpcOpenMemHandle` fails with `cudaErrorMapBufferObjectFailed`. **Both the LMCache pods and vLLM pods must have `hostIPC: true`.**
 - **`runtimeClassName: nvidia`** — uses the NVIDIA container runtime, which injects the host's NVIDIA driver libraries and device files into the container. This is required for CUDA to function inside the pod.
-- **`privileged: true`** (security context) — **required for GPU visibility without explicit GPU resource requests.** LMCache needs access to all GPUs on the node for CUDA IPC and custom data transfer kernels, but it must not claim any GPUs via `nvidia.com/gpu` resource requests (otherwise those GPUs would be unavailable to the serving engine). The combination of `runtimeClassName: nvidia` + `privileged: true` + `NVIDIA_VISIBLE_DEVICES=all` allows the container to see all GPUs without consuming device plugin resources. This means the serving engine (e.g., vLLM) can still request all GPUs on the node.
+- **`NVIDIA_VISIBLE_DEVICES=all`** — gives the engine access to all GPUs on the node for CUDA IPC and custom data transfer kernels without claiming any via `nvidia.com/gpu` resource requests (which would make those GPUs unavailable to the serving engine). The combination of `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` lets the container see all GPUs without consuming device-plugin resources, so the serving engine (e.g., vLLM) can still request all GPUs on the node. On most clusters this is sufficient; on some, the engine cannot see the GPUs unless the pod is also privileged — set `spec.privileged: true` to run the engine container privileged (default `false`).
 - **`NVIDIA_VISIBLE_DEVICES=all`** and **`NVIDIA_DRIVER_CAPABILITIES=all`** — env vars that instruct the NVIDIA container runtime to expose all GPUs and all driver capabilities to the container.
 - **`--host 0.0.0.0`** — always passed as a container arg. The server defaults to `--host localhost` which only binds to loopback; the server must bind to all interfaces so the node-local Service can route traffic to it.
 - **No `hostNetwork`** — the operator does **not** use `hostNetwork`. Instead, it creates a ClusterIP Service with `internalTrafficPolicy=Local`. kube-proxy ensures that traffic to the service is routed only to the LMCache pod on the same node. This avoids occupying host ports and reduces the privileged surface area.
 - **No `/dev/shm` emptyDir mount** — the operator intentionally does *not* mount an emptyDir at `/dev/shm`. With `hostIPC: true`, the container already sees the host's `/dev/shm`. Mounting an emptyDir would shadow the host's `/dev/shm` with a private tmpfs, breaking CUDA IPC (`cudaIpcOpenMemHandle` fails because IPC handles written by one pod are invisible to others). If your workload needs a larger `/dev/shm` for non-IPC purposes, add it via `spec.volumes` / `spec.volumeMounts`.
 
-> **Security implications:** The LMCache pods run with `privileged: true` and `hostIPC: true`. This exposes the host's IPC namespace and grants full device access to the container. This is required for GPU visibility and CUDA IPC. Only deploy in trusted environments. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace — the `baseline` and `restricted` profiles reject these settings.
+> **Security implications:** The LMCache pods run with `hostIPC: true` (required for CUDA IPC), which exposes the host's IPC namespace. When `spec.privileged: true` is set they additionally run privileged, granting full device access to the container. Only deploy in trusted environments. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace whenever `hostIPC`/`privileged` are in use — the `baseline` and `restricted` profiles reject these settings.
 
 ---
 
@@ -327,7 +333,7 @@ OnEvent(LMCacheEngine create/update/delete):
    - memoryLimit = ceil(memoryRequest * 1.5) Gi
    - containerArgs from all spec fields
 3. RECONCILE DaemonSet (CreateOrUpdate, ownerRef)
-   - Always inject: hostIPC, runtimeClassName: nvidia, privileged: true, --host 0.0.0.0
+   - Always inject: hostIPC, runtimeClassName: nvidia, NVIDIA_VISIBLE_DEVICES=all, --host 0.0.0.0 (privileged only when spec.privileged=true)
 4. RECONCILE node-local lookup Service (internalTrafficPolicy=Local)
 5. RECONCILE headless Service for metrics
 6. RECONCILE connection ConfigMap
@@ -394,8 +400,9 @@ l2Backend, scheduling, overrides, imagePullSecrets) and adds:
 DaemonSet running `lmcache server --engine-type blend` (plus
 `--l1-align-bytes 16777216`), a node-local lookup Service, a metrics Service, and
 a `<name>-connection` ConfigMap. **GPU model is identical to `LMCacheEngine`**:
-`privileged` + `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` +
-`hostIPC: true`, with **no `nvidia.com/gpu` device-plugin claim** — the engine
+`runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` + `hostIPC: true` (and
+`privileged` when `spec.privileged=true`), with **no `nvidia.com/gpu`
+device-plugin claim** — the engine
 *shares* the vLLM GPU rather than reserving one, because the blend server scatters
 re-RoPE'd KV directly into vLLM's paged KV over **same-device CUDA IPC**. The
 engine resource builders are the same name/spec-keyed cores used by

--- a/operator/README.md
+++ b/operator/README.md
@@ -14,9 +14,12 @@ See [DESIGN.md](DESIGN.md) for architecture details, reconciliation logic, and C
 - (CacheBlend only) [cert-manager](https://cert-manager.io) for the injection webhook's serving cert — see [CacheBlend](#cacheblend) below
 
 > [!IMPORTANT]
-> By default the operator runs LMCache pods with `runtimeClassName: nvidia` and `privileged: true` to gain GPU visibility without consuming GPU resources via the device plugin. This allows the serving engine (e.g., vLLM) to claim all GPUs on the node. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace.
+> By default the operator runs LMCache pods with `runtimeClassName: nvidia` and `NVIDIA_VISIBLE_DEVICES=all` to gain GPU visibility without consuming GPU resources via the device plugin. This allows the serving engine (e.g., vLLM) to claim all GPUs on the node. On most clusters that is enough; on some, the engine cannot see the GPUs unless the pod is also privileged. Set `spec.privileged: true` to run the engine container in privileged mode (default `false`). When it is enabled, clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace.
 >
 > On AMD ROCm clusters, `spec.gpuVendor: amd` omits `runtimeClassName` and skips NVIDIA-specific env vars.
+
+> [!WARNING]
+> **Upgrade note:** earlier operator versions always ran the engine container privileged. `spec.privileged` now defaults to `false`. Upgrading rewrites the DaemonSet pod template (forcing a rolling pod replacement), and on any cluster where privileged was load-bearing for GPU visibility the engine pods will come back up **without** GPU access. If your cluster relied on privileged mode (always the case for `gpuVendor: amd`), set `spec.privileged: true` on existing CRs before upgrading.
 
 ## Quick Start
 
@@ -53,7 +56,7 @@ The minimal CR just needs `l1.sizeGB`. Apply the sample (a fully-commented field
 kubectl apply -f config/samples/lmcache_v1alpha1_lmcacheengine.yaml
 ```
 
-The operator automatically handles `hostIPC`, GPU visibility (`runtimeClassName: nvidia`, `privileged: true`), node-local service routing, resource sizing, and Prometheus metrics — see [DESIGN.md](DESIGN.md) for details.
+The operator automatically handles `hostIPC`, GPU visibility (`runtimeClassName: nvidia`, `NVIDIA_VISIBLE_DEVICES=all`; set `spec.privileged: true` if your cluster also needs privileged mode), node-local service routing, resource sizing, and Prometheus metrics — see [DESIGN.md](DESIGN.md) for details.
 
 ### 3. Connect vLLM to LMCache
 
@@ -112,7 +115,7 @@ Every scenario has a ready-to-edit manifest under [`config/samples/`](config/sam
 Notes:
 
 - **GPU targeting** — `nodeSelector: {nvidia.com/gpu.present: "true"}` runs LMCache only on GPU nodes; new GPU nodes auto-get a pod.
-- **AMD (ROCm)** — `spec.gpuVendor: amd` omits `runtimeClassName` and the NVIDIA env vars; vLLM connects via HIP IPC over `hostIPC` the same way (`PYTHONHASHSEED=0` still required). Supply a `nodeSelector` matching your platform's AMD label and a ROCm-built `spec.image`.
+- **AMD (ROCm)** — `spec.gpuVendor: amd` omits `runtimeClassName` and the NVIDIA env vars; vLLM connects via HIP IPC over `hostIPC` the same way (`PYTHONHASHSEED=0` still required). Supply a `nodeSelector` matching your platform's AMD label and a ROCm-built `spec.image`. AMD has no RuntimeClass-based device injection, so set `spec.privileged: true` to let the engine reach `/dev/kfd`/`/dev/dri` (see the [AMD sample](config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml)).
 - **Custom port** — set `server.port`; the connection ConfigMap updates automatically and vLLM picks it up on restart.
 - **L2 adapters** — only one at a time today. Redis/Valkey is natively typed; cross-namespace auth Secrets are copied automatically and injected via env (never in args or `kubectl describe`). Other types (`nixl_store`, `fs`, `mock`, `raw_block`) use the `raw` escape hatch — see the commented blocks in the minimal sample. For `raw_block` with `use_odirect: true`, `--l1-align-bytes` must be ≥ `block_align`.
 - **Resources** auto-compute from `l1.sizeGB`; override with `resourceOverrides`.

--- a/operator/api/v1alpha1/cacheblendengine_types.go
+++ b/operator/api/v1alpha1/cacheblendengine_types.go
@@ -95,7 +95,7 @@ type InjectionSpec struct {
 type CacheBlendEngineSpec struct {
 	// gpuVendor selects the GPU vendor. "nvidia" (default) requires the NVIDIA
 	// GPU Operator's "nvidia" RuntimeClass; "amd" runs on the default container
-	// runtime with privileged: true.
+	// runtime.
 	// +optional
 	// +kubebuilder:default="nvidia"
 	// +kubebuilder:validation:Enum=nvidia;amd
@@ -195,6 +195,16 @@ type CacheBlendEngineSpec struct {
 	// priorityClassName is the priority class for the pods.
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// privileged runs the engine container in privileged mode. On some clusters
+	// this is required for the engine to see all node GPUs (for CUDA IPC) without
+	// claiming any via the nvidia.com/gpu device plugin; on many clusters
+	// NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
+	// defaults to false. Set it to true only on clusters where the engine cannot
+	// otherwise see the GPUs.
+	// +optional
+	// +kubebuilder:default=false
+	Privileged *bool `json:"privileged,omitempty"`
 
 	// extraArgs are additional CLI flags appended to the server command.
 	// They are appended last and can override any auto-generated flag.

--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -299,7 +299,7 @@ type CoordinatorConnectionSpec struct {
 type LMCacheEngineSpec struct {
 	// gpuVendor selects the GPU vendor. "nvidia" (default) requires the NVIDIA
 	// GPU Operator's "nvidia" RuntimeClass; "amd" runs on the default container
-	// runtime with privileged: true.
+	// runtime.
 	// +optional
 	// +kubebuilder:default="nvidia"
 	// +kubebuilder:validation:Enum=nvidia;amd
@@ -394,6 +394,15 @@ type LMCacheEngineSpec struct {
 	// +optional
 	// +kubebuilder:default=false
 	HostNetwork *bool `json:"hostNetwork,omitempty"`
+
+	// privileged runs the engine container in privileged mode. On some clusters
+	// this is required for the engine to see all node GPUs (for CUDA IPC) without
+	// claiming any via the nvidia.com/gpu device plugin; on many clusters
+	// NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
+	// defaults to false.
+	// +optional
+	// +kubebuilder:default=false
+	Privileged *bool `json:"privileged,omitempty"`
 
 	// extraArgs are additional CLI flags appended to the server command.
 	// They are appended last and can override any auto-generated flag.

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -229,6 +229,11 @@ func (in *CacheBlendEngineSpec) DeepCopyInto(out *CacheBlendEngineSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Privileged != nil {
+		in, out := &in.Privileged, &out.Privileged
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ExtraArgs != nil {
 		in, out := &in.ExtraArgs, &out.ExtraArgs
 		*out = make([]string, len(*in))
@@ -882,6 +887,11 @@ func (in *LMCacheEngineSpec) DeepCopyInto(out *LMCacheEngineSpec) {
 	}
 	if in.HostNetwork != nil {
 		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
+	if in.Privileged != nil {
+		in, out := &in.Privileged, &out.Privileged
 		*out = new(bool)
 		**out = **in
 	}

--- a/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
@@ -1209,10 +1209,10 @@ spec:
                     type: number
                   policy:
                     default: LRU
-                    description: policy is the eviction policy. Currently only LRU
-                      is supported.
+                    description: policy is the eviction policy. LRU or noop.
                     enum:
                     - LRU
+                    - noop
                     type: string
                   triggerWatermark:
                     default: 0.8
@@ -1232,7 +1232,7 @@ spec:
                 description: |-
                   gpuVendor selects the GPU vendor. "nvidia" (default) requires the NVIDIA
                   GPU Operator's "nvidia" RuntimeClass; "amd" runs on the default container
-                  runtime with privileged: true.
+                  runtime.
                 enum:
                 - nvidia
                 - amd
@@ -1388,6 +1388,7 @@ spec:
                       cache misses. "default" picks the first adapter that has the key.
                     enum:
                     - default
+                    - retain
                     type: string
                   raw:
                     description: |-
@@ -1499,6 +1500,20 @@ spec:
               priorityClassName:
                 description: priorityClassName is the priority class for the pods.
                 type: string
+              privileged:
+                default: false
+                description: |-
+                  privileged runs the engine container in privileged mode. On some clusters
+                  this is required for the engine to see all node GPUs (for CUDA IPC) without
+                  claiming any via the nvidia.com/gpu device plugin; on many clusters
+                  NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
+                  defaults to false. Set it to true only on clusters where the engine cannot
+                  otherwise see the GPUs. For gpuVendor "amd" this is effectively required:
+                  there is no NVIDIA-style RuntimeClass device injection, so privileged mode
+                  is the only way the engine reaches /dev/kfd and /dev/dri. Clusters using Pod
+                  Security Standards must allow the privileged profile for this namespace when
+                  it is enabled. Default: false.
+                type: boolean
               prometheus:
                 description: prometheus defines Prometheus monitoring configuration.
                 properties:

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -1188,10 +1188,10 @@ spec:
                     type: number
                   policy:
                     default: LRU
-                    description: policy is the eviction policy. Currently only LRU
-                      is supported.
+                    description: policy is the eviction policy. LRU or noop.
                     enum:
                     - LRU
+                    - noop
                     type: string
                   triggerWatermark:
                     default: 0.8
@@ -1211,7 +1211,7 @@ spec:
                 description: |-
                   gpuVendor selects the GPU vendor. "nvidia" (default) requires the NVIDIA
                   GPU Operator's "nvidia" RuntimeClass; "amd" runs on the default container
-                  runtime with privileged: true.
+                  runtime.
                 enum:
                 - nvidia
                 - amd
@@ -1298,6 +1298,7 @@ spec:
                       cache misses. "default" picks the first adapter that has the key.
                     enum:
                     - default
+                    - retain
                     type: string
                   raw:
                     description: |-
@@ -1408,6 +1409,20 @@ spec:
               priorityClassName:
                 description: priorityClassName is the priority class for the pods.
                 type: string
+              privileged:
+                default: false
+                description: |-
+                  privileged runs the engine container in privileged mode. On some clusters
+                  this is required for the engine to see all node GPUs (for CUDA IPC) without
+                  claiming any via the nvidia.com/gpu device plugin; on many clusters
+                  NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
+                  defaults to false. Set it to true only on clusters where the engine cannot
+                  otherwise see the GPUs. For gpuVendor "amd" this is effectively required:
+                  there is no NVIDIA-style RuntimeClass device injection, so privileged mode
+                  is the only way the engine reaches /dev/kfd and /dev/dri. Clusters using Pod
+                  Security Standards must allow the privileged profile for this namespace when
+                  it is enabled. Default: false.
+                type: boolean
               prometheus:
                 description: prometheus defines Prometheus monitoring configuration.
                 properties:

--- a/operator/config/samples/lmcache_v1alpha1_cacheblendengine.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_cacheblendengine.yaml
@@ -70,6 +70,12 @@ spec:
   # -- Logging --
   # logLevel: INFO                # DEBUG | INFO | WARNING | ERROR
 
+  # -- Security --
+  # Run the engine container in privileged mode. Defaults to false. Set to true
+  # only on clusters where the engine cannot see the node GPUs otherwise
+  # (runtimeClassName: nvidia + NVIDIA_VISIBLE_DEVICES=all is enough on most).
+  # privileged: false
+
 # ---------------------------------------------------------------------------
 # To enable CacheBlend on a vLLM pod, label it for the webhook and annotate it
 # with this engine's name. The pod (and this engine) must run in a namespace

--- a/operator/config/samples/lmcache_v1alpha1_lmcacheengine.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_lmcacheengine.yaml
@@ -99,5 +99,13 @@ spec:
   # serviceAccountName: ""
   # priorityClassName: ""
 
+  # -- Security --
+  # Run the engine container in privileged mode. Defaults to false. On most
+  # clusters runtimeClassName: nvidia + NVIDIA_VISIBLE_DEVICES=all is enough for
+  # the engine to see all GPUs; set this to true only on clusters where it
+  # cannot see them otherwise. Requires the namespace to allow the privileged
+  # Pod Security Standard.
+  # privileged: false
+
   # -- Extra CLI flags (appended last, can override any auto-generated flag) --
   # extraArgs: []

--- a/operator/config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml
@@ -4,6 +4,12 @@ metadata:
   name: amd-cache
 spec:
   gpuVendor: amd
+  # AMD has no NVIDIA-style RuntimeClass to inject GPU device files, so the ROCm
+  # engine needs privileged mode to reach /dev/kfd and /dev/dri. (privileged
+  # defaults to false, which suits NVIDIA clusters where NVIDIA_VISIBLE_DEVICES
+  # already exposes the GPUs.) The namespace must allow the privileged Pod
+  # Security Standard.
+  privileged: true
   nodeSelector:
     feature.node.kubernetes.io/amd-gpu: "true"
   l1:

--- a/operator/internal/resources/cacheblend_engine.go
+++ b/operator/internal/resources/cacheblend_engine.go
@@ -84,6 +84,7 @@ func cbSpecToEngineSpec(spec *lmcachev1alpha1.CacheBlendEngineSpec) *lmcachev1al
 		PodLabels:          spec.PodLabels,
 		ServiceAccountName: spec.ServiceAccountName,
 		PriorityClassName:  spec.PriorityClassName,
+		Privileged:         spec.Privileged,
 		ExtraArgs:          spec.ExtraArgs,
 	}
 }
@@ -109,9 +110,10 @@ func BuildCBEngineArgs(spec *lmcachev1alpha1.CacheBlendEngineSpec) []string {
 
 // BuildCBEngineDaemonSet constructs the DaemonSet for the blend_v3 engine of the
 // given CacheBlendEngine. It reuses the shared GPU/security pod-template
-// scaffolding (hostIPC, runtimeClassName=nvidia, privileged, NVIDIA_VISIBLE_DEVICES=all,
-// CPU+memory-only resources with no nvidia.com/gpu claim) so the engine shares the
-// node's GPU via CUDA IPC, and adds the blend-specific server args.
+// scaffolding (hostIPC, runtimeClassName=nvidia, NVIDIA_VISIBLE_DEVICES=all,
+// privileged only when spec.privileged=true (default false), CPU+memory-only
+// resources with no nvidia.com/gpu claim) so the engine shares the node's GPU
+// via CUDA IPC, and adds the blend-specific server args.
 func BuildCBEngineDaemonSet(engine *lmcachev1alpha1.CacheBlendEngine) *appsv1.DaemonSet {
 	engineSpec := cbSpecToEngineSpec(&engine.Spec)
 	return buildDaemonSetCore(

--- a/operator/internal/resources/cacheblend_engine_test.go
+++ b/operator/internal/resources/cacheblend_engine_test.go
@@ -125,9 +125,9 @@ func TestBuildCBEngineDaemonSet_GPUAndSecurity(t *testing.T) {
 	}
 	c := podSpec.Containers[0]
 
-	// privileged: true.
-	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
-		t.Fatal("expected privileged=true")
+	// privileged defaults to false (opt-in via spec.privileged).
+	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || *c.SecurityContext.Privileged {
+		t.Fatal("expected privileged=false by default")
 	}
 
 	// NVIDIA env exposes all GPUs without a device-plugin claim.
@@ -146,6 +146,18 @@ func TestBuildCBEngineDaemonSet_GPUAndSecurity(t *testing.T) {
 	// Blend args present on the container.
 	assertArg(t, c.Args, "--engine-type", "blend")
 	assertArg(t, c.Args, "--l1-align-bytes", "16777216")
+}
+
+func TestBuildCBEngineDaemonSet_PrivilegedEnabled(t *testing.T) {
+	engine := minimalCBEngine()
+	engine.Spec.Privileged = ptr(true)
+	ds := BuildCBEngineDaemonSet(engine)
+	c := ds.Spec.Template.Spec.Containers[0]
+
+	// spec.privileged=true threads through to the container security context.
+	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
+		t.Fatal("expected privileged=true when spec.privileged=true")
+	}
 }
 
 func TestBuildCBEngineDaemonSet_NoGPUResourceClaim(t *testing.T) {
@@ -204,7 +216,8 @@ func TestBuildCBEngineDaemonSet_AMDNoRuntimeClass(t *testing.T) {
 	if podSpec.RuntimeClassName != nil {
 		t.Fatalf("expected nil RuntimeClassName for AMD, got %q", *podSpec.RuntimeClassName)
 	}
-	// Still privileged + hostIPC.
+	// hostIPC is still injected for AMD (privileged stays at its default false
+	// here since the fixture does not opt in).
 	if !podSpec.HostIPC {
 		t.Fatal("expected HostIPC=true even for AMD")
 	}

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -51,9 +51,10 @@ func BuildDaemonSet(engine *lmcachev1alpha1.LMCacheEngine) *appsv1.DaemonSet {
 
 // buildDaemonSetCore constructs the DaemonSet shared by the LMCacheEngine and
 // CacheBlendEngine controllers. It is the single source of truth for the
-// GPU/security pod-template scaffolding (hostIPC, runtimeClassName, privileged,
-// NVIDIA_VISIBLE_DEVICES, resources without a device-plugin GPU claim) so those
-// settings cannot drift between the two engines.
+// GPU/security pod-template scaffolding (hostIPC, runtimeClassName, optional
+// privileged (default false, via spec.Privileged), NVIDIA_VISIBLE_DEVICES,
+// resources without a device-plugin GPU claim) so those settings cannot drift
+// between the two engines.
 //
 // Parameters:
 //   - name, namespace: the owning object's identity, used for labels and metadata.
@@ -80,7 +81,7 @@ func buildDaemonSetCore(
 		rc := nvidiaRuntimeClass
 		runtimeClassName = &rc
 	}
-	privileged := true
+	privileged := derefBool(spec.Privileged, false)
 
 	serverPort := derefInt32(getServerPort(spec), 5555)
 	imgRepo := defaultImageRepo

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -1152,6 +1152,29 @@ func TestBuildDaemonSet_HostNetworkEnabled(t *testing.T) {
 	}
 }
 
+func TestBuildDaemonSet_PrivilegedDefaultFalse(t *testing.T) {
+	// minimalEngine leaves spec.Privileged nil; the operator must not run the
+	// container privileged unless explicitly opted in.
+	ds := BuildDaemonSet(minimalEngine())
+	c := ds.Spec.Template.Spec.Containers[0]
+
+	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || *c.SecurityContext.Privileged {
+		t.Fatal("expected privileged=false by default")
+	}
+}
+
+func TestBuildDaemonSet_PrivilegedEnabled(t *testing.T) {
+	engine := minimalEngine()
+	engine.Spec.Privileged = ptr(true)
+
+	ds := BuildDaemonSet(engine)
+	c := ds.Spec.Template.Spec.Containers[0]
+
+	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
+		t.Fatal("expected privileged=true when spec.privileged=true")
+	}
+}
+
 // hasEnvAll reports whether envs contains an env var named name set to the
 // literal "all" (the value the GPU passthrough vars are always set to).
 func hasEnvAll(envs []corev1.EnvVar, name string) bool {

--- a/operator/test/e2e/crd_smoke_test.go
+++ b/operator/test/e2e/crd_smoke_test.go
@@ -160,10 +160,10 @@ var _ = Describe("LMCacheEngine smoke (no-GPU)", Ordered, func() {
 })
 
 // assertDaemonSetShape verifies the operator's auto-injected pod-level
-// settings: hostIPC, runtimeClassName=nvidia, container privileged
-// security context, --host 0.0.0.0 always present in container args,
-// and the absence of any /dev/shm volume mount that would shadow the
-// host's /dev/shm and break CUDA IPC.
+// settings: hostIPC, runtimeClassName=nvidia, a container security context
+// that is non-privileged by default (privileged is opt-in via spec.privileged),
+// --host 0.0.0.0 always present in container args, and the absence of any
+// /dev/shm volume mount that would shadow the host's /dev/shm and break CUDA IPC.
 func assertDaemonSetShape(ds *appsv1.DaemonSet, expectedServerPort int32) {
 	GinkgoHelper()
 	pod := ds.Spec.Template.Spec
@@ -175,7 +175,8 @@ func assertDaemonSetShape(ds *appsv1.DaemonSet, expectedServerPort int32) {
 	c := pod.Containers[0]
 	Expect(c.SecurityContext).NotTo(BeNil(), "container.securityContext must be set")
 	Expect(c.SecurityContext.Privileged).NotTo(BeNil())
-	Expect(*c.SecurityContext.Privileged).To(BeTrue(), "container.privileged must be true")
+	Expect(*c.SecurityContext.Privileged).To(BeFalse(),
+		"container.privileged must default to false (opt-in via spec.privileged)")
 	Expect(c.Args).To(ContainElements("--host", "0.0.0.0"))
 	Expect(argValue(c.Args, "--port")).To(Equal(fmt.Sprintf("%d", expectedServerPort)))
 

--- a/operator/test/e2e/smoke_helpers_test.go
+++ b/operator/test/e2e/smoke_helpers_test.go
@@ -53,12 +53,13 @@ var nsCounter atomic.Int64
 // each spec gets per-test isolation without relying on package state.
 //
 // The namespace is pre-labeled with the `privileged` PodSecurity profile
-// because the LMCache DaemonSet's pod template sets hostIPC=true and
-// privileged=true. On clusters that enforce PodSecurity admission (OCP
-// in particular), a `restricted` namespace would reject the DaemonSet at
-// creation time, which the smokes need to succeed even though they never
-// wait for pods to schedule. The label is a no-op on clusters that don't
-// enforce PodSecurity.
+// because the LMCache DaemonSet's pod template sets hostIPC=true (and
+// privileged=true only when spec.privileged is enabled), and hostIPC alone
+// is rejected by the restricted/baseline profiles. On clusters that enforce
+// PodSecurity admission (OCP in particular), a `restricted` namespace would
+// reject the DaemonSet at creation time, which the smokes need to succeed
+// even though they never wait for pods to schedule. The label is a no-op on
+// clusters that don't enforce PodSecurity.
 func createTestNamespace(ctx context.Context) string {
 	GinkgoHelper()
 	name := uniqueNamespaceName()


### PR DESCRIPTION
**What this PR does / why we need it**:

The engine DaemonSet container previously hardcoded `privileged: true` for both
LMCacheEngine and CacheBlendEngine. In many clusters that is unnecessary — the
`runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` combination already
grants the GPU visibility LMCache needs for CUDA IPC without consuming a
device-plugin GPU. Requiring privileged mode everywhere broadens the pod's
security surface (and forces Pod Security Standards to allow the `privileged`
profile) on clusters that don't need it.

This adds an optional `spec.privileged` field (default `false`) to both engine
specs, threaded into the shared DaemonSet builder. Operators set it to `true`
only on clusters where the engine cannot otherwise see the GPUs.

**Special notes for your reviewers**:

- **Default flips from `true` to `false`** — this rewrites the DaemonSet pod
  template, so upgrading forces a rolling pod replacement. Existing CRs that
  relied on privileged for GPU visibility must set `spec.privileged: true`
  before upgrading. Called out in an upgrade note in the README.
- **AMD/ROCm requires it**: `gpuVendor: amd` has no NVIDIA-style RuntimeClass
  device injection, so privileged is the only path to `/dev/kfd`/`/dev/dri`.
  The AMD sample now sets `privileged: true` explicitly and the field godoc
  documents this.
- The regenerated CRD bases also pick up pre-existing `noop`/`retain` enum
  drift from already-committed Go source on `dev` — expected, not part of this
  change's intent.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
