### PR TITLE
[ci] resolve GH_TOKEN for blend plugin clone from Buildkite secret

### DIFF
--- a/.buildkite/k3_tests/blend/buildkite-pipeline.yml
+++ b/.buildkite/k3_tests/blend/buildkite-pipeline.yml
@@ -1,18 +1,15 @@
 # Paste this into the Buildkite pipeline's "Steps" editor.
 # It uploads the real pipeline definition from the repo.
 #
-# Fill in HF_TOKEN (gated model access), GH_TOKEN (read access to the private
-# plugin repo), and CB_PLUGIN_REPO (owner/name of the plugin repo). CB_PLUGIN_REF
-# selects which plugin commit to test the PR against; CB_PLUGIN_DIR is the clone
-# destination in the pod.
+# Public repo — no secrets here. Configure in the Buildkite UI:
+#   HF_TOKEN        — env var (gated model access)
+#   GH_TOKEN        — secret BLEND_TM_PAT (clone auth), resolved by run.sh
+#   CB_PLUGIN_REPO  — secret CB_PLUGIN_REPO (private owner/name), resolved by run.sh
 agents:
   queue: "k8s"
 
 env:
-  HF_TOKEN: ""                   # HuggingFace token — gated model access (e.g. Llama)
-  GH_TOKEN: ""                   # GitHub token — read access to the private plugin repo
-  CB_PLUGIN_REPO: ""             # owner/name of the plugin repo (required; set here or in the UI)
-  CB_PLUGIN_REF: "main"          # plugin git ref to test the PR against
+  CB_PLUGIN_REF: "main"            # plugin git ref to test the PR against
   CB_PLUGIN_DIR: "/tmp/cb-plugin"  # clone destination in the pod
 
 steps:

--- a/.buildkite/k3_tests/blend/run.sh
+++ b/.buildkite/k3_tests/blend/run.sh
@@ -7,6 +7,21 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 cd "${REPO_ROOT}"
 
+# ── Private plugin coordinates (kept out of this public repo) ──
+# GH_TOKEN (clone auth) and CB_PLUGIN_REPO (private owner/name): use an exported
+# env var if set, else the Buildkite secret. Missing values surface the error in
+# setup-blend-env.sh.
+if command -v buildkite-agent >/dev/null 2>&1; then
+    if [ -z "${GH_TOKEN:-}" ]; then
+        GH_TOKEN="$(buildkite-agent secret get BLEND_TM_PAT 2>/dev/null || true)"
+        export GH_TOKEN
+    fi
+    if [ -z "${CB_PLUGIN_REPO:-}" ]; then
+        CB_PLUGIN_REPO="$(buildkite-agent secret get CB_PLUGIN_REPO 2>/dev/null || true)"
+        export CB_PLUGIN_REPO
+    fi
+fi
+
 # ── Environment setup ────────────────────────────────────────
 source .buildkite/k3_harness/setup-blend-env.sh
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The CacheBlend plugin compat CI job failed with `GH_TOKEN/GITHUB_TOKEN not set`, so it couldn't clone the private `Tensormesh-Core/cacheblend-plugin` repo. This PR resolves the token from the Buildkite secret `BLEND_TM_PAT` (honouring an existing `GH_TOKEN` if set) and fixes the bootstrap pipeline to set `CB_PLUGIN_REPO` under `env:` without hardcoding tokens.

**Special notes for your reviewers**:
- Token resolution runs in `run.sh` via `buildkite-agent secret get BLEND_TM_PAT` inside the k8s-plugin pod, avoiding reliance on secret propagation across the dynamic pipeline upload.
- Tolerant of a missing secret — `setup-blend-env.sh` still emits the actionable error.
- Requires (Buildkite UI, not code): `BLEND_TM_PAT` in the same cluster as the `k8s` queue, scoped to Contents: Read on the plugin repo, and `HF_TOKEN` set as a UI env var.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests