### PR TITLE
build: add ROCm wheel artifact builder

### DIFF
--- a/docker/Dockerfile.rocm-wheel
+++ b/docker/Dockerfile.rocm-wheel
@@ -1,0 +1,98 @@
+# syntax=docker/dockerfile:1.7
+#
+# Build an LMCache ROCm wheel artifact without installing vLLM.
+#
+# This image is intentionally narrower than docker/Dockerfile.rocm: it validates
+# the HIP extension wheel path and exports the built wheel for downstream
+# installation, CI artifacts, or release-pipeline experiments.
+
+ARG ROCM_VERSION=7.0
+ARG BASE_IMAGE=rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete
+ARG ROCM_PLATFORM=linux/amd64
+
+FROM --platform=${ROCM_PLATFORM} ${BASE_IMAGE} AS builder
+
+ARG MAX_JOBS=2
+ARG PYTORCH_ROCM_ARCH=gfx942,gfx950
+ARG PYTORCH_ROCM_INDEX_URL=https://download.pytorch.org/whl/rocm7.0
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+
+ENV BUILD_WITH_HIP=1 \
+    CXX=hipcc \
+    MAX_JOBS=${MAX_JOBS} \
+    PATH=/opt/venv/bin:${PATH} \
+    PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH} \
+    TORCH_DONT_CHECK_COMPILER_ABI=1
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        ccache \
+        git \
+        python-is-python3 \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/LMCache
+
+COPY requirements/build.txt requirements/build.txt
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m venv /opt/venv \
+    && /opt/venv/bin/python -m pip install --upgrade pip \
+    && /opt/venv/bin/python -m pip install build \
+    && /opt/venv/bin/python -m pip install -r requirements/build.txt \
+    && /opt/venv/bin/python -m pip install torch \
+        --index-url "${PYTORCH_ROCM_INDEX_URL}"
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.cache/ccache,id=lmcache-rocm-wheel-ccache \
+    python - <<'PY'
+import torch
+
+print("torch:", torch.__version__)
+print("torch.version.hip:", torch.version.hip)
+if torch.version.hip is None:
+    raise SystemExit("expected a ROCm PyTorch wheel, got torch.version.hip=None")
+PY
+
+RUN --mount=type=cache,target=/root/.cache/ccache,id=lmcache-rocm-wheel-ccache \
+    rm -rf /wheelhouse \
+    && if [ -n "${SETUPTOOLS_SCM_PRETEND_VERSION:-}" ]; then \
+        export SETUPTOOLS_SCM_PRETEND_VERSION; \
+    fi \
+    && python -m build --wheel --no-isolation --skip-dependency-check \
+        --outdir /wheelhouse
+
+FROM builder AS smoke
+
+RUN python - <<'PY'
+from pathlib import Path
+from zipfile import ZipFile
+
+wheel = next(Path("/wheelhouse").glob("lmcache-*.whl"))
+required_modules = (
+    "lmcache/c_ops",
+    "lmcache/native_storage_ops",
+    "lmcache/lmcache_redis",
+    "lmcache/lmcache_fs",
+)
+with ZipFile(wheel) as archive:
+    names = archive.namelist()
+missing = [
+    module
+    for module in required_modules
+    if not any(name.startswith(module) and name.endswith(".so") for name in names)
+]
+if missing:
+    raise SystemExit(f"missing expected native module(s): {', '.join(missing)}")
+print(f"validated wheel contents: {wheel.name}")
+PY
+
+FROM scratch AS wheel-export
+
+COPY --from=smoke /wheelhouse/ /

--- a/docker/README.md
+++ b/docker/README.md
@@ -199,6 +199,62 @@ docker build \
 
 ---
 
+### 4. `Dockerfile.rocm-wheel` - ROCm Wheel Artifact
+
+**Image**: local build stage only
+
+**Description**: Builds an LMCache ROCm wheel without installing vLLM. This is
+useful for validating the HIP extension packaging path, generating artifacts on
+AMD build hosts, and prototyping ROCm release jobs before publishing wheels.
+
+**Default targets**:
+- ROCm 7.0
+- PyTorch ROCm wheel index: `https://download.pytorch.org/whl/rocm7.0`
+- AMD GPU architectures: `gfx942,gfx950` (MI300X/MI325X and MI350X/MI355X)
+
+**Usage**:
+
+```bash
+docker/build_rocm_wheel.sh
+```
+
+The built wheel is exported to `dist/rocm/`. You can override the build inputs:
+
+```bash
+ROCM_VERSION=7.0 \
+ROCM_PLATFORM=linux/amd64 \
+PYTORCH_ROCM_ARCH="gfx942" \
+MAX_JOBS=4 \
+OUTPUT_DIR=/tmp/lmcache-rocm-wheel \
+docker/build_rocm_wheel.sh
+```
+
+Install and smoke-test the wheel on an AMD GPU host:
+
+```bash
+uv venv --python 3.12
+source .venv/bin/activate
+uv pip install /tmp/lmcache-rocm-wheel/lmcache-*.whl \
+  --index-url https://download.pytorch.org/whl/rocm7.0 \
+  --extra-index-url https://pypi.org/simple
+python - <<'PY'
+import importlib
+import torch
+
+import lmcache
+
+assert torch.version.hip is not None, torch.__version__
+assert torch.cuda.is_available()
+print("LMCache torch device:", lmcache.torch_device_type)
+backend = importlib.import_module("lmcache.c_ops")
+backend_path = str(getattr(backend, "__file__", ""))
+assert backend_path.endswith(".so"), backend_path
+print("LMCache backend:", backend_path)
+PY
+```
+
+---
+
 ## Published Images
 
 Pre-built images are available on Docker Hub:

--- a/docker/build_rocm_wheel.sh
+++ b/docker/build_rocm_wheel.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+ROCM_VERSION="${ROCM_VERSION:-7.0}"
+BASE_IMAGE="${BASE_IMAGE:-rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete}"
+ROCM_PLATFORM="${ROCM_PLATFORM:-linux/amd64}"
+PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx942,gfx950}"
+PYTORCH_ROCM_INDEX_URL="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm${ROCM_VERSION}}"
+MAX_JOBS="${MAX_JOBS:-2}"
+OUTPUT_DIR="${OUTPUT_DIR:-${REPO_ROOT}/dist/rocm}"
+SCM_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION:-}"
+
+if [[ -z "${SCM_VERSION}" && -f "${REPO_ROOT}/.git" ]]; then
+    SCM_VERSION="0.0.0.dev0"
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required to build the ROCm wheel" >&2
+    exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+cat <<EOF
+Building LMCache ROCm wheel
+  base image:              ${BASE_IMAGE}
+  target platform:         ${ROCM_PLATFORM}
+  ROCm version:            ${ROCM_VERSION}
+  PyTorch ROCm index:      ${PYTORCH_ROCM_INDEX_URL}
+  PYTORCH_ROCM_ARCH:       ${PYTORCH_ROCM_ARCH}
+  MAX_JOBS:                ${MAX_JOBS}
+  output directory:        ${OUTPUT_DIR}
+EOF
+
+build_args=(
+    --build-arg "ROCM_VERSION=${ROCM_VERSION}"
+    --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+    --build-arg "ROCM_PLATFORM=${ROCM_PLATFORM}"
+    --build-arg "PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}"
+    --build-arg "PYTORCH_ROCM_INDEX_URL=${PYTORCH_ROCM_INDEX_URL}"
+    --build-arg "MAX_JOBS=${MAX_JOBS}"
+)
+
+if [[ -n "${SCM_VERSION}" ]]; then
+    echo "  setuptools-scm version: ${SCM_VERSION}"
+    build_args+=(--build-arg "SETUPTOOLS_SCM_PRETEND_VERSION=${SCM_VERSION}")
+fi
+
+DOCKER_BUILDKIT=1 docker build \
+    --file "${REPO_ROOT}/docker/Dockerfile.rocm-wheel" \
+    --target wheel-export \
+    --output "type=local,dest=${OUTPUT_DIR}" \
+    "${build_args[@]}" \
+    "${REPO_ROOT}"
+
+echo
+echo "Built ROCm wheel artifact(s):"
+ls -lh "${OUTPUT_DIR}"/lmcache-*.whl

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -159,6 +159,45 @@ Install LMCache
                             BUILD_WITH_HIP=1 \
                             uv pip install -e . --no-build-isolation
 
+                        To build a reusable ROCm wheel artifact instead of an editable
+                        install, use the ROCm wheel builder from the repository root:
+
+                        .. code-block:: bash
+
+                            docker/build_rocm_wheel.sh
+
+                        By default, the builder uses ROCm 7.0 and produces a
+                        ``gfx942,gfx950`` wheel under ``dist/rocm/``. Override
+                        ``PYTORCH_ROCM_ARCH`` to target a narrower or broader set of
+                        AMD GPU architectures:
+
+                        .. code-block:: bash
+
+                            PYTORCH_ROCM_ARCH="gfx942" docker/build_rocm_wheel.sh
+
+                        After installing the built wheel on an AMD GPU host, verify that
+                        PyTorch is using ROCm and LMCache can import its native backend:
+
+                        .. code-block:: bash
+
+                            uv pip install dist/rocm/lmcache-*.whl \
+                                --index-url https://download.pytorch.org/whl/rocm7.0 \
+                                --extra-index-url https://pypi.org/simple
+                            python - <<'PY'
+                            import importlib
+                            import torch
+
+                            import lmcache
+
+                            assert torch.version.hip is not None, torch.__version__
+                            assert torch.cuda.is_available()
+                            print("LMCache torch device:", lmcache.torch_device_type)
+                            backend = importlib.import_module("lmcache.c_ops")
+                            backend_path = str(getattr(backend, "__file__", ""))
+                            assert backend_path.endswith(".so"), backend_path
+                            print("LMCache backend:", backend_path)
+                            PY
+
                     .. tab-item:: Intel XPU
 
                         .. code-block:: bash


### PR DESCRIPTION
## Summary

This adds a small, manual ROCm wheel artifact builder for LMCache:

- add `docker/Dockerfile.rocm-wheel` to build a ROCm/HIP LMCache wheel without installing vLLM
- add `docker/build_rocm_wheel.sh` as the documented wrapper
- document the ROCm wheel artifact path in the installation guide and Docker README

This is intended as a first, reviewable step toward #4029. It does not publish to PyPI, nightly releases, or GitHub Releases.

## Validation

Local checks:

- `git diff --check`
- `bash -n docker/build_rocm_wheel.sh`
- `docker build --check --file docker/Dockerfile.rocm-wheel --target wheel-export .`
- `pre-commit run --files docker/Dockerfile.rocm-wheel docker/build_rocm_wheel.sh docs/source/getting_started/installation.rst docker/README.md`

ROCm/MI300X validation on gfx942:

- built a ROCm wheel with `BASE_IMAGE=vllm/vllm-openai-rocm:v0.17.0`, `PYTORCH_ROCM_ARCH=gfx942`, `MAX_JOBS=4`
- verified the built wheel imports on MI300X with ROCm PyTorch `2.10.0+rocm7.0`
- verified native `lmcache.c_ops`, `native_storage_ops`, `lmcache_redis`, and `lmcache_fs` load from `.so` files
- verified `torch.cuda.is_available() == True`, one visible AMD GPU, and a CUDA-device tensor smoke
- ran an LMCache server smoke from the wheel: native `lmcache.c_ops` loaded, ZMQ started, HTTP started, and `/healthcheck`, `/config`, and `/openapi.json` responded

Follow-up validation using a stacked manual GitHub artifact workflow also produced and uploaded `lmcache-0.1.dev1969-cp312-cp312-linux_x86_64.whl`, then passed the same MI300X install/import/server smoke when installed with matching ROCm Torch.

## Notes

ROCm wheels are ABI-sensitive to the PyTorch build they are compiled against. In validation, installing the artifact into the global environment of `vllm/vllm-openai-rocm:v0.17.0` exposed a Torch ABI mismatch because that image uses a custom `torch==2.9.1+git8907517`; installing with matched ROCm Torch `2.10.0+rocm7.0` loaded native `lmcache.c_ops` successfully. Downstream deployment should use a compatible ROCm PyTorch ABI or build with the target base image/Torch stack.

Closes #4029? No: this is a builder/artifact step toward ROCm wheels, not stable/nightly PyPI publication yet.
