### PR TITLE
feat(MP): add securityContext to crd(lmcache.lmcache.ai_lmcacheengines.yaml) and modify controller

### DIFF
--- a/docs/source/locale/zh_CN/LC_MESSAGES/mp/operator.po
+++ b/docs/source/locale/zh_CN/LC_MESSAGES/mp/operator.po
@@ -1115,9 +1115,9 @@ msgid ""
 "blend``), deployed as a DaemonSet with the **same GPU model as** "
 "``LMCacheEngine`` (``runtimeClassName: nvidia`` + "
 "``NVIDIA_VISIBLE_DEVICES=all`` + ``hostIPC``, plus ``privileged`` when "
-"``spec.privileged`` is set, and **no** ``nvidia.com/gpu`` claim) so it "
+"``spec.securityContext.privileged`` is set, and **no** ``nvidia.com/gpu`` claim) so it "
 "shares the vLLM GPU for same-device CUDA IPC; and"
-msgstr "一个驻留在 GPU 上的 CacheBlend V3 引擎 (``lmcache server --engine-type blend``)，作为 DaemonSet 部署，**与** ``LMCacheEngine`` **相同的 GPU 型号** (``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all`` + ``hostIPC``，当设置了 ``spec.privileged`` 时加上 ``privileged``，并且**没有** ``nvidia.com/gpu`` 声明)，以便共享同设备的 CUDA IPC 的 vLLM GPU；并且"
+msgstr "一个驻留在 GPU 上的 CacheBlend V3 引擎 (``lmcache server --engine-type blend``)，作为 DaemonSet 部署，**与** ``LMCacheEngine`` **相同的 GPU 型号** (``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all`` + ``hostIPC``，当设置了 ``spec.securityContext.privileged`` 时加上 ``privileged``，并且**没有** ``nvidia.com/gpu`` 声明)，以便共享同设备的 CUDA IPC 的 vLLM GPU；并且"
 
 #: ../../source/mp/operator.rst:771
 msgid "the vLLM-side plugin, injected into opted-in pods by the webhook."
@@ -1794,11 +1794,11 @@ msgstr ""
 
 #: ../../source/mp/operator.rst:1224
 msgid ""
-"``spec.privileged`` defaults to ``false``. When enabled (required for "
+"``spec.securityContext.privileged`` defaults to ``false``. When enabled (required for "
 "``gpuVendor: amd``), the engine container additionally runs privileged, "
 "granting it full device access -- enable it only where GPU visibility "
 "requires it."
-msgstr "``spec.privileged`` 默认为 ``false``。启用后（对于 ``gpuVendor: amd`` 是必需的），引擎容器将以特权模式运行，授予其完全的设备访问权限——仅在 GPU 可见性需要时启用。"
+msgstr "``spec.securityContext.privileged`` 默认为 ``false``。启用后（对于 ``gpuVendor: amd`` 是必需的），引擎容器将以特权模式运行，授予其完全的设备访问权限——仅在 GPU 可见性需要时启用。"
 
 #: ../../source/mp/operator.rst:1230
 msgid "Development"

--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -459,6 +459,12 @@ GPU & Security
      - ``nvidia``
      - GPU vendor: ``nvidia`` (uses the ``nvidia`` RuntimeClass) or ``amd``
        (runs on the default runtime).
+   * - ``securityContext``
+     - --
+     - Container-level Kubernetes ``SecurityContext`` for the LMCache
+       container. When unset, the operator runs with
+       ``securityContext.privileged: false``. When set, the value is used
+       as-is.
    * - ``securityContext.privileged``
      - ``false`` (if unset)
      - Run the engine container in privileged mode. On most clusters
@@ -468,6 +474,35 @@ GPU & Security
        RuntimeClass device injection, so privileged is the only path to
        ``/dev/kfd``/``/dev/dri``). Enabling it requires the namespace to allow
        the ``privileged`` Pod Security Standard.
+   * - ``securityContext.allowPrivilegeEscalation``
+     - --
+     - Controls whether a process can gain more privileges than its parent
+       process (``no_new_privs`` behavior).
+   * - ``securityContext.capabilities``
+     - --
+     - Linux capabilities to add/drop for the LMCache container.
+   * - ``securityContext.readOnlyRootFilesystem``
+     - ``false``
+     - Make the container root filesystem read-only.
+   * - ``securityContext.runAsUser`` / ``securityContext.runAsGroup`` /
+       ``securityContext.runAsNonRoot``
+     - --
+     - Run the LMCache process with explicit UID/GID or enforce non-root
+       execution.
+   * - ``securityContext.seccompProfile`` / ``securityContext.appArmorProfile``
+     - --
+     - Container-level seccomp/AppArmor profiles. Container-level settings
+       override pod-level defaults when both are provided.
+   * - ``securityContext.seLinuxOptions``
+     - --
+     - SELinux labels applied to the container process.
+   * - ``securityContext.procMount``
+     - ``Default``
+     - Proc mount mode (requires the Kubernetes ``ProcMountType`` feature).
+   * - ``securityContext.windowsOptions``
+     - --
+     - Windows-specific container security options (Linux-only fields above do
+       not apply on Windows).
 
 Scheduling
 ~~~~~~~~~~

--- a/docs/source/mp/operator.rst
+++ b/docs/source/mp/operator.rst
@@ -459,8 +459,8 @@ GPU & Security
      - ``nvidia``
      - GPU vendor: ``nvidia`` (uses the ``nvidia`` RuntimeClass) or ``amd``
        (runs on the default runtime).
-   * - ``privileged``
-     - ``false``
+   * - ``securityContext.privileged``
+     - ``false`` (if unset)
      - Run the engine container in privileged mode. On most clusters
        ``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all`` already
        grant GPU visibility without it; set ``true`` only where the engine
@@ -765,7 +765,7 @@ It has two halves the operator runs together:
 - a GPU-resident CacheBlend V3 engine (``lmcache server --engine-type blend``),
   deployed as a DaemonSet with the **same GPU model as** ``LMCacheEngine``
   (``runtimeClassName: nvidia`` + ``NVIDIA_VISIBLE_DEVICES=all`` + ``hostIPC``,
-  plus ``privileged`` when ``spec.privileged`` is set, and **no**
+  plus ``privileged`` when ``spec.securityContext.privileged`` is set, and **no**
   ``nvidia.com/gpu`` claim) so it shares the vLLM GPU for same-device CUDA IPC;
   and
 - the vLLM-side plugin, injected into opted-in pods by the webhook.
@@ -1221,7 +1221,7 @@ resources from other processes on the same host.
 - Clusters using Pod Security Standards must allow the ``privileged`` profile
   for the LMCache namespace -- the ``baseline`` and ``restricted`` profiles
   reject ``hostIPC``.
-- ``spec.privileged`` defaults to ``false``. When enabled (required for
+- ``spec.securityContext.privileged`` defaults to ``false``. When enabled (required for
   ``gpuVendor: amd``), the engine container additionally runs privileged,
   granting it full device access -- enable it only where GPU visibility
   requires it.

--- a/operator/AGENTS.md
+++ b/operator/AGENTS.md
@@ -102,7 +102,7 @@ Both names point at the same image; only the hostnames differ.
 - **PodSecurity admission**: test namespaces are pre-labeled
   `pod-security.kubernetes.io/enforce=privileged` so the operator's
   DaemonSet (which always sets `hostIPC=true`, and `privileged=true` only
-  when `spec.privileged` is enabled) is accepted at admission time.
+  when `spec.securityContext.privileged` is enabled) is accepted at admission time.
   `hostIPC=true` alone is rejected by the `baseline`/`restricted` profiles,
   so the label is required regardless of `privileged`. Harmless on clusters
   that don't enforce PodSecurity.

--- a/operator/DESIGN.md
+++ b/operator/DESIGN.md
@@ -161,13 +161,13 @@ The operator always injects these into the pod spec:
 
 - **`hostIPC: true`** — **required for CUDA IPC between LMCache and vLLM.** LMCache uses `CudaIPCWrapper` which calls PyTorch's `_share_cuda_()` to get a GPU driver-level IPC handle. The handle is serialized and sent over ZMQ TCP. The receiving process reconstructs the tensor via `cudaIpcOpenMemHandle` at the driver level. This call requires both processes to share the same IPC namespace — without `hostIPC: true`, `cudaIpcOpenMemHandle` fails with `cudaErrorMapBufferObjectFailed`. **Both the LMCache pods and vLLM pods must have `hostIPC: true`.**
 - **`runtimeClassName: nvidia`** — uses the NVIDIA container runtime, which injects the host's NVIDIA driver libraries and device files into the container. This is required for CUDA to function inside the pod.
-- **`NVIDIA_VISIBLE_DEVICES=all`** — gives the engine access to all GPUs on the node for CUDA IPC and custom data transfer kernels without claiming any via `nvidia.com/gpu` resource requests (which would make those GPUs unavailable to the serving engine). The combination of `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` lets the container see all GPUs without consuming device-plugin resources, so the serving engine (e.g., vLLM) can still request all GPUs on the node. On most clusters this is sufficient; on some, the engine cannot see the GPUs unless the pod is also privileged — set `spec.privileged: true` to run the engine container privileged (default `false`).
+- **`NVIDIA_VISIBLE_DEVICES=all`** — gives the engine access to all GPUs on the node for CUDA IPC and custom data transfer kernels without claiming any via `nvidia.com/gpu` resource requests (which would make those GPUs unavailable to the serving engine). The combination of `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` lets the container see all GPUs without consuming device-plugin resources, so the serving engine (e.g., vLLM) can still request all GPUs on the node. On most clusters this is sufficient; on some, the engine cannot see the GPUs unless the pod is also privileged — set `spec.securityContext.privileged: true` to run the engine container privileged (default `false`).
 - **`NVIDIA_VISIBLE_DEVICES=all`** and **`NVIDIA_DRIVER_CAPABILITIES=all`** — env vars that instruct the NVIDIA container runtime to expose all GPUs and all driver capabilities to the container.
 - **`--host 0.0.0.0`** — always passed as a container arg. The server defaults to `--host localhost` which only binds to loopback; the server must bind to all interfaces so the node-local Service can route traffic to it.
 - **No `hostNetwork`** — the operator does **not** use `hostNetwork`. Instead, it creates a ClusterIP Service with `internalTrafficPolicy=Local`. kube-proxy ensures that traffic to the service is routed only to the LMCache pod on the same node. This avoids occupying host ports and reduces the privileged surface area.
 - **No `/dev/shm` emptyDir mount** — the operator intentionally does *not* mount an emptyDir at `/dev/shm`. With `hostIPC: true`, the container already sees the host's `/dev/shm`. Mounting an emptyDir would shadow the host's `/dev/shm` with a private tmpfs, breaking CUDA IPC (`cudaIpcOpenMemHandle` fails because IPC handles written by one pod are invisible to others). If your workload needs a larger `/dev/shm` for non-IPC purposes, add it via `spec.volumes` / `spec.volumeMounts`.
 
-> **Security implications:** The LMCache pods run with `hostIPC: true` (required for CUDA IPC), which exposes the host's IPC namespace. When `spec.privileged: true` is set they additionally run privileged, granting full device access to the container. Only deploy in trusted environments. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace whenever `hostIPC`/`privileged` are in use — the `baseline` and `restricted` profiles reject these settings.
+> **Security implications:** The LMCache pods run with `hostIPC: true` (required for CUDA IPC), which exposes the host's IPC namespace. When `spec.securityContext.privileged: true` is set they additionally run privileged, granting full device access to the container. Only deploy in trusted environments. Clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace whenever `hostIPC`/`privileged` are in use — the `baseline` and `restricted` profiles reject these settings.
 
 ---
 
@@ -333,7 +333,7 @@ OnEvent(LMCacheEngine create/update/delete):
    - memoryLimit = ceil(memoryRequest * 1.5) Gi
    - containerArgs from all spec fields
 3. RECONCILE DaemonSet (CreateOrUpdate, ownerRef)
-   - Always inject: hostIPC, runtimeClassName: nvidia, NVIDIA_VISIBLE_DEVICES=all, --host 0.0.0.0 (privileged only when spec.privileged=true)
+   - Always inject: hostIPC, runtimeClassName: nvidia, NVIDIA_VISIBLE_DEVICES=all, --host 0.0.0.0 (privileged only when spec.securityContext.privileged=true)
 4. RECONCILE node-local lookup Service (internalTrafficPolicy=Local)
 5. RECONCILE headless Service for metrics
 6. RECONCILE connection ConfigMap
@@ -401,7 +401,7 @@ DaemonSet running `lmcache server --engine-type blend` (plus
 `--l1-align-bytes 16777216`), a node-local lookup Service, a metrics Service, and
 a `<name>-connection` ConfigMap. **GPU model is identical to `LMCacheEngine`**:
 `runtimeClassName: nvidia` + `NVIDIA_VISIBLE_DEVICES=all` + `hostIPC: true` (and
-`privileged` when `spec.privileged=true`), with **no `nvidia.com/gpu`
+`privileged` when `spec.securityContext.privileged=true`), with **no `nvidia.com/gpu`
 device-plugin claim** — the engine
 *shares* the vLLM GPU rather than reserving one, because the blend server scatters
 re-RoPE'd KV directly into vLLM's paged KV over **same-device CUDA IPC**. The

--- a/operator/README.md
+++ b/operator/README.md
@@ -14,12 +14,12 @@ See [DESIGN.md](DESIGN.md) for architecture details, reconciliation logic, and C
 - (CacheBlend only) [cert-manager](https://cert-manager.io) for the injection webhook's serving cert — see [CacheBlend](#cacheblend) below
 
 > [!IMPORTANT]
-> By default the operator runs LMCache pods with `runtimeClassName: nvidia` and `NVIDIA_VISIBLE_DEVICES=all` to gain GPU visibility without consuming GPU resources via the device plugin. This allows the serving engine (e.g., vLLM) to claim all GPUs on the node. On most clusters that is enough; on some, the engine cannot see the GPUs unless the pod is also privileged. Set `spec.privileged: true` to run the engine container in privileged mode (default `false`). When it is enabled, clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace.
+> By default the operator runs LMCache pods with `runtimeClassName: nvidia` and `NVIDIA_VISIBLE_DEVICES=all` to gain GPU visibility without consuming GPU resources via the device plugin. This allows the serving engine (e.g., vLLM) to claim all GPUs on the node. On most clusters that is enough; on some, the engine cannot see the GPUs unless the pod is also privileged. Set `spec.securityContext.privileged: true` to run the engine container in privileged mode (default `false`). When it is enabled, clusters using Pod Security Standards must allow the `privileged` profile for the LMCache namespace.
 >
 > On AMD ROCm clusters, `spec.gpuVendor: amd` omits `runtimeClassName` and skips NVIDIA-specific env vars.
 
 > [!WARNING]
-> **Upgrade note:** earlier operator versions always ran the engine container privileged. `spec.privileged` now defaults to `false`. Upgrading rewrites the DaemonSet pod template (forcing a rolling pod replacement), and on any cluster where privileged was load-bearing for GPU visibility the engine pods will come back up **without** GPU access. If your cluster relied on privileged mode (always the case for `gpuVendor: amd`), set `spec.privileged: true` on existing CRs before upgrading.
+> **Upgrade note:** earlier operator versions always ran the engine container privileged. `spec.securityContext.privileged` now defaults to `false`. Upgrading rewrites the DaemonSet pod template (forcing a rolling pod replacement), and on any cluster where privileged was load-bearing for GPU visibility the engine pods will come back up **without** GPU access. If your cluster relied on privileged mode (always the case for `gpuVendor: amd`), set `spec.securityContext.privileged: true` on existing CRs before upgrading.
 
 ## Quick Start
 
@@ -56,7 +56,7 @@ The minimal CR just needs `l1.sizeGB`. Apply the sample (a fully-commented field
 kubectl apply -f config/samples/lmcache_v1alpha1_lmcacheengine.yaml
 ```
 
-The operator automatically handles `hostIPC`, GPU visibility (`runtimeClassName: nvidia`, `NVIDIA_VISIBLE_DEVICES=all`; set `spec.privileged: true` if your cluster also needs privileged mode), node-local service routing, resource sizing, and Prometheus metrics — see [DESIGN.md](DESIGN.md) for details.
+The operator automatically handles `hostIPC`, GPU visibility (`runtimeClassName: nvidia`, `NVIDIA_VISIBLE_DEVICES=all`; set `spec.securityContext.privileged: true` if your cluster also needs privileged mode), node-local service routing, resource sizing, and Prometheus metrics — see [DESIGN.md](DESIGN.md) for details.
 
 ### 3. Connect vLLM to LMCache
 
@@ -115,7 +115,7 @@ Every scenario has a ready-to-edit manifest under [`config/samples/`](config/sam
 Notes:
 
 - **GPU targeting** — `nodeSelector: {nvidia.com/gpu.present: "true"}` runs LMCache only on GPU nodes; new GPU nodes auto-get a pod.
-- **AMD (ROCm)** — `spec.gpuVendor: amd` omits `runtimeClassName` and the NVIDIA env vars; vLLM connects via HIP IPC over `hostIPC` the same way (`PYTHONHASHSEED=0` still required). Supply a `nodeSelector` matching your platform's AMD label and a ROCm-built `spec.image`. AMD has no RuntimeClass-based device injection, so set `spec.privileged: true` to let the engine reach `/dev/kfd`/`/dev/dri` (see the [AMD sample](config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml)).
+- **AMD (ROCm)** — `spec.gpuVendor: amd` omits `runtimeClassName` and the NVIDIA env vars; vLLM connects via HIP IPC over `hostIPC` the same way (`PYTHONHASHSEED=0` still required). Supply a `nodeSelector` matching your platform's AMD label and a ROCm-built `spec.image`. AMD has no RuntimeClass-based device injection, so set `spec.securityContext.privileged: true` to let the engine reach `/dev/kfd`/`/dev/dri` (see the [AMD sample](config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml)).
 - **Custom port** — set `server.port`; the connection ConfigMap updates automatically and vLLM picks it up on restart.
 - **L2 adapters** — only one at a time today. Redis/Valkey is natively typed; cross-namespace auth Secrets are copied automatically and injected via env (never in args or `kubectl describe`). Other types (`nixl_store`, `fs`, `mock`, `raw_block`) use the `raw` escape hatch — see the commented blocks in the minimal sample. For `raw_block` with `use_odirect: true`, `--l1-align-bytes` must be ≥ `block_align`.
 - **Resources** auto-compute from `l1.sizeGB`; override with `resourceOverrides`.

--- a/operator/api/v1alpha1/cacheblendengine_types.go
+++ b/operator/api/v1alpha1/cacheblendengine_types.go
@@ -196,15 +196,13 @@ type CacheBlendEngineSpec struct {
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
-	// privileged runs the engine container in privileged mode. On some clusters
-	// this is required for the engine to see all node GPUs (for CUDA IPC) without
-	// claiming any via the nvidia.com/gpu device plugin; on many clusters
-	// NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
-	// defaults to false. Set it to true only on clusters where the engine cannot
-	// otherwise see the GPUs.
+	// securityContext defines the container-level security context for the
+	// LMCache container.
+	//
+	// When unset, the operator runs the container with privileged: false.
+	// When set, this field is used as-is.
 	// +optional
-	// +kubebuilder:default=false
-	Privileged *bool `json:"privileged,omitempty"`
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 
 	// extraArgs are additional CLI flags appended to the server command.
 	// They are appended last and can override any auto-generated flag.

--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -398,20 +398,10 @@ type LMCacheEngineSpec struct {
 	// securityContext defines the container-level security context for the
 	// LMCache container.
 	//
-	// When unset, the operator preserves the existing default behavior and runs
-	// the container with privileged: false (unless spec.privileged is explicitly
-	// set to true).
+	// When unset, the operator runs the container with privileged: false.
+	// When set, this field is used as-is.
 	// +optional
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
-
-	// privileged runs the engine container in privileged mode. On some clusters
-	// this is required for the engine to see all node GPUs (for CUDA IPC) without
-	// claiming any via the nvidia.com/gpu device plugin; on many clusters
-	// NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
-	// defaults to false.
-	// +optional
-	// +kubebuilder:default=false
-	Privileged *bool `json:"privileged,omitempty"`
 
 	// extraArgs are additional CLI flags appended to the server command.
 	// They are appended last and can override any auto-generated flag.

--- a/operator/api/v1alpha1/lmcacheengine_types.go
+++ b/operator/api/v1alpha1/lmcacheengine_types.go
@@ -395,6 +395,15 @@ type LMCacheEngineSpec struct {
 	// +kubebuilder:default=false
 	HostNetwork *bool `json:"hostNetwork,omitempty"`
 
+	// securityContext defines the container-level security context for the
+	// LMCache container.
+	//
+	// When unset, the operator preserves the existing default behavior and runs
+	// the container with privileged: false (unless spec.privileged is explicitly
+	// set to true).
+	// +optional
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+
 	// privileged runs the engine container in privileged mode. On some clusters
 	// this is required for the engine to see all node GPUs (for CUDA IPC) without
 	// claiming any via the nvidia.com/gpu device plugin; on many clusters

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -229,10 +229,10 @@ func (in *CacheBlendEngineSpec) DeepCopyInto(out *CacheBlendEngineSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.Privileged != nil {
-		in, out := &in.Privileged, &out.Privileged
-		*out = new(bool)
-		**out = **in
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.SecurityContext)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ExtraArgs != nil {
 		in, out := &in.ExtraArgs, &out.ExtraArgs
@@ -894,11 +894,6 @@ func (in *LMCacheEngineSpec) DeepCopyInto(out *LMCacheEngineSpec) {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(v1.SecurityContext)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.Privileged != nil {
-		in, out := &in.Privileged, &out.Privileged
-		*out = new(bool)
-		**out = **in
 	}
 	if in.ExtraArgs != nil {
 		in, out := &in.ExtraArgs, &out.ExtraArgs

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -890,6 +890,11 @@ func (in *LMCacheEngineSpec) DeepCopyInto(out *LMCacheEngineSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.SecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Privileged != nil {
 		in, out := &in.Privileged, &out.Privileged
 		*out = new(bool)

--- a/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_cacheblendengines.yaml
@@ -1500,20 +1500,6 @@ spec:
               priorityClassName:
                 description: priorityClassName is the priority class for the pods.
                 type: string
-              privileged:
-                default: false
-                description: |-
-                  privileged runs the engine container in privileged mode. On some clusters
-                  this is required for the engine to see all node GPUs (for CUDA IPC) without
-                  claiming any via the nvidia.com/gpu device plugin; on many clusters
-                  NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
-                  defaults to false. Set it to true only on clusters where the engine cannot
-                  otherwise see the GPUs. For gpuVendor "amd" this is effectively required:
-                  there is no NVIDIA-style RuntimeClass device injection, so privileged mode
-                  is the only way the engine reaches /dev/kfd and /dev/dri. Clusters using Pod
-                  Security Standards must allow the privileged profile for this namespace when
-                  it is enabled. Default: false.
-                type: boolean
               prometheus:
                 description: prometheus defines Prometheus monitoring configuration.
                 properties:
@@ -1603,6 +1589,201 @@ spec:
                       If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
                       otherwise to an implementation-defined value. Requests cannot exceed Limits.
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              securityContext:
+                description: |-
+                  securityContext defines the container-level security context for the
+                  LMCache container.
+
+                  When unset, the operator runs the container with privileged: false.
+                  When set, this field is used as-is.
+                properties:
+                  allowPrivilegeEscalation:
+                    description: |-
+                      AllowPrivilegeEscalation controls whether a process can gain more
+                      privileges than its parent process. This bool directly controls if
+                      the no_new_privs flag will be set on the container process.
+                      AllowPrivilegeEscalation is true always when the container is:
+                      1) run as Privileged
+                      2) has CAP_SYS_ADMIN
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                      overrides the pod's appArmorProfile.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile loaded on the node that should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must match the loaded name of the profile.
+                          Must be set if and only if type is "Localhost".
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of AppArmor profile will be applied.
+                          Valid options are:
+                            Localhost - a profile pre-loaded on the node.
+                            RuntimeDefault - the container runtime's default profile.
+                            Unconfined - no AppArmor enforcement.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  capabilities:
+                    description: |-
+                      The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container runtime.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  privileged:
+                    description: |-
+                      Run container in privileged mode.
+                      Processes in privileged containers are essentially equivalent to root on the host.
+                      Defaults to false.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  procMount:
+                    description: |-
+                      procMount denotes the type of proc mount to use for the containers.
+                      The default value is Default which uses the container runtime defaults for
+                      readonly paths and masked paths.
+                      This requires the ProcMountType feature flag to be enabled.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                  readOnlyRootFilesystem:
+                    description: |-
+                      Whether this container has a read-only root filesystem.
+                      Default is false.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: |-
+                      Indicates that the container must run as a non-root user.
+                      If true, the Kubelet will validate the image at runtime to ensure that it
+                      does not run as UID 0 (root) and fail to start the container if it does.
+                      If unset or false, no such validation will be performed.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: |-
+                      The SELinux context to be applied to the container.
+                      If unspecified, the container runtime will allocate a random SELinux context for each
+                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: |-
+                      The seccomp options to use by this container. If seccomp options are
+                      provided at both the pod & container level, the container options
+                      override the pod options.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile defined in a file on the node should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of seccomp profile will be applied.
+                          Valid options are:
+
+                          Localhost - a profile defined in a file on the node should be used.
+                          RuntimeDefault - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will be used.
+                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                          GMSA credential spec named by the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: |-
+                          HostProcess determines if a container should be run as a 'Host Process' container.
+                          All of a Pod's containers must have the same effective HostProcess value
+                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: |-
+                          The UserName in Windows to run the entrypoint of the container process.
+                          Defaults to the user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: string
                     type: object
                 type: object
               server:

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -1409,15 +1409,6 @@ spec:
               priorityClassName:
                 description: priorityClassName is the priority class for the pods.
                 type: string
-              privileged:
-                default: false
-                description: |-
-                  privileged runs the engine container in privileged mode. On some clusters
-                  this is required for the engine to see all node GPUs (for CUDA IPC) without
-                  claiming any via the nvidia.com/gpu device plugin; on many clusters
-                  NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
-                  defaults to false.
-                type: boolean
               prometheus:
                 description: prometheus defines Prometheus monitoring configuration.
                 properties:
@@ -1514,9 +1505,8 @@ spec:
                   securityContext defines the container-level security context for the
                   LMCache container.
 
-                  When unset, the operator preserves the existing default behavior and runs
-                  the container with privileged: false (unless spec.privileged is explicitly
-                  set to true).
+                  When unset, the operator runs the container with privileged: false.
+                  When set, this field is used as-is.
                 properties:
                   allowPrivilegeEscalation:
                     description: |-

--- a/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
+++ b/operator/config/crd/bases/lmcache.lmcache.ai_lmcacheengines.yaml
@@ -1416,12 +1416,7 @@ spec:
                   this is required for the engine to see all node GPUs (for CUDA IPC) without
                   claiming any via the nvidia.com/gpu device plugin; on many clusters
                   NVIDIA_VISIBLE_DEVICES=all already grants that visibility without it, so it
-                  defaults to false. Set it to true only on clusters where the engine cannot
-                  otherwise see the GPUs. For gpuVendor "amd" this is effectively required:
-                  there is no NVIDIA-style RuntimeClass device injection, so privileged mode
-                  is the only way the engine reaches /dev/kfd and /dev/dri. Clusters using Pod
-                  Security Standards must allow the privileged profile for this namespace when
-                  it is enabled. Default: false.
+                  defaults to false.
                 type: boolean
               prometheus:
                 description: prometheus defines Prometheus monitoring configuration.
@@ -1512,6 +1507,202 @@ spec:
                       If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
                       otherwise to an implementation-defined value. Requests cannot exceed Limits.
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              securityContext:
+                description: |-
+                  securityContext defines the container-level security context for the
+                  LMCache container.
+
+                  When unset, the operator preserves the existing default behavior and runs
+                  the container with privileged: false (unless spec.privileged is explicitly
+                  set to true).
+                properties:
+                  allowPrivilegeEscalation:
+                    description: |-
+                      AllowPrivilegeEscalation controls whether a process can gain more
+                      privileges than its parent process. This bool directly controls if
+                      the no_new_privs flag will be set on the container process.
+                      AllowPrivilegeEscalation is true always when the container is:
+                      1) run as Privileged
+                      2) has CAP_SYS_ADMIN
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                      overrides the pod's appArmorProfile.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile loaded on the node that should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must match the loaded name of the profile.
+                          Must be set if and only if type is "Localhost".
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of AppArmor profile will be applied.
+                          Valid options are:
+                            Localhost - a profile pre-loaded on the node.
+                            RuntimeDefault - the container runtime's default profile.
+                            Unconfined - no AppArmor enforcement.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  capabilities:
+                    description: |-
+                      The capabilities to add/drop when running containers.
+                      Defaults to the default set of capabilities granted by the container runtime.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  privileged:
+                    description: |-
+                      Run container in privileged mode.
+                      Processes in privileged containers are essentially equivalent to root on the host.
+                      Defaults to false.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  procMount:
+                    description: |-
+                      procMount denotes the type of proc mount to use for the containers.
+                      The default value is Default which uses the container runtime defaults for
+                      readonly paths and masked paths.
+                      This requires the ProcMountType feature flag to be enabled.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                  readOnlyRootFilesystem:
+                    description: |-
+                      Whether this container has a read-only root filesystem.
+                      Default is false.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                  runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: |-
+                      Indicates that the container must run as a non-root user.
+                      If true, the Kubelet will validate the image at runtime to ensure that it
+                      does not run as UID 0 (root) and fail to start the container if it does.
+                      If unset or false, no such validation will be performed.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: |-
+                      The SELinux context to be applied to the container.
+                      If unspecified, the container runtime will allocate a random SELinux context for each
+                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: |-
+                      The seccomp options to use by this container. If seccomp options are
+                      provided at both the pod & container level, the container options
+                      override the pod options.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile defined in a file on the node should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of seccomp profile will be applied.
+                          Valid options are:
+
+                          Localhost - a profile defined in a file on the node should be used.
+                          RuntimeDefault - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will be used.
+                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                          GMSA credential spec named by the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: |-
+                          HostProcess determines if a container should be run as a 'Host Process' container.
+                          All of a Pod's containers must have the same effective HostProcess value
+                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: |-
+                          The UserName in Windows to run the entrypoint of the container process.
+                          Defaults to the user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: string
                     type: object
                 type: object
               server:

--- a/operator/config/samples/lmcache_v1alpha1_cacheblendengine.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_cacheblendengine.yaml
@@ -74,7 +74,8 @@ spec:
   # Run the engine container in privileged mode. Defaults to false. Set to true
   # only on clusters where the engine cannot see the node GPUs otherwise
   # (runtimeClassName: nvidia + NVIDIA_VISIBLE_DEVICES=all is enough on most).
-  # privileged: false
+  # securityContext:
+  #   privileged: false
 
 # ---------------------------------------------------------------------------
 # To enable CacheBlend on a vLLM pod, label it for the webhook and annotate it

--- a/operator/config/samples/lmcache_v1alpha1_lmcacheengine.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_lmcacheengine.yaml
@@ -100,12 +100,13 @@ spec:
   # priorityClassName: ""
 
   # -- Security --
-  # Run the engine container in privileged mode. Defaults to false. On most
-  # clusters runtimeClassName: nvidia + NVIDIA_VISIBLE_DEVICES=all is enough for
-  # the engine to see all GPUs; set this to true only on clusters where it
-  # cannot see them otherwise. Requires the namespace to allow the privileged
-  # Pod Security Standard.
-  # privileged: false
+  # Run the engine container in privileged mode. On most clusters
+  # runtimeClassName: nvidia + NVIDIA_VISIBLE_DEVICES=all is enough for the
+  # engine to see all GPUs; set this only on clusters where it cannot see them
+  # otherwise. Requires the namespace to allow the privileged Pod Security
+  # Standard.
+  # securityContext:
+  #   privileged: false
 
   # -- Extra CLI flags (appended last, can override any auto-generated flag) --
   # extraArgs: []

--- a/operator/config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml
+++ b/operator/config/samples/lmcache_v1alpha1_lmcacheengine_amd.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   gpuVendor: amd
   # AMD has no NVIDIA-style RuntimeClass to inject GPU device files, so the ROCm
-  # engine needs privileged mode to reach /dev/kfd and /dev/dri. (privileged
-  # defaults to false, which suits NVIDIA clusters where NVIDIA_VISIBLE_DEVICES
-  # already exposes the GPUs.) The namespace must allow the privileged Pod
-  # Security Standard.
-  privileged: true
+  # engine needs privileged mode to reach /dev/kfd and /dev/dri. Set
+  # securityContext.privileged=true. The namespace must allow the privileged
+  # Pod Security Standard.
+  securityContext:
+    privileged: true
   nodeSelector:
     feature.node.kubernetes.io/amd-gpu: "true"
   l1:

--- a/operator/internal/resources/cacheblend_engine.go
+++ b/operator/internal/resources/cacheblend_engine.go
@@ -62,6 +62,11 @@ const (
 // surfaced separately (Blend via BuildCBConnectionConfigMap, Injection via the
 // admission webhook).
 func cbSpecToEngineSpec(spec *lmcachev1alpha1.CacheBlendEngineSpec) *lmcachev1alpha1.LMCacheEngineSpec {
+	var securityContext *corev1.SecurityContext
+	if spec.SecurityContext != nil {
+		securityContext = spec.SecurityContext.DeepCopy()
+	}
+
 	return &lmcachev1alpha1.LMCacheEngineSpec{
 		GPUVendor:          spec.GPUVendor,
 		Image:              spec.Image,
@@ -84,7 +89,7 @@ func cbSpecToEngineSpec(spec *lmcachev1alpha1.CacheBlendEngineSpec) *lmcachev1al
 		PodLabels:          spec.PodLabels,
 		ServiceAccountName: spec.ServiceAccountName,
 		PriorityClassName:  spec.PriorityClassName,
-		Privileged:         spec.Privileged,
+		SecurityContext:    securityContext,
 		ExtraArgs:          spec.ExtraArgs,
 	}
 }
@@ -111,7 +116,8 @@ func BuildCBEngineArgs(spec *lmcachev1alpha1.CacheBlendEngineSpec) []string {
 // BuildCBEngineDaemonSet constructs the DaemonSet for the blend_v3 engine of the
 // given CacheBlendEngine. It reuses the shared GPU/security pod-template
 // scaffolding (hostIPC, runtimeClassName=nvidia, NVIDIA_VISIBLE_DEVICES=all,
-// privileged only when spec.privileged=true (default false), CPU+memory-only
+// privileged only when spec.securityContext.privileged=true (default false),
+// CPU+memory-only
 // resources with no nvidia.com/gpu claim) so the engine shares the node's GPU
 // via CUDA IPC, and adds the blend-specific server args.
 func BuildCBEngineDaemonSet(engine *lmcachev1alpha1.CacheBlendEngine) *appsv1.DaemonSet {

--- a/operator/internal/resources/cacheblend_engine_test.go
+++ b/operator/internal/resources/cacheblend_engine_test.go
@@ -125,7 +125,7 @@ func TestBuildCBEngineDaemonSet_GPUAndSecurity(t *testing.T) {
 	}
 	c := podSpec.Containers[0]
 
-	// privileged defaults to false (opt-in via spec.privileged).
+	// privileged defaults to false (opt-in via spec.securityContext.privileged).
 	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || *c.SecurityContext.Privileged {
 		t.Fatal("expected privileged=false by default")
 	}
@@ -148,15 +148,15 @@ func TestBuildCBEngineDaemonSet_GPUAndSecurity(t *testing.T) {
 	assertArg(t, c.Args, "--l1-align-bytes", "16777216")
 }
 
-func TestBuildCBEngineDaemonSet_PrivilegedEnabled(t *testing.T) {
+func TestBuildCBEngineDaemonSet_SecurityContextPrivilegedEnabled(t *testing.T) {
 	engine := minimalCBEngine()
-	engine.Spec.Privileged = ptr(true)
+	engine.Spec.SecurityContext = &corev1.SecurityContext{Privileged: ptr(true)}
 	ds := BuildCBEngineDaemonSet(engine)
 	c := ds.Spec.Template.Spec.Containers[0]
 
-	// spec.privileged=true threads through to the container security context.
+	// spec.securityContext.privileged=true threads through to container security context.
 	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
-		t.Fatal("expected privileged=true when spec.privileged=true")
+		t.Fatal("expected privileged=true when spec.securityContext.privileged=true")
 	}
 }
 

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -88,6 +88,10 @@ func buildDaemonSetCore(
 		containerSecurityContext = &corev1.SecurityContext{Privileged: &privileged}
 	} else {
 		containerSecurityContext = containerSecurityContext.DeepCopy()
+		if containerSecurityContext.Privileged == nil {
+			privileged := derefBool(spec.Privileged, false)
+			containerSecurityContext.Privileged = &privileged
+		}
 	}
 
 	serverPort := derefInt32(getServerPort(spec), 5555)

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -52,7 +52,8 @@ func BuildDaemonSet(engine *lmcachev1alpha1.LMCacheEngine) *appsv1.DaemonSet {
 // buildDaemonSetCore constructs the DaemonSet shared by the LMCacheEngine and
 // CacheBlendEngine controllers. It is the single source of truth for the
 // GPU/security pod-template scaffolding (hostIPC, runtimeClassName, optional
-// privileged (default false, via spec.Privileged), NVIDIA_VISIBLE_DEVICES,
+// privileged (default false, overridable via
+// spec.Privileged when spec.SecurityContext is unset), NVIDIA_VISIBLE_DEVICES,
 // resources without a device-plugin GPU claim) so those settings cannot drift
 // between the two engines.
 //
@@ -81,7 +82,13 @@ func buildDaemonSetCore(
 		rc := nvidiaRuntimeClass
 		runtimeClassName = &rc
 	}
-	privileged := derefBool(spec.Privileged, false)
+	containerSecurityContext := spec.SecurityContext
+	if containerSecurityContext == nil {
+		privileged := derefBool(spec.Privileged, false)
+		containerSecurityContext = &corev1.SecurityContext{Privileged: &privileged}
+	} else {
+		containerSecurityContext = containerSecurityContext.DeepCopy()
+	}
 
 	serverPort := derefInt32(getServerPort(spec), 5555)
 	imgRepo := defaultImageRepo
@@ -277,13 +284,11 @@ func buildDaemonSetCore(
 							Ports:           containerPorts,
 							Env:             envVars,
 							Resources:       ComputeResources(spec),
-							SecurityContext: &corev1.SecurityContext{
-								Privileged: &privileged,
-							},
-							VolumeMounts:   volumeMounts,
-							StartupProbe:   startupProbe,
-							LivenessProbe:  livenessProbe,
-							ReadinessProbe: readinessProbe,
+							SecurityContext: containerSecurityContext,
+							VolumeMounts:    volumeMounts,
+							StartupProbe:    startupProbe,
+							LivenessProbe:   livenessProbe,
+							ReadinessProbe:  readinessProbe,
 						},
 					},
 					Volumes: volumes,

--- a/operator/internal/resources/daemonset.go
+++ b/operator/internal/resources/daemonset.go
@@ -52,8 +52,8 @@ func BuildDaemonSet(engine *lmcachev1alpha1.LMCacheEngine) *appsv1.DaemonSet {
 // buildDaemonSetCore constructs the DaemonSet shared by the LMCacheEngine and
 // CacheBlendEngine controllers. It is the single source of truth for the
 // GPU/security pod-template scaffolding (hostIPC, runtimeClassName, optional
-// privileged (default false, overridable via
-// spec.Privileged when spec.SecurityContext is unset), NVIDIA_VISIBLE_DEVICES,
+// privileged (default false when spec.SecurityContext is unset),
+// NVIDIA_VISIBLE_DEVICES,
 // resources without a device-plugin GPU claim) so those settings cannot drift
 // between the two engines.
 //
@@ -84,14 +84,10 @@ func buildDaemonSetCore(
 	}
 	containerSecurityContext := spec.SecurityContext
 	if containerSecurityContext == nil {
-		privileged := derefBool(spec.Privileged, false)
+		privileged := false
 		containerSecurityContext = &corev1.SecurityContext{Privileged: &privileged}
 	} else {
 		containerSecurityContext = containerSecurityContext.DeepCopy()
-		if containerSecurityContext.Privileged == nil {
-			privileged := derefBool(spec.Privileged, false)
-			containerSecurityContext.Privileged = &privileged
-		}
 	}
 
 	serverPort := derefInt32(getServerPort(spec), 5555)

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -1153,8 +1153,7 @@ func TestBuildDaemonSet_HostNetworkEnabled(t *testing.T) {
 }
 
 func TestBuildDaemonSet_PrivilegedDefaultFalse(t *testing.T) {
-	// minimalEngine leaves spec.Privileged nil; the operator must not run the
-	// container privileged unless explicitly opted in.
+	// The container must run privileged=false by default.
 	ds := BuildDaemonSet(minimalEngine())
 	c := ds.Spec.Template.Spec.Containers[0]
 
@@ -1163,15 +1162,15 @@ func TestBuildDaemonSet_PrivilegedDefaultFalse(t *testing.T) {
 	}
 }
 
-func TestBuildDaemonSet_PrivilegedEnabled(t *testing.T) {
+func TestBuildDaemonSet_ExplicitSecurityContextPrivilegedEnabled(t *testing.T) {
 	engine := minimalEngine()
-	engine.Spec.Privileged = ptr(true)
+	engine.Spec.SecurityContext = &corev1.SecurityContext{Privileged: ptr(true)}
 
 	ds := BuildDaemonSet(engine)
 	c := ds.Spec.Template.Spec.Containers[0]
 
 	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
-		t.Fatal("expected privileged=true when spec.privileged=true")
+		t.Fatal("expected privileged=true when spec.securityContext.privileged=true")
 	}
 }
 
@@ -1208,9 +1207,8 @@ func TestBuildDaemonSet_SecurityContextPassthrough(t *testing.T) {
 	}
 }
 
-func TestBuildDaemonSet_SecurityContextPrivilegedFallsBackToSpecPrivileged(t *testing.T) {
+func TestBuildDaemonSet_SecurityContextWithoutPrivilegedKeepsNil(t *testing.T) {
 	engine := minimalEngine()
-	engine.Spec.Privileged = ptr(true)
 	engine.Spec.SecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr(false),
 		RunAsUser:                ptr(int64(1000)),
@@ -1222,8 +1220,8 @@ func TestBuildDaemonSet_SecurityContextPrivilegedFallsBackToSpecPrivileged(t *te
 	if c.SecurityContext == nil {
 		t.Fatal("expected securityContext to be set")
 	}
-	if c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
-		t.Fatal("expected securityContext.privileged to fall back to spec.privileged=true")
+	if c.SecurityContext.Privileged != nil {
+		t.Fatal("expected securityContext.privileged to remain unset when not provided in spec.securityContext")
 	}
 	if c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 1000 {
 		t.Fatal("expected other securityContext fields to be preserved")

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -1208,6 +1208,28 @@ func TestBuildDaemonSet_SecurityContextPassthrough(t *testing.T) {
 	}
 }
 
+func TestBuildDaemonSet_SecurityContextPrivilegedFallsBackToSpecPrivileged(t *testing.T) {
+	engine := minimalEngine()
+	engine.Spec.Privileged = ptr(true)
+	engine.Spec.SecurityContext = &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr(false),
+		RunAsUser:                ptr(int64(1000)),
+	}
+
+	ds := BuildDaemonSet(engine)
+	c := ds.Spec.Template.Spec.Containers[0]
+
+	if c.SecurityContext == nil {
+		t.Fatal("expected securityContext to be set")
+	}
+	if c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
+		t.Fatal("expected securityContext.privileged to fall back to spec.privileged=true")
+	}
+	if c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 1000 {
+		t.Fatal("expected other securityContext fields to be preserved")
+	}
+}
+
 // hasEnvAll reports whether envs contains an env var named name set to the
 // literal "all" (the value the GPU passthrough vars are always set to).
 func hasEnvAll(envs []corev1.EnvVar, name string) bool {

--- a/operator/internal/resources/resources_test.go
+++ b/operator/internal/resources/resources_test.go
@@ -1175,6 +1175,39 @@ func TestBuildDaemonSet_PrivilegedEnabled(t *testing.T) {
 	}
 }
 
+func TestBuildDaemonSet_SecurityContextPassthrough(t *testing.T) {
+	engine := minimalEngine()
+	engine.Spec.SecurityContext = &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr(false),
+		Privileged:               ptr(false),
+		RunAsNonRoot:             ptr(true),
+		RunAsUser:                ptr(int64(1000)),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+
+	ds := BuildDaemonSet(engine)
+	c := ds.Spec.Template.Spec.Containers[0]
+
+	if c.SecurityContext == nil {
+		t.Fatal("expected securityContext to be set from spec.securityContext")
+	}
+	if c.SecurityContext.Privileged == nil || *c.SecurityContext.Privileged {
+		t.Fatal("expected securityContext.privileged=false from spec.securityContext")
+	}
+	if c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 1000 {
+		t.Fatal("expected securityContext.runAsUser=1000")
+	}
+	if c.SecurityContext.AllowPrivilegeEscalation == nil || *c.SecurityContext.AllowPrivilegeEscalation {
+		t.Fatal("expected securityContext.allowPrivilegeEscalation=false")
+	}
+	if c.SecurityContext.Capabilities == nil || len(c.SecurityContext.Capabilities.Drop) != 1 ||
+		c.SecurityContext.Capabilities.Drop[0] != corev1.Capability("ALL") {
+		t.Fatal("expected securityContext.capabilities.drop=[ALL]")
+	}
+}
+
 // hasEnvAll reports whether envs contains an env var named name set to the
 // literal "all" (the value the GPU passthrough vars are always set to).
 func hasEnvAll(envs []corev1.EnvVar, name string) bool {

--- a/operator/test/e2e/crd_smoke_test.go
+++ b/operator/test/e2e/crd_smoke_test.go
@@ -161,7 +161,8 @@ var _ = Describe("LMCacheEngine smoke (no-GPU)", Ordered, func() {
 
 // assertDaemonSetShape verifies the operator's auto-injected pod-level
 // settings: hostIPC, runtimeClassName=nvidia, a container security context
-// that is non-privileged by default (privileged is opt-in via spec.privileged),
+// that is non-privileged by default (privileged is opt-in via
+// spec.securityContext.privileged),
 // --host 0.0.0.0 always present in container args, and the absence of any
 // /dev/shm volume mount that would shadow the host's /dev/shm and break CUDA IPC.
 func assertDaemonSetShape(ds *appsv1.DaemonSet, expectedServerPort int32) {
@@ -176,7 +177,7 @@ func assertDaemonSetShape(ds *appsv1.DaemonSet, expectedServerPort int32) {
 	Expect(c.SecurityContext).NotTo(BeNil(), "container.securityContext must be set")
 	Expect(c.SecurityContext.Privileged).NotTo(BeNil())
 	Expect(*c.SecurityContext.Privileged).To(BeFalse(),
-		"container.privileged must default to false (opt-in via spec.privileged)")
+		"container.privileged must default to false (opt-in via spec.securityContext.privileged)")
 	Expect(c.Args).To(ContainElements("--host", "0.0.0.0"))
 	Expect(argValue(c.Args, "--port")).To(Equal(fmt.Sprintf("%d", expectedServerPort)))
 

--- a/operator/test/e2e/smoke_helpers_test.go
+++ b/operator/test/e2e/smoke_helpers_test.go
@@ -54,12 +54,12 @@ var nsCounter atomic.Int64
 //
 // The namespace is pre-labeled with the `privileged` PodSecurity profile
 // because the LMCache DaemonSet's pod template sets hostIPC=true (and
-// privileged=true only when spec.privileged is enabled), and hostIPC alone
-// is rejected by the restricted/baseline profiles. On clusters that enforce
-// PodSecurity admission (OCP in particular), a `restricted` namespace would
-// reject the DaemonSet at creation time, which the smokes need to succeed
-// even though they never wait for pods to schedule. The label is a no-op on
-// clusters that don't enforce PodSecurity.
+// privileged=true only when spec.securityContext.privileged is enabled), and
+// hostIPC alone is rejected by the restricted/baseline profiles. On clusters
+// that enforce PodSecurity admission (OCP in particular), a `restricted`
+// namespace would reject the DaemonSet at creation time, which the smokes need
+// to succeed even though they never wait for pods to schedule. The label is a
+// no-op on clusters that don't enforce PodSecurity.
 func createTestNamespace(ctx context.Context) string {
 	GinkgoHelper()
 	name := uniqueNamespaceName()


### PR DESCRIPTION
## Summary
When running the `lmcache-server` DaemonSet Pod together with a vLLM Pod for IPC communication, we encountered a `cudaErrorMapBufferObjectFailed` error.

After investigation, we found that the vLLM Pod was running as the non-root `nobody` user for security reasons, while the `lmcache-server` DaemonSet Pod was running as `root`. Because of this user mismatch, the `lmcache-server` Pod could not properly read or write the IPC-related files created by the vLLM Pod.

To address this, this PR adds support for configuring `securityContext` when deploying the `lmcacheengines` CRD, so that the LMCache server Pod can run with the appropriate user settings for IPC communication.

## Details

The issue occurred when the `lmcache-server` DaemonSet Pod and the vLLM Pod were running with different users while communicating through IPC.

The vLLM Pod was running as the non-root `nobody` user for security reasons, and IPC-related files were created under `/dev/shm` with the following ownership and permissions:

```text
-rw------- 1 nobody nogroup 81920 cuda.shm.fffe.223.1
-rw------- 1 nobody nogroup 81920 cuda.shm.fffe.224.1
-rw------- 1 nobody nogroup 81920 cuda.shm.fffe.225.1
-rw------- 1 nobody nogroup 81920 cuda.shm.fffe.226.1
-rw------- 1 nobody nogroup 64424509440 lmcache_l1_pool_1
-rw------- 1 nobody nogroup 80064 torch_547_3673712610_0
-rw------- 1 nobody nogroup 80064 torch_548_3790871826_0
-rw------- 1 nobody nogroup 80064 torch_549_88063950_0
-rw------- 1 nobody nogroup 80064 torch_550_2061898546_0
```

Although these files were visible from the `lmcache-server` Pod through the shared `hostPath` mount for `/dev/shm`, the `lmcache-server` Pod was running as `root` and could not properly access the IPC files created by the vLLM Pod. As a result, LMCache failed during `REGISTER_KV_CACHE` while trying to unwrap the CUDA IPC handle:

```text
torch.AcceleratorError: CUDA error: mapping of buffer object failed
```

To resolve this, this PR adds security context-related fields to the `LMCacheEngine` CRD. It also updates the controller logic that watches the `LMCacheEngine` resource so that the configured `securityContext` is applied when creating the `lmcache-server` DaemonSet.

With this change, users can configure the `lmcache-server` Pod to run with the appropriate user and group settings required to access IPC-related files created by the vLLM Pod.