### PR TITLE
fix(mp): improve device IPC error when the receiver lacks accelerator access

### DIFF
--- a/examples/multi_process/vllm-deployment.yaml
+++ b/examples/multi_process/vllm-deployment.yaml
@@ -29,6 +29,12 @@ spec:
             - /bin/bash
             - -c
             - |
+              # The lmcache server DaemonSet runs CPU-only (no GPU request), so
+              # the CUDA worker must use engine_driven transfer mode: the worker
+              # does the device-side copy instead of asking the server to open
+              # CUDA IPC handles (which a CPU-only server cannot). Omitting this
+              # falls back to the default 'auto' (lmcache_driven) and fails at
+              # REGISTER_KV_CACHE. See issue #4186.
               vllm serve Qwen/Qwen3-14B \
                 --host 0.0.0.0 \
                 --port 8000 \
@@ -36,7 +42,7 @@ spec:
                 --max-model-len 32768 \
                 --gpu-memory-utilization 0.85 \
                 --tensor-parallel-size 4 \
-                --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"tcp://${HOST_IP}\", \"lmcache.mp.port\": 6555}}"
+                --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"tcp://${HOST_IP}\", \"lmcache.mp.port\": 6555, \"lmcache.mp.mp_transfer_mode\": \"engine_driven\"}}"
           env:
             - name: HOST_IP
               valueFrom:

--- a/examples/multi_process/vllm-deployment.yaml
+++ b/examples/multi_process/vllm-deployment.yaml
@@ -29,12 +29,6 @@ spec:
             - /bin/bash
             - -c
             - |
-              # The lmcache server DaemonSet runs CPU-only (no GPU request), so
-              # the CUDA worker must use engine_driven transfer mode: the worker
-              # does the device-side copy instead of asking the server to open
-              # CUDA IPC handles (which a CPU-only server cannot). Omitting this
-              # falls back to the default 'auto' (lmcache_driven) and fails at
-              # REGISTER_KV_CACHE. See issue #4186.
               vllm serve Qwen/Qwen3-14B \
                 --host 0.0.0.0 \
                 --port 8000 \
@@ -42,7 +36,7 @@ spec:
                 --max-model-len 32768 \
                 --gpu-memory-utilization 0.85 \
                 --tensor-parallel-size 4 \
-                --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"tcp://${HOST_IP}\", \"lmcache.mp.port\": 6555, \"lmcache.mp.mp_transfer_mode\": \"engine_driven\"}}"
+                --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_connector_extra_config\": {\"lmcache.mp.host\": \"tcp://${HOST_IP}\", \"lmcache.mp.port\": 6555}}"
           env:
             - name: HOST_IP
               valueFrom:

--- a/lmcache/v1/platform/base/ipc_wrapper.py
+++ b/lmcache/v1/platform/base/ipc_wrapper.py
@@ -88,7 +88,41 @@ class DeviceIPCWrapper:
 
     @classmethod
     def _get_device_index_from_uuid(cls, device_uuid: str) -> int:
-        """Get the physical device ordinal from its UUID."""
+        """Get the physical device ordinal from its UUID.
+
+        Args:
+            device_uuid: the UUID of the device to resolve, as carried in an
+                inter-process device handle received from a peer process.
+
+        Returns:
+            The physical device ordinal for ``device_uuid`` on this host.
+
+        Raises:
+            RuntimeError: if this process has no accelerator devices available
+                -- e.g. a CPU-only ``lmcache server`` receiving a CUDA worker's
+                IPC handle -- in which case the message points at the
+                ``engine_driven`` transfer mode; or if a device is available
+                but ``device_uuid`` is not among the discovered devices.
+        """
+        # A device-incapable process (e.g. a CPU-only lmcache server) can never
+        # resolve a peer's device IPC handle. Fail with actionable guidance
+        # instead of the generic "not found" below, which misleads operators
+        # into checking device visibility when the real fix is the transfer
+        # mode. See issue #4186.
+        if not torch_dev.is_available():
+            raise RuntimeError(
+                f"Received an inter-process handle for device {device_uuid}, "
+                "but this process has no accelerator devices available "
+                "(running on a CPU-only host). This usually means a CUDA "
+                "worker registered its KV caches with a CPU-only LMCache "
+                "server using the default 'auto' (lmcache_driven) transfer "
+                "mode, which requires the server to open device IPC handles. "
+                "Set 'lmcache.mp.mp_transfer_mode=engine_driven' in the vLLM "
+                "kv_connector_extra_config (or export "
+                "LMCACHE_MP_TRANSFER_MODE=engine_driven) so the worker performs "
+                "the device-side copy instead."
+            )
+
         cls._discover_devices()
 
         with DeviceIPCWrapper._device_mapping_lock:

--- a/lmcache/v1/platform/base/ipc_wrapper.py
+++ b/lmcache/v1/platform/base/ipc_wrapper.py
@@ -99,28 +99,29 @@ class DeviceIPCWrapper:
 
         Raises:
             RuntimeError: if this process has no accelerator devices available
-                -- e.g. a CPU-only ``lmcache server`` receiving a CUDA worker's
-                IPC handle -- in which case the message points at the
-                ``engine_driven`` transfer mode; or if a device is available
-                but ``device_uuid`` is not among the discovered devices.
+                (e.g. a device-incapable process that received an IPC handle
+                from an accelerator worker); the message points at the two
+                supported topologies -- giving the receiving process visibility
+                of the same devices, or using ``engine_driven`` transfer so the
+                sending client does the device-side copy. Also raised if a
+                device is available but ``device_uuid`` is not among the
+                discovered devices.
         """
-        # A device-incapable process (e.g. a CPU-only lmcache server) can never
-        # resolve a peer's device IPC handle. Fail with actionable guidance
-        # instead of the generic "not found" below, which misleads operators
-        # into checking device visibility when the real fix is the transfer
-        # mode. See issue #4186.
+        # A device-incapable process (e.g. one started without accelerator
+        # visibility) can never resolve a peer's device IPC handle. Fail with
+        # actionable guidance instead of the generic "not found" below, which
+        # misleads operators into checking device visibility when the real fix
+        # may be the transfer mode. This layer is engine-agnostic, so the
+        # message names neither a specific engine, process role, nor config
+        # keys. See #4186.
         if not torch_dev.is_available():
             raise RuntimeError(
-                f"Received an inter-process handle for device {device_uuid}, "
-                "but this process has no accelerator devices available "
-                "(running on a CPU-only host). This usually means a CUDA "
-                "worker registered its KV caches with a CPU-only LMCache "
-                "server using the default 'auto' (lmcache_driven) transfer "
-                "mode, which requires the server to open device IPC handles. "
-                "Set 'lmcache.mp.mp_transfer_mode=engine_driven' in the vLLM "
-                "kv_connector_extra_config (or export "
-                "LMCACHE_MP_TRANSFER_MODE=engine_driven) so the worker performs "
-                "the device-side copy instead."
+                "This process cannot access the accelerator device "
+                f"referenced by this IPC handle (device {device_uuid}); "
+                "no accelerator devices are available. Ensure the receiving "
+                "process can see the same accelerator devices, or configure "
+                "the MP deployment to use engine_driven transfer so the "
+                "sending client performs the device-side copy."
             )
 
         cls._discover_devices()

--- a/tests/v1/platform/test_ipc_wrapper.py
+++ b/tests/v1/platform/test_ipc_wrapper.py
@@ -52,6 +52,16 @@ def test_cpu_only_host_raises_actionable_engine_driven_error(
     assert "some-cuda-uuid" in message
     assert "no accelerator devices" in message
     assert "not found in the discovered" not in message
+    # Both supported topologies are offered, so the message never implies a
+    # client-only change is always sufficient.
+    assert "same accelerator devices" in message
+    assert "client performs the device-side copy" in message
+    # This layer is engine-agnostic and role-agnostic: the message must not
+    # name a specific engine, its config keys, or assume a server role
+    # (see reviewer notes on #4202).
+    assert "vLLM" not in message
+    assert "kv_connector_extra_config" not in message
+    assert "LMCache server" not in message
 
 
 def test_unknown_uuid_on_capable_host_raises_generic_error(

--- a/tests/v1/platform/test_ipc_wrapper.py
+++ b/tests/v1/platform/test_ipc_wrapper.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for UUID->ordinal resolution in
+``lmcache.v1.platform.base.ipc_wrapper.DeviceIPCWrapper``.
+
+The focus is ``_get_device_index_from_uuid``'s error behavior, in
+particular the device-incapable-host path (issue #4186): a CPU-only
+``lmcache server`` that receives a CUDA worker's IPC handle must fail
+with actionable guidance toward ``engine_driven`` transfer mode instead
+of the generic "device not found" message. These tests stay
+platform-agnostic -- they patch the ``torch_dev`` abstraction and the
+device-discovery hook rather than touching real accelerators.
+"""
+
+# Standard
+from typing import Iterator
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform.base import ipc_wrapper
+from lmcache.v1.platform.base.ipc_wrapper import DeviceIPCWrapper
+
+
+@pytest.fixture
+def restore_device_mapping() -> Iterator[None]:
+    """Snapshot and restore the shared class-level discovery cache.
+
+    ``_discovered_device_mapping`` is a class attribute shared across all
+    wrappers, so a test that seeds it must not leak into other tests.
+    """
+    saved = dict(DeviceIPCWrapper._discovered_device_mapping)
+    try:
+        yield
+    finally:
+        DeviceIPCWrapper._discovered_device_mapping = saved
+
+
+def test_cpu_only_host_raises_actionable_engine_driven_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A device-incapable process points the operator at engine_driven mode."""
+    monkeypatch.setattr(ipc_wrapper.torch_dev, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        DeviceIPCWrapper._get_device_index_from_uuid("some-cuda-uuid")
+
+    message = str(excinfo.value)
+    # The actionable guidance, not the misleading generic message.
+    assert "engine_driven" in message
+    assert "some-cuda-uuid" in message
+    assert "no accelerator devices" in message
+    assert "not found in the discovered" not in message
+
+
+def test_unknown_uuid_on_capable_host_raises_generic_error(
+    monkeypatch: pytest.MonkeyPatch,
+    restore_device_mapping: None,
+) -> None:
+    """On a device-capable host, an unknown UUID keeps the original error."""
+    monkeypatch.setattr(ipc_wrapper.torch_dev, "is_available", lambda: True)
+    monkeypatch.setattr(
+        DeviceIPCWrapper, "_discover_devices", classmethod(lambda cls: None)
+    )
+    DeviceIPCWrapper._discovered_device_mapping = {}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        DeviceIPCWrapper._get_device_index_from_uuid("missing-uuid")
+
+    message = str(excinfo.value)
+    assert "not found in the discovered" in message
+    assert "engine_driven" not in message
+
+
+def test_known_uuid_returns_ordinal(
+    monkeypatch: pytest.MonkeyPatch,
+    restore_device_mapping: None,
+) -> None:
+    """A discovered UUID resolves to its physical ordinal."""
+    monkeypatch.setattr(ipc_wrapper.torch_dev, "is_available", lambda: True)
+    monkeypatch.setattr(
+        DeviceIPCWrapper, "_discover_devices", classmethod(lambda cls: None)
+    )
+    DeviceIPCWrapper._discovered_device_mapping = {"uuid-a": 0, "uuid-b": 3}
+
+    assert DeviceIPCWrapper._get_device_index_from_uuid("uuid-b") == 3


### PR DESCRIPTION
**What this PR does / why we need it**:

In MP mode, when a process that receives an accelerator IPC handle has no accelerator visibility (for example an `lmcache server` started without GPU access), `DeviceIPCWrapper._get_device_index_from_uuid` failed at `REGISTER_KV_CACHE` with a generic "Device UUID ... not found in the discovered devices" error. That points operators at device visibility, when the real issue is that this process has no accelerator at all. This is the failure reported in #4186.

This PR makes the error actionable while keeping it engine- and role-agnostic: `DeviceIPCWrapper` is platform-base code, below the engine integration layer, so the message names no specific engine, process role, or config key. It points at the two supported topologies: give the receiving process visibility of the same accelerator devices, or configure the MP deployment to use `engine_driven` transfer so the sending client performs the device-side copy. Device-capable hosts are unaffected -- the discovery/lookup path is unchanged, and an available-device/unknown-UUID lookup still raises the original error.

**Special notes for your reviewers**:

- Scoped to the runtime diagnostic. The `examples/multi_process/` topology is intentionally out of this PR: per #2128 the example was originally a GPU-visible server using CUDA IPC, so switching it to `engine_driven` would be choosing a new topology rather than a fix. Better handled separately once the intended deployment is settled.
- Addresses the inline review: the message no longer assumes vLLM or a server role, and no longer implies a client-only change is always sufficient.

**Testing**:

```
pytest tests/v1/platform/test_ipc_wrapper.py -q
3 passed
```

Covers: a device-incapable host raises the actionable engine-agnostic error; a device-capable host with an unknown UUID still raises the original error; a known UUID resolves to its ordinal.

**If applicable**:

- [x] this PR contains unit tests

Addresses #4186
