### PR TITLE
[CI] install ffmpeg to fix vllm torchcodec import error

### DIFF
--- a/.github/workflows/cpu_device.yml
+++ b/.github/workflows/cpu_device.yml
@@ -94,6 +94,11 @@ jobs:
             pyproject.toml
             requirements/*.txt
 
+      - name: Install FFmpeg (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y ffmpeg
+
       - name: Install FFmpeg (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,10 @@ jobs:
             **/pyproject.toml
             **/requirements/*.txt
 
+      - name: Install FFmpeg
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y ffmpeg
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
<!--  Thanks for your contribution... -->

**What this PR does / why we need it**

vllm recently added torchcodec as a dependency, which requires libavutil from ffmpeg. The ubuntu-latest runner doesn't have ffmpeg pre-installed, causing all Test workflow jobs to fail with "Could not load libtorchcodec".

Affected PRs: #4088, #4091

**Special notes for your reviewers**

one-liner CI fix

**If applicable**

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests