### PR TITLE
cleanup: remove redundant local import of MooncakeLookupClient

### DIFF
--- a/lmcache/v1/lookup_client/factory.py
+++ b/lmcache/v1/lookup_client/factory.py
@@ -190,11 +190,6 @@ class LookupClientFactory:
         metadata: LMCacheMetadata,
     ) -> "MooncakeLookupClient":
         """Create a MooncakeLookupClient instance."""
-        # First Party
-        from lmcache.v1.lookup_client.mooncake_lookup_client import (
-            MooncakeLookupClient,
-        )
-
         return MooncakeLookupClient(config, metadata, master_address)
 
     @staticmethod


### PR DESCRIPTION
## What
Removes a redundant function-local `import` of `MooncakeLookupClient` in `LookupClientFactory._create_mooncake_lookup_client`. The same symbol is already imported unconditionally at module scope (line 17), so the local re-import is dead weight and the method can use the module-level name directly.

Both imports were introduced together in #936; this drops the duplicate. Behavior-preserving.

## Why
`MooncakeLookupClient` is already available at module scope, so the inner import adds nothing. The optional `mooncake` package is lazily imported inside `mooncake_lookup_client` itself, so removing this line does not change when `mooncake` is loaded.

## Testing
- `ruff check` and `ruff format --check` pass.

Refs #3372