### PR TITLE
style: drop redundant None default in dict.get() calls (SIM910)

### DIFF
--- a/lmcache/integration/request_telemetry/fastapi.py
+++ b/lmcache/integration/request_telemetry/fastapi.py
@@ -33,7 +33,7 @@ class FastAPIRequestTelemetry(RequestTelemetry):
     """
 
     def __init__(self, config: dict[str, Any]) -> None:
-        endpoint = config.get("endpoint", None)
+        endpoint = config.get("endpoint")
         if endpoint is None:
             raise ValueError(
                 "FastAPIRequestTelemetry requires setting endpoint. "

--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -318,7 +318,7 @@ class LMCacheEngine:
                     self.use_layerwise,
                     self.save_only_first_rank,
                 )
-                async_lookup_server = kwargs.get("async_lookup_server", None)
+                async_lookup_server = kwargs.get("async_lookup_server")
                 self.storage_manager = StorageManager(
                     self.config,
                     self.metadata,
@@ -556,7 +556,7 @@ class LMCacheEngine:
             self.gpu_connector.batched_from_gpu(memory_objs, starts, ends, **kwargs)
 
         with store_stats.profile_put():
-            transfer_spec = kwargs.get("transfer_spec", None)
+            transfer_spec = kwargs.get("transfer_spec")
             # TODO: we implicitly rely on batched_put to call ref_count_down
             # this management should be done in a cleaner way
             self.storage_manager.batched_put(

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -205,11 +205,11 @@ class FSL2AdapterConfig(L2AdapterConfigBase):
         base_path = d.get("base_path")
         if not isinstance(base_path, str) or not base_path:
             raise ValueError("base_path must be a non-empty string")
-        relative_tmp_dir = d.get("relative_tmp_dir", None)
+        relative_tmp_dir = d.get("relative_tmp_dir")
         if relative_tmp_dir is not None:
             if not isinstance(relative_tmp_dir, str):
                 raise ValueError("relative_tmp_dir must be a string")
-        read_ahead_size = d.get("read_ahead_size", None)
+        read_ahead_size = d.get("read_ahead_size")
         if read_ahead_size is not None:
             if not isinstance(read_ahead_size, int) or read_ahead_size <= 0:
                 raise ValueError("read_ahead_size must be a positive integer")

--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
@@ -81,7 +81,7 @@ class FSNativeL2AdapterConfig(L2AdapterConfigBase):
         if not isinstance(use_odirect, bool):
             raise ValueError("use_odirect must be a boolean")
 
-        read_ahead_size = d.get("read_ahead_size", None)
+        read_ahead_size = d.get("read_ahead_size")
         if read_ahead_size is not None:
             if not isinstance(read_ahead_size, int) or read_ahead_size <= 0:
                 raise ValueError("read_ahead_size must be a positive integer")

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -373,7 +373,7 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
             return v
 
         def _opt_str(key):
-            v = d.get(key, None)
+            v = d.get(key)
             if v is None:
                 return None
             if not isinstance(v, str):

--- a/lmcache/v1/memory_allocators/mixed_memory_allocator.py
+++ b/lmcache/v1/memory_allocators/mixed_memory_allocator.py
@@ -40,20 +40,20 @@ class MixedMemoryAllocator(MemoryAllocatorInterface):
         :param bool use_hugepages: Whether to use hugepages.
         """
 
-        self.numa_mapping = kwargs.get("numa_mapping", None)
+        self.numa_mapping = kwargs.get("numa_mapping")
         self.use_hugepages = use_hugepages
         self.align_bytes = kwargs.get("align_bytes", AddressManager.ALIGN_BYTES)
         if self.align_bytes <= 0 or self.align_bytes & (self.align_bytes - 1) != 0:
             raise ValueError("align_bytes must be a positive power of two")
 
         # Extract shm_name from config.extra_config if available
-        config = kwargs.get("config", None)
+        config = kwargs.get("config")
         if config is not None:
             self.shm_name: Optional[str] = config.get_extra_config_value(
                 "shm_name", None
             )
         else:
-            self.shm_name = kwargs.get("shm_name", None)
+            self.shm_name = kwargs.get("shm_name")
 
         self.size = size
 

--- a/lmcache/v1/multiprocess/mq.py
+++ b/lmcache/v1/multiprocess/mq.py
@@ -598,8 +598,8 @@ class MessageQueueServer:
         output_fd = self._output_efd.fileno()
         while not self.is_finished.is_set():
             socks = dict(self.poller.poll(1000))
-            inbound_state = socks.get(self.socket, None)
-            outbound_state = socks.get(output_fd, None)
+            inbound_state = socks.get(self.socket)
+            outbound_state = socks.get(output_fd)
 
             # Process the incoming requests
             if inbound_state and inbound_state & zmq.POLLIN:

--- a/lmcache/v1/transfer_channel/nixl_channel.py
+++ b/lmcache/v1/transfer_channel/nixl_channel.py
@@ -95,7 +95,7 @@ class NixlChannel(BaseTransferChannel):
         self.nixl_agent = self.nixl_wrapper.agent
 
         # Used for P2P
-        self.peer_lookup_url = kwargs.get("peer_lookup_url", None)
+        self.peer_lookup_url = kwargs.get("peer_lookup_url")
 
         self.running = True
         self.remote_xfer_handlers_dict: dict[
@@ -111,7 +111,7 @@ class NixlChannel(BaseTransferChannel):
         else:
             self.zmq_context = get_zmq_context(use_asyncio=False)
         self.peer_init_url = kwargs["peer_init_url"]
-        self.event_loop = kwargs.get("event_loop", None)
+        self.event_loop = kwargs.get("event_loop")
 
         self._init_side_channels()
 

--- a/lmcache/v1/transfer_channel/py_socket_channel.py
+++ b/lmcache/v1/transfer_channel/py_socket_channel.py
@@ -80,7 +80,7 @@ class PySocketChannel(BaseTransferChannel):
         self.align_bytes = kwargs["align_bytes"]
         self.tp_rank = kwargs["tp_rank"]
 
-        self.peer_lookup_url = kwargs.get("peer_lookup_url", None)
+        self.peer_lookup_url = kwargs.get("peer_lookup_url")
 
         self.running = True
         self.remote_connections: dict[str, dict] = {}
@@ -94,7 +94,7 @@ class PySocketChannel(BaseTransferChannel):
         else:
             self.zmq_context = get_zmq_context(use_asyncio=False)
         self.peer_init_url = kwargs["peer_init_url"]
-        self.event_loop = kwargs.get("event_loop", None)
+        self.event_loop = kwargs.get("event_loop")
 
         self._init_side_channels()
 


### PR DESCRIPTION
## What
Removes the redundant explicit `None` default in `dict.get(key, None)` calls, flagged by ruff rule **SIM910**. `dict.get(key)` already returns `None` when the key is absent, so this is behavior-preserving.

16 call sites across 9 files.

## Why
`.get(key)` and `.get(key, None)` are semantically identical; dropping the redundant `None` keeps the call sites concise and consistent.

## Testing
- `ruff check --select SIM910` is clean on all changed files.
- `ruff check` (repo config) and `ruff format --check` pass.

Refs #3372