### PR TITLE
[good-first-issue] cleanup: Move type-only imports under TYPE_CHECKING (#3730)

### DIFF
--- a/lmcache/v1/ec_engine.py
+++ b/lmcache/v1/ec_engine.py
@@ -14,7 +14,7 @@ See ``docs/design/v1/encoder-cache.md`` for the broader design.
 from __future__ import annotations
 
 # Standard
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 import hashlib
 
 # Third Party
@@ -23,11 +23,14 @@ import torch
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
-from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.event_manager import EventManager
 from lmcache.v1.memory_management import MemoryFormat
-from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.storage_manager import StorageManager
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.config import LMCacheEngineConfig
+    from lmcache.v1.metadata import LMCacheMetadata
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/mp_coordinator/cache_control/usage_manager.py
+++ b/lmcache/v1/mp_coordinator/cache_control/usage_manager.py
@@ -5,11 +5,15 @@
 from __future__ import annotations
 
 # Standard
+from typing import TYPE_CHECKING
 import threading
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.distributed.api import ObjectKey
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.api import ObjectKey
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
Refs #3372 (onboarding umbrella)

**What this PR does / why we need it:**
Closes #3730

Moves `LMCacheEngineConfig` and `LMCacheMetadata` imports in `ec_engine.py` under `TYPE_CHECKING`, since they are only used in type annotations and the file already has `from __future__ import annotations`.

**Special notes for your reviewers:**
- This is a subset of the full cleanup — additional files that also qualify (with `from __future__ import annotations` and type-only first-party imports) will be addressed in follow-up PRs.
- I ran pre-commit — all green.