### PR TITLE
[GDS] always enable thread pool for disk I/O

### DIFF
--- a/docs/source/kv_cache/storage_backends/gds.rst
+++ b/docs/source/kv_cache/storage_backends/gds.rst
@@ -34,6 +34,8 @@ Ways to configure LMCache GDS Backend
     # Disabling CPU RAM offload is sometimes recommended as the
     # CPU can get in the way of GPUDirect operations
     export LMCACHE_LOCAL_CPU=False
+    # Disk I/O Threads (default: 4, set to 0 to disable)
+    export LMCACHE_EXTRA_CONFIG='{"disk_io_threads": 8}'
 
 **2. Configuration File**:
 
@@ -51,6 +53,39 @@ Example ``config.yaml``:
     gds_path: "/mnt/gds/cache"
     # GDS Buffer Size in MiB
     gds_buffer_size: 8192
+    # Disk I/O Threads (default: 4, set to 0 to disable)
+    extra_config:
+      disk_io_threads: 8
+
+
+Disk I/O Thread Pool
+--------------------
+
+The backend uses a thread pool for parallel disk I/O. The thread pool is
+always enabled regardless of whether GDS APIs or POSIX fallback is used,
+so both code paths benefit from concurrent reads and writes.
+
+The number of worker threads is controlled by ``extra_config.disk_io_threads``
+(default: 4). Increase this on fast NVMe drives for higher parallelism. Set
+to ``0`` to disable the thread pool entirely.
+
+**Environment variable:**
+
+.. code-block:: bash
+
+    export LMCACHE_EXTRA_CONFIG='{"disk_io_threads": 8}'
+
+**YAML config:**
+
+.. code-block:: yaml
+
+    extra_config:
+      disk_io_threads: 8
+
+.. note::
+
+   The deprecated ``gds_io_threads`` key is no longer supported. Use
+   ``disk_io_threads`` instead.
 
 
 Multi-Path (Multi-Device) Support
@@ -227,6 +262,8 @@ Create a an lmcache configuration file called: ``gds-backend.yaml``
     chunk_size: 256
     gds_path: "/mnt/gds/cache"
     gds_buffer_size: 8192
+    extra_config:
+      disk_io_threads: 8
 
 If you don't want to use a config file, uncomment the first three environment variables
 and then comment out the ``LMCACHE_CONFIG_FILE`` below:
@@ -237,6 +274,7 @@ and then comment out the ``LMCACHE_CONFIG_FILE`` below:
     # LMCACHE_CHUNK_SIZE=256 \
     # LMCACHE_GDS_PATH="/mnt/gds/cache" \
     # LMCACHE_GDS_BUFFER_SIZE=8192 \
+    # LMCACHE_EXTRA_CONFIG='{"disk_io_threads": 8}' \
     LMCACHE_CONFIG_FILE="gds-backend.yaml" \
     vllm serve \
         meta-llama/Llama-3.1-8B-Instruct \

--- a/lmcache/v1/storage_backend/gds_backend.py
+++ b/lmcache/v1/storage_backend/gds_backend.py
@@ -300,20 +300,13 @@ class GdsBackend(AllocatorBackendInterface):
             assert self.use_gds
             self.data_suffix = _WEKA_DATA_FILE_SUFFIX
 
-        # Always enable the thread pool for parallel I/O
-        self.use_thread_pool = self.use_gds
-
+        # Always enable the thread pool for parallel I/O.
+        # Set disk_io_threads=0 in extra_config to disable.
+        thread_count = int(
+            config.get_extra_config_value("disk_io_threads", _DEFAULT_THREAD_COUNT)
+        )
+        self.use_thread_pool = thread_count > 0
         if self.use_thread_pool:
-            thread_count = _DEFAULT_THREAD_COUNT
-            if config.extra_config is not None:
-                if "disk_io_threads" in config.extra_config:
-                    thread_count = config.extra_config["disk_io_threads"]
-                elif "gds_io_threads" in config.extra_config:
-                    logger.warning(
-                        "extra_config.gds_io_threads is deprecated; "
-                        "use disk_io_threads instead."
-                    )
-                    thread_count = config.extra_config["gds_io_threads"]
             self._thread_pool = ThreadPoolExecutor(
                 max_workers=thread_count, thread_name_prefix="gds-io"
             )


### PR DESCRIPTION
The thread pool was previously gated on `use_gds`. Enable it unconditionally (default 4 threads) so POSIX-fallback paths also benefit from parallel I/O.  Users can set `disk_io_threads=0` in `extra_config` to disable it.

Also drops the deprecated `gds_io_threads` config key.

Generated with [Devin](https://devin.ai)

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
