### PR TITLE
[Bugfix][MP] Trim sliding-window loads when object-group separation is disabled

### DIFF
--- a/lmcache/v1/kv_layer_groups.py
+++ b/lmcache/v1/kv_layer_groups.py
@@ -561,6 +561,25 @@ class KVLayerGroupsManager:
             return self._lmcache_tokens_per_chunk
         return sw_size_tokens
 
+    def get_sw_size_chunks(self, kernel_group_idx: int) -> int:
+        """Return a kernel group's cross-chunk sliding-window size.
+
+        Args:
+            kernel_group_idx: 0-based kernel group index.
+
+        Returns:
+            The sliding-window size measured in LMCache chunks, or ``-1`` when
+            the group should retain full attention across chunks.
+        """
+        if self._full_sw_kv:
+            return -1
+        sw_size_tokens = self._kernel_groups[kernel_group_idx].sw_size_tokens
+        if sw_size_tokens == -1:
+            return -1
+        return (
+            sw_size_tokens + self._lmcache_tokens_per_chunk - 1
+        ) // self._lmcache_tokens_per_chunk
+
     def get_attn_desc(self) -> AttnWindowDesc:
         """Return the cross-chunk attention windows of all object groups.
 

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -235,6 +235,25 @@ def _recalculate_blocks_to_skip(
     return full_windows_to_skip * blocks_per_window + max(0, tail_blocks_to_skip)
 
 
+def _get_window_skip_blocks(
+    sw_size_chunks: int,
+    num_chunks: int,
+    batch_start_chunk: int,
+    batch_size: int,
+    blocks_per_window: int,
+) -> int:
+    """Return the leading blocks outside a kernel group's sliding window."""
+    if sw_size_chunks == -1:
+        return 0
+
+    out_of_window_chunks = max(0, num_chunks - sw_size_chunks)
+    batch_skip_chunks = max(
+        0,
+        min(batch_size, out_of_window_chunks - batch_start_chunk),
+    )
+    return batch_skip_chunks * blocks_per_window
+
+
 def _run_object_group_transfer_plan(
     cache_context: BaseCacheContext,
     block_ids_gpu: list[torch.Tensor],
@@ -340,7 +359,10 @@ def _run_object_group_transfer_plan(
         memory_objs, batch_size, skip_count=num_objects_to_skip
     ):
         if any(mo is None for mo in memory_object_batch):
-            if is_h2d:
+            # Separated SW object groups already trim whole objects above.
+            # A full-attention object group needs this per-kernel fallback
+            # when object-group separation is disabled.
+            if is_h2d and attn_desc.is_full_attention(object_group_id):
                 raise ValueError(
                     "MemoryObj is None for some objects in the batch, cannot "
                     "perform H2D copy. memory_object_batch: "
@@ -381,6 +403,21 @@ def _run_object_group_transfer_plan(
                 blocks_per_window,
                 orig_skip_blocks,
             )
+            # Separated SW object groups already trim whole objects above.
+            # A full-attention object group needs this per-kernel fallback
+            # when object-group separation is disabled.
+            if is_h2d and attn_desc.is_full_attention(object_group_id):
+                window_skip_blocks = _get_window_skip_blocks(
+                    kv_groups_manager.get_sw_size_chunks(kernel_group_id),
+                    len(memory_objs),
+                    start_object_idx,
+                    batch_len,
+                    blocks_per_window,
+                )
+                recalculated_skip_blocks = max(
+                    recalculated_skip_blocks,
+                    window_skip_blocks,
+                )
 
             launches.append(
                 lmc_ops.LaunchVar(
@@ -536,6 +573,18 @@ def transfer_kv_per_object_group(
                 blocks_per_window,
                 orig_skip_blocks,
             )
+            if is_h2d:
+                window_skip_blocks = _get_window_skip_blocks(
+                    kv_groups_manager.get_sw_size_chunks(kernel_group_id),
+                    len(memory_objs),
+                    start_object_idx,
+                    batch_len,
+                    blocks_per_window,
+                )
+                recalculated_skip_blocks = max(
+                    recalculated_skip_blocks,
+                    window_skip_blocks,
+                )
 
             # Launch kernel
             group_kv_pointers = cache_context.get_kernel_group_kv_pointers(

--- a/tests/v1/multiprocess/test_sliding_window_transfer.py
+++ b/tests/v1/multiprocess/test_sliding_window_transfer.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for per-kernel sliding-window retrieve trimming."""
+
+# Standard
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, cast
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.multiprocess.modules import lmcache_driven_transfer as transfer
+from lmcache.v1.platform.base.cache_context import BaseCacheContext
+
+
+class FakeTransferDirection:
+    H2D = "h2d"
+    D2H = "d2h"
+
+
+class FakeKernelGroupSpec:
+    def __init__(self, *_args: Any) -> None:
+        pass
+
+
+@dataclass
+class FakeLaunchVar:
+    spec_idx: int
+    start_block_pos: int
+    num_blocks: int
+    batch_size: int
+    skip_blocks: int
+
+
+@dataclass
+class FakeBatchStep:
+    staging: Any
+    launch_vars: list[FakeLaunchVar]
+
+
+class FakeOps:
+    TransferDirection = FakeTransferDirection
+    KernelGroupSpec = FakeKernelGroupSpec
+    LaunchVar = FakeLaunchVar
+    BatchStep = FakeBatchStep
+
+    def __init__(self) -> None:
+        self.native_skips: list[list[int]] = []
+        self.fallback_skips: list[int] = []
+
+    def execute_object_group_transfer(
+        self,
+        _direction: str,
+        _device: torch.device,
+        _pin_chunk_size: int,
+        _kernel_group_specs: list[FakeKernelGroupSpec],
+        batch_steps: list[FakeBatchStep],
+    ) -> None:
+        self.native_skips.extend(
+            [
+                [launch.skip_blocks for launch in step.launch_vars]
+                for step in batch_steps
+            ]
+        )
+
+    def multi_layer_block_kv_transfer(self, *args: Any) -> None:
+        self.fallback_skips.append(cast(int, args[-1]))
+
+
+class FakeAttnDesc:
+    def __init__(self, is_full_attention: bool) -> None:
+        self._is_full_attention = is_full_attention
+        self.num_chunks_in_sw = [-1 if is_full_attention else 1]
+
+    def is_full_attention(self, _object_group_id: int) -> bool:
+        return self._is_full_attention
+
+
+class FakeKVLayerGroupsManager:
+    def __init__(
+        self,
+        full_sw_kv: bool = False,
+        separate_object_groups: bool = False,
+    ) -> None:
+        self.full_sw_kv = full_sw_kv
+        self.separate_object_groups = separate_object_groups
+        kernel_group_indices = [1] if separate_object_groups else [0, 1]
+        self.object_groups = [
+            SimpleNamespace(kernel_group_indices=kernel_group_indices)
+        ]
+        self.kernel_groups = [
+            SimpleNamespace(sw_size_tokens=-1),
+            SimpleNamespace(sw_size_tokens=64),
+        ]
+
+    def get_subchunk_sw_size_tokens(self, kernel_group_id: int) -> int:
+        return [256, 64][kernel_group_id]
+
+    def get_sw_size_chunks(self, kernel_group_id: int) -> int:
+        if self.full_sw_kv:
+            return -1
+        return [-1, 1][kernel_group_id]
+
+    def get_attn_desc(self) -> FakeAttnDesc:
+        return FakeAttnDesc(not self.separate_object_groups)
+
+
+class FakeCacheContext:
+    lmcache_tokens_per_chunk = 256
+    max_batch_size = 2
+    device = torch.device("cpu")
+
+    def __init__(
+        self,
+        full_sw_kv: bool = False,
+        separate_object_groups: bool = False,
+    ) -> None:
+        self.kv_layer_groups_manager = FakeKVLayerGroupsManager(
+            full_sw_kv,
+            separate_object_groups,
+        )
+        self._buffers = [[torch.zeros(1), torch.zeros(1)] for _ in range(2)]
+
+    def calculate_num_blocks(self, num_tokens: int, _kernel_group_id: int) -> int:
+        return num_tokens // 32
+
+    def get_kernel_group_kv_pointers(self, kernel_group_id: int) -> torch.Tensor:
+        return self._buffers[kernel_group_id][0]
+
+    def get_temp_kernel_group_buffer(
+        self, slot: int, kernel_group_id: int
+    ) -> torch.Tensor:
+        return self._buffers[kernel_group_id][slot]
+
+    def get_shape_desc(self, _kernel_group_id: int) -> object:
+        return object()
+
+    def get_slots_per_chunk_in_sw(self, _kernel_group_id: int) -> int:
+        return 1
+
+    def get_engine_kv_format(self, _kernel_group_id: int) -> str:
+        return "fake"
+
+    def get_temp_object_group_buffer(
+        self, _slot: int, _object_group_id: int
+    ) -> torch.Tensor:
+        return torch.zeros(1)
+
+
+def run_transfer(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    use_native: bool,
+    direction: str,
+    skip_first_n_tokens: int = 0,
+    full_sw_kv: bool = False,
+    separate_object_groups: bool = False,
+) -> list[list[int]]:
+    fake_ops = FakeOps()
+    monkeypatch.setattr(transfer, "lmc_ops", fake_ops)
+    monkeypatch.setattr(
+        transfer,
+        "_HAS_NATIVE_OBJECT_GROUP_TRANSFER",
+        use_native,
+    )
+    monkeypatch.setattr(
+        transfer,
+        "build_staging_copies",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        transfer,
+        "lmcache_memcpy_async_h2d",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        transfer,
+        "lmcache_memcpy_async_d2h",
+        lambda *_args, **_kwargs: None,
+    )
+
+    memory_objs = cast(list[MemoryObj], [object() for _ in range(4)])
+    transfer.transfer_kv_per_object_group(
+        cast(
+            BaseCacheContext,
+            FakeCacheContext(full_sw_kv, separate_object_groups),
+        ),
+        [
+            torch.arange(32, dtype=torch.int64),
+            torch.arange(8, dtype=torch.int64),
+        ],
+        memory_objs,
+        object_group_id=0,
+        batch_size=2,
+        skip_first_n_tokens=skip_first_n_tokens,
+        direction=direction,
+    )
+
+    if use_native:
+        return fake_ops.native_skips
+    num_kernel_groups = 1 if separate_object_groups else 2
+    return [
+        fake_ops.fallback_skips[index : index + num_kernel_groups]
+        for index in range(
+            0,
+            len(fake_ops.fallback_skips),
+            num_kernel_groups,
+        )
+    ]
+
+
+@pytest.mark.parametrize("use_native", [False, True])
+def test_h2d_trims_sliding_window_group_in_mixed_object_group(
+    monkeypatch: pytest.MonkeyPatch,
+    use_native: bool,
+) -> None:
+    """Retrieve skips old SW chunks while loading every full-attention chunk."""
+    skips = run_transfer(
+        monkeypatch,
+        use_native=use_native,
+        direction=FakeTransferDirection.H2D,
+    )
+
+    assert skips == [[0, 4], [0, 2]]
+
+
+@pytest.mark.parametrize("use_native", [False, True])
+def test_d2h_does_not_trim_sliding_window_group(
+    monkeypatch: pytest.MonkeyPatch,
+    use_native: bool,
+) -> None:
+    """Store preserves all chunks for future requests."""
+    skips = run_transfer(
+        monkeypatch,
+        use_native=use_native,
+        direction=FakeTransferDirection.D2H,
+    )
+
+    assert skips == [[0, 0], [0, 0]]
+
+
+@pytest.mark.parametrize("use_native", [False, True])
+def test_full_sw_kv_does_not_trim_sliding_window_group(
+    monkeypatch: pytest.MonkeyPatch,
+    use_native: bool,
+) -> None:
+    """Full-SW mode preserves all chunks during retrieve."""
+    skips = run_transfer(
+        monkeypatch,
+        use_native=use_native,
+        direction=FakeTransferDirection.H2D,
+        full_sw_kv=True,
+    )
+
+    assert skips == [[0, 0], [0, 0]]
+
+
+@pytest.mark.parametrize("use_native", [False, True])
+def test_separated_sw_group_uses_object_level_trim_only(
+    monkeypatch: pytest.MonkeyPatch,
+    use_native: bool,
+) -> None:
+    """Separated SW objects keep the existing object-level trimming path."""
+    skips = run_transfer(
+        monkeypatch,
+        use_native=use_native,
+        direction=FakeTransferDirection.H2D,
+        separate_object_groups=True,
+    )
+
+    assert skips == [[0]]
+
+
+@pytest.mark.parametrize("use_native", [False, True])
+def test_window_trim_does_not_double_count_existing_prefix_skip(
+    monkeypatch: pytest.MonkeyPatch,
+    use_native: bool,
+) -> None:
+    """Overlapping APC and window prefixes use the larger skip, not their sum."""
+    skips = run_transfer(
+        monkeypatch,
+        use_native=use_native,
+        direction=FakeTransferDirection.H2D,
+        skip_first_n_tokens=736,
+    )
+
+    assert skips == [[7, 2]]

--- a/tests/v1/test_kv_layer_groups_manager.py
+++ b/tests/v1/test_kv_layer_groups_manager.py
@@ -570,10 +570,27 @@ class TestKernelAndObjectGroups:
         assert manager.get_subchunk_sw_size_tokens(0) == 256
         assert manager.get_subchunk_sw_size_tokens(1) == 64
         assert manager.get_subchunk_sw_size_tokens(2) == 256
+        assert manager.get_sw_size_chunks(0) == -1
+        assert manager.get_sw_size_chunks(1) == 1
+        assert manager.get_sw_size_chunks(2) == 2
         # Transfer slots follow the sub-chunk window (ratio 1 here).
         assert manager.get_slots_per_chunk_in_sw(0) == 256
         assert manager.get_slots_per_chunk_in_sw(1) == 64
         assert manager.get_slots_per_chunk_in_sw(2) == 256
+
+    def test_full_sw_kv_disables_cross_chunk_window(self):
+        tensors = [torch.randn(2, 32, 32, 8, 64, dtype=torch.float16)]
+        manager = _build_manager(
+            tensors,
+            engine_group_infos=[
+                EngineGroupInfo(0, (0,), sw_size_tokens=64),
+            ],
+        )
+        assert manager.get_sw_size_chunks(0) == 1
+
+        manager.enable_full_sw_kv()
+
+        assert manager.get_sw_size_chunks(0) == -1
 
     def test_mixed_sw_kernel_groups_share_single_object_group(self):
         # Object-level bucketing by sliding window size is not enabled yet:


### PR DESCRIPTION
# Sliding-window load trimming without object-group separation

## What this PR does

Fix H2D retrieve correctness for mixed-attention models when
`--no-separate-object-groups` puts full-attention and sliding-window KV groups
in one object.

## Why this is needed

With `separate_object_groups=False`, all kernel groups share one object group.
That object group is intentionally reported as full attention, so the existing
object-level sliding-window skip does not run.

For a reused prefix, the engine may already have released old sliding-window
logical blocks. Its block table can therefore contain repeated placeholder
block IDs for those out-of-window chunks. LMCache currently schedules every
cached chunk for every kernel group, causing H2D scatter to overwrite that
shared placeholder block.

The default separated-object-group path already trims the SW object as a
whole. The cache object itself is valid; the missing piece is a per-kernel
fallback for the supported no-separation mode.

## Fix

- Add `KVLayerGroupsManager.get_sw_size_chunks()` to expose each kernel group's
  effective cross-chunk window. It returns `-1` for full attention and
  `full_sw_kv`.
- Only when H2D sees a full-attention object group, calculate the leading
  out-of-window blocks independently for each kernel group. Separated SW
  object groups retain the existing object-level path.
- Combine this boundary with `skip_first_n_tokens` using `max()`. Both are
  prefixes of the same transfer range, so adding them would double-count their
  overlap.
- Apply the same logic to the native object-group planner and Python fallback.

D2H/store remains unchanged, full-attention groups remain unchanged, and
object-group separation remains the preferred/default path.

## Tests

Added regression coverage for both native and fallback transfer paths:

- mixed full-attention + sliding-window H2D trimming;
- D2H/store remains untrimmed;
- `full_sw_kv` remains untrimmed;
- separated SW objects use only the existing object-level trim;
- overlap with `skip_first_n_tokens` is not double-counted.

The regression test fails on the current `dev` base and passes with this patch:

```text
base:    4 failed, 6 passed
patched: 10 passed
```

Also added manager-level coverage for token-to-chunk window conversion and
`full_sw_kv`.

Refs #3106 and #3608.
