### PR TITLE
docs(mp-connector): correct inverted mp_transfer_mode descriptions (#4186)

### DIFF
--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -451,9 +451,9 @@ class LMCacheMPConnector(KVConnectorBase_V1):
     - lmcache.mp.heartbeat_interval: interval (seconds) between server
       heartbeat pings.
     - lmcache.mp.mp_transfer_mode: routing mode for the worker -> server
-      transfer context. One of ``auto`` (default; CUDA -> engine_driven,
-      others -> lmcache_driven), ``engine_driven`` (force IPC / SHM
-      zero-copy), ``lmcache_driven`` (force worker-side gather/scatter
+      transfer context. One of ``auto`` (default; CUDA -> lmcache_driven,
+      others -> engine_driven), ``lmcache_driven`` (force IPC / SHM
+      zero-copy), ``engine_driven`` (force worker-side gather/scatter
       copy). Overrides the ``LMCACHE_MP_TRANSFER_MODE`` env var when set.
     """
 


### PR DESCRIPTION
## What

Fixes the `lmcache.mp.mp_transfer_mode` docstring on `LMCacheMPConnector`, which described the two transfer modes **backwards** relative to the factory code in `lmcache/v1/multiprocess/transfer_context/worker_transfer.py`.

Reported in #4186 (section "Doc bugs found while debugging", item 2).

## The inversion

Current docstring (`lmcache/integration/vllm/lmcache_mp_connector_0201.py`):

```
auto (default; CUDA -> engine_driven, others -> lmcache_driven),
engine_driven (force IPC / SHM zero-copy),
lmcache_driven (force worker-side gather/scatter copy)
```

But the factory does the opposite:

```python
# worker_transfer.py
if resolved_mode is MPTransferMode.LMCACHE_DRIVEN:
    return _build_lmcache_driven_context(device_type)   # -> LMCacheDrivenTransferContext
if resolved_mode is MPTransferMode.ENGINE_DRIVEN:
    return _build_engine_driven_context()               # -> EngineDrivenTransferContext
# AUTO: dispatch by device type
if device_type == "cuda":
    return LMCacheDrivenTransferContext()
return _build_engine_driven_context()
```

And the two context classes' own docstrings confirm the semantics:

- `LMCacheDrivenTransferContext` — *"the serving engine provides device handles (IPC for CUDA, SHM wrappers for CPU) and the LMCache server performs direct device-side data transfer"* → **IPC / SHM zero-copy**.
- `EngineDrivenTransferContext` — *"the engine (worker side) owns the data movement: the worker adapter gathers/packs KV into CPU buffers"* → **worker-side gather/scatter copy**.

So the correct mapping is:

- `lmcache_driven` = IPC / SHM zero-copy
- `engine_driven` = worker-side gather/scatter copy
- `auto`: CUDA → `lmcache_driven`, others → `engine_driven`

This matters because #4186's documented escape hatch for a CPU-only lmcache server + CUDA worker is "force `engine_driven`". With the docstring inverted, a user reading it would pick the wrong mode.

## Change

Docstring-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
