### PR TITLE
[Config] make session TTL configurable via --session-ttl

### DIFF
--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -101,12 +101,13 @@ class MPServerConfig:
     thread. Default is 600 (10 minutes)."""
 
     def __post_init__(self) -> None:
-        """Validate the worker-reaping timeouts.
+        """Validate the worker-reaping timeouts and session TTL.
 
         Raises:
             ValueError: If a timeout is non-finite, the reap timeout is
-                negative or a non-zero value below the 30 s floor, or the
-                registration grace is below the reap timeout.
+                negative or a non-zero value below the 30 s floor, the
+                registration grace is below the reap timeout, or session_ttl
+                is non-finite or non-positive.
         """
         reap = self.worker_reap_timeout_seconds
         grace = self.worker_registration_grace_seconds
@@ -120,6 +121,11 @@ class MPServerConfig:
             raise ValueError(
                 "worker registration grace must be >= the worker reap timeout "
                 f"({reap}s); got {grace}"
+            )
+        if not math.isfinite(self.session_ttl) or self.session_ttl <= 0:
+            raise ValueError(
+                "session TTL must be a finite number > 0, "
+                f"got {self.session_ttl}"
             )
 
 

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -95,6 +95,11 @@ class MPServerConfig:
     sent a PING (model warmup, or death before its first request). Must be
     >= worker_reap_timeout_seconds."""
 
+    session_ttl: float = 600.0
+    """Time-to-live (seconds) for sessions in the SessionManager.
+    Sessions that exceed this TTL are cleaned up by the background
+    thread. Default is 600 (10 minutes)."""
+
     def __post_init__(self) -> None:
         """Validate the worker-reaping timeouts.
 
@@ -374,6 +379,14 @@ def add_mp_server_args(
         "retrieve failure, retain the gapped prefix so post-gap chunks stay "
         "L1-resident instead of truncating at the gap. No effect otherwise.",
     )
+    mp_group.add_argument(
+        "--session-ttl",
+        type=float,
+        default=600.0,
+        help="Session time-to-live in seconds. Sessions exceeding this TTL "
+        "are cleaned up by the background thread. "
+        "Default is 600 (10 minutes).",
+    )
     return parser
 
 
@@ -418,6 +431,7 @@ def parse_args_to_mp_server_config(
         script_allowed_imports=args.script_allowed_imports or [],
         worker_reap_timeout_seconds=args.worker_reap_timeout_seconds,
         worker_registration_grace_seconds=args.worker_registration_grace_seconds,
+        session_ttl=args.session_ttl,
     )
 
 

--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -124,8 +124,7 @@ class MPServerConfig:
             )
         if not math.isfinite(self.session_ttl) or self.session_ttl <= 0:
             raise ValueError(
-                "session TTL must be a finite number > 0, "
-                f"got {self.session_ttl}"
+                f"session TTL must be a finite number > 0, got {self.session_ttl}"
             )
 
 

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -172,6 +172,10 @@ class MPCacheServerContext:
         hash_algorithm: Hash algorithm for token hashing.
         separate_object_groups: Whether to split kernel groups into one object
             group per sliding-window size at KV-cache registration. Default True.
+        full_sw_kv: Whether sliding-window groups cache full per-chunk KV
+            (no window cutting). Default False.
+        session_ttl: Time-to-live in seconds for sessions in SessionManager.
+            Default 600 (10 minutes).
     """
 
     def __init__(
@@ -181,6 +185,7 @@ class MPCacheServerContext:
         hash_algorithm: str = "blake3",
         separate_object_groups: bool = True,
         full_sw_kv: bool = False,
+        session_ttl: float = 600.0,
     ) -> None:
         self._chunk_size = chunk_size
         self._separate_object_groups = separate_object_groups
@@ -197,7 +202,7 @@ class MPCacheServerContext:
         self._token_hasher = TokenHasher(
             chunk_size=chunk_size, hash_algorithm=hash_algorithm
         )
-        self._session_manager = SessionManager(self._token_hasher)
+        self._session_manager = SessionManager(self._token_hasher, ttl=session_ttl)
         self._event_bus = get_event_bus()
         self._layout_desc_registry = LayoutDescRegistry()
 

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -354,6 +354,7 @@ def run_cache_server(
         hash_algorithm=mp_config.hash_algorithm,
         separate_object_groups=mp_config.separate_object_groups and not is_blend,
         full_sw_kv=is_blend,
+        session_ttl=mp_config.session_ttl,
     )
 
     modules = _build_modules(ctx, mp_config, coordinator_config)

--- a/tests/v1/multiprocess/test_config.py
+++ b/tests/v1/multiprocess/test_config.py
@@ -127,3 +127,21 @@ def test_instance_id_defaults_are_distinct():
 def test_instance_id_dataclass_default_is_distinct():
     # Direct construction (no CLI) also mints a fresh id per instance.
     assert MPServerConfig().instance_id != MPServerConfig().instance_id
+
+
+@pytest.mark.parametrize("ttl", [0.0, -1.0, float("nan"), float("inf")])
+def test_config_rejects_bad_session_ttl(ttl: float) -> None:
+    """Validation rejects non-positive and non-finite session_ttl."""
+    with pytest.raises(ValueError, match="session TTL"):
+        MPServerConfig(session_ttl=ttl)
+
+
+def test_session_ttl_default() -> None:
+    """Default session_ttl is 600 (10 minutes)."""
+    assert MPServerConfig().session_ttl == 600.0
+
+
+def test_session_ttl_cli_flag() -> None:
+    """--session-ttl flag is parsed correctly."""
+    config = _parse_mp(["--session-ttl", "1800"])
+    assert config.session_ttl == 1800.0


### PR DESCRIPTION
<!--  Thanks for your contribution... -->

**What this PR does / why we need it**

The hardcoded 10-minute session TTL (from #3570) was causing sessions to expire prematurely in non-disaggregated deployments where individual tasks exceed 10 minutes. This PR exposes it through `--session-ttl` CLI argument so users can tune it for their workload.

**Special notes for your reviewers**

Follow-up from https://github.com/LMCache/LMCache/pull/3570#issuecomment-4942771932

**If applicable**

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests