### PR TITLE
refactor(mp):Platform refactor ipc abstraction

### DIFF
--- a/docs/design/v1/platform/base/event_ipc_abstraction.md
+++ b/docs/design/v1/platform/base/event_ipc_abstraction.md
@@ -1,0 +1,235 @@
+# Platform Event IPC Abstraction
+
+## Motivation
+
+The `lmcache_driven` multiprocess handle path uses device events to order
+cross-process KV-cache transfers:
+
+1. The worker records an event after producing or reserving KV-cache blocks.
+2. The server imports that event and waits before reading or writing shared
+   KV-cache memory.
+3. The server records a completion event after transfer work is queued.
+4. The worker future imports, polls, and waits for that completion event.
+
+CUDA-style backends expose this through `Event(interprocess=True)`,
+`Event.ipc_handle()`, and `Event.from_ipc_handle(...)`. MUSA has its own
+capability gate and TorchMUSA event module. If generic multiprocess modules
+import MUSA code or branch on `device.type == "musa"`, every new accelerator
+must add another special case to the same logic layer.
+
+The platform event IPC abstraction keeps that decision in
+`lmcache/v1/platform/`. Generic multiprocess code calls one backend-neutral
+interface; `DeviceSpec` selects the implementation for the requested device.
+
+## Goals
+
+- Keep the `lmcache_driven` handle path free of backend-specific imports and
+  device-type branches.
+- Preserve `CUDAMessagingFuture` and `to_cuda_future` compatibility aliases.
+- Provide CUDA-style/default and MUSA event backends behind one interface.
+- Fail before cross-process memory access when event IPC is unavailable.
+- Require each concrete `DeviceSpec` to declare its event IPC capability; do
+  not select an unrelated backend through an implicit fallback.
+
+## Non-Goals
+
+- The `STORE` and `RETRIEVE` wire formats do not change; event handles remain
+  serialized `bytes` values.
+- Tensor memory IPC remains owned by `DeviceIPCWrapper` implementations.
+- CacheBlend modules are not migrated in this change; they remain a separate
+  CUDA-only integration until a follow-up adopts the same interface.
+- Worker adapters continue to construct and initially record their producer
+  events. The abstraction covers export from the worker and all server/future
+  event operations.
+
+## API
+
+`lmcache/v1/platform/base/event_ipc.py` defines the runtime-checkable protocol:
+
+```python
+class EventIPCBackend(Protocol):
+    device_type: str
+
+    def check_event_support(self, device: object) -> None: ...
+    def create_event(self, device: object) -> object: ...
+    def export_event(self, event: object, device: object) -> bytes: ...
+    def import_event(self, handle: bytes, device: object) -> object: ...
+    def record_event(self, event: object, stream: object) -> None: ...
+    def wait_event(self, event: object, stream: object) -> None: ...
+    def query_event(self, event: object) -> bool: ...
+    def synchronize_event(self, event: object, device: object) -> None: ...
+```
+
+The lookup entry point is:
+
+```python
+def get_event_ipc_backend(device: object) -> EventIPCBackend: ...
+```
+
+`device` may be a `torch.device`-like object, a device-type string, or an
+integer device index. The lookup resolves a `DeviceSpec` and returns its
+`event_ipc_backend`. A missing `DeviceSpec` is a platform registration error,
+and a registered spec without an event backend is an unsupported-capability
+error. Both cases raise `RuntimeError` instead of selecting a fallback.
+
+All event, device, and stream values are opaque `object` handles at this layer.
+The concrete backend owns their types and ABI details.
+
+## Backend Implementations
+
+```text
+lmcache/v1/platform/base/event_ipc.py     # protocol, lookup, default backend
+lmcache/v1/platform/base/device_spec.py  # optional DeviceSpec capability
+lmcache/v1/platform/cpu/__init__.py      # CPU stub backend registration
+lmcache/v1/platform/cuda/__init__.py     # CUDA backend registration
+lmcache/v1/platform/musa/event_ipc.py    # MUSA capability gate and adapter
+lmcache/v1/platform/musa/ipc_wrapper.py  # MUSA availability and torch.musa loader
+```
+
+### Default backend
+
+`DefaultEventIPCBackend` adapts an event module with the CUDA-style API:
+
+```python
+event = event_module.Event(interprocess=True)
+handle = event.ipc_handle()
+remote_event = event_module.Event.from_ipc_handle(device, handle)
+event.record(stream)
+remote_event.wait(stream)
+remote_event.query()
+remote_event.synchronize()
+```
+
+The base `DeviceSpec.event_ipc_backend` returns `None`. `CpuDeviceSpec`
+explicitly binds this adapter to `StubCPUDevice`, while `CudaDeviceSpec` binds
+it to `torch.cuda`. Other accelerators must explicitly register a compatible
+backend before the multiprocess handle path can use them. This prevents an
+unsupported or misspelled device type from silently selecting the active
+accelerator's event implementation.
+
+### MUSA backend
+
+`MusaEventIPCBackend` lives under `lmcache/v1/platform/musa/`. It first checks
+`is_musa_handle_transfer_available()` from `musa/ipc_wrapper.py`, then adapts
+the current TorchMUSA event API through `DefaultEventIPCBackend`:
+
+```python
+torch_musa = get_torch_musa_module()
+event = torch_musa.Event(interprocess=True)
+handle = event.ipc_handle()
+remote_event = torch_musa.Event.from_ipc_handle(device, handle)
+```
+
+The generic layer does not import `platform.musa`; only the MUSA `DeviceSpec`
+and backend do. If MUSA handle transfer or the required TorchMUSA event API is
+unavailable, `check_event_support()` raises a device-named `RuntimeError`.
+
+## Registration
+
+Event backends are properties of `DeviceSpec`, alongside device detection and
+memory IPC wrapper selection:
+
+```python
+class DeviceSpec:
+    @property
+    def event_ipc_backend(self) -> EventIPCBackend | None:
+        return None
+
+class CudaDeviceSpec(DeviceSpec):
+    @property
+    def event_ipc_backend(self) -> EventIPCBackend:
+        return DefaultEventIPCBackend(event_module=torch.cuda, ...)
+
+class MusaDeviceSpec(DeviceSpec):
+    @property
+    def event_ipc_backend(self) -> EventIPCBackend:
+        return MusaEventIPCBackend()
+```
+
+This keeps platform capabilities together. Adding another backend requires a
+new platform package/spec, not an edit to the multiprocess transfer modules.
+
+## Generic Multiprocess Flow
+
+```text
+Worker adapter
+  create/record producer event using its existing device API
+  get_event_ipc_backend(device)
+  export_event(producer_event, device)
+  send event handle in STORE/RETRIEVE
+
+Server: lmcache_driven_transfer.py
+  get_event_ipc_backend(cache_context.device)
+  check_event_support(device)
+  import_event(worker_handle, device)
+  wait_event(imported_event, cache_context.stream)
+  enqueue KV transfer
+  create_event(device), record_event(done_event, stream)
+  export_event(done_event, device)
+
+Worker: futures.py
+  get_event_ipc_backend(device)
+  import_event(server_handle, device)
+  query_event / wait_event / synchronize_event
+```
+
+The following generic modules use only the platform API:
+
+- `lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py`
+- `lmcache/v1/multiprocess/futures.py`
+- `lmcache/v1/multiprocess/transfer_context/worker_transfer.py`
+
+`DeviceMessagingFuture` is the device-neutral implementation. The old
+`CUDAMessagingFuture` name remains an alias, and `to_cuda_future()` remains an
+alias for `to_device_future()`.
+
+## Error Contract
+
+`check_event_support(device)` runs before any cross-process memory transfer.
+The default backend rejects missing `Event`, missing `interprocess` support, or
+missing `Event.from_ipc_handle`. The MUSA backend additionally rejects a
+disabled/unavailable MUSA handle path, a missing TorchMUSA module, or an event
+module without the required interprocess API.
+
+Errors include the backend name and missing capability. They must not claim
+that CUDA is required when a non-CUDA backend has its own implementation.
+
+## Migration Plan
+
+1. Define `EventIPCBackend`, the default adapter, and lookup in
+   `platform/base/event_ipc.py`.
+2. Add the optional `DeviceSpec.event_ipc_backend` capability and explicit
+   CPU, CUDA, and MUSA registrations.
+3. Replace direct event creation/import/wait/record/export/query calls in the
+   `lmcache_driven` server path with the platform API.
+4. Route `DeviceMessagingFuture` import/query/wait/synchronize through the
+   platform API while preserving the CUDA aliases.
+5. Route worker-side producer-event export through the platform API.
+6. Keep CacheBlend and other out-of-scope CUDA-only integrations unchanged.
+
+## Testing
+
+Tests cover:
+
+- default event creation, export, import, record, wait, query, synchronize;
+- CPU backend selection while another accelerator is active;
+- strict failures for unregistered devices and unsupported event IPC;
+- MUSA capability failure and missing-module failure;
+- MUSA delegation to the TorchMUSA event API using a fake module;
+- future compatibility aliases and device-aware event behavior;
+- structural absence of direct MUSA imports in the generic handle-path modules.
+
+Real MUSA hardware tests remain capability-gated. The platform tests do not
+need MUSA hardware because they validate the public backend contract using
+injected event modules.
+
+## Review Checklist
+
+- [ ] Generic handle-path modules do not import `platform.musa`.
+- [ ] Generic handle-path modules do not branch on a concrete device type.
+- [ ] `CUDAMessagingFuture` and `to_cuda_future` remain compatible aliases.
+- [ ] Concrete device specs explicitly register their event IPC backends.
+- [ ] Missing specs and unsupported event IPC fail without fallback.
+- [ ] MUSA event behavior is isolated under `platform/musa`.
+- [ ] Unsupported event IPC fails before unsafe memory access.
+- [ ] Platform and future tests cover import/export and stream ordering.

--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -304,6 +304,81 @@ Host-side pinning via ``pin_memory_backend`` is *optional* and only
 affects staging-buffer performance; it is not required to enable
 LMCache-driven mode.
 
+Event IPC capability
+^^^^^^^^^^^^^^^^^^^^
+
+The LMCache-driven multiprocess handle path also requires a platform
+event-IPC backend.  The capability is declared by
+``DeviceSpec.event_ipc_backend`` and is intentionally separate from
+``DeviceOps`` and ``DeviceIPCWrapper``:
+
+* The base ``DeviceSpec`` returns ``None``.  A concrete device must
+  explicitly opt in.
+* CUDA-style event APIs can use
+  ``DefaultEventIPCBackend(event_module=..., device_type=...)``.
+* Devices with a different event ABI should implement an
+  ``EventIPCBackend`` in their own ``lmcache/v1/platform/foo/`` package.
+* Concrete device specs should cache the backend because request futures
+  may query this property repeatedly.
+
+The backend contract covers event creation, handle export/import, event
+recording, stream wait, query, and synchronization.
+``check_event_support(device)`` must raise ``RuntimeError`` when those
+operations are unavailable for the requested device.  The default backend
+checks for a CUDA-style Event type that accepts ``interprocess=True`` and
+provides ``from_ipc_handle``.  A custom backend should instead validate the
+equivalent prerequisites for its own event ABI.
+
+For a CUDA-style device, bind and cache the default backend as follows:
+
+.. code-block:: python
+
+    from typing import TYPE_CHECKING
+
+    from lmcache.v1.platform.base.device_spec import DeviceSpec
+
+    if TYPE_CHECKING:
+        from lmcache.v1.platform.base.event_ipc import EventIPCBackend
+
+    class FooDeviceSpec(DeviceSpec):
+        _event_backend_cache: "EventIPCBackend | None" = None
+
+        @property
+        def event_ipc_backend(self) -> "EventIPCBackend":
+            backend = self._event_backend_cache
+            if backend is None:
+                import torch
+
+                from lmcache.v1.platform.base.event_ipc import (
+                    DefaultEventIPCBackend,
+                )
+
+                backend = DefaultEventIPCBackend(
+                    event_module=torch.foo,
+                    device_type=self.device_type,
+                )
+                self._event_backend_cache = backend
+            return backend
+
+Event IPC operations must preserve producer/consumer stream ordering without
+adding a device-wide synchronization.  ``query_event`` must remain
+non-blocking so request futures can poll completion safely.
+
+.. note::
+
+   If the device does not support Event IPC, leave the base
+   ``event_ipc_backend`` implementation unchanged so it returns ``None``.
+   Engine-driven mode does not require this capability.  LMCache-driven
+   mode raises an explicit error rather than falling back to CUDA or to the
+   accelerator active in the process.
+
+The capability is checked during worker/server registration and before
+constructing a device-aware completion future.  This keeps unsupported
+platforms from entering an asynchronous transfer path that cannot order
+KV-cache memory safely.  The STORE and RETRIEVE message wire format is
+unchanged: the existing event handle bytes are still carried in the
+request and response payloads.
+
 Override these methods in your ``DeviceSpec``:
 
 .. code-block:: python
@@ -359,6 +434,8 @@ References
      - Path
    * - Device spec base
      - ``lmcache/v1/platform/base/device_spec.py``
+   * - Event IPC base
+     - ``lmcache/v1/platform/base/event_ipc.py``
    * - Backend loading
      - ``lmcache/v1/platform/__init__.py``
    * - Python fallback

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -409,7 +409,7 @@ class LMCacheMPConnector:
                 event.ipc_handle(),
                 skip_prefix_n_blocks,
             ],
-        ).to_cuda_future(device=self.device)
+        ).to_device_future(device=self.device)
 
     def retrieve_kv(self, load_metadata: LoadMetadata) -> int:
         """Phase 2 of the two-phase load — fires RETRIEVE only.
@@ -525,7 +525,7 @@ class LMCacheMPConnector:
                     event.ipc_handle(),
                 ],
             )
-            .to_cuda_future(device=self.device)
+            .to_device_future(device=self.device)
             .result(timeout=self._mq_timeout)
         )
         # END_SESSION is owned by ``LMCRadixCache.cache_finished_req`` so

--- a/lmcache/v1/multiprocess/futures.py
+++ b/lmcache/v1/multiprocess/futures.py
@@ -4,8 +4,10 @@ from typing import Any, Generic, Optional, TypeVar
 import threading
 
 # First Party
-from lmcache import torch_dev, torch_device_type
+from lmcache import torch_dev
+from lmcache.utils import lmcache_deprecate
 from lmcache.v1.mp_observability.errors import LMCacheTimeoutError
+from lmcache.v1.platform.base.event_ipc import get_event_ipc_backend
 
 T = TypeVar("T")
 
@@ -68,21 +70,45 @@ class MessagingFuture(Generic[T]):
         self.result_ = result
         self.is_done_.set()
 
+    def to_device_future(
+        self,
+        device: Any | None = None,
+    ) -> "DeviceMessagingFuture":
+        """Wrap this future in a device-aware future.
+
+        Args:
+            device: The device whose event backend orders completion. Defaults
+                to the active device.
+
+        Returns:
+            A DeviceMessagingFuture pending on both this future and the event.
+        """
+        # TODO: need extra type checking for the future type
+        return DeviceMessagingFuture.FromMessagingFuture(self, device)  # type: ignore
+
+    @lmcache_deprecate("Use to_device_future() instead")
     def to_cuda_future(
         self,
         device: Any | None = None,
-    ) -> "CUDAMessagingFuture":
-        # TODO: need extra type checking for the future type
-        return CUDAMessagingFuture.FromMessagingFuture(self, device)  # type: ignore
+    ) -> "DeviceMessagingFuture[T]":
+        """Return a device-aware future using the deprecated CUDA name.
+
+        Args:
+            device: Device on which the completion event will be imported.
+
+        Returns:
+            A device-aware future wrapping this messaging future.
+        """
+        return self.to_device_future(device)
 
 
-class CUDAMessagingFuture(MessagingFuture[T]):
+class DeviceMessagingFuture(MessagingFuture[T]):
     """
-    The future class that wraps both result and a CUDA IPC event.
-    The `query`, `wait`, and `result` methods will pend on both the
-    original future and the CUDA event.
+    The future class that wraps both a result and a device IPC event.
+    The `query`, `wait`, and `result` methods pend on both the original
+    future and the device event, ordered through the platform event backend.
     The original future should return tuple[bytes, T], where the first
-    element is the serialized CUDA event.
+    element is the serialized device event handle.
     """
 
     def __init__(
@@ -95,46 +121,36 @@ class CUDAMessagingFuture(MessagingFuture[T]):
         self.event_: Any | None = None
         self.result_: T | None = None
         self.device_ = device if device is not None else torch_dev.current_device()
+        self._event_backend = get_event_ipc_backend(self.device_)
+        self._event_backend.check_event_support(self.device_)
 
-    def _on_raw_future_complete(self):
+    def _on_raw_future_complete(self) -> None:
         """
-        Update the CUDA event and result when the raw future is complete.
+        Update the device event and result when the raw future is complete.
         """
         event_bytes, result = self.raw_future_.result()
         self.result_ = result
 
-        # Not all backends support interprocess Events (CUDA IPC specific)
-        if not hasattr(torch_dev, "Event") or not hasattr(
-            torch_dev.Event, "from_ipc_handle"
-        ):
-            raise RuntimeError(
-                f"Backend '{torch_device_type}' does not support interprocess "
-                "Events (Event.from_ipc_handle not available). "
-                "Multiprocess IPC requires CUDA."
-            )
-        self.event_ = torch_dev.Event.from_ipc_handle(self.device_, event_bytes)
+        self.event_ = self._event_backend.import_event(event_bytes, self.device_)
 
     def wait(self, timeout: Optional[float] = None) -> bool:
         """
-        Wait for the future to be done, with the CUDA stream.
+        Wait for the future to be done, ordered through the device event.
 
         Args:
             timeout (Optional[float]): Maximum time to wait for the UNDERLYING
                 RAW FUTURE in seconds. The exact timeout is not guaranteed
-                when waiting on the CUDA event. (NOTE: this could be improved
+                when waiting on the device event. (NOTE: this could be improved
                 with careful threading management)
 
         Returns:
             bool: True if the future is done, False if the timeout was reached.
 
-        Raises:
-            ValueError: if the timeout is not None.
-
         Notes:
             This function does not support waiting for a specific time.
         """
         if self.event_:
-            self.event_.synchronize()
+            self._event_backend.synchronize_event(self.event_, self.device_)
             return True
 
         flag = self.raw_future_.wait(timeout)
@@ -144,7 +160,7 @@ class CUDAMessagingFuture(MessagingFuture[T]):
         self._on_raw_future_complete()
 
         assert self.event_ is not None
-        self.event_.synchronize()
+        self._event_backend.synchronize_event(self.event_, self.device_)
 
         return True
 
@@ -155,7 +171,7 @@ class CUDAMessagingFuture(MessagingFuture[T]):
         Args:
             timeout (Optional[float]): Maximum time to wait for the UNDERLYING
                 RAW FUTURE in seconds. The exact timeout is not guaranteed
-                when waiting on the CUDA event. (NOTE: this could be improved
+                when waiting on the device event. (NOTE: this could be improved
                 with careful threading management)
 
         Returns:
@@ -167,7 +183,7 @@ class CUDAMessagingFuture(MessagingFuture[T]):
         flag = self.wait(timeout)
         if not flag:
             raise LMCacheTimeoutError(
-                "CUDAMessagingFuture result not available within timeout"
+                "DeviceMessagingFuture result not available within timeout"
             )
 
         assert self.result_ is not None
@@ -181,23 +197,27 @@ class CUDAMessagingFuture(MessagingFuture[T]):
             bool: True if the future is done, False otherwise.
         """
         if self.event_:
-            return self.event_.query()
+            return self._event_backend.query_event(self.event_)
 
         if self.raw_future_.query():
             self._on_raw_future_complete()
             assert self.event_ is not None
-            return self.event_.query()
+            return self._event_backend.query_event(self.event_)
 
         return False
 
     def set_result(self, result: T) -> None:
         raise NotImplementedError(
-            "CUDAMessagingFuture does not support set_result directly"
+            "DeviceMessagingFuture does not support set_result directly"
         )
 
     @staticmethod
     def FromMessagingFuture(
         raw_future: MessagingFuture[tuple[bytes, T]],
         device: Any | None = None,
-    ) -> "CUDAMessagingFuture[T]":
-        return CUDAMessagingFuture(raw_future, device)
+    ) -> "DeviceMessagingFuture[T]":
+        return DeviceMessagingFuture(raw_future, device)
+
+
+# Backward-compatible alias for existing imports.
+CUDAMessagingFuture = DeviceMessagingFuture

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -12,12 +12,11 @@ import time
 import torch
 
 # First Party
-from lmcache import torch_dev, torch_device_type
+from lmcache import torch_dev
 from lmcache.logging import init_logger
 from lmcache.utils import (
     EngineType,
     _lmcache_nvtx_annotate,
-    check_interprocess_event_support,
 )
 from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
