### PR TITLE
[Platform] drop vLLM wording from MUSA/CPU docstrings

### DIFF
--- a/lmcache/v1/platform/cpu/shm.py
+++ b/lmcache/v1/platform/cpu/shm.py
@@ -58,8 +58,8 @@ __all__ = [
 class CpuShmTensorWrapper(DeviceIPCWrapper):
     """IPC wrapper for CPU tensors backed by POSIX shared memory.
 
-    Used by the ``lmcache bench kvcache --mode cpu`` path and the
-    vLLM CPU integration so that the client and the LMCache mp server
+    Used by the ``lmcache bench kvcache --mode cpu`` path and engine
+    CPU integrations so that the client and the LMCache mp server
     map the **same** physical pages for the KV cache, mirroring the
     GPU-mode CUDA-IPC zero-copy semantics.
 

--- a/lmcache/v1/platform/musa/native_kv_transfer.py
+++ b/lmcache/v1/platform/musa/native_kv_transfer.py
@@ -188,12 +188,12 @@ def try_native_to_gpu(
     Args:
         use_mla: Whether the active layout is MLA.
         memory_tensor: LMCache contiguous memory object tensor.
-        kvcaches: vLLM paged KV tensors.
-        slot_mapping: Full vLLM slot mapping tensor.
+        kvcaches: Engine paged KV tensors.
+        slot_mapping: Full engine slot mapping tensor.
         start: Inclusive token start for this transfer.
         end: Exclusive token end for this transfer.
-        skip_prefix_n_tokens: Prefix tokens already cached by vLLM.
-        block_size: vLLM paged KV block size.
+        skip_prefix_n_tokens: Prefix tokens already cached by the engine.
+        block_size: Engine paged KV block size.
         num_heads: Number of KV heads for non-MLA layouts.
         head_size: KV head size or MLA hidden size.
 
@@ -258,11 +258,11 @@ def try_native_from_gpu(
     Args:
         use_mla: Whether the active layout is MLA.
         memory_tensor: LMCache contiguous memory object tensor to populate.
-        kvcaches: vLLM paged KV tensors.
-        slot_mapping: Full vLLM slot mapping tensor.
+        kvcaches: Engine paged KV tensors.
+        slot_mapping: Full engine slot mapping tensor.
         start: Inclusive token start for this transfer.
         end: Exclusive token end for this transfer.
-        block_size: vLLM paged KV block size.
+        block_size: Engine paged KV block size.
         num_heads: Number of KV heads for non-MLA layouts.
         head_size: KV head size or MLA hidden size.
 


### PR DESCRIPTION
<!--  Thanks for your contribution! Please read the contributing guidelines at https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md before opening a PR. -->

**What this PR does / why we need it**:

Two platform modules had docstrings that named vLLM specifically, but
the code they describe is engine-agnostic. Rename `vLLM` to `engine`
so the wording matches the rest of the file (`engine_kv_format`,
engine block IDs, etc.) and doesn't mislead readers into thinking
these paths are vLLM-only.

- `lmcache/v1/platform/musa/native_kv_transfer.py`
- `lmcache/v1/platform/cpu/shm.py`

Docstring-only change, no behavior change.

**Special notes for your reviewers**:

None.

**If applicable**:

- [ ] user facing changes docs
- [ ] unit tests