### PR TITLE
docs(mp): correct hybrid-model support surface + connector config gotchas

### DIFF
--- a/docs/source/mp/deployment.rst
+++ b/docs/source/mp/deployment.rst
@@ -37,8 +37,10 @@ Docker
 Required Docker flags:
 
 - ``--network host`` -- Allows the vLLM container to reach LMCache on localhost.
-- ``--ipc host`` -- Required for CUDA IPC shared memory transfers between
-  containers.
+- ``--ipc host`` -- Required for CUDA IPC shared memory transfers between the
+  vLLM container and the LMCache server, whether the server runs in another
+  container or as a host process. Without it the connector hangs at
+  ``Creating transfer context``.
 - ``--runtime nvidia --gpus all`` -- GPU access via the NVIDIA container
   runtime.
 

--- a/docs/source/mp/hybrid_models.rst
+++ b/docs/source/mp/hybrid_models.rst
@@ -249,8 +249,19 @@ end-to-end commands and the per-model block sizes.
 What Is Not Supported Yet
 -------------------------
 
-- **DeepSeek-V4-style compressed / indexer caches** are not yet handled by the
-  multiprocess connector.
+At registration the connector rejects only the group specs the transfer path
+cannot serve correctly (``validate_kv_cache_groups`` in
+``lmcache/integration/vllm/kv_cache_group_edits.py``):
+
+- **Encoder-decoder cross-attention caches** (``CrossAttentionSpec``).
+- **Mamba groups not in** ``align`` **mode** (``mamba_cache_mode != "align"``):
+  other modes keep no reusable per-block state snapshots.
+
+DeepSeek-V4-style **compressed / indexer caches are supported** — specs that
+declare slot compression (``compress_ratio > 1`` / ``tq_slot_size > 0``) are
+served by the compression path in ``lmcache.v1.kv_layer_groups`` and are *not*
+rejected. See the :doc:`DeepSeek-V4-Flash <../recipes/deepseek_v4_flash>` and
+:doc:`GLM 5.2 <../recipes/glm5_2>` recipes for validated end-to-end commands.
 
 Verifying Correctness
 ---------------------

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -520,7 +520,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
       e.g. "tcp://host1:6667,tcp://host2:6667".
 
     Single-server deployment:
-    - lmcache.mp.host: the host of the LMCache server.
+    - lmcache.mp.host: the host of the LMCache server, including the transport
+      scheme, e.g. "tcp://127.0.0.1" (default "tcp://localhost"). The final
+      URL is "{host}:{port}", so a bare host without a scheme produces an
+      invalid ZMQ address; prefer lmcache.mp.server_urls for full control.
     - lmcache.mp.port: the port of the LMCache server.
 
     - lmcache.mp.mq_timeout: timeout (seconds) for message queue requests.

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -520,10 +520,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
       e.g. "tcp://host1:6667,tcp://host2:6667".
 
     Single-server deployment:
-    - lmcache.mp.host: the host of the LMCache server, including the transport
-      scheme, e.g. "tcp://127.0.0.1" (default "tcp://localhost"). The final
-      URL is "{host}:{port}", so a bare host without a scheme produces an
-      invalid ZMQ address; prefer lmcache.mp.server_urls for full control.
+    - lmcache.mp.host: the host of the LMCache server, e.g. "127.0.0.1" or
+      "tcp://127.0.0.1" (default "tcp://localhost"). The final URL is
+      "{host}:{port}". If no transport scheme is provided, "tcp://" is
+      automatically prepended.
     - lmcache.mp.port: the port of the LMCache server.
 
     - lmcache.mp.mq_timeout: timeout (seconds) for message queue requests.


### PR DESCRIPTION
## Problem

The MP hybrid-models doc contradicts itself. The support table lists **DeepSeek-V4-Flash** and **GLM 5.2** as supported (with recipes), but the *What Is Not Supported Yet* section still says:

> DeepSeek-V4-style compressed / indexer caches are not yet handled by the multiprocess connector.

That is stale. `validate_kv_cache_groups` (`lmcache/integration/vllm/kv_cache_group_edits.py`) does **not** reject slot-compression specs (`compress_ratio > 1` / `tq_slot_size > 0`) — they are served by the compression path in `lmcache.v1.kv_layer_groups` and are explicitly skipped by the edits. The connector actually rejects only two spec kinds.

Validated end-to-end: GLM 5.2 (Dynamic Sparse Attention / IndexShare, INT4 TP4) serves through `LMCacheMPConnector` and stores KV to an S3 L2 tier via the `lmcache server`.

## Changes (docs/docstring only — no behavior change)

- **`docs/source/mp/hybrid_models.rst`** — replace the stale "not yet handled" bullet with the real reject list: `CrossAttentionSpec` (encoder-decoder) and non-`align` Mamba groups only; state plainly that DeepSeek-V4-style compressed/indexer caches **are** supported, with links to the DeepSeek-V4-Flash and GLM 5.2 recipes.
- **`lmcache/integration/vllm/lmcache_mp_connector.py`** — clarify in the docstring that `lmcache.mp.host` must include the transport scheme (default `tcp://localhost`); the final URL is `{host}:{port}`, so a bare host silently builds an invalid ZMQ address. Point users to `lmcache.mp.server_urls` for full control.
- **`docs/source/mp/deployment.rst`** — broaden the `--ipc host` note: it's required for CUDA IPC to a **host-process** LMCache server too (not only container-to-container); without it the connector hangs at `Creating transfer context`.

## Notes

Follow-up to #3892 / #3932. Pure documentation + one docstring; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)