### PR TITLE
[CI/Build] Add arm64/aarch64 wheels for Grace-Blackwell (GB200/GB300/Thor/Spark)

### DIFF
--- a/.github/workflows/build_main_artifacts_arm64.yml
+++ b/.github/workflows/build_main_artifacts_arm64.yml
@@ -1,0 +1,79 @@
+name: Build Main Artifacts (arm64)
+
+# Reusable workflow that builds the aarch64 CUDA wheel via cibuildwheel on a
+# native arm64 runner (ubuntu-24.04-arm). Mirrors build_main_artifacts.yml.
+# Also `workflow_dispatch`-able so contributors can validate the arm64 build
+# in their fork without the `full` PR label.
+#
+# Uploaded as the `release-artifacts-arm64` GHA artifact.
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+env:
+    LC_ALL: en_US.UTF-8
+
+defaults:
+    run:
+        shell: bash
+
+permissions:
+    contents: read
+
+jobs:
+    build-artifacts-arm64:
+        name: Build artifacts (arm64)
+        runs-on: ubuntu-24.04-arm
+        steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+              with:
+                disable-sudo-and-containers: false
+                egress-policy: audit
+
+            - name: Checkout code
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              with:
+                # for setuptools-scm
+                fetch-depth: 0
+
+            # Keep stable vX.Y.Z and rc/a/b pre-release tags; strip variant tags
+            # (v*-cu129, v*-alpha) that yield invalid PEP 440 versions (see #3123).
+            - name: Remove non-release tags (keep stable + rc/a/b pre-releases)
+              run: git tag -l | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+((rc|a|b)[0-9]+)?$' | xargs -r git tag -d
+
+            - name: Pin release version from tag (setuptools-scm)
+              if: startsWith(github.ref, 'refs/tags/v')
+              run: echo "SETUPTOOLS_SCM_PRETEND_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+            - name: Free disk space
+              uses: ./.github/actions/free-disk-space
+
+            - name: Setup Python 3.13
+              uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+              with:
+                python-version: "3.13"
+
+            - name: Install build tooling
+              run: |
+                python -m pip install --upgrade pip
+                pip install build cibuildwheel
+
+            - name: Clean up release artifacts
+              run: rm -rf dist/
+
+            - name: Build CUDA aarch64 wheels with cibuildwheel
+              # arch-specific config (manylinux-aarch64-image, --plat) lives in
+              # pyproject.toml; CIBW_BUILD narrows the selector to aarch64 so this
+              # job never accidentally emits an x86 wheel.
+              env:
+                CIBW_BUILD: "cp3*-manylinux_aarch64"
+                CIBW_TEST_COMMAND: "python -c 'import lmcache.c_ops'"
+              run: python -m cibuildwheel --output-dir dist
+
+            - name: Upload release artifacts to GHA
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                name: release-artifacts-arm64
+                path: dist/

--- a/.github/workflows/pr_full_build.yml
+++ b/.github/workflows/pr_full_build.yml
@@ -33,6 +33,11 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'full')
         uses: ./.github/workflows/build_main_artifacts.yml
 
+    build-main-arm64:
+        name: Build main (arm64)
+        if: contains(github.event.pull_request.labels.*.name, 'full')
+        uses: ./.github/workflows/build_main_artifacts_arm64.yml
+
     build-cli:
         name: Build CLI
         if: contains(github.event.pull_request.labels.*.name, 'full')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,7 @@ jobs:
                         - '.github/workflows/code_quality_checks.yml'
                         - '.github/workflows/publish.yml'
                         - '.github/workflows/build_main_artifacts.yml'
+                        - '.github/workflows/build_main_artifacts_arm64.yml'
                         - '.github/workflows/build_cli_artifacts.yml'
                         - '.github/workflows/build_cu129_artifacts.yml'
                         - '.github/workflows/build_rocm_artifacts.yml'
@@ -76,6 +77,12 @@ jobs:
         if: needs.changes.outputs.lmcache == 'true'
         name: Build main
         uses: ./.github/workflows/build_main_artifacts.yml
+
+    build-main-arm64:
+        needs: changes
+        if: needs.changes.outputs.lmcache == 'true'
+        name: Build main (arm64)
+        uses: ./.github/workflows/build_main_artifacts_arm64.yml
 
     build-cli:
         needs: changes
@@ -123,6 +130,7 @@ jobs:
         # doesn't trigger a publish that fails on the missing artifact.
         if: |
             needs.build-main.result == 'success' &&
+            needs.build-main-arm64.result == 'success' &&
             needs.test.result == 'success' &&
             needs.code-quality.result == 'success' &&
             needs.changes.outputs.lmcache == 'true' &&
@@ -133,7 +141,7 @@ jobs:
             # see https://docs.pypi.org/trusted-publishers/
             id-token: write
         runs-on: ubuntu-latest
-        needs: [changes, build-main, test, code-quality]
+        needs: [changes, build-main, build-main-arm64, test, code-quality]
 
         steps:
             - name: Harden Runner
@@ -146,6 +154,12 @@ jobs:
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
                   name: release-artifacts
+                  path: dist
+
+            - name: Fetch arm64 release artifacts
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: release-artifacts-arm64
                   path: dist
 
             - name: Upload to Test PyPI
@@ -194,6 +208,7 @@ jobs:
         name: Publish release to pypi.org
         if: |
             needs.build-main.result == 'success' &&
+            needs.build-main-arm64.result == 'success' &&
             needs.test.result == 'success' &&
             needs.code-quality.result == 'success' &&
             needs.changes.outputs.lmcache == 'true' &&
@@ -205,7 +220,7 @@ jobs:
             contents: write
 
         runs-on: ubuntu-latest
-        needs: [changes, build-main, test, code-quality]
+        needs: [changes, build-main, build-main-arm64, test, code-quality]
 
         steps:
             - name: Harden Runner
@@ -218,6 +233,12 @@ jobs:
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
                   name: release-artifacts
+                  path: dist
+
+            - name: Fetch arm64 release artifacts
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: release-artifacts-arm64
                   path: dist
 
             - name: Upload release artifacts to GitHub release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ skip = "operator/config/crd/bases/*,lmcache/integration/vllm/lmcache_mp_connecto
 ignore-regex = '"image/[^"]+": "[A-Za-z0-9+/=]+"'
 
 [tool.cibuildwheel]
-build = "cp3*-manylinux_x86_64"
+build = "cp3*-manylinux_x86_64 cp3*-manylinux_aarch64"
 
 # The wheel's *runtime* dep on torch is deliberately unpinned (see
 # requirements/common.txt), so pip would install the latest torch into the test
@@ -175,18 +175,21 @@ before-all = "grep -oE 'torch==[0-9][0-9.]*' /project/pyproject.toml | head -1 >
 # 8.6:  A40, A10, A16, A2
 # 8.9:  L4, L40, L40S
 # 9.0:  GH200, H200, H100
-# 10.0: GB200, B200
-# 12.0: RTX 50-series (PTX)
+# 10.0: GB200, B200; also GB300, B300 (sm_103) via the SM100 family / forward-compat
+# 11.0: Thor (SM110)
+# 12.0: RTX 50-series, RTX Pro; DGX Spark / GB10 (sm_121) via the SM120 family
 # CUDA 13 dropped support for compute capability 7.0 (Volta).
-environment = {TORCH_CUDA_ARCH_LIST = "7.5;8.0;8.6;8.9;9.0;10.0;12.0", ENABLE_CXX11_ABI = "1", PIP_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/cu130", PIP_CONSTRAINT = "/project/cibw-constraints.txt"}
+environment = {TORCH_CUDA_ARCH_LIST = "7.5;8.0;8.6;8.9;9.0;10.0;11.0;12.0", ENABLE_CXX11_ABI = "1", PIP_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/cu130", PIP_CONSTRAINT = "/project/cibw-constraints.txt"}
 
 # Use the PyTorch manylinux image version '2_28' that contains CUDA 13.0
 manylinux-x86_64-image = "docker.io/pytorch/manylinux2_28-builder:cuda13.0"
+# aarch64 (Grace-Blackwell) CUDA 13.0 builder image (glibc 2.28 based).
+manylinux-aarch64-image = "docker.io/pytorch/manylinuxaarch64-builder:cuda13.0"
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = """
 auditwheel repair \
-  --plat manylinux_2_28_x86_64 \
+  --plat manylinux_2_28_$(uname -m) \
   --exclude libtorch.so \
   --exclude libtorch_cuda.so \
   --exclude libtorch_python.so \


### PR DESCRIPTION
**What this PR does / why we need it**:

Revive of #1054 for the lack of GB200/GB300 and arm64 platform support in [issue#909](https://github.com/LMCache/LMCache/issues/909) and [vllm issue#30805](https://github.com/vllm-project/vllm/issues/30805).

Adds native **arm64 / aarch64 (Grace-Blackwell)** CUDA wheel builds to cibuildwheel so LMCache publishes `manylinux_2_28_aarch64` wheels alongside x86_64 — `pip install lmcache` then works on Grace-Blackwell without an in-image source build.

The kernels and build machinery are already architecture-agnostic (nvcc-detected build profile, generic C++/CUDA); only *packaging* was x86-pinned.

**Changes**
- **`pyproject.toml`**: add `cp3*-manylinux_aarch64` to the cibuildwheel matrix + the `pytorch/manylinuxaarch64-builder:cuda13.0` image; derive `auditwheel --plat` from `$(uname -m)` so one repair command serves both arches. Align the CUDA-13 arch list with upstream vLLM's cu13 Blackwell set by adding `11.0` (Thor / SM110).
- new **`.github/workflows/build_main_artifacts_arm64.yml`** — mirror of the x86 builder on `ubuntu-24.04-arm` (`workflow_call` + `workflow_dispatch`), wired into **`pr_full_build.yml`** (per-PR validation) and **`publish.yml`** (builds + publishes the aarch64 wheel to PyPI alongside x86 — Test PyPI on `dev`, PyPI on release).

**Arch coverage on CUDA 13** (aligned with vLLM's `CUDA_SUPPORTED_ARCHS` for cu13):
| platform | cc | covered by |
|---|---|---|
| GB200 / B200 | sm_100 | `10.0` |
| GB300 / B300 (Blackwell Ultra) | sm_103 | `10.0` (SM100 family target / forward binary-compat) |
| Thor | sm_110 | `11.0` |
| RTX 50 / RTX Pro 6000 | sm_120 | `12.0` |
| DGX Spark / GB10 | sm_121 | `12.0` (SM120 family target) |

So no separate `10.3` / `12.1` tokens are needed on CUDA 13 — the family targets (and forward binary-compatibility within a major arch) cover the sub-architectures, matching how upstream vLLM and LMCache's own cu12.9 build already cover GB300 with `10.0` alone.

**Note on `sm_103` / GB300:** an earlier revision of this PR added an explicit `10.3`. Verified on real GB300 hardware that this is unnecessary on CUDA 13 — an `sm_100`-only wheel (no `sm_103` SASS, no PTX) runs `c_ops` kernels on GB300 via CUDA forward binary-compatibility. `10.3` was dropped to keep the list aligned with vLLM's cu13 set.

**Special notes for your reviewers**

x86 is unaffected — cibuildwheel builds only the runner's native arch (no QEMU), so existing x86_64 wheels are unchanged.

Validated on real hardware and CI:
- **Packaging**: cibuildwheel on `ubuntu-24.04-arm` produced `manylinux_2_28_aarch64` wheels for cp310–313; `c_ops.so` = `ELF … ARM aarch64`. Build-time smoke `python -c 'import lmcache.c_ops'` runs on the arm64 runner.
- **GB200 (sm_100) & GB300 (sm_103)** — source build + `import lmcache.c_ops` (backend active) + the vLLM/SGLang integration suites:

| framework | arch | container | c_ops kernel | tests |
|---|---|---|---|---|
| vLLM | sm_100 (GB200) | `nvcr.io/nvidia/vllm:26.03-py3` | ✅ KERNEL_RAN_OK | ✅ 104 passed, 1 skipped |
| vLLM | sm_103 (GB300) | `nvcr.io/nvidia/vllm:26.03-py3` | ✅ KERNEL_RAN_OK | ✅ 104 passed, 1 skipped |
| SGLang | sm_100 (GB200) | `nvcr.io/nvidia/sglang:26.03-py3` | ✅ KERNEL_RAN_OK | ✅ 24 passed, 20 skipped |
| SGLang | sm_103 (GB300) | `nvcr.io/nvidia/sglang:26.03-py3` | ✅ KERNEL_RAN_OK | ✅ 24 passed, 20 skipped |

**Follow-ups (separate PRs):** arm64 **nightly** wheels (`nightly_build.yml` is x86-only) and arm64 **Docker images** (`publish.yml` / `nightly_build.yml` build x86-only images) are out of scope here.

AI assistance (Claude) was used; changes were human-reviewed and hardware/CI-validated.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [x] CI coverage: arm64 build + `import lmcache.c_ops` smoke on `ubuntu-24.04-arm` (per-PR and on publish)
