### PR TITLE
fix(gpu_connector): accept dim-0-padded KV views at nonzero storage_offset (DeepSeek V4 mixed-compression pools)

### DIFF
--- a/lmcache/v1/gpu_connector/kv_format/contiguity.py
+++ b/lmcache/v1/gpu_connector/kv_format/contiguity.py
@@ -90,7 +90,17 @@ def _validate_dim0_padded_layout(tensor: torch.Tensor) -> int:
     * Every interior dim ``i`` satisfies
       ``stride[i] == prod(shape[i+1:])`` -- only dim-0 may carry
       padding, with ``stride[0] >= prod(shape[1:])``.
-    * ``storage_offset == 0`` -- no slice/narrow base shift.
+    * ``storage_offset`` may be nonzero (slice/narrow base shift). This
+      is safe because every consumer addresses the tensor through
+      ``Tensor.data_ptr()`` -- which already includes the storage
+      offset -- and steps blocks via
+      :class:`PageBufferShapeDesc.block_stride_elems`; the CUDA-IPC
+      path likewise transports ``(shape, stride, storage_offset)``
+      verbatim, and PyTorch validates offset + extent against the
+      storage at view construction. DeepSeek V4 hits this: the engine
+      packs the fp8 KV and the fp4 indexer caches into ONE pool
+      buffer, so a group's KV is a base-shifted slice of that buffer
+      (dim-0-padded AND ``storage_offset != 0``).
 
     Callers must pass the stride-sorted permuted view (not the original
     tensor): for tensors that are both permuted and dim-0-padded, the
@@ -129,8 +139,6 @@ def _validate_dim0_padded_layout(tensor: torch.Tensor) -> int:
         _fail("stride[-1] != 1 (inner dim not contiguous)")
     if stride[-2] != shape[-1]:
         _fail("stride[-2] != shape[-1] (last-two dims not tightly packed)")
-    if storage_offset != 0:
-        _fail("storage_offset != 0 (slice/narrow view, base address shifted)")
     inner_tight = 1
     for i in range(ndim - 1, 0, -1):
         if i < ndim - 1 and stride[i] != inner_tight:
@@ -144,4 +152,10 @@ def _validate_dim0_padded_layout(tensor: torch.Tensor) -> int:
             f"dim-0 stride {stride[0]} < prod(shape[1:])={inner_tight} "
             "(overlapping blocks)"
         )
+    # NOTE: a base-shifted slice (storage_offset != 0) needs no extra
+    # bounds check here -- PyTorch already validates offset + extent
+    # against the storage when the view is CONSTRUCTED (both
+    # ``as_strided`` and ``Tensor.set_`` raise "setStorage: ... out of
+    # bounds" for over-reaching views), so any tensor that reaches this
+    # function is in-bounds by construction.
     return stride[0] - inner_tight

--- a/tests/v1/gpu_connector/test_utils_shape_desc.py
+++ b/tests/v1/gpu_connector/test_utils_shape_desc.py
@@ -236,3 +236,47 @@ def test_get_device_handles_every_kvcaches_shape():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_attempt_permute_accepts_dim0_padded_slice_with_storage_offset():
+    """A dim-0-padded view at a NONZERO storage offset must be accepted.
+
+    This is the DeepSeek V4 mixed-compression layout: the engine packs the
+    fp8 KV cache and the fp4 Lightning-Indexer cache into ONE pool buffer,
+    so a group's KV tensor is a base-shifted slice of that buffer -- dim-0
+    block padding AND storage_offset != 0. Consumers address via
+    Tensor.data_ptr() (offset-inclusive) and step blocks via
+    PageBufferShapeDesc.block_stride_elems, so the offset is transparent.
+    (CPU tensors: the check is pure metadata.)
+    """
+    nb, bs, hs = 7, 4, 6
+    pool_row = 40  # > bs*hs = 24 -> dim-0 padding of 16 elems/block
+    offset = 24  # group's slice starts mid-buffer
+    pool = torch.zeros(offset + nb * pool_row, dtype=torch.uint8)
+    view = pool.as_strided((nb, bs, hs), (pool_row, hs, 1), offset)
+    assert not view.is_contiguous()
+    assert view.storage_offset() == offset
+
+    out = attempt_permute_to_contiguous_view(view)
+    # zero-copy: the (identity-)permuted view aliases the same storage at
+    # the same base address -- never a .contiguous() copy
+    assert isinstance(out, torch.Tensor)
+    assert out.data_ptr() == view.data_ptr()
+    assert out.untyped_storage().data_ptr() == pool.untyped_storage().data_ptr()
+    assert tuple(out.shape) == (nb, bs, hs)
+    assert out.storage_offset() == offset
+
+
+def test_attempt_permute_still_rejects_interior_dim_padding():
+    """Interior-dim padding stays unsupported regardless of the offset
+    relaxation -- only dim-0 may carry padding. 4-D so the padding lands on
+    a TRUE interior dim; on 3-D it would trip the earlier last-two-dims
+    tight-packing check (different message) instead of the interior loop."""
+    nb, g, bs, hs = 5, 3, 4, 6
+    padded_g_row = bs * hs + 8  # interior (dim-1) padding
+    pool = torch.zeros(nb * g * padded_g_row, dtype=torch.uint8)
+    view = pool.as_strided(
+        (nb, g, bs, hs), (g * padded_g_row, padded_g_row, hs, 1), 0
+    )
+    with pytest.raises(ValueError, match="interior-dim padding"):
+        attempt_permute_to_contiguous_view(view)


### PR DESCRIPTION
## Problem

DeepSeek V4 packs the fp8 KV cache and the fp4 Lightning-Indexer cache into **one pool buffer**, so a KV group's tensor is a base-shifted slice of that buffer — dim-0 block padding **and** `storage_offset != 0` (e.g. `shape=(112432, 64, 132), stride=(1039680, 132, 1), storage_offset=8640, dtype=uint8`).

`_validate_dim0_padded_layout` accepts the dim-0 padding (added for exactly this DeepSeek V4 integration) but hard-rejects any nonzero `storage_offset`, so `LMCacheMPConnector` fails at KV registration on both sides:
- engine side: crash at KV-cache init;
- server side: `register_kv_caches` raises the same `ValueError`, and the engine's registration then times out after 300 s ("LMCache server did not respond to register_kv_caches").

This makes the MP connector unusable for DeepSeek V4 class models.

## Why accepting the offset is safe

- Every consumer addresses tensors via `Tensor.data_ptr()`, which **already includes the storage offset** (`get_kernel_ptr` in `csrc/mem_kernels.cu`; every `KVFormatSpec.data_ptrs` implementation).
- Kernels step blocks via `PageBufferShapeDesc.block_stride_elems` — never by recomputing a tight stride from the logical shape.
- The CUDA-IPC path transports `(shape, stride, storage_offset)` verbatim and rebuilds with `Tensor.set_`.
- PyTorch validates offset + extent against the storage **at view construction** (`as_strided` / `set_` raise `setStorage: ... out of bounds`), so any tensor reaching this function is in-bounds by construction — no replacement bounds check is needed.

All other invariants (inner dims tightly packed, only dim-0 padded, no overlapping blocks) are unchanged.

## Validation

Live on 8× B200 serving **deepseek-v4-flash TP4** with `LMCacheMPConnector` → per-box `lmcache server` (S3 L2):
- KV groups with `storage_offset=45360` / `padding_per_block=251728` registered cleanly on engine and server;
- `Stored 512 tokens in 0.033 seconds`;
- repeat prompt: `Prefetch request completed (L1+L2): 2/2 retained keys`.

## Tests

- new: offset-slice acceptance (DeepSeek V4 pool-slice analog, CPU tensors — the check is pure metadata);
- new: 4-D interior-dim padding still rejected (guards the relaxation's scope);
- full `tests/v1/gpu_connector/test_utils_shape_desc.py`: **15/15 pass**.