### PR TITLE
[good-first-issue] core: convert f-string log calls to %-format in storage_backend

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -180,7 +180,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
             try:
                 on_complete_callback(key)
             except Exception as e:
-                logger.warning(f"on_complete_callback failed for key {key}: {e}")
+                logger.warning("on_complete_callback failed for key %s: %s", key, e)
 
         return None
 
@@ -334,10 +334,14 @@ class LocalCPUBackend(AllocatorBackendInterface):
             max_usable_memory = max(0, system_available_memory_gb - reserve_cpu_size)
             effective_cpu_size = min(configured_cpu_size, max_usable_memory)
             logger.info(
-                f"Adjusted CPU memory size from {configured_cpu_size:.2f} GB "
-                f"to {effective_cpu_size:.2f} GB "
-                f"(system available: {system_available_memory_gb:.2f} GB, "
-                f"reserve: {reserve_cpu_size:.2f} GB)"
+                "Adjusted CPU memory size from %.2f GB "
+                "to %.2f GB "
+                "(system available: %.2f GB, "
+                "reserve: %.2f GB)",
+                configured_cpu_size,
+                effective_cpu_size,
+                system_available_memory_gb,
+                reserve_cpu_size,
             )
             assert effective_cpu_size > 0
             return effective_cpu_size
@@ -371,7 +375,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         # Detect the numa mapping
         numa_mapping = NUMADetector.get_numa_mapping(config)
-        logger.info(f"NUMA mapping {numa_mapping}")
+        logger.info("NUMA mapping %s", numa_mapping)
 
         # Calculate effective CPU memory size
         cpu_size = self._calculate_effective_cpu_size(cpu_size, config, metadata)
@@ -401,8 +405,10 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 origin_cpu_size_bytes // chunk_size_bytes * chunk_size_bytes
             )
             logger.info(
-                f"Auto align cpu size bytes, origin: {origin_cpu_size_bytes}, "
-                f"aligned: {align_cpu_size_bytes}, chunk size: {chunk_size_bytes}"
+                "Auto align cpu size bytes, origin: %s, aligned: %s, chunk size: %s",
+                origin_cpu_size_bytes,
+                align_cpu_size_bytes,
+                chunk_size_bytes,
             )
             paged_mem_allocator.init_cpu_memory_allocator(
                 align_cpu_size_bytes,
@@ -478,11 +484,13 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 )
             elif config.enable_lazy_memory_allocator:
                 logger.info(
-                    f"LazyMixedMemoryAllocator is disabled because "
-                    f"cpu_size ({cpu_size:.2f} GB) does not exceed "
-                    f"lazy_memory_safe_size "
-                    f"({config.lazy_memory_safe_size:.2f} GB). "
-                    f"Using MixedMemoryAllocator instead."
+                    "LazyMixedMemoryAllocator is disabled because "
+                    "cpu_size (%.2f GB) does not exceed "
+                    "lazy_memory_safe_size "
+                    "(%.2f GB). "
+                    "Using MixedMemoryAllocator instead.",
+                    cpu_size,
+                    config.lazy_memory_safe_size,
                 )
 
             # For io_uring, use paged memory allocator so that fixed buffer support
@@ -509,8 +517,11 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 logger.info(
                     "LocalCPUBackend: using MixedMemoryAllocator with use_paging=True "
                     "for io_uring fixed buffer support. "
-                    f"Auto align cpu size bytes, origin: {origin_cpu_size_bytes}, "
-                    f"aligned: {align_cpu_size_bytes}, chunk size: {chunk_size_bytes}"
+                    "Auto align cpu size bytes, origin: %s, "
+                    "aligned: %s, chunk size: %s",
+                    origin_cpu_size_bytes,
+                    align_cpu_size_bytes,
+                    chunk_size_bytes,
                 )
 
                 kwargs = {
@@ -636,7 +647,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
         (we use the async serializer to handle this)
         """
         logger.debug(
-            f"Allocating memory in local cpu backend with busy loop: {busy_loop}"
+            "Allocating memory in local cpu backend with busy loop: %s", busy_loop
         )
         if fmt is None:
             if self.layerwise:
@@ -670,7 +681,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                         # and don't need to wait for other requests yet
                         wait_other_requests = False
                         logger.debug(
-                            f"Evicting {len(evict_keys)} chunks from cpu memory"
+                            "Evicting %d chunks from cpu memory", len(evict_keys)
                         )
                         # remove
                         self.batched_remove(evict_keys, force=False)
@@ -692,7 +703,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 logger.warning(
                     "No eviction candidates found in local cpu backend. "
                     "Local cpu memory is under pressure. "
-                    f"Waiting for {time_to_wait} seconds before retrying."
+                    "Waiting for %s seconds before retrying.",
+                    time_to_wait,
                 )
                 # self.memory_allocator.memcheck()
                 # do not hold the lock during sleep
@@ -704,8 +716,9 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
             num_attempts += 1
             logger.debug(
-                f"Unable to allocate memory object after {num_attempts}"
-                " attempts of local cpu backend allocate()"
+                "Unable to allocate memory object after %d"
+                " attempts of local cpu backend allocate()",
+                num_attempts,
             )
 
         self.stats_monitor.update_local_cpu_evict_metrics(evict_keys_count)
@@ -740,8 +753,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
         (we use the async serializer to handle this)
         """
         logger.debug(
-            f"Batched allocating memory in local cpu backend"
-            f" with busy loop: {busy_loop}"
+            "Batched allocating memory in local cpu backend with busy loop: %s",
+            busy_loop,
         )
         if fmt is None:
             if self.layerwise:
@@ -806,7 +819,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                             self.memory_allocator.batched_free(old_mem_objs)
 
                             logger.debug(
-                                f"Evicting {len(old_mem_objs)} chunks from cpu memory"
+                                "Evicting %d chunks from cpu memory", len(old_mem_objs)
                             )
                             break
                     if wait_other_requests:
@@ -826,7 +839,8 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 logger.warning(
                     "No eviction candidates found in local cpu backend. "
                     "Local cpu memory is under pressure. "
-                    f"Waiting for {time_to_wait} seconds before retrying."
+                    "Waiting for %s seconds before retrying.",
+                    time_to_wait,
                 )
                 # self.memory_allocator.memcheck()
                 # do not hold the lock during sleep
@@ -840,8 +854,9 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
             num_attempts += 1
             logger.debug(
-                f"Unable to allocate memory object after {num_attempts}"
-                " attempts of local cpu backend batched_allocate()"
+                "Unable to allocate memory object after %d"
+                " attempts of local cpu backend batched_allocate()",
+                num_attempts,
             )
         self.stats_monitor.update_local_cpu_evict_metrics(evict_keys_count)
         return memory_objs
@@ -872,12 +887,18 @@ class LocalCPUBackend(AllocatorBackendInterface):
             # full: [kv_size, num_layers, chunk_tokens, hidden_dim]
             chunk_bytes = kv_size * num_layers * chunk_tokens * hidden_dim * dtype_size
         logger.debug(
-            f"Stats received: num_layers={num_layers}, kv_size={kv_size}, "
-            f"chunk_tokens={chunk_tokens}, head_dim={head_size}, "
-            f"dtype_size={dtype_size}, "
-            f"hidden_dim={hidden_dim}"
+            "Stats received: num_layers=%s, kv_size=%s, "
+            "chunk_tokens=%s, head_dim=%s, "
+            "dtype_size=%s, "
+            "hidden_dim=%s",
+            num_layers,
+            kv_size,
+            chunk_tokens,
+            head_size,
+            dtype_size,
+            hidden_dim,
         )
-        logger.debug(f"Calculated bytes per chunk per rank: {chunk_bytes}")
+        logger.debug("Calculated bytes per chunk per rank: %s", chunk_bytes)
         return chunk_bytes
 
     def calculate_chunk_budget(self) -> int:

--- a/lmcache/v1/storage_backend/remote_backend.py
+++ b/lmcache/v1/storage_backend/remote_backend.py
@@ -44,7 +44,7 @@ class RemoteBackend(StorageBackendInterface):
         if plugin_name is not None:
             # Using plugin-based approach
             self.remote_url = f"plugin://{plugin_name}"
-            logger.info(f"Creating RemoteBackend for plugin: {plugin_name}")
+            logger.info("Creating RemoteBackend for plugin: %s", plugin_name)
         else:
             # Legacy remote_url approach
             if config.remote_url is None:
@@ -80,10 +80,11 @@ class RemoteBackend(StorageBackendInterface):
             and metadata.world_size > 1
             and metadata.worker_id != 0
         )
-        logger.info(f"metadata={metadata}")
+        logger.info("metadata=%s", metadata)
         logger.info(
-            f"Connected to remote storage at {config.remote_url}, "
-            f"remote_mla_worker_id_as_0 mode: {self._mla_worker_id_as0_mode}"
+            "Connected to remote storage at %s, remote_mla_worker_id_as_0 mode: %s",
+            config.remote_url,
+            self._mla_worker_id_as0_mode,
         )
 
         # TODO(Jiayi): If we want to have cache admission policies,
@@ -132,7 +133,7 @@ class RemoteBackend(StorageBackendInterface):
                 # Using plugin-based approach
                 # Create a virtual URL that the adapter can recognize
                 url = f"plugin://{self.plugin_name}"
-                logger.info(f"Creating connector for plugin: {self.plugin_name}")
+                logger.info("Creating connector for plugin: %s", self.plugin_name)
             else:
                 # Legacy remote_url approach
                 if self.config.remote_url is None:
@@ -149,14 +150,14 @@ class RemoteBackend(StorageBackendInterface):
                 self.metadata,
                 plugin_name=self.plugin_name,
             )
-            logger.info(f"Connection initialized/re-established at {url}")
+            logger.info("Connection initialized/re-established at %s", url)
         except IrrecoverableException:
             logger.error("Irrecoverable error during connection initialization")
             raise
         except Exception as e:
             with self.lock:
                 self.failure_time = time.time()
-            logger.warning(f"Failed to initialize/re-establish remote connection: {e}")
+            logger.warning("Failed to initialize/re-establish remote connection: %s", e)
             self.connection = None
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
@@ -180,7 +181,7 @@ class RemoteBackend(StorageBackendInterface):
                 res = future.result()
                 return res
         except Exception as e:
-            logger.warning(f"Remote connection failed in contains: {e}")
+            logger.warning("Remote connection failed in contains: %s", e)
             logger.warning("Returning False")
             return False
 
@@ -202,7 +203,7 @@ class RemoteBackend(StorageBackendInterface):
         try:
             return self.connection.batched_contains(keys)
         except Exception as e:
-            logger.warning(f"Remote connection failed in batched_contains: {e}")
+            logger.warning("Remote connection failed in batched_contains: %s", e)
             return 0
 
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
@@ -216,7 +217,7 @@ class RemoteBackend(StorageBackendInterface):
             future.result()
         except Exception as e:
             self._put_failed_count += 1
-            logger.error(f"Put task failed for key {key}: {e}")
+            logger.error("Put task failed for key %s: %s", key, e)
 
     def submit_put_task(
         self,
@@ -261,7 +262,7 @@ class RemoteBackend(StorageBackendInterface):
                 try:
                     on_complete_callback(key)
                 except Exception as e:
-                    logger.warning(f"on_complete_callback failed for key {key}: {e}")
+                    logger.warning("on_complete_callback failed for key %s: %s", key, e)
 
         # NOTE: No need to do error handling here
         # since the `future` is never waited
@@ -323,7 +324,7 @@ class RemoteBackend(StorageBackendInterface):
                             on_complete_callback(key)
                         except Exception as e:
                             logger.warning(
-                                f"on_complete_callback failed for key {key}: {e}"
+                                "on_complete_callback failed for key %s: %s", key, e
                             )
 
             future = asyncio.run_coroutine_threadsafe(
@@ -429,8 +430,9 @@ class RemoteBackend(StorageBackendInterface):
                     future.cancel()
                 else:
                     logger.warning(
-                        f"Error occurred in batched_get_blocking: {e}, "
-                        f"returning None list"
+                        "Error occurred in batched_get_blocking: %s, "
+                        "returning None list",
+                        e,
                     )
                 memory_objs = [None] * len(keys)
         else:
@@ -462,7 +464,7 @@ class RemoteBackend(StorageBackendInterface):
                             fut.cancel()
                         else:
                             logger.warning(
-                                f"Error occurred in get_blocking: {e}, returning None"
+                                "Error occurred in get_blocking: %s, returning None", e
                             )
                         memory_obj = None
                     memory_objs.append(memory_obj)
@@ -535,7 +537,7 @@ class RemoteBackend(StorageBackendInterface):
             logger.warning("batched_async_contains timed out")
             return 0
         except Exception as e:
-            logger.warning(f"Error occurred in batched_async_contains: {e}")
+            logger.warning("Error occurred in batched_async_contains: %s", e)
             return 0
 
     async def support_batched_get_non_blocking(self) -> bool:
@@ -574,7 +576,7 @@ class RemoteBackend(StorageBackendInterface):
             logger.warning("batched_get_non_blocking timed out")
             return []
         except Exception as e:
-            logger.warning(f"Error occurred in batched_get_non_blocking: {e}")
+            logger.warning("Error occurred in batched_get_non_blocking: %s", e)
             return []
 
     def pin(self, key: CacheEngineKey) -> bool:
@@ -600,7 +602,7 @@ class RemoteBackend(StorageBackendInterface):
             return self.connection.remove_sync(key)
         except Exception as e:
             logger.exception(
-                f"Failed to remove key {key} from remote backend, error: {e}"
+                "Failed to remove key %s from remote backend, error: %s", key, e
             )
             return False
 
@@ -620,4 +622,4 @@ class RemoteBackend(StorageBackendInterface):
             future.result()
             logger.info("Remote backend closed.")
         except Exception as e:
-            logger.warning(f"Error occurred when closing remote connection: {e}")
+            logger.warning("Error occurred when closing remote connection: %s", e)

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -137,7 +137,7 @@ class WeightedSemaphore:
             )
 
         async with self._cond:
-            logger.debug(f"WeightedSemaphore: Attempting to acquire {n} chunks")
+            logger.debug("WeightedSemaphore: Attempting to acquire %d chunks", n)
             if n <= self._concurrent_budget_cap:
                 await self._cond.wait_for(lambda: self._current_chunks >= n)
                 self._current_chunks -= n
@@ -149,8 +149,9 @@ class WeightedSemaphore:
                 # Reserve everything
                 self._current_chunks = 0
             logger.debug(
-                f"WeightedSemaphore: Acquired {n} chunks, "
-                f"remaining chunks: {self._current_chunks}"
+                "WeightedSemaphore: Acquired %d chunks, remaining chunks: %d",
+                n,
+                self._current_chunks,
             )
 
     async def release(self, n: int = 1) -> None:
@@ -643,8 +644,9 @@ class StorageManager:
 
         retrieved_length = cum_chunk_lengths_total[total_retrieved_chunks]
         logger.info(
-            f"Responding to scheduler for lookup id {lookup_id}"
-            f" with retrieved length {retrieved_length}"
+            "Responding to scheduler for lookup id %s with retrieved length %s",
+            lookup_id,
+            retrieved_length,
         )
         self.async_lookup_server.send_response_to_scheduler(lookup_id, retrieved_length)
 
@@ -892,12 +894,13 @@ class StorageManager:
         with self._bypass_lock:
             if bypassed:
                 self._bypassed_backends.add(backend_name)
-                logger.info(f"StorageManager: Backend {backend_name} is now bypassed")
+                logger.info("StorageManager: Backend %s is now bypassed", backend_name)
             else:
                 self._bypassed_backends.discard(backend_name)
                 logger.info(
-                    f"StorageManager: Backend {backend_name} bypass removed, "
-                    "restored to normal operation"
+                    "StorageManager: Backend %s bypass removed, "
+                    "restored to normal operation",
+                    backend_name,
                 )
 
     def is_backend_bypassed(self, backend_name: str) -> bool:
@@ -1137,8 +1140,9 @@ class StorageManager:
                     num_cleared_tokens += backend.clear()
                 else:
                     logger.warning(
-                        f"Storage backend {backend_name} does not support "
-                        "clear operation. Skipping."
+                        "Storage backend %s does not support "
+                        "clear operation. Skipping.",
+                        backend_name,
                     )
 
         return num_cleared_tokens
@@ -1388,11 +1392,11 @@ class StorageManager:
         # Close all backends
         for name, backend in self.storage_backends.items():
             try:
-                logger.info(f"Closing storage backend: {name}")
+                logger.info("Closing storage backend: %s", name)
                 backend.close()
-                logger.info(f"Storage backend {name} closed successfully")
+                logger.info("Storage backend %s closed successfully", name)
             except Exception as e:
-                logger.error(f"Error closing backend {name}: {e}")
+                logger.error("Error closing backend %s: %s", name, e)
 
         # Stop event loop
         try:
@@ -1401,7 +1405,7 @@ class StorageManager:
                 self.loop.call_soon_threadsafe(self.loop.stop)
                 logger.info("Event loop stop signaled")
         except Exception as e:
-            logger.error(f"Error stopping event loop: {e}")
+            logger.error("Error stopping event loop: %s", e)
 
         # Wait for thread with timeout
         if self.thread.is_alive():


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #3974
Refs #3372

Converts `logger.*(f"...")` calls to lazy `%`-style formatting in three `lmcache/v1/storage_backend/` modules, so the log message is only built when the record is actually emitted (ruff G004):

- `storage_manager.py` — 10 calls
- `local_cpu_backend.py` — 16 calls
- `remote_backend.py` — 17 calls

Message text and all runtime behavior are unchanged; only the formatting style changes. Numeric fields keep their prior precision (e.g. GB sizes `:.2f` → `%.2f`, counts → `%d`).

**Special notes for your reviewers**:

- This is part of the #3372 onboarding f-string cleanup series.
- I ran `ruff check --select G004` on the three files — 0 remaining.
- I ran `ruff check` (E/F/B/SLF), `ruff format --check`, `codespell`, and `mypy` — all clean (the 2 pre-existing mypy findings in `storage_manager.py` at lines 93/113 are unrelated to this change and also present on `dev`).
- I ran `pytest tests/v1/storage_backend/test_storage_manager.py tests/v1/storage_backend/test_local_cpu_backend.py` — 36 passed.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
