### PR TITLE
docs: daily drift check — multi-process mode (2026-07-02)

### DIFF
--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -2,24 +2,27 @@
 
 The mp coordinator is a standalone **FastAPI / REST** process that coordinates
 LMCache multi-process (mp) cache servers running across nodes as a fleet. This
-document describes the backbone: the REST API, the instance registry, and the
-health-check loop. Domain capabilities (quota reconcile, blend-lookup routing,
-KV-op fan-out) are not implemented yet; they are added as new REST routers.
+document describes the backbone: the REST API, the instance registry, the
+health-check and eviction loops, and the four domain capabilities that hang off
+it (fleet membership, quota + fleet-wide L2 eviction, cache control including
+warm prefetch, and the global CacheBlend fingerprint directory).
 
 Code: `lmcache/v1/mp_coordinator/`.
 
 ## Why
 
-mp servers are independent today: quota is per-instance and in-memory, there is
-no cross-node token-match routing for model replicas, and KV operations are
-local. The coordinator is the fleet-level component those features will hang
-off. This PR ships the framework plus membership so future work plugs in
-without re-architecting.
+mp servers are independent by construction: per-instance in-memory quota, no
+cross-node token-match routing for model replicas, and node-local KV
+operations. The coordinator is the fleet-level component those capabilities
+hang off — it holds the shared trackers (quota, LRU, blend directory) and
+dispatches fleet-wide work (eviction, warm prefetch) to individual mp servers
+by resolving their `ip` / `http_port` from the registry.
 
 ## Transport
 
 The coordinator is a FastAPI app served by uvicorn. mp servers register /
-heartbeat / deregister over REST.
+heartbeat / deregister over REST; they also stream L2 usage events and blend
+fingerprints in the same shape.
 
 | Method & path | Direction | Purpose |
 | --- | --- | --- |
@@ -28,26 +31,49 @@ heartbeat / deregister over REST.
 | `DELETE /instances/{id}` | mp → coordinator | deregister (idempotent, 204) |
 | `GET /instances` | operator/tools | list the fleet |
 | `GET /healthz` | k8s probe | liveness |
+| `PUT/GET/DELETE /quota/{cache_salt}` | operator | per-tenant byte budgets |
+| `GET /quota` | operator | fleet-wide usage summary |
+| `POST /quota/events` | mp → coordinator | L2 usage event ingest |
+| `POST /cache/prefetches` | operator/scheduler | submit warm prefetch to a named server |
+| `GET /cache/prefetches/{instance_id}/{request_id}` | operator/scheduler | poll a warm prefetch |
+| `POST /blend/fingerprints` | mp → coordinator | publish stored blend chunk fingerprints |
+| `DELETE /blend/fingerprints` | mp → coordinator | evict blend fingerprints by storage key |
+| `POST /blend/match` | mp → coordinator | rolling-hash match a request against the directory |
 
-For server-initiated work (future quota reconcile, KV-op fan-out) a coordinator
-router resolves an instance's address from the registry (`ip` + `http_port`) and
-POSTs to that mp server's **specific** existing endpoint (e.g. `/pin`,
-`/quota`). There is no generic command channel and no per-instance connection
-state — just an HTTP call to the relevant resource.
+For server-initiated work (fleet-wide eviction, warm prefetch) a coordinator
+router resolves an instance's address from the registry (`ip` + `http_port`)
+and POSTs / DELETEs to that mp server's **specific** existing endpoint
+(e.g. `DELETE /cache/objects`, `POST /cache/prefetches`). There is no generic
+command channel and no per-instance connection state — just an HTTP call to
+the relevant resource.
 
 ## Layout
 
 ```
 lmcache/v1/mp_coordinator/
-  app.py            # create_app + lifespan + router discovery + health eviction
-  __main__.py       # uvicorn entrypoint
-  config.py         # MPCoordinatorConfig (LMCACHE_MP_COORDINATOR_*)
-  registry.py       # InstanceRegistry + MPInstance (pure membership)
-  schemas.py        # Pydantic request/response models (shared wire contract)
-  registrar.py      # mp-server-side register/heartbeat/deregister helpers
+  app.py                # create_app + lifespan + router discovery + health/eviction loops
+  __main__.py           # uvicorn entrypoint (`python -m lmcache.v1.mp_coordinator`)
+  config.py             # MPCoordinatorConfig (LMCACHE_MP_COORDINATOR_*)
+  registry.py           # InstanceRegistry + MPInstance (pure membership)
+  schemas.py            # Pydantic request/response models (shared wire contract)
+  registrar.py          # mp-server-side register/heartbeat/deregister helpers
+  blend_directory.py    # GlobalBlendMatcher (chunked rolling-hash directory)
+  blend_client.py       # mp-server-side blend publish/evict/match client
+  cache_control/
+    __init__.py
+    event_listener.py   # in-process forwarding of MP-server L2 events
+    eviction_manager.py # LRU + trigger-watermark driven eviction loop
+    usage_manager.py    # per-salt usage aggregation
+    prefetch_manager.py # dispatches warm prefetch to a named MP server
+    resync_manager.py   # startup resync of usage/eviction from an MP server's GET /cache/objects
   http_apis/
-    instances_api.py  # the /instances REST resource
-    health_api.py     # /healthz
+    __init__.py
+    dependencies.py     # shared FastAPI dependencies (registry, blend directory, ...)
+    instances_api.py    # /instances REST resource
+    health_api.py       # /healthz
+    quota_api.py        # /quota/{cache_salt}, /quota, /quota/events
+    cache_api.py        # /cache/prefetches, /cache/prefetches/{instance_id}/{request_id}
+    blend_directory_api.py  # /blend/fingerprints, /blend/match
 ```
 
 ## Request flow
