### PR TITLE
[good-first-issue] connector: convert f-string log calls in audit_connector.py to %-format

### DIFF
--- a/lmcache/v1/storage_backend/connector/audit_connector.py
+++ b/lmcache/v1/storage_backend/connector/audit_connector.py
@@ -124,7 +124,9 @@ class AuditConnectorMeta(abc.ABCMeta):
 
             # Generic audit logging
             self.logger.debug(
-                f"[REMOTE_AUDIT][{self.real_connector}]:{method_name.upper()}|START"
+                "[REMOTE_AUDIT][%s]:%s|START",
+                self.real_connector,
+                method_name.upper(),
             )
             t1 = time.perf_counter()
             try:
@@ -133,14 +135,18 @@ class AuditConnectorMeta(abc.ABCMeta):
                 t2 = time.perf_counter()
                 cost = (t2 - t1) * 1000
                 self.logger.info(
-                    f"[REMOTE_AUDIT][{self.real_connector}]:{method_name.upper()}|"
-                    f"SUCCESS|Cost:{cost:.6f}ms"
+                    "[REMOTE_AUDIT][%s]:%s|SUCCESS|Cost:%.6fms",
+                    self.real_connector,
+                    method_name.upper(),
+                    cost,
                 )
                 return result
             except Exception as e:
                 self.logger.error(
-                    f"[REMOTE_AUDIT][{self.real_connector}]:{method_name.upper()}|"
-                    f"FAILED|Error: {str(e)}"
+                    "[REMOTE_AUDIT][%s]:%s|FAILED|Error: %s",
+                    self.real_connector,
+                    method_name.upper(),
+                    e,
                 )
                 raise
 
@@ -160,7 +166,9 @@ class AuditConnectorMeta(abc.ABCMeta):
                 return real_method(*args, **kwargs)
 
             self.logger.debug(
-                f"[REMOTE_AUDIT][{self.real_connector}]:{method_name.upper()}|START"
+                "[REMOTE_AUDIT][%s]:%s|START",
+                self.real_connector,
+                method_name.upper(),
             )
             t1 = time.perf_counter()
             try:
@@ -169,14 +177,18 @@ class AuditConnectorMeta(abc.ABCMeta):
                 t2 = time.perf_counter()
                 cost = (t2 - t1) * 1000
                 self.logger.info(
-                    f"[REMOTE_AUDIT][{self.real_connector}]:{method_name.upper()}|"
-                    f"SUCCESS|Cost:{cost:.6f}ms"
+                    "[REMOTE_AUDIT][%s]:%s|SUCCESS|Cost:%.6fms",
+                    self.real_connector,
+                    method_name.upper(),
+                    cost,
                 )
                 return result
             except Exception as e:
                 self.logger.error(
-                    f"[REMOTE_AUDIT][{self.real_connector}]:{method_name.upper()}|"
-                    f"FAILED|Error: {str(e)}"
+                    "[REMOTE_AUDIT][%s]:%s|FAILED|Error: %s",
+                    self.real_connector,
+                    method_name.upper(),
+                    e,
                 )
                 raise
 
@@ -226,10 +238,14 @@ class AuditConnector(RemoteConnector, metaclass=AuditConnectorMeta):
         self.logger = logger.getChild("audit")
 
         logger.info(
-            f"[REMOTE_AUDIT][{self.real_connector}]:INITIALIZED|"
-            f"Calc Checksum:{self.calc_checksum}｜"
-            f"Verify Checksum: {self.verify_checksum}|"
-            f"Excluded Cmds: {self.excluded_cmds}"
+            "[REMOTE_AUDIT][%s]:INITIALIZED|"
+            "Calc Checksum:%s｜"
+            "Verify Checksum: %s|"
+            "Excluded Cmds: %s",
+            self.real_connector,
+            self.calc_checksum,
+            self.verify_checksum,
+            self.excluded_cmds,
         )
 
     def _calculate_checksum(self, data: bytes) -> str:
@@ -242,8 +258,12 @@ class AuditConnector(RemoteConnector, metaclass=AuditConnectorMeta):
         checksum = self._calculate_checksum(data) if self.calc_checksum else "N/A"
         data_size = len(data)
         self.logger.debug(
-            f"[REMOTE_AUDIT][{self.real_connector}]:PUT|START|Size:{data_size}|"
-            f"Checksum:{checksum[:8]}|Saved:{len(self.checksum_registry)}|Key:{key}"
+            "[REMOTE_AUDIT][%s]:PUT|START|Size:%s|Checksum:%s|Saved:%s|Key:%s",
+            self.real_connector,
+            data_size,
+            checksum[:8],
+            len(self.checksum_registry),
+            key,
         )
 
         try:
@@ -255,23 +275,33 @@ class AuditConnector(RemoteConnector, metaclass=AuditConnectorMeta):
                 with self.registry_lock:
                     self.checksum_registry[key] = checksum
             self.logger.info(
-                f"[REMOTE_AUDIT][{self.real_connector}]:PUT|SUCCESS|Size:{data_size}|"
-                f"Checksum:{checksum[:8]}|Cost:{cost:.6f}ms|Saved:"
-                f"{len(self.checksum_registry)}|Key:{key}"
+                "[REMOTE_AUDIT][%s]:PUT|SUCCESS|Size:%s|"
+                "Checksum:%s|Cost:%.6fms|Saved:%s|Key:%s",
+                self.real_connector,
+                data_size,
+                checksum[:8],
+                cost,
+                len(self.checksum_registry),
+                key,
             )
 
         except Exception as e:
             self.logger.error(
-                f"[REMOTE_AUDIT][{self.real_connector}]:PUT|FAILED|Size:{data_size}|"
-                f"Key:{key}|Error: {str(e)}"
+                "[REMOTE_AUDIT][%s]:PUT|FAILED|Size:%s|Key:%s|Error: %s",
+                self.real_connector,
+                data_size,
+                key,
+                e,
             )
             raise
 
     async def _audit_get(self, key: CacheEngineKey) -> Optional[MemoryObj]:
         """Retrieve data with optional integrity check"""
         self.logger.debug(
-            f"[REMOTE_AUDIT][{self.real_connector}]:GET|START|"
-            f"Saved:{len(self.checksum_registry)}|Key:{key}"
+            "[REMOTE_AUDIT][%s]:GET|START|Saved:%s|Key:%s",
+            self.real_connector,
+            len(self.checksum_registry),
+            key,
         )
 
         try:
@@ -280,8 +310,10 @@ class AuditConnector(RemoteConnector, metaclass=AuditConnectorMeta):
             t2 = time.perf_counter()
             if result is None:
                 self.logger.info(
-                    f"[REMOTE_AUDIT][{self.real_connector}]:GET|MISS|Key:{key}|"
-                    f"Saved: {len(self.checksum_registry)}"
+                    "[REMOTE_AUDIT][%s]:GET|MISS|Key:%s|Saved: %s",
+                    self.real_connector,
+                    key,
+                    len(self.checksum_registry),
                 )
                 return None
 
@@ -297,24 +329,33 @@ class AuditConnector(RemoteConnector, metaclass=AuditConnectorMeta):
 
                 if expected_checksum and current_checksum != expected_checksum:
                     self.logger.error(
-                        f"[REMOTE_AUDIT][{self.real_connector}]:"
-                        f"GET|MISMATCH|Size:{data_size}|"
-                        f"Expected:<{expected_checksum[:8]}>|"
-                        f"Actual:<{current_checksum[:8]}>|Key:{key}"
+                        "[REMOTE_AUDIT][%s]:GET|MISMATCH|Size:%s|"
+                        "Expected:<%s>|Actual:<%s>|Key:%s",
+                        self.real_connector,
+                        data_size,
+                        expected_checksum[:8],
+                        current_checksum[:8],
+                        key,
                     )
                     return None
 
             cost = (t2 - t1) * 1000
             self.logger.info(
-                f"[REMOTE_AUDIT][{self.real_connector}]:GET|SUCCESS|"
-                f"Checksum:{current_checksum[:8]}|"
-                f"Cost:{cost:.6f}ms|Saved:{len(self.checksum_registry)}|Key:{key}"
+                "[REMOTE_AUDIT][%s]:GET|SUCCESS|Checksum:%s|"
+                "Cost:%.6fms|Saved:%s|Key:%s",
+                self.real_connector,
+                current_checksum[:8],
+                cost,
+                len(self.checksum_registry),
+                key,
             )
             return result
 
         except Exception as e:
             self.logger.error(
-                f"[REMOTE_AUDIT][{self.real_connector}]:GET|"
-                f"FAILED|Key:{key}|Error: {str(e)}"
+                "[REMOTE_AUDIT][%s]:GET|FAILED|Key:%s|Error: %s",
+                self.real_connector,
+                key,
+                e,
             )
             raise

--- a/tests/v1/storage_backend/test_audit_connector.py
+++ b/tests/v1/storage_backend/test_audit_connector.py
@@ -127,6 +127,14 @@ class LogCaptureHandler(logging.Handler):
         self.stream = StringIO()
 
     def emit(self, record):
+        # Render the message eagerly so `record.msg` holds the fully
+        # interpolated text. The audit connector logs with lazy %-style
+        # formatting (ruff G004), where `record.msg` is only the template
+        # (e.g. "...Cost:%.6fms") and the values live in `record.args`.
+        # Capturing the rendered message keeps the assertions below
+        # independent of eager vs lazy formatting.
+        record.msg = record.getMessage()
+        record.args = None
         self.records.append(record)
         msg = self.format(record)
         self.stream.write(msg + "\n")


### PR DESCRIPTION
## Description

Converts the 15 f-string `logger.*` calls in
`lmcache/v1/storage_backend/connector/audit_connector.py` to lazy `%`-format,
so arguments are interpolated only when the log record is actually emitted
(ruff `G004`). This follows the same pattern as #4231 / #4232 / #4233.

## Scope

- Only `logger.*` calls are changed. Non-logging f-strings (e.g.
  `wrapper.__qualname__ = f"AuditConnector.{method_name}"`) are left as-is.
- No behavior change: the rendered messages are byte-identical, including the
  `Cost:%.6fms` formatting, the `checksum[:8]` slices, and the full-width `｜`
  separator in the `INITIALIZED` line.

## Verification

```
ruff check lmcache/v1/storage_backend/connector/audit_connector.py   # All checks passed
ruff format --check lmcache/v1/storage_backend/connector/audit_connector.py  # already formatted
```
(ruff `v0.11.7`, the version pinned in `.pre-commit-config.yaml`.)

Rendered output was diffed against the original f-strings for every converted
call site — all identical.

Refs #3372

🤖 Generated with [Claude Code](https://claude.com/claude-code)
