### PR TITLE
[CLI] add __main__ guard to entry point

### DIFF
--- a/lmcache/cli/main.py
+++ b/lmcache/cli/main.py
@@ -42,3 +42,7 @@ def main() -> None:
     except Exception:  # noqa: BLE001
         logger.exception("Command failed")
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**What this PR does / why we need it**:

main.py has a main() but no __main__ guard, so you can't do python -m lmcache.cli.main. In dev setups with multiple venvs the package often isn't pip-installed.

Adding the guard lets devs run python -m lmcache.cli.main or python lmcache/cli/main.py directly.

**Special notes for your reviewers**:

One-line change, no functional impact. 

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests