### PR TITLE
docs: consolidate daily drift-check updates (2026-06-29)

### DIFF
--- a/docs/design/v1/multiprocess/raw_cuda_ipc.md
+++ b/docs/design/v1/multiprocess/raw_cuda_ipc.md
@@ -2,7 +2,7 @@
 
 ## Why a second wrapper
 
-The default `CudaIPCWrapper` in `custom_types.py` calls
+The default `CudaIPCWrapper` in `platform/cuda/ipc_wrapper.py` calls
 `tensor.untyped_storage()._share_cuda_()` to publish the storage over
 CUDA IPC. That path only works when the storage is owned by PyTorch's
 caching allocator. TRT-LLM's KV pool is published via
@@ -23,26 +23,31 @@ no direct CuPy/NumPy equivalent, but the size in bytes is enough.
 DLPack carries no dtype semantics for the bytes view; `view(dtype)` on
 the torch side restores them.
 
-## Subclass rather than separate type
+## Shared base rather than separate type
 
-`RawCudaIPCWrapper` is a **subclass** of `CudaIPCWrapper`, not a new
-class with its own ext code. This is load-bearing for the wire format:
+`RawCudaIPCWrapper` is a **sibling** of `CudaIPCWrapper`: both subclass
+the device-agnostic `DeviceIPCWrapper` base (see
+[`device_ipc_wrapper_design.md`](device_ipc_wrapper_design.md) for the
+full hierarchy). Sharing a single base is load-bearing for the wire
+format:
 
-- `KVCache = list[CudaIPCWrapper]` is the registered msgspec type for
+- `KVCache = list[DeviceIPCWrapper]` is the registered msgspec type for
   `REGISTER_KV_CACHE`. msgspec does **not** support unions of custom
-  ext-encoded types — adding a parallel class would force a wider
-  decoder type and break either round-trip or the existing
-  `CudaIPCWrapper` consumers.
+  ext-encoded types — adding a parallel class with its own ext code
+  would force a wider decoder type and break either round-trip or the
+  existing `DeviceIPCWrapper` consumers.
 - The customized serializer (`_CUSTOMERIZED_SERIALIZERS`) is keyed on
-  `CudaIPCWrapper` and dispatched by `isinstance`, so subclass instances
-  encode through the same path with **ext code 1**.
-- `Serialize` is `pickle.dumps(obj)`, which preserves subclass
-  identity. On the receiving side `Deserialize` reconstructs the
-  subclass and `to_tensor` dispatches to the override.
+  `DeviceIPCWrapper` and dispatched by `isinstance`, so every subclass
+  instance encodes through the same path with **ext code 1**.
+- `Serialize` is `pickle.dumps(obj)`, which preserves the concrete
+  subclass identity. On the receiving side `Deserialize` reconstructs
+  the concrete subclass and `to_tensor` dispatches to the correct
+  override.
 
 The receiving server therefore needs no per-type branching: a
-`list[CudaIPCWrapper]` arriving at `MPCacheServer.register_kv_cache`
-contains either kind, and `to_tensor()` does the right thing.
+`list[DeviceIPCWrapper]` arriving at
+`LMCacheDrivenTransferModule.register_kv_cache` contains any mix of
+concrete wrappers, and `to_tensor()` does the right thing.
 
 ## Sender-side validation
 
@@ -66,5 +71,5 @@ CuPy/MemoryPointer's owner field.
 The wrapper does not try `_share_cuda_()` first. That would couple the
 two codepaths, and the failure mode is silent corruption (PyTorch
 returns a handle for a different region of memory than what the
-caller intended). Explicit subclassing keeps the choice at the call
-site.
+caller intended). Keeping `RawCudaIPCWrapper` as its own concrete
+sibling of `CudaIPCWrapper` keeps the choice at the call site.

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -451,8 +451,10 @@ pass ``lmcache.mp.host`` / ``lmcache.mp.port`` in
 
 **CPU-only (no GPU)** -- the server runs with a ``StubCPUDevice`` and shares
 KV tensors with vLLM over POSIX shared memory. Start ``lmcache server``
-normally, then set ``lmcache.mp.mp_transfer_mode=engine_driven`` on the vLLM
-side to enable the zero-copy SHM path.
+normally, then set ``lmcache.mp.mp_transfer_mode=lmcache_driven`` on the vLLM
+side to enable the zero-copy SHM handle path (the default ``auto`` routing
+maps non-CUDA devices to ``engine_driven``, which uses the worker-side
+gather/scatter copy path instead).
 
 **Docker** -- see :doc:`../production/docker_deployment`.
 

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -184,6 +184,42 @@ The HTTP frontend is included when running ``lmcache server``.
      - ``8080``
      - Port to bind the HTTP server.
 
+P2P
+---
+
+Source: ``lmcache/v1/multiprocess/config.py``
+
+These flags configure peer-to-peer KV cache sharing between MP servers
+(see :doc:`p2p`). They are registered by ``add_p2p_args()`` on the
+``lmcache server`` parser. P2P is enabled when ``--p2p-advertise-url``
+is set, which additionally requires a coordinator URL via
+``--coordinator-url`` (or ``LMCACHE_COORDINATOR_URL``).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Argument
+     - Default
+     - Description
+   * - ``--p2p-advertise-url``
+     - ``""`` (P2P disabled)
+     - Transfer-channel server ``host:port`` this instance advertises to
+       peers. Setting it enables P2P (also requires ``--coordinator-url``).
+   * - ``--p2p-listen-url``
+     - ``""``
+     - Transfer-channel server ``host:port`` to bind. Defaults to
+       ``--p2p-advertise-url``.
+   * - ``--p2p-lookup-timeout``
+     - ``30.0``
+     - Seconds before a peer lookup result counts as a miss.
+   * - ``--p2p-load-timeout``
+     - ``30.0``
+     - Seconds before a peer load counts as a failure.
+   * - ``--p2p-transfer-engine``
+     - ``nixl``
+     - Transfer-channel implementation to use.
+
 L1 Memory Manager
 ------------------
 
@@ -205,10 +241,13 @@ Source: ``lmcache/v1/distributed/config.py``
      - Enable or disable lazy allocation for L1 memory.
        Pass ``--l1-use-lazy`` to enable (default) or
        ``--no-l1-use-lazy`` to explicitly disable.
-       Lazy allocation relies on ``cudart`` host-pinned memory, so on
-       non-CUDA backends (where ``lmcache.torch_dev`` exposes no
-       ``cudart`` attribute) it is automatically downgraded to eager
-       allocation with a logged warning, regardless of the flag value.
+       Lazy allocation requires host-memory pinning, which is provided per
+       platform by the ``DeviceExt`` backend attached to ``torch_dev`` (CUDA
+       uses ``cudaHostRegister`` via the torch ``cudart`` binding, with a
+       ``libcudart`` ``ctypes`` fallback). On backends where
+       ``torch_dev.ext.is_pin_supported`` is ``False`` it is automatically
+       downgraded to eager allocation with a logged warning, regardless of
+       the flag value.
    * - ``--l1-init-size-gb``
      - ``20``
      - Initial allocation size (GB) when using lazy allocation.
@@ -437,6 +476,23 @@ On the vLLM side, specify the LMCache server host and port via the
         --kv-transfer-config \
         '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "127.0.0.1", "lmcache.mp.port": 6000}}'
 
+To target multiple LMCache servers from a single vLLM deployment, pass a
+list (or comma-separated string) of server URLs via
+``lmcache.mp.server_urls``. When set, ``server_urls`` takes precedence
+over the single-server ``host`` / ``port`` keys; vLLM's world size must
+be divisible by the number of servers, and each worker connects only to
+its locally-assigned server (global ranks are sliced into contiguous
+blocks, one block per server). Multi-server mode currently supports
+tensor parallelism only -- pipeline parallelism (``pp_size > 1``) and
+data parallelism (``dp_size > 1``) are rejected with a clear error.
+
+.. code-block:: bash
+
+    vllm serve Qwen/Qwen3-14B \
+        --tensor-parallel-size 4 \
+        --kv-transfer-config \
+        '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.server_urls": "tcp://host1:6667,tcp://host2:6667"}}'
+
 ``LMCacheMPConnector`` reads the following keys from
 ``kv_connector_extra_config``:
 
@@ -453,12 +509,24 @@ All connector-level options are passed through
    * - Key
      - Default
      - Description
+   * - ``lmcache.mp.server_urls``
+     - *(unset)*
+     - Multi-server deployment: list (or comma-separated string) of
+       ``<transport>://<host>:<port>`` URLs, e.g.
+       ``"tcp://host1:6667,tcp://host2:6667"``. When set, takes
+       precedence over ``lmcache.mp.host`` / ``lmcache.mp.port``; the
+       vLLM world size must be divisible by the number of servers, and
+       each worker connects to its locally-assigned server.
    * - ``lmcache.mp.host``
      - ``tcp://localhost``
-     - Host (with ZMQ transport prefix) of the LMCache MP server.
+     - Single-server deployment: host (with ZMQ transport prefix) of
+       the LMCache MP server. Ignored when ``lmcache.mp.server_urls``
+       is set.
    * - ``lmcache.mp.port``
      - ``5555``
-     - Port of the LMCache MP server. Must match the server's ``--port``.
+     - Single-server deployment: port of the LMCache MP server. Must
+       match the server's ``--port``. Ignored when
+       ``lmcache.mp.server_urls`` is set.
    * - ``lmcache.mp.mq_timeout``
      - ``300.0``
      - Timeout (seconds) for blocking message-queue requests, including
@@ -472,10 +540,12 @@ All connector-level options are passed through
    * - ``lmcache.mp.mp_transfer_mode``
      - ``auto``
      - Routing mode for the worker -> server transfer context. One of
-       ``auto`` (CUDA -> engine_driven, others -> lmcache_driven),
-       ``engine_driven`` (force IPC / SHM zero-copy), or
-       ``lmcache_driven`` (force worker-side gather/scatter copy).
-       Overrides the ``LMCACHE_MP_TRANSFER_MODE`` env var when set.
+       ``auto`` (CUDA -> lmcache_driven, others -> engine_driven),
+       ``lmcache_driven`` (force the IPC / SHM zero-copy handle path —
+       LMCache server pulls data via device handles), or
+       ``engine_driven`` (force the worker-side gather/scatter copy
+       path). Overrides the ``LMCACHE_MP_TRANSFER_MODE`` env var when
+       set.
 
 Environment Variables
 ---------------------

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -241,13 +241,6 @@ Source: ``lmcache/v1/distributed/config.py``
      - Enable or disable lazy allocation for L1 memory.
        Pass ``--l1-use-lazy`` to enable (default) or
        ``--no-l1-use-lazy`` to explicitly disable.
-       Lazy allocation requires host-memory pinning, which is provided per
-       platform by the ``DeviceExt`` backend attached to ``torch_dev`` (CUDA
-       uses ``cudaHostRegister`` via the torch ``cudart`` binding, with a
-       ``libcudart`` ``ctypes`` fallback). On backends where
-       ``torch_dev.ext.is_pin_supported`` is ``False`` it is automatically
-       downgraded to eager allocation with a logged warning, regardless of
-       the flag value.
    * - ``--l1-init-size-gb``
      - ``20``
      - Initial allocation size (GB) when using lazy allocation.

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -77,7 +77,7 @@ High-Level Architecture
          |
          |--- L1Manager (l1_manager.py)
          |       |--- L1MemoryManager (CPU DRAM) or
-         |       |    GDSL1MemoryManager (NVMe slab via cuFile)
+         |       |    GDSL1MemoryManager (NVMe slab via cuFile / hipFile)
          |       |--- TTLLock per object (read/write)
          |
          |--- StoreController  -----> L2 Adapter(s) (async L1->L2 push)
@@ -292,9 +292,10 @@ Communication between vLLM and LMCache uses ZMQ (DEALER/ROUTER pattern).
      - (P2P) Look up the given keys and read-lock the locally cached
        prefix. Returns a task id which the caller passes to
        ``P2P_QUERY_LOOKUP_RESULTS`` to poll for the transfer addresses.
-       Part of the peer-to-peer KV cache sharing surface; the handler
-       module is not yet wired into the default
-       ``_build_modules()`` path -- see :doc:`p2p`.
+       Served by ``P2PController`` (loaded unconditionally by
+       ``_build_modules()``); whether this server also acts as a P2P
+       client is controlled by ``--p2p-advertise-url`` -- see
+       :doc:`p2p`.
    * - ``P2P_QUERY_LOOKUP_RESULTS``
      - BLOCKING
      - (P2P) Poll the transfer addresses for a lookup task. Returns a
