### PR TITLE
[good-first-issue] core: convert f-string log calls in azure_connector to %-format (#4141)

### DIFF
--- a/lmcache/v1/storage_backend/connector/azure_connector.py
+++ b/lmcache/v1/storage_backend/connector/azure_connector.py
@@ -149,10 +149,10 @@ class AzureConnector(RemoteConnector):
             props = await blob.get_blob_properties()
             return props.size or 0
         except ResourceNotFoundError:
-            logger.debug(f"Blob not found: {key_str}")
+            logger.debug("Blob not found: %s", key_str)
             return 0
         except Exception as e:
-            logger.warning(f"Azure HEAD/properties error for {key_str}: {e}")
+            logger.warning("Azure HEAD/properties error for %s: %s", key_str, e)
             return 0
 
     # ------------------------------------------------------------------ #
@@ -231,10 +231,13 @@ class AzureConnector(RemoteConnector):
 
         if obj_size != memory_obj.get_size():
             logger.error(
-                f"Size mismatch for {key_str}: Azure has {obj_size} bytes, "
-                f"but current config expects {memory_obj.get_size()} bytes. "
-                f"This usually means the data was stored with a different "
-                f"chunk_size or model configuration."
+                "Size mismatch for %s: Azure has %s bytes, "
+                "but current config expects %s bytes. "
+                "This usually means the data was stored with a different "
+                "chunk_size or model configuration.",
+                key_str,
+                obj_size,
+                memory_obj.get_size(),
             )
             memory_obj.ref_count_down()
             return None
@@ -246,7 +249,7 @@ class AzureConnector(RemoteConnector):
             await downloader.readinto(memory_obj.byte_array)
             return memory_obj
         except Exception as e:
-            logger.error(f"Failed to download {key_str} from Azure: {e}")
+            logger.error("Failed to download %s from Azure: %s", key_str, e)
             memory_obj.ref_count_down()
             return None
 
@@ -274,10 +277,13 @@ class AzureConnector(RemoteConnector):
 
         if memory_obj.get_physical_size() != self.part_size:
             logger.error(
-                f"Cannot upload {key_str}: chunk size "
-                f"{memory_obj.get_physical_size()} bytes does not match expected "
-                f"part size {self.part_size} bytes. "
-                f"Partial/unfull chunks are not supported."
+                "Cannot upload %s: chunk size "
+                "%s bytes does not match expected "
+                "part size %s bytes. "
+                "Partial/unfull chunks are not supported.",
+                key_str,
+                memory_obj.get_physical_size(),
+                self.part_size,
             )
             return
 
@@ -291,9 +297,9 @@ class AzureConnector(RemoteConnector):
                 length=memory_obj.get_physical_size(),
             )
             self.object_size_cache[key_str] = memory_obj.get_physical_size()
-            logger.debug(f"Uploaded {key_str} to Azure successfully")
+            logger.debug("Uploaded %s to Azure successfully", key_str)
         except Exception as e:
-            logger.error(f"Failed to upload {key_str} to Azure: {e}")
+            logger.error("Failed to upload %s to Azure: %s", key_str, e)
 
     # ------------------------------------------------------------------ #
     # list / close


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #4141
Refs #3372

Convert seven f-string `logger.*` calls in `lmcache/v1/storage_backend/connector/azure_connector.py` to lazy `%-format` so arguments are interpolated only when the log record is emitted (ruff G004). No behavior change.

**Special notes for your reviewers**:
- This is my first PR to LMCache 🙇 please be gentle.
- I ran `ruff check lmcache/v1/storage_backend/connector/azure_connector.py --select G004` locally — all green.
- I ran `ruff format` / `ruff check` on the touched file — all green.
- Commit includes DCO sign-off (`-s`).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

Made with [Cursor](https://cursor.com)