### PR TITLE
fix(disk): release disk_lock and roll back on staging-allocation failure (SGLang deadlock), fixes #3855

### DIFF
--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -23,6 +23,7 @@ from lmcache.v1.cache_engine import LMCacheEngine, LMCacheEngineBuilder
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector import CreateGPUConnector
 from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.storage_backend.exceptions import StorageBackendError
 
 logger = init_logger(__name__)
 
@@ -243,11 +244,33 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
 
         indices_to_remove = []
         for i in range(len(self.layerwise_retrievers)):
-            if self.layer_load_layer[i] == layer_id + 1:
+            if self.layer_load_layer[i] != layer_id + 1:
+                continue
+            try:
                 next(self.layerwise_retrievers[i])
-                self.layer_load_layer[i] += 1
-                if self.layer_load_layer[i] == self.sgl_config.num_hidden_layers:
-                    indices_to_remove.append(i)
+            except StorageBackendError as e:
+                # The retrieve was aborted partway through this request's
+                # layerwise load (typically the CPU staging pool was exhausted).
+                # retrieve_layer has already released the buffers it acquired;
+                # drop this retriever so its remaining layers are not driven and
+                # the engine keeps serving other requests instead of hanging.
+                # NOTE: layers already loaded for this request stay in place
+                # while later layers are skipped -- a known correctness gap for
+                # the affected request under sustained memory pressure. A full
+                # fix requires reserving the whole retrieve's staging up front
+                # so failures surface in start_load_kv (see module design doc).
+                logger.error(
+                    "LMCache layerwise load aborted at layer %d (%s): %s. "
+                    "Dropping retriever for this request.",
+                    layer_id,
+                    type(e).__name__,
+                    e,
+                )
+                indices_to_remove.append(i)
+                continue
+            self.layer_load_layer[i] += 1
+            if self.layer_load_layer[i] == self.sgl_config.num_hidden_layers:
+                indices_to_remove.append(i)
 
         for i in sorted(indices_to_remove, reverse=True):
             del self.layerwise_retrievers[i]
@@ -299,9 +322,26 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
             sync=False,
         )
 
-        next(layerwise_retriever)
-        # Load First Layer
-        next(layerwise_retriever)
+        try:
+            next(layerwise_retriever)
+            # Load First Layer
+            next(layerwise_retriever)
+        except StorageBackendError as e:
+            # The retrieve was aborted before the first layer could be loaded
+            # (typically the CPU staging pool was exhausted). retrieve_layer has
+            # already released every buffer it acquired, so unpin the lookup and
+            # report zero retrieved tokens. SGLang then recomputes this prefix
+            # instead of reading uninitialized KV, which avoids both the
+            # previous deadlock and silent data corruption.
+            self.lmcache_engine.lookup_unpin(lookup_id)
+            logger.error(
+                "LMCache retrieve aborted (%s): %s. "
+                "Falling back to recompute for %d tokens.",
+                type(e).__name__,
+                e,
+                retrieve_token_num,
+            )
+            return 0
 
         self.layerwise_retrievers.append(layerwise_retriever)
         self.layer_load_layer.append(1)

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -1076,21 +1076,42 @@ class LMCacheEngine:
             next(mem_obj_consumer)
 
             to_count_down = []
-            for layer_id in range(self.num_layers):
-                task = next(get_generator)
+            try:
+                for layer_id in range(self.num_layers):
+                    task = next(get_generator)
 
-                assert task is not None
+                    assert task is not None
 
-                if layer_id == 0:
-                    # NOTE(Yuwei): For sglang integration we need to provide retrieved
-                    # tokens number in the first layer loading since there is no lookup
-                    yield torch.sum(ret_mask)
-                else:
-                    yield None
+                    if layer_id == 0:
+                        # NOTE(Yuwei): For sglang integration we need to provide
+                        # retrieved tokens number in the first layer loading since
+                        # there is no lookup
+                        yield torch.sum(ret_mask)
+                    else:
+                        yield None
 
-                mem_objs_layer = task.result()
-                mem_obj_consumer.send(mem_objs_layer)
-                to_count_down.extend(mem_objs_layer)
+                    mem_objs_layer = task.result()
+                    mem_obj_consumer.send(mem_objs_layer)
+                    to_count_down.extend(mem_objs_layer)
+            except Exception:
+                # A layer retrieve failed (e.g. StagingAllocationError when the
+                # CPU staging pool is exhausted). Release every staging buffer
+                # already loaded for this request so the failure does not leak
+                # pins/refcounts and worsen the pressure, then tear down the GPU
+                # consumer and re-raise for the caller to treat as a cache miss.
+                for mem_obj in to_count_down:
+                    if mem_obj.is_pinned:
+                        mem_obj.unpin()
+                    mem_obj.ref_count_down()
+                try:
+                    mem_obj_consumer.close()
+                except Exception:
+                    logger.warning(
+                        "[req_id=%s] Failed to close GPU consumer after an "
+                        "aborted layerwise retrieve",
+                        req_id,
+                    )
+                raise
 
             for mem_obj in to_count_down:
                 mem_obj.ref_count_down()

--- a/lmcache/v1/storage_backend/exceptions.py
+++ b/lmcache/v1/storage_backend/exceptions.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Storage backend error types.
+
+Exceptions raised by the storage backends when a retrieve or store
+operation cannot complete. Callers that can degrade gracefully (for
+example, by treating a failed retrieve as a cache miss and recomputing)
+should catch these rather than a bare ``Exception``.
+"""
+
+
+class StorageBackendError(Exception):
+    """Base class for all storage backend errors."""
+
+
+class StagingAllocationError(StorageBackendError):
+    """A CPU staging buffer could not be allocated for a retrieve.
+
+    Raised by the disk/GDS retrieve path when the CPU staging pool is
+    exhausted and ``busy_loop=False`` allocation returns ``None``. The
+    keys being retrieved were already committed (pinned) by a preceding
+    lookup, so a partial result cannot be represented safely; the backend
+    rolls back every resource it acquired for the aborted call before
+    raising this so the caller can treat the whole retrieve as a miss.
+    """

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -23,6 +23,10 @@ from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.batched_message_sender import BatchedMessageSender
 from lmcache.v1.storage_backend.cache_policy import get_cache_policy
+from lmcache.v1.storage_backend.exceptions import (
+    StagingAllocationError,
+    StorageBackendError,
+)
 from lmcache.v1.storage_backend.job_executor.pq_executor import (
     AsyncPQThreadPoolExecutor,
 )
@@ -449,6 +453,24 @@ class LocalDiskBackend(StorageBackendInterface):
 
         return memory_obj
 
+    def _rollback_prefetch(self, mem_objs: Sequence[MemoryObj]) -> None:
+        """
+        Release the CPU staging buffers acquired by an aborted
+        ``batched_get_non_blocking`` call.
+
+        Each object in ``mem_objs`` was allocated and pinned in the CPU staging
+        pool before the abort; this unpins and frees them so a failed retrieve
+        leaks no staging memory. Disk-index pins are taken only after every
+        allocation has succeeded, so the allocation-failure path never has dict
+        pins to undo.
+
+        :param mem_objs: The staging objects allocated and pinned so far.
+        """
+        for mem_obj in mem_objs:
+            if mem_obj.is_pinned:
+                mem_obj.unpin()
+            mem_obj.ref_count_down()
+
     def batched_get_blocking(
         self,
         keys: List[CacheEngineKey],
@@ -541,25 +563,65 @@ class LocalDiskBackend(StorageBackendInterface):
         keys: list[CacheEngineKey],
         transfer_spec: Any = None,
     ) -> list[MemoryObj]:
+        """
+        Allocate CPU staging buffers and schedule an async disk read for a
+        batch of pinned keys.
+
+        The keys are expected to have been pinned by a preceding lookup, so
+        every key must be present in the on-disk index. Metadata for the whole
+        batch is snapshotted under a single ``disk_lock`` acquisition, so a
+        missing key fails fast -- before any staging allocation -- and there is
+        nothing to roll back.
+
+        Staging allocation uses ``busy_loop=False`` so an exhausted CPU staging
+        pool fails fast instead of spinning on the event loop thread, and runs
+        outside ``disk_lock`` (mirroring ``get_blocking``) so it neither stalls
+        concurrent disk operations nor leaks the lock. Because the caller
+        (layerwise retrieval) has already committed to retrieving all of these
+        keys, a partial result cannot be represented safely: on allocation
+        failure the staging buffers acquired so far are freed and
+        :class:`StagingAllocationError` is raised.
+
+        :param lookup_id: Identifier of the originating lookup, used for logging.
+        :param keys: Ordered cache keys to load; all must be present on disk.
+        :param transfer_spec: Unused; accepted for interface compatibility.
+        :returns: The list of staging ``MemoryObj`` s, one per key, once the
+            batched disk read has been scheduled.
+        :raises StorageBackendError: If any key is absent from the on-disk index
+            (checked up front, before any allocation).
+        :raises StagingAllocationError: If a staging buffer cannot be allocated
+            for any key. Buffers acquired so far are freed before it propagates.
+        """
+        logger.debug(f"lookup_id: {lookup_id}; Prefetching {len(keys)} keys from disk.")
+
+        # Snapshot all metadata up front under a single lock acquisition. This
+        # lets us fail fast if any key is missing before performing any slow
+        # staging allocation -- and thus with nothing to roll back.
+        disk_metas: list[DiskCacheMetadata] = []
+        with self.disk_lock:
+            for key in keys:
+                disk_meta = self.dict.get(key)
+                if disk_meta is None:
+                    raise StorageBackendError(
+                        f"Key {key} missing from disk index during prefetch for "
+                        f"lookup_id={lookup_id}"
+                    )
+                disk_metas.append(disk_meta)
+
+        # Allocate a staging buffer for every key outside the lock. On failure,
+        # free the buffers allocated so far and abort the whole retrieve.
         mem_objs: list[MemoryObj] = []
         paths: list[str] = []
-
-        logger.debug(f"lookup_id: {lookup_id}; Prefetching {len(keys)} keys from disk.")
-        for key in keys:
-            self.disk_lock.acquire()
-            assert key in self.dict, f"Key {key} not found in disk cache after pinning"
-
-            path = self.dict[key].path
-            dtype = self.dict[key].dtype
-            shape = self.dict[key].shape
-            fmt = self.dict[key].fmt
-
+        for key, disk_meta in zip(keys, disk_metas, strict=False):
+            path = disk_meta.path
+            dtype = disk_meta.dtype
+            shape = disk_meta.shape
+            fmt = disk_meta.fmt
             assert dtype is not None
             assert shape is not None
 
-            # busy_loop=False prevents spinning on the event loop thread;
-            # if staging memory is exhausted the caller will get a logged
-            # error rather than a silent deadlock.
+            # busy_loop=False: fail fast instead of spinning on the event loop
+            # thread when the CPU staging pool is under pressure.
             memory_obj = self.local_cpu_backend.allocate(
                 shape,
                 dtype,
@@ -569,24 +631,51 @@ class LocalDiskBackend(StorageBackendInterface):
 
             if memory_obj is None:
                 logger.error(
-                    "Memory allocation failed during async disk load for key %s. "
-                    "CPU staging pool may be exhausted (unpin() not called after "
-                    "a previous retrieve). Returning partial results.",
+                    "CPU staging allocation failed during async disk load for "
+                    "key %s (lookup_id=%s). Freeing %d partially-acquired "
+                    "buffer(s) and aborting the retrieve.",
                     key,
+                    lookup_id,
+                    len(mem_objs),
                 )
-                return mem_objs
+                self._rollback_prefetch(mem_objs)
+                raise StagingAllocationError(
+                    f"CPU staging pool exhausted while prefetching key {key} "
+                    f"for lookup_id={lookup_id}"
+                )
 
-            self.dict[key].pin()
-
-            # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
-            # Update cache recency
-            self.cache_policy.update_on_hit(key, self.dict)
-
-            self.disk_lock.release()
             logger.debug(f"Prefetching {key} from disk.")
             memory_obj.pin()
             mem_objs.append(memory_obj)
             paths.append(path)
+
+        # Every buffer is allocated: pin the disk entries and record the cache
+        # hits under a single lock acquisition. The keys are pinned by the
+        # preceding lookup so eviction cannot remove them here, but a concurrent
+        # forced remove() still can -- guard against it and abort cleanly rather
+        # than raising KeyError.
+        removed_key: Optional[CacheEngineKey] = None
+        with self.disk_lock:
+            for idx, key in enumerate(keys):
+                disk_meta = self.dict.get(key)
+                if disk_meta is None:
+                    removed_key = key
+                    # Undo the prefetch pins taken so far in this loop.
+                    for prior_key in keys[:idx]:
+                        prior_meta = self.dict.get(prior_key)
+                        if prior_meta is not None:
+                            prior_meta.unpin()
+                    break
+                disk_meta.pin()
+                # NOTE(Jiayi): Currently, we consider prefetch as cache hit.
+                # Update cache recency
+                self.cache_policy.update_on_hit(key, self.dict)
+
+        if removed_key is not None:
+            self._rollback_prefetch(mem_objs)
+            raise StorageBackendError(
+                f"Key {removed_key} removed during prefetch for lookup_id={lookup_id}"
+            )
 
         return await self.disk_worker.submit_task(
             "prefetch",

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -17,6 +17,10 @@ from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.config_base import _parse_local_disk
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.storage_backend.exceptions import (
+    StagingAllocationError,
+    StorageBackendError,
+)
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 from lmcache.v1.storage_backend.local_disk_backend import LocalDiskBackend
 
@@ -467,6 +471,192 @@ class TestGetBlockingCachePolicyUpdate:
         assert result is None
         mock_update.assert_not_called()
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+
+class _StubStagingObj:
+    """Minimal stand-in for a pinned CPU staging ``MemoryObj``.
+
+    Tracks pin and reference counts so tests can assert that the rollback
+    path releases everything it acquired. A fresh allocation starts with
+    ``ref_count == 1`` (as the real allocator returns).
+    """
+
+    def __init__(self) -> None:
+        self.pin_count = 0
+        self.ref_count = 1
+
+    def pin(self) -> bool:
+        self.pin_count += 1
+        return True
+
+    def unpin(self) -> bool:
+        self.pin_count -= 1
+        return True
+
+    def ref_count_down(self) -> None:
+        self.ref_count -= 1
+
+    def get_ref_count(self) -> int:
+        return self.ref_count
+
+    @property
+    def is_pinned(self) -> bool:
+        return self.pin_count > 0
+
+
+class TestBatchedGetNonBlockingAllocationFailure:
+    """Regression tests for the disk-retrieve deadlock (SGLang hang under
+    host-memory pressure).
+
+    ``batched_get_non_blocking`` used to ``self.disk_lock.acquire()`` per
+    iteration and ``return`` a partial list when a staging allocation failed,
+    leaking ``disk_lock`` (wedging the next caller / the SGLang scheduler) and
+    returning unfilled buffers with dangling pins. The fix must always release
+    the lock, roll back every acquired resource, and raise instead of returning
+    garbage.
+    """
+
+    def _inject_key(
+        self,
+        backend: LocalDiskBackend,
+        key: CacheEngineKey,
+        shape: torch.Size,
+    ) -> None:
+        """Register a key in the disk index without writing anything to disk."""
+        meta = DiskCacheMetadata(
+            path="/nonexistent/path.pt",
+            size=0,
+            shape=shape,
+            dtype=torch.bfloat16,
+            cached_positions=None,
+            fmt=MemoryFormat.KV_2LTD,
+            pin_count=0,
+        )
+        with backend.disk_lock:
+            backend.dict[key] = meta
+            backend.cache_policy.update_on_put(key)
+
+    def _assert_lock_released(self, backend: LocalDiskBackend) -> None:
+        acquired = backend.disk_lock.acquire(timeout=1.0)
+        assert acquired, "disk_lock was leaked on the failure path"
+        backend.disk_lock.release()
+
+    def test_allocation_failure_releases_lock_and_rolls_back(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """A mid-batch allocation failure raises, releases the lock, and rolls
+        back the already-acquired key pin and staging buffer."""
+        backend = local_disk_backend
+        shape = torch.Size([28, 2, 16, 8, 128])
+        key0 = create_test_key(0)
+        key1 = create_test_key(1)
+        self._inject_key(backend, key0, shape)
+        self._inject_key(backend, key1, shape)
+
+        stub0 = _StubStagingObj()
+        # First key allocates a staging buffer; second fails (pool exhausted).
+        with patch.object(
+            backend.local_cpu_backend, "allocate", side_effect=[stub0, None]
+        ):
+            with pytest.raises(StagingAllocationError):
+                asyncio.run(backend.batched_get_non_blocking("lookup", [key0, key1]))
+
+        self._assert_lock_released(backend)
+
+        # Both disk-index pins are rolled back...
+        assert backend.dict[key0].pin_count == 0
+        assert backend.dict[key1].pin_count == 0
+        # ...and the one allocated staging buffer is unpinned and freed.
+        assert not stub0.is_pinned
+        assert stub0.get_ref_count() == 0
+
+        backend.local_cpu_backend.memory_allocator.close()
+
+    def test_allocation_failure_on_first_key_releases_lock(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """Failing on the very first key still releases the lock and leaves no
+        pins behind (nothing to roll back)."""
+        backend = local_disk_backend
+        shape = torch.Size([28, 2, 16, 8, 128])
+        key0 = create_test_key(0)
+        self._inject_key(backend, key0, shape)
+
+        with patch.object(backend.local_cpu_backend, "allocate", return_value=None):
+            with pytest.raises(StagingAllocationError):
+                asyncio.run(backend.batched_get_non_blocking("lookup", [key0]))
+
+        self._assert_lock_released(backend)
+        assert backend.dict[key0].pin_count == 0
+        backend.local_cpu_backend.memory_allocator.close()
+
+    def test_missing_key_aborts_before_allocation(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """A key absent from the index aborts with StorageBackendError during
+        the up-front metadata snapshot -- before any staging allocation -- and
+        releases the lock."""
+        backend = local_disk_backend
+        shape = torch.Size([28, 2, 16, 8, 128])
+        key0 = create_test_key(0)
+        key1 = create_test_key(1)
+        self._inject_key(backend, key0, shape)
+        # key1 is intentionally NOT injected.
+
+        with patch.object(backend.local_cpu_backend, "allocate") as mock_allocate:
+            with pytest.raises(StorageBackendError):
+                asyncio.run(backend.batched_get_non_blocking("lookup", [key0, key1]))
+            # Fail-fast: the missing key is detected up front, so no staging
+            # buffer is ever allocated (and nothing needs rolling back).
+            mock_allocate.assert_not_called()
+
+        self._assert_lock_released(backend)
+        # key0 was only snapshotted, never pinned.
+        assert backend.dict[key0].pin_count == 0
+        backend.local_cpu_backend.memory_allocator.close()
+
+    def test_success_pins_keys_and_submits_prefetch(
+        self, local_disk_backend: LocalDiskBackend
+    ) -> None:
+        """The happy path pins every key, pins each staging buffer, and submits
+        a single batched prefetch task."""
+        backend = local_disk_backend
+        shape = torch.Size([28, 2, 16, 8, 128])
+        key0 = create_test_key(0)
+        key1 = create_test_key(1)
+        self._inject_key(backend, key0, shape)
+        self._inject_key(backend, key1, shape)
+
+        stub0 = _StubStagingObj()
+        stub1 = _StubStagingObj()
+
+        captured = {}
+
+        async def fake_submit(task_type, fn, *, paths, keys, memory_objs):
+            captured["task_type"] = task_type
+            captured["paths"] = paths
+            captured["keys"] = keys
+            captured["memory_objs"] = memory_objs
+            return memory_objs
+
+        with patch.object(
+            backend.local_cpu_backend, "allocate", side_effect=[stub0, stub1]
+        ):
+            with patch.object(
+                backend.disk_worker, "submit_task", side_effect=fake_submit
+            ):
+                result = asyncio.run(
+                    backend.batched_get_non_blocking("lookup", [key0, key1])
+                )
+
+        assert result == [stub0, stub1]
+        assert captured["task_type"] == "prefetch"
+        assert captured["keys"] == [key0, key1]
+        assert len(captured["paths"]) == 2
+        assert backend.dict[key0].pin_count == 1
+        assert backend.dict[key1].pin_count == 1
+        assert stub0.is_pinned and stub1.is_pinned
+        backend.local_cpu_backend.memory_allocator.close()
 
 
 class TestBatchedGetBlocking:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #3855 

Fixes a deadlock where the **local disk backend + CPU tiering** hangs SGLang under host-memory pressure (e.g. concurrent long requests): no request can proceed and SGLang's watchdog fires because the scheduler thread is stuck.

**Root cause** is in `LocalDiskBackend.batched_get_non_blocking`. It called `self.disk_lock.acquire()` at the top of each loop iteration and, when a CPU staging allocation returned `None` (`busy_loop=False`), it `return`ed a partial list **while still holding `disk_lock`**. The next disk operation (`contains`/`lookup`/`pin`/`put`) then blocked forever on `disk_lock.acquire()`, wedging the scheduler thread. This partial-return path was introduced in #2611 (bundled into an XPU enablement PR) to avoid a *different* busy-loop hang, but it (a) leaked the lock and (b) returned staging buffers that were allocated and pinned but **never read from disk** — the batched prefetch task is only submitted on the success path — while leaving prior iterations' disk-index pins dangling. Because the layerwise/SGLang retrieve commits its token count at `lookup()` time, that partial/garbage result also surfaced as **silent KV corruption** on the SGLang side.

**Fix**:
- `batched_get_non_blocking` now snapshots metadata under the lock, allocates the staging buffer **outside** the lock (mirroring `get_blocking`), and always releases the lock. On staging-pool exhaustion it rolls back every acquired resource (dict pins + staging `unpin`/`ref_count_down`) via `_rollback_prefetch` and raises `StagingAllocationError` instead of returning garbage. Missing/evicted-key invariant breaks raise the base `StorageBackendError` after the same cleanup. (New module `lmcache/v1/storage_backend/exceptions.py`.)
- `LMCacheEngine.retrieve_layer` wraps the layer loop so staging buffers from prior successful layers are released and the GPU consumer is torn down if a later layer's retrieve raises, then re-raises for the caller.
- The SGLang connector treats an aborted retrieve as a **cache miss**: `start_load_kv` unpins the lookup and returns `0` (SGLang recomputes the prefix instead of reading uninitialized KV); `load_kv_layerwise` drops the failed retriever so the engine keeps serving other requests instead of hanging.

Net effect: an exhausted staging pool now degrades to recompute for the affected request instead of deadlocking the whole engine, and no unfilled buffers are ever handed to the GPU.

**Special notes for your reviewers**:
- The `busy_loop=False` fail-fast semantics from #2611 are preserved; this PR fixes the lock leak, the pin/refcount leaks, and the garbage/partial result it introduced.
- **Known limitation (follow-up):** a staging failure *partway* through the layerwise load still skips the remaining layers for that one request (loud `ERROR` log, no leak, no deadlock). A complete fix reserves the whole retrieve's staging up front so failures always surface in `start_load_kv`. Filing separately.
- Separately noted for a future PR: the `batched_to_gpu` connector generators don't free their GPU buffers on early close (no `try/finally`) — a pre-existing latent leak on any mid-retrieve exception, out of scope here.
- Verified on a CPU-only checkout: new tests pass, `ruff check`/`ruff format`/`isort`/`codespell` clean, and `mypy` reports no new errors (the one remaining `insert_key` arg-type error pre-exists on `dev`). SGLang integration paths were compile-checked (the `sglang` package isn't installed in this env).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests