### PR TITLE
docs: update good first issues link to current onboarding issue

### DIFF
--- a/docs/source/developer_guide/contributing.rst
+++ b/docs/source/developer_guide/contributing.rst
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to LMCache! We welcome and accept al
 - Suggest or implement new features
 - Improve documentation or contribute a how-to guide
 
-A comprehensive list of good first issues can be found in the issue `[Onboarding][Q4] Welcoming contributors with good first issues! <https://github.com/LMCache/LMCache/issues/1882>`_.
+A comprehensive list of good first issues can be found in the issue `[Onboarding 2026] Good first issues — start contributing to LMCache in one PR <https://github.com/LMCache/LMCache/issues/3372>`_.
 
 If you'd like to support our community further, then answering queries, offering PR reviews, and assisting others are also impactful ways to contribute and take LMCache further.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The Contributing Guide (`docs/source/developer_guide/contributing.rst`) links to issue #1882 as the source of "good first issues," but the project has since moved to issue #3372 ("[Onboarding 2026] Good first issues — start contributing to LMCache in one PR") as the current onboarding list. This PR updates the link and its title to point at #3372.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
