### PR TITLE
[Feat] Add SageMaker HyperPod L2 adapter for MP mode

### DIFF
--- a/docs/source/mp/l2_storage/remote_and_distributed.rst
+++ b/docs/source/mp/l2_storage/remote_and_distributed.rst
@@ -8,6 +8,7 @@ sharing cache across nodes.
    :maxdepth: 1
 
    bigtable
+   sagemaker_hyperpod
    s3
    hfbucket
    mooncake_store

--- a/docs/source/mp/l2_storage/sagemaker_hyperpod.rst
+++ b/docs/source/mp/l2_storage/sagemaker_hyperpod.rst
@@ -1,0 +1,77 @@
+SageMaker HyperPod
+==================
+
+An L2 adapter backed by the **ai-toolkit** daemon of Amazon SageMaker
+HyperPod, which provides shared memory access for LMCache.
+
+**Required fields:**
+
+- ``url``: ai-toolkit daemon URL (``sagemaker-hyperpod://host:port``).
+
+**Optional fields:**
+
+- ``bucket`` (string, default ``"lmcache"``): ai-toolkit cache namespace.
+- ``shared_memory_name`` (string, default ``"shared_memory"``): Name of
+  shared memory segment.
+- ``max_concurrent_requests`` (int, default ``100``): Maximum concurrent
+  HTTP requests.
+- ``max_connections`` (int, default ``256``): Total HTTP connection-pool
+  limit.
+- ``max_connections_per_host`` (int, default ``128``): Per-host connection
+  limit.
+- ``timeout_ms`` (int, default ``5000``): HTTP transport timeout.
+- ``lease_wait_timeout_ms`` (int, default ``1000``): How long the daemon
+  may hold a lease request before answering.
+- ``lease_ttl_ms`` (int, default ``30000``): Server-side lease lifetime.
+- ``put_stream_chunk_bytes`` (int, default ``65536``): HTTP PUT chunk size.
+- ``max_lease_size_mb`` (float, optional): Upper bound for accepted lease
+  payloads.
+- ``use_https`` (bool, default ``false``): Enable HTTPS instead of HTTP.
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    # Basic (node IP via the Kubernetes downward API)
+    --l2-adapter '{"type": "sagemaker-hyperpod", "url": "sagemaker-hyperpod://'"${NODE_IP}"':9200"}'
+
+    # Custom namespace and faster miss detection
+    --l2-adapter '{"type": "sagemaker-hyperpod", "url": "sagemaker-hyperpod://'"${NODE_IP}"':9200", "bucket": "team-a", "lease_wait_timeout_ms": 250}'
+
+Kubernetes Deployment Requirements
+-----------------------------------
+
+The ai-toolkit daemon is node-local (hostNetwork, port 9200), so the
+LMCache server must run on the same node as the daemon.
+
+Environment Variable for Node IP
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the ``NODE_IP`` environment variable to resolve the local node's IP
+address:
+
+.. code-block:: yaml
+
+   env:
+     - name: NODE_IP
+       valueFrom:
+         fieldRef:
+           fieldPath: status.hostIP
+
+/dev/shm Volume Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SageMaker Hyperpod requires /dev/shm for high-performance shared memory
+operations:
+
+.. code-block:: yaml
+
+   volumeMounts:
+     - name: dshm
+       mountPath: /dev/shm/shared_memory
+       subPath: shared_memory
+
+   volumes:
+     - name: dshm
+       hostPath:
+         path: /dev/shm

--- a/docs/source/mp/l2_storage/supported_storages.rst
+++ b/docs/source/mp/l2_storage/supported_storages.rst
@@ -28,6 +28,9 @@ target.
    * - :doc:`Bigtable <bigtable>`
      - ``bigtable``
      - Remote & Distributed
+   * - :doc:`SageMaker HyperPod <sagemaker_hyperpod>`
+     - ``sagemaker-hyperpod``
+     - Remote & Distributed
    * - :doc:`S3 <s3>`
      - ``s3``
      - Remote & Distributed

--- a/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_client.py
+++ b/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_client.py
@@ -1,0 +1,515 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP and shared-memory client for the HyperPod ai-toolkit cache daemon."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+from multiprocessing import shared_memory
+from typing import AsyncIterator
+import asyncio
+import os
+import threading
+import time
+import urllib.parse
+
+# Third Party
+import aiohttp
+
+# First Party
+from lmcache.logging import init_logger
+
+logger = init_logger(__name__)
+
+_HTTP_OK = 200
+_HTTP_CONFLICT = 409
+_DEFAULT_STREAM_CHUNK_BYTES = 64 * 1024
+#: Client-side margin over the daemon's lease wait, so a miss 504 arrives
+#: before the client aborts the connection.
+_LEASE_WAIT_TIMEOUT_MARGIN_MS = 500
+
+
+@dataclass(frozen=True)
+class SageMakerHyperPodLease:
+    """A daemon lease protecting data stored in shared memory.
+
+    Args:
+        lease_id: Identifier returned by the ai-toolkit daemon.
+        offsets: Shared-memory ``(offset, length)`` fragments for the object.
+        expires_monotonic: ``time.monotonic()`` deadline after which the
+            daemon may reclaim the fragments.
+    """
+
+    lease_id: str
+    offsets: tuple[tuple[int, int], ...]
+    expires_monotonic: float = float("inf")
+
+    @property
+    def size(self) -> int:
+        """Return the total number of bytes covered by the lease."""
+        return sum(length for _, length in self.offsets)
+
+    def is_expired(self) -> bool:
+        """Return whether the lease is past its server-side TTL and must no
+        longer be trusted for reads."""
+        return time.monotonic() >= self.expires_monotonic
+
+
+class SageMakerHyperPodClient:
+    """Client for ai-toolkit's HTTP control and shared-memory data planes.
+
+    A circuit breaker opens after ``failure_threshold`` consecutive
+    connection failures; requests then fail fast, with one probe per
+    ``circuit_cooldown_s`` to recover. HTTP statuses (e.g. the daemon's
+    504 miss reply) never trip it.
+    """
+
+    #: Consecutive connection-class failures before the circuit opens.
+    failure_threshold: int = 3
+    #: Seconds between probe requests while the circuit is open.
+    circuit_cooldown_s: float = 5.0
+
+    def __init__(
+        self,
+        url: str,
+        bucket: str = "lmcache",
+        shared_memory_name: str = "shared_memory",
+        max_concurrent_requests: int = 100,
+        max_connections: int = 256,
+        max_connections_per_host: int = 128,
+        timeout_ms: int = 5000,
+        lease_wait_timeout_ms: int = 1000,
+        lease_ttl_ms: int = 30000,
+        put_stream_chunk_bytes: int = _DEFAULT_STREAM_CHUNK_BYTES,
+        max_lease_size_mb: float | None = None,
+        use_https: bool = False,
+    ) -> None:
+        """Initialize the ai-toolkit client.
+
+        Args:
+            url: Daemon URL (``sagemaker-hyperpod://host:port``).
+            bucket: ai-toolkit cache namespace.
+            shared_memory_name: POSIX shared-memory segment containing cache data.
+            max_concurrent_requests: Maximum concurrent HTTP requests.
+            max_connections: Maximum total pooled HTTP connections.
+            max_connections_per_host: Maximum pooled connections per host.
+            timeout_ms: HTTP transport timeout in milliseconds (PUT and
+                lease release).
+            lease_wait_timeout_ms: Budget the daemon may spend holding a
+                lease request before answering; bounds worst-case lookup
+                latency.
+            lease_ttl_ms: Server-side lease lifetime in milliseconds.
+            put_stream_chunk_bytes: PUT streaming chunk size.
+            max_lease_size_mb: Optional upper bound for accepted leases.
+            use_https: Use HTTPS instead of HTTP for daemon requests.
+
+        Raises:
+            RuntimeError: If the shared-memory segment cannot be opened.
+        """
+        self._base_url = self.normalize_url(url, use_https=use_https)
+        self._bucket = bucket
+        self._max_connections = max_connections
+        self._max_connections_per_host = max_connections_per_host
+        self._timeout_s = timeout_ms / 1000.0
+        self._timeout_ms = timeout_ms
+        self._lease_wait_timeout_ms = lease_wait_timeout_ms
+        self._lease_wait_timeout_s = lease_wait_timeout_ms / 1000.0
+        self._lease_ttl_s = lease_ttl_ms / 1000.0
+        self._put_stream_chunk_bytes = put_stream_chunk_bytes
+        self._max_lease_size_bytes = (
+            int(max_lease_size_mb * 1024 * 1024)
+            if max_lease_size_mb is not None
+            else None
+        )
+        self._request_gate = asyncio.Semaphore(max_concurrent_requests)
+        self._session: aiohttp.ClientSession | None = None
+        self._session_lock = asyncio.Lock()
+        self._status_lock = threading.Lock()
+        self._consecutive_failures = 0
+        self._last_error: str | None = None
+        self._last_success_monotonic: float | None = None
+        self._next_probe_monotonic = 0.0
+
+        self._shared_memory_name = shared_memory_name
+        self._shared_memory_lock = threading.Lock()
+        try:
+            self._shared_memory = shared_memory.SharedMemory(
+                name=shared_memory_name,
+                create=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"ai-toolkit shared-memory segment {shared_memory_name!r} not found"
+            ) from exc
+        self._shared_memory_view = memoryview(self._shared_memory.buf)
+        self._shared_memory_identity = self._segment_identity()
+        self._closed = False
+        logger.info(
+            "Attached ai-toolkit shared-memory segment %s (%.1f MiB)",
+            shared_memory_name,
+            self._shared_memory.size / (1 << 20),
+        )
+
+    @staticmethod
+    def normalize_url(url: str, use_https: bool = False) -> str:
+        """Normalize a ``sagemaker-hyperpod://`` daemon URL to its
+        transport form.
+
+        Args:
+            url: Daemon URL using the ``sagemaker-hyperpod`` scheme.
+            use_https: Use HTTPS instead of HTTP for the transport.
+
+        Returns:
+            The HTTP(S) transport URL without a trailing slash.
+
+        Raises:
+            ValueError: If the URL is empty, uses another scheme, or lacks
+                a host.
+        """
+        value = url.strip().rstrip("/")
+        if not value.startswith("sagemaker-hyperpod://"):
+            raise ValueError("url must use the sagemaker-hyperpod:// scheme")
+        scheme = "https://" if use_https else "http://"
+        value = scheme + value.removeprefix("sagemaker-hyperpod://")
+        parsed = urllib.parse.urlsplit(value)
+        if not parsed.netloc:
+            raise ValueError("url must include a host")
+        return value
+
+    async def put(self, key: str, data: memoryview) -> bool:
+        """Store one object in ai-toolkit.
+
+        Args:
+            key: Backend object key before URL escaping.
+            data: Byte-oriented object data.
+
+        Returns:
+            ``True`` for a successful write or an existing object conflict.
+        """
+        view = data.cast("B") if data.format != "B" else data
+
+        async def stream() -> AsyncIterator[memoryview]:
+            for offset in range(0, len(view), self._put_stream_chunk_bytes):
+                yield view[offset : offset + self._put_stream_chunk_bytes]
+
+        response = await self._request(
+            "PUT",
+            self._object_url(key),
+            data=stream(),
+            headers={"Content-Length": str(len(view))},
+        )
+        return response is not None and response[0] in (_HTTP_OK, _HTTP_CONFLICT)
+
+    async def acquire_lease(self, key: str) -> SageMakerHyperPodLease | None:
+        """Acquire a daemon lease that pins one object in shared memory.
+
+        The daemon may hold the request for up to
+        ``lease_wait_timeout_ms`` before answering; the HTTP timeout is
+        that budget plus a margin so the daemon's answer always arrives
+        before the client aborts.
+
+        Args:
+            key: Backend object key before URL escaping.
+
+        Returns:
+            The acquired lease, or ``None`` when the object is missing, the
+            lease response is malformed, or the lease exceeds
+            ``max_lease_size_mb``. Invalid or oversized leases are released
+            best-effort before returning ``None``.
+        """
+        # Stamp the expiry conservatively, from before the request is sent.
+        acquire_start = time.monotonic()
+        response = await self._request(
+            "POST",
+            f"{self._object_url(key)}/leases",
+            params={
+                "timeout_ms": self._lease_wait_timeout_ms,
+                "ttl_s": self._lease_ttl_s,
+            },
+            timeout=aiohttp.ClientTimeout(
+                total=self._lease_wait_timeout_s
+                + _LEASE_WAIT_TIMEOUT_MARGIN_MS / 1000.0
+            ),
+        )
+        if response is None or response[0] != _HTTP_OK or response[1] is None:
+            return None
+
+        body = response[1]
+        if not isinstance(body, dict):
+            logger.warning("Malformed ai-toolkit lease response for key %s", key)
+            return None
+        try:
+            offsets = tuple(
+                (int(item["offset"]), int(item["len"]))
+                for item in body.get("offsets", [])
+            )
+            lease = SageMakerHyperPodLease(
+                str(body["id"]),
+                offsets,
+                expires_monotonic=acquire_start + self._lease_ttl_s,
+            )
+        except (KeyError, TypeError, ValueError):
+            logger.warning("Malformed ai-toolkit lease response for key %s", key)
+            return None
+        if not offsets or any(offset < 0 or length <= 0 for offset, length in offsets):
+            await self.release_lease(lease)
+            return None
+        if (
+            self._max_lease_size_bytes is not None
+            and lease.size > self._max_lease_size_bytes
+        ):
+            await self.release_lease(lease)
+            return None
+        return lease
+
+    def copy_from_lease(
+        self,
+        lease: SageMakerHyperPodLease,
+        destination: memoryview,
+    ) -> bool:
+        """Copy a leased object from shared memory into ``destination``.
+
+        The lease and destination sizes must match exactly, all fragments
+        are bounds-checked before the first destination byte is written,
+        and the whole copy must finish before the lease expiry (an expired
+        lease no longer pins its fragments). The mapping is reopened if
+        ai-toolkit recreated the shared-memory segment.
+
+        Args:
+            lease: Lease whose fragments describe the object to copy.
+            destination: Writable byte-oriented buffer for the full object.
+
+        Returns:
+            ``True`` when every fragment was validated and copied, ``False``
+            when the lease expired (before or during the copy), sizes
+            mismatch, any fragment is out of bounds, or the client is
+            closed. On ``False`` the destination contents must be treated
+            as invalid.
+        """
+        if lease.is_expired():
+            logger.warning("Refusing to copy through expired lease %s", lease.lease_id)
+            return False
+        view = destination.cast("B") if destination.format != "B" else destination
+        if lease.size != len(view):
+            return False
+
+        with self._shared_memory_lock:
+            if self._closed or not self._refresh_shared_memory_locked():
+                return False
+
+            shm_size = self._shared_memory.size
+            if any(
+                offset < 0 or length <= 0 or offset + length > shm_size
+                for offset, length in lease.offsets
+            ):
+                return False
+
+            copied = 0
+            for offset, length in lease.offsets:
+                view[copied : copied + length] = self._shared_memory_view[
+                    offset : offset + length
+                ]
+                copied += length
+            if lease.is_expired():
+                # Expired mid-copy: the destination cannot be trusted.
+                logger.warning(
+                    "Discarding copy: lease %s expired mid-copy",
+                    lease.lease_id,
+                )
+                return False
+            return copied == len(view)
+
+    async def release_lease(self, lease: SageMakerHyperPodLease) -> bool:
+        """Release a previously acquired lease.
+
+        Args:
+            lease: Lease returned by :meth:`acquire_lease`.
+
+        Returns:
+            ``True`` when the daemon confirmed the release, ``False`` on any
+            HTTP failure. An unreleased lease expires server-side after its TTL.
+        """
+        response = await self._request(
+            "POST",
+            f"{self._base_url}/v1/leases/"
+            f"{urllib.parse.quote(lease.lease_id, safe='')}/release",
+        )
+        return response is not None and response[0] == _HTTP_OK
+
+    async def close(self) -> None:
+        """Close HTTP and shared-memory resources. This method is idempotent."""
+        with self._shared_memory_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._shared_memory_view.release()
+            self._shared_memory.close()
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    def report_status(self) -> dict[str, object]:
+        """Return shared-memory and HTTP transport health.
+
+        Returns:
+            A dictionary with ``is_healthy`` plus circuit-breaker and
+            shared-memory diagnostics.
+        """
+        with self._status_lock:
+            failures = self._consecutive_failures
+            last_error = self._last_error
+            last_success = self._last_success_monotonic
+        circuit_open = failures >= self.failure_threshold
+        with self._shared_memory_lock:
+            current_identity = self._segment_identity()
+            shared_memory_current = not self._closed and (
+                current_identity == self._shared_memory_identity
+                if os.path.isdir("/dev/shm")
+                else True
+            )
+        return {
+            "is_healthy": (
+                not self._closed and shared_memory_current and not circuit_open
+            ),
+            "shared_memory_current": shared_memory_current,
+            "circuit_open": circuit_open,
+            "consecutive_http_failures": failures,
+            "last_http_error": last_error,
+            "last_http_success_monotonic": last_success,
+        }
+
+    def _segment_identity(self) -> tuple[int, int] | None:
+        """Return the current Linux POSIX shared-memory device/inode identity."""
+        path = os.path.join("/dev/shm", self._shared_memory_name.lstrip("/"))
+        try:
+            stat = os.stat(path)
+        except OSError:
+            return None
+        return stat.st_dev, stat.st_ino
+
+    def _refresh_shared_memory_locked(self) -> bool:
+        """Reattach when ai-toolkit replaced its POSIX shared-memory segment.
+
+        The caller must hold ``_shared_memory_lock``.
+        """
+        current_identity = self._segment_identity()
+        if current_identity is None:
+            # No /dev/shm (non-Linux): keep the existing mapping.
+            return True
+        if current_identity == self._shared_memory_identity:
+            return True
+
+        try:
+            replacement = shared_memory.SharedMemory(
+                name=self._shared_memory_name,
+                create=False,
+            )
+        except FileNotFoundError:
+            return False
+
+        old_view = self._shared_memory_view
+        old_shared_memory = self._shared_memory
+        self._shared_memory = replacement
+        self._shared_memory_view = memoryview(replacement.buf)
+        self._shared_memory_identity = current_identity
+        old_view.release()
+        old_shared_memory.close()
+        logger.info(
+            "Reattached ai-toolkit shared-memory segment %s (%.1f MiB)",
+            self._shared_memory_name,
+            replacement.size / (1 << 20),
+        )
+        return True
+
+    def _record_http_success(self) -> None:
+        with self._status_lock:
+            self._consecutive_failures = 0
+            self._last_error = None
+            self._last_success_monotonic = time.monotonic()
+
+    def _record_http_failure(self, error: object) -> None:
+        with self._status_lock:
+            self._consecutive_failures += 1
+            self._last_error = str(error)
+            if self._consecutive_failures == self.failure_threshold:
+                logger.error(
+                    "ai-toolkit circuit opened after %d consecutive failures; "
+                    "probing every %.1fs (last error: %s)",
+                    self._consecutive_failures,
+                    self.circuit_cooldown_s,
+                    self._last_error,
+                )
+            if self._consecutive_failures >= self.failure_threshold:
+                self._next_probe_monotonic = time.monotonic() + self.circuit_cooldown_s
+
+    def _fail_fast(self) -> bool:
+        """Return ``True`` when the circuit is open and no probe is due.
+
+        When the cooldown has elapsed, the probe window is re-armed and the
+        current request is let through as the single probe for this window.
+        """
+        with self._status_lock:
+            if self._consecutive_failures < self.failure_threshold:
+                return False
+            now = time.monotonic()
+            if now < self._next_probe_monotonic:
+                return True
+            self._next_probe_monotonic = now + self.circuit_cooldown_s
+            return False
+
+    def _object_url(self, key: str) -> str:
+        encoded_key = urllib.parse.quote(key, safe="")
+        encoded_bucket = urllib.parse.quote(self._bucket, safe="")
+        return f"{self._base_url}/v1/kv/{encoded_bucket}/{encoded_key}"
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: object,
+    ) -> tuple[int, dict | None] | None:
+        if self._fail_fast():
+            return None
+        try:
+            async with self._request_gate:
+                session = await self._get_session()
+                async with session.request(method, url, **kwargs) as response:
+                    body = None
+                    if response.content_type == "application/json":
+                        try:
+                            body = await response.json()
+                        except (aiohttp.ContentTypeError, ValueError):
+                            logger.warning("Invalid JSON response from %s", url)
+                    # Any response proves the transport is healthy; only
+                    # connection failures feed the circuit breaker.
+                    self._record_http_success()
+                    return response.status, body
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            self._record_http_failure(exc)
+            logger.warning("ai-toolkit %s %s failed: %s", method, url, exc)
+            return None
+        except Exception as exc:
+            self._record_http_failure(exc)
+            logger.exception("Unexpected ai-toolkit %s %s failure", method, url)
+            return None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is not None and not self._session.closed:
+            return self._session
+        async with self._session_lock:
+            if self._session is None or self._session.closed:
+                connector = aiohttp.TCPConnector(
+                    limit=self._max_connections,
+                    limit_per_host=self._max_connections_per_host,
+                    ttl_dns_cache=300,
+                    use_dns_cache=True,
+                    keepalive_timeout=30,
+                    enable_cleanup_closed=True,
+                )
+                self._session = aiohttp.ClientSession(
+                    connector=connector,
+                    timeout=aiohttp.ClientTimeout(total=self._timeout_s),
+                    headers={"User-Agent": "LMCache-SageMaker-HyperPod/1.0"},
+                )
+        return self._session

--- a/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py
@@ -253,7 +253,8 @@ class SageMakerHyperPodL2Adapter(L2AdapterInterface):
         except Exception:
             self._loop.call_soon_threadsafe(self._loop.stop)
             self._loop_thread.join(timeout=5)
-            self._loop.close()
+            if not self._loop_thread.is_alive():
+                self._loop.close()
             self._store_efd.close()
             self._lookup_efd.close()
             self._load_efd.close()

--- a/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py
@@ -1,0 +1,824 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SageMaker HyperPod ai-toolkit L2 adapter for LMCache MP mode."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from concurrent.futures import Future
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+import asyncio
+import threading
+import time
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.distributed.internal_api import L1MemoryDesc
+
+# First Party
+from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
+from lmcache.v1.distributed.l2_adapters.base import L2AdapterInterface, L2TaskId
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    register_l2_adapter_type,
+)
+from lmcache.v1.distributed.l2_adapters.factory import register_l2_adapter_factory
+from lmcache.v1.distributed.l2_adapters.sagemaker_hyperpod_client import (
+    SageMakerHyperPodClient,
+    SageMakerHyperPodLease,
+)
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.platform import create_event_notifier
+
+logger = init_logger(__name__)
+
+
+def _wire_key(key: ObjectKey) -> str:
+    """Serialize an MP ``ObjectKey`` to an ai-toolkit object name.
+
+    Unsalted::
+
+        <model_name>@<kv_rank_hex8>@<object_group_id_hex>@<chunk_hash_hex>
+
+    Salted (trailing ``cache_salt``)::
+
+        <model_name>@<kv_rank_hex8>@<object_group_id_hex>@<chunk_hash_hex>@<cache_salt>
+    """
+    base = (
+        f"{key.model_name}@{key.kv_rank:08x}"
+        f"@{key.object_group_id:x}@{key.chunk_hash.hex()}"
+    )
+    return f"{base}@{key.cache_salt}" if key.cache_salt else base
+
+
+class SageMakerHyperPodL2AdapterConfig(L2AdapterConfigBase):
+    """Configuration for the SageMaker HyperPod ai-toolkit L2 adapter."""
+
+    def __init__(
+        self,
+        url: str,
+        bucket: str = "lmcache",
+        shared_memory_name: str = "shared_memory",
+        max_concurrent_requests: int = 100,
+        max_connections: int = 256,
+        max_connections_per_host: int = 128,
+        timeout_ms: int = 5000,
+        lease_wait_timeout_ms: int = 1000,
+        lease_ttl_ms: int = 30000,
+        put_stream_chunk_bytes: int = 64 * 1024,
+        max_lease_size_mb: float | None = None,
+        use_https: bool = False,
+    ) -> None:
+        """Initialize and validate adapter configuration.
+
+        Args:
+            url: ai-toolkit daemon URL (``sagemaker-hyperpod://host:port``).
+            bucket: ai-toolkit cache namespace.
+            shared_memory_name: POSIX shared-memory segment name without the
+                ``/dev/shm/`` prefix.
+            max_concurrent_requests: Maximum concurrent HTTP requests.
+            max_connections: Maximum total pooled HTTP connections.
+            max_connections_per_host: Maximum pooled connections per host.
+            timeout_ms: HTTP transport timeout in milliseconds (PUT and
+                lease release).
+            lease_wait_timeout_ms: Budget the daemon may spend holding a
+                lease request before answering; bounds worst-case lookup
+                latency.
+            lease_ttl_ms: Server-side lease lifetime in milliseconds.
+            put_stream_chunk_bytes: HTTP PUT streaming chunk size.
+            max_lease_size_mb: Optional upper bound for accepted leases.
+            use_https: Use HTTPS instead of HTTP for daemon requests.
+
+        Raises:
+            ValueError: If any field is empty, non-positive, or has the
+                wrong type, or if ``url`` uses an unsupported scheme.
+        """
+        super().__init__()
+        if not isinstance(url, str) or not url:
+            raise ValueError("url must be a non-empty string")
+        if not isinstance(use_https, bool):
+            raise ValueError("use_https must be a boolean")
+        SageMakerHyperPodClient.normalize_url(url, use_https=use_https)
+        if not isinstance(bucket, str) or not bucket:
+            raise ValueError("bucket must be a non-empty string")
+        if not isinstance(shared_memory_name, str) or not shared_memory_name:
+            raise ValueError("shared_memory_name must be a non-empty string")
+        for name, value in (
+            ("max_concurrent_requests", max_concurrent_requests),
+            ("max_connections", max_connections),
+            ("max_connections_per_host", max_connections_per_host),
+            ("timeout_ms", timeout_ms),
+            ("lease_wait_timeout_ms", lease_wait_timeout_ms),
+            ("lease_ttl_ms", lease_ttl_ms),
+            ("put_stream_chunk_bytes", put_stream_chunk_bytes),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+        if max_lease_size_mb is not None and (
+            isinstance(max_lease_size_mb, bool)
+            or not isinstance(max_lease_size_mb, (int, float))
+            or max_lease_size_mb <= 0
+        ):
+            raise ValueError("max_lease_size_mb must be positive when set")
+
+        self.url = url
+        self.bucket = bucket
+        self.shared_memory_name = shared_memory_name
+        self.max_concurrent_requests = max_concurrent_requests
+        self.max_connections = max_connections
+        self.max_connections_per_host = max_connections_per_host
+        self.timeout_ms = timeout_ms
+        self.lease_wait_timeout_ms = lease_wait_timeout_ms
+        self.lease_ttl_ms = lease_ttl_ms
+        self.put_stream_chunk_bytes = put_stream_chunk_bytes
+        self.max_lease_size_mb = max_lease_size_mb
+        self.use_https = use_https
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "SageMakerHyperPodL2AdapterConfig":
+        """Parse an adapter configuration from a JSON-derived dictionary.
+
+        Args:
+            d: Parsed ``--l2-adapter`` JSON object.
+
+        Returns:
+            A validated configuration instance.
+
+        Raises:
+            ValueError: If ``d`` contains an ``eviction`` block (ai-toolkit
+                owns L2 eviction) or any field fails validation.
+        """
+        if d.get("eviction") is not None:
+            raise ValueError(
+                "sagemaker-hyperpod does not support LMCache-owned eviction"
+            )
+        return cls(
+            url=d.get("url", ""),
+            bucket=d.get("bucket", "lmcache"),
+            shared_memory_name=d.get("shared_memory_name", "shared_memory"),
+            max_concurrent_requests=d.get("max_concurrent_requests", 100),
+            max_connections=d.get("max_connections", 256),
+            max_connections_per_host=d.get("max_connections_per_host", 128),
+            timeout_ms=d.get("timeout_ms", 5000),
+            lease_wait_timeout_ms=d.get("lease_wait_timeout_ms", 1000),
+            lease_ttl_ms=d.get("lease_ttl_ms", 30000),
+            put_stream_chunk_bytes=d.get(
+                "put_stream_chunk_bytes",
+                64 * 1024,
+            ),
+            max_lease_size_mb=d.get("max_lease_size_mb"),
+            use_https=d.get("use_https", False),
+        )
+
+    @classmethod
+    def help(cls) -> str:
+        """Return CLI help for the adapter's JSON fields."""
+        return (
+            "SageMaker HyperPod L2 adapter fields:\n"
+            "- url (str, required): sagemaker-hyperpod://host:port\n"
+            "- bucket (str, default 'lmcache'): cache namespace\n"
+            "- shared_memory_name (str, default 'shared_memory')\n"
+            "- max_concurrent_requests (int, default 100)\n"
+            "- max_connections (int, default 256)\n"
+            "- max_connections_per_host (int, default 128)\n"
+            "- timeout_ms (int, default 5000): HTTP transport timeout\n"
+            "- lease_wait_timeout_ms (int, default 1000): how long the daemon\n"
+            "  may hold a lease request before answering\n"
+            "- lease_ttl_ms (int, default 30000)\n"
+            "- put_stream_chunk_bytes (int, default 65536)\n"
+            "- max_lease_size_mb (float, optional)\n"
+            "- use_https (bool, default false): HTTPS instead of HTTP\n"
+            "LMCache-owned eviction, delete, and list are not supported."
+        )
+
+
+class SageMakerHyperPodL2Adapter(L2AdapterInterface):
+    """Asynchronous MP L2 adapter backed by the node-local ai-toolkit daemon."""
+
+    def __init__(self, config: SageMakerHyperPodL2AdapterConfig) -> None:
+        """Create the adapter and start its asynchronous worker loop.
+
+        Args:
+            config: Validated adapter configuration.
+
+        Raises:
+            RuntimeError: If the worker event loop does not start in time or
+                the ai-toolkit shared-memory segment cannot be opened.
+        """
+        super().__init__()
+        self._config = config
+        self._store_efd = create_event_notifier()
+        self._lookup_efd = create_event_notifier()
+        self._load_efd = create_event_notifier()
+        self._completed_stores: dict[L2TaskId, L2StoreResult] = {}
+        self._completed_lookups: dict[L2TaskId, Bitmap] = {}
+        self._completed_loads: dict[L2TaskId, Bitmap] = {}
+        self._leases: dict[ObjectKey, list[SageMakerHyperPodLease]] = {}
+        # Stored sizes for byte-accounting dedup. NOTE: grows unbounded
+        # (delete is never called); shared limitation across remote adapters.
+        self._key_sizes: dict[ObjectKey, int] = {}
+        self._next_task_id: L2TaskId = 0
+        self._lock = threading.Lock()
+        self._closed = False
+        self._inflight: set[Future[Any]] = set()
+        self._releasing_leases: set[SageMakerHyperPodLease] = set()
+
+        self._loop = asyncio.new_event_loop()
+        self._loop_ready = threading.Event()
+        self._loop_thread = threading.Thread(
+            target=self._run_event_loop,
+            daemon=True,
+            name="sagemaker-hyperpod-l2",
+        )
+        self._loop_thread.start()
+        if not self._loop_ready.wait(timeout=5):
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._loop_thread.join(timeout=5)
+            if not self._loop_thread.is_alive():
+                self._loop.close()
+            self._store_efd.close()
+            self._lookup_efd.close()
+            self._load_efd.close()
+            raise RuntimeError("timed out starting SageMaker HyperPod L2 event loop")
+
+        try:
+            self._client = asyncio.run_coroutine_threadsafe(
+                self._create_client(config),
+                self._loop,
+            ).result(timeout=5)
+        except Exception:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._loop_thread.join(timeout=5)
+            self._loop.close()
+            self._store_efd.close()
+            self._lookup_efd.close()
+            self._load_efd.close()
+            raise
+
+        logger.info(
+            "SageMakerHyperPodL2Adapter ready: url=%s bucket=%s shared_memory=%s",
+            config.url,
+            config.bucket,
+            config.shared_memory_name,
+        )
+
+    def get_store_event_fd(self) -> int:
+        """Return the store-completion event descriptor."""
+        return self._store_efd.fileno()
+
+    def get_lookup_and_lock_event_fd(self) -> int:
+        """Return the lookup-completion event descriptor."""
+        return self._lookup_efd.fileno()
+
+    def get_load_event_fd(self) -> int:
+        """Return the load-completion event descriptor."""
+        return self._load_efd.fileno()
+
+    def submit_store_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        """Submit a non-blocking batch store.
+
+        Args:
+            keys: Object keys to store.
+            objects: L1-owned memory objects matching ``keys`` positionally.
+                The caller must keep them alive until the task completes.
+
+        Returns:
+            A task ID whose result is popped through
+            :meth:`pop_completed_store_tasks` after the store event fd fires.
+
+        Raises:
+            ValueError: If ``keys`` and ``objects`` lengths differ.
+        """
+        if len(keys) != len(objects):
+            raise ValueError("keys and objects must have equal lengths")
+        task_id = self._allocate_task_id()
+        if self._closed:
+            self._complete_closed_store(task_id)
+            return task_id
+
+        keys_snapshot = list(keys)
+        objects_snapshot = list(objects)
+        sizes = [obj.get_size() for obj in objects_snapshot]
+        future = asyncio.run_coroutine_threadsafe(
+            self._store(keys_snapshot, objects_snapshot),
+            self._loop,
+        )
+        self._track_future(
+            future,
+            lambda done: self._finish_store(
+                task_id,
+                keys_snapshot,
+                sizes,
+                done,
+            ),
+        )
+        return task_id
+
+    def pop_completed_store_tasks(self) -> dict[L2TaskId, L2StoreResult]:
+        """Pop all completed store results.
+
+        Returns:
+            A mapping from task ID to :class:`L2StoreResult`. Each result is
+            returned exactly once.
+        """
+        with self._lock:
+            completed = self._completed_stores
+            self._completed_stores = {}
+        return completed
+
+    def submit_lookup_and_lock_task(
+        self,
+        keys: list[ObjectKey],
+        layout_desc: MemoryLayoutDesc,
+    ) -> L2TaskId:
+        """Submit a lookup that retains daemon leases for every hit.
+
+        Args:
+            keys: Object keys to look up.
+            layout_desc: Unused; ai-toolkit leases are layout-independent.
+
+        Returns:
+            A task ID whose hit bitmap is queried through
+            :meth:`query_lookup_and_lock_result` after the lookup event fd
+            fires. Retained leases are held until :meth:`submit_unlock`.
+        """
+        del layout_desc
+        task_id = self._allocate_task_id()
+        if self._closed:
+            with self._lock:
+                self._completed_lookups[task_id] = Bitmap(len(keys))
+            self._lookup_efd.notify()
+            return task_id
+        keys_snapshot = list(keys)
+        future = asyncio.run_coroutine_threadsafe(
+            self._lookup(keys_snapshot),
+            self._loop,
+        )
+        self._track_future(
+            future,
+            lambda done: self._finish_lookup(task_id, keys_snapshot, done),
+        )
+        return task_id
+
+    def query_lookup_and_lock_result(self, task_id: L2TaskId) -> Bitmap | None:
+        """Pop one completed lookup result, or return ``None``.
+
+        Args:
+            task_id: Task ID returned by :meth:`submit_lookup_and_lock_task`.
+
+        Returns:
+            The hit bitmap, or ``None`` when the task has not completed or
+            the result was already popped.
+        """
+        with self._lock:
+            return self._completed_lookups.pop(task_id, None)
+
+    def submit_unlock(self, keys: list[ObjectKey]) -> None:
+        """Asynchronously release one retained lease for each key occurrence.
+
+        Args:
+            keys: Keys previously locked by a lookup. A key occurring N times
+                releases up to N retained leases. Failed releases are retried
+                until the lease TTL, after which the daemon expires them.
+        """
+        leases: list[SageMakerHyperPodLease] = []
+        with self._lock:
+            for key in keys:
+                key_leases = self._leases.get(key)
+                if not key_leases:
+                    continue
+                leases.append(key_leases.pop())
+                if not key_leases:
+                    self._leases.pop(key, None)
+        self._schedule_release(leases)
+
+    def submit_load_task(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> L2TaskId:
+        """Submit a non-blocking load into caller-owned buffers.
+
+        Args:
+            keys: Object keys to load, normally locked by a prior lookup.
+            objects: Destination memory objects matching ``keys``
+                positionally. The caller must keep them alive until the task
+                completes.
+
+        Returns:
+            A task ID whose per-key success bitmap is queried through
+            :meth:`query_load_result` after the load event fd fires.
+
+        Raises:
+            ValueError: If ``keys`` and ``objects`` lengths differ.
+        """
+        if len(keys) != len(objects):
+            raise ValueError("keys and objects must have equal lengths")
+        task_id = self._allocate_task_id()
+        if self._closed:
+            with self._lock:
+                self._completed_loads[task_id] = Bitmap(len(keys))
+            self._load_efd.notify()
+            return task_id
+        keys_snapshot = list(keys)
+        objects_snapshot = list(objects)
+        future = asyncio.run_coroutine_threadsafe(
+            self._load(keys_snapshot, objects_snapshot),
+            self._loop,
+        )
+        self._track_future(
+            future,
+            lambda done: self._finish_load(task_id, keys_snapshot, done),
+        )
+        return task_id
+
+    def query_load_result(self, task_id: L2TaskId) -> Bitmap | None:
+        """Pop one completed load result, or return ``None``.
+
+        Args:
+            task_id: Task ID returned by :meth:`submit_load_task`.
+
+        Returns:
+            The per-key success bitmap, or ``None`` when the task has not
+            completed or the result was already popped.
+        """
+        with self._lock:
+            return self._completed_loads.pop(task_id, None)
+
+    def report_status(self) -> dict[str, object]:
+        """Return adapter, shared-memory, and HTTP transport health.
+
+        Returns:
+            A dictionary with ``is_healthy`` (adapter open, worker loop
+            alive, and backend healthy), adapter identity fields (``type``,
+            ``url``, ``bucket``, ``shared_memory_name``), and the client's
+            ``backend`` health report.
+        """
+        client_report = getattr(self._client, "report_status", None)
+        backend = client_report() if callable(client_report) else {"is_healthy": True}
+        return {
+            "is_healthy": (
+                not self._closed
+                and self._loop_thread.is_alive()
+                and bool(backend.get("is_healthy", False))
+            ),
+            "type": "sagemaker-hyperpod",
+            "url": self._config.url,
+            "bucket": self._config.bucket,
+            "shared_memory_name": self._config.shared_memory_name,
+            "backend": backend,
+        }
+
+    def close(self) -> None:
+        """Cancel in-flight work, release leases, and close all resources.
+
+        Shutdown is bounded: each remaining lease gets one best-effort
+        release attempt and unreleased leases expire server-side after
+        their TTL.
+        """
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            inflight = list(self._inflight)
+
+        for task in inflight:
+            task.cancel()
+        deadline = time.monotonic() + 5.0
+        for task in inflight:
+            try:
+                task.result(timeout=max(0.0, deadline - time.monotonic()))
+            except Exception:
+                pass
+
+        with self._lock:
+            leases = [lease for values in self._leases.values() for lease in values]
+            leases.extend(self._releasing_leases)
+            self._leases.clear()
+            self._releasing_leases.clear()
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._close_async(list(set(leases))),
+            self._loop,
+        )
+        close_timeout = self._config.timeout_ms / 1000.0 + 1.0
+        try:
+            future.result(timeout=max(5.0, close_timeout))
+        except Exception as exc:
+            logger.warning("Error closing SageMaker HyperPod L2 client: %s", exc)
+
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._loop_thread.join(timeout=5)
+        if self._loop_thread.is_alive():
+            logger.error("SageMaker HyperPod L2 event loop did not stop")
+            return
+        self._loop.close()
+        self._store_efd.close()
+        self._lookup_efd.close()
+        self._load_efd.close()
+
+    async def _create_client(
+        self,
+        config: SageMakerHyperPodL2AdapterConfig,
+    ) -> SageMakerHyperPodClient:
+        return SageMakerHyperPodClient(
+            url=config.url,
+            bucket=config.bucket,
+            shared_memory_name=config.shared_memory_name,
+            max_concurrent_requests=config.max_concurrent_requests,
+            max_connections=config.max_connections,
+            max_connections_per_host=config.max_connections_per_host,
+            timeout_ms=config.timeout_ms,
+            lease_wait_timeout_ms=config.lease_wait_timeout_ms,
+            lease_ttl_ms=config.lease_ttl_ms,
+            put_stream_chunk_bytes=config.put_stream_chunk_bytes,
+            max_lease_size_mb=config.max_lease_size_mb,
+            use_https=config.use_https,
+        )
+
+    async def _store(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> list[bool]:
+        raw_results = await asyncio.gather(
+            *(
+                self._client.put(
+                    _wire_key(key),
+                    cast(memoryview, obj.byte_array),
+                )
+                for key, obj in zip(keys, objects, strict=True)
+            ),
+            return_exceptions=True,
+        )
+        return [
+            bool(result) if not isinstance(result, BaseException) else False
+            for result in raw_results
+        ]
+
+    async def _lookup(
+        self,
+        keys: list[ObjectKey],
+    ) -> list[SageMakerHyperPodLease | None]:
+        raw_results = await asyncio.gather(
+            *(self._client.acquire_lease(_wire_key(key)) for key in keys),
+            return_exceptions=True,
+        )
+        return [
+            result
+            if isinstance(result, SageMakerHyperPodLease) or result is None
+            else None
+            for result in raw_results
+        ]
+
+    async def _load(
+        self,
+        keys: list[ObjectKey],
+        objects: list[MemoryObj],
+    ) -> tuple[list[bool], list[SageMakerHyperPodLease]]:
+        lease_indices: dict[ObjectKey, int] = {}
+        selected: list[SageMakerHyperPodLease | None] = []
+        with self._lock:
+            for key in keys:
+                index = lease_indices.get(key, 0)
+                available = self._leases.get(key, [])
+                candidate = available[index] if index < len(available) else None
+                # Expired retained lease: re-acquire a fresh one below.
+                if candidate is not None and candidate.is_expired():
+                    candidate = None
+                selected.append(candidate)
+                lease_indices[key] = index + 1
+
+        # Acquire transient leases in parallel for keys without one.
+        transient_leases: list[SageMakerHyperPodLease] = []
+        missing = [index for index, lease in enumerate(selected) if lease is None]
+        if missing:
+            acquired = await asyncio.gather(
+                *(self._client.acquire_lease(_wire_key(keys[i])) for i in missing),
+                return_exceptions=True,
+            )
+            for index, result in zip(missing, acquired, strict=True):
+                if isinstance(result, BaseException):
+                    logger.warning("SageMaker HyperPod load lookup failed: %s", result)
+                elif result is not None:
+                    selected[index] = result
+                    transient_leases.append(result)
+
+        results: list[bool] = []
+        for index, obj in enumerate(objects):
+            lease = selected[index]
+            try:
+                loaded = lease is not None and self._client.copy_from_lease(
+                    lease,
+                    cast(memoryview, obj.byte_array),
+                )
+            except Exception as exc:
+                logger.warning("SageMaker HyperPod shared-memory load failed: %s", exc)
+                loaded = False
+            results.append(loaded)
+        return results, transient_leases
+
+    def _schedule_release(self, leases: list[SageMakerHyperPodLease]) -> None:
+        if not leases:
+            return
+        with self._lock:
+            self._releasing_leases.update(leases)
+            closed = self._closed
+        if closed:
+            return
+
+        future = asyncio.run_coroutine_threadsafe(self._release_all(leases), self._loop)
+
+        def _released(done: Future[Any]) -> None:
+            try:
+                done.result()
+            except Exception as exc:
+                logger.warning("SageMaker HyperPod lease release failed: %s", exc)
+            finally:
+                with self._lock:
+                    self._releasing_leases.difference_update(leases)
+
+        self._track_future(future, _released)
+
+    async def _release_all(self, leases: list[SageMakerHyperPodLease]) -> list[bool]:
+        return list(
+            await asyncio.gather(
+                *(self._release_with_retry(lease) for lease in leases),
+                return_exceptions=False,
+            )
+        )
+
+    async def _release_with_retry(self, lease: SageMakerHyperPodLease) -> bool:
+        deadline = time.monotonic() + self._config.lease_ttl_ms / 1000.0
+        while time.monotonic() < deadline:
+            if lease.is_expired():
+                # Already reclaimed server-side; nothing to release.
+                return True
+            if await self._client.release_lease(lease):
+                return True
+            await asyncio.sleep(min(0.1, self._config.lease_ttl_ms / 10000.0))
+        logger.warning("Lease %s was left for server-side expiry", lease.lease_id)
+        return False
+
+    async def _close_async(self, leases: list[SageMakerHyperPodLease]) -> None:
+        if leases:
+            # Best-effort only: unreleased leases expire server-side.
+            released = await asyncio.gather(
+                *(self._client.release_lease(lease) for lease in leases),
+                return_exceptions=True,
+            )
+            unreleased = sum(1 for result in released if result is not True)
+            if unreleased:
+                logger.warning(
+                    "%d lease(s) left for server-side expiry at close", unreleased
+                )
+        await self._client.close()
+
+    def _finish_store(
+        self,
+        task_id: L2TaskId,
+        keys: list[ObjectKey],
+        sizes: list[int],
+        future: Future[list[bool]],
+    ) -> None:
+        try:
+            per_key_ok = future.result()
+        except Exception as exc:
+            logger.warning("SageMaker HyperPod store failed: %s", exc)
+            per_key_ok = [False] * len(keys)
+        stored_keys: list[ObjectKey] = []
+        stored_sizes: list[int] = []
+        transferred = 0
+        with self._lock:
+            for key, size, ok in zip(keys, sizes, per_key_ok, strict=True):
+                if not ok:
+                    continue
+                stored_keys.append(key)
+                if key in self._key_sizes:
+                    stored_sizes.append(0)
+                else:
+                    self._key_sizes[key] = size
+                    stored_sizes.append(size)
+                    transferred += size
+            self._completed_stores[task_id] = L2StoreResult(
+                all(per_key_ok),
+                transferred,
+            )
+        if stored_keys:
+            self._notify_keys_stored(stored_keys, stored_sizes)
+        self._store_efd.notify()
+
+    def _finish_lookup(
+        self,
+        task_id: L2TaskId,
+        keys: list[ObjectKey],
+        future: Future[list[SageMakerHyperPodLease | None]],
+    ) -> None:
+        try:
+            leases = future.result()
+        except Exception as exc:
+            logger.warning("SageMaker HyperPod lookup failed: %s", exc)
+            leases = [None] * len(keys)
+        bitmap = Bitmap(len(keys))
+        accessed: list[ObjectKey] = []
+        with self._lock:
+            for index, (key, lease) in enumerate(zip(keys, leases, strict=True)):
+                if lease is None:
+                    continue
+                bitmap.set(index)
+                self._leases.setdefault(key, []).append(lease)
+                accessed.append(key)
+            self._completed_lookups[task_id] = bitmap
+        if accessed:
+            self._notify_keys_accessed(accessed)
+        self._lookup_efd.notify()
+
+    def _finish_load(
+        self,
+        task_id: L2TaskId,
+        keys: list[ObjectKey],
+        future: Future[tuple[list[bool], list[SageMakerHyperPodLease]]],
+    ) -> None:
+        transient_leases: list[SageMakerHyperPodLease] = []
+        try:
+            per_key_ok, transient_leases = future.result()
+        except Exception as exc:
+            logger.warning("SageMaker HyperPod load failed: %s", exc)
+            per_key_ok = [False] * len(keys)
+        bitmap = Bitmap(len(keys))
+        accessed: list[ObjectKey] = []
+        for index, (key, loaded) in enumerate(zip(keys, per_key_ok, strict=True)):
+            if loaded:
+                bitmap.set(index)
+                accessed.append(key)
+        with self._lock:
+            self._completed_loads[task_id] = bitmap
+        if accessed:
+            self._notify_keys_accessed(accessed)
+        self._load_efd.notify()
+        self._schedule_release(transient_leases)
+
+    def _track_future(
+        self,
+        future: Future[Any],
+        callback: Callable[[Future[Any]], None] | None = None,
+    ) -> None:
+        with self._lock:
+            self._inflight.add(future)
+
+        def _done(done: Future[Any]) -> None:
+            try:
+                if callback is not None:
+                    callback(done)
+            finally:
+                with self._lock:
+                    self._inflight.discard(done)
+
+        future.add_done_callback(_done)
+
+    def _complete_closed_store(self, task_id: L2TaskId) -> None:
+        with self._lock:
+            self._completed_stores[task_id] = L2StoreResult(False, 0)
+        self._store_efd.notify()
+
+    def _allocate_task_id(self) -> L2TaskId:
+        with self._lock:
+            task_id = self._next_task_id
+            self._next_task_id += 1
+        return task_id
+
+    def _run_event_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop_ready.set()
+        self._loop.run_forever()
+
+
+def _create_sagemaker_hyperpod_l2_adapter(
+    config: L2AdapterConfigBase,
+    l1_memory_desc: Optional["L1MemoryDesc"] = None,
+) -> L2AdapterInterface:
+    """Create a SageMaker HyperPod L2 adapter from registered configuration."""
+    del l1_memory_desc
+    if not isinstance(config, SageMakerHyperPodL2AdapterConfig):
+        raise TypeError(
+            f"expected SageMakerHyperPodL2AdapterConfig, got {type(config).__name__}"
+        )
+    return SageMakerHyperPodL2Adapter(config)
+
+
+register_l2_adapter_type(
+    "sagemaker-hyperpod",
+    SageMakerHyperPodL2AdapterConfig,
+)
+register_l2_adapter_factory(
+    "sagemaker-hyperpod",
+    _create_sagemaker_hyperpod_l2_adapter,
+)

--- a/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py
@@ -520,8 +520,8 @@ class SageMakerHyperPodL2Adapter(L2AdapterInterface):
         self._loop_thread.join(timeout=5)
         if self._loop_thread.is_alive():
             logger.error("SageMaker HyperPod L2 event loop did not stop")
-            return
-        self._loop.close()
+        else:
+            self._loop.close()
         self._store_efd.close()
         self._lookup_efd.close()
         self._load_efd.close()

--- a/tests/v1/distributed/test_sagemaker_hyperpod_l2_adapter.py
+++ b/tests/v1/distributed/test_sagemaker_hyperpod_l2_adapter.py
@@ -1,0 +1,747 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the SageMaker HyperPod MP L2 adapter."""
+
+# Standard
+from multiprocessing import shared_memory
+from typing import Iterator
+import asyncio
+import select
+import socket
+import threading
+import time
+
+# Third Party
+from aiohttp import web
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.l2_adapters.config import get_type_name_for_config
+from lmcache.v1.distributed.l2_adapters.sagemaker_hyperpod_client import (
+    SageMakerHyperPodClient,
+    SageMakerHyperPodLease,
+)
+from lmcache.v1.distributed.l2_adapters.sagemaker_hyperpod_l2_adapter import (
+    SageMakerHyperPodL2Adapter,
+    SageMakerHyperPodL2AdapterConfig,
+)
+from lmcache.v1.memory_management import (
+    MemoryFormat,
+    MemoryObj,
+    MemoryObjMetadata,
+    TensorMemoryObj,
+)
+from lmcache.v1.platform import consume_fd
+
+_EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
+
+
+class _FakeHyperPodClient:
+    """In-memory public-contract substitute for the ai-toolkit client."""
+
+    instance: "_FakeHyperPodClient | None" = None
+
+    def __init__(self, **kwargs: object) -> None:
+        del kwargs
+        self.data: dict[str, bytes] = {}
+        self.released: list[str] = []
+        self.release_calls: list[str] = []
+        self.fail_release = False
+        self.lease_expires_in: float = float("inf")
+        self.closed = False
+        self.raise_acquire_keys: set[str] = set()
+        self.block_put = False
+        self.put_started = threading.Event()
+        self.put_cancelled = False
+        self._put_loop: asyncio.AbstractEventLoop | None = None
+        self._put_gate: asyncio.Event | None = None
+        type(self).instance = self
+
+    @staticmethod
+    def normalize_url(url: str, use_https: bool = False) -> str:
+        return SageMakerHyperPodClient.normalize_url(url, use_https=use_https)
+
+    def release_put(self) -> None:
+        if self._put_loop is not None and self._put_gate is not None:
+            self._put_loop.call_soon_threadsafe(self._put_gate.set)
+
+    async def put(self, key: str, data: memoryview) -> bool:
+        if self.block_put:
+            self._put_loop = asyncio.get_running_loop()
+            self._put_gate = asyncio.Event()
+        self.put_started.set()
+        try:
+            if self._put_gate is not None:
+                await self._put_gate.wait()
+        except asyncio.CancelledError:
+            self.put_cancelled = True
+            raise
+        self.data[key] = bytes(data)
+        return True
+
+    async def acquire_lease(self, key: str) -> SageMakerHyperPodLease | None:
+        if key in self.raise_acquire_keys:
+            raise RuntimeError(f"injected acquire failure for {key}")
+        data = self.data.get(key)
+        if data is None:
+            return None
+        return SageMakerHyperPodLease(
+            key,
+            ((0, len(data)),),
+            expires_monotonic=time.monotonic() + self.lease_expires_in,
+        )
+
+    def copy_from_lease(
+        self,
+        lease: SageMakerHyperPodLease,
+        destination: memoryview,
+    ) -> bool:
+        if lease.is_expired():
+            return False
+        data = self.data.get(lease.lease_id)
+        view = destination.cast("B") if destination.format != "B" else destination
+        if data is None or len(data) != len(view):
+            return False
+        view[:] = data
+        return True
+
+    async def release_lease(self, lease: SageMakerHyperPodLease) -> bool:
+        self.release_calls.append(lease.lease_id)
+        if self.fail_release:
+            return False
+        self.released.append(lease.lease_id)
+        return True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _memory_obj(elements: int = 16, fill: float = 1.0) -> TensorMemoryObj:
+    raw = torch.full((elements,), fill, dtype=torch.float32)
+    metadata = MemoryObjMetadata(
+        shape=raw.shape,
+        dtype=raw.dtype,
+        address=raw.data_ptr(),
+        phy_size=raw.numel() * raw.element_size(),
+        ref_count=1,
+        fmt=MemoryFormat.KV_2LTD,
+    )
+    return TensorMemoryObj(raw, metadata, parent_allocator=None)
+
+
+def _key(value: int = 1, cache_salt: str = "") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=ObjectKey.IntHash2Bytes(value),
+        model_name="test/model",
+        kv_rank=1,
+        object_group_id=2,
+        cache_salt=cache_salt,
+    )
+
+
+def _wait(fd: int, timeout: float = 2.0) -> None:
+    poller = select.poll()
+    poller.register(fd, select.POLLIN)
+    assert poller.poll(int(timeout * 1000)), "adapter task did not complete"
+    consume_fd(fd)
+
+
+@pytest.fixture
+def adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[SageMakerHyperPodL2Adapter]:
+    # First Party
+    import lmcache.v1.distributed.l2_adapters.sagemaker_hyperpod_l2_adapter as mod
+
+    monkeypatch.setattr(mod, "SageMakerHyperPodClient", _FakeHyperPodClient)
+    value = SageMakerHyperPodL2Adapter(
+        SageMakerHyperPodL2AdapterConfig(
+            url="sagemaker-hyperpod://127.0.0.1:9200",
+        )
+    )
+    yield value
+    value.close()
+
+
+def test_config_registration_and_validation() -> None:
+    config = SageMakerHyperPodL2AdapterConfig.from_dict(
+        {
+            "type": "sagemaker-hyperpod",
+            "url": "sagemaker-hyperpod://127.0.0.1:9200",
+        }
+    )
+    assert config.bucket == "lmcache"
+    assert config.shared_memory_name == "shared_memory"
+    assert get_type_name_for_config(config) == "sagemaker-hyperpod"
+
+    with pytest.raises(ValueError, match="url"):
+        SageMakerHyperPodL2AdapterConfig.from_dict(
+            {"type": "sagemaker-hyperpod", "url": "127.0.0.1:9200"}
+        )
+    https_config = SageMakerHyperPodL2AdapterConfig.from_dict(
+        {
+            "type": "sagemaker-hyperpod",
+            "url": "sagemaker-hyperpod://127.0.0.1:9200",
+            "use_https": True,
+        }
+    )
+    assert https_config.use_https is True
+    assert (
+        SageMakerHyperPodClient.normalize_url(
+            "sagemaker-hyperpod://127.0.0.1:9200", use_https=True
+        )
+        == "https://127.0.0.1:9200"
+    )
+
+    with pytest.raises(ValueError, match="scheme"):
+        SageMakerHyperPodL2AdapterConfig.from_dict(
+            {"type": "sagemaker-hyperpod", "url": "http://127.0.0.1:9200"}
+        )
+    with pytest.raises(ValueError, match="eviction"):
+        SageMakerHyperPodL2AdapterConfig.from_dict(
+            {
+                "type": "sagemaker-hyperpod",
+                "url": "sagemaker-hyperpod://127.0.0.1:9200",
+                "eviction": {"policy": "lru"},
+            }
+        )
+
+
+def test_event_descriptors_are_distinct(adapter: SageMakerHyperPodL2Adapter) -> None:
+    assert (
+        len(
+            {
+                adapter.get_store_event_fd(),
+                adapter.get_lookup_and_lock_event_fd(),
+                adapter.get_load_event_fd(),
+            }
+        )
+        == 3
+    )
+
+
+def test_store_lookup_load_and_unlock(adapter: SageMakerHyperPodL2Adapter) -> None:
+    key = _key(cache_salt="tenant-a")
+    source = _memory_obj(fill=3.0)
+    destination = _memory_obj(fill=0.0)
+
+    store_id = adapter.submit_store_task([key], [source])
+    _wait(adapter.get_store_event_fd())
+    store_result = adapter.pop_completed_store_tasks()[store_id]
+    assert store_result.is_successful()
+    assert store_result.bytes_transferred() == source.get_size()
+
+    lookup_id = adapter.submit_lookup_and_lock_task([key, _key(99)], _EMPTY_LAYOUT)
+    _wait(adapter.get_lookup_and_lock_event_fd())
+    lookup = adapter.query_lookup_and_lock_result(lookup_id)
+    assert lookup is not None
+    assert lookup.test(0)
+    assert not lookup.test(1)
+    assert adapter.query_lookup_and_lock_result(lookup_id) is None
+
+    load_id = adapter.submit_load_task([key], [destination])
+    _wait(adapter.get_load_event_fd())
+    loaded = adapter.query_load_result(load_id)
+    assert loaded is not None and loaded.test(0)
+    assert bytes(destination.byte_array) == bytes(source.byte_array)
+
+    adapter.submit_unlock([key])
+    client = _FakeHyperPodClient.instance
+    assert client is not None
+    deadline = time.monotonic() + 2
+    while not client.released and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert client.released == ["test/model@00000001@2@00000001@tenant-a"]
+
+
+def test_load_size_mismatch_is_a_miss(adapter: SageMakerHyperPodL2Adapter) -> None:
+    key = _key()
+    source = _memory_obj(elements=8)
+    destination = _memory_obj(elements=16)
+
+    store_id = adapter.submit_store_task([key], [source])
+    _wait(adapter.get_store_event_fd())
+    assert adapter.pop_completed_store_tasks()[store_id].is_successful()
+
+    load_id = adapter.submit_load_task([key], [destination])
+    _wait(adapter.get_load_event_fd())
+    loaded = adapter.query_load_result(load_id)
+    assert loaded is not None and not loaded.test(0)
+
+
+def test_client_copies_fragmented_shared_memory() -> None:
+    shm = shared_memory.SharedMemory(create=True, size=16)
+    try:
+        shm.buf[:8] = b"abcdefgh"
+        client = SageMakerHyperPodClient(
+            url="sagemaker-hyperpod://127.0.0.1:9200",
+            shared_memory_name=shm.name,
+        )
+        destination = memoryview(bytearray(6))
+        lease = SageMakerHyperPodLease("lease", ((1, 3), (5, 3)))
+        assert client.copy_from_lease(lease, destination)
+        assert bytes(destination) == b"bcdfgh"
+        destination.release()
+
+        # A destination whose size differs from the lease is a miss and is
+        # never written.
+        wrong_size = memoryview(bytearray(b"XXXX"))
+        assert not client.copy_from_lease(lease, wrong_size)
+        assert bytes(wrong_size) == b"XXXX"
+        wrong_size.release()
+        asyncio.run(client.close())
+    finally:
+        shm.close()
+        shm.unlink()
+
+
+def test_client_http_and_lease_protocol() -> None:
+    async def scenario() -> None:
+        state: dict[str, object] = {
+            "put_status": 200,
+            "stored": b"",
+            "key": "",
+            "released": [],
+            "malformed_lease": False,
+            "invalid_offsets": False,
+        }
+
+        async def put(request: web.Request) -> web.Response:
+            state["key"] = request.match_info["key"]
+            state["stored"] = await request.read()
+            put_status = state["put_status"]
+            assert isinstance(put_status, int)
+            return web.Response(status=put_status)
+
+        async def acquire(request: web.Request) -> web.Response:
+            if state["malformed_lease"]:
+                return web.json_response(["not", "an", "object"])
+            if state["invalid_offsets"]:
+                return web.json_response(
+                    {"id": "lease/bad", "offsets": [{"offset": -1, "len": 4}]}
+                )
+            return web.json_response(
+                {
+                    "id": "lease/1",
+                    "offsets": [{"offset": 2, "len": 4}],
+                }
+            )
+
+        async def release(request: web.Request) -> web.Response:
+            released = state["released"]
+            assert isinstance(released, list)
+            released.append(request.match_info["lease_id"])
+            return web.Response(status=200)
+
+        app = web.Application()
+        app.router.add_put("/v1/kv/{bucket}/{key:.+}", put)
+        app.router.add_post("/v1/kv/{bucket}/{key:.+}/leases", acquire)
+        app.router.add_post("/v1/leases/{lease_id:.+}/release", release)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        site = web.SockSite(runner, sock)
+        await site.start()
+
+        shm = shared_memory.SharedMemory(create=True, size=16)
+        shm.buf[2:6] = b"data"
+        client = SageMakerHyperPodClient(
+            url=f"sagemaker-hyperpod://127.0.0.1:{port}",
+            bucket="bucket name",
+            shared_memory_name=shm.name,
+        )
+        try:
+            key = "model/name@00000001@0@abcd"
+            assert await client.put(key, memoryview(b"payload"))
+            assert state["stored"] == b"payload"
+            assert state["key"] == key
+
+            state["put_status"] = 409
+            assert await client.put(key, memoryview(b"payload"))
+            state["put_status"] = 500
+            assert not await client.put(key, memoryview(b"payload"))
+            status = client.report_status()
+            assert status["is_healthy"], "HTTP statuses must not trip the breaker"
+            assert status["consecutive_http_failures"] == 0
+            assert not status["circuit_open"]
+
+            lease = await client.acquire_lease(key)
+            assert lease is not None
+            destination = memoryview(bytearray(4))
+            assert client.copy_from_lease(lease, destination)
+            assert bytes(destination) == b"data"
+            destination.release()
+            assert await client.release_lease(lease)
+            assert state["released"] == ["lease/1"]
+            assert client.report_status()["is_healthy"]
+
+            state["malformed_lease"] = True
+            assert await client.acquire_lease(key) is None
+
+            state["malformed_lease"] = False
+            state["invalid_offsets"] = True
+            assert await client.acquire_lease(key) is None
+            assert state["released"] == ["lease/1", "lease/bad"]
+        finally:
+            await client.close()
+            shm.close()
+            shm.unlink()
+            await runner.cleanup()
+
+    asyncio.run(scenario())
+
+
+class _RecordingListener(L2AdapterListener):
+    def __init__(self) -> None:
+        self.stored: list[list[ObjectKey]] = []
+
+    def on_l2_keys_stored(
+        self,
+        keys: list[ObjectKey],
+        sizes: list[int],
+    ) -> None:
+        del sizes
+        self.stored.append(list(keys))
+
+    def on_l2_keys_accessed(self, keys: list[ObjectKey]) -> None:
+        del keys
+
+    def on_l2_keys_deleted(self, keys: list[ObjectKey]) -> None:
+        del keys
+
+
+def test_invalid_later_fragment_does_not_modify_destination() -> None:
+    shm = shared_memory.SharedMemory(create=True, size=16)
+    try:
+        client = SageMakerHyperPodClient(
+            url="sagemaker-hyperpod://127.0.0.1:9200",
+            shared_memory_name=shm.name,
+        )
+        destination = memoryview(bytearray(b"XXXXXX"))
+        lease = SageMakerHyperPodLease("lease", ((1, 3), (1 << 30, 3)))
+        assert not client.copy_from_lease(lease, destination)
+        assert bytes(destination) == b"XXXXXX"
+        destination.release()
+        asyncio.run(client.close())
+    finally:
+        shm.close()
+        shm.unlink()
+
+
+def test_lookup_partial_exception_preserves_hits(
+    adapter: SageMakerHyperPodL2Adapter,
+) -> None:
+    existing = _key(1)
+    failing = _key(99)
+    source = _memory_obj()
+
+    store_id = adapter.submit_store_task([existing], [source])
+    _wait(adapter.get_store_event_fd())
+    assert adapter.pop_completed_store_tasks()[store_id].is_successful()
+
+    client = _FakeHyperPodClient.instance
+    assert client is not None
+    client.raise_acquire_keys.add("test/model@00000001@2@00000063")
+
+    lookup_id = adapter.submit_lookup_and_lock_task(
+        [existing, failing],
+        _EMPTY_LAYOUT,
+    )
+    _wait(adapter.get_lookup_and_lock_event_fd())
+    result = adapter.query_lookup_and_lock_result(lookup_id)
+    assert result is not None
+    assert result.test(0)
+    assert not result.test(1)
+
+    adapter.submit_unlock([existing])
+    deadline = time.monotonic() + 2
+    while not client.released and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert client.released == ["test/model@00000001@2@00000001"]
+
+
+def test_submit_store_snapshots_keys(
+    adapter: SageMakerHyperPodL2Adapter,
+) -> None:
+    original = _key(1)
+    replacement = _key(2)
+    keys = [original]
+    listener = _RecordingListener()
+    adapter.register_listener(listener)
+
+    client = _FakeHyperPodClient.instance
+    assert client is not None
+    client.block_put = True
+
+    task_id = adapter.submit_store_task(keys, [_memory_obj()])
+    assert client.put_started.wait(timeout=2)
+    keys[0] = replacement
+    client.release_put()
+
+    _wait(adapter.get_store_event_fd())
+    assert adapter.pop_completed_store_tasks()[task_id].is_successful()
+    assert listener.stored == [[original]]
+
+
+def test_close_cancels_inflight_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # First Party
+    import lmcache.v1.distributed.l2_adapters.sagemaker_hyperpod_l2_adapter as mod
+
+    monkeypatch.setattr(mod, "SageMakerHyperPodClient", _FakeHyperPodClient)
+    adapter = SageMakerHyperPodL2Adapter(
+        SageMakerHyperPodL2AdapterConfig(
+            url="sagemaker-hyperpod://127.0.0.1:9200",
+            lease_ttl_ms=200,
+        )
+    )
+    client = _FakeHyperPodClient.instance
+    assert client is not None
+    client.block_put = True
+
+    adapter.submit_store_task([_key()], [_memory_obj()])
+    assert client.put_started.wait(timeout=2)
+    adapter.close()
+
+    assert client.put_cancelled
+    assert client.closed
+
+
+def test_client_circuit_breaker_fast_fails_and_probes() -> None:
+    async def scenario() -> None:
+        # Reserve a port, then leave it closed so requests are refused.
+        reserve = socket.socket()
+        reserve.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        reserve.bind(("127.0.0.1", 0))
+        port = reserve.getsockname()[1]
+        reserve.close()
+
+        shm = shared_memory.SharedMemory(create=True, size=8)
+        client = SageMakerHyperPodClient(
+            url=f"sagemaker-hyperpod://127.0.0.1:{port}",
+            shared_memory_name=shm.name,
+            timeout_ms=500,
+        )
+        client.circuit_cooldown_s = 0.2
+        runner: web.AppRunner | None = None
+        try:
+            payload = memoryview(b"x")
+            for _ in range(client.failure_threshold):
+                assert not await client.put("key", payload)
+            status = client.report_status()
+            assert status["circuit_open"]
+            assert not status["is_healthy"]
+            failures = status["consecutive_http_failures"]
+            assert isinstance(failures, int)
+            assert failures == client.failure_threshold
+
+            # Circuit open: fail fast without attempting (failure count
+            # stays put because no request is issued).
+            assert not await client.put("key", payload)
+            status = client.report_status()
+            assert status["consecutive_http_failures"] == failures
+
+            # After the cooldown one probe goes through, fails against the
+            # still-closed port, and increments the failure count.
+            await asyncio.sleep(0.25)
+            assert not await client.put("key", payload)
+            status = client.report_status()
+            assert status["consecutive_http_failures"] == failures + 1
+
+            # Bring a daemon up on the reserved port: the next probe gets an
+            # HTTP response (status irrelevant) and closes the circuit.
+            async def put(request: web.Request) -> web.Response:
+                await request.read()
+                return web.Response(status=200)
+
+            app = web.Application()
+            app.router.add_put("/v1/kv/{bucket}/{key:.+}", put)
+            runner = web.AppRunner(app)
+            await runner.setup()
+            recover_sock = socket.socket()
+            recover_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            recover_sock.bind(("127.0.0.1", port))
+            await web.SockSite(runner, recover_sock).start()
+
+            await asyncio.sleep(0.25)
+            assert await client.put("key", payload)
+            status = client.report_status()
+            assert status["is_healthy"]
+            assert not status["circuit_open"]
+            assert status["consecutive_http_failures"] == 0
+        finally:
+            await client.close()
+            shm.close()
+            shm.unlink()
+            if runner is not None:
+                await runner.cleanup()
+
+    asyncio.run(scenario())
+
+
+def test_close_releases_leases_once_without_ttl_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # First Party
+    import lmcache.v1.distributed.l2_adapters.sagemaker_hyperpod_l2_adapter as mod
+
+    monkeypatch.setattr(mod, "SageMakerHyperPodClient", _FakeHyperPodClient)
+    adapter = SageMakerHyperPodL2Adapter(
+        SageMakerHyperPodL2AdapterConfig(
+            url="sagemaker-hyperpod://127.0.0.1:9200",
+            lease_ttl_ms=30000,
+        )
+    )
+    key = _key()
+    store_id = adapter.submit_store_task([key], [_memory_obj()])
+    _wait(adapter.get_store_event_fd())
+    assert adapter.pop_completed_store_tasks()[store_id].is_successful()
+
+    lookup_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
+    _wait(adapter.get_lookup_and_lock_event_fd())
+    lookup = adapter.query_lookup_and_lock_result(lookup_id)
+    assert lookup is not None and lookup.test(0)
+
+    client = _FakeHyperPodClient.instance
+    assert client is not None
+    client.fail_release = True
+
+    begin = time.monotonic()
+    adapter.close()
+    elapsed = time.monotonic() - begin
+    assert elapsed < 5.0, "close must not retry lease release until the TTL"
+    assert client.release_calls == ["test/model@00000001@2@00000001"]
+    assert client.closed
+
+
+def test_load_transient_acquire_exception_is_isolated(
+    adapter: SageMakerHyperPodL2Adapter,
+) -> None:
+    good = _key(1)
+    failing = _key(99)
+    sources: list[MemoryObj] = [_memory_obj(fill=5.0), _memory_obj(fill=7.0)]
+    destinations: list[MemoryObj] = [_memory_obj(fill=0.0), _memory_obj(fill=0.0)]
+
+    store_id = adapter.submit_store_task([good, failing], sources)
+    _wait(adapter.get_store_event_fd())
+    assert adapter.pop_completed_store_tasks()[store_id].is_successful()
+
+    client = _FakeHyperPodClient.instance
+    assert client is not None
+    client.raise_acquire_keys.add("test/model@00000001@2@00000063")
+
+    # No prior lookup: both keys take the transient-lease path.
+    load_id = adapter.submit_load_task([good, failing], destinations)
+    _wait(adapter.get_load_event_fd())
+    loaded = adapter.query_load_result(load_id)
+    assert loaded is not None
+    assert loaded.test(0)
+    assert not loaded.test(1)
+    assert bytes(destinations[0].byte_array) == bytes(sources[0].byte_array)
+
+
+def test_copy_refuses_expired_lease() -> None:
+    shm = shared_memory.SharedMemory(create=True, size=16)
+    try:
+        shm.buf[:8] = b"abcdefgh"
+        client = SageMakerHyperPodClient(
+            url="sagemaker-hyperpod://127.0.0.1:9200",
+            shared_memory_name=shm.name,
+        )
+        destination = memoryview(bytearray(b"XXXX"))
+        expired = SageMakerHyperPodLease(
+            "lease",
+            ((0, 4),),
+            expires_monotonic=time.monotonic() - 1.0,
+        )
+        assert not client.copy_from_lease(expired, destination)
+        assert bytes(destination) == b"XXXX", "destination must stay unmodified"
+
+        valid = SageMakerHyperPodLease(
+            "lease",
+            ((0, 4),),
+            expires_monotonic=time.monotonic() + 60.0,
+        )
+        assert client.copy_from_lease(valid, destination)
+        assert bytes(destination) == b"abcd"
+        destination.release()
+        asyncio.run(client.close())
+    finally:
+        shm.close()
+        shm.unlink()
+
+
+def test_load_reacquires_when_retained_lease_expired(
+    adapter: SageMakerHyperPodL2Adapter,
+) -> None:
+    key = _key()
+    source = _memory_obj(fill=9.0)
+    destination = _memory_obj(fill=0.0)
+
+    store_id = adapter.submit_store_task([key], [source])
+    _wait(adapter.get_store_event_fd())
+    assert adapter.pop_completed_store_tasks()[store_id].is_successful()
+
+    # The lookup retains a lease that is already past its TTL.
+    client = _FakeHyperPodClient.instance
+    assert client is not None
+    client.lease_expires_in = 0.0
+
+    lookup_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
+    _wait(adapter.get_lookup_and_lock_event_fd())
+    lookup = adapter.query_lookup_and_lock_result(lookup_id)
+    assert lookup is not None and lookup.test(0)
+
+    # The load must not read through the expired retained lease; it should
+    # acquire a fresh (now valid) lease instead and still succeed.
+    client.lease_expires_in = float("inf")
+
+    load_id = adapter.submit_load_task([key], [destination])
+    _wait(adapter.get_load_event_fd())
+    loaded = adapter.query_load_result(load_id)
+    assert loaded is not None and loaded.test(0)
+    assert bytes(destination.byte_array) == bytes(source.byte_array)
+
+
+def test_copy_discards_result_when_lease_expires_mid_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # First Party
+    import lmcache.v1.distributed.l2_adapters.sagemaker_hyperpod_client as client_mod
+
+    shm = shared_memory.SharedMemory(create=True, size=8)
+    try:
+        shm.buf[:4] = b"data"
+        client = SageMakerHyperPodClient(
+            url="sagemaker-hyperpod://127.0.0.1:9200",
+            shared_memory_name=shm.name,
+        )
+
+        # Deterministic clock: valid at the pre-copy check, expired by the
+        # post-copy check — simulating a lease that dies mid-copy.
+        base = time.monotonic()
+        lease = SageMakerHyperPodLease("lease", ((0, 4),), expires_monotonic=base + 5.0)
+        ticks = iter([base, base + 10.0])
+
+        class _Clock:
+            @staticmethod
+            def monotonic() -> float:
+                return next(ticks, base + 10.0)
+
+        monkeypatch.setattr(client_mod, "time", _Clock)
+
+        destination = memoryview(bytearray(4))
+        assert not client.copy_from_lease(lease, destination), (
+            "a copy finishing after the lease expiry must be discarded"
+        )
+        destination.release()
+        monkeypatch.undo()
+        asyncio.run(client.close())
+    finally:
+        shm.close()
+        shm.unlink()


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4114

Adds an MP-mode L2 storage adapter for the Amazon SageMaker HyperPod ai-toolkit tiered cache daemon. LMCache already has an in-process connector for this backend (`sagemaker_hyperpod_connector.py`), but the new multiprocess (MP) architecture has no HyperPod backend

How it works:

- Store is a plain HTTP `PUT` to the node-local daemon.
- Load: Instead of sending bytes back over HTTP, the daemon returns a **lease** telling where the object lives inside its `/dev/shm` arena, and the adapter copies it straight out of shared memory. `lookup_and_lock`/`unlock` map directly onto lease acquire/release.
- Leases expire after a TTL, so the adapter re-checks expiry after each copy and turns any stale read into a miss.
- The daemon owns object lifecycle (no delete API), so `eviction` config is rejected. A circuit breaker fast-fails while the daemon is unreachable; HTTP errors like 404/504 are normal miss responses and never trip it.

Config example:

```
--l2-adapter '{"type": "sagemaker-hyperpod", "url": "sagemaker-hyperpod://<node-ip>:9200"}'
```

**Special notes for your reviewers**:

- Validated end-to-end on a real SageMaker HyperPod EKS cluster: Qwen on g6e/L40S and a large quantized MoE model (GLM-5.2-Int4, TP=8 on p5.48xlarge/H100), including fault drills (breaker open/recovery) and concurrent load.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
