### PR TITLE
[refactor] split NIXL into an optional `lmcache[nixl]` extra

### DIFF
--- a/.buildkite/k3_harness/ci-base.Dockerfile
+++ b/.buildkite/k3_harness/ci-base.Dockerfile
@@ -27,7 +27,8 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
 WORKDIR /workspace
 
 # Pre-install requirements that rarely change
-COPY requirements/common.txt requirements/build.txt requirements/cuda.txt /tmp/reqs/
+COPY requirements/common.txt requirements/build.txt requirements/cuda.txt \
+     requirements/cuda13_core.txt requirements/nixl.txt /tmp/reqs/
 RUN . /opt/venv/bin/activate && \
     uv pip install -r /tmp/reqs/cuda.txt && \
     uv pip install -r /tmp/reqs/build.txt && \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,9 @@ include LICENSE
 include README.md
 include requirements/common.txt
 include requirements/cuda.txt
+include requirements/cuda12_core.txt
+include requirements/cuda13_core.txt
+include requirements/nixl.txt
 
 recursive-include csrc *
 recursive-include lmcache/lmcache_frontend *

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -31,6 +31,15 @@ Install LMCache
                             You're all set! You can now start using LMCache. For hands-on guides and more
                             usage examples, see the :ref:`quickstart_examples` section.
 
+                        .. note::
+
+                            NIXL support (e.g. for disaggregated prefill and P2P KV
+                            sharing) is an optional extra:
+
+                            .. code-block:: bash
+
+                                uv pip install lmcache[nixl]
+
                     .. tab-item:: CUDA 12.9
 
                         The CUDA 12.9 wheel is published to a dedicated
@@ -118,8 +127,8 @@ Install LMCache
                             uv pip install vllm \
                                 --extra-index-url https://download.pytorch.org/whl/cu129 \
                                 --index-strategy unsafe-best-match
-                            # LMCACHE_CUDA_MAJOR=12 makes setup.py pick cupy-cuda12x / nixl-cu12
-                            # for install_requires instead of the cu13 defaults.
+                            # LMCACHE_CUDA_MAJOR=12 makes setup.py pick cupy-cuda12x
+                            # for install_requires instead of the cu13 default.
                             LMCACHE_CUDA_MAJOR=12 \
                                 uv pip install -e . --no-build-isolation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
 requires-python = ">=3.10,<3.14"
-dynamic = ["dependencies", "version"]
+dynamic = ["dependencies", "optional-dependencies", "version"]
 
 [project.scripts]
 lmcache="lmcache.cli.main:main"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,9 +1,12 @@
 # Common project dependencies
 -r common.txt
-# Vendor-specific runtime deps (cupy, nixl) baked into install_requires.
+# Vendor-specific runtime deps (cupy) baked into install_requires.
 # Defaults to the cu13 list; the cu12.9 build path overrides via setup.py
 # (LMCACHE_CUDA_MAJOR=12) and does not consume cuda.txt directly.
 -r cuda13_core.txt
+# NIXL ships as the optional `lmcache[nixl]` extra in wheels, but dev/CI
+# environments built from this file keep it installed by default.
+-r nixl.txt
 
 # Dependencies for NVIDIA GPUs
 ray >= 2.9

--- a/requirements/cuda12_core.txt
+++ b/requirements/cuda12_core.txt
@@ -2,8 +2,3 @@
 # LMCACHE_CUDA_MAJOR=12. The cu13 default lives in cuda13_core.txt.
 
 cupy-cuda12x
-# Depend on nixl-cu12 directly: it provides the top-level `nixl` namespace.
-# The `nixl` meta-package lists both nixl-cu12 and nixl-cu13 as unconditional
-# (unmarked) deps, so it drags the cu13 backend in too; pinning the backend
-# package avoids that double install.
-nixl-cu12; python_version < "3.13"

--- a/requirements/cuda13_core.txt
+++ b/requirements/cuda13_core.txt
@@ -3,8 +3,3 @@
 # The cu12 analogue lives in cuda12_core.txt.
 
 cupy-cuda13x
-# Depend on nixl-cu13 directly: it provides the top-level `nixl` namespace.
-# The `nixl` meta-package lists both nixl-cu12 and nixl-cu13 as unconditional
-# (unmarked) deps, so it drags the cu12 backend in too; pinning the backend
-# package avoids that double install.
-nixl-cu13>=1.1.0; python_version < "3.13"

--- a/requirements/nixl.txt
+++ b/requirements/nixl.txt
@@ -1,0 +1,9 @@
+# Optional NIXL transport deps, exposed as the `pip install lmcache[nixl]`
+# extra.
+
+# Depend on the `nixl` meta-package: it is the only package that provides the
+# importable top-level `nixl` module, and since 1.3.0 it dispatches at runtime
+# to the backend (nixl_cu12 / nixl_cu13) matching torch's CUDA build. The
+# nixl-cu12 / nixl-cu13 backend wheels alone do NOT provide the `nixl` module.
+# Cost: the meta-package installs both CUDA backends (~105MB each).
+nixl>=1.3.0; python_version < "3.13"

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,17 @@ if __name__ == "__main__":
     ext_modules, cmdclass, req_file = policy.collect_extensions(profile)
 
     install_requires = _read_requirements(ROOT_DIR / "requirements" / "common.txt")
-    if not BuildProfile.is_gpu_ext_disabled() and req_file is not None:
+    extras_require: dict[str, list[str]] = {}
+    if (
+        not BuildProfile.is_gpu_ext_disabled()
+        and req_file is not None
+        and profile is not None
+    ):
         install_requires += _read_requirements(ROOT_DIR / "requirements" / req_file)
+        for extra_name, extra_req_file in profile.extras_requirements().items():
+            extras_require[extra_name] = _read_requirements(
+                ROOT_DIR / "requirements" / extra_req_file
+            )
 
     setup(
         packages=find_packages(exclude=("csrc",)),
@@ -49,4 +58,5 @@ if __name__ == "__main__":
         cmdclass=cmdclass,
         include_package_data=True,
         install_requires=install_requires,
+        extras_require=extras_require,
     )

--- a/setup_extensions/build_profiles/__init__.py
+++ b/setup_extensions/build_profiles/__init__.py
@@ -35,6 +35,7 @@ class BuildProfile(ABC):
                                     common extensions defined in
                                     ``COMMON_EXTENSIONS``.
         requirements_file()        – core requirements file name.
+        extras_requirements()      – optional-extra requirements files.
     """
 
     name: str = ""
@@ -149,3 +150,14 @@ class BuildProfile(ABC):
         Return ``None`` when this profile has no extra deps.
         """
         return None
+
+    def extras_requirements(self) -> dict[str, str]:
+        """Optional-extra requirements files, relative to ``requirements/``.
+
+        Returns:
+            Mapping from pip extra name (e.g. ``"nixl"``, installed via
+            ``pip install lmcache[nixl]``) to the requirements file that
+            lists that extra's dependencies. Empty when this profile
+            exposes no optional extras.
+        """
+        return {}

--- a/setup_extensions/build_profiles/cuda.py
+++ b/setup_extensions/build_profiles/cuda.py
@@ -85,9 +85,30 @@ class CudaProfile(BuildProfile):
 
     def requirements_file(self) -> Optional[str]:
         """Return the CUDA version-specific requirements file."""
+        return "cuda%s_core.txt" % self._cuda_major()
+
+    def extras_requirements(self) -> dict[str, str]:
+        """Return the CUDA optional extras.
+
+        Returns:
+            Mapping with the ``"nixl"`` extra (``pip install lmcache[nixl]``).
+            The extra depends on the ``nixl`` meta-package, which selects the
+            CUDA backend at runtime, so it is identical for CUDA 12 and 13.
+        """
+        return {"nixl": "nixl.txt"}
+
+    def _cuda_major(self) -> str:
+        """Resolve the target CUDA major version from ``LMCACHE_CUDA_MAJOR``.
+
+        Returns:
+            ``"12"`` or ``"13"`` (default ``"13"``, matching the PyPI build).
+
+        Raises:
+            ValueError: If ``LMCACHE_CUDA_MAJOR`` is set to anything else.
+        """
         cuda_major = os.environ.get("LMCACHE_CUDA_MAJOR", "13")
         if cuda_major not in ("12", "13"):
             raise ValueError(
                 "LMCACHE_CUDA_MAJOR must be '12' or '13', got '%s'" % cuda_major
             )
-        return "cuda%s_core.txt" % cuda_major
+        return cuda_major


### PR DESCRIPTION
### **What this PR does / why we need it**

Moves NIXL from `install_requires` to an optional `lmcache[nixl]` extra, so `pip install lmcache` no longer installs NIXL by default. Users who need NIXL (e.g. disaggregated prefill, P2P KV sharing, NIXL storage) can install it via:

```bash
pip install lmcache[nixl]
```

The extra depends on the `nixl` meta-package (`>=1.3.0`), which correctly provides the `nixl` Python module and selects the appropriate backend at runtime. This also fixes a pre-existing issue where `nixl-cu13` alone did not support `import nixl`.

Other changes:
- Add `requirements/nixl.txt` and remove NIXL from core requirements.
- Add `extras_requirements()` support to `BuildProfile` and wire it into `setup.py`.
- Keep NIXL installed by default in dev/CI via `requirements/cuda.txt`.
- Runtime Docker images remain unchanged.

### **Special notes for reviewers**

- Verified wheel metadata, installation behavior, `import nixl`, CI image builds, docs, and lint.
- After merge, the Buildkite `ci-base` image must be rebuilt (`REBUILD_IMAGE=1`) to include the new `nixl.txt`.
- Existing releases (≤0.5.1) do not support `lmcache[nixl]`; the extra takes effect in the next release.
- A follow-up PR can simplify Docker release stages to use `lmcache[nixl]`.

### **If applicable**

- [x] This PR contains user-facing changes (docs added)
- [ ] This PR contains unit tests