### PR TITLE
[Bug] fix(cpu): return None instead of busy-looping forever when use_hot=False and staging buffer is full (#2942)

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -785,6 +785,17 @@ class LocalCPUBackend(AllocatorBackendInterface):
 
         assert isinstance(self.memory_allocator, MixedMemoryAllocator)
 
+        if not self.use_hot:
+            # No hot cache means no eviction mechanism is available.
+            # When local_cpu=False, the CPU pool serves only as a staging
+            # buffer for disk I/O — we cannot evict from it.  Returning
+            # None avoids an infinite busy-wait loop (issue #2942).
+            logger.warning(
+                "Local cpu memory is under pressure and use_hot=False. "
+                "No eviction mechanism available — returning None."
+            )
+            return None
+
         evict_keys_count = 0
         num_attempts = 0
         while True:

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -662,6 +662,17 @@ class LocalCPUBackend(AllocatorBackendInterface):
         if memory_obj is not None or not eviction:
             return memory_obj
 
+        if not self.use_hot:
+            # No hot cache means no eviction mechanism is available.
+            # When local_cpu=False, the CPU pool serves only as a staging
+            # buffer for disk I/O — we cannot evict from it.  Returning
+            # None avoids an infinite busy-wait loop (issue #2942).
+            logger.warning(
+                "Local cpu memory is under pressure and use_hot=False. "
+                "No eviction mechanism available — returning None."
+            )
+            return None
+
         evict_keys_count = 0
         num_attempts = 0
         while True:


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #2942

When `local_cpu=False` (`use_hot=False`), the CPU memory pool serves only as a staging buffer for disk I/O. The eviction path is entirely gated by `if self.use_hot:`, so no eviction is ever attempted — the `while True` loop just calls `time.sleep(0.1)` and retries forever, causing the engine to hang.

**Fix**: Return `None` immediately when `use_hot=False` in both `allocate()` and `batched_allocate()`, since no eviction mechanism is available. The caller has an `assert memory_obj is not None` that will produce a clean error instead of an indefinite hang.

**Note**: This PR replaces the original #3804 which was accidentally closed when the head branch was recreated after a rebase.