### PR TITLE
[CI] install ffmpeg to fix vllm torchcodec import error

### DIFF
--- a/.github/actions/install-ffmpeg/action.yml
+++ b/.github/actions/install-ffmpeg/action.yml
@@ -1,0 +1,21 @@
+name: 'Install FFmpeg'
+description: 'Install FFmpeg on Linux (apt) or macOS (brew)'
+runs:
+  using: "composite"
+  steps:
+    - name: Install FFmpeg (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y ffmpeg
+      shell: bash
+
+    - name: Install FFmpeg (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        if ! command -v ffmpeg >/dev/null 2>&1; then
+          brew install ffmpeg
+        else
+          echo "ffmpeg already installed: $(ffmpeg -version | head -n1)"
+        fi
+      shell: bash

--- a/.github/workflows/cpu_device.yml
+++ b/.github/workflows/cpu_device.yml
@@ -94,14 +94,8 @@ jobs:
             pyproject.toml
             requirements/*.txt
 
-      - name: Install FFmpeg (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          if ! command -v ffmpeg >/dev/null 2>&1; then
-            brew install ffmpeg
-          else
-            echo "ffmpeg already installed: $(ffmpeg -version | head -n1)"
-          fi
+      - name: Install FFmpeg
+        uses: ./.github/actions/install-ffmpeg
 
       - name: Cache opt-125m model (GitHub release)
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,9 @@ jobs:
             **/pyproject.toml
             **/requirements/*.txt
 
+      - name: Install FFmpeg
+        uses: ./.github/actions/install-ffmpeg
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
<!--  Thanks for your contribution... -->

**What this PR does / why we need it**

vllm recently added torchcodec as a dependency, which requires libavutil from ffmpeg. The ubuntu-latest runner doesn't have ffmpeg pre-installed, causing all Test workflow jobs to fail with "Could not load libtorchcodec".

Affected PRs: #4088, #4091

**Special notes for your reviewers**

one-liner CI fix

**If applicable**

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests