### PR TITLE
docs: daily drift check — multi-process mode (2026-07-26)

### DIFF
--- a/docs/source/mp/frontend_dashboard.rst
+++ b/docs/source/mp/frontend_dashboard.rst
@@ -245,6 +245,14 @@ CLI Reference
    * - ``--heartbeat-url``
      - *(none)*
      - If set, the dashboard itself also sends heartbeats to this URL.
+   * - ``--heartbeat-interval``
+     - ``30``
+     - Heartbeat interval in seconds. Only takes effect when
+       ``--heartbeat-url`` is set.
+   * - ``--heartbeat-initial-delay``
+     - ``0``
+     - Seconds to wait before the first heartbeat. Only takes effect when
+       ``--heartbeat-url`` is set.
    * - ``--report-host``
      - *(auto)*
      - Host reported in the heartbeat ``api_address``. When set, skips


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current
`dev` code, focused on the multi-process mode. One drift item found
today in `docs/source/`. `docs/design/` is clean today (the two open
drift-check PRs from earlier days — [#4236](https://github.com/LMCache/LMCache/pull/4236)
and [#4199](https://github.com/LMCache/LMCache/pull/4199) — still
track their `docs/design/` items).

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/mp/frontend_dashboard.rst`** — CLI Reference table
  for `python -m lmcache.lmcache_frontend.app` was missing the
  `--heartbeat-interval` and `--heartbeat-initial-delay` rows.

  The two flags have been part of the argparse in
  [`lmcache/lmcache_frontend/app.py:967-978`](https://github.com/LMCache/LMCache/blob/f1c3ed88e298744902e2f8c641dde4a990c23ff5/lmcache/lmcache_frontend/app.py#L967-L978)
  since the app file was first added, with defaults `0` and `30`
  respectively:

  ```python
  parser.add_argument("--heartbeat-initial-delay", type=int, default=0, ...)
  parser.add_argument("--heartbeat-interval", type=int, default=30, ...)
  ```

  The same page's *Plugin Config Keys* section
  ([lines 274-277](https://github.com/LMCache/LMCache/blob/f1c3ed88e298744902e2f8c641dde4a990c23ff5/docs/source/mp/frontend_dashboard.rst#L274-L277))
  already documents `plugin.frontend.heartbeat-interval` and
  `plugin.frontend.heartbeat-initial-delay`, and the MP frontend
  plugin's `build_argv` at
  [`lmcache_mp_frontend_plugin.py:114-118`](``https://github.com/LMCache/LMCache/blob/f1c3ed88e298744902e2f8c641dde4a990c23ff5/lmcache/lmcache_frontend/lmcache_mp_plugin/lmcache_mp_frontend_plugin.py#L114-L118)``
  forwards every `plugin.frontend.*` key verbatim as a `--<flag>` CLI
  arg to `app.main()`. So the CLI reference was missing rows that
  already had a mirror on the plugin-config side.

  Yesterday's PR ([#4237](https://github.com/LMCache/LMCache/pull/4237),
  commit
  [`f1c3ed88`](https://github.com/LMCache/LMCache/commit/f1c3ed88e298744902e2f8c641dde4a990c23ff5),
  "feat: Add report-host override for frontend heartbeat addr conf")
  added the `--report-host` row to the same table but did not fill in
  the two heartbeat rows, so this drift is now sitting immediately
  next to the freshly-updated section — a good time to close it out.

  | Stale doc location | Was | Now |
  |---|---|---|
  | CLI Reference table for `python -m lmcache.lmcache_frontend.app` ([lines 245-247](https://github.com/LMCache/LMCache/blob/f1c3ed88e298744902e2f8c641dde4a990c23ff5/docs/source/mp/frontend_dashboard.rst#L245-L247)) | Only `--heartbeat-url` listed | `--heartbeat-url`, `--heartbeat-interval` (default `30`), `--heartbeat-initial-delay` (default `0`) — the two new rows noted as only taking effect when `--heartbeat-url` is set. |

### `docs/design/`

No new drift found today.

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. One
file touched:

- `docs/source/mp/frontend_dashboard.rst`

## Code bugs surfaced (not fixed here)

None new from today's check. (The pre-existing
`lmcache_mp_connector_0180.py` docstring inversion flagged by the
2026-07-22 check ([#4199](https://github.com/LMCache/LMCache/pull/4199))
is still open at
[`lmcache_mp_connector_0180.py:456-458`](https://github.com/LMCache/LMCache/blob/f1c3ed88e298744902e2f8c641dde4a990c23ff5/lmcache/integration/vllm/lmcache_mp_connector_0180.py#L456-L458);
this PR does not re-flag it.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine. Needs human
review before merge. Kept as **draft**; not marked "Ready for review".
No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65ymxUzC4cYgQ44ViAPn)_