@@ -354,7 +355,13 @@ methods:
 
 - ``reserve_write()`` / ``finish_write()`` -- Two-phase write into L1.
 - ``submit_prefetch_task()`` / ``query_prefetch_status()`` -- Async lookup +
-  L2 prefetch.
+  L2 prefetch. ``query_prefetch_status()`` is non-blocking and returns
+  ``None`` while the L2 prefetch is still in flight.
+- ``wait_prefetch_status()`` -- Blocking alternative to polling
+  ``query_prefetch_status()``: waits on a controller condition variable
+  until the prefetch result is published (or a timeout expires).
+  L1-only prefetches return immediately. Used by the
+  ``WAIT_PREFETCH_STATUS`` RPC to avoid busy-polling on the load path.
 - ``read_prefetched_results()`` / ``finish_read_prefetched()`` -- Read
   prefetched data from L1 with automatic lock management.
 
@@ -383,9 +390,12 @@ tiers selected at startup (both satisfy ``L1ManagerProtocol``):
   ``--l1-size-gb``.
 - ``GDSL1MemoryManager`` -- an NVMe slab file when ``--gds-l1-path`` is set.
   The bytes live on disk; reads/writes DMA directly between the GPU staging
-  buffer and the slab via cuFile, driven by the process-global ``GDSContext``
-  (``gpu_connector/gds_context.py``) and dispatched from ``gpu_ops``. The CPU
-  tier is disabled in this mode.
+  buffer and the slab, driven by the process-global ``GDSContext``
+  (``gpu_connector/gds_context.py``) and dispatched from ``gpu_ops``. The DMA
+  backend is selected by platform via ``gpu_connector/_gds_async.py`` --
+  cuFile (``libcufile.so``) on NVIDIA and hipFile (``libhipfile.so``) on AMD
+  ROCm; see the *GDS L1 Tier* section of :doc:`configuration` for the
+  vendor-specific requirements. The CPU tier is disabled in this mode.
 
 L2 Adapters
 ~~~~~~~~~~~
