### PR TITLE
fix(l2_adapters): don't crash CLI when an adapter import raises non-ImportError (#4204)

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/factory.py
+++ b/lmcache/v1/distributed/l2_adapters/factory.py
@@ -145,10 +145,18 @@ def load_all_adapters() -> None:
         mod_path = _PENDING_MODULES.pop(0)
         try:
             importlib.import_module(mod_path)
-        except ImportError:
+        except Exception as exc:
+            # Bulk enumeration is best-effort (it backs CLI help text), so an
+            # adapter that fails to import must never take the whole CLI down.
+            # A missing third-party dep raises ImportError, but an *installed*
+            # but incompatible one can raise other errors too -- e.g. an
+            # incompatible google-cloud-bigtable/protobuf pairing raises
+            # TypeError during the bigtable adapter import (#4204). Skip any
+            # such module instead of letting the error escape.
             logger.debug(
-                "Skipping module %s during bulk load",
+                "Skipping module %s during bulk load (%s)",
                 mod_path,
+                exc,
             )
 
 


### PR DESCRIPTION
## Summary

`lmcache server` — even `lmcache server --help` — crashes on startup when an installed optional adapter dependency is incompatible with the environment, before any server logic runs. This affects users who never use the offending adapter, because adapter enumeration is mandatory at CLI construction time.

Fixes #4204.

## Root cause

`load_all_adapters()` force-imports every pending L2 adapter module so the CLI help can list all registered type names. It only caught `ImportError`:

```python
try:
    importlib.import_module(mod_path)
except ImportError:
    logger.debug("Skipping module %s during bulk load", mod_path)
```

A *missing* third-party dep raises `ImportError` and is skipped correctly. But an *installed but incompatible* one can raise something else during import — e.g. an incompatible `google-cloud-bigtable` / `protobuf` pairing raises `TypeError` while building the generated proto descriptors. That escaped the handler and took the whole CLI down:

```
File ".../lmcache/v1/distributed/config.py", line 524, in add_storage_manager_args
    add_l2_adapters_args(parser)
  ...
TypeError: ...
```

## Fix

Bulk enumeration is best-effort (it only backs the CLI help string), so any module that fails to import for any reason should be skipped and logged at debug rather than allowed to crash the CLI. Broadened the handler to `except Exception` and included the error in the debug log for diagnosability. The narrower per-adapter path (`ensure_adapter_loaded`) is untouched, so a real requested adapter still surfaces its import error.

## Testing

`lmcache server --help` no longer aborts when the bigtable adapter's protobuf conflict raises `TypeError`; the adapter is skipped and the remaining adapters/help render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
