### PR TITLE
feat(sglang/mp): add non-blocking store_kv_async for MP mode

### DIFF
--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -63,19 +63,25 @@ def _wrap_sglang_kv_caches(
     return wrapped
 
 
-def _completed_future() -> MessagingFuture[bool]:
-    """Return an already-completed future resolving to ``True``.
+def _completed_future(result: bool) -> MessagingFuture[bool]:
+    """Return an already-completed future resolving to ``result``.
 
     Used by :meth:`LMCacheMPConnector.store_kv_async` for the paths that
-    perform no wire send (unhealthy connector, or no chunk-aligned range
-    to store) so every return value is a pollable future and callers
-    never have to special-case ``None``.
+    perform no wire send, so every return value is a pollable future and
+    callers never have to special-case ``None``. ``result`` carries the
+    store outcome for that path: ``False`` when the connector is
+    unhealthy (nothing was stored), ``True`` when there was simply no
+    chunk-aligned range to store (a no-op success).
+
+    Args:
+        result: the success value the returned future resolves to.
 
     Returns:
-        A ``MessagingFuture`` whose ``result()`` is immediately ``True``.
+        A ``MessagingFuture`` whose ``result()`` is immediately
+        ``result``.
     """
     future: MessagingFuture[bool] = MessagingFuture()
-    future.set_result(True)
+    future.set_result(result)
     return future
 
 
@@ -521,9 +527,10 @@ class LMCacheMPConnector:
         The KV slots referenced by ``store_metadata`` must remain pinned
         (not evicted or reused) until the returned future reports done;
         the caller owns that lifetime. Paths that perform no wire send
-        (unhealthy connector, or no chunk-aligned range to store) return
-        an already-completed future so callers never special-case
-        ``None``.
+        return an already-completed future so callers never special-case
+        ``None``: an unhealthy connector resolves to ``False`` (nothing
+        was stored), and no chunk-aligned range resolves to ``True`` (a
+        no-op success).
 
         END_SESSION is owned by ``LMCRadixCache.cache_finished_req``
         (see :meth:`end_session`); it is not fired here.
@@ -534,16 +541,17 @@ class LMCacheMPConnector:
 
         Returns:
             A future resolving to ``True`` when the store completes
-            successfully, or ``False`` on daemon-side failure.
+            successfully (or there was nothing to store), or ``False``
+            on daemon-side failure or an unhealthy connector.
         """
         if not self.is_healthy:
-            return _completed_future()
+            return _completed_future(False)
 
         aligned_end = (len(store_metadata.token_ids) // self._lmcache_chunk_size) * (
             self._lmcache_chunk_size
         )
         if aligned_end == 0:
-            return _completed_future()
+            return _completed_future(True)
 
         request_id = store_metadata.request_id
         block_ids = self._slot_mapping_to_block_ids(
@@ -551,7 +559,7 @@ class LMCacheMPConnector:
         )
         event = torch_dev.Event(interprocess=True)
         event.record(torch_dev.current_stream())
-        return send_lmcache_request(
+        future = send_lmcache_request(
             self.mq_client,
             RequestType.STORE,
             [
@@ -568,6 +576,13 @@ class LMCacheMPConnector:
                 event.ipc_handle(),
             ],
         ).to_cuda_future(device=self.device)
+        # Keep the exporting CUDA event alive until the caller releases the
+        # future. Since we return without blocking, the local ``event`` would
+        # otherwise be garbage-collected immediately, destroying the underlying
+        # CUDA event before the daemon imports its IPC handle and waits on it.
+        # (Dynamic keepalive attribute; the future type doesn't declare it.)
+        future._export_event = event  # type: ignore[attr-defined]
+        return future
 
     def store_kv(self, store_metadata: StoreMetadata) -> None:
         if not self.is_healthy:

--- a/lmcache/integration/sglang/multi_process_adapter.py
+++ b/lmcache/integration/sglang/multi_process_adapter.py
@@ -34,6 +34,7 @@ from lmcache.v1.multiprocess.custom_types import (
     IPCCacheServerKey,
     KVCache,
 )
+from lmcache.v1.multiprocess.futures import MessagingFuture
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType
 from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
@@ -60,6 +61,22 @@ def _wrap_sglang_kv_caches(
     wrapped.extend(CudaIPCWrapper(tensor) for tensor in k_pool)
     wrapped.extend(CudaIPCWrapper(tensor) for tensor in v_pool)
     return wrapped
+
+
+def _completed_future() -> MessagingFuture[bool]:
+    """Return an already-completed future resolving to ``True``.
+
+    Used by :meth:`LMCacheMPConnector.store_kv_async` for the paths that
+    perform no wire send (unhealthy connector, or no chunk-aligned range
+    to store) so every return value is a pollable future and callers
+    never have to special-case ``None``.
+
+    Returns:
+        A ``MessagingFuture`` whose ``result()`` is immediately ``True``.
+    """
+    future: MessagingFuture[bool] = MessagingFuture()
+    future.set_result(True)
+    return future
 
 
 @dataclass
@@ -490,6 +507,67 @@ class LMCacheMPConnector:
                 if request_id in self._pending_lookups:
                     self._pending_lookups[request_id].locks_held = False
         return retrieve_token_num - offset
+
+    def store_kv_async(self, store_metadata: StoreMetadata) -> MessagingFuture[bool]:
+        """Submit a STORE and return its completion future without waiting.
+
+        Fires the STORE request for the chunk-aligned prefix of
+        ``store_metadata`` and returns immediately with a future the
+        caller can poll (``query`` / ``wait``) or block on (``result``)
+        at a later, deferred checkpoint. The future resolves to a
+        ``bool`` success flag once the daemon finishes copying the KV
+        slots GPU → warehouse.
+
+        The KV slots referenced by ``store_metadata`` must remain pinned
+        (not evicted or reused) until the returned future reports done;
+        the caller owns that lifetime. Paths that perform no wire send
+        (unhealthy connector, or no chunk-aligned range to store) return
+        an already-completed future so callers never special-case
+        ``None``.
+
+        END_SESSION is owned by ``LMCRadixCache.cache_finished_req``
+        (see :meth:`end_session`); it is not fired here.
+
+        Args:
+            store_metadata: tokens, request id, and KV slot indices for
+                the finished request.
+
+        Returns:
+            A future resolving to ``True`` when the store completes
+            successfully, or ``False`` on daemon-side failure.
+        """
+        if not self.is_healthy:
+            return _completed_future()
+
+        aligned_end = (len(store_metadata.token_ids) // self._lmcache_chunk_size) * (
+            self._lmcache_chunk_size
+        )
+        if aligned_end == 0:
+            return _completed_future()
+
+        request_id = store_metadata.request_id
+        block_ids = self._slot_mapping_to_block_ids(
+            store_metadata.kv_indices[:aligned_end]
+        )
+        event = torch_dev.Event(interprocess=True)
+        event.record(torch_dev.current_stream())
+        return send_lmcache_request(
+            self.mq_client,
+            RequestType.STORE,
+            [
+                self._create_key(
+                    store_metadata.token_ids,
+                    start=0,
+                    end=aligned_end,
+                    request_id=request_id,
+                ),
+                self.instance_id,
+                # STORE takes per-group block IDs (list[list[int]]); SGLang is
+                # non-hybrid, so wrap the flat list as a single group.
+                [block_ids],
+                event.ipc_handle(),
+            ],
+        ).to_cuda_future(device=self.device)
 
     def store_kv(self, store_metadata: StoreMetadata) -> None:
         if not self.is_healthy:

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -13,6 +13,10 @@ import threading
 import pytest
 import torch
 
+# The adapter imports ``sglang`` at module load; skip cleanly where it's absent
+# (sglang is an optional integration, not a hard LMCache dependency).
+pytest.importorskip("sglang")
+
 # First Party
 from lmcache.integration.sglang import multi_process_adapter as adapter_mod
 from lmcache.integration.sglang.multi_process_adapter import (
@@ -92,13 +96,17 @@ class _FakeTorchDev:
         return object()
 
 
-def test_completed_future_is_done_and_true() -> None:
-    future = _completed_future()
-    assert future.query() is True
-    assert future.result(timeout=0) is True
+def test_completed_future_resolves_to_given_result() -> None:
+    done_true = _completed_future(True)
+    assert done_true.query() is True
+    assert done_true.result(timeout=0) is True
+
+    done_false = _completed_future(False)
+    assert done_false.query() is True
+    assert done_false.result(timeout=0) is False
 
 
-def test_store_kv_async_unhealthy_returns_completed_future_no_send(monkeypatch) -> None:
+def test_store_kv_async_unhealthy_returns_failed_future_no_send(monkeypatch) -> None:
     conn = _make_connector(healthy=False)
 
     def _fail_send(*args, **kwargs):
@@ -110,7 +118,8 @@ def test_store_kv_async_unhealthy_returns_completed_future_no_send(monkeypatch) 
 
     assert isinstance(future, MessagingFuture)
     assert future.query() is True
-    assert future.result(timeout=0) is True
+    # Unhealthy connector stored nothing -> the future must report failure.
+    assert future.result(timeout=0) is False
 
 
 def test_store_kv_async_no_aligned_range_returns_completed_future_no_send(
@@ -154,3 +163,6 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
     # It returns the daemon's own future, and must NOT have blocked on it.
     assert future is sentinel
     assert sentinel.result_called is False
+    # The exporting CUDA event must be pinned to the future so it isn't
+    # garbage-collected before the daemon waits on its IPC handle.
+    assert hasattr(future, "_export_event")

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Public-API unit tests for ``LMCacheMPConnector.store_kv_async``. The MQ and
+GPU boundaries are stubbed; no live daemon or CUDA device needed. Covers the
+async store contract added for SGLang MP mode: ``store_kv_async`` always
+returns a pollable future -- an already-completed one on the no-op paths
+(unhealthy connector / no chunk-aligned range), and the daemon's real
+completion future on the happy path -- and never blocks on the result."""
+
+# Standard
+import threading
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.integration.sglang import multi_process_adapter as adapter_mod
+from lmcache.integration.sglang.multi_process_adapter import (
+    LMCacheMPConnector,
+    _completed_future,
+)
+from lmcache.integration.sglang.sglang_adapter import StoreMetadata
+from lmcache.v1.multiprocess.futures import MessagingFuture
+
+_CHUNK_SIZE = 256
+
+
+def _make_connector(healthy: bool = True) -> LMCacheMPConnector:
+    """Build a connector without running ``__init__`` (which opens ZMQ).
+
+    Sets only the attributes the store paths touch; anything a given
+    test needs beyond this it stubs itself.
+    """
+    conn = object.__new__(LMCacheMPConnector)
+    conn._health_event = threading.Event()
+    if healthy:
+        conn._health_event.set()
+    conn._lmcache_chunk_size = _CHUNK_SIZE
+    conn._mq_timeout = 5.0
+    return conn
+
+
+def _store_metadata(num_tokens: int) -> StoreMetadata:
+    return StoreMetadata(
+        last_node=None,
+        token_ids=list(range(num_tokens)),
+        kv_indices=torch.empty(0, dtype=torch.int64),
+        offset=0,
+        request_id="req-test",
+    )
+
+
+class _SpyFuture(MessagingFuture):
+    """Future that records whether the caller blocked on ``result``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.result_called = False
+
+    def result(self, timeout=None):
+        self.result_called = True
+        return super().result(timeout)
+
+
+class _FakeRaw:
+    """Stand-in for ``send_lmcache_request``'s return; hands back a preset
+    future from ``to_cuda_future`` so no CUDA event is needed."""
+
+    def __init__(self, future: MessagingFuture) -> None:
+        self._future = future
+
+    def to_cuda_future(self, device=None) -> MessagingFuture:
+        return self._future
+
+
+class _FakeEvent:
+    def __init__(self, interprocess: bool = False) -> None:
+        pass
+
+    def record(self, stream) -> None:
+        pass
+
+    def ipc_handle(self) -> bytes:
+        return b"fake-ipc-handle"
+
+
+class _FakeTorchDev:
+    Event = _FakeEvent
+
+    @staticmethod
+    def current_stream():
+        return object()
+
+
+def test_completed_future_is_done_and_true() -> None:
+    future = _completed_future()
+    assert future.query() is True
+    assert future.result(timeout=0) is True
+
+
+def test_store_kv_async_unhealthy_returns_completed_future_no_send(monkeypatch) -> None:
+    conn = _make_connector(healthy=False)
+
+    def _fail_send(*args, **kwargs):
+        pytest.fail("send_lmcache_request must not be called when unhealthy")
+
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", _fail_send)
+
+    future = conn.store_kv_async(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
+
+    assert isinstance(future, MessagingFuture)
+    assert future.query() is True
+    assert future.result(timeout=0) is True
+
+
+def test_store_kv_async_no_aligned_range_returns_completed_future_no_send(
+    monkeypatch,
+) -> None:
+    conn = _make_connector(healthy=True)
+
+    def _fail_send(*args, **kwargs):
+        pytest.fail("send_lmcache_request must not be called with no aligned range")
+
+    monkeypatch.setattr(adapter_mod, "send_lmcache_request", _fail_send)
+
+    # Fewer tokens than one chunk -> aligned_end == 0 -> no wire send.
+    future = conn.store_kv_async(_store_metadata(num_tokens=_CHUNK_SIZE - 1))
+
+    assert isinstance(future, MessagingFuture)
+    assert future.result(timeout=0) is True
+
+
+def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
+    monkeypatch,
+) -> None:
+    conn = _make_connector(healthy=True)
+    conn.mq_client = object()
+    conn.instance_id = 123
+    conn.device = "cpu"
+    # Stub the helpers store_kv_async calls so we exercise only its own logic.
+    conn._slot_mapping_to_block_ids = lambda kv_indices: [0, 1]
+    conn._create_key = lambda *args, **kwargs: "fake-key"
+
+    sentinel = _SpyFuture()
+    monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)
+    monkeypatch.setattr(
+        adapter_mod,
+        "send_lmcache_request",
+        lambda mq_client, request_type, payload: _FakeRaw(sentinel),
+    )
+
+    future = conn.store_kv_async(_store_metadata(num_tokens=4 * _CHUNK_SIZE))
+
+    # It returns the daemon's own future, and must NOT have blocked on it.
+    assert future is sentinel
+    assert sentinel.result_called is False

--- a/tests/v1/test_sglang_mp_adapter.py
+++ b/tests/v1/test_sglang_mp_adapter.py
@@ -143,12 +143,12 @@ def test_store_kv_async_happy_path_returns_daemon_future_without_blocking(
     monkeypatch,
 ) -> None:
     conn = _make_connector(healthy=True)
-    conn.mq_client = object()
+    conn.mq_client = object()  # type: ignore[assignment]
     conn.instance_id = 123
     conn.device = "cpu"
     # Stub the helpers store_kv_async calls so we exercise only its own logic.
-    conn._slot_mapping_to_block_ids = lambda kv_indices: [0, 1]
-    conn._create_key = lambda *args, **kwargs: "fake-key"
+    conn._slot_mapping_to_block_ids = lambda kv_indices: [0, 1]  # type: ignore[method-assign,assignment]
+    conn._create_key = lambda *args, **kwargs: "fake-key"  # type: ignore[method-assign,assignment]
 
     sentinel = _SpyFuture()
     monkeypatch.setattr(adapter_mod, "torch_dev", _FakeTorchDev)


### PR DESCRIPTION
Part of #4095

MP `store_kv` blocks on the daemon completion after the forward pass, but nothing downstream uses the result — the scheduler just sits idle waiting.

Here I add `LMCacheMPConnector.store_kv_async`: fires the same STORE and returns the `MessagingFuture` instead of blocking on `.result()`. No-op paths (unhealthy connector, no chunk-aligned range) return an
already-completed future so callers never special-case `None`.

Blocking `store_kv` is kept so MP keeps working before the SGLang-side PR lands; a follow-up will deprecate it afterward.

I have also Included the tests for the async path in `tests/v1/test_sglang_mp_adapter.py`.
