### PR TITLE
[Feat]: add disable_l1_retrieval config for MP retrieval

### DIFF
--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -244,6 +244,10 @@ class StorageManagerConfig:
     prefetch_policy: str = "default"
     """ The L2 prefetch policy name. """
 
+    disable_l1_retrieval: bool = False
+    """ When True, retrieval never serves reads from resident L1: every key is
+    routed to L2 regardless of L1 residency. """
+
     prefetch_max_in_flight: int = 8
     """ Maximum number of concurrent prefetch requests. """
 
@@ -502,6 +506,12 @@ def add_storage_manager_args(
         "Default is 'default' (pick the first adapter by index).",
     )
     policy_group.add_argument(
+        "--disable-l1-retrieval",
+        action="store_true",
+        help="Never serve reads from resident L1: route every key to L2. "
+        "Off by default.",
+    )
+    policy_group.add_argument(
         "--l2-prefetch-max-in-flight",
         type=int,
         default=8,
@@ -598,6 +608,7 @@ def parse_args_to_config(
         l2_adapter_config=l2_adapter_config,
         store_policy=args.l2_store_policy,
         prefetch_policy=args.l2_prefetch_policy,
+        disable_l1_retrieval=args.disable_l1_retrieval,
         prefetch_max_in_flight=args.l2_prefetch_max_in_flight,
         periodic_notifier_interval_ms=args.periodic_notifier_interval_ms,
     )

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -68,6 +68,7 @@ class StorageManager:
     def __init__(self, config: StorageManagerConfig):
         self._l1_manager = L1Manager(config.l1_manager_config)
         self._event_bus = get_event_bus()
+        self._disable_l1_retrieval = config.disable_l1_retrieval
 
         # L1 eviction controller
         self._eviction_controller = L1EvictionController(
@@ -457,7 +458,12 @@ class StorageManager:
         # NOTE: now we only have L1, so the prefetch is essentially checking how many
         # objects are already in L1, and adding read locks to them.
 
-        l1_read_result = self._l1_manager.reserve_read(keys, extra_count=extra_count)
+        # disable_l1_retrieval: skip the L1 hit-check so every key routes to L2.
+        l1_read_result: dict[ObjectKey, tuple[L1Error, MemoryObj | None]] = (
+            {}
+            if self._disable_l1_retrieval
+            else self._l1_manager.reserve_read(keys, extra_count=extra_count)
+        )
 
         if policy is TrimPolicy.SPARSE:
             # SPARSE: retain a read lock on every L1 hit (not just the leading

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -281,6 +281,25 @@ class TestStorageManagerBasic:
 
         storage_manager.close()
 
+    def test_prefetch_disable_l1_retrieval(self, basic_l1_config, basic_layout):
+        """With disable_l1_retrieval, resident L1 keys are never served: with
+        no L2 configured they surface as misses instead of prefix hits."""
+        config = StorageManagerConfig(
+            l1_manager_config=basic_l1_config,
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+            disable_l1_retrieval=True,
+        )
+        storage_manager = StorageManager(config)
+
+        object_keys = [make_object_key(i) for i in range(5)]
+        ret = storage_manager.reserve_write(object_keys, basic_layout, mode="new")
+        storage_manager.finish_write(list(ret.keys()))
+
+        handle = storage_manager.submit_prefetch_task(object_keys, basic_layout)
+        assert storage_manager.query_prefetch_status(handle).count_leading_ones() == 0
+
+        storage_manager.close()
+
     def test_prefetch_partial_prefix_hits(
         self, basic_storage_manager_config, basic_layout
     ):


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `StorageManagerConfig.disable_l1_retrieval` flag (and matching
`--disable-l1-retrieval` CLI arg) for MP mode. When enabled, retrieval skips the
L1 hit-check in `submit_prefetch_task` so every key is routed to L2, regardless
of whether it is already resident in L1. A key that lives only in L1 surfaces as
a miss.

This is useful for isolating/benchmarking L2 behavior and for deployments that
want L1 to act purely as a transient staging/write buffer rather than a read
cache.

**Special notes for your reviewers**:

There is no existing config that makes retrieval *never* serve from L1:

- `store_policy: "skip_l1"` is a write-path policy — it deletes a key from L1
  only *after* the async L2 store finalizes (`_finalize_store`), so the key stays
  readable in L1 for the entire store window.
- The prefetch path must stage L2 hits into L1 (the caller reads from L1), so
  concurrent readers can hit those keys while they are read-locked.

So this flag provides a hard "never serve reads from L1" guarantee rather than
relying on the emergent, transient behavior above.

Implementation is minimal: no public method signatures change. The config value
is read once in `StorageManager.__init__` and turns the existing `reserve_read`
call into a conditional (empty result → all keys route to L2, flowing unchanged
through the existing miss-handling in the SPARSE/PREFIX paths). WARM mode already
never consults L1 residency, so it is unaffected.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
