### PR TITLE
docs: daily drift check — multi-process mode (2026-07-24)

### DIFF
--- a/docs/design/v1/distributed/l2_adapters/overall.md
+++ b/docs/design/v1/distributed/l2_adapters/overall.md
@@ -251,16 +251,24 @@ StorageManager.close()
 
 ```python
 # Called from the serving thread
-request_id = controller.submit_prefetch_request(keys, layout_desc)
+request_id = controller.submit_prefetch_request(spec)
+# spec: PrefetchRequestSpec(keys, layout_desc, extra_count=0,
+#                          policy=TrimPolicy.PREFIX,
+#                          attn_desc=DEFAULT_ATTN_WINDOW_DESC,
+#                          mode=PrefetchMode.LOOKUP)
 
 # Polled by the serving thread
-result = controller.query_prefetch_result(request_id)  # int | None
+result = controller.query_prefetch_result(request_id)  # Bitmap | None
 ```
 
-- `submit_prefetch_request` enqueues the request and signals the background thread
-  via an eventfd. Returns immediately.
-- `query_prefetch_result` returns `None` while in-progress, then the **prefix hit
-  count** exactly once (pop semantics).
+- `submit_prefetch_request` takes a `PrefetchRequestSpec`
+  (`lmcache/v1/distributed/api.py`) that bundles the six L2-fetch inputs
+  (`keys`, `layout_desc`, `extra_count`, `policy`, `attn_desc`, `mode`) and
+  returns immediately after enqueueing the request and signalling the
+  background thread via an eventfd.
+- `query_prefetch_result` returns `None` while in-progress, then the retained
+  found-key bitmap exactly once (pop semantics); derive the prefix hit count
+  with `count_leading_ones`.
 
 ### Prefix-Only Loading
 
@@ -300,13 +308,13 @@ LOOKUP ────────────────────────�
 ### Data Flow
 
 ```
-submit_prefetch_request(keys, layout_desc)
+submit_prefetch_request(spec)  # PrefetchRequestSpec
   │
   ▼ (cross-thread: submission queue + eventfd signal)
 _drain_submission_queue → _pending_queue
   │
   ▼ (if below max_in_flight)
-_start_lookup_phase(request_id, keys, layout_desc)
+_start_lookup_phase(request_id, spec)
   │
   ├─ Submit lookup_and_lock_task(keys) to EVERY adapter
   │
@@ -427,13 +435,15 @@ everything together.
 
 ```python
 # 1. Submit: check L1 first, then delegate remainder to L2
-handle = sm.submit_prefetch_task(keys, layout_desc)
+spec = PrefetchRequestSpec(keys=keys, layout_desc=layout_desc)
+handle = sm.submit_prefetch_task(spec, external_request_id="")
 
 # 2. Poll: busy-wait for completion
 while True:
-    found_count = sm.query_prefetch_status(handle)
-    if found_count is not None:
+    found_bitmap = sm.query_prefetch_status(handle)
+    if found_bitmap is not None:
         break
+found_count = found_bitmap.count_leading_ones()
 
 # 3. Read: access the prefetched data (holds read locks)
 with sm.read_prefetched_results(keys[:found_count]) as objs:
@@ -449,18 +459,22 @@ sm.finish_read_prefetched(keys[:found_count])
 ```python
 @dataclass(frozen=True)
 class PrefetchHandle:
-    request_id: int          # -1 if no L2 request needed
-    l1_prefix_hit_count: int # leading keys already in L1
+    prefetch_request_id: int         # -1 if no L2 request needed
+    external_request_id: str         # caller id for end-to-end tracing
+    l1_found_indices: tuple[int, ...] # original-key indices already read-locked in L1
     total_requested_keys: int
-    submit_time: float       # for latency logging
+    submit_time: float               # for latency logging
 ```
 
-`submit_prefetch_task` first checks L1 for a contiguous prefix of hits:
-- If all keys hit L1: returns handle with `request_id=-1` (no L2 work).
+`submit_prefetch_task` takes a `PrefetchRequestSpec` (plus the two
+StorageManager-only knobs `external_request_id` and `skip_l2`) and first
+checks L1 for a contiguous prefix of hits:
+- If all keys hit L1: returns handle with `prefetch_request_id=-1` (no L2 work).
 - If some keys miss: submits the **remaining** keys to PrefetchController.
 
