### PR TITLE
docs: daily drift check — multi-process mode (2026-07-19)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -402,13 +402,17 @@ The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
 Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
 ``fs_native``, ``mock``, ``mooncake_store``, ``aerospike``, ``s3``, ``resp``,
-``plugin``, ``native_plugin``, ``raw_block``, ``dax``.
+``valkey``, ``hfbucket``, ``bigtable``, ``sagemaker-hyperpod``, ``plugin``,
+``native_plugin``, ``raw_block``, ``dax``, ``fault_inject``.
 
 Each adapter type's required and optional fields, plus per-backend examples, are
 documented on its own page under :doc:`Secondary KV Storage <l2_storage/index>`
 -- including the adapters not detailed inline here (``fs_native``,
 ``raw_block``, ``dax``, ``mooncake_store``, ``aerospike``, ``hfbucket``,
-``resp``).
+``bigtable``, ``sagemaker-hyperpod``, ``resp``). The ``valkey`` adapter's
+configuration schema is currently documented in the
+`Valkey L2 adapter design doc <https://github.com/LMCache/LMCache/blob/dev/docs/design/v1/distributed/l2_adapters/valkey.md>`_
+pending a dedicated user-facing page.
 
 Multiple adapters (cascade)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -456,6 +460,21 @@ logging, tracing).
    * - ``--prometheus-port``
      - ``9090``
      - Port for the Prometheus ``/metrics`` endpoint.
+   * - ``--metrics-sample-rate``
+     - ``0.01``
+     - Fraction of chunks/blocks to track for lifecycle histograms
+       (0, 1.0]. Counters always count all events regardless of this
+       setting. Default is 0.01 (1%).
+   * - ``--trace-level``
+     - *(none)*
+     - Enable trace recording at the given level. Currently only
+       ``storage`` is supported (records ``StorageManager`` public-API
+       calls for offline replay). See :doc:`tracing_and_debugging`.
+   * - ``--trace-output``
+     - *(none)*
+     - Path to write the trace file. If omitted while ``--trace-level``
+       is set, a timestamped file under ``$TMPDIR`` is minted and its
+       path is logged at INFO.
    * - ``--enable-extra-logging``
      - off
      - Periodic INFO logs: per-GPU L0<->L1 transfer stats and L1 memory
@@ -567,6 +586,9 @@ Environment Variables
    * - ``DO_NOT_TRACK``
      - Set to ``1`` to disable anonymous usage statistics (cross-tool
        convention).
+   * - ``LMCACHE_USAGE_TRACK_INTERVAL``
+     - Seconds between continuous usage-telemetry flushes (default
+       ``600``). See :ref:`usage-stats-collection`.
 
 Full Example
 ------------

--- a/docs/source/mp/l2_storage/supported_storages.rst
+++ b/docs/source/mp/l2_storage/supported_storages.rst
@@ -43,6 +43,9 @@ target.
    * - :doc:`RESP (Redis/Valkey) <resp>`
      - ``resp``
      - Remote & Distributed
+   * - Valkey (glide-sync) — see design doc [1]_
+     - ``valkey``
+     - Remote & Distributed
    * - :doc:`Aerospike <aerospike>`
      - ``aerospike``
      - Remote & Distributed
@@ -69,3 +72,11 @@ target.
    mock
    fault_inject
    plugin
+
+.. [1] The ``valkey`` MP L2 adapter (added in #3505) uses the
+   ``valkey-glide-sync`` client for copy-reduced GET/SET; its full
+   configuration schema is documented in
+   `docs/design/v1/distributed/l2_adapters/valkey.md
+   <https://github.com/LMCache/LMCache/blob/dev/docs/design/v1/distributed/l2_adapters/valkey.md>`_
+   pending a dedicated user-facing page. Distinct from the legacy V0
+   :doc:`Valkey backend </kv_cache/storage_backends/valkey>`.


### PR DESCRIPTION
**What this PR does / why we need it**:

Auto-generated by the daily docs drift-check routine (multi-process mode focus). Cross-checks the MP CLI/config code under `lmcache/v1/multiprocess/` and `lmcache/v1/distributed/` against `docs/source/mp/` and repairs the inconsistencies listed below. Docs-only — no code files are touched.

**Summary of drift found**

_`docs/source/mp/`_

- **Registered L2 adapter types list is incomplete.** `docs/source/mp/configuration.rst` (L2 Adapters section) lists 13 registered types but the code registers 19 (P2P is internal — not user-facing — the remaining 5 are user-facing and undocumented here).
  - Missing user-facing types: `bigtable`, `hfbucket`, `sagemaker-hyperpod`, `valkey`, `fault_inject`.
  - Evidence (permalinked to `e38ee41`):
    - [`bigtable_l2_adapter.py:1213`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/distributed/l2_adapters/bigtable_l2_adapter.py#L1213)
    - [`hfbucket_l2_adapter.py:894`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/distributed/l2_adapters/hfbucket_l2_adapter.py#L894)
    - [`sagemaker_hyperpod_l2_adapter.py:818`](``https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/distributed/l2_adapters/sagemaker_hyperpod_l2_adapter.py#L818``)
    - [`valkey_l2_adapter.py:1116`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py#L1116)
    - [`fault_inject_l2_adapter.py:426`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/distributed/l2_adapters/fault_inject_l2_adapter.py#L426)
  - **Proposed fix (applied):** Added the missing types to the list in `docs/source/mp/configuration.rst`, and mentioned the new backends in the "see other pages" sentence.

- **Observability CLI table missing three flags that already exist and are used in the same page's Full Example.** `docs/source/mp/configuration.rst` Observability table does not list `--metrics-sample-rate`, `--trace-level`, or `--trace-output`, even though the Full Example at the bottom uses `--metrics-sample-rate 0.01`.
  - Evidence (permalinked to `e38ee41`):
    - [`mp_observability/config.py:166`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/mp_observability/config.py#L166) (`--metrics-sample-rate`)
    - [`mp_observability/config.py:234`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/mp_observability/config.py#L234) (`--trace-level`)
    - [`mp_observability/config.py:242`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/mp_observability/config.py#L242) (`--trace-output`)
    - Full Example currently referencing an undocumented flag: `docs/source/mp/configuration.rst` L603 (`--metrics-sample-rate 0.01`).
  - **Proposed fix (applied):** Added rows for all three flags to the Observability table with defaults matching `mp_observability/config.py`.

- **`LMCACHE_USAGE_TRACK_INTERVAL` env var referenced in prose but not listed in the Environment Variables table.** The "Anonymous Usage Statistics" section (added in #4098) mentions `LMCACHE_USAGE_TRACK_INTERVAL` but the Environment Variables table above it lists only `LMCACHE_LOG_LEVEL`, `PYTHONHASHSEED`, `LMCACHE_TRACK_USAGE`, and `DO_NOT_TRACK`.
  - Evidence (permalinked to `e38ee41`):
    - [`usage_telemetry/continuous.py:92`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/usage_telemetry/continuous.py#L92) and [`usage_telemetry/mp_continuous.py:119`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/usage_telemetry/mp_continuous.py#L119) (env-var read, default 600s).
    - Prose reference: `docs/source/mp/configuration.rst` L613.
  - **Proposed fix (applied):** Added one row to the Environment Variables table, referencing the developer-guide page for details.

- **New MP-mode "valkey" L2 adapter missing from the supported-backends catalog.** `docs/source/mp/l2_storage/supported_storages.rst` lists every other registered L2 adapter but omits `valkey`, which was added in #3505 with a full design doc at `docs/design/v1/distributed/l2_adapters/valkey.md` and self-registers as an L2 adapter type.
  - Evidence (permalinked to `e38ee41`):
    - Registration: [`valkey_l2_adapter.py:1116`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/lmcache/v1/distributed/l2_adapters/valkey_l2_adapter.py#L1116)
    - Design doc: [`docs/design/v1/distributed/l2_adapters/valkey.md`](https://github.com/LMCache/LMCache/blob/e38ee4157a11703b07845f45fd98e714b25c13cd/docs/design/v1/distributed/l2_adapters/valkey.md)
    - Missing from: `docs/source/mp/l2_storage/supported_storages.rst`
  - **Proposed fix (applied):** Added a row to the Supported Backends table with a footnote pointing to the design doc as the interim reference. The MP `valkey` adapter is distinct from the legacy V0 `Valkey` connector page (`docs/source/kv_cache/storage_backends/valkey.rst`); the footnote calls that out. A dedicated user-facing page (`docs/source/mp/l2_storage/valkey.rst`) is out of scope for this drift-check PR — flagging it here for follow-up.

_`docs/design/`_

- No inconsistencies were found between the MP-mode design docs (`docs/design/v1/multiprocess/`, `docs/design/v1/mp_observability/`, `docs/design/v1/distributed/l2_adapters/`) and the current code beyond what's covered above. The recently added `docs/design/v1/distributed/l2_adapters/valkey.md` and `docs/design/usage_telemetry/continuous_metrics.md` match their respective code.

**Special notes for your reviewers**:

- Auto-generated by the daily docs drift-check routine (multi-process mode focus). Docs-only; requires human review before merge.
- Follow-up suggestion (not applied here): write a dedicated `docs/source/mp/l2_storage/valkey.rst` user page (and wire it into `remote_and_distributed.rst`) so the MP valkey adapter matches the treatment of the other L2 adapters. That needs product-owner input (typical config, cluster-vs-standalone guidance, TLS scope), so it's out of scope for the automated drift check.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01875rbFUkFzB522qjdc1CY9)_