### PR TITLE
[Bugfix] Handle request abort during MP retrieve

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -352,6 +352,7 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
                 extra_config=vllm_config.kv_transfer_config.kv_connector_extra_config,
             )
             self.request_trackers: dict[str, LMCacheMPRequestTracker] = {}
+            self._aborted_retrieve_req_ids: set[str] = set()
 
             # GPU block pool reference
             self._gpu_block_pool: "BlockPool | None" = None
@@ -520,6 +521,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, LMCacheMPConnectorMetadata)
+        if not self.lazy_offload:
+            self.worker_adapter.mark_aborted_retrieves(
+                metadata.aborted_retrieve_req_ids
+            )
 
         request_ids = []
         ops = []
@@ -912,6 +917,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         """
         metadata = LMCacheMPConnectorMetadata()
         metadata.need_flush_before_forward = _has_preemption_reqs(scheduler_output)
+        metadata.aborted_retrieve_req_ids = self._aborted_retrieve_req_ids
+        self._aborted_retrieve_req_ids = set()
 
         self._process_retrieve_requests(metadata)
         self._process_new_requests(scheduler_output, metadata)
@@ -933,6 +940,11 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             connector_output (KVConnectorOutput): the worker-side
                 connectors output.
         """
+        for request_id in connector_output.finished_recving or ():
+            tracker = self.request_trackers.get(request_id)
+            if tracker is not None and tracker.state == LMCacheMPRequestState.LOADING:
+                tracker.state = LMCacheMPRequestState.READY
+
         if not self.lazy_offload:
             return
         if not self._gpu_block_pool:
@@ -969,6 +981,13 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             returned by the engine.
         """
 
+        tracker = self.request_trackers.get(request.request_id)
+        load_in_flight = (
+            tracker is not None and tracker.state == LMCacheMPRequestState.LOADING
+        )
+        if load_in_flight and not self.lazy_offload:
+            self._aborted_retrieve_req_ids.add(request.request_id)
+
         params: dict[str, Any] | None = getattr(request, "kv_transfer_params", None)
         return_params: dict[str, Any] | None = {} if params is not None else None
 
@@ -977,9 +996,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             and return_params is not None
             and "cached_token_stats" in params
         ):
-            request_tracker = self._get_request_tracker(request.request_id)
-            num_vllm = request_tracker.num_vllm_hit_tokens
-            num_lmcache = request_tracker.num_lmcache_hit_tokens
+            assert tracker is not None
+            num_vllm = tracker.num_vllm_hit_tokens
+            num_lmcache = tracker.num_lmcache_hit_tokens
             return_params["cached_token_stats"] = {
                 "num_vllm_cached_tokens": num_vllm,
                 "num_lmcache_cached_tokens": num_lmcache,
@@ -994,9 +1013,10 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         self.scheduler_adapter.end_session(request.request_id)
 
         if self.lazy_offload:
-            self._pending_store.mark_req_finished(request.request_id)
+            if not load_in_flight:
+                self._pending_store.mark_req_finished(request.request_id)
             return False, (return_params or None)
-        return True, (return_params or None)
+        return not load_in_flight, (return_params or None)
 
     def request_finished_all_groups(
         self,
@@ -1090,7 +1110,9 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             )
             if r_metadata is not None:
                 metadata.add_request_metadata(r_metadata)
-            request_tracker.state = LMCacheMPRequestState.READY
+                request_tracker.state = LMCacheMPRequestState.LOADING
+            else:
+                request_tracker.state = LMCacheMPRequestState.READY
 
     def _process_new_requests(
         self,
@@ -1105,6 +1127,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             num_new_tokens = scheduler_output.num_scheduled_tokens[new_request.req_id]
             request_tracker.increase_num_scheduled_tokens(num_new_tokens)
 
+            if request_tracker.state == LMCacheMPRequestState.LOADING:
+                continue
             r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
                 request_tracker,
                 lmcache_tokens_per_chunk,
@@ -1145,6 +1169,8 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
             num_new_tokens = scheduler_output.num_scheduled_tokens[request_id]
             request_tracker.increase_num_scheduled_tokens(num_new_tokens)
 
+            if request_tracker.state == LMCacheMPRequestState.LOADING:
+                continue
             r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
                 request_tracker,
                 lmcache_tokens_per_chunk,

--- a/lmcache/integration/vllm/lmcache_mp_metadata.py
+++ b/lmcache/integration/vllm/lmcache_mp_metadata.py
@@ -30,11 +30,13 @@ class LMCacheMPRequestState(enum.Enum):
     """
     State machine:
     PREFETCHING -- update_state_after_alloc --> WAITING_FOR_LOAD
