### PR TITLE
docs: daily drift check — multi-process mode (2026-07-09)

### DIFF
--- a/docs/source/mp/l2_storage/nixl.rst
+++ b/docs/source/mp/l2_storage/nixl.rst
@@ -9,6 +9,15 @@ types share this backend:
 - ``nixl_store_dynamic`` — opens and registers files per operation, adding
   persist/recover across restarts and removing the open-file-descriptor limit.
 
+.. note::
+
+   Both adapters require the NIXL runtime, which ships as the optional
+   ``lmcache[nixl]`` extra:
+
+   .. code-block:: bash
+
+       uv pip install lmcache[nixl]
+
 Static pool — ``nixl_store``
 ----------------------------
 

--- a/docs/source/mp/p2p.rst
+++ b/docs/source/mp/p2p.rst
@@ -53,7 +53,9 @@ Requirements
   start.
 * **An RDMA-capable network** (InfiniBand / RoCE) is strongly recommended for
   production performance. By default P2P uses the ``nixl`` transfer engine,
-  which is shipped with LMCache, so there is nothing extra to install.
+  which ships as the optional ``lmcache[nixl]`` extra — install it with
+  ``uv pip install lmcache[nixl]`` (or ``pip install lmcache[nixl]``) before
+  enabling P2P.
 * **A single, contiguous L1 region.** The transfer channel registers the whole
   L1 buffer for RDMA, so P2P is incompatible with the GDS L1 tier
   (``--gds-l1-path``) and the Device-DAX L1 tier (``--l1-devdax-path``); the
@@ -112,7 +114,8 @@ selected per server with ``--p2p-transfer-engine``.
    * - Engine
      - Description
    * - ``nixl`` (default)
-     - RDMA-based transport, shipped with LMCache. Runs over InfiniBand / RoCE
+     - RDMA-based transport, shipped as the optional ``lmcache[nixl]`` extra
+       (``uv pip install lmcache[nixl]``). Runs over InfiniBand / RoCE
        fabrics.
 
 ``nixl`` is the only backend available today. The transfer engine is a


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. One new inconsistency between the multi-process (MP) docs and the current `dev` code (`upstream/dev` HEAD `0403017`) was found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/mp/p2p.rst`** — Yesterday's [PR #4040](https://github.com/LMCache/LMCache/pull/4040) (commit [`81beb88`](https://github.com/LMCache/LMCache/commit/81beb88927094062b998a4f1b3722e002633bb34)), titled *"[refactor] split NIXL into an optional `lmcache[nixl]` extra"*, moved `nixl` out of the default `install_requires` list and into an opt-in extras group (see `requirements/nixl.txt`, `setup.py` `extras_require`, and the new note in `docs/source/getting_started/installation.rst`). The MP P2P page, however, still tells the user in **two places** that NIXL is "shipped with LMCache" and that "there is nothing extra to install". Because P2P uses `nixl` by default and P2P is required (RDMA lookup + read), a user who follows the current MP install instructions (`uv pip install lmcache`) and then enables `--p2p-advertise-url` will hit `ModuleNotFoundError: No module named 'nixl'` at server startup.
- **`docs/source/mp/l2_storage/nixl.rst`** — The primary production L2 backend page describes `nixl_store` / `nixl_store_dynamic` with no mention that the NIXL runtime now requires an opt-in install. Same failure mode as above: a user who just installed `lmcache` and configures `--l2-adapter '{"type": "nixl_store", ...}'` will fail to start.

`docs/design/` (design docs):

- No new drift found in `docs/design/` beyond what open drift-check PRs #4035, #4009, #3996, #3984, #3969, and #3960 already cover.

**Evidence**

| Drift | Code / repo state (current `dev`, HEAD `0403017`) | Stale doc |
| --- | --- | --- |
| MP P2P Requirements bullet claims "shipped with LMCache, so there is nothing extra to install" | [`requirements/nixl.txt`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/requirements/nixl.txt) is now the extra's requirement file; [`setup.py#L43-L58`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/setup.py#L43-L58) wires it via `extras_require`; [`setup_extensions/build_profiles/cuda.py#L92-L100`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/setup_extensions/build_profiles/cuda.py#L92-L100) exposes it as the `nixl` extra; installation page updated in [`docs/source/getting_started/installation.rst#L34-L41`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/docs/source/getting_started/installation.rst#L34-L41) | [`docs/source/mp/p2p.rst#L54-L56`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/docs/source/mp/p2p.rst#L54-L56) |
| MP P2P "Transfer engine backends" table row calls the `nixl` engine "shipped with LMCache" | Same as above — NIXL is opt-in as of PR #4040 | [`docs/source/mp/p2p.rst#L114-L116`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/docs/source/mp/p2p.rst#L114-L116) |
| `nixl_store` / `nixl_store_dynamic` page has no install prerequisite | Adapter registration and imports at [`lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py) and [`nixl_store_dynamic_l2_adapter.py`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py) — both fail with an import error unless the extra is installed | [`docs/source/mp/l2_storage/nixl.rst`](https://github.com/LMCache/LMCache/blob/0403017a0f66188bbb02943e7e65f2b48f610c8e/docs/source/mp/l2_storage/nixl.rst) (top of page — no install note) |

**Proposed fix**

Already applied in the diff (docs only, no code touched):

1. `docs/source/mp/p2p.rst` — the *Requirements* bullet and the *Transfer engine backends* table row now describe `nixl` as shipping via the optional `lmcache[nixl]` extra and point users at `uv pip install lmcache[nixl]` before enabling P2P, matching the wording used in `docs/source/getting_started/installation.rst`.
2. `docs/source/mp/l2_storage/nixl.rst` — a new `.. note::` block at the top of the page tells users that both `nixl_store` and `nixl_store_dynamic` require the `lmcache[nixl]` extra, with the `uv pip install lmcache[nixl]` command inline.

**Special notes for your reviewers**:

- Docs-only change. No code modified. Two files touched.
- Deduped against currently-open drift PRs:
  - **#4035** (`fault_inject` + observability config gaps in `docs/source/mp/configuration.rst` — 2026-07-07): no overlap.
  - **#4009** (`docs/design/ARCHITECTURE_MULTI_HARDWARE.md` device-detection refactor — 2026-07-05): no overlap. (Note: after today's PR #4020 `DeviceInfo` → `DeviceSpec` rename, #4009's diff will itself need a small follow-up before merge — flagged there, not here.)
  - **#3996** (`lmcache.mp.host` bare-host normalization — 2026-07-03): no overlap.
  - **#3984** (coordinator `/blend/*` + `docs/design/v1/mp_coordinator/README.md` + `protocols/README.md` — 2026-07-02): no overlap.
  - **#3969** (`DevDaxL1MemoryManager` in `mp/index.rst` + deleted `l2_apis.md` refs — 2026-07-01): no overlap.
  - **#3960** (`hfbucket` in L2 adapter list + `IsolatedLRU` in `l2_storage/index.rst` — 2026-06-30): no overlap.
- Follow-ups spotted but intentionally not tackled here:
  - The `docs/source/locale/zh_CN/LC_MESSAGES/mp/p2p.po` Chinese localization file still carries the pre-PR-#4040 English source strings ("shipped with LMCache…"). The `automation/update-chinese-docs` branch already exists for the localization workflow, so this drift check leaves the `.po` regeneration to that workflow rather than hand-editing translations.
  - `docs/source/mp/coordinator.rst` and `docs/source/cli/coordinator.rst` were already refreshed in PR #3978 (Pin/Unpin Tokens API — merged 2026-07-07 as commit `dd24562e`) for the `--blend-chunk-size` → `--chunk-size` rename and the new `--hash-algorithm` flag; no residual drift in the English docs for that change.
  - Since the previous drift check on 2026-07-07, PRs #4026 (allocator import-path cleanup), #4058 (redundant `MooncakeLookupClient` import), #4056 (fs_connector log format), #4044 (`is_kv_writer` bugfix), #4047 (macOS FFmpeg CI), #4037 (CPU e2e FFmpeg install), #3884 (V2 ref-count leak), #3930 (CacheBlend + vLLM HMA compat), #3686 (Azure Blob connector — landed with its own docs), and #4024 (operator webhook cross-namespace binds) landed. None of them introduced new user-facing MP docs drift; the ref-count and `is_kv_writer` fixes are behavior-preserving from a docs standpoint, and the Azure connector ships its own page under `docs/source/kv_cache/storage_backends/`.
- This PR was **auto-generated** by the daily drift-check routine and **needs human review before merge**. Please do not merge without a maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1jLzZp4u6bUiJjkqJS8fm)_