### PR TITLE
fix(integration/vllm): guard state transition for non-chosen connector

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -1068,7 +1068,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             tracker.append_block_ids(tuple(new_block_ids))
 
         # Update the state of the tracker
-        condition = tracker.needs_retrieve()
+        # Skip retrieve when this connector is not the chosen one in a
+        # MultiConnector (num_external_tokens == 0). Otherwise the state
+        # would erroneously enter WAITING_FOR_LOAD and leak lookup locks.
+        condition = tracker.needs_retrieve() and num_external_tokens > 0
         if tracker.state == LMCacheMPRequestState.PREFETCHING:
             # If need to retrieve, change to WAITING_FOR_LOAD
             # Otherwise, change to READY

--- a/lmcache/integration/vllm/lmcache_mp_connector_0180.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0180.py
@@ -805,7 +805,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             tracker.append_block_ids(new_block_ids)
 
         # Update the state of the tracker
-        condition = tracker.needs_retrieve()
+        # Skip retrieve when this connector is not the chosen one in a
+        # MultiConnector (num_external_tokens == 0). Otherwise the state
+        # would erroneously enter WAITING_FOR_LOAD and leak lookup locks.
+        condition = tracker.needs_retrieve() and num_external_tokens > 0
         if tracker.state == LMCacheMPRequestState.PREFETCHING:
             # If need to retrieve, change to WAITING_FOR_LOAD
             # Otherwise, change to READY

--- a/lmcache/integration/vllm/lmcache_mp_connector_0180.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0180.py
@@ -852,7 +852,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             tracker.append_block_ids(new_block_ids)
 
         # Update the state of the tracker
-        condition = tracker.needs_retrieve()
+        # Skip retrieve when this connector is not the chosen one in a
+        # MultiConnector (num_external_tokens == 0). Otherwise the state
+        # would erroneously enter WAITING_FOR_LOAD and leak lookup locks.
+        condition = tracker.needs_retrieve() and num_external_tokens > 0
         if tracker.state == LMCacheMPRequestState.PREFETCHING:
             # If need to retrieve, change to WAITING_FOR_LOAD
             # Otherwise, change to READY

--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -846,7 +846,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             tracker.append_block_ids(new_block_ids)
 
         # Update the state of the tracker
-        condition = tracker.needs_retrieve()
+        # Skip retrieve when this connector is not the chosen one in a
+        # MultiConnector (num_external_tokens == 0). Otherwise the state
+        # would erroneously enter WAITING_FOR_LOAD and leak lookup locks.
+        condition = tracker.needs_retrieve() and num_external_tokens > 0
         if tracker.state == LMCacheMPRequestState.PREFETCHING:
             # If need to retrieve, change to WAITING_FOR_LOAD
             # Otherwise, change to READY

--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -865,7 +865,10 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             tracker.append_block_ids(new_block_ids)
 
         # Update the state of the tracker
-        condition = tracker.needs_retrieve()
+        # Skip retrieve when this connector is not the chosen one in a
+        # MultiConnector (num_external_tokens == 0). Otherwise the state
+        # would erroneously enter WAITING_FOR_LOAD and leak lookup locks.
+        condition = tracker.needs_retrieve() and num_external_tokens > 0
         if tracker.state == LMCacheMPRequestState.PREFETCHING:
             # If need to retrieve, change to WAITING_FOR_LOAD
             # Otherwise, change to READY


### PR DESCRIPTION
**What this PR does / why we need it**:

Syncs the state transition fix from [vLLM PR #47505](https://github.com/vllm-project/vllm/pull/47505) to LMCache's three `lmcache_mp_connector` variants.

**Bug**: In `update_state_after_alloc`, the condition `tracker.needs_retrieve()` only checks `num_lmcache_hit > num_vllm_hit` — it does not check whether this connector was the chosen one in a MultiConnector. When a non-chosen connector receives `num_external_tokens=0`:

| Consequence | Impact |
|---|---|
| State enters `WAITING_FOR_LOAD` instead of `READY` | State machine corruption |
| `free_lookup_locks` not called → read locks held until TTL (10 min) | Lock leak |
| `allocated_block_ids` populated → retrieve task created (after vLLM #46865) | Unwanted KV transfer |

**Fix** (one line per file):
```python
# Before
condition = tracker.needs_retrieve()
# After
condition = tracker.needs_retrieve() and num_external_tokens > 0
```

When `condition=False`, the existing `else` branch correctly sets state → `READY`, frees all locks, and calls `cleanup_lookup_result`.

**Files changed** (3 variants for different vLLM versions):
- `lmcache/integration/vllm/lmcache_mp_connector.py` (latest)
- `lmcache/integration/vllm/lmcache_mp_connector_0201.py` (vLLM 0.20.1)
- `lmcache/integration/vllm/lmcache_mp_connector_0180.py` (vLLM 0.18.0)

**Version compatibility verification**:

MultiConnector was introduced in vLLM PR #17564 (2025-05-14), before all three targeted versions. Verified that all three vLLM versions have identical `MultiConnector.update_state_after_alloc` behavior — non-chosen connectors receive `(empty_blocks, 0)`:

| vLLM version | Release date | MultiConnector present | Non-chosen receives `num_external_tokens=0` | `needs_retrieve()` logic |
|---|---|---|---|---|
| v0.18.0 | 2026-03-20 | ✅ | ✅ `c.update_state_after_alloc(request, empty_blocks, 0)` | `num_lmcache_hit_blocks > num_vllm_hit_blocks` |
| v0.20.1 | 2026-05-04 | ✅ | ✅ `c.update_state_after_alloc(request, empty_blocks, 0)` | `num_lmcache_hit_blocks > num_vllm_hit_blocks` |
| main | — | ✅ | ✅ `c.update_state_after_alloc(request, empty_blocks, 0)` | `num_lmcache_hit_tokens > num_vllm_hit_tokens` |

The bug exists in all three versions, and the fix applies identically to each.

**Special notes for your reviewers**:

- This is the LMCache-side sync of vLLM PR #47505 (already submitted, reviews the identical logic)
- LMCache maintains three connector copies for different vLLM API versions; all three have the same bug
- This fix is a prerequisite for safely merging vLLM PR #46865 (MultiConnector passes real blocks to non-chosen connectors)
- Refs vllm-project/vllm#47505, vllm-project/vllm#46865

**If applicable**:
- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
