### PR TITLE
fix(memory): defer host pinning in LazyMemoryAllocator to first allocate

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -5,7 +5,7 @@ Managing objects and memory for L1 cache
 
 # Standard
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 import threading
 
 # First Party
@@ -27,6 +27,10 @@ from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
 from lmcache.v1.mp_observability.otel_init import register_gauge
+
+if TYPE_CHECKING:
+    # Third Party
+    import torch
 
 logger = init_logger(__name__)
 
@@ -238,6 +242,18 @@ class L1Manager:
         """
         with self._lock:
             self._registered_listeners.append(listener)
+
+    def warm_up(self, device: "int | torch.device") -> None:
+        """Begin deferred L1 memory initialization for ``device``.
+
+        Forwards to the memory manager tier; a no-op for tiers without
+        deferred host pinning.
+
+        Args:
+            device: Device whose context the deferred initialization
+                should run under.
+        """
+        self._memory_manager.warm_up(device)
 
     @l1_mgr_synchronized
     def reserve_read(

--- a/lmcache/v1/distributed/memory_manager/gds_l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/gds_l1_memory_manager.py
@@ -2,7 +2,11 @@
 """GDS slab-file L1 memory manager."""
 
 # Standard
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    # Third Party
+    import torch
 
 # First Party
 from lmcache.integration.vllm.utils import get_size_bytes
@@ -134,6 +138,9 @@ class GDSL1MemoryManager:
     def close(self) -> None:
         """No-op: the GDSContext owning the slab is closed at server shutdown."""
         return
+
+    def warm_up(self, device: "int | torch.device") -> None:
+        """No-op: the GDS slab tier has no deferred host pinning."""
 
     def memcheck(self) -> bool:
         """For debug purposes; logs allocator state and checks consistency.

--- a/lmcache/v1/distributed/memory_manager/l1_manager_protocol.py
+++ b/lmcache/v1/distributed/memory_manager/l1_manager_protocol.py
@@ -2,7 +2,11 @@
 """Structural interface shared by the L1 memory manager tiers."""
 
 # Standard
-from typing import Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    # Third Party
+    import torch
 
 # First Party
 from lmcache.v1.distributed.api import L1BackendType, MemoryLayoutDesc
@@ -42,6 +46,13 @@ class L1ManagerProtocol(Protocol):
         """Describe the underlying L1 buffer for L2-adapter registration.
 
         Returns ``None`` for tiers with no registerable L1 buffer (e.g. GDS).
+        """
+        ...
+
+    def warm_up(self, device: "int | torch.device") -> None:
+        """Start deferred initialization (e.g. host pinning) for ``device``.
+
+        No-op for tiers without deferred initialization.
         """
         ...
 

--- a/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
+++ b/lmcache/v1/distributed/memory_manager/l1_memory_manager.py
@@ -3,6 +3,11 @@
 
 # Standard
 from multiprocessing import shared_memory
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Third Party
+    import torch
 
 # First Party
 from lmcache.logging import init_logger
@@ -215,6 +220,18 @@ class L1MemoryManager:
             size=self._size_in_bytes,
             align_bytes=self._align_bytes,
         )
+
+    def warm_up(self, device: "int | torch.device") -> None:
+        """Begin deferred allocator initialization for ``device``.
+
+        Forwards to the allocator; a no-op for allocators without
+        deferred host pinning.
+
+        Args:
+            device: Device whose context the deferred initialization
+                should run under.
+        """
+        self._allocator.warm_up(device)
 
     def close(self) -> None:
         """

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -6,7 +6,7 @@ Distributed multi-tier storage manager for MP mode
 # Standard
 from contextlib import contextmanager
 from dataclasses import replace
-from typing import Iterator, Literal, Optional
+from typing import TYPE_CHECKING, Iterator, Literal, Optional
 import threading
 import time
 
@@ -61,6 +61,10 @@ from lmcache.v1.mp_observability.trace.decorator import (
     publish_call_event,
 )
 from lmcache.v1.platform import HAS_EVENTFD
+
+if TYPE_CHECKING:
+    # Third Party
+    import torch
 
 logger = init_logger(__name__)
 
@@ -166,6 +170,19 @@ class StorageManager:
             ),
             self.get_l2_usages,
         )
+
+    def warm_up(self, device: "int | torch.device") -> None:
+        """Begin deferred L1 memory initialization for ``device``.
+
+        Called at worker registration so host pinning overlaps engine
+        startup instead of the first request; a no-op for tiers without
+        deferred pinning.
+
+        Args:
+            device: Device whose context the deferred initialization
+                should run under.
+        """
+        self._l1_manager.warm_up(device)
 
     # External APIs for serving engine integration code to call
     @enable_tracing()

--- a/lmcache/v1/lazy_memory_allocator.py
+++ b/lmcache/v1/lazy_memory_allocator.py
@@ -271,7 +271,8 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         pinned-pool CUDA context lands on the worker GPU.
         """
         if not self._pinning_started:
-            self.ensure_pinning(torch_dev.current_device())
+            device = torch_dev.current_device() if torch_dev.is_available() else 0
+            self.ensure_pinning(device)
 
     def _pin_memory_chunk(self, offset: int, size: int):
         """

--- a/lmcache/v1/lazy_memory_allocator.py
+++ b/lmcache/v1/lazy_memory_allocator.py
@@ -64,6 +64,13 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
     Background expansion logic:
     - After registering X GB memory, we call sbrk and updates _curr_size
     - Once everything is registered, the background thread stops
+
+    Deferred pinning:
+    - Pinning (``cudaHostRegister``) creates a CUDA context on the current
+      device, so doing it in ``__init__`` would squat a context on ``cuda:0``
+      at server start. Pinning and the expansion thread are instead deferred
+      to :meth:`ensure_pinning`, triggered by the first :meth:`allocate`,
+      which runs inside the worker's device context.
     """
 
     PIN_CHUNK_SIZE = 1 << 26  # 64 MB pin chunk
@@ -82,6 +89,12 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
             init_size (int): Initial size of the memory allocation in bytes.
             final_size (int): Final size of the memory allocation in bytes.
             align_bytes (int, optional): Alignment in for the underlying allocations
+            numa_mapping (NUMAMapping | None, optional): NUMA mapping used to bind
+                the host buffer to a NUMA node. ``None`` disables NUMA binding.
+
+        Raises:
+            RuntimeError: If the active device backend does not support memory
+                pinning.
         """
         # Whether using NUMA allocation
         self._use_numa = numa_mapping is not None
@@ -100,7 +113,7 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         # List of (ptr, size) for pinned memory chunks
         self._pin_record: list[tuple[int, int]] = []
 
-        # Detect numa mapping
+        # Detect numa mapping (host-only allocation; no CUDA context)
         if numa_mapping is not None:
             numa_id = get_numa_id(numa_mapping)
             ptr = lmc_ops.alloc_numa_ptr(self._final_size, numa_id)
@@ -112,10 +125,8 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
                 self._final_size, dtype=torch.uint8, device="cpu", pin_memory=False
             )
 
-        # Pin the first `curr_size` bytes (aligned to the internal chunk size)
-        self._pin_memory_chunk(0, self._curr_size)
-
-        # Create the tensor memory allocator
+        # Create the tensor memory allocator (host-side accounting only;
+        # the backing bytes are pinned later by ensure_pinning)
         self._allocator = TensorMemoryAllocator(
             tensor=self._buffer,
             align_bytes=align_bytes,
@@ -129,14 +140,38 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         # completely determined by the address manager.
         self._address_manager = self._allocator.address_manager
 
-        # Launch the background expansion thread
+        # Deferred-pinning state; see the class docstring
+        self._pin_device: int | torch.device | None = None
+        self._pinning_started = False
+        self._closed = False
+        self._init_lock = threading.Lock()
+
+        # The expansion thread is created here but started by ensure_pinning()
         self._stop_expand = threading.Event()
         self._expand_thread = threading.Thread(
             target=self._expand_worker, daemon=True, name="lazy-mem-expand-thread"
         )
-        self._expand_thread.start()
 
     # Public methods
+    def ensure_pinning(self, device: int | torch.device) -> None:
+        """
+        Pin the initial chunk on ``device`` and start background expansion.
+
+        Idempotent and thread-safe: only the first call pins and binds the
+        device; subsequent calls (and calls after close) are no-ops.
+
+        Args:
+            device (int | torch.device): Device whose CUDA context the pinned
+                host pool is bound to. Typically the worker's current device.
+        """
+        with self._init_lock:
+            if self._pinning_started or self._closed:
+                return
+            self._pin_device = device
+            self._pin_memory_chunk(0, self._curr_size)
+            self._pinning_started = True
+            self._expand_thread.start()
+
     def allocate(
         self,
         shapes: Union[torch.Size, list[torch.Size]],
@@ -144,6 +179,7 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = None,
     ) -> Optional[MemoryObj]:
+        self._ensure_pinned_for_use()
         obj = self._allocator.allocate(shapes, dtypes, fmt, allocator_type)
         # HACK(ApostaC): reset the parent allocator to this lazy allocator
         # There should be a cleaner way to decouple lazy allocator and
@@ -160,6 +196,7 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         fmt: MemoryFormat = MemoryFormat.UNDEFINED,
         allocator_type: Optional[str] = None,
     ) -> Optional[List[MemoryObj]]:
+        self._ensure_pinned_for_use()
         # HACK(ApostaC): reset the parent allocator to this lazy allocator
         # There should be a cleaner way to decouple lazy allocator and
         # tensor memory allocator
@@ -190,18 +227,25 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         self._allocator.batched_free(memory_objs, allocator_type, update_stats)
 
     def close(self):
-        # Stop the background expansion thread
-        self._stop_expand.set()
-        self._expand_thread.join()
+        # Take the init lock so close cannot race a concurrent first
+        # ensure_pinning(); _closed blocks any later pinning attempt.
+        with self._init_lock:
+            self._closed = True
 
-        # Unpin all pinned memory chunks
-        for ptr, size in self._pin_record:
-            torch_dev.ext.unpin_memory(ptr)
-        self._pin_record.clear()
+            # Stop the background expansion thread if it was started
+            if self._pinning_started:
+                self._stop_expand.set()
+                self._expand_thread.join()
 
-        # Free the underlying buffer if using NUMA allocation
-        if self._use_numa:
-            lmc_ops.free_numa_ptr(self._buffer.data_ptr(), self._final_size)
+                # Unpin in the same device context the chunks were pinned in
+                with torch_dev.device(self._pin_device):
+                    for ptr, size in self._pin_record:
+                        torch_dev.ext.unpin_memory(ptr)
+                self._pin_record.clear()
+
+            # Free the underlying buffer if using NUMA allocation
+            if self._use_numa:
+                lmc_ops.free_numa_ptr(self._buffer.data_ptr(), self._final_size)
 
     def memcheck(self) -> bool:
         return self._allocator.memcheck()
@@ -219,9 +263,19 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         return self._address_manager
 
     # Helper functions
+    def _ensure_pinned_for_use(self) -> None:
+        """
+        Pin the pool lazily on the current device before first use.
+
+        The first allocation runs inside the worker's device context, so the
+        pinned-pool CUDA context lands on the worker GPU.
+        """
+        if not self._pinning_started:
+            self.ensure_pinning(torch_dev.current_device())
+
     def _pin_memory_chunk(self, offset: int, size: int):
         """
-        Pin a chunk of memory.
+        Pin a chunk of memory on the bound device.
 
         Args:
             offset (int): Offset in the buffer to pin.
@@ -236,8 +290,11 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         assert offset + size <= self._final_size, "Pinning exceeds buffer size"
 
         ptr = self._buffer.data_ptr() + offset
-        # Use flag: cudaHostRegisterMapped (0x02)
-        if not torch_dev.ext.pin_memory(ptr, size, 2):
+        # Pin in the bound device's context so the CUDA context lands on the
+        # worker GPU. Use flag: cudaHostRegisterMapped (0x02)
+        with torch_dev.device(self._pin_device):
+            pinned = torch_dev.ext.pin_memory(ptr, size, 2)
+        if not pinned:
             logger.warning(
                 "pin_memory failed for chunk at ptr=%#x size=%d; "
                 "DMA performance may be degraded",

--- a/lmcache/v1/lazy_memory_allocator.py
+++ b/lmcache/v1/lazy_memory_allocator.py
@@ -246,6 +246,7 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
             # Free the underlying buffer if using NUMA allocation
             if self._use_numa:
                 lmc_ops.free_numa_ptr(self._buffer.data_ptr(), self._final_size)
+                self._use_numa = False
 
     def memcheck(self) -> bool:
         return self._allocator.memcheck()

--- a/lmcache/v1/memory_allocators/lazy_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/lazy_memory_allocator.py
@@ -64,6 +64,14 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
     Background expansion logic:
     - After registering X GB memory, we call sbrk and updates _curr_size
     - Once everything is registered, the background thread stops
+
+    Deferred pinning:
+    - Pinning (``cudaHostRegister``) creates a CUDA context on the calling
+      thread's current device. ``__init__`` runs before any worker's device
+      is known, so pinning there would bind that context to the default
+      device. Pinning therefore must stay out of ``__init__``: it is bound
+      to a device by :meth:`ensure_pinning`, triggered at the latest by the
+      first :meth:`allocate` / :meth:`batched_allocate`.
     """
 
     PIN_CHUNK_SIZE = 1 << 26  # 64 MB pin chunk
@@ -141,9 +149,6 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
                 f"{base_ptr % align_bytes})."
             )
 
-        # Pin the first `curr_size` bytes (aligned to the internal chunk size)
-        self._pin_memory_chunk(0, self._curr_size)
-
         # Create the tensor memory allocator
         self._allocator = TensorMemoryAllocator(
             tensor=self._buffer,
@@ -158,14 +163,42 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         # completely determined by the address manager.
         self._address_manager = self._allocator.address_manager
 
-        # Launch the background expansion thread
+        # Deferred-pinning state, all guarded by _init_lock:
+        # _pin_device is bound once by the first ensure_pinning() and never
+        # rebound; _pinning_started/_closed order pinning against close().
+        self._pin_device: int | torch.device | None = None
+        self._pinning_started = False
+        self._closed = False
+        self._init_lock = threading.Lock()
+
+        # The expansion thread is created here but started only after the
+        # initial pinning is bound to a device.
         self._stop_expand = threading.Event()
         self._expand_thread = threading.Thread(
             target=self._expand_worker, daemon=True, name="lazy-mem-expand-thread"
         )
-        self._expand_thread.start()
 
     # Public methods
+    def ensure_pinning(self, device: int | torch.device) -> None:
+        """
+        Pin the initial chunk on ``device`` and start background expansion.
+
+        Idempotent and thread-safe: only the first call pins and binds the
+        device; subsequent calls (and calls after :meth:`close`) are no-ops.
+        A call racing the initial pin blocks until it completes.
+
+        Args:
+            device (int | torch.device): Device whose CUDA context the pinned
+                host pool is bound to. Typically the worker's current device.
+        """
+        with self._init_lock:
+            if self._pinning_started or self._closed:
+                return
+            self._pin_device = device
+            self._pin_memory_chunk(0, self._curr_size)
+            self._pinning_started = True
+            self._expand_thread.start()
+
     def allocate(
         self,
         shapes: Union[torch.Size, list[torch.Size]],
@@ -183,7 +216,13 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
 
         Returns:
             A memory object, or ``None`` if the committed address space is full.
+
+        Note:
+            The first allocation (across all threads) pins the initial chunk,
+            which blocks the caller and creates a CUDA context on the calling
+            thread's current device unless :meth:`ensure_pinning` already ran.
         """
+        self._ensure_pinned_for_use()
         obj = self._allocator.allocate(shapes, dtypes, fmt, allocator_type)
         # HACK(ApostaC): reset the parent allocator to this lazy allocator
         # There should be a cleaner way to decouple lazy allocator and
@@ -211,7 +250,13 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
 
         Returns:
             Memory objects for the batch, or ``None`` if allocation fails.
+
+        Note:
+            The first allocation (across all threads) pins the initial chunk,
+            which blocks the caller and creates a CUDA context on the calling
+            thread's current device unless :meth:`ensure_pinning` already ran.
         """
+        self._ensure_pinned_for_use()
         # HACK(ApostaC): reset the parent allocator to this lazy allocator
         # There should be a cleaner way to decouple lazy allocator and
         # tensor memory allocator
@@ -255,19 +300,37 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         self._allocator.batched_free(memory_objs, allocator_type, update_stats)
 
     def close(self) -> None:
-        """Stop background expansion and release pinned or NUMA memory."""
-        # Stop the background expansion thread
-        self._stop_expand.set()
-        self._expand_thread.join()
+        """Stop background expansion and release pinned or NUMA memory.
 
-        # Unpin all pinned memory chunks
-        for ptr, size in self._pin_record:
-            current_device_spec.unpin_memory(ptr)
-        self._pin_record.clear()
+        Thread-safe and idempotent. Holds the init lock so a close racing a
+        concurrent first :meth:`ensure_pinning` is serialized against it, and
+        marks the allocator closed so any later pinning attempt is a no-op.
+        If pinning never happened there is nothing to stop or unpin.
 
-        # Free the underlying buffer if using NUMA allocation
-        if self._use_numa:
-            device_ops.free_numa_ptr(self._buffer.data_ptr(), self._final_size)
+        Note:
+            Allocations issued after close are not blocked; they proceed
+            against the unpinned (and, for NUMA, freed) buffer.
+        """
+        with self._init_lock:
+            self._closed = True
+
+            # Stop the expansion thread and unpin only if pinning started.
+            # The expansion thread never takes _init_lock, so joining it
+            # while holding the lock cannot deadlock.
+            if self._pinning_started:
+                self._stop_expand.set()
+                self._expand_thread.join()
+
+                # Unpin in the same device context the chunks were pinned in
+                with torch_dev.device(self._pin_device):
+                    for ptr, size in self._pin_record:
+                        current_device_spec.unpin_memory(ptr)
+                self._pin_record.clear()
+
+            # Free the underlying buffer if using NUMA allocation
+            if self._use_numa:
+                device_ops.free_numa_ptr(self._buffer.data_ptr(), self._final_size)
+                self._use_numa = False
 
     def memcheck(self) -> bool:
         """Return whether the delegated tensor allocator is consistent."""
@@ -286,9 +349,24 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         return self._address_manager
 
     # Helper functions
+    def _ensure_pinned_for_use(self) -> None:
+        """
+        Pin the pool on the calling thread's current device if not yet pinned.
+
+        Fallback for callers that never invoke :meth:`ensure_pinning`
+        explicitly: the first allocation binds pinning to whatever device is
+        current on the calling thread.
+        """
+        if not self._pinning_started:
+            device = torch_dev.current_device() if torch_dev.is_available() else 0
+            self.ensure_pinning(device)
+
     def _pin_memory_chunk(self, offset: int, size: int) -> None:
         """
-        Pin a chunk of memory.
+        Pin a chunk of memory inside the bound device's context.
+
+        Caller must ensure ``_pin_device`` is already bound (i.e. only call
+        this from ``ensure_pinning`` or the expansion thread it starts).
 
         Args:
             offset (int): Offset in the buffer to pin.
@@ -303,8 +381,12 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
         assert offset + size <= self._final_size, "Pinning exceeds buffer size"
 
         ptr = self._buffer.data_ptr() + offset
+        # Pin inside the bound device's context so the CUDA context the
+        # registration creates lands on that device, not the thread default.
         # Use flag: cudaHostRegisterMapped (0x02)
-        if not current_device_spec.pin_memory(ptr, size, 2):
+        with torch_dev.device(self._pin_device):
+            pinned = current_device_spec.pin_memory(ptr, size, 2)
+        if not pinned:
             logger.warning(
                 "pin_memory failed for chunk at ptr=%#x size=%d; "
                 "DMA performance may be degraded",

--- a/lmcache/v1/memory_allocators/lazy_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/lazy_memory_allocator.py
@@ -199,6 +199,30 @@ class LazyMemoryAllocator(MemoryAllocatorInterface):
             self._pinning_started = True
             self._expand_thread.start()
 
+    def warm_up(self, device: int | torch.device) -> None:
+        """Start pinning on ``device`` in a background thread.
+
+        Non-blocking counterpart of :meth:`ensure_pinning` for callers on
+        latency-sensitive paths (e.g. worker registration): the calling
+        thread returns immediately while the initial chunk is pinned and
+        background expansion starts. Idempotent: once pinning has started
+        (or after :meth:`close`), no thread is spawned and this is a no-op.
+        An allocation racing the background pin blocks until it completes.
+
+        Args:
+            device (int | torch.device): Device whose CUDA context the
+                pinned host pool is bound to.
+        """
+        with self._init_lock:
+            if self._pinning_started or self._closed:
+                return
+        threading.Thread(
+            target=self.ensure_pinning,
+            args=(device,),
+            name="lazy-allocator-warm-up",
+            daemon=True,
+        ).start()
+
     def allocate(
         self,
         shapes: Union[torch.Size, list[torch.Size]],

--- a/lmcache/v1/memory_management.py
+++ b/lmcache/v1/memory_management.py
@@ -1172,6 +1172,17 @@ class GDSMemoryObject(MemoryObj):
 
 
 class MemoryAllocatorInterface(metaclass=abc.ABCMeta):
+    def warm_up(self, device: Union[int, "torch.device"]) -> None:  # noqa: B027
+        """Start any deferred initialization for ``device``.
+
+        Default is a no-op. Allocators with deferred host pinning
+        (e.g. the lazy allocator) override this to begin pinning in the
+        background before the first allocation arrives.
+
+        :param device: Device whose context the deferred initialization
+            should run under.
+        """
+
     @abc.abstractmethod
     def allocate(
         self,

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -967,6 +967,13 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             cache_context.num_layers,
         )
 
+        # Registration is the first moment a worker device is known, well
+        # before the first request: start deferred host pinning now, in the
+        # background, so the pool is warm when traffic arrives. Idempotent
+        # across workers; REGISTER runs on the SYNC lane, so the pin must
+        # not run inline here.
+        self._ctx.storage_manager.warm_up(cache_context.device)
+
     def unregister_kv_cache(self, instance_id: int) -> None:
         """Unregister the KV cache tensors for a given GPU instance ID.
 

--- a/tests/v1/test_lazy_memory_allocator.py
+++ b/tests/v1/test_lazy_memory_allocator.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for LazyMemoryAllocator's deferred ("lazy") pinning contract.
+
+Host pinning (``cudaHostRegister``) creates a CUDA context on the calling
+thread's current device, and ``LazyMemoryAllocator.__init__`` runs before any
+worker's device is known. The allocator therefore must not pin (or touch the
+device at all) during construction; pinning is bound to a device later via
+``ensure_pinning``, triggered at the latest by the first allocation.
+
+These tests verify that contract by observing device side effects (the
+pin/unpin calls and the device context they run in) rather than by inspecting
+private state, so they need no GPU.
+"""
+
+# Standard
+from unittest.mock import call, patch
+import threading
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.memory_allocators.lazy_memory_allocator import LazyMemoryAllocator
+
+PIN_CHUNK = LazyMemoryAllocator.PIN_CHUNK_SIZE
+
+MODULE = "lmcache.v1.memory_allocators.lazy_memory_allocator"
+
+
+@pytest.fixture
+def mock_device_spec():
+    """Patch the pin/unpin backend (``current_device_spec``)."""
+    with patch(f"{MODULE}.current_device_spec") as spec:
+        spec.is_pin_supported = True
+        spec.pin_memory.return_value = True
+        yield spec
+
+
+@pytest.fixture
+def mock_torch_dev():
+    """Patch the torch device module; a MagicMock auto-supports ``with``."""
+    with patch(f"{MODULE}.torch_dev") as td:
+        td.is_available.return_value = True
+        td.current_device.return_value = 0
+        yield td
+
+
+@pytest.fixture
+def mock_tma():
+    """Patch TensorMemoryAllocator to isolate the lazy logic from it."""
+    with patch(f"{MODULE}.TensorMemoryAllocator") as tma:
+        yield tma
+
+
+def _make_allocator(
+    init: int = PIN_CHUNK, final: int = PIN_CHUNK
+) -> LazyMemoryAllocator:
+    """Build an allocator. init == final keeps the expand thread a no-op."""
+    return LazyMemoryAllocator(init, final)
+
+
+def test_construction_does_not_touch_device(mock_device_spec, mock_torch_dev, mock_tma):
+    """The core contract: __init__ neither pins nor queries the device."""
+    _make_allocator()
+
+    mock_device_spec.pin_memory.assert_not_called()
+    mock_torch_dev.current_device.assert_not_called()
+    mock_torch_dev.device.assert_not_called()
+
+
+def test_ensure_pinning_pins_initial_chunk_on_device(
+    mock_device_spec, mock_torch_dev, mock_tma
+):
+    """ensure_pinning(d) pins the initial chunk inside device d's context."""
+    allocator = _make_allocator()
+
+    allocator.ensure_pinning(3)
+
+    mock_device_spec.pin_memory.assert_called_once()
+    mock_torch_dev.device.assert_called_with(3)
+
+    allocator.close()
+
+
+def test_ensure_pinning_is_idempotent(mock_device_spec, mock_torch_dev, mock_tma):
+    """A second ensure_pinning does not re-pin or rebind the device."""
+    allocator = _make_allocator()
+
+    allocator.ensure_pinning(3)
+    pins_after_first = mock_device_spec.pin_memory.call_count
+
+    allocator.ensure_pinning(5)
+
+    assert mock_device_spec.pin_memory.call_count == pins_after_first
+    assert call(5) not in mock_torch_dev.device.call_args_list
+
+    allocator.close()
+
+
+def test_concurrent_ensure_pinning_pins_once(
+    mock_device_spec, mock_torch_dev, mock_tma
+):
+    """Under concurrent ensure_pinning calls, exactly one thread pins."""
+    allocator = _make_allocator()
+    start = threading.Barrier(8)
+
+    def worker(device: int) -> None:
+        start.wait()  # maximize contention on the init lock
+        allocator.ensure_pinning(device)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    mock_device_spec.pin_memory.assert_called_once()
+
+    allocator.close()
+
+
+def test_allocate_triggers_pinning_on_current_device(
+    mock_device_spec, mock_torch_dev, mock_tma
+):
+    """The first allocate lazily pins on the current (worker) device."""
+    mock_torch_dev.current_device.return_value = 2
+    allocator = _make_allocator()
+
+    mock_device_spec.pin_memory.assert_not_called()
+
+    allocator.allocate(torch.Size([16]), torch.uint8)
+
+    mock_device_spec.pin_memory.assert_called_once()
+    mock_torch_dev.device.assert_called_with(2)
+    mock_tma.return_value.allocate.assert_called_once()
+
+    allocator.close()
+
+
+def test_batched_allocate_triggers_pinning(mock_device_spec, mock_torch_dev, mock_tma):
+    """The first batched_allocate also triggers the lazy pinning."""
+    allocator = _make_allocator()
+
+    allocator.batched_allocate(torch.Size([16]), torch.uint8, batch_size=2)
+
+    mock_device_spec.pin_memory.assert_called_once()
+    mock_tma.return_value.batched_allocate.assert_called_once()
+
+    allocator.close()
+
+
+def test_second_allocate_does_not_repin(mock_device_spec, mock_torch_dev, mock_tma):
+    """Once pinned, later allocations do not pin again."""
+    allocator = _make_allocator()
+
+    allocator.allocate(torch.Size([16]), torch.uint8)
+    pins_after_first = mock_device_spec.pin_memory.call_count
+
+    allocator.allocate(torch.Size([16]), torch.uint8)
+
+    assert mock_device_spec.pin_memory.call_count == pins_after_first
+
+    allocator.close()
+
+
+def test_close_before_pinning_is_safe(mock_device_spec, mock_torch_dev, mock_tma):
+    """close() before any pinning neither raises nor unpins."""
+    allocator = _make_allocator()
+
+    allocator.close()
+
+    mock_device_spec.unpin_memory.assert_not_called()
+
+
+def test_ensure_pinning_after_close_is_noop(mock_device_spec, mock_torch_dev, mock_tma):
+    """ensure_pinning after close() must not pin (close/first-use race guard)."""
+    allocator = _make_allocator()
+    allocator.close()
+
+    allocator.ensure_pinning(3)
+
+    mock_device_spec.pin_memory.assert_not_called()
+
+
+def test_close_after_pinning_unpins(mock_device_spec, mock_torch_dev, mock_tma):
+    """close() after pinning unpins the chunk it recorded."""
+    allocator = _make_allocator()
+    allocator.ensure_pinning(3)
+
+    allocator.close()
+
+    mock_device_spec.unpin_memory.assert_called_once()

--- a/tests/v1/test_lazy_memory_allocator.py
+++ b/tests/v1/test_lazy_memory_allocator.py
@@ -191,3 +191,77 @@ def test_close_after_pinning_unpins(mock_device_spec, mock_torch_dev, mock_tma):
     allocator.close()
 
     mock_device_spec.unpin_memory.assert_called_once()
+
+
+def test_warm_up_pins_in_background_before_first_allocate(
+    mock_device_spec, mock_torch_dev, mock_tma
+):
+    """warm_up(d) pins on d without blocking the caller; the first
+    allocate then finds the pool already pinned and does not repin."""
+    allocator = _make_allocator()
+    pinned = threading.Event()
+    mock_device_spec.pin_memory.side_effect = lambda *a, **k: pinned.set() or True
+
+    allocator.warm_up(5)
+
+    assert pinned.wait(timeout=5.0), "background warm-up never pinned"
+    # Serialize with the background thread before asserting call counts.
+    allocator.ensure_pinning(5)
+    mock_device_spec.pin_memory.assert_called_once()
+    mock_torch_dev.device.assert_any_call(5)
+
+    allocator.allocate(torch.Size([1]), torch.uint8)
+    mock_device_spec.pin_memory.assert_called_once()
+
+
+def test_allocate_during_in_flight_warm_up_blocks_then_succeeds(
+    mock_device_spec, mock_torch_dev, mock_tma
+):
+    """An allocation racing the background pin blocks on the init lock and
+    proceeds once pinning completes, without pinning a second time."""
+    allocator = _make_allocator()
+    release = threading.Event()
+    entered = threading.Event()
+
+    def slow_pin(*args, **kwargs):
+        entered.set()
+        assert release.wait(timeout=5.0)
+        return True
+
+    mock_device_spec.pin_memory.side_effect = slow_pin
+
+    allocator.warm_up(2)
+    assert entered.wait(timeout=5.0), "background warm-up never started"
+
+    results: list = []
+    t = threading.Thread(
+        target=lambda: results.append(allocator.allocate(torch.Size([1]), torch.uint8))
+    )
+    t.start()
+    t.join(timeout=0.2)
+    assert t.is_alive(), "allocate should block behind the in-flight pin"
+
+    release.set()
+    t.join(timeout=5.0)
+    assert not t.is_alive(), "allocate never completed after pinning finished"
+    assert len(results) == 1
+    mock_device_spec.pin_memory.assert_called_once()
+
+
+def test_repeated_warm_up_pins_once(mock_device_spec, mock_torch_dev, mock_tma):
+    """warm_up is idempotent: repeated calls, even with a different device,
+    never pin a second time or rebind the device."""
+    allocator = _make_allocator()
+    pinned = threading.Event()
+    mock_device_spec.pin_memory.side_effect = lambda *a, **k: pinned.set() or True
+
+    allocator.warm_up(1)
+    assert pinned.wait(timeout=5.0)
+    allocator.warm_up(1)
+    allocator.warm_up(7)
+
+    # Serialize with any (incorrectly) spawned background pin before asserting.
+    allocator.ensure_pinning(1)
+    mock_device_spec.pin_memory.assert_called_once()
+    for c in mock_torch_dev.device.call_args_list:
+        assert c != call(7), "warm_up must not rebind the pin device"

--- a/tests/v1/test_lazy_memory_allocator.py
+++ b/tests/v1/test_lazy_memory_allocator.py
@@ -42,7 +42,7 @@ def mock_tma():
         yield tma
 
 
-def _make_allocator(init=PIN_CHUNK, final=PIN_CHUNK):
+def _make_allocator(init: int = PIN_CHUNK, final: int = PIN_CHUNK) -> LazyMemoryAllocator:
     """Build an allocator. init == final keeps the expand thread a no-op."""
     return LazyMemoryAllocator(init, final)
 

--- a/tests/v1/test_lazy_memory_allocator.py
+++ b/tests/v1/test_lazy_memory_allocator.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for LazyMemoryAllocator's deferred ("lazy") pinning contract.
+
+LazyMemoryAllocator must not create a CUDA context when it is constructed: host
+pinning (``cudaHostRegister``) creates a primary context on the current device,
+so pinning in ``__init__`` would squat a context on the default device
+(``cuda:0``) at multiprocess-server start, before any worker connects. These
+tests verify the documented contract by observing CUDA side effects (the
+pin/unpin calls and the device context they run in) rather than by inspecting
+private state, so they need no GPU.
+"""
+
+# Standard
+from unittest.mock import call, patch
+import threading
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.lazy_memory_allocator import LazyMemoryAllocator
+
+PIN_CHUNK = LazyMemoryAllocator.PIN_CHUNK_SIZE
+
+
+@pytest.fixture
+def mock_torch_dev():
+    """Patch the CUDA device layer; a MagicMock auto-supports ``with dev``."""
+    with patch("lmcache.v1.lazy_memory_allocator.torch_dev") as td:
+        td.ext.is_pin_supported = True
+        td.ext.pin_memory.return_value = True
+        td.is_available.return_value = True
+        td.current_device.return_value = 0
+        yield td
+
+
+@pytest.fixture
+def mock_tma():
+    """Patch TensorMemoryAllocator to isolate the lazy logic from it."""
+    with patch("lmcache.v1.lazy_memory_allocator.TensorMemoryAllocator") as tma:
+        yield tma
+
+
+def _make_allocator(init=PIN_CHUNK, final=PIN_CHUNK):
+    """Build an allocator. init == final keeps the expand thread a no-op."""
+    return LazyMemoryAllocator(init, final)
+
+
+def test_construction_does_not_touch_cuda(mock_torch_dev, mock_tma):
+    """The core contract: __init__ neither pins nor queries the device."""
+    _make_allocator()
+
+    mock_torch_dev.ext.pin_memory.assert_not_called()
+    mock_torch_dev.current_device.assert_not_called()
+
+
+def test_ensure_pinning_pins_initial_chunk_on_device(mock_torch_dev, mock_tma):
+    """ensure_pinning(d) pins the initial chunk inside device d's context."""
+    allocator = _make_allocator()
+
+    allocator.ensure_pinning(3)
+
+    mock_torch_dev.ext.pin_memory.assert_called_once()
+    mock_torch_dev.device.assert_called_with(3)
+
+    allocator.close()
+
+
+def test_ensure_pinning_is_idempotent(mock_torch_dev, mock_tma):
+    """A second ensure_pinning does not re-pin or rebind the device."""
+    allocator = _make_allocator()
+
+    allocator.ensure_pinning(3)
+    pins_after_first = mock_torch_dev.ext.pin_memory.call_count
+
+    allocator.ensure_pinning(5)
+
+    assert mock_torch_dev.ext.pin_memory.call_count == pins_after_first
+    assert call(5) not in mock_torch_dev.device.call_args_list
+
+    allocator.close()
+
+
+def test_allocate_triggers_pinning_on_current_device(mock_torch_dev, mock_tma):
+    """The first allocate lazily pins on the current (worker) device."""
+    mock_torch_dev.current_device.return_value = 2
+    allocator = _make_allocator()
+
+    mock_torch_dev.ext.pin_memory.assert_not_called()
+
+    allocator.allocate(torch.Size([16]), torch.uint8)
+
+    mock_torch_dev.ext.pin_memory.assert_called_once()
+    mock_torch_dev.current_device.assert_called()
+    mock_torch_dev.device.assert_called_with(2)
+    mock_tma.return_value.allocate.assert_called_once()
+
+    allocator.close()
+
+
+def test_second_allocate_does_not_repin(mock_torch_dev, mock_tma):
+    """Once pinned, later allocations do not pin again."""
+    allocator = _make_allocator()
+
+    allocator.allocate(torch.Size([16]), torch.uint8)
+    pins_after_first = mock_torch_dev.ext.pin_memory.call_count
+
+    allocator.allocate(torch.Size([16]), torch.uint8)
+
+    assert mock_torch_dev.ext.pin_memory.call_count == pins_after_first
+
+    allocator.close()
+
+
+def test_close_before_pinning_is_safe(mock_torch_dev, mock_tma):
+    """close() before any pinning neither raises nor unpins."""
+    allocator = _make_allocator()
+
+    allocator.close()
+
+    mock_torch_dev.ext.unpin_memory.assert_not_called()
+
+
+def test_ensure_pinning_after_close_is_noop(mock_torch_dev, mock_tma):
+    """ensure_pinning after close() must not pin (close/first-use race guard)."""
+    allocator = _make_allocator()
+    allocator.close()
+
+    allocator.ensure_pinning(3)
+
+    mock_torch_dev.ext.pin_memory.assert_not_called()
+
+
+def test_close_after_pinning_unpins(mock_torch_dev, mock_tma):
+    """close() after pinning unpins the chunk it recorded."""
+    allocator = _make_allocator()
+    allocator.ensure_pinning(3)
+
+    allocator.close()
+
+    mock_torch_dev.ext.unpin_memory.assert_called_once()
+
+
+def test_concurrent_ensure_pinning_pins_once(mock_torch_dev, mock_tma):
+    """Under concurrent ensure_pinning calls, exactly one thread pins."""
+    allocator = _make_allocator()
+    start = threading.Barrier(8)
+
+    def worker(device):
+        start.wait()  # maximize contention on the init lock
+        allocator.ensure_pinning(device)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    mock_torch_dev.ext.pin_memory.assert_called_once()
+
+    allocator.close()


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Fixes #4019 

### What this PR does / why we need it :
#### Problem
 
`LazyMemoryAllocator.__init__` pins the CPU KV pool with `cudaHostRegister` (`torch_dev.ext.pin_memory(..., cudaHostRegisterMapped)`). Host pinning creates a CUDA primary context on the current device. Since `__init__` runs at MP-server start, before any worker connects, the context lands on the default device `cuda:0`.
 
```python
def __init__(self, ...):
    self._pin_memory_chunk(0, self._curr_size)   # cudaHostRegister -> CUDA context on cuda:0
    ...
    self._expand_thread.start()                  # background thread pins more, also on cuda:0
```
 
As a result, the server holds a ~616 MiB context on `cuda:0` even when idle with zero workers. The MP server is a host-memory cache and does not need a GPU of its own. On a shared node this becomes an unexpected co-tenant on `cuda:0` and can contribute to OOM. Reproducible with the `LMCacheEngine` CR alone (no workers), and independent of transfer mode, so it is the boot-time pin, not IPC/worker activity.
 
 #### Solution

Defer pinning (and the background expansion thread) out of `__init__` to a new idempotent `ensure_pinning(device)`, triggered lazily by the first `allocate()` /`batched_allocate()`. The first allocation runs inside the worker's device
context, so the pinned-pool CUDA context lands on a real worker GPU instead of`cuda:0`.
- `__init__` now only does host-side work (buffer alloc, address bookkeeping) : no CUDA calls, no context.
- The chosen device is remembered (`_pin_device`) and the background expansion thread pins subsequent chunks inside the same device context.
- `close()` takes the init lock and sets a `_closed` flag, so a shutdown racing the first allocate can neither leak the expansion thread nor let pinning start after the buffer is freed. Unpinning runs in the same device context as pinning.

#### Verification

- Unit tests (`tests/v1/test_lazy_memory_allocator.py`, 9 cases, no GPU required — the device layer is mocked and the tests observe pin/unpin calls and the device context they run in):
  - construction performs no CUDA calls (core contract)
  - first allocate pins exactly once, on the current device
  - `ensure_pinning` is idempotent and pins once under 8-thread contention
  - `close()` is safe before pinning, unpins after pinning, and blocks late pinning

- End-to-end on a multi-GPU node (patched nvidia dynamo image overlaid on `lmcache/vllm-openai:latest-nightly`):
  - booting the MP engine pod alone: no CUDA context on any GPU (previously ~616 MiB squatted on `cuda:0` at. idle)
  - after launching the nvidia dynamo DGD, each worker's pinned-pool process appears on the GPU that worker actually runs on

### Special notes for your reviewers :
- The fix relies on the first `allocate()` running inside the worker's device context. This holds for the MP-server path (allocation happens during the worker's transfer, under `with torch_dev.device(...)`) and was verified end-to-end with a dynamo DGD deployment. If a new caller ever allocates outside a device context, pinning would bind to that thread's current device; `ensure_pinning(device)` is public so such a caller can bind explicitly.
- Deferring the thread start makes `close()` racy against a concurrent first allocate, so `close()` now takes the init lock and sets `_closed`. Worth a close look at the lock protocol (`ensure_pinning` / `close`); the expansion thread never takes the lock, so joining under it cannot deadlock.
- Intentionally unchanged to keep the PR scoped: the warning-only behavior on `pin_memory` failure and the alignment asserts in `_pin_memory_chunk` are pre-existing.

### If applicable:
- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
