### PR TITLE
chore(sdk): move type-only imports under TYPE_CHECKING (#3730)

### DIFF
--- a/lmcache/sdk/batch.py
+++ b/lmcache/sdk/batch.py
@@ -7,17 +7,22 @@ Public API for Batched Stream, a wrapper of Streams that are batched together.
 from __future__ import annotations
 
 # Standard
-from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import time
-
-# Third Party
-import torch
 
 # First Party
 from lmcache.cli.metrics import Metrics, StreamHandler, get_formatter
-import lmcache.sdk.stream as lmc_stream
+
+if TYPE_CHECKING:
+    # Standard
+    from collections.abc import Callable, Sequence
+
+    # Third Party
+    import torch
+
+    # First Party
+    import lmcache.sdk.stream as lmc_stream
 
 
 class LMCacheBatchedStreamError(RuntimeError):

--- a/lmcache/sdk/kvcache.py
+++ b/lmcache/sdk/kvcache.py
@@ -7,7 +7,7 @@ SDK for retrieving and storing KV cache tensors.
 from __future__ import annotations
 
 # Standard
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 import os
 import time
 import uuid
@@ -35,6 +35,10 @@ from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
     create_transfer_context,
 )
 import lmcache.c_ops as lmc_ops
+
+if TYPE_CHECKING:
+    # Standard
+    from collections.abc import Sequence
 
 logger = init_logger(__name__)
 

--- a/lmcache/sdk/stream.py
+++ b/lmcache/sdk/stream.py
@@ -7,18 +7,21 @@ Public API for LMCacheStream, a wrapper of a logical request going through the S
 from __future__ import annotations
 
 # Standard
-from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 import time
 import uuid
-
-# Third Party
-import torch
 
 # First Party
 from lmcache.logging import init_logger
 import lmcache.sdk.kvcache as lmc_sdk
+
+if TYPE_CHECKING:
+    # Standard
+    from collections.abc import Callable, Iterable, Sequence
+
+    # Third Party
+    import torch
 
 logger = init_logger(__name__)
 

--- a/lmcache/sdk/wrapper/contiguous.py
+++ b/lmcache/sdk/wrapper/contiguous.py
@@ -4,12 +4,16 @@
 # Future
 from __future__ import annotations
 
+# Standard
+from typing import TYPE_CHECKING
+
 # Third Party
 import torch
 
-# First Party
-from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
-from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContext
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+    from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContext
 
 
 class ContiguousTransferWrapper:


### PR DESCRIPTION
### Summary

Part of #3730. In `lmcache/sdk`, several imports are used **only** in type annotations, so this moves them under a `typing.TYPE_CHECKING` guard to keep them out of the runtime import path.

| File | Moved under `TYPE_CHECKING` |
|---|---|
| `sdk/batch.py` | `collections.abc.Callable`, `Sequence`; `torch`; `lmcache.sdk.stream` (module alias, annotation-only) |
| `sdk/kvcache.py` | `collections.abc.Sequence` |
| `sdk/stream.py` | `collections.abc.Callable`, `Iterable`, `Sequence`; `torch` |
| `sdk/wrapper/contiguous.py` | `IPCCacheServerKey`, `EngineDrivenContext` |

### Notes

- Each module already imports `from __future__ import annotations`, so annotations are evaluated lazily — no string-quoting of forward refs is needed.
- **Runtime-used imports are deliberately left in place**, e.g. `torch` in `contiguous.py` (constructs tensors) and the `lmcache.sdk.kvcache` alias in `stream.py` (calls `lmc_sdk.retrieve/store` at runtime). Only annotation-only imports were moved, as flagged by ruff `TC001/TC002/TC003`.

### Verification

```
ruff check lmcache/sdk/...   # All checks passed!
ruff format --check           # already formatted
isort --check                 # OK
python -m py_compile           # OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