@@ -68,39 +94,42 @@ sequenceDiagram
 
 Heartbeat is `PUT /instances/{id}/heartbeat` → `registry.update_heartbeat`; a
 404 tells the client to re-register. The health loop (in `app.py`, started by
-the lifespan) evicts instances whose heartbeat lapsed. Future server push
-resolves the address (`ip` + `http_port`) from the registry and calls the mp
-server's specific endpoint directly:
+the lifespan) evicts instances whose heartbeat lapsed. Server push resolves
+the address (`ip` + `http_port`) from the registry and calls the mp server's
+specific endpoint directly:
 
 ```mermaid
 sequenceDiagram
-    participant Ctl as future router
+    participant Ctl as coordinator router
     participant Reg as InstanceRegistry
     participant M as mp server HTTP API
 
     Ctl->>Reg: get(instance_id) -> ip, http_port
-    Ctl->>M: POST http://ip:http_port/<resource> (e.g. /pin)
-    M-->>Ctl: 200 JSON
+    Ctl->>M: <VERB> http://ip:http_port/<resource> (e.g. DELETE /cache/objects)
+    M-->>Ctl: 200 / 204 JSON
 ```
 
 ## Extension seam (adding a capability)
 
-`app.state` carries the **shared collaborators** every capability composes from:
-`config` and `registry`. Endpoints use them directly — membership is thin enough
-to have no service layer (the `/instances` router calls the registry straight,
-matching the mp server's own `http_apis` convention).
+`app.state` carries the **shared collaborators** every capability composes
+from: `config`, `registry`, `blend_directory`, and the `cache_control`
+managers. Endpoints use them directly — membership is thin enough to have no
+service layer (the `/instances` router calls the registry straight, matching
+the mp server's own `http_apis` convention).
 
-To add a capability (e.g. quota):
+To add a capability (e.g. a new domain resource):
 
-1. `http_apis/quota_api.py` — a module-level `router` (FastAPI `APIRouter`).
-   `create_app` auto-discovers it (via `lmcache/v1/utils/router_discovery.py`,
-   the same convention as the mp server's HTTP API). No edits elsewhere for the
-   route to appear; the router reads `app.state.registry`, and to push it
-   resolves an instance's `ip`/`http_port` and POSTs to that mp server's
-   endpoint.
-2. Only if the domain has real logic/state of its own (e.g. quota: persistence,
-   broadcast-on-join) add a `quota_service.py` over the shared collaborators and
-   stash it on `app.state` in `create_app`. Thin domains skip this.
+1. `http_apis/<domain>_api.py` — a module-level `router` (FastAPI
+   `APIRouter`). `create_app` auto-discovers it (via
+   `lmcache/v1/utils/router_discovery.py`, the same convention as the mp
+   server's HTTP API). No edits elsewhere for the route to appear; the router
+   reads what it needs from `app.state`, and to push it resolves an instance's
+   `ip`/`http_port` and calls that mp server's endpoint.
+2. Only if the domain has real logic/state of its own (persistence,
+   broadcast-on-join, background reconciliation, …) add a manager under
+   `cache_control/` (or a peer package) and stash it on `app.state` in
+   `create_app`. Thin domains skip this — `quota` and `blend_directory` were
+   both added this way.
 
 A capability that must react to instance join/leave can hook into the
 registration endpoint (a small observer can be reintroduced then — it was
@@ -121,43 +150,91 @@ correctly; model-aware indexing belongs to a future routing router. Thread-safe
 (`threading.Lock`); `stale()` uses a monotonic clock so an NTP step cannot skew
 liveness.
 
+## Cache control (`cache_control/`)
+
+The `cache_control/` package owns everything downstream of the fleet-wide L2
+usage stream:
+
+- `usage_manager.py` — aggregates `POST /quota/events` into per-`cache_salt`
+  bytes and per-key LRU state.
+- `eviction_manager.py` — every `EVICTION_CHECK_INTERVAL` seconds, walks
+  salts over their trigger watermark and dispatches a single
+  `DELETE /cache/objects` to a uniformly random registered mp server (all
+  servers share the backing L2, so one dispatch evicts the fleet).
+- `resync_manager.py` — one-shot startup pass that paginates one mp
+  server's `GET /cache/objects` and seeds usage + LRU trackers, so a fresh
+  coordinator does not start from zero.
+- `prefetch_manager.py` — implements `POST /cache/prefetches` fan-out to a
+  named mp server (currently warm prefetch; further cache-control operations
+  land here).
+- `event_listener.py` — in-process handler that plugs the usage stream into
+  the manager collaborators.
+
+## Global CacheBlend directory (`blend_directory.py`)
+
+`GlobalBlendMatcher` is the fleet-wide fingerprint index behind cross-request
+blend reuse. Blend-enabled mp servers publish chunk fingerprints on STORE
+(`POST /blend/fingerprints`) and query them on LOOKUP (`POST /blend/match`);
+the index is chunked at `BLEND_CHUNK_SIZE` tokens and rolling-hash-matched at
+`BLEND_PROBE_STRIDE`. `DELETE /blend/fingerprints` evicts entries when the
+backing L2 objects are dropped so matches do not go stale. The
+mp-server-side client lives in `blend_client.py`; the wire types
+(`StoreRangeModel`, `BlendMatchRequest`, `GlobalMatchModel`, …) live in
+`schemas.py`.
+
 ## Concurrency & lifecycle
 
-- Everything runs on the uvicorn event loop; the registry lock guards the one
-  piece of shared state.
+- Everything runs on the uvicorn event loop; the registry lock guards
+  membership, other managers own their own locks (see `cache_control/`).
 - The health-check loop is an asyncio task started in the app lifespan; it
   evicts instances whose heartbeat lapsed (`instance_timeout`) and is cancelled
-  on shutdown. `health_check_interval = 0` disables it.
+  on shutdown. `HEALTH_CHECK_INTERVAL = 0` disables the stale-instance loop
+  (it does not affect the L2 eviction loop, which is gated separately by
+  `EVICTION_CHECK_INTERVAL`).
+- The L2 eviction loop is a second asyncio task started in the lifespan; it
+  is cancelled on shutdown. `EVICTION_CHECK_INTERVAL = 0` disables it.
 - Registration is idempotent: re-registering replaces the entry. The registry
-  is ephemeral — rebuilt from heartbeats after a coordinator restart; durable
-  state (quota) belongs in an external store (Redis), not here.
+  is ephemeral — rebuilt from heartbeats after a coordinator restart. Durable
+  state (registered quotas) belongs in an external store, not here; the
+  startup resync pass reconstructs usage + LRU from an mp server's
+  `GET /cache/objects` on boot.
 
 ## Running
 
 ```
 lmcache coordinator [--host HOST] [--port PORT] \
-    [--instance-timeout SECS] [--health-check-interval SECS]
+    [--instance-timeout SECS] [--health-check-interval SECS] \
+    [--eviction-check-interval SECS] [--eviction-ratio RATIO] \
+    [--trigger-watermark FRACTION] \
+    [--blend-chunk-size TOKENS] [--blend-probe-stride TOKENS] \
+    [--timeout-keep-alive SECS]
 ```
 
 (or, equivalently, `python -m lmcache.v1.mp_coordinator`).
 
 Configured via `LMCACHE_MP_COORDINATOR_*` environment variables — see
-`MPCoordinatorConfig` in `config.py` (`HOST`, `PORT`, `INSTANCE_TIMEOUT`,
-`HEALTH_CHECK_INTERVAL`). The `lmcache coordinator` CLI flags override the
+`MPCoordinatorConfig` in `config.py`. The full env-var surface today is
+`HOST`, `PORT`, `INSTANCE_TIMEOUT`, `HEALTH_CHECK_INTERVAL`,
+`EVICTION_CHECK_INTERVAL`, `EVICTION_RATIO`, `TRIGGER_WATERMARK`,
+`BLEND_CHUNK_SIZE`, `BLEND_PROBE_STRIDE`, `ENABLE_STARTUP_RESYNC`,
+`RESYNC_POLL_INTERVAL`, `RESYNC_MAX_WAIT`, `RESYNC_PAGE_SIZE`, and
+`TIMEOUT_KEEP_ALIVE`. The `lmcache coordinator` CLI flags override the
 matching env-derived field; unset flags fall back to the env vars and then the
-config defaults.
+config defaults. See the user-facing
+[`docs/source/mp/coordinator.rst`](../../../source/mp/coordinator.rst) for
+descriptions and defaults.
 
-An mp server joins via the `registrar.py` helpers — no dedicated client object,
-mirroring how the coordinator just calls mp endpoints. The mp server's FastAPI
-lifespan creates a generic `httpx.AsyncClient` and launches `keep_registered()`
-as a task: it `POST`s `/instances`, `PUT`s `/instances/{id}/heartbeat` on a
-timer, and `DELETE`s on cancellation — on the mp server's own event loop, using
-the shared `schemas` models. It is wired into
-`lmcache/v1/multiprocess/http_server.py`'s lifespan and configured by a
-`CoordinatorConfig` (`lmcache/v1/multiprocess/config.py`), built from
-`--coordinator-*` flags that fall back to `LMCACHE_COORDINATOR_*` env vars. It is
-**opt-in**: with no coordinator URL, the mp server is unaffected. It is
+An mp server joins via the `registrar.py` helpers — no dedicated client
+object, mirroring how the coordinator just calls mp endpoints. The mp
+server's FastAPI lifespan creates a generic `httpx.AsyncClient` and launches
+`keep_registered()` as a task: it `POST`s `/instances`, `PUT`s
+`/instances/{id}/heartbeat` on a timer, and `DELETE`s on cancellation — on
+the mp server's own event loop, using the shared `schemas` models. It is
+wired into `lmcache/v1/multiprocess/http_server.py`'s lifespan and configured
+by a `CoordinatorConfig` (`lmcache/v1/multiprocess/config.py`), built from
+`--coordinator-*` flags that fall back to `LMCACHE_COORDINATOR_*` env vars.
+It is **opt-in**: with no coordinator URL, the mp server is unaffected. It is
 best-effort — failures are logged and retried (a down coordinator never blocks
 the server), while a malformed config is rejected at startup. The server
-advertises its own HTTP address (`ip` + `http_port`, e.g. the pod IP via the k8s
-downward API) so the coordinator can reach it.
+advertises its own HTTP address (`ip` + `http_port`, e.g. the pod IP via the
+k8s downward API) so the coordinator can reach it.

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -58,7 +58,10 @@ variables:
        fleet.
    * - ``LMCACHE_MP_COORDINATOR_HEALTH_CHECK_INTERVAL``
      - ``10``
-     - Seconds between health-check sweeps. ``0`` disables eviction.
+     - Seconds between health-check sweeps that expire stale MP-server
+       registrations. ``0`` disables the stale-instance eviction loop; it does
+       **not** affect the ``/quota`` L2 eviction loop (see
+       ``LMCACHE_MP_COORDINATOR_EVICTION_CHECK_INTERVAL`` below).
    * - ``LMCACHE_MP_COORDINATOR_EVICTION_CHECK_INTERVAL``
      - ``5``
      - Seconds between L2 eviction sweeps. ``0`` disables the loop.
@@ -163,6 +166,9 @@ The coordinator's HTTP surface (base URL ``http://localhost:9300``) groups into:
   eviction.
 - **Cache control** -- the ``/cache`` group: cache operations dispatched to a
   named server (currently warm prefetch, with more to come).
+- **CacheBlend fingerprint directory** -- the ``/blend`` group: the fleet-wide
+  fingerprint index blend-enabled MP servers publish to on STORE and query on
+  LOOKUP. Server-to-coordinator only; not usually called by hand.
 
 Each endpoint is documented below. Success is ``200`` unless noted, and
 ``{cache_salt}`` uses the ``_default`` sentinel for the empty salt. The wire
@@ -737,3 +743,138 @@ verbatim with its code.
 
     curl -s http://localhost:9300/cache/prefetches/server-1/abc123
     # -> {"status": "completed", "found_keys": 12, "total_keys": 12}
+
+CacheBlend fingerprint directory
+--------------------------------
+
+The ``/blend`` group is the fleet-wide fingerprint index behind CacheBlend
+cross-request reuse. Blend-enabled MP servers publish chunk fingerprints on
+STORE (``POST /blend/fingerprints``) and query them on LOOKUP
+(``POST /blend/match``); the index is chunked at
+``LMCACHE_MP_COORDINATOR_BLEND_CHUNK_SIZE`` tokens and rolling-hash-matched at
+``LMCACHE_MP_COORDINATOR_BLEND_PROBE_STRIDE``. These endpoints are
+server-to-coordinator; they are not usually called by hand.
+
+The wire types (``StoreRangeModel``, ``BlendFingerprintRequest``,
+``BlendMatchRequest``, ``GlobalMatchModel`` and their responses) live in
+``lmcache/v1/mp_coordinator/schemas.py``.
+
+``POST /blend/fingerprints``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Register stored chunk fingerprints (idempotent).
+
+**Request body:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Field
+     - Type
+     - Description
+   * - ``ranges``
+     - list
+     - Stored token ranges. Each entry carries ``model_scope`` (the reuse
+       scope, typically the model name), ``tokens`` (the raw stored token
+       ids), ``object_keys`` (the shared-L2 storage key per chunk, in order),
+       and ``old_st_base`` (the token position of the range's first token).
+       The directory chunks ``tokens`` at the coordinator's chunk size and
+       hashes each chunk; chunk ``i`` maps to ``object_keys[i]``.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {"inserted": 3}
+
+``inserted`` reports how many fingerprints were newly registered (existing
+entries are left in place; re-publishing is safe).
+
+**HTTP status codes:**
+
+- ``200``: fingerprints processed.
+- ``422``: request body fails field-level validation.
+
+``DELETE /blend/fingerprints``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Evict fingerprints by shared-L2 storage key (idempotent). MP servers call this
+when the underlying L2 objects are dropped, so the directory does not keep
+handing out stale matches.
+
+**Request body:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Field
+     - Type
+     - Description
+   * - ``object_keys``
+     - list[string]
+     - Storage keys whose fingerprint entries should be removed. Unknown keys
+       are ignored.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {"removed": 2}
+
+``removed`` reports how many entries were actually evicted.
+
+**HTTP status codes:**
+
+- ``200``: keys processed.
+- ``422``: request body fails field-level validation.
+
+``POST /blend/match``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Match a request's token buffer against the directory and return the reusable
+chunks.
+
+**Request body:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Field
+     - Type
+     - Description
+   * - ``model_scope``
+     - string
+     - Reuse scope to match within (typically the model name).
+   * - ``tokens_b64``
+     - string
+     - Request tokens packed as base64 little-endian ``uint32`` (see
+       ``encode_tokens`` / ``decode_tokens`` in ``schemas.py``). The
+       coordinator hashes them at
+       ``LMCACHE_MP_COORDINATOR_BLEND_CHUNK_SIZE`` positions striding by
+       ``LMCACHE_MP_COORDINATOR_BLEND_PROBE_STRIDE``.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "matches": [
+        {"object_key": "ab12...", "old_st": 0,    "cur_st": 512},
+        {"object_key": "cd34...", "old_st": 256,  "cur_st": 768}
+      ]
+    }
+
+Each entry names one reusable chunk: ``object_key`` is the shared-L2 key,
+``old_st`` is its token position in the stored sequence (re-RoPE source), and
+``cur_st`` is the position in the request (re-RoPE target). Matches are sorted
+ascending by ``cur_st``. An empty request or an unknown ``model_scope``
+returns ``{"matches": []}``.
+
+**HTTP status codes:**
+
+- ``200``: match completed (an empty match list is not an error).
+- ``422``: ``tokens_b64`` is not valid base64 or not a whole number of
+  ``uint32`` tokens.

--- a/lmcache/v1/multiprocess/protocols/README.md
+++ b/lmcache/v1/multiprocess/protocols/README.md
@@ -7,11 +7,16 @@ This directory contains the modular protocol definitions for the LMCache multipr
 ```
 protocols/
 ├── README.md           # This file
-├── __init__.py        # Protocol initialization and registration
-├── base.py            # Common types (HandlerType, ProtocolDefinition)
-├── engine.py          # Engine operations (STORE, RETRIEVE, etc.)
-├── controller.py      # Controller operations (CLEAR, GET_CHUNK_SIZE)
-└── debug.py           # Debug operations (NOOP)
+├── __init__.py         # Protocol initialization and registration
+├── base.py             # Common types (HandlerType, ProtocolDefinition, RequestType)
+├── engine.py           # Engine operations (REGISTER/UNREGISTER, STORE, RETRIEVE, LOOKUP, PREPARE/COMMIT, ...)
+├── controller.py       # Controller operations (CLEAR, GET_CHUNK_SIZE, PING)
+├── debug.py            # Debug operations (NOOP)
+├── blend.py            # CacheBlend v1 operations (CB_STORE/RETRIEVE_PRE_COMPUTED, CB_STORE_FINAL, ...)
+├── blend_v2.py         # CacheBlend v2 lookup/retrieve (CB_*_V2)
+├── blend_v3.py         # CacheBlend v3 rope + unified lookup (CB_*_V3, CB_UNIFIED_LOOKUP)
+├── observability.py    # Observability events (REPORT_BLOCK_ALLOCATION)
+└── p2p.py              # Peer-to-peer transfers (P2P_LOOKUP_AND_LOCK, P2P_QUERY_LOOKUP_RESULTS, P2P_UNLOCK_OBJECTS)
 ```
 
 ## Design Overview
@@ -23,7 +28,7 @@ The protocol system is designed to be modular, extensible, and IDE-friendly:
    - All request types visible to static analysis tools
    - Validation ensures enum stays in sync with protocol definitions
 
-2. **Protocol Modules**: Each module (engine, controller, debug) defines:
+2. **Protocol Modules**: Each module (engine, controller, debug, blend, blend_v2, blend_v3, observability, p2p) defines:
    - `REQUEST_NAMES`: List of request type names (for validation)
    - `get_protocol_definitions()`: Returns dict of name → ProtocolDefinition
 
@@ -44,7 +49,7 @@ To add new protocol operations:
 
 ### Option 1: Add to Existing Module
 
-If your operation fits an existing category (engine/controller/debug):
+If your operation fits an existing category (engine / controller / debug / blend / blend_v2 / blend_v3 / observability / p2p):
 
 1. **Add to the enum** in `protocols/base.py`:
    ```python
@@ -123,18 +128,22 @@ If you're adding a new category of operations:
        }
    ```
 
-3. **Register the module** in `__init__.py`:
+3. **Register the module** in `__init__.py` by importing it and adding
+   an entry to the `_PROTOCOL_MODULES` list:
    ```python
    from lmcache.v1.multiprocess.protocols import monitoring  # Import your module
 
-   def initialize_protocols():
-       protocol_modules = [
-           ("engine", engine),
-           ("controller", controller),
-           ("debug", debug),
-           ("monitoring", monitoring),  # Add here
-       ]
-       # ... rest of initialization ...
+   _PROTOCOL_MODULES = [
+       ("engine", engine),
+       ("controller", controller),
+       ("debug", debug),
+       ("blend", blend),
+       ("blend_v2", blend_v2),
+       ("blend_v3", blend_v3),
+       ("observability", observability),
+       ("p2p", p2p),
+       ("monitoring", monitoring),  # Add here
+   ]
    ```
 
 4. **Done!** The new operations are now available as:
@@ -188,23 +197,59 @@ has no corresponding RequestType enum member. Add 'RequestType.NEW_OP' to protoc
 
 ## Current Protocol Groups
 
+The authoritative list of request names is `REQUEST_NAMES` in each module; the
+list below is a snapshot as of this file's last update.
+
 ### Engine Operations (`engine.py`)
-Core KV cache operations:
-- `REGISTER_KV_CACHE`: Register a KV cache instance
-- `UNREGISTER_KV_CACHE`: Unregister a KV cache instance
-- `STORE`: Store KV cache blocks to the server
-- `RETRIEVE`: Retrieve KV cache blocks from the server
-- `LOOKUP`: Check if keys exist in the cache
-- `END_SESSION`: End a session and clean up resources
+Core KV cache operations and their split-phase variants:
+- `REGISTER_KV_CACHE` / `UNREGISTER_KV_CACHE`: Register / unregister the GPU KV cache
+- `REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT` / `UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT`: Register / unregister the non-GPU (engine-driven) KV cache context
+- `STORE` / `RETRIEVE`: Fused store / retrieve
+- `PREPARE_STORE` / `COMMIT_STORE` / `PREPARE_RETRIEVE` / `COMMIT_RETRIEVE`: Split-phase store / retrieve (used by the engine-driven path)
+- `LOOKUP`: Submit a prefix lookup and return a prefetch job id
+- `QUERY_PREFETCH_STATUS` / `WAIT_PREFETCH_STATUS`: Poll / block for a prefetch job's result
+- `QUERY_PREFETCH_LOOKUP_HITS` / `FREE_LOOKUP_LOCKS`: Inspect and release the read locks a lookup took on cached chunks
+- `END_SESSION`: End a session and clean up associated resources
 
 ### Controller Operations (`controller.py`)
 Cache management and configuration:
 - `CLEAR`: Clear all caches in the server
 - `GET_CHUNK_SIZE`: Get the chunk size configuration
+- `PING`: Liveness / worker probe (payload: sender's worker instance id or `None`)
 
 ### Debug Operations (`debug.py`)
 Testing and monitoring:
-- `NOOP`: No-operation command for testing/heartbeat
+- `NOOP`: No-operation command for testing / heartbeat
+
+### CacheBlend v1 (`blend.py`)
+First-generation CacheBlend operations (pre-computed lookup / retrieve, final store, and blend-scoped KV cache registration):
+- `CB_LOOKUP_PRE_COMPUTED`
+- `CB_STORE_PRE_COMPUTED`
+- `CB_RETRIEVE_PRE_COMPUTED`
+- `CB_STORE_FINAL`
+- `CB_REGISTER_KV_CACHE`
+- `CB_UNREGISTER_KV_CACHE`
+
+### CacheBlend v2 (`blend_v2.py`)
+Second-generation CacheBlend lookup + retrieve:
+- `CB_LOOKUP_PRE_COMPUTED_V2`
+- `CB_RETRIEVE_PRE_COMPUTED_V2`
+
+### CacheBlend v3 (`blend_v3.py`)
+Third-generation CacheBlend with rope state and unified lookup:
+- `CB_REGISTER_ROPE_V3` / `CB_UNREGISTER_ROPE_V3`
+- `CB_RETRIEVE_PRE_COMPUTED_V3`
+- `CB_UNIFIED_LOOKUP`
+
+### Observability (`observability.py`)
+Server-side observability events:
+- `REPORT_BLOCK_ALLOCATION`
+
+### P2P (`p2p.py`)
+Peer-to-peer transfer operations:
+- `P2P_LOOKUP_AND_LOCK`
+- `P2P_QUERY_LOOKUP_RESULTS`
+- `P2P_UNLOCK_OBJECTS`
 
 ## Handler Types
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. Three inconsistencies between the multi-process (MP) docs and the current `dev` code (`upstream/dev` HEAD `1a842582`) were found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/mp/coordinator.rst`** — the "HTTP endpoints" overview listed only three coordinator groups (fleet-membership, quota, cache-control). A **fourth** live group — the global CacheBlend fingerprint directory — was undocumented despite already shipping three endpoints in code. The same file's `LMCACHE_MP_COORDINATOR_HEALTH_CHECK_INTERVAL` row said `0` "disables eviction", which is ambiguous next to the L2 quota-eviction loop documented four rows below.

`docs/design/` (design docs):

- **`docs/design/v1/mp_coordinator/README.md`** — claimed quota reconcile, blend-lookup routing, and KV-op fan-out were "not implemented yet"; listed only `/instances` + `/healthz` in the transport table; showed a two-file `http_apis/` layout; documented a 4-flag `lmcache coordinator` CLI; and named only four `LMCACHE_MP_COORDINATOR_*` env vars. All three capabilities have shipped, the CLI now accepts 10 flags, and `MPCoordinatorConfig` reads 14 env vars.

- **`lmcache/v1/multiprocess/protocols/README.md`** (this file is symlinked from `docs/design/v1/multiprocess/protocols/README.md`) — layout tree listed only `engine.py`, `controller.py`, `debug.py`; `_PROTOCOL_MODULES` example listed the same three; "Current Protocol Groups" section only covered those three; Engine list showed 6 entries where code defines 16; Controller list omitted `PING`. Code registers 8 protocol modules.

**Evidence**

| Drift | Code / repo state (current `dev`) | Stale doc |
| --- | --- | --- |
| Coordinator `/blend/*` group undocumented | Three endpoints defined in [`lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py#L54-L107`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py#L54-L107) (`POST /blend/fingerprints`, `DELETE /blend/fingerprints`, `POST /blend/match`) | [`docs/source/mp/coordinator.rst#L157-L166`](https://github.com/LMCache/LMCache/blob/1a842582/docs/source/mp/coordinator.rst#L157-L166) |
| Ambiguous "0 disables eviction" for `HEALTH_CHECK_INTERVAL` | [`lmcache/v1/mp_coordinator/app.py`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/app.py) starts the health-check loop and the L2 eviction loop as *separate* tasks, gated by `health_check_interval` and `eviction_check_interval` respectively | [`docs/source/mp/coordinator.rst#L59-L61`](https://github.com/LMCache/LMCache/blob/1a842582/docs/source/mp/coordinator.rst#L59-L61) |
| Coordinator design README says quota / blend / KV-op fan-out are "not implemented yet"; 4-flag CLI signature; 4 env vars listed | Quota → [`http_apis/quota_api.py`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/http_apis/quota_api.py) + [`cache_control/`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/cache_control) (eviction_manager, usage_manager, prefetch_manager, resync_manager). Blend directory → [`blend_directory.py`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/blend_directory.py), [`http_apis/blend_directory_api.py`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/http_apis/blend_directory_api.py), [`blend_client.py`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/blend_client.py). Cache/KV-op fan-out → [`http_apis/cache_api.py`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/http_apis/cache_api.py). CLI: [`lmcache/cli/commands/coordinator.py#L48-L130`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/cli/commands/coordinator.py#L48-L130) (10 flags). Env vars: [`lmcache/v1/mp_coordinator/config.py#L135-L161`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/mp_coordinator/config.py#L135-L161) (14 vars) | [`docs/design/v1/mp_coordinator/README.md#L6-L8`](https://github.com/LMCache/LMCache/blob/1a842582/docs/design/v1/mp_coordinator/README.md#L6-L8), [`#L24-L31`](https://github.com/LMCache/LMCache/blob/1a842582/docs/design/v1/mp_coordinator/README.md#L24-L31), [`#L40-L51`](https://github.com/LMCache/LMCache/blob/1a842582/docs/design/v1/mp_coordinator/README.md#L40-L51), [`#L137-L147`](https://github.com/LMCache/LMCache/blob/1a842582/docs/design/v1/mp_coordinator/README.md#L137-L147) |
| Protocols design README lists 3 modules / 6 engine requests / 2 controller requests | 8 modules registered in [`lmcache/v1/multiprocess/protocols/__init__.py#L12-L44`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/multiprocess/protocols/__init__.py#L12-L44); 16 engine requests in [`engine.py#L60-L77`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/multiprocess/protocols/engine.py#L60-L77); controller `PING` at [`controller.py#L14-L18`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/multiprocess/protocols/controller.py#L14-L18) | [`lmcache/v1/multiprocess/protocols/README.md#L6-L15`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/multiprocess/protocols/README.md#L6-L15), [`#L131-L138`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/multiprocess/protocols/README.md#L131-L138), [`#L189-L207`](https://github.com/LMCache/LMCache/blob/1a842582/lmcache/v1/multiprocess/protocols/README.md#L189-L207) |

**Proposed fix**

Already applied in the diff (docs only, no code touched):

1. `docs/source/mp/coordinator.rst`
   - Added a **fourth** bullet ("CacheBlend fingerprint directory") to the HTTP-surface overview and a matching full section at the end documenting each of the three `/blend/*` endpoints (request body, response shape, status codes), following the same pattern used for `/quota/events` and other server-to-coordinator endpoints.
   - Reworded the `HEALTH_CHECK_INTERVAL` row so `0` explicitly refers to the stale-instance loop, with a pointer to `EVICTION_CHECK_INTERVAL` for the separate L2 eviction loop.
2. `docs/design/v1/mp_coordinator/README.md` — rewrote the "Why", transport table, layout tree, extension seam, new "Cache control" and "Global CacheBlend directory" sections, concurrency + lifecycle, and "Running" sections to match the current package. The `Running` section now enumerates all 10 CLI flags and all 14 env vars.
3. `lmcache/v1/multiprocess/protocols/README.md` (symlinked from `docs/design/v1/multiprocess/protocols/README.md`) — refreshed the directory-structure tree, the `_PROTOCOL_MODULES` sample used in the "Adding new protocols" instructions, and the "Current Protocol Groups" section to match `protocols/__init__.py` (engine, controller, debug, blend, blend_v2, blend_v3, observability, p2p). The Engine list now covers all 16 request names, and the Controller list includes `PING`. Added a note that the authoritative source is each module's `REQUEST_NAMES` so the snapshot ages gracefully.

**Special notes for your reviewers**:

- Docs-only change. No code modified. The single file under `lmcache/v1/multiprocess/protocols/` is `README.md` — a doc that lives co-located with code per the `CLAUDE.md` convention and is symlinked into `docs/design/v1/multiprocess/protocols/`.
- Deduped against currently-open drift PRs #3969 (adds `DevDaxL1MemoryManager` to the L1 tier list in `docs/source/mp/index.rst` and fixes deleted `l2_apis.md` references) and #3960 (adds `hfbucket` to registered L2 adapter types and `IsolatedLRU` to `--eviction-policy` choices). Those items are intentionally not touched here.
- Two follow-ups the routine spotted but intentionally did not tackle:
  - `docs/design/v1/multiprocess/http_api_extension.md` still lists a partial MP-server endpoint table; the equivalent user-facing content in `docs/source/mp/http_api.rst` is up to date, so leaving the design page for a separate cleanup avoids sprawling this PR.
  - `docs/source/mp/configuration.rst` line 404-405's list of registered L2 adapter types also omits `fault_inject` and `p2p` (in addition to the `hfbucket` gap already covered by PR #3960). Best to fold that into PR #3960 rather than open a competing edit.
- This PR was **auto-generated** by the daily drift-check routine and **needs human review before merge**. Please do not merge without a maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSWFUae1jxafBspHUuFszo)_