### PR TITLE
docs: daily drift check — multi-process mode (2026-07-22)

### DIFF
--- a/docs/design/v1/gpu_connector/layout-invariant.md
+++ b/docs/design/v1/gpu_connector/layout-invariant.md
@@ -236,8 +236,9 @@ consumer code must never do any of the following — it queries via the
   passing the `block_stride_elems` resolved by
   `resolve_block_stride_and_log_layout`. The real constructor is the
   only way in — no test-only shortcuts, no cached topology fields; the
-  manager exposes only `kv_layer_groups`, `num_groups`, and
-  `get_shape_desc`.
+  manager exposes only `kernel_groups`, `num_kernel_groups`, and
+  `get_shape_desc` (the old `kv_layer_groups` / `num_groups` properties
+  remain as deprecated aliases).
 - **`lmcache/v1/platform/cuda/cache_context.py::GPUCacheContext`** —
   constructs the manager directly at init, delegates
   `get_shape_desc(group_idx)` to it, assembles per-group GPU pointer

--- a/docs/design/v1/platform/device_ops_design.md
+++ b/docs/design/v1/platform/device_ops_design.md
@@ -57,7 +57,7 @@ Note: LMCache DeviceOps is currently stateless and follows a strict one-device-p
 
 ### 3.2 Base class — contract + torch baseline
 
-`lmcache/v1/platform/base_device_ops.py`:
+`lmcache/v1/platform/base/device_ops.py`:
 
 ```python
 from __future__ import annotations
@@ -266,14 +266,14 @@ class HpuDeviceOps(DeviceOps):
 ### 5.1 `DeviceSpec.ops_cls` and `DeviceSpec.get_ops()`
 
 ```python
-# platform/base_device_spec.py
+# platform/base/device_spec.py
 class DeviceSpec:
     _ops_cache: DeviceOps | None = None
 
     @property
     def ops_cls(self) -> type[DeviceOps]:
         """Lazy import to avoid pulling torch_ops into the import graph."""
-        from lmcache.v1.platform.base_device_ops import DeviceOps
+        from lmcache.v1.platform.base.device_ops import DeviceOps
         return DeviceOps
 
     def get_ops(self) -> DeviceOps:
@@ -327,7 +327,7 @@ back. The CPU path resolves through `CpuDeviceSpec -> CpuDeviceOps`; only `""`
 `_device_detect.py` exists as a separate module to break an import cycle:
 
 ```
-platform/__init__.py → base_device_ops → torch_ops → needs get_torch_device()
+platform/__init__.py → base/device_ops → torch_ops → needs get_torch_device()
 ```
 
 If `get_torch_device()` and `current_device_spec()` lived in
@@ -340,17 +340,17 @@ circular import. `_device_detect.py` sits outside that chain.
 lmcache/v1/platform/
   __init__.py                 # resolve_device_ops, _resolve_device_spec
   _device_detect.py           # get_torch_device, current_device_spec, registry
-  base_device_ops.py          # DeviceOps base + bind_native
-  base_device_spec.py         # DeviceSpec + ops_cls + get_ops
   torch_ops.py                # migrated torch/CPU impl (was python_ops_fallback)
   ops_types.py                # TransferDirection, EngineKVFormat, etc.
-  base_cache_context.py       # (unchanged) sibling abstractions
-  base_ipc_wrapper.py
-  base_pin_memory.py
   cache_context.py
-  device_ext.py
   event_notifier.py
-  _registry.py
+  base/
+    __init__.py               # re-exports base classes for the sub-package
+    device_ops.py             # DeviceOps base + bind_native
+    device_spec.py            # DeviceSpec + ops_cls + get_ops
+    cache_context.py          # (unchanged) sibling abstractions
+    ipc_wrapper.py
+    pin_memory.py
   cpu/
     __init__.py               # CpuDeviceSpec.ops_cls -> CpuDeviceOps
     device_ops.py             # CpuDeviceOps (no overrides = base)


### PR DESCRIPTION
## Summary

Daily drift check between LMCache/LMCache documentation and current
`dev` code, with a focus on the multi-process mode. Two drift items
were found today, both in `docs/design/`. `docs/source/` is clean
today (the previously-flagged items are still tracked by the earlier
open drift-check PRs).

Docs-only. No code touched.

## Drift items

### `docs/design/`

- **`docs/design/v1/platform/device_ops_design.md`** — many stale
  references to the pre-refactor `base_*.py` module layout.
  PR [#4184](https://github.com/LMCache/LMCache/pull/4184)
  (commit
  [`ca36f06`](https://github.com/LMCache/LMCache/commit/ca36f06340663583c38739bac0f224f4cceeaa92),
  "refactor(platform): move base classes into platform/base
  sub-package") moved `base_device_ops.py`, `base_device_spec.py`,
  `base_cache_context.py`, `base_ipc_wrapper.py` and
  `base_pin_memory.py` into `platform/base/`.  The following spots
  in the design doc still pointed at the pre-refactor paths:

  | Stale doc location | Was | Now |
  |---|---|---|
  | header above the `DeviceOps` listing (line 60) | `` `lmcache/v1/platform/base_device_ops.py` `` | `` `lmcache/v1/platform/base/device_ops.py` `` |
  | `DeviceSpec` listing comment (line 269) | `# platform/base_device_spec.py` | `# platform/base/device_spec.py` |
  | in-code import in the listing (line 276) | `from lmcache.v1.platform.base_device_ops import DeviceOps` | `from lmcache.v1.platform.base.device_ops import DeviceOps` |
  | import-cycle arrow (line 330) | `platform/__init__.py → base_device_ops → torch_ops …` | `platform/__init__.py → base/device_ops → torch_ops …` |
  | `platform/` tree diagram (lines 340–349) | flat `base_*.py` files | `base/` sub-package with `device_ops.py`, `device_spec.py`, `cache_context.py`, `ipc_wrapper.py`, `pin_memory.py` |

  While rewriting the tree diagram, also drop two files that no
  longer exist on `dev`: `_registry.py` (removed by
  PR [#4147](https://github.com/LMCache/LMCache/pull/4147),
  commit
  [`4847643`](https://github.com/LMCache/LMCache/commit/484764325fa42426e4076a25c6043b2678f34666),
  "Refactor IPC wrapper cls registry to DeviceSpec") and
  `device_ext.py` (which never existed on `dev` — the doc listed a
  file that was never present).

  Cross-reference — the corresponding user-facing pages
  (`docs/source/developer_guide/extending_lmcache/adding_a_new_device_backend.rst`
  and `docs/design/v1/multiprocess/device_ipc_wrapper_design.md`)
  were updated in the same refactor PR; only this design page was
  missed.

- **`docs/design/v1/gpu_connector/layout-invariant.md`** — the
  documented `KVLayerGroupsManager` public surface no longer matches
  the canonical property names.
  PR [#4192](https://github.com/LMCache/LMCache/pull/4192)
  (commit
  [`9a8ead0`](https://github.com/LMCache/LMCache/commit/9a8ead0dab6dc3af963ef7f1c4579cf129ced808),
  "replace deprecated kv_layer_groups/num_groups with
  kernel_groups/num_kernel_groups internally") renamed the canonical
  properties on `KVLayerGroupsManager` to `kernel_groups` and
  `num_kernel_groups`; the previous names (`kv_layer_groups`,
  `num_groups`) still resolve as `@lmcache_deprecate`-decorated
  aliases (see
  [`lmcache/v1/kv_layer_groups.py:462`](https://github.com/LMCache/LMCache/blob/9a8ead0dab6dc3af963ef7f1c4579cf129ced808/lmcache/v1/kv_layer_groups.py#L462)
  and
  [line 486](https://github.com/LMCache/LMCache/blob/9a8ead0dab6dc3af963ef7f1c4579cf129ced808/lmcache/v1/kv_layer_groups.py#L486)).
  The design doc at
  [`docs/design/v1/gpu_connector/layout-invariant.md:239`](https://github.com/LMCache/LMCache/blob/9a8ead0dab6dc3af963ef7f1c4579cf129ced808/docs/design/v1/gpu_connector/layout-invariant.md#L239)
  still described the surface as *"the manager exposes only
  `kv_layer_groups`, `num_groups`, and `get_shape_desc`"*, so new
  code written from this doc would land on the deprecated names.
  Reword to name the canonical properties and note the deprecated
  aliases.

### `docs/source/`

No new drift found today. Items previously surfaced by the
2026-07-19 / 2026-07-18 / … drift checks
(PRs [#4156](https://github.com/LMCache/LMCache/pull/4156),
[#4150](https://github.com/LMCache/LMCache/pull/4150), etc.) are
still open — this PR does not touch them.

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. Two
files touched:

- `docs/design/v1/platform/device_ops_design.md`
- `docs/design/v1/gpu_connector/layout-invariant.md`

## Code bugs surfaced (not fixed here)

The v0.1.80 vLLM multi-process connector's docstring has the same
inverted `mp_transfer_mode` description that was fixed for the
v0.2.01 connector in
PR [#4186 / #4194](https://github.com/LMCache/LMCache/pull/4194)
(commit
[`10185f8`](https://github.com/LMCache/LMCache/commit/10185f89b1906dc1c2af2b4fbe5f1e4f03413c6b)):

- [`lmcache/integration/vllm/lmcache_mp_connector_0180.py:456-458`](https://github.com/LMCache/LMCache/blob/9a8ead0dab6dc3af963ef7f1c4579cf129ced808/lmcache/integration/vllm/lmcache_mp_connector_0180.py#L456-L458)
  still says *"CUDA -> engine_driven, others -> lmcache_driven"* and
  labels `engine_driven` as *"IPC / SHM zero-copy"*, but
  `worker_transfer.py` dispatches CUDA -> `lmcache_driven`
  (IPC / SHM zero-copy) and non-CUDA -> `engine_driven`
  (worker-side gather/scatter).

Flagged for a code follow-up; not touched here per this routine's
docs-only scope.

---

**Auto-generated by the daily docs drift-check routine.** Needs
human review before merge. Kept as **draft**; not marked "Ready
for review". No code files touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bv7kC12VTS2A6AAcputQY8)_