### PR TITLE
fix: abort skipped write reservations instead of committing them

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -664,6 +664,59 @@ class L1Manager:
         return ret
 
     @l1_mgr_synchronized
+    def abort_write(self, keys: list[ObjectKey]) -> dict[ObjectKey, L1Error]:
+        """Abort write access for the given keys, discarding the objects.
+
+        Unlike ``finish_write`` followed by ``delete``, the object is never
+        published as written: ``on_l1_keys_write_finished`` is not fired, so
+        no listener (e.g. an L2 store controller) can observe or persist the
+        unwritten contents. Listeners receive ``on_l1_keys_deleted_by_manager``
+        for each aborted key.
+
+        Args:
+            keys: The list of write-reserved object keys to abort.
+
+        Returns:
+            A dictionary mapping each object key to an L1Error.
+
+        Errors:
+            KEY_NOT_EXIST: The key does not exist.
+            KEY_IN_WRONG_STATE: The key is not write-locked, or it is
+                read-locked (a reader may be observing the object).
+        """
+        need_to_free: list[MemoryObj] = []
+        ret: dict[ObjectKey, L1Error] = {}
+        successful_keys: list[ObjectKey] = []
+
+        for key in keys:
+            entry = self._objects.get(key, None)
+            if entry is None:
+                ret[key] = L1Error.KEY_NOT_EXIST
+                continue
+
+            if not entry.write_lock.is_locked() or entry.read_lock.is_locked():
+                ret[key] = L1Error.KEY_IN_WRONG_STATE
+                continue
+
+            entry.write_lock.unlock()
+            need_to_free.append(entry.memory_obj)
+            del self._objects[key]
+            ret[key] = L1Error.SUCCESS
+            successful_keys.append(key)
+
+        self._memory_manager.free(need_to_free)
+
+        for listener in self._registered_listeners:
+            listener.on_l1_keys_deleted_by_manager(successful_keys)
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.L1_KEYS_EVICTED,
+                metadata={"keys": successful_keys},
+            )
+        )
+        return ret
+
+    @l1_mgr_synchronized
     def delete(self, keys: list[ObjectKey]) -> dict[ObjectKey, L1Error]:
         """Delete the given keys from L1 cache.
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -250,6 +250,34 @@ class StorageManager:
 
         # TODO: global key states update
 
+    @enable_tracing()
+    def abort_write(
+        self,
+        keys: list[ObjectKey],
+    ) -> None:
+        """
+        Abort write reservations, discarding the objects without publishing.
+
+        Unlike ``finish_write``, aborted keys are never reported as written,
+        so store listeners cannot persist their unwritten contents.
+
+        Args:
+            keys (list[ObjectKey]): List of write-reserved object keys whose
+                contents will not be written.
+        """
+        abort_result = self._l1_manager.abort_write(keys)
+        successful_keys = [k for k, e in abort_result.items() if e == L1Error.SUCCESS]
+        failed_keys = [k for k, e in abort_result.items() if e != L1Error.SUCCESS]
+        self._event_bus.publish(
+            Event(
+                event_type=EventType.SM_WRITE_ABORTED,
+                metadata={
+                    "succeeded_keys": successful_keys,
+                    "failed_keys": failed_keys,
+                },
+            )
+        )
+
     @contextmanager
     def read_prefetched_results(
         self,

--- a/lmcache/v1/mp_observability/event.py
+++ b/lmcache/v1/mp_observability/event.py
@@ -36,6 +36,7 @@ class EventType(Enum):
     SM_READ_PREFETCHED_FINISHED = "sm.read.prefetched_finished"
     SM_WRITE_RESERVED = "sm.write.reserved"
     SM_WRITE_FINISHED = "sm.write.finished"
+    SM_WRITE_ABORTED = "sm.write.aborted"
 
     # L2 Store Controller events
     L2_STORE_SUBMITTED = "l2.store.submitted"

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -279,7 +279,10 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
 
         for obj_keys in write_obj_keys:
             if obj_keys:
-                self._ctx.storage_manager.finish_write(obj_keys)
+                # The worker died between prepare and commit, so the SHM slots
+                # hold unwritten or partially written data: abort instead of
+                # publishing the objects as valid.
+                self._ctx.storage_manager.abort_write(obj_keys)
         for obj_keys in read_obj_keys:
             if obj_keys:
                 self._ctx.storage_manager.finish_read_prefetched(obj_keys)

--- a/lmcache/v1/multiprocess/modules/server_transfer.py
+++ b/lmcache/v1/multiprocess/modules/server_transfer.py
@@ -214,23 +214,47 @@ class PickleTransferStrategy(TransferStrategy):
             obj_keys, context.layout_desc, "new"
         )
         written_keys: list[ObjectKey] = []
+        skip_reasons: dict[str, int] = {}
         try:
             for idx, obj_key in enumerate(obj_keys):
                 if obj_key not in reserved_dict:
                     continue
                 if idx >= len(chunks):
+                    skip_reasons["missing_chunk"] = (
+                        skip_reasons.get("missing_chunk", 0) + 1
+                    )
                     continue
                 memory_obj = reserved_dict[obj_key]
                 if memory_obj.tensor is None:
+                    skip_reasons["no_tensor"] = skip_reasons.get("no_tensor", 0) + 1
                     continue
                 chunk_cpu = chunks[idx]
                 if chunk_cpu.shape != memory_obj.tensor.shape:
+                    skip_reasons["shape_mismatch"] = (
+                        skip_reasons.get("shape_mismatch", 0) + 1
+                    )
                     continue
                 memory_obj.tensor.copy_(chunk_cpu)
                 written_keys.append(obj_key)
         finally:
             if written_keys:
                 self._storage_manager.finish_write(written_keys)
+            written_set = set(written_keys)
+            skipped_keys = [k for k in reserved_dict if k not in written_set]
+            if skipped_keys:
+                # Reservations that will never be filled must be aborted, not
+                # left write-locked (they would pin L1 memory and wedge future
+                # reserves) and not finish_write'd (a store listener would
+                # persist the unwritten contents).
+                self._storage_manager.abort_write(skipped_keys)
+                logger.warning(
+                    "Pickle commit_store aborted %d/%d reserved objects "
+                    "(reasons: %s) for key %s",
+                    len(skipped_keys),
+                    len(reserved_dict),
+                    skip_reasons,
+                    key,
+                )
 
         return len(written_keys) == len(reserved_dict)
 
@@ -349,7 +373,10 @@ class ShmTransferStrategy(TransferStrategy):
                 obj_key for obj_key in reserved if obj_key not in reserved_keys_set
             ]
             if unused_keys:
-                self._storage_manager.finish_write(unused_keys)
+                # These reservations never get SHM slots, so the worker will
+                # never write them: abort instead of finish_write, which would
+                # publish empty objects for lookups and L2 store listeners.
+                self._storage_manager.abort_write(unused_keys)
         if not reserved_keys:
             return PrepareStoreResponse(context={"slots": [], "chunk_indices": []})
         transfer_key = self._transfer_key_factory(key, instance_id)

--- a/tests/v1/distributed/test_abort_write.py
+++ b/tests/v1/distributed/test_abort_write.py
@@ -16,6 +16,7 @@ from lmcache.v1.distributed.config import (
     StorageManagerConfig,
 )
 from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.distributed.l1_manager import L1Manager
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
 from lmcache.v1.multiprocess.modules.server_transfer import PickleTransferStrategy
 from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContextMetadata
@@ -89,10 +90,36 @@ def test_abort_write_releases_locks_and_frees_objects(storage_manager, basic_lay
     storage_manager.abort_write(keys)
 
 
-def test_abort_write_does_not_publish_to_store_listeners(
-    storage_manager, basic_layout
-):
-    events: list[list[ObjectKey]] = []
+@pytest.fixture
+def l1_manager():
+    manager = L1Manager(
+        config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=128 * 1024 * 1024,
+                use_lazy=torch.cuda.is_available(),
+                init_size_in_bytes=64 * 1024 * 1024,
+                align_bytes=0x1000,
+            ),
+            write_ttl_seconds=600,
+            read_ttl_seconds=300,
+        )
+    )
+    yield manager
+    manager.close()
+
+
+def _reserve(manager: L1Manager, keys: list[ObjectKey], layout: MemoryLayoutDesc):
+    return manager.reserve_write(
+        keys=keys,
+        is_temporary=[False] * len(keys),
+        layout_desc=layout,
+        mode="new",
+    )
+
+
+def test_abort_write_does_not_publish_to_store_listeners(l1_manager, basic_layout):
+    written: list[list[ObjectKey]] = []
+    deleted: list[list[ObjectKey]] = []
 
     class _Listener:
         def on_l1_keys_reserved_read(self, keys):
@@ -105,13 +132,13 @@ def test_abort_write_does_not_publish_to_store_listeners(
             pass
 
         def on_l1_keys_write_finished(self, keys):
-            events.append(list(keys))
+            written.append(list(keys))
 
         def on_l1_keys_finish_write_and_reserve_read(self, keys):
             pass
 
         def on_l1_keys_deleted_by_manager(self, keys):
-            pass
+            deleted.append(list(keys))
 
         def on_l1_keys_accessed(self, keys):
             pass
@@ -125,24 +152,26 @@ def test_abort_write_does_not_publish_to_store_listeners(
         def on_l2_keys_deleted(self, keys):
             pass
 
-    storage_manager._l1_manager.register_listener(_Listener())
+    l1_manager.register_listener(_Listener())
     keys = [make_object_key(10)]
-    storage_manager.reserve_write(keys, basic_layout, "new")
-    storage_manager.abort_write(keys)
+    _reserve(l1_manager, keys, basic_layout)
+    result = l1_manager.abort_write(keys)
 
-    assert events == [] or all(not e for e in events)
+    assert result[keys[0]] == L1Error.SUCCESS
+    assert all(not e for e in written)
+    assert deleted == [keys]
 
 
-def test_l1_abort_write_rejects_unlocked_keys(storage_manager, basic_layout):
+def test_l1_abort_write_rejects_unlocked_keys(l1_manager, basic_layout):
     keys = [make_object_key(20)]
-    storage_manager.reserve_write(keys, basic_layout, "new")
-    storage_manager.finish_write(keys)
+    _reserve(l1_manager, keys, basic_layout)
+    l1_manager.finish_write(keys)
 
-    result = storage_manager._l1_manager.abort_write(keys)
+    result = l1_manager.abort_write(keys)
     assert result[keys[0]] == L1Error.KEY_IN_WRONG_STATE
 
     missing = [make_object_key(21)]
-    result = storage_manager._l1_manager.abort_write(missing)
+    result = l1_manager.abort_write(missing)
     assert result[missing[0]] == L1Error.KEY_NOT_EXIST
 
 

--- a/tests/v1/distributed/test_abort_write.py
+++ b/tests/v1/distributed/test_abort_write.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for abort_write: releasing write reservations without publishing them.
+"""
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+)
+from lmcache.v1.distributed.error import L1Error
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey
+from lmcache.v1.multiprocess.modules.server_transfer import PickleTransferStrategy
+from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContextMetadata
+
+try:
+    # First Party
+    from lmcache.v1.distributed.storage_manager import StorageManager
+except ImportError:
+    pytest.skip(
+        "Skipping because StorageManager cannot be imported", allow_module_level=True
+    )
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is not available"
+)
+
+
+@pytest.fixture
+def basic_layout():
+    return MemoryLayoutDesc(
+        shapes=[torch.Size([2, 2, 16, 16])],
+        dtypes=[torch.bfloat16],
+    )
+
+
+@pytest.fixture
+def storage_manager():
+    config = StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=128 * 1024 * 1024,
+                use_lazy=torch.cuda.is_available(),
+                init_size_in_bytes=64 * 1024 * 1024,
+                align_bytes=0x1000,
+            ),
+            write_ttl_seconds=600,
+            read_ttl_seconds=300,
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+    )
+    sm = StorageManager(config)
+    yield sm
+    sm.close()
+
+
+def make_object_key(chunk_hash: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_hash),
+        model_name="test_model",
+        kv_rank=0,
+    )
+
+
+def _locked_and_total(sm: StorageManager) -> tuple[int, int]:
+    status = sm.report_status()["l1_manager"]
+    return status["write_locked_count"], status["total_object_count"]
+
+
+def test_abort_write_releases_locks_and_frees_objects(storage_manager, basic_layout):
+    keys = [make_object_key(i) for i in range(3)]
+    reserved = storage_manager.reserve_write(keys, basic_layout, "new")
+    assert len(reserved) == 3
+    assert _locked_and_total(storage_manager) == (3, 3)
+
+    storage_manager.abort_write(keys)
+
+    assert _locked_and_total(storage_manager) == (0, 0)
+    # Aborted keys must be reservable again as "new".
+    reserved_again = storage_manager.reserve_write(keys, basic_layout, "new")
+    assert len(reserved_again) == 3
+    storage_manager.abort_write(keys)
+
+
+def test_abort_write_does_not_publish_to_store_listeners(
+    storage_manager, basic_layout
+):
+    events: list[list[ObjectKey]] = []
+
+    class _Listener:
+        def on_l1_keys_reserved_read(self, keys):
+            pass
+
+        def on_l1_keys_read_finished(self, keys):
+            pass
+
+        def on_l1_keys_reserved_write(self, keys):
+            pass
+
+        def on_l1_keys_write_finished(self, keys):
+            events.append(list(keys))
+
+        def on_l1_keys_finish_write_and_reserve_read(self, keys):
+            pass
+
+        def on_l1_keys_deleted_by_manager(self, keys):
+            pass
+
+        def on_l1_keys_accessed(self, keys):
+            pass
+
+        def on_l2_keys_stored(self, keys, sizes):
+            pass
+
+        def on_l2_keys_accessed(self, keys):
+            pass
+
+        def on_l2_keys_deleted(self, keys):
+            pass
+
+    storage_manager._l1_manager.register_listener(_Listener())
+    keys = [make_object_key(10)]
+    storage_manager.reserve_write(keys, basic_layout, "new")
+    storage_manager.abort_write(keys)
+
+    assert events == [] or all(not e for e in events)
+
+
+def test_l1_abort_write_rejects_unlocked_keys(storage_manager, basic_layout):
+    keys = [make_object_key(20)]
+    storage_manager.reserve_write(keys, basic_layout, "new")
+    storage_manager.finish_write(keys)
+
+    result = storage_manager._l1_manager.abort_write(keys)
+    assert result[keys[0]] == L1Error.KEY_IN_WRONG_STATE
+
+    missing = [make_object_key(21)]
+    result = storage_manager._l1_manager.abort_write(missing)
+    assert result[missing[0]] == L1Error.KEY_NOT_EXIST
+
+
+def test_pickle_commit_store_aborts_skipped_reservations(
+    storage_manager, basic_layout
+):
+    """A payload with fewer chunks than object keys must not leak the extra
+    write reservations (regression: leaked write locks filled L1 and every
+    subsequent reserve failed)."""
+    # Standard
+    import pickle
+
+    strategy = PickleTransferStrategy(storage_manager)
+    obj_keys = [make_object_key(30 + i) for i in range(3)]
+    metadata = EngineDrivenContextMetadata(
+        layout_desc=basic_layout, block_size=16, use_mla=False
+    )
+    key = IPCCacheServerKey(
+        model_name="test_model",
+        world_size=1,
+        worker_id=0,
+        token_ids=tuple(range(48)),
+        start=0,
+        end=48,
+        request_id="req-abort-test",
+    )
+
+    # Only one chunk for three keys: two reservations must be aborted.
+    payload = pickle.dumps([torch.ones(2, 2, 16, 16, dtype=torch.bfloat16)])
+    ok = strategy.commit_store(
+        key=key,
+        instance_id=1,
+        cpu_data=payload,
+        context=metadata,
+        resolve_obj_keys=lambda _k: obj_keys,
+    )
+
+    assert ok is False
+    locked, total = _locked_and_total(storage_manager)
+    assert locked == 0
+    # Only the written key may remain resident.
+    assert total <= 1

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -1168,7 +1168,9 @@ def test_server_prepare_store_releases_unused_reserved_write_locks(
     assert isinstance(prepare_response, PrepareStoreResponse)
     assert prepare_response.context == {"slots": [], "chunk_indices": []}
     reserved_keys = mock_storage.reserve_write.call_args[0][0]
-    mock_storage.finish_write.assert_called_once_with(reserved_keys)
+    # Unfillable reservations are aborted, never published as written.
+    mock_storage.abort_write.assert_called_once_with(reserved_keys)
+    mock_storage.finish_write.assert_not_called()
 
 
 def test_server_shm_transport_uses_engine_level_config(
@@ -1262,7 +1264,9 @@ def test_server_unregister_engine_driven_context_releases_pending_shm_locks(
 
     module.unregister_kv_cache(4)
 
-    mock_storage.finish_write.assert_called_once()
+    # Stale pending writes were never committed by the worker: abort them
+    # rather than publishing partially written objects.
+    mock_storage.abort_write.assert_called_once()
     mock_storage.finish_read_prefetched.assert_called_once()
 
 


### PR DESCRIPTION
## What

Adds `L1Manager.abort_write` / `StorageManager.abort_write` (release a write reservation without publishing it) and uses it at the three call sites that today either leak the reservation or publish never-written objects:

1. **`PickleTransferStrategy.commit_store`** (the bug that motivated this): reservations it cannot fill (missing chunk, `tensor is None`, shape mismatch) were silently `continue`d past and left **write-locked forever**. Under a sustained workload the leaked locks pin L1 until every subsequent `reserve_write` fails. Observed in production (engine_driven + pickle transport): 604/1276 L1 objects write-locked and 91.5% memory usage within ~30 minutes, with every store returning `False`. A `warning` log with per-reason skip counts replaces the silent skips.
2. **`ShmTransferStrategy.prepare_store`**: reserved keys that got no SHM slot were released via `finish_write`, which fires `on_l1_keys_write_finished`, so a store listener (e.g. the L2 StoreController) can then persist the **unwritten** contents, and lookups see a valid-looking empty object.
3. **Instance-teardown sweep** (`engine_driven_transfer`): stale pending writes from a dead worker were likewise committed via `finish_write`; the slots hold unwritten or partially written data.

`abort_write` unlocks + frees under the manager lock and notifies `on_l1_keys_deleted_by_manager` (never `write_finished`), so no listener can observe the discarded objects. New `SM_WRITE_ABORTED` event mirrors `SM_WRITE_FINISHED`.

## Tests

- `tests/v1/distributed/test_abort_write.py` (new, real `StorageManager`): lock release + re-reservability, no `write_finished` listener publication, wrong-state/missing-key errors, and a `commit_store` regression test (short chunk list → `False`, zero leaked locks).
- Updated the two existing release-semantics asserts (`prepare_store` unused keys, unregister sweep) from `finish_write` to `abort_write`.
- Full `test_engine_driven_transfer.py` + `test_report_status.py` + new file: **40 passed, 2 skipped** on CUDA (H/B-series box, python 3.10).

## Notes

Found while productionizing #3892; same deployment also surfaced that `--l1-use-lazy` (default) disables the SHM transport via `_compute_shm_pool_info`, which is what routes engine_driven workers onto this pickle path in the first place. Happy to file separately.

---

**Update (rebased on current dev).** Rebased across the ~350 commits since this was opened. Two conflicts, both from dev adding code at the same spots: dev added a `force` flag to `L1Manager.delete()` right below where `abort_write` goes (kept both), and dev added a `logger.error` at each skip branch of the pickle `commit_store`, where this PR had added skip-reason tallies. I kept dev's per-skip logs and dropped the tallies, since dev's "store incomplete" error already reports reserved versus written. The abort itself is unchanged.

All three sites are still live on dev: the pickle path still leaves skipped reservations write-locked, and the SHM `prepare_store` and the dead-worker reap still `finish_write` objects that were never written.

Verified on an A10G with torch 2.13.0+cu130 (the repo's build pin): `test_abort_write.py` passes 4/4, and reverting the pickle-path fix fails exactly `test_pickle_commit_store_aborts_skipped_reservations`. `tests/v1/distributed` plus `test_engine_driven_transfer.py` on GPU show the same single pre-existing failure on dev and on this branch, with the 4 new tests passing. On CPU, `tests/v1/distributed`, `tests/v1/multiprocess` and the adapter tests give identical failure sets on dev and on this branch.
