### PR TITLE
chore(cli/metrics): move type-only imports under TYPE_CHECKING (#3730)

### DIFF
--- a/lmcache/cli/metrics/formatter.py
+++ b/lmcache/cli/metrics/formatter.py
@@ -6,20 +6,23 @@ Formatters are attached to handlers, separating rendering from destination.
 """
 
 # Standard
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import abc
 import inspect
 import json
 
 # First Party
-from lmcache.cli.metrics.section import Section, sections_to_dict
+from lmcache.cli.metrics.section import sections_to_dict
+
+if TYPE_CHECKING:
+    from lmcache.cli.metrics.section import Section
 
 
 class MetricsFormatter(abc.ABC):
     """Base class for metrics formatters."""
 
     @abc.abstractmethod
-    def format(self, title: str, sections: list[Section]) -> str:
+    def format(self, title: str, sections: list["Section"]) -> str:
         """Render metrics into a string.
 
         Args:
@@ -107,7 +110,7 @@ class TerminalFormatter(MetricsFormatter):
     def __init__(self, width: int = 48) -> None:
         self._width = width
 
-    def format(self, title: str, sections: list[Section]) -> str:
+    def format(self, title: str, sections: list["Section"]) -> str:
         """Render metrics as an ASCII table.
 
         Args:
@@ -155,7 +158,7 @@ class JsonFormatter(MetricsFormatter):
     def __init__(self, indent: int = 2) -> None:
         self._indent = indent
 
-    def format(self, title: str, sections: list[Section]) -> str:
+    def format(self, title: str, sections: list["Section"]) -> str:
         """Render metrics as indented JSON.
 
         Args:

--- a/lmcache/cli/metrics/formatter.py
+++ b/lmcache/cli/metrics/formatter.py
@@ -15,6 +15,7 @@ import json
 from lmcache.cli.metrics.section import sections_to_dict
 
 if TYPE_CHECKING:
+    # First Party
     from lmcache.cli.metrics.section import Section
 
 

--- a/lmcache/cli/metrics/handler.py
+++ b/lmcache/cli/metrics/handler.py
@@ -7,7 +7,7 @@ the rendering.
 """
 
 # Standard
-from typing import IO, Optional, Union
+from typing import IO, TYPE_CHECKING, Optional, Union
 import abc
 import os
 import sys
@@ -15,20 +15,22 @@ import sys
 # First Party
 from lmcache.cli.metrics.formatter import (
     JsonFormatter,
-    MetricsFormatter,
     TerminalFormatter,
 )
-from lmcache.cli.metrics.section import Section
+
+if TYPE_CHECKING:
+    from lmcache.cli.metrics.formatter import MetricsFormatter
+    from lmcache.cli.metrics.section import Section
 
 
 class MetricsHandler(abc.ABC):
     """Base class for metrics handlers."""
 
-    def __init__(self, formatter: MetricsFormatter) -> None:
+    def __init__(self, formatter: "MetricsFormatter") -> None:
         self.formatter = formatter
 
     @abc.abstractmethod
-    def emit(self, title: str, sections: list[Section]) -> None:
+    def emit(self, title: str, sections: list["Section"]) -> None:
         """Format and write metrics to the destination.
 
         Args:
@@ -47,13 +49,13 @@ class StreamHandler(MetricsHandler):
 
     def __init__(
         self,
-        formatter: Optional[MetricsFormatter] = None,
+        formatter: Optional["MetricsFormatter"] = None,
         stream: Optional[IO[str]] = None,
     ) -> None:
         super().__init__(formatter or TerminalFormatter())
         self._stream = stream
 
-    def emit(self, title: str, sections: list[Section]) -> None:
+    def emit(self, title: str, sections: list["Section"]) -> None:
         """Format and write metrics to the stream.
 
         Args:
@@ -77,12 +79,12 @@ class FileHandler(MetricsHandler):
     def __init__(
         self,
         path: Union[str, os.PathLike],
-        formatter: Optional[MetricsFormatter] = None,
+        formatter: Optional["MetricsFormatter"] = None,
     ) -> None:
         super().__init__(formatter or JsonFormatter())
         self.path = path
 
-    def emit(self, title: str, sections: list[Section]) -> None:
+    def emit(self, title: str, sections: list["Section"]) -> None:
         """Format and write metrics to the file.
 
         Args:

--- a/lmcache/cli/metrics/handler.py
+++ b/lmcache/cli/metrics/handler.py
@@ -19,6 +19,7 @@ from lmcache.cli.metrics.formatter import (
 )
 
 if TYPE_CHECKING:
+    # First Party
     from lmcache.cli.metrics.formatter import MetricsFormatter
     from lmcache.cli.metrics.section import Section
 

--- a/lmcache/cli/metrics/metrics.py
+++ b/lmcache/cli/metrics/metrics.py
@@ -19,12 +19,15 @@ Example usage::
 """
 
 # Standard
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 # First Party
-from lmcache.cli.metrics.handler import FileHandler, MetricsHandler
+from lmcache.cli.metrics.handler import FileHandler
 from lmcache.cli.metrics.section import Section, sections_to_dict
 from lmcache.logging import init_logger
+
+if TYPE_CHECKING:
+    from lmcache.cli.metrics.handler import MetricsHandler
 
 logger = init_logger(__name__)
 
@@ -45,7 +48,7 @@ class Metrics:
         self._title = title
         self._sections: list[Section] = []
         self._section_map: dict[Optional[str], Section] = {}
-        self._handlers: list[MetricsHandler] = []
+        self._handlers: list["MetricsHandler"] = []
 
     def title(self, title: str) -> None:
         """Set the report title.
@@ -57,7 +60,7 @@ class Metrics:
 
     # -- Handler management -------------------------------------------------
 
-    def add_handler(self, handler: MetricsHandler) -> None:
+    def add_handler(self, handler: "MetricsHandler") -> None:
         """Register a handler.
 
         Args:

--- a/lmcache/cli/metrics/metrics.py
+++ b/lmcache/cli/metrics/metrics.py
@@ -27,6 +27,7 @@ from lmcache.cli.metrics.section import Section, sections_to_dict
 from lmcache.logging import init_logger
 
 if TYPE_CHECKING:
+    # First Party
     from lmcache.cli.metrics.handler import MetricsHandler
 
 logger = init_logger(__name__)


### PR DESCRIPTION
### What

Part of #3730. Moves the type-only internal imports in the `lmcache/cli/metrics`
module under a `typing.TYPE_CHECKING` guard so they no longer run at import time.

| File | Moved under `TYPE_CHECKING` | Kept as runtime import |
|------|-----------------------------|------------------------|
| `formatter.py` | `Section` | `sections_to_dict` |
| `handler.py` | `MetricsFormatter`, `Section` | `JsonFormatter`, `TerminalFormatter` |
| `metrics.py` | `MetricsHandler` | `FileHandler`, `Section`, `sections_to_dict` |

### Why these are safe to move

Each moved symbol is used **only** in annotations. Symbols that are executed at
runtime are deliberately left as normal imports:

- `sections_to_dict(...)` is called.
- `JsonFormatter()` / `TerminalFormatter()` are instantiated as formatter defaults.
- `FileHandler` is used with `isinstance(...)`.
- `Section(...)` is instantiated in `metrics.py`, so it stays a runtime import there
  (only `formatter.py` / `handler.py`, where it appears purely in annotations, guard it).

Annotation references to the guarded names are quoted as forward refs
(e.g. `list["Section"]`, `Optional["MetricsFormatter"]`) so they still resolve for
type checkers. No `from __future__ import annotations` was added, to keep the change localized.

### Verification

- `ruff check` and `ruff format --check` pass on all three files.
- No runtime references to the guarded names remain outside the `TYPE_CHECKING` block.

Generated with [Claude Code](https://claude.com/claude-code)