@@ -554,7 +564,7 @@ Adding a new request type
 1. Add a new member to ``RequestType`` in ``protocols/base.py``.
 2. Create a ``ProtocolDefinition`` in the appropriate ``protocols/*.py`` file
    (``engine``, ``controller``, ``observability``, ``debug``, ``blend``,
-   ``blend_v2``, or ``blend_v3``) and add the request name to that
+   ``blend_v2``, ``blend_v3``, or ``p2p``) and add the request name to that
    module's ``REQUEST_NAMES``.
 3. Implement the handler method on the appropriate ``EngineModule``
    (e.g. ``LookupModule``, ``LMCacheDrivenTransferModule``, ``BlendV3Module``) and

--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -103,7 +103,13 @@ Connecting vLLM
 ---------------
 
 The operator creates a ConfigMap named ``<engine-name>-connection`` containing
-the ``kv-transfer-config`` JSON.  Mount it in your vLLM Deployment:
+the ``kv-transfer-config`` JSON.  You can either let the operator's mutating
+webhook inject it for you (recommended -- keeps your vLLM manifest clean) or
+mount it by hand.  See :ref:`mp-operator-connection-injection` below for the
+webhook flow; the rest of this section describes the manual mount that is its
+equivalent.
+
+Mount it in your vLLM Deployment:
 
 .. code-block:: yaml
 
@@ -163,6 +169,127 @@ Key requirements for vLLM pods:
   inline.  The ConfigMap name is always ``<LMCacheEngine name>-connection``.
 - **No hostNetwork needed** -- The operator's node-local Service handles
   routing via ``internalTrafficPolicy=Local``.
+
+.. _mp-operator-connection-injection:
+
+Connection Injection (Webhook)
+-------------------------------
+
+Hand-wiring the ConfigMap mount and the ``$(cat ...)`` argument substitution
+above is repetitive across vLLM Deployments.  A **mutating admission webhook**
+shipped with the operator can do it for you so the vLLM manifest stays clean.
+It mirrors the CacheBlend webhook (see :ref:`mp-operator-cacheblend`) with an
+``lmcache-`` annotation/label discriminator so the two injectors never
+cross-fire on the same pod.
+
+When invoked on an opted-in pod whose ``<engine>-connection`` ConfigMap exists,
+the webhook mutates the pod at admission time to add:
+
+- ``--kv-transfer-config <JSON>`` -- the ``LMCacheMPConnector`` config, read
+  verbatim from the engine's ``<engine>-connection`` ConfigMap and inlined onto
+  the vLLM container's ``args`` (no volume mount needed);
+- ``hostIPC: true`` on the pod spec (CUDA IPC with the node-local server);
+- ``PYTHONHASHSEED=0`` on the vLLM container env, **set-if-absent** -- it
+  preserves a value you already set.
+
+Unlike the CacheBlend injector it does **not** consult the engine CR: the
+entire connector config lives in the connection ConfigMap, and
+``LMCacheEngine`` has no injection sub-spec.  It fails open
+(``failurePolicy: Ignore``) and is idempotent (re-admitted pods carrying the
+``lmcache.ai/lmcache-injected`` stamp are allowed unchanged).
+
+Prerequisites
+~~~~~~~~~~~~~
+
+- **cert-manager** + ``make deploy`` (not ``make run``, which is
+  controller-only and disables the webhook via ``ENABLE_WEBHOOKS=false``) --
+  same as the CacheBlend webhook; install once per cluster (see
+  :ref:`mp-operator-cacheblend` "Additional Prerequisites").
+- **Pod Security Standards** -- the injected ``hostIPC`` is rejected by the
+  ``baseline`` / ``restricted`` PSS profiles, so the vLLM pod's namespace must
+  be labeled ``pod-security.kubernetes.io/enforce=privileged``.
+- **Engine reconciled in the same namespace** -- the webhook reads the
+  ``<engine>-connection`` ConfigMap directly, so the ``LMCacheEngine`` must
+  already exist in the vLLM pod's namespace.
+
+Opting a vLLM Pod In
+~~~~~~~~~~~~~~~~~~~~
+
+Add the opt-in label and the engine-binding annotation to the pod template, and
+launch vLLM via the image **ENTRYPOINT** (args only) -- a
+``command: ["/bin/sh", "-c", ...]`` wrapper is skipped (the webhook stamps
+``lmcache.ai/lmcache-skip-reason=command-override`` because appended args would
+not reach ``vllm serve``):
+
+.. code-block:: yaml
+
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: vllm-lmcache
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: vllm-lmcache
+      template:
+        metadata:
+          labels:
+            app: vllm-lmcache
+            lmcache.ai/lmcache-inject: "true"        # opt-in (webhook objectSelector)
+          annotations:
+            lmcache.ai/lmcache-engine: "my-cache"    # bind to the engine (same namespace)
+            # Optional -- name the vLLM container if it is not the first one:
+            # lmcache.ai/lmcache-container: "vllm"
+        spec:
+          runtimeClassName: nvidia
+          # Do NOT set hostIPC here or mount an emptyDir at /dev/shm -- the
+          # webhook injects hostIPC=true; an emptyDir would shadow the host's
+          # /dev/shm and break cudaIpcOpenMemHandle.
+          containers:
+            - name: vllm
+              image: lmcache/vllm-openai:latest
+              # Args-only launch (image ENTRYPOINT is ["vllm", "serve"]). The
+              # webhook appends --kv-transfer-config; do NOT add it yourself
+              # (a user-supplied one stamps skip-reason=kv-transfer-config-present).
+              args: ["<your-model>", "--port", "8000", "--gpu-memory-utilization", "0.8"]
+              ports:
+                - name: http
+                  containerPort: 8000
+              resources:
+                limits:
+                  nvidia.com/gpu: "1"
+
+A ready-to-edit manifest lives at
+``operator/config/samples/vllm_lmcache_deployment.yaml``.
+
+Verifying Injection
+~~~~~~~~~~~~~~~~~~~
+
+The webhook mutates **Pods**, not the Deployment, so inspect a pod (not the
+Deployment spec):
+
+.. code-block:: bash
+
+    kubectl get pod -l app=vllm-lmcache -o yaml | \
+      grep -E "hostIPC|kv-transfer-config|lmcache-injected|lmcache-skip-reason"
+
+If nothing was injected, check the pod's ``lmcache.ai/lmcache-skip-reason``
+annotation:
+
+- ``command-override`` -- the pod uses a ``sh -c`` wrapper, so injected args
+  would not reach ``vllm serve``.
+- ``kv-transfer-config-present`` -- the user already supplied
+  ``--kv-transfer-config``; the webhook does not clobber it.
+- ``engine-not-found`` -- the ``<engine>-connection`` ConfigMap is missing
+  (engine not yet reconciled, or wrong namespace, or wrong name).
+- ``target-container-not-found`` -- the
+  ``lmcache.ai/lmcache-container`` annotation names a container the pod does
+  not have.
+
+With ``failurePolicy: Ignore`` a webhook / cert problem also leaves the pod
+un-mutated silently -- confirm the operator pod is ``Running`` and the
+``MutatingWebhookConfiguration`` exists.
 
 Verifying the Deployment
 ------------------------
@@ -611,6 +738,8 @@ Override Auto-Computed Resources
           cpu: "8"
         limits:
           memory: "100Gi"
+
+.. _mp-operator-cacheblend:
 
 CacheBlend
 ----------


### PR DESCRIPTION
**What this PR does / why we need it**:

Consolidates the open *daily drift check* doc PRs into a single branch. Each
proposed change was re-verified against the **current code as the single
source of truth**, since several of the individual PRs had overlapping edits
or had gone stale as `dev` moved on.

Files updated:

- **`docs/source/mp/configuration.rst`**
  - Fix the `lmcache.mp.mp_transfer_mode` `auto` routing to match code
    (`worker_transfer.py`): CUDA -> `lmcache_driven`, others -> `engine_driven`,
    and correct the `lmcache_driven` (IPC/SHM zero-copy handle path) vs
    `engine_driven` (worker-side gather/scatter copy) descriptions. The old
    text had these reversed.
  - Rewrite `--l1-use-lazy` around the actual pinning check
    (`torch_dev.ext.is_pin_supported` / the `DeviceExt` backend), replacing the
    stale "exposes no `cudart` attribute" wording.
  - Add the multi-server `lmcache.mp.server_urls` key (precedence, world-size
    divisibility, contiguous rank blocks, TP-only).
  - Add the `P2P` CLI flag table (`add_p2p_args()`).
- **`docs/source/getting_started/quickstart.rst`**: CPU-only zero-copy SHM
  handle path uses `mp_transfer_mode=lmcache_driven` (the `auto` default maps
  non-CUDA devices to `engine_driven`).
- **`docs/source/mp/index.rst`**: GDS DMA backend selection (cuFile/hipFile via
  `_gds_async.py`); the `wait_prefetch_status()` / `WAIT_PREFETCH_STATUS` RPC;
  `P2PController` is loaded unconditionally by `_build_modules()`; `p2p` added
  to the protocol-module list.
- **`docs/source/mp/operator.rst`**: document the connection-injection mutating
  admission webhook (opt-in label/annotations, injected mutations, skip
  reasons, prerequisites).
- **`docs/design/v1/multiprocess/raw_cuda_ipc.md`**: `DeviceIPCWrapper` is the
  shared base and `CudaIPCWrapper` / `RawCudaIPCWrapper` are **siblings**;
  `CudaIPCWrapper` now lives in `platform/cuda/ipc_wrapper.py`;
  `register_kv_cache` is on `LMCacheDrivenTransferModule`.

**Special notes for your reviewers**:

This PR supersedes and closes the previous daily drift-check PRs:

Closes #3928
Closes #3915
Closes #3900
Closes #3879
Closes #3863
Closes #3840
Closes #3817
Closes #3774

Reconciliation notes (code was authoritative where PRs disagreed):

- `raw_cuda_ipc.md`: #3840 ("siblings of a shared `DeviceIPCWrapper` base") is
  correct per `platform/cuda/ipc_wrapper.py`; #3863's "subclass of
  `CudaIPCWrapper`" framing was stale. This PR keeps #3840's hierarchy but
  applies #3863's correct file location and `LMCacheDrivenTransferModule`
  receiver.
- The `developer_guide/cli.rst` change from #3817 is intentionally **omitted**:
  `dev` already documents CLI auto-discovery far more thoroughly than that PR's
  edit. (Note: `dev`'s `cli.rst` still has a small pre-existing inaccuracy --
  it attributes underscore-module exclusion to `pkgutil.iter_modules`, but
  `discover_subclasses` only excludes via the caller's `module_filter`. Out of
  scope here; left for a future drift check.)

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
