### PR TITLE
docs: daily drift check — multi-process mode (2026-07-11)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -456,6 +456,22 @@ logging, tracing).
    * - ``--prometheus-port``
      - ``9090``
      - Port for the Prometheus ``/metrics`` endpoint.
+   * - ``--metrics-sample-rate``
+     - ``0.01``
+     - Fraction of chunks/blocks to track for lifecycle histograms
+       (``(0, 1.0]``). Counters always count every event regardless of this
+       setting.
+   * - ``--trace-level``
+     - *(none)*
+     - Enable trace recording at the given level. Currently only
+       ``storage`` is supported (records ``StorageManager`` public-API calls
+       for offline replay via ``lmcache trace``). When unset, trace recording
+       is off. Choices: ``storage``.
+   * - ``--trace-output``
+     - *(none)*
+     - Path to write the trace file. If omitted while ``--trace-level`` is
+       set, a timestamped file under ``$TMPDIR`` is minted
+       (``lmcache-trace-<pid>-<UTC>.lct``) and its path is logged at INFO.
 
 vLLM Client Configuration
 --------------------------


### PR DESCRIPTION
## Summary

Daily automated drift check between `docs/source/mp/` and MP-mode code
turned up one inconsistency today, in
[`docs/source/mp/configuration.rst`](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/docs/source/mp/configuration.rst).

That page opens (line 4) by promising to document "**every CLI argument
accepted by the LMCache multiprocess server**", but its Observability
table omits three flags that `add_observability_args()` in
[`lmcache/v1/mp_observability/config.py`](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/lmcache/v1/mp_observability/config.py)
actually registers:

| Flag | Default | Registered at |
| --- | --- | --- |
| `--metrics-sample-rate` | `0.01` | [`mp_observability/config.py` L158-166](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/lmcache/v1/mp_observability/config.py#L158-L166) |
| `--trace-level` | *(none)* | [`mp_observability/config.py` L207-214](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/lmcache/v1/mp_observability/config.py#L207-L214) |
| `--trace-output` | *(none)* | [`mp_observability/config.py` L215-222](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/lmcache/v1/mp_observability/config.py#L215-L222) |

The gap is also self-contradictory: the same page's "Full Example"
already uses `--metrics-sample-rate 0.01` (see
[`configuration.rst` L612](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/docs/source/mp/configuration.rst#L612))
on a flag the page never actually defines. `--trace-level` /
`--trace-output` are similarly used in
[`docs/source/mp/observability/traces.rst`](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/docs/source/mp/observability/traces.rst#L101-L129)
without being listed in the Configuration Reference.

### `docs/source/`

- **`docs/source/mp/configuration.rst`** — Observability list missing
  `--metrics-sample-rate`, `--trace-level`, `--trace-output`. Wording of
  the added rows is aligned with the argparse help strings and with
  [`docs/source/mp/observability/index.rst`](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/docs/source/mp/observability/index.rst#L248-L262)
  so the two pages stay consistent.

### `docs/design/`

- No drift found today.

## Proposed fix

Applied in this PR — three new rows in the Observability table of
`docs/source/mp/configuration.rst`, matching the language already used
in `mp/observability/index.rst`.

## Not fixed here (flagged for follow-up)

While cross-checking `lmcache.mp.mp_transfer_mode`, I noticed the
connector docstrings in
[`lmcache/integration/vllm/lmcache_mp_connector_0180.py`](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/lmcache/integration/vllm/lmcache_mp_connector_0180.py#L455-L459)
and
[`lmcache/integration/vllm/lmcache_mp_connector_0201.py`](https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/lmcache/integration/vllm/lmcache_mp_connector_0201.py#L476-L480)
describe `mp_transfer_mode="auto"` as "CUDA → engine_driven, others →
lmcache_driven" and swap the meaning of the two forced modes. That is
the opposite of what the canonical `MPTransferMode` enum says
([`v1/multiprocess/transfer_context/worker_transfer.py`
L108-L122](``https://github.com/LMCache/LMCache/blob/2756b828e86e94c18662037bb4a0c24b9de1bf13/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L108-L122``))
and what `docs/source/mp/configuration.rst` documents. This looks like a
**code-comment bug**, not a doc bug, so per the drift-check charter this
PR does not touch it — flagging here so a maintainer can update the two
connector docstrings.

## Test plan

- [ ] Sphinx builds `docs/source/mp/configuration.rst` without warnings.
- [ ] Rendered Observability table shows the three new rows immediately
      after `--prometheus-port`, before the vLLM Client Configuration
      section.

---

_Auto-generated by the daily docs drift-check routine. This is a draft;
please review before merging — no automated merge._


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pu8S72M497eiicVmizdQ49)_