### PR TITLE
[Bugfix] Use batched get in remote backend health check if supported

### DIFF
--- a/lmcache/v1/health_monitor/checks/remote_backend_check.py
+++ b/lmcache/v1/health_monitor/checks/remote_backend_check.py
@@ -289,7 +289,11 @@ class RemoteBackendHealthCheck(HealthCheck):
             future = self.backend.submit_put_task(key, put_obj)
             future.result(timeout=self._get_ping_timeout())
             # get
-            get_obj = self.backend.get_blocking(key)
+            if connector.support_batched_get():
+                get_objs = self.backend.batched_get_blocking([key])
+                get_obj = get_objs[0] if get_objs else None
+            else:
+                get_obj = self.backend.get_blocking(key)
             yield put_obj, get_obj
         except asyncio.TimeoutError:
             logger.warning("Put timeout, check failed.")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the `RemoteBackendHealthCheck` where the health check always fails when using the Mooncake storage backend. 

The Mooncake backend does not support single `get()` operations and raises `NotImplementedError` when `get()` is called. This PR updates the get step in the health check to first verify if the connector supports batched get via `connector.support_batched_get()`. If supported, it retrieves the key using `batched_get_blocking()`; otherwise, it falls back to the legacy `get_blocking()`.

**Special notes for your reviewers**:
None.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
