### PR TITLE
SGLang cache-control verification (prefetch/delete/pin) + FS L2 delete support

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/l2_eviction.md
+++ b/docs/design/v1/distributed/l2_adapters/l2_eviction.md
@@ -197,7 +197,7 @@ capacity) can omit steps 2–6 and rely on the base class no-op defaults.
 | `MockL2Adapter`            | ✓        | ✓           | stored, deleted     |
 | `NixlStoreL2Adapter`       | ✓ (skips pinned) | ✓ (pool-based) | stored, deleted |
 | `RawBlockL2Adapter`        | ✓ (skips locked) | ✓ | stored, accessed, deleted |
-| `FSL2Adapter`              | no-op    | `(-1, -1)`  | none                |
+| `FSL2Adapter`              | ✓ (unlinks data files) | ✓ (bytes tracked; no capacity, so fraction stays `-1`) | stored, deleted |
 | `NativeConnectorL2Adapter` | ✓ (via `submit_batch_delete`) | ✓ (client-side, requires `max_capacity_gb`) | stored, deleted |
 
 **Note on `NativeConnectorL2Adapter`:** Eviction support requires two things:

--- a/docs/design/v1/mp_coordinator/l2_prefetch.md
+++ b/docs/design/v1/mp_coordinator/l2_prefetch.md
@@ -80,6 +80,17 @@ node already holds or retry. Completion is observed via the status endpoint
 the load itself still surfaces through the controller's
 `L2_PREFETCH_LOAD_COMPLETED` event).
 
+### Serving engines
+
+The endpoint is engine-agnostic: keys are resolved from ``(model_name,
+world_size, cache_salt)`` and the server-side token hasher, the same
+identity every MP engine adapter (vLLM, SGLang, TensorRT-LLM) uses on
+STORE, and the load itself moves L1 buffers without touching GPU state.
+For SGLang, ``model_name`` is the ``--model-path`` string and
+``cache_salt`` stays ``""`` (the SGLang adapter stores with the default
+salt). ``tests/v1/multiprocess/test_warm_prefetch_sglang.py`` covers the
+full flow against an SGLang-shaped registration.
+
 ### Single-node vs. multi-node
 
 One `instance_id` is **one node's** MP server, and its L1 is shared with that

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -376,8 +376,8 @@ class FSL2Adapter(L2AdapterInterface):
             return self._completed_lookup_tasks.pop(task_id, None)
 
     def submit_unlock(self, keys: list[ObjectKey]) -> None:
-        # No-op: FS adapter has no eviction, so locking
-        # between lookup and load is unnecessary.
+        # No-op: the FS adapter holds no read locks. A delete racing a
+        # lookup->load window surfaces as a load miss for that key.
         pass
 
     # ------------------------------------------------------------------
@@ -421,8 +421,33 @@ class FSL2Adapter(L2AdapterInterface):
     # ------------------------------------------------------------------
 
     def delete(self, keys: list[ObjectKey]) -> None:
-        # Not implemented for the filesystem adapter.
-        pass
+        """Delete each key's data file from disk.
+
+        Missing files are skipped, so the call is idempotent. Keys are
+        removed regardless of any in-flight lookup/load window (the FS
+        adapter holds no read locks); a load racing a delete reports that
+        key as a miss. Fires ``on_l2_keys_deleted`` on registered listeners
+        for the keys actually removed.
+
+        Args:
+            keys: The keys of the objects to delete.
+        """
+        deleted_keys: list[ObjectKey] = []
+        deleted_sizes: list[int] = []
+        for key in keys:
+            file_path = self._key_to_path(key)
+            try:
+                size = os.stat(file_path).st_size
+                os.unlink(file_path)
+            except FileNotFoundError:
+                continue
+            except OSError:
+                logger.exception("FSL2Adapter failed to delete %s", file_path)
+                continue
+            deleted_keys.append(key)
+            deleted_sizes.append(size)
+        if deleted_keys:
+            self._notify_keys_deleted(deleted_keys, deleted_sizes)
 
     # ``get_usage()`` is inherited from ``L2AdapterInterface``. The FS
     # adapter declares no max capacity (default 0) so ``supports_global_eviction``
@@ -581,6 +606,8 @@ class FSL2Adapter(L2AdapterInterface):
     ) -> None:
         success = True
         bytes_written = 0
+        stored_keys: list[ObjectKey] = []
+        stored_sizes: list[int] = []
         try:
             for key, obj in zip(keys, objects, strict=True):
                 file_path, tmp_path = self._key_to_file_and_tmp_path(key)
@@ -620,6 +647,8 @@ class FSL2Adapter(L2AdapterInterface):
 
                     await aiofiles.os.replace(tmp_path, file_path)
                     bytes_written += size
+                    stored_keys.append(key)
+                    stored_sizes.append(size)
                     logger.debug(
                         "FSL2Adapter stored key %s (%d bytes)",
                         file_path.name,
@@ -640,6 +669,8 @@ class FSL2Adapter(L2AdapterInterface):
             )
             success = False
 
+        if stored_keys:
+            self._notify_keys_stored(stored_keys, stored_sizes)
         with self._lock:
             self._completed_store_tasks[task_id] = L2StoreResult(success, bytes_written)
         self._store_efd.notify()

--- a/tests/v1/distributed/l2_adapters/test_fs_l2_adapter_delete.py
+++ b/tests/v1/distributed/l2_adapters/test_fs_l2_adapter_delete.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the FS L2 adapter's delete path and byte accounting.
+
+Stores objects through the adapter's own store task, then exercises
+``delete``: data files are unlinked, ``on_l2_keys_stored`` /
+``on_l2_keys_deleted`` fire with the affected keys, ``get_usage`` tracks
+the byte totals, and deleting missing keys is a no-op.
+"""
+
+# Standard
+from pathlib import Path
+from typing import cast
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed.api import ObjectKey
+from lmcache.v1.distributed.internal_api import L2AdapterListener
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    FSL2Adapter,
+    FSL2AdapterConfig,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+OBJ_SIZE = 4096
+
+
+class _RecordingListener(L2AdapterListener):
+    """Record every stored / accessed / deleted notification."""
+
+    def __init__(self) -> None:
+        self.stored: list[tuple[ObjectKey, int]] = []
+        self.accessed: list[ObjectKey] = []
+        self.deleted: list[ObjectKey] = []
+
+    def on_l2_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+        self.stored.extend(zip(keys, sizes, strict=True))
+
+    def on_l2_keys_accessed(self, keys: list[ObjectKey]) -> None:
+        self.accessed.extend(keys)
+
+    def on_l2_keys_deleted(self, keys: list[ObjectKey]) -> None:
+        self.deleted.extend(keys)
+
+
+class _BytesObj:
+    """Minimal store payload exposing the ``byte_array`` the adapter reads."""
+
+    def __init__(self, payload: bytes) -> None:
+        self.byte_array = payload
+
+
+def _key(index: int, cache_salt: str = "") -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=bytes([index]) * 8,
+        model_name="fs-delete-model",
+        kv_rank=0,
+        cache_salt=cache_salt,
+    )
+
+
+@pytest.fixture()
+def adapter(tmp_path: Path):
+    a = FSL2Adapter(FSL2AdapterConfig(base_path=str(tmp_path)))
+    listener = _RecordingListener()
+    a.register_listener(listener)
+    yield a, listener, tmp_path
+    a.close()
+
+
+def _store(adapter: FSL2Adapter, keys: list[ObjectKey]) -> None:
+    """Store one OBJ_SIZE payload per key and wait for task completion."""
+    payloads = cast("list[MemoryObj]", [_BytesObj(b"\xab" * OBJ_SIZE)] * len(keys))
+    task_id = adapter.submit_store_task(keys, payloads)
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        done = adapter.pop_completed_store_tasks()
+        if task_id in done:
+            if int(done[task_id]) < 0:
+                raise AssertionError("store task failed")
+            return
+        time.sleep(0.05)
+    raise TimeoutError("store task did not complete")
+
+
+def _data_files(base: Path) -> list[Path]:
+    return sorted(base.glob("*.data"))
+
+
+def test_delete_removes_files_and_notifies(adapter) -> None:
+    """``delete`` unlinks stored files, fires the listeners, and updates
+    ``get_usage`` totals; keys never stored are skipped."""
+    a, listener, base = adapter
+    keys = [_key(i) for i in range(3)]
+    _store(a, keys)
+
+    assert len(_data_files(base)) == 3
+    assert sorted(s for _, s in listener.stored) == [OBJ_SIZE] * 3
+    assert a.get_usage().total_bytes_used == 3 * OBJ_SIZE
+
+    a.delete([keys[0], keys[1], _key(9)])
+
+    assert len(_data_files(base)) == 1
+    assert listener.deleted == [keys[0], keys[1]]
+    assert a.get_usage().total_bytes_used == OBJ_SIZE
+
+
+def test_delete_is_idempotent(adapter) -> None:
+    """A second delete of the same keys removes nothing and fires no
+    listener."""
+    a, listener, base = adapter
+    keys = [_key(i) for i in range(2)]
+    _store(a, keys)
+
+    a.delete(keys)
+    assert _data_files(base) == []
+    assert listener.deleted == keys
+
+    a.delete(keys)
+    assert listener.deleted == keys
+    assert a.get_usage().total_bytes_used == 0
+
+
+def test_delete_respects_cache_salt(adapter) -> None:
+    """Keys differing only in ``cache_salt`` map to different files; deleting
+    one salt leaves the other's data on disk."""
+    a, listener, base = adapter
+    plain = _key(1)
+    salted = _key(1, cache_salt="alice")
+    _store(a, [plain, salted])
+    assert len(_data_files(base)) == 2
+
+    a.delete([salted])
+
+    assert len(_data_files(base)) == 1
+    assert listener.deleted == [salted]
+    usage = a.get_usage()
+    assert usage.total_bytes_used == OBJ_SIZE
+    assert "alice" not in usage.bytes_by_cache_salt

--- a/tests/v1/multiprocess/test_warm_prefetch_sglang.py
+++ b/tests/v1/multiprocess/test_warm_prefetch_sglang.py
@@ -13,12 +13,15 @@ coordinator-facing warm-prefetch surface:
 3. ``POST /cache/prefetches`` (token-addressed, the payload the coordinator
    forwards verbatim) reloads the chunks L2 -> L1; the status poll reports
    ``found_keys == total_keys``.
-4. The L2 copies are deleted, and a normal SGLang-shaped ``LOOKUP`` +
-   ``RETRIEVE`` round-trip returns byte-identical KV -- data that can only
-   have come from the warm-prefetched L1 entries.
+4. ``DELETE /cache/objects`` removes the L2 copies, addressed by keys from
+   the coordinator-side resolver (the same resolution the pin/unpin
+   endpoints use), and a normal SGLang-shaped ``LOOKUP`` + ``RETRIEVE``
+   round-trip returns byte-identical KV -- data that can only have come
+   from the warm-prefetched L1 entries.
 """
 
 # Standard
+from dataclasses import asdict
 from typing import Generator
 import multiprocessing as mp
 import os
@@ -41,6 +44,7 @@ from lmcache.v1.distributed.config import (
 )
 from lmcache.v1.distributed.l2_adapters.config import L2AdaptersConfig
 from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import FSL2AdapterConfig
+from lmcache.v1.mp_coordinator.utils.cache_utils import resolve_object_keys
 from lmcache.v1.mp_observability.config import DEFAULT_OBSERVABILITY_CONFIG
 from lmcache.v1.multiprocess.config import (
     CoordinatorConfig,
@@ -50,6 +54,7 @@ from lmcache.v1.multiprocess.config import (
 from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey, KVCache
 from lmcache.v1.multiprocess.mq import MessageQueueClient
 from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+from lmcache.v1.multiprocess.token_hasher import TokenHasher
 from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
 
 SERVER_HOST = "127.0.0.1"
@@ -377,10 +382,30 @@ def test_warm_prefetch_restores_sglang_kv(
     assert status["total_keys"] == NUM_CHUNKS * WORLD_SIZE
     assert status["found_keys"] == status["total_keys"]
 
-    # Remove the L2 copies so the retrieve below can only be served by the
-    # warm-prefetched L1 entries.
-    for path in l2_files:
-        os.remove(path)
+    # Remove the L2 copies through the key-addressed delete API, with keys
+    # resolved by the coordinator-side resolver (the same resolution the
+    # pin/unpin endpoints use), so the retrieve below can only be served by
+    # the warm-prefetched L1 entries.
+    resolved_keys, resolved_chunks = resolve_object_keys(
+        TokenHasher(chunk_size=CHUNK_SIZE),
+        MODEL_NAME,
+        WORLD_SIZE,
+        token_ids,
+        "",
+    )
+    assert resolved_chunks == NUM_CHUNKS
+    resp = httpx.request(
+        "DELETE",
+        f"{HTTP_URL}/cache/objects",
+        json={"keys": [asdict(k.to_encoded_object_key()) for k in resolved_keys]},
+        timeout=10.0,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+    deadline = time.monotonic() + POLL_DEADLINE
+    while time.monotonic() < deadline and any(os.path.exists(p) for p in l2_files):
+        time.sleep(0.2)
+    assert not any(os.path.exists(p) for p in l2_files)
 
     matched_chunks = sgl_client.lookup(token_ids, request_id="warm-sgl-load")
     assert matched_chunks == NUM_CHUNKS

--- a/tests/v1/multiprocess/test_warm_prefetch_sglang.py
+++ b/tests/v1/multiprocess/test_warm_prefetch_sglang.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end warm-prefetch test through the SGLang wire shape.
+
+Runs the real MP server with its HTTP frontend and a filesystem L2 adapter,
+registers a KV cache exactly the way ``lmcache.integration.sglang.
+multi_process_adapter.LMCacheMPConnector`` does (flat ``[K_layers... ,
+V_layers...]`` 3-D pools, ``EngineType.SGLANG``, a ``tokens_per_block``
+layout hint, empty engine group infos), stores KV over ZMQ, then drives the
+coordinator-facing warm-prefetch surface:
+
+1. ``STORE`` writes the chunks to L1 and (write-through) to the fs L2 adapter.
+2. ``POST /cache/clear`` empties L1.
+3. ``POST /cache/prefetches`` (token-addressed, the payload the coordinator
+   forwards verbatim) reloads the chunks L2 -> L1; the status poll reports
+   ``found_keys == total_keys``.
+4. The L2 copies are deleted, and a normal SGLang-shaped ``LOOKUP`` +
+   ``RETRIEVE`` round-trip returns byte-identical KV -- data that can only
+   have come from the warm-prefetched L1 entries.
+"""
+
+# Standard
+from typing import Generator
+import multiprocessing as mp
+import os
+import tempfile
+import time
+
+# Third Party
+import httpx
+import pytest
+import torch
+import zmq
+
+# First Party
+from lmcache.utils import EngineType
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+)
+from lmcache.v1.distributed.l2_adapters.config import L2AdaptersConfig
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import FSL2AdapterConfig
+from lmcache.v1.mp_observability.config import DEFAULT_OBSERVABILITY_CONFIG
+from lmcache.v1.multiprocess.config import (
+    CoordinatorConfig,
+    HTTPFrontendConfig,
+    MPServerConfig,
+)
+from lmcache.v1.multiprocess.custom_types import IPCCacheServerKey, KVCache
+from lmcache.v1.multiprocess.mq import MessageQueueClient
+from lmcache.v1.multiprocess.protocol import RequestType, get_response_class
+from lmcache.v1.platform.cuda.ipc_wrapper import CudaIPCWrapper
+
+SERVER_HOST = "127.0.0.1"
+SERVER_PORT = 5661
+HTTP_PORT = 8661
+SERVER_URL = f"tcp://{SERVER_HOST}:{SERVER_PORT}"
+HTTP_URL = f"http://{SERVER_HOST}:{HTTP_PORT}"
+
+MODEL_NAME = "sglang-test-model"
+WORLD_SIZE = 1
+WORKER_ID = 0
+CHUNK_SIZE = 256
+PAGE_SIZE = 32
+NUM_PAGES = 64
+NUM_LAYERS = 4
+NUM_HEADS = 4
+HEAD_SIZE = 64
+NUM_TOKENS = 2 * CHUNK_SIZE
+NUM_CHUNKS = NUM_TOKENS // CHUNK_SIZE
+NUM_BLOCKS = NUM_TOKENS // PAGE_SIZE
+
+DEFAULT_TIMEOUT = 20.0
+POLL_DEADLINE = 30.0
+
+
+def _cuda_ipc_available() -> bool:
+    """Report whether CUDA tensor IPC sharing works on this host."""
+    if not torch.cuda.is_available():
+        return False
+    try:
+        buf = torch.empty(1024, device="cuda")
+        return buf.untyped_storage()._share_cuda_() is not None
+    except Exception:
+        return False
+
+
+if not _cuda_ipc_available():
+    pytest.skip(
+        "CUDA tensor IPC is not available on this system",
+        allow_module_level=True,
+    )
+
+
+def _server_process_runner(l2_path: str) -> None:
+    """Run the MP server with HTTP frontend and a filesystem L2 adapter.
+
+    Args:
+        l2_path: Directory backing the fs L2 adapter.
+    """
+    # First Party
+    from lmcache.v1.multiprocess.http_server import run_http_server
+
+    run_http_server(
+        http_config=HTTPFrontendConfig(http_host=SERVER_HOST, http_port=HTTP_PORT),
+        mp_config=MPServerConfig(
+            host=SERVER_HOST, port=SERVER_PORT, chunk_size=CHUNK_SIZE
+        ),
+        storage_manager_config=StorageManagerConfig(
+            l1_manager_config=L1ManagerConfig(
+                memory_config=L1MemoryManagerConfig(
+                    size_in_bytes=1 << 30,
+                    use_lazy=True,
+                ),
+            ),
+            eviction_config=EvictionConfig(eviction_policy="LRU"),
+            l2_adapter_config=L2AdaptersConfig(
+                adapters=[FSL2AdapterConfig(base_path=l2_path)]
+            ),
+        ),
+        obs_config=DEFAULT_OBSERVABILITY_CONFIG,
+        coordinator_config=CoordinatorConfig(),
+    )
+
+
+class _SGLangShapedClient:
+    """ZMQ client that mirrors the SGLang MP connector's wire calls.
+
+    Holds per-layer K and V pools shaped ``(num_pages * page_size, num_heads,
+    head_size)`` and issues REGISTER / STORE / LOOKUP / RETRIEVE requests with
+    the exact payloads ``LMCacheMPConnector`` sends.
+    """
+
+    def __init__(self, client: MessageQueueClient, device: torch.device) -> None:
+        torch.random.manual_seed(42)
+        self.client = client
+        self.device = device
+        self.instance_id = os.getpid()
+        pool_shape = (NUM_PAGES * PAGE_SIZE, NUM_HEADS, HEAD_SIZE)
+        self.k_pool = [
+            torch.rand(pool_shape, dtype=torch.bfloat16, device=device)
+            for _ in range(NUM_LAYERS)
+        ]
+        self.v_pool = [
+            torch.rand(pool_shape, dtype=torch.bfloat16, device=device)
+            for _ in range(NUM_LAYERS)
+        ]
+
+    def wrapped_pools(self) -> KVCache:
+        """Return the flat ``[K_layers..., V_layers...]`` IPC-wrapped pools."""
+        wrapped: KVCache = []
+        wrapped.extend(CudaIPCWrapper(t) for t in self.k_pool)
+        wrapped.extend(CudaIPCWrapper(t) for t in self.v_pool)
+        return wrapped
+
+    def register(self) -> None:
+        """Register the pools with ``EngineType.SGLANG`` and a page-size hint."""
+        result = self.client.submit_request(
+            RequestType.REGISTER_KV_CACHE,
+            [
+                self.instance_id,
+                self.wrapped_pools(),
+                MODEL_NAME,
+                WORLD_SIZE,
+                EngineType.SGLANG,
+                {"tokens_per_block": PAGE_SIZE},
+                [],
+            ],
+            get_response_class(RequestType.REGISTER_KV_CACHE),
+        ).result(timeout=DEFAULT_TIMEOUT)
+        assert result is None
+
+    def unregister(self) -> None:
+        """Unregister the instance from the server."""
+        self.client.submit_request(
+            RequestType.UNREGISTER_KV_CACHE,
+            [self.instance_id],
+            get_response_class(RequestType.UNREGISTER_KV_CACHE),
+        ).result(timeout=DEFAULT_TIMEOUT)
+
+    def store(self, token_ids: list[int], block_ids: list[int]) -> None:
+        """STORE a chunk-aligned token range from the given pool blocks."""
+        key = IPCCacheServerKey.from_token_ids(
+            MODEL_NAME,
+            WORLD_SIZE,
+            WORKER_ID,
+            token_ids,
+            start=0,
+            end=len(token_ids),
+            request_id="warm-sgl-store",
+        )
+        event = torch.cuda.Event(interprocess=True)
+        event.record(torch.cuda.current_stream())
+        result = (
+            self.client.submit_request(
+                RequestType.STORE,
+                [key, self.instance_id, [block_ids], event.ipc_handle()],
+                get_response_class(RequestType.STORE),
+            )
+            .to_cuda_future(device=self.device)
+            .result(timeout=DEFAULT_TIMEOUT)
+        )
+        assert result is True
+
+    def lookup(self, token_ids: list[int], request_id: str) -> int:
+        """LOOKUP a token range and poll until the matched chunk count is
+        ready."""
+        key = IPCCacheServerKey.from_token_ids(
+            MODEL_NAME,
+            WORLD_SIZE,
+            WORKER_ID,
+            token_ids,
+            start=0,
+            end=len(token_ids),
+            request_id=request_id,
+        ).no_worker_id_version()
+        self.client.submit_request(
+            RequestType.LOOKUP,
+            [key, WORLD_SIZE],
+            get_response_class(RequestType.LOOKUP),
+        ).result(timeout=DEFAULT_TIMEOUT)
+        deadline = time.monotonic() + POLL_DEADLINE
+        while time.monotonic() < deadline:
+            matched = self.client.submit_request(
+                RequestType.QUERY_PREFETCH_STATUS,
+                [request_id],
+                get_response_class(RequestType.QUERY_PREFETCH_STATUS),
+            ).result(timeout=DEFAULT_TIMEOUT)
+            if matched is not None:
+                return matched
+            time.sleep(0.1)
+        raise TimeoutError("LOOKUP result not published in time")
+
+    def retrieve(
+        self, token_ids: list[int], block_ids: list[int], request_id: str
+    ) -> bool:
+        """RETRIEVE a looked-up token range into the given pool blocks."""
+        key = IPCCacheServerKey.from_token_ids(
+            MODEL_NAME,
+            WORLD_SIZE,
+            WORKER_ID,
+            token_ids,
+            start=0,
+            end=len(token_ids),
+            request_id=request_id,
+        )
+        event = torch.cuda.Event(interprocess=True)
+        event.record(torch.cuda.current_stream())
+        return (
+            self.client.submit_request(
+                RequestType.RETRIEVE,
+                [key, self.instance_id, [block_ids], event.ipc_handle(), 0],
+                get_response_class(RequestType.RETRIEVE),
+            )
+            .to_cuda_future(device=self.device)
+            .result(timeout=DEFAULT_TIMEOUT)
+        )
+
+
+@pytest.fixture(scope="module")
+def l2_dir() -> Generator[str, None, None]:
+    """Provide a temp directory backing the fs L2 adapter."""
+    path = tempfile.mkdtemp(prefix="lmcache_sgl_warm_l2_")
+    yield path
+
+
+@pytest.fixture(scope="module")
+def server_process(l2_dir: str) -> Generator[mp.Process, None, None]:
+    """Start the MP server (ZMQ + HTTP) in a spawned subprocess."""
+    mp.set_start_method("spawn", force=True)
+    process = mp.Process(target=_server_process_runner, args=(l2_dir,), daemon=True)
+    process.start()
+
+    deadline = time.monotonic() + 60.0
+    while time.monotonic() < deadline:
+        try:
+            if httpx.get(f"{HTTP_URL}/healthcheck", timeout=2.0).status_code == 200:
+                break
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.5)
+    else:
+        process.terminate()
+        pytest.fail("MP server HTTP frontend did not come up in 60s")
+
+    yield process
+
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=5)
+        if process.is_alive():
+            process.kill()
+            process.join()
+
+
+@pytest.fixture(scope="function")
+def sgl_client(
+    server_process: mp.Process,
+) -> Generator[_SGLangShapedClient, None, None]:
+    """Provide a registered SGLang-shaped client; unregister on teardown."""
+    client = MessageQueueClient(server_url=SERVER_URL, context=zmq.Context.instance())
+    sgl = _SGLangShapedClient(client, torch.device("cuda:0"))
+    sgl.register()
+    yield sgl
+    try:
+        sgl.unregister()
+    finally:
+        client.close()
+        del sgl.k_pool, sgl.v_pool
+        torch.cuda.empty_cache()
+
+
+def _poll_l2_files(l2_dir: str, min_count: int) -> list[str]:
+    """Poll the fs L2 adapter's directory until ``min_count`` data files exist.
+
+    Args:
+        l2_dir: The fs adapter's base directory.
+        min_count: Number of data files to wait for.
+
+    Returns:
+        Paths of the data files found.
+    """
+    deadline = time.monotonic() + POLL_DEADLINE
+    while time.monotonic() < deadline:
+        files = [
+            os.path.join(l2_dir, name)
+            for name in os.listdir(l2_dir)
+            if name.endswith(".data")
+        ]
+        if len(files) >= min_count:
+            return files
+        time.sleep(0.2)
+    raise TimeoutError(f"L2 never reached {min_count} data files")
+
+
+def test_warm_prefetch_restores_sglang_kv(
+    sgl_client: _SGLangShapedClient, l2_dir: str
+) -> None:
+    """Warm prefetch reloads SGLang-stored chunks L2 -> L1 and the data
+    survives a lookup + retrieve round trip after the L2 copies are gone."""
+    token_ids = list(range(NUM_TOKENS))
+    src_blocks = list(range(NUM_BLOCKS))
+    dst_blocks = list(range(NUM_BLOCKS, 2 * NUM_BLOCKS))
+
+    sgl_client.store(token_ids, src_blocks)
+    l2_files = _poll_l2_files(l2_dir, NUM_CHUNKS)
+
+    resp = httpx.post(f"{HTTP_URL}/cache/clear", json={}, timeout=10.0)
+    assert resp.status_code == 200
+
+    resp = httpx.post(
+        f"{HTTP_URL}/cache/prefetches",
+        json={
+            "model_name": MODEL_NAME,
+            "world_size": WORLD_SIZE,
+            "token_ids": token_ids,
+        },
+        timeout=10.0,
+    )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "submitted"
+    assert body["chunks"] == NUM_CHUNKS
+    request_id = body["request_id"]
+
+    deadline = time.monotonic() + POLL_DEADLINE
+    status: dict = {}
+    while time.monotonic() < deadline:
+        status = httpx.get(
+            f"{HTTP_URL}/cache/prefetches/{request_id}", timeout=5.0
+        ).json()
+        if status.get("status") == "completed":
+            break
+        time.sleep(0.2)
+    assert status.get("status") == "completed", status
+    assert status["total_keys"] == NUM_CHUNKS * WORLD_SIZE
+    assert status["found_keys"] == status["total_keys"]
+
+    # Remove the L2 copies so the retrieve below can only be served by the
+    # warm-prefetched L1 entries.
+    for path in l2_files:
+        os.remove(path)
+
+    matched_chunks = sgl_client.lookup(token_ids, request_id="warm-sgl-load")
+    assert matched_chunks == NUM_CHUNKS
+
+    retrieved = sgl_client.retrieve(token_ids, dst_blocks, "warm-sgl-load")
+    assert retrieved is True
+
+    torch.cuda.synchronize()
+    rows = NUM_TOKENS
+    dst_row0 = NUM_BLOCKS * PAGE_SIZE
+    for layer in range(NUM_LAYERS):
+        for pool in (sgl_client.k_pool, sgl_client.v_pool):
+            assert torch.equal(
+                pool[layer][:rows], pool[layer][dst_row0 : dst_row0 + rows]
+            ), f"KV mismatch at layer {layer}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The coordinator's cache-control surface (warm prefetch #3827, key-addressed delete, pin/unpin) resolves token sequences to per-rank keys engine-agnostically, but nothing verified it against an SGLang engine — existing coverage is HTTP-layer fakes or vLLM-shaped registrations.

**1. End-to-end SGLang regression test** (`tests/v1/multiprocess/test_warm_prefetch_sglang.py`): runs the real MP server (ZMQ + HTTP frontend) with a filesystem L2 adapter and registers a KV cache exactly the way the SGLang MP connector does (flat `[K_layers..., V_layers...]` 3-D pools, `EngineType.SGLANG`, `tokens_per_block` hint). It walks: STORE → L2 write-through → `POST /cache/clear` → token-addressed `POST /cache/prefetches` (`found_keys == total_keys`) → `DELETE /cache/objects` addressed by keys from the coordinator-side resolver (the same resolution `POST/DELETE /cache/pins` uses; asserts the files actually disappear) → an SGLang-shaped LOOKUP + RETRIEVE returns byte-identical KV that can only have come from the warmed L1.

**2. FS L2 adapter: implement `delete` + store/delete byte accounting.** `delete()` was a silent no-op and the store path fired no listener events, so on fs-backed L2 the key-addressed delete did nothing, the coordinator's L2 event reporting saw no stores, and quota-driven eviction — and therefore pin/unpin protection — had no effect. `delete()` now unlinks the keys' data files (idempotent) and fires `on_l2_keys_deleted`; the store task fires `on_l2_keys_stored`. The adapter still declares no max capacity, so the daemon-local eviction controller keeps skipping it (`usage_fraction` stays `-1`).

**3. Docs**: coordinator L2-prefetch design doc gains a "Serving engines" section (SGLang caller inputs: `model_name` is the `--model-path` string, `cache_salt` stays `""`); the L2-eviction adapter support matrix row for `FSL2Adapter` is updated.

Verified live with real SGLang (git main, `--enable-lmcache`) + `lmcache server` + `lmcache coordinator`:
- **Prefetch**: after radix flush + L1 clear + L2 wipe, a coordinator prefetch restored 2/2 chunks and the next generation hit 256 cached tokens from L1.
- **Pin/unpin + eviction**: with `--coordinator-l2-event-reporting`, the coordinator tracked SGLang's stores under salt `""`; after pinning sequence A and arming a tiny default quota, the eviction sweep deleted exactly the unpinned sequence's files; unpinning A let the next sweep remove the rest.

**Special notes for your reviewers**:

The e2e test requires CUDA tensor IPC (module-level skip otherwise) and mirrors the wire payloads in `lmcache/integration/sglang/multi_process_adapter.py`; if that connector's REGISTER/STORE shapes change, this test is the tripwire. The FS accounting resets on restart while files persist — the same restart semantics the S3 adapter has.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
