### PR TITLE
[feat] add dual-RoPE support for cb under HMA (SWA models)

### DIFF
--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -71,9 +71,9 @@ logger = init_logger(__name__)
 class _CBRopeState:
     """Per-instance RoPE state IPC-shared from vLLM; dangles on reallocate.
 
-    Models with per-layer-type RoPE (e.g. Gemma 3: local theta=1e4 /
-    global theta=1e6) register one cache per distinct rope and a
-    per-layer index into ``cos_sin_caches``.
+    Models with per-layer-type RoPE (distinct local/global theta)
+    register one cache per distinct rope and a per-layer index into
+    ``cos_sin_caches``.
     """
 
     head_size: int
@@ -85,7 +85,7 @@ class _CBRopeState:
         """The cos/sin cache for one engine group.
 
         Engine groups partition layers by attention type, and rope follows
-        attention type (Gemma 3: sliding=local theta, full=global theta),
+        attention type (sliding=local theta, full=global theta),
         so each engine group has exactly one cache.
 
         Args:
@@ -486,8 +486,8 @@ class BlendV3Module(InstanceLivenessTarget):
         Args:
             instance_id (int): KV-cache instance to attach rope state to.
             cos_sin_caches_ipc (list[DeviceIPCWrapper]): IPC handles to vLLM's
-                cos/sin rope cache(s) — one per distinct rope (e.g. Gemma 3
-                local/global); single-rope models send one.
+                cos/sin rope cache(s) — one per distinct rope (dual-RoPE
+                models send local/global); single-rope models send one.
             head_size (int): Rotary head dimension.
             is_neox_style (bool): True for NeoX (contiguous halves), else GPT-J.
             group_to_cache (list[int]): Per-engine-group index into the
@@ -1481,7 +1481,7 @@ class BlendV3Module(InstanceLivenessTarget):
                     f"CB rope: group {group_idx} hidden_dim ({hidden_dim}) "
                     f"not a multiple of head_size ({rope_state.head_size})."
                 )
-            # Per-group rope cache: dual-RoPE models (Gemma 3) rotate each
+            # Per-group rope cache: dual-RoPE models rotate each
             # kernel group with its own theta's cos/sin.
             group_cos_sin = rope_state.cache_for_group(group.engine_group_idx)
             # slot ramp tiled across layers is invariant per (num_layers,

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -69,11 +69,42 @@ logger = init_logger(__name__)
 
 @dataclass
 class _CBRopeState:
-    """Per-instance RoPE state IPC-shared from vLLM; dangles on reallocate."""
+    """Per-instance RoPE state IPC-shared from vLLM; dangles on reallocate.
+
+    Models with per-layer-type RoPE (e.g. Gemma 3: local theta=1e4 /
+    global theta=1e6) register one cache per distinct rope and a
+    per-layer index into ``cos_sin_caches``.
+    """
 
     head_size: int
     is_neox_style: bool  # NeoX = contiguous halves; else GPT-J.
-    cos_sin_cache: torch.Tensor
+    cos_sin_caches: list[torch.Tensor]
+    group_to_cache: list[int]  # engine group idx -> cache idx; empty = cache 0
+
+    def cache_for_group(self, engine_group_idx: int) -> torch.Tensor:
+        """The cos/sin cache for one engine group.
+
+        Engine groups partition layers by attention type, and rope follows
+        attention type (Gemma 3: sliding=local theta, full=global theta),
+        so each engine group has exactly one cache.
+
+        Args:
+            engine_group_idx: The kernel group's engine group index.
+
+        Returns:
+            The group's cos/sin cache tensor.
+
+        Raises:
+            RuntimeError: If ``engine_group_idx`` is outside the map.
+        """
+        if not self.group_to_cache:
+            return self.cos_sin_caches[0]
+        if engine_group_idx >= len(self.group_to_cache):
+            raise RuntimeError(
+                f"CB re-RoPE: engine group {engine_group_idx} has no rope "
+                f"cache mapping (map covers {len(self.group_to_cache)} groups)."
+            )
+        return self.cos_sin_caches[self.group_to_cache[engine_group_idx]]
 
 
 @dataclass
@@ -441,68 +472,84 @@ class BlendV3Module(InstanceLivenessTarget):
     def cb_register_rope(
         self,
         instance_id: int,
-        cos_sin_cache_ipc: DeviceIPCWrapper,
+        cos_sin_caches_ipc: list[DeviceIPCWrapper],
         head_size: int,
         is_neox_style: bool,
+        group_to_cache: list[int],
     ) -> None:
         """Bolt CB re-RoPE state onto an already-registered KV-cache instance.
 
         Idempotent; ``REGISTER_KV_CACHE`` must precede this. Strips any
-        YaRN/longrope mscale baked into the rope cache so re-RoPE stays a pure
-        rotation.
+        YaRN/longrope mscale baked into each rope cache so re-RoPE stays a
+        pure rotation.
 
         Args:
             instance_id (int): KV-cache instance to attach rope state to.
-            cos_sin_cache_ipc (DeviceIPCWrapper): IPC handle to vLLM's cos/sin
-                rope cache.
+            cos_sin_caches_ipc (list[DeviceIPCWrapper]): IPC handles to vLLM's
+                cos/sin rope cache(s) — one per distinct rope (e.g. Gemma 3
+                local/global); single-rope models send one.
             head_size (int): Rotary head dimension.
             is_neox_style (bool): True for NeoX (contiguous halves), else GPT-J.
+            group_to_cache (list[int]): Per-engine-group index into the
+                caches list; empty means every group uses cache 0.
 
         Raises:
-            ValueError: If ``instance_id`` has no registered KV cache.
+            ValueError: If ``instance_id`` has no registered KV cache, the
+                cache list is empty, or ``group_to_cache`` references a
+                missing cache.
         """
         if self._transfer_module.get_and_touch_context_entry(instance_id) is None:
             raise ValueError(
                 f"Instance {instance_id} has no paged KV cache registered; "
                 "send REGISTER_KV_CACHE before CB_REGISTER_ROPE_V3."
             )
-
-        cos_sin_cache = cos_sin_cache_ipc.to_tensor()
-        # YaRN/longrope bake an mscale m into the rope cache (cos²+sin²=m²≠1).
-        # vLLM already folds m into stored K, but CB re-RoPE assumes a pure
-        # rotation, so an un-normalized m injects an m² error per K element
-
-        _c32 = cos_sin_cache.to(torch.float32)
-        _half = _c32.shape[1] // 2
-        _m = float((_c32[:, :_half] ** 2 + _c32[:, _half:] ** 2).mean().sqrt())
-        if abs(_m - 1.0) >= 1e-3:
-            logger.info(
-                "CB re-RoPE: stripping rope-cache mscale=%.4f (m²=%.4f → K "
-                "inflation if uncorrected) → unit magnitude",
-                _m,
-                _m * _m,
+        if not cos_sin_caches_ipc:
+            raise ValueError("CB_REGISTER_ROPE_V3 requires >=1 cos/sin cache.")
+        if group_to_cache and max(group_to_cache) >= len(cos_sin_caches_ipc):
+            raise ValueError(
+                f"group_to_cache references cache {max(group_to_cache)} but "
+                f"only {len(cos_sin_caches_ipc)} cache(s) were sent."
             )
-            cos_sin_cache = (_c32 / _m).to(cos_sin_cache.dtype)
-        else:
-            logger.info(
-                "CB re-RoPE: rope-cache magnitude≈%.4f (unit); no mscale "
-                "normalization needed",
-                _m,
-            )
+
+        cos_sin_caches: list[torch.Tensor] = []
+        for cache_idx, cache_ipc in enumerate(cos_sin_caches_ipc):
+            cos_sin_cache = cache_ipc.to_tensor()
+            # YaRN/longrope bake an mscale m into the rope cache
+            # (cos²+sin²=m²≠1). vLLM already folds m into stored K, but CB
+            # re-RoPE assumes a pure rotation, so an un-normalized m injects
+            # an m² error per K element.
+            _c32 = cos_sin_cache.to(torch.float32)
+            _half = _c32.shape[1] // 2
+            _m = float((_c32[:, :_half] ** 2 + _c32[:, _half:] ** 2).mean().sqrt())
+            if abs(_m - 1.0) >= 1e-3:
+                logger.info(
+                    "CB re-RoPE: cache %d: stripping rope-cache mscale=%.4f "
+                    "(m²=%.4f → K inflation if uncorrected) → unit magnitude",
+                    cache_idx,
+                    _m,
+                    _m * _m,
+                )
+                cos_sin_cache = (_c32 / _m).to(cos_sin_cache.dtype)
+            cos_sin_caches.append(cos_sin_cache)
+
         self._cb_rope_state[instance_id] = _CBRopeState(
             head_size=head_size,
             is_neox_style=is_neox_style,
-            cos_sin_cache=cos_sin_cache,
+            cos_sin_caches=cos_sin_caches,
+            group_to_cache=list(group_to_cache),
         )
 
         logger.info(
             "Registered CB rope state for instance %d "
-            "(cos_sin_cache shape=%s dtype=%s, head_size=%d, is_neox=%s)",
+            "(%d cache(s), shapes=%s dtype=%s, head_size=%d, is_neox=%s, "
+            "group_map=%s)",
             instance_id,
-            tuple(cos_sin_cache.shape),
-            cos_sin_cache.dtype,
+            len(cos_sin_caches),
+            [tuple(c.shape) for c in cos_sin_caches],
+            cos_sin_caches[0].dtype,
             head_size,
             is_neox_style,
+            "uniform" if not group_to_cache else str(group_to_cache),
         )
 
     def cb_unregister_rope(self, instance_id: int) -> None:
@@ -1414,21 +1461,34 @@ class BlendV3Module(InstanceLivenessTarget):
                     f"CB rope: group {group_idx} hidden_dim ({hidden_dim}) "
                     f"not a multiple of head_size ({rope_state.head_size})."
                 )
-            slot_positions = torch.arange(
-                slots, device=all_slots[0].device, dtype=torch.long
-            )
+            # Per-group rope cache: dual-RoPE models (Gemma 3) rotate each
+            # kernel group with its own theta's cos/sin.
+            group_cos_sin = rope_state.cache_for_group(group.engine_group_idx)
+            # slot ramp tiled across layers is invariant per (num_layers,
+            # slots) — cache it; each shifted slot then just adds its offset.
+            device = all_slots[0].device
+            sp_key = (str(device), num_layers, slots)
+            sp_cache = getattr(self, "_cb_sp_rep_cache", None)
+            if sp_cache is None:
+                sp_cache = {}
+                self._cb_sp_rep_cache = sp_cache
+            slot_positions_rep = sp_cache.get(sp_key)
+            if slot_positions_rep is None:
+                slot_positions_rep = torch.arange(
+                    slots, device=device, dtype=torch.long
+                ).repeat(num_layers)
+                sp_cache[sp_key] = slot_positions_rep
             for slot_idx, old_st, cur_st in slots_to_rope:
-                tmp = all_slots[slot_idx]
-                k_flat = tmp[0].reshape(num_layers * slots, hidden_dim)
-                old_positions = (old_st + slot_positions).repeat(num_layers)
-                new_positions = (cur_st + slot_positions).repeat(num_layers)
-                k_view = k_flat.view(-1, n_heads, rope_state.head_size)
+                # reshape returns an in-place view (tmp slots are contiguous).
+                k_view = all_slots[slot_idx][0].reshape(
+                    num_layers * slots, n_heads, rope_state.head_size
+                )
                 lmc_ops.rotary_embedding_k_fused(
-                    old_positions,
-                    new_positions,
+                    old_st + slot_positions_rep,
+                    cur_st + slot_positions_rep,
                     k_view,
                     rope_state.head_size,
-                    rope_state.cos_sin_cache,
+                    group_cos_sin,
                     rope_state.is_neox_style,
                 )
 

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -496,20 +496,40 @@ class BlendV3Module(InstanceLivenessTarget):
         Raises:
             ValueError: If ``instance_id`` has no registered KV cache, the
                 cache list is empty, or ``group_to_cache`` references a
-                missing cache.
+                missing cache or does not cover every engine group of the
+                registered model.
         """
-        if self._transfer_module.get_and_touch_context_entry(instance_id) is None:
+        entry = self._transfer_module.get_and_touch_context_entry(instance_id)
+        if entry is None:
             raise ValueError(
                 f"Instance {instance_id} has no paged KV cache registered; "
                 "send REGISTER_KV_CACHE before CB_REGISTER_ROPE_V3."
             )
         if not cos_sin_caches_ipc:
             raise ValueError("CB_REGISTER_ROPE_V3 requires >=1 cos/sin cache.")
-        if group_to_cache and max(group_to_cache) >= len(cos_sin_caches_ipc):
-            raise ValueError(
-                f"group_to_cache references cache {max(group_to_cache)} but "
-                f"only {len(cos_sin_caches_ipc)} cache(s) were sent."
+        if group_to_cache:
+            if min(group_to_cache) < 0 or max(group_to_cache) >= len(
+                cos_sin_caches_ipc
+            ):
+                raise ValueError(
+                    f"group_to_cache {group_to_cache} contains indices outside "
+                    f"[0, {len(cos_sin_caches_ipc)}) for the sent cache(s)."
+                )
+            # Fail at registration, not mid-retrieve: every engine group of
+            # the registered model must have a cache mapping.
+            max_eg_idx = max(
+                (
+                    g.engine_group_idx
+                    for g in entry.cache_context.kv_layer_groups_manager.kernel_groups
+                ),
+                default=-1,
             )
+            if len(group_to_cache) <= max_eg_idx:
+                raise ValueError(
+                    f"group_to_cache covers {len(group_to_cache)} engine "
+                    f"group(s) but the registered model has engine groups up "
+                    f"to index {max_eg_idx}."
+                )
 
         cos_sin_caches: list[torch.Tensor] = []
         for cache_idx, cache_ipc in enumerate(cos_sin_caches_ipc):
@@ -1622,7 +1642,15 @@ class BlendV3Module(InstanceLivenessTarget):
             for group_idx in range(num_groups):
                 eg_idx = kgm.kernel_groups[group_idx].engine_group_idx
                 if eg_idx >= len(block_ids_per_group_gpu):
-                    eg_idx = 0
+                    # Engine groups have independent block tables under HMA;
+                    # substituting another group's table would scatter KV into
+                    # the wrong physical blocks (silent corruption).
+                    raise ValueError(
+                        f"CB retrieve: kernel group {group_idx} maps to engine "
+                        f"group {eg_idx}, but only "
+                        f"{len(block_ids_per_group_gpu)} block table(s) were "
+                        "provided."
+                    )
                 resolved_groups.append(
                     (
                         block_ids_per_group_gpu[eg_idx],
@@ -1754,7 +1782,14 @@ class BlendV3Module(InstanceLivenessTarget):
                             for group_idx in range(num_groups):
                                 # This group's block table + size (resolved above).
                                 group_block_ids, group_bs = resolved_groups[group_idx]
-                                page_buffer_size = gpu_context.num_blocks * group_bs
+                                # Per-group block count: under HMA the sliding
+                                # group has fewer blocks than the full group, so
+                                # gpu_context.num_blocks (group 0's) would
+                                # truncate the other groups' bounds check.
+                                page_buffer_size = (
+                                    kgm.kernel_groups[group_idx].shape_desc.nb
+                                    * group_bs
+                                )
                                 slot_mapping = group_block_ids[
                                     pos // group_bs
                                 ] * group_bs + (pos % group_bs)

--- a/lmcache/v1/multiprocess/protocols/blend_v3.py
+++ b/lmcache/v1/multiprocess/protocols/blend_v3.py
@@ -25,7 +25,7 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         # Payload: (instance_id, cos_sin_caches_ipc, head_size, is_neox_style,
         #           group_to_cache).
         # cos_sin_caches_ipc: one IPC handle per distinct rope (dual-RoPE
-        # models like Gemma 3 send two); group_to_cache maps engine group
+        # models send two); group_to_cache maps engine group
         # idx -> cache idx (empty = all groups use cache 0). Returns: None.
         "CB_REGISTER_ROPE_V3": ProtocolDefinition(
             payload_classes=[int, list[DeviceIPCWrapper], int, bool, list[int]],

--- a/lmcache/v1/multiprocess/protocols/blend_v3.py
+++ b/lmcache/v1/multiprocess/protocols/blend_v3.py
@@ -22,10 +22,13 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
     """Return V3 blend protocol definitions."""
     return {
         # Register rope state on a previously-registered instance.
-        # Payload: (instance_id, cos_sin_cache_ipc, head_size, is_neox_style).
-        # Returns: None.
+        # Payload: (instance_id, cos_sin_caches_ipc, head_size, is_neox_style,
+        #           group_to_cache).
+        # cos_sin_caches_ipc: one IPC handle per distinct rope (dual-RoPE
+        # models like Gemma 3 send two); group_to_cache maps engine group
+        # idx -> cache idx (empty = all groups use cache 0). Returns: None.
         "CB_REGISTER_ROPE_V3": ProtocolDefinition(
-            payload_classes=[int, DeviceIPCWrapper, int, bool],
+            payload_classes=[int, list[DeviceIPCWrapper], int, bool, list[int]],
             response_class=None,
             handler_type=HandlerType.SYNC,
         ),

--- a/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
+++ b/tests/v1/multiprocess/test_blend_v3_load_store_opts.py
@@ -233,8 +233,8 @@ def _build_fake_gpu_context(batch_size: int, num_groups: int):
     gpu_context.kv_layer_groups_manager.num_kernel_groups = num_groups
     # All groups: uncompressed (tokens_per_block == slots_per_block), kv_size=2.
     groups = [
-        SimpleNamespace(tokens_per_block=4, slots_per_block=4)
-        for _ in range(num_groups)
+        SimpleNamespace(tokens_per_block=4, slots_per_block=4, engine_group_idx=idx)
+        for idx in range(num_groups)
     ]
     gpu_context.kv_layer_groups_manager.kernel_groups = groups
 
@@ -258,8 +258,11 @@ def test_batched_rope_calls_kernel_per_group_per_slot():
     from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
 
     gpu_context, head_size = _build_fake_gpu_context(batch_size=4, num_groups=2)
-    rope_state = SimpleNamespace(
-        head_size=head_size, cos_sin_cache=MagicMock(), is_neox_style=True
+    rope_state = v3_mod._CBRopeState(
+        head_size=head_size,
+        is_neox_style=True,
+        cos_sin_caches=[MagicMock()],
+        group_to_cache=[],
     )
 
     eng = MagicMock(spec=v3_mod.BlendV3Module)
@@ -304,8 +307,11 @@ def test_batched_rope_noop_on_empty_slots():
     from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
 
     gpu_context, head_size = _build_fake_gpu_context(batch_size=2, num_groups=2)
-    rope_state = SimpleNamespace(
-        head_size=head_size, cos_sin_cache=MagicMock(), is_neox_style=False
+    rope_state = v3_mod._CBRopeState(
+        head_size=head_size,
+        is_neox_style=False,
+        cos_sin_caches=[MagicMock()],
+        group_to_cache=[],
     )
     eng = MagicMock(spec=v3_mod.BlendV3Module)
     eng._apply_cb_rope_batched = v3_mod.BlendV3Module._apply_cb_rope_batched.__get__(
@@ -448,3 +454,115 @@ def test_non_overlapping_after_prefix():
     # usable 10-18 in the greedy pass (dedup-first would drop both -> []).
     out = f([m(5, 13), m(10, 18)], 8)
     assert [r.cur_st for r in out] == [10]
+
+
+# ---------------------------------------------------------------------------
+# Dual-RoPE: per-group cache selection + registration validation
+# ---------------------------------------------------------------------------
+
+
+def test_cache_for_group_uniform_and_mapped():
+    """Empty map -> every group uses cache 0; a map indexes per group;
+    a group past the map's end raises instead of guessing."""
+    # First Party
+    from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
+
+    local, global_ = MagicMock(), MagicMock()
+
+    uniform = v3_mod._CBRopeState(
+        head_size=32, is_neox_style=True, cos_sin_caches=[local], group_to_cache=[]
+    )
+    assert uniform.cache_for_group(0) is local
+    assert uniform.cache_for_group(5) is local
+
+    mapped = v3_mod._CBRopeState(
+        head_size=32,
+        is_neox_style=True,
+        cos_sin_caches=[local, global_],
+        group_to_cache=[0, 1],
+    )
+    assert mapped.cache_for_group(0) is local
+    assert mapped.cache_for_group(1) is global_
+    with pytest.raises(RuntimeError, match="no rope cache mapping"):
+        mapped.cache_for_group(2)
+
+
+def _rope_registration_engine(engine_group_indices: list[int]):
+    """A BlendV3Module mock with ``cb_register_rope`` bound and a registered
+    instance whose kernel groups span the given engine group indices."""
+    # First Party
+    from lmcache.v1.multiprocess.modules import blend_v3 as v3_mod
+
+    eng = MagicMock(spec=v3_mod.BlendV3Module)
+    eng._cb_rope_state = {}
+    eng._transfer_module = MagicMock()
+    entry = SimpleNamespace(
+        cache_context=SimpleNamespace(
+            kv_layer_groups_manager=SimpleNamespace(
+                kernel_groups=[
+                    SimpleNamespace(engine_group_idx=idx)
+                    for idx in engine_group_indices
+                ]
+            )
+        )
+    )
+    eng._transfer_module.get_and_touch_context_entry.return_value = entry
+    eng.cb_register_rope = v3_mod.BlendV3Module.cb_register_rope.__get__(eng)
+    return eng
+
+
+def _unit_rope_cache_ipc():
+    """An IPC-wrapper mock whose tensor has unit magnitude (cos=1, sin=0),
+    so registration skips mscale normalization."""
+    # Third Party
+    import torch
+
+    cache = torch.zeros(4, 8)
+    cache[:, :4] = 1.0
+    ipc = MagicMock()
+    ipc.to_tensor.return_value = cache
+    return ipc
+
+
+def test_register_rope_dual_cache_round_trip():
+    """Two caches + a full engine-group map register and land in rope state."""
+    eng = _rope_registration_engine(engine_group_indices=[0, 1])
+
+    eng.cb_register_rope(
+        instance_id=7,
+        cos_sin_caches_ipc=[_unit_rope_cache_ipc(), _unit_rope_cache_ipc()],
+        head_size=8,
+        is_neox_style=True,
+        group_to_cache=[0, 1],
+    )
+
+    state = eng._cb_rope_state[7]
+    assert len(state.cos_sin_caches) == 2
+    assert state.group_to_cache == [0, 1]
+    assert state.cache_for_group(1) is state.cos_sin_caches[1]
+
+
+def test_register_rope_rejects_invalid_group_to_cache():
+    """Out-of-range / negative cache indices and a map that does not cover
+    every engine group of the registered model are rejected."""
+    eng = _rope_registration_engine(engine_group_indices=[0, 1])
+    caches = [_unit_rope_cache_ipc(), _unit_rope_cache_ipc()]
+
+    with pytest.raises(ValueError, match="outside"):
+        eng.cb_register_rope(1, caches, 8, True, group_to_cache=[0, 2])
+    with pytest.raises(ValueError, match="outside"):
+        eng.cb_register_rope(1, caches, 8, True, group_to_cache=[-1, 0])
+    # Model has engine groups {0, 1} but the map only covers group 0.
+    with pytest.raises(ValueError, match="engine groups up to index 1"):
+        eng.cb_register_rope(1, caches, 8, True, group_to_cache=[0])
+    with pytest.raises(ValueError, match=">=1 cos/sin cache"):
+        eng.cb_register_rope(1, [], 8, True, group_to_cache=[])
+
+
+def test_register_rope_requires_registered_instance():
+    """CB_REGISTER_ROPE_V3 before REGISTER_KV_CACHE is rejected."""
+    eng = _rope_registration_engine(engine_group_indices=[0])
+    eng._transfer_module.get_and_touch_context_entry.return_value = None
+
+    with pytest.raises(ValueError, match="no paged KV cache registered"):
+        eng.cb_register_rope(1, [_unit_rope_cache_ipc()], 8, True, group_to_cache=[])


### PR DESCRIPTION
  **Description:**
Follow-up to #3930: enables CacheBlend re-RoPE for dual-RoPE SWA models (distinct local/global rope theta, e.g. Gemma 3) under the hybrid KV-cache manager.

**Changes**
- Per-engine-group rope caches: one cos/sin cache per distinct rope + group→cache mapping, carried in `CB_REGISTER_ROPE_V3` via IPC-shared caches.
- Per-group scatter: slots resolved per engine group so KV lands in the correct physical blocks under HMA.
- Fail-fast validation on rope registration/retrieve (invalid group/cache index raises instead of defaulting to group 0).

**Validation** — gemma-3-27b-it, 1×H200, HMA on:
- Correctness: `recall_match=1.0`, `output_match=1.0` (byte-identical greedy output).
- Speedup: ~3× TTFT on non-prefix reuse (2.96× @8K → 3.45× @16K), growing with context.
- Dual-RoPE path active: 2 caches, group map `[0,0,0,0,0,0,1]`.