### PR TITLE
[CLI] Add `query kvcache` lookup mode

### DIFF
--- a/docs/design/cli/commands.md
+++ b/docs/design/cli/commands.md
@@ -397,7 +397,7 @@ lmcache/cli/
 |-------|-------|
 | **0** | CLI framework (explicit registration, `Metrics`), `mock` example command, entry point — see [framework-and-metrics.md](framework-and-metrics.md) |
 | **1** | **`server`** (done), `ping kvcache`, `kvcache clear`, `kvcache end-session`, `describe kvcache` |
-| **2** | `ping engine`, `query engine`, `query kvcache`, `bench engine`, `bench server`, `bench l2`, `describe engine`, corpora |
+| **2** | `ping engine`, `query engine` (done), `query kvcache` (done, lookup-mode subset), `bench engine`, `bench server`, `bench l2`, `describe engine` (done), corpora |
 | **3** | `kvcache evict` (future) |
 
 Existing `lmcache_server` entry point kept as a deprecated alias for 2 minor releases.

--- a/docs/design/cli/commands/query-command.md
+++ b/docs/design/cli/commands/query-command.md
@@ -176,10 +176,23 @@ per-instance HTTP server or the controller HTTP server.
   (`lmcache/cli/request.py`) streams an OpenAI-compatible `/v1/chat/completions`
   or `/v1/completions` request; **Latency Metrics** repeats server usage (labeled
   **Input tokens**, not a duplicate client-side total).
-- **`query kvcache`:** stub; no handler yet.
-- **Errors:** `query_engine` catches `RuntimeError` / `ValueError`, prints the
-  message to stderr, exits `1`; unknown `query_target` prints to stderr and exits
-  `1`.
+- **`query kvcache`:** lookup mode implemented (`kvcache_command.py` +
+  `_lookup.py`). `PromptBuilder` expands `--documents`; `CacheLookup` tokenizes
+  the prompt locally via `AutoTokenizer(--model)` and posts the token IDs to the
+  controller `POST /lookup`, then `summarize_coverage` renders cached tokens,
+  cache status (`HIT` / `MISS` / `HIT (partial)`), the matched location(s), and
+  chunk counts derived from `--chunk-size` (default 256).
+  - **Honest subset (see below).** `POST /lookup` returns the longest cached
+    *prefix* and a single location per instance, so this command reports
+    token-based coverage plus that location. The design's per-tier chunk
+    histogram (`[cpu=12, disk=0]`), exact chunk counts, single-instance support,
+    and round-trip mode need a per-instance server endpoint and are deferred to a
+    follow-up PR. Chunk counts are exact only when `--chunk-size` matches the
+    server's configured chunk size. Coverage is prefix-based (breaks at first
+    miss). Token IDs must match the engine's tokenizer or coverage reads low.
+- **Errors:** both `query engine` and `query kvcache` catch `RuntimeError` /
+  `ValueError`, print the message to stderr, and exit `1`; unknown `query_target`
+  prints to stderr and exits `1`.
 
 ---
 
@@ -187,7 +200,8 @@ per-instance HTTP server or the controller HTTP server.
 
 | Phase | Work |
 |-------|------|
-| **1a** | `query engine` with prompt, max-tokens, TTFT/TPOT/throughput metrics |
-| **1b** | `query kvcache` lookup mode (prompt tokenization + cache coverage) |
-| **future** | richer query diagnostics (per-chunk detail) |
+| **1a** | `query engine` with prompt, max-tokens, TTFT/TPOT/throughput metrics (done) |
+| **1b** | `query kvcache` lookup mode against the controller `POST /lookup` (done, honest subset) |
+| **2** | per-instance lookup endpoint: per-tier chunk histogram, exact chunks, single-instance, server-side tokenization |
+| **future** | richer query diagnostics (per-chunk detail), round-trip verification |
 

--- a/docs/source/cli/query.rst
+++ b/docs/source/cli/query.rst
@@ -1,15 +1,15 @@
 lmcache query
 =============
 
-The ``lmcache query`` command sends a single OpenAI-compatible inference
-request and reports token and latency metrics. It has two targets:
+The ``lmcache query`` command runs a single, metrics-first query. It has two
+targets:
 
 .. code-block:: bash
 
    lmcache query {engine,kvcache} [options]
 
 * ``engine`` — send one request to a serving engine's HTTP API.
-* ``kvcache`` — query KV-cache endpoints (not implemented yet).
+* ``kvcache`` — report how much of a prompt is already in the KV cache.
 
 
 query engine
@@ -79,6 +79,88 @@ Options
      - No
      - Try ``/v1/chat/completions`` first, then fall back to
        ``/v1/completions``.
+   * - ``--format``
+     - No
+     - Output format: ``terminal`` (default) or ``json``.
+   * - ``--output PATH``
+     - No
+     - Save metrics to a file (format follows ``--format``).
+   * - ``-q`` / ``--quiet``
+     - No
+     - Suppress stdout output. Exit code only.
+
+
+query kvcache
+-------------
+
+The ``query kvcache`` subcommand reports how much of a prompt is already stored
+in the KV cache. It tokenizes the prompt locally with the model's tokenizer,
+posts the token IDs to the controller's ``POST /lookup`` endpoint, and
+summarizes the coverage. ``--prompt`` supports the same ``{name}`` placeholders
+as ``query engine``: bind one to a file with ``--documents NAME=PATH``, pass a
+bare ``--documents PATH`` to fill the next unnamed placeholder (or append to the
+prompt if none remain), and ``{lmcache}`` resolves to the bundled sample
+document with no ``--documents`` needed.
+
+.. code-block:: bash
+
+   lmcache query kvcache --url http://localhost:5555 \
+     --prompt "{ctx} What is the example usage of lmcache?" \
+     --documents ctx=lmcache/cli/documents/lmcache.txt \
+     --model meta-llama/Llama-3.1-8B-Instruct
+
+.. code-block:: text
+
+   =============== Query KV Cache ================
+   Model:            meta-llama/Llama-3.1-8B-Instruct
+   Prompt tokens:                             8192
+   Cached tokens:                        7680/8192
+   Cached chunks:                            30/32
+   Cache locations:                  [cpu@inst-0]
+   Cache status:                     HIT (partial)
+   ==============================================
+
+Cache status is ``HIT`` when the whole prompt is cached, ``MISS`` when nothing
+is, and ``HIT (partial)`` otherwise.
+
+.. note::
+
+   Coverage is **prefix-based**: it reports the longest cached prefix and stops
+   at the first uncached chunk. ``Cache locations`` lists the instance holding
+   that prefix (``location@instance_id``), not a per-tier chunk histogram.
+   ``Cached chunks`` is derived from ``--chunk-size`` and is exact only when
+   that value matches the server's configured chunk size. Token IDs must come
+   from the same tokenizer the engine uses, or coverage will read low.
+
+Options
+~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Flag
+     - Required
+     - Description
+   * - ``--url URL``
+     - Yes
+     - Controller HTTP endpoint (e.g. ``http://localhost:5555``).
+   * - ``--prompt TEXT``
+     - Yes
+     - Prompt text with optional ``{name}`` placeholders.
+   * - ``--model ID``
+     - Yes
+     - Tokenizer/model ID used to derive token IDs. For gated models, run
+       ``huggingface-cli login`` first.
+   * - ``--documents NAME=PATH``
+     - No
+     - Load file text for ``{NAME}`` in ``--prompt``. Accepts one or more
+       ``NAME=PATH`` or bare ``PATH`` values; a bare ``PATH`` fills the next
+       unnamed placeholder or is appended to the prompt.
+   * - ``--chunk-size N``
+     - No
+     - Tokens per cache chunk for the chunk-count display (default: 256). Must
+       match the server's configured chunk size to be exact.
    * - ``--format``
      - No
      - Output format: ``terminal`` (default) or ``json``.

--- a/lmcache/cli/commands/query/_lookup.py
+++ b/lmcache/cli/commands/query/_lookup.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cache-coverage lookup helper for ``lmcache query kvcache``.
+
+Turns a prompt into token IDs, asks the controller ``POST /lookup`` how much of
+that token sequence is already cached, and summarizes the response into a
+:class:`CoverageResult`.
+"""
+
+# Standard
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+import urllib.error
+import urllib.request
+
+
+def _normalize_url(url: str) -> str:
+    """Ensure *url* has an ``http(s)://`` scheme and no trailing slash."""
+    url = url.strip()
+    if "://" not in url:
+        url = f"http://{url}"
+    return url.rstrip("/")
+
+
+@dataclass(frozen=True)
+class CoverageResult:
+    """Cache-coverage summary for one prompt.
+
+    Attributes:
+        prompt_tokens: Total tokens in the prompt.
+        cached_tokens: Length of the longest cached prefix (in tokens).
+        cache_status: ``"HIT"``, ``"MISS"``, or ``"HIT (partial)"``.
+        cached_chunks: Number of cached chunks (derived from ``chunk_size``).
+        total_chunks: Total chunks in the prompt (derived from ``chunk_size``).
+        locations: ``(instance_id, location)`` pairs holding cached data.
+    """
+
+    prompt_tokens: int
+    cached_tokens: int
+    cache_status: str
+    cached_chunks: int
+    total_chunks: int
+    locations: list[tuple[str, str]]
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    """Return ``ceil(numerator / denominator)``, or ``0`` for a non-positive
+    denominator."""
+    if denominator <= 0:
+        return 0
+    return (numerator + denominator - 1) // denominator
+
+
+def summarize_coverage(
+    layout_info: Mapping[str, Sequence[object]],
+    total_tokens: int,
+    chunk_size: int,
+) -> CoverageResult:
+    """Summarize a ``/lookup`` ``layout_info`` map into a :class:`CoverageResult`.
+
+    Args:
+        layout_info: Map of ``instance_id`` to ``(location, cached_prefix_end)``
+            as returned by the controller ``POST /lookup`` endpoint. Values may
+            be tuples or (from JSON) lists.
+        total_tokens: Total number of tokens in the prompt.
+        chunk_size: Tokens per cache chunk, used to derive chunk counts.
+
+    Returns:
+        The coverage summary. ``cached_tokens`` is the longest cached prefix
+        across all instances; ``cache_status`` is ``MISS`` when nothing is
+        cached, ``HIT`` when the whole prompt is cached, else ``HIT (partial)``.
+    """
+    cached_tokens = 0
+    locations: list[tuple[str, str]] = []
+    for instance_id, location_end in layout_info.items():
+        location = str(location_end[0])
+        end = int(str(location_end[1]))
+        locations.append((str(instance_id), location))
+        cached_tokens = max(cached_tokens, end)
+
+    cached_tokens = min(cached_tokens, total_tokens)
+    if cached_tokens <= 0:
+        cache_status = "MISS"
+    elif cached_tokens >= total_tokens:
+        cache_status = "HIT"
+    else:
+        cache_status = "HIT (partial)"
+
+    return CoverageResult(
+        prompt_tokens=total_tokens,
+        cached_tokens=cached_tokens,
+        cache_status=cache_status,
+        cached_chunks=_ceil_div(cached_tokens, chunk_size),
+        total_chunks=_ceil_div(total_tokens, chunk_size),
+        locations=locations,
+    )
+
+
+class CacheLookup:
+    """Read-only cache-coverage client for the controller ``POST /lookup``.
+
+    Tokenizes a prompt with the model's tokenizer, asks the controller how much
+    of the token sequence is cached, and summarizes the result.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        model: str,
+        chunk_size: int = 256,
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize the lookup client.
+
+        Args:
+            url: Base URL of the controller HTTP server.
+            model: Tokenizer/model id used to derive token IDs.
+            chunk_size: Tokens per cache chunk, used to derive chunk counts.
+            timeout: HTTP timeout in seconds.
+        """
+        self._url = _normalize_url(url)
+        self._model = model
+        self._chunk_size = chunk_size
+        self._timeout = timeout
+
+    def request_lookup(self, tokens: list[int]) -> dict[str, Sequence[object]]:
+        """POST *tokens* to ``/lookup`` and return the ``layout_info`` map.
+
+        Args:
+            tokens: Token IDs to look up.
+
+        Returns:
+            The ``layout_info`` map from the response: ``{instance_id:
+            [location, cached_prefix_end]}``.
+
+        Raises:
+            RuntimeError: On connection failure, HTTP error, invalid JSON, or a
+                response missing ``layout_info``.
+        """
+        endpoint = f"{self._url}/lookup"
+        body = json.dumps({"tokens": tokens}).encode("utf-8")
+        request = urllib.request.Request(
+            endpoint,
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:512]
+            raise RuntimeError(
+                f"POST {endpoint} lookup failed (HTTP {exc.code}): "
+                f"{detail or exc.reason}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(
+                f"POST {endpoint} lookup failed: {getattr(exc, 'reason', exc)}"
+            ) from exc
+
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Invalid JSON from lookup {endpoint}: {exc}") from exc
+        layout_info = obj.get("layout_info")
+        if layout_info is None:
+            raise RuntimeError(f"lookup response missing 'layout_info': {raw[:256]}")
+        return layout_info
+
+    def tokenize(self, prompt: str) -> list[int]:
+        """Tokenize *prompt* into token IDs using the model's tokenizer.
+
+        Args:
+            prompt: The expanded prompt text.
+
+        Returns:
+            The list of token IDs.
+
+        Raises:
+            RuntimeError: If ``transformers`` is unavailable or the tokenizer
+                cannot be loaded (e.g. a gated model without credentials).
+        """
+        try:
+            # Third Party
+            from transformers import AutoTokenizer
+        except ImportError as exc:
+            raise RuntimeError(
+                "The 'transformers' package is required to tokenize the prompt; "
+                "install it with `pip install transformers`."
+            ) from exc
+
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(self._model)
+        except Exception as exc:  # noqa: BLE001 - surface any load failure
+            raise RuntimeError(
+                f"Could not load tokenizer for {self._model!r}: {exc}. "
+                "For gated models, run `huggingface-cli login` first."
+            ) from exc
+
+        return list(tokenizer.encode(prompt))
+
+    def run(self, prompt: str) -> CoverageResult:
+        """Tokenize *prompt*, look up its cache coverage, and summarize it.
+
+        Args:
+            prompt: The expanded prompt text.
+
+        Returns:
+            The cache-coverage summary.
+
+        Raises:
+            RuntimeError: On tokenization or lookup failure.
+        """
+        tokens = self.tokenize(prompt)
+        layout_info = self.request_lookup(tokens)
+        return summarize_coverage(layout_info, len(tokens), self._chunk_size)

--- a/lmcache/cli/commands/query/kvcache_command.py
+++ b/lmcache/cli/commands/query/kvcache_command.py
@@ -1,25 +1,121 @@
 # SPDX-License-Identifier: Apache-2.0
-"""``lmcache query kvcache`` — query KV-cache endpoints (placeholder)."""
+"""``lmcache query kvcache`` — report cache coverage for one prompt."""
 
 # Standard
 import argparse
+import sys
 
 # First Party
 from lmcache.cli.commands.base import BaseCommand
+from lmcache.cli.commands.query._lookup import CacheLookup, CoverageResult
+from lmcache.cli.commands.query._prompt import PromptBuilder
+
+_DEFAULT_CHUNK_SIZE = 256
+
+
+def _format_locations(locations: list[tuple[str, str]]) -> str:
+    """Render ``(instance_id, location)`` pairs as ``[location@instance, ...]``."""
+    if not locations:
+        return "none"
+    return "[" + ", ".join(f"{loc}@{inst}" for inst, loc in locations) + "]"
 
 
 class KVCacheCommand(BaseCommand):
-    """Query KV-cache endpoints (not implemented yet)."""
+    """Report how much of a prompt's KV cache is already cached."""
 
     def name(self) -> str:
+        """Return the subcommand name."""
         return "kvcache"
 
     def help(self) -> str:
-        return "Query KV-cache endpoints (not implemented yet)."
+        """Return short help text shown by ``lmcache query -h``."""
+        return "Report KV cache coverage for one prompt."
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
-        pass  # TODO: add kvcache query arguments
+        """Add ``query kvcache`` arguments.
+
+        Args:
+            parser: The ``ArgumentParser`` for this subcommand.
+        """
+        parser.add_argument(
+            "--url",
+            required=True,
+            help="Controller HTTP endpoint (e.g. http://localhost:5555).",
+        )
+        parser.add_argument(
+            "--prompt",
+            required=True,
+            help="Prompt text with optional {name} document placeholders.",
+        )
+        parser.add_argument(
+            "--model",
+            required=True,
+            metavar="ID",
+            help="Tokenizer/model id used to derive token IDs.",
+        )
+        parser.add_argument(
+            "--documents",
+            action="extend",
+            nargs="+",
+            default=[],
+            metavar="NAME=PATH",
+            help=(
+                "Load file text for {NAME} in --prompt. "
+                "Accepts one or more NAME=PATH values."
+            ),
+        )
+        parser.add_argument(
+            "--chunk-size",
+            type=int,
+            default=_DEFAULT_CHUNK_SIZE,
+            help=(
+                "Tokens per cache chunk for chunk-count display "
+                f"(default: {_DEFAULT_CHUNK_SIZE}). Must match the server's "
+                "configured chunk size to be exact."
+            ),
+        )
 
     def execute(self, args: argparse.Namespace) -> None:
-        # TODO: implement kvcache query logic
-        pass
+        """Look up and report cache coverage for the prompt.
+
+        Args:
+            args: Parsed CLI arguments.
+        """
+        try:
+            prompt_builder = PromptBuilder(args.prompt, args.documents)
+            lookup = CacheLookup(
+                url=args.url,
+                model=args.model,
+                chunk_size=args.chunk_size,
+            )
+            result = lookup.run(prompt_builder.complete_prompt)
+            self._emit(result, args)
+        except (RuntimeError, ValueError) as err:
+            print(str(err), file=sys.stderr)
+            sys.exit(1)
+
+    def _emit(self, result: CoverageResult, args: argparse.Namespace) -> None:
+        """Render *result* through the metrics framework.
+
+        Args:
+            result: The cache-coverage summary.
+            args: Parsed CLI arguments (for output format/handlers).
+        """
+        metrics = self.create_metrics("Query KV Cache", args)
+        metrics.add("model", "Model", args.model)
+        metrics.add("prompt_tokens", "Prompt tokens", result.prompt_tokens)
+        metrics.add(
+            "cached_tokens",
+            "Cached tokens",
+            f"{result.cached_tokens}/{result.prompt_tokens}",
+        )
+        metrics.add(
+            "cached_chunks",
+            "Cached chunks",
+            f"{result.cached_chunks}/{result.total_chunks}",
+        )
+        metrics.add(
+            "cache_locations", "Cache locations", _format_locations(result.locations)
+        )
+        metrics.add("cache_status", "Cache status", result.cache_status)
+        metrics.emit()

--- a/tests/cli/commands/test_query_kvcache.py
+++ b/tests/cli/commands/test_query_kvcache.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``lmcache query kvcache`` CLI command."""
+
+# Standard
+from unittest.mock import MagicMock, patch
+import argparse
+import json
+import urllib.error
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.cli.commands.query._lookup import (
+    CacheLookup,
+    CoverageResult,
+    summarize_coverage,
+)
+from lmcache.cli.commands.query.kvcache_command import KVCacheCommand
+
+
+def _kvcache_parser() -> tuple[KVCacheCommand, argparse.ArgumentParser]:
+    """Build a parser with ``KVCacheCommand`` registered as a subcommand."""
+    cmd = KVCacheCommand()
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    cmd.register(sub)
+    return cmd, parser
+
+
+def _fake_response(payload: dict) -> MagicMock:
+    """Build a mock ``urlopen`` context manager returning *payload* as JSON."""
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(payload).encode()
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+class TestSummarizeCoverage:
+    def test_full_hit(self) -> None:
+        layout = {"inst-0": ("cpu", 256)}
+        result = summarize_coverage(layout, total_tokens=256, chunk_size=256)
+        assert isinstance(result, CoverageResult)
+        assert result.prompt_tokens == 256
+        assert result.cached_tokens == 256
+        assert result.cache_status == "HIT"
+        assert result.cached_chunks == 1
+        assert result.total_chunks == 1
+        assert result.locations == [("inst-0", "cpu")]
+
+    def test_partial_hit(self) -> None:
+        layout = {"inst-0": ("cpu", 512)}
+        result = summarize_coverage(layout, total_tokens=768, chunk_size=256)
+        assert result.cache_status == "HIT (partial)"
+        assert result.cached_tokens == 512
+        assert result.cached_chunks == 2
+        assert result.total_chunks == 3
+
+    def test_miss_on_empty_layout(self) -> None:
+        result = summarize_coverage({}, total_tokens=300, chunk_size=256)
+        assert result.cache_status == "MISS"
+        assert result.cached_tokens == 0
+        assert result.cached_chunks == 0
+        assert result.total_chunks == 2
+        assert result.locations == []
+
+    def test_multiple_instances_use_longest_prefix(self) -> None:
+        # layout_info arrives from JSON as lists, not tuples.
+        layout = {"inst-0": ["cpu", 256], "inst-1": ["disk", 512]}
+        result = summarize_coverage(layout, total_tokens=512, chunk_size=256)
+        assert result.cached_tokens == 512
+        assert result.cache_status == "HIT"
+        assert ("inst-1", "disk") in result.locations
+        assert ("inst-0", "cpu") in result.locations
+
+
+class TestRequestLookup:
+    @patch("lmcache.cli.commands.query._lookup.urllib.request.urlopen")
+    def test_posts_tokens_and_returns_layout_info(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        mock_urlopen.return_value = _fake_response(
+            {"event_id": "x", "layout_info": {"inst-0": ["cpu", 256]}}
+        )
+        lookup = CacheLookup(url="http://host:5555", model="m")
+
+        layout = lookup.request_lookup([1, 2, 3])
+
+        assert layout == {"inst-0": ["cpu", 256]}
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "http://host:5555/lookup"
+        assert req.get_method() == "POST"
+        assert json.loads(req.data.decode()) == {"tokens": [1, 2, 3]}
+
+    @patch("lmcache.cli.commands.query._lookup.urllib.request.urlopen")
+    def test_bare_host_gets_http_scheme(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = _fake_response({"layout_info": {}})
+        lookup = CacheLookup(url="host:5555", model="m")
+
+        lookup.request_lookup([1])
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "http://host:5555/lookup"
+
+    @patch("lmcache.cli.commands.query._lookup.urllib.request.urlopen")
+    def test_connection_error_becomes_runtime_error(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+        lookup = CacheLookup(url="http://host:5555", model="m")
+
+        with pytest.raises(RuntimeError, match="lookup"):
+            lookup.request_lookup([1])
+
+
+class TestTokenize:
+    @patch("transformers.AutoTokenizer")
+    def test_encodes_prompt_with_model_tokenizer(self, mock_auto: MagicMock) -> None:
+        tokenizer = MagicMock()
+        tokenizer.encode.return_value = [10, 20, 30]
+        mock_auto.from_pretrained.return_value = tokenizer
+        lookup = CacheLookup(url="http://host", model="facebook/opt-125m")
+
+        tokens = lookup.tokenize("hello")
+
+        assert tokens == [10, 20, 30]
+        mock_auto.from_pretrained.assert_called_once_with("facebook/opt-125m")
+        tokenizer.encode.assert_called_once_with("hello")
+
+    def test_missing_transformers_raises_runtime_error(self) -> None:
+        lookup = CacheLookup(url="http://host", model="m")
+        with patch.dict("sys.modules", {"transformers": None}):
+            with pytest.raises(RuntimeError, match="transformers"):
+                lookup.tokenize("hello")
+
+    @patch("transformers.AutoTokenizer")
+    def test_gated_model_load_failure_hints_login(self, mock_auto: MagicMock) -> None:
+        mock_auto.from_pretrained.side_effect = OSError("gated repo")
+        lookup = CacheLookup(url="http://host", model="meta-llama/Llama-3.1-8B")
+
+        with pytest.raises(RuntimeError, match="huggingface-cli login"):
+            lookup.tokenize("hello")
+
+
+class TestRun:
+    def test_run_tokenizes_looks_up_and_summarizes(self) -> None:
+        lookup = CacheLookup(url="http://host", model="m", chunk_size=256)
+        with (
+            patch.object(lookup, "tokenize", return_value=[0] * 512),
+            patch.object(
+                lookup, "request_lookup", return_value={"inst-0": ["cpu", 512]}
+            ),
+        ):
+            result = lookup.run("prompt")
+
+        assert isinstance(result, CoverageResult)
+        assert result.prompt_tokens == 512
+        assert result.cached_tokens == 512
+        assert result.cache_status == "HIT"
+        assert result.locations == [("inst-0", "cpu")]
+
+
+class TestKVCacheCommandMetadata:
+    def test_name(self) -> None:
+        assert KVCacheCommand().name() == "kvcache"
+
+    def test_help_is_not_placeholder(self) -> None:
+        help_text = KVCacheCommand().help().lower()
+        assert "not implemented" not in help_text
+        assert "cache" in help_text
+
+
+class TestKVCacheCommandArguments:
+    def test_required_and_default_args(self) -> None:
+        _, parser = _kvcache_parser()
+        args = parser.parse_args(
+            [
+                "kvcache",
+                "--url",
+                "http://host:5555",
+                "--prompt",
+                "{ctx} question",
+                "--model",
+                "m",
+                "--documents",
+                "ctx=/tmp/x",
+            ],
+        )
+        assert args.url == "http://host:5555"
+        assert args.prompt == "{ctx} question"
+        assert args.model == "m"
+        assert args.documents == ["ctx=/tmp/x"]
+        assert args.chunk_size == 256
+
+    def test_chunk_size_override(self) -> None:
+        _, parser = _kvcache_parser()
+        args = parser.parse_args(
+            [
+                "kvcache",
+                "--url",
+                "http://host:5555",
+                "--prompt",
+                "hi",
+                "--model",
+                "m",
+                "--chunk-size",
+                "128",
+            ],
+        )
+        assert args.chunk_size == 128
+
+
+class TestKVCacheCommandExecute:
+    @patch("lmcache.cli.commands.query.kvcache_command.CacheLookup")
+    def test_execute_renders_coverage(
+        self, mock_cls: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_lookup = MagicMock()
+        mock_lookup.run.return_value = CoverageResult(
+            prompt_tokens=512,
+            cached_tokens=256,
+            cache_status="HIT (partial)",
+            cached_chunks=1,
+            total_chunks=2,
+            locations=[("inst-0", "cpu")],
+        )
+        mock_cls.return_value = mock_lookup
+
+        cmd, parser = _kvcache_parser()
+        args = parser.parse_args(
+            [
+                "kvcache",
+                "--url",
+                "http://host:5555",
+                "--prompt",
+                "hello",
+                "--model",
+                "facebook/opt-125m",
+            ],
+        )
+        cmd.execute(args)
+
+        out = capsys.readouterr().out
+        assert "Query KV Cache" in out
+        assert "HIT (partial)" in out
+        assert "256/512" in out
+        assert "1/2" in out
+        assert "cpu" in out
+        mock_cls.assert_called_once_with(
+            url="http://host:5555",
+            model="facebook/opt-125m",
+            chunk_size=256,
+        )
+        mock_lookup.run.assert_called_once_with("hello")
+
+    @patch("lmcache.cli.commands.query.kvcache_command.CacheLookup")
+    def test_execute_reports_miss(
+        self, mock_cls: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_lookup = MagicMock()
+        mock_lookup.run.return_value = CoverageResult(
+            prompt_tokens=300,
+            cached_tokens=0,
+            cache_status="MISS",
+            cached_chunks=0,
+            total_chunks=2,
+            locations=[],
+        )
+        mock_cls.return_value = mock_lookup
+
+        cmd, parser = _kvcache_parser()
+        args = parser.parse_args(
+            ["kvcache", "--url", "http://h", "--prompt", "hi", "--model", "m"],
+        )
+        cmd.execute(args)
+
+        assert "MISS" in capsys.readouterr().out
+
+    @patch("lmcache.cli.commands.query.kvcache_command.CacheLookup")
+    def test_execute_error_exits_1_to_stderr(
+        self, mock_cls: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_lookup = MagicMock()
+        mock_lookup.run.side_effect = RuntimeError("lookup boom")
+        mock_cls.return_value = mock_lookup
+
+        cmd, parser = _kvcache_parser()
+        args = parser.parse_args(
+            ["kvcache", "--url", "http://h", "--prompt", "hi", "--model", "m"],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            cmd.execute(args)
+
+        assert exc_info.value.code == 1
+        assert "lookup boom" in capsys.readouterr().err


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements `lmcache query kvcache` lookup mode, the cache coverage counterpart to the existing `query engine` command. It was previously a stub. It reports how much of a prompt is already present in the KV cache:

```
$ lmcache query kvcache --url http://localhost:5555 \
    --prompt "{ctx} What is the example usage of lmcache?" \
    --documents ctx=lmcache/cli/documents/lmcache.txt \
    --model meta-llama/Llama-3.1-8B-Instruct

=============== Query KV Cache ================
Model:            meta-llama/Llama-3.1-8B-Instruct
Prompt tokens:                             8192
Cached tokens:                        7680/8192
Cached chunks:                            30/32
Cache locations:                  [cpu@inst-0]
Cache status:                     HIT (partial)
==============================================
```

The command expands `{name}` document placeholders, tokenizes locally with the model's tokenizer, posts the token IDs to the controller `POST /lookup`, and summarizes coverage through the shared metrics framework, so `--format json` and `--output` work like the other query targets.

Refs #3720

**notes**

This is an honest subset of the design doc. The controller `POST /lookup` returns only the longest cached prefix and one location per instance (see the TODOs in `kv_controller.lookup`), so three parts of the design are deferred to a follow up:

1. Per tier chunk histogram such as `[cpu=12, disk=0]`. This PR reports the instance holding the prefix as `location@instance_id` instead.
2. Exact chunk counts. This PR derives them from a `--chunk-size` flag (default 256), exact only when it matches the server's configured chunk size.
3. Single instance targeting and round trip verification.

Coverage is prefix based (it stops at the first uncached chunk), and token IDs must come from the same tokenizer the engine uses or coverage reads low. All three caveats are documented in the user guide and design doc.

The new `CacheLookup` client plus `summarize_coverage` keep the HTTP and summary logic out of the command class, and the tests mirror the existing query command tests, so the structure should look familiar.

Docs updated alongside the code: the user guide (`docs/source/cli/query.rst`) gains a `kvcache` section, and the design doc (`docs/design/cli/commands/query-command.md`) now documents the implemented command instead of marking it stubbed. The phasing tables mark phase 1b done.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

**Follow-up**

Planned as a second PR (design phase 2): a per instance lookup endpoint exposing what the controller lookup cannot, enabling the full design output:

1. Per tier chunk histogram from real chunk location data.
2. Exact chunk counts from the server's configured chunk size, removing the client side `--chunk-size` approximation.
3. Single instance targeting to query one MP instance directly.
4. Server side tokenization so callers need no local tokenizer or model download.
5. Round trip verification mode (store then retrieve).
