### PR TITLE
[Core] add wake() to PeriodicThread

### DIFF
--- a/lmcache/v1/periodic_thread.py
+++ b/lmcache/v1/periodic_thread.py
@@ -128,6 +128,9 @@ class PeriodicThread(ABC):
         # Thread state
         self._thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
+        # Set to break out of the interval sleep early: either because
+        # stop() was called or because wake() requested an immediate run.
+        self._wake_event = threading.Event()
         self._running = False
 
         # Execution tracking
@@ -231,6 +234,7 @@ class PeriodicThread(ABC):
             return None
 
         self._stop_event.clear()
+        self._wake_event.clear()
         self._running = True
         self._start_time = time.time()
 
@@ -263,6 +267,8 @@ class PeriodicThread(ABC):
         logger.info("Stopping PeriodicThread: %s", self._name)
         self._running = False
         self._stop_event.set()
+        # Break the interval sleep so the loop notices stop immediately.
+        self._wake_event.set()
 
         if self._thread is not None and self._thread.is_alive():
             self._thread.join(timeout=timeout)
@@ -273,6 +279,17 @@ class PeriodicThread(ABC):
                     timeout,
                 )
 
+    def wake(self) -> None:
+        """Trigger one execution now instead of waiting for the next tick.
+
+        Safe to call from any thread. No-op if the thread is not running.
+        If wake() is called during an execution, the next interval sleep
+        returns immediately and another cycle runs right after.
+        """
+        if not self._running:
+            return
+        self._wake_event.set()
+
     def _run_loop(self) -> None:
         """Main thread loop."""
         # Initial wait
@@ -280,6 +297,9 @@ class PeriodicThread(ABC):
             if self._stop_event.wait(timeout=self._init_wait):
                 logger.info("PeriodicThread %s stopped during init_wait", self._name)
                 return
+            # A wake() during init_wait should not count as stop; only
+            # honor stop_event above.
+            self._wake_event.clear()
 
         logger.info(
             "PeriodicThread %s entering main loop (interval=%.1fs)",
@@ -342,8 +362,10 @@ class PeriodicThread(ABC):
                     self._total_runs += 1
                     self._failed_runs += 1
 
-            # Wait for next interval
-            if self._stop_event.wait(timeout=self._interval):
+            # Wait for next interval; wake() can shorten this wait.
+            self._wake_event.wait(timeout=self._interval)
+            self._wake_event.clear()
+            if self._stop_event.is_set():
                 break
 
         logger.info("PeriodicThread %s loop stopped", self._name)

--- a/tests/v1/test_periodic_thread.py
+++ b/tests/v1/test_periodic_thread.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for lmcache.v1.periodic_thread.PeriodicThread."""
+
+# Standard
+from typing import Optional
+import threading
+import time
+
+# First Party
+from lmcache.v1.periodic_thread import (
+    PeriodicThread,
+    PeriodicThreadRegistry,
+    ThreadLevel,
+    ThreadRunSummary,
+)
+
+
+class _CountingThread(PeriodicThread):
+    """PeriodicThread that counts executions and can gate them on an event."""
+
+    def __init__(self, interval: float, gate: Optional[threading.Event] = None):
+        super().__init__(
+            name="test-counting-thread",
+            interval=interval,
+            level=ThreadLevel.LOW,
+        )
+        self._runs = 0
+        self._gate = gate
+
+    def _execute(self) -> ThreadRunSummary:
+        if self._gate is not None:
+            self._gate.wait(timeout=5.0)
+        self._runs += 1
+        return ThreadRunSummary(success=True, message="ok")
+
+    @property
+    def runs(self) -> int:
+        return self._runs
+
+    def wait_for_runs(self, count: int, timeout: float) -> bool:
+        deadline = time.time() + timeout
+        while self._runs < count and time.time() < deadline:
+            time.sleep(0.01)
+        return self._runs >= count
+
+
+def test_wake_triggers_immediate_run():
+    """wake() should skip the interval sleep and run one cycle now."""
+    PeriodicThreadRegistry.reset()
+    # Long interval; without wake() the second run would never arrive
+    # within the test's time budget.
+    t = _CountingThread(interval=60.0)
+    t.start()
+    try:
+        assert t.wait_for_runs(1, timeout=5.0), "first run did not happen"
+        t.wake()
+        assert t.wait_for_runs(2, timeout=5.0), "wake() did not trigger a run"
+    finally:
+        t.stop(timeout=2.0)
+
+
+def test_wake_before_start_is_noop():
+    """wake() before start() must not crash and must not schedule a run."""
+    PeriodicThreadRegistry.reset()
+    t = _CountingThread(interval=60.0)
+    # Not started yet.
+    t.wake()
+    assert t.runs == 0
+    assert not t.is_running
+
+
+def test_stop_breaks_interval_sleep_promptly():
+    """stop() should return quickly even with a long interval."""
+    PeriodicThreadRegistry.reset()
+    t = _CountingThread(interval=60.0)
+    t.start()
+    try:
+        assert t.wait_for_runs(1, timeout=5.0)
+    finally:
+        started = time.time()
+        t.stop(timeout=2.0)
+        elapsed = time.time() - started
+        assert not t.is_running
+        # Was 60 s before wake support; must now be well under a second.
+        assert elapsed < 2.0, "stop() waited on interval sleep: %.2fs" % elapsed
+
+
+def test_wake_during_execute_schedules_next_cycle():
+    """wake() called while _execute is running should short-circuit the
+    following interval sleep and run once more right away."""
+    PeriodicThreadRegistry.reset()
+    gate = threading.Event()
+    t = _CountingThread(interval=60.0, gate=gate)
+    t.start()
+    try:
+        # Wake while the first _execute is blocked on the gate.
+        t.wake()
+        gate.set()
+        # First cycle completes; then the wake flag makes the next
+        # interval sleep return immediately, so runs reaches 2 without
+        # waiting on the 60 s interval.
+        assert t.wait_for_runs(2, timeout=5.0), (
+            "wake() did not carry over; runs=%d" % t.runs
+        )
+    finally:
+        gate.set()
+        t.stop(timeout=2.0)


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache! -->

**What this PR does / why we need it**:

Add a `wake()` method to `PeriodicThread` so subclasses can trigger a
run immediately instead of waiting for the next interval tick. As a
side effect, `stop()` no longer sits on the interval sleep.

**Special notes for your reviewers**:

The `UsageFlushThread` proposed in #4208 does exactly this pattern
today with its own `wake`/`stop` events. With this PR, that thread
(and any future reporter with the same shape) can be built directly on
`PeriodicThread` and drop the hand-rolled scaffolding, while still
getting the registry / status / level features for free.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
