### PR TITLE
ci: collapse cpu-only e2e steps into a matrix

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -206,25 +206,22 @@ steps:
       # runner script, so an empty string ("") is meaningful and differs
       # from unset. `__default__` is the sentinel meaning "shm mode".
       - label: ":compression: cpu_e2e_validation ({{matrix.mode}})"
-        command: bash .github/scripts/run-cpu-e2e-validation.sh
+        # matrix.adjustments does not support `env:` in Buildkite. Instead
+        # we branch on {{matrix.mode}} inside the command to set the
+        # per-mode env before invoking the shared runner script.
+        command: |
+          case "{{matrix.mode}}" in
+            shm) ;;  # rely on script defaults (engine-driven + shm transport)
+            pickle) export LMCACHE_SHM_NAME="" ;;
+            server_copy) export LMCACHE_MP_TRANSFER_MODE="lmcache_driven" ;;
+          esac
+          bash .github/scripts/run-cpu-e2e-validation.sh
         matrix:
           setup:
             mode:
               - "shm"
               - "pickle"
               - "server_copy"
-          adjustments:
-            - with:
-                mode: "shm"
-              # shm: rely on script defaults (engine-driven + shm transport)
-            - with:
-                mode: "pickle"
-              env:
-                LMCACHE_SHM_NAME: ""
-            - with:
-                mode: "server_copy"
-              env:
-                LMCACHE_MP_TRANSFER_MODE: "lmcache_driven"
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins:

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -202,62 +202,22 @@ steps:
   - group: ":compression: Multiprocess (CPU-only)"
     if: build.env("VERIFY_AND_PIN_VLLM") !~ /true/
     steps:
-      - label: ":compression: cpu_e2e_validation (shm)"
+      # Note: LMCACHE_SHM_NAME uses `${VAR-default}` (not `:-`) in the
+      # runner script, so an empty string ("") is meaningful and differs
+      # from unset. `__default__` is the sentinel meaning "shm mode".
+      - label: ":compression: cpu_e2e_validation ({{matrix}})"
         command: bash .github/scripts/run-cpu-e2e-validation.sh
-        timeout_in_minutes: 30
-        agents: { queue: "k8s" }
-        plugins:
-          - kubernetes:
-              podSpec:
-                containers:
-                  - name: container-0
-                    image: lmcache/ci-base:latest
-                    imagePullPolicy: Never
-                    resources:
-                      requests:
-                        cpu: "8"
-                        memory: "256Gi"
-                      limits:
-                        cpu: "8"
-                        memory: "256Gi"
-                    volumeMounts:
-                      - { name: hf-cache, mountPath: /root/.cache/huggingface }
-                      - { name: dshm, mountPath: /dev/shm }
-                volumes:
-                  - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
-                  - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 4Gi } }
-
-      - label: ":compression: cpu_e2e_validation (pickle)"
-        command: bash .github/scripts/run-cpu-e2e-validation.sh
-        env:
-          LMCACHE_SHM_NAME: ""
-        timeout_in_minutes: 30
-        agents: { queue: "k8s" }
-        plugins:
-          - kubernetes:
-              podSpec:
-                containers:
-                  - name: container-0
-                    image: lmcache/ci-base:latest
-                    imagePullPolicy: Never
-                    resources:
-                      requests:
-                        cpu: "8"
-                        memory: "256Gi"
-                      limits:
-                        cpu: "8"
-                        memory: "256Gi"
-                    volumeMounts:
-                      - { name: hf-cache, mountPath: /root/.cache/huggingface }
-                      - { name: dshm, mountPath: /dev/shm }
-                volumes:
-                  - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
-                  - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 4Gi } }
-
-      - label: ":compression: cpu_e2e_validation (server-side copy)"
-        command: bash .github/scripts/run-cpu-e2e-validation.sh
-        env:
-          LMCACHE_MP_TRANSFER_MODE: "lmcache_driven"
+        matrix:
+          setup: ["shm", "pickle", "server-side copy"]
+          adjustments:
+            - with: "shm"
+              # shm: rely on script defaults (engine-driven + shm transport)
+            - with: "pickle"
+              env:
+                LMCACHE_SHM_NAME: ""
+            - with: "server-side copy"
+              env:
+                LMCACHE_MP_TRANSFER_MODE: "lmcache_driven"
         timeout_in_minutes: 30
         agents: { queue: "k8s" }
         plugins:

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -205,17 +205,18 @@ steps:
       # Note: LMCACHE_SHM_NAME uses `${VAR-default}` (not `:-`) in the
       # runner script, so an empty string ("") is meaningful and differs
       # from unset. `__default__` is the sentinel meaning "shm mode".
-      - label: ":compression: cpu_e2e_validation ({{matrix}})"
+      - label: ":compression: cpu_e2e_validation ({{matrix.mode}})"
         command: bash .github/scripts/run-cpu-e2e-validation.sh
         matrix:
-          setup: ["shm", "pickle", "server-side copy"]
+          setup:
+            mode: ["shm", "pickle", "server-side copy"]
           adjustments:
-            - with: "shm"
+            - with: { mode: "shm" }
               # shm: rely on script defaults (engine-driven + shm transport)
-            - with: "pickle"
+            - with: { mode: "pickle" }
               env:
                 LMCACHE_SHM_NAME: ""
-            - with: "server-side copy"
+            - with: { mode: "server-side copy" }
               env:
                 LMCACHE_MP_TRANSFER_MODE: "lmcache_driven"
         timeout_in_minutes: 30

--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -209,14 +209,20 @@ steps:
         command: bash .github/scripts/run-cpu-e2e-validation.sh
         matrix:
           setup:
-            mode: ["shm", "pickle", "server-side copy"]
+            mode:
+              - "shm"
+              - "pickle"
+              - "server_copy"
           adjustments:
-            - with: { mode: "shm" }
+            - with:
+                mode: "shm"
               # shm: rely on script defaults (engine-driven + shm transport)
-            - with: { mode: "pickle" }
+            - with:
+                mode: "pickle"
               env:
                 LMCACHE_SHM_NAME: ""
-            - with: { mode: "server-side copy" }
+            - with:
+                mode: "server_copy"
               env:
                 LMCACHE_MP_TRANSFER_MODE: "lmcache_driven"
         timeout_in_minutes: 30


### PR DESCRIPTION
The three cpu_e2e_validation steps only differ by a couple of env vars and were dragging around three copies of the same podSpec. Folded them into a Buildkite matrix + adjustments so each mode only sets the env it actually needs.

- shm: no env override, relies on the script's default fallback (unset != empty here, so we can't just pass an empty string)
- pickle: LMCACHE_SHM_NAME=""
- server-side copy: LMCACHE_MP_TRANSFER_MODE=lmcache_driven

Behavior is identical to before, just ~40 lines lighter.