### PR TITLE
feat: Add report-host override for frontend heartbeat addr conf

### DIFF
--- a/docs/source/mp/frontend_dashboard.rst
+++ b/docs/source/mp/frontend_dashboard.rst
@@ -75,23 +75,66 @@ Install the extra dependencies used by the frontend and discovery service:
 
 These are not pulled in by the base ``lmcache`` install to keep it slim.
 
-Quick Start
------------
+Quick Start (all-in-one on ``localhost``)
+------------------------------------------
+
+The steps below spin up the **discovery service**, the **LMCache MP
+server** and the **dashboard** on a single machine and glue them
+together with ``localhost``. Open three terminals and run one command
+in each.
+
+Endpoint cheat sheet used throughout this section:
+
+- Discovery service: ``http://localhost:5000``
+- LMCache MP HTTP server: ``http://localhost:8085``
+- Dashboard UI: ``http://localhost:8000``
 
 **Step 1 — Start the discovery service**
 
 .. code-block:: bash
 
-    python3 -m lmcache.tools.simple_discover_service
+    python3 -m lmcache.tools.simple_discover_service --port 5000
 
-The service listens on ``0.0.0.0:5000`` and exposes:
+This binds to ``0.0.0.0:5000`` by default. To pick a different
+interface or port, pass ``--host`` / ``--port`` (e.g.
+``--port 5001``); if you change the port, remember to update the
+URLs in Step 2 & 3 accordingly.
+
+The service exposes:
 
 - ``GET /lmcache_heartbeat`` — record a heartbeat from an MP server.
 - ``GET /lmcache_infos`` — return all registered nodes as JSON.
 
-**Step 2 — Start the LMCache MP server with the frontend plugin**
+Verify it is up:
 
 .. code-block:: bash
+
+    curl http://localhost:5000/lmcache_infos
+
+**Step 2 — Start the LMCache MP server with the frontend plugin**
+
+.. important::
+   ``--runtime-plugin-locations`` accepts either a relative path
+   (resolved against the **current working directory**) or an
+   absolute path. The command below uses a relative path, so it
+   **must be run from the repository root**. Otherwise you will see:
+
+   .. code-block:: text
+
+       LMCache WARNING: Runtime plugin location
+       lmcache/lmcache_frontend/lmcache_mp_plugin/lmcache_mp_frontend_plugin.py
+       does not exist
+
+   and no heartbeat will be sent. Either ``cd`` into the repo root
+   first, or replace the plugin path with an absolute one such as
+   ``$(pwd)/lmcache/lmcache_frontend/lmcache_mp_plugin/lmcache_mp_frontend_plugin.py``
+   (evaluated from the repo root) or a fully-qualified path
+   ``/abs/path/to/LMCache/lmcache/lmcache_frontend/lmcache_mp_plugin/lmcache_mp_frontend_plugin.py``.
+
+.. code-block:: bash
+
+    # Run from the repository root of LMCache.
+    cd /path/to/LMCache
 
     lmcache server \
         --l1-size-gb 2 \
@@ -100,17 +143,43 @@ The service listens on ``0.0.0.0:5000`` and exposes:
         --runtime-plugin-locations \
             lmcache/lmcache_frontend/lmcache_mp_plugin/lmcache_mp_frontend_plugin.py \
         --runtime-plugin-config \
-            '{"plugin.frontend.heartbeat-url": "http://localhost:5000/lmcache_heartbeat"}'
+            '{"plugin.frontend.heartbeat-url": "http://localhost:5000/lmcache_heartbeat", "plugin.frontend.report-host": "127.0.0.1"}'
 
-The plugin subprocess will start sending heartbeats to the discovery
-service every 30 seconds (configurable via
-``plugin.frontend.heartbeat-interval``).
+The plugin subprocess sends a heartbeat to the discovery service every
+30 seconds (configurable via ``plugin.frontend.heartbeat-interval``).
 
-Alternatively, use the provided example script:
+.. important::
+   **Why ``plugin.frontend.report-host: 127.0.0.1`` matters for local dev.**
+
+   By default the plugin calls ``get_local_ip()`` to guess a
+   non-loopback IPv4 to put into the reported ``api_address``. On a
+   developer laptop that guess is often a NIC/VPN address that is
+   **not reachable** from the dashboard side (Wi-Fi switched off,
+   split-tunnel VPN, macOS firewall, etc.), so
+   ``http://localhost:5000/lmcache_infos`` will list an
+   ``apiAddress`` that the dashboard cannot connect to.
+
+   Setting ``plugin.frontend.report-host`` to ``127.0.0.1`` bypasses
+   the auto-detection and forces the reported address to
+   ``http://127.0.0.1:8085``, which is always reachable on the same
+   machine. For multi-host deployments, set it to the real IP or
+   hostname that the dashboard should use to reach this server, or
+   leave it unset to keep auto-detection.
+
+Verify the heartbeat landed:
 
 .. code-block:: bash
 
-    bash lmcache/lmcache_frontend/run_mp_server_with_frontend.sh
+    curl http://localhost:5000/lmcache_infos
+    # Expect: processInfos -> "http://127.0.0.1:8085": { ... }
+
+Alternatively, use the provided example script (accepts the
+``REPORT_HOST`` env var):
+
+.. code-block:: bash
+
+    REPORT_HOST=127.0.0.1 \
+        bash lmcache/lmcache_frontend/run_mp_server_with_frontend.sh
 
 **Step 3 — Start the dashboard**
 
@@ -121,7 +190,11 @@ Alternatively, use the provided example script:
         --host 0.0.0.0 \
         --node-supplier-url http://localhost:5000/lmcache_infos
 
-Open ``http://localhost:8000`` in your browser.
+Open ``http://localhost:8000`` in your browser. The dashboard fetches
+the node list from the discovery service and reverse-proxies to each
+node's ``apiAddress`` — with ``report-host`` set to ``127.0.0.1``
+above, this always resolves back to the local MP server on
+``:8085``.
 
 .. note::
    The dashboard auto-refreshes the node list from the supplier URL
@@ -159,7 +232,7 @@ CLI Reference
      - Port for the dashboard HTTP server.
    * - ``--node-supplier-url``
      - *(none)*
-     - URL of the discovery service's node-list endpoint, e.g.
+     - URL to fetch node information from, e.g.:
        ``http://localhost:5000/lmcache_infos``.
    * - ``--config``
      - *(built-in)*
@@ -172,6 +245,11 @@ CLI Reference
    * - ``--heartbeat-url``
      - *(none)*
      - If set, the dashboard itself also sends heartbeats to this URL.
+   * - ``--report-host``
+     - *(auto)*
+     - Host reported in the heartbeat ``api_address``. When set, skips
+       ``get_local_ip()`` auto-detection. Useful for local dev where the
+       auto-detected IP is not reachable from the discovery service side.
    * - ``--log-level``
      - ``warning``
      - Uvicorn log level (``debug``, ``info``, ``warning``, …).
@@ -197,6 +275,12 @@ Pass these inside ``--runtime-plugin-config`` when launching the MP server:
      - Heartbeat interval in seconds (default: ``30``).
    * - ``plugin.frontend.heartbeat-initial-delay``
      - Seconds to wait before the first heartbeat (default: ``0``).
+   * - ``plugin.frontend.report-host``
+     - Host reported in the heartbeat ``api_address``. When set, the
+       plugin skips ``get_local_ip()`` auto-detection and uses this
+       value verbatim. Handy for local dev (``127.0.0.1``), multi-NIC
+       hosts, or when the auto-detected IP is not reachable from the
+       discovery service side.
 
 Using a Custom Discovery Service
 ---------------------------------

