### PR TITLE
feat: multi-group (hybrid KV) support for engine-driven transfer — v1 uniform coverage

### DIFF
--- a/lmcache/v1/multiprocess/custom_types.py
+++ b/lmcache/v1/multiprocess/custom_types.py
@@ -120,6 +120,24 @@ class IPCCacheServerKey:
 KVCache = list[DeviceIPCWrapper]
 
 
+class GroupLayout(msgspec.Struct):
+    """Per-LMCache-group layout for multi-group engine-driven registration.
+
+    Attributes:
+        num_layers: Number of KV layers in this group.
+        hidden_dim_size: Flattened hidden dimension per token for this group.
+        dtype_str: Torch dtype name for this group's KV tensors.
+        tokens_per_block: Tokens covered by one paged block of this group
+            (``EngineGroupInfo.tokens_per_block``; falls back to the engine
+            ``block_size`` when the engine reported ``0``).
+    """
+
+    num_layers: int
+    hidden_dim_size: int
+    dtype_str: str
+    tokens_per_block: int
+
+
 class RegisterEngineDrivenContextPayload(msgspec.Struct):
     """Payload for the REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT protocol message.
 
@@ -132,6 +150,10 @@ class RegisterEngineDrivenContextPayload(msgspec.Struct):
         hidden_dim_size: Flattened hidden dimension per token.
         dtype_str: Torch dtype name (e.g. ``"float16"``).
         use_mla: Whether the worker KV format is MLA.
+        group_layouts: Per-group layouts for multi-group (hybrid-KV) workers,
+            in protocol group order. Empty means legacy single-group; the
+            top-level ``num_layers``/``hidden_dim_size``/``dtype_str`` then
+            describe the sole group.
     """
 
     instance_id: int
@@ -142,6 +164,7 @@ class RegisterEngineDrivenContextPayload(msgspec.Struct):
     hidden_dim_size: int
     dtype_str: str
     use_mla: bool
+    group_layouts: list[GroupLayout] = []
 
 
 @dataclass

--- a/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/engine_driven_transfer.py
@@ -297,6 +297,30 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
         non-GPU transfers."""
         return self._ctx.resolve_obj_keys(key, [0])[0]
 
+    def _resolve_obj_keys_by_group(
+        self, key: IPCCacheServerKey, num_groups: int
+    ) -> list[list[ObjectKey]]:
+        """Resolve object keys for every LMCache group, group-major.
+
+        Args:
+            key: Cache key for the token range.
+            num_groups: Number of LMCache groups the worker registered.
+
+        Returns:
+            ``keys[g][c]`` is chunk ``c``'s key in group ``g``
+            (``ObjectKey.object_group_id == g``).
+        """
+        return self._ctx.resolve_obj_keys(key, list(range(num_groups)))
+
+    def _group_keys_for(
+        self, entry: "EngineDrivenContextEntry", key: IPCCacheServerKey
+    ) -> "list[list[ObjectKey]] | None":
+        """Group-major keys when ``entry`` registered multi-group, else None."""
+        layouts = entry.metadata.group_layouts
+        if not layouts or len(layouts) < 2:
+            return None
+        return self._resolve_obj_keys_by_group(key, len(layouts))
+
     def register_kv_cache_engine_driven_context(
         self,
         payload: RegisterEngineDrivenContextPayload,
@@ -345,10 +369,33 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
             )
         )
         layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+        group_layouts: list[MemoryLayoutDesc] | None = None
+        if payload.group_layouts:
+            group_layouts = []
+            for gl in payload.group_layouts:
+                g_dtype = getattr(torch, gl.dtype_str, None)
+                if g_dtype is None or not isinstance(g_dtype, torch.dtype):
+                    raise ValueError(
+                        f"Invalid group dtype_str '{gl.dtype_str}' in "
+                        "engine-driven registration"
+                    )
+                g_shape = (
+                    torch.Size(
+                        [gl.num_layers, self._ctx.chunk_size, gl.hidden_dim_size]
+                    )
+                    if payload.use_mla
+                    else torch.Size(
+                        [2, gl.num_layers, self._ctx.chunk_size, gl.hidden_dim_size]
+                    )
+                )
+                group_layouts.append(
+                    MemoryLayoutDesc(shapes=[g_shape], dtypes=[g_dtype])
+                )
         metadata = EngineDrivenContextMetadata(
             layout_desc=layout_desc,
             block_size=payload.block_size,
             use_mla=payload.use_mla,
+            group_layouts=group_layouts,
         )
         # Build the entry and strategy outside the lock, then insert the pair
         # atomically so a concurrent reap can never strand one without the
@@ -428,6 +475,7 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
             instance_id=instance_id,
             context=entry.metadata,
             resolve_obj_keys=self._resolve_single_group_obj_keys,
+            group_keys=self._group_keys_for(entry, key),
         )
         session = self._ctx.session_manager.get_or_create(key.request_id)
         session.extras["store_start_time"] = time.perf_counter()
@@ -494,11 +542,12 @@ class EngineDrivenTransferModule(InstanceLivenessTarget):
             ValueError: If no non-GPU context is registered for the given
                 instance ID.
         """
-        _, strategy = self._resolve_for_transfer(instance_id)
+        entry, strategy = self._resolve_for_transfer(instance_id)
         response = strategy.prepare_retrieve(
             key=key,
             instance_id=instance_id,
             resolve_obj_keys=self._resolve_single_group_obj_keys,
+            group_keys=self._group_keys_for(entry, key),
         )
         session = self._ctx.session_manager.get_or_create(key.request_id)
         session.extras["retrieve_start_time"] = time.perf_counter()

--- a/lmcache/v1/multiprocess/modules/server_transfer.py
+++ b/lmcache/v1/multiprocess/modules/server_transfer.py
@@ -92,6 +92,7 @@ class TransferStrategy(abc.ABC):
         instance_id: int,
         context: EngineDrivenContextMetadata,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareStoreResponse:
         """Prepare destination resources for a store request.
 
@@ -100,6 +101,8 @@ class TransferStrategy(abc.ABC):
             instance_id: Worker instance identifier.
             context: Non-GPU transfer metadata for the instance.
             resolve_obj_keys: Callable that resolves object keys from ``key``.
+            group_keys: Group-major object keys for multi-group workers;
+                ``None`` for single-group.
 
         Returns:
             Transport-specific store preparation response.
@@ -133,6 +136,7 @@ class TransferStrategy(abc.ABC):
         key: IPCCacheServerKey,
         instance_id: int,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareRetrieveResponse:
         """Prepare source resources for a retrieve request.
 
@@ -140,6 +144,8 @@ class TransferStrategy(abc.ABC):
             key: Cache key identifying the requested token range.
             instance_id: Worker instance identifier.
             resolve_obj_keys: Callable that resolves object keys from ``key``.
+            group_keys: Group-major object keys for multi-group workers;
+                ``None`` for single-group.
 
         Returns:
             Transport-specific retrieve preparation response.
@@ -188,11 +194,16 @@ class PickleTransferStrategy(TransferStrategy):
         instance_id: int,
         context: EngineDrivenContextMetadata,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareStoreResponse:
         """Return empty store context for pickle mode.
 
         Pickle transport does not pre-allocate SHM slots during prepare.
         """
+        if group_keys is not None and len(group_keys) > 1:
+            raise RuntimeError(
+                "pickle transport does not support multi-group transfers"
+            )
         return PrepareStoreResponse(context={})
 
     def commit_store(
@@ -239,8 +250,13 @@ class PickleTransferStrategy(TransferStrategy):
         key: IPCCacheServerKey,
         instance_id: int,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareRetrieveResponse:
         """Read prefetched objects and return serialized pickle payload."""
+        if group_keys is not None and len(group_keys) > 1:
+            raise RuntimeError(
+                "pickle transport does not support multi-group transfers"
+            )
         obj_keys = resolve_obj_keys(key)
         prefetched_keys: list[ObjectKey] = []
         try:
@@ -315,49 +331,73 @@ class ShmTransferStrategy(TransferStrategy):
         instance_id: int,
         context: EngineDrivenContextMetadata,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareStoreResponse:
         """Reserve SHM-backed objects and return slot descriptors.
 
+        Args:
+            group_keys: Group-major object keys for multi-group workers
+                (``group_keys[g][c]`` is chunk ``c``'s key in group ``g``).
+                ``None`` means single-group via ``resolve_obj_keys``.
+
         Returns:
-            Context with ``slots`` and ``chunk_indices``.
+            Context with ``slots`` and ``chunk_indices``. Multi-group
+            responses additionally carry ``group_ids`` parallel to ``slots``.
         """
-        obj_keys = resolve_obj_keys(key)
-        reserved = self._storage_manager.reserve_write(
-            obj_keys, context.layout_desc, "new"
-        )
+        if group_keys is None:
+            group_layouts = [context.layout_desc]
+            group_keys = [resolve_obj_keys(key)]
+        else:
+            assert context.group_layouts is not None
+            group_layouts = context.group_layouts
+        multi_group = len(group_keys) > 1
+
         slots: list[dict[str, Any]] = []
         chunk_indices: list[int] = []
+        group_ids: list[int] = []
         reserved_keys: list[ObjectKey] = []
-        try:
-            for idx, obj_key in enumerate(obj_keys):
-                memory_obj = reserved.get(obj_key)
-                if memory_obj is None or memory_obj.tensor is None:
-                    continue
-                slots.append(
-                    ShmSlotDescriptor(
-                        offset=memory_obj.shm_offset,
-                        length=memory_obj.shm_byte_length,
-                        shape=list(memory_obj.tensor.shape),
-                        dtype=_dtype_to_name(memory_obj.tensor.dtype),
-                    ).to_dict()
-                )
-                chunk_indices.append(idx)
-                reserved_keys.append(obj_key)
-        finally:
-            reserved_keys_set = set(reserved_keys)
-            unused_keys = [
-                obj_key for obj_key in reserved if obj_key not in reserved_keys_set
-            ]
-            if unused_keys:
-                self._storage_manager.finish_write(unused_keys)
+        for gid, (g_keys, g_layout) in enumerate(
+            zip(group_keys, group_layouts, strict=True)
+        ):
+            reserved = self._storage_manager.reserve_write(g_keys, g_layout, "new")
+            g_reserved: list[ObjectKey] = []
+            try:
+                for idx, obj_key in enumerate(g_keys):
+                    memory_obj = reserved.get(obj_key)
+                    if memory_obj is None or memory_obj.tensor is None:
+                        continue
+                    slots.append(
+                        ShmSlotDescriptor(
+                            offset=memory_obj.shm_offset,
+                            length=memory_obj.shm_byte_length,
+                            shape=list(memory_obj.tensor.shape),
+                            dtype=_dtype_to_name(memory_obj.tensor.dtype),
+                        ).to_dict()
+                    )
+                    chunk_indices.append(idx)
+                    group_ids.append(gid)
+                    g_reserved.append(obj_key)
+            finally:
+                g_reserved_set = set(g_reserved)
+                unused_keys = [
+                    obj_key for obj_key in reserved if obj_key not in g_reserved_set
+                ]
+                if unused_keys:
+                    self._storage_manager.finish_write(unused_keys)
+            reserved_keys.extend(g_reserved)
+
         if not reserved_keys:
-            return PrepareStoreResponse(context={"slots": [], "chunk_indices": []})
+            empty: dict[str, Any] = {"slots": [], "chunk_indices": []}
+            if multi_group:
+                empty["group_ids"] = []
+            return PrepareStoreResponse(context=empty)
         transfer_key = self._transfer_key_factory(key, instance_id)
         with self._pending_lock:
             self._pending_writes[transfer_key] = reserved_keys
-        return PrepareStoreResponse(
-            context={"slots": slots, "chunk_indices": chunk_indices}
-        )
+        ctx: dict[str, Any] = {"slots": slots, "chunk_indices": chunk_indices}
+        if multi_group:
+            ctx["group_ids"] = group_ids
+        return PrepareStoreResponse(context=ctx)
 
     def commit_store(
         self,
@@ -394,37 +434,57 @@ class ShmTransferStrategy(TransferStrategy):
         key: IPCCacheServerKey,
         instance_id: int,
         resolve_obj_keys: Callable[[IPCCacheServerKey], list[ObjectKey]],
+        group_keys: "list[list[ObjectKey]] | None" = None,
     ) -> PrepareRetrieveResponse:
-        """Read SHM objects and return slot descriptors for worker access."""
-        obj_keys = resolve_obj_keys(key)
-        shm_prefetched_keys, shm_memory_objs = self._storage_manager.unsafe_read(
-            obj_keys
-        )
-        if (
-            not shm_memory_objs
-            or len(shm_prefetched_keys) != len(obj_keys)
-            or len(shm_memory_objs) != len(obj_keys)
-        ):
-            if shm_prefetched_keys:
-                self._storage_manager.finish_read_prefetched(shm_prefetched_keys)
-            return PrepareRetrieveResponse(success=False, data=b"", context={})
+        """Read SHM objects and return slot descriptors for worker access.
+
+        Args:
+            group_keys: Group-major object keys for multi-group workers.
+                A retrieve is a miss unless EVERY group has every chunk
+                (uniform coverage). ``None`` means single-group.
+        """
+        if group_keys is None:
+            group_keys = [resolve_obj_keys(key)]
+        multi_group = len(group_keys) > 1
+
+        all_prefetched: list[ObjectKey] = []
         slots: list[dict[str, Any]] = []
-        for memory_obj in shm_memory_objs:
-            if memory_obj.tensor is None:
-                self._storage_manager.finish_read_prefetched(shm_prefetched_keys)
-                return PrepareRetrieveResponse(success=False, data=b"", context={})
-            slots.append(
-                ShmSlotDescriptor(
-                    offset=memory_obj.shm_offset,
-                    length=memory_obj.shm_byte_length,
-                    shape=list(memory_obj.tensor.shape),
-                    dtype=_dtype_to_name(memory_obj.tensor.dtype),
-                ).to_dict()
-            )
+        group_ids: list[int] = []
+
+        def _miss() -> PrepareRetrieveResponse:
+            if all_prefetched:
+                self._storage_manager.finish_read_prefetched(all_prefetched)
+            return PrepareRetrieveResponse(success=False, data=b"", context={})
+
+        for gid, g_keys in enumerate(group_keys):
+            prefetched, memory_objs = self._storage_manager.unsafe_read(g_keys)
+            all_prefetched.extend(prefetched)
+            if (
+                not memory_objs
+                or len(prefetched) != len(g_keys)
+                or len(memory_objs) != len(g_keys)
+            ):
+                return _miss()
+            for memory_obj in memory_objs:
+                if memory_obj.tensor is None:
+                    return _miss()
+                slots.append(
+                    ShmSlotDescriptor(
+                        offset=memory_obj.shm_offset,
+                        length=memory_obj.shm_byte_length,
+                        shape=list(memory_obj.tensor.shape),
+                        dtype=_dtype_to_name(memory_obj.tensor.dtype),
+                    ).to_dict()
+                )
+                group_ids.append(gid)
+
         transfer_key = self._transfer_key_factory(key, instance_id)
         with self._pending_lock:
-            self._pending_reads[transfer_key] = shm_prefetched_keys
-        return PrepareRetrieveResponse(success=True, data=b"", context={"slots": slots})
+            self._pending_reads[transfer_key] = all_prefetched
+        ctx: dict[str, Any] = {"slots": slots}
+        if multi_group:
+            ctx["group_ids"] = group_ids
+        return PrepareRetrieveResponse(success=True, data=b"", context=ctx)
 
     def commit_retrieve(
         self,

--- a/lmcache/v1/multiprocess/modules/server_transfer.py
+++ b/lmcache/v1/multiprocess/modules/server_transfer.py
@@ -384,9 +384,7 @@ class ShmTransferStrategy(TransferStrategy):
                 finally:
                     g_reserved_set = set(g_reserved)
                     unused_keys = [
-                        obj_key
-                        for obj_key in reserved
-                        if obj_key not in g_reserved_set
+                        obj_key for obj_key in reserved if obj_key not in g_reserved_set
                     ]
                     if unused_keys:
                         self._storage_manager.finish_write(unused_keys)

--- a/lmcache/v1/multiprocess/modules/server_transfer.py
+++ b/lmcache/v1/multiprocess/modules/server_transfer.py
@@ -348,7 +348,10 @@ class ShmTransferStrategy(TransferStrategy):
             group_layouts = [context.layout_desc]
             group_keys = [resolve_obj_keys(key)]
         else:
-            assert context.group_layouts is not None
+            if context.group_layouts is None:
+                raise ValueError(
+                    "group_keys given but the instance context has no group_layouts"
+                )
             group_layouts = context.group_layouts
         multi_group = len(group_keys) > 1
 
@@ -356,35 +359,45 @@ class ShmTransferStrategy(TransferStrategy):
         chunk_indices: list[int] = []
         group_ids: list[int] = []
         reserved_keys: list[ObjectKey] = []
-        for gid, (g_keys, g_layout) in enumerate(
-            zip(group_keys, group_layouts, strict=True)
-        ):
-            reserved = self._storage_manager.reserve_write(g_keys, g_layout, "new")
-            g_reserved: list[ObjectKey] = []
-            try:
-                for idx, obj_key in enumerate(g_keys):
-                    memory_obj = reserved.get(obj_key)
-                    if memory_obj is None or memory_obj.tensor is None:
-                        continue
-                    slots.append(
-                        ShmSlotDescriptor(
-                            offset=memory_obj.shm_offset,
-                            length=memory_obj.shm_byte_length,
-                            shape=list(memory_obj.tensor.shape),
-                            dtype=_dtype_to_name(memory_obj.tensor.dtype),
-                        ).to_dict()
-                    )
-                    chunk_indices.append(idx)
-                    group_ids.append(gid)
-                    g_reserved.append(obj_key)
-            finally:
-                g_reserved_set = set(g_reserved)
-                unused_keys = [
-                    obj_key for obj_key in reserved if obj_key not in g_reserved_set
-                ]
-                if unused_keys:
-                    self._storage_manager.finish_write(unused_keys)
-            reserved_keys.extend(g_reserved)
+        try:
+            for gid, (g_keys, g_layout) in enumerate(
+                zip(group_keys, group_layouts, strict=True)
+            ):
+                reserved = self._storage_manager.reserve_write(g_keys, g_layout, "new")
+                g_reserved: list[ObjectKey] = []
+                try:
+                    for idx, obj_key in enumerate(g_keys):
+                        memory_obj = reserved.get(obj_key)
+                        if memory_obj is None or memory_obj.tensor is None:
+                            continue
+                        slots.append(
+                            ShmSlotDescriptor(
+                                offset=memory_obj.shm_offset,
+                                length=memory_obj.shm_byte_length,
+                                shape=list(memory_obj.tensor.shape),
+                                dtype=_dtype_to_name(memory_obj.tensor.dtype),
+                            ).to_dict()
+                        )
+                        chunk_indices.append(idx)
+                        group_ids.append(gid)
+                        g_reserved.append(obj_key)
+                finally:
+                    g_reserved_set = set(g_reserved)
+                    unused_keys = [
+                        obj_key
+                        for obj_key in reserved
+                        if obj_key not in g_reserved_set
+                    ]
+                    if unused_keys:
+                        self._storage_manager.finish_write(unused_keys)
+                    # Track claimed keys BEFORE any raise can escape the group
+                    # loop, so the except below releases every write lock taken
+                    # so far (earlier groups + this one).
+                    reserved_keys.extend(g_reserved)
+        except BaseException:
+            if reserved_keys:
+                self._storage_manager.finish_write(reserved_keys)
+            raise
 
         if not reserved_keys:
             empty: dict[str, Any] = {"slots": [], "chunk_indices": []}
@@ -456,27 +469,34 @@ class ShmTransferStrategy(TransferStrategy):
                 self._storage_manager.finish_read_prefetched(all_prefetched)
             return PrepareRetrieveResponse(success=False, data=b"", context={})
 
-        for gid, g_keys in enumerate(group_keys):
-            prefetched, memory_objs = self._storage_manager.unsafe_read(g_keys)
-            all_prefetched.extend(prefetched)
-            if (
-                not memory_objs
-                or len(prefetched) != len(g_keys)
-                or len(memory_objs) != len(g_keys)
-            ):
-                return _miss()
-            for memory_obj in memory_objs:
-                if memory_obj.tensor is None:
+        try:
+            for gid, g_keys in enumerate(group_keys):
+                prefetched, memory_objs = self._storage_manager.unsafe_read(g_keys)
+                all_prefetched.extend(prefetched)
+                if (
+                    not memory_objs
+                    or len(prefetched) != len(g_keys)
+                    or len(memory_objs) != len(g_keys)
+                ):
                     return _miss()
-                slots.append(
-                    ShmSlotDescriptor(
-                        offset=memory_obj.shm_offset,
-                        length=memory_obj.shm_byte_length,
-                        shape=list(memory_obj.tensor.shape),
-                        dtype=_dtype_to_name(memory_obj.tensor.dtype),
-                    ).to_dict()
-                )
-                group_ids.append(gid)
+                for memory_obj in memory_objs:
+                    if memory_obj.tensor is None:
+                        return _miss()
+                    slots.append(
+                        ShmSlotDescriptor(
+                            offset=memory_obj.shm_offset,
+                            length=memory_obj.shm_byte_length,
+                            shape=list(memory_obj.tensor.shape),
+                            dtype=_dtype_to_name(memory_obj.tensor.dtype),
+                        ).to_dict()
+                    )
+                    group_ids.append(gid)
+        except BaseException:
+            # _miss() covers coverage misses; this covers exceptions — the
+            # read locks in all_prefetched must never outlive a failed prepare.
+            if all_prefetched:
+                self._storage_manager.finish_read_prefetched(all_prefetched)
+            raise
 
         transfer_key = self._transfer_key_factory(key, instance_id)
         with self._pending_lock:

--- a/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
+++ b/lmcache/v1/multiprocess/transfer_context/async_engine_driven.py
@@ -190,6 +190,12 @@ class AsyncEngineDrivenTransferContext(EngineDrivenTransferContext):
                 "Engine-driven transfer context is not registered. "
                 "Call register() before submit_store()."
             )
+        if self._group_states:
+            # Multi-group stores take the synchronous per-group path for now;
+            # the wait-for-forward-event + copy-stream pipelining below is
+            # single-group. TODO: pipeline the grouped gather as well.
+            _event.wait()
+            return self._submit_store_multigroup(key, instance_id, kv_caches, block_ids)
         completion: MessagingFuture[bool] = MessagingFuture()
         engine_driven_context = self._engine_driven_context
         commit_executor = self._commit_executor

--- a/lmcache/v1/multiprocess/transfer_context/base.py
+++ b/lmcache/v1/multiprocess/transfer_context/base.py
@@ -110,14 +110,18 @@ class EngineDrivenContextMetadata:
     """Non-GPU context layout metadata for non-CUDA workers.
 
     Attributes:
-        layout_desc: Memory layout descriptor used to interpret chunk payloads.
+        layout_desc: Memory layout descriptor used to interpret chunk payloads
+            (group 0's layout for multi-group workers).
         block_size: Number of tokens per paged block.
         use_mla: Whether the worker KV format is MLA.
+        group_layouts: Per-LMCache-group layouts for multi-group (hybrid-KV)
+            workers, in protocol group order. ``None`` means single-group.
     """
 
     layout_desc: MemoryLayoutDesc
     block_size: int
     use_mla: bool
+    group_layouts: "list[MemoryLayoutDesc] | None" = None
 
 
 class EngineDrivenContext(ABC):
@@ -188,6 +192,33 @@ class EngineDrivenContext(ABC):
     def commit_retrieve(self, key: IPCCacheServerKey, instance_id: int) -> bool:
         """Commit retrieve. Pickle: no-op. Shm: release read locks."""
         ...
+
+    def prepare_store_grouped(
+        self, key: IPCCacheServerKey, instance_id: int
+    ) -> tuple[list[torch.Tensor], list[int], list[int]] | None:
+        """Multi-group store prepare (SHM transport only).
+
+        Returns:
+            Parallel per-slot ``(tensors, chunk_indices, group_ids)`` lists,
+            ``([], [], [])`` when fully cached, or ``None`` on a malformed
+            response.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support multi-group transfers"
+        )
+
+    def prepare_retrieve_grouped(
+        self, key: IPCCacheServerKey, instance_id: int
+    ) -> tuple[list[torch.Tensor], list[int]] | None:
+        """Multi-group retrieve prepare (SHM transport only).
+
+        Returns:
+            Parallel per-slot ``(tensors, group_ids)`` lists, or ``None`` on
+            a miss.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support multi-group transfers"
+        )
 
     @abstractmethod
     def close(self) -> None:

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -184,6 +184,65 @@ class EngineDrivenContextShm(EngineDrivenContext):
         chunk_indices: list[int] = context["chunk_indices"]
         return self._build_slot_tensors(slots), chunk_indices
 
+    def prepare_store_grouped(
+        self, key: IPCCacheServerKey, instance_id: int
+    ) -> tuple[list[torch.Tensor], list[int], list[int]] | None:
+        """Multi-group prepare: per-slot tensors, chunk indices, group ids.
+
+        Returns:
+            ``None`` on a malformed response; ``([], [], [])`` when every
+            chunk is already cached in every group; otherwise three parallel
+            per-slot lists ``(tensors, chunk_indices, group_ids)``.
+        """
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_STORE,
+            [key, instance_id],
+            get_response_class(RequestType.PREPARE_STORE),
+        )
+        if not future.wait(timeout=self.mq_timeout):
+            raise LMCacheTimeoutError(
+                f"PREPARE_STORE timed out for instance_id={instance_id} "
+                f"after {self.mq_timeout}s",
+                session_id=key.request_id,
+            )
+        response = future.result()
+        context = response.context if isinstance(response.context, dict) else {}
+        slots = context.get("slots")
+        group_ids = context.get("group_ids")
+        if not isinstance(slots, list) or not isinstance(group_ids, list):
+            return None
+        if not slots:
+            return [], [], []
+        chunk_indices: list[int] = context["chunk_indices"]
+        return self._build_slot_tensors(slots), chunk_indices, group_ids
+
+    def prepare_retrieve_grouped(
+        self, key: IPCCacheServerKey, instance_id: int
+    ) -> tuple[list[torch.Tensor], list[int]] | None:
+        """Multi-group retrieve prepare: per-slot tensors + group ids.
+
+        Returns:
+            ``None`` on a miss; otherwise parallel per-slot
+            ``(tensors, group_ids)`` covering every chunk of every group.
+        """
+        future = self.mq_client.submit_request(
+            RequestType.PREPARE_RETRIEVE,
+            [key, instance_id],
+            get_response_class(RequestType.PREPARE_RETRIEVE),
+        )
+        try:
+            response = future.result(timeout=self.mq_timeout)
+        except TimeoutError:
+            return None
+        if not response.success:
+            return None
+        context = response.context if isinstance(response.context, dict) else {}
+        slots = context.get("slots", [])
+        group_ids = context.get("group_ids")
+        if not slots or not isinstance(group_ids, list):
+            return None
+        return self._build_slot_tensors(slots), group_ids
+
     def commit_store(
         self, key: IPCCacheServerKey, instance_id: int, _chunks: list[torch.Tensor]
     ) -> bool:

--- a/lmcache/v1/multiprocess/transfer_context/shm.py
+++ b/lmcache/v1/multiprocess/transfer_context/shm.py
@@ -213,7 +213,13 @@ class EngineDrivenContextShm(EngineDrivenContext):
             return None
         if not slots:
             return [], [], []
-        chunk_indices: list[int] = context["chunk_indices"]
+        chunk_indices = context.get("chunk_indices")
+        if (
+            not isinstance(chunk_indices, list)
+            or len(chunk_indices) != len(slots)
+            or len(group_ids) != len(slots)
+        ):
+            return None
         return self._build_slot_tensors(slots), chunk_indices, group_ids
 
     def prepare_retrieve_grouped(
@@ -239,7 +245,7 @@ class EngineDrivenContextShm(EngineDrivenContext):
         context = response.context if isinstance(response.context, dict) else {}
         slots = context.get("slots", [])
         group_ids = context.get("group_ids")
-        if not slots or not isinstance(group_ids, list):
+        if not slots or not isinstance(group_ids, list) or len(group_ids) != len(slots):
             return None
         return self._build_slot_tensors(slots), group_ids
 

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -4,8 +4,9 @@
 # Standard
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Protocol
 import os
 
 # Third Party
@@ -16,7 +17,10 @@ from lmcache import torch_dev
 from lmcache.utils import EngineType, init_logger
 from lmcache.v1.distributed.api import MemoryLayoutDesc
 from lmcache.v1.gpu_connector.utils import LayoutHints
-from lmcache.v1.multiprocess.custom_types import RegisterEngineDrivenContextPayload
+from lmcache.v1.multiprocess.custom_types import (
+    GroupLayout,
+    RegisterEngineDrivenContextPayload,
+)
 from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 from lmcache.v1.multiprocess.mq import MessageQueueClient
@@ -36,6 +40,10 @@ from lmcache.v1.platform.base.event_ipc import (
     get_event_ipc_backend,
 )
 from lmcache.v1.platform.kv_wrap import wrap_kv_caches
+
+if TYPE_CHECKING:
+    # First Party
+    import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
 
@@ -172,6 +180,25 @@ class IPCEvent(Protocol):
 
 
 SendRequest = Callable[[MessageQueueClient, RequestType, list[object]], MessagingFuture]
+
+
+@dataclass
+class _GroupState:
+    """Worker-side per-LMCache-group transfer state (multi-group registration).
+
+    Attributes:
+        layer_names: KV cache dict keys belonging to this group, in group
+            layer order — selects the gather/scatter tensor subset.
+        engine_kv_format: Detected KV format for this group's tensors.
+        blocks_in_chunk: Paged blocks of THIS group per LMCache chunk
+            (``chunk_tokens / tokens_per_block``).
+        layout_desc: Chunk layout for this group's objects.
+    """
+
+    layer_names: list[str]
+    engine_kv_format: "lmc_ops.EngineKVFormat"
+    blocks_in_chunk: int
+    layout_desc: MemoryLayoutDesc
 
 
 def _single_group_block_ids(block_ids: list[list[int]]) -> list[int]:
@@ -513,6 +540,7 @@ class EngineDrivenTransferContext(TransferContext):
         self._engine_driven_context: EngineDrivenContext | None = None
         self._layout_hints: LayoutHints | None = None
         self._engine_kv_format: Any = None
+        self._group_states: list[_GroupState] = []
 
     @property
     def engine_driven_context(self) -> EngineDrivenContext:
@@ -543,16 +571,16 @@ class EngineDrivenTransferContext(TransferContext):
     ) -> None:
         """Register KV caches with the non-GPU context server.
 
-        ``engine_group_infos`` and ``engine_type`` are accepted to satisfy
-        the base interface but are currently a no-op: the non-GPU transfer
-        path does not support hybrid KV cache groups and rejects multi-
-        group transfers at store / retrieve time (see
-        ``_single_group_block_ids``).
+        With multiple ``engine_group_infos`` (hybrid-KV models), each group's
+        layers are described by their own layout and gathered/scattered with
+        that group's block-id list (uniform coverage: every group stores and
+        retrieves every chunk). Sliding-window groups are rejected because
+        uniform coverage is only correct when every group holds blocks for the
+        full token range, and multi-group transfer requires the SHM transport
+        (pickle mode is rejected). ``engine_type`` is accepted for interface
+        parity but is unused on the engine-driven path.
         """
         del engine_type  # unused on the engine-driven path
-        # TODO: per-group compression (EngineGroupInfo.tokens_per_block vs
-        # the tensor-detected slot count, e.g. DeepSeek V4) is only handled
-        # on the CUDA path. The non-CUDA path is yet to be implemented.
         (
             block_size,
             num_layers,
@@ -567,15 +595,79 @@ class EngineDrivenTransferContext(TransferContext):
         # The wire field is named use_mla but only drives the object plane
         # count: single-plane (kv_size == 1) covers MLA and fused-K/V formats.
         use_mla_flag = kv_size == 1
-        shape = (
-            torch.Size([num_layers, blocks_in_chunk * block_size, hidden_dim_size])
-            if use_mla_flag
-            else torch.Size(
-                [2, num_layers, blocks_in_chunk * block_size, hidden_dim_size]
+        chunk_tokens = blocks_in_chunk * block_size
+
+        group_layouts: list[GroupLayout] = []
+        group_states: list[_GroupState] = []
+        if len(engine_group_infos) > 1:
+            layer_names = list(kv_caches)
+            for gid, group in enumerate(engine_group_infos):
+                if group.sw_size_tokens >= 0:
+                    raise RuntimeError(
+                        "engine-driven multi-group transfer only supports "
+                        "uniform-coverage groups; group "
+                        f"{gid} is sliding-window "
+                        f"(sw_size_tokens={group.sw_size_tokens}). Run with "
+                        "a unified KV cache manager instead."
+                    )
+                subset = {
+                    layer_names[i]: kv_caches[layer_names[i]]
+                    for i in group.layer_indices
+                }
+                (
+                    g_block_size,
+                    g_num_layers,
+                    g_hidden,
+                    g_dtype_str,
+                    g_format,
+                    g_kv_size,
+                ) = compute_kv_layout(subset, layout_hints=layout_hints)
+                tokens_per_block = group.tokens_per_block or g_block_size
+                if chunk_tokens % tokens_per_block != 0:
+                    raise RuntimeError(
+                        f"group {gid} tokens_per_block={tokens_per_block} does "
+                        f"not divide the chunk size ({chunk_tokens} tokens)"
+                    )
+                g_mla = g_kv_size == 1
+                g_shape = (
+                    torch.Size([g_num_layers, chunk_tokens, g_hidden])
+                    if g_mla
+                    else torch.Size([2, g_num_layers, chunk_tokens, g_hidden])
+                )
+                group_layouts.append(
+                    GroupLayout(
+                        num_layers=g_num_layers,
+                        hidden_dim_size=g_hidden,
+                        dtype_str=g_dtype_str,
+                        tokens_per_block=tokens_per_block,
+                    )
+                )
+                group_states.append(
+                    _GroupState(
+                        layer_names=[layer_names[i] for i in group.layer_indices],
+                        engine_kv_format=g_format,
+                        blocks_in_chunk=chunk_tokens // tokens_per_block,
+                        layout_desc=MemoryLayoutDesc(
+                            shapes=[g_shape],
+                            dtypes=[getattr(torch, g_dtype_str)],
+                        ),
+                    )
+                )
+            # Group 0's layout doubles as the legacy top-level layout so
+            # single-group readers of the payload keep working.
+            shape = group_states[0].layout_desc.shapes[0]
+            layout_desc = MemoryLayoutDesc(
+                shapes=[shape], dtypes=group_states[0].layout_desc.dtypes
             )
-        )
-        dtype = getattr(torch, dtype_str)
-        layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+        else:
+            shape = (
+                torch.Size([num_layers, chunk_tokens, hidden_dim_size])
+                if use_mla_flag
+                else torch.Size([2, num_layers, chunk_tokens, hidden_dim_size])
+            )
+            dtype = getattr(torch, dtype_str)
+            layout_desc = MemoryLayoutDesc(shapes=[shape], dtypes=[dtype])
+        self._group_states = group_states
 
         future = send_request(
             mq_client,
@@ -590,6 +682,7 @@ class EngineDrivenTransferContext(TransferContext):
                     hidden_dim_size=hidden_dim_size,
                     dtype_str=dtype_str,
                     use_mla=use_mla_flag,
+                    group_layouts=group_layouts,
                 )
             ],
         )
@@ -613,10 +706,18 @@ class EngineDrivenTransferContext(TransferContext):
             pool_size=pool_size,
         )
         supported_transfer_mode = "SHM" if shm_name and pool_size > 0 else "pickle"
+        if self._group_states and supported_transfer_mode != "SHM":
+            raise RuntimeError(
+                "engine-driven multi-group transfer requires the SHM "
+                "transport, but the server returned no SHM pool (pickle "
+                "mode). Enable a non-lazy L1 pool on the MP server."
+            )
         logger.info(
-            "Worker non-GPU transfer context registered (instance_id=%d, mode=%s)",
+            "Worker non-GPU transfer context registered "
+            "(instance_id=%d, mode=%s, groups=%d)",
             instance_id,
             supported_transfer_mode,
+            max(1, len(self._group_states)),
         )
 
     def submit_store(
@@ -634,6 +735,9 @@ class EngineDrivenTransferContext(TransferContext):
                 "Engine-driven transfer context is not registered. "
                 "Call register() before submit_store()."
             )
+
+        if self._group_states:
+            return self._submit_store_multigroup(key, instance_id, kv_caches, block_ids)
 
         torch_dev.synchronize()
         result = self._engine_driven_context.prepare_store(key, instance_id)
@@ -678,6 +782,11 @@ class EngineDrivenTransferContext(TransferContext):
                 "Call register() before submit_retrieve()."
             )
 
+        if self._group_states:
+            return self._submit_retrieve_multigroup(
+                key, instance_id, kv_caches, block_ids, skip_first_n_tokens
+            )
+
         src_buffers = self._engine_driven_context.prepare_retrieve(key, instance_id)
         ok = src_buffers is not None
         if src_buffers is not None:
@@ -700,6 +809,106 @@ class EngineDrivenTransferContext(TransferContext):
         self._engine_driven_context.commit_retrieve(key, instance_id)
 
         future: MessagingFuture[bool] = MessagingFuture()
+        future.set_result(ok)
+        return future
+
+    def _group_slots(
+        self,
+        tensors: list[torch.Tensor],
+        per_slot_group_ids: list[int],
+        gid: int,
+        chunk_indices: "list[int] | None" = None,
+    ) -> "tuple[list[torch.Tensor], list[int] | None]":
+        """Select group ``gid``'s slot tensors (and chunk indices) in order."""
+        idxs = [i for i, g in enumerate(per_slot_group_ids) if g == gid]
+        picked = [tensors[i] for i in idxs]
+        if chunk_indices is None:
+            return picked, None
+        return picked, [chunk_indices[i] for i in idxs]
+
+    def _submit_store_multigroup(
+        self,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+    ) -> MessagingFuture:
+        """Uniform-coverage store: gather every group's chunks into its slots."""
+        ctx = self._engine_driven_context
+        assert ctx is not None
+        future: MessagingFuture[bool] = MessagingFuture()
+        if len(block_ids) != len(self._group_states):
+            raise RuntimeError(
+                f"got {len(block_ids)} block-id lists for "
+                f"{len(self._group_states)} registered groups"
+            )
+        torch_dev.synchronize()
+        result = ctx.prepare_store_grouped(key, instance_id)
+        if result is None:
+            future.set_result(False)
+            return future
+        tensors, chunk_indices, group_ids = result
+        if not tensors:
+            future.set_result(True)
+            return future
+        for gid, state in enumerate(self._group_states):
+            out_g, chunks_g = self._group_slots(tensors, group_ids, gid, chunk_indices)
+            if not out_g:
+                continue
+            gather_paged_kv_to_cpu(
+                {name: kv_caches[name] for name in state.layer_names},
+                block_ids[gid],
+                state.blocks_in_chunk,
+                layout_hints=self._layout_hints,
+                engine_kv_format=state.engine_kv_format,
+                out=out_g,
+                chunk_indices=chunks_g,
+            )
+        # SHM writes are async device->CPU copies; complete them before commit.
+        torch_dev.synchronize()
+        ok = ctx.commit_store(key, instance_id, [])
+        future.set_result(ok)
+        return future
+
+    def _submit_retrieve_multigroup(
+        self,
+        key: Any,
+        instance_id: int,
+        kv_caches: dict[str, torch.Tensor],
+        block_ids: list[list[int]],
+        skip_first_n_tokens: int,
+    ) -> MessagingFuture:
+        """Uniform-coverage retrieve: scatter every group's chunks from its slots."""
+        ctx = self._engine_driven_context
+        assert ctx is not None
+        future: MessagingFuture[bool] = MessagingFuture()
+        if len(block_ids) != len(self._group_states):
+            raise RuntimeError(
+                f"got {len(block_ids)} block-id lists for "
+                f"{len(self._group_states)} registered groups"
+            )
+        result = ctx.prepare_retrieve_grouped(key, instance_id)
+        ok = result is not None
+        if result is not None:
+            tensors, group_ids = result
+            try:
+                for gid, state in enumerate(self._group_states):
+                    src_g, _ = self._group_slots(tensors, group_ids, gid)
+                    scatter_cpu_to_paged_kv(
+                        {name: kv_caches[name] for name in state.layer_names},
+                        block_ids[gid],
+                        src_g,
+                        state.blocks_in_chunk,
+                        skip_first_n_tokens=skip_first_n_tokens,
+                        layout_hints=self._layout_hints,
+                        engine_kv_format=state.engine_kv_format,
+                    )
+            except (RuntimeError, ValueError, TypeError, IndexError):
+                logger.exception("Failed to scatter retrieved CPU context chunks")
+                ok = False
+            # Complete device writes before the server may reuse the slots.
+            torch_dev.synchronize()
+        ctx.commit_retrieve(key, instance_id)
         future.set_result(ok)
         return future
 

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -894,6 +894,8 @@ class EngineDrivenTransferContext(TransferContext):
             try:
                 for gid, state in enumerate(self._group_states):
                     src_g, _ = self._group_slots(tensors, group_ids, gid)
+                    if not src_g:
+                        continue
                     scatter_cpu_to_paged_kv(
                         {name: kv_caches[name] for name in state.layer_names},
                         block_ids[gid],

--- a/tests/v1/multiprocess/test_engine_driven_multigroup.py
+++ b/tests/v1/multiprocess/test_engine_driven_multigroup.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for engine-driven multi-group (uniform coverage) transfers.
+"""
+
+# Standard
+from typing import Any
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.multiprocess.custom_types import (
+    GroupLayout,
+    IPCCacheServerKey,
+    RegisterEngineDrivenContextPayload,
+)
+from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+from lmcache.v1.multiprocess.transfer_context import worker_transfer
+from lmcache.v1.multiprocess.transfer_context.base import EngineDrivenContextMetadata
+from lmcache.v1.multiprocess.transfer_context.worker_transfer import (
+    EngineDrivenTransferContext,
+)
+
+
+def _obj_key(chunk_hash: int, group: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(chunk_hash),
+        model_name="m",
+        kv_rank=0,
+        object_group_id=group,
+    )
+
+
+def _group_metadata(chunk_tokens: int = 8) -> EngineDrivenContextMetadata:
+    layouts = [
+        MemoryLayoutDesc(
+            shapes=[torch.Size([2, 2, chunk_tokens, 16])], dtypes=[torch.float32]
+        ),
+        MemoryLayoutDesc(
+            shapes=[torch.Size([2, 1, chunk_tokens, 4])], dtypes=[torch.float32]
+        ),
+    ]
+    return EngineDrivenContextMetadata(
+        layout_desc=layouts[0],
+        block_size=4,
+        use_mla=False,
+        group_layouts=layouts,
+    )
+
+
+def test_shm_strategy_multigroup_store_and_retrieve_roundtrip() -> None:
+    """Per-group reserve on store; retrieve misses until every group commits."""
+    pytest.importorskip(
+        "lmcache.native_storage_ops",
+        reason="real StorageManager requires compiled native storage ops",
+    )
+    # First Party
+    from lmcache.v1.distributed.config import (
+        EvictionConfig,
+        L1ManagerConfig,
+        L1MemoryManagerConfig,
+        StorageManagerConfig,
+    )
+    from lmcache.v1.distributed.storage_manager import StorageManager
+    from lmcache.v1.multiprocess.modules.server_transfer import (
+        PickleTransferStrategy,
+        ShmTransferStrategy,
+    )
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    config = StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=8 * 1024 * 1024,
+                use_lazy=False,
+                shm_name="lmcache_test_multigroup_pool",
+            ),
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+    )
+    sm = StorageManager(config)
+    try:
+        strategy = ShmTransferStrategy(
+            storage_manager=sm,
+            pending_writes={},
+            pending_reads={},
+            pending_lock=__import__("threading").Lock(),
+            transfer_key_factory=lambda key, iid: (iid, key),
+            fallback_strategy=PickleTransferStrategy(sm),
+        )
+        metadata = _group_metadata()
+        key = IPCCacheServerKey.from_token_ids(
+            "m", 1, 0, [1] * 16, start=0, end=16, request_id="req-mg"
+        )
+        group_keys = [
+            [_obj_key(1, 0), _obj_key(2, 0)],
+            [_obj_key(1, 1), _obj_key(2, 1)],
+        ]
+
+        prep = strategy.prepare_store(
+            key=key,
+            instance_id=7,
+            context=metadata,
+            resolve_obj_keys=lambda _k: group_keys[0],
+            group_keys=group_keys,
+        )
+        ctx = prep.context
+        assert len(ctx["slots"]) == 4
+        assert ctx["group_ids"] == [0, 0, 1, 1]
+        assert ctx["chunk_indices"] == [0, 1, 0, 1]
+        # Group layouts differ: slot shapes must match each group's layout.
+        assert ctx["slots"][0]["shape"] == [2, 2, 8, 16]
+        assert ctx["slots"][2]["shape"] == [2, 1, 8, 4]
+
+        assert (
+            strategy.commit_store(
+                key=key,
+                instance_id=7,
+                cpu_data=b"",
+                context=metadata,
+                resolve_obj_keys=lambda _k: group_keys[0],
+            )
+            is True
+        )
+
+        # prepare_retrieve reads already read-locked objects (unsafe_read); in
+        # production the connector's lookup reserve-reads the matching keys
+        # first. Simulate that prefetch per group before retrieving.
+        for g_keys in group_keys:
+            sm._l1_manager.reserve_read(g_keys)
+
+        ret = strategy.prepare_retrieve(
+            key=key,
+            instance_id=7,
+            resolve_obj_keys=lambda _k: group_keys[0],
+            group_keys=group_keys,
+        )
+        assert ret.success is True
+        assert ret.context["group_ids"] == [0, 0, 1, 1]
+        assert strategy.commit_retrieve(key=key, instance_id=7) is True
+
+        # A key range where group 1 has nothing must be a miss overall.
+        partial_keys = [
+            [_obj_key(1, 0), _obj_key(2, 0)],
+            [_obj_key(9, 1), _obj_key(10, 1)],
+        ]
+        ret_miss = strategy.prepare_retrieve(
+            key=key,
+            instance_id=7,
+            resolve_obj_keys=lambda _k: partial_keys[0],
+            group_keys=partial_keys,
+        )
+        assert ret_miss.success is False
+        # No leaked read locks after the miss.
+        status = sm.report_status()["l1_manager"]
+        assert status["read_locked_count"] == 0
+    finally:
+        sm.close()
+
+
+class _FakeGroupedContext:
+    """Grouped-context fake capturing commit calls."""
+
+    def __init__(self, tensors, chunk_indices, group_ids):
+        self._prep = (tensors, chunk_indices, group_ids)
+        self.committed = False
+
+    def prepare_store_grouped(self, _key, _iid):
+        return self._prep
+
+    def prepare_retrieve_grouped(self, _key, _iid):
+        tensors, _, group_ids = self._prep
+        return tensors, group_ids
+
+    def commit_store(self, _key, _iid, _chunks):
+        self.committed = True
+        return True
+
+    def commit_retrieve(self, _key, _iid):
+        return True
+
+    def close(self) -> None:
+        return None
+
+
+def _fanout_ctx(monkeypatch) -> tuple[EngineDrivenTransferContext, list[dict]]:
+    """Worker context with two registered groups and a capturing gather."""
+    ctx = EngineDrivenTransferContext()
+    ctx._group_states = [
+        worker_transfer._GroupState(
+            layer_names=["layer_0", "layer_1"],
+            engine_kv_format=MagicMock(),
+            blocks_in_chunk=2,
+            layout_desc=MagicMock(),
+        ),
+        worker_transfer._GroupState(
+            layer_names=["layer_2"],
+            engine_kv_format=MagicMock(),
+            blocks_in_chunk=1,
+            layout_desc=MagicMock(),
+        ),
+    ]
+    calls: list[dict] = []
+
+    def _fake_gather(kv_caches, block_ids, blocks_in_chunk, **kwargs: Any):
+        calls.append(
+            {
+                "layers": sorted(kv_caches),
+                "block_ids": block_ids,
+                "blocks_in_chunk": blocks_in_chunk,
+                "out": kwargs.get("out"),
+                "chunk_indices": kwargs.get("chunk_indices"),
+            }
+        )
+        return kwargs.get("out")
+
+    monkeypatch.setattr(worker_transfer, "gather_paged_kv_to_cpu", _fake_gather)
+    monkeypatch.setattr(
+        worker_transfer, "scatter_cpu_to_paged_kv", lambda *a, **k: None
+    )
+    return ctx, calls
+
+
+def test_submit_store_multigroup_fans_out_per_group(monkeypatch) -> None:
+    ctx, calls = _fanout_ctx(monkeypatch)
+    t = [torch.zeros(1) for _ in range(4)]
+    fake = _FakeGroupedContext(t, [0, 1, 0, 1], [0, 0, 1, 1])
+    ctx._engine_driven_context = fake  # type: ignore[assignment]
+
+    kv = {name: torch.zeros(1) for name in ("layer_0", "layer_1", "layer_2")}
+    future = ctx.submit_store(
+        "req", MagicMock(), 1, kv, [[1, 2, 3, 4], [5, 6]], MagicMock(), 2
+    )
+
+    assert future.result(timeout=1) is True
+    assert fake.committed
+    assert len(calls) == 2
+    assert calls[0]["layers"] == ["layer_0", "layer_1"]
+    assert calls[0]["block_ids"] == [1, 2, 3, 4]
+    assert calls[0]["blocks_in_chunk"] == 2
+    assert calls[0]["out"] == [t[0], t[1]]
+    assert calls[0]["chunk_indices"] == [0, 1]
+    assert calls[1]["layers"] == ["layer_2"]
+    assert calls[1]["block_ids"] == [5, 6]
+    assert calls[1]["blocks_in_chunk"] == 1
+    assert calls[1]["out"] == [t[2], t[3]]
+
+
+def test_submit_store_multigroup_group_count_mismatch(monkeypatch) -> None:
+    ctx, _ = _fanout_ctx(monkeypatch)
+    ctx._engine_driven_context = _FakeGroupedContext([], [], [])  # type: ignore[assignment]
+    with pytest.raises(RuntimeError, match="block-id lists"):
+        ctx.submit_store("req", MagicMock(), 1, {}, [[1, 2]], MagicMock(), 2)
+
+
+def test_register_rejects_sliding_window_groups() -> None:
+    ctx = EngineDrivenTransferContext()
+    kv = {f"layer_{i}": torch.zeros(2, 4, 4, 2, 8) for i in range(2)}
+    with pytest.raises(RuntimeError, match="sliding-window"):
+        ctx.register(
+            instance_id=1,
+            kv_caches=kv,
+            model_name="m",
+            world_size=1,
+            blocks_in_chunk=2,
+            mq_client=MagicMock(),
+            mq_timeout=1.0,
+            send_request=MagicMock(),
+            engine_group_infos=[
+                EngineGroupInfo(engine_group_id=0, layer_indices=(0,)),
+                EngineGroupInfo(
+                    engine_group_id=1, layer_indices=(1,), sw_size_tokens=128
+                ),
+            ],
+        )
+
+
+def test_register_payload_carries_group_layouts() -> None:
+    """Two full-attention groups produce per-group layouts in the payload."""
+    ctx = EngineDrivenTransferContext()
+    kv = {f"layer_{i}": torch.zeros(2, 6, 4, 2, 8) for i in range(3)}
+
+    # First Party
+    from lmcache.v1.multiprocess.protocols.engine import (
+        RegisterEngineDrivenContextResponse,
+    )
+
+    sent: list[Any] = []
+
+    def _send(_mq, _rt, args):
+        sent.append(args[0])
+        future = MagicMock()
+        future.result.return_value = RegisterEngineDrivenContextResponse(
+            shm_name="lmcache_l1_pool_x", pool_size=4096
+        )
+        return future
+
+    ctx.register(
+        instance_id=1,
+        kv_caches=kv,
+        model_name="m",
+        world_size=1,
+        blocks_in_chunk=2,
+        mq_client=MagicMock(),
+        mq_timeout=1.0,
+        send_request=_send,
+        engine_group_infos=[
+            EngineGroupInfo(engine_group_id=0, layer_indices=(0, 1)),
+            EngineGroupInfo(engine_group_id=1, layer_indices=(2,)),
+        ],
+    )
+    payload: RegisterEngineDrivenContextPayload = sent[0]
+    assert len(payload.group_layouts) == 2
+    assert payload.group_layouts[0].num_layers == 2
+    assert payload.group_layouts[1].num_layers == 1
+    assert isinstance(payload.group_layouts[0], GroupLayout)
+    assert len(ctx._group_states) == 2
+    assert ctx._group_states[1].layer_names == ["layer_2"]


### PR DESCRIPTION
Implements v1 of #4071 (design issue; v2 = sliding-window coverage stays open).

## What

The engine-driven transport currently rejects hybrid-KV models at `_single_group_block_ids` ("does not support hybrid KV cache groups"), which matters because engine_driven is the only transport compatible with vLLM sleep mode. This adds **uniform-coverage multi-group** support — every LMCache group stores/retrieves every chunk — which unlocks indexer-style hybrids (GLM/DeepSeek IndexShare: all groups full-length):

- **Registration** — `GroupLayout` + optional `group_layouts` on `RegisterEngineDrivenContextPayload` (msgspec round-trip verified both ways; empty = legacy single-group). The worker computes a per-group layout via `compute_kv_layout` on each group's `layer_indices` tensor subset and derives per-group `blocks_in_chunk` from `EngineGroupInfo.tokens_per_block`. The server decodes them into per-group `MemoryLayoutDesc`s on the context metadata.
- **Keys** — group-major `ObjectKey`s via the existing `resolve_obj_keys(key, group_ids)` (`object_group_id` per group), matching lmcache_driven's model.
- **Store** — `ShmTransferStrategy.prepare_store` reserves per group with that group's layout and returns slot descriptors tagged with `group_ids`; the worker gathers each group's layer subset with that group's block-id list into its slots. Flat `pending_writes` bookkeeping unchanged.
- **Retrieve** — all-groups-complete-or-miss; per-group scatter mirrors the store.
- **v1 limits, enforced with actionable errors at the right layer**: sliding-window groups rejected at register (v2, per #4071); pickle transport rejected (multi-group requires SHM); async store takes the synchronous grouped path for now (pipelining TODO).

Single-group behavior is byte-identical (`group_keys=None` paths preserve the exact previous call shapes).

## Tests

`tests/v1/multiprocess/test_engine_driven_multigroup.py`:
- Strategy round-trip on a real SHM-backed `StorageManager`: per-group slot shapes (two groups with different hidden dims), `group_ids` tagging, all-groups-or-miss retrieve, no leaked read locks (skips when native storage ops aren't compiled, mirroring the `tests/v1/distributed` pattern).
- Worker fan-out: per-group layer subsets / block-id lists / `blocks_in_chunk` / slot selection; group-count mismatch; sliding-window rejection; payload construction.

Full run on a CUDA box (B200, py3.10): multigroup + `test_engine_driven_transfer.py` + `test_async_engine_driven_transfer_context.py` all green (real-SM round-trip exercised against a compiled tree).

## Notes

Composes with #4068 (abort_write — the `finally` release in `prepare_store` keeps base semantics here to stay independently mergeable) and #4072 (transfer-guard). Same production deployment as #3892; we'll run this under burn-in on TP4/TP8 H200/B200 fleets once merged (our fleet wheels track a slightly older base, so prod validation follows a backport rather than gating this PR).