### PR TITLE
docs: daily drift check — multi-process mode (2026-07-18)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -402,7 +402,8 @@ The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
 Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
 ``fs_native``, ``mock``, ``mooncake_store``, ``aerospike``, ``s3``, ``resp``,
-``plugin``, ``native_plugin``, ``raw_block``, ``dax``.
+``sagemaker-hyperpod``, ``plugin``, ``native_plugin``, ``raw_block``,
+``dax``.
 
 Each adapter type's required and optional fields, plus per-backend examples, are
 documented on its own page under :doc:`Secondary KV Storage <l2_storage/index>`


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily LMCache docs drift-check routine. One
inconsistency between the multi-process (MP) *configuration reference*
and the current `dev` code (`upstream/dev` HEAD
[`e38ee415`](https://github.com/LMCache/LMCache/commit/e38ee4157a11703b07845f45fd98e714b25c13cd))
was found and fixed.

**Summary of drift**

`docs/source/` (user-facing):

- **`docs/source/mp/configuration.rst`** — the *L2 Adapters* "Registered
  adapter types" list (the authoritative CLI flag reference) omits
  `sagemaker-hyperpod`, even though the adapter type self-registers in
  code and ships a user-facing configuration surface via
  `--l2-adapter '{"type": "sagemaker-hyperpod", ...}'`.

  `sagemaker-hyperpod` landed with [PR #4138](https://github.com/LMCache/LMCache/pull/4138)
  (commit [`276b6f27`](https://github.com/LMCache/LMCache/commit/276b6f2737bcf98a533d39ddb2c9a05310e42e1d)),
  which also added `docs/source/mp/l2_storage/sagemaker_hyperpod.rst`,
  a row in `supported_storages.rst`, and a `remote_and_distributed.rst`
  toctree entry. It did not touch this authoritative list.

`docs/design/` (design docs):

- No new drift found in `docs/design/` beyond what open drift-check PRs
  #4140, #4125, #4117, #4087, #4066, #4035, #4009, #3996, #3984, #3969,
  and #3960 already cover. `sagemaker-hyperpod` did not ship its own
  design doc under `docs/design/v1/distributed/l2_adapters/`, but that
  is a code-side gap outside the scope of this docs-only PR — flagged
  here for maintainer awareness rather than fixed.

**Evidence**

| Drift | Code / repo state (current `dev`, HEAD `e38ee415`) | Stale doc |
| --- | --- | --- |
| `sagemaker-hyperpod` missing from the "Registered adapter types" list | [`lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py#L818-L821`](``https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py#L818-L821)`` — `register_l2_adapter_type("sagemaker-hyperpod", SageMakerHyperPodL2AdapterConfig)`; user-facing docs page at [`docs/source/mp/l2_storage/sagemaker_hyperpod.rst`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/docs/source/mp/l2_storage/sagemaker_hyperpod.rst) | [`docs/source/mp/configuration.rst#L403-L405`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/docs/source/mp/configuration.rst#L403-L405) |

**Proposed fix (applied in this PR)**

- One-file edit to `docs/source/mp/configuration.rst`: added
  `sagemaker-hyperpod` to the "Registered adapter types" list under the
  *L2 Adapters* section. The entry is grouped with the other remote /
  distributed adapter types (`aerospike`, `s3`, `resp`) for a natural
  reading order.

**Special notes for your reviewers**:

- Docs-only change. No code modified. One file, two lines rewrapped.
- Deduped against currently-open drift PRs:
  - **#4140** (`bigtable` + `valkey` in the same "Registered adapter
    types" list — 2026-07-17): **touches the same one-line list**, but
    for different entries. If both PRs land, the maintainer will need
    to resolve a trivial three-way merge on that list.
  - **#4125** (Developer Guide toctree indentation — 2026-07-16): no
    overlap.
  - **#4117** (new `docs/source/mp/l2_storage/valkey.rst` +
    `supported_storages.rst` + `remote_and_distributed.rst` toctree —
    2026-07-15): no overlap with the CLI reference list edit.
  - **#4087** (`--prometheus-*` observability rows in
    `docs/source/mp/configuration.rst` — 2026-07-11): no overlap.
  - **#4066** (`nixl_store` install extra in `docs/source/mp/p2p.rst`
    — 2026-07-09): no overlap.
  - **#4035** (`fault_inject` in the same "Registered adapter types"
    list + observability rows in `configuration.rst` — 2026-07-07):
    **touches the same one-line list**, but for a different entry
    (`fault_inject`). Same merge situation as #4140.
  - **#3960** (`hfbucket` in the same "Registered adapter types" list +
    `IsolatedLRU` in `l2_storage/index.rst` — 2026-06-30): **also
    touches the same one-line list**, but for a different entry
    (`hfbucket`). Same merge situation as above.
  - **#4009, #3996, #3984, #3969**: none cover this list.

  The full intended union across all four "Registered adapter types"
  drift PRs is: `nixl_store, nixl_store_dynamic, fs, fs_native, mock,
  mooncake_store, aerospike, bigtable, s3, resp, valkey,
  sagemaker-hyperpod, hfbucket, plugin, native_plugin, raw_block, dax,
  fault_inject`.

- `p2p` policy from prior drift PRs is preserved: intentionally **not**
  added, because `P2PL2AdapterConfig` is constructed programmatically
  by `P2PController._add_adapter()` and is not user-configurable via
  `--l2-adapter`, so listing it in a user-facing enumeration would be
  misleading.
- The following upstream `dev` commits since the previous drift check
  (2026-07-17 → today) were reviewed for new user-facing MP doc drift.
  Only `sagemaker-hyperpod` introduced any:
  - [`276b6f27`](https://github.com/LMCache/LMCache/commit/276b6f2737bcf98a533d39ddb2c9a05310e42e1d)
    (`[Feat] Add SageMaker HyperPod L2 adapter for MP mode`, #4138) —
    **drifts here**; see above.
  - [`0c1bbf1d`](https://github.com/LMCache/LMCache/commit/0c1bbf1d1d57a84b36480b4c50ac7550101a3355)
    (`[Misc] Add periodic terminal logging`, #4145) — landed with
    matching `--enable-extra-logging` /
    `--extra-logging-interval` rows in `docs/source/mp/configuration.rst`
    Observability table and a new `docs/source/mp/observability/logs.rst`
    page. Cross-checked; consistent with code.
  - [`35966666`](https://github.com/LMCache/LMCache/commit/35966666fa3c0df08e3d60f956b9beff65cea22c)
    (`[CLI] Add flame-graph profiling tool`, #4088) — landed with a
    full `flamegraph` section added to `docs/source/cli/tool.rst`. The
    subcommand name and flags cross-check against
    `lmcache/cli/commands/tool/flamegraph.py`.
  - [`88d824e8`](https://github.com/LMCache/LMCache/commit/88d824e83bf42a8a502625528026647e266e296d)
    (`[Telemetry] Collect continuous usage telemetry for LMCache MP
    mode`, #4098) — landed with matching updates to
    `docs/source/mp/configuration.rst` (Anonymous Usage Statistics
    section) and to the canonical
    `docs/source/developer_guide/usage/usage_stats_collection.rst`
    reference. Env var names (`LMCACHE_TRACK_USAGE`,
    `LMCACHE_USAGE_TRACK_INTERVAL`, `DO_NOT_TRACK`) cross-check against
    `lmcache/usage_telemetry/`.
  - [`e38ee415`](https://github.com/LMCache/LMCache/commit/e38ee4157a11703b07845f45fd98e714b25c13cd)
    (`[Docs] Add SGLang-to-vLLM KV cache sharing example`, #4130) —
    docs-only, no MP config or CLI drift.
  - [`eb2a3706`](https://github.com/LMCache/LMCache/commit/eb2a370615a107298ba633374094e0bcad15b00a),
    [`30ee82b0`](https://github.com/LMCache/LMCache/commit/30ee82b018fdcb0c8690d6851920221bb1a31a58),
    [`17043573`](https://github.com/LMCache/LMCache/commit/170435738bcb79c69a955d36c188c7a976e67bac),
    [`a41b802c`](https://github.com/LMCache/LMCache/commit/a41b802cc8cc4b0c765a570f1c608f472515ab11) —
    logging refactors and type-hint cleanups; no user-facing MP doc
    surface.
- This PR was **auto-generated** by the daily drift-check routine and
  **needs human review before merge**. Please do not merge without a
  maintainer's eyes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---

_Generated by the daily LMCache docs drift-check routine._

---
_Generated by [Claude Code](https://claude.ai/code/session_01MX9jfwTz3dWdtZxW2utUvc)_