### PR TITLE
[good-first-issue] health_monitor: convert f-string log calls in remote_backend_check.py to %-format

### DIFF
--- a/lmcache/v1/health_monitor/checks/remote_backend_check.py
+++ b/lmcache/v1/health_monitor/checks/remote_backend_check.py
@@ -69,9 +69,10 @@ class RemoteBackendHealthCheck(HealthCheck):
                 self._fallback_policy = FallbackPolicy(fallback_policy_str)
             except ValueError:
                 logger.warning(
-                    f"Invalid fallback_policy '{fallback_policy_str}' "
-                    f"for {backend}, using default: "
-                    f"{DEFAULT_FALLBACK_POLICY}"
+                    "Invalid fallback_policy '%s' for %s, using default: %s",
+                    fallback_policy_str,
+                    backend,
+                    DEFAULT_FALLBACK_POLICY,
                 )
                 self._fallback_policy = DEFAULT_FALLBACK_POLICY
         elif isinstance(fallback_policy_str, FallbackPolicy):
@@ -111,7 +112,7 @@ class RemoteBackendHealthCheck(HealthCheck):
                 check = cls(backend)
                 check._backend_name = backend_name
                 instances.append(check)
-                logger.info(f"Created {check} for {backend_name}")
+                logger.info("Created %s for %s", check, backend_name)
 
         return instances
 
@@ -239,7 +240,7 @@ class RemoteBackendHealthCheck(HealthCheck):
             self._stats_monitor.update_remote_ping_error_code(error_code)
 
             if error_code != 0:
-                logger.warning(f"Ping failed with error code: {error_code}")
+                logger.warning("Ping failed with error code: %s", error_code)
                 return False
 
             return True
@@ -249,7 +250,7 @@ class RemoteBackendHealthCheck(HealthCheck):
             self._stats_monitor.update_remote_ping_error_code(PING_TIMEOUT_ERROR_CODE)
             return False
         except Exception as e:
-            logger.error(f"Ping error: {e}")
+            logger.error("Ping error: %s", e)
             self._stats_monitor.update_remote_ping_error_code(PING_GENERIC_ERROR_CODE)
             return False
 
@@ -299,7 +300,7 @@ class RemoteBackendHealthCheck(HealthCheck):
             logger.warning("Put timeout, check failed.")
             yield None, None
         except Exception as e:
-            logger.error(f"Put error, check failed: {e}")
+            logger.error("Put error, check failed: %s", e)
             yield None, None
         finally:
             if put_obj is not None:


### PR DESCRIPTION
**What this PR does / why we need it**:

Refs #3372 (logging-format cleanup campaign).

Five `logger.*(f"...")` calls in
`lmcache/v1/health_monitor/checks/remote_backend_check.py` used eager
f-string formatting, which builds the message even when the log record is
filtered out. This converts them to lazy `%`-formatting, consistent with
ruff rule **G004** and the same treatment applied in the already-merged
#3973 / #3977 / #3982.

Only logging calls are touched. Non-logging f-strings (e.g. the `__repr__`
return) are intentionally left unchanged. No behavior change.

**Which issue(s) this PR fixes**:
Part of the G004 cleanup tracked in #3372.

**Verification**:
```
ruff check lmcache/v1/health_monitor/checks/remote_backend_check.py --select G004
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
