### PR TITLE
feat: Add generic base discovery, starting with PinMemory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     name: Ban direct torch device usage
     entry: >-
       bash -c '
-      matches=$(grep -rHnE "torch\.(cuda|xpu|hpu)" "$@");
+      matches=$(grep -rHnE "torch\.(cuda|xpu|hpu|musa)" "$@");
       if [ -n "$matches" ]; then
         echo "";
         echo "========================================";
@@ -28,6 +28,30 @@ repos:
     exclude: |
       (?x)^(
         lmcache/__init__\.py|
+        lmcache/.*/gpu_connector/.*|
+        lmcache/v1/platform/.*
+      )$
+  - id: ban-cuda-host-register
+    name: Ban cudaHostRegister/Unregister outside platform
+    entry: >-
+      bash -c '
+      matches=$(grep -rHnE "\.cudaHost(Register|Unregister)" "$@");
+      if [ -n "$matches" ]; then
+        echo "";
+        echo "=======================================================================";
+        echo "  BANNED: .cudaHostRegister/Unregister usage found outside platform dir";
+        echo "  Fix 1: They are only allowed in the platform directory";
+        echo "  Fix 2: use torch_dev.ext.pin_memory/unpin_memory instead";
+        echo "=======================================================================";
+        echo "";
+        echo "$matches";
+        exit 1;
+      fi' --
+    language: system
+    types: [python]
+    files: ^lmcache/
+    exclude: |
+      (?x)^(
         lmcache/.*/gpu_connector/.*|
         lmcache/v1/platform/.*
       )$

--- a/lmcache/v1/platform/_registry.py
+++ b/lmcache/v1/platform/_registry.py
@@ -1,21 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 """Platform backend registry.
 
-Each accelerator sub-package (``platform/cuda``, ``platform/cpu``,
-future ``platform/xpu`` ...) ships a concrete
-:class:`~lmcache.v1.platform.base_ipc_wrapper.DeviceIPCWrapper`
-subclass with a ``device_type`` ClassVar and a ``wrap`` factory
-classmethod.  :func:`_discover_wrappers_once` scans the ``platform``
-package for those subclasses at run-time and populates the factory
-table -- no static ``register_kv_wrapper`` calls needed.
+Two independent registries live here:
 
-The :func:`get_kv_wrapper_factory` lookup keys on
-``tensor.device.type`` so the call site in
-:mod:`lmcache.integration.vllm.vllm_multi_process_adapter` stays free
-of any if/elif chain.  Adding a new accelerator therefore requires
-*zero* changes to the dispatcher; it only needs to ship its own
-sub-package with a ``DeviceIPCWrapper`` subclass that sets
-``device_type`` and ``wrap``.
+**Universal 3-D registry** (``get_impl`` / ``resolve_impl``)
+    Each accelerator sub-package ships concrete subclasses of the ABC
+    base classes defined under ``lmcache/v1/platform/base/``.
+    :func:`_discover_all_once` auto-discovers those base classes and
+    their implementations and indexes them by
+    ``(base_class, device_type, impl_key)``.
+
+    * :func:`get_impl` performs a strict lookup and raises ``ValueError``
+      when nothing is registered for the requested triple.
+    * :func:`resolve_impl` is the policy-aware lookup: it re-raises for
+      abstract base classes (required capabilities) and falls back to the
+      base class itself only when the base class is concrete.
+
+**IPC wrapper registry** (``get_kv_wrapper_factory``)
+    Legacy path retained for backward compatibility.  Concrete
+    :class:`~lmcache.v1.platform.base_ipc_wrapper.DeviceIPCWrapper`
+    subclasses are discovered via :func:`_discover_wrappers_once` and
+    indexed by ``device_type``.
 """
 
 # Future
@@ -23,6 +28,7 @@ from __future__ import annotations
 
 # Standard
 from typing import Any, Callable, Dict
+import abc
 import threading
 
 # First Party
@@ -34,6 +40,277 @@ logger = init_logger(__name__)
 # fall-back regardless of the running ``torch_device_type``.
 DEFAULT_BACKEND: str = "cpu"
 
+
+# ---------------------------------------------------------------------------
+# Universal 3-D registry
+# ---------------------------------------------------------------------------
+
+# _REGISTRY[base_class][device_type][impl_key] = concrete_class
+# Populated lazily by _discover_all_once().
+_REGISTRY: Dict[type, Dict[str, Dict[str, type]]] = {}
+
+_ALL_DISCOVERED: bool = False
+_ALL_DISCOVERY_LOCK = threading.Lock()
+
+
+def _discover_base_classes() -> list[type[abc.ABC]]:
+    """Return all registry base classes from ``lmcache.v1.platform.base``.
+
+    A class qualifies when it is **directly defined** in a non-private
+    module directly under the ``base`` sub-package **and** subclasses
+    :class:`abc.ABC`.
+
+    Returns:
+        List of discovered base classes (all subclass abc.ABC).
+    """
+    # Standard
+    import importlib
+    import inspect
+    import pkgutil
+
+    base_pkg = importlib.import_module("lmcache.v1.platform.base")
+    base_classes: list[type[abc.ABC]] = []
+
+    for _, short_name, is_pkg in pkgutil.iter_modules(base_pkg.__path__):  # type: ignore[attr-defined]
+        if is_pkg or short_name.startswith("_"):
+            continue
+        full_name = "lmcache.v1.platform.base.%s" % short_name
+        try:
+            module = importlib.import_module(full_name)
+        except Exception as exc:
+            logger.warning(
+                "Failed to import %s during base-class discovery: %s", full_name, exc
+            )
+            continue
+
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                obj.__module__ == module.__name__
+                and issubclass(obj, abc.ABC)
+                and obj is not abc.ABC
+            ):
+                base_classes.append(obj)
+
+    return base_classes
+
+
+def _discover_all_once() -> None:
+    """Populate :data:`_REGISTRY` on first use.
+
+    Walks ``lmcache.v1.platform.base`` for ABC base classes, then scans
+    each device sub-package (depth 2) for concrete implementations.
+    Each implementation must set ``device_type`` (a non-empty string
+    ClassVar) to be indexed; ``impl_key`` is optional and defaults to
+    ``"default"``.
+
+    Multiple implementations claiming the same
+    ``(base_class, device_type, impl_key)`` triple trigger a warning;
+    the first one wins.
+    """
+    global _ALL_DISCOVERED
+    if _ALL_DISCOVERED:
+        return
+
+    with _ALL_DISCOVERY_LOCK:
+        if _ALL_DISCOVERED:
+            return
+
+        # First Party
+        from lmcache.v1.utils.subclass_discovery import discover_subclasses
+        import lmcache.v1.platform as platform_pkg
+
+        base_classes = _discover_base_classes()
+        if not base_classes:
+            logger.warning(
+                "No registry base classes found under lmcache.v1.platform.base; "
+                "universal registry will be empty."
+            )
+
+        for base_cls in base_classes:
+            _REGISTRY.setdefault(base_cls, {})
+            for impl_cls in discover_subclasses(
+                platform_pkg,
+                base_cls,  # type: ignore[type-abstract]
+                module_filter=lambda name: not name.startswith(("_", "base")),
+                require_defined_in_module=True,
+                on_import_error=lambda name, exc: logger.warning(
+                    "Failed to import %s during registry discovery: %s", name, exc
+                ),
+                levels=[2, 2],
+            ):
+                _register_impl(base_cls, impl_cls)
+
+        _ALL_DISCOVERED = True
+
+
+def _register_impl(base_cls: type, impl_cls: type) -> None:
+    """Register *impl_cls* in the 3-D table under *base_cls*.
+
+    The implementation must carry a non-empty ``device_type`` ClassVar.
+    ``impl_key`` defaults to ``"default"`` when absent.  Duplicate
+    ``(device_type, impl_key)`` entries trigger a warning; the first
+    registration wins.
+
+    Args:
+        base_cls: The registry base class this implementation belongs to.
+        impl_cls: The concrete implementation class to register.
+    """
+    device_type: str = getattr(impl_cls, "device_type", "")
+    if not device_type:
+        logger.warning(
+            "Skipping %s: empty device_type ClassVar; concrete subclasses of "
+            "%s must set device_type.",
+            impl_cls.__name__,
+            base_cls.__name__,
+        )
+        return
+
+    impl_key: str = getattr(impl_cls, "impl_key", "default") or "default"
+
+    device_table = _REGISTRY.setdefault(base_cls, {})
+    key_table = device_table.setdefault(device_type, {})
+
+    existing = key_table.get(impl_key)
+    if existing is not None and existing is not impl_cls:
+        logger.warning(
+            "Multiple %s subclasses registered for (device_type=%r, impl_key=%r): "
+            "%s vs %s; keeping the first.",
+            base_cls.__name__,
+            device_type,
+            impl_key,
+            existing.__name__,
+            impl_cls.__name__,
+        )
+        return
+
+    key_table[impl_key] = impl_cls
+
+
+def get_impl(base_class: type, device_type: str, impl_key: str = "default") -> type:
+    """Return the registered implementation for the given triple.
+
+    Triggers lazy auto-discovery on the first call.  Raises
+    ``ValueError`` when nothing is registered for the requested
+    ``(base_class, device_type, impl_key)``; it never falls back.
+
+    Args:
+        base_class: The registry base class (e.g. ``PinMemoryBackend``).
+        device_type: The device type string (e.g. ``"cuda"``).
+        impl_key: The implementation key (default: ``"default"``).
+
+    Returns:
+        The concrete implementation class.
+
+    Raises:
+        ValueError: If no implementation is registered for the triple.
+    """
+    _discover_all_once()
+
+    device_table = _REGISTRY.get(base_class)
+    if device_table is None:
+        raise ValueError(
+            "Base class %r is not registered in the universal registry. "
+            "Ensure it is defined in a module under lmcache/v1/platform/base/ "
+            "and subclasses abc.ABC." % base_class
+        )
+
+    key_table = device_table.get(device_type)
+    if key_table is None:
+        raise ValueError(
+            "No %s implementation registered for device_type=%r."
+            % (base_class.__name__, device_type)
+        )
+
+    impl = key_table.get(impl_key)
+    if impl is None:
+        raise ValueError(
+            "No %s implementation registered for (device_type=%r, impl_key=%r)."
+            % (base_class.__name__, device_type, impl_key)
+        )
+
+    return impl
+
+
+def resolve_impl(base_class: type, device_type: str, impl_key: str = "default") -> type:
+    """Resolve an implementation class for callers using fallback policy.
+
+    This API first performs strict lookup via :func:`get_impl`.
+    If strict lookup fails:
+
+    * Abstract base classes (``inspect.isabstract(base_class)``) re-raise
+      the original ``ValueError`` to preserve fail-fast semantics for
+      required capabilities.
+    * Concrete base classes fall back to ``base_class`` itself, which
+      lets optional capabilities provide a built-in default implementation.
+
+    Args:
+        base_class: The registry base class.
+        device_type: The device type string.
+        impl_key: The implementation key (default: ``"default"``).
+
+    Returns:
+        The concrete implementation class, or ``base_class`` when fallback
+        is allowed by the abstractness rule.
+
+    Raises:
+        ValueError: If no implementation is registered and ``base_class``
+            is abstract.
+    """
+    try:
+        return get_impl(base_class, device_type, impl_key)
+    except ValueError:
+        # Standard
+        import inspect
+
+        if inspect.isabstract(base_class):
+            raise
+        return base_class
+
+
+def reset_registry_for_tests() -> None:
+    """Wipe the universal 3-D registry and force re-discovery.
+
+    Intended **only** for test fixtures.  Clears every registered
+    implementation and flips :data:`_ALL_DISCOVERED` back to ``False``
+    so the next :func:`get_impl` / :func:`resolve_impl` call re-runs
+    :func:`_discover_all_once`.
+    """
+    global _ALL_DISCOVERED
+    _REGISTRY.clear()
+    _ALL_DISCOVERED = False
+
+
+def snapshot_registry() -> Dict[str, Any]:
+    """Return a copy of the universal registry state for test isolation.
+
+    Returns:
+        A dict with keys ``"registry"`` and ``"discovered"``.
+    """
+    return {
+        "registry": {
+            base: {dt: dict(key_table) for dt, key_table in device_table.items()}
+            for base, device_table in _REGISTRY.items()
+        },
+        "discovered": _ALL_DISCOVERED,
+    }
+
+
+def restore_registry(state: Dict[str, Any]) -> None:
+    """Restore the universal registry to a previously snapshotted state.
+
+    Args:
+        state: A snapshot dict as returned by :func:`snapshot_registry`.
+    """
+    global _ALL_DISCOVERED
+    _REGISTRY.clear()
+    for base, device_table in state.get("registry", {}).items():
+        _REGISTRY[base] = {dt: dict(kt) for dt, kt in device_table.items()}
+    _ALL_DISCOVERED = bool(state.get("discovered", False))
+
+
+# ---------------------------------------------------------------------------
+# IPC wrapper registry (legacy -- retained for backward compatibility)
+# ---------------------------------------------------------------------------
 
 # KV-cache IPC wrapper factory per device type.  Populated lazily on
 # first :func:`get_kv_wrapper_factory` call by scanning the

--- a/lmcache/v1/platform/base/__init__.py
+++ b/lmcache/v1/platform/base/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# Registry base classes for platform-specific backends.

--- a/lmcache/v1/platform/base/pin_memory.py
+++ b/lmcache/v1/platform/base/pin_memory.py
@@ -1,17 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Platform-abstraction base classes.
+"""Platform-abstraction base class for host-memory pinning.
 
-This module defines abstract base classes for platform-specific capabilities.
-:class:`PinMemoryBackend` is the first; future platform abstractions should
-be added here as well.
+:class:`PinMemoryBackend` is the registry base class for all
+device-specific pin-memory backends.  It subclasses :class:`abc.ABC`
+so the universal registry (``_registry.py``) discovers it automatically
+when it scans the modules under ``lmcache/v1/platform/base/``.
+
+The class itself is also a **no-op fallback**: because pin memory is an
+optional capability, devices that do not provide a concrete
+implementation can still call ``pin_memory`` / ``unpin_memory`` /
+``is_pin_supported`` and get safe default responses.
 """
 
+# Standard
+import abc
 
-class PinMemoryBackend:
+
+class PinMemoryBackend(abc.ABC):  # noqa: B024
     """Base class for host-memory pinning per platform.
 
     The default implementation is a no-op that always returns ``False``,
     so platforms that do not support pinning do not need to subclass this.
+    Call :func:`~lmcache.v1.platform._registry.resolve_impl` with this
+    class to obtain the best available backend for a given device type;
+    it will return the no-op base class itself when no concrete backend
+    is registered for that device.
     """
 
     def pin_memory(self, ptr: int, size: int, flags: int = 0) -> bool:

--- a/lmcache/v1/platform/base_device_info.py
+++ b/lmcache/v1/platform/base_device_info.py
@@ -20,7 +20,7 @@ enough.
 import abc
 
 # First Party
-from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
 
 
 # TODO(chunxiaozheng): bind `DeviceIPCWrapper` with `DeviceInfo`?

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -2,8 +2,8 @@
 """CUDA-specific platform primitives."""
 
 # First Party
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
 from lmcache.v1.platform.base_device_info import DeviceInfo
-from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
 from lmcache.v1.platform.cuda.pin_memory import CudaPinMemoryBackend
 
 # ---------------------------------------------------------------------------

--- a/lmcache/v1/platform/cuda/pin_memory.py
+++ b/lmcache/v1/platform/cuda/pin_memory.py
@@ -2,12 +2,13 @@
 """CUDA memory pinning: try torch cudart first, then libcudart via ctypes."""
 
 # Standard
+from typing import ClassVar
 import ctypes
 import ctypes.util
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
 
 logger = init_logger(__name__)
 
@@ -52,10 +53,17 @@ class CudaPinMemoryBackend(PinMemoryBackend):
     unavailable, the backend falls back to loading ``libcudart`` directly.
 
     Attributes:
+        device_type: Device type string used by the universal registry.
+        impl_key: Implementation key used by the universal registry.
         _cudart: Torch cudart binding when ``torch.cuda.cudart()`` succeeds.
         _libcudart: ``ctypes``-loaded CUDA runtime when torch cudart is
             unavailable.
     """
+
+    #: ``torch.device.type`` this backend handles (used by auto-discovery).
+    device_type: ClassVar[str] = "cuda"
+    #: Implementation key (used by auto-discovery).
+    impl_key: ClassVar[str] = "default"
 
     def __init__(self) -> None:
         """Initialize the backend with torch-first, libcudart-second fallback.

--- a/lmcache/v1/platform/device_ext.py
+++ b/lmcache/v1/platform/device_ext.py
@@ -8,8 +8,8 @@ torch device module.
 """
 
 # First Party
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
 from lmcache.v1.platform.base_device_info import DeviceInfo
-from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
 
 
 class DeviceExt:
@@ -29,10 +29,13 @@ class DeviceExt:
     """
 
     def __init__(self, device_info: DeviceInfo | None) -> None:
-        if device_info is not None and device_info.pin_memory_backend is not None:
-            backend_cls = device_info.pin_memory_backend
-        else:
-            backend_cls = PinMemoryBackend
+        device_type = device_info.device_type if device_info is not None else "cpu"
+
+        # Lazy import to avoid circular dependencies at module load time.
+        # First Party
+        from lmcache.v1.platform._registry import resolve_impl
+
+        backend_cls = resolve_impl(PinMemoryBackend, device_type)
         self._pin: PinMemoryBackend = backend_cls()
 
     def pin_memory(self, ptr: int, size: int, flags: int = 0) -> bool:

--- a/tests/v1/platform/test_registry_mechanism.py
+++ b/tests/v1/platform/test_registry_mechanism.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stable mechanism tests for the universal 3-D platform registry."""
+
+# Standard
+from typing import Any, ClassVar, Generator
+import abc
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform._registry import (
+    _register_impl,
+    get_impl,
+    reset_registry_for_tests,
+    resolve_impl,
+    restore_registry,
+    snapshot_registry,
+)
+import lmcache.v1.platform._registry as _reg_module
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry() -> Generator[None, None, None]:
+    """Isolate universal registry state between tests."""
+    state = snapshot_registry()
+    reset_registry_for_tests()
+    try:
+        yield
+    finally:
+        restore_registry(state)
+
+
+class OptionalBase(abc.ABC):  # noqa: B024
+    """Synthetic optional capability base (concrete despite ABC)."""
+
+    def run(self) -> str:
+        return "base"
+
+
+class RequiredBase(abc.ABC):
+    """Synthetic required capability base."""
+
+    @abc.abstractmethod
+    def run(self) -> str:
+        raise NotImplementedError
+
+
+class OptionalDefault(OptionalBase):
+    device_type: ClassVar[str] = "cuda"
+    impl_key: ClassVar[str] = "default"
+
+    def run(self) -> str:
+        return "optional-default"
+
+
+class OptionalVariant(OptionalBase):
+    device_type: ClassVar[str] = "cuda"
+    impl_key: ClassVar[str] = "variant"
+
+    def run(self) -> str:
+        return "optional-variant"
+
+
+class RequiredDefault(RequiredBase):
+    device_type: ClassVar[str] = "cuda"
+    impl_key: ClassVar[str] = "default"
+
+    def run(self) -> str:
+        return "required-default"
+
+
+class TestGetImpl:
+    """Strict lookup behavior."""
+
+    def test_get_impl_strict_success_and_default_key(self) -> None:
+        _register_impl(OptionalBase, OptionalDefault)
+        assert get_impl(OptionalBase, "cuda") is OptionalDefault
+        assert get_impl(OptionalBase, "cuda", "default") is OptionalDefault
+
+    def test_get_impl_3d_lookup_and_multiple_impl_keys(self) -> None:
+        _register_impl(OptionalBase, OptionalDefault)
+        _register_impl(OptionalBase, OptionalVariant)
+        assert get_impl(OptionalBase, "cuda", "default") is OptionalDefault
+        assert get_impl(OptionalBase, "cuda", "variant") is OptionalVariant
+
+    def test_get_impl_strict_failures(self) -> None:
+        with pytest.raises(ValueError, match="not registered"):
+            get_impl(OptionalBase, "cuda", "default")
+
+        _register_impl(OptionalBase, OptionalDefault)
+        with pytest.raises(ValueError, match="device_type"):
+            get_impl(OptionalBase, "cpu", "default")
+        with pytest.raises(ValueError, match="impl_key"):
+            get_impl(OptionalBase, "cuda", "missing")
+
+    def test_duplicate_registration_keeps_first_and_warns(self, monkeypatch) -> None:
+        class OptionalDuplicate(OptionalBase):
+            device_type: ClassVar[str] = "cuda"
+            impl_key: ClassVar[str] = "default"
+
+            def run(self) -> str:
+                return "optional-duplicate"
+
+        messages: list[str] = []
+
+        def _record_warning(message: str, *args: Any, **kwargs: Any) -> None:
+            messages.append(message % args if args else message)
+
+        monkeypatch.setattr(_reg_module.logger, "warning", _record_warning)
+        _register_impl(OptionalBase, OptionalDefault)
+        _register_impl(OptionalBase, OptionalDuplicate)
+
+        assert get_impl(OptionalBase, "cuda", "default") is OptionalDefault
+        assert any("keeping the first" in message for message in messages)
+
+    def test_missing_or_empty_device_type_is_skipped_and_warns(
+        self, monkeypatch
+    ) -> None:
+        class MissingDeviceType(OptionalBase):
+            def run(self) -> str:
+                return "missing-device-type"
+
+        class EmptyDeviceType(OptionalBase):
+            device_type: ClassVar[str] = ""
+
+            def run(self) -> str:
+                return "empty-device-type"
+
+        messages: list[str] = []
+
+        def _record_warning(message: str, *args: Any, **kwargs: Any) -> None:
+            messages.append(message % args if args else message)
+
+        monkeypatch.setattr(_reg_module.logger, "warning", _record_warning)
+        _register_impl(OptionalBase, MissingDeviceType)
+        _register_impl(OptionalBase, EmptyDeviceType)
+
+        with pytest.raises(ValueError):
+            get_impl(OptionalBase, "", "default")
+        assert any("empty device_type" in message for message in messages)
+
+
+class TestResolveImpl:
+    """Policy-aware lookup behavior."""
+
+    def test_resolve_impl_returns_registered_concrete_subclass(self) -> None:
+        _register_impl(OptionalBase, OptionalDefault)
+        assert resolve_impl(OptionalBase, "cuda", "default") is OptionalDefault
+
+    def test_resolve_impl_falls_back_for_concrete_base(self) -> None:
+        _register_impl(OptionalBase, OptionalDefault)
+        assert resolve_impl(OptionalBase, "missing_device", "default") is OptionalBase
+
+    def test_resolve_impl_reraises_for_abstract_base(self) -> None:
+        _register_impl(RequiredBase, RequiredDefault)
+        with pytest.raises(ValueError):
+            resolve_impl(RequiredBase, "missing_device", "default")

--- a/tests/v1/platform/test_registry_wiring.py
+++ b/tests/v1/platform/test_registry_wiring.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Production wiring tests for registry-based pin-memory resolution."""
+
+# Standard
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform._registry import (
+    _discover_base_classes,
+    get_impl,
+    resolve_impl,
+)
+from lmcache.v1.platform.base.pin_memory import PinMemoryBackend
+from lmcache.v1.platform.cuda.pin_memory import CudaPinMemoryBackend
+from lmcache.v1.platform.device_ext import DeviceExt
+
+
+def test_pin_memory_backend_is_discovered_from_base_package() -> None:
+    """PinMemoryBackend is discoverable from ``lmcache.v1.platform.base``."""
+    assert PinMemoryBackend in _discover_base_classes()
+
+
+def test_get_impl_returns_cuda_pin_memory_backend() -> None:
+    """Strict lookup resolves the CUDA concrete implementation."""
+    assert get_impl(PinMemoryBackend, "cuda", "default") is CudaPinMemoryBackend
+
+
+def test_get_impl_cpu_is_strict_and_raises() -> None:
+    """Strict lookup raises when no CPU pin-memory backend exists."""
+    with pytest.raises(ValueError):
+        get_impl(PinMemoryBackend, "cpu", "default")
+
+
+def test_resolve_impl_cpu_returns_noop_base_fallback() -> None:
+    """resolve_impl falls back to PinMemoryBackend for CPU."""
+    assert resolve_impl(PinMemoryBackend, "cpu", "default") is PinMemoryBackend
+
+
+def test_device_ext_uses_override_backend_when_provided() -> None:
+    """DeviceExt resolves CUDA pin memory through the registry."""
+
+    class _FakeCudaDeviceInfo:
+        @property
+        def device_type(self) -> str:
+            return "cuda"
+
+    ext = DeviceExt(_FakeCudaDeviceInfo())  # type: ignore[arg-type]
+    assert isinstance(ext._pin, CudaPinMemoryBackend)
+
+
+def test_device_ext_uses_noop_backend_for_cpu_without_override() -> None:
+    """DeviceExt resolves to no-op PinMemoryBackend for CPU/no override."""
+
+    class _FakeCpuDeviceInfo:
+        @property
+        def device_type(self) -> str:
+            return "cpu"
+
+        @property
+        def pin_memory_backend(self) -> type[PinMemoryBackend] | None:
+            return None
+
+    ext = DeviceExt(_FakeCpuDeviceInfo())  # type: ignore[arg-type]
+    assert type(ext._pin) is PinMemoryBackend
+    assert ext.is_pin_supported is False


### PR DESCRIPTION
This PR decouples platform capabilities from individual device definitions and reduces the code changes needed to add new devices or backend capabilities.

- **Generic base discovery**
  - Registry base classes are automatically discovered from `lmcache.v1.platform.base`.
  - Adding a new base capability no longer requires manually updating registry bootstrap code.

- **Device implementation auto-discovery**
  - Device-specific implementations are scanned from platform subpackages and registered by `(base_class, device_type, impl_key)`.
  - Adding a new device backend only requires defining the implementation class with `device_type`.

- **PinMemory migration**
  - Moves `PinMemoryBackend` under `lmcache.v1.platform.base`.
  - Registers `CudaPinMemoryBackend` through the generic registry.
  - Uses `PinMemoryBackend` as the first migrated capability to validate the new discovery flow.