### PR TITLE
fix(vllm/mp): realign the 0201 MP connector with the current adapter API (#4134)

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -91,6 +91,14 @@ def build_parallel_strategy(vllm_config: VllmConfig) -> ParallelStrategy:
     ``ParallelStrategy`` derives ``kv_world_size`` / ``kv_worker_id`` from the
     raw vLLM geometry (including the MLA adjustment), so the world size and
     rank are passed through unmodified.
+
+    Args:
+        vllm_config: The vLLM configuration to read the parallel geometry and
+            MLA setting from.
+
+    Returns:
+        A ``ParallelStrategy`` describing the KV parallel layout for this
+        worker, with ``n_servers`` fixed at 1.
     """
     pc = vllm_config.parallel_config
     return ParallelStrategy(

--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -84,28 +84,23 @@ def reformat_block_ids(block_ids: tuple[list[int], ...] | None) -> list[int]:
     return block_ids[0]
 
 
-def extract_world_size_and_kv_rank(
-    world_size: int,
-    rank: int,
-    vllm_config: VllmConfig,
-) -> tuple[int, int]:
+def build_parallel_strategy(vllm_config: VllmConfig) -> ParallelStrategy:
     """
-    Convert the rank for the MLA.
+    Build the KV parallel geometry from a vLLM config.
+
+    ``ParallelStrategy`` derives ``kv_world_size`` / ``kv_worker_id`` from the
+    raw vLLM geometry (including the MLA adjustment), so the world size and
+    rank are passed through unmodified.
     """
-    use_mla = mla_enabled(vllm_config.model_config)
-    if not use_mla:
-        return world_size, rank
-    else:
-        # Tensor parallel does not change the KV caches for MLA models.
-        # So we need to "exclude" the effect of TP on rank and world size
-        tp_size = vllm_config.parallel_config.tensor_parallel_size
-        # vLLM constructs TP groups first, and then construct other
-        # parallel groups on top of TP groups.
-        # for example, TP=4, PP=2,
-        # PP group: [0, 1, 2, 3], [4, 5, 6, 7]
-        # TP group: [0, 4], [1, 5], [2, 6], [3, 7]
-        # So we can "exclude" the effect of TP by rank // tp_size.
-        return world_size // tp_size, rank // tp_size
+    pc = vllm_config.parallel_config
+    return ParallelStrategy(
+        use_mla=mla_enabled(vllm_config.model_config),
+        vllm_world_size=pc.world_size,
+        vllm_worker_id=pc.rank,
+        tp_size=pc.tensor_parallel_size,
+        pp_size=pc.pipeline_parallel_size,
+        n_servers=1,
+    )
 
 
 def create_scheduler_adapter(
@@ -115,23 +110,10 @@ def create_scheduler_adapter(
     mq_timeout: float,
     heartbeat_interval: float,
 ) -> LMCacheMPSchedulerAdapter:
-    world_size, kv_rank = extract_world_size_and_kv_rank(
-        vllm_config.parallel_config.world_size,
-        vllm_config.parallel_config.rank,
-        vllm_config,
-    )
-    parallel_strategy = ParallelStrategy(
-        mla_enabled(vllm_config.model_config),
-        world_size,
-        kv_rank,
-        vllm_config.parallel_config.world_size,
-        vllm_config.parallel_config.rank,
-        vllm_config.parallel_config.tensor_parallel_size,
-        vllm_config.parallel_config.pipeline_parallel_size,
-    )
+    parallel_strategy = build_parallel_strategy(vllm_config)
 
     return LMCacheMPSchedulerAdapter(
-        server_url=server_url,
+        server_urls=[server_url],
         context=zmq_context,
         model_name=vllm_config.model_config.model,
         vllm_block_size=vllm_config.cache_config.block_size,
@@ -148,20 +130,7 @@ def create_worker_adapter(
     mq_timeout: float,
     heartbeat_interval: float,
 ) -> LMCacheMPWorkerAdapter:
-    world_size, kv_rank = extract_world_size_and_kv_rank(
-        vllm_config.parallel_config.world_size,
-        vllm_config.parallel_config.rank,
-        vllm_config,
-    )
-    parallel_strategy = ParallelStrategy(
-        mla_enabled(vllm_config.model_config),
-        world_size,
-        kv_rank,
-        vllm_config.parallel_config.world_size,
-        vllm_config.parallel_config.rank,
-        vllm_config.parallel_config.tensor_parallel_size,
-        vllm_config.parallel_config.pipeline_parallel_size,
-    )
+    parallel_strategy = build_parallel_strategy(vllm_config)
 
     return LMCacheMPWorkerAdapter(
         server_url=server_url,
@@ -648,12 +617,8 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         This prevents overwrites of paged KV buffer before saving done.
         """
-        # In MLA scenario, only the first rank of the pipeline group
-        # needs to save the KV cache.
-        if (
-            self.worker_adapter.use_mla
-            and not self.worker_adapter.is_first_rank_of_pp_group
-        ):
+        # In the MLA scenario, only the KV writer ranks store the KV cache.
+        if not self.worker_adapter.is_kv_writer:
             return
 
         metadata = self._get_connector_metadata()


### PR DESCRIPTION
## Summary

Fixes #4134 (partially — see "Scope" below).

`lmcache/integration/vllm/lmcache_mp_connector_0201.py` drifted from the current `vllm_multi_process_adapter.py`, so the MP path cannot start on vLLM 0.20.1. Three drifts, all confirmed against `dev`:

1. **`server_url=` -> `server_urls=[...]`.** `create_scheduler_adapter` passes `server_url=server_url`, but `LMCacheMPSchedulerAdapter.__init__` now takes `server_urls: list[str]` (it asserts `len(server_urls) >= 1` and fans out a `MessageQueueClient` per URL).

2. **`ParallelStrategy` arity.** Both factories construct it with 7 positional args, but the dataclass now has 6 fields — `kv_world_size` / `kv_worker_id` became derived properties (`TypeError: __init__() takes 7 positional arguments but 8 were given`).

   Since the MLA adjustment now lives inside those properties (`kv_world_size` divides by `tp_size` when `use_mla`), feeding them the *pre-adjusted* values from `extract_world_size_and_kv_rank` would adjust twice. That helper is therefore superseded and removed, and the raw vLLM geometry is passed straight through — mirroring `build_parallel_strategy_from_vllm_config` in the unversioned `lmcache_mp_connector.py`. `n_servers=1` keeps the single-server behaviour this connector already had.

3. **`wait_for_save` attributes.** It reads `self.worker_adapter.use_mla` and `.is_first_rank_of_pp_group`; neither exists on `LMCacheMPWorkerAdapter` any more (`is_first_rank_of_pp_group` now appears nowhere else in the repo). Both moved onto `parallel_strategy`, surfaced via the `is_kv_writer` property — which encodes exactly the old condition: `not is_kv_writer` ⟺ `use_mla and worker_id % (tp_size // n_servers) != 0`.

## Scope

The issue reports `_0180` as affected too, but it isn't: it calls the adapters through the **legacy positional signature** (`server_url, ctx, model, kv_world_size, kv_worker_id, block_size`), which `_normalize_adapter_init_args` still explicitly supports, and it has no `use_mla` guard in `wait_for_save`. Left untouched.

The issue's vLLM-side `KVConnectorFactory` note (registered names resolving before `kv_connector_module_path`) is upstream in vLLM and out of scope here.

## Testing

No test covers the versioned connectors (importing them requires a matching vLLM), so this is verified by inspection against the adapter signatures on `dev`: `ParallelStrategy` fields, `LMCacheMPSchedulerAdapter.__init__`, and the `is_kv_writer` property. `ruff check` / `ruff format` are clean on the changed lines (the one pre-existing `torch_device_type` unused-import warning is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
