### PR TITLE
chore(hfbucket): move type-only imports under TYPE_CHECKING (#3730)

### DIFF
--- a/lmcache/v1/storage_backend/connector/hfbucket_connector.py
+++ b/lmcache/v1/storage_backend/connector/hfbucket_connector.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 # Standard
-from collections.abc import Sequence
 from copy import copy
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 from urllib.parse import quote, unquote
 import asyncio
-import builtins
 import os
 import shutil
 import tempfile
@@ -24,12 +22,19 @@ import huggingface_hub
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey
-from lmcache.v1.config import LMCacheEngineConfig
-from lmcache.v1.memory_management import MemoryObj
-from lmcache.v1.metadata import LMCacheMetadata
 from lmcache.v1.storage_backend.connector.base_connector import RemoteConnector
-from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+
+if TYPE_CHECKING:
+    # Standard
+    from collections.abc import Sequence
+    import builtins
+
+    # First Party
+    from lmcache.utils import CacheEngineKey
+    from lmcache.v1.config import LMCacheEngineConfig
+    from lmcache.v1.memory_management import MemoryObj
+    from lmcache.v1.metadata import LMCacheMetadata
+    from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
### Summary

Part of the good-first-issue #3730 cleanup: move type-only imports under a
`TYPE_CHECKING` guard in `lmcache/v1/storage_backend/connector/hfbucket_connector.py`.

The module already has `from __future__ import annotations`, so all annotations
are strings (PEP 563) and these names are never needed at runtime. `ruff --select TC`
flagged 7 imports here that are used exclusively in type annotations:

- **stdlib**: `collections.abc.Sequence`, `builtins`
- **first-party**: `CacheEngineKey`, `LMCacheEngineConfig`, `MemoryObj`, `LMCacheMetadata`, `LocalCPUBackend`

`init_logger` and `RemoteConnector` (the base class) stay as regular imports since
they are used at runtime.

### Verification

```
ruff check --select TC lmcache/v1/storage_backend/connector/hfbucket_connector.py   # All checks passed!
ruff check           lmcache/v1/storage_backend/connector/hfbucket_connector.py     # All checks passed!
python -m py_compile  lmcache/v1/storage_backend/connector/hfbucket_connector.py     # OK
```

No functional change — imports only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
