### PR TITLE
[CI] Install FFmpeg in CPU e2e validation to fix torchcodec load failure

### DIFF
--- a/.github/scripts/run-cpu-e2e-validation.sh
+++ b/.github/scripts/run-cpu-e2e-validation.sh
@@ -406,27 +406,41 @@ if ! wait_for_endpoint_contains "http://localhost:${LMCACHE_HTTP_PORT}/healthche
 fi
 echo "✅ LMCache server is healthy"
 
-echo "[Phase 2 / Step 4] Installing libnuma (Linux only) and starting vLLM server"
+echo "[Phase 2 / Step 4] Installing system libs (Linux only) and starting vLLM server"
 if [ "$(uname -s)" = "Linux" ]; then
-  # libnuma1 is required by some vLLM CPU paths. On GitHub Actions
-  # ubuntu runners apt-get must be invoked via sudo; on hardened images
-  # without passwordless sudo it may not be available at all. Skip the
-  # install if the shared object is already present, and never let an
-  # apt-get hiccup fail the whole e2e step (vLLM startup itself will
-  # surface a clearer error if libnuma is genuinely missing).
+  # System libs vLLM's CPU serve path dlopens at import time:
+  #   - libnuma1: needed by some vLLM CPU code paths.
+  #   - ffmpeg:   provides libavutil.so.{56..60} etc. that torchcodec
+  #               dlopens. Recent vLLM nightlies import torchcodec
+  #               unconditionally, so `vllm serve` aborts with
+  #               "libavutil.so.NN: cannot open shared object file"
+  #               without FFmpeg — even for text-only models.
+  # Prefer sudo if present (GitHub ubuntu runners need it). Install only
+  # what's missing and never let an apt hiccup fail the step.
+  MISSING_PKGS=()
   if [ ! -e /usr/lib/x86_64-linux-gnu/libnuma.so.1 ] \
      && [ ! -e /lib/x86_64-linux-gnu/libnuma.so.1 ]; then
+    MISSING_PKGS+=(libnuma1)
+  fi
+  # torchcodec supports FFmpeg 4-8; the distro's ffmpeg package provides a
+  # compatible libavutil. Detect via ldconfig so we match whichever
+  # soname (56..60) the runner already ships.
+  if ! ldconfig -p 2>/dev/null | grep -q 'libavutil\.so'; then
+    MISSING_PKGS+=(ffmpeg)
+  fi
+  if [ "${#MISSING_PKGS[@]}" -gt 0 ]; then
+    echo "Installing missing system packages: ${MISSING_PKGS[*]}"
     if command -v sudo >/dev/null 2>&1; then
       sudo apt-get update \
-        && sudo apt-get install -y --no-install-recommends libnuma1 \
-        || echo "⚠️  libnuma1 install via sudo apt-get failed; continuing"
+        && sudo apt-get install -y --no-install-recommends "${MISSING_PKGS[@]}" \
+        || echo "⚠️  apt-get install (${MISSING_PKGS[*]}) via sudo failed; continuing"
     else
       apt-get update \
-        && apt-get install -y --no-install-recommends libnuma1 \
-        || echo "⚠️  libnuma1 install via apt-get failed; continuing"
+        && apt-get install -y --no-install-recommends "${MISSING_PKGS[@]}" \
+        || echo "⚠️  apt-get install (${MISSING_PKGS[*]}) failed; continuing"
     fi
   else
-    echo "libnuma1 already present, skipping apt install"
+    echo "libnuma1 and FFmpeg runtime libs already present, skipping apt install"
   fi
 fi
 # VLLM_DEVICE is the modern env var (vLLM 0.8+)


### PR DESCRIPTION
### **What this PR does / why we need it**
vllm  nighly import now `torchcodec` unconditionally at multimodal/video.py, which requires FFmpeg (`libav*`) at import time. Since the CPU CI environment doesn't include FFmpeg, `vllm serve` fails to start—even for text-only models—with:

```text
RuntimeError: Could not load libtorchcodec
OSError: libavutil.so.60: cannot open shared object file
```

This PR installs `ffmpeg` alongside `libnuma1` in `run-cpu-e2e-validation.sh`. Installation is gated by library checks to avoid unnecessary reinstalls while preserving the existing sudo fallback and fail-soft behavior.

### **Special notes for reviewers**

- Verified on Ubuntu 24.04 by reproducing the failure and confirming that installing `ffmpeg` resolves the `torchcodec` import issue.
- The script is shared by both the Buildkite pipeline and `.github/workflows/cpu_device.yml`, so this fixes both CI paths.
- Baking `ffmpeg` into the `ci-base` Docker image would be a good follow-up optimization, but this script change unblocks CI immediately.

### **If applicable**

- [ ] This PR contains user-facing changes (docs added)
- [ ] This PR contains unit tests