### PR TITLE
Support vLLM's packed (fused-K/V) layout `NL_X_NB_BS_NH_TWO_HS` in CacheBlend V3

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -256,9 +256,16 @@ __device__ __forceinline__ int64_t page_buffer_offset(
            k_or_v * block_size * scalars_per_token +
            block_offset * scalars_per_token + scalar_offset;
   }
-  // MLA formats: vLLM (NL_X_NB_BS_HS) and SGLang (NL_X_NBBS_ONE_HS)
+  // MLA formats: vLLM (NL_X_NB_BS_HS) and SGLang (NL_X_NBBS_ONE_HS); plus the
+  // fused-K/V NHD packed layout NL_X_NB_BS_NH_TWO_HS ([NB, BS, NH, 2*HS]).
+  // The latter is token-contiguous with a single fused K/V axis (kv_size == 1,
+  // scalars_per_token == NH * 2 * HS), so it addresses like MLA — K and V ride
+  // together in each token's contiguous span. (The HND-packed sibling
+  // NL_X_NB_NH_BS_TWO_HS is heads-outermost and would need its own offset case;
+  // not wired here — CB v3 only routes the NHD-packed layout.)
   else if constexpr (format == EngineKVFormat::NL_X_NB_BS_HS ||
-                     format == EngineKVFormat::NL_X_NBBS_ONE_HS) {
+                     format == EngineKVFormat::NL_X_NBBS_ONE_HS ||
+                     format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS) {
     return token_idx * scalars_per_token + scalar_offset;
   }
   // vllm flash attention (HND) — physical: [2, NB, NH, BS, HS]
@@ -543,7 +550,15 @@ void multi_layer_kv_transfer_templated(
   lmc::check_block_size(engine_kv_format, block_size);
   lmc::check_head_size(engine_kv_format, head_size_xword);
 
-  int k_or_v_size = ::is_mla(engine_kv_format) ? 1 : 2;
+  // Fused-K/V packed layouts (NL_X_NB_BS_NH_TWO_HS: [NB, BS, NH, 2*HS]) carry
+  // a single fused K/V axis like MLA — the source key_value has size(0) == 1,
+  // so the K/V grid dim must iterate once (k_or_v == 1 would read past the
+  // source and write the paged slot twice).
+  int k_or_v_size =
+      (::is_mla(engine_kv_format) ||
+       engine_kv_format == EngineKVFormat::NL_X_NB_BS_NH_TWO_HS)
+          ? 1
+          : 2;
 
   dim3 grid(num_transfer_tokens, num_layers, k_or_v_size);
   dim3 block(std::min(num_xwords, 128));
@@ -578,6 +593,10 @@ void multi_layer_kv_transfer_templated(
         LAUNCH_KERNEL_WITH_FORMAT(T, false,
                                   EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
         break;
+      case EngineKVFormat::NL_X_NB_BS_NH_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, false,
+                                  EngineKVFormat::NL_X_NB_BS_NH_TWO_HS);
+        break;
       default:
         throw std::runtime_error("Unsupported EngineKVFormat");
     }
@@ -607,6 +626,10 @@ void multi_layer_kv_transfer_templated(
       case EngineKVFormat::NL_X_NB_TWO_NH_BS_HS:
         LAUNCH_KERNEL_WITH_FORMAT(T, true,
                                   EngineKVFormat::NL_X_NB_TWO_NH_BS_HS);
+        break;
+      case EngineKVFormat::NL_X_NB_BS_NH_TWO_HS:
+        LAUNCH_KERNEL_WITH_FORMAT(T, true,
+                                  EngineKVFormat::NL_X_NB_BS_NH_TWO_HS);
         break;
       default:
         throw std::runtime_error("Unsupported EngineKVFormat");

--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -66,6 +66,12 @@ import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
 
+# vLLM's fused K/V layouts pack [K, V] into the content dim; the transfer spec
+# then reports kv_size=1 with a doubled head_size. CB v3 re-RoPE un-folds only
+# the NHD-packed variant (see _apply_cb_rope_batched). None on builds whose
+# lmc_ops predates the enum member.
+_CB_PACKED_NHD_FMT = getattr(lmc_ops.EngineKVFormat, "NL_X_NB_BS_NH_TWO_HS", None)
+
 
 @dataclass
 class _CBRopeState:
@@ -1469,18 +1475,43 @@ class BlendV3Module(InstanceLivenessTarget):
                 gpu_context.get_temp_kernel_group_buffer(slot_idx, group_idx)
                 for slot_idx in range(batch_len)
             ]
-            if all_slots[0].shape[0] != 2:
+            # Fused NHD-packed layout (kv_size==1, K/V doubled into the content
+            # dim): the transfer kernels move the packed [K, V] blob unchanged,
+            # but re-RoPE needs the K half only, so un-fold it below.
+            is_packed_kv = (
+                all_slots[0].shape[0] == 1
+                and _CB_PACKED_NHD_FMT is not None
+                and group.engine_kv_format == _CB_PACKED_NHD_FMT
+            )
+            if all_slots[0].shape[0] != 2 and not is_packed_kv:
                 raise RuntimeError(
-                    f"CB v3: group {group_idx} has kv_size={all_slots[0].shape[0]}; "
-                    "MLA layouts unsupported."
+                    f"CB v3: group {group_idx} kv_size={all_slots[0].shape[0]} "
+                    f"(format={group.engine_kv_format}) unsupported for re-RoPE. "
+                    "Only kv-split layouts and the NHD-packed "
+                    "NL_X_NB_BS_NH_TWO_HS are handled; MLA and other packed "
+                    "variants are not."
                 )
             num_layers, slots, hidden_dim = all_slots[0].shape[1:]
-            n_heads = hidden_dim // rope_state.head_size
-            if n_heads * rope_state.head_size != hidden_dim:
-                raise RuntimeError(
-                    f"CB rope: group {group_idx} hidden_dim ({hidden_dim}) "
-                    f"not a multiple of head_size ({rope_state.head_size})."
-                )
+            # The model head_dim (un-folded) — NOT the transfer spec's doubled
+            # head_size; the packed n_heads below relies on this.
+            head_size = rope_state.head_size
+            if is_packed_kv:
+                # hidden_dim is [n_heads, 2, head_size] flattened (K and V
+                # interleaved per head); re-RoPE must touch K only.
+                if hidden_dim % (2 * head_size) != 0:
+                    raise RuntimeError(
+                        f"CB rope: group {group_idx} packed hidden_dim "
+                        f"({hidden_dim}) not a multiple of 2*head_size "
+                        f"({2 * head_size})."
+                    )
+                n_heads = hidden_dim // (2 * head_size)
+            else:
+                n_heads = hidden_dim // head_size
+                if n_heads * head_size != hidden_dim:
+                    raise RuntimeError(
+                        f"CB rope: group {group_idx} hidden_dim ({hidden_dim}) "
+                        f"not a multiple of head_size ({head_size})."
+                    )
             # Per-group rope cache: dual-RoPE models rotate each
             # kernel group with its own theta's cos/sin.
             group_cos_sin = rope_state.cache_for_group(group.engine_group_idx)
@@ -1499,18 +1530,28 @@ class BlendV3Module(InstanceLivenessTarget):
                 ).repeat(num_layers)
                 sp_cache[sp_key] = slot_positions_rep
             for slot_idx, old_st, cur_st in slots_to_rope:
-                # reshape returns an in-place view (tmp slots are contiguous).
-                k_view = all_slots[slot_idx][0].reshape(
-                    num_layers * slots, n_heads, rope_state.head_size
-                )
+                buf = all_slots[slot_idx][0]
+                if is_packed_kv:
+                    # Un-fold [.., n_heads, 2, head_size]; K is [..., 0, :],
+                    # strided by the interleaved V. Gather it to a contiguous
+                    # buffer for the kernel, then scatter it back below. view()
+                    # (not reshape) so the scatter-back writes through buf —
+                    # a silent copy would lose the re-RoPE'd K.
+                    packed = buf.view(num_layers * slots, n_heads, 2, head_size)
+                    k = packed[:, :, 0, :].contiguous()
+                else:
+                    # reshape returns an in-place view (tmp slots are contiguous).
+                    k = buf.reshape(num_layers * slots, n_heads, head_size)
                 lmc_ops.rotary_embedding_k_fused(
                     old_st + slot_positions_rep,
                     cur_st + slot_positions_rep,
-                    k_view,
-                    rope_state.head_size,
+                    k,
+                    head_size,
                     group_cos_sin,
                     rope_state.is_neox_style,
                 )
+                if is_packed_kv:
+                    packed[:, :, 0, :] = k  # write re-RoPE'd K back; V untouched
 
     def cb_retrieve_pre_computed(
         self,

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -336,6 +336,111 @@ def test_multi_layer_kernel(num_tokens, engine_kv_format):
 
 
 @pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
+@pytest.mark.parametrize("head_size", [64, 128])  # 64 = gpt-oss; 128 = common
+def test_multi_layer_kernel_packed_nhd(num_tokens, head_size):
+    """Round-trip the NHD fused-K/V packed layout NL_X_NB_BS_NH_TWO_HS.
+
+    vLLM packs [K, V] into the content dim ([NB, BS, NH, 2*HS]); the transfer
+    spec reports it as kv_size=1 with a doubled head_size. This exercises the
+    multi_layer_kv_transfer H2D scatter (the CacheBlend retrieve path) and D2H
+    gather for that layout: gather a paged cache into a memory object, scatter
+    it into a fresh paged cache, and assert per-token K/V equality at the slots.
+    """
+    device = "cuda"
+    num_blocks = 1000
+    block_size = 16
+    num_heads = 8
+    chunk_size = 256
+    num_layers = 32
+    dtype = torch.bfloat16
+    fmt = lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS
+
+    kv_cache = generate_kv_cache_paged_list_tensors(
+        num_blocks,
+        device,
+        block_size,
+        dtype,
+        num_layers,
+        head_size,
+        engine_kv_format=fmt,
+    )
+    page_buffer_size = num_blocks * block_size
+    slot_mapping = torch.tensor(
+        random.sample(range(0, page_buffer_size), num_tokens), device=device
+    )
+
+    mem_allocator = PinMemoryAllocator(4 * 1024 * 1024 * 1024)
+    kv_cache_pointers = torch.empty(
+        num_layers, dtype=torch.int64, device="cpu", pin_memory=True
+    )
+    for i in range(num_layers):
+        kv_cache_pointers[i] = kv_cache[i].data_ptr()
+
+    # D2H gather: fused K/V => memory object is kv_size==1 with a doubled D.
+    mem_obj_list = []
+    for slot_mapping_temp in torch.split(slot_mapping, chunk_size):
+        mem_obj = mem_allocator.allocate(
+            torch.Size(
+                [1, num_layers, len(slot_mapping_temp), num_heads * 2 * head_size]
+            ),
+            dtype,
+        )
+        lmc_ops.multi_layer_kv_transfer(
+            mem_obj.tensor,
+            kv_cache_pointers,
+            slot_mapping_temp,
+            kv_cache[0].device,
+            page_buffer_size,
+            lmc_ops.TransferDirection.D2H,
+            fmt,
+            block_size,
+            head_size=head_size,
+        )
+        mem_obj_list.append(mem_obj)
+
+    # H2D scatter into a fresh paged cache (the path CacheBlend retrieve uses).
+    kv_cache_new = generate_kv_cache_paged_list_tensors(
+        num_blocks,
+        device,
+        block_size,
+        dtype,
+        num_layers,
+        head_size,
+        engine_kv_format=fmt,
+    )
+    kv_cache_pointers_new = torch.empty(
+        num_layers, dtype=torch.int64, device="cpu", pin_memory=True
+    )
+    for i in range(num_layers):
+        kv_cache_pointers_new[i] = kv_cache_new[i].data_ptr()
+
+    for mem_obj, slot_mapping_temp in zip(
+        mem_obj_list, torch.split(slot_mapping, chunk_size), strict=True
+    ):
+        lmc_ops.multi_layer_kv_transfer(
+            mem_obj.tensor,
+            kv_cache_pointers_new,
+            slot_mapping_temp,
+            kv_cache_new[0].device,
+            page_buffer_size,
+            lmc_ops.TransferDirection.H2D,
+            fmt,
+            block_size,
+            head_size=head_size,
+        )
+
+    check_paged_kv_cache_equal(
+        kv_cache,
+        kv_cache_new,
+        slot_mapping,
+        num_heads=num_heads,
+        head_size=head_size,
+        engine_kv_format=fmt,
+    )
+    mem_allocator.close()
+
+
+@pytest.mark.parametrize("num_tokens", [256, 500, 1024, 8000])
 @pytest.mark.parametrize("head_size", [576, 66])  # Use 68 for dsv32 (132x int8)
 @pytest.mark.parametrize(
     "engine_kv_format",

--- a/tests/v1/utils.py
+++ b/tests/v1/utils.py
@@ -320,6 +320,9 @@ def generate_kv_cache_paged_list_tensors(
         elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS:
             # blocks-first, K/V fused into the trailing dim
             shape = [num_blocks, num_heads, block_size, 2, head_size]
+        elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS:
+            # NHD blocks-first, K/V fused into the trailing dim
+            shape = [num_blocks, block_size, num_heads, 2, head_size]
         else:
             raise ValueError(f"Unsupported engine_kv_format: {engine_kv_format}")
 
@@ -569,6 +572,20 @@ def check_paged_kv_cache_equal(
                 .contiguous()
                 .reshape(-1, num_heads, head_size)
             )
+
+            assert left_k.shape[0] >= num_tokens
+            assert (left_k[slot_mapping, :, :] == right_k[slot_mapping, :, :]).all()
+            assert (left_v[slot_mapping, :, :] == right_v[slot_mapping, :, :]).all()
+
+    elif engine_kv_format == lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS:
+        # NHD fused K/V: [num_blocks, block_size, num_heads, 2, head_size].
+        # Split the trailing pair into K (index 0) and V (index 1) per head.
+        num_tokens = slot_mapping.shape[0]
+        for left_kv_layer, right_kv_layer in zip(left, right, strict=True):
+            left_k = left_kv_layer[:, :, :, 0, :].reshape(-1, num_heads, head_size)
+            left_v = left_kv_layer[:, :, :, 1, :].reshape(-1, num_heads, head_size)
+            right_k = right_kv_layer[:, :, :, 0, :].reshape(-1, num_heads, head_size)
+            right_v = right_kv_layer[:, :, :, 1, :].reshape(-1, num_heads, head_size)
 
             assert left_k.shape[0] >= num_tokens
             assert (left_k[slot_mapping, :, :] == right_k[slot_mapping, :, :]).all()


### PR DESCRIPTION
**Follow-up to #4128** (`[Fix] Add kernels for vLLM-packed KV cache format`), which added the packed layout to the **bulk/MP transfer** path (`mp_mem_kernels.cu`, the `nl_x_nb_bs_nh_two_hs` format spec, detectors, and the Python fallback). This PR extends the *same* packed layout to the two **CacheBlend-specific** paths that #4128 did not touch: the per-token scatter kernel (`mem_kernels.cu`, the sibling of the `mp_mem_kernels.cu` #4128 fixed) and the re-RoPE step (`blend_v3.py`). No file overlap with #4128.

### Summary

Teaches CacheBlend V3 to handle the fused-K/V NHD layout (`[NB, BS, NH, 2, HS]`, `kv_size == 1`) that vLLM now produces after [vllm#44455](https://github.com/vllm-project/vllm/pull/44455). After #4128 the bulk transfer already handled this (prefix reuse / offload work), but CacheBlend V3's non-prefix path still assumed a split K/V (`kv_size == 2`) in two spots - the per-token scatter kernel and the re-RoPE step - and rejected the packed layout, so ~half of cross-engine CacheBlend retrieves failed and fell back to recompute. This PR adds packed support to both, restoring **non-prefix CacheBlend reuse** for packed-layout models (e.g. `gpt-oss-120b`) on current vLLM. Bulk transfer is untouched.

### What changed

```mermaid
flowchart LR
    subgraph before["Before (packed layout)"]
        b1["re-RoPE: shape[0]!=2<br/>→ RuntimeError 'MLA unsupported'"]
        b2["scatter: no case<br/>→ RuntimeError 'Unsupported EngineKVFormat'"]
    end
    subgraph after["After"]
        a1["re-RoPE: un-fold [.,nh,2,hs],<br/>rotate K half, write back"]
        a2["scatter: fused branch + k_or_v_size=1<br/>+ H2D/D2H dispatch"]
    end
    before --> after
```
The format spec intentionally reports the packed layout as fused (`kv_size == 1`, `head_size = 2·HS`) so the NHD-fused transfer kernels move the contiguous per-head `[K, V]` blob unchanged - right for bulk store/load. CacheBlend is the only consumer that must address K and V *separately* (re-RoPE rotates K only; the per-token scatter writes specific slots). So the fix is scoped to those two paths and leaves the fused transfer representation - and all working store/load/offload - alone. Rather than blindly overlaying the packed layout as split (which the transfer kernels can't move), the scatter reuses the existing fused/MLA addressing and the re-RoPE un-folds only where it needs the K half.

### Testing

- **Kernel round-trip** (`test_multi_layer_kernel_packed_nhd`): exact K/V match at `head_size` 64 (gpt-oss) and 128, tokens {256, 500, 1024, 8000}.
- **End-to-end** on `gpt-oss-120b`, TP=2, `--engine-type blend --enable-segmented-prefix`:
  - `lmcache_blend_retrieve_failures_total`: **~50% → 0**; non-prefix reuse fires (~80k reused tokens/burst); `MLA unsupported` / `Unsupported EngineKVFormat` gone.
  - **Correctness** (known-topic oracle): CacheBlend reuse produces answers that correctly identify the reused documents' topics - i.e. the reused KV is semantically correct, not garbage-that-doesn't-error.
  - **Concurrency** 1→32: engine stable (0 errors); reuse-ON throughput ~16× (RAG) / ~8× (prefix-shift) vs recompute at load.
  - **Tiers**: verified with reuse served from both L1 (RAM) and an L2 (SSD) backend.