### PR TITLE
feat(sglang): add LMCachePDConnector for PD disaggregation over NIXL

### DIFF
--- a/docs/design/integration/sglang/pd-disaggregation.md
+++ b/docs/design/integration/sglang/pd-disaggregation.md
@@ -1,0 +1,166 @@
+# SGLang PD (Prefill/Decode) Disaggregation over NIXL
+
+## Summary
+
+This is a first-class LMCache feature for **prefill/decode (PD) disaggregation**
+in SGLang: a pool of prefill instances computes KV caches and pushes them,
+per request, to a pool of decode instances over NIXL, so decode never recomputes
+the prompt. It is *not* built on SGLang's HiCache decode-restore path — LMCache
+owns the transfer end to end via its existing `PDBackend`.
+
+The transport already exists. LMCache's `lmcache.v1.storage_backend.pd_backend.PDBackend`
+implements a complete NIXL-based cross-instance KV push (sender/receiver roles,
+side-channel handshake, remote allocation, proxy notification). What was missing
+was the SGLang glue: a way for a prefill worker to say *"store this request's KV
+**and** ship it to decode instance X"*. That is a single new piece of
+per-request routing state — `transfer_spec` — plus a connector that forwards it.
+
+The design supports **xPyD** (N prefill × M decode) from the start: routing is
+per request, so any prefill can target any decode; there is no 1:1 pinning.
+
+It runs on **Intel XPU** as well as CUDA — the LMCache side uses
+`torch_device_type` throughout, and the PD buffer device is configurable
+(`pd_buffer_device: xpu`).
+
+## Goals / Non-Goals
+
+Goals:
+
+- A dedicated `LMCachePDConnector` that pushes a completed request's KV to its
+  assigned decode peer, driven entirely by LMCache's `PDBackend`.
+- Per-request routing (`DisaggSpec`) injected by the router/proxy through
+  SGLang's request path — enabling xPyD with no static prefill↔decode pinning.
+- Full backward compatibility: a request with no routing (`transfer_spec=None`)
+  stores exactly as before (local CPU/disk/remote offload only).
+- Works on XPU and CUDA; the PD buffer device is configurable.
+
+Non-Goals:
+
+- Reusing SGLang's HiCache decode-side restore machinery (explicitly out).
+- Building a new transport — `PDBackend`/NIXL is reused unchanged.
+- The router/proxy implementation itself (xPyD scheduling policy) — this doc
+  covers only the data-plane contract the proxy must satisfy.
+- Layerwise streaming of the PD push (see *Why non-layerwise* below).
+
+## Types
+
+- **`DisaggSpec`** (`lmcache/integration/sglang/pd_types.py`, `@dataclass`):
+  per-request routing to the decode receiver. Deliberately dependency-free (no
+  `sglang`/`torch` imports) so it can be constructed and unit-tested without a
+  GPU or a full SGLang install; `sglang_adapter` re-exports it.
+  - `req_id: str` — correlation id shared with the proxy; returned in the
+    `ProxyNotif` when the last-prefill transfer completes.
+  - `receiver_host: str` — decode instance host/IP.
+  - `receiver_init_port: List[int]` — NIXL side-channel init ports, **indexed by
+    the sender's tp rank** (one listen port per receiver rank).
+  - `receiver_alloc_port: List[int]` — remote-allocation ports, indexed by tp rank.
+  - `receiver_query_port: List[int]` — cache-query ports, indexed by tp rank;
+    used only when bidirectional query is enabled, empty otherwise.
+  - `is_last_prefill: bool` — `True` on the final store for a request (triggers
+    the proxy notification). Single-shot stores set this `True`.
+  - `from_dict(spec) -> DisaggSpec` — parses/validates the proxy-injected
+    `kv_transfer_params["disagg_spec"]` mapping; raises `ValueError` on a missing
+    required key or a non-`list[int]` port field.
+
+  The port fields are lists indexed by tp rank because `PDBackend`, running on
+  the sender at rank `tp_rank`, reads `receiver_init_port[self.tp_rank]` (and the
+  alloc/query equivalents) to reach the *same* rank on the receiver. This
+  matches the field contract already consumed by
+  `PDBackend.batched_submit_put_task`.
+
+- **`StoreMetadata`** (`sglang_adapter.py`): gains
+  `transfer_spec: Optional[DisaggSpec] = None`. Default `None` keeps every
+  existing (non-PD) caller unchanged.
+
+## Connector
+
+`LMCachePDConnector(LMCacheConnector)` (`sglang_adapter.py`):
+
+- On `store_kv`, forwards `store_metadata.transfer_spec` into
+  `LMCacheEngine.store(..., transfer_spec=...)`. The storage manager routes it to
+  `PDBackend`, which performs the NIXL push to the decode peer. `transfer_spec is
+  None` degrades to a plain local store.
+- Logs at `info` when a push is issued (req_id, token count, receiver host) and
+  at `debug` when there is no routing.
+
+### Why non-layerwise
+
+`LMCachePDConnector` extends the **non-layerwise** `LMCacheConnector`, not
+`LMCacheLayerwiseConnector`, because **only** the non-layerwise
+`LMCacheEngine.store` path forwards `transfer_spec` to the storage manager.
+`store_layer` (the layerwise path) does not thread `transfer_spec` through, so a
+layerwise PD sender would silently drop the routing and never push. This is the
+key architectural constraint of the feature: the PD push is a whole-request
+store, issued once the request's KV is complete.
+
+## Data flow
+
+```
+proxy/router                 prefill worker (sender)              decode worker (receiver)
+     |                              |                                     |
+  pick decode peer,           req arrives with                           |
+  build disagg_spec  ───────► kv_transfer_params                         |
+  (req_id, host, ports)       .disagg_spec                               |
+     |                              |                                     |
+     |                        request finishes:                          |
+     |                        cache_finished_req builds                  |
+     |                        StoreMetadata(transfer_spec=               |
+     |                          DisaggSpec.from_dict(...))                |
+     |                              |                                     |
+     |                        LMCachePDConnector.store_kv                 |
+     |                              │ engine.store(transfer_spec=…)       |
+     |                              ▼                                     |
+     |                          PDBackend ── NIXL push (per tp rank) ───► KV buffer
+     |                              |          init/alloc handshake       │ populated
+     |◄─── ProxyNotif(req_id) ──────┘  (on is_last_prefill)               │
+     |                                                                    ▼
+  route req to decode ──────────────────────────────────────────► decode reads local KV
+```
+
+The port lists let each sender rank talk to the matching receiver rank, so the
+push parallelizes across tensor-parallel ranks.
+
+## SGLang-side plumbing (fork changes, out of this repo)
+
+The proxy injects routing as `kv_transfer_params={"disagg_spec": {...}}` on the
+request. To reach `cache_finished_req`, the fork must thread `kv_transfer_params`
+through: `GenerateReqInput` / `TokenizedGenerateReqInput` (`io_struct.py`),
+`tokenizer_manager.py`, `Req.__init__` (`schedule_batch.py`), the `Req` build in
+`scheduler.py`, and finally `LMCRadixCache.cache_finished_req`
+(`lmc_radix_cache.py`), which builds the `StoreMetadata` and calls the connector.
+`server_args.py` gains the flags to select `LMCachePDConnector` and point at the
+LMCache PD config. These are tracked separately from this LMCache PR.
+
+## Configuration
+
+Sender (prefill) and receiver (decode) each run an LMCache engine with PD
+enabled (`lmcache/v1/config.py`):
+
+- `enable_pd: true`
+- `pd_role: sender` (prefill) / `receiver` (decode)
+- `pd_buffer_size`, `pd_buffer_device: xpu` (or `cuda`)
+- `pd_peer_host`, `pd_peer_init_port`, `pd_peer_alloc_port`, `pd_peer_query_port`
+- `pd_backend_mode: sync | async`, `pd_bidirectional`
+
+The receiver sets `remove_after_retrieve` automatically. Legacy aliases
+(`enable_xpyd`→`enable_pd`, `nixl_role`→`pd_role`, `nixl_peer_*`→`pd_peer_*`)
+remain accepted.
+
+## Testing
+
+`tests/v1/test_sglang_pd_disagg.py`:
+
+- `DisaggSpec.from_dict` parsing/validation runs **without** sglang/torch by
+  importing from `pd_types` directly (required fields, optional fields, missing
+  key raises, non-`list[int]` ports raise, port lists copied not aliased).
+- Connector forwarding (`transfer_spec` reaches `engine.store`; `None` still
+  stores locally) is guarded by `importorskip("...sglang_adapter")` since it
+  needs the sglang import; it skips cleanly in the LMCache CI image and runs in
+  the SGLang container.
+
+## Backward compatibility
+
+`transfer_spec` defaults to `None` everywhere. Non-PD SGLang deployments, and
+every existing connector (`LMCacheConnector`, `LMCacheLayerwiseConnector`,
+`LMCacheMPConnector`), are unaffected: with no `DisaggSpec`, `store` takes the
+identical local-offload path it always has.

--- a/lmcache/integration/sglang/pd_types.py
+++ b/lmcache/integration/sglang/pd_types.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dependency-free data types for SGLang PD (prefill/decode) disaggregation.
+
+This module intentionally imports nothing from ``sglang`` or ``torch`` so that
+the routing types can be constructed and validated (and unit-tested) without a
+GPU or a full SGLang install. The heavier adapter in
+:mod:`lmcache.integration.sglang.sglang_adapter` re-exports :class:`DisaggSpec`.
+"""
+
+# Standard
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class DisaggSpec:
+    """Per-request routing information for LMCache PD disaggregation.
+
+    Describes the decode (receiver) instance that a prefill (sender) instance
+    must push this request's KV cache to over NIXL. It is duck-typed by
+    ``lmcache.v1.storage_backend.pd_backend.PDBackend.batched_submit_put_task``,
+    which reads ``receiver_host`` and indexes the port lists by the sender's
+    tensor-parallel rank (``receiver_init_port[tp_rank]`` etc.). The port fields
+    are therefore per-tp-rank lists, one listen port per receiver rank.
+
+    Args:
+        req_id: Correlation id shared with the proxy; sent back in the
+            ``ProxyNotif`` once the last-prefill transfer completes.
+        receiver_host: Hostname / IP of the decode instance.
+        receiver_init_port: NIXL side-channel init ports, indexed by tp rank.
+        receiver_alloc_port: Remote-allocation ports, indexed by tp rank.
+        receiver_query_port: Cache-query ports, indexed by tp rank. Only used
+            when bidirectional cache query is enabled; empty otherwise.
+        is_last_prefill: True on the final store for a request, which triggers
+            the proxy notification. Single-shot stores set this True.
+    """
+
+    req_id: str
+    receiver_host: str
+    receiver_init_port: List[int]
+    receiver_alloc_port: List[int]
+    receiver_query_port: List[int] = field(default_factory=list)
+    is_last_prefill: bool = True
+
+    @classmethod
+    def from_dict(cls, spec: dict) -> "DisaggSpec":
+        """Build a ``DisaggSpec`` from a proxy-injected ``kv_transfer_params``
+        ``disagg_spec`` mapping.
+
+        Expected schema (all required unless noted):
+            ``req_id`` (str), ``receiver_host`` (str),
+            ``receiver_init_port`` (list[int]), ``receiver_alloc_port`` (list[int]),
+            ``receiver_query_port`` (list[int], optional),
+            ``is_last_prefill`` (bool, optional, default True).
+
+        Args:
+            spec: The ``disagg_spec`` mapping described above.
+
+        Returns:
+            The parsed ``DisaggSpec``.
+
+        Raises:
+            ValueError: If a required key is missing or a port field is not a
+                list of ints.
+        """
+        required = (
+            "req_id",
+            "receiver_host",
+            "receiver_init_port",
+            "receiver_alloc_port",
+        )
+        missing = [k for k in required if k not in spec]
+        if missing:
+            raise ValueError(
+                f"disagg_spec is missing required keys: {missing}. "
+                f"Got keys: {sorted(spec.keys())}"
+            )
+        for port_key in ("receiver_init_port", "receiver_alloc_port"):
+            value = spec[port_key]
+            if not isinstance(value, list) or not all(
+                isinstance(p, int) for p in value
+            ):
+                raise ValueError(
+                    f"disagg_spec['{port_key}'] must be a list[int] "
+                    f"(one port per receiver tp rank), got {value!r}"
+                )
+        return cls(
+            req_id=str(spec["req_id"]),
+            receiver_host=str(spec["receiver_host"]),
+            receiver_init_port=list(spec["receiver_init_port"]),
+            receiver_alloc_port=list(spec["receiver_alloc_port"]),
+            receiver_query_port=list(spec.get("receiver_query_port", [])),
+            is_last_prefill=bool(spec.get("is_last_prefill", True)),
+        )

--- a/lmcache/integration/sglang/sglang_adapter.py
+++ b/lmcache/integration/sglang/sglang_adapter.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 
 # First Party
 from lmcache import torch_device_type
+from lmcache.integration.sglang.pd_types import DisaggSpec
 from lmcache.integration.sglang.utils import ENGINE_NAME, lmcache_get_config
 from lmcache.logging import init_logger
 from lmcache.utils import (
@@ -34,6 +35,7 @@ class StoreMetadata:
     kv_indices: torch.Tensor
     offset: int
     request_id: str = ""
+    transfer_spec: Optional[DisaggSpec] = None
 
 
 @dataclass
@@ -183,12 +185,19 @@ class LMCacheConnector:
             raise ValueError("Length of token_ids must match slot_mapping length")
         store_mask = torch.ones_like(token_ids, dtype=torch.bool)
 
+        # ``transfer_spec`` is forwarded to the storage manager, where the PD
+        # backend uses it to push the KV to the decode peer over NIXL. It is
+        # ``None`` for non-PD stores, in which case ``store`` behaves exactly as
+        # before (local CPU/disk/remote offload only). Note: only this
+        # non-layerwise ``engine.store`` path forwards ``transfer_spec`` today;
+        # ``store_layer`` does not, which is why the PD sender uses this path.
         self.lmcache_engine.store(
             token_ids,
             mask=store_mask,
             kvcaches=self.kvcaches,
             slot_mapping=slot_mapping,
             offset=offset,
+            transfer_spec=store_metadata.transfer_spec,
         )
 
     def get_kv_events(self) -> Iterable[CacheStoreEvent]:
@@ -374,3 +383,45 @@ class LMCacheLayerwiseConnector(LMCacheConnector):
                 self.lmcache_engine.lookup_unpin(lookup_id)
             except Exception as unpin_err:
                 logger.error(f"Failed to unpin lookup: {unpin_err}", exc_info=True)
+
+
+class LMCachePDConnector(LMCacheConnector):
+    """Connector for prefill/decode (PD) disaggregation over NIXL.
+
+    A prefill (sender) SGLang instance uses this connector so that, on request
+    completion, the request's KV cache is pushed to the assigned decode
+    (receiver) instance. The push is driven entirely by LMCache's
+    ``PDBackend``: this connector's only job is to forward the per-request
+    :class:`DisaggSpec` into ``engine.store`` as ``transfer_spec``.
+
+    It deliberately extends the non-layerwise :class:`LMCacheConnector` rather
+    than :class:`LMCacheLayerwiseConnector`, because only the non-layerwise
+    ``LMCacheEngine.store`` path forwards ``transfer_spec`` to the storage
+    manager (``store_layer`` does not). The engine must be configured with
+    ``enable_pd: true`` and ``pd_role: sender`` for the transfer to occur; with
+    a ``None`` ``transfer_spec`` (e.g. a request the proxy routed directly to
+    decode) the store falls back to plain local offload.
+    """
+
+    def store_kv(self, store_metadata: StoreMetadata) -> None:
+        """Store this request's KV and, if a :class:`DisaggSpec` is attached,
+        push it to the decode peer over NIXL.
+
+        Args:
+            store_metadata: The store request. ``transfer_spec`` carries the
+                decode-peer routing; when ``None`` this is a plain local store.
+        """
+        if store_metadata.transfer_spec is None:
+            logger.debug(
+                "PD store_kv with no transfer_spec (req_id=%s): storing locally "
+                "only, no peer transfer",
+                store_metadata.request_id,
+            )
+        else:
+            logger.info(
+                "PD store_kv (req_id=%s): pushing %d tokens to receiver %s",
+                store_metadata.request_id,
+                len(store_metadata.token_ids),
+                store_metadata.transfer_spec.receiver_host,
+            )
+        super().store_kv(store_metadata)

--- a/tests/v1/test_sglang_pd_disagg.py
+++ b/tests/v1/test_sglang_pd_disagg.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# tests/v1/test_sglang_pd_disagg.py
+#
+# Unit tests for the SGLang PD (prefill/decode) disaggregation glue in
+# lmcache.integration.sglang.sglang_adapter: the DisaggSpec routing struct,
+# its from_dict parser, and that LMCachePDConnector forwards transfer_spec
+# into engine.store while a plain store omits it.
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third Party
+import pytest
+
+# First Party
+# DisaggSpec lives in a dependency-free module so its parsing/validation can be
+# tested without a full SGLang (or torch/GPU) install.
+from lmcache.integration.sglang.pd_types import DisaggSpec
+
+
+def _import_adapter():
+    """Import the sglang adapter or skip: it imports `sglang` at module scope,
+    which is bind-mounted at runtime and absent from the LMCache test image."""
+    return pytest.importorskip(
+        "lmcache.integration.sglang.sglang_adapter",
+        reason="sglang is not installed",
+    )
+
+
+def _valid_spec_dict() -> dict:
+    return {
+        "req_id": "req-123",
+        "receiver_host": "10.0.0.7",
+        "receiver_init_port": [5600, 5601],
+        "receiver_alloc_port": [5700, 5701],
+    }
+
+
+class TestDisaggSpecFromDict:
+    def test_parses_required_fields(self):
+        spec = DisaggSpec.from_dict(_valid_spec_dict())
+        assert spec.req_id == "req-123"
+        assert spec.receiver_host == "10.0.0.7"
+        assert spec.receiver_init_port == [5600, 5601]
+        assert spec.receiver_alloc_port == [5700, 5701]
+        # Defaults: query ports empty, single-shot store marks last prefill.
+        assert spec.receiver_query_port == []
+        assert spec.is_last_prefill is True
+
+    def test_parses_optional_fields(self):
+        spec_dict = _valid_spec_dict()
+        spec_dict["receiver_query_port"] = [5800, 5801]
+        spec_dict["is_last_prefill"] = False
+        spec = DisaggSpec.from_dict(spec_dict)
+        assert spec.receiver_query_port == [5800, 5801]
+        assert spec.is_last_prefill is False
+
+    @pytest.mark.parametrize(
+        "missing_key",
+        ["req_id", "receiver_host", "receiver_init_port", "receiver_alloc_port"],
+    )
+    def test_missing_required_key_raises(self, missing_key):
+        spec_dict = _valid_spec_dict()
+        del spec_dict[missing_key]
+        with pytest.raises(ValueError, match="missing required keys"):
+            DisaggSpec.from_dict(spec_dict)
+
+    @pytest.mark.parametrize(
+        "bad_ports",
+        [5600, "5600", [5600, "x"], None],
+    )
+    def test_non_list_ports_raise(self, bad_ports):
+        spec_dict = _valid_spec_dict()
+        spec_dict["receiver_init_port"] = bad_ports
+        with pytest.raises(ValueError, match="must be a list\\[int\\]"):
+            DisaggSpec.from_dict(spec_dict)
+
+    def test_ports_are_copied_not_aliased(self):
+        spec_dict = _valid_spec_dict()
+        spec = DisaggSpec.from_dict(spec_dict)
+        spec_dict["receiver_init_port"].append(9999)
+        assert spec.receiver_init_port == [5600, 5601]
+
+
+class TestStoreMetadataTransferSpec:
+    def test_default_transfer_spec_is_none(self):
+        StoreMetadata = _import_adapter().StoreMetadata
+        md = StoreMetadata(
+            last_node=None,
+            token_ids=[1, 2, 3],
+            kv_indices=MagicMock(),
+            offset=0,
+        )
+        assert md.transfer_spec is None
+
+
+class TestLMCachePDConnectorForwarding:
+    """LMCachePDConnector.store_kv must forward transfer_spec into
+    engine.store; a None spec must still store (local-only)."""
+
+    def _make_connector(self):
+        # Bypass __init__ (which builds a real LMCache engine) and inject the
+        # minimal state store_kv touches.
+        LMCachePDConnector = _import_adapter().LMCachePDConnector
+        conn = LMCachePDConnector.__new__(LMCachePDConnector)
+        conn.lmcache_engine = MagicMock()
+        conn.kvcaches = [MagicMock()]
+        return conn
+
+    def _store_metadata(self, transfer_spec):
+        # kv_indices must survive .to(int64).to(device); a MagicMock returns
+        # itself from chained calls, and len() is stubbed to match token_ids.
+        StoreMetadata = _import_adapter().StoreMetadata
+        kv_indices = MagicMock()
+        kv_indices.to.return_value = kv_indices
+        kv_indices.__len__.return_value = 3
+        return StoreMetadata(
+            last_node=None,
+            token_ids=[1, 2, 3],
+            kv_indices=kv_indices,
+            offset=0,
+            request_id="req-123",
+            transfer_spec=transfer_spec,
+        )
+
+    def test_forwards_transfer_spec_to_engine_store(self, monkeypatch):
+        # torch.tensor(...).to(...) and torch.ones_like(...) are exercised by
+        # the base store_kv; keep them real but tiny.
+        conn = self._make_connector()
+        spec = DisaggSpec.from_dict(_valid_spec_dict())
+        conn.store_kv(self._store_metadata(spec))
+
+        conn.lmcache_engine.store.assert_called_once()
+        _, kwargs = conn.lmcache_engine.store.call_args
+        assert kwargs["transfer_spec"] is spec
+
+    def test_none_transfer_spec_still_stores(self):
+        conn = self._make_connector()
+        conn.store_kv(self._store_metadata(None))
+
+        conn.lmcache_engine.store.assert_called_once()
+        _, kwargs = conn.lmcache_engine.store.call_args
+        assert kwargs["transfer_spec"] is None


### PR DESCRIPTION
Enable prefill/decode (PD) disaggregation for SGLang as a first-class LMCache feature (not built on HiCache's decode-restore path). A prefill (sender) instance pushes a completed request's KV cache to its assigned decode (receiver) instance over NIXL, driven by LMCache's existing PDBackend. Supports xPyD (N prefill x M decode) via per-request routing, and runs on Intel XPU as well as CUDA.

- Add DisaggSpec (lmcache/integration/sglang/pd_types.py): dependency-free per-request routing struct (receiver host + per-tp-rank port lists) with a validating from_dict parser. Kept free of sglang/torch imports so it is unit-testable without a GPU or full SGLang install.
- StoreMetadata gains an optional transfer_spec; base LMCacheConnector.store_kv forwards it into engine.store(transfer_spec=...). None is fully backward compatible (plain local offload).
- Add LMCachePDConnector, extending the non-layerwise LMCacheConnector because only engine.store (not store_layer) forwards transfer_spec to the storage manager / PDBackend.
- Add tests/v1/test_sglang_pd_disagg.py: DisaggSpec parsing/validation runs without sglang (imports pd_types directly); connector-forwarding tests are guarded by importorskip on the sglang adapter.
- Add design doc under docs/design/integration/sglang/.

