### PR TITLE
docs: daily drift check — multi-process mode (2026-07-16)

### DIFF
--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -9,6 +9,6 @@ commands, and HTTP endpoints.
 
    contributing
    extending_lmcache/native_connectors
-extending_lmcache/adding_a_new_device_backend
+   extending_lmcache/adding_a_new_device_backend
    cli
    extending_http_api


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. One new
inconsistency between the multi-process (MP) docs and the current `dev`
code (`upstream/dev` HEAD [`41417367`](https://github.com/LMCache/LMCache/commit/41417367b400627a8cbcbc565a42feb17ce3122d))
was found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/developer_guide/index.rst`** — Today's [PR #4004](https://github.com/LMCache/LMCache/pull/4004)
  (commit [`4141736`](https://github.com/LMCache/LMCache/commit/41417367b400627a8cbcbc565a42feb17ce3122d)),
  titled *"docs: guide for integrating new non-CUDA devices via
  engine-driven MP path"*, added the new
  ``docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst``
  MP dev guide (350 lines) and inserted a toctree entry for it in the
  Developer Guide index — but the inserted line was **not indented** to
  match the surrounding entries. In Sphinx, an unindented non-blank
  line inside a ``.. toctree::`` directive silently ends the directive
  body, so on current `dev` the toctree only registers the two entries
  above the bad line:

  ```rst
  .. toctree::
     :maxdepth: 1

     contributing
     extending_lmcache/native_connectors
  extending_lmcache/adding_a_new_device_backend      <-- unindented
     cli
     extending_http_api
  ```

  Three doc pages fall out of the Developer Guide sidebar navigation as
  a result:

  - `extending_lmcache/adding_a_new_device_backend` — the new MP guide
    the same PR added is unreachable from the sidebar.
  - `cli` ([`docs/source/developer_guide/cli.rst`](https://github.com/LMCache/LMCache/blob/41417367b400627a8cbcbc565a42feb17ce3122d/docs/source/developer_guide/cli.rst))
    — collateral damage; previously reachable from the Developer Guide.
  - `extending_http_api` ([`docs/source/developer_guide/extending_http_api.rst`](https://github.com/LMCache/LMCache/blob/41417367b400627a8cbcbc565a42feb17ce3122d/docs/source/developer_guide/extending_http_api.rst))
    — same collateral damage.

`docs/design/` (design docs):

- No new drift found. PR #4004 also updated
  `docs/design/ARCHITECTURE_MULTI_HARDWARE.md` (100 lines changed) to
  describe the new transfer-context routing (`EngineDrivenTransferContext`
  / `LMCacheDrivenTransferContext`, `MPTransferMode.{AUTO,ENGINE_DRIVEN,LMCACHE_DRIVEN}`,
  `create_transfer_context(kv_caches, mode)`). All claims verified
  against `lmcache/v1/multiprocess/transfer_context/worker_transfer.py`
  and `lmcache/v1/platform/`.

**Evidence**

| Drift | Code / repo state (current `dev`, HEAD `41417367`) | Stale doc |
| --- | --- | --- |
| Toctree body ends silently, orphaning three entries | [`docs/source/developer_guide/index.rst:12`](https://github.com/LMCache/LMCache/blob/41417367b400627a8cbcbc565a42feb17ce3122d/docs/source/developer_guide/index.rst#L12) — `extending_lmcache/adding_a_new_device_backend` has zero indentation while lines 10, 11, 13, 14 all use 3-space indentation. Introduced by PR #4004 diff on this file (single-line addition). | Same file, same line. |
| The new MP guide is unreachable from nav | The file [`docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst`](````https://github.com/LMCache/LMCache/blob/41417367b400627a8cbcbc565a42feb17ce3122d/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst)```` exists and is well-formed (350 lines, `.. _part-1-basic:` / `.. _part-2-performance:` anchors matched by internal `:ref:` links, all module references verified against `lmcache/v1/platform/base_device_spec.py`, `lmcache/v1/multiprocess/transfer_context/worker_transfer.py`, and `lmcache/integration/vllm/lmcache_mp_connector.py`), so the fix is toctree-only. | Not registered in the Developer Guide toctree above. |
| `cli` and `extending_http_api` also drop out of nav | Both pages exist unchanged and are still valid Developer Guide content. | Same broken toctree. |

**Proposed fix (applied in this PR)**

- One-line edit to
  [`docs/source/developer_guide/index.rst`](https://github.com/LMCache/LMCache/blob/41417367b400627a8cbcbc565a42feb17ce3122d/docs/source/developer_guide/index.rst):
  indent
  ``extending_lmcache/adding_a_new_device_backend`` with the same
  3-space prefix used by the other toctree entries. That restores the
  toctree so all four entries (the new MP guide, ``cli``, and
  ``extending_http_api``, along with ``contributing`` and
  ``extending_lmcache/native_connectors``) are reachable from the
  Developer Guide sidebar.

**Special notes for your reviewers**:

- Docs-only change. One file, one line.
- Deduped against currently-open drift PRs:
  - **#4117** (docs/source/mp/l2_storage/valkey.rst + supported_storages
    + remote_and_distributed toctree — 2026-07-15): no overlap; #4117
    covers a different subtree (`mp/l2_storage/`), this PR fixes a
    Developer Guide toctree.
  - **#4087, #4066, #4035, #4009**: none cover the developer-guide
    toctree.
- The other two commits landed on `dev` since the previous drift check
  (2026-07-15 → today):
  - **#4107** (`[CI/CD] Add XPU pipeline directory`,
    [`2063242`](https://github.com/LMCache/LMCache/commit/2063242719fb75e0425c3a21ddf27f948ff8699e))
    — Buildkite YAML only, no user-facing docs impact.
  - **#4023** (`feat(valkey): Tag GLIDE connections as
    GlidePySync(lmcache:<ver>)`,
    [`668a1fd`](https://github.com/LMCache/LMCache/commit/668a1fd6ae4988a60fd7ea1a7cbd9f06db054b52))
    — backward-compatible feature-detected tagging in
    `lmcache/v1/storage_backend/valkey/worker_pool.py`; no new
    user-facing config or CLI flag, so no additional docs required.
    The still-missing user-facing `valkey.rst` is already covered by
    open drift PR #4117.
- This PR was **auto-generated** by the daily drift-check routine and
  **needs human review before merge**. Please do not merge without a
  maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeGdDaeWLFg4GhTbenMSmV)_