### PR TITLE
[Perf][FS] Batch filesystem L2 I/O operations

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -608,6 +608,67 @@ class FSL2Adapter(L2AdapterInterface):
 
     # ---- store ----------------------------------------------------------
 
+    async def _store_one(
+        self,
+        key: ObjectKey,
+        obj: MemoryObj,
+    ) -> tuple[bool, int]:
+        """Store a single key's bytes atomically.
+
+        Writes to a per-key temp path, then ``rename``s onto the final
+        path. Returns ``(success, bytes_written)`` where
+        ``bytes_written == 0`` on either a skipped (already-present) or
+        failed write; ``success`` is False only on I/O errors — a
+        skipped key is not a failure.
+        """
+        file_path, tmp_path = self._key_to_file_and_tmp_path(key)
+
+        if await aiofiles.os.path.exists(file_path):
+            return True, 0
+
+        buf = obj.byte_array
+        size = len(buf)
+
+        try:
+            do_odirect = self._use_odirect
+            if do_odirect:
+                aligned = self._os_disk_bs > 0 and size % self._os_disk_bs == 0
+                if not aligned:
+                    logger.warning(
+                        "Cannot use O_DIRECT for writing size %d, "
+                        "not aligned to block size %d.",
+                        size,
+                        self._os_disk_bs,
+                    )
+                    do_odirect = False
+
+            if do_odirect:
+                await self._loop.run_in_executor(
+                    None,
+                    self._write_with_odirect,
+                    tmp_path,
+                    buf,
+                )
+            else:
+                async with aiofiles.open(tmp_path, "wb") as f:
+                    await f.write(buf)
+
+            await aiofiles.os.replace(tmp_path, file_path)
+            logger.debug(
+                "FSL2Adapter stored key %s (%d bytes)",
+                file_path.name,
+                size,
+            )
+            return True, size
+        except Exception:
+            logger.exception("FSL2Adapter failed to store %s", file_path)
+            if await aiofiles.os.path.exists(tmp_path):
+                try:
+                    await aiofiles.os.unlink(tmp_path)
+                except OSError:
+                    pass
+            return False, 0
+
     async def _execute_store(
         self,
         keys: list[ObjectKey],
@@ -618,66 +679,62 @@ class FSL2Adapter(L2AdapterInterface):
         bytes_written = 0
         stored_keys: list[ObjectKey] = []
         stored_sizes: list[int] = []
+
         try:
-            for key, obj in zip(keys, objects, strict=True):
-                file_path, tmp_path = self._key_to_file_and_tmp_path(key)
-
-                # Skip if already stored on disk
-                if await aiofiles.os.path.exists(file_path):
-                    continue
-                buf = obj.byte_array
-                size = len(buf)
-
-                try:
-                    # Decide whether O_DIRECT is usable
-                    do_odirect = self._use_odirect
-                    if do_odirect:
-                        aligned = self._os_disk_bs > 0 and size % self._os_disk_bs == 0
-                        if not aligned:
-                            logger.warning(
-                                "Cannot use O_DIRECT for "
-                                "writing size %d, not "
-                                "aligned to block size "
-                                "%d.",
-                                size,
-                                self._os_disk_bs,
-                            )
-                            do_odirect = False
-
-                    if do_odirect:
-                        await self._loop.run_in_executor(
-                            None,
-                            self._write_with_odirect,
-                            tmp_path,
-                            buf,
-                        )
-                    else:
-                        async with aiofiles.open(tmp_path, "wb") as f:
-                            await f.write(buf)
-
-                    await aiofiles.os.replace(tmp_path, file_path)
-                    bytes_written += size
-                    stored_keys.append(key)
-                    stored_sizes.append(size)
-                    logger.debug(
-                        "FSL2Adapter stored key %s (%d bytes)",
-                        file_path.name,
-                        size,
-                    )
-                except Exception:
-                    logger.exception(
-                        "FSL2Adapter failed to store %s",
-                        file_path,
-                    )
-                    if await aiofiles.os.path.exists(tmp_path):
-                        await aiofiles.os.unlink(tmp_path)
-                    success = False
-        except Exception:
+            grouped = _group_objects_by_key(keys, objects)
+        except ValueError:
             logger.exception(
-                "FSL2Adapter store task %s failed",
+                "FSL2Adapter store task %s has mismatched key/object counts",
                 task_id,
             )
+            grouped = {}
             success = False
+
+        # Fan out one write per unique key. Keeping the first object for
+        # duplicates preserves the previous serial behavior, where the first
+        # occurrence created the final file and later occurrences skipped it.
+        unique_pairs = [
+            (key, occurrences[0][1]) for key, occurrences in grouped.items()
+        ]
+        if len(unique_pairs) == 1:
+            key, obj = unique_pairs[0]
+            try:
+                ok, nbytes = await self._store_one(key, obj)
+            except Exception:
+                logger.exception(
+                    "FSL2Adapter store coroutine for key %s raised",
+                    self._key_to_path(key).name,
+                )
+                ok, nbytes = False, 0
+            if not ok:
+                success = False
+            bytes_written += nbytes
+            if nbytes:
+                stored_keys.append(key)
+                stored_sizes.append(nbytes)
+        elif unique_pairs:
+            results = await asyncio.gather(
+                *(self._store_one(key, obj) for key, obj in unique_pairs),
+                return_exceptions=True,
+            )
+            for i, result in enumerate(results):
+                if isinstance(result, Exception):
+                    logger.error(
+                        "FSL2Adapter store coroutine for key %s raised: %r",
+                        self._key_to_path(unique_pairs[i][0]).name,
+                        result,
+                    )
+                    success = False
+                    continue
+                if isinstance(result, BaseException):
+                    raise result
+                ok, nbytes = result
+                if not ok:
+                    success = False
+                bytes_written += nbytes
+                if nbytes:
+                    stored_keys.append(unique_pairs[i][0])
+                    stored_sizes.append(nbytes)
 
         if stored_keys:
             self._notify_keys_stored(stored_keys, stored_sizes)

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -96,6 +96,17 @@ async def _async_readinto_full(
     return total
 
 
+def _group_objects_by_key(
+    keys: list[ObjectKey],
+    objects: list[MemoryObj],
+) -> dict[ObjectKey, list[tuple[int, MemoryObj]]]:
+    """Group key-object pairs while preserving input and occurrence order."""
+    grouped: dict[ObjectKey, list[tuple[int, MemoryObj]]] = {}
+    for index, (key, obj) in enumerate(zip(keys, objects, strict=True)):
+        grouped.setdefault(key, []).append((index, obj))
+    return grouped
+
+
 def _object_key_to_filename(key: ObjectKey) -> str:
     """Build a reversible, filesystem-safe filename.
 
@@ -717,6 +728,78 @@ class FSL2Adapter(L2AdapterInterface):
 
     # ---- load -----------------------------------------------------------
 
+    async def _load_one(
+        self,
+        key: ObjectKey,
+        mem_obj: MemoryObj,
+    ) -> bool:
+        """Load a single key's file into ``mem_obj``'s byte buffer.
+
+        Returns True on a complete read matching the buffer size, False
+        on a missing file, short read, or any I/O error. Errors are
+        logged; the caller uses the boolean to set the result bitmap.
+        """
+        file_path = self._key_to_path(key)
+        try:
+            dst_buf = mem_obj.byte_array
+            expected = len(dst_buf)
+
+            if self._use_odirect:
+                num_read = await self._loop.run_in_executor(
+                    None,
+                    self._read_with_odirect,
+                    file_path,
+                    dst_buf,
+                )
+                if num_read != expected:
+                    logger.warning(
+                        "Incomplete O_DIRECT read for %s: expected %d, got %d",
+                        file_path.name,
+                        expected,
+                        num_read or 0,
+                    )
+                    return False
+                logger.debug(
+                    "FSL2Adapter loaded key %s (%d bytes, O_DIRECT)",
+                    file_path.name,
+                    num_read,
+                )
+                return True
+
+            async with aiofiles.open(file_path, "rb") as f:
+                if self._read_ahead_size is None:
+                    num_read = await _async_readinto_full(f, dst_buf)
+                else:
+                    if not isinstance(dst_buf, memoryview):
+                        dst_buf = memoryview(dst_buf)
+                    ra = self._read_ahead_size
+                    n_head = await _async_readinto_full(f, dst_buf[:ra])
+                    if n_head == ra:
+                        n_tail = await _async_readinto_full(f, dst_buf[ra:])
+                        num_read = n_head + n_tail
+                    else:
+                        num_read = n_head
+
+                if num_read != expected:
+                    logger.warning(
+                        "Incomplete read for %s: expected %d, got %d",
+                        file_path.name,
+                        expected,
+                        num_read,
+                    )
+                    return False
+                logger.debug(
+                    "FSL2Adapter loaded key %s (%d bytes)",
+                    file_path.name,
+                    num_read,
+                )
+                return True
+        except FileNotFoundError:
+            return False
+        except Exception:
+            logger.exception("FSL2Adapter failed to load %s", file_path)
+            return False
+
     async def _execute_load(
         self,
         keys: list[ObjectKey],
@@ -724,79 +807,80 @@ class FSL2Adapter(L2AdapterInterface):
         task_id: L2TaskId,
     ) -> None:
         bitmap = Bitmap(len(keys))
-        for i, key in enumerate(keys):
-            file_path = self._key_to_path(key)
+
+        try:
+            grouped = _group_objects_by_key(keys, objects)
+        except ValueError:
+            logger.exception(
+                "FSL2Adapter load task %s has mismatched key/object counts",
+                task_id,
+            )
+            grouped = {}
+
+        # Read each unique key into its first destination, then copy those
+        # bytes to the remaining destinations for that key. The bitmap remains
+        # positional, so every successfully populated occurrence gets a bit.
+        unique_loads = list(grouped.items())
+        if len(unique_loads) == 1:
+            key, occurrences = unique_loads[0]
             try:
-                dst_buf = objects[i].byte_array
-                expected = len(dst_buf)
-                num_read: Optional[int] = None
+                results: list[bool | BaseException] = [
+                    await self._load_one(key, occurrences[0][1])
+                ]
+            except Exception as exc:
+                results = [exc]
+        elif unique_loads:
+            results = await asyncio.gather(
+                *(
+                    self._load_one(key, occurrences[0][1])
+                    for key, occurrences in unique_loads
+                ),
+                return_exceptions=True,
+            )
+        else:
+            results = []
 
-                # O_DIRECT path (sync, via executor)
-                if self._use_odirect:
-                    num_read = await self._loop.run_in_executor(
-                        None,
-                        self._read_with_odirect,
-                        file_path,
-                        dst_buf,
-                    )
-                    if num_read != expected:
-                        logger.warning(
-                            "Incomplete O_DIRECT read for %s: expected %d, got %d",
-                            file_path.name,
-                            expected,
-                            num_read or 0,
-                        )
-                    else:
-                        bitmap.set(i)
-                        logger.debug(
-                            "FSL2Adapter loaded key %s (%d bytes, O_DIRECT)",
-                            file_path.name,
-                            num_read,
-                        )
-                    continue
-
-                # Standard async path with optional
-                # read-ahead
-                expected = len(dst_buf)
-                async with aiofiles.open(file_path, "rb") as f:
-                    if self._read_ahead_size is None:
-                        num_read = await _async_readinto_full(f, dst_buf)
-                    else:
-                        if not isinstance(dst_buf, memoryview):
-                            dst_buf = memoryview(dst_buf)
-                        # Trigger readahead with a
-                        # small initial read
-                        ra = self._read_ahead_size
-                        n_head = await _async_readinto_full(f, dst_buf[:ra])
-                        if n_head == ra:
-                            n_tail = await _async_readinto_full(f, dst_buf[ra:])
-                            num_read = n_head + n_tail
-                        else:
-                            num_read = n_head
-
-                    if num_read != expected:
-                        logger.warning(
-                            "Incomplete read for %s: expected %d, got %d",
-                            file_path.name,
-                            expected,
-                            num_read,
-                        )
-                        continue
-
-                    bitmap.set(i)
-                    logger.debug(
-                        "FSL2Adapter loaded key %s (%d bytes)",
-                        file_path.name,
-                        num_read,
-                    )
-            except FileNotFoundError:
-                continue
-            except Exception:
-                logger.exception(
-                    "FSL2Adapter failed to load %s",
-                    file_path,
+        for group_index, result in enumerate(results):
+            key, occurrences = unique_loads[group_index]
+            if isinstance(result, Exception):
+                logger.error(
+                    "FSL2Adapter load coroutine for %s raised: %r",
+                    self._key_to_path(key).name,
+                    result,
                 )
                 continue
+            if isinstance(result, BaseException):
+                raise result
+            if not result:
+                continue
+
+            source_obj = occurrences[0][1]
+            source_buf = memoryview(source_obj.byte_array).cast("B")
+            for input_index, destination_obj in occurrences:
+                if destination_obj is not source_obj:
+                    try:
+                        destination_buf = memoryview(destination_obj.byte_array).cast(
+                            "B"
+                        )
+                        if len(destination_buf) != len(source_buf):
+                            logger.warning(
+                                "Cannot fan out load for %s at index %d: "
+                                "source size %d != destination size %d",
+                                self._key_to_path(key).name,
+                                input_index,
+                                len(source_buf),
+                                len(destination_buf),
+                            )
+                            continue
+                        destination_buf[:] = source_buf
+                    except Exception:
+                        logger.exception(
+                            "FSL2Adapter failed to fan out load for %s at index %d",
+                            self._key_to_path(key).name,
+                            input_index,
+                        )
+                        continue
+                bitmap.set(input_index)
 
         loaded_keys = [keys[i] for i in bitmap.get_indices_list()]
         if loaded_keys:

--- a/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_l2_adapter.py
@@ -682,11 +682,34 @@ class FSL2Adapter(L2AdapterInterface):
         keys: list[ObjectKey],
         task_id: L2TaskId,
     ) -> None:
+        # Check keys concurrently; avoid gather overhead for a single key.
         bitmap = Bitmap(len(keys))
-        for i, key in enumerate(keys):
-            if not await self._key_exists_on_disk(key):
-                continue
-            bitmap.set(i)
+        if len(keys) == 1:
+            try:
+                if await self._key_exists_on_disk(keys[0]):
+                    bitmap.set(0)
+            except Exception:
+                logger.exception(
+                    "FSL2Adapter lookup coroutine for %s raised",
+                    self._key_to_path(keys[0]).name,
+                )
+        elif keys:
+            results = await asyncio.gather(
+                *(self._key_exists_on_disk(k) for k in keys),
+                return_exceptions=True,
+            )
+            for i, result in enumerate(results):
+                if isinstance(result, Exception):
+                    logger.error(
+                        "FSL2Adapter lookup coroutine for %s raised: %r",
+                        self._key_to_path(keys[i]).name,
+                        result,
+                    )
+                    continue
+                if isinstance(result, BaseException):
+                    raise result
+                if result:
+                    bitmap.set(i)
 
         with self._lock:
             self._completed_lookup_tasks[task_id] = bitmap

--- a/tests/v1/distributed/test_fs_l2_adapter_batched_io.py
+++ b/tests/v1/distributed/test_fs_l2_adapter_batched_io.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for batched filesystem L2 store, lookup, and load operations."""
+
+# Standard
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+import asyncio
+import threading
+import time
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.native_storage_ops import Bitmap
+from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+from lmcache.v1.distributed.internal_api import L2StoreResult
+from lmcache.v1.distributed.l2_adapters import fs_l2_adapter as fs_module
+from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
+    FSL2Adapter,
+    FSL2AdapterConfig,
+)
+from lmcache.v1.memory_management import MemoryObj
+
+_EMPTY_LAYOUT = MemoryLayoutDesc(shapes=[], dtypes=[])
+_TIMEOUT = 5.0
+
+
+class _MemoryObj:
+    def __init__(self, size: int) -> None:
+        self.byte_array = bytearray(size)
+
+
+class _AsyncGate:
+    """Hold async calls until all expected calls have started."""
+
+    def __init__(self, expected: int) -> None:
+        self._expected = expected
+        self._count = 0
+        self._lock = threading.Lock()
+        self.all_started = threading.Event()
+        self.release = threading.Event()
+
+    async def wait(self) -> None:
+        with self._lock:
+            self._count += 1
+            if self._count == self._expected:
+                self.all_started.set()
+        while not self.release.is_set():
+            await asyncio.sleep(0.001)
+
+
+def _key(index: int) -> ObjectKey:
+    return ObjectKey(
+        chunk_hash=index.to_bytes(32, "big"),
+        model_name="test-model",
+        kv_rank=0,
+        object_group_id=0,
+    )
+
+
+def _objects(payloads: list[bytes]) -> list[_MemoryObj]:
+    objects = [_MemoryObj(len(payload)) for payload in payloads]
+    for obj, payload in zip(objects, payloads, strict=True):
+        obj.byte_array[:] = payload
+    return objects
+
+
+def _as_memory_objects(objects: list[_MemoryObj]) -> list[MemoryObj]:
+    return cast(list[MemoryObj], objects)
+
+
+def _wait_store(
+    adapter: FSL2Adapter,
+    task_id: int,
+    timeout: float = _TIMEOUT,
+) -> L2StoreResult:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = adapter.pop_completed_store_tasks().get(task_id)
+        if result is not None:
+            return result
+        time.sleep(0.001)
+    raise TimeoutError(f"store task {task_id} did not complete")
+
+
+def _wait_bitmap(
+    query: Callable[[int], Bitmap | None],
+    task_id: int,
+    timeout: float = _TIMEOUT,
+) -> Bitmap:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = query(task_id)
+        if result is not None:
+            return result
+        time.sleep(0.001)
+    raise TimeoutError(f"task {task_id} did not complete")
+
+
+def _store(
+    adapter: FSL2Adapter,
+    keys: list[ObjectKey],
+    payloads: list[bytes],
+) -> L2StoreResult:
+    objects = _objects(payloads)
+    task_id = adapter.submit_store_task(keys, _as_memory_objects(objects))
+    return _wait_store(adapter, task_id)
+
+
+def _lookup(adapter: FSL2Adapter, keys: list[ObjectKey]) -> Bitmap:
+    task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
+    return _wait_bitmap(adapter.query_lookup_and_lock_result, task_id)
+
+
+def _load(
+    adapter: FSL2Adapter,
+    keys: list[ObjectKey],
+    sizes: list[int],
+) -> tuple[list[_MemoryObj], Bitmap]:
+    objects = [_MemoryObj(size) for size in sizes]
+    task_id = adapter.submit_load_task(keys, _as_memory_objects(objects))
+    bitmap = _wait_bitmap(adapter.query_load_result, task_id)
+    return objects, bitmap
+
+
+def _bits(bitmap: Bitmap, size: int) -> list[bool]:
+    return [bool(bitmap.test(index)) for index in range(size)]
+
+
+@pytest.fixture
+def adapter(tmp_path: Path) -> Iterator[FSL2Adapter]:
+    instance = FSL2Adapter(
+        FSL2AdapterConfig(
+            base_path=str(tmp_path),
+            relative_tmp_dir=None,
+            read_ahead_size=None,
+            use_odirect=False,
+        )
+    )
+    try:
+        yield instance
+    finally:
+        instance.close()
+
+
+class TestBatchedIO:
+    def test_single_key_round_trip(self, adapter: FSL2Adapter) -> None:
+        key = _key(1)
+        payload = b"single-key-payload"
+
+        store_result = _store(adapter, [key], [payload])
+        assert store_result.is_successful()
+        assert store_result.bytes_transferred() == len(payload)
+        assert _bits(_lookup(adapter, [key]), 1) == [True]
+
+        loaded, bitmap = _load(adapter, [key], [len(payload)])
+        assert _bits(bitmap, 1) == [True]
+        assert bytes(loaded[0].byte_array) == payload
+
+    def test_round_trip_preserves_order(self, adapter: FSL2Adapter) -> None:
+        keys = [_key(index) for index in range(4)]
+        payloads = [
+            b"first",
+            b"second-payload",
+            bytes(range(32)),
+            b"last" * 17,
+        ]
+
+        store_result = _store(adapter, keys, payloads)
+        assert store_result.is_successful()
+        assert store_result.bytes_transferred() == sum(map(len, payloads))
+        assert _bits(_lookup(adapter, keys), len(keys)) == [True] * len(keys)
+
+        loaded, bitmap = _load(adapter, keys, [len(payload) for payload in payloads])
+        assert _bits(bitmap, len(keys)) == [True] * len(keys)
+        assert [bytes(obj.byte_array) for obj in loaded] == payloads
+
+    def test_store_starts_unique_keys_concurrently(self, adapter: FSL2Adapter) -> None:
+        keys = [_key(1), _key(2)]
+        payloads = [b"a" * 64, b"b" * 64]
+        objects = _objects(payloads)
+        gate = _AsyncGate(expected=len(keys))
+        original_replace = fs_module.aiofiles.os.replace
+
+        async def gated_replace(source: Any, destination: Any) -> None:
+            await gate.wait()
+            await original_replace(source, destination)
+
+        with patch.object(fs_module.aiofiles.os, "replace", new=gated_replace):
+            task_id = adapter.submit_store_task(keys, _as_memory_objects(objects))
+            try:
+                assert gate.all_started.wait(timeout=_TIMEOUT)
+            finally:
+                gate.release.set()
+            result = _wait_store(adapter, task_id)
+
+        assert result.is_successful()
+        assert result.bytes_transferred() == sum(map(len, payloads))
+
+    def test_lookup_starts_keys_concurrently(self, adapter: FSL2Adapter) -> None:
+        keys = [_key(1), _key(2)]
+        assert _store(adapter, keys, [b"a", b"b"]).is_successful()
+        gate = _AsyncGate(expected=len(keys))
+        original_exists = fs_module.aiofiles.os.path.exists
+
+        async def gated_exists(path: Any) -> bool:
+            await gate.wait()
+            return await original_exists(path)
+
+        with patch.object(fs_module.aiofiles.os.path, "exists", new=gated_exists):
+            task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
+            try:
+                assert gate.all_started.wait(timeout=_TIMEOUT)
+            finally:
+                gate.release.set()
+            bitmap = _wait_bitmap(adapter.query_lookup_and_lock_result, task_id)
+
+        assert _bits(bitmap, len(keys)) == [True, True]
+
+    def test_load_starts_unique_keys_concurrently(self, adapter: FSL2Adapter) -> None:
+        keys = [_key(1), _key(2)]
+        payloads = [b"a" * 64, b"b" * 64]
+        assert _store(adapter, keys, payloads).is_successful()
+        objects = [_MemoryObj(len(payload)) for payload in payloads]
+        gate = _AsyncGate(expected=len(keys))
+        original_read = fs_module._async_readinto_full
+
+        async def gated_read(file: Any, buffer: Any) -> int:
+            await gate.wait()
+            return await original_read(file, buffer)
+
+        with patch.object(fs_module, "_async_readinto_full", new=gated_read):
+            task_id = adapter.submit_load_task(keys, _as_memory_objects(objects))
+            try:
+                assert gate.all_started.wait(timeout=_TIMEOUT)
+            finally:
+                gate.release.set()
+            bitmap = _wait_bitmap(adapter.query_load_result, task_id)
+
+        assert _bits(bitmap, len(keys)) == [True, True]
+        assert [bytes(obj.byte_array) for obj in objects] == payloads
+
+
+class TestDuplicateKeys:
+    def test_store_writes_first_payload_once(self, adapter: FSL2Adapter) -> None:
+        key = _key(1)
+        first = b"first-payload"
+        second = b"other-payload"
+        replace_calls = 0
+        original_replace = fs_module.aiofiles.os.replace
+
+        async def counting_replace(source: Any, destination: Any) -> None:
+            nonlocal replace_calls
+            replace_calls += 1
+            await original_replace(source, destination)
+
+        with patch.object(fs_module.aiofiles.os, "replace", new=counting_replace):
+            result = _store(adapter, [key, key], [first, second])
+
+        assert result.is_successful()
+        assert result.bytes_transferred() == len(first)
+        assert replace_calls == 1
+        loaded, bitmap = _load(adapter, [key], [len(first)])
+        assert _bits(bitmap, 1) == [True]
+        assert bytes(loaded[0].byte_array) == first
+
+    def test_load_reads_once_and_fans_out(self, adapter: FSL2Adapter) -> None:
+        key = _key(1)
+        payload = bytes(range(64))
+        assert _store(adapter, [key], [payload]).is_successful()
+        read_calls = 0
+        original_read = fs_module._async_readinto_full
+
+        async def counting_read(file: Any, buffer: Any) -> int:
+            nonlocal read_calls
+            read_calls += 1
+            return await original_read(file, buffer)
+
+        with patch.object(fs_module, "_async_readinto_full", new=counting_read):
+            loaded, bitmap = _load(adapter, [key, key, key], [len(payload)] * 3)
+
+        assert read_calls == 1
+        assert _bits(bitmap, 3) == [True, True, True]
+        assert [bytes(obj.byte_array) for obj in loaded] == [payload] * 3
+
+
+class TestFailureIsolation:
+    def test_store_failure_does_not_prevent_other_writes(
+        self, adapter: FSL2Adapter
+    ) -> None:
+        keys = [_key(1), _key(2), _key(3)]
+        payloads = [b"first", b"failed", b"third"]
+        failed_hash = keys[1].chunk_hash.hex()
+        original_replace = fs_module.aiofiles.os.replace
+
+        async def failing_replace(source: Any, destination: Any) -> None:
+            if failed_hash in str(destination):
+                raise OSError("injected replace failure")
+            await original_replace(source, destination)
+
+        with patch.object(fs_module.aiofiles.os, "replace", new=failing_replace):
+            result = _store(adapter, keys, payloads)
+
+        assert not result.is_successful()
+        assert result.bytes_transferred() == 0
+        assert _bits(_lookup(adapter, keys), len(keys)) == [True, False, True]
+        loaded, bitmap = _load(
+            adapter, [keys[0], keys[2]], [len(payloads[0]), len(payloads[2])]
+        )
+        assert _bits(bitmap, 2) == [True, True]
+        assert [bytes(obj.byte_array) for obj in loaded] == [payloads[0], payloads[2]]
+
+    def test_lookup_failure_is_isolated(self, adapter: FSL2Adapter) -> None:
+        present_keys = [_key(1), _key(2), _key(3)]
+        assert _store(adapter, present_keys, [b"a", b"b", b"c"]).is_successful()
+        keys = [present_keys[0], present_keys[1], _key(99), present_keys[2]]
+        failed_hash = present_keys[1].chunk_hash.hex()
+        original_exists = fs_module.aiofiles.os.path.exists
+
+        async def failing_exists(path: Any) -> bool:
+            if failed_hash in str(path):
+                raise OSError("injected lookup failure")
+            return await original_exists(path)
+
+        with patch.object(fs_module.aiofiles.os.path, "exists", new=failing_exists):
+            bitmap = _lookup(adapter, keys)
+
+        assert _bits(bitmap, len(keys)) == [True, False, False, True]
+
+    def test_load_failure_is_isolated(self, adapter: FSL2Adapter) -> None:
+        keys = [_key(1), _key(2), _key(3)]
+        payloads = [b"first", b"failed", b"third"]
+        assert _store(adapter, keys, payloads).is_successful()
+        failed_hash = keys[1].chunk_hash.hex()
+        original_open = fs_module.aiofiles.open
+
+        def failing_open(file: Any, *args: Any, **kwargs: Any) -> Any:
+            if failed_hash in str(file):
+                raise OSError("injected open failure")
+            return original_open(file, *args, **kwargs)
+
+        with patch.object(fs_module.aiofiles, "open", new=failing_open):
+            loaded, bitmap = _load(
+                adapter, keys, [len(payload) for payload in payloads]
+            )
+
+        assert _bits(bitmap, len(keys)) == [True, False, True]
+        assert bytes(loaded[0].byte_array) == payloads[0]
+        assert loaded[1].byte_array == bytearray(len(payloads[1]))
+        assert bytes(loaded[2].byte_array) == payloads[2]


### PR DESCRIPTION
**What this PR does / why we need it**:

The filesystem L2 adapter previously awaited each key’s disk
operation serially. Batched execution should schedule independent
operations concurrently while preserving positional results and
per-key failure isolation.

- Runs filesystem store, lookup, and load operations concurrently
  while retaining direct single-key paths.
- Preserves positional lookup and load bitmaps.
- Isolates ordinary per-key I/O failures while propagating
  cancellation and other base exceptions.
- Adds tests for single-key and batched round trips, concurrent
  execution, duplicate keys, and failure isolation.

**Results (speedup = orig ÷ batched, median latency for the 16-key batch, tested on BM1743)**

***Buffered (default, page cache)***

| payload | store | load | lookup |
|--:|--:|--:|--:|
| 128K | 2.1× | 2.1× | 1.9× |
| 512K | 3.1× | 3.3× | 2.4× |
| 1M | 3.6× | 4.0× | 1.9× |
| 4M | 6.6× | 7.1× | 2.0× |
| 16M | 9.8× | 9.7× | 1.8× |
| 64M | 12.2× | 11.3× | 3.0× |

***O_DIRECT (page cache bypassed, real disk I/O)***

| payload | store | load | lookup |
|--:|--:|--:|--:|
| 128K | 2.3× | 2.4× | 1.9× |
| 1M | 3.9× | 3.7× | 2.6× |
| 16M | 3.9× | 3.8× | 2.2× |
| 64M | 2.6× | 5.2× | 2.8× |

**Duplicate key handling**:

- Store writes the first object for each unique key once.
- Load reads each unique key once and copies the data into all
  matching destinations.
- Each successfully populated load position is represented in the
  positional bitmap.

**Store behavior change**:

When a store batch contains duplicate keys and the first write fails,
the adapter no longer attempts a later duplicate as an implicit retry.
The original serial implementation could process the later duplicate
after the failure. The batched implementation writes each unique key
only once. This tradeoff is reasonable because filesystem write
failures are expected to be uncommon.

**Special notes for your reviewers**:

- The tests exercise the standard async filesystem path with
  O_DIRECT disabled.

Tested by:

```bash
pytest -q \
  tests/v1/distributed/test_fs_l2_adapter_batched_io.py
```

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests