### PR TITLE
docs: daily drift check — multi-process mode (2026-07-17)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -401,8 +401,9 @@ Each JSON object must include a ``"type"`` field that selects the adapter type.
 The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
 Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
-``fs_native``, ``mock``, ``mooncake_store``, ``aerospike``, ``s3``, ``resp``,
-``plugin``, ``native_plugin``, ``raw_block``, ``dax``.
+``fs_native``, ``mock``, ``mooncake_store``, ``aerospike``, ``bigtable``,
+``s3``, ``resp``, ``valkey``, ``plugin``, ``native_plugin``, ``raw_block``,
+``dax``.
 
 Each adapter type's required and optional fields, plus per-backend examples, are
 documented on its own page under :doc:`Secondary KV Storage <l2_storage/index>`


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. One
remaining inconsistency between the multi-process (MP) *configuration
reference* and the current `dev` code (`upstream/dev` HEAD
[`c9439c65`](https://github.com/LMCache/LMCache/commit/c9439c6535503c9e17fe236da9bc88807b58c2bc))
was found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/mp/configuration.rst`** — the *L2 Adapters*
  "Registered adapter types" list (the authoritative CLI reference)
  omits both `bigtable` and `valkey`, even though both adapter types
  self-register in code and both ship a user-facing configuration
  surface via `--l2-adapter '{"type": "bigtable", ...}'` /
  `--l2-adapter '{"type": "valkey", ...}'`. A user reading this page
  today has no signal from the authoritative flag reference that either
  adapter exists.

  - `bigtable` landed with [PR #3885](https://github.com/LMCache/LMCache/pull/3885)
    (commit [`f5abb8a3`](https://github.com/LMCache/LMCache/commit/f5abb8a3ce27fe38ce55e7f5aad2c1cb9d33cb27)),
    which also added `docs/source/mp/l2_storage/bigtable.rst` and a row
    in `supported_storages.rst` / `remote_and_distributed.rst`. It did
    not touch this authoritative list.
  - `valkey` landed with [PR #3505](https://github.com/LMCache/LMCache/pull/3505)
    (commit [`c828516e`](https://github.com/LMCache/LMCache/commit/c828516e2cbee42525b8e1fda975533d5405e304)).
    A companion user-facing page and supported-storages entry are already
    proposed in the still-open drift-check
    [PR #4117](https://github.com/LMCache/LMCache/pull/4117); that PR
    also does not touch this authoritative list.

`docs/design/` (design docs):

- No new drift found in `docs/design/` beyond what open drift-check PRs
  #4125, #4117, #4087, #4066, #4035, #4009, #3996, #3984, #3969, and
  #3960 already cover. Both `bigtable` and `valkey` landed with their
  own design docs
  (`docs/design/v1/distributed/l2_adapters/{bigtable,valkey}.md`),
  matched against the current code.

**Evidence**

| Drift | Code / repo state (current `dev`, HEAD `c9439c65`) | Stale doc |
| --- | --- | --- |
| `bigtable` missing from the "Registered adapter types" list | [`lmcache/v1/distributed/l2_adapters/bigtable_l2_adapter.py#L1213`](https://github.com/LMCache/LMCache/blob/c9439c6535503c9e17fe236da9bc88807b58c2bc/lmcache/v1/distributed/l2_adapters/bigtable_l2_adapter.py#L1213) — `register_l2_adapter_type("bigtable", BigtableL2AdapterConfig)`; user-facing docs page at [`docs/source/mp/l2_storage/bigtable.rst`](https://github.com/LMCache/LMCache/blob/c9439c6535503c9e17fe236da9bc88807b58c2bc/docs/source/mp/l2_storage/bigtable.rst) | [`docs/source/mp/configuration.rst#L403-L405`](https://github.com/LMCache/LMCache/blob/c9439c6535503c9e17fe236da9bc88807b58c2bc/docs/source/mp/configuration.rst#L403-L405) |
| `valkey` missing from the "Registered adapter types" list | [`lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py#L1116`](https://github.com/LMCache/LMCache/blob/c9439c6535503c9e17fe236da9bc88807b58c2bc/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py#L1116) — `register_l2_adapter_type("valkey", ValkeyL2AdapterConfig)`; user-facing docs page proposed in open drift-check [PR #4117](https://github.com/LMCache/LMCache/pull/4117) | [`docs/source/mp/configuration.rst#L403-L405`](https://github.com/LMCache/LMCache/blob/c9439c6535503c9e17fe236da9bc88807b58c2bc/docs/source/mp/configuration.rst#L403-L405) |

**Proposed fix (applied in this PR)**

- One-file edit to `docs/source/mp/configuration.rst`: added `bigtable`
  and `valkey` to the "Registered adapter types" list under the *L2
  Adapters* section. The two entries are grouped with the other remote
  / distributed adapter types (`aerospike`, `s3`, `resp`) for a natural
  reading order.

**Special notes for your reviewers**:

- Docs-only change. No code modified. One file, three lines rewrapped.
- Deduped against currently-open drift PRs:
  - **#4125** (Developer Guide toctree indentation — 2026-07-16): no
    overlap.
  - **#4117** (new `docs/source/mp/l2_storage/valkey.rst` +
    `supported_storages.rst` + `remote_and_distributed.rst` toctree —
    2026-07-15): no overlap. #4117 makes `valkey` reachable from the
    L2 storage index; this PR makes it reachable from the CLI
    configuration reference. Both edits are needed.
  - **#4087** (`--prometheus-*` observability rows in
    `docs/source/mp/configuration.rst` — 2026-07-11): no overlap.
  - **#4066** (`nixl_store` install extra in `docs/source/mp/p2p.rst`
    — 2026-07-09): no overlap.
  - **#4035** (`fault_inject` in the same "Registered adapter types"
    list + observability rows in `configuration.rst` — 2026-07-07):
    **touches the same one-line list**, but for a different entry
    (`fault_inject`). If both PRs land, the maintainer will need to
    resolve a trivial three-way merge on that list; the intended union
    is: `nixl_store, nixl_store_dynamic, fs, fs_native, mock,
    mooncake_store, aerospike, bigtable, s3, resp, valkey, plugin,
    native_plugin, raw_block, dax, fault_inject`.
  - **#3960** (`hfbucket` in the same "Registered adapter types" list +
    `IsolatedLRU` in `l2_storage/index.rst` — 2026-06-30): **also
    touches the same one-line list**, but for a different entry
    (`hfbucket`). Same merge situation as above; the full intended
    union across all three drift PRs is: `nixl_store,
    nixl_store_dynamic, fs, fs_native, mock, mooncake_store,
    aerospike, bigtable, s3, resp, valkey, hfbucket, plugin,
    native_plugin, raw_block, dax, fault_inject`.
  - **#4009, #3996, #3984, #3969**: none cover this list.
- `p2p` and `fault_inject` policy from prior drift PRs:
  - `p2p` is intentionally **not** added even though
    `P2PL2AdapterConfig` self-registers; it is constructed
    programmatically by `P2PController._add_adapter()` and is not
    user-configurable via `--l2-adapter`, so listing it in a
    user-facing enumeration would be misleading (this matches the
    intent already stated in #4035).
  - `fault_inject` is deliberately left to #4035 to keep this PR's
    diff scoped to today's newly-uncovered drift.
- The following upstream `dev` commits since the previous drift check
  (2026-07-16 → today) were reviewed for new user-facing MP doc drift
  and none introduced any:
  - [`8d3ce307`](https://github.com/LMCache/LMCache/commit/8d3ce307)
    (`[GDS] always enable thread pool for disk I/O`, #4067) — internal
    thread-pool default only, no user-facing config or CLI flag.
  - [`dd86612f`](https://github.com/LMCache/LMCache/commit/dd86612f)
    (`[MP][Coordinator] token-based cache delete API`, #3990) —
    coordinator HTTP API extension; the PR landed with matching updates
    to `docs/source/mp/coordinator.rst` and
    `docs/source/mp/http_api.rst`.
  - [`c9439c65`](https://github.com/LMCache/LMCache/commit/c9439c65)
    (`[Fix] Add kernels for vLLM-packed KV cache format`, #4128) —
    C-extension kernel addition; no user-facing docs surface.
- This PR was **auto-generated** by the daily drift-check routine and
  **needs human review before merge**. Please do not merge without a
  maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_019XPzKrGhPqo2iqPTFSGnQH)_