### PR TITLE
[Fix][RawBlock] Bounce unaligned uring_cmd writes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,6 +149,10 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Run raw-block Rust unit tests
+        run: |
+          cargo test --manifest-path rust/raw_block/Cargo.toml --no-default-features
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,6 +146,10 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Run raw-block Rust unit tests
+        run: |
+          cargo test --manifest-path rust/raw_block/Cargo.toml --no-default-features
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -1291,26 +1291,16 @@ class RawBlockCore:
             )
             return
 
-        can_batch = all(
-            int(payload_len) == int(total_len)
-            for payload_len, total_len in zip(payload_lens, total_lens, strict=True)
+        # batched_write takes payload_lens and total_lens separately, so it
+        # handles O_DIRECT padding (payload_len < total_len) by bouncing and
+        # zero-filling internally. All io_uring writes go through one batch.
+        batch_id = raw_dev.batched_write(
+            [int(offset) for offset in offsets],
+            list(buffers),
+            [int(total_len) for total_len in total_lens],
+            [int(payload_len) for payload_len in payload_lens],
         )
-        # batched_write currently accepts only total_lens. When O_DIRECT padding
-        # is required, payload_len < total_len, so fall back to write_uring; it
-        # carries both lengths and lets Rust build the aligned padded transfer.
-        if can_batch:
-            batch_id = raw_dev.batched_write(
-                [int(offset) for offset in offsets],
-                list(buffers),
-                [int(total_len) for total_len in total_lens],
-            )
-            raw_dev.wait_iouring(batch_id)
-            return
-
-        for offset, buf, payload_len, total_len in zip(
-            offsets, buffers, payload_lens, total_lens, strict=True
-        ):
-            raw_dev.write_uring(int(offset), buf, int(payload_len), int(total_len))
+        raw_dev.wait_iouring(batch_id)
 
     def _read_buffers(
         self,

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -43,6 +43,7 @@ _DEFAULT_META_VERSION = 1
 _META_HEADER_STRUCT = struct.Struct("<8sIQQI")
 RAW_BLOCK_IO_ENGINES = frozenset({"posix", "io_uring"})
 DEFAULT_IOURING_QUEUE_DEPTH = 256
+_MAX_PUT_MANY_IO_URING_BATCH_KEYS = 64
 
 
 def round_up(x: int, align: int) -> int:
@@ -637,6 +638,9 @@ class RawBlockCore:
         if len(keys) != len(objs):
             raise ValueError("keys and objs must have the same length")
 
+        if self.io_engine == "io_uring" and len(keys) > 1:
+            return self._put_many_batch_io(keys, objs)
+
         results = [False] * len(keys)
         stored_keys: list[str] = []
 
@@ -1067,6 +1071,15 @@ class RawBlockCore:
         except Exception:
             return None
 
+    def _payload_fits_slot(self, payload_len: int) -> bool:
+        """Return whether a logical payload can fit in one raw-block slot."""
+        payload_capacity = self.slot_bytes - self.header_bytes
+        if payload_len > payload_capacity:
+            return False
+        if self._requires_transfer_alignment:
+            return round_up(payload_len, self.block_align) <= payload_capacity
+        return True
+
     def _prepare_write_payload(self, memory_obj: MemoryObj) -> tuple[Any, int, int]:
         """Prepare the payload buffer and lengths for a raw-block write.
 
@@ -1282,6 +1295,9 @@ class RawBlockCore:
             int(payload_len) == int(total_len)
             for payload_len, total_len in zip(payload_lens, total_lens, strict=True)
         )
+        # batched_write currently accepts only total_lens. When O_DIRECT padding
+        # is required, payload_len < total_len, so fall back to write_uring; it
+        # carries both lengths and lets Rust build the aligned padded transfer.
         if can_batch:
             batch_id = raw_dev.batched_write(
                 [int(offset) for offset in offsets],
@@ -1394,6 +1410,217 @@ class RawBlockCore:
         except Exception as e:
             logger.error("RawBlockCore write failed for %s: %s", key.encoded, e)
             return False
+
+    def _put_many_batch_io(
+        self,
+        keys: Sequence[RawBlockKeySpec],
+        objs: Sequence[MemoryObj],
+    ) -> RawBlockPutManyResult:
+        """Persist objects using bounded io_uring batch submissions.
+
+        Large ``put_many`` calls are split into chunks so one caller cannot
+        monopolize the RawBlockCore lock or fill the default 256-entry Rust
+        io_uring queue with a single Python batch. Each key contributes two
+        write entries (header + payload), so the default 64-key chunk caps a
+        submit at 128 entries.
+        """
+        if len(keys) <= _MAX_PUT_MANY_IO_URING_BATCH_KEYS:
+            return self._put_many_batch_io_chunk(keys, objs)
+
+        results = [False] * len(keys)
+        stored_keys: list[str] = []
+        first_occurrences: dict[str, int] = {}
+        unique_plan: list[tuple[int, RawBlockKeySpec, MemoryObj]] = []
+        duplicate_indices: list[tuple[int, int]] = []
+
+        # Deduplicate before chunking so duplicates that cross chunk boundaries
+        # still inherit the first occurrence result without being rewritten.
+        for i, (key, obj) in enumerate(zip(keys, objs, strict=True)):
+            first_index = first_occurrences.get(key.encoded)
+            if first_index is not None:
+                duplicate_indices.append((i, first_index))
+                continue
+            first_occurrences[key.encoded] = i
+            unique_plan.append((i, key, obj))
+
+        chunk_size = _MAX_PUT_MANY_IO_URING_BATCH_KEYS
+        for start in range(0, len(unique_plan), chunk_size):
+            chunk = unique_plan[start : start + chunk_size]
+            chunk_result = self._put_many_batch_io_chunk(
+                [key for _, key, _ in chunk],
+                [obj for _, _, obj in chunk],
+            )
+            for local_i, (global_i, _key, _obj) in enumerate(chunk):
+                results[global_i] = chunk_result.results[local_i]
+            stored_keys.extend(chunk_result.stored_keys)
+
+        for duplicate_i, first_i in duplicate_indices:
+            results[duplicate_i] = results[first_i]
+
+        return RawBlockPutManyResult(results=results, stored_keys=stored_keys)
+
+    def _put_many_batch_io_chunk(
+        self,
+        keys: Sequence[RawBlockKeySpec],
+        objs: Sequence[MemoryObj],
+    ) -> RawBlockPutManyResult:
+        """Persist one bounded chunk with a single io_uring submission.
+
+        Eligible new keys are submitted through one ``_write_buffers`` call so
+        the io_uring path can keep those writes in flight concurrently instead
+        of writing each key serially.
+
+        Eligibility failures before submission are reported per key: already
+        indexed keys report success without rewriting, same-batch duplicates
+        share the first occurrence's final result, and keys with no free slot or
+        payloads that cannot fit one slot fail individually. Once a combined
+        device write is submitted, any write failure rolls back every submitted
+        new key and commits none of them.
+        The caller must pass a non-empty, equal-length chunk.
+
+        Args:
+            keys: Ordered raw-block key specs corresponding to ``objs``. Must be
+                the same length as ``objs``.
+            objs: Memory objects whose byte buffers should be written. Must be
+                the same length as ``keys``.
+
+        Returns:
+            Per-key success results aligned with ``keys`` and the list of
+            encoded keys that were newly committed to the index.
+
+        Raises:
+            ValueError: If ``keys`` and ``objs`` differ in length.
+        """
+        results = [False] * len(keys)
+        stored_keys: list[str] = []
+        write_plan: list[tuple[int, RawBlockKeySpec, MemoryObj, int]] = []
+        planned_keys: set[str] = set()
+        batch_duplicates: list[tuple[int, str]] = []
+
+        # Reserve slots for eligible first-occurrence keys under the lock.
+        with self._lock:
+            for i, (key, obj) in enumerate(zip(keys, objs, strict=True)):
+                if self._closed:
+                    break
+                encoded_key = key.encoded
+                if encoded_key in self._index:
+                    results[i] = True
+                    continue
+                if encoded_key in planned_keys:
+                    batch_duplicates.append((i, encoded_key))
+                    continue
+                if encoded_key in self._inflight:
+                    continue
+                payload_len = len(obj.byte_array)
+                if not self._payload_fits_slot(payload_len):
+                    logger.warning(
+                        "RawBlockCore: payload for key %s does not fit slot",
+                        encoded_key,
+                    )
+                    continue
+                try:
+                    offset = self._allocate_slot_locked()
+                except RuntimeError:
+                    logger.warning(
+                        "RawBlockCore: no free slot available for key %s",
+                        key.encoded,
+                    )
+                    continue
+                meta = DiskCacheMetadata(
+                    path=f"{self.device_path}@{offset}",
+                    size=payload_len,
+                    shape=obj.metadata.shape,
+                    dtype=obj.metadata.dtype,
+                    cached_positions=obj.metadata.cached_positions,
+                    fmt=obj.metadata.fmt,
+                    pin_count=0,
+                )
+                self._inflight[encoded_key] = _Inflight(offset=offset, meta=meta)
+                planned_keys.add(encoded_key)
+                write_plan.append((i, key, obj, offset))
+
+        if not write_plan:
+            return RawBlockPutManyResult(results=results, stored_keys=stored_keys)
+
+        # Build header/payload write entries outside the lock. Preparation
+        # failures happen before device submission and are isolated per key.
+        offsets: list[int] = []
+        buffers: list[Any] = []
+        payload_lens: list[int] = []
+        total_lens: list[int] = []
+        prepared_plan: list[tuple[int, RawBlockKeySpec, MemoryObj, int]] = []
+        write_succeeded = True
+        for i, key, obj, offset in write_plan:
+            try:
+                header = self._encode_header(key.slot_identity, len(obj.byte_array))
+                hdr_total = (
+                    round_up(len(header), self.block_align)
+                    if self._requires_transfer_alignment
+                    else len(header)
+                )
+                offsets.append(offset)
+                buffers.append(header)
+                payload_lens.append(hdr_total)
+                total_lens.append(hdr_total)
+
+                buf, payload_len, total_len = self._prepare_write_payload(obj)
+                offsets.append(offset + self.header_bytes)
+                buffers.append(buf)
+                payload_lens.append(payload_len)
+                total_lens.append(total_len)
+                prepared_plan.append((i, key, obj, offset))
+            except Exception as e:
+                logger.error(
+                    "RawBlockCore batch buffer preparation failed for %s: %s",
+                    key.encoded,
+                    e,
+                )
+                with self._lock:
+                    inflight = self._inflight.pop(key.encoded, None)
+                    if inflight is not None:
+                        self._append_free_slot_locked(
+                            self._offset_to_slot(int(inflight.offset))
+                        )
+                        self._meta_dirty_total += 1
+
+        if prepared_plan:
+            with self._lock:
+                self._inflight_io_count += len(prepared_plan)
+            try:
+                self._write_buffers(offsets, buffers, payload_lens, total_lens)
+            except Exception as e:
+                write_succeeded = False
+                logger.error("RawBlockCore batched write failed: %s", e)
+            finally:
+                with self._lock:
+                    self._inflight_io_count -= len(prepared_plan)
+                    self._last_io_ts = time.monotonic()
+
+        # Commit successful writes, or roll back submitted keys if the device
+        # write failed.
+        with self._lock:
+            for i, key, _obj, _offset in prepared_plan:
+                inflight = self._inflight.pop(key.encoded, None)
+                if inflight is None:
+                    continue
+                if not write_succeeded or inflight.canceled:
+                    self._append_free_slot_locked(
+                        self._offset_to_slot(int(inflight.offset))
+                    )
+                    self._meta_dirty_total += 1
+                    continue
+                self._index[key.encoded] = _Entry(
+                    offset=inflight.offset,
+                    size=inflight.meta.size,
+                    meta=inflight.meta,
+                )
+                self._meta_dirty_total += 1
+                results[i] = True
+                stored_keys.append(key.encoded)
+            for i, encoded_key in batch_duplicates:
+                results[i] = encoded_key in self._index
+
+        return RawBlockPutManyResult(results=results, stored_keys=stored_keys)
 
     def _encode_header(self, slot_identity: int, payload_len: int) -> bytes:
         """Encode a fixed-size raw-block slot header."""

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -1273,6 +1273,10 @@ class RawBlockCore:
                     f"Aligned payload {total_len} exceeds slot capacity "
                     f"{payload_capacity}"
                 )
+            # zero_tail is not needed for correctness because the Rust write
+            # path always zeroes [payload_len, total_len). It is what lets that
+            # path submit this buffer directly instead of bouncing it, so the
+            # zero-copy fixed-buffer write is preserved.
             direct_view = self._build_direct_odirect_view(
                 memory_obj=memory_obj,
                 payload_len=payload_len,
@@ -1536,43 +1540,25 @@ class RawBlockCore:
             )
             return
 
-        can_batch = all(
-            int(payload_len) == int(total_len)
-            for payload_len, total_len in zip(payload_lens, total_lens, strict=True)
-        )
-        # batched_write carries a single length per entry, so it cannot express
-        # O_DIRECT padding where payload_len < total_len. Fall back to
-        # write_uring, which takes both lengths and lets Rust build the aligned
-        # padded transfer.
-        if can_batch:
-            batch_id = raw_dev.batched_write(
-                [int(offset) for offset in offsets],
-                list(buffers),
-                [int(total_len) for total_len in total_lens],
-                per_write_placement_ids,
-            )
-            if not all(
-                self._wait_iouring_results(
-                    raw_dev,
-                    batch_id,
-                    len(offsets),
-                    "io_uring write",
-                )
-            ):
-                raise RuntimeError("raw-block io_uring write failed")
-            return
-
-        for offset, buf, payload_len, total_len, placement_id in zip(
-            offsets,
-            buffers,
-            payload_lens,
-            total_lens,
+        # batched_write takes payload_lens and total_lens separately, so it
+        # handles O_DIRECT padding (payload_len < total_len) by bouncing and
+        # zero-filling internally. All io_uring writes go through one batch.
+        batch_id = raw_dev.batched_write(
+            [int(offset) for offset in offsets],
+            list(buffers),
+            [int(total_len) for total_len in total_lens],
             per_write_placement_ids,
-            strict=True,
-        ):
-            raw_dev.write_uring(
-                int(offset), buf, int(payload_len), int(total_len), placement_id
+            [int(payload_len) for payload_len in payload_lens],
+        )
+        if not all(
+            self._wait_iouring_results(
+                raw_dev,
+                batch_id,
+                len(offsets),
+                "io_uring write",
             )
+        ):
+            raise RuntimeError("raw-block io_uring write failed")
 
     def _read_buffers(
         self,

--- a/rust/raw_block/Cargo.toml
+++ b/rust/raw_block/Cargo.toml
@@ -9,7 +9,11 @@ edition = "2021"
 name = "lmcache_rust_raw_block_io"
 crate-type = ["cdylib"]
 
+[features]
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.24" }
 libc = "0.2"
 io-uring = "0.7"

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -102,6 +102,12 @@ No fixed numbers are included here because results are host/device/workload depe
   requests whose offset or `total_len` is not a multiple of the configured
   alignment; misaligned write buffers are copied through an aligned bounce
   buffer.
+- `write_uring` and `batched_write` take a logical payload length alongside the
+  physical transfer length (`payload_lens` defaults to `total_lens`). They read
+  the source only up to the payload length, never modify it, and always write
+  the padding region as zeroes. A bounce buffer is used when the source is
+  shorter than the transfer length or its padding tail is not already zero,
+  so a caller buffer whose tail is zero keeps the fixed-buffer zero-copy path.
 
 ## Build
 

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -104,7 +104,7 @@ No fixed numbers are included here because results are host/device/workload depe
   buffer.
 - `write_uring` and `batched_write` take a logical payload length alongside the
   physical transfer length (`payload_lens` defaults to `total_lens`). They read
-  the source only up to the payload length, never modify it, and always write
+  only within the source buffer bounds, never modify it, and always write
   the padding region as zeroes. A bounce buffer is used when the source is
   shorter than the transfer length or its padding tail is not already zero,
   so a caller buffer whose tail is zero keeps the fixed-buffer zero-copy path.

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -571,6 +571,77 @@ impl Drop for AlignedBuf {
     }
 }
 
+struct PreparedWriteBuffer {
+    ptr_addr: usize,
+    bounce: Option<Arc<AlignedBuf>>,
+    fixed_buffer_idx: Option<u16>,
+}
+
+fn buffer_range_is_zero(ptr_addr: usize, offset: usize, len: usize) -> bool {
+    if len == 0 {
+        return true;
+    }
+    let ptr = (ptr_addr as *const u8).wrapping_add(offset);
+    unsafe {
+        slice::from_raw_parts(ptr, len)
+            .iter()
+            .all(|byte| *byte == 0)
+    }
+}
+
+fn prepare_iouring_write_buffer(
+    ptr_addr: usize,
+    cap: usize,
+    payload_len: usize,
+    total_len: usize,
+    use_odirect: bool,
+    alignment: usize,
+    fixed_buffer_idx: Option<u16>,
+) -> PyResult<PreparedWriteBuffer> {
+    if cap < payload_len {
+        return Err(PyValueError::new_err(format!(
+            "input buffer too small: cap={cap} need={payload_len}"
+        )));
+    }
+    if total_len < payload_len {
+        return Err(PyValueError::new_err("total_len must be >= payload_len"));
+    }
+
+    let needs_alignment_bounce = use_odirect && !ptr_addr.is_multiple_of(alignment);
+    let needs_capacity_bounce = cap < total_len;
+    let has_padding = payload_len < total_len;
+    let tail_is_zero = !has_padding
+        || (!needs_capacity_bounce
+            && buffer_range_is_zero(ptr_addr, payload_len, total_len - payload_len));
+    let needs_zero_bounce = has_padding && !tail_is_zero;
+    let needs_bounce = needs_alignment_bounce || needs_capacity_bounce || needs_zero_bounce;
+
+    if !needs_bounce {
+        return Ok(PreparedWriteBuffer {
+            ptr_addr,
+            bounce: None,
+            fixed_buffer_idx,
+        });
+    }
+
+    let bounce = AlignedBuf::new(total_len, alignment)?;
+    let bounce_ptr = bounce.as_mut_ptr();
+    unsafe {
+        if payload_len > 0 {
+            std::ptr::copy_nonoverlapping(ptr_addr as *const u8, bounce_ptr, payload_len);
+        }
+        if total_len > payload_len {
+            std::ptr::write_bytes(bounce_ptr.add(payload_len), 0u8, total_len - payload_len);
+        }
+    }
+    let bounce_arc = Arc::new(bounce);
+    Ok(PreparedWriteBuffer {
+        ptr_addr: bounce_arc.as_ptr() as usize,
+        bounce: Some(bounce_arc),
+        fixed_buffer_idx: None,
+    })
+}
+
 // Acquire a Python buffer view with the requested mutability.
 fn get_pybuffer<'py>(
     py: Python<'py>,
@@ -1971,13 +2042,14 @@ impl RawBlockDevice {
     ///
     /// Returns a batch_id that must be passed to wait_iouring() to wait
     /// for completions for that batch.
-    #[pyo3(signature = (offsets, buffers, total_lens))]
+    #[pyo3(signature = (offsets, buffers, total_lens, payload_lens = None))]
     fn batched_write(
         &self,
         py: Python<'_>,
         offsets: Vec<u64>,
         buffers: Vec<Bound<'_, PyAny>>,
         total_lens: Vec<usize>,
+        payload_lens: Option<Vec<usize>>,
     ) -> PyResult<u64> {
         if !self.use_iouring {
             return Err(PyRuntimeError::new_err("io_uring not enabled"));
@@ -1995,6 +2067,37 @@ impl RawBlockDevice {
             return Err(PyValueError::new_err("All vectors must have same length"));
         }
 
+        // payload_lens carries the logical (unpadded) length of each buffer. When
+        // omitted it equals total_lens, which reproduces the legacy behavior where
+        // the full transfer length is also the valid payload length.
+        let payload_lens: Vec<usize> = match payload_lens {
+            Some(p) => {
+                if p.len() != n {
+                    return Err(PyValueError::new_err("All vectors must have same length"));
+                }
+                p
+            }
+            None => total_lens.clone(),
+        };
+        for i in 0..n {
+            if payload_lens[i] > total_lens[i] {
+                return Err(PyValueError::new_err("total_len must be >= payload_len"));
+            }
+        }
+        let align = self.alignment;
+        if self.use_odirect {
+            for i in 0..n {
+                #[allow(clippy::manual_is_multiple_of)]
+                if (offsets[i] as usize) % align != 0 {
+                    return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+                }
+                #[allow(clippy::manual_is_multiple_of)]
+                if total_lens[i] % align != 0 {
+                    return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+                }
+            }
+        }
+
         // Acquire buffer views to keep them alive until wait_iouring() completes
         let mut views = Vec::with_capacity(n);
         for buffer in &buffers {
@@ -2007,6 +2110,25 @@ impl RawBlockDevice {
                 return Err(PyValueError::new_err("null buffer pointer"));
             }
             views.push(view);
+        }
+
+        // Validate buffer capacities before allocating any batch tracking so the
+        // error path stays simple (just release the views).
+        let mut cap_err: Option<(usize, usize)> = None;
+        for (i, view) in views.iter().enumerate() {
+            let cap = view.len as usize;
+            if cap < payload_lens[i] {
+                cap_err = Some((cap, payload_lens[i]));
+                break;
+            }
+        }
+        if let Some((cap, need)) = cap_err {
+            for v in views {
+                release_pybuffer(v);
+            }
+            return Err(PyValueError::new_err(format!(
+                "input buffer too small: cap={cap} need={need}"
+            )));
         }
 
         // Generate a unique batch ID for this batch
@@ -2030,10 +2152,13 @@ impl RawBlockDevice {
             }
         }
 
-        // Extract pointers as usize before releasing GIL (raw pointers are not Send)
+        // Extract pointers and capacities as usize before releasing GIL (raw
+        // pointers are not Send).
         let mut ptrs = Vec::with_capacity(n);
+        let mut caps = Vec::with_capacity(n);
         for view in &views {
             ptrs.push(view.buf as usize);
+            caps.push(view.len as usize);
         }
 
         for view in views {
@@ -2079,8 +2204,9 @@ impl RawBlockDevice {
 
             // Prepare all requests, bounce buffers (if needed) and collect submission data.
             for i in 0..n {
-                let ptr = ptrs[i] as *const u8;
                 let total_len = total_lens[i];
+                let payload_len = payload_lens[i];
+                let cap = caps[i];
                 let offset = offsets[i];
 
                 let comp = Arc::new(IoCompletion::new());
@@ -2088,28 +2214,15 @@ impl RawBlockDevice {
                 // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
                 let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
 
-                // Ensure O_DIRECT buffers are aligned
-                let (final_ptr, bounce_opt, fixed_idx) = if use_odirect {
-                    let align = alignment;
-                    #[allow(clippy::manual_is_multiple_of)]
-                    if ptrs[i] % align != 0 {
-                        let bounce = AlignedBuf::new(total_len, align)?;
-                        unsafe {
-                            libc::memcpy(
-                                bounce.as_mut_ptr() as *mut libc::c_void,
-                                ptr as *const libc::c_void,
-                                total_len,
-                            );
-                        }
-                        let bounce_arc = std::sync::Arc::new(bounce);
-                        let bounce_ptr = bounce_arc.as_ptr();
-                        (bounce_ptr, Some(bounce_arc), None)
-                    } else {
-                        (ptr, None, fixed_idx)
-                    }
-                } else {
-                    (ptr, None, fixed_idx)
-                };
+                let prepared = prepare_iouring_write_buffer(
+                    ptrs[i],
+                    cap,
+                    payload_len,
+                    total_len,
+                    use_odirect,
+                    alignment,
+                    fixed_idx,
+                )?;
 
                 // Build NVMe command data
                 let nvme_cmd_data = if let Some((nsid, lba_shift)) = nvme_cmd_data_base {
@@ -2127,11 +2240,11 @@ impl RawBlockDevice {
                     fd,
                     offset,
                     len: total_len,
-                    ptr_addr: final_ptr as usize,
+                    ptr_addr: prepared.ptr_addr,
                     is_write: true,
                     completion: comp.clone(),
-                    fixed_buffer_idx: fixed_idx,
-                    bounce: bounce_opt,
+                    fixed_buffer_idx: prepared.fixed_buffer_idx,
+                    bounce: prepared.bounce,
                     original_ptr: None,
                     payload_len: None,
                     batch_id,
@@ -2485,22 +2598,27 @@ impl RawBlockDevice {
             None
         };
 
-        // Use bounce buffer if:
-        // Buffer is not aligned (O_DIRECT requirement)
-        // Buffer capacity is less than total_len
-        let use_bounce = !ptr_aligned || cap < total_len;
+        let prepared = prepare_iouring_write_buffer(
+            ptr as usize,
+            cap,
+            payload_len,
+            total_len,
+            self.use_odirect,
+            align,
+            fixed_idx,
+        )?;
 
-        let res = if !use_bounce {
+        let res = if prepared.bounce.is_none() {
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
             let sub = IoSubmission {
                 fd: self.fd,
                 offset,
                 len: total_len,
-                ptr_addr: ptr as usize,
+                ptr_addr: prepared.ptr_addr,
                 is_write: true,
                 completion: comp.clone(),
-                fixed_buffer_idx: fixed_idx,
+                fixed_buffer_idx: prepared.fixed_buffer_idx,
                 bounce: None,
                 original_ptr: None,
                 payload_len: None,
@@ -2517,24 +2635,18 @@ impl RawBlockDevice {
             }
             py.allow_threads(move || comp.wait())
         } else {
-            let bounce = AlignedBuf::new(total_len, align)?;
-            let bounce_arc = std::sync::Arc::new(bounce);
-            let bounce_ptr = bounce_arc.as_mut_ptr();
-            // Copy data to bounce buffer before submission
-            unsafe {
-                std::ptr::copy_nonoverlapping(ptr, bounce_ptr, payload_len);
-            }
+            let bounce = prepared.bounce;
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
             let sub = IoSubmission {
                 fd: self.fd,
                 offset,
                 len: total_len,
-                ptr_addr: bounce_ptr as usize,
+                ptr_addr: prepared.ptr_addr,
                 is_write: true,
                 completion: comp.clone(),
                 fixed_buffer_idx: None,
-                bounce: Some(bounce_arc),
+                bounce,
                 original_ptr: None,
                 payload_len: Some(payload_len),
                 batch_id: 0,

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -594,7 +594,7 @@ fn prepare_iouring_write_buffer(
     cap: usize,
     payload_len: usize,
     total_len: usize,
-    use_odirect: bool,
+    needs_alignment: bool,
     alignment: usize,
     fixed_buffer_idx: Option<u16>,
 ) -> PyResult<PreparedWriteBuffer> {
@@ -607,7 +607,7 @@ fn prepare_iouring_write_buffer(
         return Err(PyValueError::new_err("total_len must be >= payload_len"));
     }
 
-    let needs_alignment_bounce = use_odirect && !ptr_addr.is_multiple_of(alignment);
+    let needs_alignment_bounce = needs_alignment && !ptr_addr.is_multiple_of(alignment);
     let needs_capacity_bounce = cap < total_len;
     let has_padding = payload_len < total_len;
     let tail_is_zero = !has_padding
@@ -640,6 +640,134 @@ fn prepare_iouring_write_buffer(
         bounce: Some(bounce_arc),
         fixed_buffer_idx: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::types::{PyByteArray, PyBytes};
+
+    fn raw_device_with_missing_nvme_metadata() -> RawBlockDevice {
+        RawBlockDevice {
+            fd: -1,
+            size: 0,
+            closed: AtomicBool::new(false),
+            use_odirect: false,
+            alignment: 4096,
+            use_iouring: true,
+            use_uring_cmd: true,
+            nvme_nsid: None,
+            nvme_lba_shift: None,
+            nvme_lba_size: None,
+            ring: None,
+            queue: Some(Arc::new(Mutex::new(Vec::new()))),
+            worker: None,
+            shutdown: None,
+            fixed_buffer_map: Arc::new(Mutex::new(HashMap::new())),
+            fixed_buffers_registered: Arc::new(AtomicBool::new(false)),
+            in_flight_count: Arc::new(AtomicU64::new(0)),
+            in_flight_cvar: Arc::new(Condvar::new()),
+            batch_in_flight: Arc::new(Mutex::new(HashMap::new())),
+            batch_ready: None,
+            batched_buffer_objs: Arc::new(Mutex::new(HashMap::new())),
+            batched_completions: Arc::new(Mutex::new(HashMap::new())),
+            next_batch_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    fn unaligned_buffer(total_len: usize, alignment: usize) -> PyResult<AlignedBuf> {
+        AlignedBuf::new(total_len + 1, alignment)
+    }
+
+    #[test]
+    fn prepare_write_buffer_keeps_unaligned_buffer_without_alignment_requirement() -> PyResult<()> {
+        let alignment = 4096;
+        let total_len = 8192;
+        let buf = unaligned_buffer(total_len, alignment)?;
+        let ptr_addr = unsafe { buf.as_ptr().add(1) as usize };
+        let fixed_buffer_idx = Some(7);
+
+        let prepared = prepare_iouring_write_buffer(
+            ptr_addr,
+            total_len,
+            total_len,
+            total_len,
+            false,
+            alignment,
+            fixed_buffer_idx,
+        )?;
+
+        assert_eq!(prepared.ptr_addr, ptr_addr);
+        assert!(prepared.bounce.is_none());
+        assert_eq!(prepared.fixed_buffer_idx, fixed_buffer_idx);
+        Ok(())
+    }
+
+    #[test]
+    fn prepare_write_buffer_bounces_unaligned_buffer_when_alignment_required() -> PyResult<()> {
+        let alignment = 4096;
+        let total_len = 8192;
+        let buf = unaligned_buffer(total_len, alignment)?;
+        let ptr_addr = unsafe { buf.as_ptr().add(1) as usize };
+        let payload = unsafe { slice::from_raw_parts_mut(ptr_addr as *mut u8, total_len) };
+        for (idx, byte) in payload.iter_mut().enumerate() {
+            *byte = (idx % 251) as u8;
+        }
+
+        let prepared = prepare_iouring_write_buffer(
+            ptr_addr,
+            total_len,
+            total_len,
+            total_len,
+            true,
+            alignment,
+            Some(7),
+        )?;
+
+        assert_ne!(prepared.ptr_addr, ptr_addr);
+        assert!(prepared.ptr_addr.is_multiple_of(alignment));
+        assert!(prepared.fixed_buffer_idx.is_none());
+
+        let bounce = prepared
+            .bounce
+            .as_ref()
+            .expect("unaligned buffer should bounce");
+        let bounced = unsafe { slice::from_raw_parts(bounce.as_ptr(), total_len) };
+        assert_eq!(bounced, payload);
+        Ok(())
+    }
+
+    #[test]
+    fn read_uring_nvme_metadata_error_does_not_leak_in_flight() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let device = raw_device_with_missing_nvme_metadata();
+            let data = PyByteArray::new(py, &[0; 4096]);
+
+            let result = device.read_uring(py, 0, data.as_any(), 4096, None);
+            let in_flight = device.in_flight_count.load(Ordering::Relaxed);
+            device.closed.store(true, Ordering::Relaxed);
+
+            assert!(result.is_err());
+            assert_eq!(in_flight, 0);
+        });
+    }
+
+    #[test]
+    fn write_uring_nvme_metadata_error_does_not_leak_in_flight() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let device = raw_device_with_missing_nvme_metadata();
+            let data = PyBytes::new(py, &[0; 4096]);
+
+            let result = device.write_uring(py, 0, data.as_any(), 4096, None);
+            let in_flight = device.in_flight_count.load(Ordering::Relaxed);
+            device.closed.store(true, Ordering::Relaxed);
+
+            assert!(result.is_err());
+            assert_eq!(in_flight, 0);
+        });
+    }
 }
 
 // Acquire a Python buffer view with the requested mutability.
@@ -2201,6 +2329,7 @@ impl RawBlockDevice {
         // Release the GIL while submitting I/O operations
         let res = py.allow_threads(move || {
             let mut submissions: Vec<(IoSubmission, Arc<IoCompletion>)> = Vec::with_capacity(n);
+            let needs_align = use_odirect || use_uring_cmd;
 
             // Prepare all requests, bounce buffers (if needed) and collect submission data.
             for i in 0..n {
@@ -2219,7 +2348,7 @@ impl RawBlockDevice {
                     cap,
                     payload_len,
                     total_len,
-                    use_odirect,
+                    needs_align,
                     alignment,
                     fixed_idx,
                 )?;
@@ -2407,6 +2536,7 @@ impl RawBlockDevice {
         if self.closed.load(Ordering::Relaxed) {
             return Err(PyRuntimeError::new_err("device is closed"));
         }
+        let nvme_cmd_data = self._build_nvme_cmd_data(0, 0)?;
 
         let view = get_pybuffer(py, data, true)?;
         if view.readonly != 0 {
@@ -2467,7 +2597,6 @@ impl RawBlockDevice {
         // Buffer is not aligned (O_DIRECT requirement)
         // Buffer capacity is less than total_len
         let use_bounce = !ptr_aligned || cap < total_len;
-
         let res = if !use_bounce {
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
@@ -2483,7 +2612,7 @@ impl RawBlockDevice {
                 original_ptr: None,
                 payload_len: None,
                 batch_id: 0,
-                nvme_cmd_data: self._build_nvme_cmd_data(0, 0)?,
+                nvme_cmd_data: nvme_cmd_data.clone(),
             };
             {
                 let q = self.queue.as_ref().expect("queue must exist");
@@ -2512,7 +2641,7 @@ impl RawBlockDevice {
                 original_ptr: Some(ptr as usize),
                 payload_len: Some(payload_len),
                 batch_id: 0,
-                nvme_cmd_data: self._build_nvme_cmd_data(0, 0)?,
+                nvme_cmd_data,
             };
             {
                 let q = self.queue.as_ref().expect("queue must exist");
@@ -2546,6 +2675,7 @@ impl RawBlockDevice {
         if self.closed.load(Ordering::Relaxed) {
             return Err(PyRuntimeError::new_err("device is closed"));
         }
+        let nvme_cmd_data = self._build_nvme_cmd_data(0, 0)?;
 
         let view = get_pybuffer(py, data, false)?;
         let ptr = view.buf as *const u8;
@@ -2581,8 +2711,8 @@ impl RawBlockDevice {
             }
         }
 
-        // Check if the buffer is aligned for O_DIRECT
-        let ptr_aligned = if self.use_odirect {
+        let needs_align = self.use_odirect || self.use_uring_cmd;
+        let ptr_aligned = if needs_align {
             (ptr as usize).is_multiple_of(align)
         } else {
             true
@@ -2603,11 +2733,10 @@ impl RawBlockDevice {
             cap,
             payload_len,
             total_len,
-            self.use_odirect,
+            needs_align,
             align,
             fixed_idx,
         )?;
-
         let res = if prepared.bounce.is_none() {
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
@@ -2623,7 +2752,7 @@ impl RawBlockDevice {
                 original_ptr: None,
                 payload_len: None,
                 batch_id: 0,
-                nvme_cmd_data: self._build_nvme_cmd_data(0, 0)?,
+                nvme_cmd_data: nvme_cmd_data.clone(),
             };
             {
                 let q = self.queue.as_ref().expect("queue must exist");
@@ -2650,7 +2779,7 @@ impl RawBlockDevice {
                 original_ptr: None,
                 payload_len: Some(payload_len),
                 batch_id: 0,
-                nvme_cmd_data: self._build_nvme_cmd_data(0, 0)?,
+                nvme_cmd_data,
             };
             {
                 let q = self.queue.as_ref().expect("queue must exist");

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -748,7 +748,7 @@ fn buffer_range_is_zero(ptr_addr: usize, offset: usize, len: usize) -> bool {
 }
 
 // Prepare one regular io_uring write so that `total_len` bytes can be submitted
-// while the source is only read up to `payload_len`.
+// while reading only within the source buffer bounds.
 //
 // The padding region [payload_len, total_len) is always written as zeroes. The
 // caller buffer is submitted directly when it can already satisfy that, which
@@ -2265,7 +2265,7 @@ impl RawBlockDevice {
     /// `total_lens` gives the physical transfer length of each write and
     /// `payload_lens` the logical length of the source data; omitting
     /// `payload_lens` makes it equal to `total_lens`. Each source buffer is
-    /// read only up to its `payload_len` and is never modified, and the
+    /// read only within its bounds and is never modified, and the
     /// padding region `[payload_len, total_len)` is always written as zeroes.
     ///
     /// Returns a batch ID that must be passed to `wait_iouring()` to wait for
@@ -2770,8 +2770,8 @@ impl RawBlockDevice {
 
     /// Synchronous write using io_uring.
     ///
-    /// `total_len` defaults to `payload_len`. The source buffer is read only up
-    /// to `payload_len` and is never modified, and the padding region
+    /// `total_len` defaults to `payload_len`. The source buffer is read only
+    /// within its bounds and is never modified, and the padding region
     /// `[payload_len, total_len)` is always written as zeroes.
     #[pyo3(signature = (offset, data, payload_len, total_len = None, placement_id = None))]
     fn write_uring(

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -720,6 +720,96 @@ impl Drop for AlignedBuf {
     }
 }
 
+/// Source description for one prepared io_uring write.
+///
+/// Fields:
+/// - `ptr_addr`: Address to submit, either the caller buffer or the bounce
+/// - `bounce`: Bounce buffer that must stay alive until the write completes
+/// - `fixed_buffer_idx`: Registered fixed-buffer index, cleared when bouncing
+struct PreparedWriteBuffer {
+    ptr_addr: usize,
+    bounce: Option<Arc<AlignedBuf>>,
+    fixed_buffer_idx: Option<u16>,
+}
+
+// Report whether `len` bytes starting at `ptr_addr + offset` are all zero.
+fn buffer_range_is_zero(ptr_addr: usize, offset: usize, len: usize) -> bool {
+    if len == 0 {
+        return true;
+    }
+    let ptr = (ptr_addr as *const u8).wrapping_add(offset);
+    // SAFETY: callers only pass ranges inside the buffer they hold, so
+    // [offset, offset + len) is readable for the lifetime of this call.
+    unsafe {
+        slice::from_raw_parts(ptr, len)
+            .iter()
+            .all(|byte| *byte == 0)
+    }
+}
+
+// Prepare one regular io_uring write so that `total_len` bytes can be submitted
+// while the source is only read up to `payload_len`.
+//
+// The padding region [payload_len, total_len) is always written as zeroes. The
+// caller buffer is submitted directly when it can already satisfy that, which
+// keeps the fixed-buffer zero-copy path. A bounce buffer is used when the
+// source is shorter than `total_len`, its padding tail is not already zero, or
+// O_DIRECT requires an aligned address. The source buffer is never modified.
+fn prepare_iouring_write_buffer(
+    ptr_addr: usize,
+    cap: usize,
+    payload_len: usize,
+    total_len: usize,
+    use_odirect: bool,
+    alignment: usize,
+    fixed_buffer_idx: Option<u16>,
+) -> PyResult<PreparedWriteBuffer> {
+    if cap < payload_len {
+        return Err(PyValueError::new_err(format!(
+            "input buffer too small: cap={cap} need={payload_len}"
+        )));
+    }
+    if total_len < payload_len {
+        return Err(PyValueError::new_err("total_len must be >= payload_len"));
+    }
+
+    let needs_alignment_bounce = use_odirect && !ptr_addr.is_multiple_of(alignment);
+    let needs_capacity_bounce = cap < total_len;
+    let has_padding = payload_len < total_len;
+    let tail_is_zero = !has_padding
+        || (!needs_capacity_bounce
+            && buffer_range_is_zero(ptr_addr, payload_len, total_len - payload_len));
+    let needs_zero_bounce = has_padding && !tail_is_zero;
+    let needs_bounce = needs_alignment_bounce || needs_capacity_bounce || needs_zero_bounce;
+
+    if !needs_bounce {
+        return Ok(PreparedWriteBuffer {
+            ptr_addr,
+            bounce: None,
+            fixed_buffer_idx,
+        });
+    }
+
+    let bounce = AlignedBuf::new(total_len, alignment)?;
+    let bounce_ptr = bounce.as_mut_ptr();
+    // SAFETY: the bounce holds total_len bytes and cap >= payload_len was
+    // checked above, so both the copy and the zero-fill stay in bounds.
+    unsafe {
+        if payload_len > 0 {
+            std::ptr::copy_nonoverlapping(ptr_addr as *const u8, bounce_ptr, payload_len);
+        }
+        if total_len > payload_len {
+            std::ptr::write_bytes(bounce_ptr.add(payload_len), 0u8, total_len - payload_len);
+        }
+    }
+    let bounce_arc = Arc::new(bounce);
+    Ok(PreparedWriteBuffer {
+        ptr_addr: bounce_arc.as_ptr() as usize,
+        bounce: Some(bounce_arc),
+        fixed_buffer_idx: None,
+    })
+}
+
 // Acquire a Python buffer view with the requested mutability.
 fn get_pybuffer<'py>(
     py: Python<'py>,
@@ -2172,11 +2262,23 @@ impl RawBlockDevice {
     /// All writes are queued to the worker thread, which processes them
     /// in batches to maximize throughput.
     ///
+    /// `total_lens` gives the physical transfer length of each write and
+    /// `payload_lens` the logical length of the source data; omitting
+    /// `payload_lens` makes it equal to `total_lens`. Each source buffer is
+    /// read only up to its `payload_len` and is never modified, and the
+    /// padding region `[payload_len, total_len)` is always written as zeroes.
+    ///
     /// Returns a batch ID that must be passed to `wait_iouring()` to wait for
     /// completion and obtain a success bitmap plus sparse completion errors.
     /// Validation or request-preparation errors are raised instead of returning
     /// a batch ID.
-    #[pyo3(signature = (offsets, buffers, total_lens, placement_ids = None))]
+    #[pyo3(signature = (
+        offsets,
+        buffers,
+        total_lens,
+        placement_ids = None,
+        payload_lens = None,
+    ))]
     fn batched_write(
         &self,
         py: Python<'_>,
@@ -2184,6 +2286,7 @@ impl RawBlockDevice {
         buffers: Vec<Bound<'_, PyAny>>,
         total_lens: Vec<usize>,
         placement_ids: Option<Vec<Option<i32>>>,
+        payload_lens: Option<Vec<usize>>,
     ) -> PyResult<u64> {
         if !self.use_iouring {
             return Err(PyRuntimeError::new_err("io_uring not enabled"));
@@ -2213,6 +2316,39 @@ impl RawBlockDevice {
             vec![None; n]
         };
 
+        // payload_lens carries the logical (unpadded) length of each buffer. When
+        // omitted it equals total_lens, which reproduces the legacy behavior where
+        // the full transfer length is also the valid payload length.
+        let payload_lens: Vec<usize> = match payload_lens {
+            Some(p) => {
+                if p.len() != n {
+                    return Err(PyValueError::new_err(
+                        "payload_lens must have same length as offsets",
+                    ));
+                }
+                p
+            }
+            None => total_lens.clone(),
+        };
+        for i in 0..n {
+            if payload_lens[i] > total_lens[i] {
+                return Err(PyValueError::new_err("total_len must be >= payload_len"));
+            }
+        }
+        let align = self.alignment;
+        if self.use_odirect {
+            for i in 0..n {
+                #[allow(clippy::manual_is_multiple_of)]
+                if (offsets[i] as usize) % align != 0 {
+                    return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
+                }
+                #[allow(clippy::manual_is_multiple_of)]
+                if total_lens[i] % align != 0 {
+                    return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
+                }
+            }
+        }
+
         // Acquire buffer views to keep them alive until wait_iouring() completes
         let mut views = Vec::with_capacity(n);
         for buffer in &buffers {
@@ -2225,6 +2361,25 @@ impl RawBlockDevice {
                 return Err(PyValueError::new_err("null buffer pointer"));
             }
             views.push(view);
+        }
+
+        // Validate buffer capacities before allocating any batch tracking so the
+        // error path stays simple (just release the views).
+        let mut cap_err: Option<(usize, usize)> = None;
+        for (i, view) in views.iter().enumerate() {
+            let cap = view.len as usize;
+            if cap < payload_lens[i] {
+                cap_err = Some((cap, payload_lens[i]));
+                break;
+            }
+        }
+        if let Some((cap, need)) = cap_err {
+            for v in views {
+                release_pybuffer(v);
+            }
+            return Err(PyValueError::new_err(format!(
+                "input buffer too small: cap={cap} need={need}"
+            )));
         }
 
         // Generate a unique batch ID for this batch
@@ -2248,10 +2403,13 @@ impl RawBlockDevice {
             }
         }
 
-        // Extract pointers as usize before releasing GIL (raw pointers are not Send)
+        // Extract pointers and capacities as usize before releasing GIL (raw
+        // pointers are not Send).
         let mut ptrs = Vec::with_capacity(n);
+        let mut caps = Vec::with_capacity(n);
         for view in &views {
             ptrs.push(view.buf as usize);
+            caps.push(view.len as usize);
         }
 
         for view in views {
@@ -2297,8 +2455,9 @@ impl RawBlockDevice {
 
             // Prepare all requests, bounce buffers (if needed) and collect submission data.
             for i in 0..n {
-                let ptr = ptrs[i] as *const u8;
                 let total_len = total_lens[i];
+                let payload_len = payload_lens[i];
+                let cap = caps[i];
                 let offset = offsets[i];
 
                 let comp = Arc::new(IoCompletion::new());
@@ -2306,39 +2465,15 @@ impl RawBlockDevice {
                 // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
                 let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
 
-                if use_odirect {
-                    #[allow(clippy::manual_is_multiple_of)]
-                    if (offset as usize) % alignment != 0 {
-                        return Err(PyValueError::new_err("O_DIRECT requires aligned offset"));
-                    }
-                    #[allow(clippy::manual_is_multiple_of)]
-                    if total_len % alignment != 0 {
-                        return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
-                    }
-                }
-
-                // Misaligned pointer is handled via bounce buffer for writes
-                let (final_ptr, bounce_opt, fixed_idx) = if use_odirect {
-                    let align = alignment;
-                    #[allow(clippy::manual_is_multiple_of)]
-                    if ptrs[i] % align != 0 {
-                        let bounce = AlignedBuf::new(total_len, align)?;
-                        unsafe {
-                            libc::memcpy(
-                                bounce.as_mut_ptr() as *mut libc::c_void,
-                                ptr as *const libc::c_void,
-                                total_len,
-                            );
-                        }
-                        let bounce_arc = std::sync::Arc::new(bounce);
-                        let bounce_ptr = bounce_arc.as_ptr();
-                        (bounce_ptr, Some(bounce_arc), None)
-                    } else {
-                        (ptr, None, fixed_idx)
-                    }
-                } else {
-                    (ptr, None, fixed_idx)
-                };
+                let prepared = prepare_iouring_write_buffer(
+                    ptrs[i],
+                    cap,
+                    payload_len,
+                    total_len,
+                    use_odirect,
+                    alignment,
+                    fixed_idx,
+                )?;
 
                 // Build NVMe command data
                 let placement_id_u16 = placement_ids[i];
@@ -2361,11 +2496,11 @@ impl RawBlockDevice {
                     fd,
                     offset,
                     len: total_len,
-                    ptr_addr: final_ptr as usize,
+                    ptr_addr: prepared.ptr_addr,
                     is_write: true,
                     completion: comp.clone(),
-                    fixed_buffer_idx: fixed_idx,
-                    bounce: bounce_opt,
+                    fixed_buffer_idx: prepared.fixed_buffer_idx,
+                    bounce: prepared.bounce,
                     original_ptr: None,
                     payload_len: None,
                     batch_id,
@@ -2634,6 +2769,10 @@ impl RawBlockDevice {
     }
 
     /// Synchronous write using io_uring.
+    ///
+    /// `total_len` defaults to `payload_len`. The source buffer is read only up
+    /// to `payload_len` and is never modified, and the padding region
+    /// `[payload_len, total_len)` is always written as zeroes.
     #[pyo3(signature = (offset, data, payload_len, total_len = None, placement_id = None))]
     fn write_uring(
         &self,
@@ -2703,23 +2842,27 @@ impl RawBlockDevice {
         };
 
         let placement_id_u16 = placement_id.map(placement_id_to_u16).transpose()?;
+        let prepared = prepare_iouring_write_buffer(
+            ptr as usize,
+            cap,
+            payload_len,
+            total_len,
+            self.use_odirect,
+            align,
+            fixed_idx,
+        )?;
 
-        // Use bounce buffer if:
-        // Buffer is not aligned (O_DIRECT requirement)
-        // Buffer capacity is less than total_len
-        let use_bounce = !ptr_aligned || cap < total_len;
-
-        let res = if !use_bounce {
+        let res = if prepared.bounce.is_none() {
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
             let sub = IoSubmission {
                 fd: self.fd,
                 offset,
                 len: total_len,
-                ptr_addr: ptr as usize,
+                ptr_addr: prepared.ptr_addr,
                 is_write: true,
                 completion: comp.clone(),
-                fixed_buffer_idx: fixed_idx,
+                fixed_buffer_idx: prepared.fixed_buffer_idx,
                 bounce: None,
                 original_ptr: None,
                 payload_len: None,
@@ -2739,24 +2882,18 @@ impl RawBlockDevice {
             }
             py.allow_threads(move || comp.wait())
         } else {
-            let bounce = AlignedBuf::new(total_len, align)?;
-            let bounce_arc = std::sync::Arc::new(bounce);
-            let bounce_ptr = bounce_arc.as_mut_ptr();
-            // Copy data to bounce buffer before submission
-            unsafe {
-                std::ptr::copy_nonoverlapping(ptr, bounce_ptr, payload_len);
-            }
+            let bounce = prepared.bounce;
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
             let sub = IoSubmission {
                 fd: self.fd,
                 offset,
                 len: total_len,
-                ptr_addr: bounce_ptr as usize,
+                ptr_addr: prepared.ptr_addr,
                 is_write: true,
                 completion: comp.clone(),
                 fixed_buffer_idx: None,
-                bounce: Some(bounce_arc),
+                bounce,
                 original_ptr: None,
                 payload_len: Some(payload_len),
                 batch_id: 0,

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -760,7 +760,7 @@ fn prepare_iouring_write_buffer(
     cap: usize,
     payload_len: usize,
     total_len: usize,
-    use_odirect: bool,
+    needs_alignment: bool,
     alignment: usize,
     fixed_buffer_idx: Option<u16>,
 ) -> PyResult<PreparedWriteBuffer> {
@@ -773,7 +773,7 @@ fn prepare_iouring_write_buffer(
         return Err(PyValueError::new_err("total_len must be >= payload_len"));
     }
 
-    let needs_alignment_bounce = use_odirect && !ptr_addr.is_multiple_of(alignment);
+    let needs_alignment_bounce = needs_alignment && !ptr_addr.is_multiple_of(alignment);
     let needs_capacity_bounce = cap < total_len;
     let has_padding = payload_len < total_len;
     let tail_is_zero = !has_padding
@@ -808,6 +808,134 @@ fn prepare_iouring_write_buffer(
         bounce: Some(bounce_arc),
         fixed_buffer_idx: None,
     })
+}
+
+#[cfg(test)]
+mod write_alignment_tests {
+    use super::*;
+    use pyo3::types::{PyByteArray, PyBytes};
+
+    fn raw_device_with_missing_nvme_metadata() -> RawBlockDevice {
+        RawBlockDevice {
+            fd: -1,
+            size: 0,
+            closed: AtomicBool::new(false),
+            use_odirect: false,
+            alignment: 4096,
+            use_iouring: true,
+            use_uring_cmd: true,
+            nvme_nsid: None,
+            nvme_lba_shift: None,
+            nvme_lba_size: None,
+            ring: None,
+            queue: Some(Arc::new(Mutex::new(Vec::new()))),
+            worker: None,
+            shutdown: None,
+            fixed_buffer_map: Arc::new(Mutex::new(HashMap::new())),
+            fixed_buffers_registered: Arc::new(AtomicBool::new(false)),
+            in_flight_count: Arc::new(AtomicU64::new(0)),
+            in_flight_cvar: Arc::new(Condvar::new()),
+            batch_in_flight: Arc::new(Mutex::new(HashMap::new())),
+            batch_ready: None,
+            batched_buffer_objs: Arc::new(Mutex::new(HashMap::new())),
+            batched_completions: Arc::new(Mutex::new(HashMap::new())),
+            next_batch_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    fn unaligned_buffer(total_len: usize, alignment: usize) -> PyResult<AlignedBuf> {
+        AlignedBuf::new(total_len + 1, alignment)
+    }
+
+    #[test]
+    fn prepare_write_buffer_keeps_unaligned_buffer_without_alignment_requirement() -> PyResult<()> {
+        let alignment = 4096;
+        let total_len = 8192;
+        let buf = unaligned_buffer(total_len, alignment)?;
+        let ptr_addr = unsafe { buf.as_ptr().add(1) as usize };
+        let fixed_buffer_idx = Some(7);
+
+        let prepared = prepare_iouring_write_buffer(
+            ptr_addr,
+            total_len,
+            total_len,
+            total_len,
+            false,
+            alignment,
+            fixed_buffer_idx,
+        )?;
+
+        assert_eq!(prepared.ptr_addr, ptr_addr);
+        assert!(prepared.bounce.is_none());
+        assert_eq!(prepared.fixed_buffer_idx, fixed_buffer_idx);
+        Ok(())
+    }
+
+    #[test]
+    fn prepare_write_buffer_bounces_unaligned_buffer_when_alignment_required() -> PyResult<()> {
+        let alignment = 4096;
+        let total_len = 8192;
+        let buf = unaligned_buffer(total_len, alignment)?;
+        let ptr_addr = unsafe { buf.as_ptr().add(1) as usize };
+        let payload = unsafe { slice::from_raw_parts_mut(ptr_addr as *mut u8, total_len) };
+        for (idx, byte) in payload.iter_mut().enumerate() {
+            *byte = (idx % 251) as u8;
+        }
+
+        let prepared = prepare_iouring_write_buffer(
+            ptr_addr,
+            total_len,
+            total_len,
+            total_len,
+            true,
+            alignment,
+            Some(7),
+        )?;
+
+        assert_ne!(prepared.ptr_addr, ptr_addr);
+        assert!(prepared.ptr_addr.is_multiple_of(alignment));
+        assert!(prepared.fixed_buffer_idx.is_none());
+
+        let bounce = prepared
+            .bounce
+            .as_ref()
+            .expect("unaligned buffer should bounce");
+        let bounced = unsafe { slice::from_raw_parts(bounce.as_ptr(), total_len) };
+        assert_eq!(bounced, payload);
+        Ok(())
+    }
+
+    #[test]
+    fn read_uring_nvme_metadata_error_does_not_leak_in_flight() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let device = raw_device_with_missing_nvme_metadata();
+            let data = PyByteArray::new(py, &[0; 4096]);
+
+            let result = device.read_uring(py, 0, data.as_any(), 4096, None);
+            let in_flight = device.in_flight_count.load(Ordering::Relaxed);
+            device.closed.store(true, Ordering::Relaxed);
+
+            assert!(result.is_err());
+            assert_eq!(in_flight, 0);
+        });
+    }
+
+    #[test]
+    fn write_uring_nvme_metadata_error_does_not_leak_in_flight() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let device = raw_device_with_missing_nvme_metadata();
+            let data = PyBytes::new(py, &[0; 4096]);
+
+            let result = device.write_uring(py, 0, data.as_any(), 4096, None, None);
+            let in_flight = device.in_flight_count.load(Ordering::Relaxed);
+            device.closed.store(true, Ordering::Relaxed);
+
+            assert!(result.is_err());
+            assert_eq!(in_flight, 0);
+        });
+    }
 }
 
 // Acquire a Python buffer view with the requested mutability.
@@ -2452,6 +2580,7 @@ impl RawBlockDevice {
         // Release the GIL while submitting I/O operations
         let res = py.allow_threads(move || {
             let mut submissions: Vec<(IoSubmission, Arc<IoCompletion>)> = Vec::with_capacity(n);
+            let needs_align = use_odirect || use_uring_cmd;
 
             // Prepare all requests, bounce buffers (if needed) and collect submission data.
             for i in 0..n {
@@ -2470,7 +2599,7 @@ impl RawBlockDevice {
                     cap,
                     payload_len,
                     total_len,
-                    use_odirect,
+                    needs_align,
                     alignment,
                     fixed_idx,
                 )?;
@@ -2643,6 +2772,7 @@ impl RawBlockDevice {
         if self.closed.load(Ordering::Relaxed) {
             return Err(PyRuntimeError::new_err("device is closed"));
         }
+        let nvme_cmd_data = self._build_nvme_cmd_data(0, 0)?;
 
         let view = get_pybuffer(py, data, true)?;
         if view.readonly != 0 {
@@ -2705,7 +2835,6 @@ impl RawBlockDevice {
         // Buffer is not aligned (O_DIRECT or io_uring_cmd PRP requirement)
         // Buffer capacity is less than total_len
         let use_bounce = !ptr_aligned || cap < total_len;
-
         let res = if !use_bounce {
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
@@ -2721,7 +2850,7 @@ impl RawBlockDevice {
                 original_ptr: None,
                 payload_len: None,
                 batch_id: 0,
-                nvme_cmd_data: self._build_nvme_cmd_data(0, 0)?,
+                nvme_cmd_data: nvme_cmd_data.clone(),
             };
             {
                 let q = self.queue.as_ref().expect("queue must exist");
@@ -2750,7 +2879,7 @@ impl RawBlockDevice {
                 original_ptr: Some(ptr as usize),
                 payload_len: Some(payload_len),
                 batch_id: 0,
-                nvme_cmd_data: self._build_nvme_cmd_data(0, 0)?,
+                nvme_cmd_data,
             };
             {
                 let q = self.queue.as_ref().expect("queue must exist");
@@ -2789,6 +2918,11 @@ impl RawBlockDevice {
         if self.closed.load(Ordering::Relaxed) {
             return Err(PyRuntimeError::new_err("device is closed"));
         }
+        let placement_id_u16 = placement_id.map(placement_id_to_u16).transpose()?;
+        let nvme_cmd_data = self._build_nvme_cmd_data(
+            if placement_id_u16.is_some() { 0x2 } else { 0x0 },
+            placement_id_u16.unwrap_or(0),
+        )?;
 
         let view = get_pybuffer(py, data, false)?;
         let ptr = view.buf as *const u8;
@@ -2824,8 +2958,8 @@ impl RawBlockDevice {
             }
         }
 
-        // Check if the buffer is aligned for O_DIRECT
-        let ptr_aligned = if self.use_odirect {
+        let needs_align = self.use_odirect || self.use_uring_cmd;
+        let ptr_aligned = if needs_align {
             (ptr as usize).is_multiple_of(align)
         } else {
             true
@@ -2841,17 +2975,15 @@ impl RawBlockDevice {
             None
         };
 
-        let placement_id_u16 = placement_id.map(placement_id_to_u16).transpose()?;
         let prepared = prepare_iouring_write_buffer(
             ptr as usize,
             cap,
             payload_len,
             total_len,
-            self.use_odirect,
+            needs_align,
             align,
             fixed_idx,
         )?;
-
         let res = if prepared.bounce.is_none() {
             self.in_flight_count.fetch_add(1, Ordering::Relaxed);
             let comp = Arc::new(IoCompletion::new());
@@ -2867,10 +2999,7 @@ impl RawBlockDevice {
                 original_ptr: None,
                 payload_len: None,
                 batch_id: 0,
-                nvme_cmd_data: self._build_nvme_cmd_data(
-                    if placement_id_u16.is_some() { 0x2 } else { 0x0 },
-                    placement_id_u16.unwrap_or(0),
-                )?,
+                nvme_cmd_data: nvme_cmd_data.clone(),
             };
             {
                 let q = self.queue.as_ref().expect("queue must exist");
@@ -2897,10 +3026,7 @@ impl RawBlockDevice {
                 original_ptr: None,
                 payload_len: Some(payload_len),
                 batch_id: 0,
-                nvme_cmd_data: self._build_nvme_cmd_data(
-                    if placement_id_u16.is_some() { 0x2 } else { 0x0 },
-                    placement_id_u16.unwrap_or(0),
-                )?,
+                nvme_cmd_data,
             };
             {
                 let q = self.queue.as_ref().expect("queue must exist");

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -123,6 +123,7 @@ class _BatchedWriteCall:
     offsets: list[int]
     buffer_byte_lens: list[int]
     total_lens: list[int]
+    payload_lens: list[int]
 
 
 @dataclass
@@ -152,25 +153,34 @@ class _FakeRawDevice:
         offsets: Sequence[int],
         buffers: Sequence[Any],
         total_lens: Sequence[int],
+        payload_lens: Sequence[int] | None = None,
     ) -> int:
+        resolved_payload_lens = (
+            [int(p) for p in payload_lens]
+            if payload_lens is not None
+            else [int(total) for total in total_lens]
+        )
         self.batched_write_calls.append(
             _BatchedWriteCall(
                 offsets=[int(off) for off in offsets],
                 buffer_byte_lens=[len(bytes(buf)) for buf in buffers],
                 total_lens=[int(total) for total in total_lens],
+                payload_lens=resolved_payload_lens,
             )
         )
         if self.fail_batched_write:
             raise RuntimeError("injected batched_write failure")
-        for i, (off, buf, total) in enumerate(
-            zip(offsets, buffers, total_lens, strict=True)
+        for i, (off, buf, total, payload) in enumerate(
+            zip(offsets, buffers, total_lens, resolved_payload_lens, strict=True)
         ):
             if (
                 self.fail_after_write_entries is not None
                 and i >= self.fail_after_write_entries
             ):
                 raise RuntimeError("injected partial batched_write failure")
-            self.store[int(off)] = bytes(buf)[: int(total)]
+            # Mirror the Rust bounce: store only the valid payload, zero-padded
+            # up to total so round-trip reads observe the padded transfer.
+            self.store[int(off)] = bytes(buf)[: int(payload)].ljust(int(total), b"\x00")
         return len(self.batched_write_calls)
 
     def wait_iouring(self, batch_id: int) -> None:
@@ -203,6 +213,11 @@ class _FakeRawDevice:
     ) -> None:
         self._copy_into(int(offset), buf, int(total_len))
 
+    def read_uring(
+        self, offset: int, buf: Any, payload_len: int, total_len: int
+    ) -> None:
+        self._copy_into(int(offset), buf, int(total_len))
+
     def close(self) -> None:
         pass
 
@@ -213,13 +228,16 @@ class _FakeRawDevice:
             buf[:n] = data[:n]
 
 
-def _make_core_with_fake(path, fake, io_engine, capacity_bytes=None):
+def _make_core_with_fake(path, fake, io_engine, capacity_bytes=None, use_odirect=False):
     """Build a RawBlockCore wired to a fake raw device for a given engine.
 
     When ``capacity_bytes`` is given it overrides the config capacity so a
-    test can constrain the number of allocatable slots.
+    test can constrain the number of allocatable slots. When ``use_odirect``
+    is set, writes are padded to ``block_align`` so payload_len < total_len.
     """
-    overrides = dict(io_engine=io_engine, load_checkpoint_on_init=False)
+    overrides = dict(
+        io_engine=io_engine, load_checkpoint_on_init=False, use_odirect=use_odirect
+    )
     if capacity_bytes is not None:
         overrides["capacity_bytes"] = capacity_bytes
     config = replace(make_raw_block_core_config(path), **overrides)
@@ -322,6 +340,60 @@ def test_raw_block_core_io_uring_put_many_round_trip(tmp_path):
 
         assert load_result == [True] * 10
         assert [memory_obj_bytes(obj) for obj in loaded] == payloads
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_padded_odirect_uses_batched_write(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring", use_odirect=True)
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(4)]
+        # Non-block-aligned payloads force O_DIRECT padding: payload_len < total_len.
+        payloads = [bytes([i + 1]) * (1000 + i * 37) for i in range(4)]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        assert core.put_many(specs, objects).results == [True] * 4
+
+        # Padded O_DIRECT writes go through batched_write, not the per-entry
+        # write_uring fallback.
+        assert len(fake.batched_write_calls) == 1
+        assert fake.write_uring_count == 0
+        call = fake.batched_write_calls[0]
+        # payload_lens are forwarded and at least one payload entry is padded.
+        assert call.payload_lens != call.total_lens
+        for payload_len, total_len in zip(
+            call.payload_lens, call.total_lens, strict=True
+        ):
+            assert payload_len <= total_len
+
+        loaded = [make_empty_memory_obj(len(payload)) for payload in payloads]
+        load_result = core.load_many_into([spec.encoded for spec in specs], loaded)
+        assert load_result == [True] * 4
+        assert [memory_obj_bytes(obj) for obj in loaded] == payloads
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_non_padded_forwards_payload_lens(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(3)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(3)]
+
+        assert core.put_many(specs, objects).results == [True] * 3
+
+        assert len(fake.batched_write_calls) == 1
+        assert fake.write_uring_count == 0
+        call = fake.batched_write_calls[0]
+        # No padding required, so payload_lens equals total_lens but is still
+        # forwarded explicitly.
+        assert call.payload_lens == call.total_lens
     finally:
         core.close()
 

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -3,12 +3,21 @@
 # Future
 from __future__ import annotations
 
+# Standard
+from collections.abc import Sequence
+from dataclasses import dataclass, field, replace
+from typing import Any
+from unittest.mock import patch
+import importlib.util
+
 # Third Party
 import pytest
 
 # First Party
 from lmcache.v1.storage_backend.raw_block import RawBlockCore, encode_object_key
 from tests.v1.storage_backend.raw_block_test_utils import (
+    RAW_BLOCK_CI_META_TOTAL_BYTES,
+    RAW_BLOCK_CI_SLOT_BYTES,
     make_empty_memory_obj,
     make_memory_obj,
     make_object_key,
@@ -17,9 +26,13 @@ from tests.v1.storage_backend.raw_block_test_utils import (
     memory_obj_bytes,
 )
 
-pytest.importorskip("lmcache_rust_raw_block_io")
+requires_rust_raw_block_io = pytest.mark.skipif(
+    importlib.util.find_spec("lmcache_rust_raw_block_io") is None,
+    reason="lmcache_rust_raw_block_io is not installed",
+)
 
 
+@requires_rust_raw_block_io
 def test_raw_block_core_store_load_and_exists(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -54,6 +67,7 @@ def test_raw_block_core_store_load_and_exists(tmp_path):
         core.close()
 
 
+@requires_rust_raw_block_io
 def test_raw_block_core_duplicate_put_keeps_original_payload(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -79,6 +93,7 @@ def test_raw_block_core_duplicate_put_keeps_original_payload(tmp_path):
         core.close()
 
 
+@requires_rust_raw_block_io
 def test_raw_block_core_delete_and_missing_load(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)
@@ -101,6 +116,419 @@ def test_raw_block_core_delete_and_missing_load(tmp_path):
         core.close()
 
 
+@dataclass
+class _BatchedWriteCall:
+    """Recorded arguments of one fake ``batched_write`` invocation."""
+
+    offsets: list[int]
+    buffer_byte_lens: list[int]
+    total_lens: list[int]
+
+
+@dataclass
+class _FakeRawDevice:
+    """In-memory raw device that records io_uring batched submissions.
+
+    The fake mirrors the subset of the Rust raw-device interface that
+    ``RawBlockCore`` uses for both the io_uring and posix write/read paths.
+    Stored bytes are keyed by device offset so round-trip reads return what
+    was written.
+    """
+
+    size: int
+    store: dict[int, bytes] = field(default_factory=dict)
+    batched_write_calls: list[_BatchedWriteCall] = field(default_factory=list)
+    wait_iouring_count: int = 0
+    pwrite_count: int = 0
+    write_uring_count: int = 0
+    fail_batched_write: bool = False
+    fail_after_write_entries: int | None = None
+
+    def size_bytes(self) -> int:
+        return self.size
+
+    def batched_write(
+        self,
+        offsets: Sequence[int],
+        buffers: Sequence[Any],
+        total_lens: Sequence[int],
+    ) -> int:
+        self.batched_write_calls.append(
+            _BatchedWriteCall(
+                offsets=[int(off) for off in offsets],
+                buffer_byte_lens=[len(bytes(buf)) for buf in buffers],
+                total_lens=[int(total) for total in total_lens],
+            )
+        )
+        if self.fail_batched_write:
+            raise RuntimeError("injected batched_write failure")
+        for i, (off, buf, total) in enumerate(
+            zip(offsets, buffers, total_lens, strict=True)
+        ):
+            if (
+                self.fail_after_write_entries is not None
+                and i >= self.fail_after_write_entries
+            ):
+                raise RuntimeError("injected partial batched_write failure")
+            self.store[int(off)] = bytes(buf)[: int(total)]
+        return len(self.batched_write_calls)
+
+    def wait_iouring(self, batch_id: int) -> None:
+        self.wait_iouring_count += 1
+
+    def batched_read(
+        self,
+        offsets: Sequence[int],
+        buffers: Sequence[Any],
+        total_lens: Sequence[int],
+    ) -> int:
+        for off, buf, total in zip(offsets, buffers, total_lens, strict=True):
+            self._copy_into(int(off), buf, int(total))
+        return -1
+
+    def pwrite_from_buffer(
+        self, offset: int, buf: Any, payload_len: int, total_len: int
+    ) -> None:
+        self.pwrite_count += 1
+        self.store[int(offset)] = bytes(buf)[: int(total_len)]
+
+    def write_uring(
+        self, offset: int, buf: Any, payload_len: int, total_len: int
+    ) -> None:
+        self.write_uring_count += 1
+        self.store[int(offset)] = bytes(buf)[: int(total_len)]
+
+    def pread_into(
+        self, offset: int, buf: Any, payload_len: int, total_len: int
+    ) -> None:
+        self._copy_into(int(offset), buf, int(total_len))
+
+    def close(self) -> None:
+        pass
+
+    def _copy_into(self, offset: int, buf: Any, total_len: int) -> None:
+        data = self.store.get(offset, b"")
+        n = min(len(data), total_len, len(buf))
+        if n:
+            buf[:n] = data[:n]
+
+
+def _make_core_with_fake(path, fake, io_engine, capacity_bytes=None):
+    """Build a RawBlockCore wired to a fake raw device for a given engine.
+
+    When ``capacity_bytes`` is given it overrides the config capacity so a
+    test can constrain the number of allocatable slots.
+    """
+    overrides = dict(io_engine=io_engine, load_checkpoint_on_init=False)
+    if capacity_bytes is not None:
+        overrides["capacity_bytes"] = capacity_bytes
+    config = replace(make_raw_block_core_config(path), **overrides)
+    with patch.object(RawBlockCore, "_rawdev", return_value=fake):
+        core = RawBlockCore(config, key_namespace="object")
+    core.set_raw_device_for_testing(fake)
+    return core
+
+
+def _available_slots(status: dict) -> int:
+    """Return slots still allocatable from the free list plus the high-water tail."""
+    return status["free_slot_count"] + (status["max_slots"] - status["next_slot"])
+
+
+def test_raw_block_core_io_uring_put_many_single_submit(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(10)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(10)]
+
+        put_result = core.put_many(specs, objects)
+
+        assert put_result.results == [True] * 10
+        assert put_result.stored_keys == [spec.encoded for spec in specs]
+
+        assert len(fake.batched_write_calls) == 1
+        call = fake.batched_write_calls[0]
+        assert len(call.offsets) == 20
+        assert len(call.buffer_byte_lens) == 20
+        assert len(call.total_lens) == 20
+        assert fake.wait_iouring_count == 1
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_chunks_large_batches(
+    tmp_path,
+):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(70)]
+        keys = specs[:65] + [specs[0]] + specs[65:]
+        payloads = [bytes([i + 1]) * 1024 for i in range(len(keys))]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        put_result = core.put_many(keys, objects)
+
+        assert put_result.results == [True] * len(keys)
+        assert put_result.stored_keys == [spec.encoded for spec in specs]
+        assert [len(call.offsets) for call in fake.batched_write_calls] == [128, 12]
+        assert fake.wait_iouring_count == 2
+
+        loaded = make_empty_memory_obj(len(payloads[0]))
+        assert core.load_many_into([specs[0].encoded], [loaded]) == [True]
+        assert memory_obj_bytes(loaded) == payloads[0]
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_header_buffer_length_guard(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(4)]
+        objects = [make_memory_obj(bytes([i + 1]) * 2048) for i in range(4)]
+
+        core.put_many(specs, objects)
+
+        call = fake.batched_write_calls[0]
+        for buf_len, total_len in zip(
+            call.buffer_byte_lens, call.total_lens, strict=True
+        ):
+            assert buf_len >= total_len
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_round_trip(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(10)]
+        payloads = [bytes([i + 1]) * (1024 + i * 16) for i in range(10)]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        assert core.put_many(specs, objects).results == [True] * 10
+
+        loaded = [make_empty_memory_obj(len(payload)) for payload in payloads]
+        load_result = core.load_many_into([spec.encoded for spec in specs], loaded)
+
+        assert load_result == [True] * 10
+        assert [memory_obj_bytes(obj) for obj in loaded] == payloads
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_skips_already_indexed(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        first_specs = [encode_object_key(make_object_key(i)) for i in range(5)]
+        first_objs = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(5)]
+        assert core.put_many(first_specs, first_objs).results == [True] * 5
+
+        new_specs = [encode_object_key(make_object_key(i)) for i in range(5, 10)]
+        new_objs = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(5, 10)]
+        combined_specs = first_specs + new_specs
+        combined_objs = first_objs + new_objs
+
+        result = core.put_many(combined_specs, combined_objs)
+
+        assert result.results == [True] * 10
+        assert result.stored_keys == [spec.encoded for spec in new_specs]
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_all_or_nothing_rollback(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        before = _available_slots(core.report_status())
+
+        specs = [encode_object_key(make_object_key(i)) for i in range(5)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(5)]
+
+        fake.fail_batched_write = True
+        result = core.put_many(specs, objects)
+
+        assert result.results == [False] * 5
+        assert result.stored_keys == []
+
+        status = core.report_status()
+        assert status["inflight_key_count"] == 0
+        assert status["indexed_key_count"] == 0
+        assert _available_slots(status) == before
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_partial_slot_exhaustion(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    # Capacity leaves room for exactly 3 data slots after the metadata region,
+    # so the last keys of a 5-key batch find no free slot.
+    capacity = RAW_BLOCK_CI_META_TOTAL_BYTES + 3 * RAW_BLOCK_CI_SLOT_BYTES
+    core = _make_core_with_fake(
+        path, fake, io_engine="io_uring", capacity_bytes=capacity
+    )
+
+    try:
+        assert core.report_status()["max_slots"] == 3
+
+        specs = [encode_object_key(make_object_key(i)) for i in range(5)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(5)]
+
+        result = core.put_many(specs, objects)
+
+        # First three keys allocate a slot and commit; the slot-starved tail
+        # fails individually while the batch for the rest still succeeds.
+        assert result.results == [True, True, True, False, False]
+        assert result.stored_keys == [spec.encoded for spec in specs[:3]]
+
+        # Only the committed keys were written: one batched_write of 2*3 entries.
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.batched_write_calls[0].offsets) == 6
+
+        status = core.report_status()
+        assert status["indexed_key_count"] == 3
+        assert status["inflight_key_count"] == 0
+        assert _available_slots(status) == 0
+
+        loaded = [make_empty_memory_obj(1024) for _ in range(3)]
+        load_result = core.load_many_into([spec.encoded for spec in specs[:3]], loaded)
+        assert load_result == [True] * 3
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_duplicate_keys_in_batch(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        spec = encode_object_key(make_object_key(51))
+        original = b"original-batch-payload"
+        duplicate = b"duplicate-must-not-overwrite"
+
+        result = core.put_many(
+            [spec, spec],
+            [make_memory_obj(original), make_memory_obj(duplicate)],
+        )
+
+        assert result.results == [True, True]
+        assert result.stored_keys == [spec.encoded]
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.batched_write_calls[0].offsets) == 2
+
+        loaded = make_empty_memory_obj(len(original))
+        assert core.load_many_into([spec.encoded], [loaded]) == [True]
+        assert memory_obj_bytes(loaded) == original
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_oversize_key_isolated(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        before = _available_slots(core.report_status())
+        specs = [encode_object_key(make_object_key(i)) for i in range(60, 65)]
+        payloads = [
+            b"a" * 1024,
+            b"b" * 2048,
+            b"c" * RAW_BLOCK_CI_SLOT_BYTES,
+            b"d" * 3072,
+            b"e" * 4096,
+        ]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        result = core.put_many(specs, objects)
+
+        assert result.results == [True, True, False, True, True]
+        expected_stored = [spec.encoded for i, spec in enumerate(specs) if i != 2]
+        assert result.stored_keys == expected_stored
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.batched_write_calls[0].offsets) == 8
+
+        status = core.report_status()
+        assert status["inflight_key_count"] == 0
+        assert status["indexed_key_count"] == 4
+        assert _available_slots(status) == before - 4
+
+        loaded_payloads = [payload for i, payload in enumerate(payloads) if i != 2]
+        loaded = [make_empty_memory_obj(len(payload)) for payload in loaded_payloads]
+        assert core.load_many_into(expected_stored, loaded) == [True] * 4
+        assert [memory_obj_bytes(obj) for obj in loaded] == loaded_payloads
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_put_many_partial_completion_rolls_back(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024, fail_after_write_entries=3)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        before = _available_slots(core.report_status())
+        specs = [encode_object_key(make_object_key(i)) for i in range(70, 74)]
+        objects = [make_memory_obj(bytes([i]) * 1024) for i in range(4)]
+
+        result = core.put_many(specs, objects)
+
+        assert result.results == [False] * 4
+        assert result.stored_keys == []
+        assert len(fake.batched_write_calls) == 1
+        assert len(fake.store) == 3
+
+        status = core.report_status()
+        assert status["inflight_key_count"] == 0
+        assert status["indexed_key_count"] == 0
+        assert _available_slots(status) == before
+        assert core.exists_many([spec.encoded for spec in specs]) == [False] * 4
+    finally:
+        core.close()
+
+
+def test_raw_block_core_posix_put_many_uses_sequential_pwrite(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    fake = _FakeRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="posix")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(3)]
+        payloads = [bytes([i + 1]) * 1024 for i in range(3)]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        put_result = core.put_many(specs, objects)
+
+        assert put_result.results == [True] * 3
+        assert fake.batched_write_calls == []
+        assert fake.pwrite_count == 6
+
+        loaded = [make_empty_memory_obj(len(payload)) for payload in payloads]
+        load_result = core.load_many_into([spec.encoded for spec in specs], loaded)
+        assert load_result == [True] * 3
+        assert [memory_obj_bytes(obj) for obj in loaded] == payloads
+    finally:
+        core.close()
+
+
+@requires_rust_raw_block_io
 def test_raw_block_core_recovers_checkpoint_from_temp_file(tmp_path):
     path = make_raw_block_file(tmp_path)
     config = make_raw_block_core_config(path)

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -297,6 +297,7 @@ class _BatchedWriteCall:
     buffer_byte_lens: list[int]
     total_lens: list[int]
     placement_ids: list[int | None]
+    payload_lens: list[int]
 
 
 @dataclass
@@ -343,26 +344,35 @@ class _RecordingRawDevice:
         buffers: Sequence[Buffer],
         total_lens: Sequence[int],
         placement_ids: Sequence[int | None] | None = None,
+        payload_lens: Sequence[int] | None = None,
     ) -> int:
+        resolved_payload_lens = (
+            [int(p) for p in payload_lens]
+            if payload_lens is not None
+            else [int(total) for total in total_lens]
+        )
         self.batched_write_calls.append(
             _BatchedWriteCall(
                 offsets=[int(off) for off in offsets],
                 buffer_byte_lens=[len(bytes(buf)) for buf in buffers],
                 total_lens=[int(total) for total in total_lens],
                 placement_ids=list(placement_ids or [None] * len(offsets)),
+                payload_lens=resolved_payload_lens,
             )
         )
         if self.fail_batched_write:
             raise RuntimeError("injected batched_write failure")
-        for i, (off, buf, total) in enumerate(
-            zip(offsets, buffers, total_lens, strict=True)
+        for i, (off, buf, total, payload) in enumerate(
+            zip(offsets, buffers, total_lens, resolved_payload_lens, strict=True)
         ):
             if (
                 self.fail_after_write_entries is not None
                 and i >= self.fail_after_write_entries
             ):
                 raise RuntimeError("injected partial batched_write failure")
-            self.store[int(off)] = bytes(buf)[: int(total)]
+            # Mirror the Rust bounce: store only the valid payload, zero-padded
+            # up to total so round-trip reads observe the padded transfer.
+            self.store[int(off)] = bytes(buf)[: int(payload)].ljust(int(total), b"\x00")
         return self._submit_batch(len(offsets))
 
     def wait_iouring(self, batch_id: int) -> tuple[list[bool], list[tuple[int, str]]]:
@@ -407,6 +417,11 @@ class _RecordingRawDevice:
     ) -> None:
         self._copy_into(int(offset), buf, int(total_len))
 
+    def read_uring(
+        self, offset: int, buf: Any, payload_len: int, total_len: int
+    ) -> None:
+        self._copy_into(int(offset), buf, int(total_len))
+
     def close(self) -> None:
         pass
 
@@ -423,16 +438,19 @@ def _make_core_with_fake(
     fake: _RecordingRawDevice,
     io_engine: str,
     capacity_bytes: int | None = None,
+    use_odirect: bool = False,
 ) -> RawBlockCore:
     """Build a RawBlockCore wired to a fake raw device for a given engine.
 
     When ``capacity_bytes`` is given it overrides the config capacity so a
-    test can constrain the number of allocatable slots.
+    test can constrain the number of allocatable slots. When ``use_odirect``
+    is set, writes are padded to ``block_align`` so payload_len < total_len.
     """
     config = replace(
         make_raw_block_core_config(path),
         io_engine=io_engine,
         load_checkpoint_on_init=False,
+        use_odirect=use_odirect,
     )
     if capacity_bytes is not None:
         config = replace(config, capacity_bytes=capacity_bytes)
@@ -535,6 +553,64 @@ def test_raw_block_core_io_uring_put_many_round_trip(tmp_path: Path) -> None:
 
         assert load_result == [True] * 10
         assert [memory_obj_bytes(obj) for obj in loaded] == payloads
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_padded_odirect_uses_batched_write(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring", use_odirect=True)
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(4)]
+        # Non-block-aligned payloads force O_DIRECT padding: payload_len < total_len.
+        payloads = [bytes([i + 1]) * (1000 + i * 37) for i in range(4)]
+        objects = [make_memory_obj(payload) for payload in payloads]
+
+        assert core.put_many(specs, objects).results == [True] * 4
+
+        # Padded O_DIRECT writes go through batched_write, not the per-entry
+        # write_uring fallback.
+        assert len(fake.batched_write_calls) == 1
+        assert fake.write_uring_count == 0
+        call = fake.batched_write_calls[0]
+        # payload_lens are forwarded and at least one payload entry is padded.
+        assert call.payload_lens != call.total_lens
+        for payload_len, total_len in zip(
+            call.payload_lens, call.total_lens, strict=True
+        ):
+            assert payload_len <= total_len
+
+        loaded = [make_empty_memory_obj(len(payload)) for payload in payloads]
+        load_result = core.load_many_into([spec.encoded for spec in specs], loaded)
+        assert load_result == [True] * 4
+        assert [memory_obj_bytes(obj) for obj in loaded] == payloads
+    finally:
+        core.close()
+
+
+def test_raw_block_core_io_uring_non_padded_forwards_payload_lens(
+    tmp_path: Path,
+) -> None:
+    path = make_raw_block_file(tmp_path)
+    fake = _RecordingRawDevice(size=128 * 1024 * 1024)
+    core = _make_core_with_fake(path, fake, io_engine="io_uring")
+
+    try:
+        specs = [encode_object_key(make_object_key(i)) for i in range(3)]
+        objects = [make_memory_obj(bytes([i + 1]) * 1024) for i in range(3)]
+
+        assert core.put_many(specs, objects).results == [True] * 3
+
+        assert len(fake.batched_write_calls) == 1
+        assert fake.write_uring_count == 0
+        call = fake.batched_write_calls[0]
+        # No padding required, so payload_lens equals total_lens but is still
+        # forwarded explicitly.
+        assert call.payload_lens == call.total_lens
     finally:
         core.close()
 
@@ -971,8 +1047,9 @@ class _FakeRawDevice:
         buffers: list[bytearray],
         total_lens: list[int],
         placement_ids: list[int | None] | None = None,
+        payload_lens: list[int] | None = None,
     ) -> int:
-        del buffers
+        del buffers, payload_lens
         self.batched_write_calls.append((offsets, total_lens, placement_ids))
         self._batch_results[123] = [True] * len(offsets)
         return 123
@@ -1081,6 +1158,21 @@ def test_raw_block_core_checkpoint_uses_metadata_placement_id(tmp_path, monkeypa
         assert checkpoint_calls[-1][2] == [7, 7]
     finally:
         core.close()
+
+
+def test_raw_block_core_checkpoint_batches_padded_metadata_write(tmp_path, monkeypatch):
+    core, raw_device = _make_fake_io_uring_core(tmp_path, monkeypatch)
+    spec = encode_object_key(make_object_key(506))
+
+    assert core.put_many([spec], [make_memory_obj(b"data")]).results == [True]
+    put_call_count = len(raw_device.batched_write_calls)
+    core.close()
+
+    # The metadata checkpoint payload is padded up to block_align, so it is the
+    # write where payload_len < total_len. It must be submitted through
+    # batched_write rather than the per-entry write_uring fallback.
+    assert len(raw_device.batched_write_calls) > put_call_count
+    assert raw_device.write_uring_calls == []
 
 
 def test_raw_block_core_checkpoint_placement_requires_uring_cmd(tmp_path, monkeypatch):

--- a/tests/v1/storage_backend/test_raw_block_device.py
+++ b/tests/v1/storage_backend/test_raw_block_device.py
@@ -121,6 +121,257 @@ def test_raw_block_device_iouring_best_effort_roundtrip(tmp_path):
             dev.close()
 
 
+def test_raw_block_device_iouring_batched_write_padded_roundtrip(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        payload = bytearray(b"padded-payload")
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+        out = bytearray(total)
+
+        # payload_len < total_len: the source holds only len(payload) bytes but
+        # the transfer is padded up to total. batched_write must copy only the
+        # payload and zero-fill the tail.
+        batch_id = dev.batched_write([4096], [payload], [total], [len(payload)])
+        dev.wait_iouring(batch_id)
+        batch_id = dev.batched_read([4096], [out], [total])
+        dev.wait_iouring(batch_id)
+
+        assert out[: len(payload)] == payload
+        assert out[len(payload) :] == bytearray(total - len(payload))
+    except Exception as e:
+        if _is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+def test_raw_block_device_iouring_batched_write_zeroes_existing_tail(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        payload = b"padded-payload"
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+        buf = bytearray([0xAB]) * total
+        buf[: len(payload)] = payload
+        out = bytearray(total)
+
+        batch_id = dev.batched_write([4096], [buf], [total], [len(payload)])
+        dev.wait_iouring(batch_id)
+        batch_id = dev.batched_read([4096], [out], [total])
+        dev.wait_iouring(batch_id)
+
+        assert out[: len(payload)] == payload
+        assert out[len(payload) :] == bytearray(total - len(payload))
+    except Exception as e:
+        if _is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+def test_raw_block_device_iouring_batched_write_mixed_padding_batch(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+        non_padded = bytearray(b"non-padded")
+        zero_tail_payload = b"zero-tail-payload"
+        zero_tail = bytearray(total)
+        zero_tail[: len(zero_tail_payload)] = zero_tail_payload
+        stale_tail_payload = b"stale-tail-payload"
+        stale_tail = bytearray([0xEF]) * total
+        stale_tail[: len(stale_tail_payload)] = stale_tail_payload
+        short_payload = bytearray(b"short-source-payload")
+
+        offsets = [4096, 8192, 12288, 16384]
+        buffers = [non_padded, zero_tail, stale_tail, short_payload]
+        total_lens = [len(non_padded), total, total, total]
+        payload_lens = [
+            len(non_padded),
+            len(zero_tail_payload),
+            len(stale_tail_payload),
+            len(short_payload),
+        ]
+
+        batch_id = dev.batched_write(offsets, buffers, total_lens, payload_lens)
+        dev.wait_iouring(batch_id)
+
+        outs = [
+            bytearray(len(non_padded)),
+            bytearray(total),
+            bytearray(total),
+            bytearray(total),
+        ]
+        batch_id = dev.batched_read(offsets, outs, total_lens)
+        dev.wait_iouring(batch_id)
+
+        assert outs[0] == non_padded
+        assert outs[1][: len(zero_tail_payload)] == zero_tail_payload
+        assert outs[1][len(zero_tail_payload) :] == bytearray(
+            total - len(zero_tail_payload)
+        )
+        assert outs[2][: len(stale_tail_payload)] == stale_tail_payload
+        assert outs[2][len(stale_tail_payload) :] == bytearray(
+            total - len(stale_tail_payload)
+        )
+        assert outs[3][: len(short_payload)] == short_payload
+        assert outs[3][len(short_payload) :] == bytearray(total - len(short_payload))
+    except Exception as e:
+        if _is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+def test_raw_block_device_iouring_write_uring_zeroes_existing_tail(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        payload = b"serial-padded-payload"
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+        buf = bytearray([0xCD]) * total
+        buf[: len(payload)] = payload
+        out = bytearray(total)
+
+        dev.write_uring(4096, buf, len(payload), total)
+        batch_id = dev.batched_read([4096], [out], [total])
+        dev.wait_iouring(batch_id)
+
+        assert out[: len(payload)] == payload
+        assert out[len(payload) :] == bytearray(total - len(payload))
+    except Exception as e:
+        if _is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+def test_raw_block_device_iouring_batched_write_validates_payload_lengths(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        with pytest.raises(ValueError, match="All vectors must have same length"):
+            dev.batched_write([4096], [bytearray(b"payload")], [4096], [])
+
+        with pytest.raises(ValueError, match="total_len must be >= payload_len"):
+            dev.batched_write([4096], [bytearray(b"payload")], [4], [5])
+
+        with pytest.raises(ValueError, match="input buffer too small"):
+            dev.batched_write([4096], [bytearray(b"x")], [4096], [2])
+    except Exception as e:
+        if _is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+@pytest.mark.skipif(
+    os.getenv("LMCACHE_RUN_ODIRECT_SMOKE") != "1",
+    reason="O_DIRECT smoke is opt-in and not part of default PR CI",
+)
+def test_raw_block_device_odirect_batched_write_padded_roundtrip(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=True,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        payload = bytearray(b"padded-odirect-payload")
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+
+        batch_id = dev.batched_write([4096], [payload], [total], [len(payload)])
+        dev.wait_iouring(batch_id)
+        dev.close()
+        dev = None
+
+        # Read the bytes physically written with a non-O_DIRECT device so the
+        # padding region can be inspected without aligned-buffer requirements.
+        verify = RawBlockDevice(
+            str(path),
+            writable=False,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="posix",
+            iouring_queue_depth=8,
+        )
+        try:
+            out = bytearray(total)
+            verify.pread_into(4096, out, total, total)
+            assert out[: len(payload)] == payload
+            assert out[len(payload) :] == bytearray(total - len(payload))
+        finally:
+            verify.close()
+    except Exception as e:
+        if _is_skip_safe_io_error(e):
+            pytest.skip(f"O_DIRECT is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
 @pytest.mark.skipif(
     os.getenv("LMCACHE_RUN_ODIRECT_SMOKE") != "1",
     reason="O_DIRECT smoke is opt-in and not part of default PR CI",

--- a/tests/v1/storage_backend/test_raw_block_device.py
+++ b/tests/v1/storage_backend/test_raw_block_device.py
@@ -104,6 +104,267 @@ def test_raw_block_device_iouring_best_effort_roundtrip(tmp_path):
             dev.close()
 
 
+def test_raw_block_device_iouring_batched_write_padded_roundtrip(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        payload = bytearray(b"padded-payload")
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+        out = bytearray(total)
+
+        # payload_len < total_len: the source holds only len(payload) bytes but
+        # the transfer is padded up to total. batched_write must copy only the
+        # payload and zero-fill the tail.
+        batch_id = dev.batched_write(
+            [4096], [payload], [total], payload_lens=[len(payload)]
+        )
+        dev.wait_iouring(batch_id)
+        batch_id = dev.batched_read([4096], [out], [total])
+        dev.wait_iouring(batch_id)
+
+        assert out[: len(payload)] == payload
+        assert out[len(payload) :] == bytearray(total - len(payload))
+    except Exception as e:
+        if is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+def test_raw_block_device_iouring_batched_write_zeroes_existing_tail(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        payload = b"padded-payload"
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+        buf = bytearray([0xAB]) * total
+        buf[: len(payload)] = payload
+        out = bytearray(total)
+
+        batch_id = dev.batched_write(
+            [4096], [buf], [total], payload_lens=[len(payload)]
+        )
+        dev.wait_iouring(batch_id)
+        batch_id = dev.batched_read([4096], [out], [total])
+        dev.wait_iouring(batch_id)
+
+        assert out[: len(payload)] == payload
+        assert out[len(payload) :] == bytearray(total - len(payload))
+    except Exception as e:
+        if is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+def test_raw_block_device_iouring_batched_write_mixed_padding_batch(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+        non_padded = bytearray(b"non-padded")
+        zero_tail_payload = b"zero-tail-payload"
+        zero_tail = bytearray(total)
+        zero_tail[: len(zero_tail_payload)] = zero_tail_payload
+        stale_tail_payload = b"stale-tail-payload"
+        stale_tail = bytearray([0xEF]) * total
+        stale_tail[: len(stale_tail_payload)] = stale_tail_payload
+        short_payload = bytearray(b"short-source-payload")
+
+        offsets = [4096, 8192, 12288, 16384]
+        buffers = [non_padded, zero_tail, stale_tail, short_payload]
+        total_lens = [len(non_padded), total, total, total]
+        payload_lens = [
+            len(non_padded),
+            len(zero_tail_payload),
+            len(stale_tail_payload),
+            len(short_payload),
+        ]
+
+        batch_id = dev.batched_write(
+            offsets, buffers, total_lens, payload_lens=payload_lens
+        )
+        dev.wait_iouring(batch_id)
+
+        outs = [
+            bytearray(len(non_padded)),
+            bytearray(total),
+            bytearray(total),
+            bytearray(total),
+        ]
+        batch_id = dev.batched_read(offsets, outs, total_lens)
+        dev.wait_iouring(batch_id)
+
+        assert outs[0] == non_padded
+        assert outs[1][: len(zero_tail_payload)] == zero_tail_payload
+        assert outs[1][len(zero_tail_payload) :] == bytearray(
+            total - len(zero_tail_payload)
+        )
+        assert outs[2][: len(stale_tail_payload)] == stale_tail_payload
+        assert outs[2][len(stale_tail_payload) :] == bytearray(
+            total - len(stale_tail_payload)
+        )
+        assert outs[3][: len(short_payload)] == short_payload
+        assert outs[3][len(short_payload) :] == bytearray(total - len(short_payload))
+    except Exception as e:
+        if is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+def test_raw_block_device_iouring_write_uring_zeroes_existing_tail(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        payload = b"serial-padded-payload"
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+        buf = bytearray([0xCD]) * total
+        buf[: len(payload)] = payload
+        out = bytearray(total)
+
+        dev.write_uring(4096, buf, len(payload), total)
+        batch_id = dev.batched_read([4096], [out], [total])
+        dev.wait_iouring(batch_id)
+
+        assert out[: len(payload)] == payload
+        assert out[len(payload) :] == bytearray(total - len(payload))
+    except Exception as e:
+        if is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+def test_raw_block_device_iouring_batched_write_validates_payload_lengths(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        with pytest.raises(
+            ValueError, match="payload_lens must have same length as offsets"
+        ):
+            dev.batched_write([4096], [bytearray(b"payload")], [4096], payload_lens=[])
+
+        with pytest.raises(ValueError, match="total_len must be >= payload_len"):
+            dev.batched_write([4096], [bytearray(b"payload")], [4], payload_lens=[5])
+
+        with pytest.raises(ValueError, match="input buffer too small"):
+            dev.batched_write([4096], [bytearray(b"x")], [4096], payload_lens=[2])
+    except Exception as e:
+        if is_skip_safe_io_error(e):
+            pytest.skip(f"io_uring is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
+@pytest.mark.skipif(
+    os.getenv("LMCACHE_RUN_ODIRECT_SMOKE") != "1",
+    reason="O_DIRECT smoke is opt-in and not part of default PR CI",
+)
+def test_raw_block_device_odirect_batched_write_padded_roundtrip(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    dev = None
+    try:
+        dev = RawBlockDevice(
+            str(path),
+            writable=True,
+            use_odirect=True,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="io_uring",
+            iouring_queue_depth=8,
+        )
+
+        payload = bytearray(b"padded-odirect-payload")
+        total = RAW_BLOCK_CI_BLOCK_ALIGN
+
+        batch_id = dev.batched_write(
+            [4096], [payload], [total], payload_lens=[len(payload)]
+        )
+        dev.wait_iouring(batch_id)
+        dev.close()
+        dev = None
+
+        # Read the bytes physically written with a non-O_DIRECT device so the
+        # padding region can be inspected without aligned-buffer requirements.
+        verify = RawBlockDevice(
+            str(path),
+            writable=False,
+            use_odirect=False,
+            alignment=RAW_BLOCK_CI_BLOCK_ALIGN,
+            io_engine="posix",
+            iouring_queue_depth=8,
+        )
+        try:
+            out = bytearray(total)
+            verify.pread_into(4096, out, total, total)
+            assert out[: len(payload)] == payload
+            assert out[len(payload) :] == bytearray(total - len(payload))
+        finally:
+            verify.close()
+    except Exception as e:
+        if is_skip_safe_io_error(e):
+            pytest.skip(f"O_DIRECT is unavailable on this runner: {e}")
+        raise
+    finally:
+        if dev is not None:
+            dev.close()
+
+
 @pytest.mark.skipif(
     os.getenv("LMCACHE_RUN_ODIRECT_SMOKE") != "1",
     reason="O_DIRECT smoke is opt-in and not part of default PR CI",

--- a/tests/v1/storage_backend/test_raw_block_uring_cmd.py
+++ b/tests/v1/storage_backend/test_raw_block_uring_cmd.py
@@ -3,9 +3,14 @@
 """Tests for io_uring command (passthrough) support in Rust raw block backend."""
 
 # Standard
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 import asyncio
 import os
+
+if TYPE_CHECKING:
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice
 
 # Third Party
 import pytest
@@ -223,6 +228,8 @@ def test_uring_cmd_get_nvme_info(loop_in_thread):
         assert lba_size > 0, f"Expected positive lba_size, got {lba_size}"
         logger.info(f"NVMe LBA size: {lba_size} bytes")
 
+    except PermissionError as e:
+        pytest.skip(f"Test device {device_path} cannot be opened: {e}")
     except Exception as e:
         pytest.fail(f"Failed to get NVMe info: {e}")
 
@@ -308,11 +315,111 @@ def test_uring_cmd_explicit_transfer_limit_must_be_block_aligned():
     with pytest.raises(
         ValueError,
         match=r"max_data_transfer_size \(5000\) must be a multiple of "
-        "block_align \(4096\)",
+        r"block_align \(4096\)",
     ):
         _build_transfer_limit_backend(
             TEST_DEVICES["char_device"], max_data_transfer_size=5000
         )
+
+
+def _open_raw_device(
+    device_path: str, *, use_uring_cmd: bool = True
+) -> "RawBlockDevice":
+    """Open the Rust raw block device for manual smoke tests."""
+    if not os.path.exists(device_path):
+        pytest.skip(f"Test device {device_path} not found.")
+
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice  # type: ignore
+
+    return RawBlockDevice(
+        device_path,
+        writable=True,
+        use_odirect=False,
+        alignment=4096,
+        io_engine="io_uring",
+        iouring_queue_depth=256,
+        use_uring_cmd=use_uring_cmd,
+    )
+
+
+def _manual_uring_cmd_write_smoke_offset() -> int:
+    """Return the scratch-device offset for destructive manual write smoke."""
+    if os.environ.get("LMCACHE_RUN_URING_CMD_WRITE_SMOKE") != "1":
+        pytest.skip("Set LMCACHE_RUN_URING_CMD_WRITE_SMOKE=1 for write smoke.")
+    if "LMCACHE_TEST_CHAR_DEVICE" not in os.environ:
+        pytest.skip("Set LMCACHE_TEST_CHAR_DEVICE to an explicit scratch device.")
+    offset_str = os.environ.get("LMCACHE_URING_CMD_WRITE_SMOKE_OFFSET")
+    if offset_str is None:
+        pytest.skip("Set LMCACHE_URING_CMD_WRITE_SMOKE_OFFSET on scratch space.")
+    else:
+        offset = int(offset_str, 0)
+    if offset % 4096 != 0:
+        pytest.skip("LMCACHE_URING_CMD_WRITE_SMOKE_OFFSET must be 4096-aligned.")
+    return offset
+
+
+def _unaligned_memoryview(data: bytes, align: int = 4096) -> memoryview:
+    """Return a memoryview whose start is offset from the backing bytearray."""
+    backing = bytearray(len(data) + align)
+    backing[1 : 1 + len(data)] = data
+    return memoryview(backing)[1 : 1 + len(data)]
+
+
+def _read_uring_cmd_bytes(
+    raw_dev: "RawBlockDevice", offset: int, total_len: int
+) -> bytes:
+    """Read back bytes in single-page chunks to avoid depending on read bounce."""
+    out = bytearray(total_len)
+    page = 4096
+    for chunk_offset in range(0, total_len, page):
+        chunk_len = min(page, total_len - chunk_offset)
+        raw_dev.read_uring(
+            offset + chunk_offset,
+            memoryview(out)[chunk_offset : chunk_offset + chunk_len],
+            chunk_len,
+            chunk_len,
+        )
+    return bytes(out)
+
+
+def test_uring_cmd_manual_write_smoke_handles_unaligned_buffers() -> None:
+    """Manually verify unaligned uring_cmd writes on a scratch NVMe namespace.
+
+    This test is destructive. It writes 24 KiB starting at
+    ``LMCACHE_URING_CMD_WRITE_SMOKE_OFFSET`` on ``LMCACHE_TEST_CHAR_DEVICE`` and
+    is skipped unless ``LMCACHE_RUN_URING_CMD_WRITE_SMOKE=1`` is set.
+    """
+    device_path = TEST_DEVICES["char_device"]
+    base_offset = _manual_uring_cmd_write_smoke_offset()
+    raw_dev = _open_raw_device(device_path, use_uring_cmd=True)
+
+    try:
+        total_len = 8192
+        first_payload = bytes((i % 251 for i in range(total_len)))
+        first_buffer = _unaligned_memoryview(first_payload)
+
+        raw_dev.write_uring(base_offset, first_buffer, total_len, total_len)
+        assert _read_uring_cmd_bytes(raw_dev, base_offset, total_len) == first_payload
+
+        batch_payloads = [
+            bytes(((i + 17) % 251 for i in range(total_len))),
+            bytes(((i + 43) % 251 for i in range(total_len))),
+        ]
+        batch_buffers = [_unaligned_memoryview(payload) for payload in batch_payloads]
+        batch_offsets = [base_offset + total_len, base_offset + 2 * total_len]
+        batch_id = raw_dev.batched_write(
+            batch_offsets,
+            batch_buffers,
+            [total_len] * len(batch_buffers),
+            [total_len] * len(batch_buffers),
+        )
+        raw_dev.wait_iouring(batch_id)
+
+        for offset, payload in zip(batch_offsets, batch_payloads, strict=True):
+            assert _read_uring_cmd_bytes(raw_dev, offset, total_len) == payload
+    finally:
+        raw_dev.close()
 
 
 if __name__ == "__main__":

--- a/tests/v1/storage_backend/test_raw_block_uring_cmd.py
+++ b/tests/v1/storage_backend/test_raw_block_uring_cmd.py
@@ -268,6 +268,8 @@ def test_uring_cmd_get_nvme_info(loop_in_thread):
         assert lba_size > 0, f"Expected positive lba_size, got {lba_size}"
         logger.info(f"NVMe LBA size: {lba_size} bytes")
 
+    except PermissionError as e:
+        pytest.skip(f"Test device {device_path} cannot be opened: {e}")
     except Exception as e:
         pytest.fail(f"Failed to get NVMe info: {e}")
 
@@ -568,6 +570,106 @@ def test_uring_cmd_explicit_transfer_limit_must_be_block_aligned():
         _build_transfer_limit_backend(
             TEST_DEVICES["char_device"], max_data_transfer_size=5000
         )
+
+
+def _open_raw_device(
+    device_path: str, *, use_uring_cmd: bool = True
+) -> "RawBlockDevice":
+    """Open the Rust raw block device for manual smoke tests."""
+    if not os.path.exists(device_path):
+        pytest.skip(f"Test device {device_path} not found.")
+
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice  # type: ignore
+
+    return RawBlockDevice(
+        device_path,
+        writable=True,
+        use_odirect=False,
+        alignment=4096,
+        io_engine="io_uring",
+        iouring_queue_depth=256,
+        use_uring_cmd=use_uring_cmd,
+    )
+
+
+def _manual_uring_cmd_write_smoke_offset() -> int:
+    """Return the scratch-device offset for destructive manual write smoke."""
+    if os.environ.get("LMCACHE_RUN_URING_CMD_WRITE_SMOKE") != "1":
+        pytest.skip("Set LMCACHE_RUN_URING_CMD_WRITE_SMOKE=1 for write smoke.")
+    if "LMCACHE_TEST_CHAR_DEVICE" not in os.environ:
+        pytest.skip("Set LMCACHE_TEST_CHAR_DEVICE to an explicit scratch device.")
+    offset_str = os.environ.get("LMCACHE_URING_CMD_WRITE_SMOKE_OFFSET")
+    if offset_str is None:
+        pytest.skip("Set LMCACHE_URING_CMD_WRITE_SMOKE_OFFSET on scratch space.")
+    else:
+        offset = int(offset_str, 0)
+    if offset % 4096 != 0:
+        pytest.skip("LMCACHE_URING_CMD_WRITE_SMOKE_OFFSET must be 4096-aligned.")
+    return offset
+
+
+def _unaligned_memoryview(data: bytes, align: int = 4096) -> memoryview:
+    """Return a memoryview whose start is offset from the backing bytearray."""
+    backing = bytearray(len(data) + align)
+    backing[1 : 1 + len(data)] = data
+    return memoryview(backing)[1 : 1 + len(data)]
+
+
+def _read_uring_cmd_bytes(
+    raw_dev: "RawBlockDevice", offset: int, total_len: int
+) -> bytes:
+    """Read back bytes in single-page chunks to avoid depending on read bounce."""
+    out = bytearray(total_len)
+    page = 4096
+    for chunk_offset in range(0, total_len, page):
+        chunk_len = min(page, total_len - chunk_offset)
+        raw_dev.read_uring(
+            offset + chunk_offset,
+            memoryview(out)[chunk_offset : chunk_offset + chunk_len],
+            chunk_len,
+            chunk_len,
+        )
+    return bytes(out)
+
+
+def test_uring_cmd_manual_write_smoke_handles_unaligned_buffers() -> None:
+    """Manually verify unaligned uring_cmd writes on a scratch NVMe namespace.
+
+    This test is destructive. It writes 24 KiB starting at
+    ``LMCACHE_URING_CMD_WRITE_SMOKE_OFFSET`` on ``LMCACHE_TEST_CHAR_DEVICE`` and
+    is skipped unless ``LMCACHE_RUN_URING_CMD_WRITE_SMOKE=1`` is set.
+    """
+    device_path = TEST_DEVICES["char_device"]
+    base_offset = _manual_uring_cmd_write_smoke_offset()
+    raw_dev = _open_raw_device(device_path, use_uring_cmd=True)
+
+    try:
+        total_len = 8192
+        first_payload = bytes((i % 251 for i in range(total_len)))
+        first_buffer = _unaligned_memoryview(first_payload)
+
+        raw_dev.write_uring(base_offset, first_buffer, total_len, total_len)
+        assert _read_uring_cmd_bytes(raw_dev, base_offset, total_len) == first_payload
+
+        batch_payloads = [
+            bytes(((i + 17) % 251 for i in range(total_len))),
+            bytes(((i + 43) % 251 for i in range(total_len))),
+        ]
+        batch_buffers = [_unaligned_memoryview(payload) for payload in batch_payloads]
+        batch_offsets = [base_offset + total_len, base_offset + 2 * total_len]
+        batch_id = raw_dev.batched_write(
+            batch_offsets,
+            batch_buffers,
+            [total_len] * len(batch_buffers),
+            payload_lens=[total_len] * len(batch_buffers),
+        )
+        assert raw_dev.wait_iouring(batch_id) == ([True] * len(batch_buffers), [])
+
+        for offset, payload in zip(batch_offsets, batch_payloads, strict=True):
+            assert _read_uring_cmd_bytes(raw_dev, offset, total_len) == payload
+    finally:
+        raw_dev.close()
 
 
 if __name__ == "__main__":

--- a/tests/v1/storage_backend/test_rust_raw_block_backend.py
+++ b/tests/v1/storage_backend/test_rust_raw_block_backend.py
@@ -107,14 +107,27 @@ class _FakeRawBlockDevice:
         buffers: list[Any],
         total_lens: list[int],
         placement_ids: list[int | None] | None = None,
+        payload_lens: list[int] | None = None,
     ) -> int:
         del placement_ids
+        resolved_payload_lens = (
+            [int(payload) for payload in payload_lens]
+            if payload_lens is not None
+            else [int(total) for total in total_lens]
+        )
         batch_id = self._next_batch_id
         self._next_batch_id += 1
         self.batched_writes.append((list(offsets), list(total_lens)))
         results = []
-        for offset, buf, total_len in zip(offsets, buffers, total_lens, strict=True):
-            self.pwrite_from_buffer(offset, buf, total_len, total_len)
+        for offset, buf, total_len, payload_len in zip(
+            offsets, buffers, total_lens, resolved_payload_lens, strict=True
+        ):
+            # Mirror the Rust bounce: store only the valid payload and zero the
+            # [payload_len, total_len) padding region.
+            self.pwrite_from_buffer(offset, buf, payload_len, total_len)
+            self._data[offset + payload_len : offset + total_len] = bytes(
+                total_len - payload_len
+            )
             results.append(True)
         self._batch_results[batch_id] = results
         return batch_id


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends the alignment check in `prepare_iouring_write_buffer` so
`uring_cmd` (NVMe passthrough) writes go through the aligned bounce
path even when `use_odirect=false`.

Today, `prepare_iouring_write_buffer` only requires an aligned bounce
when `use_odirect=true`. But NVMe passthrough (`/dev/ngXnY` via
`io_uring_cmd`) requires PRP-aligned buffers regardless of O_DIRECT.
With `use_uring_cmd=true && use_odirect=false`, an unaligned user
buffer can be passed straight to the kernel and violate PRP alignment
→ `EINVAL` / kernel reject.

Changes:

- `needs_alignment = use_odirect || use_uring_cmd` (was `use_odirect`)
  at the three `prepare_iouring_write_buffer` call sites in
  `RawBlockDevice::batched_write`, `write_uring`, and the alignment
  precheck.
- Parameter rename inside the helper: `use_odirect` → `needs_alignment`.
- Rust unit coverage for the alignment decision (aligned pass-through
  vs. unaligned bounce).
- Destructive `uring_cmd` write smoke test in
  `tests/v1/storage_backend/test_raw_block_uring_cmd.py` kept opt-in
  (env-gated) so CI doesn't touch real NVMe char devices.

**Special notes for your reviewers**:

Stacked on **#3949**, which introduces the current
`prepare_iouring_write_buffer` signature with `payload_len` /
`total_len`. Marked as **draft** until #3949 merges.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests