### PR TITLE
docs(production): add HPC/Slurm deployment guide under new orchestration section

### DIFF
--- a/docs/source/production/index.rst
+++ b/docs/source/production/index.rst
@@ -7,7 +7,5 @@ Deploying, scaling, and operating LMCache in production.
    :maxdepth: 2
 
    /mp/deployment
-   /production/kubernetes_deployment
-   /mp/operator
+   /production/orchestration/index
    /developer_guide/extending_lmcache/runtime_plugins
-   /production/dynamo_coordination

--- a/docs/source/production/orchestration/index.rst
+++ b/docs/source/production/orchestration/index.rst
@@ -1,0 +1,21 @@
+.. _orchestration:
+
+Orchestration
+=============
+
+This section groups LMCache deployment substrates. Each subsection documents
+its own launch topology, networking, connector, and storage requirements.
+
+- **Kubernetes** -- long-lived pods, managed by the Deployment manifests or the
+  LMCache Operator.
+- **NVIDIA Dynamo** -- multi-engine coordination.
+- **HPC / Slurm** -- batch jobs on a shared-filesystem supercomputing cluster
+  with a rootless container runtime and offline compute nodes.
+
+.. toctree::
+   :maxdepth: 2
+
+   /production/kubernetes_deployment
+   /mp/operator
+   /production/dynamo_coordination
+   slurm_hpc/index

--- a/docs/source/production/orchestration/slurm_hpc/container_runtime.rst
+++ b/docs/source/production/orchestration/slurm_hpc/container_runtime.rst
@@ -1,0 +1,115 @@
+.. _hpc_container_runtime:
+
+Rootless container runtime
+==========================
+
+Many shared HPC systems do not grant users root access or expose a Docker
+daemon on compute nodes. In that environment, containers commonly run through a
+**rootless runtime** such as Apptainer (formerly Singularity) or Singularity
+CE, and the runtime's node-local socket paths must stay within the Unix
+path-length limit. This page covers obtaining an image and keeping the IPC
+socket path short; it is used by the
+:ref:`single-node sbatch template <hpc_single_node_submission>`.
+
+.. contents::
+   :local:
+   :depth: 1
+
+Obtain a container image on a login node
+----------------------------------------
+
+In the fully offline compute-node profile assumed by this guide, build or
+convert the image on a login node (which has internet) and store the resulting
+``.sif`` on shared storage.
+
+**Option A -- convert an official image (simplest):**
+
+.. code-block:: bash
+
+    # On a login node, with internet access.
+    export PROJECT=<shared_fs_path>/lmcache              # your shared project directory
+    export APPTAINER_CACHEDIR=$PROJECT/apptainer_cache   # keep cache off $HOME
+    apptainer build $PROJECT/lmcache.sif \
+        docker://lmcache/vllm-openai:v0.5.1     # version validated by this guide
+
+No root and no ``--fakeroot`` is needed for this conversion -- Apptainer
+performs it fully rootless (harmless ``setxattr`` warnings during unpacking are
+expected). Check the available tags on
+`Docker Hub <https://hub.docker.com/r/lmcache/vllm-openai/tags>`_. Replace this
+tag only after validating the LMCache/vLLM combination required by your
+deployment.
+
+.. warning::
+
+   For reproducible HPC deployments, **pin a mutually compatible
+   LMCache/vLLM image tag and validate it before staging to offline compute
+   nodes**. Nightly images may change KV-cache layouts or native-kernel
+   support between builds, and on a cluster you cannot quickly iterate images
+   from a compute node, so a broken image costs a full stage-build-submit
+   cycle.
+
+.. note::
+
+   Dated example of the above: the ``latest-nightly`` image pulled on
+   2026-07-16 (vLLM 0.23.1-nightly + LMCache 0.5.2.dev52) failed at the first
+   KV store with ``RuntimeError: Unsupported EngineKVFormat`` (issue
+   `#4111 <https://github.com/LMCache/LMCache/issues/4111>`_, fixed by
+   `PR #4128 <https://github.com/LMCache/LMCache/pull/4128>`_ on 2026-07-17),
+   while the pinned ``v0.5.1`` release worked end-to-end on the same cluster.
+   The failure is specific to that build; the takeaway is the pin-and-validate
+   workflow, not any particular tag.
+
+**Option B -- build from a definition file** when you need extra site packages
+or a pinned LMCache version:
+
+.. code-block:: bash
+
+    apptainer build --fakeroot $PROJECT/lmcache.sif lmcache.def
+
+.. note::
+
+   ``--fakeroot`` requires uid/gid mappings in ``/etc/subuid`` / ``/etc/subgid``,
+   which many HPC sites do not provision. If it is unavailable, build the
+   ``.sif`` where you do have privileges (a workstation, or a remote builder)
+   and copy the file to ``$PROJECT`` -- or stick with Option A, which needs no
+   privileges at all.
+
+.. _hpc_ipc_socket_path:
+
+Avoid the IPC socket path length limit
+--------------------------------------
+
+LMCache multiprocess mode uses ZMQ ``ipc://`` Unix-domain sockets for
+lookup/offload RPC. A Unix-domain socket pathname is limited to **107 usable
+bytes** (``sockaddr_un.sun_path`` is a 108-byte array including the trailing
+``NUL``). LMCache builds the path as::
+
+    {base}/engine_{engine_id}_service_{service}_lmcache_rpc_port_{port}
+
+where ``base`` comes from vLLM's ``VLLM_RPC_BASE_PATH``, which **defaults to
+the system temp directory and therefore follows ``$TMPDIR``** (LMCache falls
+back to ``/tmp/vllm_rpc`` only when vLLM is not importable). HPC schedulers
+commonly point ``$TMPDIR`` at a long per-job scratch path -- and with a UUID
+engine id the suffix alone is already ~80 bytes, so the socket path
+overflows and the worker aborts with::
+
+    zmq.error.ZMQError: ipc path "/p/scratch/.../engine_<uuid>_service_lookup_
+    lmcache_rpc_port_1" is longer than 107 characters
+
+(reported from a real supercomputer in issue
+`#3529 <https://github.com/LMCache/LMCache/issues/3529>`_). Point
+``VLLM_RPC_BASE_PATH`` at a **short, node-local** directory -- IPC socket files
+are tiny, so node-local ``/tmp`` or ``/dev/shm`` is ideal and keeps the path
+short:
+
+.. code-block:: bash
+
+    export VLLM_RPC_BASE_PATH=/tmp/lmc_$SLURM_JOB_ID
+    mkdir -p "$VLLM_RPC_BASE_PATH"
+
+.. note::
+
+   A fix that keeps the generated path within the limit is proposed in
+   `PR #3530 <https://github.com/LMCache/LMCache/pull/3530>`_. Until PR #3530
+   is merged and included in the LMCache version you deploy, set
+   ``VLLM_RPC_BASE_PATH`` to a short node-local directory.

--- a/docs/source/production/orchestration/slurm_hpc/index.rst
+++ b/docs/source/production/orchestration/slurm_hpc/index.rst
@@ -1,0 +1,182 @@
+.. _hpc_deployment:
+
+HPC / Slurm deployment (Apptainer, rootless, shared filesystem)
+===============================================================
+
+This section covers running LMCache on HPC / supercomputing clusters. It is
+written as a recipe for the common *restricted* HPC profile below; not every
+site imposes every restriction, so skip the parts yours does not:
+
+- **Jobs run under a batch scheduler** (Slurm ``sbatch`` / ``srun``) rather than
+  a long-lived container or Kubernetes pod.
+- **You do not have root.** Containers run with a rootless runtime
+  (Apptainer / Singularity) instead of the Docker daemon.
+- **Storage is a shared parallel filesystem** (Lustre / GPFS / BeeGFS) mounted
+  on every node, plus possibly small node-local scratch.
+- **Compute-node internet access is restricted or absent at many sites.** This
+  guide assumes the fully offline case: anything that would normally be
+  downloaded at runtime (model weights, tokenizers, pip packages, container
+  images) is staged from a login node first.
+
+Each of these dimensions is covered on its own page:
+
+.. toctree::
+   :maxdepth: 2
+
+   container_runtime
+   shared_filesystem
+   offline_staging
+
+.. contents::
+   :local:
+   :depth: 2
+
+This section assumes you already understand the generic LMCache + engine wiring
+in :doc:`/getting_started/quickstart` and :doc:`/mp/deployment`; it only adds
+the HPC-specific pieces.
+
+Prerequisites
+-------------
+
+- A cluster with Slurm and either **Apptainer** (formerly Singularity) or
+  **Singularity CE**. Check with ``apptainer --version`` or
+  ``singularity --version`` on a login node.
+- A GPU partition with NVIDIA GPUs and a compatible driver on the compute nodes.
+- A directory on the shared filesystem you can write to from both login and
+  compute nodes (referred to below as ``$PROJECT``; substitute your site's
+  shared-filesystem location).
+
+.. note::
+
+   The exact container image tags, module names, and partition names below are
+   placeholders. Substitute the values for your site.
+
+Once you have staged an image (:doc:`container_runtime`), staged your models
+(:doc:`offline_staging`), and chosen a KV cache path (:doc:`shared_filesystem`),
+the pieces come together in a single-node batch job.
+
+.. _hpc_single_node_submission:
+
+Single-node Slurm submission
+----------------------------
+
+A minimal ``sbatch`` script that runs the LMCache-enabled engine inside
+Apptainer on one GPU node:
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH --job-name=lmcache-serve
+    #SBATCH --partition=<gpu_partition>
+    #SBATCH --nodes=1
+    #SBATCH --gres=gpu:1
+    #SBATCH --cpus-per-task=12
+    #SBATCH --time=01:00:00
+
+    set -euo pipefail
+
+    export PROJECT=<shared_fs_path>/lmcache
+
+    # Offline model cache (see "Network-less / offline model staging")
+    export HF_HOME=$PROJECT/hf_cache
+    export HF_HUB_OFFLINE=1
+    export TRANSFORMERS_OFFLINE=1
+
+    # LMCache KV tiers (single-GPU job -> one disk path; for multi-GPU list
+    # one path per GPU -- see "Shared filesystem")
+    export LMCACHE_CHUNK_SIZE=256
+    export LMCACHE_LOCAL_CPU=True
+    export LMCACHE_MAX_LOCAL_CPU_SIZE=20
+    export LMCACHE_LOCAL_DISK="file://$PROJECT/kv_cache"
+    export LMCACHE_MAX_LOCAL_DISK_SIZE=100
+
+    # Short node-local IPC base (see "Rootless container runtime")
+    export VLLM_RPC_BASE_PATH=/tmp/lmc_$SLURM_JOB_ID
+    mkdir -p "$VLLM_RPC_BASE_PATH"
+
+    apptainer exec --nv \
+        --bind "$PROJECT" \
+        --bind "$VLLM_RPC_BASE_PATH" \
+        $PROJECT/lmcache.sif \
+        vllm serve <org/model> \
+            --kv-transfer-config \
+            '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
+
+Key HPC-specific flags:
+
+- ``apptainer exec --nv`` -- exposes the NVIDIA driver/GPUs to the container
+  (the rootless equivalent of ``docker run --gpus all``).
+- ``--bind`` -- paths outside the runtime's default bind set must be passed
+  explicitly with ``--bind``. Explicit binding also makes the job independent
+  of site-specific Apptainer defaults. Bind ``$PROJECT`` (model cache + KV
+  cache) and the node-local IPC base.
+- ``--gres=gpu:N`` -- request GPUs from Slurm; ``--nv`` then passes them through.
+- ``--cpus-per-task`` -- sites often cap CPUs per allocated GPU (e.g. 12); an
+  over-ask is rejected at submit time.
+
+This uses the **in-process** connector (``LMCacheConnectorV1``), which needs no
+extra server process inside the job.
+
+.. note::
+
+   **Multiprocess (MP) mode under a scheduler is not yet covered here.** For MP
+   mode (a separate ``lmcache server`` plus ``LMCacheMPConnector``) see
+   :doc:`/mp/deployment`; the container, offline, path, and IPC rules in this
+   section apply the same way, but the MP topology under Slurm/Apptainer has not
+   been exercised in this guide -- validate it on your cluster before relying on
+   it.
+
+Multi-node notes
+----------------
+
+.. warning::
+
+   This section is a starting point, not a validated recipe. Multi-node LMCache
+   on HPC needs to be confirmed on the target cluster before relying on it.
+
+- **IPC sockets are per-node.** ``VLLM_RPC_BASE_PATH`` must resolve to a
+  node-local path on *every* node (``/tmp/...`` or ``/dev/shm/...``), never the
+  shared filesystem, both for the 107-byte pathname limit and because
+  Unix-domain sockets do not work across nodes.
+- **Disk-tier paths give no node-level isolation by themselves.** ``by_gpu``
+  path sharding selects from the configured path list by *node-local* GPU
+  index, so identical lists on different nodes select the same entries; keep
+  the disk tier on node-local scratch, or have the launcher generate per-node
+  paths (see :doc:`shared_filesystem`).
+- **Cross-node cache sharing** goes through a remote backend
+  (``LMCACHE_REMOTE_URL``, e.g. a Redis/Valkey/S3-compatible endpoint reachable
+  on the cluster network), not through the node-local tiers.
+- **Interconnect:** high-speed fabrics (InfiniBand / Slingshot) affect
+  remote-backend and disaggregated-prefill throughput; confirm the container
+  can use the fabric (bind the relevant devices/libraries).
+
+Known pitfalls at a glance
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Symptom
+     - Fix
+   * - ``ZMQError: ipc path ... longer than 107 characters``
+     - Set ``VLLM_RPC_BASE_PATH`` to a short node-local dir
+       (:doc:`container_runtime`, `#3529
+       <https://github.com/LMCache/LMCache/issues/3529>`_).
+   * - Model download hangs / fails on a compute node
+     - Pre-stage into ``HF_HOME`` on shared FS; set ``HF_HUB_OFFLINE=1``
+       (:doc:`offline_staging`).
+   * - Container cannot see GPUs
+     - Use ``apptainer exec --nv`` and request ``--gres=gpu``
+       (:ref:`sbatch template <hpc_single_node_submission>`).
+   * - ``FileNotFoundError`` for a path that exists on the host
+     - The path is outside the container runtime's default bind set; pass it
+       explicitly with ``--bind``
+       (:ref:`sbatch template <hpc_single_node_submission>`).
+   * - Engine dies on the first KV store (e.g.
+       ``Unsupported EngineKVFormat``)
+     - vLLM/LMCache mismatch inside the image -- pin a mutually compatible
+       release tag and validate before staging (:doc:`container_runtime`).
+   * - Restarted job ignores the KV cache files from the previous run
+     - Expected today: the disk-tier index is in-memory only and is not
+       rebuilt from existing files (:doc:`shared_filesystem`).

