### PR TITLE
[Cacheblend][Coordinator] Enable global token matching in l1 using p2p

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md
+++ b/docs/design/v1/distributed/l2_adapters/p2p_l2_adapter.md
@@ -28,7 +28,8 @@ lookup-and-lock  → query (addresses)  → load (RDMA read)  → unlock
 ```
 
 1. **lookup-and-lock** — send `P2P_LOOKUP_AND_LOCK([keys, layout_desc])` to the
-   peer; it read-locks the cached prefix in its L1 and returns a task id.
+   peer; it read-locks every L1-resident key (sparse; gaps allowed) and
+   returns a task id.
 2. **query** — poll `P2P_QUERY_LOOKUP_RESULTS(task_id)`; once ready the peer
    returns one `TransferChannelAddress` per key (invalid offset for keys it did
    not lock). The adapter stashes the valid addresses keyed by `ObjectKey` and

--- a/docs/design/v1/mp_coordinator/blend_lookup.md
+++ b/docs/design/v1/mp_coordinator/blend_lookup.md
@@ -167,8 +167,9 @@ a synchronous `httpx.Client` plus a daemon, mirroring the module's existing
     `np.frombuffer` straight to the matcher's array. Register still ships raw
     tokens as JSON (lower frequency).
 
-Opt-in via the coordinator URL `--coordinator-url`
-every publish/query path is skipped (behavior unchanged).
+Opt-in via the coordinator URL (`--coordinator-url`, falling back to
+`LMCACHE_COORDINATOR_URL` at config parsing); unset → the module receives
+`None` and every publish/query path is skipped (behavior unchanged).
 
 ## Lookup flow in `cb_unified_lookup`
 

--- a/docs/design/v1/mp_coordinator/blend_lookup.md
+++ b/docs/design/v1/mp_coordinator/blend_lookup.md
@@ -2,7 +2,8 @@
 
 A coordinator-level capability that lets a CacheBlend lookup on one mp-server
 find and reuse chunk KV cached anywhere in the fleet, fetched from a shared,
-content-addressed L2. Blend servers **publish fingerprints on STORE** and
+content-addressed L2 or directly from a peer's L1 over the P2P transfer
+channel (RDMA). Blend servers **publish fingerprints on STORE** and
 **query on LOOKUP**; the coordinator holds the fleet-wide directory and runs the
 match. It is **opt-in** (enabled only when a coordinator URL is configured) and
 **additive** (the existing local matcher fast path is unchanged).
@@ -46,7 +47,7 @@ LOOKUP (blend server, cb_unified_lookup)
                                    roll hash over tokens, probe every probe_stride
         ◀── matches: [(object_key, old_st, cur_st)] ──
   → non-prefix set (drop prefix-covered, leftmost-greedy overlap dedup)
-  → one sparse prefetch from shared L2 → retrieve + re-RoPE
+  → one sparse prefetch (shared L2 and/or peer L1 via P2P) → retrieve + re-RoPE
 ```
 
 The coordinator owns `chunk_size` (fleet config, must equal the servers'
@@ -166,7 +167,7 @@ a synchronous `httpx.Client` plus a daemon, mirroring the module's existing
     `np.frombuffer` straight to the matcher's array. Register still ships raw
     tokens as JSON (lower frequency).
 
-Opt-in via `LMCACHE_COORDINATOR_URL`; absent → the module receives `None` and
+Opt-in via the coordinator URL `--coordinator-url`
 every publish/query path is skipped (behavior unchanged).
 
 ## Lookup flow in `cb_unified_lookup`
@@ -193,6 +194,17 @@ With a coordinator:
 Without a coordinator, step 1 instead runs the local matcher and steps 3–4 use
 its matches (already non-overlapping, so the dedup is a no-op).
 
+### Fetch sources: shared L2 and peer L1
+
+The sparse prefetch fans out to **every** registered L2 adapter — P2P peer
+adapters included — so a matched chunk loads from whichever tier holds it:
+shared L2, or a peer's L1 via RDMA. The peer's `p2p_lookup_and_lock` locks
+sparse key sets (gaps allowed), not only the contiguous prefix, and the
+serving side never recurses into its own L2 (`skip_l2` holds for sparse
+lookups too). Fingerprints are published on every blend store regardless of
+L2 offload, so chunks resident only in a storer's L1 are matchable
+fleet-wide.
+
 Fleet matches are `CBMatchResult` (each `hash` is the chunk content hash — the
 coordinator's `object_key` hex — which `ipc_key_to_object_keys` expands to
 per-rank shared-L2 keys), so they ride the **identical** sparse prefetch +
@@ -214,6 +226,7 @@ publish is optional and not required for correctness.)
 | coordinator down | no global leg | HTTP times out → empty result → local-only |
 | poly-hash collision | wasted prefetch | confirmed-miss → recompute |
 | stale entry (evicted) | wasted prefetch | miss → recompute; lazy remove |
+| chunk evicted from peer L1, no L2 copy | wasted prefetch | miss → recompute |
 | cross-salt match, no same-salt copy | wasted prefetch | requester-salt ObjectKey misses → recompute |
 | publish dropped | a chunk unindexed globally | recomputed on a peer until re-published |
 

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -488,7 +488,7 @@ class StorageManager:
             )
 
             prefetch_request_id = -1
-            if remaining_keys and self._has_l2_adapters():
+            if not skip_l2 and remaining_keys and self._has_l2_adapters():
                 prefetch_request_id = self._prefetch_controller.submit_prefetch_request(
                     remaining_keys,
                     layout_desc,
@@ -503,7 +503,9 @@ class StorageManager:
                 l1_found_indices=tuple(l1_found_indices),
                 total_requested_keys=len(keys),
                 submit_time=time.monotonic(),
-                l2_orig_indices=tuple(sparse_l2_indices),
+                l2_orig_indices=(
+                    tuple(sparse_l2_indices) if prefetch_request_id != -1 else ()
+                ),
             )
 
         hit_count = 0

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -205,17 +205,22 @@ class BlendCoordinatorClient:
             self._client.close()
 
     @classmethod
-    def maybe_create(cls, url: str) -> "BlendCoordinatorClient | None":
+    def maybe_create(cls, url: str | None) -> "BlendCoordinatorClient | None":
         """Build a started client for ``url``; an empty URL returns ``None``.
 
+        Timing knobs are read from the environment:
+        ``LMCACHE_COORDINATOR_BLEND_TIMEOUT`` (seconds, default 1.0; used as
+        both the per-request HTTP timeout and the per-lookup match budget) and
+        ``LMCACHE_COORDINATOR_BLEND_MATCH_CONCURRENCY`` (default 8).
+
         Args:
-            url: Coordinator base URL; empty disables the client.
+            url: Coordinator base URL; empty or ``None`` disables the client.
 
         Returns:
             A started client, or ``None`` when ``url`` is empty (the blend
             module then runs purely local).
         """
-        url = url.strip()
+        url = (url or "").strip()
         if not url:
             return None
         concurrency = int(os.getenv("LMCACHE_COORDINATOR_BLEND_MATCH_CONCURRENCY", "8"))

--- a/lmcache/v1/mp_coordinator/blend_client.py
+++ b/lmcache/v1/mp_coordinator/blend_client.py
@@ -205,23 +205,17 @@ class BlendCoordinatorClient:
             self._client.close()
 
     @classmethod
-    def maybe_from_env(cls) -> "BlendCoordinatorClient | None":
-        """Build a client from ``LMCACHE_COORDINATOR_*`` env vars if configured.
+    def maybe_create(cls, url: str) -> "BlendCoordinatorClient | None":
+        """Build a started client for ``url``; an empty URL returns ``None``.
 
-        Reads ``LMCACHE_COORDINATOR_URL`` (required to enable) and
-        ``LMCACHE_COORDINATOR_BLEND_TIMEOUT`` (default 1.0s). This timeout is the
-        wall-clock budget on the optional global leg: the blend module polls
-        until the match resolves (matches, or ``[]`` on failure) but gives up
-        once the budget elapses, so it bounds how long the critical path waits
-        -- including time queued behind other match queries -- before proceeding
-        local-only. It is used both as the per-request HTTP timeout and as the
-        module's per-lookup deadline. Keep it small.
+        Args:
+            url: Coordinator base URL; empty disables the client.
 
         Returns:
-            A started client, or ``None`` when no coordinator URL is configured
-            (the blend module then runs purely local).
+            A started client, or ``None`` when ``url`` is empty (the blend
+            module then runs purely local).
         """
-        url = os.getenv("LMCACHE_COORDINATOR_URL", "").strip()
+        url = url.strip()
         if not url:
             return None
         concurrency = int(os.getenv("LMCACHE_COORDINATOR_BLEND_MATCH_CONCURRENCY", "8"))
@@ -271,9 +265,9 @@ class BlendCoordinatorClient:
                 )
                 for m in body.get("matches", [])
             ]
-        except Exception:
+        except Exception as e:
             # Best-effort: a failed query degrades to local-only (empty result).
-            logger.warning("Blend coordinator match failed for %s", item.rid)
+            logger.warning("Blend coordinator match failed for %s: %r", item.rid, e)
         with self._results_lock:
             # Only fill if still awaited (not taken/cleared meanwhile).
             if self._results.get(item.rid) is PENDING:
@@ -283,5 +277,7 @@ class BlendCoordinatorClient:
         """Send a best-effort register/evict; failures are logged and dropped."""
         try:
             self._request(item.method, item.path, item.payload)
-        except Exception:
-            logger.warning("Blend coordinator %s %s failed", item.method, item.path)
+        except Exception as e:
+            logger.warning(
+                "Blend coordinator %s %s failed: %r", item.method, item.path, e
+            )

--- a/lmcache/v1/multiprocess/modules/p2p_controller.py
+++ b/lmcache/v1/multiprocess/modules/p2p_controller.py
@@ -12,10 +12,12 @@ import httpx
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import (
     MemoryLayoutDesc,
     ObjectKey,
     PrefetchHandle,
+    TrimPolicy,
 )
 from lmcache.v1.distributed.l2_adapters.p2p_l2_adapter import P2PL2AdapterConfig
 from lmcache.v1.distributed.transfer_channel import (
@@ -226,8 +228,8 @@ class P2PController:
     ) -> int:
         """Submit a lookup and lock.
 
-        After L2 prefetch is enabled, the found chunks will be feteched
-        from L2 to L1.
+        Read-locks every L1-resident key (sparse; gaps allowed), not only
+        the contiguous prefix.
 
         Args:
             keys: the list of object keys to look up and lock.
@@ -245,6 +247,7 @@ class P2PController:
             keys,
             layout_desc,
             external_request_id=f"p2p-{task_id}",
+            policy=TrimPolicy.SPARSE,
             skip_l2=True,
         )
 
@@ -252,7 +255,7 @@ class P2PController:
             self._jobs[task_id] = _P2PLookupJob(handle=handle, keys=keys)
 
         logger.debug(
-            "P2P lookup submitted: task_id=%d, %d keys, %d L1 prefix hits",
+            "P2P lookup submitted: task_id=%d, %d keys, %d L1 hits",
             task_id,
             len(keys),
             len(handle.l1_found_indices),
@@ -295,7 +298,7 @@ class P2PController:
             # Still in progress (only possible once L2 prefetch is enabled).
             return None
 
-        addresses = self._build_addresses(job, found.count_leading_ones())
+        addresses = self._build_addresses(job, found)
 
         with self._job_lock:
             self._jobs.pop(task_id, None)
@@ -321,23 +324,24 @@ class P2PController:
     def _build_addresses(
         self,
         job: _P2PLookupJob,
-        hit_count: int,
+        found: Bitmap,
     ) -> list[TransferChannelAddress]:
         """Build the per-key transfer addresses for a completed lookup.
 
-        The first ``hit_count`` keys form the locked L1 prefix; their addresses
-        are read via ``unsafe_read``. Every remaining key gets an invalid
-        address.
+        Keys at set indices of ``found`` are the locked L1 hits; their
+        addresses are read via ``unsafe_read``. Every other key gets an
+        invalid address.
         """
         addresses = [_INVALID_ADDRESS] * len(job.keys)
-        if hit_count == 0:
+        found_indices = found.get_indices_list()
+        if not found_indices:
             return addresses
 
-        found_keys = job.keys[:hit_count]
+        found_keys = [job.keys[i] for i in found_indices]
         good_keys, good_objs = self._ctx.storage_manager.unsafe_read(found_keys)
         obj_by_key = dict(zip(good_keys, good_objs, strict=True))
 
-        for i, key in enumerate(found_keys):
+        for i, key in zip(found_indices, found_keys, strict=True):
             obj = obj_by_key.get(key)
             if obj is None:
                 # Locked but unreadable (e.g. evicted under a race); leave it

--- a/lmcache/v1/multiprocess/protocols/p2p.py
+++ b/lmcache/v1/multiprocess/protocols/p2p.py
@@ -3,7 +3,7 @@
 P2P protocol definitions for peer lookup-and-lock operations.
 
 This module defines the protocol for:
-- P2P_LOOKUP_AND_LOCK: Look up and read-lock the locally cached prefix
+- P2P_LOOKUP_AND_LOCK: Look up and read-lock the locally cached keys
 - P2P_QUERY_LOOKUP_RESULTS: Poll the transfer addresses of a lookup
 - P2P_UNLOCK_OBJECTS: Release the read locks held by a peer
 """
@@ -29,7 +29,8 @@ def get_protocol_definitions() -> dict[str, ProtocolDefinition]:
         Dictionary mapping request names to their protocol definitions
     """
     return {
-        # Look up and read-lock the locally cached prefix of the given keys
+        # Look up and read-lock the L1-resident subset of the given keys
+        # (sparse; gaps allowed)
         # Payload:
         #   - keys: list[ObjectKey] - Object keys to look up and lock
         #   - layout_desc: MemoryLayoutDesc - Memory layout of the objects

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -32,7 +32,9 @@ from lmcache.v1.multiprocess.config import (
     DEFAULT_COORDINATOR_CONFIG,
     CoordinatorConfig,
     MPServerConfig,
+    add_coordinator_args,
     add_mp_server_args,
+    parse_args_to_coordinator_config,
     parse_args_to_mp_server_config,
 )
 from lmcache.v1.multiprocess.engine_context import MPCacheServerContext
@@ -247,9 +249,10 @@ def _build_modules(
         transfer_module = next(
             m for m in transfer_modules if isinstance(m, LMCacheDrivenTransferModule)
         )
-        # Opt-in: enabled only when LMCACHE_COORDINATOR_URL is set; otherwise
+        # Opt-in: enabled when a coordinator URL is configured (flag or
+        # LMCACHE_COORDINATOR_URL, resolved at config parsing); otherwise
         # None and the blend module matches purely locally.
-        coordinator = BlendCoordinatorClient.maybe_from_env()
+        coordinator = BlendCoordinatorClient.maybe_create(coordinator_config.url)
         blend_v3 = BlendV3Module(
             ctx,
             transfer_module,
@@ -434,6 +437,7 @@ def parse_args():
     add_mp_server_args(parser)
     add_storage_manager_args(parser)
     add_observability_args(parser)
+    add_coordinator_args(parser)
     return parser.parse_args()
 
 
@@ -442,8 +446,10 @@ if __name__ == "__main__":
     mp_config = parse_args_to_mp_server_config(args)
     storage_manager_config = parse_args_to_config(args)
     obs_config = parse_args_to_observability_config(args)
+    coordinator_config = parse_args_to_coordinator_config(args)
     run_cache_server(
         mp_config=mp_config,
         storage_manager_config=storage_manager_config,
         obs_config=obs_config,
+        coordinator_config=coordinator_config,
     )

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -673,7 +673,8 @@ class TestStorageManagerL2Prefetch:
         # All keys reach L2; delete key 1 from L1 so it is L2-only.
         self._write_keys_and_wait_for_l2(sm, all_keys, basic_layout)
         time.sleep(0.05)
-        sm._l1_manager.delete([all_keys[1]])
+        deleted, skipped = sm.delete_l1_keys([all_keys[1]])
+        assert (deleted, skipped) == (1, 0)
 
         handle = sm.submit_prefetch_task(
             all_keys, basic_layout, policy=TrimPolicy.SPARSE, skip_l2=True

--- a/tests/v1/distributed/test_distributed_storage_manager.py
+++ b/tests/v1/distributed/test_distributed_storage_manager.py
@@ -659,6 +659,38 @@ class TestStorageManagerL2Prefetch:
 
         sm.close()
 
+    def test_sparse_skip_l2_locks_only_l1(
+        self, l2_storage_manager_config, basic_layout
+    ):
+        """``policy=SPARSE`` + ``skip_l2=True`` submits no controller request.
+
+        Only L1-resident keys are locked and reported found; keys present only
+        in L2 are reported as misses.
+        """
+        sm = StorageManager(l2_storage_manager_config)
+        all_keys = [make_object_key(i) for i in range(3)]
+
+        # All keys reach L2; delete key 1 from L1 so it is L2-only.
+        self._write_keys_and_wait_for_l2(sm, all_keys, basic_layout)
+        time.sleep(0.05)
+        sm._l1_manager.delete([all_keys[1]])
+
+        handle = sm.submit_prefetch_task(
+            all_keys, basic_layout, policy=TrimPolicy.SPARSE, skip_l2=True
+        )
+
+        # skip_l2 honored: the controller was never asked.
+        assert handle.prefetch_request_id == -1
+        assert handle.l2_orig_indices == ()
+        assert handle.l1_found_indices == (0, 2)
+
+        found = sm.query_prefetch_status(handle)
+        assert found is not None
+        assert found.get_indices_list() == [0, 2]
+
+        sm.finish_read_prefetched([all_keys[0], all_keys[2]])
+        sm.close()
+
     def test_prefetch_l2_partial_prefix(self, l2_storage_manager_config, basic_layout):
         """L2 has keys {0,1,3,4} but not 2 → L2 returns prefix of 2."""
         sm = StorageManager(l2_storage_manager_config)

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -194,6 +194,7 @@ def test_take_match_clears():
 def test_maybe_create(monkeypatch: pytest.MonkeyPatch):
     assert BlendCoordinatorClient.maybe_create("") is None
     assert BlendCoordinatorClient.maybe_create("   ") is None
+    assert BlendCoordinatorClient.maybe_create(None) is None
 
     monkeypatch.delenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", raising=False)
     client = BlendCoordinatorClient.maybe_create("http://coord:9300")

--- a/tests/v1/mp_coordinator/test_blend_client.py
+++ b/tests/v1/mp_coordinator/test_blend_client.py
@@ -191,19 +191,18 @@ def test_take_match_clears():
         client.close()
 
 
-def test_maybe_from_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("LMCACHE_COORDINATOR_URL", raising=False)
-    assert BlendCoordinatorClient.maybe_from_env() is None
+def test_maybe_create(monkeypatch: pytest.MonkeyPatch):
+    assert BlendCoordinatorClient.maybe_create("") is None
+    assert BlendCoordinatorClient.maybe_create("   ") is None
 
-    monkeypatch.setenv("LMCACHE_COORDINATOR_URL", "http://coord:9300")
     monkeypatch.delenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", raising=False)
-    client = BlendCoordinatorClient.maybe_from_env()
+    client = BlendCoordinatorClient.maybe_create("http://coord:9300")
     assert client is not None
     assert client.match_budget_s == 1.0  # default timeout
     client.close()
 
     monkeypatch.setenv("LMCACHE_COORDINATOR_BLEND_TIMEOUT", "1.5")
-    client = BlendCoordinatorClient.maybe_from_env()
+    client = BlendCoordinatorClient.maybe_create("http://coord:9300")
     assert client is not None
     assert client.match_budget_s == 1.5  # env override
     client.close()

--- a/tests/v1/multiprocess/test_p2p_controller.py
+++ b/tests/v1/multiprocess/test_p2p_controller.py
@@ -12,7 +12,8 @@ import httpx
 import torch
 
 # First Party
-from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey, TrimPolicy
 from lmcache.v1.distributed.l2_adapters.p2p_l2_adapter import P2PL2AdapterConfig
 from lmcache.v1.distributed.transfer_channel.api import TransferChannelAddress
 from lmcache.v1.multiprocess.config import CoordinatorConfig, P2PConfig
@@ -150,7 +151,8 @@ def _make_controller() -> tuple[P2PController, MagicMock]:
 
 
 def test_lookup_and_lock_submits_skip_l2_and_returns_task_id():
-    """p2p_lookup_and_lock submits a skip_l2 prefetch and returns a fresh id."""
+    """p2p_lookup_and_lock submits a sparse skip_l2 prefetch and returns a
+    fresh id."""
     controller, ctx = _make_controller()
     handle = MagicMock(l1_found_indices=(0, 1))
     ctx.storage_manager.submit_prefetch_task.return_value = handle
@@ -164,6 +166,7 @@ def test_lookup_and_lock_submits_skip_l2_and_returns_task_id():
     assert args[0] == keys
     assert args[1] is layout_desc
     assert kwargs["skip_l2"] is True
+    assert kwargs["policy"] is TrimPolicy.SPARSE
     # A second call gets a distinct id.
     assert controller.p2p_lookup_and_lock(keys, layout_desc) == 1
 
@@ -178,9 +181,7 @@ def test_query_lookup_results_builds_addresses_for_prefix():
     keys = [_make_key(0), _make_key(1), _make_key(2)]
     task_id = controller.p2p_lookup_and_lock(keys, _make_layout_desc())
 
-    found = MagicMock()
-    found.count_leading_ones.return_value = 2
-    ctx.storage_manager.query_prefetch_status.return_value = found
+    ctx.storage_manager.query_prefetch_status.return_value = Bitmap(3, 2)
     obj0 = MagicMock(shm_offset=100, shm_byte_length=10)
     obj1 = MagicMock(shm_offset=200, shm_byte_length=20)
     ctx.storage_manager.unsafe_read.return_value = ([keys[0], keys[1]], [obj0, obj1])
@@ -193,6 +194,32 @@ def test_query_lookup_results_builds_addresses_for_prefix():
     ]
 
 
+def test_query_lookup_results_builds_addresses_for_sparse_hits():
+    """A lookup with a mid-sequence L1 gap returns real offsets at the found
+    indices and an invalid offset at the gap."""
+    controller, ctx = _make_controller()
+    handle = MagicMock(l1_found_indices=(0, 2))
+    ctx.storage_manager.submit_prefetch_task.return_value = handle
+
+    keys = [_make_key(0), _make_key(1), _make_key(2)]
+    task_id = controller.p2p_lookup_and_lock(keys, _make_layout_desc())
+
+    found = Bitmap(3)
+    found.batched_set([0, 2])
+    ctx.storage_manager.query_prefetch_status.return_value = found
+    obj0 = MagicMock(shm_offset=100, shm_byte_length=10)
+    obj2 = MagicMock(shm_offset=300, shm_byte_length=30)
+    ctx.storage_manager.unsafe_read.return_value = ([keys[0], keys[2]], [obj0, obj2])
+
+    addresses = controller.p2p_query_lookup_results(task_id)
+    ctx.storage_manager.unsafe_read.assert_called_once_with([keys[0], keys[2]])
+    assert addresses == [
+        TransferChannelAddress(offset=100, size=10),
+        TransferChannelAddress(offset=-1, size=0),
+        TransferChannelAddress(offset=300, size=30),
+    ]
+
+
 def test_query_lookup_results_exactly_once():
     """Re-querying a completed task returns None (the job is consumed)."""
     controller, ctx = _make_controller()
@@ -201,9 +228,7 @@ def test_query_lookup_results_exactly_once():
     )
     task_id = controller.p2p_lookup_and_lock([_make_key(0)], _make_layout_desc())
 
-    found = MagicMock()
-    found.count_leading_ones.return_value = 0
-    ctx.storage_manager.query_prefetch_status.return_value = found
+    ctx.storage_manager.query_prefetch_status.return_value = Bitmap(1)
 
     assert controller.p2p_query_lookup_results(task_id) == [
         TransferChannelAddress(offset=-1, size=0)
@@ -229,9 +254,7 @@ def test_query_lookup_results_in_progress():
     ctx.storage_manager.query_prefetch_status.return_value = None
     assert controller.p2p_query_lookup_results(task_id) is None
     # Job is still alive; status flips to done on the next poll.
-    found = MagicMock()
-    found.count_leading_ones.return_value = 0
-    ctx.storage_manager.query_prefetch_status.return_value = found
+    ctx.storage_manager.query_prefetch_status.return_value = Bitmap(1)
     assert controller.p2p_query_lookup_results(task_id) is not None
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Let a coordinator CacheBlend match be fetched directly from a peer's L1 over the P2P transfer channel (previously shared-L2 only):

- P2P serving read-locks and returns every L1-resident key (sparse, gap-tolerant), not just the contiguous prefix; requesters still apply their own trim policy — no wire change.
- `skip_l2` honored on the SPARSE prefetch branch (prevents recursive peer fetches).
- Blend fleet directory enabled by `--coordinator-url` (resolved once at config parsing), not only `LMCACHE_COORDINATOR_URL`.

Verified e2e across two hosts (gpt-oss-20b + CacheBlend connector, NIXL).


**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

