### PR TITLE
docs: daily drift check — multi-process mode (2026-07-07)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -402,7 +402,7 @@ The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
 Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
 ``fs_native``, ``mock``, ``mooncake_store``, ``aerospike``, ``s3``, ``resp``,
-``plugin``, ``native_plugin``, ``raw_block``, ``dax``.
+``plugin``, ``native_plugin``, ``raw_block``, ``dax``, ``fault_inject``.
 
 Each adapter type's required and optional fields, plus per-backend examples, are
 documented on its own page under :doc:`Secondary KV Storage <l2_storage/index>`
@@ -456,6 +456,21 @@ logging, tracing).
    * - ``--prometheus-port``
      - ``9090``
      - Port for the Prometheus ``/metrics`` endpoint.
+   * - ``--metrics-sample-rate``
+     - ``0.01``
+     - Fraction of chunks/blocks (in ``(0.0, 1.0]``) to sample for
+       lifecycle histograms. Counters always count every event
+       regardless of this value.
+   * - ``--trace-level``
+     - *(unset)*
+     - Enable trace recording at the given level. Only ``storage`` is
+       supported today (records ``StorageManager`` public-API calls).
+       See :mod:`lmcache.v1.mp_observability.trace` for details.
+   * - ``--trace-output``
+     - *(unset)*
+     - Path to write the trace file. When ``--trace-level`` is set but
+       this is unset, a timestamped path under ``$TMPDIR`` is minted
+       at startup and logged at INFO.
 
 vLLM Client Configuration
 --------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. Two new inconsistencies between the multi-process (MP) configuration reference and the current `dev` code (`upstream/dev` HEAD `335cd3b`) were found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/mp/configuration.rst`** — the *L2 Adapters* "Registered adapter types" list omits `fault_inject`, even though `fault_inject` self-registers in code and ships a dedicated user-facing docs page (`docs/source/mp/l2_storage/fault_inject.rst`). This gap was explicitly called out as a follow-up in the special notes on PR #3984 but was never folded into PR #3960 (which only added `hfbucket`).
- **`docs/source/mp/configuration.rst`** — the *Observability* config table omits `--metrics-sample-rate`, `--trace-level`, and `--trace-output`. All three are registered by `add_observability_args()` in `lmcache/v1/mp_observability/config.py` and are user-facing. `--metrics-sample-rate` even appears in the *Full Example* further down the same page, which flatly contradicts its absence from the config table.

`docs/design/` (design docs):

- No new drift found in `docs/design/` beyond what open drift-check PRs #4009, #3996, #3984, #3969, and #3960 already cover.

**Evidence**

| Drift | Code / repo state (current `dev`, HEAD `335cd3b`) | Stale doc |
| --- | --- | --- |
| `fault_inject` missing from the "Registered adapter types" list | [`lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py#L426`](https://github.com/LMCache/LMCache/blob/335cd3b63a7cb26da88e8f4d6f59bf0f481ccaab/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py#L426) — `register_l2_adapter_type("fault_inject", FaultInjectL2AdapterConfig)`; user-facing docs page at [`docs/source/mp/l2_storage/fault_inject.rst`](https://github.com/LMCache/LMCache/blob/335cd3b63a7cb26da88e8f4d6f59bf0f481ccaab/docs/source/mp/l2_storage/fault_inject.rst) | [`docs/source/mp/configuration.rst#L403-L405`](https://github.com/LMCache/LMCache/blob/335cd3b63a7cb26da88e8f4d6f59bf0f481ccaab/docs/source/mp/configuration.rst#L403-L405) |
| `--metrics-sample-rate` registered but absent from Observability table | [`lmcache/v1/mp_observability/config.py#L158-L166`](https://github.com/LMCache/LMCache/blob/335cd3b63a7cb26da88e8f4d6f59bf0f481ccaab/lmcache/v1/mp_observability/config.py#L158-L166) — default `0.01`; used in the same doc's *Full Example* at [`docs/source/mp/configuration.rst#L591`](https://github.com/LMCache/LMCache/blob/335cd3b63a7cb26da88e8f4d6f59bf0f481ccaab/docs/source/mp/configuration.rst#L591) | [`docs/source/mp/configuration.rst#L431-L458`](https://github.com/LMCache/LMCache/blob/335cd3b63a7cb26da88e8f4d6f59bf0f481ccaab/docs/source/mp/configuration.rst#L431-L458) |
| `--trace-level` / `--trace-output` registered but absent from Observability table | [`lmcache/v1/mp_observability/config.py#L207-L222`](https://github.com/LMCache/LMCache/blob/335cd3b63a7cb26da88e8f4d6f59bf0f481ccaab/lmcache/v1/mp_observability/config.py#L207-L222) — `--trace-level` accepts `storage`; `--trace-output` defaults to a timestamped `$TMPDIR` path | [`docs/source/mp/configuration.rst#L431-L458`](https://github.com/LMCache/LMCache/blob/335cd3b63a7cb26da88e8f4d6f59bf0f481ccaab/docs/source/mp/configuration.rst#L431-L458) |

**Proposed fix**

Already applied in the diff (docs only, no code touched):

1. `docs/source/mp/configuration.rst` — appended `fault_inject` to the "Registered adapter types" list under *L2 Adapters*.
2. `docs/source/mp/configuration.rst` — appended three rows to the *Observability* config table: `--metrics-sample-rate` (default `0.01`), `--trace-level` (unset default; only `storage` supported today), and `--trace-output` (unset default; timestamped `$TMPDIR` fallback when `--trace-level` is set).

**Special notes for your reviewers**:

- Docs-only change. No code modified. Single file touched.
- Deduped against currently-open drift PRs:
  - **#4009** (`docs/design/ARCHITECTURE_MULTI_HARDWARE.md` device-detection refactor — 2026-07-05): no overlap; that PR's fix is now itself partially stale after today's `DeviceInfo` → `DeviceSpec` rename in PR #4020 (commit `964fdff`), but we intentionally leave that follow-up to the maintainer reviewing #4009.
  - **#3996** (`lmcache.mp.host` bare-host normalization — 2026-07-03): no overlap.
  - **#3984** (coordinator `/blend/*` + `docs/design/v1/mp_coordinator/README.md` + `protocols/README.md` — 2026-07-02): no overlap. That PR's "follow-ups spotted but intentionally not tackled" section explicitly flagged the `fault_inject` and `p2p` gaps in the "Registered adapter types" list; this PR closes the `fault_inject` half of that follow-up.
  - **#3969** (`DevDaxL1MemoryManager` in `mp/index.rst` + deleted `l2_apis.md` refs — 2026-07-01): no overlap.
  - **#3960** (`hfbucket` in L2 adapter list + `IsolatedLRU` in `l2_storage/index.rst` — 2026-06-30): touches the same "Registered adapter types" line but for a different entry (`hfbucket`), so the two edits will need a small conflict resolution at merge time if both land — pick both entries.
- `p2p` is intentionally **not** added to the "Registered adapter types" list even though `P2PL2AdapterConfig` self-registers. It is constructed programmatically by `P2PController._add_adapter()` and is not user-facing via `--l2-adapter`; adding it to a user-facing list would be misleading.
- This PR was **auto-generated** by the daily drift-check routine and **needs human review before merge**. Please do not merge without a maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxyrJmnMGSc6PdmVH2TCW6)_