### PR TITLE
fix: apply non-deprecated config aliases instead of silently dropping them

### DIFF
--- a/lmcache/v1/config_base.py
+++ b/lmcache/v1/config_base.py
@@ -188,24 +188,40 @@ def _resolve_config_aliases(
     config_aliases: dict,
     deprecated_configs: dict,
 ) -> dict:
-    """Resolve configuration aliases and handle deprecated configurations."""
+    """Resolve configuration aliases and handle deprecated configurations.
+
+    For each key in ``config_dict`` the resolution order is:
+
+    - If the key is listed in ``deprecated_configs``, a deprecation warning is
+      logged, independently of how the key is subsequently resolved.
+    - If the key is a current, valid key in ``config_definitions`` it is kept
+      as-is. This is checked before ``config_aliases`` so that a name which is
+      both a live key and a legacy alias keeps its current-key meaning.
+    - Otherwise, if the key is an alias in ``config_aliases``, its value is
+      remapped to the current key it points to. This happens for every alias,
+      not only those that are also listed in ``deprecated_configs``.
+    - Otherwise, if the key is deprecated but has no alias mapping, it is kept
+      under its original name for backward compatibility.
+    - Any remaining key is unknown and is dropped with a warning.
+    """
     resolved = {}
 
     # Process each key in the input
     for key, value in config_dict.items():
+        # Deprecation warnings are independent of how the key is resolved.
         if key in deprecated_configs:
-            # Log deprecation warning
             logger.warning("%s (source: %s)", deprecated_configs[key], source)
 
-            # Map to new key if alias exists
-            if key in config_aliases:
-                new_key = config_aliases[key]
-                resolved[new_key] = value
-            else:
-                # Keep deprecated key for backward compatibility
-                resolved[key] = value
-        elif key in config_definitions:
-            # Valid configuration key
+        if key in config_definitions:
+            # A current, valid key. Checked before aliases so a name that is
+            # both a live key and a legacy alias keeps its current meaning.
+            resolved[key] = value
+        elif key in config_aliases:
+            # A deprecated/alternate name: remap to its current key.
+            resolved[config_aliases[key]] = value
+        elif key in deprecated_configs:
+            # Deprecated key with no alias mapping and not a current key: keep
+            # it under its original name for backward compatibility.
             resolved[key] = value
         else:
             # Unknown configuration key

--- a/tests/v1/test_config.py
+++ b/tests/v1/test_config.py
@@ -1051,3 +1051,43 @@ class TestNixlUseHugepagesDeprecation:
         }
         config.validate()
         assert config.local_cpu_use_hugepages is True
+
+
+class TestConfigAliasResolution:
+    """Deprecated/alternate config names in ``_CONFIG_ALIASES`` must be
+    remapped to their current key names on every public constructor.
+
+    Regression test for the bug where an alias that was *not* also listed in
+    ``_DEPRECATED_CONFIGS`` (which is most of them, e.g. ``enable_xpyd``,
+    ``controller_url``, the ``nixl_*`` P/D names) fell through to the
+    "Unknown configuration key" branch and had its value silently dropped
+    instead of being applied to the current key.
+    """
+
+    def test_non_deprecated_alias_maps_to_current_key_from_dict(self):
+        # enable_xpyd -> enable_pd is an alias that is NOT in _DEPRECATED_CONFIGS.
+        config = LMCacheEngineConfig.from_dict({"enable_xpyd": True})
+        assert config.enable_pd is True
+
+    def test_non_deprecated_alias_maps_to_current_key_from_env(self, monkeypatch):
+        # controller_url -> controller_pull_url is an alias not in
+        # _DEPRECATED_CONFIGS; setting the old env name must populate the new key.
+        monkeypatch.setenv("LMCACHE_CONTROLLER_URL", "tcp://localhost:9000")
+        config = LMCacheEngineConfig.from_env()
+        assert config.controller_pull_url == "tcp://localhost:9000"
+
+    def test_deprecated_alias_still_maps_to_current_key(self):
+        # external_backends -> storage_plugins is BOTH an alias and deprecated;
+        # it must keep working after the fix.
+        config = LMCacheEngineConfig.from_dict(
+            {"external_backends": ["pluginA", "pluginB"]}
+        )
+        assert config.storage_plugins == ["pluginA", "pluginB"]
+
+    def test_alias_colliding_with_real_key_keeps_current_meaning(self):
+        # nixl_buffer_size is listed in _CONFIG_ALIASES (-> pd_buffer_size) but is
+        # also a real current config key. A live key must win over the alias so
+        # its value is not silently redirected to pd_buffer_size.
+        config = LMCacheEngineConfig.from_dict({"nixl_buffer_size": 2**30})
+        assert config.nixl_buffer_size == 2**30
+        assert config.pd_buffer_size is None


### PR DESCRIPTION
**What this PR does / why we need it**:

`_resolve_config_aliases` (`lmcache/v1/config_base.py`) only remapped a config
alias to its current key when the alias was *also* listed in
`_DEPRECATED_CONFIGS`. Every alias that lives only in `_CONFIG_ALIASES` matched
neither the deprecated branch nor the `config_definitions` branch, so it fell
through to the `else` "Unknown configuration key" branch and was **silently
dropped** (only a warning was logged, the value never reached the current key).

In `lmcache/v1/config.py` that makes ~9 of the documented backward-compat
aliases no-ops today:

- `enable_xpyd` → `enable_pd`
- `controller_url` → `controller_pull_url`
- `lmcache_worker_port` → `lmcache_worker_ports`
- `nixl_peer_host` / `nixl_peer_init_port` / `nixl_peer_alloc_port` /
  `nixl_proxy_host` / `nixl_proxy_port` / `nixl_role` → the corresponding
  `pd_*` P/D names

Setting any of these via env var, YAML file, or `from_dict` had no effect on
the intended current key.

The fix resolves each key in this order:

1. `config_definitions` first — so a name that is both a live key and a legacy
   alias keeps its current-key meaning (e.g. `nixl_buffer_size`, which is both
   a real config key and an alias for `pd_buffer_size`);
2. then `config_aliases` for **every** alias, regardless of deprecation status;
3. then keep deprecated-only keys (e.g. `nixl_peer_port`) under their original
   name for backward compatibility.

Deprecation warnings still fire independently, and unknown keys are still
dropped with a warning. The two aliases that already worked (`plugin_locations`,
`external_backends`, which are in both `_CONFIG_ALIASES` and
`_DEPRECATED_CONFIGS`) keep working.

**Special notes for your reviewers**:

- The change is in the shared helper, so it applies to every public constructor
  that calls it: `from_env`, `from_file`, `from_dict`, and
  `update_config_from_env`.
- New tests in `tests/v1/test_config.py::TestConfigAliasResolution` cover the
  `from_dict` and `from_env` alias paths, the deprecated+alias path
  (`external_backends`), and the alias/definition name collision
  (`nixl_buffer_size`). The first two fail on `dev` and pass with this change;
  the rest of `test_config.py` is unchanged (79 → 83 passing locally,
  `pytest tests/v1/test_config.py`).
- No behavior change for keys that were already resolved correctly; this only
  restores the documented aliasing that was being dropped.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