-`query_prefetch_status` combines L1 hits with L2 results:
-`total_hits = l1_prefix_hit_count + l2_prefix_hits`.
+`query_prefetch_status` returns the retained found-key bitmap once ready, and
+`StorageManager` combines L1 hits with L2 results before returning it:
+`total_hits = len(handle.l1_found_indices) + l2_prefix_hits`.
 
 ## Assumptions and Invariants Summary
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current
`dev` code, focused on the multi-process mode. One drift item found
today, in `docs/design/`. `docs/source/` is clean today (the only
open drift-check PR from an earlier day, [#4199](https://github.com/LMCache/LMCache/pull/4199),
still tracks its two `docs/design/` items).

Docs-only. No code touched.

## Drift items

### `docs/design/`

- **`docs/design/v1/distributed/l2_adapters/overall.md`** — stale
  prefetch API signatures and `PrefetchHandle` field names.
  PR [#4121](https://github.com/LMCache/LMCache/pull/4121)
  (commit
  [`7c0e7271`](https://github.com/LMCache/LMCache/commit/7c0e7271cb062a6c296ca2096fd817582a3c061d),
  "[Refactor] Group prefetch params into PrefetchRequestSpec")
  introduced a frozen `PrefetchRequestSpec` dataclass that bundles the
  six L2-fetch inputs (`keys`, `layout_desc`, `extra_count`, `policy`,
  `attn_desc`, `mode`) into one spec, and rewrote
  `PrefetchController.submit_prefetch_request` and
  `StorageManager.submit_prefetch_task` to take that spec instead of the
  old flat positional tuple (see
  [`prefetch_controller.py:329`](```https://github.com/LMCache/LMCache/blob/d8af8fe6e433c3d3bc891bdcd9df75c97445db43/lmcache/v1/distributed/storage_controllers/prefetch_controller.py#L329-L332```)
  and
  [`storage_manager.py:399`](https://github.com/LMCache/LMCache/blob/d8af8fe6e433c3d3bc891bdcd9df75c97445db43/lmcache/v1/distributed/storage_manager.py#L398-L416)).
  The `PrefetchHandle` dataclass shape was also refreshed in the same
  window: it now exposes `prefetch_request_id`, `external_request_id`,
  and `l1_found_indices: tuple[int, ...]`
  ([`api.py:333`](https://github.com/LMCache/LMCache/blob/d8af8fe6e433c3d3bc891bdcd9df75c97445db43/lmcache/v1/distributed/api.py#L333-L360)).

  The design doc still described the pre-refactor surface at:

  | Stale doc location | Was | Now |
  |---|---|---|
  | External API listing (line 254) | `` controller.submit_prefetch_request(keys, layout_desc) `` | `` controller.submit_prefetch_request(spec) `` with `spec: PrefetchRequestSpec` |
  | Data-flow diagram entry (line 303) | `submit_prefetch_request(keys, layout_desc)` and `_start_lookup_phase(request_id, keys, layout_desc)` | `submit_prefetch_request(spec)` and `_start_lookup_phase(request_id, spec)` |
  | Prefetch flow example (line 430) | `sm.submit_prefetch_task(keys, layout_desc)` | `sm.submit_prefetch_task(spec, external_request_id="")` |
  | `PrefetchHandle` dataclass block (lines 449–456) | `request_id`, `l1_prefix_hit_count`, no `external_request_id` | `prefetch_request_id`, `external_request_id`, `l1_found_indices: tuple[int, ...]` |
  | Post-block prose (lines 459, 463) | `request_id=-1` and `total_hits = l1_prefix_hit_count + l2_prefix_hits` | `prefetch_request_id=-1` and `total_hits = len(handle.l1_found_indices) + l2_prefix_hits` |
  | `query_prefetch_result` return type comment (line 257) | `` # int | None `` | `` # Bitmap | None `` (already the actual return type since PR [#3491](https://github.com/LMCache/LMCache/pull/3491); the pre-refactor doc still said `int`) |
  | Serving-side polling example (lines 433–436) | `found_count = sm.query_prefetch_status(handle)` used as an int | Poll `found_bitmap = sm.query_prefetch_status(handle)` and derive `found_count = found_bitmap.count_leading_ones()` |

### `docs/source/`

No new drift found today.

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. One
file touched:

- `docs/design/v1/distributed/l2_adapters/overall.md`

## Code bugs surfaced (not fixed here)

None from today's check. (The pre-existing `lmcache_mp_connector_0180`
docstring inversion flagged by the 2026-07-22 check
([#4199](https://github.com/LMCache/LMCache/pull/4199)) is still open;
this PR does not re-flag it.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine. Needs human
review before merge. Kept as **draft**; not marked "Ready for review".
No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHQkD5A7otERbjdNWPPL7P)_