### PR TITLE
[fix]: disable the GDS thread pool in the no-pool batched_get test

### DIFF
--- a/tests/v1/storage_backend/test_gds_backend.py
+++ b/tests/v1/storage_backend/test_gds_backend.py
@@ -513,10 +513,13 @@ class TestGdsBackend:
         temp_gds_path: str,
         async_loop: asyncio.AbstractEventLoop,
         allocator=None,
+        extra_config=None,
     ) -> GdsBackend:
         """Return a GdsBackend with tmpfs mocked so GDS is auto-disabled."""
         eff_allocator = allocator or TestGdsBackend._DummyAllocator()
         config = create_test_config(temp_gds_path)
+        if extra_config:
+            config.extra_config.update(extra_config)
         metadata = create_test_metadata()
         with (
             mock.patch(
@@ -612,7 +615,9 @@ class TestGdsBackend:
 
     def test_batched_get_blocking_no_thread_pool(self, temp_gds_path, async_loop):
         """batched_get_blocking returns None per missing key when thread pool is off."""
-        backend = self._make_mocked_backend(temp_gds_path, async_loop)
+        backend = self._make_mocked_backend(
+            temp_gds_path, async_loop, extra_config={"disk_io_threads": 0}
+        )
         try:
             assert not backend.use_thread_pool
             keys = [create_test_key(i) for i in range(3)]


### PR DESCRIPTION
#4067 made the disk I/O thread pool always-on by default, which broke test_batched_get_blocking_no_thread_pool's assumption that a default backend has the pool off. The failure only surfaces on cuFile-equipped CI nodes (TestGdsBackend is skipif-gated on GDS support), so most runs skip it. Pass disk_io_threads=0 explicitly, restoring the test's intent of exercising the no-pool path.

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
