### PR TITLE
docs: daily drift check — multi-process mode (2026-07-15)

### DIFF
--- a/docs/source/mp/l2_storage/remote_and_distributed.rst
+++ b/docs/source/mp/l2_storage/remote_and_distributed.rst
@@ -12,4 +12,5 @@ sharing cache across nodes.
    hfbucket
    mooncake_store
    resp
+   valkey
    aerospike

--- a/docs/source/mp/l2_storage/supported_storages.rst
+++ b/docs/source/mp/l2_storage/supported_storages.rst
@@ -40,6 +40,9 @@ target.
    * - :doc:`RESP (Redis/Valkey) <resp>`
      - ``resp``
      - Remote & Distributed
+   * - :doc:`Valkey <valkey>`
+     - ``valkey``
+     - Remote & Distributed
    * - :doc:`Aerospike <aerospike>`
      - ``aerospike``
      - Remote & Distributed

--- a/docs/source/mp/l2_storage/valkey.rst
+++ b/docs/source/mp/l2_storage/valkey.rst
@@ -1,0 +1,137 @@
+Valkey
+======
+
+An L2 adapter backed by the official ``valkey-glide`` **sync** Python
+client. Stores KV cache chunks in a Valkey (or Redis) server and
+supports both **standalone** (``GlideClient``) and **Valkey-Cluster**
+(``GlideClusterClient``) topologies, selected via ``cluster_mode``.
+
+I/O is dispatched through an internal ``ValkeyWorkerPool`` of worker
+threads; each worker holds its own glide client so a batch of keys
+parallelizes across threads and (in cluster mode) across primaries.
+
+Why the ``valkey`` adapter (vs. the RESP adapter)
+-------------------------------------------------
+
+The :doc:`RESP <resp>` adapter targets a single Redis/Valkey server
+over the native C++ RESP connector. The ``valkey`` adapter is a
+first-class Valkey backend: it speaks ``valkey-glide-sync`` directly,
+adds Valkey-Cluster support (slot routing, MOVED/ASK redirects, and
+topology discovery are handled inside ``GlideClusterClient``), and
+preserves copy-reduced SET/GET on multi-megabyte KV chunks (see the
+`Valkey L2 Adapter design doc
+<https://github.com/LMCache/LMCache/blob/dev/docs/design/v1/distributed/l2_adapters/valkey.md>`_
+for the full rationale, including why the sync -- not async -- glide
+client is used).
+
+Prerequisites -- installing the glide sync client
+-------------------------------------------------
+
+The ``valkey`` adapter requires the ``valkey-glide-sync`` package
+(version ``>= 2.3.0``, the first release with both copy-reduced SET
+and buffer GET). It is lazy-imported the first time a Valkey worker
+starts:
+
+.. code-block:: bash
+
+    pip install 'valkey-glide-sync>=2.3.0'
+
+If the package is missing when a Valkey worker starts, adapter
+construction fails with::
+
+    Valkey support requires the glide_sync module.
+    Install: pip install 'valkey-glide-sync>=2.3.0'
+
+**Required fields:**
+
+- ``startup_nodes``: A ``"host:port[,host:port...]"`` string of seed
+  nodes.
+
+  - In **standalone** mode (``cluster_mode: false``, the default) only
+    the first entry is used; extras trigger a warning.
+  - In **cluster** mode any reachable seed is enough -- glide auto-
+    discovers the full topology from ``CLUSTER SHARDS``.
+
+**Optional fields:**
+
+- ``cluster_mode`` (bool, default ``false``): When ``true`` use
+  ``GlideClusterClient``; otherwise use standalone ``GlideClient``.
+- ``username`` (str, default ``""``): Optional auth username.
+- ``password`` (str, default ``""``): Optional auth password.
+- ``key_prefix`` (str, default ``""``): Deployment-level key namespace,
+  joined with the standard wire key by ``@``. **Must not contain**
+  ``@``. Leave empty for a wire-format identical to the unprefixed
+  layout.
+- ``num_workers`` (int, default ``8``, > 0): Size of the internal worker
+  thread pool. Each worker holds its own glide client, so this is the
+  real I/O concurrency knob -- raise it to push throughput on large
+  batches / cluster deployments.
+- ``tls_enable`` (bool, default ``false``): Enable TLS. Required for
+  managed Valkey services such as ElastiCache Serverless.
+- ``database_id`` (int, optional): Logical database id for
+  **standalone** mode. Ignored (with a warning) when
+  ``cluster_mode: true``.
+- ``request_timeout`` (float, default ``5.0``, > 0): Per-request timeout,
+  in seconds.
+- ``connection_timeout`` (float, default ``10.0``, > 0): Initial
+  connection timeout, in seconds.
+- ``max_capacity_gb`` (float, default ``0``, >= 0): Declared aggregate
+  capacity in GB used to drive **LMCache-side** eviction. ``0`` (the
+  default and the recommended setting) disables global LMCache
+  eviction and defers to the Valkey server's own ``maxmemory`` /
+  eviction policy; per-``cache_salt`` quotas configured on the
+  coordinator still operate either way. Set ``> 0`` (together with an
+  ``eviction`` block) only when a single LMCache writer privately owns
+  the cluster -- do **not** combine ``> 0`` with server-side eviction
+  or a TTL, both of which drift LMCache's byte accounting.
+- ``ttl_seconds`` (int, optional): Opt-in per-key TTL in seconds; must
+  be a positive integer when set. Omit (default) to write keys with no
+  expiry. Enables server-side time-based expiry, required by any
+  ``volatile-*`` eviction policy configured on the Valkey server. Do
+  **not** combine with ``max_capacity_gb > 0`` (a warning is logged;
+  server-side expiry is not reported back to LMCache's byte accounting).
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    # Standalone Valkey / Redis server (server-side eviction)
+    --l2-adapter '{"type": "valkey", "startup_nodes": "127.0.0.1:6379"}'
+
+    # Valkey Cluster with TLS + auth (managed service)
+    --l2-adapter '{
+        "type": "valkey",
+        "cluster_mode": true,
+        "startup_nodes": "seed1.example.com:6379,seed2.example.com:6379",
+        "username": "lmcache",
+        "password": "secret",
+        "tls_enable": true,
+        "num_workers": 16
+    }'
+
+    # LMCache-driven eviction on a privately-owned Valkey cluster
+    --l2-adapter '{
+        "type": "valkey",
+        "cluster_mode": true,
+        "startup_nodes": "10.0.0.1:6379,10.0.0.2:6379",
+        "max_capacity_gb": 512,
+        "num_workers": 16
+    }'
+
+    # Per-key TTL (server-side expiry, no LMCache-side eviction)
+    --l2-adapter '{
+        "type": "valkey",
+        "startup_nodes": "127.0.0.1:6379",
+        "ttl_seconds": 3600
+    }'
+
+Wire key layout
+---------------
+
+Each stored value is keyed by::
+
+    [<key_prefix>@]<model_name>@<kv_rank_hex>@<chunk_hash_hex>[@<cache_salt>]
+
+The ``chunk_hash_hex`` component is a uniform content hash and the wire
+key contains no Redis hashtag (``{...}``), so keys distribute evenly
+across the 16384 cluster slots -- no manual key sharding is required.


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. One new
inconsistency between the multi-process (MP) docs and the current `dev`
code (`upstream/dev` HEAD [`76744ce`](https://github.com/LMCache/LMCache/commit/76744ce2514f3444e9a6fb06d67b23739fa93b51))
was found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/mp/l2_storage/`** — Yesterday's [PR #3505](https://github.com/LMCache/LMCache/pull/3505)
  (commit [`c828516`](https://github.com/LMCache/LMCache/commit/c828516e2cbee42525b8e1fda975533d5405e304)),
  titled *"[Feat] Add Valkey L2 adapter (standalone + cluster) for MP
  mode"*, added a **first-class** `valkey` L2 adapter that registers
  itself as `--l2-adapter type "valkey"`
  ([`valkey_l2_adapter.py:1116-1117`](``https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py#L1116-L1117)).``
  The PR shipped a design doc at
  [`docs/design/v1/distributed/l2_adapters/valkey.md`](https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/docs/design/v1/distributed/l2_adapters/valkey.md)
  but **no user-facing docs**. Concretely:
  - The `--l2-adapter` type table in
    [`docs/source/mp/l2_storage/supported_storages.rst`](https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/docs/source/mp/l2_storage/supported_storages.rst)
    lists every other adapter type (`nixl_store`, `fs`, `bigtable`,
    `s3`, `resp`, `aerospike`, `dax`, `mock`, `fault_inject`, ...) but
    does **not** list `valkey`. A user browsing that page today has no
    signal that a `valkey` adapter exists.
  - [`docs/source/mp/l2_storage/remote_and_distributed.rst`](https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/docs/source/mp/l2_storage/remote_and_distributed.rst)
    omits `valkey` from its Sphinx toctree.
  - There is no `docs/source/mp/l2_storage/valkey.rst` at all — every
    other L2 adapter has one, so users configuring
    `--l2-adapter '{"type": "valkey", ...}'` have no user-facing
    reference for its config fields (`startup_nodes`, `cluster_mode`,
    `ttl_seconds`, `max_capacity_gb`, ...), defaults, or the
    `valkey-glide-sync >= 2.3.0` install prerequisite.

  Same failure mode as [PR #4066](https://github.com/LMCache/LMCache/pull/4066)
  (`nixl_store` install extra): a user who just installed `lmcache` and
  configures `--l2-adapter '{"type": "valkey", ...}'` will fail to
  start on an `ImportError` for `glide_sync` and has no docs to
  troubleshoot from.

`docs/design/` (design docs):

- No new drift found in `docs/design/` beyond what open drift-check PRs
  #4087, #4066, #4035, #4009, #3996, #3984, #3969, and #3960 already
  cover. The valkey design doc landed with the code
  (`docs/design/v1/distributed/l2_adapters/valkey.md`).

**Evidence**

| Drift | Code / repo state (current `dev`, HEAD `76744ce`) | Stale doc |
| --- | --- | --- |
| No user-facing page for the `valkey` adapter | [`valkey_l2_adapter.py:1116-1117`](https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py#L1116-L1117) registers `--l2-adapter type "valkey"`; [`ValkeyL2AdapterConfig`](https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py#L128-L349) defines 12 config fields with defaults; [`worker_pool.py:215-220`](https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/lmcache/v1/storage_backend/valkey/worker_pool.py#L215-L220) requires the `valkey-glide-sync>=2.3.0` package. | `docs/source/mp/l2_storage/valkey.rst` does not exist. |
| `valkey` missing from adapter-type table | Same registration as above. | [`docs/source/mp/l2_storage/supported_storages.rst`](https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/docs/source/mp/l2_storage/supported_storages.rst) lists every other adapter type but not `valkey`. |
| `valkey` missing from Remote & Distributed toctree | Same. | [`docs/source/mp/l2_storage/remote_and_distributed.rst`](https://github.com/LMCache/LMCache/blob/76744ce2514f3444e9a6fb06d67b23739fa93b51/docs/source/mp/l2_storage/remote_and_distributed.rst) toctree contains only `bigtable, s3, hfbucket, mooncake_store, resp, aerospike`. |

**Proposed fix (applied in this PR)**

- Added `docs/source/mp/l2_storage/valkey.rst`. It documents:
  - Why this adapter exists next to the RESP adapter (Valkey-Cluster
    support, `valkey-glide-sync` client, copy-reduced SET/GET). Links
    to the existing design doc for the deeper rationale.
  - The `valkey-glide-sync >= 2.3.0` install prerequisite and the exact
    error message the adapter raises if the package is missing.
  - Required field (`startup_nodes`) and all 11 optional fields with
    their defaults, matching `ValkeyL2AdapterConfig.__init__` and
    `ValkeyL2AdapterConfig.help()` in the code.
  - Four `--l2-adapter` JSON examples: standalone; cluster + TLS +
    auth; LMCache-driven eviction on a privately-owned cluster; and
    opt-in per-key TTL.
  - The wire-key layout (matches the design doc's "Wire key layout"
    section) so operators understand the hashtag-free layout that
    distributes keys evenly across cluster slots.
- Added a `valkey` row to the `--l2-adapter` type table in
  `docs/source/mp/l2_storage/supported_storages.rst`, next to the
  existing RESP row.
- Added `valkey` to the Sphinx toctree in
  `docs/source/mp/l2_storage/remote_and_distributed.rst` so the new
  page is reachable from the Remote & Distributed index.

**Special notes for your reviewers**:

- Docs-only change. No code modified. Three files touched.
- Deduped against currently-open drift PRs:
  - **#4087** (`--prometheus-*` observability rows in
    `docs/source/mp/configuration.rst` — 2026-07-11): no overlap.
  - **#4066** (`nixl_store` install extra in `docs/source/mp/p2p.rst`
    — 2026-07-09): no overlap.
  - **#4035, #4009, #3996, #3984, #3969, #3960**: none cover the new
    `valkey` adapter.
- Follow-ups intentionally not tackled here:
  - The `docs/source/locale/zh_CN/LC_MESSAGES/mp/l2_storage/*.po`
    Chinese localization files still carry the pre-PR-#3505 English
    source strings. The `automation/update-chinese-docs` branch
    already regenerates these; this drift check leaves the `.po`
    regeneration to that workflow rather than hand-editing
    translations.
  - Since the previous drift check on 2026-07-11, PRs #4102 (log
    format), #3973 (log format), #4108 (XPU setup), #4015 (MP CUDA-IPC
    memory reclaim), #3885 (Cloud Bigtable — shipped with its own
    docs), #3594 (pre-commit bump), #4080 (hfbucket type-only
    imports), #4099 (Chinese docs), #4033 (CI preemption check), and
    #4097 (ffmpeg CI) landed. None of them introduced new user-facing
    MP docs drift; #3885 (Cloud Bigtable) landed with its own updates
    to `docs/source/mp/l2_storage/` (new `bigtable.rst`, updated
    `supported_storages.rst`, updated `remote_and_distributed.rst`),
    so no residual drift there.
- This PR was **auto-generated** by the daily drift-check routine and
  **needs human review before merge**. Please do not merge without a
  maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._


---
_Generated by [Claude Code](https://claude.ai/code/session_013dfxv6HFGFEr8QQsfV6HFH)_