### PR TITLE
feat: add concurrent batched_get_blocking to LocalDiskBackend

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
@@ -158,6 +158,16 @@ class LocalDiskBackend(StorageBackendInterface):
             "disk_io_threads", _DEFAULT_THREAD_COUNT
         )
         self.disk_worker = LocalDiskWorker(loop, max_workers=thread_count)
+
+        # Plain ThreadPoolExecutor for batched_get_blocking (concurrent
+        # synchronous reads).  The existing AsyncPQThreadPoolExecutor in
+        # disk_worker is async/priority-queue based and only serves writes
+        # and prefetches; a simple pool is a better fit for the blocking
+        # read path where we want ThreadPoolExecutor.map() semantics.
+        self._read_thread_pool = ThreadPoolExecutor(
+            max_workers=thread_count,
+            thread_name_prefix="disk-read",
+        )
 
         # TODO(Jiayi): We need a disk space allocator to avoid fragmentation
         # and hide the following details away from the backend.
@@ -439,6 +449,92 @@ class LocalDiskBackend(StorageBackendInterface):
 
         return memory_obj
 
+    def batched_get_blocking(
+        self,
+        keys: List[CacheEngineKey],
+    ) -> List[Optional[MemoryObj]]:
+        """Load multiple KV chunks from disk with concurrent I/O.
+
+        Metadata lookup and memory allocation are performed sequentially
+        under the disk lock, then all file reads are dispatched to a
+        ``ThreadPoolExecutor`` so they run in parallel.  The GIL is
+        released during the underlying ``readinto`` syscall, so threads
+        achieve true I/O parallelism.
+
+        :param keys: Cache keys identifying the KV chunks to load.
+        :returns: A list of ``MemoryObj`` (or ``None`` for missing keys),
+            in the same order as *keys*.
+        """
+        if len(keys) <= 1:
+            return [self.get_blocking(k) for k in keys]
+
+        # --- 1. Batch metadata lookup (single lock acquisition) -----------
+        with self.disk_lock:
+            metas = [self.dict.get(key) for key in keys]
+
+        # --- 2. Pre-allocate staging buffers (sequential) -----------------
+        memory_objs = [
+            self.local_cpu_backend.allocate(m.shape, m.dtype, m.fmt)
+            if m is not None
+            else None
+            for m in metas
+        ]
+
+        # --- 3. Concurrent file reads via thread pool ---------------------
+        paths = [m.path if m is not None else None for m in metas]
+        results: List[Optional[MemoryObj]] = list(
+            self._read_thread_pool.map(
+                self._load_chunk_into_memory, keys, paths, memory_objs
+            )
+        )
+
+        # --- 4. Update cache policy for successful loads ------------------
+        with self.disk_lock:
+            for key, mem_obj in zip(keys, results, strict=True):
+                if mem_obj is not None and key in self.dict:
+                    self.cache_policy.update_on_hit(key, self.dict)
+
+        return results
+
+    def _load_chunk_into_memory(
+        self,
+        key: CacheEngineKey,
+        path: Optional[str],
+        memory_obj: Optional[MemoryObj],
+    ) -> Optional[MemoryObj]:
+        """Read a single chunk from disk into a pre-allocated ``MemoryObj``.
+
+        Designed to be called from a thread pool — each invocation is
+        independent and performs a single blocking ``readinto`` syscall.
+
+        :param key: Cache key (used for metadata recovery and error logging).
+        :param path: File path to read from, or ``None`` if the key was not
+            found during the metadata lookup phase.
+        :param memory_obj: Pre-allocated staging buffer, or ``None`` if
+            allocation failed.
+        :returns: The populated ``MemoryObj``, or ``None`` on any failure.
+        """
+        if path is None or memory_obj is None:
+            return None
+
+        try:
+            buffer = memory_obj.byte_array
+            self.read_file(key, buffer, path)
+
+            # Recover metadata (mirrors load_bytes_from_disk).
+            with self.disk_lock:
+                disk_meta = self.dict.get(key)
+                if disk_meta is None:
+                    memory_obj.ref_count_down()
+                    return None
+                memory_obj.metadata.cached_positions = disk_meta.cached_positions
+
+            return memory_obj
+        except Exception as e:
+            logger.error("Failed to load chunk from disk for key %s: %s", key, e)
+            memory_obj.ref_count_down()
+            return None
+
     async def batched_get_non_blocking(
         self,
         lookup_id: str,
@@ -674,4 +770,5 @@ class LocalDiskBackend(StorageBackendInterface):
     def close(self) -> None:
         if self.batched_msg_sender is not None:
             self.batched_msg_sender.close()
+        self._read_thread_pool.shutdown(wait=True)
         self.disk_worker.close()

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 import shutil
 import tempfile
+import threading
 
 # Third Party
 import pytest
@@ -465,4 +466,146 @@ class TestGetBlockingCachePolicyUpdate:
 
         assert result is None
         mock_update.assert_not_called()
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class TestBatchedGetBlocking:
+    """Tests for the concurrent batched_get_blocking() override."""
+
+    _SHAPE = torch.Size([28, 2, 256, 8, 128])
+    _DTYPE = torch.bfloat16
+
+    def _write_key(
+        self,
+        backend: LocalDiskBackend,
+        key: CacheEngineKey,
+    ) -> bytes:
+        """Write random data to disk for *key* and register it in the backend.
+
+        Returns the raw bytes that were written so callers can verify reads.
+        """
+        path = backend._key_to_path(key)
+        nbytes = 1
+        for s in self._SHAPE:
+            nbytes *= s
+        nbytes *= self._DTYPE.itemsize
+        data = os.urandom(nbytes)
+        with open(path, "wb") as f:
+            f.write(data)
+        backend.insert_key(
+            key,
+            size=nbytes,
+            shape=self._SHAPE,
+            dtype=self._DTYPE,
+            fmt=MemoryFormat.KV_2LTD,
+        )
+        return data
+
+    def test_all_keys_missing(self, local_disk_backend: LocalDiskBackend) -> None:
+        """batched_get_blocking returns [None, …] when no keys are cached."""
+        keys = [create_test_key(i) for i in range(200, 204)]
+        results = local_disk_backend.batched_get_blocking(keys)
+
+        assert len(results) == len(keys)
+        assert all(r is None for r in results)
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_reads_match_written_data(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Data loaded by batched_get_blocking matches what was written."""
+        keys = [create_test_key(i) for i in range(210, 214)]
+        expected_data = {}
+        for key in keys:
+            expected_data[key] = self._write_key(local_disk_backend, key)
+
+        results = local_disk_backend.batched_get_blocking(keys)
+
+        assert len(results) == len(keys)
+        for key, mem_obj in zip(keys, results, strict=True):
+            assert mem_obj is not None, f"Expected data for {key}"
+            actual = bytes(mem_obj.byte_array)
+            assert actual == expected_data[key]
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_mixed_hit_and_miss(self, local_disk_backend: LocalDiskBackend) -> None:
+        """Handles a mix of cached and missing keys correctly."""
+        present_key = create_test_key(220)
+        missing_key = create_test_key(221)
+        expected = self._write_key(local_disk_backend, present_key)
+
+        results = local_disk_backend.batched_get_blocking([present_key, missing_key])
+
+        assert len(results) == 2
+        assert results[0] is not None
+        assert bytes(results[0].byte_array) == expected
+        assert results[1] is None
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_cache_policy_updated_only_for_hits(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """update_on_hit is called only for keys that were successfully loaded."""
+        hit_key = create_test_key(230)
+        miss_key = create_test_key(231)
+        self._write_key(local_disk_backend, hit_key)
+
+        with patch.object(
+            local_disk_backend.cache_policy, "update_on_hit"
+        ) as mock_update:
+            results = local_disk_backend.batched_get_blocking([hit_key, miss_key])
+
+        assert results[0] is not None
+        assert results[1] is None
+        mock_update.assert_called_once_with(hit_key, local_disk_backend.dict)
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_single_key_delegates_to_get_blocking(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """A single-key batch falls through to get_blocking (fast path)."""
+        key = create_test_key(240)
+        sentinel = MagicMock(spec=MemoryObj)
+        with patch.object(
+            local_disk_backend, "get_blocking", return_value=sentinel
+        ) as mock_get:
+            results = local_disk_backend.batched_get_blocking([key])
+
+        assert results == [sentinel]
+        mock_get.assert_called_once_with(key)
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_concurrent_reads_use_multiple_threads(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Verify that reads actually fan out across threads."""
+        keys = [create_test_key(i) for i in range(250, 254)]
+        for key in keys:
+            self._write_key(local_disk_backend, key)
+
+        thread_ids: list[int] = []
+        lock = threading.Lock()
+        original_read_file = local_disk_backend.read_file
+
+        def tracking_read_file(key, buffer, path):
+            with lock:
+                thread_ids.append(threading.current_thread().ident)
+            return original_read_file(key, buffer, path)
+
+        with patch.object(
+            local_disk_backend, "read_file", side_effect=tracking_read_file
+        ):
+            results = local_disk_backend.batched_get_blocking(keys)
+
+        assert all(r is not None for r in results)
+        # With 4 keys and 4 threads, we should see more than 1 unique thread.
+        assert len(set(thread_ids)) > 1, (
+            f"Expected multiple threads, got {set(thread_ids)}"
+        )
+        local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_empty_keys_list(self, local_disk_backend: LocalDiskBackend) -> None:
+        """An empty key list returns an empty result list."""
+        results = local_disk_backend.batched_get_blocking([])
+        assert results == []
         local_disk_backend.local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
LocalDiskBackend inherited the base class serial loop for batched_get_blocking, calling get_blocking one key at a time. This meant the hot read path (used by vLLM) got no I/O parallelism.

Override batched_get_blocking with a four-phase concurrent approach:
1. Batch metadata lookup under a single lock acquisition
2. Pre-allocate CPU staging buffers sequentially
3. Dispatch file reads to a ThreadPoolExecutor via map()
4. Update cache policy for successful loads

The GIL is released during readinto syscalls, so threads achieve true I/O parallelism. The new _read_thread_pool is sized by the existing disk_io_threads config (default 4), matching the GDS backend pattern.

Generated with [Devin](https://devin.ai)

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

| Aspect | `LocalDiskBackend` | `GdsBackend` |
|---|---|---|
| **`get_blocking`** | Sync read in caller thread | Sync GDS/POSIX read in caller thread |
| **`batched_get_blocking`** | `ThreadPoolExecutor.map()` — concurrent reads | `ThreadPoolExecutor.map()` — concurrent reads |
| **Async writes** | `AsyncPQThreadPoolExecutor` (priority queue + `asyncio.to_thread`) | `asyncio.to_thread()` (default executor) |
| **Async prefetches** | `AsyncPQThreadPoolExecutor` (priority 0, ahead of writes) | Stubbed out (`return False`) |
| **Task tracking** | `LocalDiskWorker` wrapper class (list + lock) | Inline `set` + `Lock` |
| **Read thread pool** | Dedicated `_read_thread_pool` | Shared `_thread_pool` (reads only, writes use default executor) |
| **Write thread pool** | `AsyncPQThreadPoolExecutor` (shared with prefetch) | Python default asyncio executor |
| **Priority scheduling** | Yes — prefetch=0, delete=1, write=2 | No |
| **`disk_io_threads` config** | Sizes both `_read_thread_pool` and `AsyncPQThreadPoolExecutor` | Sizes `_thread_pool` only |
| **`close()` cleanup** | Shuts down both pools | Shuts down `_thread_pool` |

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
