### PR TITLE
[Docs]: plugin / native_plugin L2 storage adapters

### DIFF
--- a/docs/source/mp/l2_storage/plugin.rst
+++ b/docs/source/mp/l2_storage/plugin.rst
@@ -1,0 +1,88 @@
+Plugin (Custom / External)
+==========================
+
+Two L2 adapter types load an adapter class from a *user-supplied* Python
+module at startup, so you can point LMCache at your own storage backend
+without modifying LMCache source.  This is the ``--l2-adapter`` analog of
+vLLM's ``kv_connector_module_path``.
+
+- ``plugin``: loads a pure-Python class that implements
+  ``L2AdapterInterface`` (the full L2 adapter contract).
+- ``native_plugin``: loads a pybind-wrapped C++ connector exposing a
+  six-method async batch contract and wraps it in
+  ``NativeConnectorL2Adapter``.  Use this for native backends -- see also
+  :doc:`/developer_guide/extending_lmcache/native_connectors`.
+
+``plugin``
+----------
+
+Dynamically imports ``module_path`` and instantiates ``class_name``, which
+must be a subclass of ``L2AdapterInterface`` (validated at load time; a
+mismatch raises ``TypeError``).
+
+**Required fields:**
+
+- ``module_path`` (str): Dotted Python import path of the module containing
+  the adapter class.  The module must be importable by the LMCache process
+  (installed, or on ``PYTHONPATH``).
+- ``class_name`` (str): Name of the class inside *module_path* that
+  implements ``L2AdapterInterface``.
+
+**Optional fields:**
+
+- ``adapter_params`` (dict, default ``{}``): Arbitrary dict forwarded to the
+  adapter constructor.
+- ``config_class_name`` (str): Name of a config class inside *module_path*
+  that subclasses ``L2AdapterConfigBase``.  When set (or auto-discovered),
+  the factory builds it via ``from_dict(adapter_params)`` and passes the
+  config object -- instead of the raw ``adapter_params`` dict -- to the
+  adapter constructor, matching the built-in adapter convention.  Discovery
+  order when omitted: ``<class_name>Config`` in the module, then a
+  ``config_class_name`` attribute on the adapter class; otherwise the raw
+  dict is passed.
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    # Raw-dict mode: adapter_params is passed straight to the constructor
+    --l2-adapter '{"type": "plugin", "module_path": "my_plugin.l2", "class_name": "MyL2Adapter", "adapter_params": {"host": "localhost"}}'
+
+    # Config-class mode: my_plugin.l2.MyL2AdapterConfig.from_dict(adapter_params) is built and passed
+    --l2-adapter '{"type": "plugin", "module_path": "my_plugin.l2", "class_name": "MyL2Adapter", "config_class_name": "MyL2AdapterConfig", "adapter_params": {"host": "localhost"}}'
+
+See ``examples/lmc_external_l2_adapter/`` for a complete reference plugin.
+
+``native_plugin``
+-----------------
+
+Dynamically imports ``module_path``, instantiates ``class_name`` with
+``adapter_params`` as constructor keyword arguments, verifies the instance
+exposes the required async batch methods (``event_fd``, ``submit_batch_get``,
+``submit_batch_set``, ``submit_batch_exists``, ``drain_completions``,
+``close``), and wraps it in ``NativeConnectorL2Adapter``.  An optional
+``submit_batch_delete`` enables L2 eviction deletes; without it, deletes are
+a no-op (logged as a warning).
+
+**Required fields:**
+
+- ``module_path`` (str): Dotted Python import path of the module containing
+  the connector class.
+- ``class_name`` (str): Name of the connector class inside *module_path*.
+
+**Optional fields:**
+
+- ``adapter_params`` (dict, default ``{}``): Forwarded as keyword arguments
+  to the connector constructor.
+- ``max_capacity_gb`` (float, default ``0``): Aggregate L2 capacity in GB for
+  usage tracking / eviction.  ``0`` disables aggregate eviction.
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    # Native pybind connector with constructor kwargs
+    --l2-adapter '{"type": "native_plugin", "module_path": "my_ext.connector", "class_name": "MyConnectorClient", "adapter_params": {"host": "localhost", "port": 1234}}'
+
+See ``examples/lmc_external_native_connector/`` for a complete reference
+native connector.

--- a/docs/source/mp/l2_storage/supported_storages.rst
+++ b/docs/source/mp/l2_storage/supported_storages.rst
@@ -49,6 +49,9 @@ target.
    * - :doc:`Fault Inject <fault_inject>`
      - ``fault_inject``
      - Testing
+   * - :doc:`Plugin <plugin>`
+     - ``plugin`` / ``native_plugin``
+     - Custom / External
 
 .. toctree::
    :maxdepth: 1
@@ -59,3 +62,4 @@ target.
    dax
    mock
    fault_inject
+   plugin


### PR DESCRIPTION
**What this PR does / why we need it**:

The `mp/l2_storage/supported_storages` docs page listed only the 12
built-in L2 storage backends and never documented the `plugin` /
`native_plugin` adapter types. These types load a user-supplied adapter
class from a dotted `module_path` + `class_name` at startup — the
`--l2-adapter` analog of vLLM's `kv_connector_module_path` — so users can
plug in their own L2 backend without modifying LMCache source. The
capability exists in the code (`lmcache/v1/distributed/l2_adapters/plugin_l2_adapter.py`,
`native_plugin_l2_adapter.py`) but was undiscoverable from the docs.

This PR:

- Adds `docs/source/mp/l2_storage/plugin.rst` covering both `plugin` and
  `native_plugin`, with required/optional fields (`module_path`,
  `class_name`, `adapter_params`, `config_class_name`, `max_capacity_gb`),
  the config-class auto-discovery order, the native connector's required
  batch methods, and `--l2-adapter` JSON examples. Field docs are taken
  directly from the adapter config classes.
- Registers the page in `supported_storages.rst` (a `list-table` row under a
  new "Custom / External" group, and a `toctree` entry).

Docs-only change; mirrors the existing per-backend page convention
(e.g. `s3.rst`). Cross-links the existing
`developer_guide/extending_lmcache/native_connectors` page and the
`examples/lmc_external_l2_adapter/` and `examples/lmc_external_native_connector/`
reference scaffolds.

**Special notes for your reviewers**:

RST heading/underline lengths verified. The design doc
`docs/design/v1/distributed/l2_adapters/plugin.md` already exists; this adds
the user-facing counterpart under the MP L2 storage docs.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
