### PR TITLE
style(token_database): convert f-string log calls to %-format (G004)

### DIFF
--- a/lmcache/v1/token_database.py
+++ b/lmcache/v1/token_database.py
@@ -98,7 +98,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
                 kv_cache_utils.init_none_hash(self.hash_func)
                 NONE_HASH = _normalize_hash_to_int(kv_cache_utils.NONE_HASH)
                 logger.info(
-                    f"Initialized NONE_HASH={NONE_HASH} from vLLM (>= PR#20511)"
+                    "Initialized NONE_HASH=%s from vLLM (>= PR#20511)", NONE_HASH
                 )
             else:
                 NONE_HASH = 0
@@ -152,7 +152,7 @@ class TokenDatabase(metaclass=abc.ABCMeta):
                     module = __import__(module_path, fromlist=[func_name])
                     hash_func = getattr(module, func_name)
                     logger.info(
-                        f"Loaded '{func_name}' from {module_path} (direct import)"
+                        "Loaded '%s' from %s (direct import)", func_name, module_path
                     )
                     return hash_func
                 except (ImportError, AttributeError):
@@ -160,8 +160,9 @@ class TokenDatabase(metaclass=abc.ABCMeta):
 
         # Fallback to builtin hash
         logger.warning(
-            f"Could not load '{hash_algorithm}' from vLLM. Using builtin hash. "
-            "This may cause inconsistencies in distributed caching."
+            "Could not load '%s' from vLLM. Using builtin hash. "
+            "This may cause inconsistencies in distributed caching.",
+            hash_algorithm,
         )
 
         # Check PYTHONHASHSEED when using builtin hash


### PR DESCRIPTION
## What

Converts the three `logger.*(f"...")` calls in `lmcache/v1/token_database.py` to lazy `%`-formatting, per Python's logging guidance and ruff rule **G004**.

This continues the logging-format cleanup campaign (ref #3372) — same treatment already applied to `s3_connector.py` (#3977, merged) and `local_disk_backend.py` (#3973).

## Why

`%`-style logging defers string interpolation until the record is actually emitted, so `debug`/`info` calls that are filtered out at the current level do no formatting work. It also silences ruff G004 for this file.

## Changes

- `logger.info(f"Initialized NONE_HASH={NONE_HASH} ...")` → `%s` with `NONE_HASH` arg
- `logger.info(f"Loaded '{func_name}' from {module_path} ...")` → `%s`/`%s` args
- `logger.warning(f"Could not load '{hash_algorithm}' ...")` → `%s` arg (multi-line string preserved)

No behavior change — message text and arguments are identical.

## Verification

```
ruff check --select G004 lmcache/v1/token_database.py   # All checks passed!
ruff format --check lmcache/v1/token_database.py        # already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
