### PR TITLE
[CI] pin vllm-cpu-nightly on macOS to dodge broken upstream wheel

### DIFF
--- a/.github/scripts/install_vllm_cpu.sh
+++ b/.github/scripts/install_vllm_cpu.sh
@@ -18,6 +18,11 @@
 #   PIP_BIN="uv pip" install_vllm_cpu.sh
 #                                 # use `uv pip` and pass extra flags
 #                                 # via PIP_INSTALL_EXTRA_ARGS
+#   VLLM_CPU_NIGHTLY_SPEC="vllm-cpu-nightly==0.25.2.dev202607230832" \
+#     install_vllm_cpu.sh         # pin a specific nightly build (used
+#                                 # by the macOS CI leg to dodge a
+#                                 # broken upstream wheel; see the
+#                                 # workflow for context)
 #
 # Idempotent: re-running just rewrites the alias.
 
@@ -25,12 +30,13 @@ set -euo pipefail
 
 PIP_BIN="${PIP_BIN:-pip}"
 PIP_INSTALL_EXTRA_ARGS="${PIP_INSTALL_EXTRA_ARGS:-}"
+VLLM_CPU_NIGHTLY_SPEC="${VLLM_CPU_NIGHTLY_SPEC:-vllm-cpu-nightly}"
 
 # `--extra-index-url` is required because the wheel pins torch==2.11.0
 # which only lives on the pytorch CPU index. Harmless on macOS.
 ${PIP_BIN} install "numpy<2"
 # shellcheck disable=SC2086
-${PIP_BIN} install vllm-cpu-nightly \
+${PIP_BIN} install "${VLLM_CPU_NIGHTLY_SPEC}" \
   --extra-index-url https://download.pytorch.org/whl/cpu \
   ${PIP_INSTALL_EXTRA_ARGS}
 

--- a/.github/workflows/cpu_device.yml
+++ b/.github/workflows/cpu_device.yml
@@ -174,6 +174,23 @@ jobs:
           key: hf-hub-${{ matrix.model.name }}-v2
 
       - name: Install vLLM CPU (prebuilt nightly from PyPI)
+        env:
+          # Pin the vllm-cpu-nightly wheel on macOS to a build that is
+          # ABI-compatible with the torch it pulls in. The nightly
+          # uploaded on 2026-07-24 08:34 UTC (dev202607240834) declares
+          # `torch==2.13.0` in its metadata but the shipped
+          # `vllm/_C.abi3.so` was compiled against an older libtorch —
+          # loading it on macOS fails with
+          # `Symbol not found: __ZN3c104impl3cow23materialize_cow_storage...`
+          # which then blows up cpu_worker.py at
+          # `torch.ops._C.init_cpu_memory_env(...)`.
+          # Linux dodges this because the pytorch-cpu extra index still
+          # serves `torch-2.11.0+cpu`, matching the wheel's ABI.
+          # Revert this pin once upstream ships a macOS-clean nightly.
+          VLLM_CPU_NIGHTLY_SPEC: >-
+            ${{ runner.os == 'macOS'
+                && 'vllm-cpu-nightly==0.25.2.dev202607230832'
+                || 'vllm-cpu-nightly' }}
         run: bash .github/scripts/install_vllm_cpu.sh
 
       - name: Install lmcache (CPU-only, no vLLM)


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**

`CPU Device Tests` has been red on every PR since 2026-07-24 ~08:34 UTC on the macOS legs. The last upstream `vllm-cpu-nightly` upload (`0.25.2.dev202607240834`) declares `torch==2.13.0` in its wheel metadata but the shipped `vllm/_C.abi3.so` was compiled against an older libtorch. On macOS the loader trips over:

```
Symbol not found: __ZN3c104impl3cow23materialize_cow_storageERNS_11StorageImplE
  Referenced from: .../site-packages/vllm/_C.abi3.so
  Expected in:     .../torch/lib/libc10.dylib
```

and then `cpu_worker.py` blows up at `torch.ops._C.init_cpu_memory_env(...)` with `AttributeError: '_OpNamespace' '_C' object has no attribute 'init_cpu_memory_env'`. Linux is fine because our install adds `--extra-index-url https://download.pytorch.org/whl/cpu`, which still serves `torch-2.11.0+cpu` — that matches the wheel ABI.

This pins the macOS leg to the last known-good nightly (`dev202607230832`) via a new `VLLM_CPU_NIGHTLY_SPEC` env consumed by `install_vllm_cpu.sh`. Linux keeps rolling nightly, so we don't freeze CI coverage of upstream vLLM CPU changes on the platform that actually works.

Affected runs: e.g. https://github.com/LMCache/LMCache/actions/runs/30140482282

**Special notes for your reviewers**

Temporary pin — please revert once upstream ships a macOS-clean nightly.

**If applicable**

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
