### PR TITLE
fix: make GDS POSIX fallback portable across CUDA and ROCm

### DIFF
--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -5,6 +5,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 import asyncio
 import ctypes
+import ctypes.util
 import json
 import mmap
 import os
@@ -180,6 +181,38 @@ def get_extra_config_bool(key, config: LMCacheEngineConfig) -> bool | None:
     return bool_value
 
 
+def _load_gpu_memcpy() -> Callable:
+    """Load the GPU runtime ``memcpy`` symbol (CUDA or ROCm).
+
+    Tries ``libcudart`` first, then ``libamdhip64``. On CUDA the symbol is
+    ``cudaMemcpy``; on ROCm it is ``hipMemcpy`` — both share the same
+    ``(dst, src, count, kind)`` C signature.
+
+    Returns:
+        A ``ctypes`` function pointer to the GPU ``memcpy`` symbol.
+
+    Raises:
+        RuntimeError: If neither CUDA nor ROCm runtime can be loaded.
+    """
+    candidates: list[tuple[str, str, str]] = [
+        ("cudart", "libcudart.so", "cudaMemcpy"),
+        ("amdhip64", "libamdhip64.so", "hipMemcpy"),
+    ]
+    for lib_name, fallback_path, symbol in candidates:
+        try:
+            path = ctypes.util.find_library(lib_name) or fallback_path
+            lib = ctypes.CDLL(path)
+            fn = getattr(lib, symbol)
+            logger.info("Loaded GPU runtime '%s' (symbol: %s)", path, symbol)
+            return fn
+        except (OSError, AttributeError):
+            continue
+    raise RuntimeError(
+        "GDS POSIX fallback requires a GPU runtime library "
+        "(libcudart.so or libamdhip64.so) but neither could be loaded"
+    )
+
+
 class GdsBackend(AllocatorBackendInterface):
     """
     Originally based on the open sourced WekaGdsBackend, this is a backend that
@@ -189,7 +222,7 @@ class GdsBackend(AllocatorBackendInterface):
 
     The GDS library to use is controlled by the `gds_backend` config field
     (default: ``"cufile"``). Setting ``use_gds=False`` disables the GDS API
-    and falls back to POSIX I/O via cudart.
+    and falls back to POSIX I/O via the GPU runtime (CUDA or ROCm).
 
     Cache Directory Structure created by this Backend:
     /{gds_path}/{first_level}/{second_level}/{data & metadata} This structure
@@ -291,7 +324,7 @@ class GdsBackend(AllocatorBackendInterface):
                 # Third Party
                 import cufile
 
-                self.cudart = None
+                self._gpu_memcpy = None
                 self.gds_module = cufile
                 self._gds_driver = self.gds_module.CuFileDriver()
             elif self.gds_backend == "hipfile":
@@ -300,7 +333,7 @@ class GdsBackend(AllocatorBackendInterface):
                 # First Party
                 from lmcache.v1.storage_backend import hipfile_shim
 
-                self.cudart = None
+                self._gpu_memcpy = None
                 self.gds_module = hipfile_shim
                 self._gds_driver = self.gds_module.CuFileDriver()
             else:
@@ -308,7 +341,7 @@ class GdsBackend(AllocatorBackendInterface):
         else:
             logger.info("GDS disabled, using POSIX fallback")
             self.gds_module = None
-            self.cudart = ctypes.CDLL("libcudart.so")
+            self._gpu_memcpy = _load_gpu_memcpy()
 
         self.use_direct_io = False
 
@@ -972,7 +1005,7 @@ class GdsBackend(AllocatorBackendInterface):
                     f.write(
                         addr, kv_chunk.nbytes, file_offset=offset, dev_offset=dev_offset
                     )
-            elif self.cudart:
+            elif self._gpu_memcpy:
                 # mmap the file
                 fd = os.open(tmp_path, os.O_RDWR)
                 nbytes = kv_chunk.nbytes
@@ -987,14 +1020,14 @@ class GdsBackend(AllocatorBackendInterface):
                 buf_addr = arr.__array_interface__["data"][0]
 
                 assert addr.value is not None
-                res = self.cudart.cudaMemcpy(
+                res = self._gpu_memcpy(
                     ctypes.c_void_p(buf_addr + offset),
                     ctypes.c_void_p(int(addr.value) + device_offset),
                     ctypes.c_size_t(nbytes),
                     ctypes.c_int(2),
                 )
                 if res:
-                    raise RuntimeError(f"cudaMemcpy failed {res}")
+                    raise RuntimeError(f"GPU memcpy failed {res}")
                 del arr
                 mm.close()
 
@@ -1024,7 +1057,7 @@ class GdsBackend(AllocatorBackendInterface):
                         file_offset=file_offset,
                         dev_offset=dev_offset,
                     )
-            elif self.cudart:
+            elif self._gpu_memcpy:
                 fd = os.open(gds_path, os.O_RDONLY)
                 file_size = os.fstat(fd).st_size
 
@@ -1050,7 +1083,7 @@ class GdsBackend(AllocatorBackendInterface):
                 addr = arr.__array_interface__["data"][0]
 
                 assert gpu_pointer.value is not None
-                res = self.cudart.cudaMemcpy(
+                res = self._gpu_memcpy(
                     ctypes.c_void_p(int(gpu_pointer.value) + dev_offset),
                     ctypes.c_void_p(addr + file_offset),
                     ctypes.c_size_t(size_in_bytes),
@@ -1058,13 +1091,13 @@ class GdsBackend(AllocatorBackendInterface):
                 )
 
                 if res != 0:
-                    raise RuntimeError(f"cudaMemcpy failed with code {res}")
+                    raise RuntimeError(f"GPU memcpy failed with code {res}")
                 del arr
                 mm.close()
                 return size_in_bytes
             else:
                 raise RuntimeError(
-                    "Both gds_module and cudart are None, this should not happen"
+                    "Both gds_module and _gpu_memcpy are None, this should not happen"
                 )
         except Exception as e:
             # return -1 on any exception, and log the error.


### PR DESCRIPTION
The POSIX fallback path (use_gds=False) hardcoded libcudart.so and called cudaMemcpy by name, which fails on AMD ROCm systems.

Add _load_gpu_memcpy() helper that tries libcudart/cudaMemcpy first, then falls back to libamdhip64/hipMemcpy. Both share the same (dst, src, count, kind) C signature and enum values.

Generated with [Devin](https://devin.ai)

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
