### PR TITLE
[Docs] Fix MP observability /metrics port and add a Grafana guide

### DIFF
--- a/docs/source/mp/observability/index.rst
+++ b/docs/source/mp/observability/index.rst
@@ -24,13 +24,184 @@ No extra flags are needed:
     lmcache server \
         --l1-size-gb 100 --eviction-policy LRU
 
-To enable tracing, supply an OTLP endpoint:
+The server then exposes Prometheus metrics at ``/metrics`` on its **HTTP
+frontend port** (``--http-port``, default ``8080``):
+
+.. code-block:: bash
+
+    curl http://localhost:8080/metrics | grep lmcache_mp_
+
+.. important::
+
+   For ``lmcache server``, ``/metrics`` lives on ``--http-port`` (default
+   ``8080``), **not** on ``--prometheus-port``: the HTTP frontend already
+   serves ``/metrics``, so the standalone Prometheus server is disabled and
+   ``--prometheus-port`` has no effect under this command. ``--prometheus-port``
+   *is* the metrics endpoint for the frontend-less entrypoints
+   (``python -m lmcache.v1.multiprocess.server`` and ``lmcache trace replay``)
+   — see :ref:`mp-obs-metrics-endpoint`. Also note metrics are lazy: a series
+   only appears *after* the first store/retrieve that produces it, so drive
+   some traffic before scraping.
+
+To also see L2 (storage-tier) metrics, attach an L2 backend with
+``--l2-adapter``. The simplest is the local filesystem:
+
+.. code-block:: bash
+
+    lmcache server \
+        --l1-size-gb 100 --eviction-policy LRU \
+        --l2-adapter '{"type": "fs", "base_path": "/data/lmcache/l2"}'
+
+To enable tracing instead of (or alongside) Prometheus pull, supply an OTLP
+endpoint — this switches metrics to **push mode** (see
+:ref:`mp-obs-grafana`):
 
 .. code-block:: bash
 
     lmcache server \
         --l1-size-gb 100 --eviction-policy LRU \
         --enable-tracing --otlp-endpoint http://localhost:4317
+
+.. _mp-obs-metrics-endpoint:
+
+Where ``/metrics`` lives
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The pull-mode ``/metrics`` endpoint is served in one of two places depending
+on the entrypoint. Entrypoints that embed the uvicorn HTTP frontend serve it
+there (and disable the standalone Prometheus server); entrypoints with no
+HTTP frontend start the standalone server on ``--prometheus-port`` instead.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 40
+
+   * - Entrypoint
+     - HTTP frontend?
+     - Pull-mode ``/metrics`` endpoint
+   * - ``lmcache server``
+     - yes
+     - ``--http-port`` (default ``8080``); ``--prometheus-port`` ignored
+   * - ``python -m lmcache.v1.multiprocess.server``
+     - no
+     - ``--prometheus-port`` (default ``9090``)
+   * - ``lmcache trace replay``
+     - no
+     - ``--prometheus-port`` (default ``9090``)
+
+In **push mode** (``--otlp-endpoint`` set) none of these serve ``/metrics`` —
+metrics are pushed to the collector instead.
+
+.. _mp-obs-grafana:
+
+Viewing Metrics in Grafana
+--------------------------
+
+There are two ways to get LMCache metrics into Grafana. Pick based on whether
+you also want **traces**.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 20 30 28
+
+   * - Path
+     - Server flags
+     - What you run
+     - Gives you
+   * - **A. Bundled stack**
+     - ``--otlp-endpoint`` (push)
+     - ``docker compose up`` in ``examples/observability/``
+     - Metrics **+ traces**, Grafana with the LMCache dashboard
+       auto-provisioned
+   * - **B. Pull mode**
+     - none (default)
+     - Your own Prometheus + Grafana scraping ``:8080``
+     - Metrics only, minimal moving parts, no collector
+
+Path A — bundled Prometheus + Tempo + Grafana
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The repository ships a ready-to-run stack (OpenTelemetry Collector →
+Prometheus + Tempo → Grafana) under ``examples/observability/``. Grafana comes
+with the **LMCache dashboard and datasources pre-provisioned** and anonymous
+access enabled, so there is nothing to click to log in.
+
+.. code-block:: bash
+
+    # 1. Start the observability stack (Collector :4320, Prometheus, Tempo,
+    #    Grafana :3000)
+    cd examples/observability
+    docker compose up -d
+
+    # 2. Start the LMCache server (+ vLLM) pushing OTLP to the collector
+    MODEL=/path/to/model bash start-server.sh
+
+    # 3. Generate traffic, then open Grafana
+    #    http://localhost:3000  ->  Dashboards  ->  "LMCache"
+
+In this path the server pushes to the Collector and **Prometheus scrapes the
+Collector**, so you do *not* scrape the server's ``:8080`` directly.
+
+Path B — pull mode (metrics only, no collector)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you only want metrics, skip the collector entirely and have Prometheus
+scrape the server's ``/metrics`` endpoint directly. Start the server **without**
+``--otlp-endpoint`` (see Quick Start above), then:
+
+.. code-block:: bash
+
+    # 1. Prometheus config: scrape the server's HTTP-frontend port (8080)
+    cat > prometheus.yml <<'YAML'
+    global:
+      scrape_interval: 5s
+    scrape_configs:
+      - job_name: lmcache
+        static_configs:
+          - targets: ["localhost:8080"]   # --http-port, NOT --prometheus-port
+    YAML
+
+    # 2. Run Prometheus (:9090) and Grafana (:3000) on the host network so
+    #    they can reach localhost:8080 and each other.
+    docker run -d --name lmcache-prom --network host \
+        -v "$PWD/prometheus.yml:/etc/prometheus/prometheus.yml:ro" \
+        prom/prometheus
+
+    docker run -d --name lmcache-grafana --network host \
+        -e GF_AUTH_ANONYMOUS_ENABLED=true \
+        -e GF_AUTH_ANONYMOUS_ORG_ROLE=Admin \
+        grafana/grafana
+
+Then in Grafana (``http://localhost:3000``):
+
+1. **Add a datasource** → Prometheus → URL ``http://localhost:9090`` → Save.
+2. **Import the dashboard**: Dashboards → New → Import → upload
+   ``examples/observability/grafana/provisioning/dashboards/lmcache.json``
+   and select the Prometheus datasource. This is the same dashboard the
+   bundled stack provisions (cache hit rate, L1/L2 cache ops, L1↔L2
+   throughput, eviction loop, EventBus health, and more).
+
+Verify the pipeline end to end:
+
+.. code-block:: bash
+
+    # target should be "up"
+    curl -s localhost:9090/api/v1/targets | grep -o '"health":"[a-z]*"'
+
+    # after driving traffic, L2 store throughput (GB/s) per backend:
+    curl -s localhost:9090/api/v1/query --data-urlencode \
+      'query=sum by (l2_name) (rate(lmcache_mp_l2_store_throughput_GB_per_second_sum[1m]))
+             / sum by (l2_name) (rate(lmcache_mp_l2_store_throughput_GB_per_second_count[1m]))'
+
+See :doc:`metrics` for the full metric catalog and more PromQL examples.
+
+.. note::
+
+   ``--network host`` (used above) is the simplest option on Linux. On Docker
+   Desktop (macOS/Windows), drop ``--network host``, publish ports with
+   ``-p 9090:9090`` / ``-p 3000:3000``, and set the scrape target to
+   ``host.docker.internal:8080`` and the Grafana datasource URL to
+   ``http://host.docker.internal:9090``.
 
 Configuration
 -------------
@@ -64,7 +235,16 @@ Configuration
        exporting metrics (push mode) and traces.
    * - ``--prometheus-port``
      - ``9090``
-     - Port for the Prometheus ``/metrics`` HTTP endpoint.
+     - Port of the standalone Prometheus ``/metrics`` server. Started only by
+       frontend-less entrypoints (``python -m lmcache.v1.multiprocess.server``,
+       ``lmcache trace replay``). **Ignored by** ``lmcache server`` — there the
+       HTTP frontend serves ``/metrics`` on ``--http-port`` instead, so the
+       standalone server is disabled. See :ref:`mp-obs-metrics-endpoint`.
+   * - ``--http-port``
+     - ``8080``
+     - Port of the HTTP frontend, which serves the Prometheus ``/metrics``
+       endpoint in pull mode (when ``--otlp-endpoint`` is unset) for
+       ``lmcache server``.
    * - ``--metrics-sample-rate``
      - ``0.01``
      - Fraction of chunks/blocks to track for lifecycle histograms

--- a/docs/source/mp/observability/metrics.rst
+++ b/docs/source/mp/observability/metrics.rst
@@ -1,14 +1,37 @@
 Metrics
 =======
 
-Metrics are collected via OpenTelemetry counters and exported through an
-in-process **Prometheus** ``/metrics`` HTTP endpoint (default port 9090).
-When ``--otlp-endpoint`` is set, metrics are also pushed to the OTel
-collector.
+Metrics are collected via OpenTelemetry and made available to Prometheus in
+one of two ways, depending on whether ``--otlp-endpoint`` is set:
+
+- **Pull mode (default, no collector).** When ``--otlp-endpoint`` is *not*
+  set, the server publishes a Prometheus ``/metrics`` endpoint that Prometheus
+  scrapes directly.
+
+  .. important::
+
+     For ``lmcache server``, ``/metrics`` is served by the **HTTP frontend**
+     on ``--http-port`` (default **8080**), e.g.
+     ``http://<host>:8080/metrics`` — **not** on ``--prometheus-port``.
+     ``--prometheus-port`` is *ignored* by ``lmcache server``: the standalone
+     Prometheus HTTP server is disabled because the HTTP frontend already
+     serves ``/metrics``. The frontend-less entrypoints
+     (``python -m lmcache.v1.multiprocess.server`` and ``lmcache trace
+     replay``) have no HTTP frontend, so *they* serve ``/metrics`` on
+     ``--prometheus-port`` (default 9090). See
+     :ref:`mp-obs-metrics-endpoint` for the full breakdown. Either way,
+     ``/metrics`` is empty until the first store/retrieve — drive some
+     traffic before you go looking.
+
+- **Push mode (OTLP).** When ``--otlp-endpoint`` is set, metrics are pushed to
+  an OpenTelemetry Collector, which re-exposes them for Prometheus to scrape.
+  See :doc:`index` for the bundled Collector + Prometheus + Grafana stack.
 
 All metrics use the ``lmcache_mp.`` prefix (multiprocess). On Prometheus,
 dots are converted to underscores and counters get a ``_total`` suffix
-(e.g. ``lmcache_mp_l1_read_chunks_total``).
+(e.g. ``lmcache_mp_l1_read_chunks_total``); histograms gain a unit suffix
+plus ``_sum`` / ``_count`` / ``_bucket`` (e.g.
+``lmcache_mp_l2_store_throughput_GB_per_second_sum``).
 
 .. _mp-observability-resource:
 
@@ -378,6 +401,29 @@ attribute — the registered adapter type (e.g. ``"fs"``, ``"nixl_store"``,
      - Histogram
      - L2→L1 load throughput in GB/s per (request, adapter) pair.
 
+**PromQL for average throughput (GB/s), per backend:**
+
+.. code-block:: promql
+
+    # L1 -> L2 store throughput, averaged over the last minute, per l2_name:
+    sum by (l2_name) (rate(lmcache_mp_l2_store_throughput_GB_per_second_sum[1m]))
+    / sum by (l2_name) (rate(lmcache_mp_l2_store_throughput_GB_per_second_count[1m]))
+
+    # L2 -> L1 load throughput (same shape):
+    sum by (l2_name) (rate(lmcache_mp_l2_load_throughput_GB_per_second_sum[1m]))
+    / sum by (l2_name) (rate(lmcache_mp_l2_load_throughput_GB_per_second_count[1m]))
+
+.. note::
+
+   ``l2_store_throughput`` populates whenever chunks are written to L2.
+   ``l2_load_throughput`` only populates when chunks are read **from L2 into
+   L1** — i.e. on a prefetch load after the entry has aged out of L1. If your
+   working set fits entirely in L1 (common with small models or a large
+   ``--l1-size-gb``), lookups are served from L1 and the load histogram stays
+   empty even though store throughput is non-zero. Drive enough distinct data
+   to force L1 eviction, or restart the server between store and load passes,
+   to exercise the L2 load path.
+
 Engine Counters
 ~~~~~~~~~~~~~~~
 
@@ -521,12 +567,19 @@ each metric see ``docs/design/v1/mp_observability/METRICS.md`` and
 Prometheus Scrape Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Add the LMCache server as a Prometheus scrape target:
+In **pull mode** (no ``--otlp-endpoint``), point Prometheus at the server's
+HTTP-frontend port — ``--http-port``, default **8080** — not at
+``--prometheus-port``:
 
 .. code-block:: yaml
 
     scrape_configs:
       - job_name: "lmcache-mp"
         static_configs:
-          - targets: ["<lmcache-host>:9090"]
+          - targets: ["<lmcache-host>:8080"]   # --http-port, NOT --prometheus-port
+
+In **push mode** (``--otlp-endpoint`` set), the server does not expose
+``/metrics`` itself; scrape the OpenTelemetry Collector's Prometheus exporter
+instead. The bundled stack in ``examples/observability/`` wires this up for
+you — see :doc:`index`.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The MP observability docs told users to scrape `--prometheus-port` (9090), but `lmcache server` serves `/metrics` on the **HTTP frontend** (`--http-port`, default **8080**) — the standalone Prometheus server is disabled there (`run_cache_server(..., start_prometheus_http_server=False)` in `http_server.py`). `--prometheus-port` is only honored by the frontend-less entrypoints (`python -m lmcache.v1.multiprocess.server`, `lmcache trace replay`). Following the docs as written, you scrape an endpoint that does not exist and see no metrics.

This corrects the endpoint and turns the pages from a metric *reference* into something you can follow end-to-end.

`docs/source/mp/observability/index.rst`:
- Quick Start now shows the real `/metrics` location (`--http-port`) and the "metrics are lazy until first traffic" caveat.
- New **"Where `/metrics` lives"** table mapping each entrypoint → endpoint (HTTP frontend vs. standalone Prometheus server).
- New **"Viewing Metrics in Grafana"** section with two concrete paths: the bundled `examples/observability/` compose stack (metrics + traces), and a lightweight pull-mode `docker run` for Prometheus + Grafana scraping `:8080` and importing the existing `lmcache.json` dashboard.
- Corrected `--prometheus-port` description and added an `--http-port` row.

`docs/source/mp/observability/metrics.rst`:
- Fixed the intro and the Prometheus scrape-config port (`9090` → `8080`), with pull vs. push modes explained.
- Documented the histogram `_sum`/`_count`/`_bucket` (+ unit) naming on Prometheus.
- Added verified PromQL for L2 store/load throughput and a note that `l2_load_throughput` only populates under L1 eviction.

**Special notes for your reviewers**:

- Docs-only; no code changes. Behavior described was verified against a live `lmcache server` + vLLM (`LMCacheMPConnector`) run: `/metrics` was on `:8080`, and `lmcache_mp_l2_store_throughput_GB_per_second_*` populated as documented.
- Separately, this suggests a code follow-up (not in this PR): log the resolved `/metrics` URL at server startup, and/or warn when `--prometheus-port` is explicitly set on `lmcache server` (currently silently ignored). Happy to send that as a follow-up if desired.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests