### PR TITLE
[bench CLI] Fix the KV cache size detection when running model with TP

### DIFF
--- a/docs/design/cli/commands/bench/engine_bench/bench-engine.md
+++ b/docs/design/cli/commands/bench/engine_bench/bench-engine.md
@@ -117,7 +117,7 @@ Key functions:
 |----------|---------|
 | `parse_args_to_config(args) -> EngineBenchConfig` | Converts CLI args to fully-resolved config |
 | `auto_detect_model(engine_url) -> str` | Fetches model ID from `/v1/models` |
-| `resolve_tokens_per_gb(lmcache_url, model_name) -> int` | Queries LMCache `/status` for `cache_size_per_token * world_size` |
+| `resolve_tokens_per_gb(lmcache_url, model_name) -> int` | Queries LMCache `/status`; averages `cache_size_per_token` over the model's rank entries (collapsing replicas) and multiplies by `world_size`, or by 1 for all-MLA models (TP ranks share one KV copy) |
 
 `EngineBenchConfig` contains only general parameters. Workload-specific
 configs live in their own modules and are resolved by the workload factory.

--- a/lmcache/cli/commands/bench/engine_bench/config.py
+++ b/lmcache/cli/commands/bench/engine_bench/config.py
@@ -119,44 +119,65 @@ def _fetch_lmcache_status(lmcache_url: str) -> dict:
         ) from e
 
 
-def _find_model_meta(
+def _find_model_metas(
     gpu_meta: dict,
     model_name: str,
-) -> dict:
-    """Find the GPU metadata entry matching *model_name*.
+) -> list[dict]:
+    """Find all GPU metadata entries matching *model_name*.
+
+    Every rank of every model replica registers its own entry, so a
+    tensor-parallel model appears once per rank per replica.
 
     Args:
         gpu_meta: The ``cache_context_meta`` dict from ``/status``.
         model_name: Model name to match.
 
     Returns:
-        The matching GPU metadata dict.
+        All matching GPU metadata dicts.
 
     Raises:
         RuntimeError: If no entry matches *model_name*.
     """
-    for meta in gpu_meta.values():
-        if meta.get("model_name") == model_name:
-            return meta
+    metas = [m for m in gpu_meta.values() if m.get("model_name") == model_name]
+    if not metas:
+        available = sorted({m.get("model_name", "?") for m in gpu_meta.values()})
+        raise RuntimeError(
+            f"Model {model_name!r} not found on LMCache server. "
+            f"Available: {', '.join(available)}"
+        )
+    return metas
 
-    available = sorted({m.get("model_name", "?") for m in gpu_meta.values()})
-    raise RuntimeError(
-        f"Model {model_name!r} not found on LMCache server. "
-        f"Available: {', '.join(available)}"
-    )
+
+def _is_all_mla(layout: dict) -> bool:
+    """Whether every kernel group in *layout* uses MLA attention.
+
+    Layouts without kernel-group metadata (e.g. blend deployments)
+    are treated as non-MLA.
+
+    Args:
+        layout: A ``kv_cache_layout`` dict from ``/status``.
+
+    Returns:
+        True if the layout has kernel groups and all of them are MLA.
+    """
+    kernel_groups = layout.get("kernel_groups", [])
+    return bool(kernel_groups) and all(g.get("is_mla") for g in kernel_groups)
 
 
 def resolve_tokens_per_gb(lmcache_url: str, model_name: str) -> int:
     """Query the LMCache server and compute tokens per GB of KV cache.
 
-    Fetches ``/status``, finds the model entry matching
-    *model_name*, and computes::
+    Fetches ``/status``, collects all entries matching *model_name*
+    (one per registered rank, across all replicas), and computes::
 
-        global_bytes_per_token = cache_size_per_token * world_size
+        global_bytes_per_token = mean(rank_sizes) * multiplier
         tokens_per_gb = (1024**3) // global_bytes_per_token
 
-    ``cache_size_per_token`` is rank-local, so it must be multiplied
-    by ``world_size`` for tensor-parallel models.
+    ``multiplier`` is ``world_size`` for tensor-parallel models, since
+    each rank holds only its shard of the KV cache; it is 1 when every
+    kernel group is MLA, because TP ranks then share one identical KV
+    copy. Averaging over all entries keeps multiple replicas of the
+    same model from being counted more than once.
 
     Args:
         lmcache_url: URL of the LMCache HTTP server.
@@ -168,7 +189,8 @@ def resolve_tokens_per_gb(lmcache_url: str, model_name: str) -> int:
 
     Raises:
         RuntimeError: If the server is unreachable, the model is not
-            found, or the layout is missing required fields.
+            found, the layout is missing required fields, or entries
+            report inconsistent world sizes.
     """
     data = _fetch_lmcache_status(lmcache_url)
 
@@ -183,29 +205,44 @@ def resolve_tokens_per_gb(lmcache_url: str, model_name: str) -> int:
             "is the server running with a model loaded?"
         )
 
-    meta = _find_model_meta(gpu_meta, model_name)
-    layout = meta.get("kv_cache_layout")
-    if not layout:
-        raise RuntimeError(f"No kv_cache_layout for model {model_name!r}")
+    metas = _find_model_metas(gpu_meta, model_name)
 
-    cache_size_per_token = layout.get("cache_size_per_token")
-    if cache_size_per_token is None:
+    per_rank_sizes: list[int] = []
+    all_mla = True
+    for meta in metas:
+        layout = meta.get("kv_cache_layout")
+        if not layout:
+            raise RuntimeError(f"No kv_cache_layout for model {model_name!r}")
+
+        cache_size_per_token = layout.get("cache_size_per_token")
+        if cache_size_per_token is None:
+            raise RuntimeError(
+                f"cache_size_per_token not available for model "
+                f"{model_name!r}; is the LMCache server up to date?"
+            )
+        per_rank_sizes.append(cache_size_per_token)
+        all_mla = all_mla and _is_all_mla(layout)
+
+    world_sizes = {m.get("world_size", 1) for m in metas}
+    if len(world_sizes) > 1:
         raise RuntimeError(
-            f"cache_size_per_token not available for model "
-            f"{model_name!r}; is the LMCache server up to date?"
+            f"Inconsistent world_size values {sorted(world_sizes)} for model "
+            f"{model_name!r}; cannot compute a per-replica KV cache size."
         )
+    world_size = world_sizes.pop()
 
-    world_size = meta.get("world_size", 1)
-    global_bytes_per_token = cache_size_per_token * world_size
+    multiplier = 1 if all_mla else world_size
+    global_bytes_per_token = sum(per_rank_sizes) * multiplier // len(per_rank_sizes)
     tokens_per_gb = _GB // global_bytes_per_token
 
     logger.info(
-        "Resolved from LMCache: model=%s, "
-        "cache_size_per_token=%d bytes (rank-local), "
-        "world_size=%d -> %d bytes/token (global) -> %d tokens/GB",
+        "Resolved from LMCache: model=%s, rank_entries=%d, "
+        "world_size=%d, all_mla=%s "
+        "-> %d bytes/token (global) -> %d tokens/GB",
         model_name,
-        cache_size_per_token,
+        len(per_rank_sizes),
         world_size,
+        all_mla,
         global_bytes_per_token,
         tokens_per_gb,
     )

--- a/tests/cli/commands/bench/engine_bench/test_config.py
+++ b/tests/cli/commands/bench/engine_bench/test_config.py
@@ -11,7 +11,7 @@ import pytest
 # First Party
 from lmcache.cli.commands.bench.engine_bench.config import (
     EngineBenchConfig,
-    _find_model_meta,
+    _find_model_metas,
     auto_detect_model,
     parse_args_to_config,
     resolve_tokens_per_gb,
@@ -189,11 +189,11 @@ class TestParseArgsToConfig:
 
 
 # ---------------------------------------------------------------------------
-# _find_model_meta
+# _find_model_metas
 # ---------------------------------------------------------------------------
 
 
-class TestFindModelMeta:
+class TestFindModelMetas:
     def _gpu_meta(self) -> dict:
         return {
             "gpu_0": {
@@ -206,26 +206,33 @@ class TestFindModelMeta:
                 "world_size": 4,
                 "kv_cache_layout": {"cache_size_per_token": 327680},
             },
+            "gpu_2": {
+                "model_name": "meta-llama/Llama-3.1-70B",
+                "world_size": 4,
+                "kv_cache_layout": {"cache_size_per_token": 327680},
+            },
         }
 
     def test_finds_matching_model(self) -> None:
-        meta = _find_model_meta(self._gpu_meta(), "Qwen/Qwen3-14B")
-        assert meta["model_name"] == "Qwen/Qwen3-14B"
+        metas = _find_model_metas(self._gpu_meta(), "Qwen/Qwen3-14B")
+        assert len(metas) == 1
+        assert metas[0]["model_name"] == "Qwen/Qwen3-14B"
 
-    def test_finds_second_model(self) -> None:
-        meta = _find_model_meta(
+    def test_finds_all_rank_entries(self) -> None:
+        metas = _find_model_metas(
             self._gpu_meta(),
             "meta-llama/Llama-3.1-70B",
         )
-        assert meta["world_size"] == 4
+        assert len(metas) == 2
+        assert all(m["world_size"] == 4 for m in metas)
 
     def test_missing_model_raises(self) -> None:
         with pytest.raises(RuntimeError, match="not found"):
-            _find_model_meta(self._gpu_meta(), "nonexistent-model")
+            _find_model_metas(self._gpu_meta(), "nonexistent-model")
 
     def test_error_lists_available(self) -> None:
         with pytest.raises(RuntimeError, match="Qwen/Qwen3-14B"):
-            _find_model_meta(self._gpu_meta(), "nonexistent")
+            _find_model_metas(self._gpu_meta(), "nonexistent")
 
 
 # ---------------------------------------------------------------------------
@@ -234,24 +241,31 @@ class TestFindModelMeta:
 
 
 class TestResolveTokensPerGb:
-    def _status_response(
+    def _entry(
         self,
         cache_size_per_token: int = 163840,
         world_size: int = 1,
         model_name: str = "Qwen/Qwen3-14B",
+        mla: bool = False,
     ) -> dict:
         return {
+            "model_name": model_name,
+            "world_size": world_size,
+            "kv_cache_layout": {
+                "num_layers": 40,
+                "hidden_dim_size": 1024,
+                "dtype": "torch.bfloat16",
+                "cache_size_per_token": cache_size_per_token,
+                "kernel_groups": [{"is_mla": mla}],
+            },
+        }
+
+    def _status_response(self, *entries: dict) -> dict:
+        if not entries:
+            entries = (self._entry(),)
+        return {
             "cache_context_meta": {
-                "gpu_0": {
-                    "model_name": model_name,
-                    "world_size": world_size,
-                    "kv_cache_layout": {
-                        "num_layers": 40,
-                        "hidden_dim_size": 1024,
-                        "dtype": "torch.bfloat16",
-                        "cache_size_per_token": cache_size_per_token,
-                    },
-                },
+                f"gpu_{i}": entry for i, entry in enumerate(entries)
             },
         }
 
@@ -263,8 +277,7 @@ class TestResolveTokensPerGb:
         # 1 GB = 1073741824 bytes
         # 1073741824 // 163840 = 6553
         mock_fetch.return_value = self._status_response(
-            cache_size_per_token=163840,
-            world_size=1,
+            self._entry(cache_size_per_token=163840, world_size=1),
         )
         result = resolve_tokens_per_gb(
             "http://localhost:8080",
@@ -276,18 +289,114 @@ class TestResolveTokensPerGb:
         "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",
     )
     def test_world_size_multiplier(self, mock_fetch) -> None:
-        # 163840 bytes/token (rank-local), world_size=4
-        # global = 163840 * 4 = 655360
+        # 163840 bytes/token (rank-local), world_size=4, one rank
+        # registered so far: global = 163840 * 4 = 655360
         # 1073741824 // 655360 = 1638
         mock_fetch.return_value = self._status_response(
-            cache_size_per_token=163840,
-            world_size=4,
+            self._entry(cache_size_per_token=163840, world_size=4),
         )
         result = resolve_tokens_per_gb(
             "http://localhost:8080",
             "Qwen/Qwen3-14B",
         )
         assert result == 1638
+
+    @patch(
+        "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",
+    )
+    def test_sums_across_tp_ranks(self, mock_fetch) -> None:
+        # Two TP ranks with uneven shards: 100000 + 120000 = 220000
+        # bytes/token global; 1073741824 // 220000 = 4880
+        mock_fetch.return_value = self._status_response(
+            self._entry(cache_size_per_token=100000, world_size=2),
+            self._entry(cache_size_per_token=120000, world_size=2),
+        )
+        result = resolve_tokens_per_gb(
+            "http://localhost:8080",
+            "Qwen/Qwen3-14B",
+        )
+        assert result == 4880
+
+    @patch(
+        "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",
+    )
+    def test_mla_not_multiplied_by_world_size(self, mock_fetch) -> None:
+        # All-MLA model: TP ranks share one KV copy, so global stays
+        # at 163840 bytes/token despite world_size=4.
+        mock_fetch.return_value = self._status_response(
+            *[
+                self._entry(cache_size_per_token=163840, world_size=4, mla=True)
+                for _ in range(4)
+            ],
+        )
+        result = resolve_tokens_per_gb(
+            "http://localhost:8080",
+            "Qwen/Qwen3-14B",
+        )
+        assert result == 6553
+
+    @patch(
+        "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",
+    )
+    def test_mixed_mla_groups_multiplied(self, mock_fetch) -> None:
+        # A layout with one MLA and one non-MLA kernel group is not
+        # all-MLA, so the world_size multiplier applies.
+        entry = self._entry(cache_size_per_token=163840, world_size=4)
+        entry["kv_cache_layout"]["kernel_groups"] = [
+            {"is_mla": True},
+            {"is_mla": False},
+        ]
+        mock_fetch.return_value = self._status_response(entry)
+        result = resolve_tokens_per_gb(
+            "http://localhost:8080",
+            "Qwen/Qwen3-14B",
+        )
+        assert result == 1638
+
+    @patch(
+        "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",
+    )
+    def test_replicas_not_double_counted(self, mock_fetch) -> None:
+        # Two replicas of a TP=2 model -> 4 entries. Global must equal
+        # a single replica's sum: 163840 * 2 = 327680 bytes/token.
+        # 1073741824 // 327680 = 3276
+        mock_fetch.return_value = self._status_response(
+            *[self._entry(cache_size_per_token=163840, world_size=2) for _ in range(4)],
+        )
+        result = resolve_tokens_per_gb(
+            "http://localhost:8080",
+            "Qwen/Qwen3-14B",
+        )
+        assert result == 3276
+
+    @patch(
+        "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",
+    )
+    def test_no_kernel_groups_treated_as_non_mla(self, mock_fetch) -> None:
+        # Blend layouts carry no kernel_groups; the world_size
+        # multiplier applies.
+        entry = self._entry(cache_size_per_token=163840, world_size=4)
+        del entry["kv_cache_layout"]["kernel_groups"]
+        mock_fetch.return_value = self._status_response(entry)
+        result = resolve_tokens_per_gb(
+            "http://localhost:8080",
+            "Qwen/Qwen3-14B",
+        )
+        assert result == 1638
+
+    @patch(
+        "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",
+    )
+    def test_inconsistent_world_size_raises(self, mock_fetch) -> None:
+        mock_fetch.return_value = self._status_response(
+            self._entry(cache_size_per_token=163840, world_size=2),
+            self._entry(cache_size_per_token=163840, world_size=4),
+        )
+        with pytest.raises(RuntimeError, match="Inconsistent world_size"):
+            resolve_tokens_per_gb(
+                "http://localhost:8080",
+                "Qwen/Qwen3-14B",
+            )
 
     @patch(
         "lmcache.cli.commands.bench.engine_bench.config._fetch_lmcache_status",


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Previously, when a model is launched with TP, the `lmcache bench engine` will use single TP-slice's KV cache size to calculate the number of sessions.

This PR fixes this by detecting all the ranks from the same model replica and add the KV cache size together.

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
