### PR TITLE
[Abandoned] Bug fix AzureConnector 

### DIFF
--- a/lmcache/v1/storage_backend/connector/azure_connector.py
+++ b/lmcache/v1/storage_backend/connector/azure_connector.py
@@ -201,7 +201,7 @@ class AzureConnector(RemoteConnector):
     async def get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """Download the chunk for ``key`` into a freshly allocated MemoryObj.
 
-        The blob is streamed directly into the preallocated buffer (zero-copy).
+        The blob bytes are downloaded and copied into the preallocated buffer.
 
         Args:
             key: The cache engine key to fetch.
@@ -242,8 +242,20 @@ class AzureConnector(RemoteConnector):
         try:
             blob = self.container_client.get_blob_client(self._blob_name(key_str))
             downloader = await blob.download_blob()
-            # Zero-copy: stream straight into the preallocated buffer.
-            await downloader.readinto(memory_obj.byte_array)
+            # NOTE: the aio SDK's ``readinto`` writes to a file-like *stream* (it
+            # calls ``.write``); it cannot target a raw buffer, so passing
+            # ``memory_obj.byte_array`` raises AttributeError. Download the bytes
+            # and copy them into the preallocated buffer instead.
+            data = await downloader.readall()
+            dst = memoryview(memory_obj.byte_array).cast("B")
+            if len(data) != len(dst):
+                logger.error(
+                    f"Downloaded {len(data)} bytes for {key_str} but the buffer is "
+                    f"{len(dst)} bytes; dropping."
+                )
+                memory_obj.ref_count_down()
+                return None
+            dst[:] = data
             return memory_obj
         except Exception as e:
             logger.error(f"Failed to download {key_str} from Azure: {e}")
@@ -283,12 +295,14 @@ class AzureConnector(RemoteConnector):
 
         try:
             blob = self.container_client.get_blob_client(self._blob_name(key_str))
-            # Pass the memoryview directly (zero-copy); bytes() would copy the
-            # whole chunk.
+            # NOTE: the aio SDK's ``upload_blob`` cannot consume a raw
+            # ``memoryview`` (it raises "memoryview: unsupported format ..."); it
+            # needs ``bytes``. This copy is required for correctness.
+            data = bytes(memoryview(memory_obj.byte_array).cast("B"))
             await blob.upload_blob(
-                memory_obj.byte_array,
+                data,
                 overwrite=True,
-                length=memory_obj.get_physical_size(),
+                length=len(data),
             )
             self.object_size_cache[key_str] = memory_obj.get_physical_size()
             logger.debug(f"Uploaded {key_str} to Azure successfully")

--- a/lmcache/v1/storage_backend/connector/azure_connector.py
+++ b/lmcache/v1/storage_backend/connector/azure_connector.py
@@ -242,10 +242,7 @@ class AzureConnector(RemoteConnector):
         try:
             blob = self.container_client.get_blob_client(self._blob_name(key_str))
             downloader = await blob.download_blob()
-            # NOTE: the aio SDK's ``readinto`` writes to a file-like *stream* (it
-            # calls ``.write``); it cannot target a raw buffer, so passing
-            # ``memory_obj.byte_array`` raises AttributeError. Download the bytes
-            # and copy them into the preallocated buffer instead.
+            # Read the whole blob into bytes, then copy into the buffer.
             data = await downloader.readall()
             dst = memoryview(memory_obj.byte_array).cast("B")
             if len(data) != len(dst):
@@ -295,9 +292,7 @@ class AzureConnector(RemoteConnector):
 
         try:
             blob = self.container_client.get_blob_client(self._blob_name(key_str))
-            # NOTE: the aio SDK's ``upload_blob`` cannot consume a raw
-            # ``memoryview`` (it raises "memoryview: unsupported format ..."); it
-            # needs ``bytes``. This copy is required for correctness.
+            # upload_blob cannot consume a raw memoryview; it needs bytes.
             data = bytes(memoryview(memory_obj.byte_array).cast("B"))
             await blob.upload_blob(
                 data,

--- a/tests/v1/storage_backend/test_azure_connector.py
+++ b/tests/v1/storage_backend/test_azure_connector.py
@@ -1,13 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the native Azure Blob Storage connector.
 
-TEST TYPE: unit / smoke. The ``azure-storage-blob`` / ``azure-identity`` SDKs are
-MOCKED at the ``sys.modules`` level, so these run anywhere (CPU-only, no network,
-no cloud account) and are the CI regression guard. NOTE: mocks guard the code
-path but cannot reproduce real SDK behavior — an incorrect mock is precisely what
-hid the memoryview put/get bugs. The real-API coverage lives in
-``test_azure_connector_azurite.py`` (emulator) and
-``test_azure_connector_realaccount.py`` (real cloud).
+The ``azure-storage-blob`` / ``azure-identity`` SDKs are mocked at the
+``sys.modules`` level so these tests run anywhere (including CPU-only / M1
+machines) without the real packages installed.
 """
 
 # Standard
@@ -231,10 +227,6 @@ class TestAzureConnector:
         payload = bytes(range(256)) * (size // 256) + bytes(size % 256)
         blob_client.get_blob_properties = AsyncMock(return_value=MagicMock(size=size))
 
-        # NOTE: the real aio SDK downloader exposes ``readall()`` (returns bytes);
-        # its ``readinto`` writes to a *stream*, not a buffer. The connector uses
-        # ``readall()`` + copy, so mock that — mocking ``readinto`` as a
-        # buffer-filler (the old mock) hid a real bug that failed on live Azure.
         downloader = MagicMock()
         downloader.readall = AsyncMock(return_value=payload)
         blob_client.download_blob = AsyncMock(return_value=downloader)

--- a/tests/v1/storage_backend/test_azure_connector.py
+++ b/tests/v1/storage_backend/test_azure_connector.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the native Azure Blob Storage connector.
 
-The ``azure-storage-blob`` / ``azure-identity`` SDKs are mocked at the
-``sys.modules`` level so these tests run anywhere (including CPU-only / M1
-machines) without the real packages installed.
+TEST TYPE: unit / smoke. The ``azure-storage-blob`` / ``azure-identity`` SDKs are
+MOCKED at the ``sys.modules`` level, so these run anywhere (CPU-only, no network,
+no cloud account) and are the CI regression guard. NOTE: mocks guard the code
+path but cannot reproduce real SDK behavior — an incorrect mock is precisely what
+hid the memoryview put/get bugs. The real-API coverage lives in
+``test_azure_connector_azurite.py`` (emulator) and
+``test_azure_connector_realaccount.py`` (real cloud).
 """
 
 # Standard
@@ -227,13 +231,12 @@ class TestAzureConnector:
         payload = bytes(range(256)) * (size // 256) + bytes(size % 256)
         blob_client.get_blob_properties = AsyncMock(return_value=MagicMock(size=size))
 
-        async def fake_readinto(buf):
-            mv = memoryview(buf).cast("B")
-            mv[: len(payload)] = payload[: len(mv)]
-            return len(payload)
-
+        # NOTE: the real aio SDK downloader exposes ``readall()`` (returns bytes);
+        # its ``readinto`` writes to a *stream*, not a buffer. The connector uses
+        # ``readall()`` + copy, so mock that — mocking ``readinto`` as a
+        # buffer-filler (the old mock) hid a real bug that failed on live Azure.
         downloader = MagicMock()
-        downloader.readinto = AsyncMock(side_effect=fake_readinto)
+        downloader.readall = AsyncMock(return_value=payload)
         blob_client.download_blob = AsyncMock(return_value=downloader)
 
         key = create_test_key(3)

--- a/tests/v1/storage_backend/test_azure_connector_azurite.py
+++ b/tests/v1/storage_backend/test_azure_connector_azurite.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration test for the AzureConnector against the Azurite emulator.
+
+TEST TYPE: integration against a REAL azure-storage-blob client + the official
+Azurite Blob emulator over a real socket — but NO cloud account and NO GPU. It
+uses the real SDK (not mocks), so it exercises the true serialization / API
+contract. Skips automatically if Azurite is not running on 127.0.0.1:10000.
+This is the level that actually catches real-SDK bugs the unit mocks cannot.
+
+Doing so surfaced a real bug the mock-only tests hide (see
+``test_put_memoryview_bug_and_read_path``): ``AzureConnector.put`` hands a raw
+``memoryview`` (``memory_obj.byte_array``) to ``upload_blob``, which the real
+``azure-storage-blob`` SDK rejects — so every write silently fails (best-effort)
+and the cache never populates on real Blob. The fix is one line: upload
+``bytes(memory_obj.byte_array)`` (or ``.cast('B')`` first).
+
+Start Azurite first:
+    azurite-blob --silent --location /tmp/azurite_data --blobPort 10000 --blobHost 127.0.0.1
+
+Run:
+    PYTHONPATH=. python -m pytest tests/v1/storage_backend/test_azure_connector_azurite.py -q
+"""
+
+# Standard
+import asyncio
+import socket
+import threading
+import time
+
+# Third Party
+import pytest
+import torch
+from azure.storage.blob import BlobServiceClient as SyncBlobServiceClient
+
+# First Party
+from lmcache.utils import CacheEngineKey
+from lmcache.v1.config import LMCacheEngineConfig
+from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.storage_backend.connector.azure_connector import AzureConnector
+from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+AZURITE_CONN = (
+    "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
+    "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
+    "K1SZFPTOtr/KBHBeksoGMGw==;"
+    "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+)
+
+
+def _azurite_up() -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", 10000), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _azurite_up(), reason="Azurite blob emulator not reachable on 127.0.0.1:10000"
+)
+
+
+def create_test_metadata(kv_shape=(1, 2, 16, 8, 128), chunk_size=16) -> LMCacheMetadata:
+    return LMCacheMetadata(
+        model_name="test_model",
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.bfloat16,
+        kv_shape=kv_shape,
+        chunk_size=chunk_size,
+    )
+
+
+def create_test_key(key_id: int) -> CacheEngineKey:
+    return CacheEngineKey(
+        model_name="test_model",
+        world_size=3,
+        worker_id=1,
+        chunk_hash=hash(key_id),
+        dtype=torch.bfloat16,
+    )
+
+
+@pytest.fixture
+def async_loop():
+    loop = asyncio.new_event_loop()
+    # First Party
+    from lmcache.utils import start_loop_in_thread_with_exceptions
+
+    thread = threading.Thread(
+        target=start_loop_in_thread_with_exceptions,
+        args=(loop,),
+        name="test-azurite-loop",
+    )
+    thread.start()
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5.0)
+
+
+@pytest.fixture
+def local_cpu_backend(memory_allocator):
+    config = LMCacheEngineConfig.from_legacy(chunk_size=16)
+    return LocalCPUBackend(
+        config, create_test_metadata(), memory_allocator=memory_allocator
+    )
+
+
+def run(loop, coro):
+    return asyncio.run_coroutine_threadsafe(coro, loop).result()
+
+
+def _make_connector(container, async_loop, local_cpu_backend):
+    return AzureConnector(
+        container=container,
+        loop=async_loop,
+        local_cpu_backend=local_cpu_backend,
+        connection_string=AZURITE_CONN,
+    )
+
+
+def test_real_blob_roundtrip_against_azurite(async_loop, local_cpu_backend):
+    """Full write->read round-trip of AzureConnector against REAL Blob (Azurite).
+
+    This is the regression test for the two bugs that mock-only tests hid, which
+    were found by running against Azurite:
+      * put() used to hand a raw ``memoryview`` to ``upload_blob`` -> the SDK
+        raised "memoryview: unsupported format ...", and because writes are
+        best-effort the error was swallowed, so nothing was ever stored.
+      * get() used to call ``downloader.readinto(byte_array)`` -> the aio SDK's
+        ``readinto`` writes to a *stream* (``.write``), not a buffer, so it raised
+        AttributeError and returned None even when the blob was present.
+    The connector now uploads ``bytes(...)`` and reads via ``readall()`` + copy.
+
+    What each step verifies against the real Blob API:
+      1. exists() before write  -> False   (real HEAD / get_blob_properties)
+      2. put()                  -> actually stores the chunk (fix #1)
+      3. exists() after write   -> True     (positive HEAD)
+      4. get()                  -> byte-identical MemoryObj (fix #2, real download)
+      5. list()                 -> the one blob we wrote (real list_blobs)
+      6. close()                -> clean client shutdown
+    Auth is exercised too: the connector authenticates via the Azurite connection
+    string to reach any of these endpoints.
+    """
+    sync = SyncBlobServiceClient.from_connection_string(AZURITE_CONN)
+    container = f"kvtest{int(time.time())}"
+    sync.create_container(container)  # connector assumes the container pre-exists
+
+    connector = _make_connector(container, async_loop, local_cpu_backend)
+    key = create_test_key(1)
+
+    # Allocate a full KV chunk and fill it with a known byte pattern.
+    memory_obj = local_cpu_backend.allocate(
+        connector.meta_shapes, connector.meta_dtypes, connector.meta_fmt
+    )
+    buf = memoryview(memory_obj.byte_array).cast("B")
+    pattern = (bytes(range(256)) * ((len(buf) // 256) + 1))[: len(buf)]
+    buf[:] = pattern
+    original = bytes(buf)
+
+    # 1. miss before any write
+    assert run(async_loop, connector.exists(key)) is False
+
+    # 2. put -> real upload (previously a silent no-op; now actually stores bytes)
+    run(async_loop, connector.put(key, memory_obj))
+    memory_obj.ref_count_down()
+    # Confirm at the raw-SDK level that the blob really exists now.
+    blob_name = connector._blob_name(key.to_string())
+    assert sync.get_container_client(container).get_blob_client(blob_name).exists()
+
+    # 3. exists after write (use a fresh connector so we test a real HEAD, not the
+    #    in-process size cache populated by put()).
+    reader = _make_connector(container, async_loop, local_cpu_backend)
+    assert run(async_loop, reader.exists(key)) is True
+
+    # 4. get -> real download, byte-identical to what we wrote (previously None)
+    res = run(async_loop, reader.get(key))
+    assert res is not None
+    assert bytes(memoryview(res.byte_array).cast("B")) == original
+    res.ref_count_down()
+
+    # 5. list -> exactly the one blob we stored
+    assert len(run(async_loop, reader.list())) == 1
+
+    # 6. close both clients cleanly
+    run(async_loop, reader.close())
+    run(async_loop, connector.close())

--- a/tests/v1/storage_backend/test_azure_connector_azurite.py
+++ b/tests/v1/storage_backend/test_azure_connector_azurite.py
@@ -1,18 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Integration test for the AzureConnector against the Azurite emulator.
 
-TEST TYPE: integration against a REAL azure-storage-blob client + the official
-Azurite Blob emulator over a real socket — but NO cloud account and NO GPU. It
-uses the real SDK (not mocks), so it exercises the true serialization / API
-contract. Skips automatically if Azurite is not running on 127.0.0.1:10000.
-This is the level that actually catches real-SDK bugs the unit mocks cannot.
-
-Doing so surfaced a real bug the mock-only tests hide (see
-``test_put_memoryview_bug_and_read_path``): ``AzureConnector.put`` hands a raw
-``memoryview`` (``memory_obj.byte_array``) to ``upload_blob``, which the real
-``azure-storage-blob`` SDK rejects — so every write silently fails (best-effort)
-and the cache never populates on real Blob. The fix is one line: upload
-``bytes(memory_obj.byte_array)`` (or ``.cast('B')`` first).
+Uses the real ``azure-storage-blob`` client against the Azurite Blob emulator
+(no cloud account, no GPU). Skips automatically if Azurite is not running on
+127.0.0.1:10000.
 
 Start Azurite first:
     azurite-blob --silent --location /tmp/azurite_data --blobPort 10000 --blobHost 127.0.0.1
@@ -122,27 +113,10 @@ def _make_connector(container, async_loop, local_cpu_backend):
 
 
 def test_real_blob_roundtrip_against_azurite(async_loop, local_cpu_backend):
-    """Full write->read round-trip of AzureConnector against REAL Blob (Azurite).
+    """Full write->read round-trip of AzureConnector against real Blob (Azurite).
 
-    This is the regression test for the two bugs that mock-only tests hid, which
-    were found by running against Azurite:
-      * put() used to hand a raw ``memoryview`` to ``upload_blob`` -> the SDK
-        raised "memoryview: unsupported format ...", and because writes are
-        best-effort the error was swallowed, so nothing was ever stored.
-      * get() used to call ``downloader.readinto(byte_array)`` -> the aio SDK's
-        ``readinto`` writes to a *stream* (``.write``), not a buffer, so it raised
-        AttributeError and returned None even when the blob was present.
-    The connector now uploads ``bytes(...)`` and reads via ``readall()`` + copy.
-
-    What each step verifies against the real Blob API:
-      1. exists() before write  -> False   (real HEAD / get_blob_properties)
-      2. put()                  -> actually stores the chunk (fix #1)
-      3. exists() after write   -> True     (positive HEAD)
-      4. get()                  -> byte-identical MemoryObj (fix #2, real download)
-      5. list()                 -> the one blob we wrote (real list_blobs)
-      6. close()                -> clean client shutdown
-    Auth is exercised too: the connector authenticates via the Azurite connection
-    string to reach any of these endpoints.
+    Steps: exists (miss) -> put -> exists (hit) -> get (byte-identical) ->
+    list -> close.
     """
     sync = SyncBlobServiceClient.from_connection_string(AZURITE_CONN)
     container = f"kvtest{int(time.time())}"
@@ -151,7 +125,6 @@ def test_real_blob_roundtrip_against_azurite(async_loop, local_cpu_backend):
     connector = _make_connector(container, async_loop, local_cpu_backend)
     key = create_test_key(1)
 
-    # Allocate a full KV chunk and fill it with a known byte pattern.
     memory_obj = local_cpu_backend.allocate(
         connector.meta_shapes, connector.meta_dtypes, connector.meta_fmt
     )
@@ -160,30 +133,23 @@ def test_real_blob_roundtrip_against_azurite(async_loop, local_cpu_backend):
     buf[:] = pattern
     original = bytes(buf)
 
-    # 1. miss before any write
     assert run(async_loop, connector.exists(key)) is False
 
-    # 2. put -> real upload (previously a silent no-op; now actually stores bytes)
     run(async_loop, connector.put(key, memory_obj))
     memory_obj.ref_count_down()
-    # Confirm at the raw-SDK level that the blob really exists now.
     blob_name = connector._blob_name(key.to_string())
     assert sync.get_container_client(container).get_blob_client(blob_name).exists()
 
-    # 3. exists after write (use a fresh connector so we test a real HEAD, not the
-    #    in-process size cache populated by put()).
+    # fresh connector to bypass the in-process size cache
     reader = _make_connector(container, async_loop, local_cpu_backend)
     assert run(async_loop, reader.exists(key)) is True
 
-    # 4. get -> real download, byte-identical to what we wrote (previously None)
     res = run(async_loop, reader.get(key))
     assert res is not None
     assert bytes(memoryview(res.byte_array).cast("B")) == original
     res.ref_count_down()
 
-    # 5. list -> exactly the one blob we stored
     assert len(run(async_loop, reader.list())) == 1
 
-    # 6. close both clients cleanly
     run(async_loop, reader.close())
     run(async_loop, connector.close())


### PR DESCRIPTION
## Summary

The native Azure Blob connector (`azure_connector.py`, added in #3686) is
non-functional against real Azure Blob Storage and the Azurite emulator: **every
`put()` and `get()` fails.** Both bugs come from handing a raw `memoryview` to
`azure-storage-blob`:

- **`put()`** passed `memory_obj.byte_array` to `upload_blob`, which the SDK
  cannot consume (`memoryview: unsupported format ...`). Writes are best-effort,
  so the error was swallowed and **nothing was ever stored**.
- **`get()`** called `downloader.readinto(memory_obj.byte_array)`, but the aio
  SDK's `readinto` writes to a file-like **stream** (`.write`), not a buffer, so
  it raised `AttributeError` and **returned `None` even when the blob existed**.

Both were masked because the unit tests mocked the SDK incorrectly (the mock
`readinto` filled a buffer — the opposite of the real API; the mock `upload_blob`
accepted any object). Auth, `exists`, `list`, and `close` were unaffected.

## Fix

- `put()`: upload `bytes(memory_obj.byte_array)`.
- `get()`: download via `readall()` and copy into the buffer, with a
  length-mismatch guard.

## Testing

- Fixed the mocked unit test to model `readall()` (the real API).
- Added `test_azure_connector_azurite.py`: a real-Blob round-trip
  (write → exists → get → list → close) against the Azurite emulator; skips if
  Azurite isn't running.
- Verified against **Azurite** and a **real Azure Storage account** (Entra ID
  auth, since Shared Key was disabled) — full round-trip passes, bytes identical.

## Notes

- `bytes(...)` is a copy; the previous "zero-copy" comment never actually worked
  with this SDK. A true zero-copy path (stream wrapper for download,
  buffer-protocol upload) would be a follow-up.

- [x] This PR contains unit tests
