### PR TITLE
[sglang] Support DSA (DeepSeek-V3.2) pools via a second kernel group …

### DIFF
--- a/lmcache/integration/sglang/__init__.py
+++ b/lmcache/integration/sglang/__init__.py
@@ -1,2 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-
+#
+# Package marker.

--- a/lmcache/integration/sglang/kv_cache_groups.py
+++ b/lmcache/integration/sglang/kv_cache_groups.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Build LMCache engine group infos and layout hints for sglang.
+
+sglang is a *non-hybrid* engine: every registered KV tensor shares a single
+paged-block address space (one ``engine_group_id`` == 0). The only reason we
+ever emit more than one :class:`EngineGroupInfo` is the DSA
+(``DSATokenToKVPool``) case, where the main latent KV and the sparse-attention
+``index_k_with_scale_buffer`` have different physical shapes and must therefore
+be transferred by two different copy kernels -- i.e. two *kernel groups* -- while
+still sharing the same block-id space (they are allocated in lockstep by the
+sglang paged allocator).
+
+DSA detection uses the canonical sglang classifier
+``is_deepseek_dsa(hf_config)`` -- the same check that
+``model_runner_kv_cache_mixin.py`` uses to pick ``DSATokenToKVPool``
+at init time. This avoids depending on accidental dtype properties.
+
+Keeping this classification out of :mod:`multi_process_adapter` mirrors what
+:mod:`lmcache.integration.vllm.kv_cache_groups` does for vLLM: the adapter is
+the transport layer and this module is the sglang-specific KV-cache classifier.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any
+
+# Third Party
+from sglang.srt.configs.model_config import is_deepseek_dsa
+
+# First Party
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+
+
+def create_engine_group_infos_from_sglang(
+    kv_cache_pools: "list[list[Any]]",
+    page_size: int,
+    hf_config: "Any",
+) -> "list[EngineGroupInfo]":
+    """Build the LMCache engine group infos for a sglang KV pool.
+
+    DSA detection uses the same logic as sglang's own pool selection at
+    init time (``model_runner_kv_cache_mixin.py`` calls
+    ``is_deepseek_dsa(self.model_config.hf_config)``). This is the
+    authoritative classifier and avoids depending on accidental dtype
+    properties of the index buffer.
+
+    Args:
+        kv_cache_pools: Per-group per-layer tensor lists as returned by
+            :func:`_extract_kv_pools`.
+        page_size: sglang's paged-slot page size (tokens per page).
+        hf_config: The HuggingFace model config (``PretrainedConfig``)
+            from ``model_config.hf_config``, used to call
+            ``is_deepseek_dsa``.
+
+    Returns:
+        A (possibly empty) list of :class:`EngineGroupInfo`. An empty
+        list signals \"single non-hybrid group\" to the daemon.
+    """
+    is_dsa = is_deepseek_dsa(hf_config)
+
+    if not is_dsa:
+        # MHA / GQA / MLA → non-hybrid (empty list tells the daemon to
+        # treat every registered layer as one group).
+        return []
+
+    # DSA: two kernel groups sharing engine_group_id=0 so
+    # ``expand_engine_block_ids`` broadcasts the same block-id list to
+    # both kernel groups on STORE / RETRIEVE.
+    num_layers = len(kv_cache_pools[0])
+    return [
+        EngineGroupInfo(
+            engine_group_id=0,
+            layer_indices=tuple(range(num_layers)),
+            tokens_per_block=page_size,
+        ),
+        EngineGroupInfo(
+            engine_group_id=0,
+            layer_indices=tuple(range(num_layers, 2 * num_layers)),
+            tokens_per_block=page_size,
+        ),
+    ]
+
+
+def build_sglang_layout_hints(
+    page_size: int,
+) -> "dict[str, int]":
+    """Build the ``layout_hints`` payload for REGISTER_KV_CACHE.
+
+    Only ``tokens_per_block`` is emitted -- the daemon detector uses it
+    to reshape both the MHA (2*NL flat) and the MLA (NL fused) payloads
+    into their canonical ``(NB, BS, ...)`` form so
+    ``PageBufferShapeDesc`` can be built.
+
+    No DSA-specific flag is emitted here: DSA is fully identified by
+    ``engine_group_infos`` (the sglang classifier returns two groups
+    sharing ``engine_group_id=0``, and the per-layer-formats pass in
+    :func:`normalize_and_discover_per_layer_formats` re-invokes the
+    detector on the shape-uniform index-buffer sublist, whose 2-D uint8
+    signature is a sufficient identity discriminator on sglang).
+
+    Args:
+        page_size: sglang's paged-slot page size (tokens per page).
+
+    Returns:
+        Layout hints dict to forward to REGISTER_KV_CACHE.
+    """
+    return {"tokens_per_block": page_size}

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -16,10 +16,11 @@ import zmq
 
 # First Party
 from lmcache import torch_dev
