### PR TITLE
fix(docs): Fix indentation in developer guide index.rst

### DIFF
--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -9,6 +9,6 @@ commands, and HTTP endpoints.
 
    contributing
    extending_lmcache/native_connectors
-extending_lmcache/adding_a_new_device_backend
+   extending_lmcache/adding_a_new_device_backend
    cli
    extending_http_api


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fix the issue of document `developer guide index`

<img width="1906" height="1279" alt="Clipboard_Screenshot_1784590335" src="https://github.com/user-attachments/assets/a6a5855b-b651-4215-a300-4f7526e81127" />


**Special notes for your reviewers**:

Verified locally

<img width="2182" height="1758" alt="Clipboard_Screenshot_1784590528" src="https://github.com/user-attachments/assets/6120164d-a483-477e-ae48-c2dda6dc652f" />


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