--- a/lmcache/lmcache_frontend/app.py
+++ b/lmcache/lmcache_frontend/app.py
@@ -956,6 +956,15 @@ def main():
         help="Heartbeat service URL, e.g.: http://example.com/heartbeat",
     )
     parser.add_argument(
+        "--report-host",
+        type=str,
+        default=None,
+        help="Host to report in heartbeat api_address. When set, bypasses "
+        "get_local_ip() auto-detection. Useful for local dev or multi-NIC "
+        "hosts where the auto-detected IP is not reachable from the "
+        "discovery service side.",
+    )
+    parser.add_argument(
         "--heartbeat-initial-delay",
         type=int,
         default=0,
@@ -999,13 +1008,16 @@ def main():
     # Start heartbeat service if URL is configured
     if args.heartbeat_url:
         # Set application configuration for heartbeat service
-        heartbeat_service.set_app_config(args.host, args.port, target_nodes)
+        heartbeat_service.set_app_config(
+            args.host, args.port, target_nodes, args.report_host
+        )
 
         print("Starting heartbeat service...")
         print(f"Heartbeat URL: {args.heartbeat_url}")
         print(f"Initial delay: {args.heartbeat_initial_delay}s")
         print(f"Interval: {args.heartbeat_interval}s")
-        print(f"API Address: http://{args.host}:{args.port}")
+        reported_host = args.report_host or heartbeat_service.get_local_ip()
+        print(f"API Address: http://{reported_host}:{args.port}")
         print(f"Target nodes count: {len(target_nodes)}")
 
         heartbeat_service.start(

--- a/lmcache/lmcache_frontend/heartbeat.py
+++ b/lmcache/lmcache_frontend/heartbeat.py
@@ -3,6 +3,7 @@
 
 # Standard
 from datetime import datetime
+from typing import Optional
 import asyncio
 import json
 import os
@@ -23,6 +24,11 @@ class HeartbeatService:
         self.app_host = "0.0.0.0"
         self.app_port = 8000
         self.target_nodes = []
+        # When set, ``send_heartbeat`` reports this host verbatim instead
+        # of relying on ``get_local_ip()`` auto-detection. Useful when the
+        # detected IP is unreachable from the discovery service side
+        # (e.g. local dev on macOS with VPN, multi-NIC hosts, etc.).
+        self.report_host = None
 
     def get_local_ip(self) -> str:
         """Get the local IP address of the machine using multiple methods.
@@ -84,16 +90,34 @@ class HeartbeatService:
         print("Failed to get local IP address. Falling back to loopback address.")
         return "127.0.0.1"
 
-    def set_app_config(self, host: str, port: int, target_nodes: list):
-        """Set application configuration for heartbeat reporting"""
+    def set_app_config(
+        self,
+        host: str,
+        port: int,
+        target_nodes: list,
+        report_host: Optional[str] = None,
+    ):
+        """Set application configuration for heartbeat reporting.
+
+        Args:
+            host: Bind host of the local HTTP server (informational).
+            port: Bind port of the local HTTP server; used as the port
+                part of the reported ``api_address``.
+            target_nodes: Downstream node list used for version probing.
+            report_host: If provided (non-empty), used verbatim as the
+                host part of the reported ``api_address``, bypassing
+                the ``get_local_ip()`` auto-detection.
+        """
         self.app_host = host
         self.app_port = port
         self.target_nodes = target_nodes
+        self.report_host = report_host or None
 
     async def send_heartbeat(self, heartbeat_url: str):
         """Send heartbeat request"""
         try:
-            api_address = f"http://{self.get_local_ip()}:{self.app_port}"
+            host = self.report_host or self.get_local_ip()
+            api_address = f"http://{host}:{self.app_port}"
             version = await self._get_version_from_nodes()
             if version:
                 print(f"Got version from target nodes: {version}")

--- a/lmcache/lmcache_frontend/run_mp_server_with_frontend.sh
+++ b/lmcache/lmcache_frontend/run_mp_server_with_frontend.sh
@@ -4,18 +4,43 @@
 # Launch the LMCache MP HTTP server with the frontend plugin wired in.
 # The plugin reports heartbeats to a (remote or local) discovery service
 # whose URL is passed through ``--runtime-plugin-config``.
+#
+# All tunables below can be overridden via environment variables, e.g.:
+#   HTTP_PORT=9090 REPORT_HOST=127.0.0.1 bash run_mp_server_with_frontend.sh
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PLUGIN="${REPO_ROOT}/lmcache/lmcache_frontend/lmcache_mp_plugin/lmcache_mp_frontend_plugin.py"
+
+# --- Discovery service --------------------------------------------------------
 HEARTBEAT_URL="${HEARTBEAT_URL:-http://localhost:5000/lmcache_heartbeat}"
+# Optional: host to report in heartbeat api_address. Set to e.g. 127.0.0.1
+# for local dev when get_local_ip() picks an unreachable NIC address.
+REPORT_HOST="${REPORT_HOST:-}"
+
+# --- MP server internal control channel --------------------------------------
+MP_HOST="${MP_HOST:-localhost}"
+MP_PORT="${MP_PORT:-5555}"
+
+# --- MP server outward-facing HTTP endpoint ----------------------------------
+HTTP_HOST="${HTTP_HOST:-0.0.0.0}"
+HTTP_PORT="${HTTP_PORT:-8085}"
+
+# --- Cache tuning ------------------------------------------------------------
+L1_SIZE_GB="${L1_SIZE_GB:-2}"
+EVICTION_POLICY="${EVICTION_POLICY:-LRU}"
+
+PLUGIN_CFG="{\"plugin.frontend.heartbeat-url\": \"${HEARTBEAT_URL}\""
+if [[ -n "${REPORT_HOST}" ]]; then
+    PLUGIN_CFG="${PLUGIN_CFG}, \"plugin.frontend.report-host\": \"${REPORT_HOST}\""
+fi
+PLUGIN_CFG="${PLUGIN_CFG}}"
 
 python3 -m lmcache.v1.multiprocess.http_server \
-    --host localhost --port 5555 \
-    --http-host 0.0.0.0 --http-port 8085 \
-    --l1-size-gb 2 \
-    --eviction-policy LRU \
+    --host "${MP_HOST}" --port "${MP_PORT}" \
+    --http-host "${HTTP_HOST}" --http-port "${HTTP_PORT}" \
+    --l1-size-gb "${L1_SIZE_GB}" \
+    --eviction-policy "${EVICTION_POLICY}" \
     --runtime-plugin-locations "${PLUGIN}" \
-    --runtime-plugin-config \
-        "{\"plugin.frontend.heartbeat-url\": \"${HEARTBEAT_URL}\"}"
+    --runtime-plugin-config "${PLUGIN_CFG}"

--- a/lmcache/tools/simple_discover_service.py
+++ b/lmcache/tools/simple_discover_service.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
+import argparse
 import datetime
 
 # Third Party
@@ -111,8 +112,28 @@ def get_lmcache_infos():
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reference LMCache discovery service. Accepts heartbeats at "
+            "/lmcache_heartbeat and exposes the node list at /lmcache_infos."
+        )
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="0.0.0.0",
+        help="Bind host address (default: 0.0.0.0, listen on all interfaces).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5000,
+        help="Bind port (default: 5000).",
+    )
+    cli_args = parser.parse_args()
+
     # Bind on all interfaces so remote peers (e.g. the MP server running
     # on another host) can report heartbeats. ``debug=False`` avoids
     # spawning Flask's reloader, which can double-launch the process
     # inside containers.
-    app.run(host="0.0.0.0", port=5000, debug=False)
+    app.run(host=cli_args.host, port=cli_args.port, debug=False)

--- a/tests/lmcache_frontend/test_heartbeat.py
+++ b/tests/lmcache_frontend/test_heartbeat.py
@@ -141,3 +141,40 @@ def test_status_reports_running_flag():
     assert status["running"] in (False, None)
     assert "startup_time" in status
     assert "current_time" in status
+
+
+def test_send_heartbeat_uses_report_host_when_set(patched_httpx, monkeypatch):
+    """Explicit report_host must bypass get_local_ip() auto-detection."""
+    # Poison get_local_ip so the test fails loudly if it is ever called.
+    monkeypatch.setattr(
+        HeartbeatService,
+        "get_local_ip",
+        lambda self: pytest.fail("get_local_ip() must not be called"),
+    )
+
+    svc = HeartbeatService()
+    svc.set_app_config(
+        host="0.0.0.0",
+        port=8085,
+        target_nodes=[],
+        report_host="127.0.0.1",
+    )
+
+    ok = asyncio.run(svc.send_heartbeat("http://disc.example/heartbeat"))
+    assert ok is True
+    assert patched_httpx.last_params["api_address"] == "http://127.0.0.1:8085"
+
+
+def test_empty_report_host_falls_back_to_auto_detect(patched_httpx):
+    """Empty string report_host is treated as unset and auto-detects."""
+    svc = HeartbeatService()
+    svc.set_app_config(
+        host="0.0.0.0",
+        port=8085,
+        target_nodes=[],
+        report_host="",
+    )
+
+    ok = asyncio.run(svc.send_heartbeat("http://disc.example/heartbeat"))
+    assert ok is True
+    assert patched_httpx.last_params["api_address"] == "http://10.0.0.42:8085"


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

When running the lmcache frontend dashboard locally, the MP server registers
itself with the discovery service but the dashboard cannot reach the
node it discovered. Root cause: the heartbeat plugin builds its
`api_address` from `get_local_ip()`, which picks a non-loopback NIC
address (or a VPN address on macOS). That address is often not
routable back from the dashboard side, so `/lmcache_infos` ends up
listing an unreachable `apiAddress`.

This PR gives the operator an explicit escape hatch: a new
`plugin.frontend.report-host` config key (and matching `--report-host`
CLI flag) that, when set, is used verbatim as the host part of the
reported address, skipping auto-detection entirely.

**Special notes for your reviewers**:

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
