### PR TITLE
feat(musa): add MP transfer platform adapters

### DIFF
--- a/docs/design/v1/platform/musa/mp_transfer_pointer_contract.md
+++ b/docs/design/v1/platform/musa/mp_transfer_pointer_contract.md
@@ -1,0 +1,54 @@
+# MUSA Multiprocess Transfer Pointer Contract
+
+## Goal
+
+Keep the existing multiprocess pointer APIs unchanged. MUSA tensors are opened
+through TorchMUSA IPC before transfer setup, and MUSA-specific adaptation stays
+inside the MUSA platform implementation.
+
+## Process boundary
+
+Pointers are process-local. The worker exports tensors with
+`torch.musa.ipc.export_tensor()`, and the server opens them with
+`torch.musa.ipc.open_tensor()`. Only pointers obtained from the server's opened
+tensors are passed to transfer operations; raw pointers are never serialized.
+
+The server keeps each IPC owner alive until the transfer stream is synchronized
+and the cache context closes.
+
+## Platform contract
+
+The generic path keeps the existing calls:
+
+```python
+paged_ptrs = context.get_kernel_group_kv_pointers(group_idx)
+staging_ptrs = [context.get_temp_kernel_group_buffer(i, group_idx).data_ptr()]
+lmc_ops.multi_layer_block_kv_transfer(paged_ptrs, staging_ptrs, ...)
+```
+
+`MUSACacheContext` returns the same packed `int64` pointer tensor shape used by
+the current pointer path. `construct_musa_tensor_from_data_pointer()` rebuilds
+a non-owning Tensor view from a process-local pointer and explicit shape,
+stride, dtype, device, and storage-offset metadata.
+
+The supported layouts are:
+
+- `NL x [2, NB, BS, NH, HS]`
+- `NL x [NB, BS, HS]`
+
+The helper supports explicit strides so padded block layouts can be represented
+without copying. The allocation owner must outlive every reconstructed view.
+
+## Stream ordering
+
+Generic completion and event recorders continue to pass an integer stream
+pointer. `MusaDeviceOps` wraps that pointer with TorchMUSA's external-stream
+API, synchronizes it, and then publishes to the existing Python recorder queue.
+The wrapper does not own or destroy the underlying stream.
+
+## Compatibility
+
+No pointer-versus-Tensor branch is added to generic multiprocess code. CUDA
+native signatures, callbacks, transfer planning, and wire format are unchanged.
+The MUSA block-transfer capability remains disabled until the transfer path
+consumes this contract.

--- a/lmcache/v1/platform/musa/cache_context.py
+++ b/lmcache/v1/platform/musa/cache_context.py
@@ -1,0 +1,483 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA cache context for LMCache-driven multiprocess transfer."""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+# Third Party
+import torch
+
+# First Party
+from lmcache import torch_dev
+from lmcache.logging import init_logger
+from lmcache.utils import EngineType
+from lmcache.v1.gpu_connector.kv_format.types import DiscoverableKVCache
+from lmcache.v1.gpu_connector.utils import (
+    LayoutHints,
+    get_device,
+    get_group_data_ptrs,
+    normalize_and_discover_per_layer_formats,
+)
+from lmcache.v1.kv_layer_groups import KVLayerGroupsManager
+from lmcache.v1.multiprocess.custom_types import KVCache
+from lmcache.v1.multiprocess.group_view import engine_group_layer_indices
+from lmcache.v1.platform.base.cache_context import BaseCacheContext
+from lmcache.v1.platform.ops_types import EngineKVFormat
+
+if TYPE_CHECKING:
+    # First Party
+    from lmcache.v1.multiprocess.group_view import EngineGroupInfo
+
+logger = init_logger(__name__)
+
+
+def unwrap_kv_cache_tensors(kv_caches: KVCache) -> list[torch.Tensor]:
+    """Return tensors reconstructed from MUSA IPC wrappers.
+
+    Args:
+        kv_caches: MUSA IPC wrappers received over the multiprocess wire.
+
+    Returns:
+        The reconstructed MUSA KV-cache tensors.
+    """
+    return [wrapper.to_tensor() for wrapper in kv_caches]
+
+
+class _MUSAHostCallbackStream:
+    """Small adapter for stream-ordered callback call sites.
+
+    CUDA contexts expose a CuPy stream as ``cupy_stream``. MUSA does not use
+    CuPy here, so this adapter provides ordered callback and synchronization
+    operations over a TorchMUSA stream and exposes its pointer through the
+    existing platform stream contract.
+    """
+
+    def __init__(self, stream: object) -> None:
+        self._stream = stream
+
+    def synchronize(self) -> None:
+        """Wait for all work submitted to the wrapped MUSA stream."""
+        synchronize = getattr(self._stream, "synchronize", None)
+        if not callable(synchronize):
+            raise RuntimeError("MUSA stream does not support synchronization")
+        synchronize()
+
+    @property
+    def ptr(self) -> int:
+        """Return the wrapped MUSA stream pointer for platform call sites."""
+        pointer = getattr(self._stream, "musa_stream", None)
+        if pointer is None:
+            pointer = getattr(self._stream, "ptr", None)
+        if pointer is None:
+            raise RuntimeError("MUSA stream does not expose a stream pointer")
+        return int(pointer)
+
+    def launch_host_func(self, callback: Any, arg: Any = None) -> None:
+        """Schedule or run ``callback(arg)``.
+
+        If the backend stream exposes ``launch_host_func`` directly, delegate
+        to it. Otherwise synchronize the stream before running the callback on
+        the current thread.
+        """
+        launch_host_func = getattr(self._stream, "launch_host_func", None)
+        if callable(launch_host_func):
+            launch_host_func(callback, arg)
+            return
+        self.synchronize()
+        callback(arg)
+
+
+class _TempMUSABuffer:
+    """Owns MUSA staging buffers for MP block-transfer batches."""
+
+    def __init__(
+        self,
+        kv_layer_groups_manager: KVLayerGroupsManager,
+        lmcache_tokens_per_chunk: int,
+        device: torch.device,
+        max_batch_size: int = 4,
+    ) -> None:
+        self._kv_groups_manager = kv_layer_groups_manager
+        self._lmcache_tokens_per_chunk = lmcache_tokens_per_chunk
+        self._max_batch_size = max_batch_size
+
+        self._temp_buffer = torch.empty(
+            self._get_size_for_single_batch() * max_batch_size,
+            dtype=torch.uint8,
+            device=device,
+        )
+        self._offset_map_kernel_group_only: dict[tuple[int, int], tuple[int, int]] = {}
+        self._offset_map_object_group_only: dict[tuple[int, int], tuple[int, int]] = {}
+
+        offset = 0
+        for batch_idx in range(max_batch_size):
+            for object_group_idx in range(self._kv_groups_manager.num_object_groups):
+                object_group_start_offset = offset
+                object_group_size = 0
+                object_group = self._kv_groups_manager.object_groups[object_group_idx]
+                for kernel_group_idx in object_group.kernel_group_indices:
+                    size = self._get_size_for_kernel_group(kernel_group_idx)
+                    self._offset_map_kernel_group_only[
+                        (batch_idx, kernel_group_idx)
+                    ] = (
+                        offset,
+                        size,
+                    )
+                    offset += size
+                    object_group_size += size
+
+                self._offset_map_object_group_only[(batch_idx, object_group_idx)] = (
+                    object_group_start_offset,
+                    object_group_size,
+                )
+
+        self._shape_cache_kernel_group: dict[int, tuple[torch.Size, torch.dtype]] = {}
+        for kernel_group_idx in range(self._kv_groups_manager.num_kernel_groups):
+            shape = self._get_shape_for_kernel_group(
+                self._lmcache_tokens_per_chunk,
+                kernel_group_idx,
+            )
+            group = self._kv_groups_manager.kernel_groups[kernel_group_idx]
+            self._shape_cache_kernel_group[kernel_group_idx] = (shape, group.dtype)
+
+    @property
+    def max_batch_size(self) -> int:
+        """Return the number of chunks that fit in the staging buffer."""
+        return self._max_batch_size
+
+    def get_temp_kernel_group_buffer(
+        self,
+        batch_idx: int,
+        kernel_group_idx: int,
+    ) -> torch.Tensor:
+        """Return a typed staging view for a batch/kernel-group pair."""
+        key = (batch_idx, kernel_group_idx)
+        if key not in self._offset_map_kernel_group_only:
+            raise ValueError(
+                f"Invalid batch_idx {batch_idx} or kernel_group_idx {kernel_group_idx}"
+            )
+
+        offset, size = self._offset_map_kernel_group_only[key]
+        shape, dtype = self._shape_cache_kernel_group[kernel_group_idx]
+        return self._temp_buffer[offset : offset + size].view(dtype).view(shape)
+
+    def get_temp_object_group_buffer(
+        self,
+        batch_idx: int,
+        object_group_idx: int,
+    ) -> torch.Tensor:
+        """Return a flat ``uint8`` staging view for a batch/object-group pair."""
+        key = (batch_idx, object_group_idx)
+        if key not in self._offset_map_object_group_only:
+            raise ValueError(
+                f"Invalid batch_idx {batch_idx} or object_group_idx {object_group_idx}"
+            )
+
+        offset, size = self._offset_map_object_group_only[key]
+        return self._temp_buffer[offset : offset + size]
+
+    def get_kernel_group_shape_dtype(
+        self,
+        num_tokens: int,
+        kernel_group_idx: int,
+    ) -> tuple[torch.Size, torch.dtype]:
+        """Return ``(shape, dtype)`` for a kernel group and token count."""
+        _, dtype = self._shape_cache_kernel_group[kernel_group_idx]
+        return self._get_shape_for_kernel_group(num_tokens, kernel_group_idx), dtype
+
+    def get_cache_size_per_token(self) -> int:
+        """Return total cache bytes per logical token across all groups."""
+        return self._get_size_for_single_batch() // self._lmcache_tokens_per_chunk
+
+    def _get_shape_for_kernel_group(
+        self,
+        num_tokens: int,
+        kernel_group_idx: int,
+    ) -> torch.Size:
+        if num_tokens % self._lmcache_tokens_per_chunk != 0:
+            raise ValueError(
+                f"num_tokens ({num_tokens}) must be a multiple of "
+                f"lmcache_tokens_per_chunk ({self._lmcache_tokens_per_chunk})"
+            )
+
+        group = self._kv_groups_manager.kernel_groups[kernel_group_idx]
+        sd = group.shape_desc
+        num_chunks = num_tokens // self._lmcache_tokens_per_chunk
+        num_slots = (
+            self._kv_groups_manager.get_slots_per_chunk_in_sw(kernel_group_idx)
+            * num_chunks
+        )
+        if group.engine_kv_format == EngineKVFormat.NL_X_NB_BS_HS:
+            return torch.Size((group.num_layers, num_slots, group.hidden_dim_size))
+        return torch.Size(
+            (sd.kv_size, group.num_layers, num_slots, group.hidden_dim_size)
+        )
+
+    def _get_size_for_kernel_group(self, kernel_group_idx: int) -> int:
+        shape = self._get_shape_for_kernel_group(
+            self._lmcache_tokens_per_chunk,
+            kernel_group_idx,
+        )
+        group = self._kv_groups_manager.kernel_groups[kernel_group_idx]
+        return shape.numel() * group.dtype.itemsize
+
+    def _get_size_for_object_group(self, object_group_idx: int) -> int:
+        object_group = self._kv_groups_manager.object_groups[object_group_idx]
+        return sum(
+            self._get_size_for_kernel_group(kernel_group_idx)
+            for kernel_group_idx in object_group.kernel_group_indices
+        )
+
+    def _get_size_for_single_batch(self) -> int:
+        return sum(
+            self._get_size_for_object_group(object_group_idx)
+            for object_group_idx in range(self._kv_groups_manager.num_object_groups)
+        )
+
+
+class MUSACacheContext(BaseCacheContext):
+    """Cache context for MUSA-backed KV tensors in MP handle mode."""
+
+    device_type = "musa"
+
+    def __init__(
+        self,
+        kv_caches: KVCache,
+        lmcache_tokens_per_chunk: int = 256,
+        layout_hints: LayoutHints | None = None,
+        engine_group_infos: "Sequence[EngineGroupInfo]" = (),
+        engine_type: EngineType = EngineType.VLLM,
+        separate_object_groups: bool = True,
+        full_sw_kv: bool = False,
+    ) -> None:
+        """Build a MUSA cache context from IPC-wrapped KV tensors.
+
+        Args:
+            kv_caches: MUSA IPC wrappers received during server registration.
+            lmcache_tokens_per_chunk: Tokens per LMCache object.
+            layout_hints: Optional KV layout hints from the serving engine.
+            engine_group_infos: Engine-neutral group metadata.
+            engine_type: Serving engine that produced the KV cache.
+            separate_object_groups: Whether to split object groups by window.
+            full_sw_kv: Whether sliding-window groups transfer their full KV.
+
+        Raises:
+            ValueError: If reconstructed tensors are not MUSA tensors.
+        """
+        self._ipc_wrappers = tuple(kv_caches)
+        try:
+            self._initialize(
+                kv_caches,
+                lmcache_tokens_per_chunk,
+                layout_hints,
+                engine_group_infos,
+                engine_type,
+                separate_object_groups,
+                full_sw_kv,
+            )
+        except BaseException:
+            self.close()
+            raise
+
+    def _initialize(
+        self,
+        kv_caches: KVCache,
+        lmcache_tokens_per_chunk: int,
+        layout_hints: LayoutHints | None,
+        engine_group_infos: "Sequence[EngineGroupInfo]",
+        engine_type: EngineType,
+        separate_object_groups: bool,
+        full_sw_kv: bool,
+    ) -> None:
+        """Initialize reconstructed tensors and MUSA transfer resources."""
+        unwrapped = cast(DiscoverableKVCache, unwrap_kv_cache_tensors(kv_caches))
+        discovered, engine_kv_formats = normalize_and_discover_per_layer_formats(
+            unwrapped,
+            engine_group_layer_indices(engine_group_infos),
+            engine_type,
+            layout_hints,
+        )
+        if not isinstance(discovered, list) or not all(
+            isinstance(tensor, torch.Tensor) for tensor in discovered
+        ):
+            raise ValueError("MUSACacheContext requires one tensor per KV layer")
+        kv_caches_norm = cast(list[torch.Tensor], discovered)
+        normalized_discoverable = cast(DiscoverableKVCache, kv_caches_norm)
+        self.device_ = get_device(normalized_discoverable)
+        if self.device_.type != "musa":
+            raise ValueError(
+                f"MUSACacheContext expected MUSA tensors, got {self.device_.type!r}"
+            )
+        num_layers_val = len(engine_kv_formats)
+
+        kv_layer_groups_manager = KVLayerGroupsManager(
+            normalized_discoverable,
+            engine_kv_formats=engine_kv_formats,
+            engine_group_infos=engine_group_infos,
+            lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
+            separate_object_groups=separate_object_groups,
+        )
+        if full_sw_kv:
+            kv_layer_groups_manager.enable_full_sw_kv()
+
+        block_ids_buffer = torch.empty(
+            1 << 20,
+            dtype=torch.long,
+            device=self.device_,
+        )
+
+        super().__init__(
+            kv_caches=kv_caches_norm,
+            device=self.device_,
+            num_layers=num_layers_val,
+            kv_layer_groups_manager=kv_layer_groups_manager,
+            block_ids_buffer=block_ids_buffer,
+            lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
+        )
+
+        self.group_kv_pointers_: list[torch.Tensor] = []
+        for group_idx, group in enumerate(self.kv_layer_groups_manager_.kernel_groups):
+            pointers = get_group_data_ptrs(
+                self.kv_caches_,
+                self.get_engine_kv_format(group_idx),
+                group.layer_indices,
+            )
+            self.group_kv_pointers_.append(
+                torch.tensor(pointers, dtype=torch.int64, device=self.device_)
+            )
+
+        self._temp_buffer = _TempMUSABuffer(
+            kv_layer_groups_manager=self.kv_layer_groups_manager_,
+            lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
+            device=self.device_,
+            max_batch_size=4,
+        )
+        self.stream_ = torch_dev.Stream(device=self.device_)
+        self.host_callback_stream_ = _MUSAHostCallbackStream(self.stream_)
+
+        logger.debug(
+            "MUSACacheContext: %d layers, %d blocks, dtype=%s",
+            self.num_layers_,
+            self.num_blocks,
+            self.kv_caches_[0].dtype,
+        )
+
+    def close(self) -> None:
+        """Synchronize transfers and release receiver-side IPC owners.
+
+        Returns:
+            None.
+
+        Raises:
+            RuntimeError: If the MUSA stream cannot be synchronized.
+        """
+        wrappers = self._ipc_wrappers
+        if not wrappers:
+            return
+
+        stream = getattr(self, "stream_", None)
+        synchronize = getattr(stream, "synchronize", None)
+        if callable(synchronize):
+            synchronize()
+
+        kv_tensors = getattr(self, "kv_caches_", None)
+        if isinstance(kv_tensors, list):
+            kv_tensors.clear()
+
+        for wrapper in wrappers:
+            close = getattr(wrapper, "close", None)
+            if callable(close):
+                close()
+        self._ipc_wrappers = ()
+
+    @property
+    def stream(self) -> Any:
+        """Return the MUSA stream used for transfer work."""
+        return self.stream_
+
+    @property
+    def cupy_stream(self) -> _MUSAHostCallbackStream:
+        """Return a host-callback stream adapter for shared MP code paths."""
+        return self.host_callback_stream_
+
+    def get_kernel_group_kv_pointers(self, kernel_group_idx: int) -> torch.Tensor:
+        """Return packed, process-local MUSA pointers for a kernel group.
+
+        Args:
+            kernel_group_idx: Index of the requested kernel group.
+
+        Returns:
+            A one-dimensional ``int64`` tensor containing one pointer per
+            layer in kernel order.
+        """
+        return self.group_kv_pointers_[kernel_group_idx]
+
+    def get_temp_kernel_group_buffer(
+        self,
+        batch_idx: int,
+        kernel_group_idx: int,
+    ) -> torch.Tensor:
+        """Return the MUSA staging buffer for a batch/kernel-group pair.
+
+        Args:
+            batch_idx: Index within the current transfer batch.
+            kernel_group_idx: Index of the kernel group to transfer.
+
+        Returns:
+            A typed view into the MUSA staging allocation.
+        """
+        return self._temp_buffer.get_temp_kernel_group_buffer(
+            batch_idx,
+            kernel_group_idx,
+        )
+
+    @property
+    def max_batch_size(self) -> int:
+        """Return the maximum number of chunks transferred per batch."""
+        return self._temp_buffer.max_batch_size
+
+    def get_temp_object_group_buffer(
+        self,
+        batch_idx: int,
+        object_group_idx: int,
+    ) -> torch.Tensor:
+        """Return the MUSA staging buffer for a batch/object-group pair.
+
+        Args:
+            batch_idx: Index within the current transfer batch.
+            object_group_idx: Index of the object group to transfer.
+
+        Returns:
+            A flat view covering the object's MUSA staging allocation.
+        """
+        return self._temp_buffer.get_temp_object_group_buffer(
+            batch_idx,
+            object_group_idx,
+        )
+
+    def get_kernel_group_shape_dtype(
+        self,
+        num_tokens: int,
+        kernel_group_idx: int,
+    ) -> tuple[torch.Size, torch.dtype]:
+        """Return the shape and dtype for a kernel-group allocation.
+
+        Args:
+            num_tokens: Number of tokens represented by the allocation.
+            kernel_group_idx: Index of the kernel group.
+
+        Returns:
+            The allocation shape and element dtype.
+        """
+        return self._temp_buffer.get_kernel_group_shape_dtype(
+            num_tokens,
+            kernel_group_idx,
+        )
+
+    def cache_size_per_token(self) -> int:
+        """Return total cache bytes per logical token across all groups."""
+        return self._temp_buffer.get_cache_size_per_token()

--- a/lmcache/v1/platform/musa/device_ops.py
+++ b/lmcache/v1/platform/musa/device_ops.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MUSA ops backend: the torch baseline with one native override.
+"""MUSA ops backend with transfer and stream-ordering adapters.
 
 :class:`MusaDeviceOps` overrides :meth:`multi_layer_block_kv_transfer` to
 try the native MUSA path first (when inputs are tensor-backed) and fall
-back to the torch baseline otherwise.  Every other op inherits the
-baseline via MRO.
+back to the torch baseline otherwise. Stream recorders synchronize external
+MUSA streams before publishing through the baseline queues.
 """
 
 # Future
@@ -33,6 +33,32 @@ def _tensor_list(value: object) -> list[torch.Tensor] | None:
     if not all(isinstance(item, torch.Tensor) for item in value):
         return None
     return value
+
+
+def _synchronize_stream_pointer(stream_ptr: int) -> None:
+    """Synchronize a raw MUSA stream pointer through TorchMUSA.
+
+    Args:
+        stream_ptr: Process-local pointer to an existing MUSA stream.
+
+    Raises:
+        TypeError: If ``stream_ptr`` is not an integer.
+        RuntimeError: If TorchMUSA cannot wrap or synchronize the stream.
+    """
+    if not isinstance(stream_ptr, int):
+        raise TypeError("MUSA stream pointer must be an int")
+    try:
+        # Third Party
+        import torch_musa
+
+        external_stream = getattr(torch_musa, "ExternalStream", None)
+        if not callable(external_stream):
+            raise RuntimeError("TorchMUSA ExternalStream is unavailable")
+        external_stream(stream_ptr).synchronize()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Unable to synchronize MUSA stream pointer {stream_ptr}"
+        ) from exc
 
 
 def _musa_multi_layer_block_kv_transfer(
@@ -79,7 +105,57 @@ def _musa_multi_layer_block_kv_transfer(
 
 
 class MusaDeviceOps(DeviceOps):
+    """MUSA transfer and stream-ordering operations."""
+
     device_type: ClassVar[str] = "musa"
+
+    def record_completion_on_stream(
+        self,
+        stream_ptr: int,
+        kind: str,
+        payload: bytes,
+    ) -> None:
+        """Publish a completion after prior MUSA stream work finishes.
+
+        Args:
+            stream_ptr: Process-local pointer to the MUSA transfer stream.
+            kind: Completion handler key.
+            payload: Encoded completion payload.
+
+        Raises:
+            RuntimeError: If the stream cannot be synchronized.
+        """
+        _synchronize_stream_pointer(stream_ptr)
+        super().record_completion_on_stream(0, kind, payload)
+
+    def record_event_on_stream(
+        self,
+        stream_ptr: int,
+        event_type_name: str,
+        session_id: str,
+        str_metadata: dict[str, str],
+        int_metadata: dict[str, int],
+    ) -> None:
+        """Record an event after prior MUSA stream work finishes.
+
+        Args:
+            stream_ptr: Process-local pointer to the MUSA transfer stream.
+            event_type_name: Serialized event type.
+            session_id: Session associated with the event.
+            str_metadata: String-valued event metadata.
+            int_metadata: Integer-valued event metadata.
+
+        Raises:
+            RuntimeError: If the stream cannot be synchronized.
+        """
+        _synchronize_stream_pointer(stream_ptr)
+        super().record_event_on_stream(
+            0,
+            event_type_name,
+            session_id,
+            str_metadata,
+            int_metadata,
+        )
 
     def multi_layer_block_kv_transfer(self, *args, **kwargs) -> None:
         _musa_multi_layer_block_kv_transfer(*args, **kwargs)

--- a/lmcache/v1/platform/musa/tensor_from_ptr.py
+++ b/lmcache/v1/platform/musa/tensor_from_ptr.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Build non-owning MUSA tensor views from process-local device pointers.
+
+The generic multiprocess transfer path deliberately keeps the existing pointer
+contract.  This module is the MUSA-only boundary that restores Tensor metadata
+before invoking the MUSA transfer implementation.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import Any
+
+# Third Party
+import torch
+
+
+def contiguous_row_major_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
+    """Return element strides for a contiguous row-major tensor.
+
+    Args:
+        shape: Tensor dimensions.
+
+    Returns:
+        Element strides matching a dense contiguous layout.
+    """
+    if not shape:
+        return ()
+    strides = [1] * len(shape)
+    for index in range(len(shape) - 2, -1, -1):
+        strides[index] = strides[index + 1] * int(shape[index + 1])
+    return tuple(strides)
+
+
+def _storage_nbytes(
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    stride: tuple[int, ...],
+    storage_offset: int,
+) -> int:
+    """Compute bytes needed to address a strided tensor view."""
+    if any(int(size) == 0 for size in shape):
+        return 0
+    last_element = int(storage_offset)
+    for size, step in zip(shape, stride, strict=True):
+        last_element += (int(size) - 1) * int(step)
+    return max(0, last_element + 1) * dtype.itemsize
+
+
+def _normalize_device(device: torch.device | str | int | object) -> torch.device:
+    """Normalize a device-like value and require the MUSA backend."""
+    if isinstance(device, torch.device):
+        resolved = device
+    elif isinstance(device, int):
+        resolved = torch.device("musa", device)
+    elif isinstance(device, str):
+        resolved = torch.device(device)
+    else:
+        device_type = getattr(device, "type", None)
+        if device_type != "musa":
+            raise ValueError(
+                "construct_musa_tensor_from_data_pointer requires a MUSA "
+                f"device; got {device!r}"
+            )
+        index = getattr(device, "index", None)
+        resolved = torch.device("musa", index)
+    if resolved.type != "musa":
+        raise ValueError(
+            "construct_musa_tensor_from_data_pointer requires a MUSA "
+            f"device; got {resolved!r}"
+        )
+    return resolved
+
+
+def _musac_module() -> Any:
+    """Return Torch-MUSA's tensor-construction extension module."""
+    try:
+        # Third Party
+        import torch_musa
+    except Exception as exc:
+        raise RuntimeError("TorchMUSA is required for pointer reconstruction") from exc
+    musac = getattr(torch_musa, "_MUSAC", None)
+    if musac is None:
+        raise RuntimeError("torch_musa._MUSAC is unavailable")
+    return musac
+
+
+def construct_musa_tensor_from_data_pointer(
+    ptr: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device | str | int | object,
+    *,
+    stride: tuple[int, ...] | None = None,
+    storage_offset: int = 0,
+    nbytes: int | None = None,
+) -> torch.Tensor:
+    """Create a non-owning MUSA tensor view over an existing allocation.
+
+    Args:
+        ptr: Non-zero device data pointer in the current process.
+        shape: Logical tensor dimensions.
+        dtype: Tensor element dtype.
+        device: MUSA device owning ``ptr``.
+        stride: Optional element strides; contiguous strides are used by default.
+        storage_offset: Offset from ``ptr`` in elements.
+        nbytes: Optional storage size. Otherwise it is derived from metadata.
+
+    Returns:
+        A Tensor aliasing ``ptr``. The caller owns the allocation lifetime.
+
+    Raises:
+        ValueError: If pointer, shape, stride, device, or size is invalid.
+        RuntimeError: If Torch-MUSA's construction helpers are unavailable.
+    """
+    pointer = int(ptr)
+    if pointer <= 0:
+        raise ValueError("ptr must be a non-zero positive integer")
+    if not isinstance(shape, tuple) or any(int(size) < 0 for size in shape):
+        raise ValueError("shape must be a tuple of non-negative integers")
+    if not isinstance(dtype, torch.dtype):
+        raise TypeError(f"dtype must be torch.dtype, got {type(dtype).__name__}")
+    resolved_stride = (
+        contiguous_row_major_strides(shape) if stride is None else tuple(stride)
+    )
+    if len(resolved_stride) != len(shape) or any(
+        int(step) < 0 for step in resolved_stride
+    ):
+        raise ValueError("stride must match shape and contain non-negative integers")
+    if int(storage_offset) < 0:
+        raise ValueError("storage_offset must be non-negative")
+    storage_bytes = (
+        _storage_nbytes(shape, dtype, resolved_stride, int(storage_offset))
+        if nbytes is None
+        else int(nbytes)
+    )
+    if storage_bytes < 0:
+        raise ValueError("nbytes must be non-negative")
+
+    resolved_device = _normalize_device(device)
+    construct_storage = getattr(torch._C, "_construct_storage_from_data_pointer", None)
+    if not callable(construct_storage):
+        raise RuntimeError(
+            "torch._C._construct_storage_from_data_pointer is unavailable"
+        )
+    construct_tensor = getattr(
+        _musac_module(), "_construct_MUSA_Tensor_From_Storage_And_Metadata", None
+    )
+    if not callable(construct_tensor):
+        raise RuntimeError(
+            "torch_musa._MUSAC._construct_MUSA_Tensor_From_Storage_And_Metadata "
+            "is unavailable"
+        )
+
+    storage = construct_storage(pointer, resolved_device, storage_bytes)
+    metadata = {
+        "size": tuple(int(size) for size in shape),
+        "stride": tuple(int(step) for step in resolved_stride),
+        "dtype": dtype,
+        "device": resolved_device,
+        "storage_offset": int(storage_offset),
+    }
+    return construct_tensor(metadata, storage)

--- a/tests/v1/platform/musa/test_musa_cache_context.py
+++ b/tests/v1/platform/musa/test_musa_cache_context.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MUSA cache-context IPC owner lifetime."""
+
+# First Party
+from lmcache.v1.platform.musa.cache_context import MUSACacheContext
+from lmcache.v1.platform.musa.ipc_wrapper import (
+    is_musa_block_transfer_available,
+)
+
+
+def test_platform_adapter_does_not_enable_block_transfer() -> None:
+    """Adding the cache context does not activate MUSA handle transfer."""
+    assert not is_musa_block_transfer_available()
+
+
+def test_close_synchronizes_before_releasing_ipc_owners() -> None:
+    """Context close waits for transfers, releases owners, and is idempotent."""
+    calls: list[str] = []
+
+    class _Stream:
+        def synchronize(self) -> None:
+            calls.append("synchronize")
+
+    class _Wrapper:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def close(self) -> None:
+            calls.append(self.name)
+
+    class _TestContext(MUSACacheContext):
+        def __init__(self) -> None:
+            self.stream_ = _Stream()  # type: ignore[assignment]
+            self._ipc_wrappers = (  # type: ignore[assignment]
+                _Wrapper("first"),
+                _Wrapper("second"),
+            )
+
+    context = _TestContext()
+
+    context.close()
+    context.close()
+
+    assert calls == ["synchronize", "first", "second"]

--- a/tests/v1/platform/musa/test_stream_ordering.py
+++ b/tests/v1/platform/musa/test_stream_ordering.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for MUSA stream-ordered completion and event recording."""
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.platform.musa import device_ops
+
+
+def test_completion_is_enqueued_after_stream_synchronization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Completion publication follows synchronization of the MUSA stream."""
+    calls: list[int] = []
+    ops = device_ops.MusaDeviceOps()
+    ops.drain_recorded_completions()
+    monkeypatch.setattr(device_ops, "_synchronize_stream_pointer", calls.append)
+
+    ops.record_completion_on_stream(17, "finish", b"payload")
+
+    assert calls == [17]
+    assert ops.drain_recorded_completions() == [("finish", b"payload")]
+
+
+def test_event_is_enqueued_after_stream_synchronization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Event publication follows synchronization of the MUSA stream."""
+    calls: list[int] = []
+    ops = device_ops.MusaDeviceOps()
+    ops.drain_recorded_events()
+    monkeypatch.setattr(device_ops, "_synchronize_stream_pointer", calls.append)
+
+    ops.record_event_on_stream(
+        23,
+        "mp.store.end",
+        "request-1",
+        {"device": "musa:0"},
+        {"stored_count": 1},
+    )
+
+    assert calls == [23]
+    events = ops.drain_recorded_events()
+    assert len(events) == 1
+    event_type, session_id, _timestamp, string_metadata, int_metadata = events[0]
+    assert event_type == "mp.store.end"
+    assert session_id == "request-1"
+    assert string_metadata == {"device": "musa:0"}
+    assert int_metadata == {"stored_count": 1}

--- a/tests/v1/platform/musa/test_tensor_from_ptr.py
+++ b/tests/v1/platform/musa/test_tensor_from_ptr.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MUSA-local pointer-to-Tensor adapter."""
+
+# Standard
+from types import SimpleNamespace
+from typing import cast
+
+# Third Party
+import pytest
+import torch
+
+# First Party
+from lmcache.v1.platform.musa import tensor_from_ptr
+
+
+def test_contiguous_strides() -> None:
+    """The helper reports standard dense element strides."""
+    assert tensor_from_ptr.contiguous_row_major_strides((2, 3, 4)) == (12, 4, 1)
+
+
+def test_constructs_non_owning_view_with_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TorchMUSA receives the pointer, byte size, and view metadata."""
+    fake_device = SimpleNamespace(type="musa", index=0)
+    storage = object()
+    expected = object()
+    captured: dict[str, object] = {}
+
+    def construct_storage(ptr: int, device: object, nbytes: int) -> object:
+        captured["storage_args"] = (ptr, device, nbytes)
+        return storage
+
+    def construct_tensor(metadata: dict[str, object], storage_arg: object) -> object:
+        captured["tensor_args"] = (metadata, storage_arg)
+        return expected
+
+    monkeypatch.setattr(
+        tensor_from_ptr,
+        "_normalize_device",
+        lambda _device: fake_device,  # type: ignore[return-value]
+    )
+    monkeypatch.setattr(
+        torch._C,
+        "_construct_storage_from_data_pointer",
+        construct_storage,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        tensor_from_ptr,
+        "_musac_module",
+        lambda: SimpleNamespace(
+            _construct_MUSA_Tensor_From_Storage_And_Metadata=construct_tensor
+        ),
+    )
+
+    result = tensor_from_ptr.construct_musa_tensor_from_data_pointer(
+        0xABCD,
+        (2, 3),
+        torch.float32,
+        fake_device,
+        stride=(4, 1),
+    )
+
+    assert result is expected
+    assert captured["storage_args"] == (0xABCD, fake_device, 28)
+    metadata, storage_arg = cast(
+        tuple[dict[str, object], object], captured["tensor_args"]
+    )
+    assert storage_arg is storage
+    assert metadata == {
+        "size": (2, 3),
+        "stride": (4, 1),
+        "dtype": torch.float32,
+        "device": fake_device,
+        "storage_offset": 0,
+    }
+
+
+def test_rejects_invalid_pointer_and_device() -> None:
+    """Invalid process-local pointers and non-MUSA devices fail early."""
+    with pytest.raises(ValueError, match="non-zero"):
+        tensor_from_ptr.construct_musa_tensor_from_data_pointer(
+            0,
+            (1,),
+            torch.float32,
+            "cpu",
+        )
+    with pytest.raises(ValueError, match="MUSA"):
+        tensor_from_ptr.construct_musa_tensor_from_data_pointer(
+            1,
+            (1,),
+            torch.float32,
+            "cpu",
+        )

--- a/tests/v1/platform/test_device_ops.py
+++ b/tests/v1/platform/test_device_ops.py
@@ -91,8 +91,8 @@ def test_cpu_inherits_baseline_verbatim() -> None:
         assert getattr(CpuDeviceOps, name) is getattr(DeviceOps, name), name
 
 
-def test_musa_overrides_only_one_op() -> None:
-    """MusaDeviceOps overrides exactly one hot op; the rest inherit base."""
+def test_musa_overrides_transfer_and_stream_ordering_ops() -> None:
+    """MusaDeviceOps owns transfer and stream-ordering adaptation."""
     musa_mod = pytest.importorskip(
         "lmcache.v1.platform.musa.device_ops",
         reason="musa platform package unavailable",
@@ -102,7 +102,11 @@ def test_musa_overrides_only_one_op() -> None:
         for name in _OP_NAMES
         if getattr(musa_mod.MusaDeviceOps, name) is not getattr(DeviceOps, name)
     ]
-    assert overridden == ["multi_layer_block_kv_transfer"]
+    assert overridden == [
+        "multi_layer_block_kv_transfer",
+        "record_completion_on_stream",
+        "record_event_on_stream",
+    ]
 
 
 def test_musa_override_dispatches_native_first(


### PR DESCRIPTION
<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Defines the process-local pointer contract for MUSA multiprocess transfers.

Cross-process tensors are imported through Torch-MUSA's public IPC API before the transfer context is created. The existing packed paged-buffer pointers, staging-buffer pointers, and raw stream-pointer interfaces remain unchanged.

MUSA-specific pointer validation, optional non-owning Tensor views, stream ordering, and resource lifetime handling stay inside the MUSA adapter.

Adds MUSA pointer-to-Tensor reconstruction, MP cache-context lifecycle management, and stream-ordered completion/event publication.

**Special notes for your reviewers**:

MUSA block transfer remains disabled. This PR does not change generic multiprocess logic, CUDA behavior, or the wire format.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests