### PR TITLE
docs: daily drift check — multi-process mode (2026-07-05)

### DIFF
--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -3,9 +3,10 @@
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                      lmcache/__init__.py                        │
+│               lmcache/v1/platform/__init__.py                   │
 │                                                                 │
 │  torch_dev, torch_device_type = _detect_device()                │
+│  (re-exported from lmcache/__init__.py as `lmcache.torch_dev`)  │
 │                                                                 │
 │  ┌───────────┐     ┌───────────┐     ┌───────────┐              │
 │  │ torch.cuda│     │ torch.xpu │     │ torch.hpu │  ...         │
@@ -13,11 +14,18 @@
 │        └──────────────────┴──────────────────┘                  │
 │                           │                                     │
 │                     torch_dev (unified entry)                   │
-│                  torch_device_type ("cuda"/"xpu"/"hpu"/"cpu")   │
+│              torch_device_type ("cuda"/"musa"/"xpu"/            │
+│                                 "hpu"/"cpu")                    │
 │                                                                 │
-│  [Monkey Patch Point]                                           │
-│  New hardware can be added by extending _detect_device()        │
-│  and providing a gpu_connector implementation.                  │
+│  [Registry-driven]                                              │
+│  Backends are discovered by scanning `lmcache.v1.platform`      │
+│  for `DeviceInfo` subclasses (see `base_device_info.py`).       │
+│  Adding a new hardware requires:                                │
+│    - a `DeviceInfo` subclass in a `platform/<backend>/`         │
+│      sub-package `__init__.py`,                                 │
+│    - a gpu_connector implementation.                            │
+│  The `DEVICE_TYPE` env var forces the detector to prefer        │
+│  one registered device_type when multiple are available.        │
 └──────────────────────────────┬──────────────────────────────────┘
                                │
               ┌────────────────┼──────────────────┐
@@ -82,7 +90,7 @@
 
 | Layer | Device Reference | Notes |
 |-------|-----------------|-------|
-| **Entry** `__init__.py` | `_detect_device()` -> `torch_dev` | Monkey patch point. Detect once, reuse globally. |
+| **Entry** `lmcache/v1/platform/__init__.py` | `_detect_device()` -> `torch_dev` (re-exported from `lmcache/__init__.py`) | Registry-driven detection over `DeviceInfo` subclasses. Detect once, reuse globally. |
 | **Middle** engine / storage / multiprocess | `from lmcache import torch_dev` | Hardware-agnostic unified code |
 | **Middle** CUDA-only APIs | `hasattr(torch_dev, 'xxx')` guard | Graceful runtime degradation |
 | **Bottom** GPU Connector | Direct `torch.cuda` / `torch.xpu` / `torch.hpu` | Per-hardware impl, no abstraction |
@@ -98,8 +106,9 @@ torch_device_type == "cpu"   -->  (no GPU connector; raises RuntimeError)
 
 ## CPU-Only Stub Fallback
 
-`_detect_device()` also accepts a CPU-only environment where none of the
-supported accelerators (CUDA, XPU, HPU) is available. In that case
+`_detect_device()` (defined in `lmcache/v1/platform/__init__.py`) also
+accepts a CPU-only environment where none of the supported accelerators
+(CUDA, MUSA, XPU, HPU) is available. In that case
 `torch_device_type` is `"cpu"` and `torch_dev` is either:
 
 - `lmcache.v1.platform.cpu.stub_cpu_device.StubCPUDevice` — when `torch`
@@ -129,8 +138,21 @@ which is wrong for that backend's actual KV cache layout.
 
 ## Adding New Hardware
 
