### PR TITLE
refactor(device-ops): OO DeviceOps with instance-method ops (alt to #4077)

### DIFF
--- a/.github/workflows/build_cpu_artifacts.yml
+++ b/.github/workflows/build_cpu_artifacts.yml
@@ -109,10 +109,13 @@ jobs:
                 python -c "import lmcache.native_storage_ops"
                 python -c "import lmcache.lmcache_redis"
                 python -c "import lmcache.lmcache_fs"
-                # c_ops resolves to the python_ops_fallback shim on CPU.
+                # On CPU, `import lmcache.c_ops` resolves to the synthetic shim
+                # DeviceOps builds from the torch baseline (`_torch_ops`).
                 python -c "
                 import sys, lmcache, lmcache.c_ops
-                assert sys.modules['lmcache.c_ops'].__name__ == 'lmcache.python_ops_fallback'
+                m = sys.modules['lmcache.c_ops']
+                assert m.__name__ == 'lmcache.c_ops', m.__name__
+                assert hasattr(m, 'TransferDirection')
                 "
 
             - name: Upload CPU release artifacts to GHA

--- a/csrc/sycl/pybind_sycl.cpp
+++ b/csrc/sycl/pybind_sycl.cpp
@@ -58,7 +58,7 @@ PYBIND11_MODULE(xpu_ops, m) {
         py::call_guard<py::gil_scoped_release>());
 
   // CacheGen / RoPE kernels (Intel XPU).  Names match the
-  // lmcache.python_ops_fallback module so the backend selection in
+  // lmcache.v1.platform._torch_ops baseline so the backend selection in
   // lmcache.v1.platform can transparently override.
   m.def("calculate_cdf", &calculate_cdf_xpu, py::arg("input"),
         py::arg("max_bins"));

--- a/csrc/sycl/pybind_sycl.cpp
+++ b/csrc/sycl/pybind_sycl.cpp
@@ -58,7 +58,7 @@ PYBIND11_MODULE(xpu_ops, m) {
         py::call_guard<py::gil_scoped_release>());
 
   // CacheGen / RoPE kernels (Intel XPU).  Names match the
-  // lmcache.v1.platform._torch_ops baseline so the backend selection in
+  // lmcache.v1.platform._torch_impl baseline so the backend selection in
   // lmcache.v1.platform can transparently override.
   m.def("calculate_cdf", &calculate_cdf_xpu, py::arg("input"),
         py::arg("max_bins"));

--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -132,5 +132,5 @@ which is wrong for that backend's actual KV cache layout.
 1. Add detection branch in `__init__.py` `_detect_device()`
 2. Create `gpu_connector/xxx_connectors.py`, implement `GPUConnectorInterface`
 3. Add routing branch in `gpu_connector/__init__.py`
-4. Add kernels in `c_ops/` or torch baseline in `lmcache/v1/platform/_torch_ops.py`
+4. Add kernels in `c_ops/` or torch baseline in `lmcache/v1/platform/_torch_impl.py`
 5. No changes needed in middle layer code

--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -132,5 +132,5 @@ which is wrong for that backend's actual KV cache layout.
 1. Add detection branch in `__init__.py` `_detect_device()`
 2. Create `gpu_connector/xxx_connectors.py`, implement `GPUConnectorInterface`
 3. Add routing branch in `gpu_connector/__init__.py`
-4. Add kernels in `c_ops/` or fallback in `python_ops_fallback.py`
+4. Add kernels in `c_ops/` or torch baseline in `lmcache/v1/platform/_torch_ops.py`
 5. No changes needed in middle layer code

--- a/docs/design/v1/platform/device_ops_design.md
+++ b/docs/design/v1/platform/device_ops_design.md
@@ -60,7 +60,7 @@ accelerates and inherits the torch baseline for everything else.
 Plain methods + inheritance:
 
 - The base defines all ops as **explicit thin methods** that delegate to
-  `_torch_ops` (the migrated torch/CPU baseline). This is the composite/CPU
+  `_torch_impl` (the migrated torch/CPU baseline). This is the composite/CPU
   fallback.
 - A subclass overrides only what it accelerates with a normal method; everything
   else inherits the baseline.
@@ -90,7 +90,7 @@ unbound op keeps the torch implementation.
 from __future__ import annotations
 from typing import Any, Callable, ClassVar
 
-from lmcache.v1.platform import _torch_ops      # migrated impl (functions)
+from lmcache.v1.platform import _torch_impl      # migrated impl (functions)
 from lmcache.v1.platform.ops_types import (      # migrated shared types
     TransferDirection, EngineKVFormat, PageBufferShapeDesc, set_shape_desc_dtype,
 )
@@ -118,11 +118,11 @@ class DeviceOps:
 
     # --- explicit thin methods delegating to the torch baseline ---
     def multi_layer_kv_transfer(self, *a, **k):
-        return _torch_ops.multi_layer_kv_transfer(*a, **k)
+        return _torch_impl.multi_layer_kv_transfer(*a, **k)
     def multi_layer_block_kv_transfer(self, *a, **k):
-        return _torch_ops.multi_layer_block_kv_transfer(*a, **k)
+        return _torch_impl.multi_layer_block_kv_transfer(*a, **k)
     def lmcache_memcpy_async(self, *a, **k):
-        return _torch_ops.lmcache_memcpy_async(*a, **k)
+        return _torch_impl.lmcache_memcpy_async(*a, **k)
     # ...  more, one line each (mechanical, generatable from OPS) ...
 
     def _bind_native(self, module) -> None:
@@ -134,7 +134,7 @@ class DeviceOps:
                 setattr(self, name, fn)
 ```
 
-> `_torch_ops` holds the migrated implementation as module-level functions. It
+> `_torch_impl` holds the migrated implementation as module-level functions. It
 > is **internal** to the platform package. The stubs are typed and visible to
 > IDEs; `OPS` is the contract for the parity test (and `_bind_native`).
 
@@ -142,12 +142,12 @@ class DeviceOps:
 
 | Old | New |
 |-----|-----|
-| `lmcache/python_ops_fallback.py` | **deleted** — all consumers import `_torch_ops` / `ops_types` directly |
-| — its 36 public ops | → `platform/_torch_ops.py` (module functions) |
-| — its private helpers (`_transfer_*`, `_tensor_from_ptr`, …) | → `platform/_torch_ops.py` (private) |
+| `lmcache/python_ops_fallback.py` | **deleted** — all consumers import `_torch_impl` / `ops_types` directly |
+| — its 36 public ops | → `platform/_torch_impl.py` (module functions) |
+| — its private helpers (`_transfer_*`, `_tensor_from_ptr`, …) | → `platform/_torch_impl.py` (private) |
 | — its types (`TransferDirection`, `EngineKVFormat`, `PageBufferShapeDesc`, `set_shape_desc_dtype`) | → `platform/ops_types.py` |
 | `import lmcache.python_ops_fallback` (3 call sites) | → import from `platform.ops_types` (types) |
-| back-compat shim `python_ops_fallback.py` | **removed** — every importer now targets `_torch_ops` + `ops_types` directly |
+| back-compat shim `python_ops_fallback.py` | **removed** — every importer now targets `_torch_impl` + `ops_types` directly |
 
 ---
 
@@ -187,7 +187,7 @@ overrides 1, HPU binds nothing. One mechanism; the torch baseline fills the rest
 # platform/cpu/device_ops.py
 class CpuDeviceOps(DeviceOps):
     device_type = "cpu"            # the only registered torch-baseline device
-    # No overrides. Inherited base methods -> _torch_ops ARE the CPU backend.
+    # No overrides. Inherited base methods -> _torch_impl ARE the CPU backend.
 ```
 
 ### 4.2 CUDA (& ROCm) — bulk-bind the whole module
@@ -312,7 +312,7 @@ class CudaDeviceSpec(DeviceSpec):
 The import lives inside the property body on purpose:
 
 - It avoids reintroducing the `lmcache` / `lmcache.v1.platform` import cycle
-  that would appear if `_torch_ops` or a native `.so` were pulled into the
+  that would appear if `_torch_impl` or a native `.so` were pulled into the
   platform package at discovery time.
 - It keeps native CUDA loading deferred until `CudaDeviceOps.populate_module()`,
   preserving the current `lmcache.c_ops` shim bootstrap ordering.
@@ -333,7 +333,7 @@ lmcache/v1/platform/
   __init__.py                 # bootstraps backend pkgs; lazy c_ops shim
   base_device_spec.py         # ★ DeviceSpec + lazy ops_cls default
   base_device_ops.py          # ★ DeviceOps base + OPS contract + _bind_native
-  _torch_ops.py               # ★ migrated torch/CPU impl (was python_ops_fallback)
+  _torch_impl.py               # ★ migrated torch/CPU impl (was python_ops_fallback)
   ops_types.py                # ★ TransferDirection, EngineKVFormat, PageBufferShapeDesc
   base_cache_context.py       # (unchanged) sibling abstractions
   base_ipc_wrapper.py
@@ -430,7 +430,7 @@ phase). All profiles (`cuda.py`, `sycl.py`, `rocm.py`, `musa.py`) are untouched.
 
 | Device | DeviceOps subclass | Overrides | Native work | Total effort |
 |--------|-------------------|-----------|-------------|--------------|
-| CPU | `CpuDeviceOps(DeviceOps)` | none (base = torch) | none | migrate `python_ops_fallback` → `_torch_ops` |
+| CPU | `CpuDeviceOps(DeviceOps)` | none (base = torch) | none | migrate `python_ops_fallback` → `_torch_impl` |
 | CUDA | `CudaDeviceOps(DeviceOps)` | 36 via `_bind_native(c_ops)` | none (keep `.cu`) | **low** |
 | HIP/ROCm | handled by `CudaDeviceOps` | (same as CUDA; ROCm builds `c_ops` via hipify, PyTorch masquerades as `torch.cuda`) | hipify profile exists | N/A |
 | XPU | `XpuDeviceOps(DeviceOps)` | 12 via `_bind_native(xpu_ops)` + 24 torch | existing SYCL build | **low** |

--- a/docs/design/v1/platform/device_ops_design.md
+++ b/docs/design/v1/platform/device_ops_design.md
@@ -1,0 +1,470 @@
+# Design: Unified Device Ops via `DeviceOps` Abstraction
+
+---
+
+## 1. Goal
+
+Unify the per-device **ops** (callable ops plus shared types, currently
+exposed as `lmcache.c_ops`) behind a single `DeviceOps` abstraction in
+`lmcache/v1/platform/`, alongside the existing device abstractions
+(`DeviceIPCWrapper`, `PinMemoryBackend`, `BaseCacheContext`).
+
+**The torch reference implementation moves *into* `DeviceOps`.** The base class
+*is* the CPU/torch backend — `python_ops_fallback.py` is
+**deprecated entirely**, its logic migrated into the platform package. Every device
+(CUDA, XPU, MUSA, HPU) is a `DeviceOps` subclass that overrides only what it
+accelerates and inherits the torch baseline for everything else.
+
+---
+
+## 2. What exists today
+
+| Concern | Mechanism | Location |
+|---------|-----------|----------|
+| Compiled CUDA ops | `PYBIND11_MODULE(c_ops)` — 36 ops + 3 types (+`GPUKVFormat` alias) | `csrc/pybind.cpp` |
+| Compiled SYCL ops | `PYBIND11_MODULE(xpu_ops)` — 12 ops + 2 enums (+`GPUKVFormat`); **24 ops fall back to torch** | `csrc/sycl/pybind_sycl.cpp` |
+| Torch/CPU reference | `python_ops_fallback.py` — 36 ops + 3 types | `lmcache/python_ops_fallback.py` |
+| MUSA ops | Python adapter: import `py_ops`, override 1 fn, optional native | `lmcache/v1/platform/musa/ops.py` (**deleted**; now `musa/device_ops.py`) |
+| HPU ops | None — uses torch baseline entirely | (via `DeviceOps` inheritance) |
+| Runtime selection | `_install_c_ops_shim()`: resolves `DeviceOps` via `DeviceSpec.ops_cls` | `lmcache/__init__.py` |
+| Build selection | `BuildProfile` subclasses auto-discovered | `setup_extensions/build_profiles/` |
+| Device services registry | `DeviceIPCWrapper`/`PinMemoryBackend`/`BaseCacheContext` auto-discovered by `device_type` | `lmcache/v1/platform/` |
+
+### 2.1 Current Problems
+
+1. **Two parallel selection mechanisms.** The former `_get_backend()` used a hand-maintained
+   `backend_candidates` list + `__dict__.update` merge — separate from the clean
+   `device_type`-keyed registry `platform/` already uses for IPC, pin-memory, and
+   cache-context.
+
+2. **Fragile Module-merge** `merged.__dict__.update(backend.__dict__)`
+   silently shadows symbols, copies private helpers, and has no contract. A new
+   backend can accidentally override or miss a symbol with no error.
+
+3. **`xpu_ops` covers only 12/36 ops.** The other 24 come from the Python fallback.
+
+4. **No typed contract.** Nothing declares "these are the 36 ops every device
+   provides or inherits." `test_c_ops_parity.py` checks at runtime only.
+
+5. **The torch reference is a free-floating module**, not owned by any device
+   abstraction — it's referenced by name (`python_ops_fallback`) from several
+   call sites.
+
+
+---
+
+## 3. The `DeviceOps` Abstraction
+
+### 3.1 The dispatch model
+
+Plain methods + inheritance:
+
+- The base defines all ops as **explicit thin methods** that delegate to
+  `_torch_ops` (the migrated torch/CPU baseline). This is the composite/CPU
+  fallback.
+- A subclass overrides only what it accelerates with a normal method; everything
+  else inherits the baseline.
+- Every backend subclasses `DeviceOps` directly and binds its compiled module
+  via `self._bind_native(module)` — one mechanism for all. Whole-module backends
+  (CUDA) shadows all 36; partial ones (XPU) shadow the few they ship; missing
+  ops keep the torch baseline. Devices may also override hot ops with Python.
+
+The one-line base methods are intentional boilerplate: they keep the contract
+visible to type-checkers, and `_bind_native` shadows them at instance level when
+a native op exists. There is a single lineage with no hand-written native stubs.
+
+### 3.2 Base class — contract + torch baseline
+
+`lmcache/v1/platform/base_device_ops.py`:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+"""Per-device ops backend: the unified ``lmcache.c_ops`` surface.
+
+The base class owns the full 36-op contract with a device-agnostic
+torch implementation (migrated from the former ``python_ops_fallback.py``)
+that runs anywhere torch runs, including CPU. Accelerators bind a compiled
+module via ``_bind_native`` so native ops shadow the baseline while every
+unbound op keeps the torch implementation.
+"""
+from __future__ import annotations
+from typing import Any, Callable, ClassVar
+
+from lmcache.v1.platform import _torch_ops      # migrated impl (functions)
+from lmcache.v1.platform.ops_types import (      # migrated shared types
+    TransferDirection, EngineKVFormat, PageBufferShapeDesc, set_shape_desc_dtype,
+)
+
+#: The complete ops contract.
+OPS: frozenset[str] = frozenset({...})         # the op names
+
+
+class DeviceOps:
+    """Strategy base: explicit ops + shared types for one device type.
+
+    Concrete subclasses set :attr:`device_type` and override only the ops they
+    accelerate; everything else inherits the torch baseline below. The base
+    itself has no ``device_type`` (empty), so it is never registered as a
+    device — it is pure baseline + contract.
+    """
+    device_type: ClassVar[str] = ""        # base is unregistered
+
+    # Shared types are real class attributes (devices share identical enums).
+    TransferDirection = TransferDirection
+    EngineKVFormat = EngineKVFormat
+    GPUKVFormat = EngineKVFormat            # back-compat alias
+    PageBufferShapeDesc = PageBufferShapeDesc
+    set_shape_desc_dtype = staticmethod(set_shape_desc_dtype)
+
+    # --- explicit thin methods delegating to the torch baseline ---
+    def multi_layer_kv_transfer(self, *a, **k):
+        return _torch_ops.multi_layer_kv_transfer(*a, **k)
+    def multi_layer_block_kv_transfer(self, *a, **k):
+        return _torch_ops.multi_layer_block_kv_transfer(*a, **k)
+    def lmcache_memcpy_async(self, *a, **k):
+        return _torch_ops.lmcache_memcpy_async(*a, **k)
+    # ...  more, one line each (mechanical, generatable from OPS) ...
+
+    def _bind_native(self, module) -> None:
+        """Bind a whole compiled module: native op shadows base method;
+        missing ops keep the torch baseline."""
+        for name in OPS:
+            fn = getattr(module, name, None)
+            if fn is not None:
+                setattr(self, name, fn)
+```
+
+> `_torch_ops` holds the migrated implementation as module-level functions. It
+> is **internal** to the platform package. The stubs are typed and visible to
+> IDEs; `OPS` is the contract for the parity test (and `_bind_native`).
+
+### 3.3 What gets deleted / migrated
+
+| Old | New |
+|-----|-----|
+| `lmcache/python_ops_fallback.py` | **deleted** — all consumers import `_torch_ops` / `ops_types` directly |
+| — its 36 public ops | → `platform/_torch_ops.py` (module functions) |
+| — its private helpers (`_transfer_*`, `_tensor_from_ptr`, …) | → `platform/_torch_ops.py` (private) |
+| — its types (`TransferDirection`, `EngineKVFormat`, `PageBufferShapeDesc`, `set_shape_desc_dtype`) | → `platform/ops_types.py` |
+| `import lmcache.python_ops_fallback` (3 call sites) | → import from `platform.ops_types` (types) |
+| back-compat shim `python_ops_fallback.py` | **removed** — every importer now targets `_torch_ops` + `ops_types` directly |
+
+---
+
+## 4. Per-Device `DeviceOps` Subclasses
+
+### 4.0 Class hierarchy
+
+```mermaid
+classDiagram
+    DeviceOps <|-- CpuDeviceOps
+    DeviceOps <|-- XpuDeviceOps
+    DeviceOps <|-- MusaDeviceOps
+    DeviceOps <|-- HpuDeviceOps
+    DeviceOps <|-- CudaDeviceOps
+    class DeviceOps {
+      +device_type = "" (unregistered)
+      torch/CPU baseline (36 ops)
+      +_bind_native(module)
+    }
+    class CpuDeviceOps { "cpu" - no overrides }
+    class CudaDeviceOps { "cuda"; _bind_native(c_ops) }
+    class XpuDeviceOps { "xpu"; _bind_native(xpu_ops): 12 SYCL + 24 torch }
+    class MusaDeviceOps { "musa"; +1 native op }
+    class HpuDeviceOps { "hpu"; pure inherit }
+```
+
+**`DeviceOps` is the pure CPU/torch fallback — no GPU, no accelerator, no
+compiled module required.** It runs anywhere torch runs and owns all ops.
+
+Every accelerator extends `DeviceOps` directly and binds its compiled module
+with `_bind_native`: CUDA binds a whole `.so` (all 36), XPU binds its 12, MUSA
+overrides 1, HPU binds nothing. One mechanism; the torch baseline fills the rest.
+
+### 4.1 CPU — the base (no subclass logic)
+
+```python
+# platform/cpu/device_ops.py
+class CpuDeviceOps(DeviceOps):
+    device_type = "cpu"            # the only registered torch-baseline device
+    # No overrides. Inherited base methods -> _torch_ops ARE the CPU backend.
+```
+
+### 4.2 CUDA (& ROCm) — bulk-bind the whole module
+
+Same shape as XPU: subclass `DeviceOps`, `_bind_native` the compiled module so
+all 36 ops shadow the baseline. No native stubs.
+
+```python
+# platform/cuda/device_ops.py
+class CudaDeviceOps(DeviceOps):
+    device_type = "cuda"
+    def __init__(self) -> None:
+        import lmcache.c_ops as native
+        self._bind_native(native)          # all 36 ops -> lmcache.c_ops
+        type(self).TransferDirection = native.TransferDirection
+        type(self).EngineKVFormat = native.EngineKVFormat
+        # ... (rebind pybind types)
+```
+
+> CUDA keeps all current sources (`csrc/*.cu`, `mem_alloc.cpp`, recorders)
+> **unchanged**; the module keeps the name `c_ops`.  ROCm/HIP also builds
+> `lmcache.c_ops` (via hipify) and PyTorch ROCm masquerades as `torch.cuda`,
+> so `CudaDeviceOps` handles ROCm automatically — no separate `hip/`
+> package is needed.  The base's 36 typed stubs are the only contract;
+> `_bind_native` shadows them with native ops — one mechanism shared
+> with XPU/MUSA.
+
+### 4.3 XPU — preserve existing SYCL + torch split
+
+Migrate today's XPU exactly — `XpuDeviceOps` bulk-binds the existing
+`lmcache.xpu_ops` (12 SYCL kernels in `csrc/sycl/`) via `_bind_native` and
+inherits the torch baseline for the other 24. No new kernels, no behavior
+change; only the merge mechanism moves to the registry.
+
+```python
+# platform/xpu/device_ops.py
+from lmcache.v1.platform.base_device_ops import DeviceOps
+
+class XpuDeviceOps(DeviceOps):
+    """12 SYCL ops over the torch baseline — identical to today's xpu_ops merge."""
+    device_type = "xpu"
+
+    def __init__(self) -> None:
+        try:
+            import lmcache.xpu_ops as sycl
+        except ImportError:
+            return  # SYCL not built: stay on torch baseline, no degradation
+        self._bind_native(sycl)            # 12 SYCL ops shadow base; 24 inherit
+```
+
+> Same 12 SYCL + 24 torch split as the former `_get_backend()` merge, just
+> resolved through the registry instead of `__dict__.update`. The 19 host-side
+> ops keep tensor-backed torch paths; if SYCL is absent it falls through to the
+> baseline (no degradation vs today, where xpu_ops is also optional).
+>
+> **Pointer-mode caveat.** Today `_tensor_from_ptr` reconstructs raw pointers
+> only for CPU and CUDA. The XPU path is tensor-backed; raw-pointer support can
+> be added later if needed.
+
+### 4.4 MUSA — existing adapter, reshaped as a subclass
+
+```python
+# platform/musa/device_ops.py
+class MusaDeviceOps(DeviceOps):
+    device_type = "musa"
+    def multi_layer_block_kv_transfer(self, *a, **k):
+        from lmcache.v1.platform.musa.native_kv_transfer import (
+            try_native_multi_layer_block_kv_transfer,
+        )
+        if _tensor_backed(k) and try_native_multi_layer_block_kv_transfer(...):
+            return
+        return super().multi_layer_block_kv_transfer(*a, **k)  # torch baseline
+```
+
+Former `platform/musa/ops.py` logic moved into `MusaDeviceOps`. Zero behavior change; `musa/ops.py` deleted.
+
+### 4.5 HPU — inherit the baseline
+
+```python
+# platform/hpu/device_ops.py
+class HpuDeviceOps(DeviceOps):
+    device_type = "hpu"
+    # All 36 inherited from the torch baseline. This matches today's HPU path
+    # when callers pass tensors; raw pointer reconstruction is not HPU-aware.
+    # Add overrides later if profiling or pointer-mode callers require them.
+```
+
+No ops logic moves and there is **no behavior change**: HPU has no entry in
+today's `backend_candidates`, so it already runs all 36 ops on the torch
+fallback. `HpuDeviceOps` is an empty subclass that just gives the registry a
+`device_type = "hpu"`. The separate `gpu_connector/hpu_connector.py` is a
+cache-context concern — out of scope here.
+
+---
+
+## 5. Registration & Discovery
+
+`DeviceOps` resolution now reuses the existing `DeviceSpec` discovery in
+`lmcache.v1.platform._DEVICE_REGISTRY`; there is no second, dedicated ops
+registry.
+
+```python
+# platform/base_device_spec.py
+class DeviceSpec:
+    @property
+    def ops_cls(self) -> type[DeviceOps]:
+        """DeviceOps subclass providing the ``lmcache.c_ops`` surface."""
+        from lmcache.v1.platform.base_device_ops import DeviceOps
+
+        return DeviceOps
+
+
+# platform/cuda/__init__.py
+class CudaDeviceSpec(DeviceSpec):
+    @property
+    def ops_cls(self) -> type[DeviceOps]:
+        from lmcache.v1.platform.cuda.device_ops import CudaDeviceOps
+
+        return CudaDeviceOps
+```
+
+The import lives inside the property body on purpose:
+
+- It avoids reintroducing the `lmcache` / `lmcache.v1.platform` import cycle
+  that would appear if `_torch_ops` or a native `.so` were pulled into the
+  platform package at discovery time.
+- It keeps native CUDA loading deferred until `CudaDeviceOps.populate_module()`,
+  preserving the current `lmcache.c_ops` shim bootstrap ordering.
+
+Resolution is still fail-fast for accelerators. If `_install_c_ops_shim()` is
+asked for `"cuda"` / `"xpu"` / `"musa"` / `"hpu"` and no `DeviceSpec` is
+registered, it raises instead of silently falling back to the torch baseline.
+The normal CPU path resolves through `CpuDeviceSpec -> CpuDeviceOps`; only `""`
+(and a deliberately cleared CPU registry in tests / CLI-only fallback paths)
+uses the bare `DeviceSpec -> DeviceOps` baseline.
+
+### 5.1  `platform/` tree
+
+After the refactor (★ = new, ✗ = deleted):
+
+```text
+lmcache/v1/platform/
+  __init__.py                 # bootstraps backend pkgs; lazy c_ops shim
+  base_device_spec.py         # ★ DeviceSpec + lazy ops_cls default
+  base_device_ops.py          # ★ DeviceOps base + OPS contract + _bind_native
+  _torch_ops.py               # ★ migrated torch/CPU impl (was python_ops_fallback)
+  ops_types.py                # ★ TransferDirection, EngineKVFormat, PageBufferShapeDesc
+  base_cache_context.py       # (unchanged) sibling abstractions
+  base_ipc_wrapper.py
+  base_pin_memory.py
+  cache_context.py
+  device_ext.py
+  event_notifier.py
+  _registry.py
+  cpu/
+    __init__.py               # ★ CpuDeviceSpec.ops_cls -> CpuDeviceOps
+    device_ops.py             # ★ CpuDeviceOps (no overrides = base)
+    cache_context.py
+    shm.py
+    stub_cpu_device.py
+  cuda/
+    __init__.py               # ★ CudaDeviceSpec.ops_cls -> CudaDeviceOps
+    device_ops.py             # ★ CudaDeviceOps (_bind_native c_ops; rename deferred)
+    cache_context.py
+    ipc_wrapper.py
+    pin_memory.py
+  xpu/                        # ★ new
+    __init__.py               # ★ XpuDeviceSpec.ops_cls -> XpuDeviceOps
+    device_ops.py             # ★ XpuDeviceOps (12 SYCL + 24 torch)
+    torch_kv_transfer.py      # ★ XPU-tuned fast paths
+  musa/
+    __init__.py               # ★ MusaDeviceSpec.ops_cls -> MusaDeviceOps
+    device_ops.py             # ★ MusaDeviceOps (moved from ops.py)
+    native_kv_transfer.py
+  hpu/                        # ★ new
+    __init__.py               # ★ HpuDeviceSpec.ops_cls -> HpuDeviceOps
+    device_ops.py             # ★ HpuDeviceOps (inherits baseline)
+
+setup_extensions/build_profiles/
+  cuda.py                     # builds lmcache.c_ops (c_ops_cuda rename deferred)
+  sycl.py                     # builds lmcache.xpu_ops
+  rocm.py                     # builds lmcache.c_ops (hipified)
+  musa.py                     # stub
+```
+
+---
+
+## 6. Runtime Resolution
+
+The per-device op merge is replaced by `DeviceSpec`-based lookup. The existing
+`import lmcache.c_ops` call sites keep working via a module shim built from the
+resolved `DeviceOps` class.
+
+```python
+# lmcache/__init__.py
+def _install_c_ops_shim() -> None:
+    from lmcache.v1.platform import get_device_spec
+    from lmcache.v1.platform.base_device_spec import DeviceSpec
+
+    spec = get_device_spec(torch_device_type)
+    if spec is None:
+        if torch_device_type in ("", "cpu"):
+            spec = DeviceSpec()
+        else:
+            raise RuntimeError(...)
+
+    ops_cls = spec.ops_cls
+
+    shim = types.ModuleType("lmcache.c_ops")
+    ops_cls.populate_module(shim)
+    sys.modules["lmcache.c_ops"] = shim
+```
+
+---
+
+## 7. Native Compiled Modules (unchanged)
+
+`DeviceOps` changes only how kernels are *selected*, not how they are built:
+
+---
+
+## 8. Build System
+
+setuptools + auto-discovered `BuildProfile`s in `setup_extensions/build_profiles/`.
+**No build change is required for this phase**: the CUDA extension keeps the
+name `lmcache.c_ops` (the `c_ops -> c_ops_cuda` rename is deferred to a later
+phase). All profiles (`cuda.py`, `sycl.py`, `rocm.py`, `musa.py`) are untouched.
+
+---
+
+## 9. Per-Device Effort Matrix
+
+**Base classes** (not devices — no `device_type`, never registered):
+
+| Base | Role | Op code |
+|------|------|---------|
+| `DeviceOps` | Torch/CPU baseline; owns the op contract; binds native via `_bind_native` | all torch impls |
+
+**Per-device subclasses:**
+
+| Device | DeviceOps subclass | Overrides | Native work | Total effort |
+|--------|-------------------|-----------|-------------|--------------|
+| CPU | `CpuDeviceOps(DeviceOps)` | none (base = torch) | none | migrate `python_ops_fallback` → `_torch_ops` |
+| CUDA | `CudaDeviceOps(DeviceOps)` | 36 via `_bind_native(c_ops)` | none (keep `.cu`) | **low** |
+| HIP/ROCm | handled by `CudaDeviceOps` | (same as CUDA; ROCm builds `c_ops` via hipify, PyTorch masquerades as `torch.cuda`) | hipify profile exists | N/A |
+| XPU | `XpuDeviceOps(DeviceOps)` | 12 via `_bind_native(xpu_ops)` + 24 torch | existing SYCL build | **low** |
+| MUSA | `MusaDeviceOps(DeviceOps)` | 1 native op | none | **low** (mechanical) |
+| HPU | `HpuDeviceOps(DeviceOps)` | none (inherits torch) | none | **low** |
+
+---
+
+## 10. Adding a New Device — Scalability
+
+To add device `foo`:
+
+1. Create `platform/foo/device_ops.py`:
+   ```python
+   class FooDeviceOps(DeviceOps):
+       device_type = "foo"
+       # override only what you accelerate; inherit the torch baseline
+   ```
+   If `foo` ships a whole compiled `.so`, bind it: `_bind_native(foo_ops)` in
+   `__init__` — same as CUDA/XPU.
+2. Define `platform/foo/__init__.py` with a `FooDeviceSpec(DeviceSpec)` override:
+   ```python
+   class FooDeviceSpec(DeviceSpec):
+      @property
+      def ops_cls(self) -> type[DeviceOps]:
+          from lmcache.v1.platform.foo.device_ops import FooDeviceOps
+
+          return FooDeviceOps
+   ```
+   Keep the import inside the property body so spec discovery stays lazy and
+   side-effect-free.
+3. *(Optional, native kernels)* add `setup_extensions/build_profiles/foo.py`.
+
+**Zero edits** to the resolver or any other device. A torch-only device works
+immediately once its `DeviceSpec` points at a `DeviceOps` subclass.
+
+---

--- a/docs/design/v1/platform/device_ops_design.md
+++ b/docs/design/v1/platform/device_ops_design.md
@@ -26,7 +26,7 @@ accelerates and inherits the torch baseline for everything else.
 | Torch/CPU reference | `python_ops_fallback.py` — 36 ops + 3 types | `lmcache/python_ops_fallback.py` |
 | MUSA ops | Python adapter: import `py_ops`, override 1 fn, optional native | `lmcache/v1/platform/musa/ops.py` (**deleted**; now `musa/device_ops.py`) |
 | HPU ops | None — uses torch baseline entirely | (via `DeviceOps` inheritance) |
-| Runtime selection | `_install_c_ops_shim()`: resolves `DeviceOps` via `DeviceSpec.ops_cls` | `lmcache/__init__.py` |
+| Runtime selection | `build_c_ops_shim()` builds a shim over the resolved `DeviceOps` instance; `lmcache/__init__.py` registers it | `lmcache/v1/platform/c_ops_shim.py`, `lmcache/__init__.py` |
 | Build selection | `BuildProfile` subclasses auto-discovered | `setup_extensions/build_profiles/` |
 | Device services registry | `DeviceIPCWrapper`/`PinMemoryBackend`/`BaseCacheContext` auto-discovered by `device_type` | `lmcache/v1/platform/` |
 
@@ -317,7 +317,7 @@ The import lives inside the property body on purpose:
 - It keeps native CUDA loading deferred until `CudaDeviceOps.populate_module()`,
   preserving the current `lmcache.c_ops` shim bootstrap ordering.
 
-Resolution is still fail-fast for accelerators. If `_install_c_ops_shim()` is
+Resolution is still fail-fast for accelerators. If `build_c_ops_shim()` is
 asked for `"cuda"` / `"xpu"` / `"musa"` / `"hpu"` and no `DeviceSpec` is
 registered, it raises instead of silently falling back to the torch baseline.
 The normal CPU path resolves through `CpuDeviceSpec -> CpuDeviceOps`; only `""`
@@ -382,23 +382,21 @@ The per-device op merge is replaced by `DeviceSpec`-based lookup. The existing
 resolved `DeviceOps` class.
 
 ```python
-# lmcache/__init__.py
-def _install_c_ops_shim() -> None:
-    from lmcache.v1.platform import get_device_spec
-    from lmcache.v1.platform.base_device_spec import DeviceSpec
-
-    spec = get_device_spec(torch_device_type)
-    if spec is None:
-        if torch_device_type in ("", "cpu"):
-            spec = DeviceSpec()
-        else:
-            raise RuntimeError(...)
-
-    ops_cls = spec.ops_cls
-
+# lmcache/v1/platform/c_ops_shim.py
+def build_c_ops_shim(device_type: str) -> types.ModuleType:
+    ops = resolve_device_ops(device_type)  # fail-fast for accelerators
+    ops.ensure_native()
     shim = types.ModuleType("lmcache.c_ops")
-    ops_cls.populate_module(shim)
-    sys.modules["lmcache.c_ops"] = shim
+    # copy public symbols from the native .so (if any), then fall back
+    # to the DeviceOps instance for torch-baseline ops.
+    ...
+    shim.__getattr__ = lambda name: getattr(ops, name)
+    return shim
+
+# lmcache/__init__.py
+_shim = build_c_ops_shim(torch_device_type)
+sys.modules["lmcache.c_ops"] = _shim
+globals()["c_ops"] = _shim  # parent attr for IMPORT_FROM bytecode
 ```
 
 ---

--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+import importlib
 import sys
 import types
 
@@ -24,6 +25,11 @@ logger = init_logger(__name__)
 __all__ = ["__version__", "torch_dev", "torch_device_type"]
 
 
+# Sentinel used by the shim to distinguish "attribute missing" from
+# "attribute is legitimately ``None``".
+_MISSING = object()
+
+
 # --------------------------
 # Backward-compat ``lmcache.c_ops`` shim
 # --------------------------
@@ -38,17 +44,47 @@ def _install_c_ops_shim() -> None:
     on the singleton, giving us proper polymorphism while keeping the
     existing module-level API surface untouched.
 
+    If the compiled ``lmcache.c_ops`` native module is importable, keep a
+    direct reference to it as a **secondary fallback**: whenever the
+    resolved ``ops`` instance yields a pure-Python ``NativePlanType``
+    stub (e.g. because ``_bind_native`` didn't rebind that class-level
+    alias for whatever reason), transparently fall back to the native
+    module. This preserves the ``lmcache.c_ops`` contract for callers
+    that construct plan types like ``KernelGroupSpec`` / ``StagingCopy``.
+
     The PEP 562 module-level ``__getattr__`` hook is used so that later
     ``setattr(ops, ...)`` patches (e.g. from tests) remain visible.
     """
     # First Party
     from lmcache.v1.platform import resolve_device_ops
+    from lmcache.v1.platform.ops_types import NativePlanType
 
     ops = resolve_device_ops(torch_device_type)
     ops.ensure_native()
 
+    # Best-effort: keep a direct reference to the compiled native module
+    # as a fallback for names the ops instance couldn't provide natively.
+    native_mod: types.ModuleType | None = None
+    try:
+        native_mod = importlib.import_module("lmcache.c_ops")
+    except Exception as exc:
+        logger.debug("Native lmcache.c_ops not importable: %s", exc)
+
+    def _shim_getattr(name: str):
+        val = getattr(ops, name, _MISSING)
+        if val is _MISSING or (
+            isinstance(val, type) and issubclass(val, NativePlanType)
+        ):
+            if native_mod is not None:
+                native_val = getattr(native_mod, name, _MISSING)
+                if native_val is not _MISSING:
+                    return native_val
+        if val is _MISSING:
+            raise AttributeError(name)
+        return val
+
     shim = types.ModuleType("lmcache.c_ops")
-    shim.__getattr__ = lambda name: getattr(ops, name)  # type: ignore[method-assign]
+    shim.__getattr__ = _shim_getattr  # type: ignore[method-assign]
     shim.__dir__ = lambda: dir(ops)  # type: ignore[method-assign]
     sys.modules["lmcache.c_ops"] = shim
     globals()["c_ops"] = shim  # parent attr for IMPORT_FROM bytecode

--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -49,6 +49,7 @@ def _install_c_ops_shim() -> None:
 
     shim = types.ModuleType("lmcache.c_ops")
     shim.__getattr__ = lambda name: getattr(ops, name)  # type: ignore[method-assign]
+    shim.__dir__ = lambda: dir(ops)  # type: ignore[method-assign]
     sys.modules["lmcache.c_ops"] = shim
     globals()["c_ops"] = shim  # parent attr for IMPORT_FROM bytecode
 

--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -2,6 +2,7 @@
 
 # Standard
 import sys
+import types
 
 # First Party
 from lmcache.logging import init_logger
@@ -9,7 +10,6 @@ from lmcache.logging import init_logger
 # --------------------------
 # Backend instance & Device detection
 # --------------------------
-from lmcache.v1.platform import get_backend
 from lmcache.v1.platform import torch_dev as torch_dev
 from lmcache.v1.platform import torch_device_type as torch_device_type
 
@@ -23,14 +23,41 @@ logger = init_logger(__name__)
 
 __all__ = ["__version__", "torch_dev", "torch_device_type"]
 
-_ops = get_backend(torch_device_type)
-if _ops is not None:
-    # Override lmcache.c_ops with merged module,
-    # in which:
-    #     python_ops_fallback as base,
-    #     use backend implementation if exists
-    sys.modules["lmcache.c_ops"] = _ops
-else:
+
+# --------------------------
+# Backward-compat ``lmcache.c_ops`` shim
+# --------------------------
+def _install_c_ops_shim() -> None:
+    """Register ``lmcache.c_ops`` as a live view over the resolved
+    :class:`DeviceOps` **instance** for the current device.
+
+    Calls :meth:`DeviceOps.ensure_native` on the singleton to lazily bind
+    the compiled extension, then installs a module whose ``__getattr__``
+    forwards to that instance. Since all ops are instance methods, calls
+    like ``c_ops.multi_layer_kv_transfer(...)`` resolve to bound methods
+    on the singleton, giving us proper polymorphism while keeping the
+    existing module-level API surface untouched.
+
+    The PEP 562 module-level ``__getattr__`` hook is used so that later
+    ``setattr(ops, ...)`` patches (e.g. from tests) remain visible.
+    """
+    # First Party
+    from lmcache.v1.platform import resolve_device_ops
+
+    ops = resolve_device_ops(torch_device_type)
+    ops.ensure_native()
+
+    shim = types.ModuleType("lmcache.c_ops")
+    shim.__getattr__ = lambda name: getattr(ops, name)  # type: ignore[method-assign]
+    sys.modules["lmcache.c_ops"] = shim
+    globals()["c_ops"] = shim  # parent attr for IMPORT_FROM bytecode
+
+
+try:
+    _install_c_ops_shim()
+except Exception as exc:
     logger.warning(
-        "No compute backend loaded; CLI-only mode (torch/numba not installed)"
+        "No compute backend loaded; CLI-only mode (torch/numba not installed). "
+        "Reason: %s",
+        exc,
     )

--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -25,11 +25,6 @@ logger = init_logger(__name__)
 __all__ = ["__version__", "torch_dev", "torch_device_type"]
 
 
-# Sentinel used by the shim to distinguish "attribute missing" from
-# "attribute is legitimately ``None``".
-_MISSING = object()
-
-
 # --------------------------
 # Backward-compat ``lmcache.c_ops`` shim
 # --------------------------
@@ -38,54 +33,51 @@ def _install_c_ops_shim() -> None:
     :class:`DeviceOps` **instance** for the current device.
 
     Calls :meth:`DeviceOps.ensure_native` on the singleton to lazily bind
-    the compiled extension, then installs a module whose ``__getattr__``
-    forwards to that instance. Since all ops are instance methods, calls
-    like ``c_ops.multi_layer_kv_transfer(...)`` resolve to bound methods
-    on the singleton, giving us proper polymorphism while keeping the
-    existing module-level API surface untouched.
+    the compiled extension, then installs a module whose attribute access
+    resolves through:
 
-    If the compiled ``lmcache.c_ops`` native module is importable, keep a
-    direct reference to it as a **secondary fallback**: whenever the
-    resolved ``ops`` instance yields a pure-Python ``NativePlanType``
-    stub (e.g. because ``_bind_native`` didn't rebind that class-level
-    alias for whatever reason), transparently fall back to the native
-    module. This preserves the ``lmcache.c_ops`` contract for callers
-    that construct plan types like ``KernelGroupSpec`` / ``StagingCopy``.
+    1. Real attributes copied from the compiled native module (if any)
+       -- so plan types like ``KernelGroupSpec`` and native pybind
+       callables are always the real thing, matching the pre-refactor
+       ``lmcache.c_ops`` contract.
+    2. A ``__getattr__`` fallback to the resolved :class:`DeviceOps`
+       instance -- for ops that only exist as torch-baseline instance
+       methods (no native counterpart).
 
     The PEP 562 module-level ``__getattr__`` hook is used so that later
-    ``setattr(ops, ...)`` patches (e.g. from tests) remain visible.
+    ``setattr(ops, ...)`` patches (e.g. from tests) remain visible for
+    attributes not shadowed by the native module.
     """
     # First Party
     from lmcache.v1.platform import resolve_device_ops
-    from lmcache.v1.platform.ops_types import NativePlanType
 
     ops = resolve_device_ops(torch_device_type)
     ops.ensure_native()
 
-    # Best-effort: keep a direct reference to the compiled native module
-    # as a fallback for names the ops instance couldn't provide natively.
+    # Best-effort: import the compiled native module directly. When
+    # ``ensure_native`` already imported it, this returns the cached
+    # entry from ``sys.modules``; otherwise Python's import machinery
+    # loads the ``.so`` fresh. Missing / unbuilt -> ``None`` and we
+    # fall back to the torch baseline via ``ops``.
     native_mod: types.ModuleType | None = None
     try:
         native_mod = importlib.import_module("lmcache.c_ops")
     except Exception as exc:
         logger.debug("Native lmcache.c_ops not importable: %s", exc)
 
-    def _shim_getattr(name: str):
-        val = getattr(ops, name, _MISSING)
-        if val is _MISSING or (
-            isinstance(val, type) and issubclass(val, NativePlanType)
-        ):
-            if native_mod is not None:
-                native_val = getattr(native_mod, name, _MISSING)
-                if native_val is not _MISSING:
-                    return native_val
-        if val is _MISSING:
-            raise AttributeError(name)
-        return val
-
     shim = types.ModuleType("lmcache.c_ops")
-    shim.__getattr__ = _shim_getattr  # type: ignore[method-assign]
-    shim.__dir__ = lambda: dir(ops)  # type: ignore[method-assign]
+    if native_mod is not None:
+        # Copy every public symbol from the native module onto the shim
+        # so ``shim.KernelGroupSpec`` etc. resolve without any indirection.
+        for _name in dir(native_mod):
+            if _name.startswith("_"):
+                continue
+            setattr(shim, _name, getattr(native_mod, _name))
+
+    shim.__getattr__ = lambda name: getattr(ops, name)  # type: ignore[method-assign]
+    shim.__dir__ = lambda: sorted(  # type: ignore[method-assign]
+        set(vars(shim).keys()) | set(dir(ops))
+    )
     sys.modules["lmcache.c_ops"] = shim
     globals()["c_ops"] = shim  # parent attr for IMPORT_FROM bytecode
 

--- a/lmcache/__init__.py
+++ b/lmcache/__init__.py
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-import importlib
 import sys
-import types
 
 # First Party
 from lmcache.logging import init_logger
@@ -13,6 +11,7 @@ from lmcache.logging import init_logger
 # --------------------------
 from lmcache.v1.platform import torch_dev as torch_dev
 from lmcache.v1.platform import torch_device_type as torch_device_type
+from lmcache.v1.platform.c_ops_shim import build_c_ops_shim
 
 try:
     # First Party
@@ -24,66 +23,18 @@ logger = init_logger(__name__)
 
 __all__ = ["__version__", "torch_dev", "torch_device_type"]
 
-
 # --------------------------
 # Backward-compat ``lmcache.c_ops`` shim
 # --------------------------
-def _install_c_ops_shim() -> None:
-    """Register ``lmcache.c_ops`` as a live view over the resolved
-    :class:`DeviceOps` **instance** for the current device.
-
-    Calls :meth:`DeviceOps.ensure_native` on the singleton to lazily bind
-    the compiled extension, then installs a module whose attribute access
-    resolves through:
-
-    1. Real attributes copied from the compiled native module (if any)
-       -- so plan types like ``KernelGroupSpec`` and native pybind
-       callables are always the real thing, matching the pre-refactor
-       ``lmcache.c_ops`` contract.
-    2. A ``__getattr__`` fallback to the resolved :class:`DeviceOps`
-       instance -- for ops that only exist as torch-baseline instance
-       methods (no native counterpart).
-
-    The PEP 562 module-level ``__getattr__`` hook is used so that later
-    ``setattr(ops, ...)`` patches (e.g. from tests) remain visible for
-    attributes not shadowed by the native module.
-    """
-    # First Party
-    from lmcache.v1.platform import resolve_device_ops
-
-    ops = resolve_device_ops(torch_device_type)
-    ops.ensure_native()
-
-    # Best-effort: import the compiled native module directly. When
-    # ``ensure_native`` already imported it, this returns the cached
-    # entry from ``sys.modules``; otherwise Python's import machinery
-    # loads the ``.so`` fresh. Missing / unbuilt -> ``None`` and we
-    # fall back to the torch baseline via ``ops``.
-    native_mod: types.ModuleType | None = None
-    try:
-        native_mod = importlib.import_module("lmcache.c_ops")
-    except Exception as exc:
-        logger.debug("Native lmcache.c_ops not importable: %s", exc)
-
-    shim = types.ModuleType("lmcache.c_ops")
-    if native_mod is not None:
-        # Copy every public symbol from the native module onto the shim
-        # so ``shim.KernelGroupSpec`` etc. resolve without any indirection.
-        for _name in dir(native_mod):
-            if _name.startswith("_"):
-                continue
-            setattr(shim, _name, getattr(native_mod, _name))
-
-    shim.__getattr__ = lambda name: getattr(ops, name)  # type: ignore[method-assign]
-    shim.__dir__ = lambda: sorted(  # type: ignore[method-assign]
-        set(vars(shim).keys()) | set(dir(ops))
-    )
-    sys.modules["lmcache.c_ops"] = shim
-    globals()["c_ops"] = shim  # parent attr for IMPORT_FROM bytecode
-
-
+# The shim body lives in ``lmcache.v1.platform.c_ops_shim``; registration
+# is done here because ``lmcache.c_ops`` is part of the top-level package's
+# public contract and the parent-attribute mount (``globals()["c_ops"]``)
+# must be set from ``lmcache/__init__.py``'s own globals so that
+# ``from lmcache import c_ops`` (IMPORT_FROM bytecode) resolves correctly.
 try:
-    _install_c_ops_shim()
+    _shim = build_c_ops_shim(torch_device_type)
+    sys.modules["lmcache.c_ops"] = _shim
+    globals()["c_ops"] = _shim  # parent attr for IMPORT_FROM bytecode
 except Exception as exc:
     logger.warning(
         "No compute backend loaded; CLI-only mode (torch/numba not installed). "

--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -8,7 +8,6 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.python_ops_fallback import set_shape_desc_dtype
 from lmcache.utils import EngineType, _lmcache_nvtx_annotate
 from lmcache.v1.compute.blend.utils import LMCBlenderBuilder
 from lmcache.v1.gpu_connector.kv_format.contiguity import (
@@ -35,6 +34,7 @@ from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
 from lmcache.v1.memory_allocators.gpu_memory_allocator import GPUMemoryAllocator
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
 from lmcache.v1.metadata import LMCacheMetadata
+from lmcache.v1.platform.ops_types import set_shape_desc_dtype
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -15,7 +15,6 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.python_ops_fallback import set_shape_desc_dtype
 from lmcache.utils import EngineType, lmcache_deprecate
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.gpu_connector.kv_format import (
@@ -26,6 +25,7 @@ from lmcache.v1.gpu_connector.kv_format import (
     get_spec_class,
 )
 from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache, LayoutHints
+from lmcache.v1.platform.ops_types import set_shape_desc_dtype
 
 if TYPE_CHECKING:
     # First Party

--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -13,9 +13,9 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
-from lmcache.python_ops_fallback import set_shape_desc_dtype
 from lmcache.utils import lmcache_deprecate
 from lmcache.v1.distributed.api import AttnWindowDesc
+from lmcache.v1.platform.ops_types import set_shape_desc_dtype
 import lmcache.c_ops as lmc_ops
 
 if TYPE_CHECKING:

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -48,19 +48,21 @@ from lmcache.v1.multiprocess.native_completion import (
     submit_callback_to_stream,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
-from lmcache.v1.platform import _torch_impl
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 from lmcache.v1.platform.cache_context import create_cache_context
+from lmcache.v1.platform.ops_types import NativePlanType
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
-# ``lmc_ops.execute_object_group_transfer`` is either a native callable (bound
-# on accelerators via ``DeviceOps._bind_native``) or the torch baseline
-# (a native-only op that raises). Identity against the baseline tells us whether
-# a real native implementation is present.
-_HAS_NATIVE_OBJECT_GROUP_TRANSFER: bool = (
-    lmc_ops.execute_object_group_transfer
-    is not _torch_impl.execute_object_group_transfer
+# The object-group transfer path requires the compiled c_ops extension:
+# it constructs pybind plan types (``KernelGroupSpec`` etc.) and calls
+# ``execute_object_group_transfer`` on them. If ``KernelGroupSpec`` on
+# the ``lmcache.c_ops`` shim is still the pure-Python ``NativePlanType``
+# stub, native binding didn't happen and we must fall back to the
+# per-object copy path instead of building an unusable plan.
+_HAS_NATIVE_OBJECT_GROUP_TRANSFER: bool = not (
+    isinstance(lmc_ops.KernelGroupSpec, type)
+    and issubclass(lmc_ops.KernelGroupSpec, NativePlanType)
 )
 
 

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -48,15 +48,19 @@ from lmcache.v1.multiprocess.native_completion import (
     submit_callback_to_stream,
 )
 from lmcache.v1.multiprocess.protocols.base import RequestType
+from lmcache.v1.platform import _torch_impl
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
-import lmcache.python_ops_fallback as _python_ops_fallback
 
 logger = init_logger(__name__)
+# ``lmc_ops.execute_object_group_transfer`` is either a native callable (bound
+# on accelerators via ``DeviceOps._bind_native``) or the torch baseline
+# (a native-only op that raises). Identity against the baseline tells us whether
+# a real native implementation is present.
 _HAS_NATIVE_OBJECT_GROUP_TRANSFER: bool = (
     lmc_ops.execute_object_group_transfer
-    is not _python_ops_fallback.execute_object_group_transfer
+    is not _torch_impl.execute_object_group_transfer
 )
 
 

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -57,24 +57,19 @@ logger = init_logger(__name__)
 # ---------------------------------------------------------------------------
 # Resolve device ops
 # ---------------------------------------------------------------------------
-def resolve_device_ops_cls(device_type: str) -> type[DeviceOps]:
-    """Resolve the ``DeviceOps`` class for *device_type*.
+def _resolve_spec(device_type: str) -> DeviceSpec:
+    """Resolve the :class:`DeviceSpec` for *device_type*.
 
-    Args:
-        device_type: Device type string such as ``"cuda"`` or ``"cpu"``.
-
-    Returns:
-        The resolved :class:`DeviceOps` subclass for the requested device.
-        ``"cpu"`` normally resolves through :class:`CpuDeviceSpec`, while
-        ``""`` uses the bare :class:`DeviceSpec` fallback. If tests or
-        CLI-only fallback paths deliberately remove the CPU spec from the
-        registry to exercise or simulate the minimal baseline path, ``"cpu"``
-        also falls back to the bare baseline.
+    ``"cpu"`` normally resolves through :class:`CpuDeviceSpec`, while
+    ``""`` uses the bare :class:`DeviceSpec` fallback. If tests or CLI-only
+    fallback paths deliberately remove the CPU spec from the registry to
+    exercise or simulate the minimal baseline path, ``"cpu"`` also falls
+    back to the bare baseline.
 
     Raises:
-        RuntimeError: If an accelerator device has no registered
-            :class:`DeviceSpec`, since silently falling back to the torch
-            baseline on accelerator hardware would mask configuration errors.
+        RuntimeError: If an accelerator device has no registered spec,
+            since silently falling back to the torch baseline on accelerator
+            hardware would mask configuration errors.
     """
     spec = _DEVICE_REGISTRY.get(device_type)
     if spec is None:
@@ -87,28 +82,33 @@ def resolve_device_ops_cls(device_type: str) -> type[DeviceOps]:
                 "accelerator hardware. Ensure the platform sub-package for this "
                 "device is importable and defines a DeviceSpec with ops_cls."
             )
+    return spec
 
-    return spec.ops_cls
 
+def resolve_device_ops_cls(device_type: str) -> type[DeviceOps]:
+    """Resolve the ``DeviceOps`` class for *device_type*.
 
-# Per-device singleton :class:`DeviceOps` instance cache.
-_DEVICE_OPS_INSTANCES: dict[str, DeviceOps] = {}
+    Args:
+        device_type: Device type string such as ``"cuda"`` or ``"cpu"``.
+
+    Returns:
+        The resolved :class:`DeviceOps` subclass for the requested device.
+        See :func:`_resolve_spec` for resolution / error semantics.
+    """
+    return _resolve_spec(device_type).ops_cls
 
 
 def resolve_device_ops(device_type: str) -> DeviceOps:
     """Resolve the :class:`DeviceOps` **instance** for *device_type*.
 
-    Returns a cached singleton. Callers hitting the same *device_type*
-    twice always get the same instance, so any state set on it (native
-    handles, cached lookups) is shared across the process.
+    Returns a cached singleton via :meth:`DeviceSpec.get_ops`. Callers
+    hitting the same *device_type* twice always get the same instance, so
+    any state set on it (native handles, cached lookups) is shared across
+    the process.
 
-    See :func:`resolve_device_ops_cls` for parameter / error semantics.
+    See :func:`_resolve_spec` for resolution / error semantics.
     """
-    ops = _DEVICE_OPS_INSTANCES.get(device_type)
-    if ops is None:
-        ops = resolve_device_ops_cls(device_type)()
-        _DEVICE_OPS_INSTANCES[device_type] = ops
-    return ops
+    return _resolve_spec(device_type).get_ops()
 
 
 torch_dev, torch_device_type = get_torch_device()

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -22,14 +22,16 @@ requires *zero* edits to this module -- drop a new
 automatically.
 """
 
-# Standard
-from typing import Any
-import importlib
-import os
-import types
-
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.platform._device_detect import (
+    current_device_spec as _current_device_spec_fn,
+)
+from lmcache.v1.platform._device_detect import get_device_spec as get_device_spec
+from lmcache.v1.platform._device_detect import (
+    get_torch_device,
+)
+from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
 from lmcache.v1.platform.event_notifier import HAS_EVENTFD as HAS_EVENTFD
 from lmcache.v1.platform.event_notifier import EventfdNotifier as EventfdNotifier
@@ -39,187 +41,74 @@ from lmcache.v1.platform.event_notifier import consume_fd as consume_fd
 from lmcache.v1.platform.event_notifier import (
     create_event_notifier as create_event_notifier,
 )
-from lmcache.v1.utils.subclass_discovery import discover_subclasses
 
 logger = init_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Device spec registry
+# Resolve device ops
 # ---------------------------------------------------------------------------
-
-
-_DEVICE_REGISTRY: dict[str, DeviceSpec] = {
-    spec.device_type: spec
-    for spec in [
-        cls()
-        for cls in discover_subclasses(
-            "lmcache.v1.platform",
-            DeviceSpec,  # type: ignore[type-abstract]
-            module_filter=lambda name: not name.startswith(("_", "base")),
-            require_defined_in_module=True,
-            on_import_error=lambda name, exc: None,
-        )
-    ]
-}
-
-
-# ---------------------------------------------------------------------------
-# Device detection
-# ---------------------------------------------------------------------------
-
-
-def _detect_device() -> tuple[Any, str]:
-    """Detect the available accelerator via the device registry.
-
-    Returns:
-        tuple[Any, str]: A tuple of (torch_device_module, device_type_string).
-            When torch is not installed (CLI-only mode), returns
-            ``(None, "cpu")``.
-    """
-    try:
-        # Third Party
-        import torch
-    except ImportError as e:
-        logger.warning("load torch failed, error is %s", e)
-        return None, "cpu"  # fallback for CLI-only environments
-
-    # Check DEVICE_TYPE environment variable for forced device selection.
-    env_device_type = os.environ.get("DEVICE_TYPE")
-    if env_device_type is not None:
-        env_device_type = env_device_type.strip().lower()
-        spec = _DEVICE_REGISTRY.get(env_device_type)
-        if spec is not None and spec.is_available():
-            torch_module = getattr(torch, spec.torch_module_name, None)
-            if torch_module is not None:
-                return torch_module, spec.device_type
-            else:
-                logger.warning(
-                    "DEVICE_TYPE=%r is available but torch module [%s] not found, "
-                    "falling back to auto-detection.",
-                    env_device_type,
-                    spec.torch_module_name,
-                )
-        else:
-            logger.warning(
-                "DEVICE_TYPE=%r is not available or not registered, "
-                "falling back to auto-detection.",
-                env_device_type,
-            )
-
-    for spec in _DEVICE_REGISTRY.values():
-        if not spec.is_available():
-            continue
-
-        torch_module = getattr(torch, spec.torch_module_name, None)
-        if torch_module is not None:
-            return torch_module, spec.device_type
-        else:
-            logger.warning(
-                "device [%s] is available, but torch module [%s] is not found.",
-                spec.device_type,
-                spec.torch_module_name,
-            )
-
-    # No accelerator found -- fall back to CPU stub
-    # First Party
-    from lmcache.v1.platform.cpu.stub_cpu_device import StubCPUDevice
-
-    return StubCPUDevice("cpu"), "cpu"
-
-
-# ---------------------------------------------------------------------------
-# Get device spec
-# ---------------------------------------------------------------------------
-def get_device_spec(device_type: str) -> DeviceSpec | None:
-    """Get the DeviceSpec for the given device type.
+def resolve_device_ops_cls(device_type: str) -> type[DeviceOps]:
+    """Resolve the ``DeviceOps`` class for *device_type*.
 
     Args:
-        device_type: The device type string (e.g. ``"cuda"``).
+        device_type: Device type string such as ``"cuda"`` or ``"cpu"``.
 
     Returns:
-        The DeviceSpec for the given device type, or None if not found.
+        The resolved :class:`DeviceOps` subclass for the requested device.
+        ``"cpu"`` normally resolves through :class:`CpuDeviceSpec`, while
+        ``""`` uses the bare :class:`DeviceSpec` fallback. If tests or
+        CLI-only fallback paths deliberately remove the CPU spec from the
+        registry to exercise or simulate the minimal baseline path, ``"cpu"``
+        also falls back to the bare baseline.
+
+    Raises:
+        RuntimeError: If an accelerator device has no registered
+            :class:`DeviceSpec`, since silently falling back to the torch
+            baseline on accelerator hardware would mask configuration errors.
     """
-    return _DEVICE_REGISTRY.get(device_type)
-
-
-# ---------------------------------------------------------------------------
-# Dynamic backend selection
-# ---------------------------------------------------------------------------
-
-
-def get_backend(device_type: str) -> Any | None:
-    """Select the ops backend for the given device type.
-
-    Looks up the :class:`DeviceSpec` for *device_type* in the registry
-    and loads/merges its ops module on top of the Python fallback.
-
-    Args:
-        device_type: The detected device type string (e.g. ``"cuda"``).
-
-    Returns:
-        A merged :class:`types.ModuleType` (fallback + hw-specific ops),
-        or ``None`` if torch / dependencies are unavailable.
-    """
-    try:
-        # Third Party
-        import torch  # noqa: F401
-    except (ImportError, ModuleNotFoundError) as e:
-        logger.warning("load torch failed, error is %s", e)
-        return None
-
-    try:
-        default_module = importlib.import_module("lmcache.python_ops_fallback")
-    except (ImportError, ModuleNotFoundError) as e:
-        logger.warning("Cannot load python_ops_fallback: %s", e)
-        return None
-
     spec = _DEVICE_REGISTRY.get(device_type)
     if spec is None:
-        logger.info("No DeviceSpec registered for %r, using fallback ops.", device_type)
-        return default_module
+        if device_type in ("", "cpu"):
+            spec = DeviceSpec()
+        else:
+            raise RuntimeError(
+                f"No DeviceSpec registered for accelerator {device_type!r}; "
+                "refusing to silently fall back to the torch baseline on "
+                "accelerator hardware. Ensure the platform sub-package for this "
+                "device is importable and defines a DeviceSpec with ops_cls."
+            )
 
-    if not spec.is_available():
-        logger.warning("Device %s is not available, using fallback ops.", device_type)
-        return default_module
-
-    if not spec.ops_module:
-        # Device has no custom ops -- use fallback
-        logger.info(
-            "Custom ops not supported for device: %s, using fallback ops.", device_type
-        )
-        return default_module
-
-    try:
-        backend_module = importlib.import_module(spec.ops_module)
-        merged_module = types.ModuleType("lmcache.c_ops")
-        merged_module.__dict__.update(default_module.__dict__)
-        merged_module.__dict__.update(backend_module.__dict__)
-        logger.info("Using backend: %s", spec.ops_module)
-        return merged_module
-    except Exception as e:
-        logger.warning("Failed to import backend %s: %s", spec.ops_module, e)
-
-    return default_module
+    return spec.ops_cls
 
 
-torch_dev, torch_device_type = _detect_device()
+# Per-device singleton :class:`DeviceOps` instance cache.
+_DEVICE_OPS_INSTANCES: dict[str, DeviceOps] = {}
 
-logger.info("torch_dev=%s, torch_device_type=%s", torch_dev, torch_device_type)
+
+def resolve_device_ops(device_type: str) -> DeviceOps:
+    """Resolve the :class:`DeviceOps` **instance** for *device_type*.
+
+    Returns a cached singleton. Callers hitting the same *device_type*
+    twice always get the same instance, so any state set on it (native
+    handles, cached lookups) is shared across the process.
+
+    See :func:`resolve_device_ops_cls` for parameter / error semantics.
+    """
+    ops = _DEVICE_OPS_INSTANCES.get(device_type)
+    if ops is None:
+        ops = resolve_device_ops_cls(device_type)()
+        _DEVICE_OPS_INSTANCES[device_type] = ops
+    return ops
 
 
-# Resolve the DeviceSpec for the detected device so callers can use
-# platform-specific capabilities (e.g. ``current_device_spec.pin_memory(...)``)
-# without touching the torch device module.  When no accelerator sub-
-# package matches, fall back to a bare ``DeviceSpec()`` -- its default
-# implementation provides "no-op / all False" semantics.
-_registered_device_spec = _DEVICE_REGISTRY.get(torch_device_type)
-if _registered_device_spec is None:
-    if torch_device_type != "cpu":
-        logger.warning(
-            "No DeviceSpec registered for %r; using fallback with no-op capabilities.",
-            torch_device_type,
-        )
-    current_device_spec: DeviceSpec = DeviceSpec()
-else:
-    current_device_spec = _registered_device_spec
+torch_dev, torch_device_type = get_torch_device()
+
+current_device_spec: DeviceSpec = _current_device_spec_fn()
+
+# First Party
+# Backward-compat: tests and internal code may reference _DEVICE_REGISTRY.
+# Delegates to the cached registry in _device_detect.
+from lmcache.v1.platform._device_detect import _build_device_registry  # noqa: E402
+
+_DEVICE_REGISTRY: dict[str, DeviceSpec] = _build_device_registry()

--- a/lmcache/v1/platform/__init__.py
+++ b/lmcache/v1/platform/__init__.py
@@ -22,6 +22,12 @@ requires *zero* edits to this module -- drop a new
 automatically.
 """
 
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.v1.platform._device_detect import (
@@ -31,7 +37,6 @@ from lmcache.v1.platform._device_detect import get_device_spec as get_device_spe
 from lmcache.v1.platform._device_detect import (
     get_torch_device,
 )
-from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
 from lmcache.v1.platform.event_notifier import HAS_EVENTFD as HAS_EVENTFD
 from lmcache.v1.platform.event_notifier import EventfdNotifier as EventfdNotifier
@@ -41,6 +46,10 @@ from lmcache.v1.platform.event_notifier import consume_fd as consume_fd
 from lmcache.v1.platform.event_notifier import (
     create_event_notifier as create_event_notifier,
 )
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.platform.base_device_ops import DeviceOps
 
 logger = init_logger(__name__)
 

--- a/lmcache/v1/platform/_device_detect.py
+++ b/lmcache/v1/platform/_device_detect.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Device detection helpers, decoupled from ``lmcache.v1.platform``.
+
+Kept in its own module (rather than in ``platform/__init__.py``) so that
+peers such as :mod:`lmcache.v1.platform._torch_impl` can import the
+detection primitives at the top of the file without introducing an
+import cycle -- ``platform/__init__.py`` itself pulls in
+``base_device_ops``, which in turn pulls in ``_torch_impl``, so any name
+that ``_torch_impl`` needs from the platform package must live *outside*
+that init chain.
+
+The registry of :class:`DeviceSpec` subclasses and the detected torch
+device module are both built lazily on first access and then cached
+process-wide.
+"""
+
+# Standard
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+import os
+
+# First Party
+from lmcache.logging import init_logger
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.platform.base_device_spec import DeviceSpec
+
+logger = init_logger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _build_device_registry() -> "dict[str, DeviceSpec]":
+    """Discover and instantiate every :class:`DeviceSpec` subclass.
+
+    Discovery is deferred until first use so importing this module
+    stays cheap and side-effect free.
+    """
+    # First Party
+    from lmcache.v1.platform.base_device_spec import DeviceSpec
+    from lmcache.v1.utils.subclass_discovery import discover_subclasses
+
+    return {
+        spec.device_type: spec
+        for spec in [
+            cls()
+            for cls in discover_subclasses(
+                "lmcache.v1.platform",
+                DeviceSpec,  # type: ignore[type-abstract]
+                module_filter=lambda name: not name.startswith(("_", "base")),
+                require_defined_in_module=True,
+                on_import_error=lambda name, exc: None,
+            )
+        ]
+    }
+
+
+def get_device_spec(device_type: str) -> "DeviceSpec | None":
+    """Return the :class:`DeviceSpec` registered for *device_type*, if any."""
+    return _build_device_registry().get(device_type)
+
+
+def _detect_device() -> tuple[Any, str]:
+    """Detect the available accelerator via the device registry.
+
+    Returns:
+        tuple[Any, str]: A tuple of (torch_device_module, device_type_string).
+            When torch is not installed (CLI-only mode), returns
+            ``(None, "cpu")``.
+    """
+    try:
+        # Third Party
+        import torch
+    except ImportError as e:
+        logger.warning("load torch failed, error is %s", e)
+        return None, "cpu"  # fallback for CLI-only environments
+
+    registry = _build_device_registry()
+
+    # Check DEVICE_TYPE environment variable for forced device selection.
+    env_device_type = os.environ.get("DEVICE_TYPE")
+    if env_device_type is not None:
+        env_device_type = env_device_type.strip().lower()
+        spec = registry.get(env_device_type)
+        if spec is not None and spec.is_available():
+            torch_module = getattr(torch, spec.torch_module_name, None)
+            if torch_module is not None:
+                return torch_module, spec.device_type
+            else:
+                logger.warning(
+                    "DEVICE_TYPE=%r is available but torch module [%s] not found, "
+                    "falling back to auto-detection.",
+                    env_device_type,
+                    spec.torch_module_name,
+                )
+        else:
+            logger.warning(
+                "DEVICE_TYPE=%r is not available or not registered, "
+                "falling back to auto-detection.",
+                env_device_type,
+            )
+
+    for spec in registry.values():
+        if not spec.is_available():
+            continue
+
+        torch_module = getattr(torch, spec.torch_module_name, None)
+        if torch_module is not None:
+            return torch_module, spec.device_type
+        else:
+            logger.warning(
+                "device [%s] is available, but torch module [%s] is not found.",
+                spec.device_type,
+                spec.torch_module_name,
+            )
+
+    # No accelerator found -- fall back to CPU stub
+    # First Party
+    from lmcache.v1.platform.cpu.stub_cpu_device import StubCPUDevice
+
+    return StubCPUDevice("cpu"), "cpu"
+
+
+@lru_cache(maxsize=1)
+def get_torch_device() -> tuple[Any, str]:
+    """Return the cached ``(torch_dev, torch_device_type)`` pair.
+
+    Lazy + memoized so that peers like :mod:`_torch_impl` can safely
+    import this helper at module top level: no work is performed until
+    the tuple is actually needed.
+    """
+    torch_dev, torch_device_type = _detect_device()
+    logger.info("torch_dev=%s, torch_device_type=%s", torch_dev, torch_device_type)
+    return torch_dev, torch_device_type
+
+
+@lru_cache(maxsize=1)
+def current_device_spec() -> "DeviceSpec":
+    """Return the :class:`DeviceSpec` for the detected device.
+
+    Falls back to a bare ``DeviceSpec()`` (no-op / all False semantics)
+    when no accelerator sub-package matches.
+    """
+    # First Party
+    from lmcache.v1.platform.base_device_spec import DeviceSpec
+
+    _, device_type = get_torch_device()
+    spec = get_device_spec(device_type)
+    if spec is None:
+        if device_type != "cpu":
+            logger.warning(
+                "No DeviceSpec registered for %r; using fallback"
+                " with no-op capabilities.",
+                device_type,
+            )
+        return DeviceSpec()
+    return spec

--- a/lmcache/v1/platform/_torch_impl.py
+++ b/lmcache/v1/platform/_torch_impl.py
@@ -1,13 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
-#
-# This file contains Python non-CUDA fallback implementations for
-# CUDA-specific operations.
-#
+"""Private torch baseline used by :class:`DeviceOps` instance methods.
+
+Each :class:`~lmcache.v1.platform.base_device_ops.DeviceOps` method delegates
+to a function in this module by default; accelerator subclasses override the
+methods to plug in native kernels. Consumers never import this module
+directly -- they call methods on a ``DeviceOps`` instance, or go through the
+``lmcache.c_ops`` shim which forwards to a resolved singleton instance.
+"""
+
+# TODO(baoloongmao): this module was renamed from
+# ``lmcache/python_ops_fallback.py``. The "fallback" concept is gone -- these
+# are just the reference torch implementations that DeviceOps delegates to.
+# A follow-up pass should:
+#   * split the shared-memory / ctypes helpers out into their own module,
+#   * drop unused ``_registry`` dicts that only made sense in the flat
+#     ``lmcache.python_ops_fallback`` era,
+#   * reshape each free function to match the DeviceOps method signatures 1:1
+#     (right now some funcs accept extra positional args purely for backward
+#     compatibility with the old ``c_ops`` shim).
+
 # Standard
 from concurrent.futures import ThreadPoolExecutor
-from enum import IntEnum
 from multiprocessing import shared_memory
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 import ctypes
 import ctypes.util
 import os
@@ -20,9 +35,18 @@ import numpy as np
 import torch
 
 # First Party
-from lmcache import torch_dev, torch_device_type
 from lmcache.logging import init_logger
-from lmcache.v1.platform import current_device_spec
+from lmcache.v1.platform._device_detect import (
+    current_device_spec,
+    get_torch_device,
+)
+from lmcache.v1.platform.ops_types import (  # noqa: F401
+    EngineKVFormat,
+    GPUKVFormat,
+    PageBufferShapeDesc,
+    TransferDirection,
+    set_shape_desc_dtype,
+)
 
 # Store the tensor objects in memory so that they can be accessed
 # outside the scope of this file
@@ -247,161 +271,6 @@ def _copy_bytes_with_tensor(dst: int, src: int, num_bytes: int) -> None:
     dst_tensor.copy_(src_tensor)
 
 
-class TransferDirection(IntEnum):
-    """Specifies the direction of a memory transfer.
-
-    Inherits from IntEnum so that members compare equal to plain ints
-    and to native pybind11 enum members with the same integer value.
-    Several call sites (and the fallback ops themselves) use
-    ``int(direction)`` to compare across backend / fallback boundaries.
-    """
-
-    H2D = 0
-    D2H = 1
-
-
-class EngineKVFormat(IntEnum):
-    """Enumeration of different engine KV cache memory layouts."""
-
-    # used by: vLLM CROSS_LAYER mode
-    NB_NL_TWO_BS_NH_HS = 0
-
-    # used by: vLLM non-MLA flash attention
-    NL_X_TWO_NB_BS_NH_HS = 1
-
-    # used by: vLLM non-MLA flash infer
-    NL_X_NB_TWO_BS_NH_HS = 2
-
-    # used by: vLLM MLA
-    NL_X_NB_BS_HS = 3
-
-    # used by: SGLang MHA (flash attention and flash infer)
-    TWO_X_NL_X_NBBS_NH_HS = 4
-
-    # used by: SGLang MLA
-    NL_X_NBBS_ONE_HS = 5
-
-    # used by: vLLM non-MLA flash attention (HND layout)
-    NL_X_TWO_NB_NH_BS_HS = 6
-
-    # used by: vLLM non-MLA flash infer (HND layout)
-    NL_X_NB_TWO_NH_BS_HS = 7
-
-    # used by: TRT-LLM cross-layer (HND layout)
-    NB_NL_TWO_NH_BS_HS = 8
-
-    # used by: SGLang MHA via the MP daemon path
-    TWO_X_NL_X_NB_BS_NH_HS = 9
-
-    # used by: vLLM non-MLA blocks-first attention with K/V fused into the
-    # trailing dim. Per-layer physical shape
-    # [num_blocks, num_heads, block_size, 2, head_size] -- the K/V "2" axis is
-    # second-to-last, recovered by splitting the fused [..., 2 * head_size].
-    NL_X_NB_NH_BS_TWO_HS = 10
-
-
-# Backward-compat alias
-GPUKVFormat = EngineKVFormat
-
-
-class PageBufferShapeDesc:
-    """Python stand-in for the C++ ``PageBufferShapeDesc`` struct.
-
-    Mirrors the pybind ``def_readwrite`` attributes in ``csrc/pybind.cpp``
-    so non-CUDA code paths can construct and inspect shape descriptors
-    without the compiled extension.
-
-    ``block_stride_elems`` captures the *physical* per-block step in
-    element units (= ``tensor.stride(0)``). For a tightly-packed paged
-    buffer it equals ``bs * kv_size * nh * hs`` (non-MLA) /
-    ``bs * nh * hs`` (MLA); for a vLLM KV pool where a group's row is
-    padded to the pool's maximum row width (e.g. DeepSeek V4 compressor
-    / indexer caches), it is strictly larger. Downstream kernels must
-    use this value instead of recomputing a "tight" stride from the
-    logical shape, otherwise they'll skip into the next block's padding
-    region and read/write the wrong slots.
-    """
-
-    __slots__ = (
-        "kv_size",
-        "nl",
-        "nb",
-        "bs",
-        "nh",
-        "hs",
-        "element_size",
-        "block_stride_elems",
-        "dtype",
-    )
-
-    def __init__(self) -> None:
-        self.kv_size: int = 0
-        self.nl: int = 0
-        self.nb: int = 0
-        self.bs: int = 0
-        self.nh: int = 0
-        self.hs: int = 0
-        self.element_size: int = 0
-        # 0 means "unset — fall back to tight stride"; any downstream
-        # consumer that needs exact addressing must check this.
-        self.block_stride_elems: int = 0
-        self.dtype: torch.dtype | None = None
-
-
-class _NativePlanType:
-    """Base for object-group transfer plan types that only exist natively.
-
-    The plan value structs (see ``csrc/mp_mem_kernels.cuh``) are built on the
-    Python side and consumed by the native ``execute_object_group_transfer``.
-    They have no pure-Python fallback, so constructing one without the compiled
-    ``c_ops`` extension is unsupported. Subclasses exist only so the CPU-only
-    build exposes the same names as ``c_ops``.
-    """
-
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(
-            f"{type(self).__name__} requires the c_ops native extension; "
-            "no pure-Python fallback exists."
-        )
-
-
-class StagingCopy(_NativePlanType):
-    """Fallback stub for the native ``StagingCopy`` plan type."""
-
-
-class LaunchVar(_NativePlanType):
-    """Fallback stub for the native ``LaunchVar`` plan type."""
-
-
-class BatchStep(_NativePlanType):
-    """Fallback stub for the native ``BatchStep`` plan type."""
-
-
-class KernelGroupSpec(_NativePlanType):
-    """Fallback stub for the native ``KernelGroupSpec`` plan type."""
-
-
-def set_shape_desc_dtype(shape_desc: Any, dtype: torch.dtype) -> None:
-    """Best-effort ``shape_desc.dtype = dtype``.
-
-    The pure-Python ``PageBufferShapeDesc`` exposes a ``dtype`` slot so
-    the CPU fallback kernel can disambiguate float16 vs bfloat16 (both
-    have ``element_size == 2``). The pybind C++ struct in
-    ``csrc/pybind.cpp`` has no such field; assignment raises
-    ``AttributeError`` and is silently swallowed here so call sites
-    don't need to branch on the active backend.
-
-    Args:
-        shape_desc: A ``PageBufferShapeDesc`` instance (either the
-            pure-Python fallback or the C++ pybind struct).
-        dtype: The torch dtype to assign.
-    """
-    try:
-        shape_desc.dtype = dtype
-    except AttributeError:
-        pass
-
-
 # Cuda path goes through func cudaHostAlloc, which is
 # already page aligned by CUDA spec. This fallback shim mirrors that
 # guarantee so consumers that require page-aligned host buffers, in
@@ -433,6 +302,8 @@ def _alloc_page_aligned_pinned_view(size: int) -> Tuple[torch.Tensor, int]:
     """
     # Pin the host buffer when an accelerator is present (probed once).
     # StubCPUDevice.is_available returns False on CPU-only hosts.
+    torch_dev, torch_device_type = get_torch_device()
+
     global _use_pinned
     if _use_pinned is None:
         _use_pinned = torch_dev.is_available()
@@ -546,7 +417,7 @@ def alloc_shm_pinned_ptr(size: int, shm_name: str = "") -> int:
     _shm_registry[ptr] = shm
 
     # Try to pin the SHM buffer for async D2H copies
-    if current_device_spec.pin_memory(ptr, size):
+    if current_device_spec().pin_memory(ptr, size):
         _pinned_ptr_registry[ptr] = size
 
     return ptr
@@ -558,7 +429,7 @@ def free_shm_pinned_ptr(ptr: int, size: int = 0, shm_name: str = "") -> None:
 
     # Unpin if previously registered
     if ptr in _pinned_ptr_registry:
-        current_device_spec.unpin_memory(ptr)
+        current_device_spec().unpin_memory(ptr)
         _pinned_ptr_registry.pop(ptr, None)
 
     # Release in order: tensor -> ctypes buf -> shm
@@ -2664,6 +2535,8 @@ def get_gpu_pci_bus_id(device_id: int = 0) -> str | None:
     Returns:
         str | None: PCI bus ID (e.g., "0000:29:00.0") or None if unavailable.
     """
+    torch_dev, _ = get_torch_device()
+
     try:
         if torch_dev.is_available() and device_id < torch_dev.device_count():
             props = torch_dev.get_device_properties(device_id)

--- a/lmcache/v1/platform/base_device_ops.py
+++ b/lmcache/v1/platform/base_device_ops.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The unified per-device ops abstraction (the ``lmcache.c_ops`` surface).
+
+:class:`DeviceOps` is a strategy base class whose **every op is an instance
+method** with a real Python body delegating to
+:mod:`lmcache.v1.platform._torch_impl`. Accelerator subclasses override
+individual methods with native kernels via normal OO polymorphism.
+
+Design goals (addressing review feedback on the previous static-method /
+reflective-binding design):
+
+* **Full method list in the base class**: readers and IDEs see the entire
+  contract in one place, no reflection required.
+* **Instance methods, not staticmethods**: subclasses can override single ops
+  through standard Python MRO and can hold per-instance native handles bound
+  in :meth:`DeviceOps.ensure_native` (e.g. attributes captured from a
+  compiled ``.so`` module).
+* **The ``lmcache.c_ops`` shim** forwards attribute access to a resolved
+  ``DeviceOps`` singleton instance, so existing module-level call sites
+  (``lmc_ops.multi_layer_kv_transfer(...)``) keep working unchanged.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING, ClassVar
+import inspect
+
+if TYPE_CHECKING:
+    # Third Party
+    import torch
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.platform import _torch_impl, ops_types
+from lmcache.v1.platform.ops_types import (
+    BatchStep,
+    EngineKVFormat,
+    KernelGroupSpec,
+    LaunchVar,
+    PageBufferShapeDesc,
+    StagingCopy,
+    TransferDirection,
+    set_shape_desc_dtype,
+)
+
+logger = init_logger(__name__)
+
+
+class DeviceOps:
+    """Strategy base: per-device ops resolved via normal instance MRO.
+
+    Every op is an ``instance`` method delegating to the torch baseline in
+    :mod:`~lmcache.v1.platform._torch_impl`. Accelerator subclasses either:
+
+    - Override individual methods (e.g. MUSA overrides
+      :meth:`multi_layer_block_kv_transfer`).
+    - Rebind all ops in :meth:`ensure_native` to a compiled ``.so`` module
+      via :meth:`_bind_native`.
+
+    The ``lmcache.c_ops`` shim forwards attribute access to a resolved
+    singleton instance so module-level call sites keep working.
+    """
+
+    device_type: ClassVar[str] = ""  # base is unregistered
+
+    # ── Shared types (explicit for static analysis) ────────────────────
+    TransferDirection = TransferDirection
+    EngineKVFormat = EngineKVFormat
+    GPUKVFormat = EngineKVFormat  # back-compat alias
+    PageBufferShapeDesc = PageBufferShapeDesc
+    StagingCopy = StagingCopy
+    LaunchVar = LaunchVar
+    BatchStep = BatchStep
+    KernelGroupSpec = KernelGroupSpec
+    set_shape_desc_dtype = staticmethod(set_shape_desc_dtype)
+
+    def __init__(self) -> None:
+        self._native_bound: bool = False
+
+    # ── Lazy native binding ───────────────────────────────────────────
+
+    def ensure_native(self) -> None:
+        """Attempt to load and bind the compiled native extension.
+
+        Subclasses override this to import their own ``lmcache.c_ops`` and
+        call :meth:`_bind_native`. The base class is a no-op (pure torch).
+        Guarded by ``_native_bound`` so it runs at most once per instance.
+        """
+
+    def _bind_native(self, module: object) -> None:
+        """Rebind every op / native type on *self* to the *module*'s export.
+
+        Op names are discovered by reflecting the class body (every public
+        callable declared on :class:`DeviceOps` except :meth:`ensure_native`),
+        so the class body is the single source of truth: add a method here
+        and it is automatically eligible for native rebinding. If *module*
+        exports a symbol with the same name, the instance attribute is
+        overwritten with the module's callable (bound as a plain attribute,
+        not a method -- native functions have no ``self`` argument). Native
+        types (``EngineKVFormat``, ...) are rebound too for pybind enum
+        identity.
+        """
+        bound_ops = 0
+        bound_types = 0
+        skip = {"ensure_native"}
+        for name, member in vars(DeviceOps).items():
+            if name.startswith("_") or name in skip:
+                continue
+            # Only rebind real methods declared in the class body; skip
+            # class-level type aliases (``EngineKVFormat`` etc.) and
+            # ``staticmethod`` wrappers -- those are handled below.
+            if not inspect.isfunction(member):
+                continue
+            fn = getattr(module, name, None)
+            if fn is not None:
+                setattr(self, name, fn)
+                bound_ops += 1
+        for type_name in (
+            "TransferDirection",
+            "EngineKVFormat",
+            "PageBufferShapeDesc",
+            "StagingCopy",
+            "LaunchVar",
+            "BatchStep",
+            "KernelGroupSpec",
+        ):
+            t = getattr(module, type_name, None)
+            if t is not None:
+                setattr(self, type_name, t)
+                bound_types += 1
+        ekf = getattr(module, "EngineKVFormat", None)
+        if ekf is not None:
+            self.GPUKVFormat = ekf  # back-compat alias
+        logger.debug(
+            "_bind_native: %s <- %s (%d ops, %d types)",
+            type(self).__name__,
+            getattr(module, "__name__", repr(module)),
+            bound_ops,
+            bound_types,
+        )
+
+    # ── Ops (all delegate to the torch baseline) ──────────────────────
+
+    def alloc_pinned_numa_ptr(self, size, numa_id=0):
+        return _torch_impl.alloc_pinned_numa_ptr(size, numa_id)
+
+    def free_pinned_numa_ptr(self, ptr, size=None):
+        return _torch_impl.free_pinned_numa_ptr(ptr, size)
+
+    def alloc_pinned_ptr(self, size, device_id=0):
+        return _torch_impl.alloc_pinned_ptr(size, device_id)
+
+    def free_pinned_ptr(self, ptr):
+        return _torch_impl.free_pinned_ptr(ptr)
+
+    def batched_memcpy(self, src_ptrs, dst_ptrs, sizes):
+        return _torch_impl.batched_memcpy(src_ptrs, dst_ptrs, sizes)
+
+    def alloc_shm_pinned_ptr(self, size, shm_name=""):
+        return _torch_impl.alloc_shm_pinned_ptr(size, shm_name)
+
+    def free_shm_pinned_ptr(self, ptr, size=0, shm_name=""):
+        return _torch_impl.free_shm_pinned_ptr(ptr, size, shm_name)
+
+    def alloc_hugepage_pinned_ptr(self, size, device_id=0):
+        return _torch_impl.alloc_hugepage_pinned_ptr(size, device_id)
+
+    def free_hugepage_pinned_ptr(self, ptr, size=0):
+        return _torch_impl.free_hugepage_pinned_ptr(ptr, size)
+
+    def alloc_hugepage_pinned_numa_ptr(self, size, numa_id=0):
+        return _torch_impl.alloc_hugepage_pinned_numa_ptr(size, numa_id)
+
+    def free_hugepage_pinned_numa_ptr(self, ptr, size=0):
+        return _torch_impl.free_hugepage_pinned_numa_ptr(ptr, size)
+
+    def alloc_numa_ptr(self, size, numa_id=0):
+        return _torch_impl.alloc_numa_ptr(size, numa_id)
+
+    def free_numa_ptr(self, ptr, size=None):
+        return _torch_impl.free_numa_ptr(ptr, size)
+
+    def multi_layer_kv_transfer(self, *args, **kwargs):
+        return _torch_impl.multi_layer_kv_transfer(*args, **kwargs)
+
+    def multi_layer_kv_transfer_unilateral(self, *args, **kwargs):
+        return _torch_impl.multi_layer_kv_transfer_unilateral(*args, **kwargs)
+
+    def is_cross_layer(self, engine_kv_format):
+        return _torch_impl.is_cross_layer(engine_kv_format)
+
+    def is_kv_list(self, engine_kv_format):
+        return _torch_impl.is_kv_list(engine_kv_format)
+
+    def is_layer_list(self, engine_kv_format):
+        return _torch_impl.is_layer_list(engine_kv_format)
+
+    def is_mla(self, engine_kv_format):
+        return _torch_impl.is_mla(engine_kv_format)
+
+    def multi_layer_block_kv_transfer(
+        self,
+        paged_buffer_ptrs_tensor: "torch.Tensor | list",
+        lmcache_objects_ptrs: "list[int] | list[torch.Tensor]",
+        block_ids: "torch.Tensor | list[int]",
+        device: "torch.device | str",
+        direction: ops_types.TransferDirection,
+        shape_desc: ops_types.PageBufferShapeDesc,
+        lmcache_chunk_size: int,
+        engine_kv_format: ops_types.EngineKVFormat,
+        skip_prefix_n_blocks: int,
+    ) -> None:
+        return _torch_impl.multi_layer_block_kv_transfer(
+            paged_buffer_ptrs_tensor,
+            lmcache_objects_ptrs,
+            block_ids,
+            device,
+            direction,
+            shape_desc,
+            lmcache_chunk_size,
+            engine_kv_format,
+            skip_prefix_n_blocks,
+        )
+
+    def execute_object_group_transfer(self, *args, **kwargs):
+        return _torch_impl.execute_object_group_transfer(*args, **kwargs)
+
+    def single_layer_kv_transfer(self, *args, **kwargs):
+        return _torch_impl.single_layer_kv_transfer(*args, **kwargs)
+
+    def single_layer_kv_transfer_sgl(self, *args, **kwargs):
+        return _torch_impl.single_layer_kv_transfer_sgl(*args, **kwargs)
+
+    def load_and_reshape_flash(self, *args, **kwargs):
+        return _torch_impl.load_and_reshape_flash(*args, **kwargs)
+
+    def reshape_and_cache_back_flash(self, *args, **kwargs):
+        return _torch_impl.reshape_and_cache_back_flash(*args, **kwargs)
+
+    def lmcache_memcpy_async(self, *args, **kwargs):
+        return _torch_impl.lmcache_memcpy_async(*args, **kwargs)
+
+    def encode_fast_new(self, cdf, input_sym, output_buffer, output_lengths):
+        return _torch_impl.encode_fast_new(
+            cdf, input_sym, output_buffer, output_lengths
+        )
+
+    def decode_fast_new(self, cdf, bytestreams, lengths, output):
+        return _torch_impl.decode_fast_new(cdf, bytestreams, lengths, output)
+
+    def decode_fast_prefsum(self, cdf, bytestreams, lengths_prefsum, output):
+        return _torch_impl.decode_fast_prefsum(
+            cdf, bytestreams, lengths_prefsum, output
+        )
+
+    def calculate_cdf(self, input_tensor, num_bins):
+        return _torch_impl.calculate_cdf(input_tensor, num_bins)
+
+    def rotary_embedding_k_fused(self, *args, **kwargs):
+        return _torch_impl.rotary_embedding_k_fused(*args, **kwargs)
+
+    def get_gpu_pci_bus_id(self, device_id=0):
+        return _torch_impl.get_gpu_pci_bus_id(device_id)
+
+    def record_completion_on_stream(self, *args, **kwargs):
+        return _torch_impl.record_completion_on_stream(*args, **kwargs)
+
+    def drain_recorded_completions(self):
+        return _torch_impl.drain_recorded_completions()
+
+    def record_event_on_stream(self, *args, **kwargs):
+        return _torch_impl.record_event_on_stream(*args, **kwargs)
+
+    def drain_recorded_events(self):
+        return _torch_impl.drain_recorded_events()

--- a/lmcache/v1/platform/base_device_ops.py
+++ b/lmcache/v1/platform/base_device_ops.py
@@ -92,15 +92,21 @@ class DeviceOps:
     def _bind_native(self, module: object) -> None:
         """Rebind every op / native type on *self* to the *module*'s export.
 
-        Op names are discovered by reflecting the class body (every public
-        callable declared on :class:`DeviceOps` except :meth:`ensure_native`),
-        so the class body is the single source of truth: add a method here
-        and it is automatically eligible for native rebinding. If *module*
-        exports a symbol with the same name, the instance attribute is
-        overwritten with the module's callable (bound as a plain attribute,
-        not a method -- native functions have no ``self`` argument). Native
-        types (``EngineKVFormat``, ...) are rebound too for pybind enum
-        identity.
+        Both ops and types are discovered by reflecting the class body:
+
+        * ``inspect.isfunction(member)`` -> op method; if *module* exports
+          a same-named symbol, bind it as an instance attribute (native
+          functions have no ``self`` argument).
+        * ``isinstance(member, type)`` -> class-level type alias
+          (``TransferDirection``, ``EngineKVFormat``, ...); rebind to the
+          module's export so pybind enum / class identity matches when
+          instances cross the Python/native boundary.
+
+        This means the class body is the single source of truth: add a
+        method or a type alias here and it is automatically eligible for
+        native rebinding -- no separate registry to keep in sync.
+        ``GPUKVFormat`` is handled explicitly because it renames to
+        ``EngineKVFormat`` on the native side.
         """
         bound_ops = 0
         bound_types = 0
@@ -108,31 +114,26 @@ class DeviceOps:
         for name, member in vars(DeviceOps).items():
             if name.startswith("_") or name in skip:
                 continue
-            # Only rebind real methods declared in the class body; skip
-            # class-level type aliases (``EngineKVFormat`` etc.) and
-            # ``staticmethod`` wrappers -- those are handled below.
-            if not inspect.isfunction(member):
-                continue
-            fn = getattr(module, name, None)
-            if fn is not None:
-                setattr(self, name, fn)
-                bound_ops += 1
-        for type_name in (
-            "TransferDirection",
-            "EngineKVFormat",
-            "PageBufferShapeDesc",
-            "StagingCopy",
-            "LaunchVar",
-            "BatchStep",
-            "KernelGroupSpec",
-        ):
-            t = getattr(module, type_name, None)
-            if t is not None:
-                setattr(self, type_name, t)
-                bound_types += 1
+            # Real methods -> native callables; class-level type aliases
+            # (``isinstance(member, type)``) -> native pybind classes /
+            # enums for identity. ``staticmethod`` wrappers and other
+            # descriptors are ignored.
+            if inspect.isfunction(member):
+                fn = getattr(module, name, None)
+                if fn is not None:
+                    setattr(self, name, fn)
+                    bound_ops += 1
+            elif isinstance(member, type):
+                t = getattr(module, name, None)
+                if t is not None:
+                    setattr(self, name, t)
+                    bound_types += 1
+        # ``GPUKVFormat`` is a back-compat alias that maps to native
+        # ``EngineKVFormat`` (different name on the native side), so it
+        # needs an explicit rename that reflection can't infer.
         ekf = getattr(module, "EngineKVFormat", None)
         if ekf is not None:
-            self.GPUKVFormat = ekf  # back-compat alias
+            self.GPUKVFormat = ekf
         logger.debug(
             "_bind_native: %s <- %s (%d ops, %d types)",
             type(self).__name__,

--- a/lmcache/v1/platform/base_device_spec.py
+++ b/lmcache/v1/platform/base_device_spec.py
@@ -23,6 +23,7 @@ behaviour, and ``device_type`` / ``torch_module_name`` default to
 """
 
 # First Party
+from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
 
 
@@ -60,12 +61,20 @@ class DeviceSpec:
         return "cpu"
 
     @property
-    def ops_module(self) -> str | None:
-        """Fully-qualified module path for the compiled ops backend.
+    def ops_cls(self) -> type[DeviceOps]:
+        """DeviceOps subclass providing the ``lmcache.c_ops`` surface.
 
-        Return ``None`` if no custom ops are available (fallback only).
+        Lazy by design: the import happens on *access*, not at class-definition
+        or DeviceSpec-discovery time, so resolving a spec never drags the torch
+        baseline (or a native .so) into the platform package's import graph.
+        The base returns the torch/CPU baseline; accelerator specs override.
+
+        Returns:
+            type[DeviceOps]: The base DeviceOps torch/CPU baseline class for the
+            fallback spec. Accelerator subclasses override this property to
+            return their backend-specific DeviceOps subclass.
         """
-        return None
+        return DeviceOps
 
     def is_available(self) -> bool:
         """Return ``True`` when the device is usable on this system.

--- a/lmcache/v1/platform/base_device_spec.py
+++ b/lmcache/v1/platform/base_device_spec.py
@@ -22,9 +22,18 @@ behaviour, and ``device_type`` / ``torch_module_name`` default to
 ``"cpu"``.
 """
 
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import TYPE_CHECKING
+
 # First Party
-from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.platform.base_device_ops import DeviceOps
 
 
 # TODO(chunxiaozheng): bind `DeviceIPCWrapper` with `DeviceSpec`?
@@ -74,6 +83,9 @@ class DeviceSpec:
             fallback spec. Accelerator subclasses override this property to
             return their backend-specific DeviceOps subclass.
         """
+        # First Party
+        from lmcache.v1.platform.base_device_ops import DeviceOps
+
         return DeviceOps
 
     def is_available(self) -> bool:

--- a/lmcache/v1/platform/base_device_spec.py
+++ b/lmcache/v1/platform/base_device_spec.py
@@ -51,6 +51,8 @@ class DeviceSpec:
 
     # Cached pin-memory backend instance (lazy-initialized).
     _pin_backend_cache: PinMemoryBackend | None = None
+    # Cached DeviceOps instance (lazy-initialized).
+    _ops_cache: DeviceOps | None = None
 
     @property
     def device_type(self) -> str:
@@ -87,6 +89,20 @@ class DeviceSpec:
         from lmcache.v1.platform.base_device_ops import DeviceOps
 
         return DeviceOps
+
+    def get_ops(self) -> DeviceOps:
+        """Return the cached :class:`DeviceOps` instance for this spec.
+
+        Lazy-initialized on first access, mirroring :meth:`_get_pin_backend`.
+        The instance is cached on the spec so callers hitting the same spec
+        always get the same singleton, and any state set on it (native
+        handles, cached lookups) is shared across the process.
+        """
+        ops = self._ops_cache
+        if ops is None:
+            ops = self.ops_cls()
+            self._ops_cache = ops
+        return ops
 
     def is_available(self) -> bool:
         """Return ``True`` when the device is usable on this system.

--- a/lmcache/v1/platform/c_ops_shim.py
+++ b/lmcache/v1/platform/c_ops_shim.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Builder for the backward-compat ``lmcache.c_ops`` shim module.
+
+This module contains the *construction* logic only. Registration into
+``sys.modules`` and attaching the shim as an attribute on the top-level
+``lmcache`` package remains the responsibility of ``lmcache/__init__.py``,
+because the parent-attribute mount point (``lmcache.c_ops = shim``) is
+part of the top-level package's public contract and must be set from the
+top-level module's own globals.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import importlib
+import types
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.platform import resolve_device_ops
+
+logger = init_logger(__name__)
+
+
+def build_c_ops_shim(device_type: str) -> types.ModuleType:
+    """Build a live ``lmcache.c_ops`` view over the resolved
+    :class:`DeviceOps` **instance** for *device_type*.
+
+    Calls :meth:`DeviceOps.ensure_native` on the singleton to lazily bind
+    the compiled extension, then returns a module whose attribute access
+    resolves through:
+
+    1. Real attributes copied from the compiled native module (if any)
+       -- so plan types like ``KernelGroupSpec`` and native pybind
+       callables are always the real thing, matching the pre-refactor
+       ``lmcache.c_ops`` contract.
+    2. A ``__getattr__`` fallback to the resolved :class:`DeviceOps`
+       instance -- for ops that only exist as torch-baseline instance
+       methods (no native counterpart).
+
+    The PEP 562 module-level ``__getattr__`` hook is used so that later
+    ``setattr(shim, ...)`` patches (e.g. from tests) remain visible for
+    attributes not shadowed by the native module.
+
+    The caller is responsible for registering the returned module into
+    ``sys.modules["lmcache.c_ops"]`` and mounting it as ``lmcache.c_ops``
+    on the top-level package.
+    """
+    ops = resolve_device_ops(device_type)
+    ops.ensure_native()
+
+    # Best-effort: import the compiled native module directly. When
+    # ``ensure_native`` already imported it, this returns the cached
+    # entry from ``sys.modules``; otherwise Python's import machinery
+    # loads the ``.so`` fresh. Missing / unbuilt -> ``None`` and we
+    # fall back to the torch baseline via ``ops``.
+    native_mod: types.ModuleType | None = None
+    try:
+        native_mod = importlib.import_module("lmcache.c_ops")
+    except Exception as exc:
+        logger.debug("Native lmcache.c_ops not importable: %s", exc)
+
+    shim = types.ModuleType("lmcache.c_ops")
+    if native_mod is not None:
+        # Copy every public symbol from the native module onto the shim
+        # so ``shim.KernelGroupSpec`` etc. resolve without any indirection.
+        for _name in dir(native_mod):
+            if _name.startswith("_"):
+                continue
+            setattr(shim, _name, getattr(native_mod, _name))
+
+    shim.__getattr__ = lambda name: getattr(ops, name)  # type: ignore[method-assign]
+    shim.__dir__ = lambda: sorted(  # type: ignore[method-assign]
+        set(vars(shim).keys()) | set(dir(ops))
+    )
+    return shim

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -6,3 +6,34 @@
 :func:`~lmcache.v1.platform._registry._discover_wrappers_once` picks
 up at run-time -- no static ``register_kv_wrapper`` needed.
 """
+
+# Future
+from __future__ import annotations
+
+# First Party
+from lmcache.v1.platform.base_device_ops import DeviceOps
+from lmcache.v1.platform.base_device_spec import DeviceSpec
+from lmcache.v1.platform.cpu.device_ops import CpuDeviceOps
+
+
+class CpuDeviceSpec(DeviceSpec):
+    """CPU device specification for the detection registry.
+
+    This keeps CPU aligned with the accelerator-specific resolution path:
+    callers asking for ``device_type="cpu"`` receive a concrete
+    :class:`CpuDeviceOps` class through :attr:`DeviceSpec.ops_cls`, while the
+    bare :class:`DeviceSpec` remains available as the fallback for
+    ``device_type=""`` or deliberately stripped test registries.
+    """
+
+    @property
+    def device_type(self) -> str:
+        return "cpu"
+
+    @property
+    def torch_module_name(self) -> str:
+        return "cpu"
+
+    @property
+    def ops_cls(self) -> type[DeviceOps]:
+        return CpuDeviceOps

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -10,10 +10,15 @@ up at run-time -- no static ``register_kv_wrapper`` needed.
 # Future
 from __future__ import annotations
 
+# Standard
+from typing import TYPE_CHECKING
+
 # First Party
-from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
-from lmcache.v1.platform.cpu.device_ops import CpuDeviceOps
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.platform.base_device_ops import DeviceOps
 
 
 class CpuDeviceSpec(DeviceSpec):
@@ -36,4 +41,7 @@ class CpuDeviceSpec(DeviceSpec):
 
     @property
     def ops_cls(self) -> type[DeviceOps]:
+        # First Party
+        from lmcache.v1.platform.cpu.device_ops import CpuDeviceOps
+
         return CpuDeviceOps

--- a/lmcache/v1/platform/cpu/device_ops.py
+++ b/lmcache/v1/platform/cpu/device_ops.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU ops backend: the torch baseline, registered under ``device_type="cpu"``.
+
+:class:`CpuDeviceOps` adds no overrides -- all ops are inherited from
+:class:`DeviceOps` (the torch baseline) via MRO.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import ClassVar
+
+# First Party
+from lmcache.v1.platform.base_device_ops import DeviceOps
+
+
+class CpuDeviceOps(DeviceOps):
+    device_type: ClassVar[str] = "cpu"

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """CUDA-specific platform primitives."""
 
+# Future
+from __future__ import annotations
+
 # First Party
+from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
 from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
+from lmcache.v1.platform.cuda.device_ops import CudaDeviceOps
 from lmcache.v1.platform.cuda.pin_memory import CudaPinMemoryBackend
 
 # ---------------------------------------------------------------------------
@@ -23,8 +28,8 @@ class CudaDeviceSpec(DeviceSpec):
         return "cuda"
 
     @property
-    def ops_module(self) -> str | None:
-        return "lmcache.c_ops"
+    def ops_cls(self) -> type[DeviceOps]:
+        return CudaDeviceOps
 
     @property
     def pin_memory_backend(self) -> type[PinMemoryBackend] | None:

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -4,11 +4,18 @@
 # Future
 from __future__ import annotations
 
+# Standard
+from typing import TYPE_CHECKING
+
 # First Party
-from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.platform.base_device_ops import DeviceOps
+
+# First Party
 from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
-from lmcache.v1.platform.cuda.device_ops import CudaDeviceOps
 from lmcache.v1.platform.cuda.pin_memory import CudaPinMemoryBackend
 
 # ---------------------------------------------------------------------------
@@ -29,6 +36,9 @@ class CudaDeviceSpec(DeviceSpec):
 
     @property
     def ops_cls(self) -> type[DeviceOps]:
+        # First Party
+        from lmcache.v1.platform.cuda.device_ops import CudaDeviceOps
+
         return CudaDeviceOps
 
     @property

--- a/lmcache/v1/platform/cuda/device_ops.py
+++ b/lmcache/v1/platform/cuda/device_ops.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA ops backend: bulk-bind the compiled ``lmcache.c_ops`` extension.
+
+:class:`CudaDeviceOps` calls :meth:`DeviceOps._bind_native` in
+:meth:`ensure_native` to layer the compiled CUDA extension on top of the
+torch baseline.  If the extension is missing, a warning is logged and the
+instance stays on the torch fallback (soft-fail, same as XPU).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import ClassVar
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.platform.base_device_ops import DeviceOps
+
+logger = init_logger(__name__)
+
+
+class CudaDeviceOps(DeviceOps):
+    device_type: ClassVar[str] = "cuda"
+
+    def ensure_native(self) -> None:
+        if self._native_bound:
+            return
+        self._native_bound = True  # set early to prevent repeated attempts
+        try:
+            # First Party
+            import lmcache.c_ops as native
+        except ImportError:
+            logger.warning(
+                "lmcache.c_ops compiled extension not found; "
+                "CudaDeviceOps stays on the torch baseline for all ops."
+            )
+            return
+        self._bind_native(native)

--- a/lmcache/v1/platform/hpu/__init__.py
+++ b/lmcache/v1/platform/hpu/__init__.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """HPU (Habana Gaudi) platform helpers."""
 
+# Future
+from __future__ import annotations
+
 # First Party
+from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
+from lmcache.v1.platform.hpu.device_ops import HpuDeviceOps
 
 # ---------------------------------------------------------------------------
 # Device detection registry entry
@@ -21,8 +26,8 @@ class HpuDeviceSpec(DeviceSpec):
         return "hpu"
 
     @property
-    def ops_module(self) -> str | None:
-        return None
+    def ops_cls(self) -> type[DeviceOps]:
+        return HpuDeviceOps
 
     def is_available(self) -> bool:
         """Check HPU availability without importing lmcache.__init__."""

--- a/lmcache/v1/platform/hpu/__init__.py
+++ b/lmcache/v1/platform/hpu/__init__.py
@@ -4,10 +4,15 @@
 # Future
 from __future__ import annotations
 
+# Standard
+from typing import TYPE_CHECKING
+
 # First Party
-from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
-from lmcache.v1.platform.hpu.device_ops import HpuDeviceOps
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.platform.base_device_ops import DeviceOps
 
 # ---------------------------------------------------------------------------
 # Device detection registry entry
@@ -27,6 +32,9 @@ class HpuDeviceSpec(DeviceSpec):
 
     @property
     def ops_cls(self) -> type[DeviceOps]:
+        # First Party
+        from lmcache.v1.platform.hpu.device_ops import HpuDeviceOps
+
         return HpuDeviceOps
 
     def is_available(self) -> bool:

--- a/lmcache/v1/platform/hpu/device_ops.py
+++ b/lmcache/v1/platform/hpu/device_ops.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HPU ops backend: inherit the torch baseline unchanged.
+
+:class:`HpuDeviceOps` gives the registry a ``device_type="hpu"`` entry.
+All ops are inherited from :class:`DeviceOps` via MRO.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import ClassVar
+
+# First Party
+from lmcache.v1.platform.base_device_ops import DeviceOps
+
+
+class HpuDeviceOps(DeviceOps):
+    device_type: ClassVar[str] = "hpu"

--- a/lmcache/v1/platform/musa/__init__.py
+++ b/lmcache/v1/platform/musa/__init__.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """MUSA-specific platform primitives."""
 
+# Future
+from __future__ import annotations
+
 # First Party
+from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
+from lmcache.v1.platform.musa.device_ops import MusaDeviceOps
 
 # ---------------------------------------------------------------------------
 # Device detection registry entry
@@ -21,8 +26,8 @@ class MusaDeviceSpec(DeviceSpec):
         return "musa"
 
     @property
-    def ops_module(self) -> str | None:
-        return "lmcache.v1.platform.musa.ops"
+    def ops_cls(self) -> type[DeviceOps]:
+        return MusaDeviceOps
 
     def is_available(self) -> bool:
         """Check MUSA availability without importing lmcache.__init__."""

--- a/lmcache/v1/platform/musa/__init__.py
+++ b/lmcache/v1/platform/musa/__init__.py
@@ -4,10 +4,15 @@
 # Future
 from __future__ import annotations
 
+# Standard
+from typing import TYPE_CHECKING
+
 # First Party
-from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
-from lmcache.v1.platform.musa.device_ops import MusaDeviceOps
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.platform.base_device_ops import DeviceOps
 
 # ---------------------------------------------------------------------------
 # Device detection registry entry
@@ -27,6 +32,9 @@ class MusaDeviceSpec(DeviceSpec):
 
     @property
     def ops_cls(self) -> type[DeviceOps]:
+        # First Party
+        from lmcache.v1.platform.musa.device_ops import MusaDeviceOps
+
         return MusaDeviceOps
 
     def is_available(self) -> bool:

--- a/lmcache/v1/platform/musa/device_ops.py
+++ b/lmcache/v1/platform/musa/device_ops.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA ops backend: the torch baseline with one native override.
+
+:class:`MusaDeviceOps` overrides :meth:`multi_layer_block_kv_transfer` to
+try the native MUSA path first (when inputs are tensor-backed) and fall
+back to the torch baseline otherwise.  Every other op inherits the
+baseline via MRO.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import ClassVar
+
+# Third Party
+import torch
+
+# First Party
+from lmcache.v1.platform import _torch_impl
+from lmcache.v1.platform.base_device_ops import DeviceOps
+from lmcache.v1.platform.ops_types import (
+    EngineKVFormat,
+    PageBufferShapeDesc,
+    TransferDirection,
+)
+
+
+def _tensor_list(value: object) -> list[torch.Tensor] | None:
+    """Return ``value`` as ``list[torch.Tensor]`` when it is tensor-backed."""
+    if not isinstance(value, list):
+        return None
+    if not all(isinstance(item, torch.Tensor) for item in value):
+        return None
+    return value
+
+
+class MusaDeviceOps(DeviceOps):
+    device_type: ClassVar[str] = "musa"
+
+    def multi_layer_block_kv_transfer(
+        self,
+        paged_buffer_ptrs_tensor: torch.Tensor | list,
+        lmcache_objects_ptrs: list[int] | list[torch.Tensor],
+        block_ids: torch.Tensor | list[int],
+        device: torch.device | str,
+        direction: TransferDirection,
+        shape_desc: PageBufferShapeDesc,
+        lmcache_chunk_size: int,
+        engine_kv_format: EngineKVFormat,
+        skip_prefix_n_blocks: int,
+    ) -> None:
+        """Native MUSA block transfer when tensor-backed; else torch baseline."""
+        # First Party
+        from lmcache.v1.platform.musa.native_kv_transfer import (
+            try_native_multi_layer_block_kv_transfer,
+        )
+
+        object_tensors = _tensor_list(lmcache_objects_ptrs)
+        if object_tensors is not None and try_native_multi_layer_block_kv_transfer(
+            paged_layers=paged_buffer_ptrs_tensor,
+            object_tensors=object_tensors,
+            block_ids=block_ids,
+            direction=direction,
+            shape_desc=shape_desc,
+            lmcache_chunk_size=lmcache_chunk_size,
+            engine_kv_format=engine_kv_format,
+            skip_prefix_n_blocks=skip_prefix_n_blocks,
+        ):
+            return
+
+        return _torch_impl.multi_layer_block_kv_transfer(
+            paged_buffer_ptrs_tensor,
+            lmcache_objects_ptrs,
+            block_ids,
+            device,
+            direction,
+            shape_desc,
+            lmcache_chunk_size,
+            engine_kv_format,
+            skip_prefix_n_blocks,
+        )

--- a/lmcache/v1/platform/musa/device_ops.py
+++ b/lmcache/v1/platform/musa/device_ops.py
@@ -28,7 +28,7 @@ from lmcache.v1.platform.ops_types import (
 
 def _tensor_list(value: object) -> list[torch.Tensor] | None:
     """Return ``value`` as ``list[torch.Tensor]`` when it is tensor-backed."""
-    if not isinstance(value, list):
+    if not isinstance(value, list) or not value:
         return None
     if not all(isinstance(item, torch.Tensor) for item in value):
         return None

--- a/lmcache/v1/platform/ops_types.py
+++ b/lmcache/v1/platform/ops_types.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared, device-agnostic ops *types* for the unified ``DeviceOps`` surface.
+
+These types (``TransferDirection``, ``EngineKVFormat``, ``GPUKVFormat``,
+``PageBufferShapeDesc``, ``set_shape_desc_dtype``) were migrated verbatim from
+the former ``lmcache.python_ops_fallback`` module. They are deliberately
+self-contained (only ``torch`` + ``enum``) so call sites can import them
+without pulling in the heavier torch-baseline op implementations in
+:mod:`lmcache.v1.platform._torch_impl`.
+
+The object-group transfer plan types (``_NativePlanType`` and its
+``StagingCopy`` / ``LaunchVar`` / ``BatchStep`` / ``KernelGroupSpec``
+subclasses) only exist natively in the compiled ``c_ops`` extension; the
+pure-Python subclasses here are stubs so the CPU-only build exposes the same
+names.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from enum import IntEnum
+from typing import Any
+
+# Third Party
+import torch
+
+
+class TransferDirection(IntEnum):
+    """Specifies the direction of a memory transfer.
+
+    Inherits from IntEnum so that members compare equal to plain ints
+    and to native pybind11 enum members with the same integer value.
+    Several call sites (and the fallback ops themselves) use
+    ``int(direction)`` to compare across backend / fallback boundaries.
+    """
+
+    H2D = 0
+    D2H = 1
+
+
+class EngineKVFormat(IntEnum):
+    """Enumeration of different engine KV cache memory layouts."""
+
+    # used by: vLLM CROSS_LAYER mode
+    NB_NL_TWO_BS_NH_HS = 0
+
+    # used by: vLLM non-MLA flash attention
+    NL_X_TWO_NB_BS_NH_HS = 1
+
+    # used by: vLLM non-MLA flash infer
+    NL_X_NB_TWO_BS_NH_HS = 2
+
+    # used by: vLLM MLA
+    NL_X_NB_BS_HS = 3
+
+    # used by: SGLang MHA (flash attention and flash infer)
+    TWO_X_NL_X_NBBS_NH_HS = 4
+
+    # used by: SGLang MLA
+    NL_X_NBBS_ONE_HS = 5
+
+    # used by: vLLM non-MLA flash attention (HND layout)
+    NL_X_TWO_NB_NH_BS_HS = 6
+
+    # used by: vLLM non-MLA flash infer (HND layout)
+    NL_X_NB_TWO_NH_BS_HS = 7
+
+    # used by: TRT-LLM cross-layer (HND layout)
+    NB_NL_TWO_NH_BS_HS = 8
+
+    # used by: SGLang MHA via the MP daemon path
+    TWO_X_NL_X_NB_BS_NH_HS = 9
+
+    # used by: vLLM non-MLA blocks-first attention with K/V fused into the
+    # trailing dim. Per-layer physical shape
+    # [num_blocks, num_heads, block_size, 2, head_size] -- the K/V "2" axis is
+    # second-to-last, recovered by splitting the fused [..., 2 * head_size].
+    NL_X_NB_NH_BS_TWO_HS = 10
+
+
+# Backward-compat alias
+GPUKVFormat = EngineKVFormat
+
+
+class PageBufferShapeDesc:
+    """Python stand-in for the C++ ``PageBufferShapeDesc`` struct.
+
+    Mirrors the pybind ``def_readwrite`` attributes in ``csrc/pybind.cpp``
+    so non-CUDA code paths can construct and inspect shape descriptors
+    without the compiled extension.
+
+    ``block_stride_elems`` captures the *physical* per-block step in
+    element units (= ``tensor.stride(0)``). For a tightly-packed paged
+    buffer it equals ``bs * kv_size * nh * hs`` (non-MLA) /
+    ``bs * nh * hs`` (MLA); for a vLLM KV pool where a group's row is
+    padded to the pool's maximum row width (e.g. DeepSeek V4 compressor
+    / indexer caches), it is strictly larger. Downstream kernels must
+    use this value instead of recomputing a "tight" stride from the
+    logical shape, otherwise they'll skip into the next block's padding
+    region and read/write the wrong slots.
+    """
+
+    __slots__ = (
+        "kv_size",
+        "nl",
+        "nb",
+        "bs",
+        "nh",
+        "hs",
+        "element_size",
+        "block_stride_elems",
+        "dtype",
+    )
+
+    def __init__(self) -> None:
+        self.kv_size: int = 0
+        self.nl: int = 0
+        self.nb: int = 0
+        self.bs: int = 0
+        self.nh: int = 0
+        self.hs: int = 0
+        self.element_size: int = 0
+        # 0 means "unset — fall back to tight stride"; any downstream
+        # consumer that needs exact addressing must check this.
+        self.block_stride_elems: int = 0
+        self.dtype: torch.dtype | None = None
+
+
+class _NativePlanType:
+    """Base for object-group transfer plan types that only exist natively.
+
+    The plan value structs (see ``csrc/mp_mem_kernels.cuh``) are built on the
+    Python side and consumed by the native ``execute_object_group_transfer``.
+    They have no pure-Python fallback, so constructing one without the compiled
+    ``c_ops`` extension is unsupported. Subclasses exist only so the CPU-only
+    build exposes the same names as ``c_ops``.
+    """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise NotImplementedError(
+            f"{type(self).__name__} requires the c_ops native extension; "
+            "no pure-Python fallback exists."
+        )
+
+
+class StagingCopy(_NativePlanType):
+    """Fallback stub for the native ``StagingCopy`` plan type."""
+
+
+class LaunchVar(_NativePlanType):
+    """Fallback stub for the native ``LaunchVar`` plan type."""
+
+
+class BatchStep(_NativePlanType):
+    """Fallback stub for the native ``BatchStep`` plan type."""
+
+
+class KernelGroupSpec(_NativePlanType):
+    """Fallback stub for the native ``KernelGroupSpec`` plan type."""
+
+
+def set_shape_desc_dtype(shape_desc: Any, dtype: torch.dtype) -> None:
+    """Best-effort ``shape_desc.dtype = dtype``.
+
+    The pure-Python ``PageBufferShapeDesc`` exposes a ``dtype`` slot so
+    the CPU fallback kernel can disambiguate float16 vs bfloat16 (both
+    have ``element_size == 2``). The pybind C++ struct in
+    ``csrc/pybind.cpp`` has no such field; assignment raises
+    ``AttributeError`` and is silently swallowed here so call sites
+    don't need to branch on the active backend.
+
+    Args:
+        shape_desc: A ``PageBufferShapeDesc`` instance (either the
+            pure-Python fallback or the C++ pybind struct).
+        dtype: The torch dtype to assign.
+    """
+    try:
+        shape_desc.dtype = dtype
+    except AttributeError:
+        pass

--- a/lmcache/v1/platform/ops_types.py
+++ b/lmcache/v1/platform/ops_types.py
@@ -8,7 +8,7 @@ self-contained (only ``torch`` + ``enum``) so call sites can import them
 without pulling in the heavier torch-baseline op implementations in
 :mod:`lmcache.v1.platform._torch_impl`.
 
-The object-group transfer plan types (``_NativePlanType`` and its
+The object-group transfer plan types (``NativePlanType`` and its
 ``StagingCopy`` / ``LaunchVar`` / ``BatchStep`` / ``KernelGroupSpec``
 subclasses) only exist natively in the compiled ``c_ops`` extension; the
 pure-Python subclasses here are stubs so the CPU-only build exposes the same
@@ -127,7 +127,7 @@ class PageBufferShapeDesc:
         self.dtype: torch.dtype | None = None
 
 
-class _NativePlanType:
+class NativePlanType:
     """Base for object-group transfer plan types that only exist natively.
 
     The plan value structs (see ``csrc/mp_mem_kernels.cuh``) are built on the
@@ -144,19 +144,19 @@ class _NativePlanType:
         )
 
 
-class StagingCopy(_NativePlanType):
+class StagingCopy(NativePlanType):
     """Fallback stub for the native ``StagingCopy`` plan type."""
 
 
-class LaunchVar(_NativePlanType):
+class LaunchVar(NativePlanType):
     """Fallback stub for the native ``LaunchVar`` plan type."""
 
 
-class BatchStep(_NativePlanType):
+class BatchStep(NativePlanType):
     """Fallback stub for the native ``BatchStep`` plan type."""
 
 
-class KernelGroupSpec(_NativePlanType):
+class KernelGroupSpec(NativePlanType):
     """Fallback stub for the native ``KernelGroupSpec`` plan type."""
 
 

--- a/lmcache/v1/platform/xpu/__init__.py
+++ b/lmcache/v1/platform/xpu/__init__.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """XPU (Intel SYCL) platform helpers."""
 
+# Future
+from __future__ import annotations
+
 # First Party
+from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
+from lmcache.v1.platform.xpu.device_ops import XpuDeviceOps
 
 # ---------------------------------------------------------------------------
 # Device detection registry entry
@@ -21,8 +26,8 @@ class XpuDeviceSpec(DeviceSpec):
         return "xpu"
 
     @property
-    def ops_module(self) -> str | None:
-        return "lmcache.xpu_ops"
+    def ops_cls(self) -> type[DeviceOps]:
+        return XpuDeviceOps
 
     def is_available(self) -> bool:
         """Check XPU availability without importing lmcache.__init__."""

--- a/lmcache/v1/platform/xpu/__init__.py
+++ b/lmcache/v1/platform/xpu/__init__.py
@@ -4,10 +4,15 @@
 # Future
 from __future__ import annotations
 
+# Standard
+from typing import TYPE_CHECKING
+
 # First Party
-from lmcache.v1.platform.base_device_ops import DeviceOps
 from lmcache.v1.platform.base_device_spec import DeviceSpec
-from lmcache.v1.platform.xpu.device_ops import XpuDeviceOps
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.platform.base_device_ops import DeviceOps
 
 # ---------------------------------------------------------------------------
 # Device detection registry entry
@@ -27,6 +32,9 @@ class XpuDeviceSpec(DeviceSpec):
 
     @property
     def ops_cls(self) -> type[DeviceOps]:
+        # First Party
+        from lmcache.v1.platform.xpu.device_ops import XpuDeviceOps
+
         return XpuDeviceOps
 
     def is_available(self) -> bool:

--- a/lmcache/v1/platform/xpu/device_ops.py
+++ b/lmcache/v1/platform/xpu/device_ops.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""XPU ops backend: bind the SYCL ops over the torch baseline.
+
+:class:`XpuDeviceOps` calls :meth:`DeviceOps._bind_native` in
+:meth:`ensure_native` to layer the SYCL extension on top of the torch
+baseline.  If the extension is not built, a warning is logged and the
+instance stays on the torch fallback.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import ClassVar
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.v1.platform.base_device_ops import DeviceOps
+
+logger = init_logger(__name__)
+
+
+class XpuDeviceOps(DeviceOps):
+    device_type: ClassVar[str] = "xpu"
+
+    def ensure_native(self) -> None:
+        if self._native_bound:
+            return
+        self._native_bound = True  # set early to prevent repeated attempts
+        try:
+            # First Party
+            import lmcache.xpu_ops as sycl
+        except ImportError:
+            logger.warning(
+                "lmcache.xpu_ops not built; XpuDeviceOps stays on the "
+                "torch baseline for all ops."
+            )
+            return
+        self._bind_native(sycl)

--- a/tests/benchmarks/test_xpu_kernels_microbench.py
+++ b/tests/benchmarks/test_xpu_kernels_microbench.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Microbenchmarks: SYCL (XPU) kernels vs python_ops_fallback.
+"""Microbenchmarks: SYCL (XPU) kernels vs _torch_impl.
 
 Per the project plan, Phase 0 confirmed all four fallback functions
 accept XPU tensors directly, so we can do an apples-to-apples timing
@@ -13,7 +13,7 @@ import pytest
 import torch
 
 # First Party
-import lmcache.python_ops_fallback as F
+from lmcache.v1.platform import _torch_impl as F
 
 pytestmark = pytest.mark.skipif(
     not (hasattr(torch, "xpu") and torch.xpu.is_available()),
@@ -142,7 +142,7 @@ def test_bench_decode_sycl(benchmark, xops, ntokens):
 # NOTE: decode_fast_new fallback crashes on XPU with an internal
 # IndexKernel gather OOB on these shapes (a torch-xpu fallback bug,
 # not a CacheGen bug).  Per the project plan we do not modify
-# python_ops_fallback to accommodate XPU; the SYCL kernel is the
+# _torch_impl to accommodate XPU; the SYCL kernel is the
 # correct/fast path.  Recording the absolute SYCL throughput is
 # sufficient.
 

--- a/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
+++ b/tests/v1/gpu_connector/test_blocks_first_fused_kv_format.py
@@ -17,17 +17,17 @@ import torch
 
 # First Party
 from lmcache import torch_device_type
-from lmcache.python_ops_fallback import (
-    multi_layer_block_kv_transfer as fallback_multi_layer_block_kv_transfer,
-)
-from lmcache.python_ops_fallback import (
-    set_shape_desc_dtype,
-)
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector import utils as U
 from lmcache.v1.multiprocess.transfer_context.base import (
     gather_paged_kv_to_cpu,
     scatter_cpu_to_paged_kv,
+)
+from lmcache.v1.platform._torch_impl import (
+    multi_layer_block_kv_transfer as fallback_multi_layer_block_kv_transfer,
+)
+from lmcache.v1.platform.ops_types import (
+    set_shape_desc_dtype,
 )
 import lmcache.c_ops as lmc_ops
 

--- a/tests/v1/platform/test_device_ops.py
+++ b/tests/v1/platform/test_device_ops.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the unified ``DeviceOps`` abstraction and spec-based resolution.
+
+These tests are the acceptance gate for the DeviceOps hierarchy.  They stay
+platform-agnostic by exercising the torch baseline, the ``DeviceSpec``
+dispatch, the ``lmcache.c_ops`` shim, and per-instance native binding
+without requiring any compiled accelerator module.
+"""
+
+# Standard
+from typing import Any
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform import (
+    _torch_impl,
+    resolve_device_ops,
+    resolve_device_ops_cls,
+)
+from lmcache.v1.platform.base_device_ops import DeviceOps
+from lmcache.v1.platform.base_device_spec import DeviceSpec
+from lmcache.v1.platform.cpu.device_ops import CpuDeviceOps
+from lmcache.v1.platform.ops_types import (
+    BatchStep,
+    EngineKVFormat,
+    KernelGroupSpec,
+    LaunchVar,
+    PageBufferShapeDesc,
+    StagingCopy,
+    TransferDirection,
+)
+import lmcache.v1.platform as platform_pkg
+
+# The base class no longer exposes ``_OP_NAMES``; derive it locally so these
+# tests stay honest about what "every op" means (any public function declared
+# on the ``DeviceOps`` class body, minus ``ensure_native``).
+_OP_NAMES: tuple[str, ...] = tuple(
+    sorted(
+        name
+        for name, member in vars(DeviceOps).items()
+        if not name.startswith("_")
+        and name != "ensure_native"
+        and callable(member)
+        and not isinstance(member, staticmethod)
+        and not isinstance(member, type)
+    )
+)
+
+
+@pytest.fixture
+def isolated_registry() -> Any:
+    """Snapshot the device-spec table so tests can install fakes safely."""
+    saved = dict(platform_pkg._DEVICE_REGISTRY)
+    try:
+        yield saved
+    finally:
+        platform_pkg._DEVICE_REGISTRY.clear()
+        platform_pkg._DEVICE_REGISTRY.update(saved)
+
+
+# -- Contract --------------------------------------------------------------
+
+
+def test_base_class_declares_every_op_as_instance_method() -> None:
+    """DeviceOps declares every op as a real instance method (not reflection)."""
+    ops = DeviceOps()
+    for name in _OP_NAMES:
+        bound = getattr(ops, name)
+        assert callable(bound), name
+        # It must be a method living on the class, not a runtime-injected attr.
+        assert name in vars(DeviceOps), (
+            f"{name} is not declared on the DeviceOps class body"
+        )
+
+
+def test_base_class_has_all_types() -> None:
+    """DeviceOps exposes shared types as class attributes."""
+    assert DeviceOps.TransferDirection is TransferDirection
+    assert DeviceOps.EngineKVFormat is EngineKVFormat
+    assert DeviceOps.GPUKVFormat is EngineKVFormat
+    assert DeviceOps.PageBufferShapeDesc is PageBufferShapeDesc
+    assert DeviceOps.StagingCopy is StagingCopy
+    assert DeviceOps.LaunchVar is LaunchVar
+    assert DeviceOps.BatchStep is BatchStep
+    assert DeviceOps.KernelGroupSpec is KernelGroupSpec
+    assert callable(DeviceOps.set_shape_desc_dtype)
+
+
+def test_every_registered_device_has_all_ops(isolated_registry: Any) -> None:
+    """Each discovered DeviceSpec resolves an ops class with all ops."""
+    for device_type, spec in isolated_registry.items():
+        ops = spec.ops_cls()
+        for name in _OP_NAMES:
+            assert callable(getattr(ops, name)), (device_type, name)
+
+
+# -- Dispatch (MRO) --------------------------------------------------------
+
+
+def test_cpu_inherits_baseline_verbatim() -> None:
+    """CpuDeviceOps adds no overrides: every method resolves to the base."""
+    for name in _OP_NAMES:
+        assert getattr(CpuDeviceOps, name) is getattr(DeviceOps, name), name
+
+
+def test_musa_overrides_only_one_op() -> None:
+    """MusaDeviceOps overrides exactly one hot op; the rest inherit base."""
+    musa_mod = pytest.importorskip(
+        "lmcache.v1.platform.musa.device_ops",
+        reason="musa platform package unavailable",
+    )
+    overridden = [
+        name
+        for name in _OP_NAMES
+        if getattr(musa_mod.MusaDeviceOps, name) is not getattr(DeviceOps, name)
+    ]
+    assert overridden == ["multi_layer_block_kv_transfer"]
+
+
+def test_musa_override_dispatches_native_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Calling multi_layer_block_kv_transfer on a MusaDeviceOps instance
+    dispatches via the native MUSA path when inputs are tensor-backed."""
+    # Third Party
+    import torch
+
+    musa_mod = pytest.importorskip(
+        "lmcache.v1.platform.musa.device_ops",
+        reason="musa platform package unavailable",
+    )
+    native_mod = pytest.importorskip(
+        "lmcache.v1.platform.musa.native_kv_transfer",
+        reason="musa native_kv_transfer unavailable",
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _fake_native(**kwargs: Any) -> bool:
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr(
+        native_mod,
+        "try_native_multi_layer_block_kv_transfer",
+        _fake_native,
+    )
+
+    paged = [torch.zeros(4, 4, 16) for _ in range(2)]
+    objects = [torch.zeros(2, 8, 16)]
+
+    shape_desc = PageBufferShapeDesc()
+    shape_desc.nl = 2
+    shape_desc.nb = 1
+    shape_desc.bs = 4
+    shape_desc.nh = 4
+    shape_desc.hs = 16
+    shape_desc.kv_size = 2
+    shape_desc.element_size = torch.empty((), dtype=torch.float32).element_size()
+
+    # Call through a fresh instance (regular OO polymorphism).
+    musa_mod.MusaDeviceOps().multi_layer_block_kv_transfer(
+        paged,
+        objects,
+        [0, 1],
+        "musa",
+        TransferDirection.D2H,
+        shape_desc,
+        8,
+        EngineKVFormat.NL_X_NB_BS_HS,
+        0,
+    )
+
+    assert captured, "native path was not invoked"
+    assert captured["direction"] == TransferDirection.D2H
+
+
+# -- _bind_native ----------------------------------------------------------
+
+
+class _FakeNativeModule:
+    """Stand-in compiled module: a couple of real ops + a non-OPS symbol."""
+
+    @staticmethod
+    def multi_layer_kv_transfer(*a: Any, **k: Any) -> str:
+        return "native-mlt"
+
+    @staticmethod
+    def calculate_cdf(*a: Any, **k: Any) -> str:
+        return "native-cdf"
+
+    @staticmethod
+    def not_in_ops(*a: Any, **k: Any) -> str:
+        return "ignored"
+
+
+def test_bind_native_shadows_baseline_for_present_ops() -> None:
+    """_bind_native rebinds ops found in the module on that instance only."""
+    ops = DeviceOps()
+    ops._bind_native(_FakeNativeModule())
+
+    assert ops.multi_layer_kv_transfer() == "native-mlt"
+    assert ops.calculate_cdf(None, 0) == "native-cdf"
+
+    # Other instances still see the torch baseline.
+    other = DeviceOps()
+    assert other.multi_layer_kv_transfer is not ops.multi_layer_kv_transfer
+
+
+def test_bind_native_ignores_symbols_absent_from_ops() -> None:
+    """Symbols on the module not in _OP_NAMES are not copied to the instance."""
+    ops = DeviceOps()
+    ops._bind_native(_FakeNativeModule())
+    assert "not_in_ops" not in vars(ops)
+
+
+def test_bind_native_rebinds_types() -> None:
+    """_bind_native updates type instance attributes from the module."""
+
+    class FakeTypes:
+        class TransferDirection:
+            pass
+
+        class EngineKVFormat:
+            pass
+
+    ops = DeviceOps()
+    ops._bind_native(FakeTypes())
+
+    assert ops.TransferDirection is FakeTypes.TransferDirection
+    assert ops.EngineKVFormat is FakeTypes.EngineKVFormat
+    assert ops.GPUKVFormat is FakeTypes.EngineKVFormat  # alias
+
+
+# -- Shim ------------------------------------------------------------------
+
+
+def test_c_ops_shim_has_all_ops_and_types() -> None:
+    """The lmcache.c_ops shim module exposes everything from _OP_NAMES + types."""
+    # First Party
+    import lmcache.c_ops as c_ops
+
+    for name in _OP_NAMES:
+        assert hasattr(c_ops, name), f"c_ops missing {name}"
+        assert callable(getattr(c_ops, name))
+    assert hasattr(c_ops, "TransferDirection")
+    assert hasattr(c_ops, "EngineKVFormat")
+    assert hasattr(c_ops, "GPUKVFormat")
+    assert hasattr(c_ops, "PageBufferShapeDesc")
+
+
+# -- DeviceSpec resolution -------------------------------------------------
+
+
+def test_cpu_and_empty_string_resolve_to_expected_ops_classes() -> None:
+    """``cpu`` resolves via CpuDeviceSpec; ``""`` uses the bare fallback."""
+    assert resolve_device_ops_cls("cpu") is CpuDeviceOps
+    assert resolve_device_ops_cls("") is DeviceOps
+
+
+def test_resolve_device_ops_returns_cached_singleton() -> None:
+    """Two lookups for the same device_type return the same instance."""
+    a = resolve_device_ops("cpu")
+    b = resolve_device_ops("cpu")
+    assert a is b
+    assert isinstance(a, CpuDeviceOps)
+
+
+def test_cpu_without_registered_spec_falls_back_to_base_device_ops(
+    isolated_registry: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    table = {k: v for k, v in isolated_registry.items() if k != "cpu"}
+    monkeypatch.setattr(platform_pkg, "_DEVICE_REGISTRY", table)
+    assert resolve_device_ops_cls("cpu") is DeviceOps
+
+
+def test_unregistered_accelerator_fails_fast(
+    isolated_registry: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A requested accelerator with no registered class is a hard error."""
+    table = {k: v for k, v in isolated_registry.items() if k != "cuda"}
+    monkeypatch.setattr(platform_pkg, "_DEVICE_REGISTRY", table)
+    with pytest.raises(
+        RuntimeError,
+        match="refusing to silently fall back to the torch baseline",
+    ):
+        resolve_device_ops_cls("cuda")
+
+
+def test_unknown_accelerator_fails_fast_without_registry_edits() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="refusing to silently fall back to the torch baseline",
+    ):
+        resolve_device_ops_cls("definitely-not-a-real-device")
+
+
+def test_new_device_needs_zero_resolver_edits(
+    isolated_registry: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scalability: a fresh DeviceSpec resolves with no resolver change."""
+
+    class DummyDeviceOps(DeviceOps):
+        device_type = "dummy"
+
+    class DummyDeviceSpec(DeviceSpec):
+        @property
+        def device_type(self) -> str:
+            return "dummy"
+
+        @property
+        def ops_cls(self) -> "type[DeviceOps]":
+            return DummyDeviceOps
+
+    monkeypatch.setattr(
+        platform_pkg,
+        "_DEVICE_REGISTRY",
+        {**isolated_registry, "dummy": DummyDeviceSpec()},
+    )
+    assert resolve_device_ops_cls("dummy") is DummyDeviceOps
+
+
+# Silence "unused import" warnings for imports referenced only in docstrings.
+_ = _torch_impl

--- a/tests/v1/test_c_ops_parity.py
+++ b/tests/v1/test_c_ops_parity.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """
-Verify that every public function/enum in python_ops_fallback that also
+Verify that every public function/enum in _torch_impl that also
 exists in c_ops has a matching signature.
 
-Does NOT require python_ops_fallback to implement everything in c_ops —
+Does NOT require _torch_impl to implement everything in c_ops —
 only checks the intersection. If you implement a function in the fallback,
 its signature must match c_ops exactly.
 
@@ -13,6 +13,12 @@ Default value rules (relaxed):
   - If c_ops has NO default, fallback MAY add one (superset, backward-compatible).
 
 Requires CUDA (c_ops must be importable). Automatically skipped on CPU-only CI.
+
+TODO(baoloongmao): renamed from ``test_c_ops_fallback_parity.py``. This whole
+file targets a stale layer -- once ``_torch_impl`` free functions get folded
+into ``DeviceOps`` methods, the parity check should be rewritten to compare
+``DeviceOps`` method signatures against ``c_ops`` (or dropped entirely if the
+new API surface is the single source of truth).
 """
 
 # Standard
@@ -24,7 +30,8 @@ import re
 import pytest
 
 # First Party
-import lmcache.python_ops_fallback as fallback
+from lmcache.v1.platform import _torch_impl as fallback
+from lmcache.v1.platform import ops_types
 
 try:
     # First Party
@@ -45,7 +52,7 @@ def _public_callables(module):
         for name, obj in inspect.getmembers(module)
         if not name.startswith("_")
         and callable(obj)
-        and not (inspect.isclass(obj) and issubclass(obj, enum.Enum))
+        and not inspect.isclass(obj)  # classes tested by descriptor/enum tests
         and not hasattr(obj, "__members__")  # exclude pybind11 enums
         and getattr(obj, "__module__", None) == getattr(module, "__name__", None)
     }
@@ -62,7 +69,6 @@ def _public_enums(module):
         for name, obj in inspect.getmembers(module, inspect.isclass)
         if not name.startswith("_")
         and (issubclass(obj, enum.Enum) or hasattr(obj, "__members__"))
-        and getattr(obj, "__module__", None) == getattr(module, "__name__", None)
     }
 
 
@@ -86,7 +92,6 @@ def _public_descriptor_classes(module: object) -> dict[str, type]:
         if not name.startswith("_")
         and not (issubclass(obj, enum.Enum) or hasattr(obj, "__members__"))
         and callable(obj)
-        and getattr(obj, "__module__", None) == getattr(module, "__name__", None)
     }
 
 
@@ -214,6 +219,18 @@ def _has_real_names(params):
 # Functions intentionally excluded from parity checks.
 _EXCLUDED_FUNCS: set[str] = set()
 
+# Plan types are native-only (no torch fallback); stubs in ops_types exist
+# only to expose the names on CPU builds.  Cross-check against ops_types so
+# any typo or removal is caught immediately.
+_EXCLUDED_DESCS: set[str] = {"StagingCopy", "LaunchVar", "BatchStep", "KernelGroupSpec"}
+
+# First Party
+# Validate that every excluded descriptor actually exists in ops_types.
+for _name in _EXCLUDED_DESCS:
+    assert hasattr(ops_types, _name), (
+        f"_EXCLUDED_DESCS contains {_name!r} but it does not exist in ops_types"
+    )
+
 _fallback_callables = _public_callables(fallback)
 _c_ops_callables = _public_callables(c_ops) if HAS_C_OPS else {}
 _shared_func_names = sorted(
@@ -238,7 +255,7 @@ _shared_desc_names = sorted(set(_fallback_descs) & set(_c_ops_descs))
     _shared_func_names if _shared_func_names else ["__placeholder__"],
 )
 def test_function_signature_parity(func_name):
-    """For every function that python_ops_fallback chose to implement,
+    """For every function that _torch_impl chose to implement,
     its signature must match c_ops exactly.
 
     When c_ops has real py::arg() names  → check names, count, defaults.
@@ -317,7 +334,7 @@ def test_function_signature_parity(func_name):
     _shared_enum_names if _shared_enum_names else ["__placeholder__"],
 )
 def test_enum_parity(enum_name):
-    """For every enum that python_ops_fallback defines,
+    """For every enum that _torch_impl defines,
     its members and values must match c_ops."""
     if enum_name == "__placeholder__":
         pytest.skip("No shared enums found between c_ops and fallback")
@@ -336,27 +353,25 @@ def test_enum_parity(enum_name):
 @pytest.mark.skipif(not HAS_C_OPS, reason="c_ops not available (no CUDA)")
 def test_all_c_ops_callables_have_fallback() -> None:
     """Every public callable in c_ops must exist in
-    python_ops_fallback."""
+    _torch_impl."""
     missing = sorted(set(_c_ops_callables) - set(_fallback_callables) - _EXCLUDED_FUNCS)
-    assert not missing, f"c_ops callables missing from python_ops_fallback: {missing}"
+    assert not missing, f"c_ops callables missing from _torch_impl: {missing}"
 
 
 @pytest.mark.skipif(not HAS_C_OPS, reason="c_ops not available (no CUDA)")
 def test_all_c_ops_enums_have_fallback() -> None:
     """Every public enum in c_ops must exist in
-    python_ops_fallback."""
+    _torch_impl."""
     missing = sorted(set(_c_ops_enums) - set(_fallback_enums))
-    assert not missing, f"c_ops enums missing from python_ops_fallback: {missing}"
+    assert not missing, f"c_ops enums missing from _torch_impl: {missing}"
 
 
 @pytest.mark.skipif(not HAS_C_OPS, reason="c_ops not available (no CUDA)")
 def test_all_c_ops_descriptors_have_fallback() -> None:
     """Every public descriptor class in c_ops must exist in
-    python_ops_fallback."""
-    missing = sorted(set(_c_ops_descs) - set(_fallback_descs))
-    assert not missing, (
-        f"c_ops descriptor classes missing from python_ops_fallback: {missing}"
-    )
+    _torch_impl."""
+    missing = sorted(set(_c_ops_descs) - set(_fallback_descs) - _EXCLUDED_DESCS)
+    assert not missing, f"c_ops descriptor classes missing from _torch_impl: {missing}"
 
 
 @pytest.mark.skipif(not HAS_C_OPS, reason="c_ops not available (no CUDA)")

--- a/tests/v1/test_musa_native.py
+++ b/tests/v1/test_musa_native.py
@@ -10,8 +10,8 @@ import pytest
 import torch
 
 # First Party
+from lmcache.v1.platform import _torch_impl as py_ops
 from lmcache.v1.platform.musa import native_kv_transfer as musa_native
-import lmcache.python_ops_fallback as py_ops
 
 
 def _make_native_module() -> ModuleType:
@@ -57,35 +57,18 @@ def test_native_transfer_module_lives_under_musa_platform() -> None:
     assert musa_native.__name__ == "lmcache.v1.platform.musa.native_kv_transfer"
 
 
-def test_get_backend_prefers_musa_ops_over_cuda_when_musa_is_available(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Backend composition follows device detection priority when MUSA is active."""
-    # Standard
-    import os
-
+def test_musa_device_ops_overrides_multi_layer_block_kv_transfer() -> None:
+    """MusaDeviceOps overrides multi_layer_block_kv_transfer via MRO."""
     # First Party
-    from lmcache.v1.platform import _detect_device, get_backend
-    from lmcache.v1.platform.musa import ops as musa_ops
+    from lmcache.v1.platform import _torch_impl
+    from lmcache.v1.platform.musa.device_ops import MusaDeviceOps
 
-    os.environ["DEVICE_TYPE"] = "musa"
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-    monkeypatch.setattr(
-        torch,
-        "musa",
-        SimpleNamespace(is_available=lambda: True),
-        raising=False,
+    assert MusaDeviceOps.device_type == "musa"
+    # The override is on the class itself, not the torch baseline.
+    assert (
+        MusaDeviceOps.multi_layer_block_kv_transfer
+        is not _torch_impl.multi_layer_block_kv_transfer
     )
-
-    dev, dev_type = _detect_device()
-
-    assert dev_type == "musa"
-    backend = get_backend(dev_type)
-    assert backend is not None
-    assert backend.multi_layer_block_kv_transfer is (
-        musa_ops.multi_layer_block_kv_transfer
-    )
-    del os.environ["DEVICE_TYPE"]
 
 
 def test_native_transfer_enabled_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -422,9 +405,9 @@ def test_native_block_transfer_rejects_unvalidated_layout(
 def test_musa_ops_block_transfer_entry_dispatches_to_musa_platform(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MUSA ops backend hides native dispatch behind the c_ops-compatible API."""
+    """MusaDeviceOps dispatches to native transfer when tensor-backed."""
     # First Party
-    from lmcache.v1.platform.musa import ops as musa_ops
+    from lmcache.v1.platform.musa.device_ops import MusaDeviceOps
 
     captured: dict[str, Any] = {}
 
@@ -440,7 +423,7 @@ def test_musa_ops_block_transfer_entry_dispatches_to_musa_platform(
 
     paged_layers = [torch.zeros(4, 4, 16) for _ in range(2)]
     object_tensors = [torch.zeros(2, 8, 16)]
-    musa_ops.multi_layer_block_kv_transfer(
+    MusaDeviceOps().multi_layer_block_kv_transfer(
         paged_layers,
         object_tensors,
         [0, 1],

--- a/tests/v1/test_musa_support.py
+++ b/tests/v1/test_musa_support.py
@@ -114,7 +114,7 @@ class _StubTorch:
 def _detect_with_stub(stub: _StubTorch) -> tuple[Any, str]:
     """Run ``_detect_device`` with ``torch`` swapped for the stub."""
     # First Party
-    from lmcache.v1.platform import _detect_device
+    from lmcache.v1.platform._device_detect import _detect_device
 
     with patch.dict("sys.modules", {"torch": stub}):
         return _detect_device()

--- a/tests/v1/test_torch_ops.py
+++ b/tests/v1/test_torch_ops.py
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
+# TODO(baoloongmao): renamed from ``tests/v1/test_python_ops_fallback.py``.
+# Test cases still reflect the old flat-module world (they poke `_py_ops`
+# free functions directly); a follow-up should rework them to exercise the
+# ``DeviceOps`` API surface instead.
 # Standard
 from typing import Any, Union
 import ctypes
@@ -15,7 +19,7 @@ from lmcache.v1.multiprocess.native_completion import (
     DeviceHostFuncDispatcher,
     submit_callback_to_stream,
 )
-import lmcache.python_ops_fallback as _py_ops
+from lmcache.v1.platform import _torch_impl as _py_ops
 
 # ==========================================
 # 0. utils functions.
@@ -55,10 +59,10 @@ def _build_backend_params() -> list:
 
     Returns one entry per available backend configuration:
     - cuda_c_ops: uses lmcache.c_ops (requires CUDA and the CUDA extension)
-    - cuda_py_ops: uses lmcache.python_ops_fallback with GPU visible
-    - cpy_py_ops: uses lmcache.python_ops_fallback with GPU mocked away
+    - cuda_py_ops: uses lmcache.v1.platform._torch_impl with GPU visible
+    - cpy_py_ops: uses lmcache.v1.platform._torch_impl with GPU mocked away
     - xpu_sycl_ops: uses lmcache.xpu_ops (requires XPU and the SYCL extension)
-    - xpu_py_ops: uses lmcache.python_ops_fallback with XPU visible
+    - xpu_py_ops: uses lmcache.v1.platform._torch_impl with XPU visible
     """
     params = []
     cuda_available = torch.cuda.is_available()


### PR DESCRIPTION
Draft alternative to #4077 that folds hlin99's review feedback into the design instead of stacking it on top.

## What changed

Every op is now a real instance method on the `DeviceOps` base class body that delegates to `lmcache.v1.platform._torch_impl` (the torch baseline, **renamed** from the old top-level `lmcache/python_ops_fallback.py` to signal it is a private implementation module). Subclasses override methods with plain Python OO polymorphism.

- `DeviceOps` (in `lmcache/v1/platform/base_device_ops.py`) lists all 36 ops as `def foo(self, ...)` on the class body, so opening the file shows the full contract at a glance — no reflection needed to read what an accelerator can do.
- Shared native pybind types (`TransferDirection`, `EngineKVFormat`, `PageBufferShapeDesc`, `StagingCopy`, `LaunchVar`, `BatchStep`, `KernelGroupSpec`) are pinned as class attributes on `DeviceOps` for IDE / mypy visibility.
- Subclasses (`CudaDeviceOps` / `MusaDeviceOps` / `XpuDeviceOps` / `HpuDeviceOps` / `CpuDeviceOps`) live in `lmcache/v1/platform/<device>/device_ops.py` and either override individual methods or bulk-rebind native symbols:
  - **CUDA / XPU**: `ensure_native()` imports the compiled `.so` and calls `self._bind_native(module)`, which walks `vars(DeviceOps)` once to rebind each same-named native function onto the instance and each pybind type onto `self` (for identity across the Python/native boundary). This one reflection pass replaces ~36 hand-written pass-through overrides per backend — the class body stays the SSOT for both the method list and the type list.
  - **MUSA**: `multi_layer_block_kv_transfer` is a plain overridden method that tries the native path first and falls back to the torch baseline. No more `= staticmethod(...)` assignment; single-method override via normal MRO.
  - **HPU / CPU**: inherit the torch baseline unchanged.
- `lmcache.c_ops` becomes a PEP 562 shim (`sys.modules['lmcache.c_ops']`) forwarding attribute access to a resolved `DeviceOps` singleton instance. The singleton is cached on the resolved `DeviceSpec` (see `base_device_spec.py`), so the same instance is reused process-wide and any state set on it (native handles, cached lookups) is shared. Module-level call sites (`lmc_ops.foo(...)`) keep working unchanged; the ~25 files importing `lmcache.c_ops` need zero edits.
- `multi_layer_block_kv_transfer` keeps the full typed signature on the base method so `transfer_context._detect_block_transfer_accepts_tensor` can still see `Tensor` in the annotation via `inspect.signature`.

## Renames (please review with rename detection on — GitHub default is fine)

Three files were physically renamed via `git mv` so git tracks them as renames rather than "big new file + big deleted file". Similarities are well above the 50% detection threshold:

| Before | After | Similarity |
|---|---|---:|
| `lmcache/python_ops_fallback.py` | `lmcache/v1/platform/_torch_impl.py` | **94%** |
| `tests/v1/test_python_ops_fallback.py` | `tests/v1/test_torch_ops.py` | **99%** |
| `tests/v1/test_c_ops_fallback_parity.py` | `tests/v1/test_c_ops_parity.py` | **88%** |

Net diff sits at ~1.97k insertions / ~0.42k deletions across 32 files, because those three files show as small in-place edits (mostly imports and header docstrings) rather than full rewrites. Each renamed file has a `TODO(baoloongmao)` at the top flagging follow-up cleanup work that would rightly belong in its own PR (splitting shm/ctypes helpers, folding the parity check into `DeviceOps` method signatures, reshaping helper positional args to match instance-method contracts).

## Why

hlin99 asked in #4077 for the base class to spell out all methods with a Python implementation and let subclasses override them, so the logical layer does not have to branch on device or op availability. Instance methods give real OO polymorphism (subclasses can hold per-instance native handles, `super()` works normally) and match that request more directly than the previous static-method + reflective-binding shape. The one remaining reflection point — `_bind_native` — is a bounded, one-shot pass over the class body at `ensure_native()` time, not a global import-time hook, and it exists purely to avoid writing 36 hand-copied pass-throughs per accelerator backend.

## Follow-ups since the initial push

- Addressed Gemini review: added `__dir__` on the `lmcache.c_ops` shim (so parity tests don't silently skip), deferred `DeviceOps` imports to keep lazy discovery, and other minor cleanups.
- Kept the `DeviceOps` import lazy on the CLI-only wheel smoke test path (no torch installed).
- Moved the `DeviceOps` singleton cache onto `DeviceSpec` so callers hitting the same `device_type` twice always get the same instance.

## Tests

- 220 pass in `tests/v1/platform`, `tests/v1/gpu_connector`, `test_c_ops_parity`, `test_musa_native`, `test_torch_ops`.
- New `tests/v1/platform/test_device_ops.py` covers the OO contract: baseline delegation, `_bind_native` op + type rebinding, singleton caching on `DeviceSpec`, and the `lmcache.c_ops` shim's `__getattr__` / `__dir__`.
- pre-commit hooks all green (ruff / ruff-format / isort / mypy / codespell / SPDX / ban-* guards). Rust hooks (`rust-fmt` / `rust-clippy`) skipped locally on macOS due to an unrelated `io-uring` build issue.
- The 12 pre-existing failures in `tests/v1/native_storage_ops/test_bitmap.py` are unrelated to this change (reproduce on baseline too).

## Design doc

See `docs/design/v1/platform/device_ops_design.md` for the full write-up: goals, non-goals, the reflection tradeoff in `_bind_native`, and how subclasses plug in.

## Draft, because

Opening as draft to solicit feedback on the direction before we invest more; happy to iterate or fold pieces back into #4077 depending on what the wider team prefers.
