### PR TITLE
[Docs][good-first-issue] quickstart.rst: add note directing SGLang users to current MP-mode instructions

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -228,6 +228,12 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
 
    .. tab-item:: SGLang
 
+      .. note::
+         The SGLang integration now defaults to MP (multi-process) mode.
+         Please refer to `examples/sgl_integration/README.md
+         <https://github.com/LMCache/LMCache/blob/dev/examples/sgl_integration/README.md>`_
+         for the current setup instructions.
+
       **Install SGLang**
 
       .. code-block:: bash

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -230,9 +230,9 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
 
       .. note::
          The SGLang integration now defaults to MP (multi-process) mode.
-         Please refer to `examples/sgl_integration/README.md
-         <https://github.com/LMCache/LMCache/blob/dev/examples/sgl_integration/README.md>`_
-         for the current setup instructions.
+         Please refer to `examples/sgl_integration/README.md`_ for the current setup instructions.
+
+      .. _examples/sgl_integration/README.md: https://github.com/LMCache/LMCache/blob/dev/examples/sgl_integration/README.md
 
       **Install SGLang**
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Refs #3372

The LMCache SGLang tab in `docs/source/getting_started/quickstart.rst` currently documents the old in-process mode (env var `LMCACHE_CONFIG_FILE`, `chunk_size`/`local_cpu` config keys), but the current SGLang integration now defaults to MP (multi-process) mode and requires `--lmcache-config-file` as a CLI argument. Following the quickstart as written results in a `ValueError` at startup — see SGLang `python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py:139+`.

This PR adds a `.. note::` at the top of the SGLang tab for quickstart.rst directing readers to `examples/sgl_integration/README.md`, which documents the current MP-mode workflow. The existing content is left in place so maintainers can decide if it is needed to rewrite the tab.

**Special notes for your reviewers**:

- This is my second PR to LMCache — thanks for reviewing.
- The note is minimal. No deletion or rewriting the existing SGLang instructions, since that may be a decision better left to maintainers.
- `examples/sgl_integration/README.md` uses the correct MP-mode config (`mp_host` / `mp_port`) and two-terminal workflow.
- Verified on RTX 4090 with LMCache 0.5.1rc2 + SGLang 0.5.14.
- `codespell` passes on the changed file. Pre-commit `ruff` / `isort` / `clang-format` / `mypy` are not applicable to `.rst` files (the `codespell` hook is relevant for doc changes).
<details>
<summary><b>Test verification (click to expand)</b></summary>

Verified on 2026-07-05 with:
- LMCache: 0.5.1rc2 (dev branch, commit `c9742db4`)
- SGLang: 0.5.14
- GPU: RTX 4090 24GB, NVIDIA driver 570.181 (CUDA 12.8)
- Model: Qwen3-8B

**First request (cold):**
```
Prefill batch, #new-seq: 1, #new-token: 35, #cached-token: 0, ...
```

**Second request (same prefix — cache hit):**
```
Prefill batch, #new-seq: 1, #new-token: 10, #cached-token: 30, ...
```

The `#cached-token` behavior matches the quickstart documentation exactly (35→0, 10→30). The prefill caching works; only the startup instructions are out of date.

LMCache server log confirms registration:
```
LMCache INFO: Engine KV Format: 9 2 x NL x [NB, BS, NH, HS]
LMCache INFO: Registered KV cache for GPU ID XXXXX with 36 layers
LMCache INFO: Initialized cuda stream on device cuda:0
```

codespell docs/source/getting_started/quickstart.rst && echo "codespell: OK"
codespell: OK
</details>

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
