### PR TITLE
[good-first-issue] cleanup: Move type-only imports under TYPE_CHECKIN…

### DIFF
--- a/lmcache/v1/distributed/serde/factory.py
+++ b/lmcache/v1/distributed/serde/factory.py
@@ -13,21 +13,24 @@ in L2 adapter configs:
 """
 
 # Standard
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.distributed.serde.base import SerdeConfig, SerdeProcessor
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.serde.base import SerdeConfig, SerdeProcessor
 
 logger = init_logger(__name__)
 
 # name -> factory(kwargs) -> SerdeProcessor.
 # Factories receive the type-specific kwargs (everything except "type").
-_SERDE_FACTORY_REGISTRY: dict[str, Callable[[dict[str, object]], SerdeProcessor]] = {}
+_SERDE_FACTORY_REGISTRY: dict[str, Callable[[dict[str, object]], "SerdeProcessor"]] = {}
 
 
 def register_serde_factory(
-    name: str, factory: Callable[[dict[str, object]], SerdeProcessor]
+    name: str, factory: Callable[[dict[str, object]], "SerdeProcessor"]
 ) -> None:
     """Register a serde factory under a type name.
 
@@ -49,7 +52,7 @@ def get_registered_serde_types() -> list[str]:
     return list(_SERDE_FACTORY_REGISTRY)
 
 
-def create_serde_processor(config: SerdeConfig) -> SerdeProcessor:
+def create_serde_processor(config: "SerdeConfig") -> "SerdeProcessor":
     """Build a SerdeProcessor from a SerdeConfig.
 
     Args:

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -53,7 +53,6 @@ from lmcache.v1.platform import (
     create_event_notifier,
 )
 
-
 if TYPE_CHECKING:
     # First Party
     from lmcache.v1.memory_management import MemoryObj

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -173,7 +173,7 @@ class InFlightPrefetchRequest:
     load_results: dict[int, Bitmap] = field(default_factory=dict)
     # Load phase: keys that were write-reserved in L1
     write_reserved_keys: list[ObjectKey] = field(default_factory=list)
-    write_reserved_objs: dict[ObjectKey, MemoryObj] = field(default_factory=dict)
+    write_reserved_objs: dict[ObjectKey, "MemoryObj"] = field(default_factory=dict)
 
     def all_lookups_done(self) -> bool:
         return len(self.pending_lookup_tasks) == 0

--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -15,7 +15,7 @@ The controller runs a background thread with an event-driven loop that:
 # Standard
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 import enum
 import select
 import threading
@@ -45,7 +45,6 @@ from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
 )
-from lmcache.v1.memory_management import MemoryObj
 from lmcache.v1.mp_observability.event import Event, EventType
 from lmcache.v1.mp_observability.event_bus import get_event_bus
 from lmcache.v1.mp_observability.otel_init import register_gauge
@@ -53,6 +52,11 @@ from lmcache.v1.platform import (
     consume_fd,
     create_event_notifier,
 )
+
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.memory_management import MemoryObj
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -1,14 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 # Third Party
 import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 
 logger = init_logger(__name__)
 
@@ -63,7 +66,7 @@ class LMCacheMetadata:
     :class:`KVLayerGroupsManager`. Consumers must guard against ``None``
     when accessed before registration.
     """
-    kv_layer_groups_manager: Optional[KVLayerGroupsManager] = None
+    kv_layer_groups_manager: Optional["KVLayerGroupsManager"] = None
     """ engine_id for RPC path (used by lookup client/server) """
     engine_id: Optional[str] = None
     """ extra config from kv_connector (e.g., lmcache_rpc_port) """

--- a/lmcache/v1/protocol.py
+++ b/lmcache/v1/protocol.py
@@ -2,7 +2,7 @@
 # Standard
 from dataclasses import dataclass
 from enum import IntEnum, auto
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 import struct
 
 # Third Party
@@ -10,8 +10,13 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.utils import CacheEngineKey, LayerCacheEngineKey, parse_cache_key
+from lmcache.utils import parse_cache_key
 from lmcache.v1.memory_management import MemoryFormat
+
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.utils import CacheEngineKey, LayerCacheEngineKey
 
 logger = init_logger(__name__)
 
@@ -214,7 +219,7 @@ class ClientMetaMessage:
     """
 
     command: ClientCommand
-    key: Union[CacheEngineKey, LayerCacheEngineKey]
+    key: Union["CacheEngineKey", "LayerCacheEngineKey"]
     length: int
     fmt: MemoryFormat
     dtype: Optional[torch.dtype]

--- a/lmcache/v1/protocol.py
+++ b/lmcache/v1/protocol.py
@@ -13,7 +13,6 @@ from lmcache.logging import init_logger
 from lmcache.utils import parse_cache_key
 from lmcache.v1.memory_management import MemoryFormat
 
-
 if TYPE_CHECKING:
     # First Party
     from lmcache.utils import CacheEngineKey, LayerCacheEngineKey


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #3730
Refs #3372

Moves imports that are used only for type annotations under `TYPE_CHECKING` blocks
in four files:

- `lmcache/v1/metadata.py` — `KVLayerGroupsManager`
- `lmcache/v1/protocol.py` — `CacheEngineKey`, `LayerCacheEngineKey`
- `lmcache/v1/distributed/storage_controllers/prefetch_controller.py` — `MemoryObj`
- `lmcache/v1/distributed/serde/factory.py` — `SerdeConfig`, `SerdeProcessor`

**Special notes for your reviewers**:
- This is my first PR to LMCache 🙇
- Ran `ruff check` and `ruff format` — all green.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests