### PR TITLE
[Fix] MiniMax M3 and other Mamba Model for incoming vLLM 0.26

### DIFF
--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -4,8 +4,8 @@
 This is needed to mask out attention-specific details while making sure that
 LMCache can still store / load KV cache correctly.
 
-Currently there are two edits, one per :class:`KVCacheGroupEdit` subclass
-below. Both are for Mamba-hybrid models; the registry is only consulted when
+Currently there are three edits, one per :class:`KVCacheGroupEdit` subclass
+below. All are for Mamba-hybrid models; the registry is only consulted when
 ``kv_cache_config.has_mamba_layers``. :func:`validate_kv_cache_groups`
 additionally rejects, at startup, group specs the transfer path cannot serve
 correctly yet (see its docstring).
@@ -51,6 +51,7 @@ import torch
 
 # First Party
 from lmcache.logging import init_logger
+from lmcache.v1.gpu_connector.utils import LayoutHints
 
 logger = init_logger(__name__)
 
@@ -184,12 +185,18 @@ class KVCacheGroupEdit(ABC):
         """
 
     @abstractmethod
-    def apply(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> torch.Tensor:
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        layout_hints: LayoutHints,
+    ) -> torch.Tensor:
         """Return the edited view for a layer this rule matched.
 
         Args:
             spec: The layer's vLLM KV cache spec (from its group).
             kv_cache: The layer's registered cache value.
+            layout_hints: The layout hints from vLLM (see :class:`LayoutHints`).
 
         Raises:
             ValueError: If the cache's layout violates the rule's invariants.
@@ -216,9 +223,16 @@ class _MambaPageViewEdit(KVCacheGroupEdit):
     name = "mamba-page-view"
 
     def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
-        return get_kv_cache_spec_kind(spec) == KVCacheSpecKind.MAMBA
+        return get_kv_cache_spec_kind(spec) == KVCacheSpecKind.MAMBA and isinstance(
+            kv_cache, list
+        )
 
-    def apply(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> torch.Tensor:
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        _layout_hints: LayoutHints,
+    ) -> torch.Tensor:
         # vLLM lays out one padded page per block as (conv | ssm | pad), and
         # the conv state is the view that starts at the page base: its leading
         # dim is the block count and its per-block stride is one full page.
@@ -290,7 +304,12 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
             and kv_cache.shape[2] != spec.block_size
         )
 
-    def apply(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> torch.Tensor:
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        _layout_hints: LayoutHints,
+    ) -> torch.Tensor:
         """Re-view ``kv_cache`` at logical-block granularity.
 
         The tensor is kernel-paged as ``(num_kernel_pages, 2,
@@ -349,8 +368,60 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
         return kv_cache.view(num_blocks, 2, logical_block_size, num_heads, head_size)
 
 
+class _MambaUnifiedViewEdit(KVCacheGroupEdit):
+    """Re-view mamba's unified state as a single attention tensor
+
+    This is for vLLM >= 0.26.0, where the unified KV cache layout is implemented.
+
+    In this case, Mamba's KV layer will be a single tensor with the shape of:
+    - [num_blocks, 1, 1, context_size]
+    Where the context size equals to vllm_block_size * ``head_size''
+
+
+    What we do here is to convert the shape to
+    - [num_blocks, 1, vllm_block_size, head_size]
+    """
+
+    name = "mamba-unified-view"
+
+    def matches(self, spec: KVCacheSpec, kv_cache: RegisteredKVCache) -> bool:
+        """
+        Matches the mamba kv cache with unified layout.
+        """
+        return (
+            get_kv_cache_spec_kind(spec) == KVCacheSpecKind.MAMBA
+            and isinstance(kv_cache, torch.Tensor)
+            and kv_cache.ndim == 4
+        )
+
+    def apply(
+        self,
+        spec: KVCacheSpec,
+        kv_cache: RegisteredKVCache,
+        layout_hints: LayoutHints,
+    ) -> torch.Tensor:
+        """
+        Convert [num_blocks, 1, 1, context_size] to
+        [num_blocks, 1, vllm_block_size, head_size] for HND layout, or
+        [num_blocks, vllm_block_size, 1, head_size] for NHD layout.
+        """
+        assert isinstance(kv_cache, torch.Tensor), (
+            "single-layer KV cache must be a torch.Tensor"
+        )
+        kv_layout = layout_hints.get("kv_layout", "none")
+        if kv_layout == "NHD":
+            return kv_cache.view(kv_cache.shape[0], spec.block_size, 1, -1)
+        elif kv_layout == "HND":
+            return kv_cache.view(kv_cache.shape[0], 1, spec.block_size, -1)
+        else:
+            raise ValueError(
+                f"Unsupported kv_layout: {kv_layout}. Only NHD and HND are supported."
+            )
+
+
 # Rule registry, in match priority order.
 _EDITS: tuple[KVCacheGroupEdit, ...] = (
+    _MambaUnifiedViewEdit(),
     _MambaPageViewEdit(),
     _SubpagedAttentionViewEdit(),
 )
@@ -359,6 +430,7 @@ _EDITS: tuple[KVCacheGroupEdit, ...] = (
 def apply_kv_cache_group_edits(
     kv_cache_config: KVCacheConfig | None,
     kv_caches: Mapping[str, RegisteredKVCache],
+    layout_hints: LayoutHints,
 ) -> dict[str, RegisteredKVCache]:
     """Apply all KV cache group metadata edits for LMCache registration.
 
@@ -371,6 +443,7 @@ def apply_kv_cache_group_edits(
         kv_cache_config: vLLM ``KVCacheConfig`` (read for per-group specs).
         kv_caches: Registered tensors keyed by layer name. Mamba entries are
             ``[conv_state, ssm_state]`` lists; others are single tensors.
+        layout_hints: layout hints from vLLM (see :class:`LayoutHints`).
 
     Returns:
         A new ``dict`` with edited layers re-viewed, others untouched.
@@ -392,7 +465,7 @@ def apply_kv_cache_group_edits(
         for name in group.layer_names:
             for edit in _EDITS:
                 if edit.matches(spec, kv_caches[name]):
-                    edited[name] = edit.apply(spec, kv_caches[name])
+                    edited[name] = edit.apply(spec, kv_caches[name], layout_hints)
                     counts[edit.name] += 1
                     break
     logger.info(

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -750,11 +750,14 @@ class LMCacheMPConnector(KVConnectorBase_V1, SupportsHMA):
         kv_cache_config = getattr(self, "_kv_cache_config", None)
         # Must precede both group-info creation and transfer registration so
         # they see the same edited views.
-        kv_caches = apply_kv_cache_group_edits(kv_cache_config, kv_caches)
+        layout_hints = vllm_layout_hints()
+        kv_caches = apply_kv_cache_group_edits(
+            kv_cache_config, kv_caches, layout_hints=layout_hints
+        )
         engine_group_infos = create_engine_group_infos_from_vllm(
             kv_cache_config,
             kv_caches,
-            layout_hints=vllm_layout_hints(),
+            layout_hints=layout_hints,
         )
         self.worker_adapter.register_kv_caches(
             kv_caches, engine_group_infos=engine_group_infos

--- a/lmcache/v1/gpu_connector/kv_format/__init__.py
+++ b/lmcache/v1/gpu_connector/kv_format/__init__.py
@@ -11,7 +11,10 @@ Public surface:
 """
 
 # First Party
-from lmcache.v1.gpu_connector.kv_format.detection import detect_format
+from lmcache.v1.gpu_connector.kv_format.detection import (
+    detect_format,
+    extract_kv_cache_shapes,
+)
 from lmcache.v1.gpu_connector.kv_format.specs import (
     KVFormatSpec,
     concrete_shape,
@@ -25,6 +28,7 @@ __all__ = [
     "concrete_shape",
     "describe_shape",
     "detect_format",
+    "extract_kv_cache_shapes",
     "get_spec",
     "get_spec_class",
 ]

--- a/lmcache/v1/gpu_connector/kv_format/contiguity.py
+++ b/lmcache/v1/gpu_connector/kv_format/contiguity.py
@@ -17,6 +17,29 @@ from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache
 logger = init_logger(__name__)
 
 
+def _get_expected_shape(stride: tuple[int, ...], num_elems: int) -> tuple[int, ...]:
+    """Return the expected shape for a stride-sorted tensor view.
+
+    The returned shape is the tightest possible (contiguous) layout
+    that preserves the original storage size and stride ordering. For
+    example, a tensor with ``stride=(16, 4, 1)`` has an expected shape
+    of ``(4, 4, 4)``, which is the smallest shape that can be laid out
+    in memory with those strides.
+
+    Args:
+        stride: The stride of the tensor.
+        num_elems: The total number of elements in the tensor.
+
+    Returns:
+        The expected shape for a contiguous layout.
+    """
+    assert len(stride) > 0, "Stride must have at least one dimension"
+    expected_shape = [num_elems // stride[0]]
+    for i in range(0, len(stride) - 1):
+        expected_shape.append(stride[i] // stride[i + 1])
+    return tuple(dim for dim in expected_shape)
+
+
 def attempt_permute_to_contiguous_view(
     kv_caches: DiscoverableKVCache,
 ) -> DiscoverableKVCache:
@@ -50,13 +73,11 @@ def attempt_permute_to_contiguous_view(
     preserved.
     """
     if isinstance(kv_caches, torch.Tensor):
-        if kv_caches.is_contiguous():
-            return kv_caches
         strides = kv_caches.stride()
         perm = sorted(range(kv_caches.ndim), key=lambda i: strides[i], reverse=True)
         result = kv_caches.permute(perm)
         if result.is_contiguous():
-            return result
+            return result.view(_get_expected_shape(result.stride(), result.numel()))
         padding_per_block = _validate_dim0_padded_layout(result)
         logger.debug(
             "attempt_permute_to_contiguous_view: accepting dim-0-padded "

--- a/lmcache/v1/gpu_connector/kv_format/detection.py
+++ b/lmcache/v1/gpu_connector/kv_format/detection.py
@@ -5,6 +5,9 @@
 off to the engine's :class:`EngineDetector` to reshape and identify the format.
 """
 
+# Third Party
+import torch
+
 # First Party
 from lmcache.logging import init_logger
 from lmcache.utils import EngineType
@@ -17,6 +20,28 @@ from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache, Layout
 import lmcache.c_ops as lmc_ops
 
 logger = init_logger(__name__)
+
+
+def extract_kv_cache_shapes(
+    kv_caches: DiscoverableKVCache,
+) -> set[torch.Size]:
+    """Extract the tensor shapes that is in the kv_caches structure.
+
+    Args:
+        kv_caches (DiscoverableKVCache): The kv_caches structure to extract shapes
+        from.
+
+    Returns:
+        set[torch.Size]: A set of tensor shapes found in the kv_caches structure.
+    """
+    if isinstance(kv_caches, torch.Tensor):
+        return {kv_caches.shape}
+
+    shapes = set()
+    for t in kv_caches:
+        shapes.update(extract_kv_cache_shapes(t))
+
+    return shapes
 
 
 def detect_format(

--- a/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
+++ b/lmcache/v1/gpu_connector/kv_format/detectors/vllm.py
@@ -40,6 +40,9 @@ class VLLM_Detector(EngineDetector):
         # (HND) or BS/NH (NHD) -- indistinguishable from the shape alone, so the
         # resolved kv_layout decides. Split [NB, *, *, 2*HS] into
         # [NB, *, *, 2, HS].
+
+        # TODO(ApostaC): deprecate NL_X_NB_NH_BS_TWO_HS/NL_X_NB_BS_NH_TWO_HS
+        # and introduce more clear formats: NL_X_NB_NH_BS_CS/NL_X_NB_BS_NH_CS
         if (
             isinstance(kv_caches, list)
             and kv_caches

--- a/lmcache/v1/gpu_connector/utils.py
+++ b/lmcache/v1/gpu_connector/utils.py
@@ -22,6 +22,7 @@ from lmcache.v1.gpu_connector.kv_format import (
     concrete_shape,
     describe_shape,
     detect_format,
+    extract_kv_cache_shapes,
     get_spec,
     get_spec_class,
 )
@@ -237,13 +238,15 @@ def normalize_and_discover_per_layer_formats(
 
     # Detect the whole structure once. A format that isn't a per-layer list (a
     # cross-layer tensor, or a K/V-split) is single-format -- return it whole.
-    whole_format, whole_normalized = detect_format(
-        kv_caches, serving_engine, layout_hints
-    )
-    if not lmc_ops.is_layer_list(whole_format):
-        return whole_normalized, [whole_format] * get_num_layers(
-            whole_normalized, whole_format
+    extracted_shapes = extract_kv_cache_shapes(kv_caches)
+    if len(extracted_shapes) == 1:
+        whole_format, whole_normalized = detect_format(
+            kv_caches, serving_engine, layout_hints
         )
+        if not lmc_ops.is_layer_list(whole_format):
+            return whole_normalized, [whole_format] * get_num_layers(
+                whole_normalized, whole_format
+            )
 
     # Per-layer list: re-detect per engine group, split by tensor shape so a group
     # that mixes layouts gets the right format per layer.

--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -231,12 +231,13 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
 
     # Validate and normalise the tensor *before* touching the registry
     # or mutating storage, so a bad input never leaves things half-done.
-    tensor = attempt_permute_to_contiguous_view(tensor)
+    normalized = attempt_permute_to_contiguous_view(tensor)
+    assert isinstance(normalized, torch.Tensor)
     if tensor.device.type != "cpu":
         raise ValueError(
             "migrate_to_shm_and_wrap requires a CPU tensor, got %s" % tensor.device
         )
-    if not tensor.is_contiguous():
+    if not normalized.is_contiguous():
         raise ValueError("migrate_to_shm_and_wrap requires a contiguous tensor")
 
     tid = id(tensor)
@@ -279,9 +280,9 @@ def migrate_to_shm_and_wrap(tensor: torch.Tensor) -> CpuShmTensorWrapper:
         shm_storage = torch.frombuffer(buf, dtype=torch.uint8).untyped_storage()
         tensor.set_(
             shm_storage,
-            tensor.storage_offset(),
-            tensor.shape,
-            tensor.stride(),
+            normalized.storage_offset(),
+            normalized.shape,
+            normalized.stride(),
         )
     except Exception:
         # Make sure the SHM resources don't leak if migration fails

--- a/tests/v1/gpu_connector/test_kv_format_detection.py
+++ b/tests/v1/gpu_connector/test_kv_format_detection.py
@@ -14,7 +14,7 @@ import torch
 
 # First Party
 from lmcache.utils import EngineType
-from lmcache.v1.gpu_connector.kv_format import detect_format
+from lmcache.v1.gpu_connector.kv_format import detect_format, extract_kv_cache_shapes
 import lmcache.c_ops as lmc_ops
 
 NB, NL, BS, NH, HS = 7, 5, 3, 2, 4
@@ -30,7 +30,8 @@ def test_vllm_cross_layer():
     kv = _t(NB, NL, 2, BS, NH, HS)
     fmt, out = detect_format(kv, EngineType.VLLM, {"kv_layout": "NHD"})
     assert fmt == F.NB_NL_TWO_BS_NH_HS
-    assert out is kv
+    assert tuple(out.shape) == tuple(kv.shape)
+    assert out.data_ptr() == kv.data_ptr()
 
 
 # The CPU-HND safeguard forces HND regardless of hint when running on a CPU
@@ -124,3 +125,20 @@ def test_unsupported_structure_raises():
     kv = [_t(NB, HS) for _ in range(NL)]
     with pytest.raises(ValueError):
         detect_format(kv, EngineType.VLLM, {"kv_layout": "NHD"})
+
+
+def test_extract_kv_cache_shapes_single_tensor():
+    assert extract_kv_cache_shapes(_t(NB, BS, HS)) == {(NB, BS, HS)}
+
+
+def test_extract_kv_cache_shapes_uniform_list_dedups():
+    kv = [_t(2, NB, BS, NH, HS) for _ in range(NL)]
+    assert extract_kv_cache_shapes(kv) == {(2, NB, BS, NH, HS)}
+
+
+def test_extract_kv_cache_shapes_mixed_nested():
+    kv = [
+        [_t(NB, BS, NH, HS), _t(NB, BS, HS)],
+        [_t(NB, BS, NH, HS)],
+    ]
+    assert extract_kv_cache_shapes(kv) == {(NB, BS, NH, HS), (NB, BS, HS)}

--- a/tests/v1/gpu_connector/test_utils_shape_desc.py
+++ b/tests/v1/gpu_connector/test_utils_shape_desc.py
@@ -181,13 +181,14 @@ def test_get_group_data_ptrs_cross_layer_returns_single_base():
 
 
 def test_attempt_permute_preserves_bare_tensor():
-    """A bare torch.Tensor input (cross-layer shape) must pass through
-    attempt_permute_to_contiguous_view unchanged — no list wrapping — so the
+    """A bare torch.Tensor input (cross-layer shape) must come back as a bare
+    tensor — no list wrapping, no copy, shape intact — so the
     DiscoverableKVCache recursive union is respected end-to-end."""
     big = torch.empty(32, 80, 2, 16, 8, 64, dtype=torch.bfloat16, device="cuda")
     out = attempt_permute_to_contiguous_view(big)
     assert isinstance(out, torch.Tensor)
-    assert out is big
+    assert tuple(out.shape) == tuple(big.shape)
+    assert out.data_ptr() == big.data_ptr()
 
 
 def test_attempt_permute_recurses_all_shapes():
@@ -219,6 +220,34 @@ def test_attempt_permute_recurses_all_shapes():
     out_nested = attempt_permute_to_contiguous_view([k, v])
     assert isinstance(out_nested, list)
     assert all(t.is_contiguous() for sublist in out_nested for t in sublist)
+
+
+def test_attempt_permute_reorders_misleading_size_one_dims():
+    """A single-head HND-physical tensor exposed as an NHD logical view is
+    torch-contiguous (size-1 dims are stride-exempt), so a plain contiguity
+    check would pass it through with a shape that lies about the physical
+    layout. The stride sort must still reorder it to the stride-truthful
+    HND shape, zero-copy."""
+    phys = torch.empty(2, 32, 1, 16, 64, dtype=torch.bfloat16, device="cuda")
+    logical = phys.permute(0, 1, 3, 2, 4)  # [2, NB, BS, 1, HS]
+    assert logical.is_contiguous()
+
+    out = attempt_permute_to_contiguous_view(logical)
+    assert tuple(out.shape) == (2, 32, 1, 16, 64)
+    assert out.data_ptr() == phys.data_ptr()
+
+
+def test_attempt_permute_reviews_collapsed_size_one_strides():
+    """A contiguous view whose size-1 dims carry collapsed (stride-1) strides
+    hides the true extent of its inner dim; the re-view must recover the
+    tightest shape implied by the strides, zero-copy."""
+    base = torch.empty(8 * 32, dtype=torch.bfloat16, device="cuda")
+    t = base.as_strided((8, 1, 1, 32), (32, 1, 1, 1))
+    assert t.is_contiguous()
+
+    out = attempt_permute_to_contiguous_view(t)
+    assert tuple(out.shape) == (8, 32, 1, 1)
+    assert out.data_ptr() == base.data_ptr()
 
 
 def test_get_device_handles_every_kvcaches_shape():

--- a/tests/v1/platform/test_cpu_shm.py
+++ b/tests/v1/platform/test_cpu_shm.py
@@ -49,6 +49,32 @@ def test_migrate_to_shm_and_wrap_zero_copy_view():
         shm_unlink(wrapper.shm_name)
 
 
+def test_migrate_normalizes_layout_in_place_on_caller_tensor():
+    """Layout normalization must not detach migration from the caller's tensor.
+
+    ``attempt_permute_to_contiguous_view`` returns a *new view* object; the
+    migration must still re-point the caller's tensor (its storage, and its
+    shape/stride to the stride-truthful layout) and key the unlink finalizer
+    on it. Regression for the premature-unlink bug where the finalizer was
+    attached to the temporary view and the segment vanished on return.
+    """
+    # Torch-contiguous, but the size-1 dims hide the true inner extent:
+    # the stride-truthful layout is (8, 32, 1, 1).
+    src = torch.zeros(8 * 32, dtype=torch.float32).as_strided(
+        (8, 1, 1, 32), (32, 1, 1, 1)
+    )
+    wrapper = migrate_to_shm_and_wrap(src)
+    try:
+        assert tuple(src.shape) == (8, 32, 1, 1)
+        assert wrapper.shape == (8, 32, 1, 1)
+        # Writes via the caller's tensor land in the SHM segment.
+        src.add_(3.0)
+        view = wrapper.to_tensor()
+        assert torch.equal(view, src)
+    finally:
+        shm_unlink(wrapper.shm_name)
+
+
 def test_migrate_handles_empty_tensor():
     """Empty tensors must not call ``mmap`` (length 0 is EINVAL).
 


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Fixes #4154 

This PR adds support for incoming vLLM 0.26 unified KV cache, with the following changes:
- Introduce a new KV cache edit module for unified Mamba cache
- Fixed logical errors during KV cache detection when the KV cache list contains multiple different formats
- Fixed the wrong head-size detection issue (#4154) caused by incorrect permutations during KV cache registration.


**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