--- a/docs/source/production/orchestration/slurm_hpc/offline_staging.rst
+++ b/docs/source/production/orchestration/slurm_hpc/offline_staging.rst
@@ -1,0 +1,40 @@
+.. _hpc_offline_staging:
+
+Network-less / offline model staging
+====================================
+
+Many HPC sites **restrict or fully block outbound internet on compute nodes**.
+This page assumes the fully offline case: anything that would normally be
+downloaded at runtime -- model weights, tokenizers, pip packages -- is staged
+from a login node first. It covers staging the model and tokenizer into a
+Hugging Face cache on the shared filesystem, then running fully offline; it is
+used by the :ref:`single-node sbatch template <hpc_single_node_submission>`.
+
+Pre-download the model **and** tokenizer into a Hugging Face cache on the
+shared filesystem from a login node (which has internet), then run fully
+offline inside the job. With current ``huggingface_hub`` releases the CLI is
+``hf`` (the old ``huggingface-cli`` entry point is deprecated and refuses to
+run):
+
+.. code-block:: bash
+
+    # On a login node.
+    export PROJECT=<shared_fs_path>/lmcache              # your shared project directory
+    export HF_HOME=$PROJECT/hf_cache
+    hf download <org/model>
+
+Inside the job, point the container at that cache and forbid network access so a
+missing file fails fast instead of hanging on a blocked download:
+
+.. code-block:: bash
+
+    export HF_HOME=$PROJECT/hf_cache
+    export HF_HUB_OFFLINE=1
+    export TRANSFORMERS_OFFLINE=1
+
+Bind-mount ``$HF_HOME`` into the container (see the
+:ref:`single-node sbatch template <hpc_single_node_submission>`).
+
+With ``HF_HUB_OFFLINE=1``, a model that is missing from the cache fails
+immediately with a clear "couldn't connect" error instead of stalling on the
+compute node's blocked network -- stage every model you plan to serve.

--- a/docs/source/production/orchestration/slurm_hpc/shared_filesystem.rst
+++ b/docs/source/production/orchestration/slurm_hpc/shared_filesystem.rst
@@ -1,0 +1,57 @@
+.. _hpc_shared_filesystem:
+
+Shared filesystem (KV cache paths)
+==================================
+
+On HPC clusters the primary storage is a **shared parallel filesystem**
+(Lustre / GPFS / BeeGFS) mounted on every node, often alongside small
+node-local scratch. This page covers where to put LMCache's disk tier; it is
+used by the :ref:`single-node sbatch template <hpc_single_node_submission>`.
+
+LMCache's disk tier is controlled by ``LMCACHE_LOCAL_DISK`` (a ``file://`` URI
+or bare path; comma-separate several) and capped by
+``LMCACHE_MAX_LOCAL_DISK_SIZE`` (GB). On HPC you must decide **where** that path
+lives:
+
+- **Node-local NVMe / scratch** (e.g. ``/local/$SLURM_JOB_ID``): lowest latency,
+  gone when the job ends. **Usually the right choice** -- within a job the disk
+  tier acts as spill capacity below the CPU-RAM tier.
+- **Shared parallel filesystem** (``$PROJECT``): the KV files survive the job
+  and the disk tier works correctly on Lustre/GPFS, **but a new process does
+  not reuse them**: the disk tier's index lives in memory and is not rebuilt
+  from existing files on startup, so a restarted engine treats the old files
+  as a miss and re-stores them. Do not choose the shared filesystem expecting
+  warm-start across jobs.
+
+.. code-block:: bash
+
+    export PROJECT=<shared_fs_path>/lmcache       # your shared project directory
+    export LMCACHE_CHUNK_SIZE=256
+    export LMCACHE_LOCAL_CPU=True
+    export LMCACHE_MAX_LOCAL_CPU_SIZE=20          # GB of pinned host memory
+    export LMCACHE_LOCAL_DISK="file://$PROJECT/kv_cache"
+    export LMCACHE_MAX_LOCAL_DISK_SIZE=100        # GB
+
+Multiple GPUs and path sharding
+-------------------------------
+
+``LMCACHE_LOCAL_DISK`` accepts a comma-separated list of paths, and
+``LMCACHE_LOCAL_DISK_PATH_SHARDING=by_gpu`` (the default and currently the only
+strategy) makes each worker select **one of the listed paths** --
+``paths[device_id % len(paths)]``, where ``device_id`` is the worker's
+node-local GPU index. No per-GPU subdirectories are created: with a single
+configured path, every GPU on the node writes into that same directory.
+
+- **Single node, multiple GPUs:** list one path per GPU explicitly, e.g. for a
+  4-GPU job on node-local scratch:
+
+  .. code-block:: bash
+
+      export LMCACHE_LOCAL_DISK=/local/$SLURM_JOB_ID/cache0,/local/$SLURM_JOB_ID/cache1,/local/$SLURM_JOB_ID/cache2,/local/$SLURM_JOB_ID/cache3
+
+- **Multiple nodes:** GPU indices restart at 0 on every node, so identical path
+  lists on different nodes select the same entries. Node-local paths (as above)
+  are naturally isolated per node. If the listed paths are on the shared
+  filesystem, ``by_gpu`` provides **no node-level isolation** -- have your
+  launcher generate per-node paths (e.g. embed ``$SLURM_NODEID`` or the
+  hostname in the path), or use a remote backend for cross-node sharing.


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #4126. Adds an HPC deployment guide for running LMCache on Slurm clusters with a rootless container runtime (Apptainer/Singularity CE), a shared parallel filesystem (Lustre/GPFS), and offline compute nodes — an environment the current docs don't cover (demand examples: #3529, #4049).

It implements the structure @sammshen suggested on the tracking issue: Kubernetes, Dynamo, and the new HPC/Slurm docs are grouped under a single **orchestration** section inside *Use LMCache in Production*, and the HPC guide is split into the three environment subtopics (rootless container runtime / shared filesystem / network-less offline staging):

```
production/
├── index.rst                      →  Deployment Guide, Orchestration, Runtime Plugins
└── orchestration/
    ├── index.rst                  →  Kubernetes Deployment, Kubernetes Operator,
    │                                 Dynamo Integration, HPC / Slurm
    └── slurm_hpc/
        ├── index.rst              (overview + single-node sbatch + multi-node + pitfalls)
        ├── container_runtime.rst  (rootless image build + ipc:// socket path limit, refs #3529)
        ├── shared_filesystem.rst  (KV disk-tier paths, by_gpu sharding semantics, restart behavior)
        └── offline_staging.rst    (hf download staging + HF_HUB_OFFLINE)
```

The existing Kubernetes/Operator/Dynamo pages are re-parented **via toctree only** — files and built URLs are unchanged; only the sidebar grouping moves.

**Special notes for your reviewers**:

- The single-node workflow (docker→SIF conversion, offline model staging, disk-tier config, IPC socket paths, the sbatch template, and an in-session KV-cache hit) was validated end-to-end on a real Slurm + Apptainer 1.4.3 + Lustre cluster with one H200 GPU using the `v0.5.1` image.
- Multi-node topologies and MP mode under Slurm are **explicitly marked in the text as unvalidated starting points** (warning/note admonitions), not presented as supported recipes.
- Sphinx builds with zero new warnings vs `dev`; all cross-references resolve.
- Happy to collapse the three subtopics into one page or move things around if you'd prefer a different granularity.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