-    WAITING_FOR_LOAD -- process_loading_requests --> READY
+    WAITING_FOR_LOAD -- process_loading_requests --> LOADING
+    LOADING -- finished_recving --> READY
     """
 
     PREFETCHING = enum.auto()
     WAITING_FOR_LOAD = enum.auto()
+    LOADING = enum.auto()
     READY = enum.auto()
 
 
@@ -346,6 +348,7 @@ class LMCacheMPConnectorMetadata(KVConnectorMetadata):
         super().__init__()
         self.requests: list[LMCacheMPRequestMetadata] = []
         self.need_flush_before_forward: bool = False
+        self.aborted_retrieve_req_ids: set[str] = set()
 
     def add_request_metadata(self, request_metadata: LMCacheMPRequestMetadata):
         self.requests.append(request_metadata)

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1127,6 +1127,11 @@ class LMCacheMPWorkerAdapter:
         # submit_retrieve_request. get_finished must still report each id
         # exactly once, or async loads hang in WAITING_FOR_REMOTE_KVS.
         self._dropped_retrieves: set[str] = set()
+        # Scheduler-confirmed aborts that occurred while a retrieve was in
+        # flight. This marker survives the window where a worker has already
+        # reported finished_recving and removed the retrieve future, but sees
+        # the engine-finished request ID in a later step.
+        self._aborted_retrieves: set[str] = set()
 
         # The store requests that have finished execution in LMCache
         self.finished_stores: set[str] = set()
@@ -1572,6 +1577,21 @@ class LMCacheMPWorkerAdapter:
         self._returned_finished.update(ret_stores)
         return ret_stores
 
+    def mark_aborted_retrieves(self, request_ids: set[str]) -> None:
+        """Record scheduler-confirmed aborts of in-flight retrieves.
+
+        Args:
+            request_ids: Request IDs aborted while their retrieve was active.
+
+        Returns:
+            None.
+
+        Notes:
+            Markers persist across ``get_finished()`` calls until the matching
+            engine-finished notification is observed.
+        """
+        self._aborted_retrieves.update(request_ids)
+
     @_lmcache_nvtx_annotate
     def get_finished(
         self, finished_req_ids_from_engine: set[str]
@@ -1626,7 +1646,8 @@ class LMCacheMPWorkerAdapter:
             finished_retrieves.update(dropped)
 
             ret_stores = self._process_finished_stores(
-                finished_stores, finished_req_ids_from_engine
+                finished_stores,
+                finished_req_ids_from_engine - self._aborted_retrieves,
             )
             # A request may have a pending retrieve AND appear in
             # finished_req_ids_from_engine (it ran without loading KV after
@@ -1634,6 +1655,9 @@ class LMCacheMPWorkerAdapter:
             # first and deletes the request, so we must not also report it
             # in finished_sending.
             ret_stores -= finished_retrieves
+            handled_aborts = finished_req_ids_from_engine & self._aborted_retrieves
+            self._returned_finished.update(handled_aborts)
+            self._aborted_retrieves.difference_update(handled_aborts)
             return ret_stores, finished_retrieves
 
         finished_stores = set()
@@ -1685,10 +1709,20 @@ class LMCacheMPWorkerAdapter:
         self._dropped_retrieves = set()
         finished_retrieves.update(dropped)
 
+        # An engine-finished request can still have a retrieve in flight after
+        # an abort. It has no store completion for the scheduler to wait on;
+        # reporting both directions would let recv free the request before
+        # the scheduler processes send.
+        retrieving_req_ids = set(self.retrieve_futures) | finished_retrieves
+
         # Update the internal states
         ret_stores = self._process_finished_stores(
-            finished_stores, finished_req_ids_from_engine
+            finished_stores,
+            finished_req_ids_from_engine - retrieving_req_ids - self._aborted_retrieves,
         )
+        handled_aborts = finished_req_ids_from_engine & self._aborted_retrieves
+        self._returned_finished.update(handled_aborts)
+        self._aborted_retrieves.difference_update(handled_aborts)
 
         # the invocation of `get_finished` means that
         # these requests' KV caches are already fully stored.

--- a/tests/v1/test_lmcache_mp_connector.py
+++ b/tests/v1/test_lmcache_mp_connector.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import pytest
+
+pytest.importorskip("vllm", reason="MP connector imports vLLM at module top")
+
+# Third Party
+from vllm.v1.outputs import KVConnectorOutput  # noqa: E402
+
+# First Party
+from lmcache.integration.vllm.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPConnector,
+)
+from lmcache.integration.vllm.lmcache_mp_metadata import (  # noqa: E402
+    LMCacheMPConnectorMetadata,
+    LMCacheMPRequestMetadata,
+    LMCacheMPRequestState,
+)
+
+
+def _make_scheduler_connector(
+    state: LMCacheMPRequestState,
+) -> tuple[LMCacheMPConnector, MagicMock]:
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    tracker = MagicMock()
+    tracker.state = state
+    connector.request_trackers = {"req": tracker}
+    connector._aborted_retrieve_req_ids = set()
+    connector.scheduler_adapter = MagicMock()
+    connector.scheduler_adapter.lmcache_tokens_per_chunk = 256
+    connector._group_tokens_per_block = [16]
+    connector.lazy_offload = False
+    return connector, tracker
+
+
+def test_retrieve_metadata_keeps_request_loading_until_completion() -> None:
+    connector, tracker = _make_scheduler_connector(
+        LMCacheMPRequestState.WAITING_FOR_LOAD
+    )
+    metadata = LMCacheMPConnectorMetadata()
+
+    with patch.object(
+        LMCacheMPRequestMetadata,
+        "GetRetrieveMetadata",
+        return_value=MagicMock(),
+    ):
+        connector._process_retrieve_requests(metadata)
+
+    assert tracker.state == LMCacheMPRequestState.LOADING
+
+    connector.update_connector_output(KVConnectorOutput(finished_recving={"req"}))
+
+    assert tracker.state == LMCacheMPRequestState.READY
+
+
+def test_loading_request_does_not_enqueue_store() -> None:
+    connector, tracker = _make_scheduler_connector(LMCacheMPRequestState.LOADING)
+    metadata = LMCacheMPConnectorMetadata()
+    scheduler_output = SimpleNamespace(
+        scheduled_new_reqs=[SimpleNamespace(req_id="req")],
+        num_scheduled_tokens={"req": 32},
+        total_num_scheduled_tokens=0,
+    )
+
+    connector._process_new_requests(scheduler_output, metadata)
+
+    tracker.increase_num_scheduled_tokens.assert_called_once_with(32)
+    assert len(metadata) == 0
+
+
+def test_loading_cached_request_does_not_enqueue_store() -> None:
+    connector, tracker = _make_scheduler_connector(LMCacheMPRequestState.LOADING)
+    metadata = LMCacheMPConnectorMetadata()
+    scheduler_output = SimpleNamespace(
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=["req"],
+            new_block_ids=[[]],
+            resumed_req_ids=set(),
+        ),
+        num_scheduled_tokens={"req": 32},
+        total_num_scheduled_tokens=0,
+    )
+
+    connector._process_cached_requests(scheduler_output, metadata)
+
+    tracker.increase_num_scheduled_tokens.assert_called_once_with(32)
+    assert len(metadata) == 0
+
+
+def test_request_finished_during_load_does_not_wait_for_store() -> None:
+    connector, _tracker = _make_scheduler_connector(LMCacheMPRequestState.LOADING)
+    request = SimpleNamespace(request_id="req", kv_transfer_params=None)
+
+    delay_free, return_params = connector.request_finished(request, [])
+
+    assert delay_free is False
+    assert return_params is None
+    assert "req" not in connector.request_trackers
+    assert connector._aborted_retrieve_req_ids == {"req"}
+    cast(MagicMock, connector.scheduler_adapter).end_session.assert_called_once_with(
+        "req"
+    )
+
+
+def test_lazy_offload_abort_does_not_finish_nonexistent_store() -> None:
+    connector, _tracker = _make_scheduler_connector(LMCacheMPRequestState.LOADING)
+    connector.lazy_offload = True
+    connector._pending_store = MagicMock()
+    request = SimpleNamespace(request_id="req", kv_transfer_params=None)
+
+    delay_free, return_params = connector.request_finished(request, [])
+
+    assert delay_free is False
+    assert return_params is None
+    assert connector._aborted_retrieve_req_ids == set()
+    connector._pending_store.mark_req_finished.assert_not_called()
+
+
+def test_aborted_retrieve_marker_is_sent_once_in_metadata() -> None:
+    connector, _tracker = _make_scheduler_connector(LMCacheMPRequestState.LOADING)
+    connector._aborted_retrieve_req_ids.add("req")
+
+    with (
+        patch.object(connector, "_process_retrieve_requests"),
+        patch.object(connector, "_process_new_requests"),
+        patch.object(connector, "_process_cached_requests"),
+        patch.object(connector, "_report_block_allocation_deltas"),
+    ):
+        metadata = connector.build_connector_meta(SimpleNamespace())
+
+    assert metadata.aborted_retrieve_req_ids == {"req"}
+    assert connector._aborted_retrieve_req_ids == set()
+
+
+def test_worker_consumes_abort_marker_without_new_retrieve() -> None:
+    connector = LMCacheMPConnector.__new__(LMCacheMPConnector)
+    metadata = LMCacheMPConnectorMetadata()
+    metadata.aborted_retrieve_req_ids = {"req"}
+    connector._connector_metadata = metadata
+    connector.worker_adapter = MagicMock()
+    connector.lazy_offload = False
+
+    connector.start_load_kv(SimpleNamespace())
+
+    connector.worker_adapter.mark_aborted_retrieves.assert_called_once_with({"req"})
+    connector.worker_adapter.batched_submit_retrieve_requests.assert_not_called()

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -385,6 +385,78 @@ def test_retrieve_keeps_event_until_future_finishes(fake_adapter):
     assert event_ref() is None
 
 
+def test_abort_during_pending_retrieve_does_not_report_store(fake_adapter) -> None:
+    adapter, _send_mock, _future = fake_adapter
+    retrieve_future = MagicMock(name="retrieve_future")
+    retrieve_future.query.return_value = False
+    adapter.retrieve_futures["req-1"] = (retrieve_future, [7])
+
+    finished_stores, finished_retrieves = adapter.get_finished({"req-1"})
+
+    assert finished_stores == set()
+    assert finished_retrieves == set()
+
+    finished_stores, finished_retrieves = adapter.get_finished({"req-1"})
+
+    assert finished_stores == set()
+    assert finished_retrieves == set()
+
+
+def test_abort_when_retrieve_finishes_reports_only_retrieve(fake_adapter) -> None:
+    adapter, _send_mock, _future = fake_adapter
+    retrieve_future = MagicMock(name="retrieve_future")
+    retrieve_future.query.return_value = True
+    retrieve_future.result.return_value = True
+    adapter.retrieve_futures["req-1"] = (retrieve_future, [7])
+
+    finished_stores, finished_retrieves = adapter.get_finished({"req-1"})
+
+    assert finished_stores == set()
+    assert finished_retrieves == {"req-1"}
+
+
+def test_abort_after_retrieve_completion_does_not_report_store(fake_adapter) -> None:
+    adapter, _send_mock, _future = fake_adapter
+    retrieve_future = MagicMock(name="retrieve_future")
+    retrieve_future.query.return_value = True
+    retrieve_future.result.return_value = True
+    adapter.retrieve_futures["req-1"] = (retrieve_future, [7])
+
+    finished_stores, finished_retrieves = adapter.get_finished(set())
+    assert finished_stores == set()
+    assert finished_retrieves == {"req-1"}
+
+    adapter.mark_aborted_retrieves({"req-1"})
+    finished_stores, finished_retrieves = adapter.get_finished({"req-1"})
+
+    assert finished_stores == set()
+    assert finished_retrieves == set()
+
+    finished_stores, finished_retrieves = adapter.get_finished({"req-1"})
+
+    assert finished_stores == set()
+    assert finished_retrieves == set()
+
+
+def test_unhealthy_worker_preserves_aborted_retrieve_suppression(
+    fake_adapter,
+) -> None:
+    adapter, _send_mock, _future = fake_adapter
+    adapter.mark_aborted_retrieves({"req-1"})
+    adapter._health_event.clear()
+
+    finished_stores, finished_retrieves = adapter.get_finished({"req-1"})
+
+    assert finished_stores == set()
+    assert finished_retrieves == set()
+
+    adapter._health_event.set()
+    finished_stores, finished_retrieves = adapter.get_finished({"req-1"})
+
+    assert finished_stores == set()
+    assert finished_retrieves == set()
+
+
 def test_instance_id_is_uuid_derived_63_bit_int(fake_adapter) -> None:
     """instance_id is a 63-bit int, not the PID, and unique per adapter."""
     adapter, _send_mock, _ = fake_adapter


### PR DESCRIPTION
Fixes the LMCacheMP side of vllm-project/vllm#43226.

## Problem

When a request is aborted while an asynchronous retrieve is active, the worker adapter can report a nonexistent store completion for that request. The receive and abort notifications may also cross scheduler steps: a worker can remove its completed retrieve future before the abort-related `finished_req_ids` arrives.

In either case, vLLM can receive both `finished_recving` and `finished_sending` for the same aborted request. Because the scheduler processes receive completions first, it frees the request and then fails the ownership assertion while processing the send completion.

## Root cause

- The scheduler moved a submitted retrieve directly to `READY`, so later scheduling in the same loading window could create store metadata.
- The worker treated an engine-finished request with no active or completed store future as store-complete, even when that request still had a retrieve in flight.
- A retrieve can finish in one worker step and the scheduler-confirmed abort can arrive in a later step, after the retrieve future has been removed.

## Fix

- Add an explicit `LOADING` state for submitted retrieves:
  `PREFETCHING -> WAITING_FOR_LOAD -> LOADING -> READY`.
- Transition `LOADING -> READY` only after `finished_recving`.
- Do not submit store metadata for new or cached requests while they are `LOADING`.
- Do not wait for a nonexistent store when a loading request is aborted.
- Carry scheduler-confirmed aborted-retrieve IDs to workers and retain them across `get_finished()` calls.
- Suppress store completion for pending retrieves, retrieves completed in the current step, and explicitly marked cross-step aborts.
- Deduplicate handled abort IDs so repeated engine notifications cannot synthesize a later store completion.
- Preserve the current lazy-offload path without marking a nonexistent pending store.

This preserves vLLM's scheduler ownership assertions and enforces the connector invariant that an active retrieve cannot also enter the store-completion lifecycle. This is different from vllm-project/vllm#46304.

## Tests

The refreshed single commit is based on LMCache `dev` at `09bc14c`.

- `pytest -q --confcutdir=tests/v1 tests/v1/test_vllm_mp_adapter.py tests/v1/test_lazy_offload_pending_store.py tests/v1/test_lmcache_mp_connector.py tests/v1/test_mp_connector_mm_keys.py` — 57 passed, 2 skipped. The vLLM-dependent connector modules are skipped on the current macOS development host because vLLM is unavailable there.
- Repository pre-commit hooks on all five changed files — passed, including SPDX, isort, ruff, ruff-format, codespell, and mypy.
- `python -m compileall` on all changed Python files — passed.
- `git diff --check` — passed.

Coverage includes pending-retrieve aborts, same-step retrieve completion plus abort, cross-step retrieve completion then abort, repeated engine notifications, unhealthy-worker handling, new/cached request store suppression while loading, metadata marker delivery, and lazy-offload behavior.

## Production validation

The earlier implementation of this fix was validated with vLLM v0.25.1, MiniMax M3, TP=8, and LMCache MP:

- built and ran one version-consistent LMCache image for the server and all vLLM workers;
- primed a shared prefix, restarted only vLLM to clear its local prefix cache, then disconnected 32 concurrent requests during confirmed remote retrieval;
- LMCache reported 9,216-token retrieves for the abort-stress requests;
- no `AssertionError`, traceback, or EngineCore failure occurred;
- `/health` remained successful and a post-abort completion succeeded.

The current rebased commit preserves that core fix while adapting it to the latest metadata split and lazy-offload changes. It has not yet been rerun on a GPU host; the regression and static checks above were rerun after the rebase.
