### PR TITLE
docs: daily drift check — multi-process mode (2026-07-01)

### DIFF
--- a/docs/design/v1/mp_coordinator/l2_prefetch.md
+++ b/docs/design/v1/mp_coordinator/l2_prefetch.md
@@ -34,10 +34,11 @@ registry, `POST`s to its `/cache/prefetches`, and relays the server's
 `request_id` back. The client then polls
 `GET /cache/prefetches/{instance_id}/{request_id}` on the coordinator, which proxies
 the server's status. The warm holds **no read-lock** — completion is reported
-reactively and releases nothing; see `docs/design/v1/multiprocess/l2_apis.md`
-for the warm-prefetch lifecycle (retain-permanent, no-lock load). There is no
-background polling on either side: the submit and status calls are quick and
-the client drives completion on demand.
+reactively and releases nothing; see the warm-prefetch endpoint reference in
+`docs/source/mp/http_api.rst` and the coordinator-side flow in
+`docs/source/mp/coordinator.rst` for the retain-permanent, no-lock load
+lifecycle. There is no background polling on either side: the submit and
+status calls are quick and the client drives completion on demand.
 
 ## Components
 
@@ -70,7 +71,7 @@ loops) so request handlers can issue outbound calls.
   503 (`Unavailable`), surfaced to the caller via the 502/proxy path.
 - **Client abandons polling** → the server's job lingers as a small handle
   entry (no lock held, no L1 pinned) until polled or swept — see the no-lock
-  lifecycle in `l2_apis.md`.
+  lifecycle in `docs/source/mp/http_api.rst` (warm-prefetch endpoint).
 
 ## Scope
 

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -76,7 +76,8 @@ High-Level Architecture
     StorageManager (distributed/storage_manager.py)
          |
          |--- L1Manager (l1_manager.py)
-         |       |--- L1MemoryManager (CPU DRAM) or
+         |       |--- L1MemoryManager (CPU DRAM),
+         |       |    DevDaxL1MemoryManager (Device-DAX slab), or
          |       |    GDSL1MemoryManager (NVMe slab via cuFile / hipFile)
          |       |--- TTLLock per object (read/write)
          |
@@ -383,11 +384,16 @@ Manages objects in CPU memory with a state machine:
 Each object has two ``TTLLock`` instances (read and write) with configurable
 timeouts to prevent deadlocks from crashed clients.
 
-The underlying memory allocation is handled by one of two interchangeable
-tiers selected at startup (both satisfy ``L1ManagerProtocol``):
+The underlying memory allocation is handled by one of three interchangeable
+tiers selected at startup (all satisfy ``L1ManagerProtocol``):
 
 - ``L1MemoryManager`` (default) -- pinned CPU DRAM, with lazy growth up to
   ``--l1-size-gb``.
+- ``DevDaxL1MemoryManager`` -- a Device-DAX-backed L1 slab when
+  ``--l1-devdax-path`` is set. A pure Device-DAX configuration maps the DAX
+  device as the full L1 arena; a hybrid configuration uses DRAM first and
+  spills overflow allocations into Device-DAX. See the *L1 Memory* section
+  of :doc:`configuration` for the accepted knobs.
 - ``GDSL1MemoryManager`` -- an NVMe slab file when ``--gds-l1-path`` is set.
   The bytes live on disk; reads/writes DMA directly between the GPU staging
   buffer and the slab, driven by the process-global ``GDSContext``


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. Two inconsistencies between the multi-process (MP) docs and the current `dev` code (`upstream/dev` HEAD `9f5cee0c`) were found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/mp/index.rst`** — the *High-Level Architecture* ASCII diagram and the *L1 Manager* tier list both said the L1 memory backend was one of **two** interchangeable tiers (`L1MemoryManager` for CPU DRAM and `GDSL1MemoryManager` for NVMe/GDS). A third peer tier, `DevDaxL1MemoryManager`, now owns the Device-DAX path that used to live inside the generic CPU L1 manager — so the diagram and prose were missing an entire tier that is already selectable via a documented CLI flag.

`docs/design/` (design docs):

- **`docs/design/v1/mp_coordinator/l2_prefetch.md`** — two cross-references pointed at `docs/design/v1/multiprocess/l2_apis.md` for the warm-prefetch lifecycle (retain-permanent, no-lock load). That file has been deleted; the equivalent content now lives in the user-facing HTTP API and coordinator pages.

**Evidence**

| Drift | Code / repo state (current `dev`) | Stale doc |
| --- | --- | --- |
| `DevDaxL1MemoryManager` missing from the L1 tier list | [`lmcache/v1/distributed/memory_manager/__init__.py`](https://github.com/LMCache/LMCache/blob/9f5cee0c4923cd65a5c6708f356097f5be7b10ac/lmcache/v1/distributed/memory_manager/__init__.py#L4-L9) — three peers under `L1ManagerProtocol` (`L1MemoryManager`, `DevDaxL1MemoryManager`, `GDSL1MemoryManager`); introduced by PR #3947 ([b8c6a8df](https://github.com/LMCache/LMCache/commit/b8c6a8df1843e03bcb1f5443dd2a98729aaee118)) which added [`devdax_l1_memory_manager.py`](https://github.com/LMCache/LMCache/blob/9f5cee0c4923cd65a5c6708f356097f5be7b10ac/lmcache/v1/distributed/memory_manager/devdax_l1_memory_manager.py) | [`docs/source/mp/index.rst#L78-L80`](https://github.com/LMCache/LMCache/blob/9f5cee0c4923cd65a5c6708f356097f5be7b10ac/docs/source/mp/index.rst#L78-L80) and [`docs/source/mp/index.rst#L386-L391`](https://github.com/LMCache/LMCache/blob/9f5cee0c4923cd65a5c6708f356097f5be7b10ac/docs/source/mp/index.rst#L386-L391) |
| Broken reference to deleted `l2_apis.md` | File `docs/design/v1/multiprocess/l2_apis.md` was deleted by PR #3948 ([3e872f52](https://github.com/LMCache/LMCache/commit/3e872f52462f736c836a353afe39a73c75b699ba)) — the same PR moved the equivalent content into `docs/source/mp/http_api.rst` and `docs/source/mp/coordinator.rst` | [`docs/design/v1/mp_coordinator/l2_prefetch.md#L37`](https://github.com/LMCache/LMCache/blob/9f5cee0c4923cd65a5c6708f356097f5be7b10ac/docs/design/v1/mp_coordinator/l2_prefetch.md#L37) and [`docs/design/v1/mp_coordinator/l2_prefetch.md#L73`](https://github.com/LMCache/LMCache/blob/9f5cee0c4923cd65a5c6708f356097f5be7b10ac/docs/design/v1/mp_coordinator/l2_prefetch.md#L73) |

**Proposed fix**

Already applied in the diff (docs only, no code touched):

1. `docs/source/mp/index.rst` — the ASCII diagram now lists all three L1 tiers, and the tier list has been updated from *"one of two"* to *"one of three"*, with a new bullet for `DevDaxL1MemoryManager` that points readers at the existing `--l1-devdax-path` / `--l1-devdax-size-gb` knobs described in the *L1 Memory* section of `configuration.rst`.
2. `docs/design/v1/mp_coordinator/l2_prefetch.md` — the two references to the deleted `l2_apis.md` are replaced with pointers to `docs/source/mp/http_api.rst` (warm-prefetch endpoint reference) and `docs/source/mp/coordinator.rst` (coordinator-side flow), which is where the retain-permanent, no-lock lifecycle is now described.

**Special notes for your reviewers**:

- Docs-only change. No code modified.
- This PR was **auto-generated** by the daily drift-check routine and **needs human review before merge**. Please do not merge without a maintainer's eyes.
- Two related items were checked but intentionally not touched here:
  - PR #3960 (still open) already covers `hfbucket` in the L2 adapter list and `IsolatedLRU` in the `--eviction-policy` table.
  - The `L1MemoryManager` module's own package docstring in `lmcache/v1/distributed/memory_manager/__init__.py` still says "Two interchangeable tiers" but lists three — that is a code-file comment (not a docs file), so it's out of scope for this drift check. Flagging it here for a maintainer to consider fixing alongside PR #3947 follow-up.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gcfrvr1tP1yxyvygAAPtN1)_