### PR TITLE
[Misc] NIXL L2 connector, Optimized nixl l2 dynamic connector

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
@@ -103,6 +103,7 @@ class DynamicNixlStorageAgent:
         self.backend_params = backend_params
         self.l1_align_bytes = l1_memory_desc.align_bytes
         self.file_path = backend_params["file_path"]
+        self.devId = 0
         os.makedirs(self.file_path, exist_ok=True)
         self.use_direct_io = (
             str(backend_params.get("use_direct_io", "false")).lower() == "true"
@@ -143,27 +144,55 @@ class DynamicNixlStorageAgent:
 
     # ---- Per-operation file helpers ----
 
-    def _open_flags(self, create: bool) -> int:
-        """Return os.open flags for storage files."""
-        flags = os.O_RDWR
+    def _generate_file_path_string(self, file_path: str, create: bool) -> str:
+        """Return the NIXL path-mode string for a storage file."""
+        flags = ["rw"]
         if create:
-            # O_TRUNC ensures any orphaned file from a previous crash
-            # is truncated, avoiding stale trailing bytes on disk.
-            flags |= os.O_CREAT | os.O_TRUNC
-        if self.use_direct_io and hasattr(os, "O_DIRECT"):
-            flags |= os.O_DIRECT
-        return flags
+            flags.append("create")
+        if self.use_direct_io:
+            flags.append("direct")
+        return f"{','.join(flags)}:{file_path}"
 
-    def _register_single_file(self, fd: int, file_size: int, page_size: int):
+    def _register_files(self, file_info_tuples: list[tuple[str, int]], page_size: int):
+        """Register files with nixl and return (reg_descs, xfer_handler).
+
+        Returns:
+            Tuple of (reg_descs, xfer_handler) for later cleanup.
+        """
+        reg_list = []
+        xfer_desc = []
+        
+        for file_path_mode, file_size in file_info_tuples:
+            self.devId += 1  # unique device ID for each file registration
+            num_pages = file_size // page_size
+            
+            reg_list.append((0, file_size, self.devId, file_path_mode))
+            xfer_desc.extend([
+                (offset * page_size, page_size, self.devId) for offset in range(num_pages)
+            ])
+
+        reg_descs = self.nixl_agent.register_memory(reg_list, mem_type="FILE")
+        xfer_descs = self.nixl_agent.get_xfer_descs(xfer_desc, mem_type="FILE")
+        xfer_handler = self.nixl_agent.prep_xfer_dlist(
+            self.agent_name, xfer_descs, mem_type="FILE"
+        )
+        return reg_descs, xfer_handler
+
+    def _register_single_file(
+        self, file_path_mode: str, file_size: int, page_size: int
+    ):
         """Register a single file with nixl and return (reg_descs, xfer_handler).
 
         Returns:
             Tuple of (reg_descs, xfer_handler) for later cleanup.
         """
         num_pages = file_size // page_size
+        self.devId += 1  # unique device ID for each file registration
 
-        reg_list = [(0, file_size, fd, "")]
-        xfer_desc = [(offset * page_size, page_size, fd) for offset in range(num_pages)]
+        reg_list = [(0, file_size, self.devId, file_path_mode)]
+        xfer_desc = [
+            (offset * page_size, page_size, self.devId) for offset in range(num_pages)
+        ]
 
         reg_descs = self.nixl_agent.register_memory(reg_list, mem_type="FILE")
         xfer_descs = self.nixl_agent.get_xfer_descs(xfer_desc, mem_type="FILE")
@@ -193,66 +222,56 @@ class DynamicNixlStorageAgent:
         """
         file_size = len(mem_indices) * page_size
         tmp_path = f"{file_path}.tmp.{uuid.uuid4().hex}"
-        fd = os.open(tmp_path, self._open_flags(create=True))
+        file_path_mode = self._generate_file_path_string(tmp_path, create=True)
+        reg_descs, xfer_handler = self._register_single_file(
+            file_path_mode, file_size, page_size
+        )
         try:
-            reg_descs, xfer_handler = self._register_single_file(
-                fd, file_size, page_size
+            storage_indices = list(range(len(mem_indices)))
+            handle = self.nixl_agent.make_prepped_xfer(
+                "WRITE",
+                self.mem_xfer_handler,
+                mem_indices,
+                xfer_handler,
+                storage_indices,
             )
-            try:
-                storage_indices = list(range(len(mem_indices)))
-                handle = self.nixl_agent.make_prepped_xfer(
-                    "WRITE",
-                    self.mem_xfer_handler,
-                    mem_indices,
-                    xfer_handler,
-                    storage_indices,
-                )
-                await self._post_non_blocking(handle)
-                self.nixl_agent.release_xfer_handle(handle)
-            finally:
-                self._deregister_file(reg_descs, xfer_handler)
-        except BaseException:
-            # Best-effort cleanup of the temp file on failure.
-            try:
-                os.unlink(tmp_path)
-            except FileNotFoundError:
-                pass
-            raise
+            await self._post_non_blocking(handle)
+            self.nixl_agent.release_xfer_handle(handle)
         finally:
-            os.close(fd)
+            self._deregister_file(reg_descs, xfer_handler)
 
         # Atomic publish: readers only ever see a complete file at file_path.
         # TODO(Jiayi): Only guaranteed to be atomic within the local posix filesystems.
         os.rename(tmp_path, file_path)
 
-    async def dynamic_load_file(
+    async def dynamic_load_files(
         self,
-        mem_indices: list[int],
-        file_path: str,
+        file_mem_indices_tuples: list[tuple[str, list[int]]],
         page_size: int,
     ) -> None:
         """Open an existing file, DMA read into L1 memory, then clean up."""
-        file_size = len(mem_indices) * page_size
-        fd = os.open(file_path, self._open_flags(create=False))
+        file_info_tuples = []
+
+        for file_path, mem_indices in file_mem_indices_tuples:
+            file_size = len(mem_indices) * page_size
+            file_path_mode = self._generate_file_path_string(file_path, create=False)
+            file_info_tuples.append((file_path_mode, file_size))
+
+        reg_descs, xfer_handler = self._register_files(file_info_tuples, page_size)
         try:
-            reg_descs, xfer_handler = self._register_single_file(
-                fd, file_size, page_size
+            aggregate_mem_indices = [idx for _, mem_indices in file_mem_indices_tuples for idx in mem_indices]
+            storage_indices = list(range(sum(len(mem_indices) for _, mem_indices in file_mem_indices_tuples)))
+            handle = self.nixl_agent.make_prepped_xfer(
+                "READ",
+                self.mem_xfer_handler,
+                aggregate_mem_indices,
+                xfer_handler,
+                storage_indices,
             )
-            try:
-                storage_indices = list(range(len(mem_indices)))
-                handle = self.nixl_agent.make_prepped_xfer(
-                    "READ",
-                    self.mem_xfer_handler,
-                    mem_indices,
-                    xfer_handler,
-                    storage_indices,
-                )
-                await self._post_non_blocking(handle)
-                self.nixl_agent.release_xfer_handle(handle)
-            finally:
-                self._deregister_file(reg_descs, xfer_handler)
+            await self._post_non_blocking(handle)
+            self.nixl_agent.release_xfer_handle(handle)
         finally:
-            os.close(fd)
+            self._deregister_file(reg_descs, xfer_handler)
 
     def dynamic_delete_file(self, file_path: str) -> None:
         """Delete a storage file from disk."""
@@ -735,6 +754,8 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         """Load each found key from its file via dynamic DMA read."""
         bitmap = Bitmap(len(keys))
         accessed_keys: list[ObjectKey] = []
+        file_mem_indices_tuples: list[tuple[str, list[int]]] = []
+        
         try:
             for i, key in enumerate(keys):
                 with self._lock:
@@ -747,15 +768,17 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
                 mem_indices = self.nixl_agent.get_memory_indices(mem_addr, mem_size)
                 file_path = self.nixl_agent.get_file_path_for_key(key)
 
-                await self.nixl_agent.dynamic_load_file(
-                    mem_indices, file_path, self.nixl_agent.l1_align_bytes
-                )
-
+                file_mem_indices_tuples.append((file_path, mem_indices))
                 bitmap.set(i)
                 accessed_keys.append(key)
 
         except Exception:
             logger.exception("Dynamic NIXL load task %d failed", task_id)
+
+        await self.nixl_agent.dynamic_load_files(
+            file_mem_indices_tuples, self.nixl_agent.l1_align_bytes
+        )
+
 
         if accessed_keys:
             self._notify_keys_accessed(accessed_keys)

--- a/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_dynamic_l2_adapter.py
@@ -161,38 +161,18 @@ class DynamicNixlStorageAgent:
         """
         reg_list = []
         xfer_desc = []
-        
+
         for file_path_mode, file_size in file_info_tuples:
             self.devId += 1  # unique device ID for each file registration
             num_pages = file_size // page_size
-            
+
             reg_list.append((0, file_size, self.devId, file_path_mode))
-            xfer_desc.extend([
-                (offset * page_size, page_size, self.devId) for offset in range(num_pages)
-            ])
-
-        reg_descs = self.nixl_agent.register_memory(reg_list, mem_type="FILE")
-        xfer_descs = self.nixl_agent.get_xfer_descs(xfer_desc, mem_type="FILE")
-        xfer_handler = self.nixl_agent.prep_xfer_dlist(
-            self.agent_name, xfer_descs, mem_type="FILE"
-        )
-        return reg_descs, xfer_handler
-
-    def _register_single_file(
-        self, file_path_mode: str, file_size: int, page_size: int
-    ):
-        """Register a single file with nixl and return (reg_descs, xfer_handler).
-
-        Returns:
-            Tuple of (reg_descs, xfer_handler) for later cleanup.
-        """
-        num_pages = file_size // page_size
-        self.devId += 1  # unique device ID for each file registration
-
-        reg_list = [(0, file_size, self.devId, file_path_mode)]
-        xfer_desc = [
-            (offset * page_size, page_size, self.devId) for offset in range(num_pages)
-        ]
+            xfer_desc.extend(
+                [
+                    (offset * page_size, page_size, self.devId)
+                    for offset in range(num_pages)
+                ]
+            )
 
         reg_descs = self.nixl_agent.register_memory(reg_list, mem_type="FILE")
         xfer_descs = self.nixl_agent.get_xfer_descs(xfer_desc, mem_type="FILE")
@@ -206,43 +186,84 @@ class DynamicNixlStorageAgent:
         self.nixl_agent.release_dlist_handle(xfer_handler)
         self.nixl_agent.deregister_memory(reg_descs)
 
-    async def dynamic_store_file(
+    async def dynamic_store_files(
         self,
-        mem_indices: list[int],
-        file_path: str,
+        file_mem_indices_tuples: list[tuple[str, list[int]]],
         page_size: int,
     ) -> None:
-        """Write-to-temp-then-rename to publish the final file atomically.
+        """Store multiple L1 objects with one file registration and transfer.
 
-        The DMA write goes to ``<file_path>.tmp.<uuid>`` in the same
-        directory. Only after the transfer completes successfully is the
-        temp file atomically renamed to the final path, ensuring that
-        concurrent readers (including other processes sharing the same
-        directory) never observe a partially-written file.
+        Each DMA write targets a ``<file_path>.tmp.<uuid>`` file in the same
+        directory. All temporary files are registered together and written by
+        one aggregate transfer. After the transfer succeeds, each temporary
+        file is atomically renamed to its final path so readers never observe
+        partially written data.
+
+        Args:
+            file_mem_indices_tuples: Final file paths paired with the L1 page
+                indices containing each object's data.
+            page_size: Size in bytes of each registered memory page.
+
+        Raises:
+            Exception: If file registration, transfer, cleanup, or publication
+                fails. The original backend or filesystem exception is
+                propagated.
         """
-        file_size = len(mem_indices) * page_size
-        tmp_path = f"{file_path}.tmp.{uuid.uuid4().hex}"
-        file_path_mode = self._generate_file_path_string(tmp_path, create=True)
-        reg_descs, xfer_handler = self._register_single_file(
-            file_path_mode, file_size, page_size
-        )
-        try:
-            storage_indices = list(range(len(mem_indices)))
-            handle = self.nixl_agent.make_prepped_xfer(
-                "WRITE",
-                self.mem_xfer_handler,
-                mem_indices,
-                xfer_handler,
-                storage_indices,
-            )
-            await self._post_non_blocking(handle)
-            self.nixl_agent.release_xfer_handle(handle)
-        finally:
-            self._deregister_file(reg_descs, xfer_handler)
+        if not file_mem_indices_tuples:
+            return
 
-        # Atomic publish: readers only ever see a complete file at file_path.
-        # TODO(Jiayi): Only guaranteed to be atomic within the local posix filesystems.
-        os.rename(tmp_path, file_path)
+        tmp_final_path_pairs = [
+            (f"{file_path}.tmp.{uuid.uuid4().hex}", file_path)
+            for file_path, _ in file_mem_indices_tuples
+        ]
+        file_info_tuples = [
+            (
+                self._generate_file_path_string(tmp_path, create=True),
+                len(mem_indices) * page_size,
+            )
+            for (tmp_path, _), (_, mem_indices) in zip(
+                tmp_final_path_pairs, file_mem_indices_tuples, strict=True
+            )
+        ]
+
+        try:
+            reg_descs, xfer_handler = self._register_files(file_info_tuples, page_size)
+            try:
+                aggregate_mem_indices = [
+                    idx
+                    for _, mem_indices in file_mem_indices_tuples
+                    for idx in mem_indices
+                ]
+                storage_indices = list(range(len(aggregate_mem_indices)))
+                handle = self.nixl_agent.make_prepped_xfer(
+                    "WRITE",
+                    self.mem_xfer_handler,
+                    aggregate_mem_indices,
+                    xfer_handler,
+                    storage_indices,
+                )
+                try:
+                    await self._post_non_blocking(handle)
+                finally:
+                    self.nixl_agent.release_xfer_handle(handle)
+            finally:
+                self._deregister_file(reg_descs, xfer_handler)
+
+            for tmp_path, file_path in tmp_final_path_pairs:
+                # TODO(Jiayi): Only guaranteed to be atomic within local POSIX
+                # filesystems.
+                os.rename(tmp_path, file_path)
+        except Exception:
+            for tmp_path, _ in tmp_final_path_pairs:
+                try:
+                    os.unlink(tmp_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as error:
+                    logger.warning(
+                        "Failed to remove temporary file %s: %s", tmp_path, error
+                    )
+            raise
 
     async def dynamic_load_files(
         self,
@@ -259,8 +280,14 @@ class DynamicNixlStorageAgent:
 
         reg_descs, xfer_handler = self._register_files(file_info_tuples, page_size)
         try:
-            aggregate_mem_indices = [idx for _, mem_indices in file_mem_indices_tuples for idx in mem_indices]
-            storage_indices = list(range(sum(len(mem_indices) for _, mem_indices in file_mem_indices_tuples)))
+            aggregate_mem_indices = [
+                idx for _, mem_indices in file_mem_indices_tuples for idx in mem_indices
+            ]
+            storage_indices = list(
+                range(
+                    sum(len(mem_indices) for _, mem_indices in file_mem_indices_tuples)
+                )
+            )
             handle = self.nixl_agent.make_prepped_xfer(
                 "READ",
                 self.mem_xfer_handler,
@@ -611,14 +638,27 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         objects: list[MemoryObj],
         task_id: L2TaskId,
     ) -> None:
-        """Store each key-object pair to its own file via dynamic DMA write."""
+        """Store key-object pairs with one dynamic file registration and write."""
         success = True
         stored_keys: list[ObjectKey] = []
         stored_sizes: list[int] = []
+        pending_stores: list[tuple[ObjectKey, NixlStoreObj]] = []
+        file_mem_indices_tuples: list[tuple[str, list[int]]] = []
         try:
             for key, obj in zip(keys, objects, strict=False):
                 mem_addr = obj.meta.address
                 mem_size = obj.meta.phy_size
+                mem_indices = self.nixl_agent.get_memory_indices(mem_addr, mem_size)
+                file_path = self.nixl_agent.get_file_path_for_key(key)
+                store_obj = NixlStoreObj(
+                    page_indices=[],  # not used in dynamic mode
+                    size=mem_size,
+                    layout=MemoryLayoutDesc(
+                        [obj.meta.shape],
+                        [obj.meta.dtype],
+                    ),
+                    pin_count=1,
+                )
 
                 # Reserve the key and capacity under the lock *before*
                 # the DMA write so that concurrent coroutines (other
@@ -635,38 +675,30 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
                     self._inflight_stores.add(key)
                     self._total_bytes += mem_size
 
-                try:
-                    mem_indices = self.nixl_agent.get_memory_indices(mem_addr, mem_size)
-                    file_path = self.nixl_agent.get_file_path_for_key(key)
+                pending_stores.append((key, store_obj))
+                file_mem_indices_tuples.append((file_path, mem_indices))
 
-                    await self.nixl_agent.dynamic_store_file(
-                        mem_indices, file_path, self.nixl_agent.l1_align_bytes
-                    )
+            if pending_stores:
+                await self.nixl_agent.dynamic_store_files(
+                    file_mem_indices_tuples, self.nixl_agent.l1_align_bytes
+                )
 
-                    store_obj = NixlStoreObj(
-                        page_indices=[],  # not used in dynamic mode
-                        size=mem_size,
-                        layout=MemoryLayoutDesc(
-                            [obj.meta.shape],
-                            [obj.meta.dtype],
-                        ),
-                        pin_count=1,
-                    )
-                    with self._lock:
+                with self._lock:
+                    for key, store_obj in pending_stores:
                         self._inflight_stores.discard(key)
                         self._memory_objects[key] = store_obj
                         store_obj.decrease_pin_count()
-                    stored_keys.append(key)
-                    stored_sizes.append(mem_size)
-                except Exception:
-                    # Un-reserve on failure so capacity accounting
-                    # stays correct.
-                    with self._lock:
-                        self._inflight_stores.discard(key)
-                        self._total_bytes -= mem_size
-                    raise
+                        stored_keys.append(key)
+                        stored_sizes.append(store_obj.size)
 
         except Exception:
+            # Un-reserve the entire batch on failure so capacity accounting
+            # stays correct.
+            with self._lock:
+                for key, store_obj in pending_stores:
+                    if key in self._inflight_stores:
+                        self._inflight_stores.remove(key)
+                        self._total_bytes -= store_obj.size
             logger.exception("Dynamic NIXL store task %d failed", task_id)
             success = False
 
@@ -755,7 +787,7 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         bitmap = Bitmap(len(keys))
         accessed_keys: list[ObjectKey] = []
         file_mem_indices_tuples: list[tuple[str, list[int]]] = []
-        
+
         try:
             for i, key in enumerate(keys):
                 with self._lock:
@@ -778,7 +810,6 @@ class DynamicNixlStoreL2Adapter(L2AdapterInterface):
         await self.nixl_agent.dynamic_load_files(
             file_mem_indices_tuples, self.nixl_agent.l1_align_bytes
         )
-
 
         if accessed_keys:
             self._notify_keys_accessed(accessed_keys)

--- a/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
@@ -270,6 +270,44 @@ class TestStoreInterface:
         expected_file = os.path.join(tmp_dir, _object_key_to_filename(key))
         assert os.path.exists(expected_file)
 
+    def test_store_multiple_objects_in_one_task(self, adapter):
+        adpt, buf, tmp_dir = adapter
+        keys = [create_object_key(1), create_object_key(2)]
+        objects = [
+            create_memory_obj(buf, page_index=0, fill_value=11.0),
+            create_memory_obj(buf, page_index=1, fill_value=22.0),
+        ]
+
+        task_id = adpt.submit_store_task(keys, objects)
+        assert wait_for_event_fd(adpt.get_store_event_fd())
+
+        completed = adpt.pop_completed_store_tasks()
+        assert completed[task_id].is_successful()
+        assert completed[task_id].bytes_transferred() == 2 * PAGE_SIZE
+        for key in keys:
+            expected_file = os.path.join(tmp_dir, _object_key_to_filename(key))
+            assert os.path.getsize(expected_file) == PAGE_SIZE
+
+        lookup_task = adpt.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
+        assert wait_for_event_fd(adpt.get_lookup_and_lock_event_fd())
+        lookup_result = adpt.query_lookup_and_lock_result(lookup_task)
+        assert lookup_result is not None
+        assert all(lookup_result.test(i) for i in range(len(keys)))
+
+        load_objects = [
+            create_memory_obj(buf, page_index=2, fill_value=0.0),
+            create_memory_obj(buf, page_index=3, fill_value=0.0),
+        ]
+        load_task = adpt.submit_load_task(keys, load_objects)
+        assert wait_for_event_fd(adpt.get_load_event_fd())
+        load_result = adpt.query_load_result(load_task)
+        assert load_result is not None
+        assert all(load_result.test(i) for i in range(len(keys)))
+        assert torch.all(buf[2 * PAGE_SIZE : 3 * PAGE_SIZE].view(torch.float32) == 11.0)
+        assert torch.all(buf[3 * PAGE_SIZE : 4 * PAGE_SIZE].view(torch.float32) == 22.0)
+
+        adpt.submit_unlock(keys)
+
     def test_submit_multiple_store_tasks_unique_ids(self, adapter):
         adpt, buf, _ = adapter
         key1 = create_object_key(1)
@@ -392,6 +430,27 @@ class TestLoadInterface:
         assert result2 is None
 
         adpt.submit_unlock([key])
+
+    def test_load_missing_file_does_not_recreate_it(self, adapter):
+        adpt, buf, tmp_dir = adapter
+        key = create_object_key(1)
+        store_obj = create_memory_obj(buf, page_index=0)
+
+        adpt.submit_store_task([key], [store_obj])
+        wait_for_event_fd(adpt.get_store_event_fd())
+        adpt.pop_completed_store_tasks()
+
+        data_file = os.path.join(tmp_dir, _object_key_to_filename(key))
+        os.unlink(data_file)
+
+        load_obj = create_memory_obj(buf, page_index=1)
+        task_id = adpt.submit_load_task([key], [load_obj])
+        wait_for_event_fd(adpt.get_load_event_fd())
+
+        bitmap = adpt.query_load_result(task_id)
+        assert bitmap is not None
+        assert not bitmap.test(0)
+        assert not os.path.exists(data_file)
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_dynamic_l2_adapter.py
@@ -431,28 +431,6 @@ class TestLoadInterface:
 
         adpt.submit_unlock([key])
 
-    def test_load_missing_file_does_not_recreate_it(self, adapter):
-        adpt, buf, tmp_dir = adapter
-        key = create_object_key(1)
-        store_obj = create_memory_obj(buf, page_index=0)
-
-        adpt.submit_store_task([key], [store_obj])
-        wait_for_event_fd(adpt.get_store_event_fd())
-        adpt.pop_completed_store_tasks()
-
-        data_file = os.path.join(tmp_dir, _object_key_to_filename(key))
-        os.unlink(data_file)
-
-        load_obj = create_memory_obj(buf, page_index=1)
-        task_id = adpt.submit_load_task([key], [load_obj])
-        wait_for_event_fd(adpt.get_load_event_fd())
-
-        bitmap = adpt.query_load_result(task_id)
-        assert bitmap is not None
-        assert not bitmap.test(0)
-        assert not os.path.exists(data_file)
-
-
 # =============================================================================
 # Store-Lookup-Load End-to-End Test
 # =============================================================================


### PR DESCRIPTION
Changed the dynamic to use path mode and flattened the transfer request so NIXL does the whole transfer in one call instead of one per file and the os.open isn't called anymore.

**What this PR does / why we need it**:

The NIXL store dynamic connector uses NIXL to transfer KVs to files.  NIXL recently introduced a mode to reduce the need for os level calls for opening and closing files.  The change in addition to batching all reads together increases performance of the dynamic l2 storage path.

These changes yield significant performance gains on the NIXL dynamic storage L2 adapter:

This is the TTFT of varying context lengths using the original nixl store dynamic and the modified nixl store dynamic adapters on Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 on an NVIDIA L40s (chunk size 256)
<img width="1318" height="495" alt="image" src="https://github.com/user-attachments/assets/a0137c3a-cf22-418b-86c0-c311d76934dc" />

- [x] this PR contains unit tests
