### PR TITLE
[fix] Fix non-prefix  TP desync when a chunk's shard is missing on one TP rank

### DIFF
--- a/lmcache/v1/multiprocess/modules/blend_v3.py
+++ b/lmcache/v1/multiprocess/modules/blend_v3.py
@@ -925,11 +925,16 @@ class BlendV3Module(InstanceLivenessTarget):
             # NOTE(Kuntai): assumes uniform world size and prefix-ordered keys
             # that break at the first miss.
             leading = bm.count_leading_ones() // ws
-            retained = (
-                sorted({ki // ws for ki in bm.get_indices_list()})
-                if segmented
-                else None
-            )
+            # Retain a chunk only if EVERY rank shard loaded (AND across the ws
+            # shards); a chunk missing any rank's shard is demoted to a gap.
+            if segmented:
+                shard_counts: dict[int, int] = {}
+                for ki in bm.get_indices_list():
+                    c = ki // ws
+                    shard_counts[c] = shard_counts.get(c, 0) + 1
+                retained = sorted(c for c, n in shard_counts.items() if n == ws)
+            else:
+                retained = None
         else:
             # No GPU context / no full chunk: nothing loaded.
             leading, retained = 0, ([] if segmented else None)
@@ -1718,7 +1723,11 @@ class BlendV3Module(InstanceLivenessTarget):
                     all_obj_keys
                 ) as memory_objs:
                     if memory_objs is None:
-                        return event_ipc_handle, False
+                        # Read failed: return a valid server event + False, never
+                        # the client's own handle (self-import raises
+                        # cudaErrorDeviceUninitialized, crashing TP).
+                        event.record()
+                        return event.ipc_handle(), False
 
                     # Per-token scatter handles any cur_st; just bound the
                     # matched range to the allocated slots.
@@ -1868,7 +1877,10 @@ class BlendV3Module(InstanceLivenessTarget):
                         session_id=key.request_id,
                     ),
                 )
-                return event_ipc_handle, False
+                # Valid server event + False (never echo the client handle; see
+                # the memory_objs-None path above).
+                event.record()
+                return event.ipc_handle(), False
 
             event.record()
             self._event_bus.publish_on_stream(


### PR DESCRIPTION
 
**DESCRIPTION:**

## Problem
Under TP a chunk's KV is sharded one-object-per-rank, so a chunk is usable only if *every* rank's shard is present. Two spots in the V3 blend server violated this and could crash the TP engine:

1. `_poll_prefix_leg` built the SEGMENTED `retained` set by ORing per-rank shard bits (`{ki // ws for ki in found}`). A chunk missing a shard on one rank was still retained and delivered as a pure-load prefix chunk; that rank then read a missing object, desyncing the TP executor (EngineDead).
2. On a failed retrieve, `cb_retrieve_pre_computed` returned the **client's own** event handle. Importing a self-exported IPC event raises `cudaErrorDeviceUninitialized`, turning a recoverable miss into a hard crash.

Only reproduces at TP > 1 (at TP=1, `ws=1`, so OR ≡ AND and there's no cross-rank collective to desync).

## Fix
- **Retain a chunk only if every rank's shard loaded** (AND): count shards per chunk, keep only full-complement chunks. A single-rank miss now demotes the whole chunk to a recompute gap, uniformly across ranks.
- **Never echo the client's handle on failure**: return a valid server event plus a `False` scatter-ran status, so the client imports the event and observes the failure instead of crashing.

## Testing
Reproduced on an 8×NVMe TP=4 stack with a fault-injecting L2 adapter dropping one rank's shard: before, segmented retrieve crashed the engine; after, the affected chunk is demoted to a gap and recomputed while the rest is reused — recall unchanged, no desync, CacheBlend reuse preserved.