### PR TITLE
[CI/CD]Add XPU pipeline directory

### DIFF
--- a/.buildkite/k3_tests/xpu/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/xpu/BK_WEB_SETUP.md
@@ -1,0 +1,49 @@
+# Buildkite Web UI Setup: XPU Smoke Test
+
+**Steps editor**: paste the contents of `buildkite-pipeline.yml`.
+
+**GitHub trigger settings**:
+- Filter: `build.pull_request.labels includes "xpu"`
+- Rebuild on PR label change: Yes
+- Skip queued / cancel running branch builds: Yes
+
+This pipeline now has a single step: it runs the XPU smoke test directly in a
+prebuilt public image and installs LMCache from source inside the job pod.
+
+With this trigger filter, the pipeline only starts when the PR has the `xpu`
+label. If the label is missing, the XPU pipeline is not triggered.
+
+## Required host setup
+
+Before creating the pipeline, prepare the machine that will run the `xpu` queue:
+
+1. Run [setup-cluster.sh](../../k3_harness/setup-cluster.sh) to install K3s, the GPU Operator, and the shared host volumes.
+2. Run [install-agent-stack.sh](../../k3_harness/install-agent-stack.sh) with a Buildkite agent token and a GitHub token.
+3. Make sure the host can reach `public.ecr.aws` so the pod can pull the public XPU image.
+
+## Queue and image notes
+
+- The pipeline uses the `xpu` queue.
+- The test pod runs `setup-lmcache-only-env.sh`, which installs LMCache from source on top of the public XPU base image.
+- The test pod pulls `public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ee0da84ab9e04ac7610e28580af62c365e898389-xpu` directly from ECR Public.
+- The XPU test pod requests `deviceclass.resource.kubernetes.io/gpu.intel.com` through DRA.
+
+## Buildkite UI snippet
+
+If you want to create the pipeline manually, paste this into the Steps editor:
+
+```yaml
+agents:
+  queue: "xpu"
+
+steps:
+  - label: ":pipeline: Upload pipeline"
+    command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/xpu/pipeline.yml
+```
+
+## What this pipeline does
+
+- Runs the XPU smoke test on the `xpu` queue
+- Uses the prebuilt public XPU image from ECR Public
+- Installs LMCache from source via `setup-lmcache-only-env.sh`
+- Verifies `torch.xpu.is_available()` inside the job pod

--- a/.buildkite/k3_tests/xpu/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/xpu/BK_WEB_SETUP.md
@@ -3,30 +3,21 @@
 **Steps editor**: paste the contents of `buildkite-pipeline.yml`.
 
 **GitHub trigger settings**:
-- Filter: `build.pull_request.labels includes "xpu"`
+- Filter: `build.pull_request.labels includes "xpu" || build.pull_request.labels includes "full" || build.branch == 'dev'`
 - Rebuild on PR label change: Yes
 - Skip queued / cancel running branch builds: Yes
 
 This pipeline now has a single step: it runs the XPU smoke test directly in a
-prebuilt public image and installs LMCache from source inside the job pod.
+prebuilt public vLLM image and installs LMCache from source inside the job pod.
 
-With this trigger filter, the pipeline only starts when the PR has the `xpu`
-label. If the label is missing, the XPU pipeline is not triggered.
 
 ## Required host setup
 
-Before creating the pipeline, prepare the machine that will run the `xpu` queue:
+Before creating the pipeline, prepare the machine that will run the `intel-xpu` queue:
 
 1. Run [setup-cluster.sh](../../k3_harness/setup-cluster.sh) to install K3s, the GPU Operator, and the shared host volumes.
 2. Run [install-agent-stack.sh](../../k3_harness/install-agent-stack.sh) with a Buildkite agent token and a GitHub token.
-3. Make sure the host can reach `public.ecr.aws` so the pod can pull the public XPU image.
 
-## Queue and image notes
-
-- The pipeline uses the `xpu` queue.
-- The test pod runs `setup-lmcache-only-env.sh`, which installs LMCache from source on top of the public XPU base image.
-- The test pod pulls `public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ee0da84ab9e04ac7610e28580af62c365e898389-xpu` directly from ECR Public.
-- The XPU test pod requests `deviceclass.resource.kubernetes.io/gpu.intel.com` through DRA.
 
 ## Buildkite UI snippet
 
@@ -34,7 +25,7 @@ If you want to create the pipeline manually, paste this into the Steps editor:
 
 ```yaml
 agents:
-  queue: "xpu"
+  queue: "intel-xpu"
 
 steps:
   - label: ":pipeline: Upload pipeline"
@@ -43,7 +34,17 @@ steps:
 
 ## What this pipeline does
 
-- Runs the XPU smoke test on the `xpu` queue
-- Uses the prebuilt public XPU image from ECR Public
+- Runs the XPU smoke test on the `intel-xpu` queue
+- Uses the prebuilt public vLLM image
 - Installs LMCache from source via `setup-lmcache-only-env.sh`
 - Verifies `torch.xpu.is_available()` inside the job pod
+
+## TODO
+
+- Enable vLLM/LMCache nightly build to catch up latest code changes
+
+- Design XPU path filter to precisely trigger `k3s-xpu-test` 
+
+- Refactor unit tests targeting multiple devices.
+
+- Enable more `xpu` tests within current CI architecture.

--- a/.buildkite/k3_tests/xpu/buildkite-pipeline.yml
+++ b/.buildkite/k3_tests/xpu/buildkite-pipeline.yml
@@ -1,0 +1,8 @@
+# Paste this into the Buildkite pipeline's "Steps" editor.
+# It uploads the real pipeline definition from the repo.
+agents:
+  queue: "xpu"
+
+steps:
+  - label: ":pipeline: Upload pipeline"
+    command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/xpu/pipeline.yml

--- a/.buildkite/k3_tests/xpu/buildkite-pipeline.yml
+++ b/.buildkite/k3_tests/xpu/buildkite-pipeline.yml
@@ -1,7 +1,10 @@
 # Paste this into the Buildkite pipeline's "Steps" editor.
 # It uploads the real pipeline definition from the repo.
 agents:
-  queue: "xpu"
+  queue: "intel-xpu"
+
+env:
+  HF_TOKEN: ""  # set your HuggingFace token here (needed for gated model access)
 
 steps:
   - label: ":pipeline: Upload pipeline"

--- a/.buildkite/k3_tests/xpu/pipeline.yml
+++ b/.buildkite/k3_tests/xpu/pipeline.yml
@@ -1,0 +1,25 @@
+# XPU smoke test.
+# Runs on a dedicated `xpu` queue using the public XPU CI image.
+
+steps:
+  - label: ":gpu: XPU smoke test"
+    command: bash "${BUILDKITE_BUILD_CHECKOUT_PATH:-.}/.buildkite/k3_tests/xpu/run.sh"
+    timeout_in_minutes: 180
+    agents: { queue: "xpu" }
+    plugins:
+      - kubernetes:
+          podSpec:
+            # Use the prebuilt public XPU CI image.
+            containers:
+              - name: container-0
+                image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ee0da84ab9e04ac7610e28580af62c365e898389-xpu
+                imagePullPolicy: Always
+                resources:
+                  requests:
+                    deviceclass.resource.kubernetes.io/gpu.intel.com: "1"
+                  limits:
+                    deviceclass.resource.kubernetes.io/gpu.intel.com: "1"
+                volumeMounts:
+                  - { name: hf-cache, mountPath: /root/.cache/huggingface }
+            volumes:
+              - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }

--- a/.buildkite/k3_tests/xpu/pipeline.yml
+++ b/.buildkite/k3_tests/xpu/pipeline.yml
@@ -1,8 +1,8 @@
 # XPU smoke test.
-# Runs on a dedicated `xpu` queue using the public XPU CI image.
+# Runs on a dedicated `intel-xpu` queue using the public XPU CI image.
 
 steps:
-  - label: ":gpu: XPU smoke test"
+  - label: ":intel-xpu-unit-tests"
     command: bash "${BUILDKITE_BUILD_CHECKOUT_PATH:-.}/.buildkite/k3_tests/xpu/run.sh"
     timeout_in_minutes: 180
     agents: { queue: "intel-xpu" }
@@ -13,7 +13,7 @@ steps:
             containers:
               - name: container-0
                 image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ee0da84ab9e04ac7610e28580af62c365e898389-xpu
-                imagePullPolicy: Never
+                imagePullPolicy: IfNotPresent
                 resources:
                   requests:
                     deviceclass.resource.kubernetes.io/gpu.intel.com: "1"

--- a/.buildkite/k3_tests/xpu/pipeline.yml
+++ b/.buildkite/k3_tests/xpu/pipeline.yml
@@ -13,7 +13,7 @@ steps:
             containers:
               - name: container-0
                 image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ee0da84ab9e04ac7610e28580af62c365e898389-xpu
-                imagePullPolicy: Always
+                imagePullPolicy: Never
                 resources:
                   requests:
                     deviceclass.resource.kubernetes.io/gpu.intel.com: "1"

--- a/.buildkite/k3_tests/xpu/pipeline.yml
+++ b/.buildkite/k3_tests/xpu/pipeline.yml
@@ -5,7 +5,7 @@ steps:
   - label: ":gpu: XPU smoke test"
     command: bash "${BUILDKITE_BUILD_CHECKOUT_PATH:-.}/.buildkite/k3_tests/xpu/run.sh"
     timeout_in_minutes: 180
-    agents: { queue: "xpu" }
+    agents: { queue: "intel-xpu" }
     plugins:
       - kubernetes:
           podSpec:

--- a/.buildkite/k3_tests/xpu/run.sh
+++ b/.buildkite/k3_tests/xpu/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# XPU smoke test entrypoint.
+# Runs directly inside the agent-stack-k8s job pod.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+log() {
+  echo "[xpu-test] $*"
+}
+
+fail() {
+  echo "[xpu-test] ERROR: $*" >&2
+  exit 1
+}
+
+export TEST_SELECTOR="${TEST_SELECTOR:-calculate_cdf or get_gpu_pci_bus_id or load_and_reshape_flash}"
+cd "${REPO_ROOT}"
+
+source "${REPO_ROOT}/.buildkite/k3_harness/setup-lmcache-only-env.sh"
+
+if [ -f /opt/intel/oneapi/setvars.sh ]; then
+  # Intel XPU runtime environment.
+  # shellcheck disable=SC1091
+  source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1 || true
+fi
+
+log "installing job dependencies"
+uv pip install -r requirements/common.txt -r requirements/test.txt
+
+log "checking torch.xpu availability"
+python - <<'PY'
+import torch
+
+assert hasattr(torch, "xpu") and torch.xpu.is_available(), "Intel XPU not available in pod"
+print("torch.xpu.is_available() = True")
+PY
+
+log "running XPU smoke tests"
+pytest -q tests/test_serde.py tests/v1/test_python_ops_fallback.py \
+  -k "${TEST_SELECTOR}" --maxfail=1
+
+log "xpu smoke test finished successfully"

--- a/.buildkite/k3_tests/xpu/run.sh
+++ b/.buildkite/k3_tests/xpu/run.sh
@@ -7,24 +7,24 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 log() {
-  echo "[xpu-test] $*"
+  echo "[intel-xpu-unit-tests] $*"
 }
 
 fail() {
-  echo "[xpu-test] ERROR: $*" >&2
+  echo "[intel-xpu-unit-tests] ERROR: $*" >&2
   exit 1
 }
-
-export TEST_SELECTOR="${TEST_SELECTOR:-calculate_cdf or get_gpu_pci_bus_id or load_and_reshape_flash}"
-cd "${REPO_ROOT}"
-
-source "${REPO_ROOT}/.buildkite/k3_harness/setup-lmcache-only-env.sh"
 
 if [ -f /opt/intel/oneapi/setvars.sh ]; then
   # Intel XPU runtime environment.
   # shellcheck disable=SC1091
+  log "enable Intel XPU runtime environment"
   source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1 || true
 fi
+
+export TEST_SELECTOR="${TEST_SELECTOR:-calculate_cdf or get_gpu_pci_bus_id or load_and_reshape_flash}"
+cd "${REPO_ROOT}"
+source "${REPO_ROOT}/.buildkite/k3_harness/setup-lmcache-only-env.sh"
 
 log "installing job dependencies"
 uv pip install -r requirements/common.txt -r requirements/test.txt


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the XPU Buildkite flow under `.buildkite/k3_tests/xpu/`.

This change introduces four files:
- `.buildkite/k3_tests/xpu/BK_WEB_SETUP.md`: Buildkite UI setup instructions and trigger rules for the XPU pipeline.
- `.buildkite/k3_tests/xpu/buildkite-pipeline.yml`: the Steps-editor snippet that uploads the real pipeline.
- `.buildkite/k3_tests/xpu/pipeline.yml`: the actual XPU smoke-test pipeline, using the public XPU image.
- `.buildkite/k3_tests/xpu/run.sh`: the XPU smoke-test entrypoint, which installs LMCache from source via `setup-lmcache-only-env.sh` and runs the smoke tests.

**Special notes for your reviewers**:

The XPU flow no longer builds or pushes a local image. It pulls the prebuilt public XPU image from ECR Public and installs LMCache from source inside the job pod.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests