### PR TITLE
fix: guard transfer-context close against in-flight gather/scatter

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1283,6 +1283,7 @@ class LMCacheMPWorkerAdapter:
         self.kv_caches = kv_caches
         transfer_ctx = create_transfer_context(kv_caches, mode=self._mp_transfer_mode)
         layout_hints = vllm_layout_hints()
+        old_ctx = self.transfer_ctx
         self.transfer_ctx = transfer_ctx
         try:
             # Register on the local, not self.transfer_ctx: a concurrent
@@ -1306,6 +1307,15 @@ class LMCacheMPWorkerAdapter:
                 "register_kv_caches within "
                 f"{self._mq_timeout}s. Is the server running?"
             ) from None
+        if old_ctx is not None:
+            # Release the displaced context deterministically instead of at
+            # GC time: its close() drains in-flight transfers before
+            # unpinning/unmapping the old SHM pool, so a store racing the
+            # re-registration can never dereference an unmapped view.
+            try:
+                old_ctx.close()
+            except Exception:
+                logger.exception("Failed to close displaced transfer context")
 
     def _ensure_heartbeat_started(self) -> None:
         """Lazily start the heartbeat thread on first store/retrieve.

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1302,6 +1302,15 @@ class LMCacheMPWorkerAdapter:
                 engine_group_infos=self.engine_group_infos,
             )
         except TimeoutError:
+            # Roll back: the new context never registered, so close it (it
+            # holds an SHM mapping but has no transfers) and keep the old
+            # context current — the next recovery attempt displaces and
+            # closes it through the success path below.
+            self.transfer_ctx = old_ctx
+            try:
+                transfer_ctx.close()
+            except Exception:
+                logger.exception("Failed to close unregistered transfer context")
             raise ConnectionError(
                 "LMCache server did not respond to "
                 "register_kv_caches within "

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1427,12 +1427,11 @@ class LMCacheMPWorkerAdapter:
         self.kv_caches = kv_caches
         transfer_ctx = create_transfer_context(kv_caches, mode=self._mp_transfer_mode)
         layout_hints = self._layout_hints
-        old_ctx = self.transfer_ctx
-        self.transfer_ctx = transfer_ctx
         try:
-            # Register on the local, not self.transfer_ctx: a concurrent
-            # shutdown() may null self.transfer_ctx between publish and this
-            # call. The local is always non-None.
+            # Register before publishing: a context becomes visible to the
+            # transfer paths only once its transport exists, so a store
+            # arriving mid-recovery keeps using the context it replaces
+            # instead of meeting a half-built one.
             transfer_ctx.register(
                 self.instance_id,
                 kv_caches,
@@ -1446,11 +1445,9 @@ class LMCacheMPWorkerAdapter:
                 engine_type=EngineType.VLLM,
             )
         except TimeoutError:
-            # Roll back: the new context never registered, so close it (it
-            # holds an SHM mapping but has no transfers) and keep the old
-            # context current — the next recovery attempt displaces and
-            # closes it through the success path below.
-            self.transfer_ctx = old_ctx
+            # Never published, so there is nothing to roll back: close the
+            # context that failed to register (it holds an SHM mapping but no
+            # transfers) and leave the working one current.
             try:
                 transfer_ctx.close()
             except Exception:
@@ -1460,6 +1457,8 @@ class LMCacheMPWorkerAdapter:
                 "register_kv_caches within "
                 f"{self._mq_timeout}s. Is the server running?"
             ) from None
+        old_ctx = self.transfer_ctx
+        self.transfer_ctx = transfer_ctx
         if old_ctx is not None:
             # Release the displaced context deterministically instead of at
             # GC time: its close() drains in-flight transfers before
@@ -1610,12 +1609,13 @@ class LMCacheMPWorkerAdapter:
             cache_salt=cache_salt,
             request_configs=request_configs,
         )
-        if self.transfer_ctx is None:
+        transfer_ctx = self.transfer_ctx
+        if transfer_ctx is None:
             raise RuntimeError(
                 "Transfer context is not initialized. "
                 "Call register_kv_caches() before submitting store requests."
             )
-        future = self.transfer_ctx.submit_store(
+        future = transfer_ctx.submit_store(
             request_id,
             key,
             self.instance_id,
@@ -1669,12 +1669,13 @@ class LMCacheMPWorkerAdapter:
             cache_salt=cache_salt,
             request_configs=request_configs,
         )
-        if self.transfer_ctx is None:
+        transfer_ctx = self.transfer_ctx
+        if transfer_ctx is None:
             raise RuntimeError(
                 "Transfer context is not initialized. "
                 "Call register_kv_caches() before submitting retrieve requests."
             )
-        future = self.transfer_ctx.submit_retrieve(
+        future = transfer_ctx.submit_retrieve(
             request_id,
             key,
             self.instance_id,
@@ -2092,9 +2093,10 @@ class LMCacheMPWorkerAdapter:
         """
         if not need_flush_before_forward:
             return
-        if not self.is_healthy or self.transfer_ctx is None:
+        transfer_ctx = self.transfer_ctx
+        if not self.is_healthy or transfer_ctx is None:
             return
-        self.transfer_ctx.flush_inflight_stores()
+        transfer_ctx.flush_inflight_stores()
         # Force device sync here, compare to preemption, perf panelty is trivial
         torch_dev.synchronize()
 

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1446,6 +1446,15 @@ class LMCacheMPWorkerAdapter:
                 engine_type=EngineType.VLLM,
             )
         except TimeoutError:
+            # Roll back: the new context never registered, so close it (it
+            # holds an SHM mapping but has no transfers) and keep the old
+            # context current — the next recovery attempt displaces and
+            # closes it through the success path below.
+            self.transfer_ctx = old_ctx
+            try:
+                transfer_ctx.close()
+            except Exception:
+                logger.exception("Failed to close unregistered transfer context")
             raise ConnectionError(
                 "LMCache server did not respond to "
                 "register_kv_caches within "

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1427,6 +1427,7 @@ class LMCacheMPWorkerAdapter:
         self.kv_caches = kv_caches
         transfer_ctx = create_transfer_context(kv_caches, mode=self._mp_transfer_mode)
         layout_hints = self._layout_hints
+        old_ctx = self.transfer_ctx
         self.transfer_ctx = transfer_ctx
         try:
             # Register on the local, not self.transfer_ctx: a concurrent
@@ -1450,6 +1451,15 @@ class LMCacheMPWorkerAdapter:
                 "register_kv_caches within "
                 f"{self._mq_timeout}s. Is the server running?"
             ) from None
+        if old_ctx is not None:
+            # Release the displaced context deterministically instead of at
+            # GC time: its close() drains in-flight transfers before
+            # unpinning/unmapping the old SHM pool, so a store racing the
+            # re-registration can never dereference an unmapped view.
+            try:
+                old_ctx.close()
+            except Exception:
+                logger.exception("Failed to close displaced transfer context")
 
     def _ensure_heartbeat_started(self) -> None:
         """Lazily start the heartbeat thread on first store/retrieve.

--- a/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
+++ b/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
@@ -13,7 +13,10 @@ import torch
 from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.v1.multiprocess.futures import MessagingFuture
-from lmcache.v1.multiprocess.transfer_context.base import gather_paged_kv_to_cpu
+from lmcache.v1.multiprocess.transfer_context.base import (
+    ContextClosedError,
+    gather_paged_kv_to_cpu,
+)
 from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
     EngineDrivenTransferContext,
     IPCEvent,
@@ -214,85 +217,106 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
                 used_shm_direct = False
                 staged_chunks: list[torch.Tensor] = []
                 try:
-                    # --- Phase 1: prepare_store ---
-                    # In pickle mode this is the costliest step (sync RPC
-                    # round-trip).  Running it here keeps the forward thread free.
-                    result = engine_driven_context.prepare_store(key, instance_id)
-                    out_buffers, chunk_indices = (
-                        result if result is not None else (None, None)
-                    )
-
-                    if chunk_indices is not None and len(chunk_indices) == 0:
-                        # All chunks are already in cache: no gather, no commit.
-                        ok = True
-                        return
-
-                    num_chunks = (
-                        len(chunk_indices)
-                        if chunk_indices is not None
-                        else len(full_block_ids) // blocks_in_chunk
-                    )
-
-                    # Determine gather target:
-                    # - SHM path (out_buffers available): gather into SHM views
-                    # - Pickle path (no out_buffers): gather into pinned staging
-                    if out_buffers is not None:
-                        gather_target = out_buffers
-                        used_shm_direct = True
-                    else:
-                        layout_desc = engine_driven_context.layout_desc
-                        if not layout_desc.shapes:
-                            raise RuntimeError(
-                                "engine-driven layout_desc.shapes is empty"
-                            )
-                        if not layout_desc.dtypes:
-                            raise RuntimeError(
-                                "engine-driven layout_desc.dtypes is empty"
-                            )
-                        staged_chunks = self._alloc_pinned_staging(
-                            layout_desc.shapes[0],
-                            layout_desc.dtypes[0],
-                            num_chunks,
+                    # The whole prepare/gather/commit sequence dereferences
+                    # context-owned SHM views; the guard keeps a concurrent
+                    # context swap or shutdown from unmapping them mid-copy.
+                    with engine_driven_context.transfer_guard():
+                        # --- Phase 1: prepare_store ---
+                        # In pickle mode this is the costliest step (sync RPC
+                        # round-trip). Running it here keeps the forward
+                        # thread free.
+                        result = engine_driven_context.prepare_store(
+                            key, instance_id
                         )
-                        gather_target = staged_chunks
-
-                    # --- Phase 2: gather (GPU->CPU copy on copy stream) ---
-                    with torch.inference_mode(), torch_dev.stream(self._copy_stream):
-                        _event.wait(stream=self._copy_stream)
-
-                        gather_paged_kv_to_cpu(
-                            kv_caches,
-                            full_block_ids,
-                            blocks_in_chunk,
-                            layout_hints=self._layout_hints,
-                            engine_kv_format=self._engine_kv_format,
-                            out=gather_target,
-                            chunk_indices=chunk_indices,
+                        out_buffers, chunk_indices = (
+                            result if result is not None else (None, None)
                         )
 
-                        gather_done = torch_dev.Event()
-                        gather_done.record(self._copy_stream)
+                        if chunk_indices is not None and len(chunk_indices) == 0:
+                            # All chunks already in cache: no gather, no commit.
+                            ok = True
+                            return
 
-                    with self._inflight_lock:
+                        num_chunks = (
+                            len(chunk_indices)
+                            if chunk_indices is not None
+                            else len(full_block_ids) // blocks_in_chunk
+                        )
+
+                        # Determine gather target:
+                        # - SHM path (out_buffers available): gather into SHM
+                        #   views
+                        # - Pickle path (no out_buffers): gather into pinned
+                        #   staging
+                        if out_buffers is not None:
+                            gather_target = out_buffers
+                            used_shm_direct = True
+                        else:
+                            layout_desc = engine_driven_context.layout_desc
+                            if not layout_desc.shapes:
+                                raise RuntimeError(
+                                    "engine-driven layout_desc.shapes is empty"
+                                )
+                            if not layout_desc.dtypes:
+                                raise RuntimeError(
+                                    "engine-driven layout_desc.dtypes is empty"
+                                )
+                            staged_chunks = self._alloc_pinned_staging(
+                                layout_desc.shapes[0],
+                                layout_desc.dtypes[0],
+                                num_chunks,
+                            )
+                            gather_target = staged_chunks
+
+                        # --- Phase 2: gather (GPU->CPU copy on copy stream) ---
+                        with (
+                            torch.inference_mode(),
+                            torch_dev.stream(self._copy_stream),
+                        ):
+                            _event.wait(stream=self._copy_stream)
+
+                            gather_paged_kv_to_cpu(
+                                kv_caches,
+                                full_block_ids,
+                                blocks_in_chunk,
+                                layout_hints=self._layout_hints,
+                                engine_kv_format=self._engine_kv_format,
+                                out=gather_target,
+                                chunk_indices=chunk_indices,
+                            )
+
+                            gather_done = torch_dev.Event()
+                            gather_done.record(self._copy_stream)
+
+                        with self._inflight_lock:
+                            if gather_done is not None:
+                                self._inflight_gather_events.add(gather_done)
+                            self._pending_stores.discard(gather_launched)
+                        gather_launched.set()
+
                         if gather_done is not None:
-                            self._inflight_gather_events.add(gather_done)
-                        self._pending_stores.discard(gather_launched)
-                    gather_launched.set()
+                            gather_done.synchronize()
 
-                    if gather_done is not None:
-                        gather_done.synchronize()
-
-                    # --- Phase 3: commit ---
-                    with self._commit_lock:
-                        ok = engine_driven_context.commit_store(
-                            key, instance_id, gather_target
-                        )
+                        # --- Phase 3: commit ---
+                        with self._commit_lock:
+                            ok = engine_driven_context.commit_store(
+                                key, instance_id, gather_target
+                            )
 
                     if not ok:
                         logger.error(
                             "Async engine-driven commit_store failed for request_id=%s",
                             _request_id,
                         )
+                except ContextClosedError:
+                    # Context is being swapped/shut down; the store is simply
+                    # lost (same contract as a store against an unhealthy
+                    # server).
+                    logger.info(
+                        "Store for request_id=%s dropped: transfer context closing",
+                        _request_id,
+                    )
+                    ok = False
                 except Exception:
                     logger.exception(
                         "Async engine-driven store failed for request_id=%s",

--- a/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
+++ b/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
@@ -248,9 +248,7 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
                         # In pickle mode this is the costliest step (sync RPC
                         # round-trip). Running it here keeps the forward
                         # thread free.
-                        result = engine_driven_context.prepare_store(
-                            key, instance_id
-                        )
+                        result = engine_driven_context.prepare_store(key, instance_id)
                         out_buffers, chunk_indices = (
                             result if result is not None else (None, None)
                         )

--- a/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
+++ b/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
@@ -13,7 +13,10 @@ import torch
 from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.v1.multiprocess.futures import MessagingFuture
-from lmcache.v1.multiprocess.transfer_context.base import gather_paged_kv_to_cpu
+from lmcache.v1.multiprocess.transfer_context.base import (
+    ContextClosedError,
+    gather_paged_kv_to_cpu,
+)
 from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
     EngineDrivenTransferContext,
     IPCEvent,
@@ -237,85 +240,106 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
                 used_shm_direct = False
                 staged_chunks: list[torch.Tensor] = []
                 try:
-                    # --- Phase 1: prepare_store ---
-                    # In pickle mode this is the costliest step (sync RPC
-                    # round-trip).  Running it here keeps the forward thread free.
-                    result = engine_driven_context.prepare_store(key, instance_id)
-                    out_buffers, chunk_indices = (
-                        result if result is not None else (None, None)
-                    )
-
-                    if chunk_indices is not None and len(chunk_indices) == 0:
-                        # All chunks are already in cache: no gather, no commit.
-                        ok = True
-                        return
-
-                    num_chunks = (
-                        len(chunk_indices)
-                        if chunk_indices is not None
-                        else len(full_block_ids) // blocks_in_chunk
-                    )
-
-                    # Determine gather target:
-                    # - SHM path (out_buffers available): gather into SHM views
-                    # - Pickle path (no out_buffers): gather into pinned staging
-                    if out_buffers is not None:
-                        gather_target = out_buffers
-                        used_shm_direct = True
-                    else:
-                        layout_desc = engine_driven_context.layout_desc
-                        if not layout_desc.shapes:
-                            raise RuntimeError(
-                                "engine-driven layout_desc.shapes is empty"
-                            )
-                        if not layout_desc.dtypes:
-                            raise RuntimeError(
-                                "engine-driven layout_desc.dtypes is empty"
-                            )
-                        staged_chunks = self._alloc_pinned_staging(
-                            layout_desc.shapes[0],
-                            layout_desc.dtypes[0],
-                            num_chunks,
+                    # The whole prepare/gather/commit sequence dereferences
+                    # context-owned SHM views; the guard keeps a concurrent
+                    # context swap or shutdown from unmapping them mid-copy.
+                    with engine_driven_context.transfer_guard():
+                        # --- Phase 1: prepare_store ---
+                        # In pickle mode this is the costliest step (sync RPC
+                        # round-trip). Running it here keeps the forward
+                        # thread free.
+                        result = engine_driven_context.prepare_store(
+                            key, instance_id
                         )
-                        gather_target = staged_chunks
-
-                    # --- Phase 2: gather (GPU->CPU copy on copy stream) ---
-                    with torch.inference_mode(), torch_dev.stream(self._copy_stream):
-                        _event.wait(stream=self._copy_stream)
-
-                        gather_paged_kv_to_cpu(
-                            kv_caches,
-                            full_block_ids,
-                            blocks_in_chunk,
-                            layout_hints=self._layout_hints,
-                            engine_kv_format=self._engine_kv_format,
-                            out=gather_target,
-                            chunk_indices=chunk_indices,
+                        out_buffers, chunk_indices = (
+                            result if result is not None else (None, None)
                         )
 
-                        gather_done = torch_dev.Event()
-                        gather_done.record(self._copy_stream)
+                        if chunk_indices is not None and len(chunk_indices) == 0:
+                            # All chunks already in cache: no gather, no commit.
+                            ok = True
+                            return
 
-                    with self._inflight_lock:
+                        num_chunks = (
+                            len(chunk_indices)
+                            if chunk_indices is not None
+                            else len(full_block_ids) // blocks_in_chunk
+                        )
+
+                        # Determine gather target:
+                        # - SHM path (out_buffers available): gather into SHM
+                        #   views
+                        # - Pickle path (no out_buffers): gather into pinned
+                        #   staging
+                        if out_buffers is not None:
+                            gather_target = out_buffers
+                            used_shm_direct = True
+                        else:
+                            layout_desc = engine_driven_context.layout_desc
+                            if not layout_desc.shapes:
+                                raise RuntimeError(
+                                    "engine-driven layout_desc.shapes is empty"
+                                )
+                            if not layout_desc.dtypes:
+                                raise RuntimeError(
+                                    "engine-driven layout_desc.dtypes is empty"
+                                )
+                            staged_chunks = self._alloc_pinned_staging(
+                                layout_desc.shapes[0],
+                                layout_desc.dtypes[0],
+                                num_chunks,
+                            )
+                            gather_target = staged_chunks
+
+                        # --- Phase 2: gather (GPU->CPU copy on copy stream) ---
+                        with (
+                            torch.inference_mode(),
+                            torch_dev.stream(self._copy_stream),
+                        ):
+                            _event.wait(stream=self._copy_stream)
+
+                            gather_paged_kv_to_cpu(
+                                kv_caches,
+                                full_block_ids,
+                                blocks_in_chunk,
+                                layout_hints=self._layout_hints,
+                                engine_kv_format=self._engine_kv_format,
+                                out=gather_target,
+                                chunk_indices=chunk_indices,
+                            )
+
+                            gather_done = torch_dev.Event()
+                            gather_done.record(self._copy_stream)
+
+                        with self._inflight_lock:
+                            if gather_done is not None:
+                                self._inflight_gather_events.add(gather_done)
+                            self._pending_stores.discard(gather_launched)
+                        gather_launched.set()
+
                         if gather_done is not None:
-                            self._inflight_gather_events.add(gather_done)
-                        self._pending_stores.discard(gather_launched)
-                    gather_launched.set()
+                            gather_done.synchronize()
 
-                    if gather_done is not None:
-                        gather_done.synchronize()
-
-                    # --- Phase 3: commit ---
-                    with self._commit_lock:
-                        ok = engine_driven_context.commit_store(
-                            key, instance_id, gather_target
-                        )
+                        # --- Phase 3: commit ---
+                        with self._commit_lock:
+                            ok = engine_driven_context.commit_store(
+                                key, instance_id, gather_target
+                            )
 
                     if not ok:
                         logger.error(
                             "Async engine-driven commit_store failed for request_id=%s",
                             _request_id,
                         )
+                except ContextClosedError:
+                    # Context is being swapped/shut down; the store is simply
+                    # lost (same contract as a store against an unhealthy
+                    # server).
+                    logger.info(
+                        "Store for request_id=%s dropped: transfer context closing",
+                        _request_id,
+                    )
+                    ok = False
                 except Exception:
                     logger.exception(
                         "Async engine-driven store failed for request_id=%s",

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -17,9 +17,13 @@ from __future__ import annotations
 
 # Standard
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 import inspect
+import threading
+import time
 
 # Third Party
 import numpy as np
@@ -120,12 +124,22 @@ class EngineDrivenContextMetadata:
     use_mla: bool
 
 
+class ContextClosedError(RuntimeError):
+    """Raised when a transfer is submitted to a closing/closed context."""
+
+
 class EngineDrivenContext(ABC):
     """Abstract base class for CPU-side KV data transfer contexts.
 
     All concrete implementations share a common message-queue client and
     expose a uniform two-phase ``prepare/commit`` interface so that the
     worker adapter is implementation-agnostic.
