### PR TITLE
docs: daily drift check — multi-process mode (2026-07-03)

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -54,14 +54,16 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
 
             Start vLLM with the MP connector in a separate terminal. Point the
             connector at the server above via ``lmcache.mp.host`` /
-            ``lmcache.mp.port`` in ``kv_connector_extra_config`` -- the host
-            **must** carry a ZMQ transport prefix such as ``tcp://``:
+            ``lmcache.mp.port`` in ``kv_connector_extra_config``. The host may
+            include a ZMQ transport prefix (e.g. ``tcp://``); a bare
+            ``host``/``host:port`` is also accepted and is normalized to
+            ``tcp://`` automatically:
 
             .. code-block:: bash
 
                vllm serve Qwen/Qwen3-8B \
                    --port 8000 --kv-transfer-config \
-                   '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "tcp://localhost", "lmcache.mp.port": 5555}}'
+                   '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "localhost", "lmcache.mp.port": 5555}}'
 
             .. note::
                **Where does** ``LMCacheMPConnector`` **resolve to?** This depends on your vLLM version:

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -461,13 +461,15 @@ vLLM Client Configuration
 --------------------------
 
 On the vLLM side, specify the LMCache server host and port via the
-``kv_connector_extra_config`` parameter:
+``kv_connector_extra_config`` parameter. The ``tcp://`` transport prefix
+on ``lmcache.mp.host`` is optional -- a bare host is accepted and
+normalized to ``tcp://`` by the connector:
 
 .. code-block:: bash
 
     vllm serve Qwen/Qwen3-14B \
         --kv-transfer-config \
-        '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "tcp://127.0.0.1", "lmcache.mp.port": 6000}}'
+        '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "127.0.0.1", "lmcache.mp.port": 6000}}'
 
 To target multiple LMCache servers from a single vLLM deployment, pass a
 list (or comma-separated string) of server URLs via
@@ -506,15 +508,19 @@ All connector-level options are passed through
      - *(unset)*
      - Multi-server deployment: list (or comma-separated string) of
        ``<transport>://<host>:<port>`` URLs, e.g.
-       ``"tcp://host1:6667,tcp://host2:6667"``. When set, takes
-       precedence over ``lmcache.mp.host`` / ``lmcache.mp.port``; the
-       vLLM world size must be divisible by the number of servers, and
-       each worker connects to its locally-assigned server.
+       ``"tcp://host1:6667,tcp://host2:6667"``. The transport prefix
+       may be omitted -- bare ``host:port`` entries such as
+       ``"host1:6667,host2:6667"`` are normalized to ``tcp://`` by the
+       connector. When set, takes precedence over ``lmcache.mp.host`` /
+       ``lmcache.mp.port``; the vLLM world size must be divisible by the
+       number of servers, and each worker connects to its
+       locally-assigned server.
    * - ``lmcache.mp.host``
      - ``tcp://localhost``
-     - Single-server deployment: host (with ZMQ transport prefix) of
-       the LMCache MP server. Ignored when ``lmcache.mp.server_urls``
-       is set.
+     - Single-server deployment: host of the LMCache MP server. A ZMQ
+       transport prefix (e.g. ``tcp://``) is optional -- a bare
+       ``localhost`` / ``127.0.0.1`` is normalized to ``tcp://`` by the
+       connector. Ignored when ``lmcache.mp.server_urls`` is set.
    * - ``lmcache.mp.port``
      - ``5555``
      - Single-server deployment: port of the LMCache MP server. Must


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. One new inconsistency between the multi-process (MP) docs and the current `dev` code (`upstream/dev` HEAD `c9742db`) was found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/getting_started/quickstart.rst`** and **`docs/source/mp/configuration.rst`** — following [PR #3951](https://github.com/LMCache/LMCache/pull/3951) (commit [`6af5f69`](https://github.com/LMCache/LMCache/commit/6af5f696b8536cfe63a3b2223af9b916817b917b)), which was titled *"[Patch][Docs]: allow bare host in lmcache.mp.host"* and added the `_ensure_zmq_scheme` helper so bare `host` / `host:port` entries are normalized to `tcp://` by the connector, the user-facing docs still assert the transport prefix is required. Concretely: the quickstart says the host "**must** carry a ZMQ transport prefix such as ``tcp://``"; the connector-config table row for `lmcache.mp.host` describes it as "host (with ZMQ transport prefix)"; the vLLM-side single-server example writes `tcp://127.0.0.1`. All three flatly contradict the shipped code and the PR's own intent.

`docs/design/` (design docs):

- No new drift found in `docs/design/` beyond what open drift-check PRs #3960, #3969, and #3984 already cover.

**Evidence**

| Drift | Code / repo state (current `dev`) | Stale doc |
| --- | --- | --- |
| Quickstart tells users the prefix is mandatory | [`lmcache/integration/vllm/lmcache_mp_connector.py#L492-L509`](https://github.com/LMCache/LMCache/blob/c9742db/lmcache/integration/vllm/lmcache_mp_connector.py#L492-L509) — `_ensure_zmq_scheme` prepends `tcp://` when the URL has no `://` scheme; applied to both single-server and multi-server URLs at [`#L567-L569`](https://github.com/LMCache/LMCache/blob/c9742db/lmcache/integration/vllm/lmcache_mp_connector.py#L567-L569) | [`docs/source/getting_started/quickstart.rst#L55-L64`](https://github.com/LMCache/LMCache/blob/c9742db/docs/source/getting_started/quickstart.rst#L55-L64) |
| `lmcache.mp.host` row calls the transport prefix required | Same normalization at [`lmcache_mp_connector.py#L567-L569`](https://github.com/LMCache/LMCache/blob/c9742db/lmcache/integration/vllm/lmcache_mp_connector.py#L567-L569) | [`docs/source/mp/configuration.rst#L513-L517`](https://github.com/LMCache/LMCache/blob/c9742db/docs/source/mp/configuration.rst#L513-L517) |
| vLLM-side single-server example still writes `tcp://127.0.0.1` | Ditto — bare `127.0.0.1` is accepted at [`lmcache_mp_connector.py#L567-L569`](https://github.com/LMCache/LMCache/blob/c9742db/lmcache/integration/vllm/lmcache_mp_connector.py#L567-L569) | [`docs/source/mp/configuration.rst#L466-L470`](https://github.com/LMCache/LMCache/blob/c9742db/docs/source/mp/configuration.rst#L466-L470) |

**Proposed fix**

Already applied in the diff (docs only, no code touched):

1. `docs/source/getting_started/quickstart.rst` — the paragraph that previously said the host "**must** carry a ZMQ transport prefix such as ``tcp://``" now documents the prefix as optional and notes that a bare `host` / `host:port` is normalized to `tcp://` automatically. The accompanying `vllm serve` example is switched from `"tcp://localhost"` to `"localhost"` to demonstrate the bare-host form matching the PR title.
2. `docs/source/mp/configuration.rst`
   - The `lmcache.mp.host` row description is rewritten so the `tcp://` prefix is called out as optional.
   - The `lmcache.mp.server_urls` row picks up a matching note that bare `host:port` entries are also accepted (the same `_ensure_zmq_scheme` helper runs over every element).
   - The narrative example above the table is updated so the vLLM-side command uses `"127.0.0.1"` (no prefix) and a lead-in sentence explains that the prefix is optional.

**Special notes for your reviewers**:

- Docs-only change. No code modified.
- Deduped against currently-open drift PRs: **#3984** (coordinator `/blend/*` + design-doc rewrites — 2026-07-02), **#3969** (`DevDaxL1MemoryManager` + deleted `l2_apis.md` refs — 2026-07-01), and **#3960** (`hfbucket` in L2 adapter list + `IsolatedLRU` — 2026-06-30). None of them touch `mp.host` / `mp.server_urls` documentation, so there is no overlap.
- The `tcp://localhost` default listed in the `lmcache.mp.host` row is intentionally left as-is: it matches the code default at [`lmcache_mp_connector.py#L560`](https://github.com/LMCache/LMCache/blob/c9742db/lmcache/integration/vllm/lmcache_mp_connector.py#L560).
- Follow-ups spotted but intentionally not tackled in this PR:
  - `lmcache/integration/vllm/lmcache_mp_connector_0180.py` and `lmcache_mp_connector_0201.py` do **not** apply `_ensure_zmq_scheme`. If a user opts into one of those vendored variants via `kv_connector_module_path`, bare hosts will still error. That is a code question (should the helper be extended?), not a docs one, so it is called out here rather than fixed.
  - `docs/design/v1/multiprocess/http_api_extension.md` still lists a partial MP-server endpoint table (noted in #3984); leaving it for a dedicated design-doc cleanup.
- This PR was **auto-generated** by the daily drift-check routine and **needs human review before merge**. Please do not merge without a maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01W42ivp9Tab5xZ2h5yAnD7F)_