-from lmcache.integration.sglang.sglang_adapter import (
-    LoadMetadata,
-    StoreMetadata,
+from lmcache.integration.sglang.kv_cache_groups import (
+    build_sglang_layout_hints,
+    create_engine_group_infos_from_sglang,
 )
+from lmcache.integration.sglang.sglang_adapter import LoadMetadata, StoreMetadata
 from lmcache.integration.vllm.vllm_multi_process_adapter import (
     DEFAULT_HEARTBEAT_INTERVAL,
     DEFAULT_MQ_TIMEOUT,
@@ -35,6 +36,7 @@ from lmcache.v1.multiprocess.custom_types import (
     KVCache,
 )
 from lmcache.v1.multiprocess.futures import MessagingFuture
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo, expand_engine_block_ids
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
@@ -47,19 +49,18 @@ _WAIT_LOOKUP_RESPONSE_BUFFER_S = 5.0
 
 
 def _wrap_sglang_kv_caches(
-    k_pool: list[torch.Tensor],
-    v_pool: list[torch.Tensor],
+    kv_cache_pools: list[list[torch.Tensor]],
 ) -> KVCache:
-    """Flatten SGLang's depth-2 ``[K_layers, V_layers]`` KV layout into a
-    single flat ``KVCache`` so it fits upstream's wire
-    ``KVCache`` payload type. The daemon's
-    :func:`normalize_kv_and_discover_format` recognizes this shape from
-    ``EngineType.SGLANG`` plus a ``tokens_per_block`` ``LayoutHints`` field
-    and splits it back at its midpoint before format detection.
+    """Flatten SGLang's pool groups into a single flat ``KVCache`` so it
+    fits upstream's wire ``KVCache`` payload type.  Each element of
+    *kv_cache_pools* is a per-layer tensor list for one pool group
+    (K, V, DSA-index, …).  The daemon's
+    :func:`normalize_kv_and_discover_format` resolves the layout from
+    ``EngineType.SGLANG`` plus ``tokens_per_block``.
     """
     wrapped: KVCache = []
-    wrapped.extend(CudaIPCWrapper(tensor) for tensor in k_pool)
-    wrapped.extend(CudaIPCWrapper(tensor) for tensor in v_pool)
+    for pool in kv_cache_pools:
+        wrapped.extend(CudaIPCWrapper(tensor) for tensor in pool)
     return wrapped
 
 
@@ -132,8 +133,7 @@ class LMCacheMPConnector:
         page_size: int,
         host: str,
         port: int,
-        k_pool: list[torch.Tensor],
-        v_pool: list[torch.Tensor],
+        kv_cache_pools: list[list[torch.Tensor]],
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         mq_timeout: float = DEFAULT_MQ_TIMEOUT,
         heartbeat_interval: float = DEFAULT_HEARTBEAT_INTERVAL,
@@ -141,9 +141,9 @@ class LMCacheMPConnector:
         self.tp_size = tp_size
         self.worker_id = rank
         self.page_size = page_size
-        self.device = k_pool[0].device
+        self.device = kv_cache_pools[0][0].device
         self.model_name = sgl_config.model_path
-        self.num_layers = len(k_pool)
+        self.num_layers = len(kv_cache_pools[0])
         self.tp_group = tp_group
         self.instance_id = os.getpid()
         self._mq_timeout = mq_timeout
@@ -165,27 +165,29 @@ class LMCacheMPConnector:
                 f"{self._lmcache_chunk_size} and {self.page_size}"
             )
 
+        # DSA classification is delegated to ``create_engine_group_infos_from_sglang``
+        # (uses the same ``is_deepseek_dsa(hf_config)`` check as sglang's pool init).
+        layout_hints = build_sglang_layout_hints(self.page_size)
+        self.engine_group_infos: list[EngineGroupInfo] = (
+            create_engine_group_infos_from_sglang(
+                kv_cache_pools, self.page_size, sgl_config.hf_config
+            )
+        )
+
         # Upstream's REGISTER_KV_CACHE protocol takes flat positional args:
         # (instance_id, kv_cache, model_name, world_size, engine_type,
-        # layout_hints, engine_group_infos). SGLang's natural KV layout is depth-2
-        # ([K_layers, V_layers]); we flatten it on the wire to fit
-        # ``KVCache = list[DeviceIPCWrapper]``. The daemon recognizes the
-        # SGLang-MHA flat-of-2NL pattern from ``EngineType.SGLANG`` plus the
-        # ``tokens_per_block`` hint and un-flattens + reshapes per layer.
-        # SGLang is non-hybrid (a single KV cache group), so engine_group_infos is the
-        # empty list -- which the server treats as one group spanning all layers
-        # (matching the vLLM non-hybrid and TensorRT-LLM register paths).
+        # layout_hints, engine_group_infos).
         send_lmcache_request(
             self.mq_client,
             RequestType.REGISTER_KV_CACHE,
             [
                 self.instance_id,
-                _wrap_sglang_kv_caches(k_pool, v_pool),
+                _wrap_sglang_kv_caches(kv_cache_pools),
                 self.model_name,
                 self.tp_size,
                 EngineType.SGLANG,
-                {"tokens_per_block": self.page_size},
-                [],
+                layout_hints,
+                self.engine_group_infos,
             ],
         ).result(timeout=self._mq_timeout)
         self._registered = True
@@ -210,11 +212,18 @@ class LMCacheMPConnector:
         return self._lmcache_chunk_size
 
     @torch.no_grad()
-    def _global_min_tokens(self, local_tokens: int) -> int:
+    def _broadcast_lookup_result(self, local_tokens: int) -> int:
+        """Broadcast the lookup result from rank 0 to all TP ranks.
+
+        Only rank 0 performs the daemon LOOKUP + WAIT_PREFETCH_STATUS
+        flow (see :meth:`lookup_kv`). This method broadcasts the
+        result so every rank sees the same matched-token count without
+        independently querying the daemon.
+        """
         if self.tp_size == 1:
             return local_tokens
         t = torch.tensor([local_tokens], dtype=torch.int32, device=self.device)
-        dist.all_reduce(t, op=dist.ReduceOp.MIN, group=self.tp_group)
+        dist.broadcast(t, src=0, group=self.tp_group)
         return int(t.item())
 
     def _create_key(
@@ -286,6 +295,7 @@ class LMCacheMPConnector:
         end: int,
         request_id: str,
     ) -> None:
+        """Release *this rank's* read locks in ``[start, end)``."""
         if start >= end or not self.is_healthy:
             return
         send_lmcache_request(
@@ -297,7 +307,7 @@ class LMCacheMPConnector:
                     start=start,
                     end=end,
                     request_id=request_id,
-                    no_worker_id=True,
+                    no_worker_id=False,
                 ),
                 self.tp_size,
             ],
@@ -323,9 +333,8 @@ class LMCacheMPConnector:
         if not self.is_healthy or not request_id:
             return 0
 
-        # If a previous LOOKUP for this rid is still pending (e.g., a
-        # rescheduling pass or a prior partial flow), release its locks
-        # first so we don't accumulate read-lock reservations.
+        # Release any stale locks from a prior LOOKUP for the same rid
+        # (e.g., a rescheduling pass) before firing a new one.
         with self._pending_lookups_lock:
             stale = self._pending_lookups.pop(request_id, None)
         if stale is not None and stale.locks_held:
@@ -339,20 +348,25 @@ class LMCacheMPConnector:
         if aligned_end == 0:
             return 0  # too few tokens; no chunk-aligned range to LOOKUP
 
-        lookup_key = self._create_key(
-            token_ids,
-            start=0,
-            end=aligned_end,
-            request_id=request_id,
-            no_worker_id=True,
-        )
-        send_lmcache_request(
-            self.mq_client,
-            RequestType.LOOKUP,
-            [lookup_key, self.tp_size],
-        ).result(timeout=self._mq_timeout)
-        matched = self._wait_for_lookup(request_id)
-        matched = self._global_min_tokens(matched)
+        # Only rank 0 talks to the daemon; the matched-token count is
+        # broadcast to the followers.
+        if self.worker_id == 0:
+            lookup_key = self._create_key(
+                token_ids,
+                start=0,
+                end=aligned_end,
+                request_id=request_id,
+                no_worker_id=True,
+            )
+            send_lmcache_request(
+                self.mq_client,
+                RequestType.LOOKUP,
+                [lookup_key, self.tp_size],
+            ).result(timeout=self._mq_timeout)
+            matched = self._wait_for_lookup(request_id)
+        else:
+            matched = 0
+        matched = self._broadcast_lookup_result(matched)
 
         # Daemon now holds read locks for the matched chunks. Record
         # state for the eventual retrieve_kv / release_pending /
@@ -398,11 +412,19 @@ class LMCacheMPConnector:
             pending = self._pending_lookups.pop(request_id, None)
         if pending is None:
             return
+        # Every rank frees *its own* still-held read locks. LOOKUP is
+        # rank-0-only on the wire, but the daemon reserves an
+        # independent lock per TP rank (worker_id=None expansion), so a
+        # rank-0-only release would leak the other ranks' locks until
+        # read-lock TTL expiry.
         if pending.locks_held and pending.matched_token_num > 0:
             self._free_lookup_locks(
                 pending.token_ids, 0, pending.matched_token_num, request_id
             )
-        send_lmcache_request(self.mq_client, RequestType.END_SESSION, [request_id])
+        # END_SESSION targets shared daemon-side session state, so only
+        # rank 0 sends it.
+        if self.worker_id == 0:
+            send_lmcache_request(self.mq_client, RequestType.END_SESSION, [request_id])
 
     def _submit_retrieve(
         self,
@@ -426,9 +448,15 @@ class LMCacheMPConnector:
                     request_id=request_id,
                 ),
                 self.instance_id,
-                # RETRIEVE takes per-group block IDs (list[list[int]]); SGLang is
-                # non-hybrid, so wrap the flat list as a single group.
-                [block_ids],
+                # RETRIEVE takes per-kernel-group block IDs (list[list[int]]).
+                # sglang is non-hybrid, so we always feed ONE engine-side
+                # block-id list; ``expand_engine_block_ids`` fans it out to
+                # every kernel group according to ``engine_group_infos``:
+                #   * MHA / MLA (empty engine_group_infos): returns [block_ids]
+                #   * DSA       (two infos, both engine_group_id=0):
+                #     returns [block_ids, block_ids] -- one copy per kernel
+                #     group, both pointing at the same paged pages.
+                expand_engine_block_ids(self.engine_group_infos, [block_ids]),
                 event.ipc_handle(),
                 skip_prefix_n_blocks,
             ],
@@ -478,6 +506,9 @@ class LMCacheMPConnector:
         fresh_start = offset + prefix_pad
         prefix_pad_pages = prefix_pad // self.page_size
 
+        # Free this rank's prefix read locks in ``[0, offset)``; the
+        # daemon's RETRIEVE handler only consumes the trailing suffix
+        # in ``[offset, retrieve_token_num)``.
         self._free_lookup_locks(token_ids, 0, offset, request_id)
         fresh_block_ids = self._slot_mapping_to_block_ids(
             load_metadata.slot_mapping[fresh_start:retrieve_token_num]
@@ -506,6 +537,9 @@ class LMCacheMPConnector:
             retrieve_succeeded = True
         finally:
             if not retrieve_succeeded:
+                # Free this rank's suffix read locks that the daemon
+                # would have consumed on success. Per-rank because
+                # RETRIEVEs are independent across ranks.
                 self._free_lookup_locks(
                     token_ids, offset, retrieve_token_num, request_id
                 )
@@ -570,9 +604,12 @@ class LMCacheMPConnector:
                     request_id=request_id,
                 ),
                 self.instance_id,
-                # STORE takes per-group block IDs (list[list[int]]); SGLang is
-                # non-hybrid, so wrap the flat list as a single group.
-                [block_ids],
+                # STORE takes per-kernel-group block IDs (list[list[int]]).
+                # Same story as RETRIEVE: sglang is non-hybrid, so we
+                # send ONE engine-side block-id list and let
+                # ``expand_engine_block_ids`` broadcast it to each
+                # kernel group (see ``_submit_retrieve``).
+                expand_engine_block_ids(self.engine_group_infos, [block_ids]),
                 event.ipc_handle(),
             ],
         ).to_cuda_future(device=self.device)
@@ -612,9 +649,12 @@ class LMCacheMPConnector:
                         request_id=request_id,
                     ),
                     self.instance_id,
-                    # STORE takes per-group block IDs (list[list[int]]); SGLang is
-                    # non-hybrid, so wrap the flat list as a single group.
-                    [block_ids],
+                    # STORE takes per-kernel-group block IDs (list[list[int]]).
+                    # Same story as RETRIEVE: sglang is non-hybrid, so we
+                    # send ONE engine-side block-id list and let
+                    # ``expand_engine_block_ids`` broadcast it to each
+                    # kernel group (see ``_submit_retrieve``).
+                    expand_engine_block_ids(self.engine_group_infos, [block_ids]),
                     event.ipc_handle(),
                 ],
             )

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -111,18 +111,17 @@ class LMCacheConnector:
         sgl_config: ModelConfig,
         tp_size: int,
         rank: int,
-        k_pool: List[torch.Tensor],
-        v_pool: List[torch.Tensor],
+        kv_cache_pools: List[List[torch.Tensor]],
         config_file: str,
     ):
-        if not k_pool:
-            raise ValueError("k_pool cannot be empty during initialization.")
-        kv_dtype = k_pool[0].dtype
+        if not kv_cache_pools or not kv_cache_pools[0]:
+            raise ValueError("kv_cache_pools[0] cannot be empty during initialization.")
+        kv_dtype = kv_cache_pools[0][0].dtype
         if (
-            k_pool[0].device.type == torch_device_type
-            and k_pool[0].device.index is not None
+            kv_cache_pools[0][0].device.type == torch_device_type
+            and kv_cache_pools[0][0].device.index is not None
         ):
