### PR TITLE
fix: scope keys_in_request per lookup via ContextVar (#4137)

### DIFF
--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -2,6 +2,7 @@
 # Standard
 from concurrent.futures import Future
 from contextlib import nullcontext
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 import threading
 import time
@@ -37,6 +38,28 @@ if TYPE_CHECKING:
     from lmcache.v1.cache_controller.worker import LMCacheWorker
 
 logger = init_logger(__name__)
+
+# Per-task / per-thread list of keys touched during a pin=True lookup.
+# Must not be instance state: StorageManager serves concurrent lookups as
+# interleaved coroutines on one asyncio thread, so a shared list lets one
+# request's touch_cache() wipe another request's keys (see #4137).
+_keys_in_request_var: ContextVar[Optional[List[CacheEngineKey]]] = ContextVar(
+    "local_cpu_keys_in_request", default=None
+)
+
+
+def _get_keys_in_request() -> List[CacheEngineKey]:
+    keys = _keys_in_request_var.get()
+    if keys is None:
+        keys = []
+        _keys_in_request_var.set(keys)
+    return keys
+
+
+def _take_keys_in_request() -> List[CacheEngineKey]:
+    keys = _keys_in_request_var.get()
+    _keys_in_request_var.set(None)
+    return keys if keys is not None else []
 
 
 class LocalCPUBackend(AllocatorBackendInterface):
@@ -85,11 +108,6 @@ class LocalCPUBackend(AllocatorBackendInterface):
         self.config = config
         self.metadata = metadata
 
-        # to help maintain suffix -> prefix order in the dict
-        # assumption: only one request is looked up at a time
-        # (only one worker per cache engine)
-        self.keys_in_request: List[CacheEngineKey] = []
-
         # Batched message sender for controller communication
         self.batched_msg_sender: Optional[BatchedMessageSender] = None
 
@@ -118,7 +136,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
             lambda: len(self.hot_cache)
         )
         prometheus_logger.local_cpu_keys_in_request_count.set_function(
-            lambda: len(self.keys_in_request)
+            lambda: len(_keys_in_request_var.get() or [])
         )
 
     def __str__(self):
@@ -131,15 +149,15 @@ class LocalCPUBackend(AllocatorBackendInterface):
             if pin:
                 self.hot_cache[key].pin()
                 # vllm lookup sets pin to True
-                self.keys_in_request.append(key)
+                _get_keys_in_request().append(key)
             return True
 
     def touch_cache(self):
         # flip the order of the keys in the request
         with self.cpu_lock:
-            for key in reversed(self.keys_in_request):
+            keys_in_request = _take_keys_in_request()
+            for key in reversed(keys_in_request):
                 self.cache_policy.update_on_hit(key, self.hot_cache)
-            self.keys_in_request = []
 
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
         """
@@ -251,7 +269,7 @@ class LocalCPUBackend(AllocatorBackendInterface):
                 if pin:
                     self.hot_cache[key].pin()
                     # vllm lookup sets pin to True
-                    self.keys_in_request.append(key)
+                    _get_keys_in_request().append(key)
                 num_hit_chunks += 1
         return num_hit_chunks
 

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -157,6 +157,14 @@ class LocalCPUBackend(AllocatorBackendInterface):
         with self.cpu_lock:
             keys_in_request = _take_keys_in_request()
             for key in reversed(keys_in_request):
+                # A key can leave hot_cache between the lookup that pinned it and
+                # this touch. update_on_hit assumes it is still there -- the LRU
+                # policy calls hot_cache.move_to_end(key), which raises KeyError --
+                # so skip anything that is gone. This was previously masked: with a
+                # single shared list, the first touch_cache() consumed every
+                # request's keys, so the rest were dropped rather than touched.
+                if key not in self.hot_cache:
+                    continue
                 self.cache_policy.update_on_hit(key, self.hot_cache)
 
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -2,6 +2,7 @@
 # Standard
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import nullcontext
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
 import os
@@ -36,6 +37,27 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 _DEFAULT_THREAD_COUNT = 4
+
+# Per-task / per-thread list of keys touched during a pin=True lookup.
+# Shared instance state is incorrect under concurrent lookups on one
+# asyncio thread (see #4137 / LocalCPUBackend).
+_keys_in_request_var: ContextVar[Optional[List[CacheEngineKey]]] = ContextVar(
+    "local_disk_keys_in_request", default=None
+)
+
+
+def _get_keys_in_request() -> List[CacheEngineKey]:
+    keys = _keys_in_request_var.get()
+    if keys is None:
+        keys = []
+        _keys_in_request_var.set(keys)
+    return keys
+
+
+def _take_keys_in_request() -> List[CacheEngineKey]:
+    keys = _keys_in_request_var.get()
+    _keys_in_request_var.set(None)
+    return keys if keys is not None else []
 
 
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
@@ -174,11 +196,6 @@ class LocalDiskBackend(StorageBackendInterface):
         self.max_cache_size = int(config.max_local_disk_size * 1024**3)
         self.current_cache_size = 0.0
 
-        # to help maintain suffix -> prefix order in the dict
-        # assumption: only one request is looked up at a time
-        # (only one worker per cache engine)
-        self.keys_in_request: List[CacheEngineKey] = []
-
         self.lmcache_worker = lmcache_worker
         self.instance_id = config.lmcache_instance_id
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
@@ -214,15 +231,15 @@ class LocalDiskBackend(StorageBackendInterface):
             if pin:
                 self.dict[key].pin()
                 # vllm lookup sets pin to True
-                self.keys_in_request.append(key)
+                _get_keys_in_request().append(key)
             return True
 
     def touch_cache(self):
         # flip the order of the keys in the request
         with self.disk_lock:
-            for key in reversed(self.keys_in_request):
+            keys_in_request = _take_keys_in_request()
+            for key in reversed(keys_in_request):
                 self.cache_policy.update_on_hit(key, self.dict)
-            self.keys_in_request = []
 
     def exists_in_put_tasks(self, key: CacheEngineKey) -> bool:
         return self.disk_worker.exists_in_put_tasks(key)
@@ -611,7 +628,7 @@ class LocalDiskBackend(StorageBackendInterface):
                     return num_hit_counts
                 if pin:
                     self.dict[key].pin()
-                    self.keys_in_request.append(key)
+                    _get_keys_in_request().append(key)
                 num_hit_counts += 1
         return num_hit_counts
 

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -725,65 +725,73 @@ class StorageManager:
         tier_expected_chunks = []
         # we also keep track of the keys for each tier and each chunk
         loading_task_keys: list[list[CacheEngineKey]] = []
-        for backend_name, backend in self.get_active_storage_backends(
-            search_range=search_range
-        ):
-            num_hit_keys_raw = await backend.batched_async_contains(
-                lookup_id, keys, pin
-            )
-            # Round down to a whole-chunk boundary. If a backend has only
-            # some of a chunk's per-layer keys (e.g., partial eviction),
-            # we treat the chunk as a miss to keep the chunk-level
-            # invariant required by the prefix-match retrieval pattern.
-            num_hit_chunks = num_hit_keys_raw // keys_per_chunk
-            num_hit_keys = num_hit_chunks * keys_per_chunk
-
-            # `pin=True` pins every matching key inside batched_async_contains.
-            # The rounded-off tail (keys[num_hit_keys:num_hit_keys_raw]) is
-            # dropped from backend_keys and never retrieved, so release those
-            # pins here to avoid leaking refcount budget.
-            if pin and num_hit_keys < num_hit_keys_raw:
-                for k in keys[num_hit_keys:num_hit_keys_raw]:
-                    backend.unpin(k)
-
-            if num_hit_chunks == 0:
-                continue
-
-            num_total_hit_chunks += num_hit_chunks
-            tier_expected_chunks.append(num_hit_chunks)
-
-            backend_keys = keys[:num_hit_keys]
-            loading_task_keys.append(backend_keys)
-
-            assert self.async_serializer is not None, (
-                "Async serializer must be initialized via post_init before using "
-                "async_lookup_and_prefetch."
-            )
-            # num_hit_chunks is only used for the multi serializer
-            get_coro = self.async_serializer.run(
-                backend.batched_get_non_blocking(
-                    lookup_id,
-                    backend_keys,
-                    {"cum_chunk_lengths": cum_chunk_lengths[: num_hit_chunks + 1]},
-                ),
-                num_hit_chunks,
-            )
-            loading_task = asyncio.create_task(get_coro)
-            loading_task.add_done_callback(
-                functools.partial(
-                    self.prefetch_single_done_callback,
-                    keys=keys,
-                    backend_name=backend_name,
+        try:
+            for backend_name, backend in self.get_active_storage_backends(
+                search_range=search_range
+            ):
+                num_hit_keys_raw = await backend.batched_async_contains(
+                    lookup_id, keys, pin
                 )
-            )
+                # Round down to a whole-chunk boundary. If a backend has only
+                # some of a chunk's per-layer keys (e.g., partial eviction),
+                # we treat the chunk as a miss to keep the chunk-level
+                # invariant required by the prefix-match retrieval pattern.
+                num_hit_chunks = num_hit_keys_raw // keys_per_chunk
+                num_hit_keys = num_hit_chunks * keys_per_chunk
 
-            loading_tasks.append(loading_task)
+                # `pin=True` pins every matching key inside batched_async_contains.
+                # The rounded-off tail (keys[num_hit_keys:num_hit_keys_raw]) is
+                # dropped from backend_keys and never retrieved, so release those
+                # pins here to avoid leaking refcount budget.
+                if pin and num_hit_keys < num_hit_keys_raw:
+                    for k in keys[num_hit_keys:num_hit_keys_raw]:
+                        backend.unpin(k)
 
-            cum_chunk_lengths = cum_chunk_lengths[num_hit_chunks:]
+                if num_hit_chunks == 0:
+                    continue
 
-            if num_total_hit_chunks == num_total_chunks:
-                break
-            keys = keys[num_hit_keys:]
+                num_total_hit_chunks += num_hit_chunks
+                tier_expected_chunks.append(num_hit_chunks)
+
+                backend_keys = keys[:num_hit_keys]
+                loading_task_keys.append(backend_keys)
+
+                assert self.async_serializer is not None, (
+                    "Async serializer must be initialized via post_init before using "
+                    "async_lookup_and_prefetch."
+                )
+                # num_hit_chunks is only used for the multi serializer
+                get_coro = self.async_serializer.run(
+                    backend.batched_get_non_blocking(
+                        lookup_id,
+                        backend_keys,
+                        {"cum_chunk_lengths": cum_chunk_lengths[: num_hit_chunks + 1]},
+                    ),
+                    num_hit_chunks,
+                )
+                loading_task = asyncio.create_task(get_coro)
+                loading_task.add_done_callback(
+                    functools.partial(
+                        self.prefetch_single_done_callback,
+                        keys=keys,
+                        backend_name=backend_name,
+                    )
+                )
+
+                loading_tasks.append(loading_task)
+
+                cum_chunk_lengths = cum_chunk_lengths[num_hit_chunks:]
+
+                if num_total_hit_chunks == num_total_chunks:
+                    break
+                keys = keys[num_hit_keys:]
+        finally:
+            # Record LRU hits for this request's pin=True contains. Must run
+            # even when there were zero hits, and must be request-scoped
+            # (ContextVar in local backends) so concurrent lookups cannot
+            # clear each other's keys (#4137).
+            if pin:
+                self.touch_cache()
 
         # If no chunks were hit across all backends, respond immediately and return.
         if num_total_hit_chunks == 0:

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+import asyncio
 import threading
 
 # Third Party
@@ -730,3 +731,92 @@ class TestLocalCPUBackendAllocatorAlignment:
             assert kwargs.get("align_bytes") == 4096
         finally:
             backend.memory_allocator.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_pin_lookups_isolate_keys_in_request(
+        self, local_cpu_backend
+    ):
+        """Concurrent pin lookups must not clear each other's keys (#4137)."""
+        key_a = create_test_key("key_a")
+        key_b = create_test_key("key_b")
+        mem_a = create_test_memory_obj()
+        mem_b = create_test_memory_obj()
+        local_cpu_backend.submit_put_task(key_a, mem_a)
+        local_cpu_backend.submit_put_task(key_b, mem_b)
+
+        touched: list[CacheEngineKey] = []
+        original_update_on_hit = local_cpu_backend.cache_policy.update_on_hit
+
+        def tracking_update_on_hit(key, cache_dict):
+            touched.append(key)
+            original_update_on_hit(key, cache_dict)
+
+        local_cpu_backend.cache_policy.update_on_hit = tracking_update_on_hit
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def lookup_one(lookup_id: str, key: CacheEngineKey, wait: bool):
+            n = await local_cpu_backend.batched_async_contains(
+                lookup_id, [key], pin=True
+            )
+            assert n == 1
+            if wait:
+                started.set()
+                await release.wait()
+            else:
+                await started.wait()
+                local_cpu_backend.touch_cache()
+                release.set()
+                return
+            local_cpu_backend.touch_cache()
+
+        # Request A records keys, then yields; B contains+touches (would wipe a
+        # shared list); A then touches and must still see its own keys.
+        await asyncio.gather(
+            lookup_one("a", key_a, wait=True),
+            lookup_one("b", key_b, wait=False),
+        )
+
+        assert set(touched) == {key_a, key_b}
+        local_cpu_backend.memory_allocator.close()
+
+    def test_threaded_pin_lookups_isolate_keys_in_request(self, local_cpu_backend):
+        """Thread-concurrent pin lookups must isolate keys_in_request (#4137)."""
+        key_a = create_test_key("threaded_a")
+        key_b = create_test_key("threaded_b")
+        local_cpu_backend.submit_put_task(key_a, create_test_memory_obj())
+        local_cpu_backend.submit_put_task(key_b, create_test_memory_obj())
+
+        touched: list[CacheEngineKey] = []
+        touch_lock = threading.Lock()
+        original_update_on_hit = local_cpu_backend.cache_policy.update_on_hit
+
+        def tracking_update_on_hit(key, cache_dict):
+            with touch_lock:
+                touched.append(key)
+            original_update_on_hit(key, cache_dict)
+
+        local_cpu_backend.cache_policy.update_on_hit = tracking_update_on_hit
+
+        barrier = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def lookup_one(key: CacheEngineKey):
+            try:
+                assert local_cpu_backend.contains(key, pin=True)
+                barrier.wait(timeout=5)
+                local_cpu_backend.touch_cache()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        t1 = threading.Thread(target=lookup_one, args=(key_a,))
+        t2 = threading.Thread(target=lookup_one, args=(key_b,))
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert not errors
+        assert set(touched) == {key_a, key_b}
+        local_cpu_backend.memory_allocator.close()

--- a/tests/v1/storage_backend/test_local_cpu_backend.py
+++ b/tests/v1/storage_backend/test_local_cpu_backend.py
@@ -733,6 +733,30 @@ class TestLocalCPUBackendAllocatorAlignment:
             backend.memory_allocator.close()
 
     @pytest.mark.asyncio
+    async def test_touch_cache_skips_keys_evicted_after_lookup(self, local_cpu_backend):
+        """A key can leave hot_cache between the pinning lookup and touch_cache().
+
+        The LRU policy's update_on_hit calls hot_cache.move_to_end(key), which raises
+        KeyError for a key that is gone. Isolating keys_in_request per request means
+        each request now touches its own keys instead of having them wiped by whoever
+        called touch_cache() first, so stale entries reach update_on_hit for the first
+        time and have to be skipped.
+        """
+        key = create_test_key("evicted_key")
+        local_cpu_backend.submit_put_task(key, create_test_memory_obj())
+
+        assert (
+            await local_cpu_backend.batched_async_contains("req", [key], pin=True) == 1
+        )
+
+        # Drop it behind the lookup's back, as an eviction or explicit removal would.
+        with local_cpu_backend.cpu_lock:
+            local_cpu_backend.hot_cache.pop(key)
+
+        # Must not raise.
+        local_cpu_backend.touch_cache()
+
+    @pytest.mark.asyncio
     async def test_concurrent_pin_lookups_isolate_keys_in_request(
         self, local_cpu_backend
     ):


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #4137. `LocalCPUBackend` / `LocalDiskBackend` kept a single instance-level `keys_in_request` list under the assumption that only one lookup runs at a time. Under concurrent pin=True lookups (interleaved coroutines on StorageManager's asyncio thread, or concurrent sync lookups on worker threads), one request's `touch_cache()` clears another request's keys before `cache_policy.update_on_hit()` runs. Resident prefixes then look cold to LRU and get evicted under write load, showing up as full-miss TTFT even with ample CPU-tier capacity.

This PR:
- Scopes the key list with `contextvars.ContextVar` (per asyncio task / per thread) in both local backends
- Calls `touch_cache()` from `async_lookup_and_prefetch` when `pin=True`, so the async connector path actually records hits (previously keys were appended but never touched on that path)
- Adds asyncio + threaded regression tests for isolation

**Special notes for your reviewers**:

- `threading.local()` is not enough here: all async lookups share one OS thread on the storage-manager loop.
- Prometheus `local_cpu_keys_in_request_count` now reads the ContextVar (typically 0 on the scrape thread between requests, same practical behavior as an empty list between lookups).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

Made with [Cursor](https://cursor.com)