### PR TITLE
[Test] Require an explicit GDS-capable dir for the DMA roundtrip tests

### DIFF
--- a/tests/v1/gpu_connector/test_gds_context.py
+++ b/tests/v1/gpu_connector/test_gds_context.py
@@ -33,6 +33,7 @@ from lmcache.v1.gpu_connector.gds_context import (
     get_gds_context,
     initialize_gds_context,
 )
+from lmcache.v1.memory_management import GDSMemoryObject
 
 
 def _fake_stream(handle: int):
@@ -345,6 +346,7 @@ def test_gds_write_read_roundtrip(gds_slab_dir: Path):
         )
         assert err == L1Error.SUCCESS
         mem_obj = objs[0]
+        assert isinstance(mem_obj, GDSMemoryObject)
 
         buf.fill_(0xAB)
         torch.cuda.synchronize()
@@ -383,6 +385,7 @@ def test_gds_chunk_larger_than_region_roundtrip(gds_slab_dir: Path):
         )
         assert err == L1Error.SUCCESS
         mem_obj = objs[0]
+        assert isinstance(mem_obj, GDSMemoryObject)
 
         # Position-dependent pattern: a mis-offset or swapped segment (e.g. the
         # second segment using the wrong slab offset) would corrupt the bytes

--- a/tests/v1/gpu_connector/test_gds_context.py
+++ b/tests/v1/gpu_connector/test_gds_context.py
@@ -10,8 +10,11 @@ skipped unless that stack is present (see :func:`_gds_available`).
 """
 
 # Standard
+from collections.abc import Iterator
+from pathlib import Path
 from types import SimpleNamespace
 import os
+import tempfile
 
 # Third Party
 import pytest
@@ -64,6 +67,82 @@ requires_gds = pytest.mark.skipif(
     not _gds_available(),
     reason="needs CUDA + nvidia-fs or ROCm + libhipfile.so (real GPUDirect Storage)",
 )
+
+
+def _skip_unless_gds_registrable(directory: Path) -> None:
+    """Skip the calling test when ``directory`` cannot back a GDS slab file.
+
+    Creates a small preallocated file in ``directory``, opens it with
+    ``O_DIRECT``, and registers it with the GDS driver, mirroring how
+    ``GDSContext`` opens its slab. Registration fails on filesystems the
+    driver does not support; on NVIDIA, nvidia-fs rejects files on
+    device-mapper volumes (LVM) with cuFile error 5008 whenever cuFile compat
+    mode is disabled.
+
+    Args:
+        directory: The directory in which the roundtrip test would place the
+            GDS slab file.
+    """
+    probe_path = directory / ".gds_registration_probe"
+    try:
+        fd = os.open(probe_path, os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            os.posix_fallocate(fd, 0, 4096)
+        finally:
+            os.close(fd)
+        fd = os.open(probe_path, os.O_RDWR | os.O_DIRECT)
+        try:
+            handle = ca.register_handle(fd)
+            ca.deregister_handle(handle)
+        finally:
+            os.close(fd)
+    except (OSError, RuntimeError) as exc:
+        # OSError: open/fallocate; RuntimeError: cufile/hipfile registration.
+        pytest.skip(
+            f"GDS driver cannot register files under {directory} ({exc}); "
+            "point LMCACHE_GDS_TEST_DIR at a GDS-capable filesystem"
+        )
+    finally:
+        probe_path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def gds_slab_dir(tmp_path: Path) -> Iterator[Path]:
+    """Directory holding the GDS slab file for the real-DMA roundtrip tests.
+
+    On NVIDIA the directory must be named explicitly via the
+    ``LMCACHE_GDS_TEST_DIR`` environment variable, pointing at a GDS-capable
+    filesystem (e.g. ext4 on a directly attached NVMe device); otherwise the
+    roundtrip tests are skipped. pytest's ``tmp_path`` is deliberately not
+    used as a fallback: it lives on the OS disk rather than a data disk set
+    up for GDS, and OS disks commonly use LVM/device-mapper volumes that
+    nvidia-fs cannot register, where cuFile either fails with error 5008 or,
+    with compat mode enabled, silently falls back to POSIX IO, so a passing
+    test would not have exercised the DMA path it claims to.
+
+    On AMD ROCm ``tmp_path`` is used when the variable is unset: per
+    :func:`_gds_available`, library loadability is a sufficient gate for
+    these correctness checks because the hipFile host-bounce fallback still
+    round-trips correctly, so no GDS-capable filesystem is required.
+
+    The resolved directory is probed with a small registration first and the
+    test is skipped, rather than failed, when the driver rejects it.
+    """
+    override = os.environ.get("LMCACHE_GDS_TEST_DIR", "")
+    if not override:
+        if torch.version.hip is None:
+            pytest.skip(
+                "set LMCACHE_GDS_TEST_DIR to a directory on a GDS-capable "
+                "filesystem to run the real-DMA roundtrip tests (pytest's "
+                "tmp_path may silently use the POSIX compat fallback)"
+            )
+        _skip_unless_gds_registrable(tmp_path)
+        yield tmp_path
+        return
+    with tempfile.TemporaryDirectory(dir=override, prefix="lmcache_gds_test_") as d:
+        slab_dir = Path(d)
+        _skip_unless_gds_registrable(slab_dir)
+        yield slab_dir
 
 
 @pytest.fixture(autouse=True)
@@ -193,10 +272,10 @@ class TestPerStreamRegistration:
 
 
 @requires_gds
-def test_gds_two_stream_write_read(tmp_path):
+def test_gds_two_stream_write_read(gds_slab_dir: Path):
     """Two CUDA streams each register their own buffer and round-trip a chunk
     through real cuFile DMA; verify the data stays isolated per stream."""
-    cfg = GdsL1Config(file_location=str(tmp_path), size_in_bytes=64 << 20)
+    cfg = GdsL1Config(file_location=str(gds_slab_dir), size_in_bytes=64 << 20)
     chunk_bytes = 8 << 20
     ctx = GDSContext()
     ctx.initialize(cfg)
@@ -249,9 +328,9 @@ def test_gds_two_stream_write_read(tmp_path):
 
 
 @requires_gds
-def test_gds_write_read_roundtrip(tmp_path):
+def test_gds_write_read_roundtrip(gds_slab_dir: Path):
     """Cold write then read of a chunk through the real cuFile DMA path."""
-    cfg = GdsL1Config(file_location=str(tmp_path), size_in_bytes=64 << 20)
+    cfg = GdsL1Config(file_location=str(gds_slab_dir), size_in_bytes=64 << 20)
     ctx = GDSContext()
     ctx.initialize(cfg)
     try:
@@ -283,13 +362,13 @@ def test_gds_write_read_roundtrip(tmp_path):
 
 
 @requires_gds
-def test_gds_chunk_larger_than_region_roundtrip(tmp_path):
+def test_gds_chunk_larger_than_region_roundtrip(gds_slab_dir: Path):
     """A chunk larger than the 16 MiB cuFile region cap round-trips correctly.
 
     Exercises the multi-region registration and the split (per-segment) DMA
     path: a 24 MiB chunk is registered/transferred as a 16 MiB + 8 MiB pair.
     """
-    cfg = GdsL1Config(file_location=str(tmp_path), size_in_bytes=64 << 20)
+    cfg = GdsL1Config(file_location=str(gds_slab_dir), size_in_bytes=64 << 20)
     ctx = GDSContext()
     ctx.initialize(cfg)
     try:


### PR DESCRIPTION
**What this PR does / why we need it**:

The roundtrip tests in `test_gds_context.py` (`test_gds_write_read_roundtrip`, `test_gds_chunk_larger_than_region_roundtrip`, `test_gds_two_stream_write_read`) place the GDS slab file in pytest's `tmp_path`. `tmp_path` lives under `/tmp`, which is typically on the OS disk rather than a data disk set up for GDS. OS disks commonly use LVM/device-mapper volumes that nvidia-fs cannot register, so on NVIDIA hosts this leads to one of two outcomes, neither desirable:

1. With cuFile compat mode disabled, `cuFileHandleRegister` returns error 5008 and the tests fail even though the code under test is correct.
2. With compat mode enabled (the default), cuFile silently falls back to POSIX IO and the tests pass without ever exercising the DMA path they claim to.

Changes:

1. On NVIDIA, a new `LMCACHE_GDS_TEST_DIR` environment variable must name a directory on a GDS-capable filesystem (e.g. ext4 on a directly attached NVMe device). When unset, the roundtrip tests are skipped with an actionable reason. `tmp_path` is deliberately not used as a fallback because compat mode can silently turn it into POSIX IO and produce false positives.
2. The named directory is probed first: a small preallocated file is opened with `O_DIRECT` and registered with the GDS driver, mirroring how `GDSContext` opens its slab. If registration fails (e.g. the variable points at the OS disk), the tests skip with the underlying error instead of failing.
3. The slab is placed in a private subdirectory created with `tempfile.TemporaryDirectory` and cleaned up after the test.
4. On ROCm, `tmp_path` remains the default when the variable is unset. Per `_gds_available`, library loadability is a sufficient gate for these correctness checks because the hipFile host-bounce fallback still round-trips correctly, so no GDS-capable filesystem is required. ROCm behavior is unchanged.

The seven pure-logic tests (mocked cuFile seam) are unaffected.

**Special notes**:

Verified on an A100 host with a directly attached NVMe (ext4), nvidia-fs loaded, and `allow_compat_mode: false`:

1. `LMCACHE_GDS_TEST_DIR` unset: 7 passed, 3 skipped, with the skip reason explaining the variable and why `tmp_path` is not used.
2. `LMCACHE_GDS_TEST_DIR=/tmp` (deliberately pointing at the OS disk): 3 skipped, with the underlying cuFile error 5008 and the directory in the skip reason.
3. `LMCACHE_GDS_TEST_DIR` pointing at the NVMe mount: 10 passed, all through the real DMA path, temporary slab directories cleaned up.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests