### PR TITLE
docs: align configuration reference with canonical names

### DIFF
--- a/docs/source/api_reference/configurations.rst
+++ b/docs/source/api_reference/configurations.rst
@@ -185,15 +185,15 @@ Settings for enabling and configuring peer-to-peer CPU KV cache sharing and glob
      - Description
    * - enable_p2p
      - LMCACHE_ENABLE_P2P
-     - Whether to enable peer-to-peer sharing. Values: true/false. Default: false
+     - Whether to enable peer-to-peer sharing. Requires ``enable_controller=true`` and the controller settings below. Values: true/false. Default: false
    * - p2p_host
      - LMCACHE_P2P_HOST
      - Ip address. Required if enable_p2p is true
-   * - peer_init_ports
-     - LMCACHE_PEER_INIT_PORTS
+   * - p2p_init_ports
+     - LMCACHE_P2P_INIT_PORTS
      - Ports for p2p peer init. Required if enable_p2p is true
-   * - peer_lookup_ports
-     - LMCACHE_PEER_lookup_PORTS
+   * - p2p_lookup_ports
+     - LMCACHE_P2P_LOOKUP_PORTS
      - Ports for p2p peer lookup. Required if enable_p2p is true
    * - transfer_channel
      - LMCACHE_TRANSFER_CHANNEL
@@ -216,13 +216,16 @@ Settings for the KV cache controller functionality.
      - Whether to enable controller. Values: true/false. Default: false
    * - lmcache_instance_id
      - LMCACHE_LMCACHE_INSTANCE_ID
-     - ID of the LMCache instance. Default: "lmcache_default_instance"
-   * - controller_url
-     - LMCACHE_CONTROLLER_URL
-     - URL of the controller server
-   * - lmcache_worker_port
-     - LMCACHE_LMCACHE_WORKER_PORT
-     - Port number for LMCache worker
+     - ID of the LMCache instance. Must be non-null if ``enable_controller`` is true. If omitted, a unique ``lmcacheengineconfig_<uuid>`` value is generated
+   * - controller_pull_url
+     - LMCACHE_CONTROLLER_PULL_URL
+     - URL used by workers to pull commands from the controller server. Required if ``enable_controller`` is true
+   * - controller_reply_url
+     - LMCACHE_CONTROLLER_REPLY_URL
+     - URL used by workers to send replies to the controller server. Required if ``enable_controller`` is true
+   * - lmcache_worker_ports
+     - LMCACHE_LMCACHE_WORKER_PORTS
+     - Non-empty list of port numbers for LMCache workers. Required if ``enable_controller`` is true
 
 Disaggregated Prefill Configurations
 -------------------------------------------
@@ -279,13 +282,13 @@ Settings for disaggregated prefill functionality. The latest/default PD is imple
      - Port for proxy server. Required for senders to connect to inform the proxy when transfer to decoder has been completed
    * - pd_allocation_timeout_sec
      - LMCACHE_PD_ALLOCATION_TIMEOUT_SEC
-     - Maximum seconds to retry memory allocation before giving up. Default: 5.0
+     - Maximum seconds to retry memory allocation before giving up. Default: infinity (no timeout)
    * - pd_shutdown_timeout_sec
      - LMCACHE_PD_SHUTDOWN_TIMEOUT_SEC
      - Maximum seconds to wait for event loop shutdown and thread join. Default: 5.0
    * - pd_condition_poll_interval_sec
      - LMCACHE_PD_CONDITION_POLL_INTERVAL_SEC
-     - Polling interval in seconds when waiting on a threading/asyncio Condition. Small enough to be responsive, large enough not to spin-waste CPU. Default: 0.05
+     - Polling interval in seconds when waiting on a threading/asyncio Condition. Small enough to be responsive, large enough not to spin-waste CPU. Default: 0.005
    * - pd_max_prefill_len
      - LMCACHE_PD_MAX_PREFILL_LEN
      - Maximum prefill token length that the PD buffer must be able to hold. If > 0, initialization raises ValueError when the buffer capacity (in tokens) is smaller than this value. Set to 0 (default) to skip the check.
@@ -535,9 +538,9 @@ Settings for plugin system.
    * - YAML Config Name
      - Environment Variable
      - Description
-   * - plugin_locations
-     - LMCACHE_PLUGIN_LOCATIONS
-     - List of plugin locations. Default: []
+   * - runtime_plugin_locations
+     - LMCACHE_RUNTIME_PLUGIN_LOCATIONS
+     - List of runtime plugin locations. Default: null
 
 Deprecated Configurations
 -------------------------
@@ -554,4 +557,7 @@ These configurations are deprecated and may be removed in future versions.
    * - audit_actual_remote_url
      - LMCACHE_AUDIT_ACTUAL_REMOTE_URL
      - (Deprecated) URL of actual remote LMCache instance for auditing. Use extra_config['audit_actual_remote_url'] instead
+   * - plugin_locations
+     - LMCACHE_PLUGIN_LOCATIONS
+     - Deprecated alias for ``runtime_plugin_locations``
      


### PR DESCRIPTION
The in-process configuration reference still used several pre-rename aliases as primary names, and two PD defaults had drifted from `_CONFIG_DEFINITIONS`.

This updates the reference to:
- use canonical `p2p_*`, controller, and runtime plugin names with their actual environment variables;
- document `plugin_locations` as the deprecated alias it is;
- match the current PD allocation and condition polling defaults.

Validation:
- compared each documented key, default, and generated `LMCACHE_*` name against `lmcache/v1/config.py::_CONFIG_DEFINITIONS`;
- built `configurations.rst` in an isolated Sphinx 8.2 project with warnings treated as errors.