### PR TITLE
[MP][DAX] Split Device-DAX L1 from CPU L1 manager

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -20,6 +20,9 @@ from lmcache.v1.distributed.memory_manager import (
     L1ManagerProtocol,
     L1MemoryManager,
 )
+from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
+    DevDaxL1MemoryManager,
+)
 from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
@@ -188,13 +191,15 @@ class L1Manager:
 
         self._objects: dict[ObjectKey, L1ObjectState] = {}
 
-        # GDS and CPU L1 are mutually exclusive tiers, each driven by its own
-        # config: the GDS tier reads only ``gds_l1_config`` (slab size +
-        # alignment), the CPU tier only ``memory_config``.
+        # GDS, Device-DAX, and CPU L1 are mutually exclusive tiers. Each tier
+        # owns its backing allocator instead of branching inside the CPU path.
         self._memory_manager: L1ManagerProtocol
         if config.gds_l1_config is not None:
             self._memory_manager = GDSL1MemoryManager(config.gds_l1_config)
             logger.info("L1Manager: GDS L1 tier enabled; CPU pinned-DRAM L1 disabled")
+        elif config.memory_config.devdax_path:
+            self._memory_manager = DevDaxL1MemoryManager(config.memory_config)
+            logger.info("L1Manager: Device-DAX L1 tier enabled; CPU-only L1 disabled")
         else:
             self._memory_manager = L1MemoryManager(config.memory_config)
 

--- a/lmcache/v1/distributed/memory_manager/__init__.py
+++ b/lmcache/v1/distributed/memory_manager/__init__.py
@@ -4,10 +4,14 @@
 Two interchangeable tiers behind :class:`L1ManagerProtocol`:
 
 - :class:`L1MemoryManager` -- CPU pinned-DRAM slab.
+- :class:`DevDaxL1MemoryManager` -- Device-DAX-backed L1 slab.
 - :class:`GDSL1MemoryManager` -- GDS slab file (cuFile DMA).
 """
 
 # First Party
+from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
+    DevDaxL1MemoryManager,
+)
 from lmcache.v1.distributed.memory_manager.gds_l1_memory_manager import (
     GDSL1MemoryManager,
 )
@@ -18,6 +22,7 @@ from lmcache.v1.distributed.memory_manager.l1_memory_manager import (
 )
 
 __all__ = [
+    "DevDaxL1MemoryManager",
     "GDSL1MemoryManager",
     "L1ManagerProtocol",
     "L1MemoryManager",

--- a/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Device-DAX L1 memory manager."""
+
+# Standard
+from typing import cast
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.distributed.config import L1MemoryManagerConfig
+from lmcache.v1.distributed.internal_api import L1MemoryDesc
+from lmcache.v1.distributed.memory_manager.l1_memory_manager import L1MemoryManager
+from lmcache.v1.memory_management import DevDaxMemoryAllocator
+
+logger = init_logger(__name__)
+
+
+class DevDaxL1MemoryManager(L1MemoryManager):
+    """L1 memory manager for Device-DAX-backed L1 memory.
+
+    This is a peer of
+    :class:`~lmcache.v1.distributed.memory_manager.l1_memory_manager.L1MemoryManager`
+    and owns the Device-DAX allocator path that used to live inside the generic
+    CPU L1 manager. A pure Device-DAX configuration maps the DAX device as the
+    full L1 arena. A hybrid configuration uses DRAM first and spills overflow
+    allocations into Device-DAX.
+    """
+
+    def __init__(self, config: L1MemoryManagerConfig) -> None:
+        """Create a Device-DAX L1 memory manager.
+
+        Args:
+            config: L1 memory configuration with ``devdax_path`` set.
+
+        Raises:
+            ValueError: If ``devdax_path`` is not configured.
+        """
+        if not config.devdax_path:
+            raise ValueError("DevDaxL1MemoryManager requires devdax_path")
+
+        devdax_size = config.devdax_size_in_bytes or config.size_in_bytes
+        local_size = config.size_in_bytes if config.devdax_size_in_bytes else 0
+        logger.debug(
+            "use devdax memory allocator, dram size is %d bytes, "
+            "devdax path is %s, devdax size is %d bytes, align bytes is %d bytes",
+            local_size,
+            config.devdax_path,
+            devdax_size,
+            config.align_bytes,
+        )
+        self._allocator = DevDaxMemoryAllocator(
+            devdax_size,
+            config.devdax_path,
+            local_size=local_size,
+            shm_name=config.shm_name or None,
+            align_bytes=config.align_bytes,
+        )
+        self._size_in_bytes = config.size_in_bytes
+        self._align_bytes = config.align_bytes
+
+    def get_l1_memory_desc(self) -> L1MemoryDesc:
+        """Return a descriptor for the primary L1 buffer.
+
+        Existing callers expect Device-DAX L1 to expose the mapped buffer here.
+        Hybrid DRAM + Device-DAX L1 is still rejected by transfer paths that
+        require one registerable L1 region via ``l1_exposes_single_memory_region``.
+        """
+        allocator = cast(DevDaxMemoryAllocator, self._allocator)
+        buffer = allocator.buffer
+        return L1MemoryDesc(
+            ptr=buffer.data_ptr(),
+            size=self._size_in_bytes,
+            align_bytes=self._align_bytes,
+        )

--- a/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py
@@ -63,6 +63,9 @@ class DevDaxL1MemoryManager(L1MemoryManager):
         Existing callers expect Device-DAX L1 to expose the mapped buffer here.
         Hybrid DRAM + Device-DAX L1 is still rejected by transfer paths that
         require one registerable L1 region via ``l1_exposes_single_memory_region``.
+
+        Returns:
+            The descriptor for the primary L1 buffer.
         """
         allocator = cast(DevDaxMemoryAllocator, self._allocator)
         buffer = allocator.buffer

--- a/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
@@ -12,7 +12,6 @@ from lmcache.v1.distributed.error import L1Error
 from lmcache.v1.distributed.internal_api import L1MemoryDesc
 from lmcache.v1.lazy_memory_allocator import LazyMemoryAllocator
 from lmcache.v1.memory_management import (
-    DevDaxMemoryAllocator,
     MemoryAllocatorInterface,
     MemoryObj,
     MixedMemoryAllocator,
@@ -52,26 +51,7 @@ def create_memory_allocator(config: L1MemoryManagerConfig) -> MemoryAllocatorInt
     Returns:
         MemoryAllocatorInterface: An instance of a memory allocator.
     """
-    if config.devdax_path:
-        devdax_size = config.devdax_size_in_bytes or config.size_in_bytes
-        local_size = config.size_in_bytes if config.devdax_size_in_bytes else 0
-        logger.debug(
-            "use devdax memory allocator, dram size is %d bytes, "
-            "devdax path is %s, "
-            "devdax size is %d bytes, align bytes is %d bytes",
-            local_size,
-            config.devdax_path,
-            devdax_size,
-            config.align_bytes,
-        )
-        return DevDaxMemoryAllocator(
-            devdax_size,
-            config.devdax_path,
-            local_size=local_size,
-            shm_name=config.shm_name or None,
-            align_bytes=config.align_bytes,
-        )
-    elif config.use_lazy:
+    if config.use_lazy:
         logger.debug(
             "use lazy memory allocator, init size is %d bytes, "
             "final size is %d bytes, align bytes is %d bytes",
@@ -210,8 +190,6 @@ class L1MemoryManager:
             NotImplementedError: If the allocator type does not support this operation.
         """
         if isinstance(self._allocator, MixedMemoryAllocator):
-            buffer = self._allocator.buffer
-        elif isinstance(self._allocator, DevDaxMemoryAllocator):
             buffer = self._allocator.buffer
         elif isinstance(self._allocator, LazyMemoryAllocator):
             # TODO(ApostaC): need to test if the RDMA registration works

--- a/tests/v1/distributed/test_devdax_l1_allocator.py
+++ b/tests/v1/distributed/test_devdax_l1_allocator.py
@@ -34,7 +34,9 @@ from lmcache.v1.distributed.l2_adapters.config import (
     L2AdaptersConfig,
     get_type_name_for_config,
 )
-from lmcache.v1.distributed.memory_manager import L1MemoryManager
+from lmcache.v1.distributed.memory_manager.devdax_l1_memory_manager import (
+    DevDaxL1MemoryManager,
+)
 from lmcache.v1.memory_management import DevDaxMemoryAllocator
 from lmcache.v1.multiprocess.config import add_mp_server_args
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
@@ -337,9 +339,9 @@ def test_l1_manager_round_trip_on_devdax_mapping(tmp_path):
         assert f.read(1) == bytes([0x23])
 
 
-def test_l1_memory_manager_spills_from_dram_to_devdax(tmp_path):
+def test_devdax_l1_memory_manager_spills_from_dram_to_devdax(tmp_path):
     path = _make_mmap_file(tmp_path, size=8192)
-    manager = L1MemoryManager(
+    manager = DevDaxL1MemoryManager(
         L1MemoryManagerConfig(
             size_in_bytes=8192,
             use_lazy=False,
@@ -379,9 +381,9 @@ def test_l1_memory_manager_spills_from_dram_to_devdax(tmp_path):
         assert f.read(4096) == bytes([0x6D]) * 4096
 
 
-def test_l1_memory_manager_reports_devdax_desc(tmp_path):
+def test_devdax_l1_memory_manager_reports_devdax_desc(tmp_path):
     path = _make_mmap_file(tmp_path)
-    manager = L1MemoryManager(
+    manager = DevDaxL1MemoryManager(
         L1MemoryManagerConfig(
             size_in_bytes=1024 * 1024,
             use_lazy=False,


### PR DESCRIPTION
  **What this PR does / why we need it**:

  This PR routes Device-DAX L1 configurations through a dedicated `DevDaxL1MemoryManager` 
instead of handling Device-DAX inside the generic CPU `L1MemoryManager`.

  The Device-DAX allocator implementation remains unchanged; the refactor only separates the L1 manager responsibility:
  - `L1Manager` selects `DevDaxL1MemoryManager` when `--l1-devdax-path` is configured.
  - `L1MemoryManager` now remove Device-DAX configs so the CPU L1 path stays CPU-only.
  - Existing Device-DAX spill/descriptor behavior is preserved behind the new manager.

  **If applicable**:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
