### PR TITLE
[Patch][Docs]: allow bare host in lmcache.mp.host

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -34,7 +34,9 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
          .. tab-item:: MP mode (recommended)
             :sync: mp
 
-            Start the LMCache server:
+            Start the LMCache server. ``--host`` / ``--port`` set the ZMQ
+            address vLLM connects to; they are spelled out here so the two
+            commands line up (these are also the defaults):
 
             .. code-block:: bash
 
@@ -42,20 +44,24 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
                # prompt produces visible cache traffic; use the default
                # (256) in production.
                lmcache server \
+                   --host localhost --port 5555 \
                    --l1-size-gb 20 --eviction-policy LRU --chunk-size 16
 
-            The ZMQ port (default **5555**) accepts connections from vLLM;
-            the HTTP frontend (default **8080**) serves the management and
-            metrics endpoints. See :doc:`../mp/configuration` for the full
-            list of ``lmcache server`` and connector options.
+            The ZMQ port (``--port``, default **5555**) accepts connections
+            from vLLM; the HTTP frontend (default **8080**) serves the
+            management and metrics endpoints. See :doc:`../mp/configuration`
+            for the full list of ``lmcache server`` and connector options.
 
-            Start vLLM with the MP connector in a separate terminal:
+            Start vLLM with the MP connector in a separate terminal. Point the
+            connector at the server above via ``lmcache.mp.host`` /
+            ``lmcache.mp.port`` in ``kv_connector_extra_config`` -- the host
+            **must** carry a ZMQ transport prefix such as ``tcp://``:
 
             .. code-block:: bash
 
                vllm serve Qwen/Qwen3-8B \
                    --port 8000 --kv-transfer-config \
-                   '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+                   '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "tcp://localhost", "lmcache.mp.port": 5555}}'
 
             .. note::
                **Where does** ``LMCacheMPConnector`` **resolve to?** This depends on your vLLM version:
@@ -447,7 +453,7 @@ pass ``lmcache.mp.host`` / ``lmcache.mp.port`` in
 .. code-block:: bash
 
    vllm serve Qwen/Qwen3-8B --kv-transfer-config \
-     '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "10.0.0.1", "lmcache.mp.port": 6555}}'
+     '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "tcp://10.0.0.1", "lmcache.mp.port": 6555}}'
 
 **CPU-only (no GPU)** -- the server runs with a ``StubCPUDevice`` and shares
 KV tensors with vLLM over POSIX shared memory. Start ``lmcache server``

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -435,7 +435,7 @@ On the vLLM side, specify the LMCache server host and port via the
 
     vllm serve Qwen/Qwen3-14B \
         --kv-transfer-config \
-        '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "127.0.0.1", "lmcache.mp.port": 6000}}'
+        '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "tcp://127.0.0.1", "lmcache.mp.port": 6000}}'
 
 ``LMCacheMPConnector`` reads the following keys from
 ``kv_connector_extra_config``:

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -489,6 +489,26 @@ class LMCacheMPConnectorMetadata(KVConnectorMetadata):
         return self.__str__()
 
 
+def _ensure_zmq_scheme(server_url: str) -> str:
+    """Ensure a ZMQ server URL carries a transport scheme.
+
+    ZeroMQ requires an explicit transport (e.g. ``tcp://``) in the address;
+    a bare ``host:port`` such as ``127.0.0.1:5557`` is rejected with
+    ``ZMQError: Invalid argument``. Users naturally configure
+    ``lmcache.mp.host`` as a plain IP/hostname, so prepend ``tcp://`` when no
+    scheme is present.
+
+    Args:
+        server_url: A server URL, with or without a ``<scheme>://`` prefix.
+
+    Returns:
+        The URL with a transport scheme, defaulting to ``tcp://``.
+    """
+    if "://" in server_url:
+        return server_url
+    return f"tcp://{server_url}"
+
+
 class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
     """
     The connector for LMCache multi-process mode.
@@ -543,6 +563,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 "lmcache.mp.port", 5555
             )
             server_urls = [f"{server_host}:{server_port}"]
+
+        # Normalize so a bare host:port (no transport scheme) is accepted;
+        # ZMQ requires an explicit transport such as ``tcp://``.
+        server_urls = [_ensure_zmq_scheme(u) for u in server_urls]
 
         # The server count is derived from lmcache.mp.server_urls.
         n_servers = len(server_urls)


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting `lmcache.mp.host` to a bare host/IP (e.g. `127.0.0.1`) — exactly as the docs example showed — crashed EngineCore on startup:

```
zmq.error.ZMQError: Invalid argument (addr='127.0.0.1:5557')
```

ZeroMQ requires an explicit transport scheme. The connector builds the server URL as `f"{host}:{port}"`, so a bare host yields `127.0.0.1:5557`, which `zmq.Socket.connect` rejects. The default (`tcp://localhost`) hid the issue because the scheme was baked into the default string; any user override of the host silently broke it.

This PR normalizes all resolved server URLs through a new `_ensure_zmq_scheme()` helper that prepends `tcp://` when no `<scheme>://` prefix is present. Already-schemed URLs (`tcp://`, `ipc://`, …) pass through unchanged, so the multi-server `lmcache.mp.server_urls` path is unaffected.

**Special notes for your reviewers**:

Also fixes the docs that produced the bad command:
- `quickstart.rst` / `configuration.rst` examples used a bare host → now use `tcp://`.
- `quickstart.rst` makes the server `--host`/`--port` explicit so the `lmcache server` and `vllm serve` commands visibly line up, surfaces the full `kv_connector_extra_config` (previously you had to hunt for where it goes), and notes the host must carry a transport prefix.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests