### PR TITLE
docs: daily drift check — multi-process mode (2026-06-30)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -370,7 +370,7 @@ The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
 Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
 ``fs_native``, ``mock``, ``mooncake_store``, ``aerospike``, ``s3``, ``resp``,
-``plugin``, ``native_plugin``, ``raw_block``, ``dax``.
+``hfbucket``, ``plugin``, ``native_plugin``, ``raw_block``, ``dax``.
 
 Each adapter type's required and optional fields, plus per-backend examples, are
 documented on its own page under :doc:`Secondary KV Storage <l2_storage/index>`

--- a/docs/source/mp/l2_storage/index.rst
+++ b/docs/source/mp/l2_storage/index.rst
@@ -179,7 +179,10 @@ policy evicts a fraction of the least-recently-used keys.
      - Description
    * - ``--eviction-policy``
      - *(required)*
-     - Policy name: ``LRU`` or ``noop``.
+     - Policy name: ``LRU``, ``IsolatedLRU``, or ``noop``. ``IsolatedLRU``
+       maintains one LRU list per ``cache_salt`` and relies on per-salt
+       quotas registered via the ``/quota`` HTTP endpoints; see
+       :doc:`/mp/configuration` for the full description.
    * - ``--eviction-trigger-watermark``
      - ``0.8``
      - L1 usage fraction [0, 1] above which eviction is triggered.


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. Two inconsistencies between the multi-process (MP) docs and the current `dev` code (`upstream/dev` HEAD `92bcd2b5`) were found and fixed in `docs/source/`.

Summary of drift (all under `docs/source/`; nothing in `docs/design/`):

- **`docs/source/mp/configuration.rst`** — the "Registered adapter types" list under *L2 Adapters* was missing `hfbucket`, while the very next paragraph of the same section ("adapters not detailed inline here") already names it. The `hfbucket` adapter self-registers in code and ships a dedicated docs page.
- **`docs/source/mp/l2_storage/index.rst`** — the `--eviction-policy` table row only listed `LRU` and `noop` as valid policy names, omitting `IsolatedLRU`. The companion `docs/source/mp/configuration.rst` already lists all three choices (and explains `IsolatedLRU`).

**Evidence**

| Drift | Code (current `dev`) | Stale doc |
| --- | --- | --- |
| `hfbucket` missing from registered L2 types list | [`lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py`](https://github.com/LMCache/LMCache/blob/92bcd2b521d129fb60f8c8df7c8a2df7f47d9d89/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py#L893) — `register_l2_adapter_type("hfbucket", HFBucketL2AdapterConfig)` | [`docs/source/mp/configuration.rst#L371-L373`](https://github.com/LMCache/LMCache/blob/92bcd2b521d129fb60f8c8df7c8a2df7f47d9d89/docs/source/mp/configuration.rst#L371-L373) |
| `IsolatedLRU` choice missing from `--eviction-policy` doc | [`lmcache/v1/distributed/config.py#L446-L451`](https://github.com/LMCache/LMCache/blob/92bcd2b521d129fb60f8c8df7c8a2df7f47d9d89/lmcache/v1/distributed/config.py#L446-L451) — `choices=["LRU", "IsolatedLRU", "noop"]` | [`docs/source/mp/l2_storage/index.rst#L180-L182`](https://github.com/LMCache/LMCache/blob/92bcd2b521d129fb60f8c8df7c8a2df7f47d9d89/docs/source/mp/l2_storage/index.rst#L180-L182) |

**Proposed fix**

Already applied in the diff: `hfbucket` is added to the L2 adapter list, and the `--eviction-policy` row now lists all three policy choices with a brief pointer to the full description in `docs/source/mp/configuration.rst`.

**Special notes for your reviewers**:

- Docs-only change. No code modified.
- The drift checker also looked at the LMCache connection auto-injection webhook (#3822) added on 2026-06-26. Its docs change is already in flight as #3915, so it was intentionally not duplicated here.
- This was auto-generated by the daily drift-check routine and **needs human review before merge**. Please do not merge without a maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01CZx7nzDPDk8fvj19gufBCf)_