### PR TITLE
docs(quickstart): pin disagg_proxy_server.py link to vLLM v0.20.0 (#3958)

### DIFF
--- a/docs/source/getting_started/quickstart/disaggregated_prefill.rst
+++ b/docs/source/getting_started/quickstart/disaggregated_prefill.rst
@@ -120,7 +120,7 @@ Step-by-Step Setup
 
    c. Launch a proxy server to coordinate between prefiller and decoder:
 
-      The code for the proxy server is available `in vLLM repo <https://github.com/vllm-project/vllm/blob/main/examples/others/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py>`_.
+      The code for the proxy server is available `in vLLM repo <https://github.com/vllm-project/vllm/blob/releases/v0.20.0/examples/others/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py>`_.
 
       .. code-block:: bash
 


### PR DESCRIPTION
### What

The [disaggregated-prefill quickstart](https://docs.lmcache.ai/getting_started/quickstart/disaggregated_prefill.html#step-by-step-setup) links to `disagg_proxy_server.py` at `vllm-project/vllm/blob/main/examples/others/lmcache/disagg_prefill_lmcache_v1/disagg_proxy_server.py`, but that file was **removed from vLLM in v0.21.0**, so the link now 404s.

This pins the reference to the `releases/v0.20.0` tag (where the file still exists), exactly as suggested in the issue.

### Verification

- `…/blob/main/…/disagg_proxy_server.py` → **404**
- `…/blob/releases/v0.20.0/…/disagg_proxy_server.py` → **200**

Fixes #3958

> Note: as maintainers noted in the issue, the `LMCacheConnectorV1` disagg path is being migrated to `LMCacheMPConnector`. This PR is a minimal link fix so the existing page stops 404ing in the meantime; it does not touch the deprecation story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
