### PR TITLE
[CI] cu129 release image: use stable vLLM wheel instead of nightly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,11 +126,12 @@ WORKDIR /workspace
 ENTRYPOINT ["/opt/venv/bin/vllm", "serve"]
 
 #################### vLLM IMAGE & LMCache (Release, cu129) ######################
-# Installs nightly cu129 vLLM  
+# Installs the stable cu129 vLLM release wheel and
 # lmcache from the v{tag}-cu129 GitHub Release.
+# The cu129 torch index is hinted explicitly so vLLM resolves to its cu129 build.
 
 FROM base AS image-release-cu129
- 
+
 ARG CUDA_VERSION=12.9
 ARG LMCACHE_VERSION
 
@@ -140,9 +141,8 @@ RUN . /opt/venv/bin/activate && \
     VER=$(echo ${LMCACHE_VERSION} | sed 's/^v//') && \
     VLLM_PRECOMPILED_WHEEL_VARIANT=${CUDA_TAG} uv pip install --prerelease=allow \
         vllm[runai,tensorizer,flashinfer] \
-        --extra-index-url https://wheels.vllm.ai/nightly/${CUDA_TAG} \
         --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \
-        --index-strategy unsafe-first-match && \
+        --index-strategy unsafe-best-match && \
     python3 -c 'import torch; print("TORCH=", torch.__version__)' && \
     uv pip install lmcache==${VER} \
         --extra-index-url https://download.pytorch.org/whl/${CUDA_TAG} \


### PR DESCRIPTION
**What this PR does / why we need it**:

The `image-release-cu129` stage in `docker/Dockerfile` backs the **stable** Docker release: the `publish-image` job builds `lmcache/vllm-openai:latest-cu129` (and the versioned tag) from it whenever a non-RC GitHub release is published. That stage was still resolving vLLM from the nightly index (`https://wheels.vllm.ai/nightly/`), so stable cu129 images shipped on top of a moving nightly vLLM build instead of a pinned stable release.

This drops the nightly `--extra-index-url` and resolves vLLM from the stable PyPI wheel with the cu129 torch index hinted, switching `--index-strategy` from `unsafe-first-match` to `unsafe-best-match`. It mirrors the existing cu13 `image-release` stage so both stable release images install stable vLLM.

**Special notes for your reviewers**:

Build-stage-only change; the cu13 `image-release` stage already uses this exact pattern. No user-facing docs reference the cu129 vLLM build index, so no docs change is needed.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
