### PR TITLE
[good-first-issue] sdk: move type-only imports (#3730)

### DIFF
--- a/lmcache/sdk/kvcache.py
+++ b/lmcache/sdk/kvcache.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 import os
 import time
 import uuid
@@ -22,7 +23,6 @@ from lmcache.integration.vllm.vllm_multi_process_adapter import send_lmcache_req
 from lmcache.logging import init_logger
 from lmcache.sdk.wrapper.contiguous import ContiguousTransferWrapper
 from lmcache.v1.gpu_connector.utils import (
-    DiscoverableKVCache,
     LayoutHints,
     get_block_size,
     get_num_heads,
@@ -35,6 +35,10 @@ from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
     create_transfer_context,
 )
 import lmcache.c_ops as lmc_ops
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.gpu_connector.utils import DiscoverableKVCache
 
 logger = init_logger(__name__)
 

--- a/lmcache/sdk/wrapper/contiguous.py
+++ b/lmcache/sdk/wrapper/contiguous.py
@@ -4,12 +4,16 @@
 # Future
 from __future__ import annotations
 
+# Standard
+from typing import TYPE_CHECKING
+
 # Third Party
 import torch
 
-# First Party
-from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
-from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContext
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+    from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContext
 
 
 class ContiguousTransferWrapper:


### PR DESCRIPTION
**What this PR does / why we need it**:
Refs #3730

Moves SDK annotation-only imports behind `TYPE_CHECKING` guards in `kvcache.py` and `wrapper/contiguous.py`. This keeps runtime imports smaller while preserving type hints through `from __future__ import annotations`.

**Special notes for your reviewers**:
- This is my first PR to LMCache; please be gentle.
- I ran `env UV_CACHE_DIR=/Users/bowenli/Documents/LMCache/LMCache/.uv-cache UV_TOOL_DIR=/Users/bowenli/Documents/LMCache/LMCache/.uv-tools uvx ruff check lmcache/sdk/wrapper/contiguous.py lmcache/sdk/kvcache.py` locally — all green.
- I ran `python3 -m py_compile lmcache/sdk/wrapper/contiguous.py lmcache/sdk/kvcache.py` locally — all green.
- I did not run `pre-commit run --all-files`; `pre-commit` is not installed locally.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
