### PR TITLE
docs: consolidated daily drift-check updates (2026-06-30 .. 2026-07-19)

### DIFF
--- a/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
+++ b/docs/design/ARCHITECTURE_MULTI_HARDWARE.md
@@ -22,6 +22,8 @@ multiprocess (MP) mode.
 │  [Registry Discovery Point]                                     │
 │  DeviceSpec subclasses are auto-discovered under                │
 │  lmcache.v1.platform and selected by availability.              │
+│  The DEVICE_TYPE env var forces the detector to prefer one      │
+│  registered device_type when multiple are available.            │
 └──────────────────────────────┬──────────────────────────────────┘
                                │
               ┌────────────────┼──────────────────┐
@@ -111,7 +113,7 @@ Override: LMCACHE_MP_TRANSFER_MODE env var or the mode argument to create_transf
 ## CPU-Only Stub Fallback
 
 `_detect_device()` also accepts a CPU-only environment where none of the
-supported accelerators (CUDA, XPU, HPU) is available. In that case
+supported accelerators (CUDA, MUSA, XPU, HPU) is available. In that case
 `torch_device_type` is `"cpu"` and `torch_dev` is either:
 
 - `lmcache.v1.platform.cpu.stub_cpu_device.StubCPUDevice` — when `torch`
@@ -149,4 +151,5 @@ which is wrong for that backend's actual KV cache layout.
    vendor-specific APIs must not leak to upper layers.
 
 No edits to ``lmcache/__init__.py`` or global backend candidate lists
-are required.
+are required. Users can set ``DEVICE_TYPE=<device_type>`` at runtime to
+force selection of a registered device when multiple are available.

--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -2,24 +2,27 @@
 
 The mp coordinator is a standalone **FastAPI / REST** process that coordinates
 LMCache multi-process (mp) cache servers running across nodes as a fleet. This
-document describes the backbone: the REST API, the instance registry, and the
-health-check loop. Domain capabilities (quota reconcile, blend-lookup routing,
-KV-op fan-out) are not implemented yet; they are added as new REST routers.
+document describes the backbone: the REST API, the instance registry, the
+health-check and eviction loops, and the four domain capabilities that hang off
+it (fleet membership, quota + fleet-wide L2 eviction, cache control including
+warm prefetch / pin / delete, and the global CacheBlend fingerprint directory).
 
 Code: `lmcache/v1/mp_coordinator/`.
 
 ## Why
 
-mp servers are independent today: quota is per-instance and in-memory, there is
-no cross-node token-match routing for model replicas, and KV operations are
-local. The coordinator is the fleet-level component those features will hang
-off. This PR ships the framework plus membership so future work plugs in
-without re-architecting.
+mp servers are independent by construction: per-instance in-memory quota, no
+cross-node token-match routing for model replicas, and node-local KV
+operations. The coordinator is the fleet-level component those capabilities
+hang off — it holds the shared trackers (quota, LRU, blend directory) and
+dispatches fleet-wide work (eviction, warm prefetch) to individual mp servers
+by resolving their `ip` / `http_port` from the registry.
 
 ## Transport
 
 The coordinator is a FastAPI app served by uvicorn. mp servers register /
-heartbeat / deregister over REST.
+heartbeat / deregister over REST; they also stream L2 usage events and blend
+fingerprints in the same shape.
 
 | Method & path | Direction | Purpose |
 | --- | --- | --- |
@@ -28,26 +31,52 @@ heartbeat / deregister over REST.
 | `DELETE /instances/{id}` | mp → coordinator | deregister (idempotent, 204) |
 | `GET /instances` | operator/tools | list the fleet |
 | `GET /healthz` | k8s probe | liveness |
+| `PUT/GET /quota/config` | operator | fleet-wide quota configuration |
+| `PUT/GET/DELETE /quota/{cache_salt}` | operator | per-tenant byte budgets |
+| `GET /quota` | operator | fleet-wide usage summary |
+| `POST /quota/events` | mp → coordinator | L2 usage event ingest |
+| `POST /cache/prefetches` | operator/scheduler | submit warm prefetch to a named server |
+| `GET /cache/prefetches/{instance_id}/{request_id}` | operator/scheduler | poll a warm prefetch |
+| `POST/DELETE /cache/pins` | operator | pin / unpin keys against fleet-wide eviction |
+| `POST /cache/delete` | operator | delete cached objects on a named server |
+| `POST /blend/fingerprints` | mp → coordinator | publish stored blend chunk fingerprints |
+| `DELETE /blend/fingerprints` | mp → coordinator | evict blend fingerprints by storage key |
+| `POST /blend/match` | mp → coordinator | rolling-hash match a request against the directory |
 
-For server-initiated work (future quota reconcile, KV-op fan-out) a coordinator
-router resolves an instance's address from the registry (`ip` + `http_port`) and
-POSTs to that mp server's **specific** existing endpoint (e.g. `/pin`,
-`/quota`). There is no generic command channel and no per-instance connection
-state — just an HTTP call to the relevant resource.
+For server-initiated work (fleet-wide eviction, warm prefetch) a coordinator
+router resolves an instance's address from the registry (`ip` + `http_port`)
+and POSTs / DELETEs to that mp server's **specific** existing endpoint
+(e.g. `DELETE /cache/objects`, `POST /cache/prefetches`). There is no generic
+command channel and no per-instance connection state — just an HTTP call to
+the relevant resource.
 
 ## Layout
 
 ```
 lmcache/v1/mp_coordinator/
-  app.py            # create_app + lifespan + router discovery + health eviction
-  __main__.py       # uvicorn entrypoint
-  config.py         # MPCoordinatorConfig (LMCACHE_MP_COORDINATOR_*)
-  registry.py       # InstanceRegistry + MPInstance (pure membership)
-  schemas.py        # Pydantic request/response models (shared wire contract)
-  registrar.py      # mp-server-side register/heartbeat/deregister helpers
+  app.py                # create_app + lifespan + router discovery + health/eviction loops
+  __main__.py           # uvicorn entrypoint (`python -m lmcache.v1.mp_coordinator`)
+  config.py             # MPCoordinatorConfig (LMCACHE_MP_COORDINATOR_*)
+  registry.py           # InstanceRegistry + MPInstance (pure membership)
+  schemas.py            # Pydantic request/response models (shared wire contract)
+  registrar.py          # mp-server-side register/heartbeat/deregister helpers
+  blend_directory.py    # GlobalBlendMatcher (chunked rolling-hash directory)
+  blend_client.py       # mp-server-side blend publish/evict/match client
+  cache_control/
+    __init__.py
+    event_listener.py   # in-process forwarding of MP-server L2 events
+    eviction_manager.py # LRU + trigger-watermark driven eviction loop, pin tracking
+    usage_manager.py    # per-salt usage aggregation
+    prefetch_manager.py # dispatches warm prefetch to a named MP server
+    resync_manager.py   # startup resync of usage/eviction from an MP server's GET /cache/objects
   http_apis/
-    instances_api.py  # the /instances REST resource
-    health_api.py     # /healthz
+    __init__.py
+    dependencies.py     # shared FastAPI dependencies (registry, blend directory, ...)
+    instances_api.py    # /instances REST resource
+    health_api.py       # /healthz
+    quota_api.py        # /quota/config, /quota/{cache_salt}, /quota, /quota/events
+    cache_api.py        # /cache/prefetches, /cache/pins, /cache/delete
+    blend_directory_api.py  # /blend/fingerprints, /blend/match
 ```
 
 ## Request flow
@@ -68,39 +97,42 @@ sequenceDiagram
 
 Heartbeat is `PUT /instances/{id}/heartbeat` → `registry.update_heartbeat`; a
 404 tells the client to re-register. The health loop (in `app.py`, started by
-the lifespan) evicts instances whose heartbeat lapsed. Future server push
-resolves the address (`ip` + `http_port`) from the registry and calls the mp
-server's specific endpoint directly:
+the lifespan) evicts instances whose heartbeat lapsed. Server push resolves
+the address (`ip` + `http_port`) from the registry and calls the mp server's
+specific endpoint directly:
 
 ```mermaid
 sequenceDiagram
-    participant Ctl as future router
+    participant Ctl as coordinator router
     participant Reg as InstanceRegistry
     participant M as mp server HTTP API
 
     Ctl->>Reg: get(instance_id) -> ip, http_port
-    Ctl->>M: POST http://ip:http_port/<resource> (e.g. /pin)
-    M-->>Ctl: 200 JSON
+    Ctl->>M: <VERB> http://ip:http_port/<resource> (e.g. DELETE /cache/objects)
+    M-->>Ctl: 200 / 204 JSON
 ```
 
 ## Extension seam (adding a capability)
 
-`app.state` carries the **shared collaborators** every capability composes from:
-`config` and `registry`. Endpoints use them directly — membership is thin enough
-to have no service layer (the `/instances` router calls the registry straight,
-matching the mp server's own `http_apis` convention).
+`app.state` carries the **shared collaborators** every capability composes
+from: `config`, `registry`, `blend_directory`, and the `cache_control`
+managers. Endpoints use them directly — membership is thin enough to have no
+service layer (the `/instances` router calls the registry straight, matching
+the mp server's own `http_apis` convention).
 
-To add a capability (e.g. quota):
+To add a capability (e.g. a new domain resource):
 
-1. `http_apis/quota_api.py` — a module-level `router` (FastAPI `APIRouter`).
-   `create_app` auto-discovers it (via `lmcache/v1/utils/router_discovery.py`,
-   the same convention as the mp server's HTTP API). No edits elsewhere for the
-   route to appear; the router reads `app.state.registry`, and to push it
-   resolves an instance's `ip`/`http_port` and POSTs to that mp server's
-   endpoint.
-2. Only if the domain has real logic/state of its own (e.g. quota: persistence,
-   broadcast-on-join) add a `quota_service.py` over the shared collaborators and
-   stash it on `app.state` in `create_app`. Thin domains skip this.
+1. `http_apis/<domain>_api.py` — a module-level `router` (FastAPI
+   `APIRouter`). `create_app` auto-discovers it (via
+   `lmcache/v1/utils/router_discovery.py`, the same convention as the mp
+   server's HTTP API). No edits elsewhere for the route to appear; the router
+   reads what it needs from `app.state`, and to push it resolves an instance's
+   `ip`/`http_port` and calls that mp server's endpoint.
+2. Only if the domain has real logic/state of its own (persistence,
+   broadcast-on-join, background reconciliation, …) add a manager under
+   `cache_control/` (or a peer package) and stash it on `app.state` in
+   `create_app`. Thin domains skip this — `quota` and `blend_directory` were
+   both added this way.
 
 A capability that must react to instance join/leave can hook into the
 registration endpoint (a small observer can be reintroduced then — it was
@@ -121,43 +153,93 @@ correctly; model-aware indexing belongs to a future routing router. Thread-safe
 (`threading.Lock`); `stale()` uses a monotonic clock so an NTP step cannot skew
 liveness.
 
+## Cache control (`cache_control/`)
+
+The `cache_control/` package owns everything downstream of the fleet-wide L2
+usage stream:
+
+- `usage_manager.py` — aggregates `POST /quota/events` into per-`cache_salt`
+  bytes and per-key LRU state.
+- `eviction_manager.py` — every `EVICTION_CHECK_INTERVAL` seconds, walks
+  salts over their trigger watermark and dispatches `DELETE /cache/objects`
+  requests (chunked at `MAX_DELETE_BATCH`) to a uniformly random registered
+  mp server (all servers share the backing L2, so one dispatch evicts the
+  fleet). Also tracks the pins taken via `POST /cache/pins` so pinned keys
+  are excluded from eviction and delete.
+- `resync_manager.py` — one-shot startup pass that paginates one mp
+  server's `GET /cache/objects` and seeds usage + LRU trackers, so a fresh
+  coordinator does not start from zero.
+- `prefetch_manager.py` — implements `POST /cache/prefetches` dispatch to a
+  named mp server and proxies status polls.
+- `event_listener.py` — in-process handler that plugs the usage stream into
+  the manager collaborators.
+
+## Global CacheBlend directory (`blend_directory.py`)
+
+`GlobalBlendMatcher` is the fleet-wide fingerprint index behind cross-request
+blend reuse. Blend-enabled mp servers publish chunk fingerprints on STORE
+(`POST /blend/fingerprints`) and query them on LOOKUP (`POST /blend/match`);
+the index is chunked at the fleet chunk size (`CHUNK_SIZE`) and
+rolling-hash-matched at `BLEND_PROBE_STRIDE`. `DELETE /blend/fingerprints`
+evicts entries when the backing L2 objects are dropped so matches do not go
+stale. The mp-server-side client lives in `blend_client.py`; the wire types
+(`StoreRangeModel`, `BlendMatchRequest`, `GlobalMatchModel`, …) live in
+`schemas.py`.
+
 ## Concurrency & lifecycle
 
-- Everything runs on the uvicorn event loop; the registry lock guards the one
-  piece of shared state.
+- Everything runs on the uvicorn event loop; the registry lock guards
+  membership, other managers own their own locks (see `cache_control/`).
 - The health-check loop is an asyncio task started in the app lifespan; it
   evicts instances whose heartbeat lapsed (`instance_timeout`) and is cancelled
-  on shutdown. `health_check_interval = 0` disables it.
+  on shutdown. `HEALTH_CHECK_INTERVAL = 0` disables the stale-instance loop
+  (it does not affect the L2 eviction loop, which is gated separately by
+  `EVICTION_CHECK_INTERVAL`).
+- The L2 eviction loop is a second asyncio task started in the lifespan; it
+  is cancelled on shutdown. `EVICTION_CHECK_INTERVAL = 0` disables it.
 - Registration is idempotent: re-registering replaces the entry. The registry
-  is ephemeral — rebuilt from heartbeats after a coordinator restart; durable
-  state (quota) belongs in an external store (Redis), not here.
+  is ephemeral — rebuilt from heartbeats after a coordinator restart. Durable
+  state (registered quotas) belongs in an external store, not here; the
+  startup resync pass reconstructs usage + LRU from an mp server's
+  `GET /cache/objects` on boot.
 
 ## Running
 
 ```
 lmcache coordinator [--host HOST] [--port PORT] \
-    [--instance-timeout SECS] [--health-check-interval SECS]
+    [--instance-timeout SECS] [--health-check-interval SECS] \
+    [--eviction-check-interval SECS] [--eviction-ratio RATIO] \
+    [--trigger-watermark FRACTION] \
+    [--chunk-size TOKENS] [--hash-algorithm ALGO] \
+    [--blend-probe-stride POSITIONS] \
+    [--timeout-keep-alive SECS]
 ```
 
 (or, equivalently, `python -m lmcache.v1.mp_coordinator`).
 
 Configured via `LMCACHE_MP_COORDINATOR_*` environment variables — see
-`MPCoordinatorConfig` in `config.py` (`HOST`, `PORT`, `INSTANCE_TIMEOUT`,
-`HEALTH_CHECK_INTERVAL`). The `lmcache coordinator` CLI flags override the
-matching env-derived field; unset flags fall back to the env vars and then the
-config defaults.
+`MPCoordinatorConfig` in `config.py`. The full env-var surface today is
+`HOST`, `PORT`, `INSTANCE_TIMEOUT`, `HEALTH_CHECK_INTERVAL`,
+`EVICTION_CHECK_INTERVAL`, `EVICTION_RATIO`, `TRIGGER_WATERMARK`,
+`CHUNK_SIZE`, `HASH_ALGORITHM`, `BLEND_PROBE_STRIDE`,
+`ENABLE_STARTUP_RESYNC`, `RESYNC_POLL_INTERVAL`, `RESYNC_MAX_WAIT`,
+`RESYNC_PAGE_SIZE`, and `TIMEOUT_KEEP_ALIVE`. The `lmcache coordinator` CLI
+flags override the matching env-derived field (the resync knobs are env-only);
+unset flags fall back to the env vars and then the config defaults. See the
+user-facing [`docs/source/mp/coordinator.rst`](../../../source/mp/coordinator.rst)
+for descriptions and defaults.
 
-An mp server joins via the `registrar.py` helpers — no dedicated client object,
-mirroring how the coordinator just calls mp endpoints. The mp server's FastAPI
-lifespan creates a generic `httpx.AsyncClient` and launches `keep_registered()`
-as a task: it `POST`s `/instances`, `PUT`s `/instances/{id}/heartbeat` on a
-timer, and `DELETE`s on cancellation — on the mp server's own event loop, using
-the shared `schemas` models. It is wired into
-`lmcache/v1/multiprocess/http_server.py`'s lifespan and configured by a
-`CoordinatorConfig` (`lmcache/v1/multiprocess/config.py`), built from
-`--coordinator-*` flags that fall back to `LMCACHE_COORDINATOR_*` env vars. It is
-**opt-in**: with no coordinator URL, the mp server is unaffected. It is
+An mp server joins via the `registrar.py` helpers — no dedicated client
+object, mirroring how the coordinator just calls mp endpoints. The mp
+server's FastAPI lifespan creates a generic `httpx.AsyncClient` and launches
+`keep_registered()` as a task: it `POST`s `/instances`, `PUT`s
+`/instances/{id}/heartbeat` on a timer, and `DELETE`s on cancellation — on
+the mp server's own event loop, using the shared `schemas` models. It is
+wired into `lmcache/v1/multiprocess/http_server.py`'s lifespan and configured
+by a `CoordinatorConfig` (`lmcache/v1/multiprocess/config.py`), built from
+`--coordinator-*` flags that fall back to `LMCACHE_COORDINATOR_*` env vars.
+It is **opt-in**: with no coordinator URL, the mp server is unaffected. It is
 best-effort — failures are logged and retried (a down coordinator never blocks
 the server), while a malformed config is rejected at startup. The server
-advertises its own HTTP address (`ip` + `http_port`, e.g. the pod IP via the k8s
-downward API) so the coordinator can reach it.
+advertises its own HTTP address (`ip` + `http_port`, e.g. the pod IP via the
+k8s downward API) so the coordinator can reach it.

--- a/docs/design/v1/mp_coordinator/l2_prefetch.md
+++ b/docs/design/v1/mp_coordinator/l2_prefetch.md
@@ -34,10 +34,11 @@ registry, `POST`s to its `/cache/prefetches`, and relays the server's
 `request_id` back. The client then polls
 `GET /cache/prefetches/{instance_id}/{request_id}` on the coordinator, which proxies
 the server's status. The warm holds **no read-lock** — completion is reported
-reactively and releases nothing; see `docs/design/v1/multiprocess/l2_apis.md`
-for the warm-prefetch lifecycle (retain-permanent, no-lock load). There is no
-background polling on either side: the submit and status calls are quick and
-the client drives completion on demand.
+reactively and releases nothing; see the warm-prefetch endpoint reference in
+`docs/source/mp/http_api.rst` and the coordinator-side flow in
+`docs/source/mp/coordinator.rst` for the retain-permanent, no-lock load
+lifecycle. There is no background polling on either side: the submit and
+status calls are quick and the client drives completion on demand.
 
 ## Components
 
@@ -70,7 +71,7 @@ loops) so request handlers can issue outbound calls.
   503 (`Unavailable`), surfaced to the caller via the 502/proxy path.
 - **Client abandons polling** → the server's job lingers as a small handle
   entry (no lock held, no L1 pinned) until polled or swept — see the no-lock
-  lifecycle in `l2_apis.md`.
+  lifecycle in `docs/source/mp/http_api.rst` (warm-prefetch endpoint).
 
 ## Scope
 

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -9,6 +9,6 @@ commands, and HTTP endpoints.
 
    contributing
    extending_lmcache/native_connectors
-extending_lmcache/adding_a_new_device_backend
+   extending_lmcache/adding_a_new_device_backend
    cli
    extending_http_api

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -54,14 +54,16 @@ This guide helps you get LMCache running end-to-end in a couple of minutes. Use 
 
             Start vLLM with the MP connector in a separate terminal. Point the
             connector at the server above via ``lmcache.mp.host`` /
-            ``lmcache.mp.port`` in ``kv_connector_extra_config`` -- the host
-            **must** carry a ZMQ transport prefix such as ``tcp://``:
+            ``lmcache.mp.port`` in ``kv_connector_extra_config``. The host may
+            include a ZMQ transport prefix (e.g. ``tcp://``); a bare
+            ``host``/``host:port`` is also accepted and is normalized to
+            ``tcp://`` automatically:
 
             .. code-block:: bash
 
                vllm serve Qwen/Qwen3-8B \
                    --port 8000 --kv-transfer-config \
-                   '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "tcp://localhost", "lmcache.mp.port": 5555}}'
+                   '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "localhost", "lmcache.mp.port": 5555}}'
 
             .. note::
                **Where does** ``LMCacheMPConnector`` **resolve to?** This depends on your vLLM version:

--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -401,14 +401,17 @@ Each JSON object must include a ``"type"`` field that selects the adapter type.
 The order of ``--l2-adapter`` arguments determines the adapter order (cascade).
 
 Registered adapter types: ``nixl_store``, ``nixl_store_dynamic``, ``fs``,
-``fs_native``, ``mock``, ``mooncake_store``, ``aerospike``, ``s3``, ``resp``,
-``plugin``, ``native_plugin``, ``raw_block``, ``dax``.
+``fs_native``, ``mock``, ``mooncake_store``, ``aerospike``, ``bigtable``,
+``sagemaker-hyperpod``, ``s3``, ``hfbucket``, ``resp``, ``valkey``,
+``plugin``, ``native_plugin``, ``raw_block``, ``dax``, ``fault_inject``.
+(A ``p2p`` type is also registered, but it is wired in dynamically by the
+:doc:`P2P subsystem </mp/p2p>` rather than configured via ``--l2-adapter``.)
 
 Each adapter type's required and optional fields, plus per-backend examples, are
 documented on its own page under :doc:`Secondary KV Storage <l2_storage/index>`
 -- including the adapters not detailed inline here (``fs_native``,
-``raw_block``, ``dax``, ``mooncake_store``, ``aerospike``, ``hfbucket``,
-``resp``).
+``raw_block``, ``dax``, ``mooncake_store``, ``aerospike``, ``bigtable``,
+``sagemaker-hyperpod``, ``hfbucket``, ``resp``, ``valkey``).
 
 Multiple adapters (cascade)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -456,6 +459,23 @@ logging, tracing).
    * - ``--prometheus-port``
      - ``9090``
      - Port for the Prometheus ``/metrics`` endpoint.
+   * - ``--metrics-sample-rate``
+     - ``0.01``
+     - Fraction of chunks/blocks in ``(0, 1.0]`` to track for lifecycle
+       histograms. Counters always count every event regardless of this
+       setting.
+   * - ``--trace-level``
+     - *(none)*
+     - Enable trace recording at the given level. Currently only
+       ``storage`` is supported (records ``StorageManager`` public-API
+       calls for offline replay via ``lmcache trace``). See
+       :doc:`tracing_and_debugging`.
+   * - ``--trace-output``
+     - *(none)*
+     - Path to write the trace file. If omitted while ``--trace-level``
+       is set, a timestamped file under ``$TMPDIR``
+       (``lmcache-trace-<pid>-<UTC>.lct``) is minted and its path is
+       logged at INFO.
    * - ``--enable-extra-logging``
      - off
      - Periodic INFO logs: per-GPU L0<->L1 transfer stats and L1 memory
@@ -468,13 +488,15 @@ vLLM Client Configuration
 --------------------------
 
 On the vLLM side, specify the LMCache server host and port via the
-``kv_connector_extra_config`` parameter:
+``kv_connector_extra_config`` parameter. The ``tcp://`` transport prefix
+on ``lmcache.mp.host`` is optional -- a bare host is accepted and
+normalized to ``tcp://`` by the connector:
 
 .. code-block:: bash
 
     vllm serve Qwen/Qwen3-14B \
         --kv-transfer-config \
-        '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "tcp://127.0.0.1", "lmcache.mp.port": 6000}}'
+        '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both", "kv_connector_extra_config": {"lmcache.mp.host": "127.0.0.1", "lmcache.mp.port": 6000}}'
 
 To target multiple LMCache servers from a single vLLM deployment, pass a
 list (or comma-separated string) of server URLs via
@@ -513,15 +535,19 @@ All connector-level options are passed through
      - *(unset)*
      - Multi-server deployment: list (or comma-separated string) of
        ``<transport>://<host>:<port>`` URLs, e.g.
-       ``"tcp://host1:6667,tcp://host2:6667"``. When set, takes
-       precedence over ``lmcache.mp.host`` / ``lmcache.mp.port``; the
-       vLLM world size must be divisible by the number of servers, and
-       each worker connects to its locally-assigned server.
+       ``"tcp://host1:6667,tcp://host2:6667"``. The transport prefix
+       may be omitted -- bare ``host:port`` entries such as
+       ``"host1:6667,host2:6667"`` are normalized to ``tcp://`` by the
+       connector. When set, takes precedence over ``lmcache.mp.host`` /
+       ``lmcache.mp.port``; the vLLM world size must be divisible by the
+       number of servers, and each worker connects to its
+       locally-assigned server.
    * - ``lmcache.mp.host``
      - ``tcp://localhost``
-     - Single-server deployment: host (with ZMQ transport prefix) of
-       the LMCache MP server. Ignored when ``lmcache.mp.server_urls``
-       is set.
+     - Single-server deployment: host of the LMCache MP server. A ZMQ
+       transport prefix (e.g. ``tcp://``) is optional -- a bare
+       ``localhost`` / ``127.0.0.1`` is normalized to ``tcp://`` by the
+       connector. Ignored when ``lmcache.mp.server_urls`` is set.
    * - ``lmcache.mp.port``
      - ``5555``
      - Single-server deployment: port of the LMCache MP server. Must
@@ -567,6 +593,9 @@ Environment Variables
    * - ``DO_NOT_TRACK``
      - Set to ``1`` to disable anonymous usage statistics (cross-tool
        convention).
+   * - ``LMCACHE_USAGE_TRACK_INTERVAL``
+     - Seconds between continuous usage-telemetry flushes (default
+       ``600``). See :ref:`usage-stats-collection`.
 
 Full Example
 ------------

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -59,7 +59,10 @@ variables:
        fleet.
    * - ``LMCACHE_MP_COORDINATOR_HEALTH_CHECK_INTERVAL``
      - ``10``
-     - Seconds between health-check sweeps. ``0`` disables eviction.
+     - Seconds between health-check sweeps that expire stale MP-server
+       registrations. ``0`` disables the stale-instance eviction loop; it does
+       **not** affect the ``/quota`` L2 eviction loop (see
+       ``LMCACHE_MP_COORDINATOR_EVICTION_CHECK_INTERVAL`` below).
    * - ``LMCACHE_MP_COORDINATOR_EVICTION_CHECK_INTERVAL``
      - ``5``
      - Seconds between L2 eviction sweeps. ``0`` disables the loop.
@@ -170,6 +173,9 @@ The coordinator's HTTP surface (base URL ``http://localhost:9300``) groups into:
   eviction.
 - **Cache control** -- the ``/cache`` group: cache operations dispatched to a
   named server (warm prefetch, pin/unpin, and delete, with more to come).
+- **CacheBlend fingerprint directory** -- the ``/blend`` group: the fleet-wide
+  fingerprint index blend-enabled MP servers publish to on STORE and query on
+  LOOKUP. Server-to-coordinator only; not usually called by hand.
 
 Each endpoint is documented below. Success is ``200`` unless noted, and
 ``{cache_salt}`` uses the ``_default`` sentinel for the empty salt. The wire
@@ -981,3 +987,138 @@ sequence returns ``status`` ``"noop"``.
             "force": false
         }'
     # -> {"instance_id": "server-1", "requested": 12, "affected": 24, "skipped": 0, "status": "deleted"}
+
+CacheBlend fingerprint directory
+--------------------------------
+
+The ``/blend`` group is the fleet-wide fingerprint index behind CacheBlend
+cross-request reuse. Blend-enabled MP servers publish chunk fingerprints on
+STORE (``POST /blend/fingerprints``) and query them on LOOKUP
+(``POST /blend/match``); the index is chunked at
+``LMCACHE_MP_COORDINATOR_CHUNK_SIZE`` tokens and rolling-hash-matched at
+``LMCACHE_MP_COORDINATOR_BLEND_PROBE_STRIDE``. These endpoints are
+server-to-coordinator; they are not usually called by hand.
+
+The wire types (``StoreRangeModel``, ``BlendFingerprintRequest``,
+``BlendMatchRequest``, ``GlobalMatchModel`` and their responses) live in
+``lmcache/v1/mp_coordinator/schemas.py``.
+
+``POST /blend/fingerprints``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Register stored chunk fingerprints (idempotent).
+
+**Request body:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Field
+     - Type
+     - Description
+   * - ``ranges``
+     - list
+     - Stored token ranges. Each entry carries ``model_scope`` (the reuse
+       scope, typically the model name), ``tokens`` (the raw stored token
+       ids), ``object_keys`` (the shared-L2 storage key per chunk, in order),
+       and ``old_st_base`` (the token position of the range's first token).
+       The directory chunks ``tokens`` at the coordinator's chunk size and
+       hashes each chunk; chunk ``i`` maps to ``object_keys[i]``.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {"inserted": 3}
+
+``inserted`` reports how many fingerprints were newly registered (existing
+entries are left in place; re-publishing is safe).
+
+**HTTP status codes:**
+
+- ``200``: fingerprints processed.
+- ``422``: request body fails field-level validation.
+
+``DELETE /blend/fingerprints``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Evict fingerprints by shared-L2 storage key (idempotent). MP servers call this
+when the underlying L2 objects are dropped, so the directory does not keep
+handing out stale matches.
+
+**Request body:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Field
+     - Type
+     - Description
+   * - ``object_keys``
+     - list[string]
+     - Storage keys whose fingerprint entries should be removed. Unknown keys
+       are ignored.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {"removed": 2}
+
+``removed`` reports how many entries were actually evicted.
+
+**HTTP status codes:**
+
+- ``200``: keys processed.
+- ``422``: request body fails field-level validation.
+
+``POST /blend/match``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Match a request's token buffer against the directory and return the reusable
+chunks.
+
+**Request body:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Field
+     - Type
+     - Description
+   * - ``model_scope``
+     - string
+     - Reuse scope to match within (typically the model name).
+   * - ``tokens_b64``
+     - string
+     - Request tokens packed as base64 little-endian ``uint32`` (see
+       ``encode_tokens`` / ``decode_tokens`` in ``schemas.py``). The
+       coordinator hashes them at
+       ``LMCACHE_MP_COORDINATOR_CHUNK_SIZE`` positions striding by
+       ``LMCACHE_MP_COORDINATOR_BLEND_PROBE_STRIDE``.
+
+**Response** (``200 OK``):
+
+.. code-block:: json
+
+    {
+      "matches": [
+        {"object_key": "ab12...", "old_st": 0,    "cur_st": 512},
+        {"object_key": "cd34...", "old_st": 256,  "cur_st": 768}
+      ]
+    }
+
+Each entry names one reusable chunk: ``object_key`` is the shared-L2 key,
+``old_st`` is its token position in the stored sequence (re-RoPE source), and
+``cur_st`` is the position in the request (re-RoPE target). Matches are sorted
+ascending by ``cur_st``. An empty request or an unknown ``model_scope``
+returns ``{"matches": []}``.
+
+**HTTP status codes:**
+
+- ``200``: match completed (an empty match list is not an error).
+- ``422``: ``tokens_b64`` is not valid base64 or not a whole number of
+  ``uint32`` tokens.

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -76,7 +76,8 @@ High-Level Architecture
     StorageManager (distributed/storage_manager.py)
          |
          |--- L1Manager (l1_manager.py)
-         |       |--- L1MemoryManager (CPU DRAM) or
+         |       |--- L1MemoryManager (CPU DRAM),
+         |       |    DevDaxL1MemoryManager (Device-DAX slab), or
          |       |    GDSL1MemoryManager (NVMe slab via cuFile / hipFile)
          |       |--- TTLLock per object (read/write)
          |
@@ -383,11 +384,16 @@ Manages objects in CPU memory with a state machine:
 Each object has two ``TTLLock`` instances (read and write) with configurable
 timeouts to prevent deadlocks from crashed clients.
 
-The underlying memory allocation is handled by one of two interchangeable
-tiers selected at startup (both satisfy ``L1ManagerProtocol``):
+The underlying memory allocation is handled by one of three interchangeable
+tiers selected at startup (all satisfy ``L1ManagerProtocol``):
 
 - ``L1MemoryManager`` (default) -- pinned CPU DRAM, with lazy growth up to
   ``--l1-size-gb``.
+- ``DevDaxL1MemoryManager`` -- a Device-DAX-backed L1 slab when
+  ``--l1-devdax-path`` is set. A pure Device-DAX configuration maps the DAX
+  device as the full L1 arena; a hybrid configuration uses DRAM first and
+  spills overflow allocations into Device-DAX. See the *L1 Memory Manager*
+  section of :doc:`configuration` for the accepted knobs.
 - ``GDSL1MemoryManager`` -- an NVMe slab file when ``--gds-l1-path`` is set.
   The bytes live on disk; reads/writes DMA directly between the GPU staging
   buffer and the slab, driven by the process-global ``GDSContext``

--- a/docs/source/mp/l2_storage/index.rst
+++ b/docs/source/mp/l2_storage/index.rst
@@ -179,7 +179,10 @@ policy evicts a fraction of the least-recently-used keys.
      - Description
    * - ``--eviction-policy``
      - *(required)*
-     - Policy name: ``LRU`` or ``noop``.
+     - Policy name: ``LRU``, ``IsolatedLRU``, or ``noop``. ``IsolatedLRU``
+       maintains one LRU list per ``cache_salt`` and relies on per-salt
+       quotas registered via the ``/quota`` HTTP endpoints; see
+       :doc:`/mp/configuration` for the full description.
    * - ``--eviction-trigger-watermark``
      - ``0.8``
      - L1 usage fraction [0, 1] above which eviction is triggered.

--- a/docs/source/mp/l2_storage/nixl.rst
+++ b/docs/source/mp/l2_storage/nixl.rst
@@ -9,6 +9,15 @@ types share this backend:
 - ``nixl_store_dynamic`` — opens and registers files per operation, adding
   persist/recover across restarts and removing the open-file-descriptor limit.
 
+.. note::
+
+   Both adapters require the NIXL runtime, which ships as the optional
+   ``lmcache[nixl]`` extra:
+
+   .. code-block:: bash
+
+       uv pip install lmcache[nixl]
+
 Static pool — ``nixl_store``
 ----------------------------
 

--- a/docs/source/mp/l2_storage/remote_and_distributed.rst
+++ b/docs/source/mp/l2_storage/remote_and_distributed.rst
@@ -13,4 +13,5 @@ sharing cache across nodes.
    hfbucket
    mooncake_store
    resp
+   valkey
    aerospike

--- a/docs/source/mp/l2_storage/supported_storages.rst
+++ b/docs/source/mp/l2_storage/supported_storages.rst
@@ -43,6 +43,9 @@ target.
    * - :doc:`RESP (Redis/Valkey) <resp>`
      - ``resp``
      - Remote & Distributed
+   * - :doc:`Valkey <valkey>`
+     - ``valkey``
+     - Remote & Distributed
    * - :doc:`Aerospike <aerospike>`
      - ``aerospike``
      - Remote & Distributed

--- a/docs/source/mp/l2_storage/valkey.rst
+++ b/docs/source/mp/l2_storage/valkey.rst
@@ -1,0 +1,138 @@
+Valkey
+======
+
+An L2 adapter backed by the official ``valkey-glide`` **sync** Python
+client. Stores KV cache chunks in a Valkey (or Redis) server and
+supports both **standalone** (``GlideClient``) and **Valkey-Cluster**
+(``GlideClusterClient``) topologies, selected via ``cluster_mode``.
+
+I/O is dispatched through an internal ``ValkeyWorkerPool`` of worker
+threads; each worker holds its own glide client so a batch of keys
+parallelizes across threads and (in cluster mode) across primaries.
+
+Why the ``valkey`` adapter (vs. the RESP adapter)
+-------------------------------------------------
+
+The :doc:`RESP <resp>` adapter targets a single Redis/Valkey server
+over the native C++ RESP connector. The ``valkey`` adapter is a
+first-class Valkey backend: it speaks ``valkey-glide-sync`` directly,
+adds Valkey-Cluster support (slot routing, MOVED/ASK redirects, and
+topology discovery are handled inside ``GlideClusterClient``), and
+preserves copy-reduced SET/GET on multi-megabyte KV chunks (see the
+`Valkey L2 Adapter design doc
+<https://github.com/LMCache/LMCache/blob/dev/docs/design/v1/distributed/l2_adapters/valkey.md>`_
+for the full rationale, including why the sync -- not async -- glide
+client is used).
+
+Prerequisites -- installing the glide sync client
+-------------------------------------------------
+
+The ``valkey`` adapter requires the ``valkey-glide-sync`` package
+(version ``>= 2.3.0``, the first release with both copy-reduced SET
+and buffer GET). It is lazy-imported the first time a Valkey worker
+starts:
+
+.. code-block:: bash
+
+    pip install 'valkey-glide-sync>=2.3.0'
+
+If the package is missing when a Valkey worker starts, adapter
+construction fails with::
+
+    Valkey support requires the glide_sync module.
+    Install: pip install 'valkey-glide-sync>=2.3.0'
+    (note: the plain 'valkey-glide' package is async-only)
+
+**Required fields:**
+
+- ``startup_nodes``: A ``"host:port[,host:port...]"`` string of seed
+  nodes.
+
+  - In **standalone** mode (``cluster_mode: false``, the default) only
+    the first entry is used; extras trigger a warning.
+  - In **cluster** mode any reachable seed is enough -- glide auto-
+    discovers the full topology.
+
+**Optional fields:**
+
+- ``cluster_mode`` (bool, default ``false``): When ``true`` use
+  ``GlideClusterClient``; otherwise use standalone ``GlideClient``.
+- ``username`` (str, default ``""``): Optional auth username.
+- ``password`` (str, default ``""``): Optional auth password.
+- ``key_prefix`` (str, default ``""``): Deployment-level key namespace,
+  joined with the standard wire key by ``@``. **Must not contain**
+  ``@``. Leave empty for a wire-format identical to the unprefixed
+  layout.
+- ``num_workers`` (int, default ``8``, > 0): Size of the internal worker
+  thread pool. Each worker holds its own glide client, so this is the
+  real I/O concurrency knob -- raise it to push throughput on large
+  batches / cluster deployments.
+- ``tls_enable`` (bool, default ``false``): Enable TLS. Required for
+  managed Valkey services such as ElastiCache Serverless.
+- ``database_id`` (int, optional): Logical database id for
+  **standalone** mode. Ignored (with a warning) when
+  ``cluster_mode: true``.
+- ``request_timeout`` (float, default ``5.0``, > 0): Per-request timeout,
+  in seconds.
+- ``connection_timeout`` (float, default ``10.0``, > 0): Initial
+  connection timeout, in seconds.
+- ``max_capacity_gb`` (float, default ``0``, >= 0): Declared aggregate
+  capacity in GB used to drive **LMCache-side** eviction. ``0`` (the
+  default and the recommended setting) disables global LMCache
+  eviction and defers to the Valkey server's own ``maxmemory`` /
+  eviction policy; per-``cache_salt`` quotas configured on the
+  coordinator still operate either way. Set ``> 0`` (together with an
+  ``eviction`` block) only when a single LMCache writer privately owns
+  the cluster -- do **not** combine ``> 0`` with server-side eviction
+  or a TTL, both of which drift LMCache's byte accounting.
+- ``ttl_seconds`` (int, optional): Opt-in per-key TTL in seconds; must
+  be a positive integer when set. Omit (default) to write keys with no
+  expiry. Enables server-side time-based expiry, required by any
+  ``volatile-*`` eviction policy configured on the Valkey server. Do
+  **not** combine with ``max_capacity_gb > 0`` (a warning is logged;
+  server-side expiry is not reported back to LMCache's byte accounting).
+
+**Configuration examples:**
+
+.. code-block:: bash
+
+    # Standalone Valkey / Redis server (server-side eviction)
+    --l2-adapter '{"type": "valkey", "startup_nodes": "127.0.0.1:6379"}'
+
+    # Valkey Cluster with TLS + auth (managed service)
+    --l2-adapter '{
+        "type": "valkey",
+        "cluster_mode": true,
+        "startup_nodes": "seed1.example.com:6379,seed2.example.com:6379",
+        "username": "lmcache",
+        "password": "secret",
+        "tls_enable": true,
+        "num_workers": 16
+    }'
+
+    # LMCache-driven eviction on a privately-owned Valkey cluster
+    --l2-adapter '{
+        "type": "valkey",
+        "cluster_mode": true,
+        "startup_nodes": "10.0.0.1:6379,10.0.0.2:6379",
+        "max_capacity_gb": 512,
+        "num_workers": 16
+    }'
+
+    # Per-key TTL (server-side expiry, no LMCache-side eviction)
+    --l2-adapter '{
+        "type": "valkey",
+        "startup_nodes": "127.0.0.1:6379",
+        "ttl_seconds": 3600
+    }'
+
+Wire key layout
+---------------
+
+Each stored value is keyed by::
+
+    [<key_prefix>@]<model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>[@<cache_salt>]
+
+The ``chunk_hash_hex`` component is a uniform content hash and the wire
+key contains no Redis hashtag (``{...}``), so keys distribute evenly
+across the 16384 cluster slots -- no manual key sharding is required.

--- a/docs/source/mp/p2p.rst
+++ b/docs/source/mp/p2p.rst
@@ -53,7 +53,9 @@ Requirements
   start.
 * **An RDMA-capable network** (InfiniBand / RoCE) is strongly recommended for
   production performance. By default P2P uses the ``nixl`` transfer engine,
-  which is shipped with LMCache, so there is nothing extra to install.
+  which ships as the optional ``lmcache[nixl]`` extra — install it with
+  ``uv pip install lmcache[nixl]`` (or ``pip install lmcache[nixl]``) before
+  enabling P2P.
 * **A single, contiguous L1 region.** The transfer channel registers the whole
   L1 buffer for RDMA, so P2P is incompatible with the GDS L1 tier
   (``--gds-l1-path``) and the Device-DAX L1 tier (``--l1-devdax-path``); the
@@ -112,7 +114,8 @@ selected per server with ``--p2p-transfer-engine``.
    * - Engine
      - Description
    * - ``nixl`` (default)
-     - RDMA-based transport, shipped with LMCache. Runs over InfiniBand / RoCE
+     - RDMA-based transport, shipped as the optional ``lmcache[nixl]`` extra
+       (``uv pip install lmcache[nixl]``). Runs over InfiniBand / RoCE
        fabrics.
 
 ``nixl`` is the only backend available today. The transfer engine is a

--- a/lmcache/v1/multiprocess/protocols/README.md
+++ b/lmcache/v1/multiprocess/protocols/README.md
@@ -7,11 +7,16 @@ This directory contains the modular protocol definitions for the LMCache multipr
 ```
 protocols/
 ├── README.md           # This file
-├── __init__.py        # Protocol initialization and registration
-├── base.py            # Common types (HandlerType, ProtocolDefinition)
-├── engine.py          # Engine operations (STORE, RETRIEVE, etc.)
-├── controller.py      # Controller operations (CLEAR, GET_CHUNK_SIZE)
-└── debug.py           # Debug operations (NOOP)
+├── __init__.py         # Protocol initialization and registration
+├── base.py             # Common types (HandlerType, ProtocolDefinition, RequestType)
+├── engine.py           # Engine operations (REGISTER/UNREGISTER, STORE, RETRIEVE, LOOKUP, PREPARE/COMMIT, ...)
+├── controller.py       # Controller operations (CLEAR, GET_CHUNK_SIZE, PING)
+├── debug.py            # Debug operations (NOOP)
+├── blend.py            # CacheBlend v1 operations (CB_STORE/RETRIEVE_PRE_COMPUTED, CB_STORE_FINAL, ...)
+├── blend_v2.py         # CacheBlend v2 lookup/retrieve (CB_*_V2)
+├── blend_v3.py         # CacheBlend v3 rope + unified lookup (CB_*_V3, CB_UNIFIED_LOOKUP)
+├── observability.py    # Observability events (REPORT_BLOCK_ALLOCATION)
+└── p2p.py              # Peer-to-peer transfers (P2P_LOOKUP_AND_LOCK, P2P_QUERY_LOOKUP_RESULTS, P2P_UNLOCK_OBJECTS)
 ```
 
 ## Design Overview
@@ -23,7 +28,7 @@ The protocol system is designed to be modular, extensible, and IDE-friendly:
    - All request types visible to static analysis tools
    - Validation ensures enum stays in sync with protocol definitions
 
-2. **Protocol Modules**: Each module (engine, controller, debug) defines:
+2. **Protocol Modules**: Each module (engine, controller, debug, blend, blend_v2, blend_v3, observability, p2p) defines:
    - `REQUEST_NAMES`: List of request type names (for validation)
    - `get_protocol_definitions()`: Returns dict of name → ProtocolDefinition
 
@@ -44,7 +49,7 @@ To add new protocol operations:
 
 ### Option 1: Add to Existing Module
 
-If your operation fits an existing category (engine/controller/debug):
+If your operation fits an existing category (engine / controller / debug / blend / blend_v2 / blend_v3 / observability / p2p):
 
 1. **Add to the enum** in `protocols/base.py`:
    ```python
@@ -123,18 +128,22 @@ If you're adding a new category of operations:
        }
    ```
 
-3. **Register the module** in `__init__.py`:
+3. **Register the module** in `__init__.py` by importing it and adding
+   an entry to the `_PROTOCOL_MODULES` list:
    ```python
    from lmcache.v1.multiprocess.protocols import monitoring  # Import your module
 
-   def initialize_protocols():
-       protocol_modules = [
-           ("engine", engine),
-           ("controller", controller),
-           ("debug", debug),
-           ("monitoring", monitoring),  # Add here
-       ]
-       # ... rest of initialization ...
+   _PROTOCOL_MODULES = [
+       ("engine", engine),
+       ("controller", controller),
+       ("debug", debug),
+       ("blend", blend),
+       ("blend_v2", blend_v2),
+       ("blend_v3", blend_v3),
+       ("observability", observability),
+       ("p2p", p2p),
+       ("monitoring", monitoring),  # Add here
+   ]
    ```
 
 4. **Done!** The new operations are now available as:
@@ -188,23 +197,59 @@ has no corresponding RequestType enum member. Add 'RequestType.NEW_OP' to protoc
 
 ## Current Protocol Groups
 
+The authoritative list of request names is `REQUEST_NAMES` in each module; the
+list below is a snapshot as of this file's last update.
+
 ### Engine Operations (`engine.py`)
-Core KV cache operations:
-- `REGISTER_KV_CACHE`: Register a KV cache instance
-- `UNREGISTER_KV_CACHE`: Unregister a KV cache instance
-- `STORE`: Store KV cache blocks to the server
-- `RETRIEVE`: Retrieve KV cache blocks from the server
-- `LOOKUP`: Check if keys exist in the cache
-- `END_SESSION`: End a session and clean up resources
+Core KV cache operations and their split-phase variants:
+- `REGISTER_KV_CACHE` / `UNREGISTER_KV_CACHE`: Register / unregister the GPU KV cache
+- `REGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT` / `UNREGISTER_KV_CACHE_ENGINE_DRIVEN_CONTEXT`: Register / unregister the non-GPU (engine-driven) KV cache context
+- `STORE` / `RETRIEVE`: Fused store / retrieve
+- `PREPARE_STORE` / `COMMIT_STORE` / `PREPARE_RETRIEVE` / `COMMIT_RETRIEVE`: Split-phase store / retrieve (used by the engine-driven path)
+- `LOOKUP`: Submit a prefix lookup and return a prefetch job id
+- `QUERY_PREFETCH_STATUS` / `WAIT_PREFETCH_STATUS`: Poll / block for a prefetch job's result
+- `QUERY_PREFETCH_LOOKUP_HITS` / `FREE_LOOKUP_LOCKS`: Inspect and release the read locks a lookup took on cached chunks
+- `END_SESSION`: End a session and clean up associated resources
 
 ### Controller Operations (`controller.py`)
 Cache management and configuration:
 - `CLEAR`: Clear all caches in the server
 - `GET_CHUNK_SIZE`: Get the chunk size configuration
+- `PING`: Liveness / worker probe (payload: sender's worker instance id or `None`)
 
 ### Debug Operations (`debug.py`)
 Testing and monitoring:
-- `NOOP`: No-operation command for testing/heartbeat
+- `NOOP`: No-operation command for testing / heartbeat
+
+### CacheBlend v1 (`blend.py`)
+First-generation CacheBlend operations (pre-computed lookup / retrieve, final store, and blend-scoped KV cache registration):
+- `CB_LOOKUP_PRE_COMPUTED`
+- `CB_STORE_PRE_COMPUTED`
+- `CB_RETRIEVE_PRE_COMPUTED`
+- `CB_STORE_FINAL`
+- `CB_REGISTER_KV_CACHE`
+- `CB_UNREGISTER_KV_CACHE`
+
+### CacheBlend v2 (`blend_v2.py`)
+Second-generation CacheBlend lookup + retrieve:
+- `CB_LOOKUP_PRE_COMPUTED_V2`
+- `CB_RETRIEVE_PRE_COMPUTED_V2`
+
+### CacheBlend v3 (`blend_v3.py`)
+Third-generation CacheBlend with rope state and unified lookup:
+- `CB_REGISTER_ROPE_V3` / `CB_UNREGISTER_ROPE_V3`
+- `CB_RETRIEVE_PRE_COMPUTED_V3`
+- `CB_UNIFIED_LOOKUP`
+
+### Observability (`observability.py`)
+Server-side observability events:
+- `REPORT_BLOCK_ALLOCATION`
+
+### P2P (`p2p.py`)
+Peer-to-peer transfer operations:
+- `P2P_LOOKUP_AND_LOCK`
+- `P2P_QUERY_LOOKUP_RESULTS`
+- `P2P_UNLOCK_OBJECTS`
 
 ## Handler Types
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Consolidates the 13 open daily doc-drift PRs (2026-06-30 through 2026-07-19) into a single change. Every edit was re-verified against the current code on `dev` as the single source of truth, since several of the older automated PRs had gone stale in the meantime. Corrections made relative to the original drift PRs:

- **Coordinator env vars / CLI** (#3984 was wrong): the config field is `CHUNK_SIZE` (`--chunk-size`), not `BLEND_CHUNK_SIZE` / `--blend-chunk-size`, and `HASH_ALGORITHM` / the resync knobs are included. The transport table now also covers `PUT/GET /quota/config`, `POST/DELETE /cache/pins`, and `POST /cache/delete`, which landed after that PR was generated.
- **Valkey** (#4117 vs #4156 conflict): #4156 claimed the user-facing page was still "pending"; this PR ships #4117's dedicated `docs/source/mp/l2_storage/valkey.rst` page instead, with the wire-key layout corrected to include the `<object_group_id_hex>` component and the exact `valkey-glide-sync` install error message.
- **Multi-hardware architecture** (#4009 was superseded): the doc had already been rewritten for the `DeviceSpec` refactor (#4147), so only the two still-missing bits are applied — the `DEVICE_TYPE` env-var override and MUSA in the CPU-fallback accelerator list.
- **Adapter type list**: verified against the registry; adds `bigtable`, `sagemaker-hyperpod`, `hfbucket`, `valkey`, `fault_inject`, plus a note that the registered `p2p` type is wired in dynamically by the P2P subsystem rather than configured via `--l2-adapter`.

Everything else applies as in the original PRs: `--metrics-sample-rate` / `--trace-level` / `--trace-output` rows, optional `tcp://` prefix for the vLLM MP connector, `LMCACHE_USAGE_TRACK_INTERVAL`, `IsolatedLRU`, `DevDaxL1MemoryManager` as the third L1 tier, the `/blend` fingerprint-directory API reference, the `lmcache[nixl]` optional extra, dangling `l2_apis.md` references, the protocols README refresh, and the developer-guide toctree indentation fix.

Docs build verified with `sphinx-build` — no new warnings or errors in any touched file.

This PR closes #3960, closes #3969, closes #3984, closes #3996, closes #4009, closes #4035, closes #4066, closes #4087, closes #4117, closes #4125, closes #4140, closes #4150, closes #4156 (the previous daily doc-drift PRs).

**Special notes for your reviewers**:

Where a newer drift PR and an older one touched the same section (7 of them touch `configuration.rst`), the merged text was chosen by checking the code, not by PR recency.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
