### PR TITLE
chore(storage_backend): move type-only imports under TYPE_CHECKING

### DIFF
--- a/lmcache/v1/storage_backend/plugins/dax_backend.py
+++ b/lmcache/v1/storage_backend/plugins/dax_backend.py
@@ -5,27 +5,34 @@ from __future__ import annotations
 
 # Standard
 from collections import OrderedDict
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Callable, List, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, cast
 import asyncio
 import ctypes
 import os
 import threading
 
-# Third Party
-import torch
+import lmcache.c_ops as lmc_ops
 
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
-from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
-from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.abstract_backend import StoragePluginInterface
 from lmcache.v1.storage_backend.dax.core import DaxCore
-from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
-import lmcache.c_ops as lmc_ops
+
+if TYPE_CHECKING:
+    # Standard
+    from concurrent.futures import Future
+
+    # Third Party
+    import torch
+
+    # First Party
+    from lmcache.v1.config import LMCacheEngineConfig
+    from lmcache.v1.metadata import LMCacheMetadata
+    from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/storage_backend/plugins/dax_backend.py
+++ b/lmcache/v1/storage_backend/plugins/dax_backend.py
@@ -13,14 +13,13 @@ import ctypes
 import os
 import threading
 
-import lmcache.c_ops as lmc_ops
-
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.storage_backend.abstract_backend import StoragePluginInterface
 from lmcache.v1.storage_backend.dax.core import DaxCore
+import lmcache.c_ops as lmc_ops
 
 if TYPE_CHECKING:
     # Standard

--- a/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
+++ b/lmcache/v1/storage_backend/plugins/rust_raw_block_backend.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Mapping
-from concurrent.futures import Future
-from typing import Any, Callable, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
 import threading
 import time
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey
-from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.storage_backend.abstract_backend import (
     AllocatorBackendInterface,
     StoragePluginInterface,
@@ -30,6 +27,14 @@ from lmcache.v1.storage_backend.raw_block import (
     round_up,
     validate_raw_block_io_options,
 )
+
+if TYPE_CHECKING:
+    # Standard
+    from concurrent.futures import Future
+
+    # First Party
+    from lmcache.utils import CacheEngineKey
+    from lmcache.v1.memory_management import MemoryObj
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Ref #3730

Move imports that are used only in type annotations under a `typing.TYPE_CHECKING` guard so they are not evaluated at import time. Scoped to three files under `lmcache/v1/storage_backend/`:

- `connector/hfbucket_connector.py`
- `plugins/dax_backend.py`
- `plugins/rust_raw_block_backend.py`

Only names used purely in annotations are moved; runtime-required imports (base classes, `MemoryFormat`, etc.) stay as normal imports. Each file already has `from __future__ import annotations`, so annotations are strings at runtime and this is behavior-preserving.

**Special notes for your reviewers**:
- `ruff check --select TC001,TC002,TC003` is clean on all three files.
- `ruff check` (I/F/E) and `ruff format --check` pass.