@@ -49,6 +48,10 @@ from lmcache.v1.multiprocess.native_completion import (
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
 from lmcache.v1.platform.base.cache_context import BaseCacheContext
+from lmcache.v1.platform.base.event_ipc import (
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
 from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
 
@@ -594,6 +597,7 @@ class ContextEntry:
         has_liveness_signal: True once the instance has sent at least one
             PING. Selects the reap window (timeout vs registration grace).
             Latched only by PING, never by traffic.
+        event_backend: Cached event backend selected for this context's device.
     """
 
     cache_context: BaseCacheContext
@@ -601,6 +605,7 @@ class ContextEntry:
     world_size: int
     last_seen: float = 0.0
     has_liveness_signal: bool = False
+    event_backend: EventIPCBackend | None = None
 
 
 class LMCacheDrivenTransferModule(InstanceLivenessTarget):
@@ -761,7 +766,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         torch_dev.empty_cache()
         ipc_collect = getattr(torch_dev, "ipc_collect", None)
         if ipc_collect is not None:
-            # Non-CUDA device modules (xpu / musa) do not expose ipc_collect.
+            # Backends without IPC collection omit this optional operation.
             ipc_collect()
 
     def get_handlers(self) -> list[HandlerSpec]:
@@ -879,6 +884,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             separate_object_groups=self._ctx.separate_object_groups,
             full_sw_kv=self._ctx.full_sw_kv,
         )
+        event_backend = get_event_ipc_backend(cache_context.device)
+        event_backend.check_event_support(cache_context.device)
         layout_desc = get_layout_desc(
             cache_context, self._ctx.chunk_size, object_group_id=0
         )
@@ -895,6 +902,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 world_size=world_size,
                 last_seen=now,
                 has_liveness_signal=False,
+                event_backend=event_backend,
             )
 
         logger.info(
@@ -970,6 +978,9 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             raise ValueError(f"No GPU context registered for instance ID {instance_id}")
         cache_context = entry.cache_context
         model_name = entry.model_name
+        event_backend = entry.event_backend
+        if event_backend is None:
+            raise RuntimeError("Registered cache context has no event backend")
 
         num_object_groups = cache_context.kv_layer_groups_manager.num_object_groups
         obj_keys_per_obj_group = self._ctx.resolve_obj_keys(
@@ -991,8 +1002,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             torch_dev.device(cache_context.device),
             torch_dev.stream(cache_context.stream),
         ):
-            check_interprocess_event_support()
-            event = torch_dev.Event(interprocess=True)
+            event = event_backend.create_event(cache_context.device)
 
             # Fail closed: every LMCache group must have block IDs covering all
             # chunks. A short list (e.g. a caller/protocol bug) would otherwise
@@ -1015,23 +1025,17 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                     num_chunks,
                     blocks_per_chunk,
                 )
-                event.record()
-                return event.ipc_handle(), False
+                event_backend.record_event(event, cache_context.stream)
+                return event_backend.export_event(event, cache_context.device), False
 
             block_ids_per_group_gpu = downsample_and_stage_block_ids(
                 cache_context, gpu_block_ids
             )
 
-            if not hasattr(torch_dev.Event, "from_ipc_handle"):
-                raise RuntimeError(
-                    f"Backend '{torch_device_type}' does not support IPC event "
-                    "handles (Event.from_ipc_handle not available). "
-                    "Multiprocess IPC requires CUDA."
-                )
-            vllm_event = torch_dev.Event.from_ipc_handle(
-                cache_context.device, event_ipc_handle
+            producer_event = event_backend.import_event(
+                event_ipc_handle, cache_context.device
             )
-            vllm_event.wait(stream=cache_context.stream)
+            event_backend.wait_event(producer_event, cache_context.stream)
 
             # CPU-synchronous sentinel: a GPU store is about to be enqueued.
             # Must be published via publish() (not publish_on_stream) so the
@@ -1098,9 +1102,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 store_succeeded = True
             except Exception:
                 logger.exception("Cannot store keys due to exception")
-                return event.ipc_handle(), False
             finally:
-                event.record()
+                event_backend.record_event(event, cache_context.stream)
                 # Fail closed: commit the reserved objects only when every chunk
                 # copied successfully; otherwise the whole store is skipped.
                 stored_count = len(all_dict) if store_succeeded else 0
@@ -1136,7 +1139,10 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                 num_chunks * self._ctx.chunk_size,
                 ed - st,
             )
-        return event.ipc_handle(), True
+        return (
+            event_backend.export_event(event, cache_context.device),
+            store_succeeded,
+        )
 
     @_lmcache_nvtx_annotate
     def retrieve(
@@ -1168,6 +1174,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
 
         Raises:
             ValueError: If no GPU context is registered for the given instance ID.
+            RuntimeError: If the backend does not support IPC event handles.
         """
         st = time.perf_counter()
 
@@ -1176,6 +1183,9 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             raise ValueError(f"No GPU context registered for instance ID {instance_id}")
         cache_context = entry.cache_context
         model_name = entry.model_name
+        event_backend = entry.event_backend
+        if event_backend is None:
+            raise RuntimeError("Registered cache context has no event backend")
 
         num_object_groups = cache_context.kv_layer_groups_manager.num_object_groups
         obj_keys_per_obj_group = self._ctx.resolve_obj_keys(
@@ -1218,8 +1228,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             torch_dev.device(cache_context.device),
             torch_dev.stream(cache_context.stream),
         ):
-            check_interprocess_event_support()
-            event = torch_dev.Event(interprocess=True)
+            event = event_backend.create_event(cache_context.device)
 
             # Fail closed: a short block-id list would drive the transfer
             # kernel to write out-of-bounds GPU memory. Checked on the raw
@@ -1240,16 +1249,21 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                     num_chunks,
                     blocks_per_chunk,
                 )
-                event.record()
-                return event.ipc_handle(), False
+                event_backend.record_event(event, cache_context.stream)
+                return event_backend.export_event(event, cache_context.device), False
 
             # Cut and stage all block_ids to GPU once before the transfer
             block_ids_per_group_gpu = downsample_and_stage_block_ids(
                 cache_context, gpu_block_ids
             )
+            producer_event = event_backend.import_event(
+                event_ipc_handle, cache_context.device
+            )
+            event_backend.wait_event(producer_event, cache_context.stream)
 
             prefetched_keys: list[ObjectKey] = []
             total_bytes = 0
+            retrieve_succeeded = True
             try:
                 for obj_group_id in range(num_object_groups):
                     obj_keys = obj_keys_per_obj_group[obj_group_id]
@@ -1258,7 +1272,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                     ) as memory_objs:
                         if not memory_objs or len(memory_objs) != len(obj_keys):
                             logger.error("Some keys not found during retrieve!")
-                            return event.ipc_handle(), False
+                            retrieve_succeeded = False
+                            break
 
                         total_bytes += sum(mo.get_size() for mo in memory_objs)
 
@@ -1277,9 +1292,9 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                         prefetched_keys.extend(obj_keys)
             except Exception:
                 logger.exception("Cannot retrieve keys due to exception")
-                return event.ipc_handle(), False
+                retrieve_succeeded = False
             finally:
-                event.record()
+                event_backend.record_event(event, cache_context.stream)
                 if prefetched_keys:
                     submit_callback_to_stream(
                         cache_context.cupy_stream,
@@ -1307,12 +1322,16 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
                         },
                     ),
                 )
-        tokens_retrieved = num_chunks * self._ctx.chunk_size
-        ed = time.perf_counter()
-        logger.info(
-            "Retrieved %d tokens in %.3f seconds",
-            tokens_retrieved,
-            ed - st,
-        )
+        if retrieve_succeeded:
+            tokens_retrieved = num_chunks * self._ctx.chunk_size
+            ed = time.perf_counter()
+            logger.info(
+                "Retrieved %d tokens in %.3f seconds",
+                tokens_retrieved,
+                ed - st,
+            )
 
-        return event.ipc_handle(), True
+        return (
+            event_backend.export_event(event, cache_context.device),
+            retrieve_succeeded,
+        )

--- a/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
+++ b/lmcache/v1/multiprocess/transfer_context/worker_transfer.py
@@ -31,6 +31,10 @@ from lmcache.v1.multiprocess.transfer_context.base import (
     scatter_cpu_to_paged_kv,
 )
 from lmcache.v1.platform import get_device_spec, resolve_kv_wrapper_factory
+from lmcache.v1.platform.base.event_ipc import (
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
 
 logger = init_logger(__name__)
 
@@ -160,10 +164,7 @@ def _build_lmcache_driven_context(device_type: str) -> "TransferContext":
 
 
 class IPCEvent(Protocol):
-    """Protocol for IPC-capable CUDA events used by transport operations."""
-
-    def ipc_handle(self) -> object:
-        """Return an IPC handle consumable by the multiprocess server."""
+    """Protocol for device events used by transport operations."""
 
     def wait(self, stream: object | None = None) -> None:
         """Make ``stream`` wait for this event (async ordering primitive)."""
@@ -181,12 +182,29 @@ def _single_group_block_ids(block_ids: list[list[int]]) -> list[int]:
     return block_ids[0]
 
 
+def _get_kv_device(kv_caches: dict[str, torch.Tensor]) -> torch.device:
+    """Return the device shared by a non-empty KV-cache mapping.
+
+    Args:
+        kv_caches: Worker KV-cache tensors keyed by layer name.
+
+    Returns:
+        The device of the first KV-cache tensor.
+
+    Raises:
+        ValueError: If ``kv_caches`` is empty.
+    """
+    if not kv_caches:
+        raise ValueError("LMCache-driven transfer requires at least one KV cache")
+    return next(iter(kv_caches.values())).device
+
+
 class TransferContext(ABC):
     """Abstract transport layer for worker-side KV transfer.
 
     Concrete implementations encapsulate how worker-side store/retrieve
-    operations are transmitted to the multiprocess server. CUDA paths return
-    CUDA-aware futures backed by MQ requests, while CPU paths may perform
+    operations are transmitted to the multiprocess server. Device-handle paths
+    return event-aware futures backed by MQ requests, while CPU paths may perform
     gather/scatter synchronously and return already-resolved futures.
     """
 
@@ -194,7 +212,7 @@ class TransferContext(ABC):
     def register(
         self,
         instance_id: int,
-        kv_caches: dict[str, torch.Tensor],
+        _kv_caches: dict[str, torch.Tensor],
         model_name: str,
         world_size: int,
         blocks_in_chunk: int,
@@ -304,14 +322,16 @@ class TransferContext(ABC):
 class LMCacheDrivenTransferContext(TransferContext):
     """LMCache-driven IPC + MQ future transport context.
 
-    In this mode the serving engine provides device handles (IPC for CUDA,
-    SHM wrappers for CPU with CUDA-IPC-like semantics) and the LMCache
-    server performs direct device-side data transfer.
+    In this mode the serving engine provides device handles (accelerator IPC,
+    or SHM wrappers for CPU with IPC-like semantics) and the LMCache server
+    performs direct device-side data transfer.
     """
 
     def __init__(self) -> None:
         self._mq_client: MessageQueueClient | None = None
         self._send_request: SendRequest | None = None
+        self._device: torch.device | None = None
+        self._event_backend: EventIPCBackend | None = None
 
     def register(
         self,
@@ -326,8 +346,30 @@ class LMCacheDrivenTransferContext(TransferContext):
         layout_hints: LayoutHints | None = None,
         engine_group_infos: Sequence[EngineGroupInfo] = (),
     ) -> None:
+        """Register the worker KV cache with the LMCache server.
+
+        Args:
+            instance_id: Worker process instance identifier.
+            kv_caches: Worker KV-cache tensors keyed by layer name.
+            model_name: Model identifier used by the server.
+            world_size: Tensor-parallel world size.
+            _blocks_in_chunk: Engine blocks per LMCache chunk.
+            mq_client: Message-queue client used for requests.
+            mq_timeout: Timeout for the registration response.
+            send_request: Request sender used by this context.
+            layout_hints: Optional KV-layout metadata.
+            engine_group_infos: Optional engine KV-group metadata.
+
+        Raises:
+            RuntimeError: If event IPC is unsupported for the KV-cache device.
+            ValueError: If ``kv_caches`` is empty.
+        """
         # First Party
         from lmcache.integration.vllm.vllm_multi_process_adapter import wrap_kv_caches
+
+        device = _get_kv_device(kv_caches)
+        event_backend = get_event_ipc_backend(device)
+        event_backend.check_event_support(device)
 
         self._mq_client = mq_client
         self._send_request = send_request
@@ -345,27 +387,54 @@ class LMCacheDrivenTransferContext(TransferContext):
             ],
         )
         future.result(timeout=mq_timeout)
