### PR TITLE
[CI]  fix non-CUDA unit tests broken by vllm 0.25.0 torchcodec/FFmpeg dep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,11 @@ jobs:
             **/pyproject.toml
             **/requirements/*.txt
 
+      - name: Install FFmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
vLLM 0.25.0 imports torchcodec transitively, which dlopen()s FFmpeg's libav* shared libraries at import time. Without FFmpeg on the runner the load fails and every test that imports vllm aborts during collection, failing the non-CUDA unit test job.

Install FFmpeg in the job so torchcodec can load, mirroring the macOS FFmpeg step added for cpu_device.yml in #4047.

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