+
+    Transfers that dereference context-owned resources (SHM tensor views,
+    pinned buffers) must run inside :meth:`transfer_guard`; ``close``
+    implementations must call :meth:`_drain_transfers` before releasing
+    those resources, so a context swap or shutdown can never unmap memory
+    under a live gather/scatter.
 
     Args:
         metadata: Layout metadata describing the chunk format.
@@ -142,6 +156,55 @@ class EngineDrivenContext(ABC):
         self.metadata = metadata
         self.mq_client = mq_client
         self.mq_timeout = mq_timeout
+        self._guard_cond = threading.Condition()
+        self._inflight_transfers = 0
+        self._closing = False
+
+    @contextmanager
+    def transfer_guard(self) -> Iterator[None]:
+        """Hold the context open for the duration of one transfer.
+
+        Raises:
+            ContextClosedError: If the context is closing or closed.
+        """
+        with self._guard_cond:
+            if self._closing:
+                raise ContextClosedError(
+                    "transfer context is closing; transfer rejected"
+                )
+            self._inflight_transfers += 1
+        try:
+            yield
+        finally:
+            with self._guard_cond:
+                self._inflight_transfers -= 1
+                if self._inflight_transfers == 0:
+                    self._guard_cond.notify_all()
+
+    def _drain_transfers(self, timeout: float = 30.0) -> bool:
+        """Reject new transfers and wait for in-flight ones to finish.
+
+        Returns:
+            ``True`` when the context drained within ``timeout``; ``False``
+            when transfers were still in flight after it. The caller
+            proceeds with resource release either way — a bounded wait must
+            not hang shutdown — so the overrun is logged as a warning.
+        """
+        deadline = time.monotonic() + timeout
+        with self._guard_cond:
+            self._closing = True
+            while self._inflight_transfers > 0:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "Context close proceeding with %d transfer(s) still "
+                        "in flight after %.0fs drain timeout",
+                        self._inflight_transfers,
+                        timeout,
+                    )
+                    return False
+                self._guard_cond.wait(timeout=remaining)
+        return True
 
     @property
     def layout_desc(self) -> MemoryLayoutDesc:

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -17,9 +17,13 @@ from __future__ import annotations
 
 # Standard
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 import inspect
+import threading
+import time
 
 # Third Party
 import numpy as np
@@ -121,12 +125,22 @@ class EngineDrivenContextMetadata:
     use_mla: bool
 
 
+class ContextClosedError(RuntimeError):
+    """Raised when a transfer is submitted to a closing/closed context."""
+
+
 class EngineDrivenContext(ABC):
     """Abstract base class for CPU-side KV data transfer contexts.
 
     All concrete implementations share a common request client and
     expose a uniform two-phase ``prepare/commit`` interface so that the
     worker adapter is implementation-agnostic.
+
+    Transfers that dereference context-owned resources (SHM tensor views,
+    pinned buffers) must run inside :meth:`transfer_guard`; ``close``
+    implementations must call :meth:`_drain_transfers` before releasing
+    those resources, so a context swap or shutdown can never unmap memory
+    under a live gather/scatter.
 
     Args:
         metadata: Layout metadata describing the chunk format.
@@ -143,6 +157,55 @@ class EngineDrivenContext(ABC):
         self.metadata = metadata
         self.req_client = req_client
         self.mq_timeout = mq_timeout
+        self._guard_cond = threading.Condition()
+        self._inflight_transfers = 0
+        self._closing = False
+
+    @contextmanager
+    def transfer_guard(self) -> Iterator[None]:
+        """Hold the context open for the duration of one transfer.
+
+        Raises:
+            ContextClosedError: If the context is closing or closed.
+        """
+        with self._guard_cond:
+            if self._closing:
+                raise ContextClosedError(
+                    "transfer context is closing; transfer rejected"
+                )
+            self._inflight_transfers += 1
+        try:
+            yield
+        finally:
+            with self._guard_cond:
+                self._inflight_transfers -= 1
+                if self._inflight_transfers == 0:
+                    self._guard_cond.notify_all()
+
+    def _drain_transfers(self, timeout: float = 30.0) -> bool:
+        """Reject new transfers and wait for in-flight ones to finish.
+
+        Returns:
+            ``True`` when the context drained within ``timeout``; ``False``
+            when transfers were still in flight after it. The caller
+            proceeds with resource release either way — a bounded wait must
+            not hang shutdown — so the overrun is logged as a warning.
+        """
+        deadline = time.monotonic() + timeout
+        with self._guard_cond:
+            self._closing = True
+            while self._inflight_transfers > 0:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(
+                        "Context close proceeding with %d transfer(s) still "
+                        "in flight after %.0fs drain timeout",
+                        self._inflight_transfers,
+                        timeout,
+                    )
+                    return False
+                self._guard_cond.wait(timeout=remaining)
+        return True
 
     @property
     def layout_desc(self) -> MemoryLayoutDesc:

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -228,6 +228,10 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def close(self) -> None:
         if self._shm is None:
             return
+        # Unpinning and unmapping while a gather/scatter still holds tensor
+        # views into the pool is a native crash (use-after-unmap under a
+        # copy kernel); drain first, bounded so shutdown cannot hang.
+        self._drain_transfers()
         self._unpin_shm_buffer()
         try:
             self._shm.close()

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -211,6 +211,10 @@ class EngineDrivenContextShm(EngineDrivenContext):
     def close(self) -> None:
         if self._shm is None:
             return
+        # Unpinning and unmapping while a gather/scatter still holds tensor
+        # views into the pool is a native crash (use-after-unmap under a
+        # copy kernel); drain first, bounded so shutdown cannot hang.
+        self._drain_transfers()
         self._unpin_shm_buffer()
         try:
             self._shm.close()

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -23,6 +23,7 @@ from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.multiprocess.protocols.engine import RegisterEngineDrivenContextResponse
 from lmcache.v1.multiprocess.transfer_context.base import (
+    ContextClosedError,
     EngineDrivenContext,
     EngineDrivenContextMetadata,
     compute_kv_layout,
@@ -526,29 +527,39 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_store()."
             )
 
-        torch_dev.synchronize()
-        result = self._engine_driven_context.prepare_store(key, instance_id)
-        out_buffers, chunk_indices = result if result is not None else (None, None)
-        # All chunks already in cache — nothing to gather or commit.
-        if chunk_indices is not None and len(chunk_indices) == 0:
-            future: MessagingFuture[bool] = MessagingFuture()
-            future.set_result(True)
+        ctx = self._engine_driven_context
+        future: MessagingFuture[bool] = MessagingFuture()
+        try:
+            with ctx.transfer_guard():
+                torch_dev.synchronize()
+                result = ctx.prepare_store(key, instance_id)
+                out_buffers, chunk_indices = (
+                    result if result is not None else (None, None)
+                )
+                # All chunks already in cache — nothing to gather or commit.
+                if chunk_indices is not None and len(chunk_indices) == 0:
+                    future.set_result(True)
+                    return future
+                cpu_chunks = gather_paged_kv_to_cpu(
+                    kv_caches,
+                    _single_group_block_ids(block_ids),
+                    blocks_in_chunk,
+                    layout_hints=self._layout_hints,
+                    engine_kv_format=self._engine_kv_format,
+                    out=out_buffers,
+                    chunk_indices=chunk_indices,
+                )
+                if out_buffers is not None:
+                    # SHM path uses async device->CPU copies; complete them
+                    # before commit.
+                    torch_dev.synchronize()
+                ok = ctx.commit_store(key, instance_id, cpu_chunks)
+        except ContextClosedError:
+            # Context is being swapped/shut down; the store is simply lost
+            # (same contract as a store against an unhealthy server).
+            future.set_result(False)
             return future
-        cpu_chunks = gather_paged_kv_to_cpu(
-            kv_caches,
-            _single_group_block_ids(block_ids),
-            blocks_in_chunk,
-            layout_hints=self._layout_hints,
-            engine_kv_format=self._engine_kv_format,
-            out=out_buffers,
-            chunk_indices=chunk_indices,
-        )
-        if out_buffers is not None:
-            # SHM path uses async device->CPU copies; complete them before commit.
-            torch_dev.synchronize()
-        ok = self._engine_driven_context.commit_store(key, instance_id, cpu_chunks)
 
-        future = MessagingFuture()
         future.set_result(ok)
         return future
 
@@ -569,28 +580,39 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_retrieve()."
             )
 
-        src_buffers = self._engine_driven_context.prepare_retrieve(key, instance_id)
-        ok = src_buffers is not None
-        if src_buffers is not None:
-            try:
-                scatter_cpu_to_paged_kv(
-                    kv_caches,
-                    _single_group_block_ids(block_ids),
-                    src_buffers,
-                    blocks_in_chunk,
-                    skip_first_n_tokens=skip_first_n_tokens,
-                    layout_hints=self._layout_hints,
-                    engine_kv_format=self._engine_kv_format,
-                )
-            except (RuntimeError, ValueError, TypeError, IndexError):
-                logger.exception("Failed to scatter retrieved CPU context chunks")
-                ok = False
-            # SHM path: ensure all device writes are complete before releasing
-            # the SHM slot (server may immediately reuse it after commit_retrieve).
-            torch_dev.synchronize()
-        self._engine_driven_context.commit_retrieve(key, instance_id)
-
+        ctx = self._engine_driven_context
         future: MessagingFuture[bool] = MessagingFuture()
+        try:
+            with ctx.transfer_guard():
+                src_buffers = ctx.prepare_retrieve(key, instance_id)
+                ok = src_buffers is not None
+                if src_buffers is not None:
+                    try:
+                        scatter_cpu_to_paged_kv(
+                            kv_caches,
+                            _single_group_block_ids(block_ids),
+                            src_buffers,
+                            blocks_in_chunk,
+                            skip_first_n_tokens=skip_first_n_tokens,
+                            layout_hints=self._layout_hints,
+                            engine_kv_format=self._engine_kv_format,
+                        )
+                    except (RuntimeError, ValueError, TypeError, IndexError):
+                        logger.exception(
+                            "Failed to scatter retrieved CPU context chunks"
+                        )
+                        ok = False
+                    # SHM path: ensure all device writes are complete before
+                    # releasing the SHM slot (server may immediately reuse it
+                    # after commit_retrieve).
+                    torch_dev.synchronize()
+                ctx.commit_retrieve(key, instance_id)
+        except ContextClosedError:
+            # Context is being swapped/shut down; report a miss so the
+            # engine recomputes the blocks.
+            future.set_result(False)
+            return future
+
         future.set_result(ok)
         return future
 

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -21,6 +21,7 @@ from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.protocols.engine import RegisterEngineDrivenContextResponse
 from lmcache.v1.multiprocess.transfer_context.base import (
+    ContextClosedError,
     EngineDrivenContext,
     EngineDrivenContextMetadata,
     compute_kv_layout,
@@ -787,32 +788,42 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_store()."
             )
 
-        torch_dev.synchronize()
-        result = self._engine_driven_context.prepare_store(key, instance_id)
-        out_buffers, chunk_indices = result if result is not None else (None, None)
-        # All chunks already in cache — nothing to gather or commit.
-        if chunk_indices is not None and len(chunk_indices) == 0:
-            future: MessagingFuture[bool] = MessagingFuture()
-            future.set_result(True)
+        ctx = self._engine_driven_context
+        future: MessagingFuture[bool] = MessagingFuture()
+        try:
+            with ctx.transfer_guard():
+                torch_dev.synchronize()
+                result = ctx.prepare_store(key, instance_id)
+                out_buffers, chunk_indices = (
+                    result if result is not None else (None, None)
+                )
+                # All chunks already in cache — nothing to gather or commit.
+                if chunk_indices is not None and len(chunk_indices) == 0:
+                    future.set_result(True)
+                    return future
+                cpu_chunks = gather_paged_kv_to_cpu(
+                    kv_caches,
+                    _single_group_block_ids(block_ids),
+                    blocks_in_chunk,
+                    layout_hints=self._layout_hints,
+                    engine_kv_format=self._engine_kv_format,
+                    out=out_buffers,
+                    chunk_indices=chunk_indices,
+                )
+                # Gather issues async device->CPU copies on BOTH transports:
+                # into the SHM slots when out_buffers is given, otherwise into
+                # fresh buffers that commit_store serializes immediately. Either
+                # way the copies must be complete first, so this is
+                # unconditional -- guarding it on out_buffers left the pickle
+                # path serializing a buffer still being written.
+                torch_dev.synchronize()
+                ok = ctx.commit_store(key, instance_id, cpu_chunks)
+        except ContextClosedError:
+            # Context is being swapped/shut down; the store is simply lost
+            # (same contract as a store against an unhealthy server).
+            future.set_result(False)
             return future
-        cpu_chunks = gather_paged_kv_to_cpu(
-            kv_caches,
-            _single_group_block_ids(block_ids),
-            blocks_in_chunk,
-            layout_hints=self._layout_hints,
-            engine_kv_format=self._engine_kv_format,
-            out=out_buffers,
-            chunk_indices=chunk_indices,
-        )
-        # Gather issues async device->CPU copies on BOTH transports: into the
-        # SHM slots when out_buffers is given, otherwise into fresh buffers that
-        # commit_store serializes immediately. Either way the copies must be
-        # complete first, so this is unconditional -- guarding it on out_buffers
-        # left the pickle path serializing a buffer still being written.
-        torch_dev.synchronize()
-        ok = self._engine_driven_context.commit_store(key, instance_id, cpu_chunks)
 
-        future = MessagingFuture()
         future.set_result(ok)
         return future
 
@@ -833,28 +844,39 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_retrieve()."
             )
 
-        src_buffers = self._engine_driven_context.prepare_retrieve(key, instance_id)
-        ok = src_buffers is not None
-        if src_buffers is not None:
-            try:
-                scatter_cpu_to_paged_kv(
-                    kv_caches,
-                    _single_group_block_ids(block_ids),
-                    src_buffers,
-                    blocks_in_chunk,
-                    skip_first_n_tokens=skip_first_n_tokens,
-                    layout_hints=self._layout_hints,
-                    engine_kv_format=self._engine_kv_format,
-                )
-            except (RuntimeError, ValueError, TypeError, IndexError):
-                logger.exception("Failed to scatter retrieved CPU context chunks")
-                ok = False
-            # SHM path: ensure all device writes are complete before releasing
-            # the SHM slot (server may immediately reuse it after commit_retrieve).
-            torch_dev.synchronize()
-        self._engine_driven_context.commit_retrieve(key, instance_id)
-
+        ctx = self._engine_driven_context
         future: MessagingFuture[bool] = MessagingFuture()
+        try:
+            with ctx.transfer_guard():
+                src_buffers = ctx.prepare_retrieve(key, instance_id)
+                ok = src_buffers is not None
+                if src_buffers is not None:
+                    try:
+                        scatter_cpu_to_paged_kv(
+                            kv_caches,
+                            _single_group_block_ids(block_ids),
+                            src_buffers,
+                            blocks_in_chunk,
+                            skip_first_n_tokens=skip_first_n_tokens,
+                            layout_hints=self._layout_hints,
+                            engine_kv_format=self._engine_kv_format,
+                        )
+                    except (RuntimeError, ValueError, TypeError, IndexError):
+                        logger.exception(
+                            "Failed to scatter retrieved CPU context chunks"
+                        )
+                        ok = False
+                    # SHM path: ensure all device writes are complete before
+                    # releasing the SHM slot (server may immediately reuse it
+                    # after commit_retrieve).
+                    torch_dev.synchronize()
+                ctx.commit_retrieve(key, instance_id)
+        except ContextClosedError:
+            # Context is being swapped/shut down; report a miss so the
+            # engine recomputes the blocks.
+            future.set_result(False)
+            return future
+
         future.set_result(ok)
         return future
 

--- a/tests/v1/multiprocess/test_async_engine_driven_transfer_context.py
+++ b/tests/v1/multiprocess/test_async_engine_driven_transfer_context.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
-from contextlib import nullcontext
+from collections.abc import Iterator
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Callable
@@ -49,6 +50,10 @@ class _FakeStoreContext:
         self, _key: object, _instance_id: int, chunks: list[torch.Tensor]
     ) -> bool:
         return bool(self.commit_impl(chunks))
+
+    @contextmanager
+    def transfer_guard(self) -> Iterator[None]:
+        yield
 
     def close(self) -> None:
         return None

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -458,6 +458,10 @@ def test_musa_data_context_store_uses_device_agnostic_gather(
         def commit_store(self, *_args: Any, **_kwargs: Any) -> bool:
             return True
 
+        @contextmanager
+        def transfer_guard(self) -> Iterator[None]:
+            yield
+
         def close(self) -> None:
             return None
 
@@ -529,6 +533,10 @@ def test_musa_data_context_retrieve_uses_device_agnostic_scatter(
 
         def commit_retrieve(self, *_args: Any, **_kwargs: Any) -> bool:
             return True
+
+        @contextmanager
+        def transfer_guard(self) -> Iterator[None]:
+            yield
 
         def close(self) -> None:
             return None

--- a/tests/v1/multiprocess/test_engine_driven_transfer.py
+++ b/tests/v1/multiprocess/test_engine_driven_transfer.py
@@ -502,6 +502,10 @@ def test_musa_data_context_store_uses_device_agnostic_gather(
         def commit_store(self, *_args: Any, **_kwargs: Any) -> bool:
             return True
 
+        @contextmanager
+        def transfer_guard(self) -> Iterator[None]:
+            yield
+
         def close(self) -> None:
             return None
 
@@ -575,6 +579,10 @@ def test_musa_data_context_retrieve_uses_device_agnostic_scatter(
 
         def commit_retrieve(self, *_args: Any, **_kwargs: Any) -> bool:
             return True
+
+        @contextmanager
+        def transfer_guard(self) -> Iterator[None]:
+            yield
 
         def close(self) -> None:
             return None

--- a/tests/v1/multiprocess/test_transfer_ctx_guard.py
+++ b/tests/v1/multiprocess/test_transfer_ctx_guard.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for the transfer guard: context close must never release resources
+while a transfer holds context-owned views (use-after-unmap hardening).
+"""
+
+# Standard
+from unittest.mock import MagicMock
+import threading
+import time
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc
+from lmcache.v1.multiprocess.transfer_context.base import (
+    ContextClosedError,
+    EngineDrivenContext,
+    EngineDrivenContextMetadata,
+)
+
+
+class _FakeContext(EngineDrivenContext):
+    """Minimal concrete context recording when close releases resources."""
+
+    def __init__(self) -> None:
+        metadata = EngineDrivenContextMetadata(
+            layout_desc=MemoryLayoutDesc(
+                shapes=[torch.Size([1])], dtypes=[torch.float32]
+            ),
+            block_size=16,
+            use_mla=False,
+        )
+        super().__init__(metadata, MagicMock(), mq_timeout=1.0)
+        self.released = threading.Event()
+        self.drain_timeout = 5.0
+
+    def prepare_store(self, key, instance_id):
+        return None
+
+    def commit_store(self, key, instance_id, chunks):
+        return True
+
+    def prepare_retrieve(self, key, instance_id):
+        return None
+
+    def commit_retrieve(self, key, instance_id):
+        return True
+
+    def close(self) -> None:
+        self._drain_transfers(timeout=self.drain_timeout)
+        self.released.set()
+
+
+def test_close_waits_for_inflight_transfer():
+    ctx = _FakeContext()
+    transfer_entered = threading.Event()
+    release_transfer = threading.Event()
+
+    def _transfer():
+        with ctx.transfer_guard():
+            transfer_entered.set()
+            release_transfer.wait(timeout=5.0)
+
+    t = threading.Thread(target=_transfer)
+    t.start()
+    assert transfer_entered.wait(timeout=5.0)
+
+    closer = threading.Thread(target=ctx.close)
+    closer.start()
+    # Close must not release resources while the transfer is in flight.
+    time.sleep(0.2)
+    assert not ctx.released.is_set()
+
+    release_transfer.set()
+    closer.join(timeout=5.0)
+    t.join(timeout=5.0)
+    assert ctx.released.is_set()
+
+
+def test_closing_context_rejects_new_transfers():
+    ctx = _FakeContext()
+    ctx.close()
+    with pytest.raises(ContextClosedError):
+        with ctx.transfer_guard():
+            pass
+
+
+def test_drain_timeout_proceeds_with_warning():
+    ctx = _FakeContext()
+    ctx.drain_timeout = 0.1
+    stuck_entered = threading.Event()
+    release_stuck = threading.Event()
+
+    def _stuck_transfer():
+        with ctx.transfer_guard():
+            stuck_entered.set()
+            release_stuck.wait(timeout=10.0)
+
+    t = threading.Thread(target=_stuck_transfer)
+    t.start()
+    assert stuck_entered.wait(timeout=5.0)
+
+    start = time.monotonic()
+    ctx.close()
+    elapsed = time.monotonic() - start
+    # Bounded: close returned despite the stuck transfer.
+    assert ctx.released.is_set()
+    assert elapsed < 2.0
+
+    release_stuck.set()
+    t.join(timeout=5.0)
+
+
+def test_guard_reentrant_across_sequential_transfers():
+    ctx = _FakeContext()
+    for _ in range(3):
+        with ctx.transfer_guard():
+            pass
+    ctx.close()
+    assert ctx.released.is_set()

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -717,12 +717,14 @@ def test_startup_does_not_warn_for_default_heartbeat_interval(
     assert not any("reap" in msg for msg in warnings)
 
 
-def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+def test_recover_callback_rebuilds_and_closes_previous_transfer_ctx(
     fake_adapter, monkeypatch
 ) -> None:
-    """Pin current behavior: every recover-callback invocation rebuilds
-    ``transfer_ctx`` without closing the previous context (known IPC leak;
-    in-flight submissions may still hold a reference to the old context)."""
+    """Every recover-callback invocation rebuilds ``transfer_ctx`` and closes
+    the displaced context deterministically. Closing is safe now that
+    ``close()`` drains in-flight transfers before releasing resources
+    (transfer guard); this replaces the previously pinned behavior of
+    abandoning the old context to GC timing (a known IPC leak)."""
     adapter, _send_mock, _ = fake_adapter
     contexts = _patch_transfer_context_factory(monkeypatch)
 
@@ -736,15 +738,14 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
     assert len(contexts) == 1
     assert adapter.transfer_ctx is contexts[0]
 
-    # Each recover-callback invocation rebuilds transfer_ctx without closing
-    # the previous context (known IPC leak; in-flight submissions may still
-    # hold a reference to the old context).
     assert heartbeat.recover_callback() is True
     assert len(contexts) == 2
     assert adapter.transfer_ctx is contexts[1]
-    contexts[0].close.assert_not_called()
+    contexts[0].close.assert_called_once()
+    contexts[1].close.assert_not_called()
 
     assert heartbeat.recover_callback() is True
     assert len(contexts) == 3
     assert adapter.transfer_ctx is contexts[2]
-    contexts[1].close.assert_not_called()
+    contexts[1].close.assert_called_once()
+    contexts[2].close.assert_not_called()

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -204,6 +204,31 @@ def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
         adapter.register_kv_caches({"layer.0": fake_tensor})
 
 
+def test_register_timeout_rolls_back_and_closes_unregistered_ctx(
+    fake_adapter, monkeypatch
+):
+    """A failed re-registration closes the never-registered context and
+    keeps the previous context current (the next successful recovery
+    displaces and closes it through the normal path)."""
+    adapter, _send_mock, future = fake_adapter
+    contexts = _patch_transfer_context_factory(monkeypatch)
+
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
+    adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[0]
+    assert adapter.transfer_ctx is contexts[0]
+
+    future.result.side_effect = TimeoutError("server down")
+    with pytest.raises(ConnectionError, match="did not respond"):
+        adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[1]
+
+    assert len(contexts) == 2
+    # Old context stays current and open; the unregistered one is closed.
+    assert adapter.transfer_ctx is contexts[0]
+    contexts[0].close.assert_not_called()
+    contexts[1].close.assert_called_once()
+
+
 def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
     fake_adapter, monkeypatch
 ):

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -218,7 +218,19 @@ def test_register_timeout_rolls_back_and_closes_unregistered_ctx(
     adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[0]
     assert adapter.transfer_ctx is contexts[0]
 
-    future.result.side_effect = TimeoutError("server down")
+    # The factory mints mock contexts, so the timeout must come from the
+    # next context's own register.
+    def _create_timing_out_ctx(
+        kv_caches: dict[str, torch.Tensor], mode: str
+    ) -> MagicMock:
+        ctx = MagicMock(name=f"transfer_ctx_{len(contexts)}")
+        ctx.register.side_effect = TimeoutError("server down")
+        contexts.append(ctx)
+        return ctx
+
+    monkeypatch.setattr(
+        adapter_mod, "create_transfer_context", _create_timing_out_ctx
+    )
     with pytest.raises(ConnectionError, match="did not respond"):
         adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[1]
 

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -252,9 +252,7 @@ def test_register_timeout_rolls_back_and_closes_unregistered_ctx(
         contexts.append(ctx)
         return ctx
 
-    monkeypatch.setattr(
-        adapter_mod, "create_transfer_context", _create_timing_out_ctx
-    )
+    monkeypatch.setattr(adapter_mod, "create_transfer_context", _create_timing_out_ctx)
     with pytest.raises(ConnectionError, match="did not respond"):
         adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[1]
 

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -998,12 +998,14 @@ def test_startup_does_not_warn_for_default_heartbeat_interval(
     assert not any("reap" in msg for msg in warnings)
 
 
-def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+def test_recover_callback_rebuilds_and_closes_previous_transfer_ctx(
     fake_adapter, monkeypatch
 ) -> None:
-    """Pin current behavior: every recover-callback invocation rebuilds
-    ``transfer_ctx`` without closing the previous context (known IPC leak;
-    in-flight submissions may still hold a reference to the old context)."""
+    """Every recover-callback invocation rebuilds ``transfer_ctx`` and closes
+    the displaced context deterministically. Closing is safe now that
+    ``close()`` drains in-flight transfers before releasing resources
+    (transfer guard); this replaces the previously pinned behavior of
+    abandoning the old context to GC timing (a known IPC leak)."""
     adapter, _send_mock, _ = fake_adapter
     contexts = _patch_transfer_context_factory(monkeypatch)
 
@@ -1017,18 +1019,17 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
     assert len(contexts) == 1
     assert adapter.transfer_ctx is contexts[0]
 
-    # Each recover-callback invocation rebuilds transfer_ctx without closing
-    # the previous context (known IPC leak; in-flight submissions may still
-    # hold a reference to the old context).
     assert heartbeat.recover_callback() is True
     assert len(contexts) == 2
     assert adapter.transfer_ctx is contexts[1]
-    contexts[0].close.assert_not_called()
+    contexts[0].close.assert_called_once()
+    contexts[1].close.assert_not_called()
 
     assert heartbeat.recover_callback() is True
     assert len(contexts) == 3
     assert adapter.transfer_ctx is contexts[2]
-    contexts[1].close.assert_not_called()
+    contexts[1].close.assert_called_once()
+    contexts[2].close.assert_not_called()
 
 
 # For the experimental dispatcher

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -228,6 +228,31 @@ def test_register_kv_caches_raises_connection_error_on_timeout(fake_adapter):
         adapter.register_kv_caches({"layer.0": fake_tensor})
 
 
+def test_register_timeout_rolls_back_and_closes_unregistered_ctx(
+    fake_adapter, monkeypatch
+):
+    """A failed re-registration closes the never-registered context and
+    keeps the previous context current (the next successful recovery
+    displaces and closes it through the normal path)."""
+    adapter, _send_mock, future = fake_adapter
+    contexts = _patch_transfer_context_factory(monkeypatch)
+
+    fake_tensor = MagicMock()
+    fake_tensor.device.type = "cuda"
+    adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[0]
+    assert adapter.transfer_ctx is contexts[0]
+
+    future.result.side_effect = TimeoutError("server down")
+    with pytest.raises(ConnectionError, match="did not respond"):
+        adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[1]
+
+    assert len(contexts) == 2
+    # Old context stays current and open; the unregistered one is closed.
+    assert adapter.transfer_ctx is contexts[0]
+    contexts[0].close.assert_not_called()
+    contexts[1].close.assert_called_once()
+
+
 def test_register_kv_caches_cpu_submits_engine_driven_context_registration(
     fake_adapter, monkeypatch
 ):

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -242,7 +242,19 @@ def test_register_timeout_rolls_back_and_closes_unregistered_ctx(
     adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[0]
     assert adapter.transfer_ctx is contexts[0]
 
-    future.result.side_effect = TimeoutError("server down")
+    # The factory mints mock contexts, so the timeout must come from the
+    # next context's own register.
+    def _create_timing_out_ctx(
+        kv_caches: dict[str, torch.Tensor], mode: str
+    ) -> MagicMock:
+        ctx = MagicMock(name=f"transfer_ctx_{len(contexts)}")
+        ctx.register.side_effect = TimeoutError("server down")
+        contexts.append(ctx)
+        return ctx
+
+    monkeypatch.setattr(
+        adapter_mod, "create_transfer_context", _create_timing_out_ctx
+    )
     with pytest.raises(ConnectionError, match="did not respond"):
         adapter.register_kv_caches({"layer.0": fake_tensor})  # contexts[1]
 


### PR DESCRIPTION
Fixes #4069.

## The crash

With engine_driven workers in SHM mode, restarting the MP server killed a production vLLM engine: one TP rank died natively (no Python traceback), the multiproc executor shut down, and the next request hit `AssertionError: collective_rpc should not be called on follower node`. Full timeline in #4069.

The underlying class of bug: `EngineDrivenContextShm.close()` unpins (cudaHostUnregister) and unmaps the SHM pool with no synchronization against transfers that still hold `torch.frombuffer` views into it, and the heartbeat re-registration path (`_send_register_kv_caches_request`) dropped the displaced context to GC timing: so a gather/scatter racing a context swap or shutdown can dereference unmapped, unpinned memory under a copy kernel.

## The fix

- `EngineDrivenContext` gains a **transfer guard**: transfers run inside `transfer_guard()` (raises `ContextClosedError` once the context is closing) and `_drain_transfers(timeout)` lets `close()` wait, bounded so shutdown can never hang, for in-flight transfers before releasing resources. `EngineDrivenContextShm.close()` drains before unpin/unmap.
- Sync (`EngineDrivenTransferContext`) and async (`AsyncEngineDrivenTransferContext`) store/retrieve paths wrap their prepare→gather/scatter→commit sequences in the guard; a rejected transfer resolves its future `False` (store: same contract as storing against an unhealthy server; retrieve: reported as a miss so the engine recomputes).
- The adapter closes the **displaced** context deterministically after a successful re-registration instead of leaving it to GC.

## Tests

- `tests/v1/multiprocess/test_transfer_ctx_guard.py` (new, pure threading, no CUDA): close blocks on an in-flight transfer and releases only after it finishes; closing context rejects new transfers; bounded drain proceeds past a stuck transfer; sequential guard reuse.
- Existing fakes in the engine_driven / async suites gained the `transfer_guard` method.
- Full run on a CUDA box (B200, python 3.10): **56 passed** across the new file + `test_engine_driven_transfer.py` + `test_async_engine_driven_transfer_context.py`.

Same production context as #3892 / #4068.

---

**Update (rebased on current dev).** Rebased across the ~330 commits since this was opened, and folded in two fixes for the same bug that I had written separately in #5020, which is now closed as a duplicate of this:

- **A context is published only once `register()` has returned.** Previously it was published first and rolled back on failure, which left a window where a store arriving mid-recovery met a context whose transport did not exist yet. Registering first removes the window and the rollback with it.
- **`self.transfer_ctx` is read once** in the store, retrieve and pre-forward flush paths. The guard inside the context already makes a concurrent swap safe, but the two reads could disagree about which context the call belongs to.

Two conflicts came out of the rebase and are worth flagging for review: `submit_store` now keeps the unconditional device sync from #4830 (this branch predated it and still had the older `if out_buffers is not None` form), and the recover-callback test keeps the dev tests that were added after this branch.

Verified against dev on the same rig: identical failure sets (9 pre-existing, all in p2p / lookup-prefetch / the `[mla]` gather-scatter cases, none related), with this branch running 5 more passing tests. Pinned pre-commit hooks clean.
