### PR TITLE
[Bugfix] Change use_mla to mla_only so that MLA/Mamba mixed model can work normally

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -69,6 +69,22 @@ steps:
         plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
         artifact_paths: ["*.log"]
 
+      # Cross-TP-rank KV correctness for a hybrid MLA + linear-attention model.
+      # Launches Kimi-Linear with TP=2 (both GPUs) + LMCache, sends one long
+      # request to populate LMCache, restarts vLLM (LMCache server kept alive),
+      # re-sends the identical request now served by LMCache, and asserts the
+      # two outputs are byte-identical. A broken cross-rank restore (see
+      # utils.py::mla_only) hands non-zero ranks rank 0's mamba shard and
+      # diverges the output. Two 48B loads (cold + post-restart) need the long
+      # timeout.
+      - label: ":compression: kimi_linear_tp"
+        command: .buildkite/k3_tests/multiprocess/run.sh kimi_linear_tp
+        timeout_in_minutes: 60
+        retry: *flaky-retry
+        agents: { queue: "k8s" }
+        plugins: [{ kubernetes: { podSpec: *pod-2gpu } }]
+        artifact_paths: ["*.log"]
+
   - group: ":compression: Multiprocess (1-GPU)"
     if: build.env("VERIFY_AND_PIN_VLLM") !~ /true/
     steps:

--- a/.buildkite/k3_tests/multiprocess/run.sh
+++ b/.buildkite/k3_tests/multiprocess/run.sh
@@ -3,12 +3,12 @@
 # Usage: run.sh <test_name>
 #   test_name: lm_eval | lm_eval_preemption | hma_lm_eval_gemma4 | vllm_bench
 #              | long_doc_qa | long_doc_qa_l2 | fault_tolerance | deadlock
-#              | restart_recovery | gds_smoke_test | p2p
+#              | restart_recovery | gds_smoke_test | p2p | kimi_linear_tp
 # Thin wrapper: sets up environment, then delegates to scripts/.
 # No Docker -- all processes run natively in the pod.
 set -euo pipefail
 
-TEST_NAME="${1:?Usage: $0 <test_name>  (lm_eval|lm_eval_preemption|hma_lm_eval_gemma4|vllm_bench|long_doc_qa|long_doc_qa_l2|fault_tolerance|deadlock|restart_recovery|cache_stats|http_api|p2p)}"
+TEST_NAME="${1:?Usage: $0 <test_name>  (lm_eval|lm_eval_preemption|hma_lm_eval_gemma4|vllm_bench|long_doc_qa|long_doc_qa_l2|fault_tolerance|deadlock|restart_recovery|cache_stats|http_api|p2p|kimi_linear_tp)}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 

--- a/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
@@ -100,7 +100,6 @@ launch_vllm() {
     local saved_port="$VLLM_PORT"
     unset VLLM_PORT
 
-    CUDA_VISIBLE_DEVICES=0,1 \
     VLLM_ENABLE_V1_MULTIPROCESSING=0 \
     PYTHONHASHSEED=0 \
     vllm serve "$MODEL" \
@@ -223,7 +222,6 @@ count_retrieves() {
 
 # ── 1. Launch LMCache MP server (kept alive across the vLLM restart) ──
 echo "=== Launching LMCache MP server (port $LMCACHE_PORT) ==="
-CUDA_VISIBLE_DEVICES=0 \
 lmcache server \
     --host localhost \
     --port "$LMCACHE_PORT" \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# Cross-TP-rank KV correctness for a hybrid MLA + linear-attention model
+# (Kimi-Linear) served with tensor parallelism, across a vLLM restart.
+#
+# Why this test exists:
+#   Kimi-Linear is hybrid -- MLA full-attention layers (whose KV latent is
+#   REPLICATED across TP ranks) plus Kimi-Delta-Attention linear-attention
+#   layers (whose recurrent/conv "mamba" state is SHARDED across TP ranks).
+#   LMCache's MLA optimization ("store KV once on rank 0, share it with every
+#   TP rank") is only valid when all cached state is replicated. Applying it to
+#   this hybrid model made every TP rank load rank 0's mamba shard on a cache
+#   hit, so a request served from LMCache produced a different (wrong) output
+#   than the same request computed from scratch. See
+#   lmcache/integration/vllm/utils.py::mla_only.
+#
+# This test is self-contained: it launches its own LMCache server + a TP=2 vLLM
+# (both GPUs) instead of using launch-processes.sh / wait-for-servers.sh, since
+# it needs tensor parallelism and trust-remote-code. PIDs are written to the
+# shared PID_FILE so the dispatcher's cleanup.sh trap still tears everything down.
+#
+# Flow (2 GPUs, TP=2):
+#   1. Launch the LMCache server (kept alive for the whole test) + vLLM.
+#   2. vLLM run: send one long deterministic (greedy) completion request; vLLM
+#      computes it from scratch and populates LMCache. Capture output A.
+#   3. Restart vLLM (kill + relaunch), keeping the LMCache server running. The
+#      fresh vLLM has an empty prefix cache, so the request's prefix KV --
+#      including the per-rank linear-attention state -- must be served by
+#      LMCache. (A prefix-cache reset would not work here: vLLM's
+#      /reset_prefix_cache does not evict mamba state, so a full restart is the
+#      only way to force LMCache to serve the linear-attention state.)
+#   4. LMCache retrieve run: send the identical request. Capture output B.
+#   5. Assert A == B. A broken cross-rank restore hands the non-zero ranks the
+#      wrong state shard, which diverges the greedy decode -- so the outputs
+#      differ. The stored state is byte-reloaded (not recomputed), so a correct
+#      run is deterministic and the two outputs match exactly.
+#   6. Assert LMCache actually served retrieves in run 2 (non-vacuous).
+set -e
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+source "${REPO_ROOT}/.buildkite/k3_tests/common_scripts/helpers.sh"
+
+# ── Configuration ───────────────────────────────────────────
+MODEL="${MODEL:-moonshotai/Kimi-Linear-48B-A3B-Instruct}"
+LMCACHE_PORT="${LMCACHE_PORT:-6555}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+BUILD_ID="${BUILD_ID:-local_$$}"
+PID_FILE="/tmp/lmcache_mp_pids_${BUILD_ID}"
+LMCACHE_LOG="/tmp/build_${BUILD_ID}_lmcache.log"
+
+# vLLM block size == LMCache chunk size for this model. 'align' requires
+# block_size <= max_num_batched_tokens < 2*block_size so every prefill step
+# advances exactly one block (one reusable linear-attention snapshot per chunk).
+CHUNK_SIZE="${CHUNK_SIZE:-944}"
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-1500}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.85}"
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-900}"
+# Seconds to wait for vLLM's GPU memory to be released after a restart before
+# relaunching (avoids an OOM racing the dying process).
+GPU_RELEASE_TIMEOUT="${GPU_RELEASE_TIMEOUT:-180}"
+
+# Tokens to generate per request. Greedy (temperature 0); a divergence in the
+# resumed state shows up within the first few tokens, but a longer generation
+# makes an accidental match astronomically unlikely.
+MAX_TOKENS="${MAX_TOKENS:-128}"
+# Seconds to let async LMCache stores drain before restarting vLLM.
+STORE_DRAIN_SECONDS="${STORE_DRAIN_SECONDS:-20}"
+
+RESULTS_DIR="${RESULTS_DIR:-/tmp/lmcache_ci_results_${BUILD_ID}}"
+TP_DIR="$RESULTS_DIR/kimi_linear_tp"
+mkdir -p "$TP_DIR"
+PROMPT_FILE="$TP_DIR/prompt.txt"
+OUT_A="$TP_DIR/output_vllm_run.txt"
+OUT_B="$TP_DIR/output_retrieve_run.txt"
+
+VLLM_PID=""
+
+echo "=== Kimi-Linear cross-TP-rank KV correctness test (vLLM restart) ==="
+echo "Model: $MODEL"
+echo "LMCache port: $LMCACHE_PORT | vLLM port: $VLLM_PORT | TP=2"
+echo "Chunk size: $CHUNK_SIZE | max_num_batched_tokens: $MAX_NUM_BATCHED_TOKENS"
+echo "Results dir: $TP_DIR"
+echo ""
+
+# Launch a TP=2 vLLM+LMCache instance and wait until it serves.
+# Arguments:
+#   $1 log_file - where to redirect vLLM stdout/stderr.
+# Sets the global VLLM_PID and appends it to PID_FILE for cleanup.
+launch_vllm() {
+    local log_file="$1"
+    echo "=== Launching vLLM (Kimi-Linear, TP=2, port $VLLM_PORT) ==="
+    echo "Log: $log_file"
+    # Save and unset VLLM_PORT: vLLM's internal get_open_port() would otherwise
+    # collide with the serving port for torch.distributed.
+    local saved_port="$VLLM_PORT"
+    unset VLLM_PORT
+
+    CUDA_VISIBLE_DEVICES=0,1 \
+    VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+    PYTHONHASHSEED=0 \
+    vllm serve "$MODEL" \
+        --tensor-parallel-size 2 \
+        --trust-remote-code \
+        --enforce-eager \
+        --enable-prefix-caching \
+        --mamba-cache-mode align \
+        --max-model-len auto \
+        --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" \
+        --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
+        --no-async-scheduling \
+        --port "$saved_port" \
+        --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 30}}" \
+        > "$log_file" 2>&1 &
+    VLLM_PID=$!
+    echo "$VLLM_PID" >> "$PID_FILE"
+    export VLLM_PORT="$saved_port"
+    echo "vLLM started (PID=$VLLM_PID)"
+
+    if ! wait_for_server "$VLLM_PORT" "$MAX_WAIT_SECONDS" "$log_file"; then
+        echo "vLLM failed to start."
+        return 1
+    fi
+    echo ""
+}
+
+# Poll a GPU's used memory until it drops below a threshold (i.e. the previous
+# vLLM instance's weights/KV have been freed) or a timeout elapses.
+# Arguments:
+#   $1 gpu_index      - GPU to poll.
+#   $2 threshold_mib  - consider "released" once used memory is below this.
+wait_for_gpu_release() {
+    local gpu_index="$1"
+    local threshold_mib="$2"
+    local deadline=$(( $(date +%s) + GPU_RELEASE_TIMEOUT ))
+    echo "=== Waiting for GPU $gpu_index memory to be released (< ${threshold_mib} MiB) ==="
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        local used
+        used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits \
+            -i "$gpu_index" 2>/dev/null | tr -d ' ' || echo 999999)
+        if [ -n "$used" ] && [ "$used" -lt "$threshold_mib" ]; then
+            echo "GPU $gpu_index memory released (used=${used} MiB)."
+            echo ""
+            return 0
+        fi
+        sleep 3
+    done
+    echo "WARNING: GPU $gpu_index still busy after ${GPU_RELEASE_TIMEOUT}s; relaunching anyway."
+    echo ""
+}
+
+# Kill the current vLLM instance (keeping the LMCache server), then wait for its
+# GPU memory to be freed so the relaunch has room for the 48B weights.
+stop_vllm() {
+    echo "=== Stopping vLLM (PID=$VLLM_PID), keeping LMCache server alive ==="
+    if [ -n "$VLLM_PID" ] && kill -0 "$VLLM_PID" 2>/dev/null; then
+        kill "$VLLM_PID" 2>/dev/null || true
+        # Give vLLM time to shut its TP workers down cleanly.
+        local wait_deadline=$(( $(date +%s) + 60 ))
+        while [ "$(date +%s)" -lt "$wait_deadline" ] && kill -0 "$VLLM_PID" 2>/dev/null; do
+            sleep 2
+        done
+        kill -9 "$VLLM_PID" 2>/dev/null || true
+        wait "$VLLM_PID" 2>/dev/null || true
+    fi
+    # Free the serving port in case a child socket lingers.
+    fuser -k "${VLLM_PORT}/tcp" 2>/dev/null || true
+    # GPU 1 is used exclusively by vLLM (the LMCache server pins its CUDA
+    # context on GPU 0), so its memory dropping to near-idle is a clean signal
+    # that the old vLLM (and its TP workers) are fully gone.
+    wait_for_gpu_release 1 2000
+}
+
+# Send one greedy completion request and write the generated text to a file.
+# Uses only the Python stdlib so no extra client dependency is required.
+send_completion() {
+    local out_file="$1"
+    local run_name="$2"
+    echo "=== Sending completion ($run_name) on port $VLLM_PORT ==="
+    python3 - "$VLLM_PORT" "$MODEL" "$PROMPT_FILE" "$MAX_TOKENS" "$out_file" <<'PYEOF'
+import json
+import sys
+import urllib.request
+
+port, model, prompt_file, max_tokens, out_file = sys.argv[1:6]
+prompt = open(prompt_file).read()
+body = json.dumps(
+    {
+        "model": model,
+        "prompt": prompt,
+        "temperature": 0.0,
+        "max_tokens": int(max_tokens),
+        "seed": 0,
+    }
+).encode()
+req = urllib.request.Request(
+    f"http://127.0.0.1:{port}/v1/completions",
+    data=body,
+    headers={"Content-Type": "application/json"},
+)
+with urllib.request.urlopen(req, timeout=600) as resp:
+    data = json.load(resp)
+text = data["choices"][0]["text"]
+with open(out_file, "w") as f:
+    f.write(text)
+print(f"  generated {len(text)} chars")
+PYEOF
+    echo "$run_name completed"
+    echo ""
+}
+
+# Count completed LMCache retrieves in the server log (proves run 2 was served
+# by LMCache, so the comparison can't pass vacuously by recomputing).
+count_retrieves() {
+    [ -f "$LMCACHE_LOG" ] || { echo 0; return; }
+    grep -c "Retrieved" "$LMCACHE_LOG" 2>/dev/null || true
+}
+
+# ── 1. Launch LMCache MP server (kept alive across the vLLM restart) ──
+echo "=== Launching LMCache MP server (port $LMCACHE_PORT) ==="
+CUDA_VISIBLE_DEVICES=0 \
+lmcache server \
+    --host localhost \
+    --port "$LMCACHE_PORT" \
+    --chunk-size "$CHUNK_SIZE" \
+    --l1-size-gb 80 \
+    --eviction-policy LRU \
+    --max-workers 4 \
+    > "$LMCACHE_LOG" 2>&1 &
+LMCACHE_PID=$!
+echo "$LMCACHE_PID" >> "$PID_FILE"
+echo "LMCache MP server started (PID=$LMCACHE_PID)"
+sleep 10
+
+# ── 2. Build a long, deterministic prompt, then ask for a summary ──
+# A ~7-8k word document (well over the several-thousand-token span needed for
+# the request to store multiple linear-attention snapshots) built by repeating
+# a fixed paragraph, so the input is identical on every run.
+python3 - "$PROMPT_FILE" <<'PYEOF'
+import sys
+
+prompt_file = sys.argv[1]
+paragraph = (
+    "The poll() system call waits for one of a set of file descriptors to "
+    "become ready to perform I/O. The set of file descriptors to be monitored "
+    "is specified in the fds argument, which is an array of pollfd structures. "
+    "The caller should specify the number of items in the fds array in nfds. "
+    "The timeout argument specifies the number of milliseconds that poll() "
+    "should block waiting for a file descriptor to become ready. The call will "
+    "block until either a file descriptor becomes ready, the call is "
+    "interrupted by a signal handler, or the timeout expires. "
+)
+# ~97 words/paragraph * 80 ~= 7.8k words.
+with open(prompt_file, "w") as f:
+    f.write(paragraph * 80)
+    f.write("\n\nSummarize the manual page text above:")
+PYEOF
+echo "Prompt built ($(wc -w < "$PROMPT_FILE") words)."
+echo ""
+
+# ── 3. vLLM run: compute from scratch, populating LMCache ───
+launch_vllm "/tmp/build_${BUILD_ID}_vllm.log"
+send_completion "$OUT_A" "vLLM run"
+
+echo "Waiting ${STORE_DRAIN_SECONDS}s for LMCache stores to drain..."
+sleep "$STORE_DRAIN_SECONDS"
+retrieves_before=$(count_retrieves)
+
+# ── 4. Restart vLLM (keep LMCache) so the prefix must come from LMCache ──
+stop_vllm
+launch_vllm "/tmp/build_${BUILD_ID}_vllm_restart.log"
+
+# ── 5. Retrieve run: fresh vLLM APC is empty -> LMCache serves the KV ─
+send_completion "$OUT_B" "LMCache retrieve run"
+retrieves_after=$(count_retrieves)
+
+# ── 6. Compare outputs and verify LMCache was actually used ──
+echo "============================================"
+echo "=== Verifying cross-TP-rank KV correctness ==="
+echo "============================================"
+echo "LMCache retrieves logged: before=${retrieves_before}, after=${retrieves_after}"
+
+failed=0
+
+if cmp -s "$OUT_A" "$OUT_B"; then
+    echo "PASS: vLLM-run and LMCache-retrieve outputs are identical."
+else
+    echo "FAILED: outputs differ between the cold run and the LMCache-served run."
+    echo "--- vLLM run (first 400 chars) ---"
+    head -c 400 "$OUT_A"; echo
+    echo "--- LMCache retrieve run (first 400 chars) ---"
+    head -c 400 "$OUT_B"; echo
+    failed=1
+fi
+
+if [ "$retrieves_after" -le "$retrieves_before" ]; then
+    echo "FAILED: LMCache served no retrieves during the retrieve run "
+    echo "        (before=${retrieves_before}, after=${retrieves_after}); the "
+    echo "        comparison would be vacuous."
+    failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+    exit 1
+fi
+
+echo ""
+echo "============================================"
+echo "=== Kimi-Linear cross-TP-rank KV test passed ==="
+echo "  outputs identical; LMCache served $((retrieves_after - retrieves_before)) retrieves."
+echo "============================================"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
@@ -59,7 +59,7 @@ GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.85}"
 # Readiness timeout per vLLM launch. This is owned by the test (a 48B TP-shard
 # load is slow) and deliberately does NOT reuse MAX_WAIT_SECONDS, which
 # run-single-test.sh pre-exports to 300s -- that would shadow the value here.
-VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-450}"
+VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-900}"
 # Seconds to wait for vLLM's GPU memory to be released after a restart before
 # relaunching (avoids an OOM racing the dying process).
 GPU_RELEASE_TIMEOUT="${GPU_RELEASE_TIMEOUT:-180}"

--- a/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
@@ -59,7 +59,7 @@ GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.85}"
 # Readiness timeout per vLLM launch. This is owned by the test (a 48B TP-shard
 # load is slow) and deliberately does NOT reuse MAX_WAIT_SECONDS, which
 # run-single-test.sh pre-exports to 300s -- that would shadow the value here.
-VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-900}"
+VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-450}"
 # Seconds to wait for vLLM's GPU memory to be released after a restart before
 # relaunching (avoids an OOM racing the dying process).
 GPU_RELEASE_TIMEOUT="${GPU_RELEASE_TIMEOUT:-180}"
@@ -100,18 +100,16 @@ launch_vllm() {
     local saved_port="$VLLM_PORT"
     unset VLLM_PORT
 
-    VLLM_ENABLE_V1_MULTIPROCESSING=0 \
-    PYTHONHASHSEED=0 \
     vllm serve "$MODEL" \
         --tensor-parallel-size 2 \
         --trust-remote-code \
         --enforce-eager \
+        --no-enable-flashinfer-autotune \
         --enable-prefix-caching \
         --mamba-cache-mode align \
         --max-model-len auto \
         --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" \
         --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
-        --no-async-scheduling \
         --port "$saved_port" \
         --block-size 944 \
         --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 30}}" \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
@@ -55,7 +55,7 @@ LMCACHE_LOG="/tmp/build_${BUILD_ID}_lmcache.log"
 # advances exactly one block (one reusable linear-attention snapshot per chunk).
 CHUNK_SIZE="${CHUNK_SIZE:-944}"
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-1500}"
-GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.85}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.8}"
 # Readiness timeout per vLLM launch. This is owned by the test (a 48B TP-shard
 # load is slow) and deliberately does NOT reuse MAX_WAIT_SECONDS, which
 # run-single-test.sh pre-exports to 300s -- that would shadow the value here.
@@ -106,6 +106,7 @@ launch_vllm() {
         --enforce-eager \
         --no-enable-flashinfer-autotune \
         --enable-prefix-caching \
+        --moe-backend triton \
         --mamba-cache-mode align \
         --max-model-len auto \
         --max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS" \

--- a/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-kimi-linear-tp.sh
@@ -56,7 +56,10 @@ LMCACHE_LOG="/tmp/build_${BUILD_ID}_lmcache.log"
 CHUNK_SIZE="${CHUNK_SIZE:-944}"
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-1500}"
 GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.85}"
-MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-900}"
+# Readiness timeout per vLLM launch. This is owned by the test (a 48B TP-shard
+# load is slow) and deliberately does NOT reuse MAX_WAIT_SECONDS, which
+# run-single-test.sh pre-exports to 300s -- that would shadow the value here.
+VLLM_READY_TIMEOUT="${VLLM_READY_TIMEOUT:-900}"
 # Seconds to wait for vLLM's GPU memory to be released after a restart before
 # relaunching (avoids an OOM racing the dying process).
 GPU_RELEASE_TIMEOUT="${GPU_RELEASE_TIMEOUT:-180}"
@@ -111,6 +114,7 @@ launch_vllm() {
         --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
         --no-async-scheduling \
         --port "$saved_port" \
+        --block-size 944 \
         --kv-transfer-config "{\"kv_connector\":\"LMCacheMPConnector\", \"kv_role\":\"kv_both\", \"kv_load_failure_policy\": \"recompute\", \"kv_connector_extra_config\": {\"lmcache.mp.port\": $LMCACHE_PORT, \"lmcache.mp.mq_timeout\": 30}}" \
         > "$log_file" 2>&1 &
     VLLM_PID=$!
@@ -118,7 +122,7 @@ launch_vllm() {
     export VLLM_PORT="$saved_port"
     echo "vLLM started (PID=$VLLM_PID)"
 
-    if ! wait_for_server "$VLLM_PORT" "$MAX_WAIT_SECONDS" "$log_file"; then
+    if ! wait_for_server "$VLLM_PORT" "$VLLM_READY_TIMEOUT" "$log_file"; then
         echo "vLLM failed to start."
         return 1
     fi

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -59,6 +59,12 @@ elif [ "$TEST_NAME" = "hma_lm_eval_qwen3_5" ]; then
     export BATCH_INVARIANT="${BATCH_INVARIANT:-0}"
     export SCORE_TOLERANCE="${SCORE_TOLERANCE:-0.05}"
     export LIMIT="${LIMIT:-300}"
+elif [ "$TEST_NAME" = "kimi_linear_tp" ]; then
+    # Self-contained test: run-kimi-linear-tp.sh owns the server lifecycle and
+    # all launch flags (TP=2, trust-remote-code, align, chunk/batch sizes). Only
+    # the model name is declared here so the banner and the script's ${MODEL:-}
+    # fallback both resolve to Kimi-Linear rather than the generic default below.
+    export MODEL="${MODEL:-moonshotai/Kimi-Linear-48B-A3B-Instruct}"
 else
     export MODEL="${MODEL:-Qwen/Qwen3-14B}"
 fi

--- a/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
+++ b/.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh
@@ -84,7 +84,7 @@ echo "Results dir: $RESULTS_DIR"
 echo ""
 
 # Tests that handle their own server lifecycle (different GPU/model config)
-SELF_CONTAINED_TESTS=" deadlock p2p "
+SELF_CONTAINED_TESTS=" deadlock p2p kimi_linear_tp "
 
 # Tests that compare against a baseline vLLM (no LMCache) on a second GPU.
 # Only these need the baseline server (and thus a 2-GPU pod); everything
@@ -161,6 +161,9 @@ case "$TEST_NAME" in
     p2p)
         exec_script="${SCRIPT_DIR}/run-p2p.sh"
         ;;
+    kimi_linear_tp)
+        exec_script="${SCRIPT_DIR}/run-kimi-linear-tp.sh"
+        ;;
     http_api)
         exec_script="${SCRIPT_DIR}/run-http-api.sh"
         ;;
@@ -169,7 +172,7 @@ case "$TEST_NAME" in
         ;;
     *)
         echo "Unknown test: $TEST_NAME"
-        echo "Valid tests: lm_eval, lm_eval_preemption, hma_lm_eval_gemma4, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock, restart_recovery, cache_stats, http_api, gds_smoke_test, p2p"
+        echo "Valid tests: lm_eval, lm_eval_preemption, hma_lm_eval_gemma4, vllm_bench, long_doc_qa, long_doc_qa_l2, fault_tolerance, deadlock, restart_recovery, cache_stats, http_api, gds_smoke_test, p2p, kimi_linear_tp"
         exit 1
         ;;
 esac

--- a/docs/source/mp/hybrid_models.rst
+++ b/docs/source/mp/hybrid_models.rst
@@ -38,6 +38,9 @@ Recipe pages for the validated hybrid-attention architectures:
    * - Qwen3.5 / Qwen3.6 series
      - Mamba / GDN + full
      - :doc:`/recipes/qwen3_5`
+   * - Kimi-Linear
+     - KDA linear-attention + MLA full
+     - :doc:`/recipes/kimi_linear`
    * - DeepSeek-V4-Flash
      - Sparse-MLA (multiple KV groups)
      - :doc:`/recipes/deepseek_v4_flash`
@@ -56,6 +59,7 @@ Recipe pages for the validated hybrid-attention architectures:
    /recipes/gemma4
    /recipes/gpt_oss
    /recipes/qwen3_5
+   /recipes/kimi_linear
    /recipes/deepseek_v4_flash
    /recipes/glm5_2
    /recipes/minimax_m3
@@ -127,7 +131,9 @@ Mamba / Linear-Attention Hybrids
 
 Models that interleave **Mamba / Gated-DeltaNet (GDN) linear-attention layers**
 with full attention — the Qwen3.5 and Qwen3.6 series (``Qwen/Qwen3.5-0.8B``,
-``Qwen/Qwen3.6-27B``, …), Qwen3-Next, and other GDN hybrids — are supported.
+``Qwen/Qwen3.6-27B``, …), Qwen3-Next, Kimi-Linear
+(``moonshotai/Kimi-Linear-48B-A3B-Instruct``), and other GDN hybrids — are
+supported.
 Unlike a paged key/value cache, their linear-attention layers keep a recurrent
 **state cache** (a convolution + SSM state). LMCache reinterprets that state as
 an opaque page at registration time, so prefix caching and KV reuse work end to
@@ -194,6 +200,9 @@ example:
    * - ``Qwen/Qwen3.5-0.8B``
      - 544
      - 1
+   * - ``moonshotai/Kimi-Linear-48B-A3B-Instruct``
+     - 944
+     - 2
 
 Step 2 — derive the three required flags from ``N``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -245,12 +254,6 @@ Caveats
 
 See the :doc:`Qwen3.5 / Qwen3.6 recipe <../recipes/qwen3_5>` for the validated
 end-to-end commands and the per-model block sizes.
-
-What Is Not Supported Yet
--------------------------
-
-- **DeepSeek-V4-style compressed / indexer caches** are not yet handled by the
-  multiprocess connector.
 
 Verifying Correctness
 ---------------------

--- a/docs/source/recipes/kimi_linear.rst
+++ b/docs/source/recipes/kimi_linear.rst
@@ -1,0 +1,165 @@
+.. _recipe_kimi_linear:
+
+Kimi-Linear
+===========
+
+A hybrid architecture from Moonshot AI that interleaves **Kimi Delta Attention
+(KDA)** linear-attention layers with **Multi-head Latent Attention (MLA)**
+full-attention layers. Like other Mamba / linear-attention hybrids, the KDA
+layers keep a recurrent **state cache** (a convolution + delta-net state)
+instead of a paged key/value cache; LMCache reinterprets that state as an opaque
+page at registration time, so prefix caching and KV reuse work end to end. See
+:doc:`../mp/hybrid_models` for the general handling of Mamba / linear-attention
+models.
+
+Validated models
+----------------
+
+- `moonshotai/Kimi-Linear-48B-A3B-Instruct
+  <https://huggingface.co/moonshotai/Kimi-Linear-48B-A3B-Instruct>`_
+  (48B-parameter MoE, 3B active; 2 GPUs)
+
+.. tab-set::
+   :sync-group: engine
+
+   .. tab-item:: vLLM
+
+      **Engine documentation:**
+      `Kimi-Linear in vLLM supported models
+      <https://docs.vllm.ai/en/latest/models/supported_models.html#text-generation>`_
+      (architecture ``KimiLinearForCausalLM``).
+
+      **Status:** Validated with LMCache.
+
+      As a Mamba / linear-attention hybrid, Kimi-Linear needs the same three
+      settings as the other GDN hybrids: the ``align`` Mamba cache mode, prefix
+      caching, and a chunk size matched to vLLM's *unified block size* ``N``.
+      That block size is model- and parallelism-specific — vLLM logs
+      ``Setting attention block size to N tokens`` at startup. Because the KDA
+      state is sharded across tensor-parallel ranks (while the MLA cache is
+      not), ``N`` depends on ``--tensor-parallel-size``; read it from the log
+      for your own configuration:
+
+      .. list-table::
+         :header-rows: 1
+         :widths: 50 25 25
+
+         * - Model
+           - Unified block size ``N``
+           - GPUs (TP)
+         * - ``moonshotai/Kimi-Linear-48B-A3B-Instruct``
+           - 944
+           - 2
+
+      Set the LMCache server's ``--chunk-size`` to that ``N`` (or a multiple of
+      it), and vLLM's ``--max-num-batched-tokens`` to ``2N-1`` (the largest
+      value below ``2N``).
+
+      .. note::
+
+         ``N`` **scales inversely with the tensor-parallel size** for this
+         model, so changing ``--tensor-parallel-size`` changes both derived
+         flags. The MLA cache is *replicated* across TP ranks (its per-rank
+         size is fixed), while the KDA state is *sharded* (its per-rank size is
+         divided by the TP degree). vLLM picks ``N`` so an attention page is at
+         least as large as a KDA state page, so a smaller per-rank KDA state
+         yields a smaller ``N`` — and vice versa. Concretely, going from
+         **TP=2 → TP=1** doubles the per-rank KDA state, so ``N`` doubles from
+         ``944`` to ``1888``; ``--chunk-size`` (``= N``) and
+         ``--max-num-batched-tokens`` (``= 2N-1``, i.e. ``3775``) both double to
+         match. Always re-read ``N`` from the startup log after changing the TP
+         degree — do not scale it by hand.
+
+      Start the LMCache MP server (``N = 944``):
+
+      .. code-block:: bash
+
+         lmcache server --chunk-size 944 --l1-size-gb 100 --eviction-policy LRU
+
+      |
+
+      Start vLLM with the LMCache MP connector
+      (2 GPUs, ``N = 944`` → ``2N-1 = 1887``):
+
+      .. code-block:: bash
+
+         vllm serve moonshotai/Kimi-Linear-48B-A3B-Instruct \
+             --tensor-parallel-size 2 \
+             --trust-remote-code \
+             --enable-prefix-caching \
+             --mamba-cache-mode align \
+             --max-num-batched-tokens 1887 \
+             --kv-transfer-config \
+             '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}'
+
+      |
+
+      **Why these settings:**
+
+      - ``--mamba-cache-mode align`` and ``--enable-prefix-caching`` are
+        **required**. ``align`` is the only Mamba cache mode the KDA backend
+        supports, and prefix caching must be on for LMCache to store and reuse
+        the recurrent state.
+      - ``--chunk-size`` (server) must be a multiple of the unified block size
+        ``N`` — ``--chunk-size N`` is the simplest choice. LMCache raises at
+        engine startup if it is not.
+      - ``--max-num-batched-tokens`` must be in ``[N, 2N)``. ``align`` snapshots
+        the KDA state only at the *end* of each scheduler step, on a block
+        boundary, and the scheduler splits prefills into whole ``N``-token
+        blocks — so the per-step token budget must cover at least one block but
+        stay below two (a larger budget could advance past a boundary and leave
+        no snapshot for LMCache to store). Prefer the maximum, ``2N-1``: a
+        single request still advances exactly one block per step, and the spare
+        ``N-1`` budget lets decodes co-schedule with a prefill block instead of
+        serializing behind it. Setting it to exactly ``N`` makes the per-step
+        budget one block, so once any request is decoding no new request can
+        start prefill.
+      - ``--trust-remote-code`` loads Kimi-Linear's custom modeling code.
+      - ``--tensor-parallel-size 2`` shards the weights across two GPUs. Adjust
+        it to your hardware — but note it changes ``N`` and the two derived
+        flags (see the note above).
+
+      No attention-backend or ``--no-disable-hybrid-kv-cache-manager`` flag is
+      needed; ``LMCacheMPConnector`` advertises hybrid support and vLLM
+      auto-selects the KDA and MLA backends. For the generic LMCache + vLLM
+      wiring (ports, remote hosts), see :doc:`../getting_started/quickstart`.
+
+   .. tab-item:: SGLang
+
+      **Status:** Not validated with LMCache.
+
+   .. tab-item:: TRT-LLM
+
+      **Status:** Not validated with LMCache.
+
+CacheBlend support
+------------------
+
+Not supported: the hybrid groups' cached pages are byte-opaque (see Caveats).
+
+Compression support
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 55
+
+   * - Method
+     - Status
+     - Notes
+   * - :doc:`CacheGen <../kv_cache_optimizations/compression/cachegen>`
+     - Not supported
+     - Hybrid groups' cached pages are byte-opaque.
+
+Caveats
+-------
+
+- Generation is **not guaranteed bit-exact** between a cached and a fresh run
+  under concurrent load: KDA / GDN linear-attention backends do not support
+  vLLM's batch-invariant mode, so kernel results can vary with batch
+  composition. Validate with a score-level comparison, not a token-level diff.
+- Cached pages for the KDA and MLA groups are byte-opaque views, so
+  content-aware processing (CacheGen, CacheBlend) does not apply, and cache
+  entries must not be shared across engines with different attention backends or
+  kernel block sizes.
+- vLLM's Mamba prefix caching in ``align`` mode is experimental upstream.

--- a/lmcache/integration/vllm/lmcache_mp_connector.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector.py
@@ -46,7 +46,7 @@ from lmcache.integration.vllm.kv_cache_group_edits import (
 from lmcache.integration.vllm.kv_cache_groups import (
     create_engine_group_infos_from_vllm,
 )
-from lmcache.integration.vllm.utils import mla_enabled, vllm_layout_hints
+from lmcache.integration.vllm.utils import mla_only, vllm_layout_hints
 from lmcache.utils import init_logger as lmcache_init_logger
 from lmcache.v1.multiprocess.group_view import slice_block_ids_per_group
 
@@ -189,7 +189,7 @@ def build_parallel_strategy_from_vllm_config(
     """
     pc = vllm_config.parallel_config
     return ParallelStrategy(
-        use_mla=mla_enabled(vllm_config.model_config),
+        mla_only=mla_only(vllm_config.model_config),
         vllm_world_size=pc.world_size,
         vllm_worker_id=pc.rank,
         tp_size=pc.tensor_parallel_size,

--- a/lmcache/integration/vllm/lmcache_mp_connector_0201.py
+++ b/lmcache/integration/vllm/lmcache_mp_connector_0201.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import torch
 import zmq
 from lmcache import torch_dev, torch_device_type
-from lmcache.integration.vllm.utils import mla_enabled
+from lmcache.integration.vllm.utils import mla_only
 from lmcache.utils import init_logger as lmcache_init_logger
 from lmcache.utils import check_interprocess_event_support
 
@@ -102,7 +102,7 @@ def build_parallel_strategy(vllm_config: VllmConfig) -> ParallelStrategy:
     """
     pc = vllm_config.parallel_config
     return ParallelStrategy(
-        use_mla=mla_enabled(vllm_config.model_config),
+        mla_only=mla_only(vllm_config.model_config),
         vllm_world_size=pc.world_size,
         vllm_worker_id=pc.rank,
         tp_size=pc.tensor_parallel_size,

--- a/lmcache/integration/vllm/utils.py
+++ b/lmcache/integration/vllm/utils.py
@@ -195,6 +195,30 @@ def mla_enabled(model_config: "ModelConfig") -> bool:
     )
 
 
+def _use_multiple_attentions(model_config: "ModelConfig") -> bool:
+    """Whether the model has multiple different attention layers.
+
+    Note:
+        Right now, this function uses ``ModelConfig.is_hybrid`` flag from vLLM, which
+        will be true for the models that implements the ``IsHybrid`` interface,
+        i.e. models that mix attention with mamba / SSM / linear-attention blocks.
+
+        This behavior may be changed in the future
+    """
+    return bool(getattr(model_config, "is_hybrid", False))
+
+
+def mla_only(model_config: "ModelConfig") -> bool:
+    """Whether every cached KV tensor is *replicated* across TP ranks.
+
+    LMCache's MLA parallel optimization stores the KV cache once on TP rank 0
+    and shares those bytes with every other rank on retrieve. That is only
+    correct when *all* cached state is identical across TP ranks -- i.e. the
+    model is "MLA-only":
+    """
+    return mla_enabled(model_config) and not _use_multiple_attentions(model_config)
+
+
 def create_lmcache_metadata(
     vllm_config=None,
     model_config=None,

--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -298,8 +298,11 @@ def send_ping(
 
 @dataclass
 class ParallelStrategy:
-    use_mla: bool
-    """Whether to use the MLA."""
+    mla_only: bool
+    """
+    True only for pure-MLA models. This flag indicates whether the KV cache
+    tensor is replicated across TP ranks.
+    """
 
     vllm_world_size: int
     """Number of workers managed by one vLLM scheduler (TP × PP; excludes DP).
@@ -323,7 +326,7 @@ class ParallelStrategy:
     def kv_world_size(self) -> int:
         """Number of pieces a single token chunk's KV cache is split into
         on the LMCache server storage."""
-        if self.use_mla:
+        if self.mla_only:
             # In this PR we do not support PP + TP + MLA in multi-server mode.
             # A precondition check enforces pp_size == 1, so kv_world_size for
             # MLA can be derived as world_size / tp_size.
@@ -335,7 +338,7 @@ class ParallelStrategy:
         """Index of the piece of a single token chunk's KV cache
         that the current worker is responsible for,
         in ``[0, kv_world_size)``."""
-        if self.use_mla:
+        if self.mla_only:
             return self.vllm_worker_id // self.tp_size
         return self.vllm_worker_id % (self.vllm_world_size // self.n_servers)
 
@@ -347,9 +350,9 @@ class ParallelStrategy:
     @property
     def is_kv_writer(self) -> bool:
         """Whether this rank is responsible for storing KV."""
-        if not self.use_mla:
+        if not self.mla_only:
             return True
-        # MLA: only first rank per node is a writer.
+        # MLA-only: only first rank per node is a writer.
         return self.vllm_worker_id % (self.tp_size // self.n_servers) == 0
 
 
@@ -388,7 +391,7 @@ def _normalize_adapter_init_args(
     kv_world_size = int(vllm_block_size)
     kv_worker_id = int(parallel_strategy)
     strategy = ParallelStrategy(
-        use_mla=False,
+        mla_only=False,
         vllm_world_size=kv_world_size,
         vllm_worker_id=kv_worker_id,
         tp_size=kv_world_size,
@@ -580,7 +583,7 @@ class LMCacheMPSchedulerAdapter:
             model_name: The model name used for LMCache keys
             vllm_block_size: The block size used in vLLM
             parallel_strategy:
-                The parallel strategy, which includes `use_mla`,
+                The parallel strategy, which includes `mla_only`,
                 `kv_world_size`, `kv_worker_id` and so on. Older vLLM
                 connectors pass the KV worker id here.
             legacy_block_size: The vLLM block size passed positionally by

--- a/tests/v1/test_vllm_mp_adapter.py
+++ b/tests/v1/test_vllm_mp_adapter.py
@@ -99,7 +99,7 @@ def _make_worker_adapter(
     network boundary must already be patched (see ``fake_adapter``).
     ``extra_config`` forwards ``lmcache.mp.*`` overrides."""
     parallel_strategy = ParallelStrategy(
-        use_mla=False,
+        mla_only=False,
         vllm_world_size=1,
         vllm_worker_id=0,
         tp_size=1,
@@ -656,7 +656,7 @@ def test_register_uses_local_context_when_self_transfer_ctx_nulled(
     )
 
     parallel_strategy = ParallelStrategy(
-        use_mla=False,
+        mla_only=False,
         vllm_world_size=1,
         vllm_worker_id=0,
         tp_size=1,


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Previously, for MLA/Mamba mixed models (like Kimi Linear), we only saved and hit the KV cache for rank 0 when running TP.

This PR changes the behavior of `use_mla` to `mla_only`

This PR also adds the following things:

- A CI test for Kimi linear model
- The recipe for kimi linear model

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