-            local_rank = k_pool[0].device.index
+            local_rank = kv_cache_pools[0][0].device.index
         else:
             # Fallback for CPU / odd cases
             local_rank = rank
@@ -140,7 +139,7 @@ class LMCacheConnector:
         self.sgl_config = sgl_config
         self.tp_size = tp_size
         self.rank = local_rank  # Use local_rank for torch.device() calls
-        self.kvcaches = k_pool + v_pool
+        self.kvcaches = sum(kv_cache_pools, [])
         self.num_layer = sgl_config.num_hidden_layers
 
         self.lmcache_engine.post_init(kvcaches=self.kvcaches)
@@ -212,16 +211,15 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
         sgl_config: ModelConfig,
         tp_size: int,
         rank: int,
-        k_pool: List[torch.Tensor],
-        v_pool: List[torch.Tensor],
+        kv_cache_pools: List[List[torch.Tensor]],
         config_file: str,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
     ):
-        super().__init__(sgl_config, tp_size, rank, k_pool, v_pool, config_file)
+        super().__init__(sgl_config, tp_size, rank, kv_cache_pools, config_file)
         self._lmcache_chunk_size = self.lmcache_engine.config.chunk_size
         self.layerwise_retrievers: List[Any] = []
         self.layer_load_layer: List[int] = []
-        self.kvcaches = [k_pool, v_pool]
+        self.kvcaches = kv_cache_pools
         self.tp_group = tp_group
         self.lookup_id_list: List[str] = []
 

--- a/lmcache/v1/gpu_connector/kv_format/detectors/sglang.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/sglang.py
@@ -18,50 +18,109 @@ from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache, Layout
 import lmcache.c_ops as lmc_ops
 
 
+def _two_level_nested_format(
+    kv_caches: DiscoverableKVCache,
+) -> Optional[lmc_ops.EngineKVFormat]:
+    list_depth, tensor_ndim, _ = measure_list_depth_until_tensor(kv_caches)
+    if list_depth != 2:
+        return None
+    return (
+        lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS
+        if tensor_ndim == 4
+        else lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS
+    )
+
+
+def _reshape_and_regroup_mha_gqa(
+    kv_caches: list[torch.Tensor], block_size: Optional[int]
+) -> Optional[list[list[torch.Tensor]]]:
+    if block_size is None or len(kv_caches) % 2 != 0:
+        return None
+
+    half = len(kv_caches) // 2
+    regrouped: list[list[torch.Tensor]] = []
+    for layers in (kv_caches[:half], kv_caches[half:]):
+        reshaped: list[torch.Tensor] = []
+        for layer in layers:
+            if layer.shape[0] % block_size != 0:
+                raise ValueError(
+                    f"SGLang page_buffer_size {layer.shape[0]} not "
+                    f"divisible by tokens_per_block {block_size}"
+                )
+            num_blocks = layer.shape[0] // block_size
+            reshaped.append(layer.view(num_blocks, block_size, *layer.shape[1:]))
+        regrouped.append(reshaped)
+
+    return regrouped
+
+
 class SGLANG_Detector(EngineDetector):
     engine_type = EngineType.SGLANG
 
     def discover(
         self, kv_caches: DiscoverableKVCache, layout_hints: LayoutHints
     ) -> "tuple[Optional[lmc_ops.EngineKVFormat], DiscoverableKVCache]":
-        # MP path: a flat list[2*NL] of 3-D tensors (K layers then V layers)
-        # plus a tokens_per_block hint. Regroup into [K_layers, V_layers] and
-        # reshape each (PBS, NH, HS) -> (NB, BS, NH, HS).
-        if (
-            isinstance(kv_caches, list)
-            and len(kv_caches) > 0
-            and len(kv_caches) % 2 == 0
-            and isinstance(kv_caches[0], torch.Tensor)
-            and kv_caches[0].dim() == 3
-            and kv_caches[0].shape[1] > 1
-            and "tokens_per_block" in layout_hints
-        ):
-            block_size = layout_hints["tokens_per_block"]
-            half = len(kv_caches) // 2
-            regrouped: list[DiscoverableKVCache] = []
-            for layers in (kv_caches[:half], kv_caches[half:]):
-                reshaped: list[DiscoverableKVCache] = []
-                for layer in layers:
-                    page_buffer_size = layer.shape[0]
-                    if page_buffer_size % block_size != 0:
-                        raise ValueError(
-                            f"SGLang page_buffer_size {page_buffer_size} not "
-                            f"divisible by tokens_per_block {block_size}"
-                        )
-                    num_blocks = page_buffer_size // block_size
-                    reshaped.append(
-                        layer.view(num_blocks, block_size, *layer.shape[1:])
-                    )
-                regrouped.append(reshaped)
-            kv_caches = regrouped
+        # -- Non-list/empty-list → try nested 2-level [[K_layers], [V_layers]] --
+        if not (isinstance(kv_caches, list) and len(kv_caches) > 0):
+            nested_format = _two_level_nested_format(kv_caches)
+            if nested_format is not None:
+                return nested_format, kv_caches
+            return None, kv_caches
 
-        list_depth, tensor_ndim, first_tensor = measure_list_depth_until_tensor(
-            kv_caches
-        )
-        if list_depth == 1 and first_tensor.shape[1] == 1:  # MLA, fused PBS
+        first = kv_caches[0]
+
+        # -- 2-level nested [[K_layers], [V_layers]] (non-MP MHA/GQA) --
+        if not isinstance(first, torch.Tensor):
+            nested_format = _two_level_nested_format(kv_caches)
+            if nested_format is not None:
+                return nested_format, kv_caches
+            return None, kv_caches
+
+        block_size = layout_hints.get("tokens_per_block")
+
+        # -- shape[1] > 1 (MHA/GQA): flat list[2*NL] of 3-D (PBS, NH, HS) --
+        # Regroup [K_layers, V_layers] and reshape (PBS, NH, HS) → (NB, BS, NH, HS).
+        if first.dim() == 3 and first.shape[1] > 1:
+            regrouped = _reshape_and_regroup_mha_gqa(kv_caches, block_size)
+            if regrouped is None:
+                return None, kv_caches
+
+            # Regrouped into 2-level nested → detect final format
+            nested_format = _two_level_nested_format(regrouped)
+            if nested_format is not None:
+                return nested_format, regrouped
+            return None, regrouped
+
+        # -- shape[1] == 1 (MLA / DSA-mixed): list of 3-D (PBS, 1, HS) --
+        # Pure MLA: all layers uniform → reshape with tokens_per_block.
+        # DSA-mixed: trailing 2-D index buffers → pass through, per-shape retry
+        # in normalize_and_discover_per_layer_formats handles each group.
+        elif first.dim() == 3 and first.shape[1] == 1:
+            if block_size is not None:
+                reshaped: list[DiscoverableKVCache] = []
+                for layer in kv_caches:
+                    if (
+                        not isinstance(layer, torch.Tensor)
+                        or layer.dim() != 3
+                        or layer.shape[1] != 1
+                        or layer.shape[0] % block_size != 0
+                    ):
+                        # Mixed shape (DSA) — let per-shape retry classify each group
+                        return (
+                            lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS,
+                            kv_caches,
+                        )
+                    num_blocks = layer.shape[0] // block_size
+                    reshaped.append(layer.view(num_blocks, block_size, layer.shape[2]))
+                return lmc_ops.EngineKVFormat.NL_X_NB_BS_HS, reshaped
+            # No block_size → generic pass-through
             return lmc_ops.EngineKVFormat.NL_X_NBBS_ONE_HS, kv_caches
-        if list_depth == 2:
-            if tensor_ndim == 4:  # MP daemon: NB/BS split into separate axes
-                return lmc_ops.EngineKVFormat.TWO_X_NL_X_NB_BS_NH_HS, kv_caches
-            return lmc_ops.EngineKVFormat.TWO_X_NL_X_NBBS_NH_HS, kv_caches
+
+        # -- 2-D uint8 (DSA index buffer): list[NL] of (num_pages, page_bytes) --
+        # Treat each page as an opaque slot (block_size=1).
+        elif first.dim() == 2 and first.dtype == torch.uint8:
+            return lmc_ops.EngineKVFormat.NL_X_NB_BS_HS, [
+                t.unsqueeze(1) for t in kv_caches
+            ]
+
         return None, kv_caches


### PR DESCRIPTION
### What this PR does / why we need it
Add DSA (DeepSeek-V3.2 sparse attention) support for SGLang multi-process LMCache integration.

SGLang DSA maintains two coupled layer buffers sharing page allocator & block-id space but different tensor layouts:
1. `kv_buffer[layer]`: Fused latent K/V `(PBS, 1, HS)`, bf16/fp8
2. `index_k_with_scale_buffer[layer]`: 2D uint8 page blob storing fp8 keys + fp32 scales

Referencing vLLM hybrid-KV design, we register two `EngineGroupInfo` with the same `engine_group_id=0` to sync store/evict of both buffers.

### Code Changes
1. `lmcache/integration/sglang/multi_process_adapter.py`
   - Add `dsa_index_buffer` param to `LMCacheMPConnector`
   - DSA registers dual engine groups; original single-group logic reserved for MHA/MLA
   - Replace hardcoded block-id duplication with `expand_engine_block_ids`

2. New `lmcache/integration/sglang/kv_cache_groups.py`
   - Factory function returns dual groups for DSA, empty list for vanilla attention
   - Minimal vLLM-aligned layout hints without extra DSA flag

3. `lmcache/v1/gpu_connector/kv_format/detectors/sglang.py`
   - Standardize MLA tensor layout to unified `NL_X_NB_BS_HS`
   - Detect 2D uint8 DSA index buffer, reshape to isolate single-page blocks
   - Support mixed-shape tensor list split detection

4. `lmcache/integration/sglang/__init__.py`
   - Remove legacy monkey-patch & DSA pool registry
   - Directly consume `k_pool/v_pool/dsa_index_buffer` from new SGLang interface
   - Identify MLA via `k_pool[i] is v_pool[i]`

### Special Notes for Reviewers
1. Dependency: Matching SGLang PR required to pass `dsa_index_buffer`：https://github.com/sgl-project/sglang/pull/30662
2. Backward Compatibility: MHA/MLA wire protocol unchanged, fully bit-compatible
3. Design: Shared `engine_group_id=0` ensures one block-id controls both KV and index pages
4. Identification: DSA index buffer uniquely matched by `ndim=2 + uint8 dtype`
5. Guard: Throw error if DSA buffer is used with non-MLA pools

### Validation
- No user-facing config/docs changes; auto-enable when `dsa_index_buffer` is not None
- No new unit tests, full end-to-end manual validation with DeepSeek-V3.2
- Warm hit output bitwise consistent with cold inference

### Checklist
- [ ] Docs updated (No user-facing changes)
- [ ] Unit tests added (Manually verified)