### PR TITLE
[Fix][FS Native] Fix fs native object group key parsing

### DIFF
--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -27,22 +27,25 @@ std::string FSConnector::replace_all(const std::string& str,
 
 std::string FSConnector::key_to_filename(const std::string& key) {
   // Input key format (from _object_key_to_string):
-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+  //   Unsalted:
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
+  //   Salted  :
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@
+  //   <chunk_hash_hex>@<cache_salt>
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+  //   Unsalted:
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>@
+  //   <chunk_hash_hex>.data
   //   Salted  :
-  //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
-  //
-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
-  // format, so existing cache directories remain valid.
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>@
+  //   <chunk_hash_hex>@<cache_salt>.data
   //
   // NOTE: both model_name and cache_salt are forbidden from containing
   // '@' (invariant enforced on the Python side), so splitting on '@'
   // is unambiguous — no marker, no rsplit.
 
-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
+  // Split on '@' — must yield 4 (unsalted) or 5 (salted) fields.
   std::vector<std::string> parts;
   size_t start = 0;
   for (size_t pos = 0; pos <= key.size(); ++pos) {
@@ -51,29 +54,32 @@ std::string FSConnector::key_to_filename(const std::string& key) {
       start = pos + 1;
     }
   }
-  if (parts.size() != 3 && parts.size() != 4) {
+  if (parts.size() != 4 && parts.size() != 5) {
     throw std::runtime_error(
-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
+        "FSConnector: malformed key (expected 4 or 5 '@'-separated fields): " +
         key);
   }
 
   const std::string& model_name = parts[0];
   const std::string& kv_rank_hex = parts[1];
-  const std::string& chunk_hash = parts[2];
-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+  const std::string& object_group_id = parts[2];
+  const std::string& chunk_hash = parts[3];
+  const std::string cache_salt = parts.size() == 5 ? parts[4] : std::string();
 
   // Replace '/' with '-SEP-' for filesystem safety
   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
 
-  // Emit filename. Salt is appended at the tail so the unsalted shape
-  // matches what older builds wrote to disk.
+  // Emit filename. Salt is appended at the tail to match fs_l2_adapter.py.
   std::string result;
-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+  result.reserve(safe_model.size() + kv_rank_hex.size() +
+                 object_group_id.size() + chunk_hash.size() +
                  cache_salt.size() + 32);
   result += safe_model;
   result += KEY_SEP;
   result += "0x";
   result += kv_rank_hex;
+  result += KEY_SEP;
+  result += object_group_id;
   result += KEY_SEP;
   result += chunk_hash;
   if (!cache_salt.empty()) {

--- a/csrc/storage_backends/fs/connector.cpp
+++ b/csrc/storage_backends/fs/connector.cpp
@@ -28,22 +28,25 @@ std::string FSConnector::replace_all(const std::string& str,
 
 std::string FSConnector::key_to_filename(const std::string& key) {
   // Input key format (from _object_key_to_string):
-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
+  //   Unsalted:
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
+  //   Salted  :
+  //   <model_name>@<kv_rank_hex>@<object_group_id_hex>@
+  //   <chunk_hash_hex>@<cache_salt>
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+  //   Unsalted:
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>@
+  //   <chunk_hash_hex>.data
   //   Salted  :
-  //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
-  //
-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
-  // format, so existing cache directories remain valid.
+  //   <model_name_safe>@0x<kv_rank_hex>@<object_group_id_hex>@
+  //   <chunk_hash_hex>@<cache_salt>.data
   //
   // NOTE: both model_name and cache_salt are forbidden from containing
   // '@' (invariant enforced on the Python side), so splitting on '@'
   // is unambiguous — no marker, no rsplit.
 
-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
+  // Split on '@' — must yield 4 (unsalted) or 5 (salted) fields.
   std::vector<std::string> parts;
   size_t start = 0;
   for (size_t pos = 0; pos <= key.size(); ++pos) {
@@ -52,29 +55,32 @@ std::string FSConnector::key_to_filename(const std::string& key) {
       start = pos + 1;
     }
   }
-  if (parts.size() != 3 && parts.size() != 4) {
+  if (parts.size() != 4 && parts.size() != 5) {
     throw std::runtime_error(
-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
+        "FSConnector: malformed key (expected 4 or 5 '@'-separated fields): " +
         key);
   }
 
   const std::string& model_name = parts[0];
   const std::string& kv_rank_hex = parts[1];
-  const std::string& chunk_hash = parts[2];
-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+  const std::string& object_group_id = parts[2];
+  const std::string& chunk_hash = parts[3];
+  const std::string cache_salt = parts.size() == 5 ? parts[4] : std::string();
 
   // Replace '/' with '-SEP-' for filesystem safety
   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
 
-  // Emit filename. Salt is appended at the tail so the unsalted shape
-  // matches what older builds wrote to disk.
+  // Emit filename. Salt is appended at the tail to match fs_l2_adapter.py.
   std::string result;
-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+  result.reserve(safe_model.size() + kv_rank_hex.size() +
+                 object_group_id.size() + chunk_hash.size() +
                  cache_salt.size() + 32);
   result += safe_model;
   result += KEY_SEP;
   result += "0x";
   result += kv_rank_hex;
+  result += KEY_SEP;
+  result += object_group_id;
   result += KEY_SEP;
   result += chunk_hash;
   if (!cache_salt.empty()) {

--- a/csrc/storage_backends/fs/connector.h
+++ b/csrc/storage_backends/fs/connector.h
@@ -52,17 +52,23 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
   // Build the filesystem-safe filename from a serialized key string.
   //
   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
+  //   Unsalted:
+  //   "{model}@{kv_rank:08x}@{object_group_id:x}@{hash.hex()}"
+  //   Salted  :
+  //   "{model}@{kv_rank:08x}@{object_group_id:x}@"
+  //   "{hash.hex()}@{cache_salt}"
   //
   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
+  //   Unsalted:
+  //   "{safe_model}@{kv_rank:#010x}@{object_group_id:x}@{hash.hex()}.data"
+  //   Salted  :
+  //   "{safe_model}@{kv_rank:#010x}@{object_group_id:x}@"
+  //   "{hash.hex()}@{cache_salt}.data"
   //
-  // Differences from the input: '/' in model becomes '-SEP-', kv_rank
-  // gains a '0x' prefix, and '.data' is appended. Both model_name and
-  // cache_salt are forbidden from containing '@' (enforced on the
-  // Python side), so the parse is unambiguous.
+  // Differences from the input: '/' in model becomes '-SEP-', kv_rank gains
+  // a '0x' prefix, and '.data' is appended. Both model_name and cache_salt
+  // are forbidden from containing '@' (enforced on the Python side), so the
+  // parse is unambiguous.
   static std::string key_to_filename(const std::string& key);
 
   static std::string replace_all(const std::string& str,

--- a/tests/v1/distributed/test_fs_native_connector_keys.py
+++ b/tests/v1/distributed/test_fs_native_connector_keys.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for fs_native ObjectKey filename handling."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+import select
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
+    NativeConnectorL2Adapter,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd
+
+lmcache_fs = pytest.importorskip(
+    "lmcache.lmcache_fs",
+    reason="lmcache_fs native extension required for fs_native connector tests",
+)
+
+
+def create_memory_obj(size: int = 16, fill_value: float = 1.0) -> TensorMemoryObj:
+    """Create a CPU-backed memory object for fs_native store tests.
+
+    Args:
+        size: Number of float32 elements to allocate.
+        fill_value: Value used to initialize the tensor contents.
+
+    Returns:
+        A TensorMemoryObj whose byte buffer can be passed to an L2 adapter.
+    """
+    raw_data = torch.empty(size, dtype=torch.float32)
+    raw_data.fill_(fill_value)
+    metadata = MemoryObjMetadata(
+        shape=torch.Size([size]),
+        dtype=torch.float32,
+        address=0,
+        phy_size=size * 4,
+        fmt=MemoryFormat.KV_2LTD,
+        ref_count=1,
+    )
+    return TensorMemoryObj(raw_data, metadata, parent_allocator=None)
+
+
+@contextmanager
+def fs_native_adapter(base_path: Path) -> Iterator[NativeConnectorL2Adapter]:
+    """Create a NativeConnectorL2Adapter backed by LMCacheFSClient.
+
+    Args:
+        base_path: Directory where the fs_native connector stores data files.
+
+    Yields:
+        A NativeConnectorL2Adapter wrapping the native filesystem connector.
+    """
+    client = lmcache_fs.LMCacheFSClient(str(base_path), 1, "", False, 0)
+    adapter = NativeConnectorL2Adapter(client)
+    try:
+        yield adapter
+    finally:
+        adapter.close()
+
+
+def store_key_and_require_success(
+    adapter: NativeConnectorL2Adapter,
+    key: ObjectKey,
+) -> None:
+    """Store one ObjectKey and fail the test if the store does not complete.
+
+    Args:
+        adapter: Adapter used to submit and observe the store task.
+        key: ObjectKey to store through the adapter's public interface.
+
+    Raises:
+        AssertionError: If the store event is not signaled or the task fails.
+    """
+    task_id = adapter.submit_store_task([key], [create_memory_obj()])
+    poll = select.poll()
+    poll.register(adapter.get_store_event_fd(), select.POLLIN)
+    events = poll.poll(5000)
+    if not events:
+        raise AssertionError("fs_native store task did not signal completion")
+
+    try:
+        consume_fd(adapter.get_store_event_fd())
+    except BlockingIOError:
+        pass
+
+    completed = adapter.pop_completed_store_tasks()
+    result = completed.get(task_id)
+    if result is None:
+        raise AssertionError("fs_native store task was not completed")
+    if not result.is_successful():
+        raise AssertionError("fs_native store task failed")
+
+
+def test_fs_native_stores_unsalted_object_group_filename(tmp_path: Path) -> None:
+    """Unsalted fs_native stores include object_group_id in the filename."""
+    key = ObjectKey(
+        chunk_hash=b"\x00\x01\x02\x03",
+        model_name="llama",
+        kv_rank=255,
+        object_group_id=5,
+    )
+
+    with fs_native_adapter(tmp_path) as adapter:
+        store_key_and_require_success(adapter, key)
+
+    assert (tmp_path / "llama@0x000000ff@5@00010203.data").exists()
+
+
+def test_fs_native_stores_salted_object_group_filename(tmp_path: Path) -> None:
+    """Salted fs_native stores include object_group_id before cache_salt."""
+    key = ObjectKey(
+        chunk_hash=b"\x00\x01\x02\x03",
+        model_name="llama",
+        kv_rank=255,
+        object_group_id=5,
+        cache_salt="alice",
+    )
+
+    with fs_native_adapter(tmp_path) as adapter:
+        store_key_and_require_success(adapter, key)
+
+    assert (tmp_path / "llama@0x000000ff@5@00010203@alice.data").exists()

--- a/tests/v1/storage_backend/test_fs_native_connector.py
+++ b/tests/v1/storage_backend/test_fs_native_connector.py
@@ -93,7 +93,7 @@ def test_odirect_read_does_not_split_for_read_ahead(tmp_path) -> None:
         pytest.skip("filesystem block size is unavailable")
 
     size = block_size * 2
-    key = "test_model@00000000@0123456789abcdef"
+    key = "test_model@00000000@0@0123456789abcdef"
     _source_raw, source = _aligned_memoryview(size, block_size)
     _dest_raw, dest = _aligned_memoryview(size, block_size)
     _fill(source)
@@ -119,7 +119,7 @@ def test_odirect_fails_for_misaligned_buffer(tmp_path) -> None:
         pytest.skip("filesystem block size is unavailable")
 
     size = block_size * 2
-    key = "test_model@00000000@fedcba9876543210"
+    key = "test_model@00000000@0@fedcba9876543210"
     _source_raw, source = _misaligned_memoryview(size, block_size)
     _fill(source)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes fs_native filesystem key parsing for ObjectKey values that include `object_group_id`.

The Python fs_native adapter serializes keys as:

- unsalted: `model@kv_rank@object_group_id@chunk_hash`
- salted: `model@kv_rank@object_group_id@chunk_hash@cache_salt`

The C++ `FSConnector` still parsed the older 3/4-field format, so salted fs_native stores failed before creating the expected file. This PR updates the C++ parser to accept the current 4/5-field format and preserve `object_group_id` in generated filenames, matching the Python fs_l2 filename layout.

**Special notes for your reviewers**:

Added a native-backed regression test that exercises `NativeConnectorL2Adapter + LMCacheFSClient` instead of only mocking the native connector. The new test verifies both unsalted and salted fs_native stores create filenames with `object_group_id`.

Tested with:

- `NO_GPU_EXT=1 python -m pip install -e . --no-build-isolation`
- `python -m pytest -xvs tests/v1/distributed/test_fs_native_connector_keys.py`
- `python -m pytest -xvs tests/v1/distributed/test_native_connector_l2_adapter.py::TestObjectKeySerialization tests/v1/distributed/test_fs_l2_adapter_keys.py`
- `python -m ruff check --no-cache tests/v1/distributed/test_fs_native_connector_keys.py`
- `python -m ruff format --check tests/v1/distributed/test_fs_native_connector_keys.py`
- `clang-format --dry-run --Werror csrc/storage_backends/fs/connector.cpp csrc/storage_backends/fs/connector.h`
- `git diff --check`

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests