### PR TITLE
ci(docker): build and push lmcache-payload image on release and nightly

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -171,6 +171,27 @@ jobs:
           docker push lmcache/vllm-openai:latest-nightly
           docker push lmcache/vllm-openai:nightly-${{ env.NOW }}
 
+      # Payload (docker/Dockerfile.payload) extracts lmcache from the cu13 nightly
+      # image just pushed above — still local, and dropped by the standalone
+      # build's leading prune, so build here.
+      - name: Build lmcache/lmcache-payload image (nightly)
+        run: |
+          docker build \
+          --build-arg SOURCE_IMAGE=lmcache/vllm-openai:latest-nightly \
+          --tag lmcache/lmcache-payload:latest-nightly --tag lmcache/lmcache-payload:nightly-${{ env.NOW }} \
+          --file docker/Dockerfile.payload .
+
+      # Run the ENTRYPOINT copy; assert the lmcache tree lands.
+      - name: Smoke test lmcache/lmcache-payload (nightly)
+        run: |
+          docker run --rm -e SHARED_DIR=/out -v "$PWD/payload-out:/out" lmcache/lmcache-payload:nightly-${{ env.NOW }}
+          test -f payload-out/lmcache/__init__.py
+
+      - name: Push lmcache/lmcache-payload nightly image to DockerHub
+        run: |
+          docker push lmcache/lmcache-payload:latest-nightly
+          docker push lmcache/lmcache-payload:nightly-${{ env.NOW }}
+
       - name: Build lmcache/standalone container image (cu13 nightly)
         run: |
           docker system prune -f --all
@@ -203,6 +224,27 @@ jobs:
         run: |
           docker push lmcache/vllm-openai:latest-nightly-cu129
           docker push lmcache/vllm-openai:nightly-${{ env.NOW }}-cu129
+
+      # Payload extracts lmcache from the cu129 nightly image just pushed above —
+      # still local, and dropped by the standalone build's leading prune, so
+      # build here.
+      - name: Build lmcache/lmcache-payload image (cu129 nightly)
+        run: |
+          docker build \
+          --build-arg SOURCE_IMAGE=lmcache/vllm-openai:latest-nightly-cu129 \
+          --tag lmcache/lmcache-payload:latest-nightly-cu129 --tag lmcache/lmcache-payload:nightly-${{ env.NOW }}-cu129 \
+          --file docker/Dockerfile.payload .
+
+      # Run the ENTRYPOINT copy; assert the lmcache tree lands.
+      - name: Smoke test lmcache/lmcache-payload (cu129 nightly)
+        run: |
+          docker run --rm -e SHARED_DIR=/out -v "$PWD/payload-out-cu129:/out" lmcache/lmcache-payload:nightly-${{ env.NOW }}-cu129
+          test -f payload-out-cu129/lmcache/__init__.py
+
+      - name: Push lmcache/lmcache-payload cu12.9 nightly image to DockerHub
+        run: |
+          docker push lmcache/lmcache-payload:latest-nightly-cu129
+          docker push lmcache/lmcache-payload:nightly-${{ env.NOW }}-cu129
 
       - name: Build lmcache/standalone container image (cu12.9 nightly)
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -368,6 +368,27 @@ jobs:
                 docker push lmcache/vllm-openai:latest
                 docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}
 
+            # Payload (docker/Dockerfile.payload) extracts lmcache from the cu13
+            # image just pushed above — still local, and dropped by the prune
+            # below, so build here.
+            - name: Build lmcache/lmcache-payload image
+              run: |
+                docker build \
+                --build-arg SOURCE_IMAGE=lmcache/vllm-openai:${{ env.LATEST_TAG }} \
+                --tag lmcache/lmcache-payload:latest --tag lmcache/lmcache-payload:${{ env.LATEST_TAG }} \
+                --file docker/Dockerfile.payload .
+
+            # Run the ENTRYPOINT copy; assert the lmcache tree lands.
+            - name: Smoke test lmcache/lmcache-payload
+              run: |
+                docker run --rm -e SHARED_DIR=/out -v "$PWD/payload-out:/out" lmcache/lmcache-payload:${{ env.LATEST_TAG }}
+                test -f payload-out/lmcache/__init__.py
+
+            - name: Push lmcache/lmcache-payload image to DockerHub
+              run: |
+                docker push lmcache/lmcache-payload:latest
+                docker push lmcache/lmcache-payload:${{ env.LATEST_TAG }}
+
             - name: Clean up Docker layers and cache
               run: |
                 docker system prune -f --all
@@ -441,6 +462,29 @@ jobs:
               run: |
                 docker push lmcache/vllm-openai:latest-cu129
                 docker push lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu129
+
+            # Payload extracts lmcache from the cu129 image just pushed above —
+            # still local, and dropped by the prune below, so build here.
+            - name: Build lmcache/lmcache-payload image (cu129)
+              if: needs.publish-cu129-github-release.result == 'success'
+              run: |
+                docker build \
+                --build-arg SOURCE_IMAGE=lmcache/vllm-openai:${{ env.LATEST_TAG }}-cu129 \
+                --tag lmcache/lmcache-payload:latest-cu129 --tag lmcache/lmcache-payload:${{ env.LATEST_TAG }}-cu129 \
+                --file docker/Dockerfile.payload .
+
+            # Run the ENTRYPOINT copy; assert the lmcache tree lands.
+            - name: Smoke test lmcache/lmcache-payload (cu129)
+              if: needs.publish-cu129-github-release.result == 'success'
+              run: |
+                docker run --rm -e SHARED_DIR=/out -v "$PWD/payload-out-cu129:/out" lmcache/lmcache-payload:${{ env.LATEST_TAG }}-cu129
+                test -f payload-out-cu129/lmcache/__init__.py
+
+            - name: Push lmcache/lmcache-payload cu129 image to DockerHub
+              if: needs.publish-cu129-github-release.result == 'success'
+              run: |
+                docker push lmcache/lmcache-payload:latest-cu129
+                docker push lmcache/lmcache-payload:${{ env.LATEST_TAG }}-cu129
 
             - name: Clean up Docker layers and cache
               run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

The operator's code-payload injection (`docker/Dockerfile.payload`) needs a published `lmcache/lmcache-payload` image — the operator injection sample already references `repository: lmcache/lmcache-payload` — but no pipeline builds one. This adds the build to both the release and nightly image pipelines, for the cu13 and cu12.9 variants.

The payload Dockerfile does not recompile lmcache; it `FROM ${SOURCE_IMAGE}` and extracts the already-installed `lmcache` tree, then ships a busybox image whose ENTRYPOINT copies that tree into the shared dir the webhook mounts. So its `SOURCE_IMAGE` is a just-built `lmcache/vllm-openai` image.

Placement in each pipeline handles the build ordering — each payload builds right after its `vllm-openai` source image is built **and** pushed, and **before** the prune that drops the local source image (cleanup prune in `publish.yml`, the next standalone build's leading prune in `nightly_build.yml`). Reusing the still-local source image avoids a multi-GB re-pull and guarantees the payload ships the exact lmcache the operator injects alongside that same image.

Tags follow the `vllm-openai` convention:

| Pipeline | Payload tags | SOURCE_IMAGE |
|---|---|---|
| `publish.yml` | `latest`, `<tag>` | `vllm-openai:<tag>` |
| `publish.yml` | `latest-cu129`, `<tag>-cu129` | `vllm-openai:<tag>-cu129` |
| `nightly_build.yml` | `latest-nightly`, `nightly-<date>` | `vllm-openai:latest-nightly` |
| `nightly_build.yml` | `latest-nightly-cu129`, `nightly-<date>-cu129` | `vllm-openai:latest-nightly-cu129` |

**Special notes for your reviewers**:

- Each build is smoke-tested before push: it runs the ENTRYPOINT copy (`SHARED_DIR=/out`) and asserts `lmcache/__init__.py` lands, so a broken payload fails the build before it ships.
- The cu129 release steps carry the same `needs.publish-cu129-github-release.result == 'success'` guard as the surrounding cu129 image steps, so they skip when the cu129 release is absent.
- Scoped to stable releases (not RC — the RC job's contract is "does not touch latest or other image variants").

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
