### PR TITLE
Explicit KV-layout support for CPU-presented host-memory backends

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -46,7 +46,11 @@ from lmcache.integration.vllm.kv_cache_group_edits import (
 from lmcache.integration.vllm.kv_cache_groups import (
     create_engine_group_infos_from_vllm,
 )
-from lmcache.integration.vllm.utils import mla_enabled, vllm_layout_hints
+from lmcache.integration.vllm.utils import (
+    mla_enabled,
+    read_explicit_kv_layout_from_config,
+    vllm_layout_hints,
+)
 from lmcache.utils import init_logger as lmcache_init_logger
 from lmcache.v1.multiprocess.group_view import slice_block_ids_per_group
 
@@ -581,6 +585,17 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
 
         assert vllm_config.kv_transfer_config is not None
 
+        # Resolve the explicit KV-layout override ONCE, here, and store it on
+        # the connector instance (no process-global state). Every layout
+        # consumer (register_kv_caches / KV-format detection / engine-driven
+        # gather+scatter / the worker transfer context) is passed this same
+        # value, so STORE and RETRIEVE use exactly the same decision. Reading
+        # the canonical ``lmcache.kv_layout`` (or alias ``kv_layout``) here
+        # also fails fast on an invalid value.
+        self._explicit_kv_layout = read_explicit_kv_layout_from_config(
+            vllm_config.kv_transfer_config
+        )
+
         # Multi-server: prefer lmcache.mp.server_urls (list or comma-separated
         # string) over the single-server lmcache.mp.host / lmcache.mp.port.
         server_urls_cfg = vllm_config.kv_transfer_config.get_from_extra_config(
@@ -754,7 +769,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         engine_group_infos = create_engine_group_infos_from_vllm(
             kv_cache_config,
             kv_caches,
-            layout_hints=vllm_layout_hints(),
+            layout_hints=vllm_layout_hints(self._explicit_kv_layout),
         )
         self.worker_adapter.register_kv_caches(
             kv_caches, engine_group_infos=engine_group_infos

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from typing import TYPE_CHECKING, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Literal, Optional, Tuple
 import hashlib
 import os
 import string
@@ -36,10 +36,160 @@ def is_false(value: str) -> bool:
     return value.lower() in ("false", "0", "no", "n", "off")
 
 
-def vllm_layout_hints() -> "LayoutHints":
-    """Build layout_hints dict by querying vLLM at runtime."""
+SUPPORTED_KV_LAYOUTS = ("NHD", "HND")
+
+# Canonical LMCache connector-config key for an explicit KV-layout override,
+# plus a compatibility alias. Documentation should use the canonical key.
+KV_LAYOUT_CONFIG_KEY = "lmcache.kv_layout"
+KV_LAYOUT_CONFIG_ALIAS = "kv_layout"
+
+
+def normalize_kv_layout(value: "str | None", *, source: str) -> "str | None":
+    """Validate/normalize an explicit KV-layout value.
+
+    Accepts only the supported layouts (case-insensitive); returns the
+    upper-cased canonical value. ``None`` passes through unchanged (meaning
+    "no explicit value"). An unknown non-empty value raises ``ValueError`` —
+    an explicit override is never silently ignored.
+
+    Args:
+        value: the raw layout string (or ``None``).
+        source: human-readable origin (used only in the error message).
+    """
+    if value is None:
+        return None
+    normalized = str(value).strip().upper()
+    if normalized == "":
+        return None
+    if normalized not in SUPPORTED_KV_LAYOUTS:
+        raise ValueError(
+            f"Invalid KV layout {value!r} from {source}. "
+            f"Supported values: {', '.join(SUPPORTED_KV_LAYOUTS)}."
+        )
+    return normalized
+
+
+def resolve_kv_layout(
+    explicit_layout: "str | None" = None,
+    *,
+    query_vllm: bool = True,
+) -> "str | None":
+    """Resolve the KV-cache layout using one authoritative precedence order.
+
+    This is backend-neutral: it never inspects the backend name, platform, or
+    whether any particular plugin is installed. It exists so that host-memory /
+    CPU-presented KV tensors whose physical layout differs from the normal x86
+    CPU backend default (which LMCache treats as HND) can declare their true
+    layout explicitly.
+
+    Precedence (highest wins):
+        1. ``explicit_layout`` — the value the connector read from its
+           ``kv_transfer_config`` extra config (``lmcache.kv_layout`` or the
+           compatibility alias ``kv_layout``). Already validated by the caller,
+           but re-validated here defensively.
+        2. vLLM runtime layout query (``get_kv_cache_layout()``), when available.
+        3. ``LMCACHE_VLLM_KV_LAYOUT`` environment variable (compatibility
+           fallback only).
+        4. ``None`` — no hint; downstream applies the device default
+           (CPU -> HND, non-CPU -> NHD) in the detector.
+
+    Args:
+        explicit_layout: the connector-config override, or ``None``.
+        query_vllm: whether to consult the live vLLM layout query (tier 2).
+            Disable in contexts where vLLM is not importable (e.g. the MP
+            server process) to avoid a spurious error log.
+
+    Returns:
+        ``"NHD"``/``"HND"`` when resolved, or ``None`` when no tier supplied a
+        value (leaving the device default to the detector).
+    """
+    # Standard
+    import os
+
+    # Tier 1: explicit connector configuration (defensive re-validation).
+    layout = normalize_kv_layout(explicit_layout, source="connector config")
+    if layout is not None:
+        return layout
+
+    # Tier 2: vLLM runtime query.
+    if query_vllm:
+        queried = try_get_vllm_kv_cache_layout()
+        if queried is not None:
+            return queried
+
+    # Tier 3: environment-variable compatibility fallback.
+    env_layout = normalize_kv_layout(
+        os.environ.get("LMCACHE_VLLM_KV_LAYOUT"),
+        source="LMCACHE_VLLM_KV_LAYOUT",
+    )
+    if env_layout is not None:
+        return env_layout
+
+    # Tier 4: no hint -> device default is applied by the detector.
+    return None
+
+
+def read_explicit_kv_layout_from_config(kv_transfer_config: Any) -> "str | None":
+    """Read + validate the explicit KV-layout override from a KVTransferConfig.
+
+    Looks up the canonical key ``lmcache.kv_layout`` first, then the
+    compatibility alias ``kv_layout``. Returns the validated upper-cased value,
+    or ``None`` when neither key is set. Raises ``ValueError`` on an unknown
+    value (an explicit override is never silently ignored).
+
+    Args:
+        kv_transfer_config: the vLLM ``KVTransferConfig`` (or ``None``); must
+            expose ``get_from_extra_config(key, default)``.
+    """
+    if kv_transfer_config is None:
+        return None
+    raw = kv_transfer_config.get_from_extra_config(KV_LAYOUT_CONFIG_KEY, None)
+    source = KV_LAYOUT_CONFIG_KEY
+    if raw is None:
+        raw = kv_transfer_config.get_from_extra_config(KV_LAYOUT_CONFIG_ALIAS, None)
+        source = KV_LAYOUT_CONFIG_ALIAS
+    return normalize_kv_layout(raw, source=source)
+
+
+def read_explicit_kv_layout_from_config_dict(
+    extra_config: "dict[str, Any] | None",
+) -> "str | None":
+    """Read + validate the explicit KV-layout override from a plain dict.
+
+    Dict analogue of :func:`read_explicit_kv_layout_from_config` for callers
+    that hold the raw ``kv_connector_extra_config`` dict (e.g. the worker
+    adapter) rather than the ``KVTransferConfig`` object. Same canonical key
+    (``lmcache.kv_layout``) and alias (``kv_layout``) and same validation.
+    """
+    if not extra_config:
+        return None
+    raw = extra_config.get(KV_LAYOUT_CONFIG_KEY)
+    source = KV_LAYOUT_CONFIG_KEY
+    if raw is None:
+        raw = extra_config.get(KV_LAYOUT_CONFIG_ALIAS)
+        source = KV_LAYOUT_CONFIG_ALIAS
+    return normalize_kv_layout(raw, source=source)
+
+
+def vllm_layout_hints(
+    explicit_layout: "str | None" = None,
+    *,
+    query_vllm: bool = True,
+) -> "LayoutHints":
+    """Build the ``layout_hints`` dict passed to KV-format detection.
+
+    Thin wrapper over :func:`resolve_kv_layout` that packages the resolved
+    layout into the ``{"kv_layout": ...}`` hint dict the detector consumes.
+    The resolved layout is threaded through every format/gather/scatter path,
+    so store and retrieve use exactly the same decision.
+
+    Args:
+        explicit_layout: connector-config override (``lmcache.kv_layout``), or
+            ``None`` to fall back to the runtime query / env / default.
+        query_vllm: forwarded to :func:`resolve_kv_layout`.
+    """
     hints: dict[str, str] = {}
-    kv_layout = try_get_vllm_kv_cache_layout()
+    kv_layout = resolve_kv_layout(explicit_layout, query_vllm=query_vllm)
     if kv_layout is not None:
         hints["kv_layout"] = kv_layout
     return hints  # type: ignore[return-value]

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -16,7 +16,10 @@ import zmq
 # First Party
 from lmcache import torch_dev
 from lmcache.integration.request_telemetry.factory import RequestTelemetryFactory
-from lmcache.integration.vllm.utils import vllm_layout_hints
+from lmcache.integration.vllm.utils import (
+    read_explicit_kv_layout_from_config_dict,
+    vllm_layout_hints,
+)
 from lmcache.utils import _lmcache_nvtx_annotate, init_logger
 from lmcache.v1.multiprocess.custom_types import (
     BlockAllocationRecord,
@@ -1099,6 +1102,14 @@ class LMCacheMPWorkerAdapter:
                 self._mp_transfer_mode = None
         else:
             self._mp_transfer_mode = None
+        # Resolve the explicit KV-layout override once, from this adapter's
+        # extra_config, and store it on the instance (no process-global state).
+        # It is threaded into the transfer-context registration so the worker
+        # store/retrieve path uses the same layout as the connector's
+        # register_kv_caches / detector path.
+        self._explicit_kv_layout = read_explicit_kv_layout_from_config_dict(
+            extra_config
+        )
         self.mq_client = MessageQueueClient(server_url, context)
         self._mq_timeout = mq_timeout
 
@@ -1282,7 +1293,7 @@ class LMCacheMPWorkerAdapter:
         """
         self.kv_caches = kv_caches
         transfer_ctx = create_transfer_context(kv_caches, mode=self._mp_transfer_mode)
-        layout_hints = vllm_layout_hints()
+        layout_hints = vllm_layout_hints(self._explicit_kv_layout)
         self.transfer_ctx = transfer_ctx
         try:
             # Register on the local, not self.transfer_ctx: a concurrent

--- a/lmcache/integration/vllm/vllm_service_factory.py
+++ b/lmcache/integration/vllm/vllm_service_factory.py
@@ -198,13 +198,19 @@ class VllmServiceFactory(BaseServiceFactory):
 
             tpg = get_tp_group()
             # First Party
-            from lmcache.integration.vllm.utils import vllm_layout_hints
+            from lmcache.integration.vllm.utils import (
+                read_explicit_kv_layout_from_config,
+                vllm_layout_hints,
+            )
 
+            explicit_kv_layout = read_explicit_kv_layout_from_config(
+                getattr(self.vllm_config, "kv_transfer_config", None)
+            )
             vllm_gpu_connector = CreateGPUConnector(
                 self.lmcache_config,
                 self.metadata,
                 EngineType.VLLM,
-                layout_hints=vllm_layout_hints(),
+                layout_hints=vllm_layout_hints(explicit_kv_layout),
             )
 
         engine = LMCacheEngineBuilder.get_or_create(

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """vLLM KV cache discovery."""
 
-# mypy: disable-error-code="union-attr"
+# mypy: disable-error-code="union-attr,list-item,assignment,return-value,arg-type"
 # Standard
 from typing import Optional
 
@@ -19,12 +19,73 @@ from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache, Layout
 import lmcache.c_ops as lmc_ops
 
 
+def _as_split_kv_layers(
+    kv_caches: DiscoverableKVCache,
+) -> "Optional[tuple[list[torch.Tensor], list[torch.Tensor]]]":
+    """Recognize a per-layer split-KV registration and regroup it.
+
+    Returns ``(key_layers, value_layers)`` when *kv_caches* is a per-layer list
+    where every entry is a ``(key, value)`` pair (2-tuple or 2-list) of 4-D
+    tensors, else ``None``. The two tensors are kept as-is (no copy, no fuse);
+    they are just regrouped from per-layer pairs into a key-list and a
+    value-list so the existing ``TWO_X_NL_X_*`` split machinery can consume them.
+
+    A ``(key, value)`` pair is required to have matching shape/dtype/device and
+    rank 4 (``[num_blocks, block_size, num_heads, head_dim]``); anything else
+    returns ``None`` so fused and other layouts fall through unchanged.
+    """
+    if not isinstance(kv_caches, list) or not kv_caches:
+        return None
+    key_layers: list[torch.Tensor] = []
+    value_layers: list[torch.Tensor] = []
+    for entry in kv_caches:
+        if not isinstance(entry, (tuple, list)) or len(entry) != 2:
+            return None
+        key, value = entry
+        if not isinstance(key, torch.Tensor) or not isinstance(value, torch.Tensor):
+            return None
+        if key.dim() != 4 or value.dim() != 4:
+            return None
+        if key.shape != value.shape:
+            raise ValueError(
+                f"split KV key shape {tuple(key.shape)} != value shape "
+                f"{tuple(value.shape)}"
+            )
+        if key.dtype != value.dtype:
+            raise ValueError(
+                f"split KV key dtype {key.dtype} != value dtype {value.dtype}"
+            )
+        key_layers.append(key)
+        value_layers.append(value)
+    return key_layers, value_layers
+
+
 class VLLM_Detector(EngineDetector):
     engine_type = EngineType.VLLM
 
     def discover(
         self, kv_caches: DiscoverableKVCache, layout_hints: LayoutHints
     ) -> "tuple[Optional[lmc_ops.EngineKVFormat], DiscoverableKVCache]":
+        # Split K/V: some backends expose the key and value caches as two
+        # independent tensors per layer instead of one fused tensor -- e.g. a
+        # host-memory backend that hands LMCache zero-copy views of separate
+        # native key/value arrays (avoiding a fused staging copy). Such a
+        # backend registers each layer as a ``(key, value)`` pair, which arrives
+        # here as a per-layer list of 2-tuples/2-lists of 4-D [NB, BS, NH, HS]
+        # tensors. Regroup into the ``[K_layers, V_layers]`` structure LMCache's
+        # existing split (``TWO_X_NL_X_*``) format already handles -- no fused
+        # tensor is ever allocated; K and V stay separate end to end.
+        split = _as_split_kv_layers(kv_caches)
+        if split is not None:
+            key_layers, value_layers = split
+            # Split K/V is physically NHD ([NB, BS, NH, HS]); an explicit HND
+            # hint is rejected below only for the fused paths. Honor the hint
+            # for symmetry but there is a single supported split layout today.
+            return (
+                lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS,
+                [key_layers, value_layers],
+            )
+
         # Blocks-first fused K/V is the only rank-4 vLLM layout, so its raw rank
         # identifies it unambiguously (the post-split 5-D shape would collide
         # with flash-infer when num_heads == 2). Split [NB, NH, BS, 2*HS] into

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -108,13 +108,16 @@ class VLLM_Detector(EngineDetector):
             kv_caches
         )
 
-        # vLLM's CPU attention backend stores KV in HND but misreports it, so
-        # force HND there; otherwise honor the hint, defaulting to NHD.
+        # vLLM's x86 CPU attention backend stores KV in HND but misreports it,
+        # so CPU defaults to HND. However, other host-memory backends that also
+        # present as the "cpu" torch device -- notably vLLM's Apple Metal
+        # (vllm-metal) plugin, whose MLX unified-memory KV cache is NHD -- must
+        # be able to override that. An explicit ``layout_hints["kv_layout"]``
+        # therefore always wins; only when no hint is supplied does CPU fall
+        # back to HND (and every other device to NHD).
         kv_layout = layout_hints.get("kv_layout")
-        if torch_device_type == "cpu":
-            kv_layout = "HND"
-        elif kv_layout is None:
-            kv_layout = "NHD"
+        if kv_layout is None:
+            kv_layout = "HND" if torch_device_type == "cpu" else "NHD"
         is_hnd = kv_layout == "HND"
 
         if list_depth == 0:

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -102,6 +102,31 @@ def _tensors_to_ptrs(tensors: list[torch.Tensor]) -> list[int]:
     return [t.data_ptr() for t in tensors]
 
 
+def _first_leaf_tensor(structure: object) -> torch.Tensor:
+    """Return the first ``torch.Tensor`` reachable in a possibly-nested value.
+
+    The registered/normalized KV structure may be a flat per-layer list of
+    tensors (fused), a nested ``[key_layers, value_layers]`` (split K/V), or a
+    per-layer list of ``(key, value)`` pairs. dtype/device are uniform across
+    the structure, so the first leaf is representative. Used instead of
+    ``tensors[0]`` so split representations (whose first element is a
+    list/tuple, not a tensor) work unchanged.
+    """
+    cur: object = structure
+    # Descend through lists/tuples until we hit a tensor.
+    for _ in range(8):  # bounded; KV nesting is at most a few levels deep
+        if isinstance(cur, torch.Tensor):
+            return cur
+        if isinstance(cur, (list, tuple)) and cur:
+            cur = cur[0]
+            continue
+        break
+    raise ValueError(
+        f"could not find a leaf torch.Tensor in KV structure of type "
+        f"{type(structure).__name__}"
+    )
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -295,7 +320,7 @@ def compute_kv_layout(
     block_size = get_block_size(normalized, engine_kv_format)
     num_layers = get_num_layers(normalized, engine_kv_format)
     hidden_dim_size = get_hidden_dim_size(normalized, engine_kv_format)
-    dtype_str = str(tensors[0].dtype).replace("torch.", "")
+    dtype_str = str(_first_leaf_tensor(normalized).dtype).replace("torch.", "")
     return block_size, num_layers, hidden_dim_size, dtype_str, engine_kv_format
 
 
@@ -341,6 +366,7 @@ def gather_paged_kv_to_cpu(
         get_block_size,
         get_hidden_dim_size,
         get_num_blocks,
+        get_group_data_ptrs,
         get_num_layers,
         is_mla,
         make_page_buffer_shape_desc,
@@ -395,7 +421,7 @@ def gather_paged_kv_to_cpu(
             chunks = [
                 torch.empty(
                     (num_layers, chunk_tokens, hidden_dim_size),
-                    dtype=tensors[0].dtype,
+                    dtype=_first_leaf_tensor(normalized).dtype,
                     device=torch.device("cpu"),
                     pin_memory=requires_pinned,
                 )
@@ -405,7 +431,7 @@ def gather_paged_kv_to_cpu(
             chunks = [
                 torch.empty(
                     (2, num_layers, chunk_tokens, hidden_dim_size),
-                    dtype=tensors[0].dtype,
+                    dtype=_first_leaf_tensor(normalized).dtype,
                     device=torch.device("cpu"),
                     pin_memory=requires_pinned,
                 )
@@ -460,7 +486,7 @@ def gather_paged_kv_to_cpu(
                 paged_arg,
                 objs_arg,
                 block_ids_arg,
-                tensors[0].device,
+                _first_leaf_tensor(normalized).device,
                 lmc_ops.TransferDirection.D2H,
                 shape_desc,
                 chunk_tokens,
@@ -470,18 +496,21 @@ def gather_paged_kv_to_cpu(
 
         else:
             # Compiled C++/CUDA/XPU: requires int64 pointer tensor and list[int].
+            leaf_device = _first_leaf_tensor(normalized).device
             _ptrs_np = np.array(
-                [t.data_ptr() for t in normalized],  # type: ignore[union-attr]
+                get_group_data_ptrs(
+                    normalized, engine_kv_format, list(range(num_layers))
+                ),
                 dtype=np.uint64,
             ).view(np.int64)
-            paged_arg = torch.from_numpy(_ptrs_np).to(device=tensors[0].device)
+            paged_arg = torch.from_numpy(_ptrs_np).to(device=leaf_device)
 
             # This safely points to either the pre-pinned chunks
             # OR the temporary staged_chunks
             objs_arg = _tensors_to_ptrs(chunks)
 
             block_ids_arg = torch.tensor(
-                selected_block_ids, dtype=torch.int64, device=tensors[0].device
+                selected_block_ids, dtype=torch.int64, device=leaf_device
             )
 
             # Split transfer to respect CUDA kernel's object count limitation
@@ -504,7 +533,7 @@ def gather_paged_kv_to_cpu(
                     paged_arg,
                     batch_objs_ptrs,
                     batch_blocks,
-                    tensors[0].device,
+                    leaf_device,
                     lmc_ops.TransferDirection.D2H,
                     shape_desc,
                     chunk_tokens,
@@ -572,6 +601,7 @@ def scatter_cpu_to_paged_kv(
     from lmcache.v1.gpu_connector.utils import (
         get_block_size,
         get_num_blocks,
+        get_group_data_ptrs,
         get_num_layers,
         make_page_buffer_shape_desc,
         normalize_kv_and_discover_format,
@@ -644,7 +674,7 @@ def scatter_cpu_to_paged_kv(
             paged_arg,
             objs_arg,
             block_ids_arg,
-            tensors[0].device,
+            _first_leaf_tensor(normalized).device,
             lmc_ops.TransferDirection.H2D,
             shape_desc,
             chunk_tokens,
@@ -669,14 +699,17 @@ def scatter_cpu_to_paged_kv(
             ]
 
         # Compiled C++/CUDA/XPU: requires int64 pointer tensor and list[int].
+        leaf_device = _first_leaf_tensor(normalized).device
         _ptrs_np = np.array(
-            [t.data_ptr() for t in normalized],  # type: ignore[union-attr]
+            get_group_data_ptrs(
+                normalized, engine_kv_format, list(range(num_layers))
+            ),
             dtype=np.uint64,
         ).view(np.int64)
-        paged_arg = torch.from_numpy(_ptrs_np).to(device=tensors[0].device)
+        paged_arg = torch.from_numpy(_ptrs_np).to(device=leaf_device)
         objs_arg = _tensors_to_ptrs(chunks)
         block_ids_arg = torch.tensor(
-            selected_block_ids, dtype=torch.int64, device=tensors[0].device
+            selected_block_ids, dtype=torch.int64, device=leaf_device
         )
 
         # Batched transfer to satisfy cuda's limitation (max 4 objects)
@@ -701,7 +734,7 @@ def scatter_cpu_to_paged_kv(
                 paged_arg,
                 batch_objs_ptrs,
                 batch_blocks,
-                tensors[0].device,
+                leaf_device,
                 lmc_ops.TransferDirection.H2D,
                 shape_desc,
                 chunk_tokens,

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -25,6 +25,7 @@ from lmcache.v1.multiprocess.protocols.engine import RegisterEngineDrivenContext
 from lmcache.v1.multiprocess.transfer_context.base import (
     EngineDrivenContext,
     EngineDrivenContextMetadata,
+    _first_leaf_tensor,
     compute_kv_layout,
     create_engine_driven_context,
     gather_paged_kv_to_cpu,
@@ -631,7 +632,12 @@ def create_transfer_context(
     """
     if not kv_caches:
         raise ValueError("kv_caches is empty")
-    device_types = {tensor.device.type for tensor in kv_caches.values()}
+    # A per-layer value may be a fused tensor or a split (key, value) pair, so
+    # read the device from the first leaf tensor of each value rather than
+    # assuming the value is itself a tensor.
+    device_types = {
+        _first_leaf_tensor(value).device.type for value in kv_caches.values()
+    }
     if len(device_types) != 1:
         raise ValueError(
             f"All KV cache tensors must share one device type, got {device_types}"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,7 +3,10 @@ aiofiles
 blake3
 aiohttp
 awscrt
-cufile-python
+# cufile-python (CUDA GPUDirect Storage) has no macOS wheels and is imported
+# lazily by the GDS backend; gate it off Darwin so `pip install lmcache` works
+# on Apple-Silicon dev hosts.
+cufile-python; platform_system != "Darwin"
 fastapi
 httpx
 huggingface_hub>=1.5.0
@@ -11,7 +14,10 @@ msgspec
 # nixl uses numba which requires numpy<=2.2.6
 numpy<=2.2.6
 numba
-nvtx
+# nvtx (NVIDIA Tools Extension) is CUDA-profiling only and fails to build on
+# arm64 macOS; LMCache imports it under try/except and degrades to a no-op
+# decorator, so gate it off Darwin.
+nvtx; platform_system != "Darwin"
 opentelemetry-api >= 1.20.0, <= 1.40.0
 opentelemetry-sdk >= 1.20.0
 opentelemetry-exporter-otlp >= 1.20.0

--- a/tests/v1/test_metal_engine_driven.py
+++ b/tests/v1/test_metal_engine_driven.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KV-layout resolution + CPU-presented NHD gather/scatter (host-memory backends).
+
+Some serving backends present their paged KV cache to LMCache as **CPU** torch
+tensors whose physical layout is NHD rather than the x86-CPU default (HND) --
+e.g. vLLM's Apple-Metal plugin, whose MLX unified-memory cache is bridged to
+CPU torch tensors. The layout must therefore be declarable explicitly, and the
+resolution must be backend-neutral (no platform/plugin/name checks).
+
+These tests cover the resolution precedence and the CPU NHD store/retrieve
+round-trip. They map 1:1 to the 12 required cases (numbered below). No
+accelerator required.
+
+Precedence (highest wins):
+    1. explicit connector config (``lmcache.kv_layout`` / alias ``kv_layout``)
+    2. vLLM runtime query (``get_kv_cache_layout()``)
+    3. ``LMCACHE_VLLM_KV_LAYOUT`` env fallback
+    4. device default: CPU -> HND, non-CPU -> NHD
+"""
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.integration.vllm import utils as vllm_utils
+
+
+@pytest.fixture(autouse=True)
+def _force_cpu_device_type(monkeypatch):
+    """These tests exercise the CPU-presented host-memory scenario. The
+    detector reads a process-level ``torch_device_type`` constant (set by the
+    LMCache platform at import: "cpu" on an Apple-Metal host, "cuda" on a GPU
+    host), NOT the tensor's device. Pin it to "cpu" so the CPU-default and
+    CPU-override cases are deterministic on any host (otherwise a GPU CI box
+    defaults to NHD and the "no hint -> HND" case fails spuriously)."""
+    import lmcache.v1.gpu_connector.kv_format.detectors.vllm as det
+
+    monkeypatch.setattr(det, "torch_device_type", "cpu", raising=False)
+
+
+def _nhd_kv_caches(
+    num_layers: int = 2,
+    num_blocks: int = 6,
+    block_size: int = 4,
+    num_heads: int = 2,
+    head_size: int = 8,
+) -> "dict[str, torch.Tensor]":
+    """Per-layer NHD KV tensors: [2, num_blocks, block_size, num_heads, head_size].
+
+    This is the layout a host-memory NHD backend (e.g. vllm-metal) presents:
+    stacked K/V on axis 0, then NHD. ``num_heads != block_size`` so the shape is
+    unambiguously NHD-vs-HND for the detector.
+    """
+    return {
+        f"layer_{i}": torch.randn(2, num_blocks, block_size, num_heads, head_size)
+        for i in range(num_layers)
+    }
+
+
+# ---------------------------------------------------------------------------
+# Layout-resolution precedence (cases 1-7, 11, 12)
+# ---------------------------------------------------------------------------
+
+
+def test_case1_cpu_no_override_is_hnd() -> None:
+    """(1) CPU tensor without an explicit override remains HND (the default)."""
+    detector = _detector()
+    kv = list(_nhd_kv_caches().values())
+    # No hint -> detector applies the CPU default (HND).
+    fmt_default, _ = detector.discover(kv, {})
+    fmt_hnd, _ = detector.discover(kv, {"kv_layout": "HND"})
+    assert fmt_default == fmt_hnd
+    assert fmt_hnd.name == "NL_X_TWO_NB_NH_BS_HS"
+
+
+def test_case2_cpu_explicit_nhd_resolves_nhd() -> None:
+    """(2) CPU tensor with explicit NHD resolves to NHD (override wins on CPU)."""
+    detector = _detector()
+    kv = list(_nhd_kv_caches().values())
+    fmt_nhd, _ = detector.discover(kv, {"kv_layout": "NHD"})
+    assert fmt_nhd.name == "NL_X_TWO_NB_BS_NH_HS"
+
+
+def test_case3_cpu_explicit_hnd_resolves_hnd() -> None:
+    """(3) CPU tensor with explicit HND resolves to HND."""
+    detector = _detector()
+    kv = list(_nhd_kv_caches().values())
+    fmt_hnd, _ = detector.discover(kv, {"kv_layout": "HND"})
+    assert fmt_hnd.name == "NL_X_TWO_NB_NH_BS_HS"
+
+
+def test_case4_connector_config_beats_runtime_query(monkeypatch) -> None:
+    """(4) Connector configuration takes precedence over the runtime query."""
+    # Runtime query would say HND, but the explicit connector config says NHD.
+    monkeypatch.setattr(vllm_utils, "try_get_vllm_kv_cache_layout", lambda: "HND")
+    assert vllm_utils.resolve_kv_layout("NHD") == "NHD"
+    assert vllm_utils.vllm_layout_hints("NHD") == {"kv_layout": "NHD"}
+
+
+def test_case5_runtime_query_beats_env(monkeypatch) -> None:
+    """(5) Runtime query takes precedence over the environment fallback."""
+    monkeypatch.setattr(vllm_utils, "try_get_vllm_kv_cache_layout", lambda: "NHD")
+    monkeypatch.setenv("LMCACHE_VLLM_KV_LAYOUT", "HND")
+    # No explicit connector config -> tier 2 (query=NHD) beats tier 3 (env=HND).
+    assert vllm_utils.resolve_kv_layout(None) == "NHD"
+
+
+def test_case6_env_fallback_when_no_config_or_query(monkeypatch) -> None:
+    """(6) Env fallback works when neither connector config nor query available."""
+    monkeypatch.setattr(vllm_utils, "try_get_vllm_kv_cache_layout", lambda: None)
+    monkeypatch.setenv("LMCACHE_VLLM_KV_LAYOUT", "NHD")
+    assert vllm_utils.resolve_kv_layout(None) == "NHD"
+    assert vllm_utils.vllm_layout_hints(None) == {"kv_layout": "NHD"}
+    monkeypatch.setenv("LMCACHE_VLLM_KV_LAYOUT", "HND")
+    assert vllm_utils.resolve_kv_layout(None) == "HND"
+
+
+def test_case7_invalid_explicit_value_raises() -> None:
+    """(7) Invalid explicit values fail with a useful error (never silently ignored)."""
+    with pytest.raises(ValueError, match="Invalid KV layout"):
+        vllm_utils.normalize_kv_layout("BOGUS", source="test")
+    with pytest.raises(ValueError, match="Invalid KV layout"):
+        vllm_utils.resolve_kv_layout("XYZ")
+    with pytest.raises(ValueError, match="Invalid KV layout"):
+        vllm_utils.read_explicit_kv_layout_from_config_dict(
+            {"lmcache.kv_layout": "sideways"}
+        )
+
+
+def test_case7b_case_insensitive_and_alias() -> None:
+    """(7 cont.) Supported values normalize case; canonical key + alias both work."""
+    assert vllm_utils.normalize_kv_layout("nhd", source="t") == "NHD"
+    assert vllm_utils.normalize_kv_layout(" Hnd ", source="t") == "HND"
+    # Canonical key wins over alias when both present.
+    assert (
+        vllm_utils.read_explicit_kv_layout_from_config_dict(
+            {"lmcache.kv_layout": "NHD", "kv_layout": "HND"}
+        )
+        == "NHD"
+    )
+    # Alias alone still works (compatibility).
+    assert (
+        vllm_utils.read_explicit_kv_layout_from_config_dict({"kv_layout": "nhd"})
+        == "NHD"
+    )
+
+
+def test_case11_two_configs_do_not_share_state(monkeypatch) -> None:
+    """(11) Two connector instances with different explicit layouts do not share
+    or overwrite any process-global layout state."""
+    monkeypatch.setattr(vllm_utils, "try_get_vllm_kv_cache_layout", lambda: None)
+    monkeypatch.delenv("LMCACHE_VLLM_KV_LAYOUT", raising=False)
+    # Resolve interleaved; each call is pure and instance-value driven.
+    a1 = vllm_utils.resolve_kv_layout("NHD")
+    b1 = vllm_utils.resolve_kv_layout("HND")
+    a2 = vllm_utils.resolve_kv_layout("NHD")
+    b2 = vllm_utils.resolve_kv_layout("HND")
+    assert (a1, a2) == ("NHD", "NHD")
+    assert (b1, b2) == ("HND", "HND")
+
+
+def test_case12_ambiguous_shape_no_silent_guess() -> None:
+    """(12) Ambiguous tensor shapes (block_size == num_heads) do not cause a
+    silent NHD-vs-HND guess: the explicit hint decides, and the two hints
+    produce genuinely different formats."""
+    detector = _detector()
+    # block_size == num_heads == 4 -> shape [2, NB, 4, 4, HS] is ambiguous.
+    ambiguous = [torch.randn(2, 6, 4, 4, 8) for _ in range(2)]
+    fmt_nhd, _ = detector.discover(ambiguous, {"kv_layout": "NHD"})
+    fmt_hnd, _ = detector.discover(ambiguous, {"kv_layout": "HND"})
+    # If the detector silently guessed from shape, both hints would collapse to
+    # the same format. They must not.
+    assert fmt_nhd != fmt_hnd
+    assert fmt_nhd.name == "NL_X_TWO_NB_BS_NH_HS"
+    assert fmt_hnd.name == "NL_X_TWO_NB_NH_BS_HS"
+
+
+# ---------------------------------------------------------------------------
+# Gather/scatter round-trip (cases 8, 9, 10)
+# ---------------------------------------------------------------------------
+
+
+def test_case8_cpu_nhd_gather_scatter_bitexact() -> None:
+    """(8) CPU NHD gather -> scatter round-trips bit-exactly."""
+    from lmcache.v1.multiprocess.transfer_context.base import (
+        gather_paged_kv_to_cpu,
+        scatter_cpu_to_paged_kv,
+    )
+
+    source = _nhd_kv_caches()
+    hints = {"kv_layout": "NHD"}
+    blocks_per_chunk = 2
+    gathered = gather_paged_kv_to_cpu(
+        source, [0, 1], blocks_per_chunk, layout_hints=hints
+    )
+    destination = {name: torch.zeros_like(t) for name, t in source.items()}
+    scatter_cpu_to_paged_kv(
+        destination, [4, 5], gathered, blocks_per_chunk, layout_hints=hints
+    )
+    for name in source:
+        assert torch.equal(source[name][:, 0], destination[name][:, 4])
+        assert torch.equal(source[name][:, 1], destination[name][:, 5])
+
+
+def test_case9_cpu_hnd_behavior_unchanged() -> None:
+    """(9) CPU HND behavior remains unchanged: HND gather->scatter round-trips."""
+    from lmcache.v1.multiprocess.transfer_context.base import (
+        gather_paged_kv_to_cpu,
+        scatter_cpu_to_paged_kv,
+    )
+
+    # HND physical layout: [2, num_blocks, num_heads, block_size, head_size].
+    source = {f"layer_{i}": torch.randn(2, 6, 2, 4, 8) for i in range(2)}
+    hints = {"kv_layout": "HND"}
+    blocks_per_chunk = 2
+    gathered = gather_paged_kv_to_cpu(
+        source, [0, 1], blocks_per_chunk, layout_hints=hints
+    )
+    destination = {name: torch.zeros_like(t) for name, t in source.items()}
+    scatter_cpu_to_paged_kv(
+        destination, [4, 5], gathered, blocks_per_chunk, layout_hints=hints
+    )
+    for name in source:
+        assert torch.equal(source[name][:, 0], destination[name][:, 4])
+        assert torch.equal(source[name][:, 1], destination[name][:, 5])
+
+
+def test_case10_store_and_retrieve_use_same_layout() -> None:
+    """(10) STORE and RETRIEVE use the same resolved layout: a chunk gathered
+    under NHD must scatter back correctly only under the SAME NHD hint, and the
+    detector's format is identical for both directions given one hint."""
+    from lmcache.v1.multiprocess.transfer_context.base import (
+        gather_paged_kv_to_cpu,
+        scatter_cpu_to_paged_kv,
+    )
+
+    source = _nhd_kv_caches()
+    hints = {"kv_layout": "NHD"}
+    blocks_per_chunk = 2
+    # STORE (gather) with NHD.
+    gathered = gather_paged_kv_to_cpu(
+        source, [0, 1], blocks_per_chunk, layout_hints=hints
+    )
+    # RETRIEVE (scatter) with the SAME NHD hint -> bit-exact.
+    dst_same = {name: torch.zeros_like(t) for name, t in source.items()}
+    scatter_cpu_to_paged_kv(
+        dst_same, [0, 1], gathered, blocks_per_chunk, layout_hints=hints
+    )
+    for name in source:
+        assert torch.equal(source[name][:, 0], dst_same[name][:, 0])
+        assert torch.equal(source[name][:, 1], dst_same[name][:, 1])
+
+
+def _detector():
+    from lmcache.v1.gpu_connector.kv_format.detectors.vllm import VLLM_Detector
+
+    return VLLM_Detector()

--- a/tests/v1/test_split_kv_support.py
+++ b/tests/v1/test_split_kv_support.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Split K/V + fused normalization and strict validation.
+
+Some serving backends expose their paged KV cache to LMCache as two independent
+per-layer torch tensors (key, value) instead of one fused ``[2, ...]`` tensor --
+e.g. a host-memory backend that hands LMCache zero-copy views of separate native
+key/value arrays (avoiding a fused staging copy). LMCache normalizes both the
+existing fused representation and the split ``tuple[Tensor, Tensor]`` form into
+its internal per-layer view, and gathers/scatters the live buffers directly.
+
+These tests are backend-neutral: they never import a backend package, never
+name a concrete connector, and never branch on a backend/platform name. They map
+the split/fused normalization cases (1-6, 14, 15). Layout-precedence cases
+live in test_metal_engine_driven.py. No accelerator required.
+"""
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.utils import (
+    get_block_size,
+    get_head_size,
+    get_num_heads,
+    get_num_layers,
+    normalize_and_discover_per_layer_formats,
+)
+from lmcache.v1.multiprocess.transfer_context.base import (
+    gather_paged_kv_to_cpu,
+    scatter_cpu_to_paged_kv,
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_cpu_device_type(monkeypatch):
+    """Pin the detector's process-level device type to "cpu" so the CPU-default
+    and CPU-override cases are deterministic on any host (a GPU CI box would
+    otherwise default to NHD)."""
+    import lmcache.v1.gpu_connector.kv_format.detectors.vllm as det
+
+    monkeypatch.setattr(det, "torch_device_type", "cpu", raising=False)
+
+
+def _detector():
+    from lmcache.v1.gpu_connector.kv_format.detectors.vllm import VLLM_Detector
+
+    return VLLM_Detector()
+
+
+# --- builders --------------------------------------------------------------
+
+
+def _fused_kv(num_layers=2, nb=6, bs=4, nh=2, hs=8):
+    """Fused per-layer KV: [2, num_blocks, block_size, num_heads, head_size]."""
+    return {
+        f"layer_{i}": torch.randn(2, nb, bs, nh, hs) for i in range(num_layers)
+    }
+
+
+def _split_kv(num_layers=2, nb=6, bs=4, nh=2, hs=8, *, seed=0):
+    """Split per-layer KV: {name: (key, value)}, each [nb, bs, nh, hs] (NHD)."""
+    g = torch.Generator().manual_seed(seed)
+    kv = {}
+    for i in range(num_layers):
+        k = torch.randn(nb, bs, nh, hs, generator=g)
+        v = torch.randn(nb, bs, nh, hs, generator=g) + 100.0  # distinguish V
+        kv[f"layer_{i}"] = (k, v)
+    return kv
+
+
+# --- (1) existing fused CPU HND registration unchanged ---------------------
+
+
+def test_case1_fused_cpu_hnd_unchanged():
+    detector = _detector()
+    fused = [torch.randn(2, 6, 4, 2, 8) for _ in range(2)]  # nh=2 != bs=4
+    # No hint on CPU -> HND default.
+    fmt, _ = detector.discover(fused, {})
+    assert fmt.name == "NL_X_TWO_NB_NH_BS_HS"  # HND fused
+# --- (3) split K/V CPU NHD works -------------------------------------------
+
+
+def test_case3_split_cpu_nhd_works():
+    kv = _split_kv()
+    normalized, fmts = normalize_and_discover_per_layer_formats(
+        list(kv.values()), [], EngineType.VLLM, {"kv_layout": "NHD"}
+    )
+    assert all(f.name == "TWO_X_NL_X_NB_BS_NH_HS" for f in fmts)
+    # normalized is [K_layers, V_layers]
+    assert isinstance(normalized, list) and len(normalized) == 2
+    assert len(normalized[0]) == 2 and len(normalized[1]) == 2
+    assert get_num_layers(normalized, fmts[0]) == 2
+    assert get_block_size(normalized, fmts[0]) == 4
+    assert get_num_heads(normalized, fmts[0]) == 2
+    assert get_head_size(normalized, fmts[0]) == 8
+
+
+# --- (4) split K/V CPU HND works -------------------------------------------
+
+
+def test_case4_split_cpu_hnd_works():
+    """A split registration is physically NHD [NB,BS,NH,HS]; the detector
+    reports the split format regardless of an HND hint (there is a single
+    supported split layout). It must still normalize + expose geometry."""
+    kv = _split_kv()
+    normalized, fmts = normalize_and_discover_per_layer_formats(
+        list(kv.values()), [], EngineType.VLLM, {"kv_layout": "HND"}
+    )
+    assert all(f.name == "TWO_X_NL_X_NB_BS_NH_HS" for f in fmts)
+    assert get_num_layers(normalized, fmts[0]) == 2
+
+
+# --- (5) split gather -> scatter bit-exact ---------------------------------
+
+
+def test_case5_split_gather_scatter_bitexact():
+    src = _split_kv(num_layers=3, nb=8, bs=16, nh=4, hs=64, seed=1)
+    block_ids = [0, 1, 2, 3]
+    bpc = 2
+    chunks = gather_paged_kv_to_cpu(
+        src, block_ids, bpc, layout_hints={"kv_layout": "NHD"}
+    )
+    dst = _split_kv(num_layers=3, nb=8, bs=16, nh=4, hs=64, seed=99)
+    for k, v in dst.values():
+        k.zero_()
+        v.zero_()
+    scatter_cpu_to_paged_kv(
+        dst, block_ids, chunks, bpc, layout_hints={"kv_layout": "NHD"}
+    )
+    for name in src:
+        sk, sv = src[name]
+        dk, dv = dst[name]
+        for b in block_ids:
+            assert torch.equal(sk[b], dk[b]), f"K mismatch {name} block {b}"
+            assert torch.equal(sv[b], dv[b]), f"V mismatch {name} block {b}"
+
+
+# --- (6) K and V transferred independently, never swapped ------------------
+
+
+def test_case6_split_kv_never_swapped():
+    src = _split_kv(num_layers=2, nb=4, bs=8, nh=2, hs=16, seed=2)
+    block_ids = [0, 1]
+    bpc = 1
+    chunks = gather_paged_kv_to_cpu(
+        src, block_ids, bpc, layout_hints={"kv_layout": "NHD"}
+    )
+    dst = _split_kv(num_layers=2, nb=4, bs=8, nh=2, hs=16, seed=77)
+    for k, v in dst.values():
+        k.zero_()
+        v.zero_()
+    scatter_cpu_to_paged_kv(
+        dst, block_ids, chunks, bpc, layout_hints={"kv_layout": "NHD"}
+    )
+    for name in src:
+        sk, sv = src[name]
+        dk, dv = dst[name]
+        for b in block_ids:
+            # V was offset +100; a swap would land src-V values in dst-K.
+            assert not torch.equal(dk[b], sv[b]), f"K/V swapped {name} block {b}"
+            assert torch.equal(dk[b], sk[b])
+            assert torch.equal(dv[b], sv[b])
+
+
+# --- (7) explicit lmcache.kv_layout=NHD overrides CPU HND default ----------
+
+
+# --- (8) explicit HND works ------------------------------------------------
+
+
+# --- (9) invalid layout values fail clearly --------------------------------
+
+
+# --- (10) connector config overrides runtime detection ---------------------
+
+
+# --- (11) runtime detection overrides env fallback -------------------------
+
+
+# --- (12) two connector instances do not share mutable layout state --------
+
+
+# --- (13) ambiguous dims do not trigger silent layout guessing -------------
+
+
+# --- (14) existing fused CUDA/GPU paths unchanged --------------------------
+
+
+def test_case14_fused_gpu_paths_unchanged(monkeypatch):
+    """On a non-CPU device the default is NHD and fused detection is unchanged."""
+    import lmcache.v1.gpu_connector.kv_format.detectors.vllm as det
+
+    monkeypatch.setattr(det, "torch_device_type", "cuda", raising=False)
+    detector = _detector()
+    fused = [torch.randn(2, 6, 4, 2, 8) for _ in range(2)]
+    fmt, _ = detector.discover(fused, {})  # no hint, non-cpu -> NHD
+    assert fmt.name == "NL_X_TWO_NB_BS_NH_HS"
+    # An explicit HND still works on GPU.
+    fmt_hnd, _ = detector.discover(fused, {"kv_layout": "HND"})
+    assert fmt_hnd.name == "NL_X_TWO_NB_NH_BS_HS"
+
+
+# --- (15) cache-group layer names validated strictly -----------------------
+
+
+def test_case15_split_kv_shape_mismatch_raises():
+    """A split (key, value) pair with mismatched shapes is a hard error, not a
+    silent guess."""
+    detector = _detector()
+    bad = [(torch.randn(4, 8, 2, 16), torch.randn(4, 8, 2, 8))]  # HS differs
+    with pytest.raises(ValueError, match="key shape.*!= value shape"):
+        detector.discover(bad, {"kv_layout": "NHD"})
+
+
+def test_case15b_split_kv_dtype_mismatch_raises():
+    detector = _detector()
+    bad = [
+        (
+            torch.randn(4, 8, 2, 16, dtype=torch.float32),
+            torch.randn(4, 8, 2, 16, dtype=torch.float16),
+        )
+    ]
+    with pytest.raises(ValueError, match="key dtype.*!= value dtype"):
+        detector.discover(bad, {"kv_layout": "NHD"})


### PR DESCRIPTION
## Summary
Three independent, reviewable commits. Split-KV support is a **generic LMCache representation capability**, not a Metal-specific workaround.

### Commit A — generic split-KV registration + normalization
Support registering a layer's KV cache as a split `(key, value)` tensor pair alongside the existing fused single-tensor form. Any serving engine whose native key and value caches are physically separate (e.g. a host-memory backend exposing zero-copy views of distinct key/value buffers) can register `{layer: (key, value)}`; LMCache normalizes it into its internal per-layer structure with **no fused tensor ever allocated**, reusing the existing `TWO_X_NL_X_NB_BS_NH_HS` split format. Mismatched K/V shape or dtype is a hard `ValueError`. Fused paths unchanged. Backend-neutral: no backend import, no MLX import, no backend-name conditional.

### Commit B — explicit KV-layout resolution for CPU-presented backends
LMCache treats the `"cpu"` torch device as HND by default. Some backends present KV as CPU torch tensors whose physical layout is NHD; LMCache must be configurable to interpret those CPU-presented tensors using the backend-defined NHD layout. Authoritative precedence (canonical key `lmcache.kv_layout`, alias `kv_layout`; then vLLM runtime query; then `LMCACHE_VLLM_KV_LAYOUT`; then device default). Invalid explicit values raise before registration/transfer; layout is never silently guessed from ambiguous dimensions. Resolved layout is **connector-instance state**, never process-global.

> Ownership: LMCache owns connector-specific layout resolution, validation, format interpretation, gather and scatter. It does **not** own the backend's physical cache layout — it is configured to interpret the CPU-presented split tensors using their backend-defined NHD layout.

### Commit C — gate CUDA-only deps off Darwin
`cufile-python` and `nvtx` have no macOS wheels / fail to build on arm64 macOS. Both are imported lazily and degrade gracefully, so gate them behind `platform_system != "Darwin"`. Packaging only; no data-plane behavior change; Linux/CUDA installs unaffected.

## Tests
- `tests/v1/test_split_kv_support.py` (commit A): fused unchanged; split CPU NHD/HND normalize; split gather→scatter bit-exact; K/V never swapped; fused GPU paths unchanged; split shape/dtype mismatch raises.
- `tests/v1/test_metal_engine_driven.py` (commit B): CPU default HND; explicit NHD/HND; precedence (config > runtime > env); invalid raises; two instances don't share state; ambiguous shape no silent guess; CPU NHD gather/scatter bit-exact.
- Existing 118 fused `gpu_connector` tests pass unchanged.

DCO: all three commits signed off.