-1. Add detection branch in `__init__.py` `_detect_device()`
+1. Create a `lmcache/v1/platform/<backend>/` sub-package and define a
+   concrete `DeviceInfo` subclass in its `__init__.py`. Fill in the
+   abstract properties (`device_type`, `torch_module_name`,
+   `ops_module`) and `is_available()`; optionally override
+   `pin_memory_backend` and `is_handle_transfer_available`. The
+   sub-package is picked up automatically by `discover_subclasses` in
+   `lmcache.v1.platform` -- no manual registration is required. See the
+   existing `platform/cuda/`, `platform/musa/`, `platform/xpu/`,
+   `platform/hpu/` entries for reference. Optionally: users can set
+   `DEVICE_TYPE=<device_type>` at runtime to force selection when
+   multiple registered devices are available.
 2. Create `gpu_connector/xxx_connectors.py`, implement `GPUConnectorInterface`
 3. Add routing branch in `gpu_connector/__init__.py`
-4. Add kernels in `c_ops/` or fallback in `python_ops_fallback.py`
+4. Add kernels in `c_ops/` or fallback in `python_ops_fallback.py`; if
+   the new backend ships its own compiled ops, point the `DeviceInfo`
+   subclass' `ops_module` at the correct fully-qualified module path so
+   `get_backend()` merges it on top of `python_ops_fallback`.
 5. No changes needed in middle layer code


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. One design-doc inconsistency introduced by yesterday's device-detection refactor was found and fixed. No user-facing (`docs/source/`) drift was found today.

**Summary of drift**

`docs/source/` (user-facing):

- No new drift found today. Open drift-check PRs #3996, #3984, #3969, and #3960 already cover the outstanding items in this tree; none of them are re-touched here.

`docs/design/` (design docs):

- **`docs/design/ARCHITECTURE_MULTI_HARDWARE.md`** — after [PR #3924](https://github.com/LMCache/LMCache/pull/3924) (commit [`bf20f51`](https://github.com/LMCache/LMCache/commit/bf20f51c8280ac2787a4cb75a28ee933ec7714cc)), titled *"[platform][refactor] refactor device detection"*, the design doc no longer matches the code. The refactor moved `_detect_device()` out of `lmcache/__init__.py` into `lmcache/v1/platform/__init__.py`, replaced the in-line `if hasattr(torch, "musa")…elif hasattr(torch, "xpu")…` chain with a `DeviceInfo` subclass registry populated via `discover_subclasses`, added a new `DEVICE_TYPE` environment variable that forces the detector to prefer a given registered `device_type` when multiple are available, and promoted the previously-not-registered `hpu` / `xpu` sub-packages to first-class `DeviceInfo` implementations. The design doc still (a) drew `_detect_device()` living in `lmcache/__init__.py`, (b) told contributors to add a new hardware by "extending `_detect_device()`", (c) omitted `musa` from the `torch_device_type` value list, and (d) made no mention of the `DeviceInfo` registry or the `DEVICE_TYPE` override.

**Evidence**

| Drift | Code / repo state (current `dev`, HEAD `bf20f51`) | Stale doc |
| --- | --- | --- |
| `_detect_device()` shown in `lmcache/__init__.py` | Moved to [`lmcache/v1/platform/__init__.py#L65-L118`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/__init__.py#L65-L118). `lmcache/__init__.py` now simply re-exports `torch_dev` / `torch_device_type` — see [`lmcache/__init__.py#L10-L14`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/__init__.py#L10-L14) | [`docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L4-L21`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L4-L21), [`#L85`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L85), [`#L101`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L101) |
| "Add detection branch in `__init__.py` `_detect_device()`" no longer the way to add hardware | Detection is now registry-driven: [`base_device_info.py`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/base_device_info.py) defines `DeviceInfo`; concrete subclasses live in [`platform/cuda/__init__.py`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/cuda/__init__.py), [`platform/musa/__init__.py`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/musa/__init__.py), [`platform/xpu/__init__.py`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/xpu/__init__.py), [`platform/hpu/__init__.py`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/hpu/__init__.py); discovery at [`platform/__init__.py#L50-L63`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/__init__.py#L50-L63) | [`docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L132`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L132) |
| `DEVICE_TYPE` env-var override not documented | New forced-selection knob in [`lmcache/v1/platform/__init__.py#L87-L108`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/__init__.py#L87-L108) | `docs/design/ARCHITECTURE_MULTI_HARDWARE.md` — the env var is absent from the entire file |
| `musa` missing from the `torch_device_type` value list in the diagram | `MusaDeviceInfo` returns `"musa"` at [`platform/musa/__init__.py#L15-L17`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/musa/__init__.py#L15-L17), and MUSA has been a first-class detection branch since well before this refactor | [`docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L16`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/docs/design/ARCHITECTURE_MULTI_HARDWARE.md#L16) |

**Proposed fix**

Already applied in the diff (docs only, no code touched):

1. **ASCII diagram** (top of the file) — the entry-block header now reads `lmcache/v1/platform/__init__.py` with a note that `torch_dev` / `torch_device_type` are re-exported from `lmcache/__init__.py`, the `torch_device_type` value list now includes `"musa"`, the "Monkey Patch Point" callout is replaced with a "Registry-driven" callout that describes how backends are discovered via `DeviceInfo` subclasses, and the new `DEVICE_TYPE` env-var override is called out.
2. **Design Principles table** (Entry row) — updated to point at `lmcache/v1/platform/__init__.py` and to note that detection is registry-driven over `DeviceInfo` subclasses.
3. **CPU-Only Stub Fallback** narrative — the sentence that references `_detect_device()` now names its actual location and adds `MUSA` to the list of accelerators that are attempted before falling through to the stub.
4. **"Adding New Hardware"** step list — step 1 is rewritten to describe defining a `DeviceInfo` subclass in a `platform/<backend>/` sub-package `__init__.py`, listing the abstract properties (`device_type`, `torch_module_name`, `ops_module`, `is_available`) and the two optional hooks (`pin_memory_backend`, `is_handle_transfer_available`), pointing at the existing `cuda` / `musa` / `xpu` / `hpu` entries for reference, and mentioning the `DEVICE_TYPE` override; step 4 picks up a note that new backends can plug their compiled ops into `get_backend()` via the `DeviceInfo.ops_module` property.

**Special notes for your reviewers**:

- Docs-only change. No code modified. Single file touched.
- Deduped against currently-open drift PRs: **#3996** (`_ensure_zmq_scheme` bare-host doc rewrites — 2026-07-03), **#3984** (coordinator `/blend/*` + design-doc rewrites for `mp_coordinator` and `multiprocess/protocols` — 2026-07-02), **#3969** (`DevDaxL1MemoryManager` + deleted `l2_apis.md` refs — 2026-07-01), and **#3960** (`hfbucket` in L2 adapter list + `IsolatedLRU` — 2026-06-30). None of them touch `docs/design/ARCHITECTURE_MULTI_HARDWARE.md`, so there is no overlap.
- Only one upstream commit (`bf20f51`, PR #3924) landed on `dev` since PR #3996 was opened, and it is the sole source of today's drift. No new drift in `docs/source/` today.
- Follow-ups spotted but intentionally not tackled here:
  - The `Connector Routing` block still lists only `cuda`/`xpu`/`hpu` and the `GPU Connector Layer` diagram omits `musa`. Those look like *pre-existing* gaps (they predate PR #3924) rather than drift newly introduced by yesterday's change, so they are left for a separate cleanup to keep this drift PR's scope tight to the refactor's fallout.
  - The `_registry.py` module docstring in [`lmcache/v1/platform/_registry.py`](https://github.com/LMCache/LMCache/blob/bf20f51c8280ac2787a4cb75a28ee933ec7714cc/lmcache/v1/platform/_registry.py) still refers to `platform/xpu` as "future", though `platform/xpu/` now ships. That is a code-file docstring, not a `docs/` file, so it is out of scope for this drift check.
  - The refactor's PR description carried a Chinese-language string in the commit body (`你没事吧？`); that is a commit-message quirk, not a docs issue.
- This PR was **auto-generated** by the daily drift-check routine and **needs human review before merge**. Please do not merge without a maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsnVKuEX66ctGQvv5xhwWg)_