### PR TITLE
[good-first-issue] core: convert f-string log calls in cache_controller to %-format

### DIFF
--- a/lmcache/v1/cache_controller/config.py
+++ b/lmcache/v1/cache_controller/config.py
@@ -86,7 +86,7 @@ def _log_config(self):
         value = getattr(self, name)
         config_dict[name] = value
 
-    logger.info(f"Controller Configuration: {config_dict}")
+    logger.info("Controller Configuration: %s", config_dict)
     return self
 
 
@@ -134,7 +134,7 @@ def override_controller_config_from_dict(
                         converted_value = env_converter(value)
                         setattr(config, key, converted_value)
                     except (ValueError, json.JSONDecodeError) as e:
-                        logger.warning(f"Failed to convert {key}={value!r}: {e}")
+                        logger.warning("Failed to convert %s=%r: %s", key, value, e)
                         # Keep the original value if conversion fails
                         setattr(config, key, value)
                 else:
@@ -145,10 +145,13 @@ def override_controller_config_from_dict(
             new_value = getattr(config, key)
             if old_value != new_value:
                 logger.info(
-                    f"Override controller config: {key} = {new_value} (was {old_value})"
+                    "Override controller config: %s = %s (was %s)",
+                    key,
+                    new_value,
+                    old_value,
                 )
         else:
-            logger.warning(f"Unknown controller config key: {key}, ignoring")
+            logger.warning("Unknown controller config key: %s, ignoring", key)
 
 
 def load_controller_config_with_overrides(

--- a/lmcache/v1/cache_controller/utils.py
+++ b/lmcache/v1/cache_controller/utils.py
@@ -123,7 +123,7 @@ class WorkerNode:
                 elif op.op_type.value == "evict":
                     self.kv_store[location].discard(op.key)
                 else:
-                    logger.error(f"Unknown op_type: {op.op_type}")
+                    logger.error("Unknown op_type: %s", op.op_type)
 
                 # Skip sequence check during full sync
                 if is_full_sync:

--- a/lmcache/v1/cache_controller/worker.py
+++ b/lmcache/v1/cache_controller/worker.py
@@ -174,7 +174,7 @@ class LMCacheWorker:
             bind_or_connect="bind",
         )
 
-        logger.info(f"Reply socket established at {self.lmcache_worker_internal_url}")
+        logger.info("Reply socket established at %s", self.lmcache_worker_internal_url)
 
         self.loop = asyncio.new_event_loop()
         self.thread = threading.Thread(
@@ -518,13 +518,13 @@ class LMCacheWorker:
         while True:
             try:
                 msgs = await self.batched_get_msg()
-                logger.debug(f"Sending {len(msgs)} messages")
+                logger.debug("Sending %d messages", len(msgs))
                 self.push_socket.send_multipart(
                     [msgspec.msgpack.encode(msg) for msg in msgs]
                 )
 
             except Exception as e:
-                logger.error(f"Push error: {e}")
+                logger.error("Push error: %s", e)
 
     async def handle_request(self):
         """
@@ -534,7 +534,7 @@ class LMCacheWorker:
             try:
                 serialized_request = await self.reply_socket.recv()
                 request = msgspec.msgpack.decode(serialized_request, type=Msg)
-                logger.debug(f"Received message: {request}")
+                logger.debug("Received message: %s", request)
                 if isinstance(request, MoveWorkerMsg):
                     tokens = request.tokens
                     old_position = request.old_position
@@ -617,14 +617,14 @@ class LMCacheWorker:
                         HealthWorkerRetMsg(error_code=error_code)
                     )
                 else:
-                    logger.error(f"Unknown message: {request}")
+                    logger.error("Unknown message: %s", request)
                     serialized_ret_msg = msgspec.msgpack.encode(
                         ErrorMsg(error=f"Unknown message: {request}")
                     )
 
                 await self.reply_socket.send(serialized_ret_msg)
             except Exception as e:
-                logger.error(f"Worker error: {e}")
+                logger.error("Worker error: %s", e)
                 serialized_ret_msg = msgspec.msgpack.encode(
                     ErrorMsg(error=f"Worker error: {e}")
                 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #3372

Convert f-string logger calls to lazy %-format style in 3 files under :
- : 4 calls (info, warning)
- : 6 calls (info, debug, error)
- : 1 call (error)

This matches the project's logging standards (ruff G004) — %-format avoids building the message string unless the log level actually emits.

**Special notes for your reviewers**:
- This is my first PR to LMCache 🙇 please be gentle.
- I ran All checks passed! and 4 files reformatted, 1067 files left unchanged — all green.
- 3 files changed, 14 insertions, 11 deletions

**If applicable**:
- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

Ref #3372