### PR TITLE
[chore]replace deprecated kv_layer_groups/num_groups with kernel_groups/num_kernel_groups internally

### DIFF
--- a/lmcache/v1/gpu_connector/gpu_connectors.py
+++ b/lmcache/v1/gpu_connector/gpu_connectors.py
@@ -494,7 +494,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
         # mismatch surfaces before it turns into a data-corruption bug;
         # the MP path (see ``GPUCacheContext`` / mp server) handles
         # per-group ``bs`` correctly and should be used instead.
-        heterogeneous_bs = {g.shape_desc.bs for g in klg_manager.kv_layer_groups}
+        heterogeneous_bs = {g.shape_desc.bs for g in klg_manager.kernel_groups}
         if len(heterogeneous_bs) > 1:
             logger.warning(
                 "VLLMPagedMemGPUConnectorV3 detected heterogeneous per-group "
@@ -516,7 +516,7 @@ class VLLMPagedMemGPUConnectorV3(GPUConnectorInterface):
             ]
 
         self.group_kv_cache_pointers_on_gpu = []
-        for group in klg_manager.kv_layer_groups:
+        for group in klg_manager.kernel_groups:
             ptrs = get_group_data_ptrs(
                 self.kvcaches, self.engine_kv_format, group.layer_indices
             )

--- a/lmcache/v1/gpu_connector/xpu_connectors.py
+++ b/lmcache/v1/gpu_connector/xpu_connectors.py
@@ -325,7 +325,7 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
     def _initialize_kv_cache_pointers(self):
         if self.init:
             return
-        assert self.metadata.kv_layer_groups_manager.kv_layer_groups
+        assert self.metadata.kv_layer_groups_manager.kernel_groups
         if self.use_gpu:
             # init tmp buffer
             tmp_buf_shapes = self.metadata.get_shapes(self.chunk_size)
@@ -338,7 +338,7 @@ class VLLMPagedMemXPUConnectorV3(GPUConnectorInterface):
                 )
             ]
         self.group_kv_cache_pointers_on_gpu = []
-        for group in self.metadata.kv_layer_groups_manager.kv_layer_groups:
+        for group in self.metadata.kv_layer_groups_manager.kernel_groups:
             # init kv cache pointers
             num_layers = group.num_layers
             kv_cache_pointers = torch.empty(

--- a/lmcache/v1/metadata.py
+++ b/lmcache/v1/metadata.py
@@ -80,8 +80,8 @@ class LMCacheMetadata:
         """Return per-group dtypes, or the legacy single dtype if the
         manager has not been registered yet (e.g. some unit tests)."""
         klg_manager = self.kv_layer_groups_manager
-        if klg_manager is not None and klg_manager.kv_layer_groups:
-            return [group.dtype for group in klg_manager.kv_layer_groups]
+        if klg_manager is not None and klg_manager.kernel_groups:
+            return [group.dtype for group in klg_manager.kernel_groups]
         return [self.kv_dtype]
 
     def get_shapes(self, num_tokens: Optional[int] = None) -> list[torch.Size]:
@@ -89,7 +89,7 @@ class LMCacheMetadata:
         if num_tokens is None:
             num_tokens = self.chunk_size
         klg_manager = self.kv_layer_groups_manager
-        if klg_manager is not None and klg_manager.kv_layer_groups:
+        if klg_manager is not None and klg_manager.kernel_groups:
             # Read kv_size from each group's shape_desc rather than self.use_mla
             # so heterogeneous groups (should any ever co-exist) are handled.
             return [
@@ -101,7 +101,7 @@ class LMCacheMetadata:
                         group.hidden_dim_size,
                     ]
                 )
-                for group in klg_manager.kv_layer_groups
+                for group in klg_manager.kernel_groups
             ]
         return [
             torch.Size(
@@ -116,6 +116,6 @@ class LMCacheMetadata:
 
     def get_num_groups(self) -> int:
         klg_manager = self.kv_layer_groups_manager
-        if klg_manager is not None and klg_manager.kv_layer_groups:
-            return klg_manager.num_groups
+        if klg_manager is not None and klg_manager.kernel_groups:
+            return klg_manager.num_kernel_groups
         return 1

--- a/lmcache/v1/platform/base/cache_context.py
+++ b/lmcache/v1/platform/base/cache_context.py
@@ -163,7 +163,7 @@ class BaseCacheContext(ABC):
         """Returns hidden dimension sizes per KV layer group."""
         return [
             group.hidden_dim_size
-            for group in self.kv_layer_groups_manager.kv_layer_groups
+            for group in self.kv_layer_groups_manager.kernel_groups
         ]
 
     @property
@@ -190,7 +190,7 @@ class BaseCacheContext(ABC):
                 ``parse_kvcache_shape_spec`` should never reach the transfer
                 path; detection-built groups always carry one).
         """
-        groups = self.kv_layer_groups_manager.kv_layer_groups
+        groups = self.kv_layer_groups_manager.kernel_groups
         engine_kv_format = groups[kernel_group_idx].engine_kv_format
         if engine_kv_format is None:
             raise ValueError(
@@ -228,7 +228,7 @@ class BaseCacheContext(ABC):
         self, logical_num_tokens: int, group_idx: int = 0
     ) -> torch.Size:
         """Returns the KV buffer shape for *logical_num_tokens*."""
-        group = self.kv_layer_groups_manager.kv_layer_groups[group_idx]
+        group = self.kv_layer_groups_manager.kernel_groups[group_idx]
         compress_ratio = group.tokens_per_block // group.slots_per_block
         if logical_num_tokens % compress_ratio != 0:
             raise ValueError(
@@ -277,7 +277,7 @@ class BaseCacheContext(ABC):
     @property
     def concrete_engine_kv_shape(self) -> str:
         """Returns the engine KV shape with actual numeric values."""
-        group = self.kv_layer_groups_manager.kv_layer_groups[0]
+        group = self.kv_layer_groups_manager.kernel_groups[0]
         return get_concrete_engine_kv_shape_from_shape_desc(
             group.shape_desc, group.engine_kv_format
         )

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -140,7 +140,7 @@ class CPUCacheContext(BaseCacheContext):
                 ),
                 dtype=torch.long,
             )
-            for idx, group in enumerate(self.kv_layer_groups_manager_.kv_layer_groups)
+            for idx, group in enumerate(self.kv_layer_groups_manager_.kernel_groups)
         ]
 
         self.kv_cache_pointers_ = torch.tensor(
@@ -151,9 +151,7 @@ class CPUCacheContext(BaseCacheContext):
         # GPUCacheContext but on CPU).
         self._max_batch_size = 4
         self.tmp_chunk_group_offsets_: list[int] = [0]
-        for group_idx, group in enumerate(
-            self.kv_layer_groups_manager_.kv_layer_groups
-        ):
+        for group_idx, group in enumerate(self.kv_layer_groups_manager_.kernel_groups):
             shape = self.get_kv_buffer_shape(lmcache_tokens_per_chunk, group_idx)
             byte_size = shape.numel() * group.dtype.itemsize
             self.tmp_chunk_group_offsets_.append(
@@ -255,15 +253,14 @@ class CPUCacheContext(BaseCacheContext):
     @property
     def block_size(self) -> int:
         """Returns the block size (tokens per block)."""
-        return self.kv_layer_groups_manager_.kv_layer_groups[0].shape_desc.bs
+        return self.kv_layer_groups_manager_.kernel_groups[0].shape_desc.bs
 
     @property
     def group_slots_per_blocks(self) -> list[int]:
         """Per-group physical slot count (``shape_desc.bs``) in group
         order."""
         return [
-            group.shape_desc.bs
-            for group in self.kv_layer_groups_manager_.kv_layer_groups
+            group.shape_desc.bs for group in self.kv_layer_groups_manager_.kernel_groups
         ]
 
     def blocks_for_tokens(self, num_logical_tokens: int, group_idx: int) -> int:
@@ -271,7 +268,7 @@ class CPUCacheContext(BaseCacheContext):
 
         Mirrors :meth:`GPUCacheContext.blocks_for_tokens`.
         """
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        group = self.kv_layer_groups_manager_.kernel_groups[group_idx]
         physical_slots = (
             num_logical_tokens * group.slots_per_block // group.tokens_per_block
         )
@@ -307,7 +304,7 @@ class CPUCacheContext(BaseCacheContext):
         Returns:
             A ``(shape, dtype)`` tuple for the given kernel group.
         """
-        group = self.kv_layer_groups_manager_.kv_layer_groups[kernel_group_idx]
+        group = self.kv_layer_groups_manager_.kernel_groups[kernel_group_idx]
         compress_ratio = group.tokens_per_block // group.slots_per_block
         if num_tokens % compress_ratio != 0:
             raise ValueError(
@@ -349,7 +346,7 @@ class CPUCacheContext(BaseCacheContext):
             raise ValueError(
                 "batch_idx %d >= max_batch_size %d" % (batch_idx, self.max_batch_size)
             )
-        group = self.kv_layer_groups_manager_.kv_layer_groups[kernel_group_idx]
+        group = self.kv_layer_groups_manager_.kernel_groups[kernel_group_idx]
         shape = self.get_kv_buffer_shape(
             self.lmcache_tokens_per_chunk, kernel_group_idx
         )
@@ -396,7 +393,7 @@ class CPUCacheContext(BaseCacheContext):
 
     def get_tmp_chunk_gpu_buffer(self, group_idx: int = 0) -> torch.Tensor:
         """Returns a typed view of the temp buffer for one chunk."""
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        group = self.kv_layer_groups_manager_.kernel_groups[group_idx]
         shape = self.get_kv_buffer_shape(self.lmcache_tokens_per_chunk, group_idx)
         start = self.tmp_chunk_group_offsets_[group_idx]
         end = self.tmp_chunk_group_offsets_[group_idx + 1]
@@ -410,7 +407,7 @@ class CPUCacheContext(BaseCacheContext):
             raise ValueError(
                 "batch_size %d > max_batch_size %d" % (batch_size, self.max_batch_size)
             )
-        group = self.kv_layer_groups_manager_.kv_layer_groups[group_idx]
+        group = self.kv_layer_groups_manager_.kernel_groups[group_idx]
         shape = self.get_kv_buffer_shape(self.lmcache_tokens_per_chunk, group_idx)
         g_start = self.tmp_chunk_group_offsets_[group_idx]
         g_end = self.tmp_chunk_group_offsets_[group_idx + 1]
@@ -429,9 +426,7 @@ class CPUCacheContext(BaseCacheContext):
         Mirrors :meth:`GPUCacheContext.cache_size_per_token`.
         """
         total = 0
-        for group_idx, group in enumerate(
-            self.kv_layer_groups_manager_.kv_layer_groups
-        ):
+        for group_idx, group in enumerate(self.kv_layer_groups_manager_.kernel_groups):
             compress_ratio = group.tokens_per_block // group.slots_per_block
             numels = self.get_kv_buffer_shape(compress_ratio, group_idx).numel()
             slot_bytes = numels * group.dtype.itemsize

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -396,7 +396,7 @@ class GPUCacheContext(BaseCacheContext):
         )
 
         self.group_kv_pointers_: list[torch.Tensor] = []
-        for idx, group in enumerate(self.kv_layer_groups_manager_.kv_layer_groups):
+        for idx, group in enumerate(self.kv_layer_groups_manager_.kernel_groups):
             ptrs = get_group_data_ptrs(
                 self.kv_caches_, self.get_engine_kv_format(idx), group.layer_indices
             )


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

LMCache internal code still uses deprecated `kv_layer_groups` / `num_groups` aliases, triggering own deprecation warnings at runtime:

```
[2026-07-22 15:56:43,091] LMCache WARNING: KVLayerGroupsManager.kv_layer_groups is deprecated: `kv_layer_groups` is an outdated alias for `kernel_groups` (utils.py:734:lmcache.utils)
```

Replace them with `kernel_groups` / `num_kernel_groups` in all production code.

**Special notes for your reviewers**:


**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
