### PR TITLE
pre-commit: ban cudaHostRegister/Unregister outside platform dir & extend torch device

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     name: Ban direct torch device usage
     entry: >-
       bash -c '
-      matches=$(grep -rHnE "torch\.(cuda|xpu|hpu)" "$@");
+      matches=$(grep -rHnE "torch\.(cuda|xpu|hpu|npu|tpu|musa)" "$@");
       if [ -n "$matches" ]; then
         echo "";
         echo "========================================";
@@ -28,6 +28,30 @@ repos:
     exclude: |
       (?x)^(
         lmcache/__init__\.py|
+        lmcache/.*/gpu_connector/.*|
+        lmcache/v1/platform/.*
+      )$
+  - id: ban-cuda-host-register
+    name: Ban cudaHostRegister/Unregister outside platform
+    entry: >-
+      bash -c '
+      matches=$(grep -rHnE "\.cudaHost(Register|Unregister)" "$@");
+      if [ -n "$matches" ]; then
+        echo "";
+        echo "=======================================================================";
+        echo "  BANNED: .cudaHostRegister/Unregister usage found outside platform dir";
+        echo "  Fix 1: They are only allowed in the platform directory";
+        echo "  Fix 2: use current_device_spec.pin_memory/unpin_memory instead";
+        echo "=======================================================================";
+        echo "";
+        echo "$matches";
+        exit 1;
+      fi' --
+    language: system
+    types: [python]
+    files: ^lmcache/
+    exclude: |
+      (?x)^(
         lmcache/.*/gpu_connector/.*|
         lmcache/v1/platform/.*
       )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,16 +7,24 @@ repos:
     entry: python tools/check_spdx_header.py
     language: python
     types: [python]
-  - id: ban-torch-device
+  - id: ban-direct-torch-device
     name: Ban direct torch device usage
     entry: >-
       bash -c '
-      matches=$(grep -rHnE "torch\.(cuda|xpu|hpu|npu|tpu|musa)" "$@");
+      pattern=$(find lmcache/v1/platform -mindepth 1 -maxdepth 1 -type d \
+        -exec basename {} \; | grep -v "^__" | grep -v "^base$" | sort | paste -sd "|");
+      if [ -z "$pattern" ]; then
+        echo "WARNING: no platform dirs found, skipping check";
+        exit 0;
+      fi;
+      echo "Detected platforms: ${pattern//|/, }";
+      echo "Ban pattern: torch.($pattern)";
+      matches=$(grep -rHnE "torch\.($pattern)" "$@");
       if [ -n "$matches" ]; then
         echo "";
         echo "========================================";
-        echo "  BANNED: direct torch device usage found";
-        echo "  Fix: use torch_dev/torch_device_type";
+        echo "  BANNED: Direct torch device API usage";
+        echo "  Use lmcache.v1.platform abstractions instead";
         echo "========================================";
         echo "";
         echo "$matches";
@@ -27,7 +35,6 @@ repos:
     files: ^lmcache/
     exclude: |
       (?x)^(
-        lmcache/__init__\.py|
         lmcache/.*/gpu_connector/.*|
         lmcache/v1/platform/.*
       )$


### PR DESCRIPTION
- Add ban-cuda-host-register hook: prevents direct .cudaHostRegister()
  and .cudaHostUnregister() calls outside lmcache/v1/platform/. Callers
  should use current_device_spec.pin_memory/unpin_memory instead.

- Extend ban-direct-torch-device pattern to also catch torch.npu,
  torch.tpu, and torch.musa usage.