### PR TITLE
refactor(platfrom): Use DeviceSpec registry for cache context

### DIFF
--- a/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
+++ b/docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst
@@ -290,10 +290,15 @@ checks — both must succeed, otherwise the factory raises
 
 Separately, the LMCache-driven server module also requires a
 ``BaseCacheContext`` subclass under
-``lmcache/v1/platform/foo/cache_context.py``.  ``create_cache_context``
-discovers it lazily at runtime and raises ``ValueError`` if no backend
-matches the device type; it manages the KV cache layout and pointers
-used for IPC transfer.
+``lmcache/v1/platform/foo/cache_context.py`` **and** a matching
+``DeviceSpec.create_cache_context`` override that lazy-imports and
+instantiates it.  The platform-agnostic factory
+``lmcache.v1.platform.cache_context.create_cache_context`` dispatches
+by ``device_type`` through the ``DeviceSpec`` registry and invokes
+that hook; the default ``DeviceSpec.create_cache_context`` raises
+``NotImplementedError`` so a missing override surfaces loudly instead
+of silently falling back.  The cache context itself manages the KV
+cache layout and pointers used for IPC transfer.
 
 Host-side pinning via ``pin_memory_backend`` is *optional* and only
 affects staging-buffer performance; it is not required to enable
@@ -326,6 +331,16 @@ Override these methods in your ``DeviceSpec``:
             Optional; only affects host staging performance.
             """
             return None  # default
+
+        def create_cache_context(self, *args, **kwargs):
+            """Lazy-import and instantiate the BaseCacheContext for this device.
+
+            Required for LMCache-driven mode; the base-class default
+            raises ``NotImplementedError``.
+            """
+            from lmcache.v1.platform.foo.cache_context import FooCacheContext
+
+            return FooCacheContext(*args, **kwargs)
 
 Opt into LMCache-driven mode by setting ``lmcache.mp.mp_transfer_mode``
 to ``lmcache_driven`` in the vLLM ``kv_connector_extra_config`` shown

--- a/lmcache/v1/platform/base_device_spec.py
+++ b/lmcache/v1/platform/base_device_spec.py
@@ -27,13 +27,14 @@ empty string (concrete backends -- including CPU via
 from __future__ import annotations
 
 # Standard
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 # First Party
 from lmcache.v1.platform.base_pin_memory import PinMemoryBackend
 
 if TYPE_CHECKING:
     # First Party
+    from lmcache.v1.platform.base_cache_context import BaseCacheContext
     from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
 
 
@@ -163,3 +164,26 @@ class DeviceSpec:
     def is_pin_supported(self) -> bool:
         """Whether the current platform supports memory pinning."""
         return self._get_pin_backend().is_pin_supported
+
+    # ------------------------------------------------------------------
+    # Cache context factory
+    # ------------------------------------------------------------------
+
+    def create_cache_context(self, *args: Any, **kwargs: Any) -> "BaseCacheContext":
+        """Instantiate the ``BaseCacheContext`` implementation for this device.
+
+        Subclasses that ship a ``cache_context`` module (e.g. ``cuda``,
+        ``cpu``) must override this hook: perform a lazy import of the
+        concrete subclass and forward ``*args`` / ``**kwargs`` verbatim
+        so the call site in
+        :func:`lmcache.v1.platform.cache_context.create_cache_context`
+        stays backend-agnostic.
+
+        The default implementation raises :class:`NotImplementedError`
+        so a missing override surfaces loudly instead of silently
+        falling back to the CPU path.
+        """
+        raise NotImplementedError(
+            "DeviceSpec for device_type=%r does not provide a "
+            "BaseCacheContext implementation." % self.device_type
+        )

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -42,6 +42,9 @@ from lmcache.v1.platform import get_device_spec
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 
 if TYPE_CHECKING:
+    # Standard
+    from collections.abc import Callable
+
     # First Party
     from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 
@@ -63,7 +66,7 @@ logger = init_logger(__name__)
 _BACKEND_OVERRIDES: dict[str, type] = {}
 
 
-def _resolve_factory(device_type: str):
+def _resolve_factory(device_type: str) -> "Callable[..., BaseCacheContext]":
     """Return a zero-arg-ready callable that builds a cache context.
 
     Overrides installed via :func:`restore_backends` win over the

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -9,18 +9,21 @@ The concrete implementations live in their respective sub-packages:
   CPU-only fallback (POSIX-SHM-backed KV tensors).
 
 :func:`create_cache_context` keeps the dispatch out of the call site
-in :mod:`lmcache.v1.multiprocess.server`. Selection is data-driven:
-each backend sub-package ships its own
-:class:`~lmcache.v1.platform.base_cache_context.BaseCacheContext`
-subclass under ``platform/<backend>/cache_context.py`` and declares
-the ``torch.device.type`` it handles via the
-:attr:`BaseCacheContext.device_type` ClassVar. The first
-:func:`create_cache_context` call discovers those subclasses with
-:func:`lmcache.v1.utils.subclass_discovery.discover_subclasses` and
-memoises the resulting ``device_type -> class`` map. Adding a new
-accelerator therefore requires *zero* edits to this module -- just
-drop a new ``platform/<backend>/cache_context.py`` whose subclass
-sets ``device_type``.
+in :mod:`lmcache.v1.multiprocess.server`. Selection is data-driven
+and delegated to the :class:`~lmcache.v1.platform.base_device_spec.
+DeviceSpec` registry maintained by :mod:`lmcache.v1.platform`: each
+backend sub-package ships a ``DeviceSpec`` subclass whose
+``create_cache_context`` hook lazy-imports and instantiates the
+matching :class:`~lmcache.v1.platform.base_cache_context.
+BaseCacheContext`. Adding a new accelerator therefore requires
+*zero* edits to this module -- just implement
+``DeviceSpec.create_cache_context`` in the sub-package's
+``__init__.py``.
+
+Tests can still swap in fakes without touching the ``DeviceSpec``
+registry via the :func:`snapshot_backends` / :func:`restore_backends`
+overrides: any ``device_type`` present in the override table wins
+over the registry lookup.
 """
 
 # Future
@@ -35,8 +38,8 @@ from lmcache.logging import init_logger
 from lmcache.utils import EngineType
 from lmcache.v1.gpu_connector.utils import LayoutHints
 from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.platform import get_device_spec
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
-from lmcache.v1.utils.subclass_discovery import discover_subclasses
 
 if TYPE_CHECKING:
     # First Party
@@ -44,99 +47,63 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-# ``device_type -> BaseCacheContext`` subclass.  Populated lazily on
-# the first :func:`create_cache_context` call by scanning the
-# ``platform`` package for ``cache_context`` leaf modules at depth 2
-# (i.e. ``platform/<backend>/cache_context.py``).  Tests substitute
-# entries via :func:`snapshot_backends` / :func:`restore_backends`.
+# ``device_type -> BaseCacheContext`` subclass override table.
+#
+# Empty by default: production dispatch flows through the
+# ``DeviceSpec`` registry (see :func:`_resolve_factory`).  Tests
+# install fakes here via :func:`snapshot_backends` /
+# :func:`restore_backends`; any device type registered here wins over
+# the ``DeviceSpec`` hook so a single test can shadow a real backend
+# without mutating the shared registry.
 #
 # The value type is the loose ``type`` (rather than
 # ``type[BaseCacheContext]``) so callers can instantiate it with the
 # concrete subclass' positional ``__init__`` signature without mypy
 # resolving the abstract-base ``__init__`` instead.
-_BACKENDS: dict[str, type] = {}
-_BACKENDS_DISCOVERED: bool = False
+_BACKEND_OVERRIDES: dict[str, type] = {}
 
 
-def _discover_backends_once() -> None:
-    """Populate :data:`_BACKENDS` on first use.
+def _resolve_factory(device_type: str):
+    """Return a zero-arg-ready callable that builds a cache context.
 
-    Walks ``lmcache.v1.platform`` two levels deep (``platform`` ->
-    ``<backend>`` -> ``cache_context``) and indexes every concrete
-    :class:`BaseCacheContext` subclass by its ``device_type``
-    ClassVar.  Subclasses with an empty ``device_type`` are skipped
-    with a warning so a missing override surfaces loudly instead of
-    silently shadowing a real backend.
+    Overrides installed via :func:`restore_backends` win over the
+    ``DeviceSpec`` registry so tests can shadow a real backend
+    without mutating shared state.
     """
-    global _BACKENDS_DISCOVERED
-    if _BACKENDS_DISCOVERED:
-        return
+    override = _BACKEND_OVERRIDES.get(device_type)
+    if override is not None:
+        return override
 
-    # First Party
-    import lmcache.v1.platform as platform_pkg
-
-    for cls in discover_subclasses(
-        platform_pkg,
-        BaseCacheContext,  # type: ignore[type-abstract]
-        module_filter=lambda short_name: short_name == "cache_context",
-        levels=[2, 2],
-    ):
-        device_type = getattr(cls, "device_type", "")
-        if not device_type:
-            logger.warning(
-                "Skipping %s: empty device_type ClassVar; concrete "
-                "BaseCacheContext subclasses must override it.",
-                cls.__name__,
-            )
-            continue
-        existing = _BACKENDS.get(device_type)
-        if existing is not None and existing is not cls:
-            logger.warning(
-                "Multiple cache-context classes claim device_type=%r "
-                "(%s vs %s); keeping the first.",
-                device_type,
-                existing.__name__,
-                cls.__name__,
-            )
-            continue
-        _BACKENDS[device_type] = cls
-
-    _BACKENDS_DISCOVERED = True
-
-
-def _resolve_backend(device_type: str) -> type:
-    _discover_backends_once()
-    cls = _BACKENDS.get(device_type)
-    if cls is None:
+    spec = get_device_spec(device_type)
+    if spec is None:
         raise ValueError(
             "No cache-context class registered for device type %r. "
-            "Make sure ``lmcache.v1.platform.<backend>.cache_context`` "
-            "ships a BaseCacheContext subclass with the matching "
-            "``device_type`` ClassVar." % device_type
+            "Make sure ``lmcache.v1.platform.<backend>.__init__`` "
+            "ships a DeviceSpec subclass whose ``create_cache_context`` "
+            "hook returns a BaseCacheContext instance." % device_type
         )
-    return cls
+    return spec.create_cache_context
 
 
 def snapshot_backends() -> dict[str, type]:
-    """Return a shallow copy of the backend table.
+    """Return a shallow copy of the override table.
 
     Pair with :func:`restore_backends` in test fixtures so installing
     fakes for one test does not leak into the next.
     """
-    _discover_backends_once()
-    return dict(_BACKENDS)
+    return dict(_BACKEND_OVERRIDES)
 
 
 def restore_backends(state: dict[str, type]) -> None:
-    """Replace the backend table with *state*.
+    """Replace the override table with *state*.
 
-    Marks the table as already-discovered so further calls do not
-    re-trigger filesystem scanning and overwrite the test's fakes.
+    Any ``device_type`` present in *state* shadows the corresponding
+    ``DeviceSpec.create_cache_context`` hook for the lifetime of the
+    override.  Pass an empty dict to fall back to registry-driven
+    dispatch.
     """
-    global _BACKENDS_DISCOVERED
-    _BACKENDS.clear()
-    _BACKENDS.update(state)
-    _BACKENDS_DISCOVERED = True
+    _BACKEND_OVERRIDES.clear()
+    _BACKEND_OVERRIDES.update(state)
 
 
 def _detect_device_type(kv_caches: KVCache) -> str:
@@ -171,11 +138,10 @@ def create_cache_context(
     backend.
 
     Selection is driven by ``tensor.device.type`` of *kv_caches*:
-    on first use the platform package is scanned for
-    ``BaseCacheContext`` subclasses and the one whose
-    ``device_type`` ClassVar matches is instantiated.  ``"cuda"``,
-    ``"cpu"``, future ``"xpu"`` ... all resolve through the same
-    code path -- no ``isinstance`` / ``if-elif`` chain.
+    the platform ``DeviceSpec`` registry is consulted and the
+    matching spec's ``create_cache_context`` hook is invoked.
+    ``"cuda"``, ``"cpu"``, future ``"xpu"`` ... all resolve through
+    the same code path -- no ``isinstance`` / ``if-elif`` chain.
 
     Args:
         kv_caches: KV cache tensor wrappers from the serving engine.
@@ -204,8 +170,8 @@ def create_cache_context(
         raise ValueError("create_cache_context requires a non-empty kv_caches list")
 
     device_type = _detect_device_type(kv_caches)
-    cls = _resolve_backend(device_type)
-    return cls(
+    factory = _resolve_factory(device_type)
+    return factory(
         kv_caches,
         lmcache_tokens_per_chunk,
         layout_hints,

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -19,11 +19,6 @@ BaseCacheContext`. Adding a new accelerator therefore requires
 *zero* edits to this module -- just implement
 ``DeviceSpec.create_cache_context`` in the sub-package's
 ``__init__.py``.
-
-Tests can still swap in fakes without touching the ``DeviceSpec``
-registry via the :func:`snapshot_backends` / :func:`restore_backends`
-overrides: any ``device_type`` present in the override table wins
-over the registry lookup.
 """
 
 # Future
@@ -42,71 +37,10 @@ from lmcache.v1.platform import get_device_spec
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 
 if TYPE_CHECKING:
-    # Standard
-    from collections.abc import Callable
-
     # First Party
     from lmcache.v1.multiprocess.group_view import EngineGroupInfo
 
 logger = init_logger(__name__)
-
-# ``device_type -> BaseCacheContext`` subclass override table.
-#
-# Empty by default: production dispatch flows through the
-# ``DeviceSpec`` registry (see :func:`_resolve_factory`).  Tests
-# install fakes here via :func:`snapshot_backends` /
-# :func:`restore_backends`; any device type registered here wins over
-# the ``DeviceSpec`` hook so a single test can shadow a real backend
-# without mutating the shared registry.
-#
-# The value type is the loose ``type`` (rather than
-# ``type[BaseCacheContext]``) so callers can instantiate it with the
-# concrete subclass' positional ``__init__`` signature without mypy
-# resolving the abstract-base ``__init__`` instead.
-_BACKEND_OVERRIDES: dict[str, type] = {}
-
-
-def _resolve_factory(device_type: str) -> "Callable[..., BaseCacheContext]":
-    """Return a zero-arg-ready callable that builds a cache context.
-
-    Overrides installed via :func:`restore_backends` win over the
-    ``DeviceSpec`` registry so tests can shadow a real backend
-    without mutating shared state.
-    """
-    override = _BACKEND_OVERRIDES.get(device_type)
-    if override is not None:
-        return override
-
-    spec = get_device_spec(device_type)
-    if spec is None:
-        raise ValueError(
-            "No cache-context class registered for device type %r. "
-            "Make sure ``lmcache.v1.platform.<backend>.__init__`` "
-            "ships a DeviceSpec subclass whose ``create_cache_context`` "
-            "hook returns a BaseCacheContext instance." % device_type
-        )
-    return spec.create_cache_context
-
-
-def snapshot_backends() -> dict[str, type]:
-    """Return a shallow copy of the override table.
-
-    Pair with :func:`restore_backends` in test fixtures so installing
-    fakes for one test does not leak into the next.
-    """
-    return dict(_BACKEND_OVERRIDES)
-
-
-def restore_backends(state: dict[str, type]) -> None:
-    """Replace the override table with *state*.
-
-    Any ``device_type`` present in *state* shadows the corresponding
-    ``DeviceSpec.create_cache_context`` hook for the lifetime of the
-    override.  Pass an empty dict to fall back to registry-driven
-    dispatch.
-    """
-    _BACKEND_OVERRIDES.clear()
-    _BACKEND_OVERRIDES.update(state)
 
 
 def _detect_device_type(kv_caches: KVCache) -> str:
@@ -173,8 +107,15 @@ def create_cache_context(
         raise ValueError("create_cache_context requires a non-empty kv_caches list")
 
     device_type = _detect_device_type(kv_caches)
-    factory = _resolve_factory(device_type)
-    return factory(
+    spec = get_device_spec(device_type)
+    if spec is None:
+        raise ValueError(
+            "No cache-context class registered for device type %r. "
+            "Make sure ``lmcache.v1.platform.<backend>.__init__`` "
+            "ships a DeviceSpec subclass whose ``create_cache_context`` "
+            "hook returns a BaseCacheContext instance." % device_type
+        )
+    return spec.create_cache_context(
         kv_caches,
         lmcache_tokens_per_chunk,
         layout_hints,

--- a/lmcache/v1/platform/cpu/__init__.py
+++ b/lmcache/v1/platform/cpu/__init__.py
@@ -6,19 +6,27 @@ Defines :class:`CpuDeviceSpec` for the device registry.  The spec's
 :class:`~lmcache.v1.platform.cpu.shm.CpuShmTensorWrapper` to the
 ``"cpu"`` device, so the multiprocess adapter can dispatch by
 ``tensor.device.type`` without any if/elif chain.
+
+:class:`CpuDeviceSpec` also participates in the ``DeviceSpec`` registry so
+callers can resolve the CPU cache-context implementation via
+:func:`lmcache.v1.platform.get_device_spec`. It intentionally reports
+``is_available() == False`` so that ``_detect_device`` never picks it
+up during auto-detection -- CPU is exclusively reached through the
+``StubCPUDevice`` fallback path.
 """
 
 # Future
 from __future__ import annotations
 
 # Standard
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 # First Party
 from lmcache.v1.platform.base_device_spec import DeviceSpec
 
 if TYPE_CHECKING:
     # First Party
+    from lmcache.v1.platform.base_cache_context import BaseCacheContext
     from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
 
 
@@ -30,6 +38,9 @@ class CpuDeviceSpec(DeviceSpec):
     callers dispatching on ``tensor.device.type`` never fall through
     to the bare :class:`DeviceSpec` fallback when the CPU backend is
     installed.
+
+    Also used for ``get_device_spec("cpu")`` lookups (e.g. by
+    :func:`lmcache.v1.platform.cache_context.create_cache_context`).
 
     Invariant:
         ``is_available()`` must inherit the base-class ``False`` (i.e.
@@ -58,3 +69,9 @@ class CpuDeviceSpec(DeviceSpec):
         from lmcache.v1.platform.cpu.shm import CpuShmTensorWrapper
 
         return CpuShmTensorWrapper
+
+    def create_cache_context(self, *args: Any, **kwargs: Any) -> "BaseCacheContext":
+        # First Party
+        from lmcache.v1.platform.cpu.cache_context import CPUCacheContext
+
+        return CPUCacheContext(*args, **kwargs)

--- a/lmcache/v1/platform/cuda/__init__.py
+++ b/lmcache/v1/platform/cuda/__init__.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 # Standard
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 # First Party
 from lmcache.v1.platform.base_device_spec import DeviceSpec
@@ -14,6 +14,7 @@ from lmcache.v1.platform.cuda.pin_memory import CudaPinMemoryBackend
 
 if TYPE_CHECKING:
     # First Party
+    from lmcache.v1.platform.base_cache_context import BaseCacheContext
     from lmcache.v1.platform.base_ipc_wrapper import DeviceIPCWrapper
 
 # ---------------------------------------------------------------------------
@@ -56,3 +57,9 @@ class CudaDeviceSpec(DeviceSpec):
             return torch.cuda.is_available()
         except Exception:
             return False
+
+    def create_cache_context(self, *args: Any, **kwargs: Any) -> "BaseCacheContext":
+        # First Party
+        from lmcache.v1.platform.cuda.cache_context import GPUCacheContext
+
+        return GPUCacheContext(*args, **kwargs)

--- a/tests/v1/platform/test_cache_context_dispatch.py
+++ b/tests/v1/platform/test_cache_context_dispatch.py
@@ -31,14 +31,30 @@ class _FakeWrapper:
 
     ``create_cache_context`` only ever reads ``to_tensor().device.type``
     from the wrappers it receives, so a 0-byte tensor on the requested
-    device is enough.
+    device is enough.  For device types torch itself does not know
+    about (``"fakedev"``), we return a duck-typed stub instead so the
+    unregistered-device branch can still be exercised.
     """
 
     def __init__(self, device_type: str) -> None:
         self._device_type = device_type
 
     def to_tensor(self) -> torch.Tensor:
-        return torch.empty(0, device=torch.device(self._device_type))
+        try:
+            return torch.empty(0, device=torch.device(self._device_type))
+        except (RuntimeError, TypeError):
+            # ``torch.device("fakedev")`` raises -- return a stub that
+            # only implements the ``.device.type`` protocol used by
+            # ``_detect_device_type``.
+            device_type = self._device_type
+
+            class _StubDevice:
+                type = device_type
+
+            class _StubTensor:
+                device = _StubDevice()
+
+            return _StubTensor()  # type: ignore[return-value]
 
 
 class _FakeContext(BaseCacheContext):
@@ -192,6 +208,29 @@ def test_mixed_device_types_raises(isolated_registry: None) -> None:
 
 def test_unregistered_device_type_raises(isolated_registry: None) -> None:
     """An unknown device type is a hard failure with a clear hint."""
-    wrappers = [_FakeWrapper("cpu")]
+    wrappers = [_FakeWrapper("fakedev")]
     with pytest.raises(ValueError, match="No cache-context class"):
         create_cache_context(wrappers)  # type: ignore[arg-type]
+
+
+def test_dispatches_via_device_spec_when_no_override(
+    isolated_registry: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With an empty override table, dispatch must delegate to the
+    ``DeviceSpec.create_cache_context`` hook of the matching spec."""
+    # First Party
+    from lmcache.v1.platform import get_device_spec
+
+    spec = get_device_spec("cpu")
+    assert spec is not None, "CpuDeviceSpec should be registered"
+
+    def _fake_factory(*args: Any, **kwargs: Any) -> _FakeCPUContext:
+        return _FakeCPUContext(*args, **kwargs)
+
+    monkeypatch.setattr(spec, "create_cache_context", _fake_factory)
+
+    wrappers = [_FakeWrapper("cpu")]
+    ctx = create_cache_context(wrappers)  # type: ignore[arg-type]
+
+    assert isinstance(ctx, _FakeCPUContext)
+    assert ctx.kv_caches is wrappers

--- a/tests/v1/platform/test_cache_context_dispatch.py
+++ b/tests/v1/platform/test_cache_context_dispatch.py
@@ -4,13 +4,12 @@
 ``lmcache.v1.platform.cache_context.create_cache_context``.
 
 The facade routes by the ``torch.device.type`` reported by the
-wrappers' ``to_tensor()`` output and looks up the registered cache
-context class via :mod:`lmcache.v1.platform.cache_context`. These tests
-exercise that dispatch without touching CUDA or the real
-``GPUCacheContext`` / ``CPUCacheContext`` constructors -- they
-install fake classes in the backend table through
-``snapshot_backends``/``restore_backends`` so the test stays
-platform-agnostic.
+wrappers' ``to_tensor()`` output and delegates to the matching
+:class:`~lmcache.v1.platform.base_device_spec.DeviceSpec` instance's
+``create_cache_context`` hook. These tests exercise that dispatch
+without touching CUDA or the real ``GPUCacheContext`` /
+``CPUCacheContext`` constructors -- they ``monkeypatch`` the hook on
+the registered ``DeviceSpec`` so the test stays platform-agnostic.
 """
 
 # Standard
@@ -21,7 +20,7 @@ import pytest
 import torch
 
 # First Party
-from lmcache.v1.platform import cache_context as cache_context_module
+from lmcache.v1.platform import get_device_spec
 from lmcache.v1.platform.base_cache_context import BaseCacheContext
 from lmcache.v1.platform.cache_context import create_cache_context
 
@@ -145,29 +144,20 @@ class _FakeCUDAContext(_FakeContext):
     device_type = "cuda"
 
 
-@pytest.fixture
-def isolated_registry() -> Any:
-    """Snapshot the backend table so each test can install fakes
-    without polluting other tests / the production setup."""
-    saved = cache_context_module.snapshot_backends()
-    # Start each test from an empty backend table so we can assert
-    # the "no class registered" branch deterministically.
-    cache_context_module.restore_backends({})
-    try:
-        yield
-    finally:
-        cache_context_module.restore_backends(saved)
+def _patch_hook(
+    monkeypatch: pytest.MonkeyPatch, device_type: str, factory: type
+) -> None:
+    """Install *factory* as the ``create_cache_context`` hook on the
+    ``DeviceSpec`` registered for *device_type*."""
+    spec = get_device_spec(device_type)
+    assert spec is not None, f"DeviceSpec for {device_type!r} not registered"
+    monkeypatch.setattr(spec, "create_cache_context", factory)
 
 
-def _install(**backends: type) -> None:
-    """Replace the live backend table with *backends*."""
-    cache_context_module.restore_backends(dict(backends))
-
-
-def test_dispatches_by_cpu_device_type(isolated_registry: None) -> None:
+def test_dispatches_by_cpu_device_type(monkeypatch: pytest.MonkeyPatch) -> None:
     """Wrappers reporting ``cpu`` tensors must yield the cpu-registered
     class."""
-    _install(cpu=_FakeCPUContext)
+    _patch_hook(monkeypatch, "cpu", _FakeCPUContext)
 
     wrappers: List[_FakeWrapper] = [_FakeWrapper("cpu"), _FakeWrapper("cpu")]
     ctx = create_cache_context(wrappers)  # type: ignore[arg-type]
@@ -176,12 +166,12 @@ def test_dispatches_by_cpu_device_type(isolated_registry: None) -> None:
     assert ctx.kv_caches is wrappers
 
 
-def test_dispatches_by_cuda_device_type(isolated_registry: None) -> None:
+def test_dispatches_by_cuda_device_type(monkeypatch: pytest.MonkeyPatch) -> None:
     """Wrappers reporting a non-cpu device type must route to the
     matching registered class -- no isinstance branching."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
-    _install(cuda=_FakeCUDAContext)
+    _patch_hook(monkeypatch, "cuda", _FakeCUDAContext)
 
     wrappers = [_FakeWrapper("cuda")]
     ctx = create_cache_context(wrappers, lmcache_tokens_per_chunk=128)  # type: ignore[arg-type]
@@ -190,47 +180,25 @@ def test_dispatches_by_cuda_device_type(isolated_registry: None) -> None:
     assert ctx.lmcache_tokens_per_chunk == 128
 
 
-def test_empty_kv_caches_raises(isolated_registry: None) -> None:
+def test_empty_kv_caches_raises() -> None:
     with pytest.raises(ValueError, match="non-empty"):
         create_cache_context([])
 
 
-def test_mixed_device_types_raises(isolated_registry: None) -> None:
+def test_mixed_device_types_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cross-device batches are unsupported and must fail loudly."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
-    _install(cpu=_FakeCPUContext, cuda=_FakeCUDAContext)
+    _patch_hook(monkeypatch, "cpu", _FakeCPUContext)
+    _patch_hook(monkeypatch, "cuda", _FakeCUDAContext)
 
     wrappers = [_FakeWrapper("cpu"), _FakeWrapper("cuda")]
     with pytest.raises(ValueError, match="share one"):
         create_cache_context(wrappers)  # type: ignore[arg-type]
 
 
-def test_unregistered_device_type_raises(isolated_registry: None) -> None:
+def test_unregistered_device_type_raises() -> None:
     """An unknown device type is a hard failure with a clear hint."""
     wrappers = [_FakeWrapper("fakedev")]
     with pytest.raises(ValueError, match="No cache-context class"):
         create_cache_context(wrappers)  # type: ignore[arg-type]
-
-
-def test_dispatches_via_device_spec_when_no_override(
-    isolated_registry: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """With an empty override table, dispatch must delegate to the
-    ``DeviceSpec.create_cache_context`` hook of the matching spec."""
-    # First Party
-    from lmcache.v1.platform import get_device_spec
-
-    spec = get_device_spec("cpu")
-    assert spec is not None, "CpuDeviceSpec should be registered"
-
-    def _fake_factory(*args: Any, **kwargs: Any) -> _FakeCPUContext:
-        return _FakeCPUContext(*args, **kwargs)
-
-    monkeypatch.setattr(spec, "create_cache_context", _fake_factory)
-
-    wrappers = [_FakeWrapper("cpu")]
-    ctx = create_cache_context(wrappers)  # type: ignore[arg-type]
-
-    assert isinstance(ctx, _FakeCPUContext)
-    assert ctx.kv_caches is wrappers


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

CacheContext's discover functionality is migrated out of standalone scanning and integrated into DeviceSpec.

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
