### PR TITLE
[MP][S3 L2 adapter] support self signed certs and path style access

### DIFF
--- a/docs/source/mp/l2_storage/s3.rst
+++ b/docs/source/mp/l2_storage/s3.rst
@@ -7,8 +7,9 @@ S3-compatible endpoint (MinIO, Ceph RGW, etc.).
 
 **Required fields:**
 
-- ``s3_endpoint``: Bucket URL -- either ``"s3://<bucket>"`` or the bare host form
-  (used for non-AWS endpoints).
+- ``s3_endpoint``: Virtual-hosted bucket URL by default -- either
+  ``"s3://<bucket>"`` or the bare host form. With path-style addressing, this
+  is the S3 service host without a bucket prefix.
 - ``s3_region``: AWS region string (e.g. ``"us-west-2"``).
 
 **Optional fields:**
@@ -19,6 +20,13 @@ S3-compatible endpoint (MinIO, Ceph RGW, etc.).
   for S3 Express One Zone buckets.
 - ``disable_tls`` (bool, default ``false``): Bypass TLS when pointing at a
   plain-HTTP endpoint (e.g. a local MinIO).
+- ``s3_addressing_style`` (string, default ``"virtual"``): Request addressing
+  style. Set to ``"path"`` for S3-compatible services that require
+  ``/<bucket>/<object-key>`` requests.
+- ``s3_bucket`` (string): Required with ``s3_addressing_style="path"``. The
+  bucket placed in each request path.
+- ``s3_ca_bundle`` (string): Optional PEM CA bundle used by AWS CRT to verify
+  a private S3 endpoint's TLS certificate.
 - ``aws_access_key_id`` / ``aws_secret_access_key`` (string): Static
   credentials; omit both to use the AWS default credential provider chain
   (environment, EC2 instance profile, etc.).
@@ -38,3 +46,6 @@ S3-compatible endpoint (MinIO, Ceph RGW, etc.).
 
     # Local MinIO over plain HTTP
     --l2-adapter '{"type": "s3", "s3_endpoint": "minio.local:9000", "s3_region": "us-east-1", "disable_tls": true, "aws_access_key_id": "minio", "aws_secret_access_key": "minio123"}'
+
+    # Private S3-compatible service with path-style access and a custom CA
+    --l2-adapter '{"type": "s3", "s3_endpoint": "s3.internal:8111", "s3_region": "us-east-1", "s3_addressing_style": "path", "s3_bucket": "lmcache", "s3_ca_bundle": "/etc/ssl/private-s3-ca.pem"}'

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -1018,7 +1018,7 @@ class S3L2Adapter(L2AdapterInterface):
         # urlencode handles percent-escaping of values (continuation
         # tokens are typically base64 with ``+``/``/``/``=`` chars).
         path_prefix = (
-            "/" if self._bucket is None else f"/{url_quote(self._bucket, safe='')}/"
+            "/" if self._bucket is None else f"/{url_quote(self._bucket, safe='')}"
         )
         path = path_prefix + "?" + urlencode(params, quote_via=url_quote)
 

--- a/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/s3_l2_adapter.py
@@ -188,9 +188,21 @@ def _object_key_to_string(key: ObjectKey) -> str:
     return base
 
 
-def _format_safe_path(key_str: str) -> str:
-    """URL-encode the object name to form a safe HTTP path."""
-    return "/" + url_quote(key_str)
+def _format_safe_path(key_str: str, bucket: Optional[str] = None) -> str:
+    """URL-encode an object name to form a virtual- or path-style HTTP path.
+
+    Args:
+        key_str: S3 object name.
+        bucket: Bucket name for path-style addressing. When omitted, produce
+            the virtual-hosted-style path.
+
+    Returns:
+        The request path for the object.
+    """
+    object_path = url_quote(key_str)
+    if bucket is None:
+        return "/" + object_path
+    return "/" + url_quote(bucket, safe="") + "/" + object_path
 
 
 def _make_credentials_provider(
@@ -309,12 +321,15 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
     """Config for the S3 L2 adapter.
 
     Fields:
-    - s3_endpoint (str, required): bucket URL using **virtual-hosted**
-      style; accepts either ``"s3://<bucket>.<host>"`` or the bare
-      ``"<bucket>.<host>"`` form. The bucket name must be part of the
-      host because requests are signed and routed against this Host
-      header (path-style addressing is not supported).
+    - s3_endpoint (str, required): virtual-hosted bucket URL by default;
+      accepts either ``"s3://<bucket>.<host>"`` or the bare
+      ``"<bucket>.<host>"`` form. With ``s3_addressing_style="path"``,
+      it is the S3 service host, without a bucket prefix.
     - s3_region (str, required): AWS region used for SigV4.
+    - s3_addressing_style (str): ``"virtual"`` (default) or ``"path"``.
+    - s3_bucket (str): required for path-style addressing.
+    - s3_ca_bundle (str): optional PEM bundle used to trust the S3 data
+      plane's TLS certificate.
     - s3_num_io_threads (int): CRT IO threads.
     - s3_prefer_http2 (bool): ALPN negotiate to HTTP/2.
     - s3_enable_s3express (bool): enable S3 Express signing.
@@ -337,6 +352,9 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
         s3_prefer_http2: bool = True,
         s3_enable_s3express: bool = False,
         disable_tls: bool = False,
+        s3_addressing_style: str = "virtual",
+        s3_bucket: Optional[str] = None,
+        s3_ca_bundle: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
         max_capacity_gb: float = 0.0,
@@ -347,6 +365,9 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
         self.s3_prefer_http2 = s3_prefer_http2
         self.s3_enable_s3express = s3_enable_s3express
         self.disable_tls = disable_tls
+        self.s3_addressing_style = s3_addressing_style
+        self.s3_bucket = s3_bucket
+        self.s3_ca_bundle = s3_ca_bundle
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
         self.max_capacity_gb = max_capacity_gb
@@ -359,6 +380,10 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
         region = d.get("s3_region")
         if not isinstance(region, str) or not region:
             raise ValueError("s3_region must be a non-empty string")
+
+        addressing_style = d.get("s3_addressing_style", "virtual")
+        if addressing_style not in ("virtual", "path"):
+            raise ValueError("s3_addressing_style must be 'virtual' or 'path'")
 
         def _int(key, default):
             v = d.get(key, default)
@@ -380,6 +405,10 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
                 raise ValueError(f"{key} must be a string")
             return v
 
+        bucket = _opt_str("s3_bucket")
+        if addressing_style == "path" and not bucket:
+            raise ValueError("s3_bucket is required when s3_addressing_style is 'path'")
+
         max_cap = d.get("max_capacity_gb", 0.0)
         if not isinstance(max_cap, (int, float)) or isinstance(max_cap, bool):
             raise ValueError("max_capacity_gb must be a number")
@@ -391,6 +420,9 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
             s3_prefer_http2=_bool("s3_prefer_http2", True),
             s3_enable_s3express=_bool("s3_enable_s3express", False),
             disable_tls=_bool("disable_tls", False),
+            s3_addressing_style=addressing_style,
+            s3_bucket=bucket,
+            s3_ca_bundle=_opt_str("s3_ca_bundle"),
             aws_access_key_id=_opt_str("aws_access_key_id"),
             aws_secret_access_key=_opt_str("aws_secret_access_key"),
             max_capacity_gb=float(max_cap),
@@ -402,9 +434,12 @@ class S3L2AdapterConfig(L2AdapterConfigBase):
     def help(cls) -> str:
         return (
             "S3 L2 adapter config fields:\n"
-            "- s3_endpoint (str, required): virtual-hosted bucket URL "
-            "('s3://<bucket>.<host>' or '<bucket>.<host>')\n"
+            "- s3_endpoint (str, required): virtual-hosted bucket URL by default; "
+            "service host when s3_addressing_style is 'path'\n"
             "- s3_region (str, required): AWS region for SigV4\n"
+            "- s3_addressing_style (str): 'virtual' (default) or 'path'\n"
+            "- s3_bucket (str): required for path-style addressing\n"
+            "- s3_ca_bundle (str): optional PEM bundle for S3 TLS trust\n"
             "- s3_num_io_threads (int): CRT IO threads (default 64)\n"
             "- s3_prefer_http2 (bool): try HTTP/2 via ALPN (default true)\n"
             "- s3_enable_s3express (bool): S3 Express signing (default false)\n"
@@ -452,6 +487,9 @@ class S3L2Adapter(L2AdapterInterface):
         self._endpoint = endpoint
         self._region = config.s3_region
         self._enable_s3express = config.s3_enable_s3express
+        self._bucket = (
+            config.s3_bucket if config.s3_addressing_style == "path" else None
+        )
 
         # awscrt client setup (mirrors s3_connector.py:103-153)
         event_loop_group = io.EventLoopGroup(config.s3_num_io_threads)
@@ -461,13 +499,19 @@ class S3L2Adapter(L2AdapterInterface):
         self._credentials_provider = _make_credentials_provider(config)
 
         tls_opts = None
-        if config.s3_prefer_http2:
-            tls_ctx = ClientTlsContext(TlsContextOptions())
+        if config.s3_prefer_http2 or config.s3_ca_bundle:
+            tls_ctx_options = TlsContextOptions()
+            if config.s3_ca_bundle:
+                tls_ctx_options.override_default_trust_store_from_path(
+                    ca_filepath=config.s3_ca_bundle,
+                )
+            tls_ctx = ClientTlsContext(tls_ctx_options)
             tls_opts = TlsConnectionOptions(tls_ctx)
-            try:
-                tls_opts.set_alpn_list(["h2", "http/1.1"])
-            except Exception:
-                tls_opts = None
+            if config.s3_prefer_http2:
+                try:
+                    tls_opts.set_alpn_list(["h2", "http/1.1"])
+                except Exception:
+                    tls_opts = None
 
         signing_config = None
         if self._enable_s3express:
@@ -838,7 +882,7 @@ class S3L2Adapter(L2AdapterInterface):
                 headers.add(k, v)
         return HttpRequest(
             method,
-            _format_safe_path(key_str),
+            _format_safe_path(key_str, self._bucket),
             headers,
             body_stream=body_stream,
         )
@@ -973,7 +1017,10 @@ class S3L2Adapter(L2AdapterInterface):
             params.append(("continuation-token", continuation_token))
         # urlencode handles percent-escaping of values (continuation
         # tokens are typically base64 with ``+``/``/``/``=`` chars).
-        path = "/?" + urlencode(params, quote_via=url_quote)
+        path_prefix = (
+            "/" if self._bucket is None else f"/{url_quote(self._bucket, safe='')}/"
+        )
+        path = path_prefix + "?" + urlencode(params, quote_via=url_quote)
 
         headers = HttpHeaders()
         headers.add("Host", self._endpoint)

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -178,6 +178,7 @@ class _FakeS3Request:
         **kwargs,
     ):
         self.finished_future: ConcurrentFuture = ConcurrentFuture()
+        self.request = request
 
         # Extract method + path from the HttpRequest
         method = request.method
@@ -190,7 +191,7 @@ class _FakeS3Request:
         if (
             method == "GET"
             and operation_name == "ListObjectsV2"
-            and path.startswith("/?")
+            and (path.startswith("/?") or "/?" in path)
         ):
             prefix, max_keys, cont = _parse_list_query(path)
             xml = _build_list_objects_v2_response(_BACKEND, prefix, max_keys, cont)
@@ -727,6 +728,9 @@ class TestConfig:
                 "s3_prefer_http2": False,
                 "s3_enable_s3express": True,
                 "disable_tls": True,
+                "s3_addressing_style": "path",
+                "s3_bucket": "my-bucket",
+                "s3_ca_bundle": "/certs/ca.pem",
                 "aws_access_key_id": "id",
                 "aws_secret_access_key": "secret",
                 "max_capacity_gb": 2.5,
@@ -738,6 +742,9 @@ class TestConfig:
         assert cfg.s3_prefer_http2 is False
         assert cfg.s3_enable_s3express is True
         assert cfg.disable_tls is True
+        assert cfg.s3_addressing_style == "path"
+        assert cfg.s3_bucket == "my-bucket"
+        assert cfg.s3_ca_bundle == "/certs/ca.pem"
         assert cfg.aws_access_key_id == "id"
         assert cfg.aws_secret_access_key == "secret"
         assert cfg.max_capacity_gb == 2.5
@@ -745,6 +752,48 @@ class TestConfig:
     def test_help_nonempty(self):
         assert isinstance(S3L2AdapterConfig.help(), str)
         assert "s3_endpoint" in S3L2AdapterConfig.help()
+
+
+    def test_path_style_requires_bucket(self):
+        with pytest.raises(ValueError, match="s3_bucket"):
+            S3L2AdapterConfig.from_dict(
+                {
+                    "s3_endpoint": "s3.example.test",
+                    "s3_region": "us-east-1",
+                    "s3_addressing_style": "path",
+                }
+            )
+
+    def test_rejects_unknown_addressing_style(self):
+        with pytest.raises(ValueError, match="s3_addressing_style"):
+            S3L2AdapterConfig.from_dict(
+                {
+                    "s3_endpoint": "s3://bucket",
+                    "s3_region": "us-east-1",
+                    "s3_addressing_style": "invalid",
+                }
+            )
+
+
+def test_path_style_uses_service_host_bucket_prefix_and_bucket_root():
+    """Path-style requests address objects and ListObjectsV2 under the bucket."""
+    config = S3L2AdapterConfig(
+        s3_endpoint="s3.example.test",
+        s3_region="us-east-1",
+        s3_addressing_style="path",
+        s3_bucket="path-bucket",
+        s3_prefer_http2=False,
+        s3_num_io_threads=1,
+    )
+    adapter = S3L2Adapter(config)
+    try:
+        request = adapter._make_request("GET", "object@key")
+        assert request.path == "/path-bucket/object%40key"
+
+        s3_request, _body_chunks, _captured = adapter._list_request(None, 100, None)
+        assert s3_request.request.path.startswith("/path-bucket/?list-type=2")
+    finally:
+        adapter.close()
 
 
 # =============================================================================

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -791,7 +791,7 @@ class TestPathStyleAddressing:
             assert request.path == "/path-bucket/object%40key"
 
             s3_request, _body_chunks, _captured = adapter._list_request(None, 100, None)
-            assert s3_request.request.path.startswith("/path-bucket/?list-type=2")
+            assert s3_request.request.path.startswith("/path-bucket?list-type=2")
         finally:
             adapter.close()
 

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -753,7 +753,6 @@ class TestConfig:
         assert isinstance(S3L2AdapterConfig.help(), str)
         assert "s3_endpoint" in S3L2AdapterConfig.help()
 
-
     def test_path_style_requires_bucket(self):
         with pytest.raises(ValueError, match="s3_bucket"):
             S3L2AdapterConfig.from_dict(

--- a/tests/v1/distributed/test_s3_l2_adapter.py
+++ b/tests/v1/distributed/test_s3_l2_adapter.py
@@ -774,25 +774,26 @@ class TestConfig:
             )
 
 
-def test_path_style_uses_service_host_bucket_prefix_and_bucket_root():
-    """Path-style requests address objects and ListObjectsV2 under the bucket."""
-    config = S3L2AdapterConfig(
-        s3_endpoint="s3.example.test",
-        s3_region="us-east-1",
-        s3_addressing_style="path",
-        s3_bucket="path-bucket",
-        s3_prefer_http2=False,
-        s3_num_io_threads=1,
-    )
-    adapter = S3L2Adapter(config)
-    try:
-        request = adapter._make_request("GET", "object@key")
-        assert request.path == "/path-bucket/object%40key"
+class TestPathStyleAddressing:
+    def test_uses_service_host_bucket_prefix_and_bucket_root(self):
+        """Path-style requests address objects and ListObjectsV2 under the bucket."""
+        config = S3L2AdapterConfig(
+            s3_endpoint="s3.example.test",
+            s3_region="us-east-1",
+            s3_addressing_style="path",
+            s3_bucket="path-bucket",
+            s3_prefer_http2=False,
+            s3_num_io_threads=1,
+        )
+        adapter = S3L2Adapter(config)
+        try:
+            request = adapter._make_request("GET", "object@key")
+            assert request.path == "/path-bucket/object%40key"
 
-        s3_request, _body_chunks, _captured = adapter._list_request(None, 100, None)
-        assert s3_request.request.path.startswith("/path-bucket/?list-type=2")
-    finally:
-        adapter.close()
+            s3_request, _body_chunks, _captured = adapter._list_request(None, 100, None)
+            assert s3_request.request.path.startswith("/path-bucket/?list-type=2")
+        finally:
+            adapter.close()
 
 
 # =============================================================================


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds S3 L2 adapter support for private S3-compatible object storage deployments that require:
  - Path-style S3 addressing (/<bucket>/<object-key>)
  - A custom/self-signed CA certificate bundle

This supports small on-premises object-storage clusters such as MinIO, Ceph RGW, and similar deployments where virtual-hosted DNS and publicly trusted TLS certificates are not available.

**What is changed**
  - Adds s3_addressing_style, with virtual as the backward-compatible default and path for path-style requests.
  - Adds required s3_bucket when path-style addressing is selected.
  - Adds optional s3_ca_bundle, passed to AWS CRT’s TLS trust store.
  - Updates object operations and ListObjectsV2 paths for path-style addressing.
  - Documents the new options and adds unit coverage for configuration validation and request paths.

  Example:
  {
    "type": "s3",
    "s3_endpoint": "s3.internal:9000",
    "s3_region": "us-east-1",
    "s3_addressing_style": "path",
    "s3_bucket": "lmcache",
    "s3_ca_bundle": "/etc/ssl/private-s3-ca.pem"
  }

**Special notes for your reviewers**:
This patch also addressed problem in #3593, which enables OBJ backend in NIXL.
NIXL library has no delete interface and has limitation in batched operations, therefore we'd better update s3 l2 adpater to support self-hosted object storage.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
