### PR TITLE
[CI/CD]Add XPU web setup doc

### DIFF
--- a/.buildkite/k3_tests/xpu/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/xpu/BK_WEB_SETUP.md
@@ -1,0 +1,49 @@
+# Buildkite Web UI Setup: XPU Smoke Test
+
+**Steps editor**: paste the contents of `buildkite-pipeline.yml`.
+
+**GitHub trigger settings**:
+- Filter: `build.pull_request.labels includes "xpu"`
+- Rebuild on PR label change: Yes
+- Skip queued / cancel running branch builds: Yes
+
+This pipeline now has a single step: it runs the XPU smoke test directly in a
+prebuilt public image and installs LMCache from source inside the job pod.
+
+With this trigger filter, the pipeline only starts when the PR has the `xpu`
+label. If the label is missing, the XPU pipeline is not triggered.
+
+## Required host setup
+
+Before creating the pipeline, prepare the machine that will run the `xpu` queue:
+
+1. Run [setup-cluster.sh](../../k3_harness/setup-cluster.sh) to install K3s, the GPU Operator, and the shared host volumes.
+2. Run [install-agent-stack.sh](../../k3_harness/install-agent-stack.sh) with a Buildkite agent token and a GitHub token.
+3. Make sure the host can reach `public.ecr.aws` so the pod can pull the public XPU image.
+
+## Queue and image notes
+
+- The pipeline uses the `xpu` queue.
+- The test pod runs `setup-lmcache-only-env.sh`, which installs LMCache from source on top of the public XPU base image.
+- The test pod pulls `public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ee0da84ab9e04ac7610e28580af62c365e898389-xpu` directly from ECR Public.
+- The XPU test pod requests `deviceclass.resource.kubernetes.io/gpu.intel.com` through DRA.
+
+## Buildkite UI snippet
+
+If you want to create the pipeline manually, paste this into the Steps editor:
+
+```yaml
+agents:
+  queue: "xpu"
+
+steps:
+  - label: ":pipeline: Upload pipeline"
+    command: bash .buildkite/k3_tests/common_scripts/upload-pipeline.sh .buildkite/k3_tests/xpu/pipeline.yml
+```
+
+## What this pipeline does
+
+- Runs the XPU smoke test on the `xpu` queue
+- Uses the prebuilt public XPU image from ECR Public
+- Installs LMCache from source via `setup-lmcache-only-env.sh`
+- Verifies `torch.xpu.is_available()` inside the job pod

--- a/.buildkite/k3_tests/xpu/BK_WEB_SETUP.md
+++ b/.buildkite/k3_tests/xpu/BK_WEB_SETUP.md
@@ -3,30 +3,21 @@
 **Steps editor**: paste the contents of `buildkite-pipeline.yml`.
 
 **GitHub trigger settings**:
-- Filter: `build.pull_request.labels includes "xpu"`
+- Filter: `build.pull_request.labels includes "xpu" || build.pull_request.labels includes "full" || build.branch == 'dev'`
 - Rebuild on PR label change: Yes
 - Skip queued / cancel running branch builds: Yes
 
 This pipeline now has a single step: it runs the XPU smoke test directly in a
-prebuilt public image and installs LMCache from source inside the job pod.
+prebuilt public vLLM image and installs LMCache from source inside the job pod.
 
-With this trigger filter, the pipeline only starts when the PR has the `xpu`
-label. If the label is missing, the XPU pipeline is not triggered.
 
 ## Required host setup
 
-Before creating the pipeline, prepare the machine that will run the `xpu` queue:
+Before creating the pipeline, prepare the machine that will run the `intel-xpu` queue:
 
 1. Run [setup-cluster.sh](../../k3_harness/setup-cluster.sh) to install K3s, the GPU Operator, and the shared host volumes.
 2. Run [install-agent-stack.sh](../../k3_harness/install-agent-stack.sh) with a Buildkite agent token and a GitHub token.
-3. Make sure the host can reach `public.ecr.aws` so the pod can pull the public XPU image.
 
-## Queue and image notes
-
-- The pipeline uses the `xpu` queue.
-- The test pod runs `setup-lmcache-only-env.sh`, which installs LMCache from source on top of the public XPU base image.
-- The test pod pulls `public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:ee0da84ab9e04ac7610e28580af62c365e898389-xpu` directly from ECR Public.
-- The XPU test pod requests `deviceclass.resource.kubernetes.io/gpu.intel.com` through DRA.
 
 ## Buildkite UI snippet
 
@@ -34,7 +25,7 @@ If you want to create the pipeline manually, paste this into the Steps editor:
 
 ```yaml
 agents:
-  queue: "xpu"
+  queue: "intel-xpu"
 
 steps:
   - label: ":pipeline: Upload pipeline"
@@ -43,7 +34,17 @@ steps:
 
 ## What this pipeline does
 
-- Runs the XPU smoke test on the `xpu` queue
-- Uses the prebuilt public XPU image from ECR Public
+- Runs the XPU smoke test on the `intel-xpu` queue
+- Uses the prebuilt public vLLM image
 - Installs LMCache from source via `setup-lmcache-only-env.sh`
 - Verifies `torch.xpu.is_available()` inside the job pod
+
+## TODO
+
+- Enable vLLM/LMCache nightly build to catch up latest code changes
+
+- Design XPU path filter to precisely trigger `k3s-xpu-test` 
+
+- Refactor unit tests targeting multiple devices.
+
+- Enable more `xpu` tests within current CI architecture.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the XPU Buildkite web setup documentation for the new XPU pipeline path. The doc now matches the current public-image flow and LMCache-only setup used by the XPU smoke test.

**Special notes for your reviewers**:

This is a docs-only change. The XPU pipeline uses the prebuilt public image and installs LMCache from source inside the job pod.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests