### PR TITLE
fix: Resolve bare-bucket s3_endpoint to a virtual-hosted hostname

### DIFF
--- a/docs/source/mp/l2_storage/s3.rst
+++ b/docs/source/mp/l2_storage/s3.rst
@@ -7,8 +7,18 @@ S3-compatible endpoint (MinIO, Ceph RGW, etc.).
 
 **Required fields:**
 
-- ``s3_endpoint``: Bucket URL -- either ``"s3://<bucket>"`` or the bare host form
-  (used for non-AWS endpoints).
+- ``s3_endpoint``: Bucket URL.  The endpoint is used as the request ``Host``
+  header (virtual-hosted addressing), so it must resolve in DNS.  Accepted
+  forms:
+
+  - ``"s3://<bucket>"`` (bare bucket name): expanded automatically to
+    ``"<bucket>.s3.<s3_region>.amazonaws.com"``.
+  - ``"s3://<bucket>.<host>"`` or ``"<bucket>.<host>"``: used as-is.  Required
+    for bucket names containing dots and for S3 Express One Zone directory
+    buckets (their hostname embeds the availability-zone id, e.g.
+    ``"<bucket>.s3express-<az-id>.<region>.amazonaws.com"``).
+  - ``"<host>:<port>"``: used as-is (S3-compatible endpoints such as
+    MinIO/Ceph).
 - ``s3_region``: AWS region string (e.g. ``"us-west-2"``).
 
 **Optional fields:**

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -340,6 +340,7 @@ def resolve_s3_endpoint(
             hostname embeds the availability-zone id and cannot be
             derived from the region alone.
     """
+    endpoint = endpoint.rstrip("/")
     if endpoint.startswith("s3://"):
         endpoint = endpoint[len("s3://") :]
         if "." not in endpoint and ":" not in endpoint:

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -305,15 +305,67 @@ def _is_connection_error(error_msg: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def resolve_s3_endpoint(
+    endpoint: str, region: str, enable_s3express: bool = False
+) -> str:
+    """Resolve the configured ``s3_endpoint`` into the request Host.
+
+    The endpoint is used verbatim as the ``Host`` header, so it must be
+    a resolvable virtual-hosted hostname. Three input forms are
+    accepted:
+
+    - ``"s3://<bucket>"`` (bare bucket name, no dots or port): expanded
+      to the AWS virtual-hosted form
+      ``"<bucket>.s3.<region>.amazonaws.com"``. Without this expansion
+      the bare name fails DNS resolution (``AWS_IO_DNS_INVALID_NAME``)
+      and every request errors out.
+    - ``"s3://<bucket>.<host>"``: the ``s3://`` scheme is stripped and
+      the remainder is used as-is.
+    - ``"<host>"`` or ``"<host>:<port>"``: used as-is (S3-compatible
+      endpoints such as MinIO/Ceph).
+
+    Args:
+        endpoint: the raw ``s3_endpoint`` config value.
+        region: the ``s3_region`` config value, used to build the AWS
+            virtual-hosted hostname when ``endpoint`` is a bare bucket
+            name.
+        enable_s3express: the ``s3_enable_s3express`` config value.
+
+    Returns:
+        The hostname (optionally with port) to use as the request Host.
+
+    Raises:
+        ValueError: ``endpoint`` is a bare bucket name and
+            ``enable_s3express`` is true — an S3 Express One Zone
+            hostname embeds the availability-zone id and cannot be
+            derived from the region alone.
+    """
+    if endpoint.startswith("s3://"):
+        endpoint = endpoint[len("s3://") :]
+        if "." not in endpoint and ":" not in endpoint:
+            if enable_s3express:
+                raise ValueError(
+                    "s3_endpoint: cannot derive an S3 Express One Zone "
+                    "hostname from a bare bucket name; use the full "
+                    "virtual-hosted form "
+                    '"<bucket>.s3express-<az-id>.<region>.amazonaws.com"'
+                )
+            endpoint = f"{endpoint}.s3.{region}.amazonaws.com"
+    return endpoint
+
+
 class S3L2AdapterConfig(L2AdapterConfigBase):
     """Config for the S3 L2 adapter.
 
     Fields:
     - s3_endpoint (str, required): bucket URL using **virtual-hosted**
-      style; accepts either ``"s3://<bucket>.<host>"`` or the bare
-      ``"<bucket>.<host>"`` form. The bucket name must be part of the
-      host because requests are signed and routed against this Host
-      header (path-style addressing is not supported).
+      style; accepts ``"s3://<bucket>.<host>"``, the bare
+      ``"<bucket>.<host>"`` form, or ``"s3://<bucket>"`` (bare bucket
+      name), which is expanded to
+      ``"<bucket>.s3.<s3_region>.amazonaws.com"``. The bucket name must
+      be part of the host because requests are signed and routed
+      against this Host header (path-style addressing is not
+      supported).
     - s3_region (str, required): AWS region used for SigV4.
     - s3_num_io_threads (int): CRT IO threads.
     - s3_prefer_http2 (bool): ALPN negotiate to HTTP/2.
@@ -446,9 +498,15 @@ class S3L2Adapter(L2AdapterInterface):
         super().__init__(max_capacity_bytes=int(config.max_capacity_gb * (1024**3)))
         self._config = config
 
-        endpoint = config.s3_endpoint
-        if endpoint.startswith("s3://"):
-            endpoint = endpoint[len("s3://") :]
+        endpoint = resolve_s3_endpoint(
+            config.s3_endpoint, config.s3_region, config.s3_enable_s3express
+        )
+        if endpoint != config.s3_endpoint:
+            logger.info(
+                "S3L2Adapter resolved s3_endpoint %r -> %r",
+                config.s3_endpoint,
+                endpoint,
+            )
         self._endpoint = endpoint
         self._region = config.s3_region
         self._enable_s3express = config.s3_enable_s3express

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -900,3 +900,50 @@ class TestS3L2AdapterListKeys:
             page.entries[0].key
             == create_object_key(0, model_name="m").to_encoded_object_key()
         )
+
+
+# =============================================================================
+# resolve_s3_endpoint
+# =============================================================================
+
+
+class TestResolveS3Endpoint:
+    def test_bare_bucket_expands_to_virtual_hosted(self):
+        assert (
+            s3mod.resolve_s3_endpoint("s3://my-bucket", "us-west-2")
+            == "my-bucket.s3.us-west-2.amazonaws.com"
+        )
+
+    def test_scheme_with_full_hostname_is_stripped_only(self):
+        assert (
+            s3mod.resolve_s3_endpoint(
+                "s3://my-bucket.s3.us-west-2.amazonaws.com", "us-west-2"
+            )
+            == "my-bucket.s3.us-west-2.amazonaws.com"
+        )
+
+    def test_full_hostname_passthrough(self):
+        assert (
+            s3mod.resolve_s3_endpoint(
+                "my-bucket.s3express-usw2-az1.us-west-2.amazonaws.com",
+                "us-west-2",
+                enable_s3express=True,
+            )
+            == "my-bucket.s3express-usw2-az1.us-west-2.amazonaws.com"
+        )
+
+    def test_host_port_passthrough(self):
+        assert (
+            s3mod.resolve_s3_endpoint("minio.local:9000", "us-east-1")
+            == "minio.local:9000"
+        )
+
+    def test_bare_host_with_port_passthrough(self):
+        # no dots, but the port marks it as a host, not a bucket name
+        assert s3mod.resolve_s3_endpoint("s3://minio:9000", "us-east-1") == "minio:9000"
+
+    def test_bare_bucket_with_s3express_rejected(self):
+        with pytest.raises(ValueError, match="S3 Express One Zone"):
+            s3mod.resolve_s3_endpoint(
+                "s3://my-bucket", "us-west-2", enable_s3express=True
+            )

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -947,3 +947,15 @@ class TestResolveS3Endpoint:
             s3mod.resolve_s3_endpoint(
                 "s3://my-bucket", "us-west-2", enable_s3express=True
             )
+
+    def test_trailing_slash_stripped_before_resolution(self):
+        assert (
+            s3mod.resolve_s3_endpoint("s3://my-bucket/", "us-west-2")
+            == "my-bucket.s3.us-west-2.amazonaws.com"
+        )
+        assert (
+            s3mod.resolve_s3_endpoint(
+                "my-bucket.s3.us-west-2.amazonaws.com/", "us-west-2"
+            )
+            == "my-bucket.s3.us-west-2.amazonaws.com"
+        )


### PR DESCRIPTION
**What this PR does / why we need it**:

The S3 L2 adapter passes `s3_endpoint` verbatim as the request `Host` header. The documented quick-start form `{"s3_endpoint": "s3://my-bucket"}` (docs/source/mp/l2_storage/s3.rst) is a bare bucket name, which fails DNS resolution with `AWS_IO_DNS_INVALID_NAME`, so every PUT/GET errors out. The failure is also effectively silent: the circuit breaker only logs connection-class errors, so users only see generic `Store task N to adapter failed` warnings with no root cause.

This PR makes the documented form work by resolving a bare bucket name (`s3://<bucket>`, no dots or port) to the AWS virtual-hosted hostname `<bucket>.s3.<s3_region>.amazonaws.com`:

- full hostnames (`s3://<bucket>.<host>` / `<bucket>.<host>`) are unchanged
- `host:port` endpoints (MinIO/Ceph) are unchanged
- a bare bucket name with `s3_enable_s3express: true` is rejected with a clear error, since the Express hostname embeds the availability-zone id and cannot be derived from the region

Verified against a real AWS S3 bucket on EKS (vLLM 0.24.0 + `LMCacheMPConnector`): with the same bare-bucket config, the unpatched adapter fails with `AWS_IO_DNS_INVALID_NAME`, while the patched adapter resolves the endpoint and successfully lists real objects (`list_l2_keys`) over the full signed HTTPS path.

**Special notes for your reviewers**:

- `resolve_s3_endpoint()` is a module-level pure function so the resolution rules are unit-testable without CRT or network.
- Compatibility: this cannot break AWS users — the bare-bucket form never worked against AWS. One theoretical edge case: a single-label non-AWS host configured as `s3://<label>` (no port) may previously have resolved via DNS search domains and would now be expanded to an AWS hostname; such setups should use the bare `<host>` or `<host>:<port>` form, which is unchanged. The docs now spell out all three accepted forms.
- The legacy in-process connector (`lmcache/v1/storage_backend/connector/s3_connector.py`) has the same endpoint-as-Host pattern (it requires the `s3://` prefix and uses the remainder verbatim), and public configs in the wild use the bare-bucket form with it (e.g. `remote_url: "s3://<bucket>"`). Happy to send a follow-up PR applying the same resolution there if that's welcome.

**If applicable**:
- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
