### PR TITLE
[RawBlock] Re-enable uring_cmd batched recovery header validation

### DIFF
--- a/benchmarks/storage_backend_io/README.md
+++ b/benchmarks/storage_backend_io/README.md
@@ -170,6 +170,32 @@ print(f"rust vs local: {(rust / local - 1.0) * 100.0:+.2f}%")
 PY
 ```
 
+## Raw Block Recovery Bringup Benchmark
+
+`raw_block_recovery_bringup_bench.py` measures synthetic `RawBlockCore` restart
+recovery. The prepare step writes checkpoint metadata and per-slot headers only;
+it does not write full payload contents. Use it to compare checkpoint loading and
+slot-header validation across recovery thread counts.
+
+```bash
+python benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py \
+  --device-path /dev/nvme1n1 \
+  --cache-space-gb 250 \
+  --prepare \
+  --measure \
+  --i-understand-this-overwrites-device
+```
+
+Important options:
+- `--cache-space-gb`: Logical cache space to prepare/use, in GiB units.
+- `--slot-bytes`: Slot size, defaulting to 16 MiB.
+- `--threads`: Recovery thread counts to compare, defaulting to `1 8`.
+- `--use-odirect` / `--no-use-odirect`: Enable or disable O_DIRECT for recovery
+  measurement. O_DIRECT is enabled by default.
+
+Warning: `--prepare` overwrites raw-block metadata and slot headers on the target
+path. Use a disposable file or an unmounted raw device.
+
 ## Output
 
 The script prints a summary and optionally writes JSON results if `--output-json` is provided.

--- a/benchmarks/storage_backend_io/README.md
+++ b/benchmarks/storage_backend_io/README.md
@@ -175,7 +175,9 @@ PY
 `raw_block_recovery_bringup_bench.py` measures synthetic `RawBlockCore` restart
 recovery. The prepare step writes checkpoint metadata and per-slot headers only;
 it does not write full payload contents. Use it to compare checkpoint loading and
-slot-header validation across recovery thread counts.
+slot-header validation across I/O engines and recovery thread counts. POSIX
+recovery is swept over reader-thread counts; io_uring recovery uses a single
+batched-read variant.
 
 ```bash
 python benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py \
@@ -189,7 +191,10 @@ python benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py \
 Important options:
 - `--cache-space-gb`: Logical cache space to prepare/use, in GiB units.
 - `--slot-bytes`: Slot size, defaulting to 16 MiB.
-- `--threads`: Recovery thread counts to compare, defaulting to `1 8`.
+- `--io-engine`: Engines to measure, defaulting to `posix`. Pass
+  `--io-engine posix io_uring` to compare the POSIX thread-pool path against the
+  io_uring batched-read path on the same fixture.
+- `--threads`: POSIX recovery thread counts to compare, defaulting to `1 8`.
 - `--use-odirect` / `--no-use-odirect`: Enable or disable O_DIRECT for recovery
   measurement. O_DIRECT is enabled by default.
 

--- a/benchmarks/storage_backend_io/README.md
+++ b/benchmarks/storage_backend_io/README.md
@@ -176,8 +176,8 @@ PY
 recovery. The prepare step writes checkpoint metadata and per-slot headers only;
 it does not write full payload contents. Use it to compare checkpoint loading and
 slot-header validation across I/O engines and recovery thread counts. POSIX
-recovery is swept over reader-thread counts; io_uring recovery uses a single
-batched-read variant.
+recovery is swept over reader-thread counts; io_uring and io_uring_cmd recovery
+use a single batched-read variant each.
 
 ```bash
 python benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py \
@@ -188,12 +188,29 @@ python benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py \
   --i-understand-this-overwrites-device
 ```
 
+To include NVMe passthrough recovery, prepare the fixture through the block
+device and measure through the NVMe namespace character device:
+
+```bash
+python benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py \
+  --device-path /dev/nvme1n1 \
+  --cmd-device-path /dev/ng1n1 \
+  --cache-space-gb 250 \
+  --measure \
+  --io-engine posix io_uring io_uring_cmd
+```
+
 Important options:
 - `--cache-space-gb`: Logical cache space to prepare/use, in GiB units.
 - `--slot-bytes`: Slot size, defaulting to 16 MiB.
 - `--io-engine`: Engines to measure, defaulting to `posix`. Pass
-  `--io-engine posix io_uring` to compare the POSIX thread-pool path against the
-  io_uring batched-read path on the same fixture.
+  `--io-engine posix io_uring io_uring_cmd` to compare the POSIX thread-pool
+  path against the io_uring and NVMe passthrough batched-read paths on the same
+  fixture.
+- `--cmd-device-path`: NVMe namespace character device path required when
+  measuring `io_uring_cmd`. The synthetic checkpoint omits `device_path` so one
+  fixture prepared through `/dev/nvmeXnY` can be measured through `/dev/ngXnY`;
+  production raw-block checkpoints still record `device_path`.
 - `--threads`: POSIX recovery thread counts to compare, defaulting to `1 8`.
 - `--use-odirect` / `--no-use-odirect`: Enable or disable O_DIRECT for recovery
   measurement. O_DIRECT is enabled by default.

--- a/benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py
+++ b/benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py
@@ -203,7 +203,7 @@ def prepare_fixture(args: argparse.Namespace) -> None:
         os.close(fd)
 
 
-def make_config(args: argparse.Namespace) -> RawBlockCoreConfig:
+def make_config(args: argparse.Namespace, io_engine: str) -> RawBlockCoreConfig:
     return RawBlockCoreConfig(
         device_path=args.device_path,
         capacity_bytes=args.capacity_bytes,
@@ -220,47 +220,72 @@ def make_config(args: argparse.Namespace) -> RawBlockCoreConfig:
         meta_enable_periodic=False,
         meta_verify_on_load=True,
         load_checkpoint_on_init=True,
-        io_engine="posix",
+        io_engine=io_engine,
         iouring_queue_depth=256,
         use_uring_cmd=False,
     )
 
 
-def time_bringup(args: argparse.Namespace, recovery_threads: int) -> float:
+# A measurement variant: (label, io_engine, recovery_threads).
+Variant = tuple[str, str, int]
+
+
+def time_bringup(args: argparse.Namespace, variant: Variant) -> float:
+    label, io_engine, recovery_threads = variant
     raw_block_core.DEFAULT_RECOVERY_READ_THREADS = recovery_threads
     started = time.perf_counter()
-    core = RawBlockCore(make_config(args), key_namespace="object")
+    core = RawBlockCore(make_config(args, io_engine), key_namespace="object")
     elapsed = time.perf_counter() - started
     status = core.report_status()
     core.close()
     print(
-        f"threads={recovery_threads}: {elapsed:.6f}s, "
+        f"{label}: {elapsed:.6f}s, "
         f"indexed={status['indexed_key_count']}, "
         f"free_slots={status['free_slot_count']}"
     )
     return elapsed
 
 
+def build_variants(args: argparse.Namespace) -> list[Variant]:
+    """Build measurement variants to compare.
+
+    POSIX is swept over --threads; io_uring uses one batched variant since its
+    recovery reads do not use the POSIX reader thread pool.
+    """
+    variants: list[Variant] = []
+    for io_engine in args.io_engine:
+        if io_engine == "io_uring":
+            variants.append(("io_uring/batched", "io_uring", 1))
+        else:
+            for threads in args.threads:
+                variants.append((f"posix/threads={threads}", "posix", threads))
+    return variants
+
+
 def measure(args: argparse.Namespace) -> None:
-    results: dict[int, list[float]] = {threads: [] for threads in args.threads}
+    variants = build_variants(args)
+    results: dict[str, list[float]] = {variant[0]: [] for variant in variants}
     for repeat in range(args.repeats):
         print(f"repeat {repeat + 1}/{args.repeats}")
-        for threads in args.threads:
-            results[threads].append(time_bringup(args, threads))
+        for variant in variants:
+            results[variant[0]].append(time_bringup(args, variant))
 
     print("\nsummary")
-    for threads, samples in results.items():
+    for label, samples in results.items():
         print(
-            f"threads={threads}: "
+            f"{label}: "
             f"median={statistics.median(samples):.6f}s "
             f"mean={statistics.mean(samples):.6f}s "
             f"samples={[round(sample, 6) for sample in samples]}"
         )
-    if 1 in results and 8 in results:
-        old = statistics.median(results[1])
-        new = statistics.median(results[8])
+    baseline_label = variants[0][0]
+    baseline = statistics.median(results[baseline_label])
+    for label, samples in results.items():
+        if label == baseline_label:
+            continue
+        new = statistics.median(samples)
         if new > 0:
-            print(f"speedup median threads=1/threads=8: {old / new:.2f}x")
+            print(f"speedup median {baseline_label}/{label}: {baseline / new:.2f}x")
 
 
 def parse_args() -> argparse.Namespace:
@@ -291,6 +316,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--measure", action="store_true")
     parser.add_argument("--repeats", type=int, default=3)
     parser.add_argument("--threads", type=int, nargs="+", default=[1, 8])
+    parser.add_argument(
+        "--io-engine",
+        nargs="+",
+        choices=["posix", "io_uring"],
+        default=["posix"],
+        help=(
+            "Engines to measure. posix is swept over --threads; io_uring uses a "
+            "single batched-read variant."
+        ),
+    )
     parser.add_argument("--max-entries", type=int)
     parser.add_argument(
         "--i-understand-this-overwrites-device",

--- a/benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py
+++ b/benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare and measure synthetic RawBlockCore checkpoint recovery.
+
+This benchmark creates a checkpoint with many indexed raw-block entries and
+writes only each slot header. It does not write full payload contents; it is
+intended to measure bringup checkpoint loading plus slot-header validation.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+import argparse
+import json
+import os
+import statistics
+import struct
+import time
+import zlib
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.memory_management import MemoryFormat
+from lmcache.v1.storage_backend.raw_block import core as raw_block_core
+from lmcache.v1.storage_backend.raw_block.core import RawBlockCore, RawBlockCoreConfig
+from lmcache.v1.storage_backend.raw_block.key_codec import encode_object_key
+
+META_HEADER_STRUCT = struct.Struct("<8sIQQI")
+META_MAGIC = b"LMCIDX01"
+META_VERSION = 1
+SLOT_MAGIC = b"LMCBLK01"
+MODEL_NAME = "raw-block-bringup-bench"
+PAYLOAD_LEN = 4096
+PROGRESS_EVERY = 50000
+
+
+def gib(value: float) -> int:
+    return int(value * 1024**3)
+
+
+def mib(value: float) -> int:
+    return int(value * 1024**2)
+
+
+def round_up(value: int, align: int) -> int:
+    return ((value + align - 1) // align) * align
+
+
+def encode_slot_header(
+    slot_identity: int,
+    payload_len: int,
+    header_bytes: int,
+) -> bytes:
+    header = bytearray(header_bytes)
+    header[0:8] = SLOT_MAGIC
+    header[8:16] = int(slot_identity & ((1 << 64) - 1)).to_bytes(
+        8, "little", signed=False
+    )
+    header[16:24] = int(payload_len).to_bytes(8, "little", signed=False)
+    return bytes(header)
+
+
+def object_key_for_slot(slot: int, model_name: str) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=slot.to_bytes(16, "big", signed=False),
+        model_name=model_name,
+        kv_rank=0,
+        object_group_id=0,
+    )
+
+
+def iter_entry_items(
+    *,
+    num_slots: int,
+    data_base_offset: int,
+    slot_bytes: int,
+    model_name: str,
+) -> Iterable[tuple[int, str, int]]:
+    for slot in range(num_slots):
+        spec = encode_object_key(object_key_for_slot(slot, model_name))
+        offset = data_base_offset + slot * slot_bytes
+        yield offset, spec.encoded, spec.slot_identity
+
+
+def build_checkpoint_payload(args: argparse.Namespace, num_slots: int) -> bytes:
+    entries: dict[str, dict[str, Any]] = {}
+    data_base_offset = args.meta_total_bytes
+    for offset, encoded_key, _slot_identity in iter_entry_items(
+        num_slots=num_slots,
+        data_base_offset=data_base_offset,
+        slot_bytes=args.slot_bytes,
+        model_name=MODEL_NAME,
+    ):
+        entries[encoded_key] = {
+            "offset": offset,
+            "size": PAYLOAD_LEN,
+            "shape": [1],
+            "dtype": "uint8",
+            "fmt": MemoryFormat.BINARY.name,
+            "cached_positions": None,
+        }
+
+    state = {
+        "version": 1,
+        "device_path": args.device_path,
+        "capacity_bytes": args.capacity_bytes,
+        "block_align": args.block_align,
+        "header_bytes": args.header_bytes,
+        "slot_bytes": args.slot_bytes,
+        "meta_total_bytes": args.meta_total_bytes,
+        "meta_magic": META_MAGIC.decode("ascii"),
+        "meta_version": META_VERSION,
+        "data_base_offset": data_base_offset,
+        "next_slot": num_slots,
+        "free_slots": [],
+        "entries": entries,
+    }
+    return json.dumps(state, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def write_all(fd: int, data: bytes, offset: int) -> None:
+    view = memoryview(data)
+    written = 0
+    while written < len(view):
+        written += os.pwrite(fd, view[written:], offset + written)
+
+
+def prepare_fixture(args: argparse.Namespace) -> None:
+    device = Path(args.device_path)
+    if not args.i_understand_this_overwrites_device:
+        raise SystemExit(
+            "Refusing to prepare fixture without "
+            "--i-understand-this-overwrites-device. This overwrites raw-block "
+            "metadata and slot headers on the target path."
+        )
+
+    if args.capacity_bytes <= args.meta_total_bytes:
+        raise SystemExit("capacity_bytes must be greater than meta_total_bytes")
+
+    num_slots = (args.capacity_bytes - args.meta_total_bytes) // args.slot_bytes
+    if args.max_entries is not None:
+        num_slots = min(num_slots, args.max_entries)
+    if num_slots <= 0:
+        raise SystemExit("computed slot count is zero")
+
+    if not device.exists() or device.is_file():
+        with device.open("ab") as f:
+            f.truncate(args.capacity_bytes)
+
+    payload = build_checkpoint_payload(args, num_slots)
+    meta_container_bytes = (
+        (args.meta_total_bytes // 2) // args.block_align
+    ) * args.block_align
+    payload_cap = meta_container_bytes - args.block_align
+    if len(payload) > payload_cap:
+        raise SystemExit(
+            f"checkpoint payload is too large: {len(payload)} > {payload_cap}. "
+            "Increase --meta-total-bytes or increase --slot-bytes."
+        )
+
+    flags = os.O_RDWR
+    fd = os.open(args.device_path, flags)
+    try:
+        print(
+            f"Preparing {num_slots} entries "
+            f"({num_slots * args.slot_bytes / 1024**3:.2f} GiB logical slots)"
+        )
+        started = time.perf_counter()
+        for slot, (offset, _encoded_key, slot_identity) in enumerate(
+            iter_entry_items(
+                num_slots=num_slots,
+                data_base_offset=args.meta_total_bytes,
+                slot_bytes=args.slot_bytes,
+                model_name=MODEL_NAME,
+            )
+        ):
+            header = encode_slot_header(
+                slot_identity=slot_identity,
+                payload_len=PAYLOAD_LEN,
+                header_bytes=args.header_bytes,
+            )
+            write_all(fd, header, offset)
+            if (slot + 1) % PROGRESS_EVERY == 0:
+                elapsed = time.perf_counter() - started
+                print(f"  wrote {slot + 1}/{num_slots} slot headers in {elapsed:.1f}s")
+
+        payload_total_len = round_up(len(payload), args.block_align)
+        payload_block = payload + b"\0" * (payload_total_len - len(payload))
+        crc = zlib.crc32(payload) & 0xFFFFFFFF
+        header_block = bytearray(args.block_align)
+        header_block[: META_HEADER_STRUCT.size] = META_HEADER_STRUCT.pack(
+            META_MAGIC, META_VERSION, 1, len(payload), crc
+        )
+        for container_offset in (0, meta_container_bytes):
+            write_all(fd, payload_block, container_offset + args.block_align)
+            write_all(fd, bytes(header_block), container_offset)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def make_config(args: argparse.Namespace) -> RawBlockCoreConfig:
+    return RawBlockCoreConfig(
+        device_path=args.device_path,
+        capacity_bytes=args.capacity_bytes,
+        block_align=args.block_align,
+        header_bytes=args.header_bytes,
+        slot_bytes=args.slot_bytes,
+        use_odirect=args.use_odirect,
+        enable_zero_copy=False,
+        meta_total_bytes=args.meta_total_bytes,
+        meta_magic=META_MAGIC,
+        meta_version=META_VERSION,
+        meta_checkpoint_interval_sec=3600,
+        meta_idle_quiet_ms=0,
+        meta_enable_periodic=False,
+        meta_verify_on_load=True,
+        load_checkpoint_on_init=True,
+        io_engine="posix",
+        iouring_queue_depth=256,
+        use_uring_cmd=False,
+    )
+
+
+def time_bringup(args: argparse.Namespace, recovery_threads: int) -> float:
+    raw_block_core.DEFAULT_RECOVERY_READ_THREADS = recovery_threads
+    started = time.perf_counter()
+    core = RawBlockCore(make_config(args), key_namespace="object")
+    elapsed = time.perf_counter() - started
+    status = core.report_status()
+    core.close()
+    print(
+        f"threads={recovery_threads}: {elapsed:.6f}s, "
+        f"indexed={status['indexed_key_count']}, "
+        f"free_slots={status['free_slot_count']}"
+    )
+    return elapsed
+
+
+def measure(args: argparse.Namespace) -> None:
+    results: dict[int, list[float]] = {threads: [] for threads in args.threads}
+    for repeat in range(args.repeats):
+        print(f"repeat {repeat + 1}/{args.repeats}")
+        for threads in args.threads:
+            results[threads].append(time_bringup(args, threads))
+
+    print("\nsummary")
+    for threads, samples in results.items():
+        print(
+            f"threads={threads}: "
+            f"median={statistics.median(samples):.6f}s "
+            f"mean={statistics.mean(samples):.6f}s "
+            f"samples={[round(sample, 6) for sample in samples]}"
+        )
+    if 1 in results and 8 in results:
+        old = statistics.median(results[1])
+        new = statistics.median(results[8])
+        if new > 0:
+            print(f"speedup median threads=1/threads=8: {old / new:.2f}x")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prepare and benchmark synthetic RawBlockCore checkpoint bringup "
+            "slot-header validation. Prepare writes checkpoint metadata and "
+            "slot headers, not full payload data."
+        )
+    )
+    parser.add_argument("--device-path", required=True)
+    parser.add_argument(
+        "--cache-space-gb",
+        type=float,
+        default=100,
+        help="Logical cache space to prepare/use, in GiB units.",
+    )
+    parser.add_argument("--slot-bytes", type=int, default=mib(16))
+    parser.add_argument("--block-align", type=int, default=4096)
+    parser.add_argument("--header-bytes", type=int, default=4096)
+    parser.add_argument("--meta-total-bytes", type=int, default=mib(256))
+    parser.add_argument(
+        "--use-odirect",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument("--prepare", action="store_true")
+    parser.add_argument("--measure", action="store_true")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--threads", type=int, nargs="+", default=[1, 8])
+    parser.add_argument("--max-entries", type=int)
+    parser.add_argument(
+        "--i-understand-this-overwrites-device",
+        action="store_true",
+        help=(
+            "Required with --prepare because metadata and slot headers are overwritten."
+        ),
+    )
+    args = parser.parse_args()
+    args.capacity_bytes = gib(args.cache_space_gb)
+    if not args.prepare and not args.measure:
+        args.measure = True
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    if args.prepare:
+        prepare_fixture(args)
+    if args.measure:
+        measure(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py
+++ b/benchmarks/storage_backend_io/raw_block_recovery_bringup_bench.py
@@ -106,7 +106,6 @@ def build_checkpoint_payload(args: argparse.Namespace, num_slots: int) -> bytes:
 
     state = {
         "version": 1,
-        "device_path": args.device_path,
         "capacity_bytes": args.capacity_bytes,
         "block_align": args.block_align,
         "header_bytes": args.header_bytes,
@@ -119,6 +118,10 @@ def build_checkpoint_payload(args: argparse.Namespace, num_slots: int) -> bytes:
         "free_slots": [],
         "entries": entries,
     }
+    # Benchmark-only fixture detail: omit device_path so the same prepared
+    # checkpoint can be measured through either the block device
+    # (/dev/nvmeXnY) or the io_uring_cmd character device (/dev/ngXnY).
+    # Production checkpoints still include device_path via RawBlockCore.
     return json.dumps(state, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
 
 
@@ -203,14 +206,19 @@ def prepare_fixture(args: argparse.Namespace) -> None:
         os.close(fd)
 
 
-def make_config(args: argparse.Namespace, io_engine: str) -> RawBlockCoreConfig:
+def make_config(
+    args: argparse.Namespace,
+    io_engine: str,
+    use_uring_cmd: bool,
+) -> RawBlockCoreConfig:
+    device_path = args.cmd_device_path if use_uring_cmd else args.device_path
     return RawBlockCoreConfig(
-        device_path=args.device_path,
+        device_path=device_path,
         capacity_bytes=args.capacity_bytes,
         block_align=args.block_align,
         header_bytes=args.header_bytes,
         slot_bytes=args.slot_bytes,
-        use_odirect=args.use_odirect,
+        use_odirect=False if use_uring_cmd else args.use_odirect,
         enable_zero_copy=False,
         meta_total_bytes=args.meta_total_bytes,
         meta_magic=META_MAGIC,
@@ -222,19 +230,22 @@ def make_config(args: argparse.Namespace, io_engine: str) -> RawBlockCoreConfig:
         load_checkpoint_on_init=True,
         io_engine=io_engine,
         iouring_queue_depth=256,
-        use_uring_cmd=False,
+        use_uring_cmd=use_uring_cmd,
     )
 
 
-# A measurement variant: (label, io_engine, recovery_threads).
-Variant = tuple[str, str, int]
+# A measurement variant: (label, io_engine, use_uring_cmd, recovery_threads).
+Variant = tuple[str, str, bool, int]
 
 
 def time_bringup(args: argparse.Namespace, variant: Variant) -> float:
-    label, io_engine, recovery_threads = variant
+    label, io_engine, use_uring_cmd, recovery_threads = variant
     raw_block_core.DEFAULT_RECOVERY_READ_THREADS = recovery_threads
     started = time.perf_counter()
-    core = RawBlockCore(make_config(args, io_engine), key_namespace="object")
+    core = RawBlockCore(
+        make_config(args, io_engine, use_uring_cmd),
+        key_namespace="object",
+    )
     elapsed = time.perf_counter() - started
     status = core.report_status()
     core.close()
@@ -249,16 +260,19 @@ def time_bringup(args: argparse.Namespace, variant: Variant) -> float:
 def build_variants(args: argparse.Namespace) -> list[Variant]:
     """Build measurement variants to compare.
 
-    POSIX is swept over --threads; io_uring uses one batched variant since its
-    recovery reads do not use the POSIX reader thread pool.
+    POSIX is swept over --threads; io_uring and io_uring_cmd each use one
+    batched variant since their recovery reads do not use the POSIX reader
+    thread pool.
     """
     variants: list[Variant] = []
     for io_engine in args.io_engine:
         if io_engine == "io_uring":
-            variants.append(("io_uring/batched", "io_uring", 1))
+            variants.append(("io_uring/batched", "io_uring", False, 1))
+        elif io_engine == "io_uring_cmd":
+            variants.append(("io_uring_cmd/batched", "io_uring", True, 1))
         else:
             for threads in args.threads:
-                variants.append((f"posix/threads={threads}", "posix", threads))
+                variants.append((f"posix/threads={threads}", "posix", False, threads))
     return variants
 
 
@@ -298,6 +312,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--device-path", required=True)
     parser.add_argument(
+        "--cmd-device-path",
+        help=(
+            "NVMe namespace character device path (for example /dev/ng0n1) "
+            "used when measuring --io-engine io_uring_cmd. The prepare step "
+            "always writes through --device-path."
+        ),
+    )
+    parser.add_argument(
         "--cache-space-gb",
         type=float,
         default=100,
@@ -319,11 +341,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--io-engine",
         nargs="+",
-        choices=["posix", "io_uring"],
+        choices=["posix", "io_uring", "io_uring_cmd"],
         default=["posix"],
         help=(
-            "Engines to measure. posix is swept over --threads; io_uring uses a "
-            "single batched-read variant."
+            "Engines to measure. posix is swept over --threads; io_uring and "
+            "io_uring_cmd each use a single batched-read variant."
         ),
     )
     parser.add_argument("--max-entries", type=int)
@@ -336,6 +358,8 @@ def parse_args() -> argparse.Namespace:
     )
     args = parser.parse_args()
     args.capacity_bytes = gib(args.cache_space_gb)
+    if "io_uring_cmd" in args.io_engine and not args.cmd_device_path:
+        raise SystemExit("--cmd-device-path is required with --io-engine io_uring_cmd")
     if not args.prepare and not args.measure:
         args.measure = True
     return args

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -98,6 +98,9 @@ Rules:
 - optional verification on load
 - recovery by loading the latest durable checkpoint and rebuilding the in-memory
   index
+- POSIX recovery validates per-slot headers with an internal pool of 8 reader
+  threads; `io_uring` keeps the serial validation path until batched header
+  recovery is added there
 
 The on-device format is intentionally unchanged by the MP adapter work.
 

--- a/docs/design/v1/distributed/l2_adapters/raw_block.md
+++ b/docs/design/v1/distributed/l2_adapters/raw_block.md
@@ -98,9 +98,10 @@ Rules:
 - optional verification on load
 - recovery by loading the latest durable checkpoint and rebuilding the in-memory
   index
-- POSIX recovery validates per-slot headers with an internal pool of 8 reader
-  threads; `io_uring` keeps the serial validation path until batched header
-  recovery is added there
+- POSIX recovery validates per-slot headers with an internal pool of reader
+  threads; `io_uring` validates headers with batched reads, including
+  `use_uring_cmd` after the passthrough read path is aligned for batched
+  recovery
 
 The on-device format is intentionally unchanged by the MP adapter work.
 

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -48,6 +48,8 @@ caller-provided load buffers during prefetch.
 - ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
   through ``RawBlockCore``. Slot reclamation is driven by the shared/global
   L2 eviction controller or explicit ``delete()`` calls.
+- POSIX restart recovery validates slot headers with an internal pool of 8
+  reader threads. ``io_uring`` recovery keeps the existing serial validation path.
 - If ``use_odirect`` is enabled, the server's ``--l1-align-bytes`` should be
   at least ``block_align``.
 - ``persist_enabled`` must remain ``true`` for this adapter.

--- a/docs/source/mp/l2_storage/raw_block.rst
+++ b/docs/source/mp/l2_storage/raw_block.rst
@@ -48,8 +48,10 @@ caller-provided load buffers during prefetch.
 - ``raw_block`` owns on-device slot allocation, checkpointing, and recovery
   through ``RawBlockCore``. Slot reclamation is driven by the shared/global
   L2 eviction controller or explicit ``delete()`` calls.
-- POSIX restart recovery validates slot headers with an internal pool of 8
-  reader threads. ``io_uring`` recovery keeps the existing serial validation path.
+- POSIX restart recovery validates slot headers with an internal reader pool.
+  ``io_uring`` recovery validates headers with batched reads, including
+  ``use_uring_cmd=true`` once the passthrough read path is aligned for batched
+  recovery.
 - If ``use_odirect`` is enabled, the server's ``--l1-align-bytes`` should be
   at least ``block_align``.
 - ``persist_enabled`` must remain ``true`` for this adapter.

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -1868,7 +1868,7 @@ class RawBlockCore:
         headers = self._read_slot_headers(offsets)
         to_drop = [
             encoded_key
-            for (encoded_key, entry), slot_hdr in zip(items, headers, strict=False)
+            for (encoded_key, entry), slot_hdr in zip(items, headers, strict=True)
             if self._is_stale_header(encoded_key, entry, slot_hdr)
         ]
 
@@ -1899,7 +1899,7 @@ class RawBlockCore:
         n = len(offsets)
         if self.io_engine == "posix" and self._recovery_read_threads > 1 and n > 1:
             return self._read_slot_headers_posix_parallel(offsets)
-        if self.io_engine == "io_uring" and not self.use_uring_cmd and n > 1:
+        if self.io_engine == "io_uring" and n > 1:
             return self._read_slot_headers_batched(offsets)
         return [self._read_slot_header(off) for off in offsets]
 
@@ -1965,9 +1965,9 @@ class RawBlockCore:
 
         Allocates a single contiguous pointer-aligned buffer for the batch,
         issues one ``batched_read`` + ``wait_iouring``, and decodes each header
-        independently. Used for the regular io_uring (block) path; NVMe
-        passthrough (``use_uring_cmd``) recovery uses the serial path until its
-        passthrough read is validated separately.
+        independently. Used for both regular io_uring block I/O and NVMe
+        passthrough (``use_uring_cmd``) after the passthrough read path has
+        been validated for aligned batched reads.
 
         Args:
             offsets: Device byte offsets for this batch (non-empty).

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -1935,12 +1935,77 @@ class RawBlockCore:
         self,
         offsets: list[int],
     ) -> list[Optional[tuple[int, int]]]:
-        """Return slot headers using a batched io_uring read path (TODO)."""
-        # TODO: Add batched io_uring slot-header reads here. Use
-        # _build_recovery_item_ranges() to bound each batch, submit all
-        # slot-header reads for a range with one io_uring submission, then
-        # return headers in the same order as the input offsets.
-        return [self._read_slot_header(off) for off in offsets]
+        """Return slot headers using the batched io_uring read path.
+
+        Splits the reads into ``iouring_queue_depth``-sized batches so a large
+        checkpoint does not allocate one buffer for every entry at once, then
+        reads each batch and concatenates results in input order.
+
+        Args:
+            offsets: Device byte offsets for each slot header to read.
+
+        Returns:
+            Decoded (slot_identity, payload_len) per slot, or None on error,
+            in the same order as ``offsets``.
+        """
+        n = len(offsets)
+        batch_size = max(1, self.iouring_queue_depth)
+        headers: list[Optional[tuple[int, int]]] = []
+        for start in range(0, n, batch_size):
+            headers.extend(
+                self._read_slot_header_batch(offsets[start : start + batch_size])
+            )
+        return headers
+
+    def _read_slot_header_batch(
+        self,
+        offsets: list[int],
+    ) -> list[Optional[tuple[int, int]]]:
+        """Read one bounded batch of slot headers via a single batched_read.
+
+        Allocates a single contiguous pointer-aligned buffer for the batch,
+        issues one ``batched_read`` + ``wait_iouring``, and decodes each header
+        independently. Used for the regular io_uring (block) path; NVMe
+        passthrough (``use_uring_cmd``) recovery uses the serial path until its
+        passthrough read is validated separately.
+
+        Args:
+            offsets: Device byte offsets for this batch (non-empty).
+
+        Returns:
+            Decoded (slot_identity, payload_len) per slot, or None on error.
+            A batched read fails as a whole even if only one slot errored and
+            does not report which; on any I/O exception this falls back to
+            per-slot reads so a single bad slot is isolated (only it becomes
+            None) instead of dropping every recovered entry in the batch.
+        """
+        n = len(offsets)
+        align = self.block_align
+        hdr = self.header_bytes
+        raw_buf = bytearray(n * hdr + align - 1)
+        addr = ctypes.addressof(ctypes.c_byte.from_buffer(raw_buf))
+        pad = (-addr) % align
+        views = [
+            memoryview(raw_buf)[pad + i * hdr : pad + (i + 1) * hdr] for i in range(n)
+        ]
+
+        with self._lock:
+            self._inflight_io_count += 1
+        try:
+            raw_dev = self._rawdev()
+            batch_id = raw_dev.batched_read(offsets, views, [hdr] * n)
+            raw_dev.wait_iouring(batch_id)
+        except Exception:
+            # TODO: when io_uring returns per-I/O completion results, use them
+            # to drop only the slot(s) that actually failed instead of
+            # re-reading every slot in this fallback.
+            return [self._read_slot_header(off) for off in offsets]
+        finally:
+            with self._lock:
+                self._inflight_io_count -= 1
+                self._last_io_ts = time.monotonic()
+
+        return [self._decode_slot_header(bytes(v)) for v in views]
 
     def _is_stale_header(
         self,

--- a/lmcache/v1/storage_backend/raw_block/core.py
+++ b/lmcache/v1/storage_backend/raw_block/core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 # Standard
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Optional
 import ctypes
@@ -43,6 +44,10 @@ _DEFAULT_META_VERSION = 1
 _META_HEADER_STRUCT = struct.Struct("<8sIQQI")
 RAW_BLOCK_IO_ENGINES = frozenset({"posix", "io_uring"})
 DEFAULT_IOURING_QUEUE_DEPTH = 256
+# Slot-header validation issues many small pread calls during POSIX restart
+# recovery. Use a conservative reader count to expose device parallelism without
+# relying on high thread counts; io_uring recovery should use batched reads.
+DEFAULT_RECOVERY_READ_THREADS = 8
 
 
 def round_up(x: int, align: int) -> int:
@@ -222,6 +227,7 @@ class RawBlockCore:
         self.io_engine = normalize_raw_block_io_engine(config.io_engine)
         self.iouring_queue_depth = int(config.iouring_queue_depth)
         self.use_uring_cmd = bool(config.use_uring_cmd)
+        self._recovery_read_threads = DEFAULT_RECOVERY_READ_THREADS
         if self.use_uring_cmd and self.use_odirect:
             logger.warning(
                 "RawBlockCore: use_odirect is ignored for NVMe namespace "
@@ -1852,29 +1858,19 @@ class RawBlockCore:
 
     def _validate_loaded_entries(self) -> None:
         """Drop recovered entries whose slot headers do not match metadata."""
-        to_drop: list[str] = []
         with self._lock:
             items = list(self._index.items())
 
-        for encoded_key, entry in items:
-            slot_hdr = self._read_slot_header(int(entry.offset))
-            if slot_hdr is None:
-                to_drop.append(encoded_key)
-                continue
-            try:
-                expected_identity = slot_identity_from_encoded_key(
-                    encoded_key,
-                    self.key_namespace,
-                )
-            except Exception:
-                to_drop.append(encoded_key)
-                continue
-            slot_identity, payload_len = slot_hdr
-            if int(slot_identity) != int(expected_identity):
-                to_drop.append(encoded_key)
-                continue
-            if int(payload_len) != int(entry.size):
-                to_drop.append(encoded_key)
+        if not items:
+            return
+
+        offsets = [int(entry.offset) for _, entry in items]
+        headers = self._read_slot_headers(offsets)
+        to_drop = [
+            encoded_key
+            for (encoded_key, entry), slot_hdr in zip(items, headers, strict=False)
+            if self._is_stale_header(encoded_key, entry, slot_hdr)
+        ]
 
         if not to_drop:
             return
@@ -1894,6 +1890,90 @@ class RawBlockCore:
             "slot-header validation",
             len(to_drop),
         )
+
+    def _read_slot_headers(
+        self,
+        offsets: list[int],
+    ) -> list[Optional[tuple[int, int]]]:
+        """Dispatch slot-header reads to the appropriate engine path."""
+        n = len(offsets)
+        if self.io_engine == "posix" and self._recovery_read_threads > 1 and n > 1:
+            return self._read_slot_headers_posix_parallel(offsets)
+        if self.io_engine == "io_uring" and not self.use_uring_cmd and n > 1:
+            return self._read_slot_headers_batched(offsets)
+        return [self._read_slot_header(off) for off in offsets]
+
+    def _read_slot_headers_posix_parallel(
+        self,
+        offsets: list[int],
+    ) -> list[Optional[tuple[int, int]]]:
+        """Return slot headers using a bounded POSIX reader thread pool."""
+        n = len(offsets)
+        max_workers = min(self._recovery_read_threads, n)
+        ranges = self._build_recovery_item_ranges(n, max_workers)
+        work_items = [(offsets, start, end) for start, end in ranges]
+        results: list[Optional[tuple[int, int]]] = [None] * n
+
+        def read_range(
+            work_item: tuple[list[int], int, int],
+        ) -> list[tuple[int, Optional[tuple[int, int]]]]:
+            offsets_in, start, end = work_item
+            return [
+                (i, self._read_slot_header(offsets_in[i])) for i in range(start, end)
+            ]
+
+        with ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="rawblk-recover",
+        ) as pool:
+            for range_results in pool.map(read_range, work_items):
+                for i, hdr in range_results:
+                    results[i] = hdr
+        return results
+
+    def _read_slot_headers_batched(
+        self,
+        offsets: list[int],
+    ) -> list[Optional[tuple[int, int]]]:
+        """Return slot headers using a batched io_uring read path (TODO)."""
+        # TODO: Add batched io_uring slot-header reads here. Use
+        # _build_recovery_item_ranges() to bound each batch, submit all
+        # slot-header reads for a range with one io_uring submission, then
+        # return headers in the same order as the input offsets.
+        return [self._read_slot_header(off) for off in offsets]
+
+    def _is_stale_header(
+        self,
+        encoded_key: str,
+        entry: _Entry,
+        slot_hdr: Optional[tuple[int, int]],
+    ) -> bool:
+        """Return True when the recovered slot header does not match metadata."""
+        if slot_hdr is None:
+            return True
+        try:
+            expected_identity = slot_identity_from_encoded_key(
+                encoded_key,
+                self.key_namespace,
+            )
+        except Exception:
+            return True
+        slot_identity, payload_len = slot_hdr
+        return int(slot_identity) != int(expected_identity) or int(payload_len) != int(
+            entry.size
+        )
+
+    def _build_recovery_item_ranges(
+        self,
+        item_count: int,
+        num_ranges: int,
+    ) -> list[tuple[int, int]]:
+        """Build bounded work ranges for recovered checkpoint entries."""
+        range_size = max(1, (item_count + num_ranges - 1) // num_ranges)
+        return [
+            (start, min(start + range_size, item_count))
+            for start in range(0, item_count, range_size)
+        ]
 
     def _load_checkpoint_from_device(self) -> None:
         """Load the newest valid checkpoint from the raw device if present."""

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -57,7 +57,11 @@ StoreController / PrefetchController
 ```
 
 This split lets LMCache reuse the same on-device metadata and recovery model in
-both non-MP and MP mode without duplicating the raw-block implementation.
+both non-MP and MP mode without duplicating the raw-block implementation. During
+restart recovery, the shared `RawBlockCore` validates POSIX per-slot headers with
+an internal pool of 8 reader threads. The `io_uring` recovery path intentionally
+keeps the existing serial validation behavior until batched header recovery is
+added for that engine.
 
 ## Zero-Copy Data Path
 

--- a/rust/raw_block/README.md
+++ b/rust/raw_block/README.md
@@ -59,9 +59,8 @@ StoreController / PrefetchController
 This split lets LMCache reuse the same on-device metadata and recovery model in
 both non-MP and MP mode without duplicating the raw-block implementation. During
 restart recovery, the shared `RawBlockCore` validates POSIX per-slot headers with
-an internal pool of 8 reader threads. The `io_uring` recovery path intentionally
-keeps the existing serial validation behavior until batched header recovery is
-added for that engine.
+an internal pool of 8 reader threads, while both `io_uring` and `io_uring_cmd`
+recovery use batched header validation.
 
 ## Zero-Copy Data Path
 

--- a/rust/raw_block/src/lib.rs
+++ b/rust/raw_block/src/lib.rs
@@ -2333,8 +2333,10 @@ impl RawBlockDevice {
             }
         }
 
-        // Check if the buffer is aligned for O_DIRECT
-        let ptr_aligned = if self.use_odirect {
+        // O_DIRECT and NVMe io_uring_cmd both require a page-aligned ptr for
+        // multi-page transfers (kernel / PRP list entries).
+        let needs_align = self.use_odirect || self.use_uring_cmd;
+        let ptr_aligned = if needs_align {
             (ptr as usize).is_multiple_of(align)
         } else {
             true
@@ -2351,7 +2353,7 @@ impl RawBlockDevice {
         };
 
         // Use bounce buffer if:
-        // Buffer is not aligned (O_DIRECT requirement)
+        // Buffer is not aligned (O_DIRECT or io_uring_cmd PRP requirement)
         // Buffer capacity is less than total_len
         let use_bounce = !ptr_aligned || cap < total_len;
 
@@ -2642,6 +2644,7 @@ impl RawBlockDevice {
 
         let fd = self.fd;
         let use_odirect = self.use_odirect;
+        let use_uring_cmd = self.use_uring_cmd;
         let alignment = self.alignment;
         let fixed_buffers_registered = self.fixed_buffers_registered.load(Ordering::Relaxed);
         // Clone the fixed buffer map before releasing GIL to avoid lock contention
@@ -2668,19 +2671,12 @@ impl RawBlockDevice {
         let res = py.allow_threads(move || {
             let mut submissions: Vec<(IoSubmission, Arc<IoCompletion>)> = Vec::with_capacity(n);
 
-            // Prepare all requests, validate buffers and collect submission data.
+            // Per-item bounce decision mirrors `read_uring`.
+            let needs_align = use_odirect || use_uring_cmd;
             for i in 0..n {
                 let total_len = total_lens[i];
                 let offset = offsets[i];
                 let cap = caps[i];
-
-                // Validate buffer capacity
-                if cap < total_len {
-                    return Err(PyValueError::new_err(format!(
-                        "output buffer too small: cap={} need={}",
-                        cap, total_len
-                    )));
-                }
 
                 if use_odirect {
                     #[allow(clippy::manual_is_multiple_of)]
@@ -2691,28 +2687,57 @@ impl RawBlockDevice {
                     if total_len % alignment != 0 {
                         return Err(PyValueError::new_err("O_DIRECT requires aligned total_len"));
                     }
-                    #[allow(clippy::manual_is_multiple_of)]
-                    if ptrs[i] % alignment != 0 {
-                        return Err(PyValueError::new_err("O_DIRECT requires aligned buffers"));
-                    }
                 }
+
+                // cap < total_len is OK (bounce handles it); cap == 0 is invalid.
+                if cap == 0 {
+                    return Err(PyValueError::new_err(format!(
+                        "output buffer too small: cap={} need={}",
+                        cap, total_len
+                    )));
+                }
+
+                let ptr_aligned = if needs_align {
+                    ptrs[i].is_multiple_of(alignment)
+                } else {
+                    true
+                };
+                let use_bounce = !ptr_aligned || cap < total_len;
 
                 let comp = Arc::new(IoCompletion::new());
 
-                // Fixed buffers are pre-registered with io_uring, enabling true zero-copy I/O
-                let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
+                let (ptr_addr, fixed_idx, bounce_opt, original_ptr_opt, payload_len_opt) =
+                    if use_bounce {
+                        let bounce = AlignedBuf::new(total_len, alignment)?;
+                        let bounce_arc = Arc::new(bounce);
+                        let bounce_ptr = bounce_arc.as_mut_ptr() as usize;
+                        // Copy-back bounded by caller capacity.
+                        let payload_len = std::cmp::min(cap, total_len);
+                        (
+                            bounce_ptr,
+                            None,
+                            Some(bounce_arc),
+                            Some(ptrs[i]),
+                            Some(payload_len),
+                        )
+                    } else {
+                        // Fixed buffers are pre-registered with io_uring,
+                        // enabling true zero-copy I/O.
+                        let fixed_idx = fixed_buffer_map.get(&ptrs[i]).map(|(idx, _)| *idx);
+                        (ptrs[i], fixed_idx, None, None, None)
+                    };
 
                 let sub = IoSubmission {
                     fd,
                     offset,
                     len: total_len,
-                    ptr_addr: ptrs[i],
+                    ptr_addr,
                     is_write: false, // read operation
                     completion: comp.clone(),
                     fixed_buffer_idx: fixed_idx,
-                    bounce: None,
-                    original_ptr: None,
-                    payload_len: None,
+                    bounce: bounce_opt,
+                    original_ptr: original_ptr_opt,
+                    payload_len: payload_len_opt,
                     batch_id,
                     nvme_cmd_data: nvme_cmd_data.clone(),
                 };

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 # Standard
+from typing import Any
+from unittest.mock import Mock, call
 import threading
 
 # Third Party
@@ -283,12 +285,18 @@ def test_raw_block_core_iouring_recovery_does_not_use_posix_threads(monkeypatch)
     core._lock_refcnt = {}
     core._meta_dirty_total = 0
     core.io_engine = "io_uring"
+    core.use_uring_cmd = False
     core._recovery_read_threads = 8
     core.key_namespace = "object"
     core._read_slot_header = lambda offset: (
         specs[(offset // 4096) - 1].slot_identity,
         7,
     )
+    # io_uring dispatch reads headers via the batched path; stub it to the
+    # single-read helper so this test exercises dispatch without real io_uring.
+    core._read_slot_headers_batched = lambda offsets: [
+        core._read_slot_header(off) for off in offsets
+    ]
 
     def fail_thread_pool_executor(*args, **kwargs):
         raise AssertionError("io_uring recovery must not use POSIX read threads")
@@ -300,4 +308,176 @@ def test_raw_block_core_iouring_recovery_does_not_use_posix_threads(monkeypatch)
 
     core._validate_loaded_entries()
 
+    assert list(core._index) == [spec.encoded for spec in specs]
+
+
+def _make_recovery_core(
+    specs: list[Any],
+    *,
+    io_engine: str = "io_uring",
+    use_uring_cmd: bool = False,
+) -> RawBlockCore:
+    """Build a minimal RawBlockCore for recovery dispatch tests."""
+    core = object.__new__(RawBlockCore)
+    core._lock = threading.Lock()
+    core._index = {
+        spec.encoded: type("Entry", (), {"offset": 4096 * (i + 1), "size": 64})()
+        for i, spec in enumerate(specs)
+    }
+    core._lock_refcnt = {}
+    core._meta_dirty_total = 0
+    core.io_engine = io_engine
+    core.use_uring_cmd = use_uring_cmd
+    core._recovery_read_threads = 1
+    core.key_namespace = "object"
+    return core
+
+
+def _make_iouring_header_core() -> RawBlockCore:
+    """Build a minimal RawBlockCore for batched slot-header reads."""
+    core = object.__new__(RawBlockCore)
+    core._lock = threading.Lock()
+    core._inflight_io_count = 0
+    core._last_io_ts = 0.0
+    core.block_align = 4096
+    core.header_bytes = 4096
+    core.iouring_queue_depth = 256
+    return core
+
+
+def _slot_header(core: RawBlockCore, identity: int, payload_len: int) -> bytes:
+    header = bytearray(core.header_bytes)
+    header[0:8] = b"LMCBLK01"
+    header[8:16] = int(identity).to_bytes(8, "little")
+    header[16:24] = int(payload_len).to_bytes(8, "little")
+    return bytes(header)
+
+
+def test_read_slot_headers_batched_reads_and_decodes_one_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # White-box: single-batch decode and the batch_id -> wait_iouring wiring have
+    # no public projection, so this asserts the io_uring read path directly.
+    core = _make_iouring_header_core()
+    offsets = [4096, 8192]
+    expected = [(0xCAFE, 128), (0xBEEF, 256)]
+    raw_dev = Mock()
+
+    def batched_read(
+        batch_offsets: list[int],
+        buffers: list[memoryview],
+        total_lens: list[int],
+    ) -> int:
+        assert batch_offsets == offsets
+        assert total_lens == [core.header_bytes, core.header_bytes]
+        for buffer, header in zip(
+            buffers,
+            [_slot_header(core, identity, size) for identity, size in expected],
+            strict=True,
+        ):
+            buffer[:] = header
+        return 77
+
+    raw_dev.batched_read.side_effect = batched_read
+    monkeypatch.setattr(core, "_rawdev", lambda: raw_dev)
+
+    assert core._read_slot_headers_batched(offsets) == expected
+    raw_dev.wait_iouring.assert_called_once_with(77)
+
+
+def test_read_slot_headers_batched_splits_by_iouring_queue_depth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # White-box: queue_depth batching has no public projection; the only
+    # observable is the batched_read call pattern, so assert it directly.
+    core = _make_iouring_header_core()
+    core.iouring_queue_depth = 2
+    offsets = [4096, 8192, 12288, 16384, 20480]
+    seen_batches: list[list[int]] = []
+    raw_dev = Mock()
+
+    def batched_read(
+        batch_offsets: list[int],
+        buffers: list[memoryview],
+        total_lens: list[int],
+    ) -> int:
+        seen_batches.append(list(batch_offsets))
+        for offset, buffer in zip(batch_offsets, buffers, strict=True):
+            buffer[:] = _slot_header(core, offset, 64)
+        return len(seen_batches)
+
+    raw_dev.batched_read.side_effect = batched_read
+    monkeypatch.setattr(core, "_rawdev", lambda: raw_dev)
+
+    assert core._read_slot_headers_batched(offsets) == [
+        (4096, 64),
+        (8192, 64),
+        (12288, 64),
+        (16384, 64),
+        (20480, 64),
+    ]
+    assert seen_batches == [[4096, 8192], [12288, 16384], [20480]]
+    assert raw_dev.wait_iouring.call_count == 3
+
+
+def test_read_slot_headers_batched_falls_back_per_slot_on_batch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # White-box: per-slot fallback isolation has no public projection; the only
+    # observable is the per-slot re-read pattern, so assert it directly.
+    core = _make_iouring_header_core()
+    raw_dev = Mock()
+    raw_dev.batched_read.side_effect = RuntimeError("read failed")
+    monkeypatch.setattr(core, "_rawdev", lambda: raw_dev)
+    read_mock = Mock(side_effect=[(1, 64), None, (3, 64)])
+    monkeypatch.setattr(core, "_read_slot_header", read_mock)
+
+    assert core._read_slot_headers_batched([4096, 8192, 12288]) == [
+        (1, 64),
+        None,
+        (3, 64),
+    ]
+    assert read_mock.call_args_list == [
+        call(4096),
+        call(8192),
+        call(12288),
+    ]
+
+
+def test_validate_loaded_entries_iouring_multi_entry_uses_batched_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    specs = [encode_object_key(make_object_key(i)) for i in range(3)]
+    core = _make_recovery_core(specs)
+    expected_offsets = [4096, 8192, 12288]
+    batched_mock = Mock(return_value=[(spec.slot_identity, 64) for spec in specs])
+    monkeypatch.setattr(core, "_read_slot_headers_batched", batched_mock)
+    read_mock = Mock()
+    monkeypatch.setattr(core, "_read_slot_header", read_mock)
+
+    core._validate_loaded_entries()
+
+    batched_mock.assert_called_once_with(expected_offsets)
+    read_mock.assert_not_called()
+    assert list(core._index) == [spec.encoded for spec in specs]
+
+
+def test_validate_loaded_entries_uring_cmd_keeps_sequential_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    specs = [encode_object_key(make_object_key(i)) for i in range(3)]
+    core = _make_recovery_core(specs, use_uring_cmd=True)
+    batched_mock = Mock()
+    monkeypatch.setattr(core, "_read_slot_headers_batched", batched_mock)
+    read_mock = Mock(side_effect=[(spec.slot_identity, 64) for spec in specs])
+    monkeypatch.setattr(core, "_read_slot_header", read_mock)
+
+    core._validate_loaded_entries()
+
+    batched_mock.assert_not_called()
+    assert read_mock.call_args_list == [
+        call(4096),
+        call(8192),
+        call(12288),
+    ]
     assert list(core._index) == [spec.encoded for spec in specs]

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -462,22 +462,19 @@ def test_validate_loaded_entries_iouring_multi_entry_uses_batched_reader(
     assert list(core._index) == [spec.encoded for spec in specs]
 
 
-def test_validate_loaded_entries_uring_cmd_keeps_sequential_reader(
+def test_validate_loaded_entries_uring_cmd_uses_batched_reader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     specs = [encode_object_key(make_object_key(i)) for i in range(3)]
     core = _make_recovery_core(specs, use_uring_cmd=True)
-    batched_mock = Mock()
+    expected_offsets = [4096, 8192, 12288]
+    batched_mock = Mock(return_value=[(spec.slot_identity, 64) for spec in specs])
     monkeypatch.setattr(core, "_read_slot_headers_batched", batched_mock)
-    read_mock = Mock(side_effect=[(spec.slot_identity, 64) for spec in specs])
+    read_mock = Mock()
     monkeypatch.setattr(core, "_read_slot_header", read_mock)
 
     core._validate_loaded_entries()
 
-    batched_mock.assert_not_called()
-    assert read_mock.call_args_list == [
-        call(4096),
-        call(8192),
-        call(12288),
-    ]
+    batched_mock.assert_called_once_with(expected_offsets)
+    read_mock.assert_not_called()
     assert list(core._index) == [spec.encoded for spec in specs]

--- a/tests/v1/storage_backend/test_raw_block_core.py
+++ b/tests/v1/storage_backend/test_raw_block_core.py
@@ -3,6 +3,9 @@
 # Future
 from __future__ import annotations
 
+# Standard
+import threading
+
 # Third Party
 import pytest
 
@@ -187,3 +190,114 @@ def test_raw_block_core_rebuilds_missing_free_slots_from_checkpoint(tmp_path):
         assert core.report_status()["next_slot"] == 2
     finally:
         core.close()
+
+
+def test_raw_block_core_drops_checkpoint_entry_with_stale_slot_header(tmp_path):
+    path = make_raw_block_file(tmp_path)
+    config = make_raw_block_core_config(path)
+    spec = encode_object_key(make_object_key(41))
+    payload = b"stale-slot-header-payload"
+
+    core = RawBlockCore(config, key_namespace="object")
+    try:
+        put_result = core.put_many([spec], [make_memory_obj(payload)])
+        assert put_result.results == [True]
+        offset = core.entry_offset(spec.encoded)
+        assert offset is not None
+        core.checkpoint_now()
+    finally:
+        core.close()
+
+    with path.open("r+b") as f:
+        f.seek(offset)
+        f.write(b"STALEHDR")
+
+    recovered = RawBlockCore(config, key_namespace="object")
+    try:
+        assert recovered.contains_key(spec.encoded) is False
+        loaded = make_empty_memory_obj(len(payload))
+        assert recovered.load_many_into([spec.encoded], [loaded]) == [False]
+    finally:
+        recovered.close()
+
+
+def test_raw_block_core_uses_bounded_posix_recovery_read_tasks(monkeypatch):
+    specs = [encode_object_key(make_object_key(i)) for i in range(50, 60)]
+    core = object.__new__(RawBlockCore)
+    core._lock = threading.Lock()
+    core._index = {
+        spec.encoded: type("Entry", (), {"offset": 4096 * (i + 1), "size": 7})()
+        for i, spec in enumerate(specs)
+    }
+    core._lock_refcnt = {}
+    core._meta_dirty_total = 0
+    core.io_engine = "posix"
+    core._recovery_read_threads = 3
+    core.key_namespace = "object"
+    core._read_slot_header = lambda offset: (
+        specs[(offset // 4096) - 1].slot_identity,
+        7,
+    )
+
+    max_worker_calls: list[int] = []
+    mapped_item_counts: list[int] = []
+
+    class RecordingThreadPoolExecutor:
+        def __init__(self, *, max_workers, thread_name_prefix):
+            max_worker_calls.append(max_workers)
+            self._max_workers = max_workers
+            self._thread_name_prefix = thread_name_prefix
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def map(self, fn, items):
+            mapped_items = list(items)
+            mapped_item_counts.append(len(mapped_items))
+            return map(fn, mapped_items)
+
+    monkeypatch.setattr(
+        "lmcache.v1.storage_backend.raw_block.core.ThreadPoolExecutor",
+        RecordingThreadPoolExecutor,
+    )
+
+    core._validate_loaded_entries()
+
+    # 10 entries with 3 workers → 3 work ranges dispatched
+    assert max_worker_calls == [3]
+    assert mapped_item_counts == [3]
+    assert list(core._index) == [spec.encoded for spec in specs]
+
+
+def test_raw_block_core_iouring_recovery_does_not_use_posix_threads(monkeypatch):
+    specs = [encode_object_key(make_object_key(i)) for i in range(51, 61)]
+    core = object.__new__(RawBlockCore)
+    core._lock = threading.Lock()
+    core._index = {
+        spec.encoded: type("Entry", (), {"offset": 4096 * (i + 1), "size": 7})()
+        for i, spec in enumerate(specs)
+    }
+    core._lock_refcnt = {}
+    core._meta_dirty_total = 0
+    core.io_engine = "io_uring"
+    core._recovery_read_threads = 8
+    core.key_namespace = "object"
+    core._read_slot_header = lambda offset: (
+        specs[(offset // 4096) - 1].slot_identity,
+        7,
+    )
+
+    def fail_thread_pool_executor(*args, **kwargs):
+        raise AssertionError("io_uring recovery must not use POSIX read threads")
+
+    monkeypatch.setattr(
+        "lmcache.v1.storage_backend.raw_block.core.ThreadPoolExecutor",
+        fail_thread_pool_executor,
+    )
+
+    core._validate_loaded_entries()
+
+    assert list(core._index) == [spec.encoded for spec in specs]

--- a/tests/v1/storage_backend/test_raw_block_uring_cmd.py
+++ b/tests/v1/storage_backend/test_raw_block_uring_cmd.py
@@ -3,9 +3,14 @@
 """Tests for io_uring command (passthrough) support in Rust raw block backend."""
 
 # Standard
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 import asyncio
 import os
+
+if TYPE_CHECKING:
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice
 
 # Third Party
 import pytest
@@ -287,6 +292,94 @@ def test_uring_cmd_auto_transfer_limit_fails_when_sysfs_unavailable():
             )
 
     mock_read.assert_called_once_with(expected_path)
+
+
+def _open_raw_device(
+    device_path: str, *, use_uring_cmd: bool = True
+) -> "RawBlockDevice":
+    """Open the Rust RawBlockDevice; skip the test if the device is absent."""
+    if not os.path.exists(device_path):
+        pytest.skip(f"Test device {device_path} not found.")
+
+    # Third Party
+    from lmcache_rust_raw_block_io import RawBlockDevice  # type: ignore
+
+    return RawBlockDevice(
+        device_path,
+        writable=True,
+        use_odirect=False,
+        alignment=4096,
+        io_engine="io_uring",
+        iouring_queue_depth=256,
+        use_uring_cmd=use_uring_cmd,
+    )
+
+
+def _unaligned_bytearray(total_len: int, align: int = 4096) -> bytearray:
+    """Return a bytearray that is likely (best-effort) not ``align``-aligned."""
+    backing = bytearray(total_len + align)
+    return bytearray(backing[1 : 1 + total_len])
+
+
+def test_uring_cmd_read_uring_handles_unaligned_buffer() -> None:
+    """``read_uring`` must accept an unaligned buffer under ``use_uring_cmd``."""
+    device_path = TEST_DEVICES["char_device"]
+    raw_dev = _open_raw_device(device_path, use_uring_cmd=True)
+
+    try:
+        total_len = 8192  # multi-page to require a PRP list
+        buf = _unaligned_bytearray(total_len)
+        raw_dev.read_uring(0, buf, total_len, total_len)
+    finally:
+        raw_dev.close()
+
+
+def test_uring_cmd_batched_read_handles_unaligned_buffer() -> None:
+    """``batched_read`` must accept unaligned buffers under ``use_uring_cmd``."""
+    device_path = TEST_DEVICES["char_device"]
+    raw_dev = _open_raw_device(device_path, use_uring_cmd=True)
+
+    try:
+        total_len = 8192
+        offsets = [0, total_len, 2 * total_len, 3 * total_len]
+        buffers = [_unaligned_bytearray(total_len) for _ in offsets]
+        total_lens = [total_len] * len(offsets)
+
+        batch_id = raw_dev.batched_read(offsets, buffers, total_lens)
+        raw_dev.wait_iouring(batch_id)
+    finally:
+        raw_dev.close()
+
+
+def test_uring_cmd_batched_read_short_buffer_uses_bounce() -> None:
+    """``batched_read`` must bounce when caller capacity is below ``total_len``."""
+    device_path = TEST_DEVICES["char_device"]
+    raw_dev = _open_raw_device(device_path, use_uring_cmd=True)
+
+    try:
+        total_len = 8192
+        buf = bytearray(4096)
+        batch_id = raw_dev.batched_read([0], [buf], [total_len])
+        raw_dev.wait_iouring(batch_id)
+    finally:
+        raw_dev.close()
+
+
+def test_uring_cmd_batched_read_independent_per_item_bounce_decision() -> None:
+    """``batched_read`` must choose bounce per item, not for the whole batch."""
+    device_path = TEST_DEVICES["char_device"]
+    raw_dev = _open_raw_device(device_path, use_uring_cmd=True)
+
+    try:
+        total_len = 8192
+        offsets = [0, total_len]
+        buffers = [bytearray(total_len), _unaligned_bytearray(total_len)]
+        total_lens = [total_len, total_len]
+
+        batch_id = raw_dev.batched_read(offsets, buffers, total_lens)
+        raw_dev.wait_iouring(batch_id)
+    finally:
+        raw_dev.close()
 
 
 def test_uring_cmd_explicit_transfer_limit_must_be_block_aligned():


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-enables the `use_uring_cmd` path in batched recovery header
validation. Scope is restart recovery read path only.

Changes:

- `RawBlockCore._read_slot_headers`: drop the `not self.use_uring_cmd`
  guard so the batched path is used for both `io_uring` and
  `io_uring_cmd` when `n > 1`.
- `_read_slot_header_batch` docstring: remove the "uring_cmd
  passthrough falls back to serial reader" note.
- Unit test rename:
  `test_validate_loaded_entries_uring_cmd_keeps_sequential_reader`
  → `..._uses_batched_reader`, with the assertion inverted.
- `raw_block_recovery_bringup_bench.py`:
  - Add `io_uring_cmd` as a benchmark engine option.
  - Add `--cmd-device-path` so prepare can run on a block device while
    measurement runs on the NVMe char device.
  - Extend variant tuple to
    `(label, io_engine, use_uring_cmd, recovery_threads)`.
  - Omit `device_path` on the synthetic checkpoint payload to avoid
    block/char path mismatch in the benchmark fixture (fixture-only,
    not a production schema change).
- Docs (`docs/design/v1/distributed/l2_adapters/raw_block.md`,
  `docs/source/mp/l2_storage/raw_block.rst`): note that both
  `io_uring` and `io_uring_cmd` recovery use batched header
  validation.

**Special notes for your reviewers**:

Stacked on **#3891** (read-path `uring_cmd` alignment prerequisite)
and **#3835** (batched recovery header validation infra). Marked as
**draft** until both merge.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests