### PR TITLE
[feat]: strided fused-K re-RoPE for vLLM packed KV

### DIFF
--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -153,3 +153,12 @@ LMC_KV_FORMAT_HD constexpr bool is_mla(EngineKVFormat f) {
   return f == EngineKVFormat::NL_X_NB_BS_HS ||   // vLLM MLA
          f == EngineKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
 }
+
+// vLLM fused K/V: K and V packed into the trailing dim (2 * head_size) with no
+// separate K/V axis. The device transfer kernels treat these as a single
+// k_or_v == 0 pass whose per-head copy width is 2 * head_size, so each head copy
+// moves the packed K+V pair (like MLA's single-plane transfer).
+LMC_KV_FORMAT_HD constexpr bool is_fused_packed(EngineKVFormat f) {
+  return f == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||  // fused HND
+         f == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS;    // fused NHD
+}

--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -156,8 +156,8 @@ LMC_KV_FORMAT_HD constexpr bool is_mla(EngineKVFormat f) {
 
 // vLLM fused K/V: K and V packed into the trailing dim (2 * head_size) with no
 // separate K/V axis. The device transfer kernels treat these as a single
-// k_or_v == 0 pass whose per-head copy width is 2 * head_size, so each head copy
-// moves the packed K+V pair (like MLA's single-plane transfer).
+// k_or_v == 0 pass whose per-head copy width is 2 * head_size, so each head
+// copy moves the packed K+V pair (like MLA's single-plane transfer).
 LMC_KV_FORMAT_HD constexpr bool is_fused_packed(EngineKVFormat f) {
   return f == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||  // fused HND
          f == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS;    // fused NHD

--- a/csrc/engine_kv_format.h
+++ b/csrc/engine_kv_format.h
@@ -154,10 +154,8 @@ LMC_KV_FORMAT_HD constexpr bool is_mla(EngineKVFormat f) {
          f == EngineKVFormat::NL_X_NBBS_ONE_HS;  // SGLang MLA
 }
 
-// vLLM fused K/V: K and V packed into the trailing dim (2 * head_size) with no
-// separate K/V axis. The device transfer kernels treat these as a single
-// k_or_v == 0 pass whose per-head copy width is 2 * head_size, so each head
-// copy moves the packed K+V pair (like MLA's single-plane transfer).
+// vLLM fused K/V: K and V packed in the trailing dim (2 * head_size), no
+// separate K/V axis — transferred as one k_or_v == 0 pass (like MLA).
 LMC_KV_FORMAT_HD constexpr bool is_fused_packed(EngineKVFormat f) {
   return f == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS ||  // fused HND
          f == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS;    // fused NHD

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -285,10 +285,8 @@ __device__ __forceinline__ int64_t page_buffer_offset(
            head_idx * block_size * head_size + block_offset * head_size +
            head_offset;
   }
-  // vllm fused-K/V (HND) — physical: [NB, NH, BS, 2*HS], K and V packed in the
-  // trailing dim. Same head-decomposed HND addressing as NL_X_TWO_NB_NH_BS_HS,
-  // but there is no separate K/V plane (k_or_v is always 0) and the per-head
-  // copy width is 2*head_size, so each head copy moves the packed K+V pair.
+  // Fused-K/V HND: [NB, NH, BS, 2*HS]. HND addressing like NL_X_TWO_NB_NH_BS_HS
+  // but no K/V plane (k_or_v == 0) and per-head width 2*head_size (K+V packed).
   else if constexpr (format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS) {
     const int hs2 = 2 * head_size;  // packed K+V width per head (xword units)
     const int block_idx = token_idx / block_size;
@@ -299,10 +297,8 @@ __device__ __forceinline__ int64_t page_buffer_offset(
     return block_idx * num_heads * block_size * hs2 +
            head_idx * block_size * hs2 + block_offset * hs2 + head_offset;
   }
-  // vllm fused-K/V (NHD) — physical: [NB, BS, NH, 2*HS], tokens before heads.
-  // token_idx already encodes block * block_size + block_offset, so the packed
-  // per-token stride (scalars_per_token = NH * 2*HS) lands directly on the
-  // slot; no separate K/V plane (k_or_v is always 0).
+  // Fused-K/V NHD: [NB, BS, NH, 2*HS]. token_idx already encodes the slot, so
+  // the packed per-token stride lands directly on it (k_or_v == 0).
   else if constexpr (format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS) {
     return token_idx * scalars_per_token + scalar_offset;
   }
@@ -564,8 +560,7 @@ void multi_layer_kv_transfer_templated(
   lmc::check_block_size(engine_kv_format, block_size);
   lmc::check_head_size(engine_kv_format, head_size_xword);
 
-  // Fused K/V packs both planes in the trailing dim (kv_size == 1, like MLA),
-  // so there is a single k_or_v == 0 pass rather than separate K and V passes.
+  // Fused packs K+V in the trailing dim (kv_size == 1, like MLA): single pass.
   int k_or_v_size =
       (::is_mla(engine_kv_format) || ::is_fused_packed(engine_kv_format)) ? 1
                                                                           : 2;

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -301,8 +301,8 @@ __device__ __forceinline__ int64_t page_buffer_offset(
   }
   // vllm fused-K/V (NHD) — physical: [NB, BS, NH, 2*HS], tokens before heads.
   // token_idx already encodes block * block_size + block_offset, so the packed
-  // per-token stride (scalars_per_token = NH * 2*HS) lands directly on the slot;
-  // no separate K/V plane (k_or_v is always 0).
+  // per-token stride (scalars_per_token = NH * 2*HS) lands directly on the
+  // slot; no separate K/V plane (k_or_v is always 0).
   else if constexpr (format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS) {
     return token_idx * scalars_per_token + scalar_offset;
   }

--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -285,6 +285,27 @@ __device__ __forceinline__ int64_t page_buffer_offset(
            head_idx * block_size * head_size + block_offset * head_size +
            head_offset;
   }
+  // vllm fused-K/V (HND) — physical: [NB, NH, BS, 2*HS], K and V packed in the
+  // trailing dim. Same head-decomposed HND addressing as NL_X_TWO_NB_NH_BS_HS,
+  // but there is no separate K/V plane (k_or_v is always 0) and the per-head
+  // copy width is 2*head_size, so each head copy moves the packed K+V pair.
+  else if constexpr (format == EngineKVFormat::NL_X_NB_NH_BS_TWO_HS) {
+    const int hs2 = 2 * head_size;  // packed K+V width per head (xword units)
+    const int block_idx = token_idx / block_size;
+    const int block_offset = token_idx % block_size;
+    const int head_idx = scalar_offset / hs2;
+    const int head_offset = scalar_offset % hs2;
+    const int num_heads = scalars_per_token / hs2;
+    return block_idx * num_heads * block_size * hs2 +
+           head_idx * block_size * hs2 + block_offset * hs2 + head_offset;
+  }
+  // vllm fused-K/V (NHD) — physical: [NB, BS, NH, 2*HS], tokens before heads.
+  // token_idx already encodes block * block_size + block_offset, so the packed
+  // per-token stride (scalars_per_token = NH * 2*HS) lands directly on the slot;
+  // no separate K/V plane (k_or_v is always 0).
+  else if constexpr (format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS) {
+    return token_idx * scalars_per_token + scalar_offset;
+  }
 }
 
 __device__ __forceinline__ int64_t page_buffer_offset_unilateral(
@@ -543,7 +564,11 @@ void multi_layer_kv_transfer_templated(
   lmc::check_block_size(engine_kv_format, block_size);
   lmc::check_head_size(engine_kv_format, head_size_xword);
 
-  int k_or_v_size = ::is_mla(engine_kv_format) ? 1 : 2;
+  // Fused K/V packs both planes in the trailing dim (kv_size == 1, like MLA),
+  // so there is a single k_or_v == 0 pass rather than separate K and V passes.
+  int k_or_v_size =
+      (::is_mla(engine_kv_format) || ::is_fused_packed(engine_kv_format)) ? 1
+                                                                          : 2;
 
   dim3 grid(num_transfer_tokens, num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));
@@ -578,6 +603,14 @@ void multi_layer_kv_transfer_templated(
         LAUNCH_KERNEL_WITH_FORMAT(T, false,
                                   EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
         break;
+      case EngineKVFormat::NL_X_NB_NH_BS_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_NH_BS_TWO_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_BS_NH_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_BS_NH_TWO_HS);
+        break;
       default:
         throw std::runtime_error("Unsupported EngineKVFormat");
     }
@@ -607,6 +640,14 @@ void multi_layer_kv_transfer_templated(
       case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:
         LAUNCH_KERNEL_WITH_FORMAT(T, true,
                                   EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_NH_BS_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_NH_BS_TWO_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_BS_NH_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_BS_NH_TWO_HS);
         break;
       default:
         throw std::runtime_error("Unsupported EngineKVFormat");

--- a/csrc/pos_kernels.cu
+++ b/csrc/pos_kernels.cu
@@ -59,8 +59,7 @@ inline __device__ void apply_rotary_embedding_fused(
                                  // head_size]
     const scalar_t* old_cache_ptr, const scalar_t* new_cache_ptr,
     const int head_size, const int num_kv_heads, const int rot_dim,
-    const int token_idx, const int64_t key_stride,
-    const int64_t head_stride) {
+    const int token_idx, const int64_t key_stride, const int64_t head_stride) {
   const int embed_dim = rot_dim / 2;
   const scalar_t* old_cos_ptr = old_cache_ptr;
   const scalar_t* old_sin_ptr = old_cache_ptr + embed_dim;
@@ -115,10 +114,12 @@ __global__ void rotary_embedding_kernel_fused(
 // [.., num_kv_heads, 2*head_size]) pass head_stride = 2*head_size so only the
 // K half of each head is rotated in place (V, the trailing head_size, is left
 // untouched). rot_dim (<= head_size) bounds the rotation, so V is never read.
-void rotary_embedding_k_fused_strided(
-    const torch::Tensor& old_positions, const torch::Tensor& new_positions,
-    torch::Tensor& key, int64_t head_size, int64_t head_stride,
-    const torch::Tensor& cos_sin_cache, bool is_neox) {
+void rotary_embedding_k_fused_strided(const torch::Tensor& old_positions,
+                                      const torch::Tensor& new_positions,
+                                      torch::Tensor& key, int64_t head_size,
+                                      int64_t head_stride,
+                                      const torch::Tensor& cos_sin_cache,
+                                      bool is_neox) {
   int64_t num_tokens = key.numel() / (key.size(-1) * key.size(-2));
   int rot_dim = cos_sin_cache.size(1);
   int num_kv_heads = key.size(-2);
@@ -149,10 +150,11 @@ void rotary_embedding_k_fused_strided(
 }
 
 // Contiguous [num_tokens, num_kv_heads, head_size]: head_stride == head_size.
-void rotary_embedding_k_fused(
-    const torch::Tensor& old_positions, const torch::Tensor& new_positions,
-    torch::Tensor& key, int64_t head_size,
-    const torch::Tensor& cos_sin_cache, bool is_neox) {
+void rotary_embedding_k_fused(const torch::Tensor& old_positions,
+                              const torch::Tensor& new_positions,
+                              torch::Tensor& key, int64_t head_size,
+                              const torch::Tensor& cos_sin_cache,
+                              bool is_neox) {
   rotary_embedding_k_fused_strided(old_positions, new_positions, key, head_size,
                                    head_size, cos_sin_cache, is_neox);
 }

--- a/csrc/pos_kernels.cu
+++ b/csrc/pos_kernels.cu
@@ -108,12 +108,10 @@ __global__ void rotary_embedding_kernel_fused(
 
 }  // namespace lmc
 
-// General form: ``head_stride`` is the element distance between consecutive
-// heads in ``key``. For a contiguous [num_tokens, num_kv_heads, head_size]
-// buffer it equals head_size; for vLLM's fused K/V (K and V packed as
-// [.., num_kv_heads, 2*head_size]) pass head_stride = 2*head_size so only the
-// K half of each head is rotated in place (V, the trailing head_size, is left
-// untouched). rot_dim (<= head_size) bounds the rotation, so V is never read.
+// head_stride: element distance between consecutive heads in `key`. Contiguous
+// [num_tokens, num_kv_heads, head_size] passes head_size; fused K/V (packed
+// [.., num_kv_heads, 2*head_size]) passes 2*head_size to rotate only the K half
+// in place (rot_dim <= head_size, so the trailing V is never touched).
 void rotary_embedding_k_fused_strided(const torch::Tensor& old_positions,
                                       const torch::Tensor& new_positions,
                                       torch::Tensor& key, int64_t head_size,

--- a/csrc/pos_kernels.cu
+++ b/csrc/pos_kernels.cu
@@ -59,7 +59,8 @@ inline __device__ void apply_rotary_embedding_fused(
                                  // head_size]
     const scalar_t* old_cache_ptr, const scalar_t* new_cache_ptr,
     const int head_size, const int num_kv_heads, const int rot_dim,
-    const int token_idx, const int64_t key_stride) {
+    const int token_idx, const int64_t key_stride,
+    const int64_t head_stride) {
   const int embed_dim = rot_dim / 2;
   const scalar_t* old_cos_ptr = old_cache_ptr;
   const scalar_t* old_sin_ptr = old_cache_ptr + embed_dim;
@@ -70,7 +71,7 @@ inline __device__ void apply_rotary_embedding_fused(
   const int nk = num_kv_heads * embed_dim;
   for (int i = threadIdx.x; i < nk; i += blockDim.x) {
     const int head_idx = i / embed_dim;
-    const int64_t token_head = token_idx * key_stride + head_idx * head_size;
+    const int64_t token_head = token_idx * key_stride + head_idx * head_stride;
     const int rot_offset = i % embed_dim;
     apply_token_rotary_embedding_fused<scalar_t, IS_NEOX>(
         key + token_head, old_cos_ptr, old_sin_ptr, new_cos_ptr, new_sin_ptr,
@@ -92,7 +93,7 @@ __global__ void rotary_embedding_kernel_fused(
     const scalar_t* __restrict__ cos_sin_cache,  // [max_position, 2, rot_dim //
                                                  // 2]
     const int rot_dim, const int64_t key_stride, const int num_kv_heads,
-    const int head_size) {
+    const int head_size, const int64_t head_stride) {
   // Each thread block is responsible for one token.
   const int token_idx = blockIdx.x;
   int64_t old_pos = old_positions[token_idx];
@@ -103,25 +104,25 @@ __global__ void rotary_embedding_kernel_fused(
 
   apply_rotary_embedding_fused<scalar_t, IS_NEOX>(
       key, old_cache_ptr, new_cache_ptr, head_size, num_kv_heads, rot_dim,
-      token_idx, key_stride);
+      token_idx, key_stride, head_stride);
 }
 
 }  // namespace lmc
 
-void rotary_embedding_k_fused(
-    const torch::Tensor&
-        old_positions,  // [batch_size, seq_len] or [num_tokens]
-    const torch::Tensor&
-        new_positions,   // [batch_size, seq_len] or [num_tokens]
-    torch::Tensor& key,  // [batch_size, seq_len, num_kv_heads * head_size] or
-                         // Jiayi: [num_tokens, num_kv_heads, head_size]
-    int64_t head_size,
-    const torch::Tensor& cos_sin_cache,  // [max_position, rot_dim]
-    bool is_neox) {
+// General form: ``head_stride`` is the element distance between consecutive
+// heads in ``key``. For a contiguous [num_tokens, num_kv_heads, head_size]
+// buffer it equals head_size; for vLLM's fused K/V (K and V packed as
+// [.., num_kv_heads, 2*head_size]) pass head_stride = 2*head_size so only the
+// K half of each head is rotated in place (V, the trailing head_size, is left
+// untouched). rot_dim (<= head_size) bounds the rotation, so V is never read.
+void rotary_embedding_k_fused_strided(
+    const torch::Tensor& old_positions, const torch::Tensor& new_positions,
+    torch::Tensor& key, int64_t head_size, int64_t head_stride,
+    const torch::Tensor& cos_sin_cache, bool is_neox) {
   int64_t num_tokens = key.numel() / (key.size(-1) * key.size(-2));
   int rot_dim = cos_sin_cache.size(1);
   int num_kv_heads = key.size(-2);
-  int64_t key_stride = num_kv_heads * head_size;
+  int64_t key_stride = num_kv_heads * head_stride;
 
   dim3 grid(num_tokens);
   dim3 block(std::min<int64_t>(num_kv_heads * rot_dim / 2, 512));
@@ -135,14 +136,23 @@ void rotary_embedding_k_fused(
                   old_positions.data_ptr<int64_t>(),
                   new_positions.data_ptr<int64_t>(), key.data_ptr<scalar_t>(),
                   cos_sin_cache.data_ptr<scalar_t>(), rot_dim, key_stride,
-                  num_kv_heads, head_size);
+                  num_kv_heads, head_size, head_stride);
         } else {
           lmc::rotary_embedding_kernel_fused<scalar_t, false>
               <<<grid, block, 0, stream>>>(
                   old_positions.data_ptr<int64_t>(),
                   new_positions.data_ptr<int64_t>(), key.data_ptr<scalar_t>(),
                   cos_sin_cache.data_ptr<scalar_t>(), rot_dim, key_stride,
-                  num_kv_heads, head_size);
+                  num_kv_heads, head_size, head_stride);
         }
       });
+}
+
+// Contiguous [num_tokens, num_kv_heads, head_size]: head_stride == head_size.
+void rotary_embedding_k_fused(
+    const torch::Tensor& old_positions, const torch::Tensor& new_positions,
+    torch::Tensor& key, int64_t head_size,
+    const torch::Tensor& cos_sin_cache, bool is_neox) {
+  rotary_embedding_k_fused_strided(old_positions, new_positions, key, head_size,
+                                   head_size, cos_sin_cache, is_neox);
 }

--- a/csrc/pos_kernels.cuh
+++ b/csrc/pos_kernels.cuh
@@ -9,3 +9,13 @@ void rotary_embedding_k_fused(const torch::Tensor& old_positions,
                               const torch::Tensor& new_positions,
                               torch::Tensor& key, int64_t head_size,
                               const torch::Tensor& cos_sin_cache, bool is_neox);
+
+// Like rotary_embedding_k_fused but with an explicit per-head element stride
+// (head_stride). Contiguous keys pass head_stride == head_size; fused-K/V keys
+// pass 2*head_size to rotate only the K half in place. See pos_kernels.cu.
+void rotary_embedding_k_fused_strided(const torch::Tensor& old_positions,
+                                      const torch::Tensor& new_positions,
+                                      torch::Tensor& key, int64_t head_size,
+                                      int64_t head_stride,
+                                      const torch::Tensor& cos_sin_cache,
+                                      bool is_neox);

--- a/csrc/pos_kernels.cuh
+++ b/csrc/pos_kernels.cuh
@@ -10,9 +10,8 @@ void rotary_embedding_k_fused(const torch::Tensor& old_positions,
                               torch::Tensor& key, int64_t head_size,
                               const torch::Tensor& cos_sin_cache, bool is_neox);
 
-// Like rotary_embedding_k_fused but with an explicit per-head element stride
-// (head_stride). Contiguous keys pass head_stride == head_size; fused-K/V keys
-// pass 2*head_size to rotate only the K half in place. See pos_kernels.cu.
+// rotary_embedding_k_fused with an explicit per-head stride: contiguous keys
+// pass head_size; fused K/V pass 2*head_size to rotate only the K half.
 void rotary_embedding_k_fused_strided(const torch::Tensor& old_positions,
                                       const torch::Tensor& new_positions,
                                       torch::Tensor& key, int64_t head_size,

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -74,6 +74,7 @@ PYBIND11_MODULE(c_ops, m) {
   m.def("decode_fast_prefsum", &decode_cuda_prefsum);
   m.def("calculate_cdf", &calculate_cdf);
   m.def("rotary_embedding_k_fused", &rotary_embedding_k_fused);
+  m.def("rotary_embedding_k_fused_strided", &rotary_embedding_k_fused_strided);
   m.def("alloc_pinned_ptr", &alloc_pinned_ptr,
         py::call_guard<py::gil_scoped_release>());
   m.def("free_pinned_ptr", &free_pinned_ptr);

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -2762,23 +2762,9 @@ def rotary_embedding_k_fused_strided(
     cos_sin_cache: torch.Tensor,
     is_neox: bool,
 ) -> None:
-    """Strided variant of rotary_embedding_k_fused.
-
-    ``key``'s last dim is ``head_stride`` per head; rotate only the leading
-    ``head_size`` elements (the K half of a packed K/V pair) in place, leaving
-    the trailing ``head_stride - head_size`` (the V half) untouched. When
-    ``head_stride == head_size`` this is exactly ``rotary_embedding_k_fused``.
-    The leading ``head_size`` slice is a view, so the in-place rotation writes
-    back through to ``key``.
-
-    Args:
-        old_positions: Token positions whose rotary embedding to reverse.
-        new_positions: Token positions whose rotary embedding to apply.
-        key: Key tensor to update in-place (last dim packs K then V per head).
-        head_size: Rotated (K) width per head.
-        head_stride: Full per-head element stride (e.g. 2 * head_size for fused).
-        cos_sin_cache: Precomputed cosine/sine cache indexed by position.
-        is_neox: If True, uses NeoX-style rotary; otherwise GPT-J-style.
+    """Strided rotary_embedding_k_fused: ``key``'s last dim is ``head_stride``
+    per head; rotate only the leading ``head_size`` (K) in place via a view,
+    leaving the trailing V. ``head_stride == head_size`` is the contiguous case.
     """
     rotary_embedding_k_fused(
         old_positions,

--- a/lmcache/python_ops_fallback.py
+++ b/lmcache/python_ops_fallback.py
@@ -2753,6 +2753,43 @@ def rotary_embedding_k_fused(
         key[..., 1:rot_dim:2] = y_out
 
 
+def rotary_embedding_k_fused_strided(
+    old_positions: torch.Tensor,
+    new_positions: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    head_stride: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    """Strided variant of rotary_embedding_k_fused.
+
+    ``key``'s last dim is ``head_stride`` per head; rotate only the leading
+    ``head_size`` elements (the K half of a packed K/V pair) in place, leaving
+    the trailing ``head_stride - head_size`` (the V half) untouched. When
+    ``head_stride == head_size`` this is exactly ``rotary_embedding_k_fused``.
+    The leading ``head_size`` slice is a view, so the in-place rotation writes
+    back through to ``key``.
+
+    Args:
+        old_positions: Token positions whose rotary embedding to reverse.
+        new_positions: Token positions whose rotary embedding to apply.
+        key: Key tensor to update in-place (last dim packs K then V per head).
+        head_size: Rotated (K) width per head.
+        head_stride: Full per-head element stride (e.g. 2 * head_size for fused).
+        cos_sin_cache: Precomputed cosine/sine cache indexed by position.
+        is_neox: If True, uses NeoX-style rotary; otherwise GPT-J-style.
+    """
+    rotary_embedding_k_fused(
+        old_positions,
+        new_positions,
+        key[..., :head_size],
+        head_size,
+        cos_sin_cache,
+        is_neox,
+    )
+
+
 def get_gpu_pci_bus_id(device_id: int = 0) -> str | None:
     """
     Get the PCI bus ID via CUDA/ROCm runtime.

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1470,10 +1470,8 @@ class BlendV3Module(InstanceLivenessTarget):
                 for slot_idx in range(batch_len)
             ]
             kv_size = all_slots[0].shape[0]
-            # vLLM's fused blocks-first K/V formats pack K and V into a doubled
-            # head dim and report kv_size==1 (the K/V axis stays packed inside
-            # each head copy). Detect them so the K half is re-RoPE'd in place
-            # via the strided kernel; everything else must be genuine K/V.
+            # Fused blocks-first K/V pack K+V into a doubled head dim
+            # (kv_size==1); detect so only the K half is re-RoPE'd in place.
             _ekf = getattr(group, "engine_kv_format", None)
             fused_packed = _ekf is not None and int(_ekf) in (
                 int(lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
@@ -1485,8 +1483,7 @@ class BlendV3Module(InstanceLivenessTarget):
                     "and fused-packed K/V layouts are supported (MLA unsupported)."
                 )
             num_layers, slots, hidden_dim = all_slots[0].shape[1:]
-            # Fused-packed: each head is [K(head_size) | V(head_size)], so the
-            # per-head width is 2*head_size and only the K half is rotated.
+            # Fused-packed: per-head width is 2*head_size; only K is rotated.
             per_head = rope_state.head_size * (2 if fused_packed else 1)
             n_heads = hidden_dim // per_head
             if n_heads * per_head != hidden_dim:
@@ -1517,8 +1514,7 @@ class BlendV3Module(InstanceLivenessTarget):
                     num_layers * slots, n_heads, per_head
                 )
                 if fused_packed:
-                    # Strided kernel rotates only the first head_size (K) of each
-                    # per-head 2*head_size slot in place, leaving V untouched.
+                    # Strided kernel rotates only the K half of each slot.
                     lmc_ops.rotary_embedding_k_fused_strided(
                         old_st + slot_positions_rep,
                         cur_st + slot_positions_rep,

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1469,17 +1469,29 @@ class BlendV3Module(InstanceLivenessTarget):
                 gpu_context.get_temp_kernel_group_buffer(slot_idx, group_idx)
                 for slot_idx in range(batch_len)
             ]
-            if all_slots[0].shape[0] != 2:
+            kv_size = all_slots[0].shape[0]
+            # vLLM's fused blocks-first K/V formats pack K and V into a doubled
+            # head dim and report kv_size==1 (the K/V axis stays packed inside
+            # each head copy). Detect them so the K half is re-RoPE'd in place
+            # via the strided kernel; everything else must be genuine K/V.
+            fused_packed = int(group.engine_kv_format) in (
+                int(lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
+                int(lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS),
+            )
+            if kv_size != 2 and not fused_packed:
                 raise RuntimeError(
-                    f"CB v3: group {group_idx} has kv_size={all_slots[0].shape[0]}; "
-                    "MLA layouts unsupported."
+                    f"CB v3: group {group_idx} has kv_size={kv_size}; only K/V (2) "
+                    "and fused-packed K/V layouts are supported (MLA unsupported)."
                 )
             num_layers, slots, hidden_dim = all_slots[0].shape[1:]
-            n_heads = hidden_dim // rope_state.head_size
-            if n_heads * rope_state.head_size != hidden_dim:
+            # Fused-packed: each head is [K(head_size) | V(head_size)], so the
+            # per-head width is 2*head_size and only the K half is rotated.
+            per_head = rope_state.head_size * (2 if fused_packed else 1)
+            n_heads = hidden_dim // per_head
+            if n_heads * per_head != hidden_dim:
                 raise RuntimeError(
-                    f"CB rope: group {group_idx} hidden_dim ({hidden_dim}) "
-                    f"not a multiple of head_size ({rope_state.head_size})."
+                    f"CB rope: group {group_idx} hidden_dim ({hidden_dim}) not a "
+                    f"multiple of per-head width ({per_head}; fused={fused_packed})."
                 )
             # Per-group rope cache: dual-RoPE models rotate each
             # kernel group with its own theta's cos/sin.
@@ -1501,16 +1513,29 @@ class BlendV3Module(InstanceLivenessTarget):
             for slot_idx, old_st, cur_st in slots_to_rope:
                 # reshape returns an in-place view (tmp slots are contiguous).
                 k_view = all_slots[slot_idx][0].reshape(
-                    num_layers * slots, n_heads, rope_state.head_size
+                    num_layers * slots, n_heads, per_head
                 )
-                lmc_ops.rotary_embedding_k_fused(
-                    old_st + slot_positions_rep,
-                    cur_st + slot_positions_rep,
-                    k_view,
-                    rope_state.head_size,
-                    group_cos_sin,
-                    rope_state.is_neox_style,
-                )
+                if fused_packed:
+                    # Strided kernel rotates only the first head_size (K) of each
+                    # per-head 2*head_size slot in place, leaving V untouched.
+                    lmc_ops.rotary_embedding_k_fused_strided(
+                        old_st + slot_positions_rep,
+                        cur_st + slot_positions_rep,
+                        k_view,
+                        rope_state.head_size,
+                        per_head,  # head_stride: hop over the packed V half
+                        group_cos_sin,
+                        rope_state.is_neox_style,
+                    )
+                else:
+                    lmc_ops.rotary_embedding_k_fused(
+                        old_st + slot_positions_rep,
+                        cur_st + slot_positions_rep,
+                        k_view,
+                        rope_state.head_size,
+                        group_cos_sin,
+                        rope_state.is_neox_style,
+                    )
 
     def cb_retrieve_pre_computed(
         self,

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1474,7 +1474,8 @@ class BlendV3Module(InstanceLivenessTarget):
             # head dim and report kv_size==1 (the K/V axis stays packed inside
             # each head copy). Detect them so the K half is re-RoPE'd in place
             # via the strided kernel; everything else must be genuine K/V.
-            fused_packed = int(group.engine_kv_format) in (
+            _ekf = group.engine_kv_format
+            fused_packed = _ekf is not None and int(_ekf) in (
                 int(lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
                 int(lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS),
             )

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -1474,7 +1474,7 @@ class BlendV3Module(InstanceLivenessTarget):
             # head dim and report kv_size==1 (the K/V axis stays packed inside
             # each head copy). Detect them so the K half is re-RoPE'd in place
             # via the strided kernel; everything else must be genuine K/V.
-            _ekf = group.engine_kv_format
+            _ekf = getattr(group, "engine_kv_format", None)
             fused_packed = _ekf is not None and int(_ekf) in (
                 int(lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS),
                 int(lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS),

--- a/tests/v1/test_fused_rerope.py
+++ b/tests/v1/test_fused_rerope.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused-K/V CacheBlend re-RoPE: correctness + efficiency of the two ways to
+rotate only the K half of a packed ``[.., num_kv_heads, 2*head_size]`` buffer.
+
+* Option 1 (no new kernel): gather K into a contiguous ``[T, H, head_size]``
+  buffer, rotate with the existing ``rotary_embedding_k_fused``, scatter back.
+* Option 2 (strided kernel, #4128 follow-up): ``rotary_embedding_k_fused_strided``
+  with ``head_stride = 2*head_size`` rotates K in place, hopping over V.
+
+Option 1 uses the trusted contiguous kernel, so it is the correctness reference;
+Option 2 must match its K exactly and leave V byte-identical. Run directly for
+the timing comparison:  ``python tests/v1/test_fused_rerope.py``
+"""
+
+# Standard
+import time
+
+# Third Party
+import torch
+
+try:
+    import pytest
+
+    _skipif = pytest.mark.skipif
+except Exception:  # allow running as a plain script (bench) without pytest
+    def _skipif(*_a, **_k):
+        return lambda f: f
+
+# First Party
+import lmcache.c_ops as lmc_ops
+
+_CUDA = torch.cuda.is_available()
+
+
+def _make_inputs(n_tokens, n_heads, head_size, max_pos, dtype, device, seed=0):
+    g = torch.Generator(device=device).manual_seed(seed)
+    # Packed per head: [K(head_size) | V(head_size)] -> [T, H, 2, head_size].
+    packed = torch.randn(
+        n_tokens, n_heads, 2, head_size, dtype=dtype, device=device, generator=g
+    )
+    old_pos = torch.randint(0, max_pos, (n_tokens,), dtype=torch.int64, device=device)
+    new_pos = torch.randint(0, max_pos, (n_tokens,), dtype=torch.int64, device=device)
+    # Real rotary cos_sin_cache: [max_pos, rot_dim] with rot_dim == head_size,
+    # cos in [:head_size//2], sin in [head_size//2:] (matches the kernel). Unit
+    # magnitude -> repeated in-place rotation in the bench stays bounded.
+    half = head_size // 2
+    inv_freq = 1.0 / (10000.0 ** (torch.arange(0, half, device=device).float() / half))
+    ang = torch.outer(torch.arange(max_pos, device=device).float(), inv_freq)
+    cos_sin = torch.cat([ang.cos(), ang.sin()], dim=1).to(dtype)
+    return packed, old_pos, new_pos, cos_sin
+
+
+def _option1_copy(packed, old_pos, new_pos, cos_sin, head_size, is_neox=True):
+    """Gather K contiguous -> existing kernel -> scatter back (in place)."""
+    t, h = packed.shape[0], packed.shape[1]
+    k = packed[:, :, 0, :].reshape(t, h, head_size).contiguous()
+    lmc_ops.rotary_embedding_k_fused(old_pos, new_pos, k, head_size, cos_sin, is_neox)
+    packed[:, :, 0, :] = k.reshape(t, h, head_size)
+
+
+def _option2_strided(packed, old_pos, new_pos, cos_sin, head_size, is_neox=True):
+    """Strided kernel: rotate the K half in place (head_stride = 2*head_size)."""
+    t, h = packed.shape[0], packed.shape[1]
+    view = packed.reshape(t, h, 2 * head_size)  # contiguous view
+    lmc_ops.rotary_embedding_k_fused_strided(
+        old_pos, new_pos, view, head_size, 2 * head_size, cos_sin, is_neox
+    )
+
+
+@_skipif(not _CUDA, reason="requires CUDA + built c_ops")
+def test_option2_matches_option1_and_preserves_v():
+    dev, dtype = "cuda", torch.bfloat16
+    packed, old_pos, new_pos, cos_sin = _make_inputs(
+        n_tokens=512, n_heads=8, head_size=64, max_pos=4096, dtype=dtype, device=dev
+    )
+    p0 = packed.clone()          # original (for V-untouched check)
+    p1, p2 = packed.clone(), packed.clone()
+
+    _option1_copy(p1, old_pos, new_pos, cos_sin, 64)
+    _option2_strided(p2, old_pos, new_pos, cos_sin, 64)
+    torch.cuda.synchronize()
+
+    # K rotated identically by both paths.
+    assert torch.equal(p1[:, :, 0, :], p2[:, :, 0, :]), "option2 K != option1 K"
+    # V left byte-identical by both paths.
+    assert torch.equal(p2[:, :, 1, :], p0[:, :, 1, :]), "option2 modified V"
+    assert torch.equal(p1[:, :, 1, :], p0[:, :, 1, :]), "option1 modified V"
+    # And re-RoPE actually changed K (sanity: not a no-op).
+    assert not torch.equal(p2[:, :, 0, :], p0[:, :, 0, :]), "K unchanged (no-op?)"
+
+
+def _bench(fn, packed, *args, iters=200):
+    # In place, no per-iter clone, so the timing isolates the op (not a full
+    # KV clone). Bounded rotary cos/sin keeps repeated rotation numerically safe.
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn(packed, *args)
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3  # ms/iter
+
+
+@_skipif(not _CUDA, reason="requires CUDA + built c_ops")
+def test_bench_option1_vs_option2(capsys):
+    # Timing report; run with `pytest -s` to see the table.
+    with capsys.disabled():
+        main()
+
+
+def main():
+    if not _CUDA:
+        print("CUDA unavailable; skipping fused re-RoPE bench")
+        return
+    dev, dtype = "cuda", torch.bfloat16
+    print(f"{'config (T x H x D)':>22} | {'opt1 copy':>10} | {'opt2 strided':>12} | speedup")
+    for t, h, d in [(512, 8, 64), (2048, 8, 128), (4096, 16, 128), (8192, 8, 128)]:
+        packed, old_pos, new_pos, cos_sin = _make_inputs(t, h, d, 16384, dtype, dev)
+        # warmup (compile/caches)
+        _option1_copy(packed.clone(), old_pos, new_pos, cos_sin, d)
+        _option2_strided(packed.clone(), old_pos, new_pos, cos_sin, d)
+        ms1 = _bench(_option1_copy, packed, old_pos, new_pos, cos_sin, d)
+        ms2 = _bench(_option2_strided, packed, old_pos, new_pos, cos_sin, d)
+        print(f"{t:>6} x {h:>2} x {d:>3}       | {ms1:>8.4f}ms | {ms2:>10.4f}ms | "
+              f"{ms1 / ms2:>5.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/v1/test_fused_rerope.py
+++ b/tests/v1/test_fused_rerope.py
@@ -30,9 +30,18 @@ except Exception:  # allow running as a plain script (bench) without pytest
 
 
 # First Party
-import lmcache.c_ops as lmc_ops
+try:
+    # First Party
+    import lmcache.c_ops as lmc_ops
 
-_CUDA = torch.cuda.is_available()
+    _HAS_STRIDED = hasattr(lmc_ops, "rotary_embedding_k_fused_strided")
+except Exception:  # CPU-only / no built c_ops (e.g. the unit-test runner)
+    lmc_ops = None
+    _HAS_STRIDED = False
+
+# These tests need CUDA and the built c_ops carrying the strided kernel; without
+# both they skip cleanly (keeps CPU-only pytest collection from erroring).
+_REQ = torch.cuda.is_available() and _HAS_STRIDED
 
 
 def _make_inputs(n_tokens, n_heads, head_size, max_pos, dtype, device, seed=0):
@@ -70,7 +79,7 @@ def _option2_strided(packed, old_pos, new_pos, cos_sin, head_size, is_neox=True)
     )
 
 
-@_skipif(not _CUDA, reason="requires CUDA + built c_ops")
+@_skipif(not _REQ, reason="requires CUDA + built c_ops")
 def test_option2_matches_option1_and_preserves_v():
     dev, dtype = "cuda", torch.bfloat16
     packed, old_pos, new_pos, cos_sin = _make_inputs(
@@ -103,7 +112,7 @@ def _bench(fn, packed, *args, iters=200):
     return (time.perf_counter() - t0) / iters * 1e3  # ms/iter
 
 
-@_skipif(not _CUDA, reason="requires CUDA + built c_ops")
+@_skipif(not _REQ, reason="requires CUDA + built c_ops")
 def test_bench_option1_vs_option2(capsys):
     # Timing report; run with `pytest -s` to see the table.
     with capsys.disabled():
@@ -111,7 +120,7 @@ def test_bench_option1_vs_option2(capsys):
 
 
 def main():
-    if not _CUDA:
+    if not _REQ:
         print("CUDA unavailable; skipping fused re-RoPE bench")
         return
     dev, dtype = "cuda", torch.bfloat16

--- a/tests/v1/test_fused_rerope.py
+++ b/tests/v1/test_fused_rerope.py
@@ -19,12 +19,15 @@ import time
 import torch
 
 try:
+    # Third Party
     import pytest
 
     _skipif = pytest.mark.skipif
 except Exception:  # allow running as a plain script (bench) without pytest
+
     def _skipif(*_a, **_k):
         return lambda f: f
+
 
 # First Party
 import lmcache.c_ops as lmc_ops
@@ -73,7 +76,7 @@ def test_option2_matches_option1_and_preserves_v():
     packed, old_pos, new_pos, cos_sin = _make_inputs(
         n_tokens=512, n_heads=8, head_size=64, max_pos=4096, dtype=dtype, device=dev
     )
-    p0 = packed.clone()          # original (for V-untouched check)
+    p0 = packed.clone()  # original (for V-untouched check)
     p1, p2 = packed.clone(), packed.clone()
 
     _option1_copy(p1, old_pos, new_pos, cos_sin, 64)
@@ -112,7 +115,10 @@ def main():
         print("CUDA unavailable; skipping fused re-RoPE bench")
         return
     dev, dtype = "cuda", torch.bfloat16
-    print(f"{'config (T x H x D)':>22} | {'opt1 copy':>10} | {'opt2 strided':>12} | speedup")
+    print(
+        f"{'config (T x H x D)':>22} | {'opt1 copy':>10} | "
+        f"{'opt2 strided':>12} | speedup"
+    )
     for t, h, d in [(512, 8, 64), (2048, 8, 128), (4096, 16, 128), (8192, 8, 128)]:
         packed, old_pos, new_pos, cos_sin = _make_inputs(t, h, d, 16384, dtype, dev)
         # warmup (compile/caches)
@@ -120,8 +126,10 @@ def main():
         _option2_strided(packed.clone(), old_pos, new_pos, cos_sin, d)
         ms1 = _bench(_option1_copy, packed, old_pos, new_pos, cos_sin, d)
         ms2 = _bench(_option2_strided, packed, old_pos, new_pos, cos_sin, d)
-        print(f"{t:>6} x {h:>2} x {d:>3}       | {ms1:>8.4f}ms | {ms2:>10.4f}ms | "
-              f"{ms1 / ms2:>5.2f}x")
+        print(
+            f"{t:>6} x {h:>2} x {d:>3}       | {ms1:>8.4f}ms | {ms2:>10.4f}ms | "
+            f"{ms1 / ms2:>5.2f}x"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/v1/test_fused_rerope.py
+++ b/tests/v1/test_fused_rerope.py
@@ -1,15 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Fused-K/V CacheBlend re-RoPE: correctness + efficiency of the two ways to
-rotate only the K half of a packed ``[.., num_kv_heads, 2*head_size]`` buffer.
+"""Fused-K/V CacheBlend re-RoPE: rotate the K half of a packed
+``[.., num_kv_heads, 2*head_size]`` buffer two ways and compare.
 
-* Option 1 (no new kernel): gather K into a contiguous ``[T, H, head_size]``
-  buffer, rotate with the existing ``rotary_embedding_k_fused``, scatter back.
-* Option 2 (strided kernel, #4128 follow-up): ``rotary_embedding_k_fused_strided``
-  with ``head_stride = 2*head_size`` rotates K in place, hopping over V.
-
-Option 1 uses the trusted contiguous kernel, so it is the correctness reference;
-Option 2 must match its K exactly and leave V byte-identical. Run directly for
-the timing comparison:  ``python tests/v1/test_fused_rerope.py``
+Option 1 (reference): gather K contiguous -> rotary_embedding_k_fused -> scatter.
+Option 2: rotary_embedding_k_fused_strided rotates K in place. Option 2 must
+match Option 1's K exactly and leave V byte-identical.
+Run for the timing table: ``python tests/v1/test_fused_rerope.py``.
 """
 
 # Standard


### PR DESCRIPTION
vLLM's packed KV layout stores K and V interleaved per head as [.., num_kv_heads, 2*head_size] (lmcache formats NL_X_NB_NH_BS_TWO_HS / NL_X_NB_BS_NH_TWO_HS, kv_size=1). CacheBlend's re-RoPE only rotates the K half, but rotary_embedding_k_fused assumes a contiguous [.., num_kv_heads, head_size] key buffer.

Add rotary_embedding_k_fused_strided: the rotary device functions take an explicit per-head element stride (head_stride), so K can be rotated in place over the packed buffer by passing head_stride = 2*head_size (V, the trailing head_size, is left untouched). The original rotary_embedding_k_fused delegates with head_stride = head_size, so all existing callers are unchanged.

blend_v3._apply_cb_rope_batched detects the fused-packed formats and routes to the strided kernel instead of rejecting them as MLA.

tests/v1/test_fused_rerope.py validates the strided kernel against a copy-based reference (contiguous gather -> existing kernel -> scatter): K bit-identical, V byte-identical, and the strided path is 2.4-3.6x faster (no gather/scatter of the K half).

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
