### PR TITLE
[Fix] Fix num_heads misdetection for single-KV-head models

### DIFF
--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -51,7 +51,18 @@ class VLLM_Detector(EngineDetector):
                 raise ValueError(
                     f"blocks-first fused trailing dim {fused_dim} is not 2 * head_size"
                 )
-            split = [t.reshape(*t.shape[:3], 2, fused_dim // 2) for t in kv_caches]
+            # Leave non-rank-4 layers untouched: a hybrid model can mix this
+            # layout with another rank (e.g. a rank-3 key-only indexer), and
+            # the caller re-detects per shape anyway.
+            split = [
+                t.reshape(*t.shape[:3], 2, fused_dim // 2) if t.dim() == 4 else t
+                for t in kv_caches
+            ]
+            # Degenerate head axis, mirror of the rank-5 branch below: the
+            # packed view is head-first, so a lone head sits at shape[1]; read
+            # it as heads regardless of the unreliable hint.
+            if kv_caches[0].shape[1] == 1 and kv_caches[0].shape[2] != 1:
+                return lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS, split
             if is_hnd:
                 return lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS, split
             return lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS, split

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -52,6 +52,11 @@ class VLLM_Detector(EngineDetector):
                     f"blocks-first fused trailing dim {fused_dim} is not 2 * head_size"
                 )
             split = [t.reshape(*t.shape[:3], 2, fused_dim // 2) for t in kv_caches]
+            # Degenerate head axis, mirror of the rank-5 branch below: the
+            # packed view is head-first, so a lone head sits at shape[1]; read
+            # it as heads regardless of the unreliable hint.
+            if kv_caches[0].shape[1] == 1 and kv_caches[0].shape[2] != 1:
+                return lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS, split
             if is_hnd:
                 return lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS, split
             return lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS, split
@@ -68,6 +73,12 @@ class VLLM_Detector(EngineDetector):
                     return lmc_ops.EngineKVFormat.NL_X_TWO_NB_NH_BS_HS, kv_caches
                 return lmc_ops.EngineKVFormat.NL_X_TWO_NB_BS_NH_HS, kv_caches
             if first_tensor.shape[1] == 2:  # num_blocks first
+                # A length-1 head axis makes HND and NHD byte-identical, so the
+                # hint is unreliable. vLLM emits a token-first view, so a lone
+                # head sits at shape[3]; read it as NHD rather than letting the
+                # hint mislabel block-size as heads. Trust the hint otherwise.
+                if first_tensor.shape[3] == 1 and first_tensor.shape[2] != 1:
+                    return lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS, kv_caches
                 if is_hnd:
                     return lmc_ops.EngineKVFormat.NL_X_NB_TWO_NH_BS_HS, kv_caches
                 return lmc_ops.EngineKVFormat.NL_X_NB_TWO_BS_NH_HS, kv_caches

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -52,11 +52,6 @@ class VLLM_Detector(EngineDetector):
                     f"blocks-first fused trailing dim {fused_dim} is not 2 * head_size"
                 )
             split = [t.reshape(*t.shape[:3], 2, fused_dim // 2) for t in kv_caches]
-            # Degenerate head axis, mirror of the rank-5 branch below: the
-            # packed view is head-first, so a lone head sits at shape[1]; read
-            # it as heads regardless of the unreliable hint.
-            if kv_caches[0].shape[1] == 1 and kv_caches[0].shape[2] != 1:
-                return lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS, split
             if is_hnd:
                 return lmc_ops.EngineKVFormat.NL_X_NB_NH_BS_TWO_HS, split
             return lmc_ops.EngineKVFormat.NL_X_NB_BS_NH_TWO_HS, split

--- a/tests/v1/gpu_connector/test_kv_format_detection.py
+++ b/tests/v1/gpu_connector/test_kv_format_detection.py
@@ -56,6 +56,28 @@ def test_vllm_flash_infer_nhd(monkeypatch):
     assert fmt == F.NL_X_NB_TWO_BS_NH_HS
 
 
+def test_vllm_flash_infer_single_head_hnd_resolves_to_nhd(monkeypatch):
+    # A physically-NHD single-KV-head tensor (e.g. FlashInfer forcing an HND
+    # hint) has a degenerate head axis, so the HND permute is a no-op and the
+    # hint cannot be trusted. Shape [NB, 2, BS, 1, HS] must be read as NHD
+    # (num_heads=1), not HND (which would treat BS as the head count and blow
+    # past the CUDA 1024-thread block limit downstream).
+    monkeypatch.setattr(_VLLM_DEV, "cuda")
+    kv = [_t(NB, 2, BS, 1, HS) for _ in range(NL)]
+    fmt, _ = detect_format(kv, EngineType.VLLM, {"kv_layout": "HND"})
+    assert fmt == F.NL_X_NB_TWO_BS_NH_HS
+
+
+def test_vllm_flash_infer_multi_head_hnd_still_honours_hint(monkeypatch):
+    # Guard against over-correction: when neither axis is degenerate
+    # (num_heads > 1), the hint must still decide, so a genuine HND tensor
+    # [NB, 2, NH, BS, HS] is classified as HND.
+    monkeypatch.setattr(_VLLM_DEV, "cuda")
+    kv = [_t(NB, 2, NH, BS, HS) for _ in range(NL)]
+    fmt, _ = detect_format(kv, EngineType.VLLM, {"kv_layout": "HND"})
+    assert fmt == F.NL_X_NB_TWO_NH_BS_HS
+
+
 def test_vllm_mla():
     kv = [_t(NB, BS, HS) for _ in range(NL)]
     fmt, _ = detect_format(kv, EngineType.VLLM, {"kv_layout": "NHD"})
@@ -85,6 +107,19 @@ def test_vllm_blocks_first_fused_nhd_vs_hnd(monkeypatch):
     raw_hnd = [_t(NB, NH, BS, 2 * HS) for _ in range(NL)]
     fmt_hnd, _ = detect_format(raw_hnd, EngineType.VLLM, {"kv_layout": "HND"})
     assert fmt_hnd == F.NL_X_NB_NH_BS_TWO_HS
+
+
+def test_vllm_blocks_first_fused_single_head_hint_ignored(monkeypatch):
+    # Packed (rank-4) contract with a single KV head. vLLM's packed view is
+    # head-first, so the head axis is shape[1] == 1, making the layout
+    # byte-identical under NHD and HND. Regardless of the hint, detection must
+    # read num_heads from the length-1 axis (the NH-before-BS format).
+    monkeypatch.setattr(_VLLM_DEV, "cuda")
+    raw = [_t(NB, 1, BS, 2 * HS) for _ in range(NL)]
+    fmt_hnd, _ = detect_format(raw, EngineType.VLLM, {"kv_layout": "HND"})
+    assert fmt_hnd == F.NL_X_NB_NH_BS_TWO_HS
+    fmt_nhd, _ = detect_format(raw, EngineType.VLLM, {"kv_layout": "NHD"})
+    assert fmt_nhd == F.NL_X_NB_NH_BS_TWO_HS
 
 
 def test_sglang_mla_depth1():

--- a/tests/v1/gpu_connector/test_kv_format_detection.py
+++ b/tests/v1/gpu_connector/test_kv_format_detection.py
@@ -109,19 +109,6 @@ def test_vllm_blocks_first_fused_nhd_vs_hnd(monkeypatch):
     assert fmt_hnd == F.NL_X_NB_NH_BS_TWO_HS
 
 
-def test_vllm_blocks_first_fused_single_head_hint_ignored(monkeypatch):
-    # Packed (rank-4) contract with a single KV head. vLLM's packed view is
-    # head-first, so the head axis is shape[1] == 1, making the layout
-    # byte-identical under NHD and HND. Regardless of the hint, detection must
-    # read num_heads from the length-1 axis (the NH-before-BS format).
-    monkeypatch.setattr(_VLLM_DEV, "cuda")
-    raw = [_t(NB, 1, BS, 2 * HS) for _ in range(NL)]
-    fmt_hnd, _ = detect_format(raw, EngineType.VLLM, {"kv_layout": "HND"})
-    assert fmt_hnd == F.NL_X_NB_NH_BS_TWO_HS
-    fmt_nhd, _ = detect_format(raw, EngineType.VLLM, {"kv_layout": "NHD"})
-    assert fmt_nhd == F.NL_X_NB_NH_BS_TWO_HS
-
-
 def test_sglang_mla_depth1():
     kv = [_t(NB * BS, 1, HS) for _ in range(NL)]
     fmt, _ = detect_format(kv, EngineType.SGLANG, {})

--- a/tests/v1/gpu_connector/test_kv_format_detection.py
+++ b/tests/v1/gpu_connector/test_kv_format_detection.py
@@ -109,6 +109,19 @@ def test_vllm_blocks_first_fused_nhd_vs_hnd(monkeypatch):
     assert fmt_hnd == F.NL_X_NB_NH_BS_TWO_HS
 
 
+def test_vllm_blocks_first_fused_single_head_hint_ignored(monkeypatch):
+    # Packed (rank-4) contract with a single KV head. vLLM's packed view is
+    # head-first, so the head axis is shape[1] == 1, making the layout
+    # byte-identical under NHD and HND. Regardless of the hint, detection must
+    # read num_heads from the length-1 axis (the NH-before-BS format).
+    monkeypatch.setattr(_VLLM_DEV, "cuda")
+    raw = [_t(NB, 1, BS, 2 * HS) for _ in range(NL)]
+    fmt_hnd, _ = detect_format(raw, EngineType.VLLM, {"kv_layout": "HND"})
+    assert fmt_hnd == F.NL_X_NB_NH_BS_TWO_HS
+    fmt_nhd, _ = detect_format(raw, EngineType.VLLM, {"kv_layout": "NHD"})
+    assert fmt_nhd == F.NL_X_NB_NH_BS_TWO_HS
+
+
 def test_sglang_mla_depth1():
     kv = [_t(NB * BS, 1, HS) for _ in range(NL)]
     fmt, _ = detect_format(kv, EngineType.SGLANG, {})


### PR DESCRIPTION
**What this PR does / why we need it**:

For issue https://github.com/LMCache/LMCache/issues/4154

Detect the degenerate (length-1) head axis directly instead of trusting the layout hint 

**Special notes for your reviewers**:

I'll run cross-validation on H-series and B series GPUs later today to ensure

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