+        self._device = device
+        self._event_backend = event_backend
 
     def submit_store(
         self,
         _request_id: str,
         key: Any,
         instance_id: int,
-        _kv_caches: dict[str, torch.Tensor],
+        kv_caches: dict[str, torch.Tensor],
         block_ids: list[list[int]],
         event: IPCEvent,
         _blocks_in_chunk: int,
     ) -> MessagingFuture:
-        if self._mq_client is None or self._send_request is None:
+        """Submit a handle-based store ordered by ``event``.
+
+        Args:
+            _request_id: External request identifier (unused by this transport).
+            key: LMCache key for the store range.
+            instance_id: Worker process instance identifier.
+            _kv_caches: Worker KV-cache tensors accepted for interface
+                consistency; the registered device is reused.
+            block_ids: Engine block IDs indexed by LMCache KV group.
+            event: Producer event that orders reads of the engine KV cache.
+            _blocks_in_chunk: Engine blocks per chunk (unused by this transport).
+
+        Returns:
+            A device-event-aware future for the server response.
+
+        Raises:
+            RuntimeError: If the context is not registered or event IPC is
+                unsupported.
+        """
+        if (
+            self._mq_client is None
+            or self._send_request is None
+            or self._device is None
+            or self._event_backend is None
+        ):
             raise RuntimeError(
                 "LMCache-driven transfer context is not registered. "
                 "Call register() before submit_store()."
             )
+        event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._send_request(
             self._mq_client,
             RequestType.STORE,
-            [key, instance_id, block_ids, event.ipc_handle()],
-        ).to_cuda_future()
+            [key, instance_id, block_ids, event_ipc_handle],
+        ).to_device_future(device=self._device)
 
     def submit_retrieve(
         self,
@@ -378,20 +447,49 @@ class LMCacheDrivenTransferContext(TransferContext):
         _blocks_in_chunk: int,
         skip_first_n_tokens: int = 0,
     ) -> MessagingFuture:
-        if self._mq_client is None or self._send_request is None:
+        """Submit a handle-based retrieve ordered by ``event``.
+
+        Args:
+            _request_id: External request identifier (unused by this transport).
+            key: LMCache key for the retrieve range.
+            instance_id: Worker process instance identifier.
+            _kv_caches: Worker KV-cache tensors accepted for interface
+                consistency; the registered device is reused.
+            block_ids: Engine block IDs indexed by LMCache KV group.
+            event: Producer event that orders writes to the engine KV cache.
+            _blocks_in_chunk: Engine blocks per chunk (unused by this transport).
+            skip_first_n_tokens: Initial tokens the server must not overwrite.
+
+        Returns:
+            A device-event-aware future for the server response.
+
+        Raises:
+            RuntimeError: If the context is not registered or event IPC is
+                unsupported.
+        """
+        if (
+            self._mq_client is None
+            or self._send_request is None
+            or self._device is None
+            or self._event_backend is None
+        ):
             raise RuntimeError(
                 "LMCache-driven transfer context is not registered. "
                 "Call register() before submit_retrieve()."
             )
+        event_ipc_handle = self._event_backend.export_event(event, self._device)
         return self._send_request(
             self._mq_client,
             RequestType.RETRIEVE,
-            [key, instance_id, block_ids, event.ipc_handle(), skip_first_n_tokens],
-        ).to_cuda_future()
+            [key, instance_id, block_ids, event_ipc_handle, skip_first_n_tokens],
+        ).to_device_future(device=self._device)
 
     def close(self) -> None:
+        """Release the message queue and cached event-backend state."""
         self._mq_client = None
         self._send_request = None
+        self._device = None
+        self._event_backend = None
 
     def flush_inflight_stores(self) -> None:
         pass

--- a/lmcache/v1/platform/base/device_spec.py
+++ b/lmcache/v1/platform/base/device_spec.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     # First Party
     from lmcache.v1.platform.base.cache_context import BaseCacheContext
     from lmcache.v1.platform.base.device_ops import DeviceOps
+    from lmcache.v1.platform.base.event_ipc import EventIPCBackend
     from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
 
 
@@ -124,6 +125,18 @@ class DeviceSpec:
         """Return ``True`` when the device is usable for handle transfer."""
         # TODO(chunxiaozheng): implement on subclasses
         return True
+
+    @property
+    def event_ipc_backend(self) -> "EventIPCBackend | None":
+        """Return the device-event IPC backend for this device, if supported.
+
+        Concrete device specifications must explicitly provide an event IPC
+        backend when they support cross-process event synchronization.
+
+        Returns:
+            The device's ``EventIPCBackend``, or ``None`` when unsupported.
+        """
+        return None
 
     @property
     def pin_memory_backend(self) -> type[PinMemoryBackend] | None:

--- a/lmcache/v1/platform/base/event_ipc.py
+++ b/lmcache/v1/platform/base/event_ipc.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform device-event IPC abstraction.
+
+The ``lmcache_driven`` multiprocess handle path orders cross-process KV-cache
+transfers with device events. Accelerators expose different event IPC ABIs.
+This module defines a small backend-neutral interface so generic MP code never
+imports a specific backend or branches on device type.
+
+Event, device, and stream values are intentionally typed as opaque ``object``
+handles: their concrete types differ per backend and generic code must not
+depend on any one of them. See
+``docs/design/v1/platform/base/event_ipc_abstraction.md``.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Protocol, runtime_checkable
+import inspect
+
+# First Party
+from lmcache import torch_dev, torch_device_type
+
+
+def _accepts_interprocess(event_cls: object) -> bool:
+    """Return whether ``event_cls`` accepts an ``interprocess`` parameter."""
+    for obj in (
+        event_cls,
+        getattr(event_cls, "__init__", None),
+        getattr(event_cls, "__new__", None),
+    ):
+        if obj is None:
+            continue
+        try:
+            signature = inspect.signature(obj)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if "interprocess" in signature.parameters:
+            return True
+    return False
+
+
+def _resolve_device_type(device: object) -> str:
+    """Resolve a device-type string from a device-like object.
+
+    Args:
+        device: A ``torch.device``-like object (has ``.type``), a device-type
+            string, or an integer device index.
+
+    Returns:
+        The device-type string. Integer indices use the active
+        ``torch_device_type`` for backend selection; the original integer is
+        still passed unchanged to backend operations by the caller.
+    """
+    if isinstance(device, int):
+        return torch_device_type
+    device_type = getattr(device, "type", None)
+    if isinstance(device_type, str):
+        return device_type
+    if isinstance(device, str):
+        return device.split(":", maxsplit=1)[0]
+    return str(device)
+
+
+@runtime_checkable
+class EventIPCBackend(Protocol):
+    """Backend-neutral device-event IPC operations.
+
+    Implementations serialize/deserialize device events across processes and
+    order stream work against them. ``check_event_support`` must raise before
+    any cross-process memory transfer when the backend cannot provide IPC
+    ordering (fail closed).
+    """
+
+    device_type: str
+
+    def check_event_support(self, device: object) -> None:
+        """Validate that event IPC is available for ``device``.
+
+        Args:
+            device: Device that will create or import IPC events.
+
+        Raises:
+            RuntimeError: If the backend cannot provide event IPC support.
+        """
+        ...
+
+    def create_event(self, device: object) -> object:
+        """Create an interprocess event on ``device``.
+
+        Args:
+            device: Device on which to create the event.
+
+        Returns:
+            A backend-native event object.
+        """
+        ...
+
+    def export_event(self, event: object, device: object) -> bytes:
+        """Serialize ``event`` for import by another process.
+
+        Args:
+            event: Backend-native event to export.
+            device: Device that owns the event.
+
+        Returns:
+            Serialized event handle.
+        """
+        ...
+
+    def import_event(self, handle: bytes, device: object) -> object:
+        """Import a serialized event handle on ``device``.
+
+        Args:
+            handle: Serialized event handle from another process.
+            device: Device on which to import the event.
+
+        Returns:
+            The imported backend-native event.
+        """
+        ...
+
+    def record_event(self, event: object, stream: object) -> None:
+        """Record ``event`` on ``stream``.
+
+        Args:
+            event: Backend-native event to record.
+            stream: Stream that should record the event.
+        """
+        ...
+
+    def wait_event(self, event: object, stream: object) -> None:
+        """Make ``stream`` wait for ``event``.
+
+        Args:
+            event: Backend-native event to wait for.
+            stream: Stream that should wait for the event.
+        """
+        ...
+
+    def query_event(self, event: object) -> bool:
+        """Return whether ``event`` has completed.
+
+        Args:
+            event: Backend-native event to query.
+
+        Returns:
+            ``True`` when the event has completed; otherwise ``False``.
+        """
+        ...
+
+    def synchronize_event(self, event: object, device: object) -> None:
+        """Block the host until ``event`` completes.
+
+        Args:
+            event: Backend-native event to synchronize.
+            device: Device that owns the event.
+        """
+        ...
+
+
+class DefaultEventIPCBackend:
+    """CUDA-style event IPC backend over an injectable event module.
+
+    Works for any backend whose ``Event`` class supports interprocess handles,
+    including the ``StubEvent`` used in CPU-only environments.
+
+    Args:
+        event_module: Object exposing an ``Event`` class that supports
+            ``Event(interprocess=True)``, ``ipc_handle()``,
+            ``from_ipc_handle(device, handle)``, ``record(stream)``,
+            ``wait(stream)``, ``query()`` and ``synchronize()``. Defaults to the
+            active ``torch_dev`` module; injectable for testing.
+        device_type: Device-type label used in error messages. Defaults to the
+            active ``torch_device_type``.
+    """
+
+    def __init__(
+        self,
+        event_module: object | None = None,
+        device_type: str | None = None,
+    ) -> None:
+        self._event_module = event_module if event_module is not None else torch_dev
+        self.device_type = device_type if device_type is not None else torch_device_type
+
+    def check_event_support(self, device: object) -> None:
+        """Raise ``RuntimeError`` if interprocess events are unsupported.
+
+        Args:
+            device: The target device (used only for the error message here).
+
+        Raises:
+            RuntimeError: If no ``Event`` class is available, it does not accept
+                ``interprocess=True``, or ``from_ipc_handle`` is missing.
+        """
+        event_cls = getattr(self._event_module, "Event", None)
+        if event_cls is None:
+            raise RuntimeError(
+                f"Device backend '{self.device_type}' does not support "
+                "interprocess events: no Event class is available."
+            )
+        if not _accepts_interprocess(event_cls):
+            raise RuntimeError(
+                f"Device backend '{self.device_type}' does not support "
+                "interprocess events: Event does not accept interprocess=True."
+            )
+        if not hasattr(event_cls, "from_ipc_handle"):
+            raise RuntimeError(
+                f"Device backend '{self.device_type}' does not support "
+                "interprocess event handles: Event.from_ipc_handle is missing."
+            )
+
+    def create_event(self, device: object) -> object:
+        """Create a new interprocess-capable event."""
+        return self._event_module.Event(interprocess=True)  # type: ignore[union-attr]
+
+    def export_event(self, event: object, device: object) -> bytes:
+        """Serialize ``event`` into a process-portable IPC handle."""
+        return event.ipc_handle()  # type: ignore[attr-defined]
+
+    def import_event(self, handle: bytes, device: object) -> object:
+        """Reconstruct an event from an IPC handle on ``device``."""
+        return self._event_module.Event.from_ipc_handle(  # type: ignore[union-attr]
+            device, handle
+        )
+
+    def record_event(self, event: object, stream: object) -> None:
+        """Record ``event`` on ``stream``."""
+        event.record(stream)  # type: ignore[attr-defined]
+
+    def wait_event(self, event: object, stream: object) -> None:
+        """Make ``stream`` wait for ``event``."""
+        event.wait(stream)  # type: ignore[attr-defined]
+
+    def query_event(self, event: object) -> bool:
+        """Return whether ``event`` has completed."""
+        return bool(event.query())  # type: ignore[attr-defined]
+
+    def synchronize_event(self, event: object, device: object) -> None:
+        """Block the host until ``event`` completes."""
+        event.synchronize()  # type: ignore[attr-defined]
+
+
+def get_event_ipc_backend(device: object) -> EventIPCBackend:
+    """Return the event IPC backend for ``device``'s device type.
+
+    Args:
+        device: A ``torch.device``-like object, a device-type string, or an
+            integer device index. Integer indices use the active
+            ``torch_device_type``.
+
+    Returns:
+        The registered ``EventIPCBackend`` for the resolved device type.
+
+    Raises:
+        RuntimeError: If the device type has no registered ``DeviceSpec`` or
+            its specification does not provide an event IPC backend.
+    """
+    device_type = _resolve_device_type(device)
+    # Platform subclass discovery can import this module before
+    # platform.__init__ has defined get_device_spec, so this import must stay
+    # lazy to avoid a circular-initialization failure.
+    # First Party
+    from lmcache.v1.platform import get_device_spec
+
+    spec = get_device_spec(device_type)
+    if spec is None:
+        raise RuntimeError(f"No DeviceSpec registered for device type {device_type!r}.")
+
+    backend = spec.event_ipc_backend
+    if backend is None:
+        raise RuntimeError(f"Device type {device_type!r} does not support event IPC.")
+    return backend

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     # First Party
     from lmcache.v1.platform.base.cache_context import BaseCacheContext
     from lmcache.v1.platform.base.device_ops import DeviceOps
+    from lmcache.v1.platform.base.event_ipc import EventIPCBackend
     from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
 
 
@@ -44,6 +45,8 @@ class CpuDeviceSpec(DeviceSpec):
     :func:`lmcache.v1.platform.cache_context.create_cache_context`).
     """
 
+    _event_backend_cache: "EventIPCBackend | None" = None
+
     @property
     def device_type(self) -> str:
         return "cpu"
@@ -51,6 +54,22 @@ class CpuDeviceSpec(DeviceSpec):
     @property
     def torch_module_name(self) -> str:
         return "cpu"
+
+    @property
+    def event_ipc_backend(self) -> "EventIPCBackend":
+        """Return the stub-backed CPU event IPC backend."""
+        backend = self._event_backend_cache
+        if backend is None:
+            # First Party
+            from lmcache.v1.platform.base.event_ipc import DefaultEventIPCBackend
+            from lmcache.v1.platform.cpu.stub_cpu_device import StubCPUDevice
+
+            backend = DefaultEventIPCBackend(
+                event_module=StubCPUDevice("cpu"),
+                device_type=self.device_type,
+            )
+            self._event_backend_cache = backend
+        return backend
 
     @property
     def ipc_wrapper_cls(self) -> type[DeviceIPCWrapper] | None:

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     # First Party
     from lmcache.v1.platform.base.cache_context import BaseCacheContext
     from lmcache.v1.platform.base.device_ops import DeviceOps
+    from lmcache.v1.platform.base.event_ipc import EventIPCBackend
     from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
 
 # ---------------------------------------------------------------------------
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
 
 class CudaDeviceSpec(DeviceSpec):
     """CUDA device specification for the detection registry."""
+
+    _event_backend_cache: "EventIPCBackend | None" = None
 
     @property
     def device_type(self) -> str:
@@ -40,6 +43,24 @@ class CudaDeviceSpec(DeviceSpec):
         from lmcache.v1.platform.cuda.device_ops import CudaDeviceOps
 
         return CudaDeviceOps
+
+    @property
+    def event_ipc_backend(self) -> "EventIPCBackend":
+        """Return the CUDA event IPC backend."""
+        backend = self._event_backend_cache
+        if backend is None:
+            # Third Party
+            import torch
+
+            # First Party
+            from lmcache.v1.platform.base.event_ipc import DefaultEventIPCBackend
+
+            backend = DefaultEventIPCBackend(
+                event_module=torch.cuda,
+                device_type=self.device_type,
+            )
+            self._event_backend_cache = backend
+        return backend
 
     @property
     def pin_memory_backend(self) -> type[PinMemoryBackend] | None:

--- a/lmcache/v1/platform/musa/__init__.py
+++ b/lmcache/v1/platform/musa/__init__.py
@@ -13,6 +13,7 @@ from lmcache.v1.platform.base.device_spec import DeviceSpec
 if TYPE_CHECKING:
     # First Party
     from lmcache.v1.platform.base.device_ops import DeviceOps
+    from lmcache.v1.platform.base.event_ipc import EventIPCBackend
     from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
 
 # ---------------------------------------------------------------------------
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
 
 class MusaDeviceSpec(DeviceSpec):
     """MUSA device specification for the detection registry."""
+
+    _event_backend_cache: "EventIPCBackend | None" = None
 
     @property
     def device_type(self) -> str:
@@ -62,3 +65,15 @@ class MusaDeviceSpec(DeviceSpec):
         )
 
         return is_musa_handle_transfer_available()
+
+    @property
+    def event_ipc_backend(self) -> "EventIPCBackend":
+        """Return the TorchMUSA event IPC backend."""
+        backend = self._event_backend_cache
+        if backend is None:
+            # First Party
+            from lmcache.v1.platform.musa.event_ipc import MusaEventIPCBackend
+
+            backend = MusaEventIPCBackend()
+            self._event_backend_cache = backend
+        return backend

--- a/lmcache/v1/platform/musa/event_ipc.py
+++ b/lmcache/v1/platform/musa/event_ipc.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA device-event IPC backend.
+
+The MUSA capability gate and TorchMUSA module loading stay in this platform
+package. Generic multiprocess code depends only on
+:class:`lmcache.v1.platform.base.event_ipc.EventIPCBackend`.
+"""
+
+# Standard
+from typing import Any
+
+# First Party
+from lmcache.v1.platform.base.event_ipc import (
+    DefaultEventIPCBackend,
+    EventIPCBackend,
+)
+
+
+class MusaEventIPCBackend:
+    """Event IPC backend backed by TorchMUSA interprocess events."""
+
+    device_type: str = "musa"
+
+    def __init__(self, ipc_module: Any | None = None) -> None:
+        """Create a MUSA event IPC backend.
+
+        Args:
+            ipc_module: Optional adapter exposing the MUSA capability and module
+                helpers from ``platform.musa.ipc_wrapper``. It is injectable for
+                tests.
+        """
+        self._ipc_module = ipc_module
+        self._default_backend_cache: DefaultEventIPCBackend | None = None
+
+    def _ipc(self) -> Any:
+        """Return the MUSA IPC wrapper module, importing it lazily."""
+        if self._ipc_module is None:
+            # First Party
+            from lmcache.v1.platform.musa import ipc_wrapper
+
+            self._ipc_module = ipc_wrapper
+        return self._ipc_module
+
+    def _default_backend(self) -> DefaultEventIPCBackend:
+        """Return a default event adapter bound to the TorchMUSA module.
+
+        Returns:
+            A CUDA-style event adapter using the current TorchMUSA event API.
+
+        Raises:
+            RuntimeError: If TorchMUSA cannot be loaded.
+        """
+        backend = self._default_backend_cache
+        if backend is not None:
+            return backend
+
+        get_torch_musa_module = getattr(self._ipc(), "get_torch_musa_module", None)
+        if not callable(get_torch_musa_module):
+            raise RuntimeError("MUSA event IPC requires the TorchMUSA module")
+        torch_musa = get_torch_musa_module()
+        if torch_musa is None:
+            raise RuntimeError("MUSA event IPC requires the TorchMUSA module")
+        backend = DefaultEventIPCBackend(
+            event_module=torch_musa,
+            device_type=self.device_type,
+        )
+        self._default_backend_cache = backend
+        return backend
+
+    def check_event_support(self, device: object) -> None:
+        """Fail closed unless MUSA handle and event IPC are available.
+
+        Args:
+            device: Target MUSA device.
+
+        Raises:
+            RuntimeError: If the MUSA handle path or TorchMUSA event API is
+                unavailable.
+        """
+        is_available = getattr(self._ipc(), "is_musa_handle_transfer_available", None)
+        if not callable(is_available) or not is_available():
+            raise RuntimeError(
+                "Device backend 'musa' does not support interprocess events: "
+                "MUSA handle transfer is unavailable."
+            )
+        try:
+            self._default_backend().check_event_support(device)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"Device backend 'musa' does not support interprocess events: {exc}"
+            ) from exc
+
+    def create_event(self, device: object) -> object:
+        """Create a TorchMUSA interprocess event."""
+        return self._default_backend().create_event(device)
+
+    def export_event(self, event: object, device: object) -> bytes:
+        """Serialize a TorchMUSA event for another process."""
+        return self._default_backend().export_event(event, device)
+
+    def import_event(self, handle: bytes, device: object) -> object:
+        """Import a TorchMUSA event handle on ``device``."""
+        return self._default_backend().import_event(handle, device)
+
+    def record_event(self, event: object, stream: object) -> None:
+        """Record an event on a TorchMUSA stream."""
+        self._default_backend().record_event(event, stream)
+
+    def wait_event(self, event: object, stream: object) -> None:
+        """Make a TorchMUSA stream wait for an event."""
+        self._default_backend().wait_event(event, stream)
+
+    def query_event(self, event: object) -> bool:
+        """Return whether a TorchMUSA event has completed."""
+        return self._default_backend().query_event(event)
+
+    def synchronize_event(self, event: object, device: object) -> None:
+        """Block the host until a TorchMUSA event completes."""
+        self._default_backend().synchronize_event(event, device)
+
+
+assert isinstance(MusaEventIPCBackend(), EventIPCBackend)

--- a/tests/v1/multiprocess/test_cache_server.py
+++ b/tests/v1/multiprocess/test_cache_server.py
@@ -199,7 +199,7 @@ def store_keys(
             [key, instance_id, [block_ids], event.ipc_handle()],
             get_response_class(RequestType.STORE),
         )
-        result = future.to_cuda_future().result(timeout=timeout)
+        result = future.to_device_future().result(timeout=timeout)
         assert result is True, f"Store should succeed for key {i}"
 
 
@@ -222,7 +222,7 @@ def retrieve_keys(
             [key, instance_id, [block_ids], event.ipc_handle(), 0],
             get_response_class(RequestType.RETRIEVE),
         )
-        result = future.to_cuda_future().result(timeout=timeout)
+        result = future.to_device_future().result(timeout=timeout)
         results.append(result)
     return results
 
@@ -487,7 +487,7 @@ def test_store_fails_closed_on_incomplete_block_ids(
             ],
             get_response_class(RequestType.STORE),
         )
-        .to_cuda_future()
+        .to_device_future()
         .result(timeout=DEFAULT_TIMEOUT)
     )
     assert result is False, "Store should fail closed (skip) on a short list"

--- a/tests/v1/multiprocess/test_event_ipc_handle_path.py
+++ b/tests/v1/multiprocess/test_event_ipc_handle_path.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for platform event IPC use in the LMCache-driven handle path."""
+
+# Standard
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+from typing import Any, Iterator, cast
+from unittest.mock import MagicMock
+import inspect
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.multiprocess.futures import DeviceMessagingFuture, MessagingFuture
+from lmcache.v1.multiprocess.protocol import RequestType
+
+
+class _FakeEventBackend:
+    """Record event backend calls while returning opaque fake events."""
+
+    device_type = "fake"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self._next_event = 0
+
+    def check_event_support(self, device: object) -> None:
+        self.calls.append(("check", device))
+
+    def create_event(self, device: object) -> object:
+        event = ("local", self._next_event)
+        self._next_event += 1
+        self.calls.append(("create", device, event))
+        return event
+
+    def export_event(self, event: object, device: object) -> bytes:
+        self.calls.append(("export", event, device))
+        return b"completion-handle"
+
+    def import_event(self, handle: bytes, device: object) -> object:
+        event = ("remote", handle)
+        self.calls.append(("import", handle, device, event))
+        return event
+
+    def record_event(self, event: object, stream: object) -> None:
+        self.calls.append(("record", event, stream))
+
+    def wait_event(self, event: object, stream: object) -> None:
+        self.calls.append(("wait", event, stream))
+
+    def query_event(self, event: object) -> bool:
+        self.calls.append(("query", event))
+        return True
+
+    def synchronize_event(self, event: object, device: object) -> None:
+        self.calls.append(("synchronize", event, device))
+
+
+class _WorkerEvent:
+    """Worker event without a direct ``ipc_handle`` method."""
+
+    def wait(self, stream: object | None = None) -> None:
+        return None
+
+
+class _NoopDispatcher:
+    """Avoid starting native callback threads in the server unit test."""
+
+    def register(self, kind: str, handler: object, payload_type: object) -> None:
+        return None
+
+    def start(self) -> None:
+        return None
+
+
+class _FakeStorageManager:
+    """Minimal storage surface used by the server handle-path test."""
+
+    def finish_write(self, keys: list[object]) -> None:
+        return None
+
+    def finish_read_prefetched(self, keys: list[object]) -> None:
+        return None
+
+    def reserve_write(
+        self,
+        keys: list[object],
+        layout: object,
+        mode: str,
+    ) -> dict[object, object]:
+        return {}
+
+    @contextmanager
+    def read_prefetched_results(self, keys: list[object]) -> Iterator[list[object]]:
+        yield []
+
+
+def _resolved_future(result: object) -> MessagingFuture[object]:
+    """Return a messaging future already resolved to ``result``."""
+    future: MessagingFuture[object] = MessagingFuture()
+    future.set_result(result)
+    return future
+
+
+def test_worker_exports_events_through_platform_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Store and retrieve send backend-exported handles and keep device context."""
+    # First Party
+    from lmcache.integration.vllm import vllm_multi_process_adapter
+    from lmcache.v1.multiprocess.transfer_context import worker_transfer
+
+    backend = _FakeEventBackend()
+    monkeypatch.setattr(
+        worker_transfer,
+        "get_event_ipc_backend",
+        lambda device: backend,
+    )
+    monkeypatch.setattr(
+        vllm_multi_process_adapter,
+        "wrap_kv_caches",
+        lambda kv_caches: list(kv_caches.values()),
+    )
+
+    sent: list[tuple[RequestType, list[object]]] = []
+
+    def send_request(
+        _client: object,
+        request_type: RequestType,
+        payload: list[object],
+    ) -> MessagingFuture:
+        sent.append((request_type, payload))
+        if request_type == RequestType.REGISTER_KV_CACHE:
+            return _resolved_future(True)
+        return MessagingFuture()
+
+    context = worker_transfer.LMCacheDrivenTransferContext()
+    kv_caches = {"layer_0": torch.empty(1)}
+    context.register(
+        1,
+        kv_caches,
+        "model",
+        1,
+        1,
+        MagicMock(),
+        1.0,
+        send_request,
+    )
+
+    store_future = context.submit_store(
+        "request",
+        "key",
+        1,
+        kv_caches,
+        [[0]],
+        _WorkerEvent(),
+        1,
+    )
+    retrieve_future = context.submit_retrieve(
+        "request",
+        "key",
+        1,
+        kv_caches,
+        [[0]],
+        _WorkerEvent(),
+        1,
+        skip_first_n_tokens=2,
+    )
+
+    assert isinstance(store_future, DeviceMessagingFuture)
+    assert isinstance(retrieve_future, DeviceMessagingFuture)
+    assert sent[1] == (
+        RequestType.STORE,
+        ["key", 1, [[0]], b"completion-handle"],
+    )
+    assert sent[2] == (
+        RequestType.RETRIEVE,
+        ["key", 1, [[0]], b"completion-handle", 2],
+    )
+    assert [call[0] for call in backend.calls] == [
+        "check",
+        "export",
+        "export",
+    ]
+    assert all(call[-1] == torch.device("cpu") for call in backend.calls)
+
+
+def test_server_store_and_retrieve_delegate_event_ordering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Server imports, waits, records, and exports through the event backend."""
+    # First Party
+    from lmcache.v1.multiprocess.modules import lmcache_driven_transfer
+
+    backend = _FakeEventBackend()
+
+    def unexpected_backend_lookup(_device: object) -> _FakeEventBackend:
+        raise AssertionError("server should reuse the registered event backend")
+
+    monkeypatch.setattr(
+        lmcache_driven_transfer,
+        "get_event_ipc_backend",
+        unexpected_backend_lookup,
+    )
+    monkeypatch.setattr(
+        lmcache_driven_transfer,
+        "DeviceHostFuncDispatcher",
+        _NoopDispatcher,
+    )
+    monkeypatch.setattr(
+        lmcache_driven_transfer,
+        "downsample_and_stage_block_ids",
+        lambda cache_context, block_ids: block_ids,
+    )
+    monkeypatch.setattr(
+        lmcache_driven_transfer,
+        "get_layout_desc",
+        lambda cache_context, num_tokens, object_group_id: object(),
+    )
+    monkeypatch.setattr(
+        lmcache_driven_transfer,
+        "transfer_kv_per_object_group",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        lmcache_driven_transfer.torch_dev,
+        "device",
+        lambda device: nullcontext(),
+    )
+    monkeypatch.setattr(
+        lmcache_driven_transfer.torch_dev,
+        "stream",
+        lambda stream: nullcontext(),
+    )
+
+    storage_manager = _FakeStorageManager()
+    server_context = SimpleNamespace(
+        chunk_size=1,
+        storage_manager=storage_manager,
+        event_bus=SimpleNamespace(
+            publish=lambda event: None,
+            publish_on_stream=lambda stream, event: None,
+        ),
+        resolve_obj_keys=lambda key, group_ids: [[]],
+    )
+    module = lmcache_driven_transfer.LMCacheDrivenTransferModule(
+        cast(Any, server_context)
+    )
+    cache_context = SimpleNamespace(
+        device=torch.device("cpu"),
+        stream="transfer-stream",
+        cupy_stream="cupy-stream",
+        max_batch_size=1,
+        kv_layer_groups_manager=SimpleNamespace(
+            num_object_groups=1,
+            num_kernel_groups=1,
+        ),
+        calculate_num_blocks=lambda chunk_size, group_idx: 1,
+    )
+    entry = lmcache_driven_transfer.ContextEntry(
+        cache_context=cast(Any, cache_context),
+        model_name="model",
+        world_size=1,
+        event_backend=cast(Any, backend),
+    )
+    monkeypatch.setattr(
+        module,
+        "get_and_touch_context_entry",
+        lambda instance_id: entry,
+    )
+    key = SimpleNamespace(request_id="request", cache_salt="")
+
+    assert module.store(key, 1, [[]], b"store-producer") == (
+        b"completion-handle",
+        True,
+    )
+    assert module.retrieve(key, 1, [[]], b"retrieve-producer") == (
+        b"completion-handle",
+        False,
+    )
+
+    imported_handles = [call[1] for call in backend.calls if call[0] == "import"]
+    waited_handles = [call[1][1] for call in backend.calls if call[0] == "wait"]
+    assert imported_handles == [b"store-producer", b"retrieve-producer"]
+    assert waited_handles == [b"store-producer", b"retrieve-producer"]
+    assert sum(call[0] == "record" for call in backend.calls) == 2
+    assert sum(call[0] == "export" for call in backend.calls) == 2
+    for index, call in enumerate(backend.calls):
+        if call[0] == "export":
+            assert backend.calls[index - 1][0] == "record"
+
+
+def test_handle_path_has_no_musa_specific_imports_or_branches() -> None:
+    """The scoped multiprocess modules remain backend-neutral."""
+    # First Party
+    from lmcache.v1.multiprocess import futures
+    from lmcache.v1.multiprocess.modules import lmcache_driven_transfer
+    from lmcache.v1.multiprocess.transfer_context import worker_transfer
+
+    for module in (futures, lmcache_driven_transfer, worker_transfer):
+        source = inspect.getsource(module)
+        assert "lmcache.v1.platform.musa" not in source
+        assert 'device.type == "musa"' not in source

--- a/tests/v1/multiprocess/test_futures.py
+++ b/tests/v1/multiprocess/test_futures.py
@@ -407,7 +407,7 @@ def test_cuda_messaging_future_result_timeout_reached():
 
     # Try to get result with timeout (result never set)
     with pytest.raises(
-        TimeoutError, match="CUDAMessagingFuture result not available within timeout"
+        TimeoutError, match="DeviceMessagingFuture result not available within timeout"
     ):
         cuda_future.result(timeout=0.2)
 
@@ -521,9 +521,9 @@ def test_cuda_messaging_future_complex_type():
     not torch.cuda.is_available(),
     reason="CUDA is required for CUDAMessagingFuture tests",
 )
-def test_messaging_future_to_cuda_future():
-    """Test converting MessagingFuture to CUDAMessagingFuture
-    using to_cuda_future method.
+def test_messaging_future_to_device_future():
+    """Test converting MessagingFuture to DeviceMessagingFuture
+    using to_device_future method.
     """
     torch.cuda.init()
 
@@ -539,18 +539,18 @@ def test_messaging_future_to_cuda_future():
 
     raw_future = MessagingFuture[tuple[bytes, int]]()
 
-    # Convert to CUDA future
-    cuda_future = raw_future.to_cuda_future()
+    # Convert to device future
+    device_future = raw_future.to_device_future()
 
     # Verify it's a CUDAMessagingFuture instance
-    assert isinstance(cuda_future, CUDAMessagingFuture), (
-        "to_cuda_future should return CUDAMessagingFuture instance"
+    assert isinstance(device_future, CUDAMessagingFuture), (
+        "to_device_future should return DeviceMessagingFuture instance"
     )
 
     # Set result and verify it works
     raw_future.set_result((event_bytes, 999))
 
-    result = cuda_future.result()
+    result = device_future.result()
     assert result == 999, f"Expected result 999, got {result}"
 
 
@@ -584,3 +584,103 @@ def test_cuda_messaging_future_with_explicit_device():
     # Get result
     result = cuda_future.result()
     assert result == "explicit device", f"Expected 'explicit device', got {result}"
+
+
+# ==============================================================================
+# Device-neutral future wiring (no CUDA required)
+# ==============================================================================
+
+
+def test_cuda_future_is_alias_of_device_future():
+    # First Party
+    from lmcache.v1.multiprocess.futures import (
+        CUDAMessagingFuture,
+        DeviceMessagingFuture,
+    )
+
+    assert CUDAMessagingFuture is DeviceMessagingFuture
+
+
+def test_to_cuda_future_returns_device_future_instance():
+    # First Party
+    from lmcache.v1.multiprocess.futures import DeviceMessagingFuture
+
+    raw = MessagingFuture()
+    with pytest.warns(DeprecationWarning, match="to_device_future"):
+        fut = raw.to_cuda_future(device="cpu")
+    assert isinstance(fut, DeviceMessagingFuture)
+
+
+def test_device_future_stub_end_to_end():
+    # First Party
+    from lmcache.v1.multiprocess.futures import DeviceMessagingFuture
+
+    raw = MessagingFuture[tuple[bytes, int]]()
+    fut = DeviceMessagingFuture.FromMessagingFuture(raw, device="cpu")
+    assert not fut.query()
+    raw.set_result((b"stub_ipc_handle", 7))
+    assert fut.wait() is True
+    assert fut.result() == 7
+    assert fut.query() is True
+
+
+def test_device_future_delegates_to_backend(monkeypatch):
+    # First Party
+    from lmcache.v1.multiprocess.futures import DeviceMessagingFuture
+
+    calls = []
+
+    class _FakeBackend:
+        device_type = "fake"
+
+        def check_event_support(self, device):
+            calls.append(("check", device))
+
+        def import_event(self, handle, device):
+            calls.append(("import", handle, device))
+            return "EVT"
+
+        def synchronize_event(self, event, device):
+            calls.append(("sync", event, device))
+
+        def query_event(self, event):
+            calls.append(("query", event))
+            return True
+
+    monkeypatch.setattr(
+        "lmcache.v1.multiprocess.futures.get_event_ipc_backend",
+        lambda device=None: _FakeBackend(),
+    )
+
+    raw = MessagingFuture[tuple[bytes, int]]()
+    fut = DeviceMessagingFuture.FromMessagingFuture(raw, device="dev")
+    raw.set_result((b"h", 99))
+    assert fut.wait() is True
+    assert fut.result() == 99
+    assert ("check", "dev") in calls
+    assert ("import", b"h", "dev") in calls
+    assert any(c[0] == "sync" for c in calls)
+
+
+def test_device_future_checks_backend_support_during_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsupported event IPC fails before the future enters the wait path."""
+    # First Party
+    from lmcache.v1.multiprocess.futures import DeviceMessagingFuture
+
+    class _UnsupportedBackend:
+        device_type = "fake"
+
+        def check_event_support(self, device: object) -> None:
+            raise RuntimeError("event IPC unavailable")
+
+    monkeypatch.setattr(
+        "lmcache.v1.multiprocess.futures.get_event_ipc_backend",
+        lambda device=None: _UnsupportedBackend(),
+    )
+
+    with pytest.raises(RuntimeError, match="event IPC unavailable"):
+        DeviceMessagingFuture.FromMessagingFuture(
+            MessagingFuture[tuple[bytes, int]](), device="dev"
+        )

--- a/tests/v1/multiprocess/test_ipc_memory_reclaim.py
+++ b/tests/v1/multiprocess/test_ipc_memory_reclaim.py
@@ -10,7 +10,8 @@ All tests drive the module through its public surface: the real constructor,
 ``register_kv_cache`` (with the module-level context factory stubbed),
 ``unregister_kv_cache`` / ``reap_stale_instances`` / ``close``, and
 ``context_entries_snapshot`` for reads. The stubbed boundaries are external
-by nature: the GPU context factory and the device module (``torch_dev``).
+by nature: the GPU context factory, event IPC backend lookup, and the device
+module (``torch_dev``).
 """
 
 # Standard
@@ -68,7 +69,13 @@ def _register(
     """
     cache_context = MagicMock(name=f"cache_context-{instance_id}")
     cache_context.num_layers = 1
+    event_backend = MagicMock(name=f"event_backend-{instance_id}")
     monkeypatch.setattr(gpu_mod, "create_cache_context", lambda *a, **kw: cache_context)
+    monkeypatch.setattr(
+        gpu_mod,
+        "get_event_ipc_backend",
+        lambda device: event_backend,
+    )
     monkeypatch.setattr(gpu_mod, "get_layout_desc", lambda *a, **kw: MagicMock())
     real_monotonic = time.monotonic
     if age_s:

--- a/tests/v1/multiprocess/test_lmcache_driven_layout_registry.py
+++ b/tests/v1/multiprocess/test_lmcache_driven_layout_registry.py
@@ -28,6 +28,7 @@ class _FakeKVLayerGroupsManager:
 class _FakeGPUContext:
     """Small stand-in for GPUCacheContext used by registration tests."""
 
+    device: torch.device = torch.device("cpu")
     num_layers: int = 2
     kv_layer_groups_manager: _FakeKVLayerGroupsManager = _FakeKVLayerGroupsManager()
 

--- a/tests/v1/multiprocess/test_worker_liveness.py
+++ b/tests/v1/multiprocess/test_worker_liveness.py
@@ -57,8 +57,18 @@ def _bare_non_gpu_module() -> EngineDrivenTransferModule:
     return module
 
 
+def _stub_gpu_registration_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub Event IPC lookup for liveness tests unrelated to event handling."""
+    monkeypatch.setattr(
+        gpu_mod,
+        "get_event_ipc_backend",
+        MagicMock(return_value=MagicMock(name="event_backend")),
+    )
+
+
 def test_gpu_register_inserts_unlatched_entry(monkeypatch) -> None:
     """register_kv_cache inserts an entry that is not yet ping-proven."""
+    _stub_gpu_registration_backend(monkeypatch)
     monkeypatch.setattr(
         gpu_mod, "create_cache_context", lambda *a, **kw: MagicMock(num_layers=2)
     )
@@ -75,6 +85,7 @@ def test_gpu_register_inserts_unlatched_entry(monkeypatch) -> None:
 def test_gpu_noop_register_refreshes_without_latching(monkeypatch) -> None:
     """Re-registering a known instance refreshes last_seen but does not
     rebuild the context or latch the ping-proven flag."""
+    _stub_gpu_registration_backend(monkeypatch)
     create = MagicMock(return_value=MagicMock(num_layers=2))
     monkeypatch.setattr(gpu_mod, "create_cache_context", create)
     monkeypatch.setattr(gpu_mod, "get_layout_desc", lambda *a, **kw: MagicMock())

--- a/tests/v1/platform/test_event_ipc.py
+++ b/tests/v1/platform/test_event_ipc.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import inspect
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache import torch_device_type
+from lmcache.v1.platform.base.device_spec import DeviceSpec
+from lmcache.v1.platform.base.event_ipc import (
+    DefaultEventIPCBackend,
+    EventIPCBackend,
+    get_event_ipc_backend,
+)
+from lmcache.v1.platform.cpu import CpuDeviceSpec
+from lmcache.v1.platform.cuda import CudaDeviceSpec
+import lmcache.v1.platform as platform
+
+
+class _FakeEvent:
+    def __init__(self, interprocess: bool = False) -> None:
+        self.interprocess = interprocess
+        self.calls: list[tuple] = []
+
+    def ipc_handle(self) -> bytes:
+        return b"handle-bytes"
+
+    @classmethod
+    def from_ipc_handle(cls, device, handle):
+        ev = cls(interprocess=True)
+        ev.calls.append(("from_ipc_handle", device, handle))
+        return ev
+
+    def record(self, stream=None):
+        self.calls.append(("record", stream))
+
+    def wait(self, stream=None):
+        self.calls.append(("wait", stream))
+
+    def query(self) -> bool:
+        return True
+
+    def synchronize(self) -> None:
+        self.calls.append(("synchronize",))
+
+
+class _FakeEventModule:
+    Event = _FakeEvent
+
+
+class _NoInterprocessEvent:
+    def __init__(self) -> None:  # no interprocess parameter
+        pass
+
+    @classmethod
+    def from_ipc_handle(cls, device, handle):
+        return cls()
+
+
+class _NoInterprocessModule:
+    Event = _NoInterprocessEvent
+
+
+class _Device:
+    def __init__(self, type_: str) -> None:
+        self.type = type_
+
+
+class _FakeDeviceSpec:
+    def __init__(self, backend: EventIPCBackend | None) -> None:
+        self.event_ipc_backend = backend
+
+
+def test_default_backend_create_export_import_delegate():
+    backend = DefaultEventIPCBackend(
+        event_module=_FakeEventModule(), device_type="fake"
+    )
+    event = backend.create_event(_Device("fake"))
+    assert isinstance(event, _FakeEvent) and event.interprocess is True
+    assert backend.export_event(event, _Device("fake")) == b"handle-bytes"
+    imported = backend.import_event(b"h", _Device("fake"))
+    assert (
+        "from_ipc_handle",
+        _is_device := imported.calls[0][1],
+        b"h",
+    ) == imported.calls[0]
+
+
+def test_default_backend_record_wait_query_synchronize_delegate():
+    backend = DefaultEventIPCBackend(
+        event_module=_FakeEventModule(), device_type="fake"
+    )
+    event = backend.create_event(_Device("fake"))
+    backend.record_event(event, "STREAM")
+    backend.wait_event(event, "STREAM")
+    assert backend.query_event(event) is True
+    backend.synchronize_event(event, _Device("fake"))
+    assert ("record", "STREAM") in event.calls
+    assert ("wait", "STREAM") in event.calls
+    assert ("synchronize",) in event.calls
+
+
+def test_check_event_support_raises_with_device_name_when_no_interprocess():
+    backend = DefaultEventIPCBackend(
+        event_module=_NoInterprocessModule(), device_type="weirddev"
+    )
+    with pytest.raises(RuntimeError, match="weirddev"):
+        backend.check_event_support(_Device("weirddev"))
+
+
+def test_check_event_support_passes_for_capable_module():
+    backend = DefaultEventIPCBackend(
+        event_module=_FakeEventModule(), device_type="fake"
+    )
+    backend.check_event_support(_Device("fake"))  # must not raise
+
+
+def test_get_event_ipc_backend_resolves_cpu_to_default():
+    backend = get_event_ipc_backend(_Device("cpu"))
+    assert isinstance(backend, EventIPCBackend)
+    assert isinstance(backend, DefaultEventIPCBackend)
+
+
+def test_get_event_ipc_backend_requires_device() -> None:
+    signature = inspect.signature(get_event_ipc_backend)
+    assert signature.parameters["device"].default is inspect.Parameter.empty
+
+
+def test_get_event_ipc_backend_accepts_string_device_type():
+    assert isinstance(get_event_ipc_backend("cpu"), DefaultEventIPCBackend)
+
+
+@pytest.mark.parametrize(
+    ("device", "expected_device_type"),
+    [
+        pytest.param(0, torch_device_type, id="integer-index"),
+        pytest.param(2, torch_device_type, id="nonzero-integer-index"),
+        pytest.param("cuda:0", "cuda", id="indexed-cuda-string"),
+        pytest.param("musa:3", "musa", id="indexed-musa-string"),
+    ],
+)
+def test_get_event_ipc_backend_normalizes_indexed_devices(
+    monkeypatch: pytest.MonkeyPatch,
+    device: object,
+    expected_device_type: str,
+) -> None:
+    """Backend lookup uses the base type for integer and indexed devices."""
+    backend = DefaultEventIPCBackend(
+        event_module=_FakeEventModule(), device_type="fake"
+    )
+    resolved_device_types: list[str] = []
+
+    def fake_get_device_spec(device_type: str) -> _FakeDeviceSpec:
+        resolved_device_types.append(device_type)
+        return _FakeDeviceSpec(backend)
+
+    monkeypatch.setattr(platform, "get_device_spec", fake_get_device_spec)
+
+    assert get_event_ipc_backend(device) is backend
+    assert resolved_device_types == [expected_device_type]
+
+
+def test_get_event_ipc_backend_rejects_unregistered_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unregistered device is a platform configuration error."""
+    monkeypatch.setattr(platform, "get_device_spec", lambda device_type: None)
+
+    with pytest.raises(
+        RuntimeError,
+        match="No DeviceSpec registered for device type 'unregistered'",
+    ):
+        get_event_ipc_backend("unregistered:0")
+
+
+def test_get_event_ipc_backend_rejects_unsupported_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registered device must explicitly provide event IPC support."""
+    monkeypatch.setattr(
+        platform,
+        "get_device_spec",
+        lambda device_type: _FakeDeviceSpec(None),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Device type 'unsupported' does not support event IPC",
+    ):
+        get_event_ipc_backend("unsupported")
+
+
+def test_get_event_ipc_backend_cpu_uses_stub_when_accelerator_is_active() -> None:
+    """Explicit CPU lookups do not use the active accelerator event module."""
+    backend = get_event_ipc_backend("cpu")
+    backend.check_event_support("cpu")
+    event = backend.create_event("cpu")
+
+    assert backend.export_event(event, "cpu") == b"stub_ipc_handle"
+
+
+def test_device_spec_does_not_expose_event_backend() -> None:
+    spec = DeviceSpec()
+    assert spec.event_ipc_backend is None
+
+
+def test_cpu_device_spec_exposes_cached_default_event_backend() -> None:
+    spec = CpuDeviceSpec()
+    assert isinstance(spec.event_ipc_backend, DefaultEventIPCBackend)
+    assert spec.event_ipc_backend is spec.event_ipc_backend
+
+
+def test_cuda_device_spec_exposes_cached_default_event_backend() -> None:
+    spec = CudaDeviceSpec()
+    assert isinstance(spec.event_ipc_backend, DefaultEventIPCBackend)
+    assert spec.event_ipc_backend.device_type == "cuda"
+    assert spec.event_ipc_backend is spec.event_ipc_backend
+
+
+def test_default_backend_stub_end_to_end():
+    # Uses the real active torch_dev (StubCPUDevice/StubEvent) via the default.
+    backend = get_event_ipc_backend("cpu")
+    backend.check_event_support("cpu")
+    event = backend.create_event("cpu")
+    handle = backend.export_event(event, "cpu")
+    assert isinstance(handle, bytes)
+    remote = backend.import_event(handle, "cpu")
+    backend.record_event(event, None)
+    assert backend.query_event(remote) is True
+    backend.synchronize_event(remote, "cpu")
+
+
+def test_protocol_signatures_match_default_backend():
+    proto_methods = {
+        "check_event_support",
+        "create_event",
+        "export_event",
+        "import_event",
+        "record_event",
+        "wait_event",
+        "query_event",
+        "synchronize_event",
+    }
+    for name in proto_methods:
+        assert callable(getattr(DefaultEventIPCBackend, name))
+        assert inspect.signature(getattr(DefaultEventIPCBackend, name)) is not None

--- a/tests/v1/platform/test_musa_event_ipc.py
+++ b/tests/v1/platform/test_musa_event_ipc.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from typing import Any
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform.base.event_ipc import EventIPCBackend
+from lmcache.v1.platform.musa import MusaDeviceSpec, ipc_wrapper
+from lmcache.v1.platform.musa.event_ipc import MusaEventIPCBackend
+
+
+class _UnavailableIPC:
+    def is_musa_handle_transfer_available(self) -> bool:
+        return False
+
+
+class _AvailableIPC:
+    """Fake MUSA IPC wrapper exposing a TorchMUSA-style Event API."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+        self.torch_musa_module_calls = 0
+
+    def is_musa_handle_transfer_available(self) -> bool:
+        return True
+
+    def get_torch_musa_module(self) -> object:
+        self.torch_musa_module_calls += 1
+        outer = self
+
+        class _Event:
+            def __init__(
+                self,
+                interprocess: bool = False,
+                *,
+                imported: bool = False,
+            ) -> None:
+                if not imported:
+                    outer.calls.append(("create", interprocess))
+
+            @classmethod
+            def from_ipc_handle(cls, device: object, handle: bytes) -> "_Event":
+                outer.calls.append(("import", device, handle))
+                return cls(imported=True)
+
+            def ipc_handle(self) -> bytes:
+                outer.calls.append(("export", self))
+                return b"musa-handle"
+
+            def record(self, stream: object | None = None) -> None:
+                outer.calls.append(("record", self, stream))
+
+            def wait(self, stream: object | None = None) -> None:
+                outer.calls.append(("wait", self, stream))
+
+            def query(self) -> bool:
+                outer.calls.append(("query", self))
+                return True
+
+            def synchronize(self) -> None:
+                outer.calls.append(("synchronize", self))
+
+        class _MusaModule:
+            Event = _Event
+
+        return _MusaModule()
+
+
+class _Device:
+    def __init__(self, type_: str, index: int | None = None) -> None:
+        self.type = type_
+        self.index = index
+
+
+def test_musa_backend_is_event_ipc_backend() -> None:
+    """MUSA exposes the generic event IPC contract."""
+    assert isinstance(
+        MusaEventIPCBackend(ipc_module=_UnavailableIPC()), EventIPCBackend
+    )
+    assert MusaEventIPCBackend(ipc_module=_UnavailableIPC()).device_type == "musa"
+
+
+def test_check_event_support_fails_closed_when_unavailable() -> None:
+    """Unavailable MUSA handle transfer fails before event creation."""
+    backend = MusaEventIPCBackend(ipc_module=_UnavailableIPC())
+    with pytest.raises(RuntimeError, match="musa"):
+        backend.check_event_support(_Device("musa", 0))
+
+
+def test_check_event_support_fails_closed_when_module_missing() -> None:
+    """A missing TorchMUSA module fails the capability check."""
+
+    class _AvailableWithoutModule:
+        def is_musa_handle_transfer_available(self) -> bool:
+            return True
+
+    backend = MusaEventIPCBackend(ipc_module=_AvailableWithoutModule())
+    with pytest.raises(RuntimeError, match="TorchMUSA"):
+        backend.check_event_support(_Device("musa", 0))
+
+
+def test_event_operations_delegate_to_torch_musa() -> None:
+    """MUSA operations use the TorchMUSA interprocess Event API."""
+    ipc = _AvailableIPC()
+    backend = MusaEventIPCBackend(ipc_module=ipc)
+    device = _Device("musa", 1)
+
+    backend.check_event_support(device)
+    event = backend.create_event(device)
+    assert backend.export_event(event, device) == b"musa-handle"
+    remote = backend.import_event(b"musa-handle", device)
+    backend.record_event(event, "STREAM")
+    backend.wait_event(remote, "STREAM")
+    assert backend.query_event(remote) is True
+    backend.synchronize_event(remote, device)
+
+    assert [call[0] for call in ipc.calls] == [
+        "create",
+        "export",
+        "import",
+        "record",
+        "wait",
+        "query",
+        "synchronize",
+    ]
+    assert ("import", device, b"musa-handle") in ipc.calls
+    assert ipc.torch_musa_module_calls == 1
+
+
+def test_default_backend_loads_ipc_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production backend resolves the current MUSA IPC wrapper module."""
+    ipc = _AvailableIPC()
+    monkeypatch.setattr(
+        ipc_wrapper,
+        "is_musa_handle_transfer_available",
+        ipc.is_musa_handle_transfer_available,
+    )
+    monkeypatch.setattr(
+        ipc_wrapper,
+        "get_torch_musa_module",
+        ipc.get_torch_musa_module,
+    )
+
+    backend = MusaEventIPCBackend()
+    backend.check_event_support(_Device("musa", 0))
+    event = backend.create_event(_Device("musa", 0))
+
+    assert backend.export_event(event, _Device("musa", 0)) == b"musa-handle"
+    assert ipc.torch_musa_module_calls == 1
+
+
+def test_musa_device_spec_returns_musa_backend() -> None:
+    """The MUSA device specification owns its event backend."""
+    backend = MusaDeviceSpec().event_ipc_backend
+    assert isinstance(backend, MusaEventIPCBackend)


### PR DESCRIPTION
## What this PR does / why we need it

This PR introduces a platform-level event IPC abstraction for the LMCache-driven multiprocess handle path.

- Adds `EventIPCBackend`, a CUDA-style default implementation, and `DeviceSpec`-based backend lookup.
- Adds a fail-closed MUSA backend using the current TorchMUSA interprocess `Event` API through `platform/musa/ipc_wrapper.py`.
- Routes server-side store/retrieve event creation, import, wait, record, and export through the platform backend.
- Routes worker-side producer-event export through the platform backend.
- Generalizes `CUDAMessagingFuture` to `DeviceMessagingFuture` while preserving the `CUDAMessagingFuture` and `to_cuda_future()` compatibility aliases.
- Ensures retrieve operations wait for the worker producer event before writing KV-cache blocks.
- Records completion events before exporting their handles.
- Preserves the existing message wire format.
- Binds default event backends to the torch module declared by the requested `DeviceSpec`, rather than whichever accelerator is globally active.

This removes backend-specific event handling from the LMCache-driven multiprocess path. Additional accelerators can provide safe event IPC implementations without adding device-specific imports or branches to generic multiprocess code.

## Special notes for reviewers

- MUSA support remains explicitly opt-in and capability-gated.
- MUSA fails closed unless handle transfer and the required TorchMUSA interprocess `Event` API are available.
- The MUSA backend follows the latest `dev` platform structure and uses `platform/musa/ipc_wrapper.py`.
- The implementation no longer depends on the removed native `musa_aiter` event helper interface or Stage4 native event helpers.
- Generic LMCache-driven multiprocess modules do not import MUSA packages or branch on the MUSA device type.
- Worker-side event construction and initial recording in integration adapters remain unchanged.
- Focused validation completed with 96 tests passing and 13 platform-specific tests skipped.
- Ruff, formatting, isort, codespell, SPDX checks, clang-format, and mypy pass.

## If applicable

- [x] This PR contains user-facing changes — docs added
- [x] This PR contains unit tests