### PR TITLE
fix(examples/disagg): guard chat streaming loop against empty choices

### DIFF
--- a/examples/disagg_prefill/disagg_proxy_server.py
+++ b/examples/disagg_prefill/disagg_proxy_server.py
@@ -714,6 +714,14 @@ async def handle_chat_completions(request: Request):
                         json_str = chunk_str[6:].strip()  # Remove 'data: ' prefix
                         if json_str:
                             completion_data = json.loads(json_str)
+                            # Decoder can emit non-token chunks (usage, final
+                            # metadata, keepalives) with an empty choices list.
+                            # Those aren't chat-completion deltas, so pass the
+                            # original chunk through unchanged instead of
+                            # indexing into an empty list.
+                            if not completion_data.get("choices"):
+                                yield chunk
+                                continue
                             chat_completion_data = {
                                 "id": completion_data["id"],
                                 "object": "chat.completion.chunk",


### PR DESCRIPTION
**What this PR does / why we need it**:

Closes #3475

The disaggregated-prefill proxy's `/v1/chat/completions` handler converts
each decoder stream chunk into the chat-completion delta format by
indexing `completion_data["choices"][0]["text"]`. When the decoder emits
a valid non-token chunk (final `usage` chunk, metadata, keepalive, etc.)
with an empty `choices` list, that indexing raises `IndexError` — which
the surrounding `except (json.JSONDecodeError, KeyError)` clause does not
catch — and the ASGI streaming response fails even though the decoder
itself returned HTTP 200.

**Fix**: guard the branch. If `completion_data["choices"]` is empty or
missing, forward the original chunk unchanged instead of trying to
build a chat-completion delta from it. Non-delta chunks like `usage`
are already part of the OpenAI chat streaming spec, so downstream
clients know how to handle them.

**Special notes for your reviewers**:

- One-line behavioral guard before the existing conversion block. No
  refactor of surrounding code.
- Repro: send a chat completion request against the proxy with
  `stream=True` and `stream_options={"include_usage": true}` — the
  decoder's final usage chunk (`choices: []`) will exercise the fixed
  path.
- `pre-commit run --all-files` on the touched file — all green.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

(Fixes a proxy bug in an example; behavioral scope is narrow enough
that adding a test to the examples tree seems out of proportion.
Happy to add one if a reviewer wants it.)