### PR TITLE
[MP][Bugfix] Split store batches into uniform-size sub-batches for native connectors

### DIFF
--- a/docs/design/v1/mp_observability/METRICS.md
+++ b/docs/design/v1/mp_observability/METRICS.md
@@ -467,6 +467,39 @@ prefetch reservations are crowding out cacheable data.
 
 ---
 
+## L2 Adapter Pending-Entry Gauge
+
+Leak watchdog for `NativeConnectorL2Adapter`.  The adapter tracks every
+native submission in three dicts (`_pending_ops`, `_pending_store_tasks`,
+`_pending_store_sizes`) that are popped when the native connector delivers
+a completion.  If a completion never arrives, or the adapter's demux
+thread dies, those entries stay forever, along with the L1 read locks
+held by the in-flight store.  This gauge makes that state visible.
+
+| OTel metric name | Prometheus name | Type | Source of truth | Calculation |
+|---|---|---|---|---|
+| `lmcache_mp.l2_adapter_pending_entries` | `lmcache_mp_l2_adapter_pending_entries` | ObservableGauge (attrs: `l2_name`, `map`) | `NativeConnectorL2Adapter.collect_pending_entries_observations()` | `len()` of each pending dict per live adapter at scrape time |
+
+Attributes:
+
+- `l2_name`: the adapter's registered type name (e.g. `"resp"`,
+  `"mooncake_store"`).  Counts from adapters that share a type name are
+  summed into one series.
+- `map`: the dict the count belongs to (`pending_ops`,
+  `pending_store_tasks`, or `pending_store_sizes`).
+
+Zero counts are reported (unlike the in-flight gauges above), so a
+backlog draining back to zero is observable.  Adapters removed by
+`close()` stop reporting.
+
+**What it answers:** Did every native store/lookup/load submission get its
+completion back? Under load the values move with traffic; a series that
+grows and never returns to zero after traffic stops means a native
+future was lost (worker died, connection never came up) and the paired
+entries plus their L1 read locks leaked.
+
+---
+
 ## Cache Blending (CB) Metrics
 
 Metrics for Cache Blending operations use the `lmcache_blend.` prefix (distinct from the

--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
@@ -161,7 +161,7 @@ def _create_fs_native_l2_adapter(
     return NativeConnectorL2Adapter(
         native_client,
         max_capacity_gb=config.max_capacity_gb,
-        type_name="FSNativeL2Adapter",
+        type_name="fs_native",
         extra_status={
             "base_path": config.base_path,
             "use_odirect": config.use_odirect,

--- a/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/mooncake_store_l2_adapter.py
@@ -207,7 +207,7 @@ def _create_mooncake_store_l2_adapter(
         config.per_op_workers,
         l1_registration.enabled and l1_registration.size > 0,
     )
-    return NativeConnectorL2Adapter(native_client)
+    return NativeConnectorL2Adapter(native_client, type_name="mooncake_store")
 
 
 # Self-register config type and adapter factory

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 # Standard
 from collections import defaultdict
 from typing import Any
+import dataclasses
 import select
 import threading
 
@@ -81,6 +82,16 @@ def _obj_to_memoryview(
     return obj.byte_array  # type: ignore[return-value]
 
 
+@dataclasses.dataclass
+class _PendingStoreTask:
+    """Aggregation state for one store task split into uniform-size
+    sub-batches (see ``submit_store_task``)."""
+
+    remaining: int
+    ok: bool = True
+    bytes_stored: int = 0
+
+
 class NativeConnectorL2Adapter(L2AdapterInterface):
     """
     Wraps a pybind-wrapped C++ IStorageConnector to
@@ -129,6 +140,10 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
             int,
             tuple[str, L2TaskId, int, list[ObjectKey] | None],
         ] = {}
+
+        # Store tasks split into uniform-size sub-batches:
+        # task_id → aggregation state across its native futures
+        self._pending_store_tasks: dict[L2TaskId, _PendingStoreTask] = {}
 
         # Completed results (same pattern as MockL2Adapter)
         self._completed_stores: dict[L2TaskId, L2StoreResult] = {}
@@ -195,19 +210,61 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
         memviews = [_obj_to_memoryview(obj) for obj in objects]
         per_key_sizes = [obj.get_size() for obj in objects]
 
+        # Native connectors require every buffer in a batch to share one
+        # size: the pybind wrapper takes the first buffer's size as
+        # batch_chunk_num_bytes and the C++ side rejects any other size
+        # ("buffer size mismatch"), failing the whole batch. Real store
+        # batches can mix sizes (e.g. a trailing partial chunk, or
+        # heterogeneous object groups), so group the keys by buffer size
+        # and submit one native batch per size, aggregated under a single
+        # task id.
+        size_groups: dict[int, list[int]] = {}
+        for idx, memview in enumerate(memviews):
+            size_groups.setdefault(memview.nbytes, []).append(idx)
+        # An empty submit keeps its native error behavior via one empty call.
+        index_groups = list(size_groups.values()) or [[]]
+
         # Register pending op BEFORE submit to avoid race
         # with demux thread. The native submit is
         # non-blocking so holding the lock is brief.
         with self._lock:
             task_id = self._get_next_task_id()
-            future_id = int(self._client.submit_batch_set(key_strings, memviews))
-            self._pending_ops[future_id] = (
-                self._OP_STORE,
-                task_id,
-                len(keys),
-                None,
+            self._pending_store_tasks[task_id] = _PendingStoreTask(
+                remaining=len(index_groups)
             )
-            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
+            submitted = 0
+            try:
+                for indices in index_groups:
+                    future_id = int(
+                        self._client.submit_batch_set(
+                            [key_strings[i] for i in indices],
+                            [memviews[i] for i in indices],
+                        )
+                    )
+                    self._pending_ops[future_id] = (
+                        self._OP_STORE,
+                        task_id,
+                        len(indices),
+                        None,
+                    )
+                    self._pending_store_sizes[future_id] = (
+                        [keys[i] for i in indices],
+                        [per_key_sizes[i] for i in indices],
+                    )
+                    submitted += 1
+            except Exception:
+                if submitted == 0:
+                    # Nothing in flight: drop the task and let the caller
+                    # see the native error, as before.
+                    self._pending_store_tasks.pop(task_id, None)
+                else:
+                    # Some sub-batches are in flight; shrink the aggregate
+                    # so their completions still close the task, marked
+                    # failed.
+                    state = self._pending_store_tasks[task_id]
+                    state.remaining = submitted
+                    state.ok = False
+                raise
 
         return task_id
 
@@ -451,7 +508,19 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
                     if op_type == self._OP_STORE:
                         store_info = self._pending_store_sizes.pop(fid, None)
-                        task_bytes = 0
+                        state = self._pending_store_tasks.get(task_id)
+                        if state is None:
+                            # Should not happen; recover with a
+                            # single-sub-batch aggregate.
+                            state = _PendingStoreTask(remaining=1)
+                            self._pending_store_tasks[task_id] = state
+                        if not ok:
+                            state.ok = False
+                            logger.warning(
+                                "Native store sub-batch failed (%d keys): %s",
+                                num_keys,
+                                error,
+                            )
                         if ok and store_info is not None:
                             store_keys, sizes = store_info
                             for key, size in zip(store_keys, sizes, strict=True):
@@ -466,12 +535,17 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
                                     self._key_sizes[key] = size
                                     keys_stored.append(key)
                                     sizes_stored.append(size)
-                                    task_bytes += size
+                                    state.bytes_stored += size
                                 else:
                                     keys_stored.append(key)
                                     sizes_stored.append(0)
-                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
-                        self._store_efd.notify()
+                        state.remaining -= 1
+                        if state.remaining <= 0:
+                            self._pending_store_tasks.pop(task_id, None)
+                            self._completed_stores[task_id] = L2StoreResult(
+                                state.ok, state.bytes_stored
+                            )
+                            self._store_efd.notify()
 
                     elif op_type == self._OP_LOOKUP:
                         bitmap = Bitmap(num_keys)

--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
@@ -26,6 +26,7 @@ from typing import Any
 import dataclasses
 import select
 import threading
+import weakref
 
 # First Party
 from lmcache.logging import init_logger
@@ -37,6 +38,7 @@ from lmcache.v1.distributed.l2_adapters.base import (
     L2TaskId,
 )
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.mp_observability.otel_init import register_gauge
 from lmcache.v1.platform import create_event_notifier
 
 logger = init_logger(__name__)
@@ -113,6 +115,17 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     _OP_LOAD = "load"
     _OP_DELETE = "delete"
 
+    # Process-wide gauge dispatch: the OTel SDK only honors the first registration
+    # of a gauge name, so ``lmcache_mp.l2_adapter_pending_entries`` is registered
+    # once and its callback aggregates over every live adapter tracked here.
+    # ``close()`` is the removal path (the demux thread keeps its adapter alive
+    # until then); the weak references are a backstop for adapters whose thread
+    # already exited without a ``close()`` call.  ``_gauge_lock`` guards the set
+    # and the register-once flag against the OTel scrape thread.
+    _gauge_registered: bool = False
+    _gauge_instances: "weakref.WeakSet[NativeConnectorL2Adapter]" = weakref.WeakSet()
+    _gauge_lock: threading.Lock = threading.Lock()
+
     def __init__(
         self,
         native_client: Any,
@@ -174,6 +187,24 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
 
         # Lock for all shared state above
         self._lock = threading.Lock()
+
+        # Leak gauge: track this instance and register the process-wide
+        # gauge on first construction.
+        with NativeConnectorL2Adapter._gauge_lock:
+            NativeConnectorL2Adapter._gauge_instances.add(self)
+            if not NativeConnectorL2Adapter._gauge_registered:
+                NativeConnectorL2Adapter._gauge_registered = True
+                register_gauge(
+                    "lmcache.l2_adapter",
+                    "lmcache_mp.l2_adapter_pending_entries",
+                    (
+                        "Entries in each pending-state dict of live native L2 "
+                        "adapters, tagged by ``l2_name`` and ``map``. A series "
+                        "that keeps growing without returning to zero points "
+                        "at a native completion that never arrived."
+                    ),
+                    NativeConnectorL2Adapter.collect_pending_entries_observations,
+                )
 
         # Background demux thread
         self._stop = threading.Event()
@@ -402,6 +433,59 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     # Status Interface
     # ---------------------------------------------------------------
 
+    def get_pending_entry_counts(self) -> dict[str, int]:
+        """Entry counts of the pending-state dicts, keyed by dict name.
+
+        Feeds ``collect_pending_entries_observations`` (the
+        ``lmcache_mp.l2_adapter_pending_entries`` gauge callback).  Zero
+        counts are included so a backlog draining back to zero stays
+        observable.
+
+        ``len()`` on a dict is atomic under the CPython GIL, so reading
+        from the OTel scrape thread without ``_lock`` is safe; the
+        snapshot may be one mutation stale, which is fine at scrape
+        cadence.
+
+        Returns:
+            ``{"pending_ops": <n>, "pending_store_tasks": <n>,
+            "pending_store_sizes": <n>}``.
+        """
+        return {
+            "pending_ops": len(self._pending_ops),
+            "pending_store_tasks": len(self._pending_store_tasks),
+            "pending_store_sizes": len(self._pending_store_sizes),
+        }
+
+    @classmethod
+    def collect_pending_entries_observations(
+        cls,
+    ) -> list[tuple[int | float, dict[str, object]]]:
+        """Aggregate pending-entry counts across live adapters.
+
+        Callback for the ``lmcache_mp.l2_adapter_pending_entries`` gauge.
+        Counts that share the same ``(l2_name, map)`` attribute pair are
+        summed, so two adapters registered under the same type name
+        report one combined series.  Adapters removed by ``close()``
+        report nothing.
+
+        Returns:
+            A list of ``(count, attrs)`` tuples where ``attrs`` is
+            ``{"l2_name": <adapter type name>, "map": <dict name>}``,
+            one per distinct pair over all live adapters.
+        """
+        with cls._gauge_lock:
+            adapters = list(cls._gauge_instances)
+        totals: dict[tuple[str, str], int] = {}
+        for adapter in adapters:
+            for map_name, count in adapter.get_pending_entry_counts().items():
+                pair = (adapter._type_name, map_name)
+                totals[pair] = totals.get(pair, 0) + count
+        observations: list[tuple[int | float, dict[str, object]]] = [
+            (count, {"l2_name": l2_name, "map": map_name})
+            for (l2_name, map_name), count in totals.items()
+        ]
+        return observations
+
     def report_status(self) -> dict[str, Any]:
         """Return a status dict for this native-connector L2 adapter.
 
@@ -426,6 +510,8 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
     # ---------------------------------------------------------------
 
     def close(self) -> None:
+        with NativeConnectorL2Adapter._gauge_lock:
+            NativeConnectorL2Adapter._gauge_instances.discard(self)
         self._stop.set()
         self._demux_thread.join(timeout=5)
 

--- a/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/native_plugin_l2_adapter.py
@@ -191,7 +191,9 @@ def _create_native_plugin_l2_adapter(
         config.adapter_params,
     )
     return NativeConnectorL2Adapter(
-        native_client, max_capacity_gb=config.max_capacity_gb
+        native_client,
+        max_capacity_gb=config.max_capacity_gb,
+        type_name="native_plugin",
     )
 
 

--- a/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/resp_l2_adapter.py
@@ -167,7 +167,9 @@ def _create_resp_l2_adapter(
         config.num_workers,
     )
     return NativeConnectorL2Adapter(
-        native_client, max_capacity_gb=config.max_capacity_gb
+        native_client,
+        max_capacity_gb=config.max_capacity_gb,
+        type_name="resp",
     )
 
 

--- a/tests/v1/distributed/test_mooncake_store_l2_adapter.py
+++ b/tests/v1/distributed/test_mooncake_store_l2_adapter.py
@@ -408,7 +408,7 @@ class TestMooncakeStoreL1RegistrationFactory:
         monkeypatch.setattr(
             native_connector_l2_adapter,
             "NativeConnectorL2Adapter",
-            lambda client: ("wrapped", client),
+            lambda client, **kwargs: ("wrapped", client),
         )
 
         config = MooncakeStoreL2AdapterConfig.from_dict(
@@ -461,7 +461,7 @@ class TestMooncakeStoreL1RegistrationFactory:
         monkeypatch.setattr(
             native_connector_l2_adapter,
             "NativeConnectorL2Adapter",
-            lambda client: ("wrapped", client),
+            lambda client, **kwargs: ("wrapped", client),
         )
 
         config = MooncakeStoreL2AdapterConfig.from_dict(
@@ -512,7 +512,7 @@ class TestMooncakeStoreL1RegistrationFactory:
         monkeypatch.setattr(
             native_connector_l2_adapter,
             "NativeConnectorL2Adapter",
-            lambda client: ("wrapped", client),
+            lambda client, **kwargs: ("wrapped", client),
         )
 
         config = MooncakeStoreL2AdapterConfig.from_dict(

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -23,6 +23,7 @@ from lmcache.v1.distributed.l2_adapters.native_connector_l2_adapter import (
 )
 from lmcache.v1.memory_management import (
     MemoryFormat,
+    MemoryObj,
     MemoryObjMetadata,
     TensorMemoryObj,
 )
@@ -1438,3 +1439,119 @@ class TestUsageTracking:
         usage = adp.get_usage()
         assert usage.usage_fraction == pytest.approx(0.2)
         assert usage.total_bytes_used == 400
+
+
+# =============================================================================
+# Pending-Entries Gauge Tests
+# =============================================================================
+
+
+class StalledStoreConnector(MockNativeConnector):
+    """Mock whose store submissions stay pending until ``release()``.
+
+    Lets tests observe non-zero pending-map counts deterministically:
+    the base mock pushes its completion inside ``submit_batch_set``, so
+    the demux thread drains it before the test can look.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._held_fids: list[int] = []
+
+    def submit_batch_set(self, keys: list[str], memoryviews: list) -> int:
+        with self._lock:
+            fid = self._next_id
+            self._next_id += 1
+            self._held_fids.append(fid)
+        return fid
+
+    def release(self) -> None:
+        """Push a success completion for every held store submission."""
+        with self._lock:
+            held = list(self._held_fids)
+            self._held_fids.clear()
+        for fid in held:
+            self._push_completion(fid, True, "", None)
+
+
+class TestPendingEntriesGauge:
+    def test_counts_rise_and_drain_to_zero(self):
+        client = StalledStoreConnector()
+        adp = NativeConnectorL2Adapter(client, type_name="stalled")
+        try:
+            keys = [create_object_key(i) for i in range(2)]
+            objs: list[MemoryObj] = [create_memory_obj(size=64) for _ in range(2)]
+            adp.submit_store_task(keys, objs)
+
+            # One uniform-size sub-batch in flight: one entry per map.
+            assert adp.get_pending_entry_counts() == {
+                "pending_ops": 1,
+                "pending_store_tasks": 1,
+                "pending_store_sizes": 1,
+            }
+
+            client.release()
+            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=5.0)
+
+            # Zero counts are still reported so a drain is observable.
+            assert adp.get_pending_entry_counts() == {
+                "pending_ops": 0,
+                "pending_store_tasks": 0,
+                "pending_store_sizes": 0,
+            }
+        finally:
+            adp.close()
+
+    def test_mixed_sizes_count_one_entry_per_sub_batch(self):
+        client = StalledStoreConnector()
+        adp = NativeConnectorL2Adapter(client, type_name="stalled")
+        try:
+            keys = [create_object_key(i) for i in range(3)]
+            objs: list[MemoryObj] = [
+                create_memory_obj(size=64),
+                create_memory_obj(size=64),
+                create_memory_obj(size=16),
+            ]
+            adp.submit_store_task(keys, objs)
+
+            # Two buffer sizes -> two native sub-batches under one task.
+            assert adp.get_pending_entry_counts() == {
+                "pending_ops": 2,
+                "pending_store_tasks": 1,
+                "pending_store_sizes": 2,
+            }
+        finally:
+            adp.close()
+
+    def test_aggregation_sums_same_type_and_skips_closed(self):
+        client_a = StalledStoreConnector()
+        client_b = StalledStoreConnector()
+        adp_a = NativeConnectorL2Adapter(client_a, type_name="stalled")
+        adp_b = NativeConnectorL2Adapter(client_b, type_name="stalled")
+        b_closed = False
+
+        def stalled_totals() -> dict[str, int | float]:
+            return {
+                str(attrs["map"]): count
+                for count, attrs in (
+                    NativeConnectorL2Adapter.collect_pending_entries_observations()
+                )
+                if attrs["l2_name"] == "stalled"
+            }
+
+        try:
+            for adp in (adp_a, adp_b):
+                adp.submit_store_task(
+                    [create_object_key(1)], [create_memory_obj(size=64)]
+                )
+
+            assert stalled_totals()["pending_ops"] == 2
+            assert stalled_totals()["pending_store_tasks"] == 2
+
+            adp_b.close()
+            b_closed = True
+            assert stalled_totals()["pending_ops"] == 1
+        finally:
+            adp_a.close()
+            if not b_closed:
+                adp_b.close()

--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
+++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
@@ -491,6 +491,86 @@ class TestStoreInterface:
 
 
 # =============================================================================
+# Uniform-Size Store Sub-Batching Tests
+# =============================================================================
+
+
+class _RecordingConnector(MockNativeConnector):
+    """Mock that records submit_batch_set calls and enforces the native
+    uniform-size contract (mixed sizes fail the whole batch, mirroring
+    csrc/storage_backends/connector_pybind_utils.h)."""
+
+    def __init__(self, fail_sizes: set | None = None):
+        super().__init__()
+        self.set_call_sizes: list[list[int]] = []
+        self._fail_sizes = fail_sizes or set()
+
+    def submit_batch_set(self, keys: list[str], memoryviews: list) -> int:
+        sizes = [mv.nbytes for mv in memoryviews]
+        self.set_call_sizes.append(sizes)
+        if len(set(sizes)) > 1 or (sizes and sizes[0] in self._fail_sizes):
+            with self._lock:
+                fid = self._next_id
+                self._next_id += 1
+            self._push_completion(fid, False, "buffer size mismatch", None)
+            return fid
+        return super().submit_batch_set(keys, memoryviews)
+
+
+class TestUniformSizeSubBatching:
+    def _run_store(self, client, keys, objs):
+        adapter = NativeConnectorL2Adapter(client)
+        try:
+            store_fd = adapter.get_store_event_fd()
+            task_id = adapter.submit_store_task(keys, objs)
+            completed = {}
+            while task_id not in completed:
+                assert wait_for_event_fd(store_fd, timeout=5.0)
+                completed.update(adapter.pop_completed_store_tasks())
+            return completed[task_id]
+        finally:
+            adapter.close()
+
+    def test_mixed_size_batch_splits_into_uniform_sub_batches(self):
+        client = _RecordingConnector()
+        keys = [create_object_key(i) for i in range(4)]
+        objs = [
+            create_memory_obj(size=1024),
+            create_memory_obj(size=256),
+            create_memory_obj(size=1024),
+            create_memory_obj(size=256),
+        ]
+        result = self._run_store(client, keys, objs)
+        assert result.is_successful()
+        # One native call per distinct buffer size, each uniform.
+        assert len(client.set_call_sizes) == 2
+        for sizes in client.set_call_sizes:
+            assert len(set(sizes)) == 1
+        # Every key landed despite the mixed input batch.
+        for key in keys:
+            assert _object_key_to_string(key) in client._store
+
+    def test_uniform_batch_stays_single_native_call(self):
+        client = _RecordingConnector()
+        keys = [create_object_key(i) for i in range(3)]
+        objs = [create_memory_obj(size=512) for _ in range(3)]
+        result = self._run_store(client, keys, objs)
+        assert result.is_successful()
+        assert len(client.set_call_sizes) == 1
+
+    def test_failed_sub_batch_marks_task_failed(self):
+        failing_nbytes = 256 * 4  # float32 elements -> bytes
+        client = _RecordingConnector(fail_sizes={failing_nbytes})
+        keys = [create_object_key(i) for i in range(2)]
+        objs = [create_memory_obj(size=1024), create_memory_obj(size=256)]
+        result = self._run_store(client, keys, objs)
+        assert not result.is_successful()
+        # The healthy sub-batch still landed.
+        assert _object_key_to_string(keys[0]) in client._store
+        assert _object_key_to_string(keys[1]) not in client._store
+
+
+# =============================================================================
 # Lookup and Lock Interface Tests
 # =============================================================================
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`NativeConnectorL2Adapter.submit_store_task` sends a whole store batch in one `submit_batch_set` call. The pybind wrapper takes the first buffer's size as `batch_chunk_num_bytes` ("all must match" in `connector_pybind_utils.h`), and the C++ connectors throw `buffer size mismatch` on any other size, failing the whole batch. It fails silently too: `do_batch_set` has no per-key logging (unlike `do_batch_get`) and the adapter reduces the completion to a bare `ok=False`, so the data is dropped with no log line and no retry.

Batches do arrive mixed. `StoreController._group_keys_by_shape` buckets keys by `(model_name, kv_rank)`, one bucket per `submit_store_task`, on the invariant its docstring states ("Each bucket shares a single `(shape, dtype)`") and asks to extend when a shape-affecting field is added to `ObjectKey`. `object_group_id` is such a field and is missing from the tuple. Under `separate_object_groups=True` (the MP default) each object group gets its own key from `ipc_key_to_object_keys` and its own memory-object size, so a hybrid-attention model puts two sizes in one bucket and the connector rejects all of it.

Observed on vLLM MP, a Gemma model with heterogeneous KV layout, RESP L2 to Redis 7.2.4: 5318 of 5326 store keys failed over a 5000-request benchmark and L2 stayed empty, while a single-key `submit_batch_set` probe to the same Redis from the same pod succeeded.

- `submit_store_task` groups keys by `memoryview.nbytes` and submits one native batch per size, aggregated under a single task id (`_PendingStoreTask`). The `L2TaskId` contract and `pop_completed_store_tasks` are unchanged, and a uniform batch still makes exactly one native call.
- The demux thread logs the native error string on a failed sub-batch instead of swallowing it.
- A native submit that raises partway through shrinks the aggregate to the sub-batches already submitted, so the task completes as failed rather than hanging.
- Adds `lmcache_mp.l2_adapter_pending_entries`, an observable gauge reporting `len()` of each pending map per live adapter, tagged by `l2_name` and `map`. Zero counts are reported so a draining backlog is visible.

**Special notes for your reviewers**:

1. The `StoreController` grouping tuple needs fixing too. I will send it separately since it is a different module and this PR is already under review. That one keeps buckets uniform at the source, this one makes the adapter hold the native contract on its own.

2. The store-bytes event just below the submit call assumes uniformity as well: `successful_objs[0].get_size() * len(successful_objs)`. I left it alone here; it becomes correct once the tuple is fixed.

3. @maobaolong asked for a way to confirm the pending maps are not leaking. The gauge covers `_pending_ops`, `_pending_store_sizes`, and the new `_pending_store_tasks`. Wiring the `l2_name` tag surfaced that adapter-side type names did not match the registered names other l2-tagged metrics use, so the factories now pass the registered ones (`resp`, `mooncake_store`, `native_plugin`, `fs_native`). The leak paths the gauge exposes are tracked in #4342.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
