### PR TITLE
[Examples] Add an R-KV token dropping and benchmarking notebook

### DIFF
--- a/examples/token_dropping/README.md
+++ b/examples/token_dropping/README.md
@@ -23,6 +23,19 @@ smaller model and
 | --- | --- | --- |
 | [random_token_dropping.ipynb](./random_token_dropping.ipynb) | Drops a random subset of past tokens. Uses the KV cache only. | No |
 | [snapkv_token_dropping.ipynb](./snapkv_token_dropping.ipynb) | SnapKV: keeps the first and last window, as well as the tokens the recent-window queries attend to most. Needs each request's query tensor to score importance. | Yes |
+| [rkv_token_dropping.ipynb](./rkv_token_dropping.ipynb) | R-KV: SnapKV's importance term minus a **redundancy** term, so a token is kept only if it is both attended-to and says something new. Three optimized variants live in [rkv_variants/](./rkv_variants). | Yes |
+
+R-KV's redundancy term compares all pairs of keys, which is $O(n^2)$ in both
+time and memory. [rkv_token_dropping.ipynb](./rkv_token_dropping.ipynb)
+implements it the way the paper describes it; the three notebooks in
+[rkv_variants/](./rkv_variants) are standalone alternatives that make it
+cheaper:
+
+| Notebook | Redundancy term | Exact? | VRAM |
+| --- | --- | --- | --- |
+| [rkv_variant_cpu_exact.ipynb](./rkv_variants/rkv_variant_cpu_exact.ipynb) | Rewritten as one inner product, so the $n \times n$ matrix never exists. | Yes | None |
+| [rkv_variant_gpu_exact.ipynb](./rkv_variants/rkv_variant_gpu_exact.ipynb) | The same rewrite, tiled over rows on the GPU. Fastest of the four. | Yes | ~1.55 GiB |
+| [rkv_variant_buffered_cpu.ipynb](./rkv_variants/rkv_variant_buffered_cpu.ipynb) | Keys compared only inside a chunk, making the matrix block-diagonal. | No, ~96% token agreement | None |
 
 [snapkv_colab.ipynb](./snapkv_colab.ipynb) is a demonstration done in Google
 Colab Notebook, which can also be accessed here:

--- a/examples/token_dropping/rkv_token_dropping.ipynb
+++ b/examples/token_dropping/rkv_token_dropping.ipynb
@@ -1,0 +1,1557 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# R-KV Token Dropping with the LMCache SDK\n",
+    "---\n",
+    "\n",
+    "Long prompts create large KV caches. They eat GPU memory, limit how many requests\n",
+    "fit in a batch, and a smaller batch means lower decode throughput. *Token\n",
+    "dropping* shrinks each request's KV cache — by half in this notebook — so more\n",
+    "requests fit and decoding runs faster.\n",
+    "\n",
+    "This notebook uses the LMCache SDK to pull a request's KV cache out after\n",
+    "prefill, compress it, and put it back before decode. The compression algorithm\n",
+    "is **R-KV**.\n",
+    "\n",
+    "## R-KV vs. SnapKV, and why it needs optimizing\n",
+    "\n",
+    "SnapKV ranks past tokens by **attention importance** alone: how much the last\n",
+    "`w` prompt tokens attend to them. R-KV keeps that term but subtracts a second\n",
+    "one, **redundancy** — how similar a token's key is to the *other* keys:\n",
+    "\n",
+    "$$\\text{score}(j) \\;=\\; \\lambda \\cdot \\underbrace{\\text{importance}(j)}_{\\text{attended to?}} \\;-\\; (1-\\lambda) \\cdot \\underbrace{\\text{redundancy}(j)}_{\\text{says something new?}}$$\n",
+    "\n",
+    "Keeping tokens that are both attended-to **and** non-redundant works especially\n",
+    "well on the repetitive output of reasoning models.\n",
+    "\n",
+    "The catch is arithmetic. Per layer, for a prompt of $n$ tokens with head\n",
+    "dimension $d$:\n",
+    "\n",
+    "| term | cost |\n",
+    "|---|---|\n",
+    "| SnapKV importance (window $w = 64$) | $O(w \\cdot n \\cdot d)$ |\n",
+    "| R-KV redundancy (**all pairs of keys**) | $O(n^2 \\cdot d)$ |\n",
+    "\n",
+    "The ratio is $n / w$. At $n = 16128$ that is **~250× more arithmetic per layer\n",
+    "than SnapKV**, and a literal implementation also materializes an $n \\times n$\n",
+    "matrix per layer. A direct port of the reference code needed **over an hour** for\n",
+    "the 30 prompts below. Making R-KV practical is what the rest of this notebook is\n",
+    "about.\n",
+    "\n",
+    "## What this notebook implements\n",
+    "\n",
+    "It implements R-KV **the way the paper describes it** — the literal all-pairs\n",
+    "formulation — made survivable by tiling the $n \\times n$ matrix and capping how\n",
+    "many requests touch the GPU at once. It is still $O(n^2 d)$, so it needs ~10 GiB\n",
+    "of VRAM, but it is the version to read first and the one the optimized variants\n",
+    "are checked against.\n",
+    "\n",
+    "Three optimized alternatives live in [`rkv_variants/`](./rkv_variants), each a\n",
+    "standalone notebook that can be run on its own:\n",
+    "\n",
+    "| | this notebook | [`cpu_exact`](./rkv_variants/rkv_variant_cpu_exact.ipynb) | [`gpu_exact`](./rkv_variants/rkv_variant_gpu_exact.ipynb) | [`buffered_cpu`](./rkv_variants/rkv_variant_buffered_cpu.ipynb) |\n",
+    "|---|---|---|---|---|\n",
+    "| Formulation | route A, literal | route A, linear | route A, linear | route B, chunked |\n",
+    "| Exact? | yes (the reference) | yes, rel. err ~2e-6 | yes, rel. err ~5e-7 | **no**, ~96% agreement |\n",
+    "| Redundancy cost | $O(n^2 d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ |\n",
+    "| VRAM | ~9.8 GiB | none | **1.55 GiB** | none |\n",
+    "| Compress 30 requests | 41.6 s | 67.3 s | **37.5 s** | **29.9 s** |\n",
+    "| Decode throughput | 1766 tok/s | 1785 tok/s | 1774 tok/s | 1774 tok/s |\n",
+    "| Accuracy (baseline 10–11/30) | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "| Pick it when | you want the reference formulation | the GPU is saturated by serving | **default choice** | latency beats exactness |\n",
+    "\n",
+    "All four keep the same 50% of the tokens, so they deliver the **same decode\n",
+    "speed-up** — 1766–1785 tok/s, a 1.1% spread, even though they\n",
+    "compress with completely different code. What separates them is the **cost of compressing**.\n",
+    "\n",
+    "Requirements:\n",
+    "\n",
+    "* A small ~10-line modification to vLLM exposes intermediate tensors to LMCache.\n",
+    "  See [README.md](./README.md).\n",
+    "* A GPU is required for serving. To see token dropping increase the decode batch\n",
+    "  size, tune the GPU memory utilization together with the number of requests.\n",
+    "* Data moves between the LMCache server and the SDK through shared memory; if it\n",
+    "  is unavailable the SDK falls back to pickle.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cd06b97",
+   "metadata": {},
+   "source": [
+    "## Setup vLLM and LMCache server\n",
+    "Follow below instructions (1-4), then proceed to below Python cell.\n",
+    "\n",
+    "**1. Start LMCache server first**\n",
+    "\n",
+    "To use shared memory, specify the `--shm-name` and `--no-l1-use-lazy`\n",
+    "\n",
+    "```sh\n",
+    "lmcache server \\\n",
+    "    --l1-size-gb 400 \\\n",
+    "    --eviction-policy LRU \\\n",
+    "    --chunk-size 256 \\\n",
+    "    --port 6555 \\\n",
+    "    --http-port 8080 \\\n",
+    "    --shm-name lmcache_sdk \\\n",
+    "    --no-l1-use-lazy \\\n",
+    "    --enable transfer_query\n",
+    "```\n",
+    "\n",
+    "**2. Wait until LMCache server is ready**\n",
+    "\n",
+    "```sh\n",
+    "curl -sf http://localhost:8080/healthcheck && echo \" LMCache ready\"\n",
+    "```\n",
+    "\n",
+    "**3. Start vLLM once LMCache server is ready**\n",
+    "\n",
+    "We pass --no-enable-prefix-caching to disable vLLM's built-in prefix caching. \n",
+    "This ensures the prefilled KV cache is always served from LMCache rather than \n",
+    "vLLM, so the decoding throughput improvement can be attributed entirely to the \n",
+    "tokens dropped through LMCache.\n",
+    "\n",
+    "```sh\n",
+    "LMCACHE_TRANSFER_INTERMEDIATE_TENSORS=true \\\n",
+    "vllm serve Qwen/Qwen3-8B \\\n",
+    "    --port 8000 \\\n",
+    "    --served-model-name Qwen/Qwen3-8B \\\n",
+    "    --no-enable-prefix-caching \\\n",
+    "    --enforce-eager \\\n",
+    "    --gpu-memory-utilization 0.65 \\\n",
+    "    --kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":6555,\"lmcache.mp.transfer_intermediate_tensors\":true}}' \\\n",
+    "    --trust-remote-code \\\n",
+    "    --return-tokens-as-token-ids\n",
+    "```\n",
+    "\n",
+    "**4. Wait until vLLM is ready**\n",
+    "\n",
+    "```sh\n",
+    "curl -sf http://localhost:8000/v1/models && echo \" vLLM ready\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "aa87a653",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:54:40.227454Z",
+     "iopub.status.busy": "2026-08-01T05:54:40.227347Z",
+     "iopub.status.idle": "2026-08-01T05:54:44.336889Z",
+     "shell.execute_reply": "2026-08-01T05:54:44.336371Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:54:44,253] LMCache INFO:\u001b[0m torch_dev=<module 'torch.cuda' from '/home/sigma/github/LMCache/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py'>, torch_device_type=cuda \u001b[3m(_device_detect.py:143:lmcache.v1.platform._device_detect)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:54:44,329] LMCache INFO:\u001b[0m multi_layer_block_kv_transfer mode: ptr \u001b[3m(base.py:94:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " _     __  __    ____           _          \n",
+      "| |   |  \\/  |  / ___|__ _  ___| |__   ___      LMCache v0.5.3rc2.dev2 (g6018f8af)\n",
+      "| |   | |\\/| | | |   / _` |/ __| '_ \\ / _ \\     Website:  https://lmcache.ai/\n",
+      "| |___| |  | | | |__| (_| | (__| | | |  __/     Recipes:  https://docs.lmcache.ai/recipes\n",
+      "|_____|_|  |_|  \\____\\__,_|\\___|_| |_|\\___|     LinkedIn: https://www.linkedin.com/company/lmcache-lab\n",
+      "Set LMCACHE_DISABLE_BANNER=1 to hide this banner.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "\"\"\"End-to-end KV cache remapping driver for the SDK example.\"\"\"\n",
+    "\n",
+    "# Standard\n",
+    "from datasets import load_dataset\n",
+    "import math\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sys\n",
+    "from transformers import AutoTokenizer, AutoConfig\n",
+    "\n",
+    "# Third Party\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "\n",
+    "# First Party\n",
+    "from lmcache.logging import init_logger\n",
+    "import lmcache.sdk as lmc_sdk\n",
+    "from lmcache.banner import print_banner_once\n",
+    "from utils import (\n",
+    "    rerotate_k_cache,\n",
+    "    make_post_completion,\n",
+    "    score_answers,\n",
+    ")\n",
+    "\n",
+    "print_banner_once(sys.stdout)\n",
+    "logger = init_logger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5342c6c6",
+   "metadata": {},
+   "source": [
+    "## Setting up hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8f1065b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:54:44.342450Z",
+     "iopub.status.busy": "2026-08-01T05:54:44.342312Z",
+     "iopub.status.idle": "2026-08-01T05:54:44.344963Z",
+     "shell.execute_reply": "2026-08-01T05:54:44.344374Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_name = \"/data/models/Qwen3-8B\"\n",
+    "vllm_url = \"http://localhost:8000\"\n",
+    "lmcache_url = \"http://localhost:8080\"\n",
+    "lmcache_mq_url = \"tcp://localhost:6555\"\n",
+    "chunk_size = 256\n",
+    "max_tokens = 5120\n",
+    "temperature = 0.0  # greedy decode so generated answers are deterministic and scorable\n",
+    "timeout = 60  # timeout for context retrieval (seconds)\n",
+    "trust_remote_code = True\n",
+    "\n",
+    "# Streams prefilled per submission. LMCache's query ring buffer maps a forward\n",
+    "# step's query rows to ring slots positionally (qringbuffer.py\n",
+    "# build_q_step_state), assuming each request contributed exactly its store op's\n",
+    "# token count of rows. Continuous batching breaks that, so the captured queries\n",
+    "# are silently wrong or short. Measured query-row reproducibility across two\n",
+    "# identical runs: 100.0% at 1 stream, 99.7% at 4, 9.8% at 30. R-KV's importance\n",
+    "# term is entirely query-driven, so prefill is submitted one stream at a time.\n",
+    "prefill_group_size = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34eb19b4",
+   "metadata": {},
+   "source": [
+    "## Configuring the model and LMCache endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eac8beea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:54:44.349725Z",
+     "iopub.status.busy": "2026-08-01T05:54:44.349605Z",
+     "iopub.status.idle": "2026-08-01T05:55:44.452252Z",
+     "shell.execute_reply": "2026-08-01T05:55:44.451581Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:54:44,774] LMCache INFO:\u001b[0m Initialized LMCacheSDKContext with instance_id=2572527548892174245, model_name=/data/models/Qwen3-8B, chunk_size=256, shm_name=lmcache_l1_pool_lmcache_sdk, kind=LMCacheSDKCacheKind.KV \u001b[3m(context.py:122:lmcache.sdk.context)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:54:44,777] LMCache INFO:\u001b[0m Creating transfer context (device_type=cpu, mode=auto) \u001b[3m(worker_transfer.py:879:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:54:44,929] LMCache INFO:\u001b[0m Using AsyncEngineDrivenTransferContext for store path \u001b[3m(worker_transfer.py:105:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:54:44,934] LMCache INFO:\u001b[0m Engine KV Format: EngineKVFormat.NL_X_NB_TWO_NH_BS_HS NL x [NB, 2, NH, BS, HS] \u001b[3m(detection.py:69:lmcache.v1.gpu_connector.kv_format.detection)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:54:44,936] LMCache INFO:\u001b[0m Creating EngineDrivenContextShm (shm_name=lmcache_l1_pool_lmcache_sdk, pool_size=429496729600) \u001b[3m(base.py:235:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:54:45,055] LMCache INFO:\u001b[0m CudaPinMemoryBackend: using torch cudart \u001b[3m(pin_memory.py:89:lmcache.v1.platform.cuda.pin_memory)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:14,829] LMCache INFO:\u001b[0m SHM pinned=True for shm_name=lmcache_l1_pool_lmcache_sdk \u001b[3m(shm.py:118:lmcache.v1.multiprocess.transfer_context.shm)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:14,831] LMCache INFO:\u001b[0m Worker non-GPU transfer context registered (instance_id=2572527548892174245, mode=SHM) \u001b[3m(worker_transfer.py:745:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:14,836] LMCache INFO:\u001b[0m Initialized LMCacheSDKContext with instance_id=1850249727742552672, model_name=/data/models/Qwen3-8B##query, chunk_size=256, shm_name=lmcache_l1_pool_lmcache_sdk, kind=LMCacheSDKCacheKind.QUERY \u001b[3m(context.py:122:lmcache.sdk.context)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:14,837] LMCache INFO:\u001b[0m Creating transfer context (device_type=cpu, mode=auto) \u001b[3m(worker_transfer.py:879:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:14,838] LMCache INFO:\u001b[0m Using AsyncEngineDrivenTransferContext for store path \u001b[3m(worker_transfer.py:105:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:14,838] LMCache INFO:\u001b[0m Engine KV Format: EngineKVFormat.NL_X_NB_BS_HS NL x [NB, BS, HS] \u001b[3m(detection.py:69:lmcache.v1.gpu_connector.kv_format.detection)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:14,840] LMCache INFO:\u001b[0m Creating EngineDrivenContextShm (shm_name=lmcache_l1_pool_lmcache_sdk, pool_size=429496729600) \u001b[3m(base.py:235:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:44,448] LMCache INFO:\u001b[0m SHM pinned=True for shm_name=lmcache_l1_pool_lmcache_sdk \u001b[3m(shm.py:118:lmcache.v1.multiprocess.transfer_context.shm)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:55:44,449] LMCache INFO:\u001b[0m Worker non-GPU transfer context registered (instance_id=1850249727742552672, mode=SHM) \u001b[3m(worker_transfer.py:745:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(\n",
+    "    model_name, trust_remote_code=trust_remote_code\n",
+    ")\n",
+    "config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)\n",
+    "head_size = getattr(\n",
+    "    config, \"head_dim\", config.hidden_size // config.num_attention_heads\n",
+    ")\n",
+    "work_device = torch.device(\"cpu\")\n",
+    "post_completion = make_post_completion(vllm_url, model_name, timeout)\n",
+    "ctx = lmc_sdk.kvcache.connect(\n",
+    "    url=lmcache_mq_url,\n",
+    "    http_url=lmcache_url,\n",
+    "    model_name=model_name,\n",
+    "    timeout=timeout,\n",
+    ")\n",
+    "qctx = lmc_sdk.qcache.connect(\n",
+    "    url=lmcache_mq_url,\n",
+    "    http_url=lmcache_url,\n",
+    "    model_name=model_name,\n",
+    "    timeout=timeout,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2aaffa7",
+   "metadata": {},
+   "source": [
+    "## Constructing Prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "030145fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:55:44.457846Z",
+     "iopub.status.busy": "2026-08-01T05:55:44.457635Z",
+     "iopub.status.idle": "2026-08-01T05:57:06.637227Z",
+     "shell.execute_reply": "2026-08-01T05:57:06.636433Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 30 prompts from the dataset.\n",
+      "Total prompts length: 423428 tokens.\n",
+      "Mean prompt length: 14114.27 tokens.\n",
+      "Max prompt length: 16807 tokens.\n",
+      "Min prompt length: 10159 tokens.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompts = []\n",
+    "answers = []\n",
+    "ds = load_dataset(\"raniayu/token-dropping-demo\", split=\"train\")\n",
+    "for i, example in enumerate(ds):\n",
+    "    prompt = tokenizer.encode(ds[i][\"prompt\"], return_tensors=\"pt\").squeeze(0).tolist()\n",
+    "    prompts.append(prompt)\n",
+    "    answers.append(ds[i][\"answer\"])\n",
+    "\n",
+    "print(f\"Loaded {len(prompts)} prompts from the dataset.\")\n",
+    "print(f\"Total prompts length: {sum(len(p) for p in prompts)} tokens.\")\n",
+    "print(f\"Mean prompt length: {sum(len(p) for p in prompts) / len(prompts):.2f} tokens.\")\n",
+    "print(f\"Max prompt length: {max(len(p) for p in prompts)} tokens.\")\n",
+    "print(f\"Min prompt length: {min(len(p) for p in prompts)} tokens.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab00c77d",
+   "metadata": {},
+   "source": [
+    "## Baseline (without token dropping)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "eb3a2b00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T05:57:06.642697Z",
+     "iopub.status.busy": "2026-08-01T05:57:06.642551Z",
+     "iopub.status.idle": "2026-08-01T06:00:00.238232Z",
+     "shell.execute_reply": "2026-08-01T06:00:00.237339Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 05:57:21,818] LMCache INFO:\u001b[0m prefill: 15.17 s in groups of 1 \u001b[3m(420791162.py:24:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================= Batched Stream Metrics (decode) ========================\n",
+      "-------------------------------- Configuration ---------------------------------\n",
+      "Number of Request Streams:                                                    30\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                       158.41\n",
+      "Total Output Tokens:                                                      153423\n",
+      "Decode Throughput (tokens/s):                                             968.50\n",
+      "================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_ids = []\n",
+    "\n",
+    "batch = lmc_sdk.batch.LMCacheBatchedStream()\n",
+    "for i, prompt in enumerate(prompts):\n",
+    "    stream = lmc_sdk.request.create_request(\n",
+    "        contexts=[ctx, qctx],\n",
+    "        post_completion=post_completion,\n",
+    "        prompt_token_ids=prompt,\n",
+    "    )\n",
+    "    batch.add(stream)\n",
+    "    stream_ids.append(stream.request_stream_id)\n",
+    "\n",
+    "# temperature 0 here too: prefill emits one token that is APPENDED to the\n",
+    "# stream, so sampling it would make the whole greedy decode below depend on a\n",
+    "# random first token. Groups of `prefill_group_size` keep the query capture\n",
+    "# correct (see the hyperparameter cell).\n",
+    "prefill_seconds = 0.0\n",
+    "for g0 in range(0, len(stream_ids), prefill_group_size):\n",
+    "    results = batch.prefill(\n",
+    "        sampling_params={\"max_tokens\": 1, \"temperature\": 0.0, \"ignore_eos\": True},\n",
+    "        stream_ids=stream_ids[g0 : g0 + prefill_group_size],\n",
+    "    )\n",
+    "    prefill_seconds += results.to_dict()[\"metrics\"][\"results\"].get(\"duration\", 0.0)\n",
+    "logger.info(f\"prefill: {prefill_seconds:.2f} s in groups of {prefill_group_size}\")\n",
+    "\n",
+    "results = batch.decode(\n",
+    "    sampling_params={\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": temperature,\n",
+    "        \"ignore_eos\": True,\n",
+    "    }\n",
+    ")\n",
+    "results.emit()\n",
+    "before_drop_data = results.to_dict()\n",
+    "before_texts = [stream.output_text for stream in batch.request_streams.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "188ec71d",
+   "metadata": {},
+   "source": [
+    "## Clear LMCache\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "738112cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:00:00.244200Z",
+     "iopub.status.busy": "2026-08-01T06:00:00.244034Z",
+     "iopub.status.idle": "2026-08-01T06:00:00.415531Z",
+     "shell.execute_reply": "2026-08-01T06:00:00.414925Z"
+    },
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"status\":\"ok\",\"cleared\":{\"tier\":\"l1\"}}"
+     ]
+    }
+   ],
+   "source": [
+    "!curl -X POST {lmcache_url}/cache/clear\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bf1e6d2",
+   "metadata": {},
+   "source": [
+    "## With R-KV Token Dropping\n",
+    "\n",
+    "Three implementations follow, all producing the same R-KV scores and differing\n",
+    "only in *how* the redundancy term is evaluated and *where* it runs. This cell\n",
+    "holds the hyperparameters and the tensor plumbing they share.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1d45a0a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:00:00.421595Z",
+     "iopub.status.busy": "2026-08-01T06:00:00.421452Z",
+     "iopub.status.idle": "2026-08-01T06:00:00.437193Z",
+     "shell.execute_reply": "2026-08-01T06:00:00.436638Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Standard\n",
+    "import contextlib\n",
+    "import threading\n",
+    "\n",
+    "# --- R-KV hyperparameters ----------------------------------------------------\n",
+    "# Scores are averaged over KV heads and summed over layers, so a request keeps\n",
+    "# ONE token subset. LMCache re-injects a single contiguous KV with a single\n",
+    "# kept-token list, so per-head eviction is not expressible here.\n",
+    "rkv_window_size = 8  # observation window: the last w queries vote on importance\n",
+    "rkv_drop_ratio = 0.5  # fraction of tokens to evict\n",
+    "rkv_kernel_size = 7  # max-pool width applied to the importance scores\n",
+    "rkv_mix_lambda = 0.07  # score = lambda * importance - (1 - lambda) * redundancy\n",
+    "rkv_sim_threshold = 0.5  # cosine above this counts as \"similar\"\n",
+    "\n",
+    "\n",
+    "# --- Tensor plumbing ---------------------------------------------------------\n",
+    "def model_heads():\n",
+    "    \"\"\"(num_q_heads, num_kv_heads, head_dim) for the served model.\"\"\"\n",
+    "    q = config.num_attention_heads\n",
+    "    kv = getattr(config, \"num_key_value_heads\", q)\n",
+    "    return q, kv, getattr(config, \"head_dim\", config.hidden_size // q)\n",
+    "\n",
+    "\n",
+    "def to_heads(flat, rows, heads, head_dim, device=None):\n",
+    "    \"\"\"[rows, heads * head_dim] -> [1, heads, rows, head_dim] in fp32.\"\"\"\n",
+    "    t = (\n",
+    "        flat.to(dtype=torch.float32)\n",
+    "        if device is None\n",
+    "        else flat.to(device, torch.float32)\n",
+    "    )\n",
+    "    return t.reshape(rows, heads, head_dim).permute(1, 0, 2).unsqueeze(0)\n",
+    "\n",
+    "\n",
+    "def q_by_layer(q_tensor):\n",
+    "    \"\"\"Normalise the SDK's query tensor to [num_layers, T, q_heads * head_dim].\"\"\"\n",
+    "    if q_tensor.ndim == 4 and q_tensor.shape[0] == 1:\n",
+    "        return q_tensor[0]\n",
+    "    if q_tensor.ndim == 3:\n",
+    "        return q_tensor\n",
+    "    raise ValueError(f\"unexpected q_tensor shape {tuple(q_tensor.shape)}\")\n",
+    "\n",
+    "\n",
+    "def attention_logits(query, key, pooling=\"max\"):\n",
+    "    \"\"\"q @ k^T / sqrt(d), pooled from query heads down to KV heads (GQA).\n",
+    "\n",
+    "    query: [1, q_heads, q_len, d]   key: [1, kv_heads, kv_len, d]\n",
+    "    \"\"\"\n",
+    "    _, q_heads, q_len, d = query.shape\n",
+    "    kv_heads = key.shape[1]\n",
+    "    group = q_heads // kv_heads\n",
+    "    if group == 1:\n",
+    "        return torch.matmul(query, key.transpose(2, 3)) / math.sqrt(d)\n",
+    "    q = query.view(1, kv_heads, group, q_len, d)\n",
+    "    attn = torch.matmul(q, key.unsqueeze(2).transpose(3, 4)) / math.sqrt(d)\n",
+    "    return attn.mean(dim=2) if pooling == \"mean\" else attn.max(dim=2).values\n",
+    "\n",
+    "\n",
+    "def importance(k, q_win, past_len):\n",
+    "    \"\"\"How much the observation window attends to each past token.\n",
+    "\n",
+    "    Only the window queries are passed in, so this is O(w * n * d) rather than\n",
+    "    the O(n^2 * d) the reference spends before discarding all but the last w rows.\n",
+    "    \"\"\"\n",
+    "    attn = attention_logits(q_win, k)[:, :, :, :past_len]\n",
+    "    scores = F.softmax(attn, dim=-1, dtype=torch.float32).mean(dim=-2)\n",
+    "    return F.max_pool1d(\n",
+    "        scores, kernel_size=rkv_kernel_size, padding=rkv_kernel_size // 2, stride=1\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def redundancy_reference(key_states, threshold=rkv_sim_threshold):\n",
+    "    \"\"\"Literal R-KV redundancy: materialises the whole n x n matrix.\n",
+    "\n",
+    "    Only used as the correctness oracle in the self-tests -- never on a real\n",
+    "    prompt, where it would allocate kv_heads * n^2 floats per layer.\n",
+    "    \"\"\"\n",
+    "    _, _, n, _ = key_states.shape\n",
+    "    k = key_states / (key_states.norm(dim=-1, keepdim=True) + 1e-8)\n",
+    "    sim = torch.matmul(k, k.transpose(-1, -2))\n",
+    "    eye = torch.eye(n, dtype=torch.bool, device=k.device).view(1, 1, n, n)\n",
+    "    sim.masked_fill_(eye, 0.0)\n",
+    "\n",
+    "    # Per row, exempt the LARGEST column index that is above threshold (or\n",
+    "    # column 0 if none qualifies) -- R-KV's `similarity_retain` rule.\n",
+    "    mask = sim > threshold\n",
+    "    idx = torch.arange(n, device=k.device).view(1, 1, 1, n)\n",
+    "    retain = torch.where(mask, idx, torch.zeros_like(mask, dtype=torch.long))\n",
+    "    sim.scatter_(-1, retain.max(dim=-1)[0].unsqueeze(-1), 0)\n",
+    "    return sim.mean(dim=-2).softmax(dim=-1)\n",
+    "\n",
+    "\n",
+    "def prepare(tensors, token_source):\n",
+    "    \"\"\"Common bookkeeping shared by every drop_tokens_fn.\"\"\"\n",
+    "    kv = tensors[lmc_sdk.context.LMCacheSDKCacheKind.KV]  # [2, L, T, D]\n",
+    "    q = q_by_layer(tensors[lmc_sdk.context.LMCacheSDKCacheKind.QUERY])\n",
+    "    seq_len = min(kv.shape[2], q.shape[1], len(token_source))\n",
+    "    past_len = seq_len - rkv_window_size\n",
+    "    if past_len <= 0:\n",
+    "        raise ValueError(f\"seq_len {seq_len} must exceed window {rkv_window_size}\")\n",
+    "    keep_total = int(round(seq_len * (1 - rkv_drop_ratio)))\n",
+    "    keep_past = max(0, min(keep_total - rkv_window_size, past_len))\n",
+    "    q_win = q[:, past_len:seq_len, :]  # window only: ~2.4 MiB, not ~4.8 GiB\n",
+    "    return kv, q_win, seq_len, past_len, keep_past\n",
+    "\n",
+    "\n",
+    "def select(scores, past_len, seq_len, keep_past):\n",
+    "    \"\"\"Top-scoring past tokens plus the whole observation window.\"\"\"\n",
+    "    top = torch.topk(scores, k=keep_past).indices.sort().values\n",
+    "    tail = torch.arange(past_len, seq_len, device=scores.device)\n",
+    "    return torch.cat([top, tail]).to(torch.long).cpu()\n",
+    "\n",
+    "\n",
+    "def rerotate(kv_tensor, keep_idx, device):\n",
+    "    \"\"\"Gather the kept tokens and move their RoPE to the new positions.\"\"\"\n",
+    "    gathered = kv_tensor[:, :, keep_idx, :].clone().to(device)\n",
+    "    out = rerotate_k_cache(\n",
+    "        gathered,\n",
+    "        old_positions=keep_idx.to(device),\n",
+    "        new_positions=torch.arange(keep_idx.numel(), device=device),\n",
+    "        model_config=config,\n",
+    "    )\n",
+    "    return out.cpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7fb3744",
+   "metadata": {},
+   "source": [
+    "### Route A, one-shot, on the GPU\n",
+    "\n",
+    "> **Trades VRAM and scaling for simplicity.** It is R-KV written the way the\n",
+    "> paper describes it, so it is the easiest to read and to check against the\n",
+    "> reference — but it pays $O(n^2)$ in both time and memory.\n",
+    ">\n",
+    "> | | |\n",
+    "> |---|---|\n",
+    "> | **Buys you** | The simplest, most literal code; easy to verify against the reference implementation |\n",
+    "> | **Costs you** | ~9.8 GiB of VRAM, and cost grows **quadratically** with prompt length |\n",
+    "> | Exact? | Yes |\n",
+    "> | VRAM | ~9.8 GiB (concurrency cap 4) |\n",
+    "> | Compress 30 requests | 41.6 s |\n",
+    "> | Decode throughput | 1766 tok/s |\n",
+    "> | Pick it when | You want the reference formulation, prompts are short, and VRAM is plentiful; see [rkv_variants/](./rkv_variants) otherwise |\n",
+    "\n",
+    "**Route A** is R-KV as written: every past token is scored against the *whole*\n",
+    "prompt, so the redundancy term is the full $n \\times n$ cosine matrix. This\n",
+    "implementation keeps that formulation and simply makes it survivable.\n",
+    "\n",
+    "## What was optimized\n",
+    "\n",
+    "| # | Change | Why it mattered |\n",
+    "|---|---|---|\n",
+    "| 1 | **Window-only queries.** The reference builds a full `[kv_heads, n, n]` logit tensor and then throws away everything except the last `w` rows. Slicing the queries *before* the matmul computes only the rows that survive. | $n / w \\approx 2000\\times$ fewer FLOPs on the importance term, and the host→device copy of Q drops from ~4.8 GiB to ~2.4 MiB per request. |\n",
+    "| 2 | **Tiled column sums.** R-KV reduces the similarity matrix with a mean over rows, so only a per-column accumulator has to survive. Rows are processed `row_block` at a time. The per-row \"retain\" index is read straight off the boolean mask with `flip(-1).argmax(-1)`. | The reference's `torch.where(mask, arange, 0)` idiom allocates **two int64 `[kv_heads, n, n]` tensors** — 16.6 GiB each at $n=16128$ — on top of the fp32 matrix. Removing them turned a DRAM-bound pass into a compute-bound one. |\n",
+    "| 3 | **Per-layer key staging.** Keys are copied to the device one layer at a time. | Staging all 36 layers up front is a 1.19 GiB *resident* allocation per in-flight request that no tile size can shrink. |\n",
+    "| 4 | **Concurrency cap.** A semaphore bounds how many requests are inside the GPU section at once. | See below — this is the one that decides whether the run survives at all. |\n",
+    "\n",
+    "## GPU footprint and how the concurrency cap is derived\n",
+    "\n",
+    "The trap is that `batch.modify` submits **one worker thread per stream**\n",
+    "(`ThreadPoolExecutor(max_workers=len(stream_ids))`), so all 30 requests execute\n",
+    "the compression function *simultaneously in one CUDA context*. A single-request\n",
+    "measurement therefore understates the real peak by 30×.\n",
+    "\n",
+    "Per-request footprint is estimated from tensor shapes, as the larger of the two\n",
+    "phases (they never overlap inside a thread):\n",
+    "\n",
+    "$$\n",
+    "\\text{scoring} = \\underbrace{n \\cdot D \\cdot 10}_{\\text{staged + fp32 + normalised}} + \\underbrace{H \\cdot \\text{row\\_block} \\cdot n \\cdot 7}_{\\text{fp32 tile + masks}}\n",
+    "\\qquad\n",
+    "\\text{rerotate} = 2 L \\cdot \\text{keep} \\cdot D \\cdot 2 \\;+\\; \\text{RoPE temporaries}\n",
+    "$$\n",
+    "\n",
+    "At $n = 16807$, keep 50%: scoring 1.06 GiB vs rerotate **1.28 GiB** — the\n",
+    "rerotate gather binds, which is why lowering `row_block` would *not* help here.\n",
+    "Total peak was then fitted against a measured 30-thread sweep and rounded up:\n",
+    "\n",
+    "$$\\text{peak}(\\text{cap}) \\approx \\text{per\\_request} \\times (1.4 \\cdot \\text{cap} + 3.0)$$\n",
+    "\n",
+    "| cap | measured peak |\n",
+    "|---|---|\n",
+    "| 2 | 6.47 GiB |\n",
+    "| 4 | 9.80 GiB |\n",
+    "| 8 | 16.25 GiB |\n",
+    "\n",
+    "Inverting it gives the cap from the free VRAM reported by\n",
+    "`torch.cuda.mem_get_info` — which is device-wide, so vLLM's pool and the LMCache\n",
+    "server's own CUDA context are already subtracted — minus a reserve for what\n",
+    "grows *after* the snapshot (vLLM activations during decode, allocator\n",
+    "fragmentation). If not even one request fits, scoring falls back to the CPU\n",
+    "instead of crashing.\n",
+    "\n",
+    "Wall-clock was flat at 42.9 / 42.2 / 41.5 s for cap 2 / 4 / 8, so the cap costs\n",
+    "no throughput: the slow part of `modify` is waiting on LMCache, which happens\n",
+    "before the gate and stays fully concurrent.\n",
+    "\n",
+    "**Result: ~9.8 GiB of VRAM, 41.6 s to compress 30 requests.**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a495be98",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:00:00.442123Z",
+     "iopub.status.busy": "2026-08-01T06:00:00.441980Z",
+     "iopub.status.idle": "2026-08-01T06:00:00.685934Z",
+     "shell.execute_reply": "2026-08-01T06:00:00.685318Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:00,464] LMCache INFO:\u001b[0m Route A one-shot on cuda:0: 37.4/139.8 GiB free, reserving 8.0 -> 29.4 GiB usable; 1.28 GiB per request (bound by the rerotate gather) -> cap 4 \u001b[3m(3054693816.py:72:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:00,683] LMCache INFO:\u001b[0m Route A one-shot self-test: max |reference - tiled| = 4.66e-10 \u001b[3m(3054693816.py:132:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Knobs -------------------------------------------------------------------\n",
+    "oneshot_device = \"cuda:0\"  # a request only; downgraded to CPU if VRAM is short\n",
+    "oneshot_row_block = 1024  # rows scored per tile\n",
+    "oneshot_vram_reserve_gib = 8.0  # held back for what grows after the snapshot\n",
+    "oneshot_cap_limit = 4  # ceiling on the auto-sized concurrency cap\n",
+    "oneshot_allow_tf32 = True  # kept-token set was bit-identical to strict fp32\n",
+    "\n",
+    "# peak(cap) ~= per_request * (GROWTH * cap + BASE), fitted above the measured\n",
+    "# 30-thread sweep (6.47 / 9.80 / 16.25 GiB at cap 2 / 4 / 8) so sizing errs small.\n",
+    "_PEAK_GROWTH, _PEAK_BASE = 1.4, 3.0\n",
+    "\n",
+    "\n",
+    "def _oneshot_redundancy(key_states, row_block):\n",
+    "    \"\"\"Route A redundancy, tiled over rows.\n",
+    "\n",
+    "    Same values as `redundancy_reference` but peak memory is\n",
+    "    O(kv_heads * row_block * n) instead of O(kv_heads * n^2), and no int64\n",
+    "    temporaries are built.\n",
+    "    \"\"\"\n",
+    "    bsz, kv_heads, n, _ = key_states.shape\n",
+    "    k = key_states / (key_states.norm(dim=-1, keepdim=True) + 1e-8)\n",
+    "    col_sum = torch.zeros((bsz, kv_heads, n), dtype=torch.float32, device=k.device)\n",
+    "\n",
+    "    for r0 in range(0, n, row_block):\n",
+    "        r1 = min(r0 + row_block, n)\n",
+    "        sim = torch.matmul(k[:, :, r0:r1, :], k.transpose(-1, -2))\n",
+    "        local = torch.arange(r1 - r0, device=k.device)\n",
+    "        sim[:, :, local, r0 + local] = 0.0  # a token is not redundant with itself\n",
+    "\n",
+    "        # `similarity_retain`: the largest above-threshold column per row, read\n",
+    "        # as \"first True scanning from the right\"; column 0 when none qualifies.\n",
+    "        over = sim > rkv_sim_threshold\n",
+    "        hit = over.any(dim=-1)\n",
+    "        last = (n - 1) - over.flip(-1).to(torch.uint8).argmax(dim=-1)\n",
+    "        retain = torch.where(hit, last, torch.zeros_like(last))\n",
+    "        sim.scatter_(-1, retain.unsqueeze(-1), 0.0)\n",
+    "\n",
+    "        col_sum += sim.sum(dim=-2)\n",
+    "        del sim, over, hit, last, retain\n",
+    "\n",
+    "    return (col_sum / n).softmax(dim=-1)\n",
+    "\n",
+    "\n",
+    "def _oneshot_estimate(seq_len, num_layers, kv_heads, head_dim, row_block):\n",
+    "    \"\"\"Per-request device bytes: (peak, scoring, rerotate).\"\"\"\n",
+    "    kvd = kv_heads * head_dim\n",
+    "    scoring = seq_len * kvd * 10 + kv_heads * min(row_block, seq_len) * seq_len * 7\n",
+    "    keep = int(round(seq_len * (1 - rkv_drop_ratio)))\n",
+    "    rerotate_b = 2 * num_layers * keep * kvd * 2 + 8 * keep * kvd * 2\n",
+    "    return max(scoring, rerotate_b), scoring, rerotate_b\n",
+    "\n",
+    "\n",
+    "def _oneshot_plan(spec):\n",
+    "    \"\"\"Pick the device and size the concurrency cap from free VRAM.\"\"\"\n",
+    "    dev = torch.device(spec)\n",
+    "    if dev.type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        logger.info(\"Route A one-shot: running on the CPU, no cap needed.\")\n",
+    "        return torch.device(\"cpu\"), 0\n",
+    "\n",
+    "    seq_len = max(len(p) for p in prompts)  # size against the worst case\n",
+    "    _, kv_heads, head_dim = model_heads()\n",
+    "    per_req, scoring, rerotate_b = _oneshot_estimate(\n",
+    "        seq_len, int(config.num_hidden_layers), kv_heads, head_dim, oneshot_row_block\n",
+    "    )\n",
+    "    binding = \"scoring tile\" if scoring >= rerotate_b else \"rerotate gather\"\n",
+    "\n",
+    "    free_b, total_b = torch.cuda.mem_get_info(dev)\n",
+    "    usable = free_b - int(oneshot_vram_reserve_gib * 2**30)\n",
+    "    cap = int((usable / per_req - _PEAK_BASE) / _PEAK_GROWTH) if usable > 0 else 0\n",
+    "    cap = max(0, min(cap, oneshot_cap_limit))\n",
+    "\n",
+    "    logger.info(\n",
+    "        f\"Route A one-shot on {dev}: {free_b / 2**30:.1f}/\"\n",
+    "        f\"{total_b / 2**30:.1f} GiB free, \"\n",
+    "        f\"reserving {oneshot_vram_reserve_gib:.1f} -> {usable / 2**30:.1f} GiB usable; \"\n",
+    "        f\"{per_req / 2**30:.2f} GiB per request (bound by the {binding}) -> cap {cap}\"\n",
+    "    )\n",
+    "    if cap < 1:\n",
+    "        logger.warning(\"Not enough VRAM for one request; falling back to the CPU.\")\n",
+    "        return torch.device(\"cpu\"), 0\n",
+    "    return dev, cap\n",
+    "\n",
+    "\n",
+    "_oneshot_dev, _oneshot_cap = _oneshot_plan(oneshot_device)\n",
+    "_oneshot_slot = (\n",
+    "    threading.Semaphore(_oneshot_cap) if _oneshot_cap else contextlib.nullcontext()\n",
+    ")\n",
+    "if _oneshot_dev.type == \"cuda\":\n",
+    "    torch.backends.cuda.matmul.allow_tf32 = oneshot_allow_tf32\n",
+    "    torch.backends.cudnn.allow_tf32 = oneshot_allow_tf32\n",
+    "\n",
+    "\n",
+    "def drop_tokens_oneshot(tensors, token_source):\n",
+    "    \"\"\"Route A token dropping. Runs on ~30 threads at once, hence the gate.\"\"\"\n",
+    "    kv, q_win, seq_len, past_len, keep_past = prepare(tensors, token_source)\n",
+    "    num_q, num_kv, head_dim = model_heads()\n",
+    "    dev = _oneshot_dev\n",
+    "\n",
+    "    with _oneshot_slot:\n",
+    "        q_win = q_win.to(dev, non_blocking=True)\n",
+    "        scores = torch.zeros(past_len, dtype=torch.float32, device=dev)\n",
+    "\n",
+    "        for layer in range(kv.shape[1]):\n",
+    "            # One layer of K at a time: 33 MiB instead of 1.19 GiB resident.\n",
+    "            k = to_heads(kv[0, layer, :seq_len, :], seq_len, num_kv, head_dim, dev)\n",
+    "            qw = to_heads(q_win[layer], rkv_window_size, num_q, head_dim, dev)\n",
+    "            imp = importance(k, qw, past_len)\n",
+    "            red = _oneshot_redundancy(k, oneshot_row_block)[:, :, :past_len]\n",
+    "            layer_score = imp * rkv_mix_lambda - red * (1 - rkv_mix_lambda)\n",
+    "            scores += layer_score.mean(dim=1).squeeze(0)\n",
+    "            del k, qw, imp, red, layer_score\n",
+    "\n",
+    "        keep_idx = select(scores, past_len, seq_len, keep_past)\n",
+    "        del scores, q_win\n",
+    "\n",
+    "        e_kv = rerotate(kv, keep_idx, dev)\n",
+    "\n",
+    "    logger.info(f\"compacted {e_kv.shape[2]}/{kv.shape[2]} tokens.\")\n",
+    "    return e_kv, [token_source[i] for i in keep_idx.tolist()]\n",
+    "\n",
+    "\n",
+    "def _selftest_oneshot(n=384, layers=3):\n",
+    "    \"\"\"The tiled redundancy must equal the literal reference.\"\"\"\n",
+    "    torch.manual_seed(0)\n",
+    "    _, num_kv, head_dim = model_heads()\n",
+    "    worst = 0.0\n",
+    "    for _ in range(layers):\n",
+    "        k = torch.randn(1, num_kv, n, head_dim, device=_oneshot_dev)\n",
+    "        ref = redundancy_reference(k)\n",
+    "        got = _oneshot_redundancy(k, row_block=64)  # force multiple tiles\n",
+    "        worst = max(worst, (ref - got).abs().max().item())\n",
+    "    logger.info(f\"Route A one-shot self-test: max |reference - tiled| = {worst:.2e}\")\n",
+    "    assert worst < 1e-5, f\"tiled redundancy diverged ({worst:.2e})\"\n",
+    "\n",
+    "\n",
+    "_selftest_oneshot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4d17ad6d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:00:00.691321Z",
+     "iopub.status.busy": "2026-08-01T06:00:00.691188Z",
+     "iopub.status.idle": "2026-08-01T06:02:24.382755Z",
+     "shell.execute_reply": "2026-08-01T06:02:24.381791Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:15,919] LMCache INFO:\u001b[0m prefill: 15.20 s in groups of 1 \u001b[3m(2183302842.py:24:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:21,323] LMCache INFO:\u001b[0m compacted 5120/10240 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:21,541] LMCache INFO:\u001b[0m compacted 4992/9984 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:22,265] LMCache INFO:\u001b[0m compacted 5504/11008 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:22,540] LMCache INFO:\u001b[0m compacted 5376/10752 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:24,898] LMCache INFO:\u001b[0m compacted 5376/10752 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:25,409] LMCache INFO:\u001b[0m compacted 6144/12288 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:25,995] LMCache INFO:\u001b[0m compacted 5632/11264 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:26,790] LMCache INFO:\u001b[0m compacted 6272/12544 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:29,042] LMCache INFO:\u001b[0m compacted 5632/11264 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:30,008] LMCache INFO:\u001b[0m compacted 6400/12800 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:30,577] LMCache INFO:\u001b[0m compacted 6656/13312 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:31,526] LMCache INFO:\u001b[0m compacted 6656/13312 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:34,029] LMCache INFO:\u001b[0m compacted 6784/13568 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:35,295] LMCache INFO:\u001b[0m compacted 6912/13824 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:36,003] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:37,030] LMCache INFO:\u001b[0m compacted 7680/15360 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:40,097] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:41,289] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:41,957] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:42,773] LMCache INFO:\u001b[0m compacted 7552/15104 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:45,810] LMCache INFO:\u001b[0m compacted 7552/15104 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:47,017] LMCache INFO:\u001b[0m compacted 7296/14592 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:47,935] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:48,701] LMCache INFO:\u001b[0m compacted 8192/16384 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:51,771] LMCache INFO:\u001b[0m compacted 7808/15616 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:53,155] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:53,992] LMCache INFO:\u001b[0m compacted 7808/15616 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:54,680] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:56,692] LMCache INFO:\u001b[0m compacted 8320/16640 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:57,399] LMCache INFO:\u001b[0m compacted 8320/16640 tokens. \u001b[3m(3054693816.py:118:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:00:57,516] LMCache INFO:\u001b[0m \n",
+      "\n",
+      " \u001b[3m(2183302842.py:29:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================== Batched Stream Modify Metrics =========================\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                        41.60\n",
+      "================================================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================= Batched Stream Metrics (decode) ========================\n",
+      "-------------------------------- Configuration ---------------------------------\n",
+      "Number of Request Streams:                                                    30\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                        86.86\n",
+      "Total Output Tokens:                                                      153359\n",
+      "Decode Throughput (tokens/s):                                            1765.62\n",
+      "================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_ids = []\n",
+    "\n",
+    "batch = lmc_sdk.batch.LMCacheBatchedStream()\n",
+    "for i, prompt in enumerate(prompts):\n",
+    "    stream = lmc_sdk.request.create_request(\n",
+    "        contexts=[ctx, qctx],\n",
+    "        post_completion=post_completion,\n",
+    "        prompt_token_ids=prompt,\n",
+    "    )\n",
+    "    batch.add(stream)\n",
+    "    stream_ids.append(stream.request_stream_id)\n",
+    "\n",
+    "# temperature 0 here too: prefill emits one token that is APPENDED to the\n",
+    "# stream, so sampling it would make the whole greedy decode below depend on a\n",
+    "# random first token. Groups of `prefill_group_size` keep the query capture\n",
+    "# correct (see the hyperparameter cell).\n",
+    "prefill_seconds = 0.0\n",
+    "for g0 in range(0, len(stream_ids), prefill_group_size):\n",
+    "    results = batch.prefill(\n",
+    "        sampling_params={\"max_tokens\": 1, \"temperature\": 0.0, \"ignore_eos\": True},\n",
+    "        stream_ids=stream_ids[g0 : g0 + prefill_group_size],\n",
+    "    )\n",
+    "    prefill_seconds += results.to_dict()[\"metrics\"][\"results\"].get(\"duration\", 0.0)\n",
+    "logger.info(f\"prefill: {prefill_seconds:.2f} s in groups of {prefill_group_size}\")\n",
+    "\n",
+    "results = batch.modify(drop_tokens_oneshot)\n",
+    "results.emit()\n",
+    "\n",
+    "logger.info(\"\\n\\n\")\n",
+    "\n",
+    "results = batch.decode(\n",
+    "    sampling_params={\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": temperature,\n",
+    "        \"ignore_eos\": True,\n",
+    "    }\n",
+    ")\n",
+    "results.emit()\n",
+    "oneshot_drop_data = results.to_dict()\n",
+    "oneshot_texts = [stream.output_text for stream in batch.request_streams.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "source": [
+    "## Other implementations\n",
+    "\n",
+    "The version above is the literal R-KV formulation: easy to read, easy to check\n",
+    "against the reference, and $O(n^2)$ in both time and memory. Three optimized\n",
+    "alternatives live in [`rkv_variants/`](./rkv_variants). Each is a **standalone\n",
+    "notebook** — same setup, same prompts, same baseline, but a different way of\n",
+    "evaluating the redundancy term:\n",
+    "\n",
+    "| Notebook | What it changes | Result |\n",
+    "|---|---|---|\n",
+    "| [`cpu_exact.ipynb`](./rkv_variants/rkv_variant_cpu_exact.ipynb) | Rewrites the column sum R-KV actually needs as a single inner product, so the $n \\times n$ matrix never exists. | Same tokens, $O(n d)$ plus a short scan, **no VRAM at all**. |\n",
+    "| [`gpu_exact.ipynb`](./rkv_variants/rkv_variant_gpu_exact.ipynb) | The same rewrite on the GPU, tiled over rows so the footprint is a knob rather than a function of prompt length. | Same tokens, **~1.55 GiB** and the fastest of the four. |\n",
+    "| [`buffered_cpu.ipynb`](./rkv_variants/rkv_variant_buffered_cpu.ipynb) | Compares keys only inside a chunk, making the similarity matrix block-diagonal. | **Approximate** (~96% token agreement), the quickest CPU option. |\n",
+    "\n",
+    "| | this notebook | [`cpu_exact`](./rkv_variants/rkv_variant_cpu_exact.ipynb) | [`gpu_exact`](./rkv_variants/rkv_variant_gpu_exact.ipynb) | [`buffered_cpu`](./rkv_variants/rkv_variant_buffered_cpu.ipynb) |\n",
+    "|---|---|---|---|---|\n",
+    "| Formulation | route A, literal | route A, linear | route A, linear | route B, chunked |\n",
+    "| Exact? | yes (the reference) | yes, rel. err ~2e-6 | yes, rel. err ~5e-7 | **no**, ~96% agreement |\n",
+    "| Redundancy cost | $O(n^2 d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ |\n",
+    "| VRAM | ~9.8 GiB | none | **1.55 GiB** | none |\n",
+    "| Compress 30 requests | 41.6 s | 67.3 s | **37.5 s** | **29.9 s** |\n",
+    "| Decode throughput | 1766 tok/s | 1785 tok/s | 1774 tok/s | 1774 tok/s |\n",
+    "| Accuracy (baseline 10–11/30) | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "| Pick it when | you want the reference formulation | the GPU is saturated by serving | **default choice** | latency beats exactness |\n",
+    "\n",
+    "The two exact variants assert themselves against `redundancy_reference` — the\n",
+    "same oracle used in the cell above — so their notebooks fail loudly if the\n",
+    "rewrite ever stops reproducing R-KV.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99dcfd4c",
+   "metadata": {},
+   "source": [
+    "### Accuracy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "12b6a527",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:02:24.389333Z",
+     "iopub.status.busy": "2026-08-01T06:02:24.389159Z",
+     "iopub.status.idle": "2026-08-01T06:02:24.394570Z",
+     "shell.execute_reply": "2026-08-01T06:02:24.393991Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:24,392] LMCache INFO:\u001b[0m Baseline (no drop): 10/30 correct (33.3%) \u001b[3m(3159123651.py:4:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:24,392] LMCache INFO:\u001b[0m R-KV one-shot (GPU): 13/30 correct (43.3%) \u001b[3m(3159123651.py:8:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "before_correct, total, before_map = score_answers(answers, before_texts)\n",
+    "oneshot_correct, total, oneshot_map = score_answers(answers, oneshot_texts)\n",
+    "\n",
+    "logger.info(\n",
+    "    f\"Baseline (no drop): {before_correct}/{total} correct \"\n",
+    "    f\"({100 * before_correct / total:.1f}%)\"\n",
+    ")\n",
+    "logger.info(\n",
+    "    f\"R-KV one-shot (GPU): {oneshot_correct}/{total} correct \"\n",
+    "    f\"({100 * oneshot_correct / total:.1f}%)\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1038e21",
+   "metadata": {},
+   "source": [
+    "## Result Plot\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a801eaa0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:02:24.399949Z",
+     "iopub.status.busy": "2026-08-01T06:02:24.399827Z",
+     "iopub.status.idle": "2026-08-01T06:02:24.505427Z",
+     "shell.execute_reply": "2026-08-01T06:02:24.504839Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEiCAYAAAD9DXUdAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAATfVJREFUeJzt3XdUVEf7B/DvsvRerRQRFBCxIQoqiqhYEEWxocRoNNb42qKJb2wxGuwajbGBxsQulkgUFRtWBGyI0dhQikoTAWWpO78/+HFfr7vA7ro0eT7n7Dnu7Ny5z13WffbemTsjYIwxEEIIIf9PpboDIIQQUrNQYiCEEMJDiYEQQggPJQZCCCE8lBgIIYTwUGIghBDCQ4mBEEIIDyUGQgghPJQYCCGE8FBiIIQQwkOJgShNQUEBQkJC8OjRo+oO5bN09OhR3Lt3r7rDqDUKCgoQGRmJw4cP4/LlywCAkJAQxMXFVXNkNZ+A5koiZ86cQXZ2doX1rKys4OLiUubr6enpMDMzw6pVq/Dtt98qM0SF3Lt3D//++y8AQCAQQFNTE8bGxnBwcIChoWH1BqcATU1NfPPNN1i9enW17P/vv/9GXl4e91xdXR3m5uZwdHSEhoZGtcRUlvT0dHh4eCA/Px+tWrVC69atsXDhQggEAnz33XdYvnw5VzckJAT29vZo2bJlNUZcs6hWdwCk+p04cQLJycnc80ePHuHevXvw8PCAiYkJV961a9dyE0NNs2vXLqxZswZ9+/aFtrY2CgoK8OrVK9y7dw9t27bF3LlzMWjQoOoOU2aDBw9Gq1atqm3/48ePR1FRETw8PAAAeXl5uHv3LoqKirBy5Up88cUX1RbbxzZu3IiEhASkpKRAS0uLK/fz84OTkxOv7tChQyWSRZ3HCPnIqlWrGAB2+fJlubZLS0tjANiqVasqKTL5zJ49mwFg8fHxvPKMjAw2bdo0BoD98MMP1RNcLVS/fn3WuXNnXllhYSEbMGAAEwqF7MmTJ9UUmaTBgwczR0dHmeoCYN99910lR1S70BkDkVlxcTHu3LmD5ORkmJqaon379lBXV69wu+zsbISHh8PY2Bjdu3fnyrOysnDz5k28f/8ezZs3h52dHW+7yMhIvH37Fn369EF2djYiIyOhpqYGNzc3aGpqKnwcxsbG2LBhA9LS0rBs2TIMHDiQOxP6cJ85OTm4ceMGVFVVuV/JYrEYd+/eRVJSEoyMjNC+fXteLGKxGEeOHEGLFi3QokUL/Pvvv3j8+DGsra3h6OjIi0OeukBJH4OtrS33i/fj7Z8+fYoHDx7A0tKyzDOL/Px8XL9+Hfn5+ejQoQOMjIxw6tQpGBoawtXVVe73UlVVFUOHDsXx48dx+/Zt2NjYSNR5+vQpHj58CHV1dbRv3x5GRkZlvgeyHEN5bWZlZSE8PByPHz/G+/fvERISIrFt6WWj3NxcnDx5EgDw77//cnUbN24MNzc3ud+Lz0p1ZyZS80g7Y4iKimK2trbM1NSU9erVi1lYWLD69euz0NBQro60M4b4+Hjm6OjImjVrxh49esQYY6y4uJjNnz+faWpqstatW7OePXsyfX191q9fP5aZmclt6+fnx2xsbNi5c+eYo6Mj8/LyYmZmZszc3Jz9+++/FR5HWWcMpaKjoxkANmXKFIl9njhxgtnb27Pu3bszT09Pxhhjd+/eZQ4ODszY2Jj16tWLNWnShJmamrKDBw9y24tEIgaALVy4kH399desXbt2zN3dnamrq7MBAwaw9+/fK1SXMcY0NDTY7NmzJbZftGgRmzlzJmvXrh3r1q0bU1VVZX5+fkwsFvO2v3r1KmvUqBGrX78+8/LyYnZ2diw0NJTZ2NgwPz+/Ct9PaWcMjDG2YMECBoDdvHmTV56UlMQ8PT2Zjo4O8/DwYB06dGDa2tps9erVCh9DRW3Gx8czPz8/Vq9ePWZgYMD8/Px4D3xwdpCamsqV2dnZcXVWrFhR4XvxuaPEQCR8nBjS0tKYiYkJ69y5M8vKymKMMVZQUMCGDRvG1NXV2b1797h6HyaGa9eusXr16rFu3bqxjIwMrv3FixczFRUVduTIEa4sKSmJWVtb876g/Pz8mKmpKRs3bhzLy8tjjJX8Z27YsCEbNGhQhcdRUWIoKipiampqrGPHjhL7DAgIYCKRiDHG2KNHj1hWVhZr2LAhc3Z25o6lqKiIjRkzhqmqqrKoqCjG2P++6GxsbNiuXbu4diMjI5mWlhabOHEiVyZPXcbKTgx2dnZs9+7dXPn+/fsZAHb48GGuLDMzk5mZmbFu3bqxd+/eMcYYy8vLY6NHj2ampqYyJwZ7e3t26NAhdujQIbZ79242a9Yspqury4uLMcby8/NZixYtmIODA0tMTOTKDx48yACwo0ePyn0MsrbJGGM9evRgrVu3ljgGSLlsJK2srqPEQCR8nBjWrFnDALDr16/z6r169YqpqalxX2AfJoZ9+/YxTU1NNmbMGFZQUMBtk5uby7S1tZm/v7/Efrdu3coAcP/pS3/NvXjxgldv+vTpTEtLq8LjqCgxMMaYiYkJa9asGfe8dJ8PHz6UGlt4eDiv/M2bN0xbW5uNGjWKMfa/L7oOHTpI7GvSpElMTU2NS67y1GWs7MTg7u7O21YsFjMzMzM2fvx4rmzLli0MAIuMjOTVffLkCQMgc2IwMTHhflkPGDCAOTg4MDs7O7Zv3z5e3d27dzMA7MSJExLtuLu7Mw8PD7mPQdY2GaPE8Kmoj4FU6Pbt2xAKhWjfvj2vvEGDBmjSpAlu3brFK9+1axfu37+PJUuWYP78+bzX7t69i9zcXOjo6ODYsWNg/z9amjGG1NRUACXDTM3NzQEApqamsLS05LVhaWkJkUiE9PR0mJqaftKxiUQi6Ojo8Mr09PQk+jtu374NAOjYsSOv3MjICHZ2dhLvgbTRWx06dMCWLVsQFxeHTp06KVRXGmdnZ95zgUAAc3NzJCYm8uIXCARo164dr66NjQ0MDAzKbf9D9vb2EtftV69eDX9/fwgEAgwfPhwAcP36dQDAmzdvuL9z6d9aU1MTN2/elPsY5G2TKI4SA6lQQUEB1NXVoaoq+XHR0dFBfn4+r8zU1BSqqqq4c+cOt20pkUgEAIiNjUVmZqZEe35+frzOSWlfWqXtfTimXhGJiYnIzc1F8+bNeeVmZmYSdQsKCiAQCHhDH0vp6OggKyuLV6atrS1Rr7Ts4/dLnrrSlPUeffj+FBQUQE1NTerfUNr+5TFz5kz897//xW+//cYlBpFIBIFAgGPHjknU19fXR+/eveU+BnnbJIqjxEAq1KRJE4hEIiQnJ6Nx48ZceVFREeLj47kRO6W8vb3x/fffY/DgwfDx8cGRI0e4X+Wlo1a8vb2xcOHCKjsGafbt2wcAGDhwIK9cIBBI1G3SpAkYY3j69CnvbIIxhidPnkiMInr69KlEG0+ePAEAWFtbK1xXUU2aNEFBQQGSk5O5szEAyM3NRUpKyie1LRQKoaWlxZ3xASV/Z8YYVq5ciaZNm35S+5XZJpGOpsQgFRo2bBgAYMOGDbzynTt3IisrCyNGjJDYpnfv3ggPD0dUVBR69erFnR1YWlrCy8sLW7duRUZGhsR2CQkJlXAEkq5cuYIlS5bAzc2N+5VbniFDhkBFRUXiPdi/fz9ev34t8R6cO3cOL1684J6LRCIEBwfDxcUFTZo0Ubiuovz8/CAQCLB582Ze+bZt26CmpvZJbUdFRSE7O5t3mSogIACampr4+eefpW7z4SUiWVVGmwBgYmIiccZX19EZA6mQs7MzfvzxRyxatAipqano2rUr7t27h40bN+LLL7+UmhgAoFOnToiIiEDv3r3h4eGB06dPo0GDBti1axf69u2Lli1bYsKECbC1tUVKSgqioqIQGxuLhw8fKjX+sLAwmJmZobCwEK9fv8aFCxcQFhYGPz8/bN68GUKhsMI2HBwcsHLlSsyZMweZmZno2bMn/v33X6xfvx5DhgzBV199xas/evRoBAQEYODAgdDR0UFwcDAyMzNx9OhRibblqasoR0dHLFq0CIsXL0ZaWhrc3Nxw584dAIC5ubnUsyRpMjIyuD6GoqIiPH78GL/++iuaNm2KZcuWcfUsLS2xb98+BAQE4MmTJ/D19YWRkRGePXuG0NBQ9O/fH0uWLJHrGCqjTQDw8vLCkSNH0KpVK5iZmdF9DKDEQKSws7ODn58fr2N34cKF6NWrF0JCQnDmzBmYmpoiNDQUffr04epoaGjAz8+Pd6mlVatWuHz5MubPn49ffvkFS5cuRYMGDRAdHY2jR48iIiICT548gbm5Ofz9/bnLOwDg5uaGhg0bSsRna2sLPz+/Cq+Nt2rVCn5+fjh37hwEAgE0NDRgbGyMfv36YcOGDVJ/jZe1TwCYPXs2PDw8cODAAZw9exaGhoY4dOgQfHx8JL5YjY2NERISgt9++w23b99Gnz59MHHiRFhYWEi0K2vdj6fEEAqF8PPzQ4sWLSTa9PT0lDgTWLRoEdzc3HD48GFcunQJnp6eCAgIwJ49eyQ64KXx8fFBZmYm9u/fD6Dk5rZGjRph1apV8Pf3l9ifr68vnjx5gr179+Lu3bsASi4H/fHHH9y8RPIegyxtAiXTt+Tk5Ei0KW1KjC1btmDz5s24du0a8vLy4OLiUucTA02iR4gS5eXlQUtLi/t1rqy6leXt27cwMjLCkiVLsGDBgmqJgdQ81MdASB2Rnp4uUbZu3ToIBAKJDnhSt9GlJELqiD179iAsLAx9+vSBrq4uLl68iD179mDevHnVOmsrqXkoMRCiROVdM/+Uusowffp0ODo6Ijw8HElJSahXrx4uXLggMdyYEOpjIIQQwkN9DIQQQngoMRBCCOGhxEB44uLi0LNnTxgbG0NVVZVbyIRIOnnyJFRVVXH16tUq3e/KlSuhqqpa6+/WbdOmDY2GqqEoMRCe4cOHQ0VFBU+ePEFeXh769u1bafs6ePAgVFVVuYe2tjYaNmyIbt26YeHChbxpImoisViM4uJifGo3XVZWFu99KO/x22+/KW2/1a2oqAjFxcXVGoOrqytNvicFJQbCSU1NxT///ANfX1/ujEHWqRIUUfoFt3fvXuTl5SEzMxMxMTGYPn06zp8/D3t7e+zcubPS9l9TGBgYIC8vj/cYOHAgiouL8f79e1755MmTqzvcz0pNSE41ESUGwklLSwPw6dMwy0tFRQWqqqrQ0NBA48aNMXjwYERERKBv374YP348Nw//5+zjM4PShCwUCqWWE1KZKDEQAMC4cePQunVr7t+qqqq8uYTu3r0LX19fmJqaQldXF87OztixYwevjdJr32lpaZg7dy4aN24MPT09heIRCoVYu3YtN83yh5KSkvD111/D0tIS2traaNasGX766ScUFRVJ1Js0aRKsra2hq6uL1q1bY8OGDbx6shwXUDIba5cuXaCrqwsbGxv89ttvZcYua3yfqqioCPPmzUPDhg1hYGCAwYMH49WrV7w6Ff1NgoOD4ezsDF1dXZiamsLX1xexsbG8NkxNTTF16lSJ/Q8fPhz29va8MrFYjMDAQDRt2hR6enro1q0b7ty5g1GjRsHW1lbqcTx9+hR9+/aFvr4+LC0teZPxlSrtj/jnn3/Qo0cP6Ovrw9raGkuXLoVYLFYo3gYNGuDmzZs4f/48l3iVNZttbUeJgQAAtm/fzq2AtX37duTl5XHrBNy+fRudOnXC+/fvcenSJTx9+hTDhw/H119/zZtfp/TS0OzZs+Hg4IA7d+5IfKnLo0mTJmjevDkuXLjAlb148QLt27dHXFwcDh06hJcvX2Ljxo3YvHkzvvzyS67es2fP4OzsjKioKPz+++9ISkrCnj178PTpU0RERMh1XNHR0ejZsyfq1auH27dv49KlS3jx4gV+//13iZhljU8ZfvjhB9jb2yMuLg4nT55EZGQkxo0bx6tT3t9kwYIFmDBhAoYNG4anT5/i0qVLyM3NhZubG7diHVD25Zbi4mKJZDdnzhwsXrwYc+bMQXx8PDZs2IAffvgBr169kpoYs7Ky8O2332LJkiV4/vw5pk+fjvnz52Pv3r28ekVFRUhPT8esWbOwfPlyPHv2DP/973+xdOlSzJgxQ6KuLPEmJyfD2dkZ3bt35y7VSVsbo06Sdy3Q/Px8dvr0afbDDz+wL7/8kn355Zds/vz57MyZM7y1fUntc+/ePQaA7dy5k1feu3dvZmRkxLKzs3nlY8eOZaqqqiwpKYkxxlhgYCADwBYtWiTT/vbt28cAsEOHDpVZp0ePHgwAe//+PWOMsWHDhjEjIyOWlpbGq1e6IPzNmzcZY4wNHjyY6enpsZSUlDLblvW4vLy8WMOGDVleXh6vnqenJ29tbHniq0jp2tOFhYUSr5W+z8uXL+eVl67VnZCQIFH347/Jy5cvmZqaGhszZgyvPCcnhxkbG7NevXpxZQYGBty63h/HaGNjwz1PTk5mQqGQTZ8+nVcvKSmJqaurMysrK165o6MjU1NTk1iTu02bNqxr164SdVVUVNijR4945XPnzmUqKirs2bNncsfLGGPOzs6sR48eEnXrOpnPGEQiEZYuXQpLS0v4+PggLCwMqampSE1NxcmTJ+Ht7c2dBpYu30hqv+LiYly8eBFeXl4Sl4WGDRuGoqIi7hd4KV9fX6XHIRAIIBaLceLECXh6ekqs9ezl5QUAuHjxIsRiMcLCwtC7d2/Uq1dPanuyHldpvT59+kBDQ4NXb/DgwbznssanLD4+PrznpfMdPXv2TKLux3+TiIgIFBYWws/Pj1euq6uLvn374uLFi3Jf+rp06RKKi4sxYMAAXnnjxo0l1nQu1bJlS4nLN05OTlKPwdHREc2aNeOVDR48GGKxGOfPn5crVlI+medKcnBwgJOTE7Zt2wYvLy9oamryXheJRDhz5gyCgoLg4OCA58+fKztWUg3evXuH/Px8qWsUNGjQAMD/Oq1Lfbj856dKTk6GgYEBtLS0kJWVhffv3+PYsWPQ1NTkhmuyDxaFT09PR05ODkQiUblxyHpcOTk5KCgoQP369cusVyonJ0em+JTl49j19fUBlEyl/bGP34vS1fPKOv7CwkJkZWXBxMSkzP2zj4bLlh6btPeqfv36ePnyZYXHAJQch7RjKO9vIMv7+nG8pGwyJ4ZDhw7BxcWlzNe1tLQwcOBADBw4EFFRUUoJjlQ/XV1dqKurS10XuLTs4y+PT10qslRCQgL+/fdf7heorq4uNDQ0MGLECAQFBUndRkWl5CRYU1NT6hdRKVmPS09PD2pqarz1jD+u92GbssanDGWNUJL2Bfjx38TY2BiA5DGUlqmpqXGJxsDAAO/evZOo9/H7W9pmamqqxBrY0t4/eY+hvL/Bh59BWeMlZZP5U1peUvhYhw4dFAqG1DxCoRDu7u44e/YscnNzea8dPXoUQqEQ3bp1U/p+GWOYO3cuBAIB5syZw8XSp08fhIeHIzc3V+oNYCoqKlBRUUHv3r1x5swZqetKy3NcpfXOnDmDwsJCXr3jx49LtClLfDVB165dIRQK8ddff/HKc3NzcebMGXTp0oVLJk2bNkVcXByv3suXL7mlQT9sU0VFBWFhYbzylJQUbmDDp7h//77ElYjjx49DIBDwZoiVNV4A0NHRQUFBwSfH9rlR6FP64sUL3pCyZcuWccMBnzx5orTgSM2wbNkyZGVlwd/fH/Hx8cjKysKvv/6K4OBgzJgxQ+pylYpgjOHNmzcICwtDz549cfToUWzevBmdO3fm6qxevRqFhYXw8fFBZGQkRCIR0tPTcf78eQwdOhT37t0DUDJMUygUwtvbG1FRUcjLy8OTJ0/w/fffc9f5ZT2uJUuW4PXr1xgzZgySkpLw5s0bLFmyBOrq6hLHIGt81a1x48aYMWMGduzYgY0bNyIrKwvx8fHw9/fH27dvERgYyNUdP3487t69i19//RW5ubm4f/8+pk6dKvED0NzcHFOmTMHGjRuxa9cuvHv3Do8ePcLEiRPRsWPHT47ZxcUF33zzDe7fv4/3799jz549WLt2LcaNG8cbCitrvEBJv0VcXBxd+v6YIj3WgwcPZn/99RdjjLHnz58zTU1NFhQUxEaPHs0GDBjwyT3ipHqUNSqJMcYiIyOZl5cX09HRYUKhkNnb27MNGzYwsVjM1SkdAZOZmSnT/kpHJamoqDChUMhUVVWZoaEhc3FxYXPmzGGPHz+Wul1iYiKbMGECMzc3Z0KhkNWrV4/16tWLhYSEsOLiYq7e06dP2ahRo5ipqSlTVVVl9vb2bOXKlSw/P1+u42KMsfDwcNauXTsmFApZw4YN2cqVK1loaKjEqCR54iuPLKOSPn6fr1+/zgCwo0ePVliXMcbEYjHbsGEDc3BwYKqqqkxbW5v16tWL3bhxQ6LeokWLmJmZGVNTU2OdO3dmcXFxUkf5FBUVsQULFrAGDRowNTU15uLiwm7cuMEGDRrEmjdvzqvr6OjIvL29JeKaOnUq09HRkVr31q1brGPHjkxNTY3Vr1+fzZs3T+I9kife5ORk1qNHD6alpcWEQqHEyKm6SqH1GIyNjfHixQvo6elh69atCA8PR0hICNLT02Fvb6/UDjZStYqKiiAUChW6w5YxhuLiYqiqytZ1VVq/lKzb1RTyHq88xGIxxGKx1LbL2+/Hf7/KjpExBqFQWGHdDh06QEtLizeCrbi4GAKBQOLymrR2S0cv/f3335UWb+lnUZbj+dwpdClJIBBwowZOnz4NT0/PksZUVKjnv5b7lGkXBAKBXF9ApfVLH7WNvMcrj9JpQuTd78d/v8qOUZYv0efPn+P27dvo2rUrr1woFErtc5G1XXlV1K5QKKSk8P8U+sT07NkTX3zxBTp16oTTp09jw4YNAErGMVdGRyQhpHY4c+YMYmJi4O/vj4YNGyI2NhaTJ0+GoaGh1GkqSM2k0BnDpk2b0KxZM8TExOCPP/6Aubk5ACAkJASLFi1SaoCEkNrD3d0dIpEIffr0gb6+Pnr37o0mTZrg6tWrEvd9kJpLrj6GgoICqSMxCCGkMpXVH0Eqh1zvsqmpKfz8/LBz506pN8YQQkhlKKs/glQOuc4YYmNjERoair///hsxMTFo164d+vfvj/79+6Nt27Zy77yoqAiHDx/GtWvXoKqqii5dusDX11ei8/Pp06fYsWMHUlJS4OTkhAkTJkBLS6tS6hBCSF2n0HBVoGQemZMnT+Lvv//GmTNnoKenB29vb/Tv3x89evSocLEXsVgMe3t7ODs7w83NDbm5uVi/fj26deuGAwcOcPViY2PRpUsXeHt7w9XVFTt27ICGhgauXLnCXdZSVp2KiMVivHz5Enp6erRgCiGkVmGMIScnB40aNar47EsZN0MUFBSws2fPshkzZrBmzZoxTU1N1q9fv3K3EYvFEtPtXrp0SWJq4r59+zIvLy/ueUpKCtPU1GTbtm1Tep2KJCYmMgD0oAc96FFrH4mJiRV+1yl8xlCeR48eITQ0FLNnz5Zru+TkZJibm+P06dPw8vJCQUEBdHV1sXnzZt4CJN7e3lBVVcVff/2ltDqyyMrKgqGhIRITE7kJxgghpDbIzs6GhYUF3r59CwMDg3LrKnQfw4sXL7B792788MMPAErmnAkMDISNjQ0OHz6M5s2by50UAOC3336Dnp4eN6dJQkICCgsLYWVlxatnZWWFy5cvK7WONPn5+cjPz+ee5+TkACiZFpgSAyGkNpLlMrhC3fyzZs2Ck5MTgJIksXTpUvzyyy9o06aNQgkBAI4dO4YVK1Zg8+bNMDQ0BABuwR9dXV1eXT09Pe41ZdWRJjAwEAYGBtxDWZPFEUJITaZQYrhw4QK6d+8OADh16hS8vb0xbtw4rFmzBlevXpW7vVOnTmHEiBFYs2YNRo0axZWXnu5kZmby6r9584Z7TVl1pJk3bx6ysrK4R2JiotzHRgghtU21z5V0+vRpDBo0CIGBgZg+fTrvNQsLCxgaGkrMrX7v3j3ujEVZdaTR0NDgLhvR5SNCSF1RrXMlhYeHw9fXFz///DNmzpwp8bpAIMCIESMQHByMSZMmQU9PD9euXUNUVBSWLFmi1DqEkMqVmpqKK1euoHnz5mjZsiXvtcjISCQlJUlso62tjX79+vHKioqKEBMTg5ycHHTs2JH3g+3ly5e4du2aRDve3t4V3rNUXrt1jsxjNT+QlpbGxo8fz80xX2rUqFHszp07MrWRnZ3NtLS0WL169dioUaN4jwsXLnD13rx5w9q3b88sLS1Z3759ma6uLps1axavLWXVqUhWVhYDwLKysuTajpC6LCEhgY0YMYI1btyY6erqsu+++06izurVq5mfnx/voaury1xdXXn1bty4waytrVnz5s1Z//79WfPmzVl4eDj3+tGjR5lQKJRoKyMjo9wYK2r3cyDP91elDFeVRX5+Pg4dOiT1NTc3N9jY2HDPi4uLcfXqVe6OZXt7e4ltlFWnPNnZ2TAwMEBWVlbd/jVBiBxiY2MRFxeHIUOGcLMlLF++vNxtkpKSYGVlhS1btuDrr78GUHLG0aJFC4waNQrr16/nLmnfunWLu5x97NgxBAQESF3zuSyytPs5kOf765Mmas/Ly+P6Gj4kyyyKGhoaCAgIkGk/QqFQYi73yqpDCFGuVq1aoVWrVnJts3PnTmhra8Pf358r27JlC4qLi7FixQpuyKWhoaHElzdjDBcuXEBRUREcHR3RqFGjcvcla7t1iUKJIS4uDmPHjsXNmzeldjZX00kIIeQzwBjDzp07MWLECN4Q84iICHh4eKCoqAinTp2Crq4u2rRpIzEMvaioCAsWLAAAREdHY/z48di4cWOZ00DI2m5dolBi+Prrr2FpaYm1a9fCyMhI2TERQuqw8+fPIz4+nruEVCo1NRVisRht2rRB06ZNkZKSgpcvX+LPP/9Enz59AAC2trZ4+PAhrK2tAZQkhq5du6J58+YSox7labeuUSgxxMbG4uTJk5QUCCFKFxQUhFatWnEzIJTS0NDA1atXERMTw12amj59OgICAvD69WuoqqpKjHZycXHBoEGDcPz48TITgyzt1jUK3cdgaWkpV+cOIYTIIjMzE0ePHpU4WwAAGxsb2NnZ8forhg4dioyMDDx79qzMNg0MDJCamlrm64q2+zlTKDHMnDkT06ZNK/fNJoQQee3evRsqKipSB6b0798fycnJeP/+PVf26NEjqKiocB3MHy8gJhKJcPr0abRv354rS05ORkhICDcdjizt1jUKDVc1NDREVlYWgJIJ5T6elEnaSKXPAQ1XJUR++fn5CA0NBVAyz5qzszNGjRoFExMTbmqdUm3atEHr1q2xa9cuiXaKi4vh4eEBgUCAsWPHIiUlBStWrMDUqVOxdOlSAMAXX3wBgUCALl26oLCwEEFBQcjIyMClS5fQpEkTACVr0w8dOhSJiYkwNzeXqd3PQaUPVw0KClIoMEJI3SMSibB//34A4PoN9u/fj+bNm/MSQ0pKCmxtbTFt2jSp7QiFQoSHh2Pbtm04f/48jIyMsHfvXvTt25er88cff+Dw4cM4f/48xGIxxo0bh6+++oq3cJi5uTn8/Py4MlnarWuq7Qa32ojOGAghtZU831+ftLr206dPER4e/ilNEEIIqWEUSgxpaWno3r07bG1t4eXlxZX37dsXFy5cUFpwhBBCqp5CiWH27NkwMTGRGAEwd+7cz6qzhhBC6iKFOp9Pnz6NO3fuoF69erzydu3a4fr160oJjBBCSPVQ6IwhJyeH69H/cKhqZmYm1NTUlBMZIYSQaqFQYnB1dcW+ffsA/C8xFBcXY/HixXB3d1dedIQQQqqcQpeSVq5ciR49euDs2bNgjGHatGk4e/YskpOTceXKFWXHSAiRxV5BxXXI52Fk5d5loNAZQ/v27RETE4P69evDxcUFkZGR6Nq1K27evCn3vOuEEEJqFoXOGE6ePIl+/fph06ZNEq8tX74c33///ScHRgghpHoodMYwYsQIXL16VaI8MDAQP//88ycHRQghpPoolBg2btwIHx8fxMbGcmU///wzli9fjtOnTystOEIIIVVPoUtJX375JdLT09G7d29cuXIF+/fvx8qVK3H69Gm4uroqO0ZCCCFVSOGliWbPno309HS4uLiguLgYZ86cQceOHZUZGyGEkGogc2JYv369RFn9+vWho6MDd3d3XL9+nbvrecaMGcqKjxBCSBWTedrtj9dSLU9cXJzCAdVkNO02qdHoPoa6Q4H7GCploZ7P9cueEEII3yetx0AIIeTzo3Dn85s3b7Bt2zY8ePAAjDG0aNECEyZMgLGxsTLjI4QQUsUUOmOIjo6GjY0NNm3ahKysLOTk5GDTpk2wtbVFdHS0smMkhBBShRQ6Y5g1axYCAgKwbt06qKqWNFFUVISZM2di9uzZuHTpklKDJIQQUnVkHpX0IU1NTSQnJ8PExIRXnp6eDnNzc+Tl5SktwJqERiWRGo1GJdUdlTwqSaFLSbq6unj16pVE+atXr6Crq6tIk4QQQmoIhRKDn58fRowYgbNnzyI7OxvZ2dkIDw/HiBEj4Ofnp+wYCSGEVCGF+hjWrFmDKVOmwMvLC6VXogQCAQICArB27VqlBkgIIaRqKZQYioqK8Mcff2D58uV48OABBAIB7O3t0ahRI7x9+1bJIRJCCKlKCiUGIyMjMMbQqFEjNGrUSOprskpKSkJQUBAePnyIhQsXokWLFrzXg4ODER4eziuzsLDAqlWreGWPHz9GUFAQUlJS4OTkhEmTJkFHR0fuOoQQUtcp9c7nvLw8aGpqylx/7dq16NKlCzIyMnDgwAGkpqZK1ImOjsbz58/h6+vLPXr06MGrc+fOHbRt2xYvX76Ei4sL9uzZg65du6KgoECuOoQQQuQcrrp8+XIAwLx58xAYGMh7TSwWIyYmBomJiTLf5BYfHw9LS0u8evUKFhYWuHDhAjw8PHh1Jk2ahPT0dISEhJTZTp8+fSAQCBAWFgagZNispaUl1q1bh4kTJ8pcpyI0XJXUaDRcte6oKZPoAeB9OX/8Ra2mpoYmTZpgx44dMrdnbW0tU7379+/jq6++goGBAdzd3TF48GDutfz8fJw7dw5bt27lykxNTeHp6YkTJ05g4sSJMtUhhBBSQq7EEBMTA6Dk1/epU6cqJaCPCYVCtGvXDq6urkhOTsb48eOxb98+HDp0CACQkJCAoqIiWFpa8razsrJCRESEzHWkyc/PR35+Pvc8OztbWYdFCCE1lsyJITs7mzv9qCgpZGVlwcDA4NMi+39Llizh3WE9YMAAuLi4IDQ0FD4+Ptxd1h/fWKerq8u9JksdaQIDA/Hjjz8q5TgIIaS2kLnz2c7ODitWrEBaWlqZdV6/fo3AwEDY29srJTgAEtNuODs7w8rKClFRUQDAJaA3b97w6mVkZMDQ0FDmOtLMmzcPWVlZ3CMxMfFTDoUQQmoFmc8YLly4gNmzZ2PhwoXo2LEjnJ2dUb9+fTDG8Pr1a0RHRyM6OhpeXl64cOFCZcaMnJwcCAQlHW0WFhYwNDREXFwc+vXrx9W5d+8enJycZK4jjYaGBjQ0NCrpKAghpGaS+YzB3t4eJ06cwO3bt+Hh4YHY2Fjs2LEDv//+O+Li4tCrVy/ExsbixIkTSjtjKCwsxIEDB3hl69evR0ZGBnx8fACU3HE9cuRIBAcHc30AV65cQVRUFAICAmSuQwghpIRCs6sqS0REBDZv3gyRSITjx4+je/fuqFevHoYMGYIhQ4ZALBbjyy+/RGRkJOzt7ZGQkICEhASsWrUK48eP59p5+/Yt+vTpg6SkJLRo0QLXrl3D1KlTsWLFCrnqVISGq5IajYar1h2VPFy1WhNDfHw8bty4IVHesmVLtGzZknuelJSEu3fvwsjICE5OTtDT05PYRiwWIzIykrur2dbWVqE65aHEQGo0Sgx1x+ecGGobSgykRqPEUHfUxPUYCCGEfL4USgzlzaBKs6sSQkjtplBiMDIyUug1QgghNV+1zq5KCCGk5pFrrqTS2VU//jfwv9lVPxxNRAghpPap1tlVCSGE1Dw1fnZVQgghVUuhPgZKCoQQ8vlSaM3n+fPnl/v60qVLFQqGEEJI9VMoMVy5coX3XCwW49mzZ0hOTkanTp2UEhghhJDqoVBiuHjxokSZWCzGzJkzJRbDIYQQUrso7T4GFRUVLFiwAHv37lVWk4QQQqqBUm9we//+vcQqaYQQQmoXhS4l7d69W6IsMzMTQUFB8PT0/OSgCCGEVB+FEsO3334rUWZkZAR3d3csW7bsk4MihBBSfRRKDK9fv1Z2HIQQQmoIWo+BEEIIj8KJYffu3XB2doaOjg50dHTQvn17GpFECCGfAYUuJS1btgyBgYGYNGkS5s6dCwCIjo7GhAkTkJCQgO+//16pQRJCCKk6Cq35XK9ePezYsQP9+/fnlYeGhmL8+PFISUlRWoA1Ca35TGo0WvO57qiJaz4XFRWha9euEuXdunVDYWGhIk0SQgipIRRKDJ06dcLBgwclyg8ePEhzJRFCSC2nUB9D8+bNMXHiRBw/fhwuLi5gjCEmJgYnTpzA9OnTsX79eq7ujBkzlBQqIYSQqqBQH4M8y3fGxcXJ23yNVVf6GG7cuIGwsDBkZGSgffv2GDVqFFRVJX9DhIeHIzw8HOrq6hg5ciRatGjBe/3mzZsIDQ1FRkYGzM3N4e/vD0tLyzL3e+jQIZw+fZpXZmpqKrGMLCkD9THUHTWxjyEuLk7mB6ld1qxZA09PT7x79w7W1tb45Zdf0K9fP4jFYq6OWCzGqFGjEBAQAG1tbZiYmGDMmDGIjo7m6gQFBcHNzQ2ZmZmws7NDVFQU7O3teXU+duPGDURGRsLV1ZV7tG3btlKPlxAiSaEzhrrqcz9jEIlEMDAwwJo1azBt2jQAJcdsZWWFTZs2YeTIkQCAzZs3Y/bs2bh79y6aNWsGACgoKEBWVhbMzMwAAO3atYOLiwu2bt3Ktd+6dWt06dIFmzZtkrr/b7/9FnFxcbRCoKLojKHuqOQzBoX6GADgxIkTuHr1qtTZVLds2aJos6QaJScno7CwEK1bt+bK9PX10aRJE/z1119cYtiyZQuGDh3KJQUAUFdX55ICAJibmyMtLY17np+fj6ysLFhYWJQbQ3x8PKZPnw49PT24ubnB29tbWYdHCJGRQpeS5s+fj0GDBuHGjRtIT0+XeJDaqUmTJjAwMMCJEye4smfPnuHhw4d4/PgxAKCwsBBxcXFwc3PD3r17MW3aNCxbtgyPHj3itbV161YwxuDm5oaAgAC0bdsWQ4YMwaxZs8rcv0AggI2NDSwtLVFQUIBRo0Zh6NChlXOwhJAyKXTGEBQUhNOnT6N79+7KjodUI1VVVQQHB2PMmDG4fv06GjZsiKioKLRt2xaZmZkAStbcEIvFWLNmDRwdHeHp6Ylbt27ByckJx44dQ9++fQEAt2/fxvXr1+Hn5wc7OzuIRCL8/fffmDhxIu9M40OzZs1Cw4YNuecjR45E+/btERISgiFDhlT+G0AIAaBgH4OpqSkSEhKgra1dGTHVWJ97H0OptLQ0REZG4t27d/Dw8MCMGTPw8uVLXL58GYWFhdDU1ISbmxtv7e+AgAA8ePAAN2/ehFgsRv369TFlyhT8+OOPXB0vLy9oaGggNDRU5lgcHR3Ru3dvrF27VqnH+FmiPoa6oyaOSnJ3d0d4eLgim5JawMzMDD4+PvD394eZmRkiIiLg7u4OAFBTU4O9vT1atWrF28bJyQkJCQkASj6A6enpEnVat26NJ0+eyBWLSCQCjY8gpGrJfCnpw5vWbGxsMHLkSIwZMwa2trYQCPi/VOimttorMjISrVu3hpaWFgAgMDAQIpEIU6ZM4eoEBATg999/h0gkgpaWFoqLi3Hq1Cm0b98eAGBoaAhLS0v8/fff8PPzA1DS+XzmzBlex/aBAwdw+/Zt7j6Fv/76CwMHDuRe37dvH+Lj47nLU4SQqiHzpaS6elPbh+rCpaTQ0FDMnTsXbdq0QXx8POLj47Fv3z7ekq35+fkYNGgQHjx4ADc3N9y9exeFhYUICwuDjY0NAODs2bMYPnw4rK2tYWdnh+vXr0NNTQ1nzpyBlZUVgJIfEMeOHcPz588BlPQpxMbGomXLlnj16hWio6OxYMECzJs3r8rfh1qJLiXVHZV8Kana72NISkpCUFAQHj58iIULF0rcPQsAjx8/RlBQEFJSUuDk5IRJkyZBR0enUuqUpy4kBqBkhb5Lly5BV1cXHh4eZfYlXbt2Dc+ePUPjxo3RpUsXqKmp8V7Pzs5GZGQk0tLSYGFhgU6dOvHuoI6MjMSLFy8wfPhwruzp06e4efMm9PX10bZtW9SvX79yDvJzRImh7vicE8PatWuxYcMG+Pj44Ndff8WFCxfg4eHBq3Pnzh106dIFgwYNgqurK4KDgyEQCHD9+nWoq6srtU5F6kpiILUUJYa6oyYmhvnz55f5moaGBpo2bYr+/fvDwMCg3Hbi4+NhaWmJV69ewcLCQmpi6NOnDwQCAcLCwgAA6enpsLS0xLp16zBx4kSl1qkIJQZSo1FiqDtq4p3Ply5dwuXLl6Gnpwc7OzsIBAI8fPgQOTk5cHFxQXx8PGbMmIHLly/D3t6+zHasra3L3U9+fj7OnTvHm1bB1NQUnp6eOHHiBCZOnKi0OoQQQkooNFy1ffv2GDNmDNdBGBUVhZcvX2L06NFwd3dHUlISvL29y73LVRYJCQkoKiqSmJHTysoKz549U2odafLz85Gdnc17EELI506hxBASEoKVK1fyOm51dXWxatUqhISEQENDAz/99BOioqI+Kbi8vDyu7Q/p6upyrymrjjSBgYEwMDDgHhXN80MIIZ8DhRJDeno6N0XChzIzM7m5krS1tWXu1C1LaR/FxxP1ZWRkwNDQUKl1pJk3bx6ysrK4R2JioqKHQgghtYZCiaFv377w9/fH5cuXkZubi9zcXFy+fBn+/v7czUihoaGfPDOmhYUFDA0NJe6LuHfvHpycnJRaRxoNDQ3o6+vzHoQQ8rlTKDFs374d1tbW6NatG3R0dKCjo4Nu3bqhadOm2LZtGwBAT08Pq1ev/qTgBAIBRo4cieDgYO76/pUrVxAVFYWAgACl1qlMAgE96sqDkM/BJ93HkJSUhIcPH0IgEMDOzg7m5uZybR8REYHNmzdDJBLh+PHj6N69O+rVq4chQ4Zws2m+ffsWffr0QVJSElq0aIFr165h6tSpWLFiBdeOsupURNHhqvSFUXdU6+2iNFy17qiJ9zEoS3x8PG7cuCFR3rJlS94UHGKxGJGRkdwdy7a2thLbKKtOeSgxkIpQYiBVoiYmhvJucAOApUuXyttkrUCJgVSEEgOpEjXxBrcP5+EHSn6JP3v2DMnJyejUqZMiTRJCCKkhFEoMFy9elCgTi8WYOXOmxL0ChBBCaheFRiVJbUhFBQsWLMDevXuV1SQhhJBqoLTEAJSsB/zxTWSEEEJqF4UuJe3evVuiLDMzE0FBQbwFXQghhNQ+CiWGb7/9VqLMyMgI7u7uWLZs2ScHRQghpPoolBhev36t7DgIIYTUEErtYyCEEFL7KXTGAJTMVLpt2zY8ePAAjDG0aNECEyZMgLGxsTLjI4QQUsUUOmOIjo6GjY0NNm3ahKysLOTk5GDTpk2wtbVFdHS0smMkhBBShRQ6Y5g1axYCAgKwbt06qKqWNFFUVISZM2di9uzZuHTpklKDJIQQUnUUmitJU1MTycnJMDEx4ZWnp6fD3Ny83FXRajOaK4lUhOZKIlWikudKUuhSkq6uLl69eiVR/urVK5oSgxBCajmFEoOfnx9GjBiBs2fPIjs7G9nZ2QgPD8eIESPg5+en7BgJIYRUIYX6GNasWYMpU6bAy8sLpVeiBAIBAgICsHbtWqUGSAghpGp90kI9L1++xIMHDyAQCGBvb49GjRopM7Yah/oYSEWoj4FUiZq4HoOWlhZEIhEaNWr02ScDQgipaxTqY9DT00N6erqyYyGEEFIDKJQYxo4dix9//BGFhYXKjocQQkg1U3hpz2vXrmH//v1o1qwZ1NXVea9LW+GNEEJI7aBQYujevTu6d++u7FgIIYTUAAolhqVLlyo7DkIIITUETbtNCCGER6EzhtTUVPzwww+4evWq1DWeaSEfQgipvRRKDOPHj0dCQgImT54MIyMjZcdECCGkGimUGC5evIi4uDhYWloqOx5CCCHVTKE+BhMTE5pFlRBCPlMKJYaRI0ciMDAQYrFY2fEQQgipZjJfSvLw8OD+XVhYyN3g1rRpUwg+miWObnAjhJDaS+bE0KVLF95zusGNEEI+TzInBrqpjRBC6ga5+hjatGlTSWEQQgipKeRKDHfv3q2sOAghhNQQCt3HUJW2bduGM2fO8MosLS0llhB9+PAhtm/fjpSUFDg5OWHq1KkSQ2plqUMIIXWd3Inhzp07FdZR5iWnW7duITk5GbNnz+bKDAwMJOq4u7tj2LBhcHd3R1BQEPbv34/IyEhoaGjIXIcQQoicaz5/PCy1LJ+wjLSESZMmIT09HSEhIWXW6d27N1RVVXHixAkAQEZGBiwsLLB27VpMmjRJ5joVoTWfSUVozWdSJWrams/R0dFyB/Sp4uLiMHr0aBgYGHC/+kvl5+fj/Pnz2LZtG1dmYmKCHj164OTJk5g0aZJMdQghhJSQOzG0b9++MuIok6qqKjp27Ihu3bohOTkZU6ZMwb59+3D06FEAQEJCAoqKiiTmbbK0tERERITMdaTJz89Hfn4+9zw7O1tZh0UIITVWje98/umnn3gzuPbv3x/Ozs7466+/MHDgQO6LW1tbm7edrq4u8vLyAECmOtIEBgbixx9/VMpxEEJIbSHXcFVHR8fKiqNMH0/r3bZtW1hZWXGXtEo7ojMzM3n1MjIyYGhoKHMdaebNm4esrCzukZiY+CmHQgghtYJciSEuLq6y4pAZYww5OTkQCoUAAHNzcxgZGSE2NpZXLzY2Fq1atZK5jjQaGhrQ19fnPQgh5HNXo5f2LCwsxJ49e3hla9aswZs3b+Dj4wOgZKTUqFGjEBwcjLdv3wIAIiIiEB0djYCAAJnrEEIIKVGj+xiEQiHOnj2LBQsWwM7ODomJiXj16hWCg4N5neDLli3DrVu34ODgAAcHB9y4cQP//e9/4enpKVcdQgghct7HUF1evXqF2NhYGBkZwdHRETo6OhJ1GGOIjo5GSkoKWrZsCWtra4XqlIfuYyAVofsYSJWoafcxfCwtLQ1mZmaf2ky5GjZsiIYNG5ZbRyAQoEOHDp9chxBC6jqF+hjy8vIwY8YM6Ovro169elz52LFj8c8//ygtOEIIIVVPocSwePFiXLlyRWKaCh8fHxr3TwghtZxCl5L27duH06dPw97enlfu7u6Or776SimBEUIIqR4KnTG8fv0aFhYWAPgT6xUXF6OgoEA5kRFCCKkWCiUGR0dHXLx4EQA/MQQHB6Ndu3ZKCYwQQkj1UOhS0sKFC/HFF19g1qxZAEoSwqlTp3DkyBFuWmtCCCG1k0KJwdfXF+rq6li2bBnU1NQwefJktG3bFqGhoejTp4+yYySEEFKFFL6PoV+/fujXr58yYyGEEFID1Oi5kgghhFQ9mc8YWrZsKXOjNWEWVkIIIYqROTF8uPzl8+fPsW7dOvj4+MDFxQVAyZKfoaGhXIc0IYSQ2knmxPDNN99w/+7Xrx+2b98ucTNbcHAwjhw5orzoCCGEVDmF+hiuX7+OIUOGSJQPHToU169f/+SgCCGEVB+FEoO6ujoiIiIkyi9evAh1dfVPDooQQkj1UWi46syZM+Hv748JEybAxcUFjDHExMRg27ZtWLhwobJjJIQQUoUUSgzff/89mjRpgnXr1iEoKAgA4ODggODgYAwfPlypARJCCKlaCt/gNmLECIwYMUKZsRBCCKkB6AY3QgghPAonhqNHj8LV1RUGBgYwMDCAq6srjh49qszYCCGEVAOFEsPWrVvh7++PNm3a4JdffsGGDRvQpk0b+Pv7Y+vWrcqOkRBCSBUSMMaYvBvZ2tri559/xrBhw3jlBw4cwA8//IAnT54oLcCaJDs7GwYGBsjKyoK+vr7M232wZAX5zMn/v0mJ9tIHrc4YKf8HTZ7vL4XOGF68eCF1eu2+ffsiISFBkSYJIYTUEAolBisrK5w5c0ai/NSpU7C0tPzkoAghhFQfhYarfvvttxg9ejQuXryIDh06AABu3LiBHTt2YP369cqMjxBCSBVTKDFMmjQJ9erVw8qVK/HHH38AAFq0aIE9e/Zg8ODBSg2QEEJI1VL4BrfBgwdTEiCEkM+QwvcxvH//XqYyQgghtYtCiWHHjh2YNm2aRPk333yDXbt2fXJQhBBCqo9C9zE0a9YMp06dgo2NDa/8yZMn8PHxwYMHD5QWYE1C9zGQitB9DKRK1MT7GBITE2FkZCRRbmRkhOfPnyvSJCGEkBpCocTQsmVL7N27V6J8z549cHBw+OSgCCGEVB+FRiXNnz8fw4YNw61bt9C1a1cwxnDp0iXs3r0bhw4dUnaMhBBCqpBCicHX1xchISFYtmwZdu/eDQBo27Ytjhw5Ah8fH6UGSAghpGopfB/DgAEDMGDAAGXGUunu37+Pbdu2ISUlBU5OTpg2bZpcnciEEFIXfPJCPWlpacqIo9LFxMTAxcUF79+/R69evXD8+HF06dIFeXl51R0aIYTUKAolhry8PMyYMQP6+vqoV68eVz527Fj8888/SgtOmebNm4cePXogKCgI48aNw6lTp/D06VPs2LGjukMjhJAaRaHEsHjxYly5cgUhISG8ch8fH/z4449KCUyZ8vLycOHCBfj5+XFlRkZG6NGjB8LCwqoxMkIIqXkU6mPYt28fTp8+DXt7e165u7s7vvrqK6UEpkyJiYkoLi6GhYUFr9zCwgIRERFlbpefn4/8/HzueVZWFoCSG0UIkaZaPxq51bhvUrUU+KCVfm/Jck+zQonh9evX3Jes4IPbeouLi1FQUKBIk5Wq9MtdW1ubV66rq1tuH0NgYKDUM6CPEwwhpQwMqjsCUid8rfgHLScnBwYVfFAVSgyOjo64ePEivL29eYkhODgY7dq1U6TJSlX6JmRmZvLKMzIypN7BXWrevHmYNWsW91wsFuPNmzcwMTHhHTeRlJ2dDQsLCyQmJtLIL1Jp6HMmO8YYcnJy0KhRowrrKpQYFi5ciC+++IL70gwODsapU6dw5MgRnDhxQpEmK5W5uTmMjY1x9+5d9OvXjyu/c+cOWrduXeZ2Ghoa0NDQ4JUZGhpWVpifJX19ffoPSyodfc5kU9GZQimFOp99fX2xe/duhIWFQU1NDZMnT0ZCQgJCQ0OlrgVd3QQCAQICAhAcHMydNZw/fx43b97EF198Uc3REUJIzaLQ7Kq1UU5ODvr3748HDx7A3t4eMTExmDNnTo0cRfU5UHQmWkLkQZ+zyqHwnc95eXl4+fIlBAIBGjVqJHHJpabR09PDxYsXcfv2baSkpKBly5bUiVyJNDQ0sGjRohr/uSC1G33OKofcZwzx8fGYNWsWTp48yY1A0tDQgLe3N9auXQsrK6tKCZQQQkjVkCsxZGRkoFWrVtDT08PYsWNhZ2cHAHj48CF27NgBkUiE2NjYckf6EEIIqdnkSgwLFizAhQsXcPbsWWhqavJeE4lE8PT0RO/evbF48WJlx0kIIaSKyDUqKSwsDAsXLpRICgCgpaWFxYsX4+TJk0oLjtQcr1+/xs2bN8utk5ycjDt37lRNQISQSiNXYnj8+DE6duxY5usdO3bE48ePPzkoUnmioqKQlJTEK8vMzMSVK1eQkZHBK09OTsb169cBAMeOHcPw4cO51169eoVbt27x6u/btw9jxoypnMA/Im3/hBDlkCsxVHQrtYGBAc0jVMPNnTsX8+bN45UFBwfD3d0dW7Zs4ZUvWrQI//nPfwAADRs2RPv27bnXDh8+jJEjR1Z+wGWo7v2TuunkyZNwc3Or7jAqnVyJoaLuCIFAALFY/EkBkcrVvXt3XLhwgVd24cIFdOjQQWp59+7dAZScDc6ZMwcAkJ6ejmfPnkEkEuHKlSu4cuUKXr58yds2JSUFd+/ehUgkkhpHamqq1LMXAHjx4gXi4uIk6kdHR8u8fyKb6dOnw97eHvb29mjVqhX69euH33//vcL/x7du3YK9vT0SEhK4sqKiIkyYMAHu7u74888/0aJFC6SmpkrdfsyYMZg6dapSj6UqZGdnK+WqyLlz5+Ds7KyEiCoJkwMApqGhUe5DziZJFYuIiGAA2OPHjxljjBUVFTF9fX124sQJpqWlxfLz8xljjCUkJDAALCwsjDHG2ObNm5mNjQ1jjLGzZ8+ypk2bMi0tLda5c2fWuXNndvDgQbZq1SpmbW3N+vbty5o1a8aaNm3KzMzM2PXr17n9FxcXs4kTJzJNTU3m5OTEtLW12aBBg9j79++5Ot999x3r0aMHL+6dO3eyxo0bl7t/Ij8/Pz/m4eHBHjx4wGJjY9lvv/3G1NTU2OrVq8vd7vLly7zPUW5uLuvfvz+zsLBgDx48YLm5uczAwEBqO4mJiUxFRaVW/s327dvHTExMPrmdo0ePMh0dHSVEVDnk+hbfvHmzTA9Sc+Xn5zMtLS22bds2xhhjN27cYKampkwsFrMmTZqwS5cuMcYY27VrF1NTU2Pv3r1jjPETA2OMbdy4kdnZ2fHaXrVqFQPAtm/fzhhjTCwWs1GjRrGuXbtydbZv384MDAzY/fv3GWMlXxKWlpZs/vz5XJ2KEkNZ+yfy8/PzY97e3ryykSNHsjZt2pS73YeJ4e3bt6xLly7MwcGBJSYmcnUmTZrEWrRoIbHtTz/9xExNTbkfIdLcu3ePjRgxgrVq1Yp5enqyP//8k/f6iRMnmKurKzt37hwbNGgQc3Z2ZuPGjWOpqam8eklJSWzKlCmsbdu2zMPDgy1fvpwVFBSUe2wikYgtWrSIde7cmXXq1InNnz+f++FSmhgq2m958d+8eZM1btyYCQQCZmdnx+zs7NiKFSvKjamq0c/7Oqhnz57M39+fMcbY8uXLmZ+fH2OMsS+//JL9+OOPjDHGxowZwzp16sRtI2tiaNiwIa/swIEDzMjIiHvu5ubG/vOf//DqrF69mjVq1Ih7Tomh6khLDJMnT2ZWVlblbleaGC5fvsxat27NOnTowNLT03l1YmJiGADeGaNYLGY2NjZs5syZZbadnJzM9PT02Pjx49n169fZ1q1bmba2NveDg7GSL2gVFRXWoUMHdubMGXblyhXm4uLCO5bXr1+zxo0bs+nTp7PIyEh29uxZ5uLiwr744otyj23WrFmsVatWLDw8nN24cYMFBgay7777Tub9VhR/bm4u+/XXX5m2tjZ78OABe/DggURiqW4KT4lBaq/u3btj48aNAEr6Efr37w8A6NatG/744w8sXLgQFy5cUGiCwQ+XegVK1sDIzf3fCjLPnj2TaNfBwQEvX76ESCSClpaW3PskypOQkIC//voLffv2lam+r68v7O3tcerUKejq6vJec3Z2Rps2bbBjxw64uroCAC5evIinT59i3LhxZba5cuVKWFtbY/v27QAAV1dXpKSkYMGCBRg/fjxXTywW4+DBg9xsC4sXL4avry+Ki4shFAqxevVqODk5Yf369dw2u3fvhp2dHVauXIkGDRpI3f/NmzcxbNgw9OzZEwDQoUMHFBUVybzfiuLX0tJC48aNIRAIJBY7qykUml2V1G7du3fH69evERcXh6tXr8LDwwNASWK4fv06Hjx4gBcvXnAdz8qkr6+Pd+/e8cpycnKgqanJ3R8jEAgkBjrUxAWgPhcXL16Evb09bGxsYGNjAxcXF/zyyy8ybdusWTP8888/+Pfff6W+Pm7cOOzfv5/7cRAcHAxXV1c4OjqW2ebt27fh6enJK+vVqxdev36N169fc2UGBga8KXgaNWqEwsJCvH37FgBw+fJlxMTEoGXLlnB0dESLFi0wcOBAACi3A7l///5YvXo15s+fj0uXLqGwsBCqqv/7DV3RfmWNvyajxFAHubi4QFdXFytXroSmpib3n7Rp06YwMzNDYGAgNDU10alTpzLb0NLSQmFhoUL7PnXqFK8sLCwMzs7O3OJHDRo0QGJiIq9OVFSUUvZPJLm4uODYsWM4fPgwZs2ahfPnz/O+6N3c3LiRS6NGjeJtu3PnTvTq1Qs9e/aU+BsBQEBAAAoLC3Ho0CG8ffsWR44c4f3ql0bamWPp8w/PPj/8sv5Q6Y8KkUiEAQMGICQkBIcPH8aRI0dw9OhRPHjwgBsRJO3Yvv32Wxw5cgRZWVmYNGkSGjRogIMHD8q1X1nir8noUlIdpKqqii5dumDv3r3w9fXlrUbXrVs37N27F127dpV6h3spJycnvHjxArt370aTJk3QtGlTmfa9aNEitGvXDhMnToSvry8iIiKwd+9enD17lqvTv39/zJkzB3PnzkXPnj0RERGBgwcP8qZVlrZ/WVamIpJ0dHS4Sxpt2rRBfHw8xo4di9u3b0NFRQV//vkndynl4+VxVVVVsXfvXowePRq9evXC6dOnuctGQMnCVoMHD8aOHTvw/v17CIVC3o2S0tja2uLevXu8stjYWKirq8PS0lLm47Kzs8PDhw/LvVxT1rF1796dO2P+6aef8M0332DYsGEy7VeW+IVCoUxrL1cXOmOoo0aMGAFXV1cMGTKEVz5o0CC4urrC39+fV/7xDW4dOnTApk2bcPDgQcybNw9Xr16Fubk52rZty9vO2NgYnTt35p43b94cN27cQHFxMVatWoWkpCRcvHgRXbt25erY2Njg7NmzSEhIwMaNG6Gjo4Ndu3ahQ4cO5e6fKMeKFSvw8OFD7Nq1C0DJF13pr2ppX8xCoRB//vknfH194eXlJfG3GD9+PC5duoRVq1Zh+PDhEn0RH5s8eTLCwsIQFhYGoOQu92XLluHrr78u89e6NNOnT8eNGzewYsUK7r6Mly9f8pbrlXZs8+fPx6NHjwCUnAXk5ubKtdaDLPE3bNgQubm5SElJkbndKlWtXd+EkGolbVQSY4zNmDGDmZubM5FIJHW7j+9jYKzkHpWvvvqK6erqcsOeGfvfSCQA7Nq1azLF9csvvzB9fX3WoEEDpq6uzvz8/Fh2djb3urT7CW7fvs0AsLS0NK7s6NGjrGnTpkxHR4c1aNCAWVhYsC1btpS775CQEGZnZ8fq1avHTE1NWfPmzdmVK1fk2m9F8YvFYtavXz+mp6dXI4er1pkV3Aghkl6+fAmxWAxzc3NeuUgkwosXL2BlZSV1pFjp6zY2NlBTU+PKGWN49OgRNDU1eR20r169QnZ2NjdVvywKCgqQlJQEY2NjibXWc3JykJKSAltbW64sPz8f8fHxaNasGYRCocRxCoVC1K9fX+b9p6amQiAQwMzMTKH9lhd/qTdv3iAtLQ3Gxsa8/VQ3SgyEEEJ4qI+BEEIIDyUGQgghPJQYCCGE8FBiIIQQwkOJgRBSbaZOnVqt96D8/vvvWLduXbXtv6aiUUmEkGoRGhqKOXPm4P79+7xhnjExMThw4AAePXoENTU1NG3aFL6+vrwpWg4dOoStW7cCKLnBrmHDhujVqxf8/f2hoqKCtWvX4vnz59iwYQNvn0+fPsXEiRPx22+/oXnz5nj9+jUcHBwQExMDGxubqjnwWoDOGAgh1eLnn3/GlClTeElhzpw56Nq1KwoLCzF69GgEBASgfv36mDdvHm9J2hcvXiA6Ohrff/89Zs+eDScnJ0yePJlbivaff/6ROndTTk4Ozp07xy1B3KBBA/Tr14/OGj5CcyURQqrcP//8g8jISBw9epQr+/PPP7F69WqcPXsWPXr04NWfPXs2MjIyeGVqamrc1NheXl4oKCjAwoULsXbtWrliGTZsGEaPHo3169fLNeXG54zOGAghVe78+fNo0qQJb02EDRs2oHfv3hJJoZSJiUm5bVpYWKCoqIib/lpWnTp1QnZ2ttQzjLqKEgMhpMo9efKENyEfYwx37txBu3btFGqvsLAQBw4cgKWlpcRiURUxMzODpqYmnjx5otC+P0d03kQIqXIikYg3rXthYSGKiook5hSaPXs27t69C6CkP2D37t3ca9nZ2ejZsyfEYjEePXoEoVDIe10eWlpatWathKpAiYEQUuXMzMxw8+ZN7rm6ujpMTEzw/PlzXr2RI0eib9+++OOPP3Dp0iXea1paWvj++++hoqKCBg0aoFmzZtyEfurq6lJX/cvPzwcAaGhocGXFxcXIysqS+0zjc0aXkgghVa59+/Z48OABby1lb29vHD9+HCKRiCtzdnZGz549pS4EVdr57OnpiRYtWvBmeW3atCkSEhK4dRhKlSYea2trriwuLg5isZi33kddR4mBEFLlPD09oaKigmvXrnFlixcvRm5uLgICApCens6rL2+Hsq+vL969e4dNmzZxZdnZ2fjll1/g7e3NWyzo3LlzaNeuncTU43UZJQZCSJXT19fHmDFjsHPnTq7M2toaV69eRWZmJszNzeHo6Ah3d3dYWlri9OnTWLhwoczt29raYvfu3Vi2bBmaNWsGNzc3WFlZQU9Pj7sxrtSuXbvwzTffKO3YPgd05zMhpFqkpqbC0dERUVFRvEs7AJCWlobHjx9DVVUVVlZWEgvsJCQk4Pnz57wlYaUpLCzEs2fP8ObNG1hbW/OGxwIld1//8MMPuH37tsTiPnUZJQZCSLWJi4uDvr6+1LWkq8L9+/ehq6vLW22OUGIghBDyEepjIIQQwkOJgRBCCA8lBkIIITyUGAghhPBQYiCEEMJDiYEQQggPJQZCCCE8lBgIIYTwUGIghBDCQ4mBEEIIDyUGQgghPJQYCCGE8PwfGxWWjf9OG7MAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 400x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "labels = [\"Without\", \"R-KV one-shot\\n(GPU)\"]\n",
+    "data = [\n",
+    "    before_drop_data[\"metrics\"][\"results\"][\"output_tput\"],\n",
+    "    oneshot_drop_data[\"metrics\"][\"results\"][\"output_tput\"],\n",
+    "]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(4, 3))\n",
+    "bars = ax.bar(labels, data, color=[\"blue\", \"orange\"])\n",
+    "ax.bar_label(bars, fmt=\"%.1f\", padding=3)\n",
+    "ax.set_ylabel(\"Decode Throughput (tokens/s)\")\n",
+    "ax.set_title(\"Token Dropping Benefit\\nfor Decode Throughput\")\n",
+    "ax.margins(y=0.15)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14bc7c6e",
+   "metadata": {},
+   "source": [
+    "## Reading these numbers\n",
+    "\n",
+    "All four notebooks were run back to back on one machine against the same vLLM\n",
+    "and LMCache servers, and each re-measures its own no-drop baseline. That gives\n",
+    "four independent measurements of an **identical** configuration — a direct read\n",
+    "on how much of any difference is real:\n",
+    "\n",
+    "| | one-shot | gpu_exact | cpu_exact | buffered_cpu |\n",
+    "|---|---|---|---|---|\n",
+    "| baseline decode | 969 tok/s | 1008 tok/s | 1002 tok/s | 975 tok/s |\n",
+    "| baseline accuracy | 10/30 | 10/30 | 11/30 | 11/30 |\n",
+    "| decode after dropping | 1766 tok/s | 1774 tok/s | 1785 tok/s | 1774 tok/s |\n",
+    "| accuracy after dropping | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "\n",
+    "Three things follow.\n",
+    "\n",
+    "1. **Decode throughput after dropping is the solid number.** It lands in\n",
+    "   1766–1785 tok/s — a 1.1% spread — although the four notebooks compress with\n",
+    "   completely different code. That is the claim this example makes: the speed-up\n",
+    "   comes from halving the KV cache, not from how the halving is computed.\n",
+    "\n",
+    "2. **Don't quote a speed-up ratio.** The no-drop baseline swung 969–1008 tok/s\n",
+    "   here, and 894–1076 tok/s — **20%** — over an earlier sweep of the same four\n",
+    "   notebooks, so the ratio moves between 1.6x and 2.0x on noise alone. Compare\n",
+    "   the absolute post-drop throughput instead.\n",
+    "\n",
+    "3. **Don't rank the variants by accuracy.** R-KV beat the same-run baseline in\n",
+    "   all four runs (+3 to +4 of 30), which is the meaningful result. But the 1/30\n",
+    "   spread *between* variants is the same size as the baseline's own spread, so\n",
+    "   it says nothing about the algorithms.\n",
+    "\n",
+    "### Why identical inputs give different text\n",
+    "\n",
+    "Decoding is greedy — `temperature = 0.0` for both prefill and decode — yet the\n",
+    "generated text still differs between runs. `temperature = 0` fixes the *rule*\n",
+    "(take the argmax); it does not make the argmax stable.\n",
+    "\n",
+    "Prefill is submitted one stream at a time (`prefill_group_size = 1`) and it\n",
+    "**is** reproducible: 15.19 s and 15.21 s, to the same hundredth of a second, in\n",
+    "every notebook. Decode is not. `batch.decode` hands all 30 streams to vLLM at\n",
+    "once, so continuous batching gives the decode batch a different composition on\n",
+    "every run. GPU reductions are not batch-invariant, logits move by ~1e-6,\n",
+    "near-ties flip, and autoregression amplifies the divergence.\n",
+    "\n",
+    "This is a property of the serving stack, not of token dropping — but it is the\n",
+    "reason a single accuracy number here should not be read as a ranking.\n",
+    "\n",
+    "### The exact variants pick the same tokens — their caches still differ\n",
+    "\n",
+    "Verified directly on real requests: `cpu_exact` and `gpu_exact` produce score\n",
+    "vectors that differ by ~1e-6, but the top-k they select was identical on every\n",
+    "request tested, and so were the kept token ids. Their compacted caches are\n",
+    "nevertheless not byte-identical:\n",
+    "\n",
+    "| | differing elements | largest difference |\n",
+    "|---|---|---|\n",
+    "| V — a pure gather | **0** | 0 |\n",
+    "| K — goes through the RoPE re-rotation | 0.004% | one to two bfloat16 ULP |\n",
+    "\n",
+    "Every difference is in K, and it is the *device*: `cpu_exact` re-rotates on the\n",
+    "CPU, `gpu_exact` on the GPU, and their sin/cos implementations and fused\n",
+    "multiply-adds round differently before the result is stored back as bfloat16.\n",
+    "Feeding one identical tensor to `rerotate_k_cache` on each device reproduces the\n",
+    "same signature exactly, so nothing else is involved.\n",
+    "\n",
+    "One ULP in K is enough to move an attention logit, flip a near-tied greedy\n",
+    "argmax, and diverge from there. That is why two implementations which provably\n",
+    "select the same tokens still generate different text, and can land on a\n",
+    "different answer for one or two of the 30 questions.\n",
+    "\n",
+    "#### Why the re-rotation runs in fp32\n",
+    "\n",
+    "`utils.rerotate_k_cache` detaches one RoPE and attaches another: six multiplies\n",
+    "and two adds per element. Carrying that out in the cache's own bfloat16 rounds\n",
+    "at every step. Measured on keys with a standard deviation of 3:\n",
+    "\n",
+    "| arithmetic | keys changed vs fp32 | rotate-away-and-back error | re-rotate 30 requests |\n",
+    "|---|---|---|---|\n",
+    "| bfloat16 | 50% | 2.5e-1 | 3.2 s |\n",
+    "| **fp32** (used here) | — | **6.3e-2** | 6.1 s |\n",
+    "\n",
+    "fp32 costs 1.9x on the re-rotation step itself, because it moves twice the\n",
+    "bytes. End to end that is much less than it sounds: compressing the 30 requests\n",
+    "went from 41.4 to 41.6 s (one-shot), 37.3 to 37.5 s (`gpu_exact`) and 67.1 to\n",
+    "67.3 s (`cpu_exact`) — around +0.2 s, because `modify` spends most of its time\n",
+    "waiting on LMCache and the extra arithmetic fits in that slack. Only\n",
+    "`buffered_cpu` shows it, 27.9 to 29.9 s (+7%), because its compression is the\n",
+    "shortest so the re-rotation is the largest share of it. That buys a 4x better\n",
+    "round trip and takes an extra ULP of error off half the keys, so it is the\n",
+    "default. It does **not** remove the CPU/GPU split above: that is\n",
+    "the final rounding back to bfloat16, which is there whatever precision the\n",
+    "rotation is computed in.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03cca85b",
+   "metadata": {},
+   "source": [
+    "## Close both contexts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f83db925",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:02:24.510513Z",
+     "iopub.status.busy": "2026-08-01T06:02:24.510384Z",
+     "iopub.status.idle": "2026-08-01T06:02:24.512987Z",
+     "shell.execute_reply": "2026-08-01T06:02:24.512495Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Only close the context when done.\n",
+    "ctx.close()\n",
+    "qctx.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "defaultInterpreterPath: 3.12.3.final.0",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/token_dropping/rkv_variants/rkv_variant_buffered_cpu.ipynb
+++ b/examples/token_dropping/rkv_variants/rkv_variant_buffered_cpu.ipynb
@@ -1,0 +1,1559 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# R-KV Token Dropping — Route B, buffered / chunked, on the CPU\n",
+    "---\n",
+    "\n",
+    "Long prompts create large KV caches. They eat GPU memory, limit how many requests\n",
+    "fit in a batch, and a smaller batch means lower decode throughput. *Token\n",
+    "dropping* shrinks each request's KV cache — by half in this notebook — so more\n",
+    "requests fit and decoding runs faster.\n",
+    "\n",
+    "This notebook uses the LMCache SDK to pull a request's KV cache out after\n",
+    "prefill, compress it, and put it back before decode. The compression algorithm\n",
+    "is **R-KV**: it ranks past tokens by **attention importance**, like SnapKV, and\n",
+    "subtracts a second term, **redundancy** — how similar a token's key is to the\n",
+    "*other* keys:\n",
+    "\n",
+    "$$\\text{score}(j) \\;=\\; \\lambda \\cdot \\underbrace{\\text{importance}(j)}_{\\text{attended to?}} \\;-\\; (1-\\lambda) \\cdot \\underbrace{\\text{redundancy}(j)}_{\\text{says something new?}}$$\n",
+    "\n",
+    "Keeping tokens that are both attended-to **and** non-redundant works especially\n",
+    "well on the repetitive output of reasoning models. The catch is that the\n",
+    "redundancy term compares **all pairs of keys**: $O(n^2 d)$ per layer, against\n",
+    "$O(w n d)$ for SnapKV's importance term. At $n = 16128$ with window $w = 64$\n",
+    "that is ~250x more arithmetic per layer, and a literal implementation also\n",
+    "materializes an $n \\times n$ matrix per layer.\n",
+    "\n",
+    "## This notebook\n",
+    "\n",
+    "It takes the other branch, **route B**: keys are compared only inside a chunk,\n",
+    "which makes the similarity matrix block-diagonal and the redundancy term\n",
+    "$O(n c d)$. This is the approach the R-KV serving ports take. It is an\n",
+    "**approximation** — ~96% kept-token agreement with the exact route — and it is\n",
+    "the quickest CPU option, included so the trade-off is on the table.\n",
+    "\n",
+    "It is one of four independent notebooks that keep the same 50% of the tokens and\n",
+    "therefore deliver the **same decode speed-up** — 1766–1785 tok/s, a 1.1% spread, even\n",
+    "though they compress with completely different code. What separates them is the **cost of\n",
+    "compressing**:\n",
+    "\n",
+    "| | [one-shot](../rkv_token_dropping.ipynb) | [cpu_exact](./rkv_variant_cpu_exact.ipynb) | [gpu_exact](./rkv_variant_gpu_exact.ipynb) | [buffered_cpu](./rkv_variant_buffered_cpu.ipynb) |\n",
+    "|---|---|---|---|---|\n",
+    "| Formulation | route A, literal | route A, linear | route A, linear | route B, chunked |\n",
+    "| Exact? | yes (the reference) | yes, rel. err ~2e-6 | yes, rel. err ~5e-7 | **no**, ~96% agreement |\n",
+    "| Redundancy cost | $O(n^2 d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ |\n",
+    "| VRAM | ~9.8 GiB | none | **1.55 GiB** | none |\n",
+    "| Compress 30 requests | 41.6 s | 67.3 s | **37.5 s** | **29.9 s** |\n",
+    "| Decode throughput | 1766 tok/s | 1785 tok/s | 1774 tok/s | 1774 tok/s |\n",
+    "| Accuracy (baseline 10–11/30) | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "\n",
+    "\n",
+    "Start with the [one-shot notebook](../rkv_token_dropping.ipynb): it is R-KV\n",
+    "written the way the paper describes it, and it is the reference the exact\n",
+    "variants here are checked against.\n",
+    "\n",
+    "Numbers above were measured on 30 LongBench-v2 prompts (~16k tokens each) with\n",
+    "Qwen3-8B on one H200 and a 96-core Xeon. They are hardware- and\n",
+    "workload-dependent; treat them as reference measurements, not guarantees.\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "* A small ~10-line modification to vLLM exposes intermediate tensors to LMCache.\n",
+    "  See [README.md](../README.md).\n",
+    "* A GPU is required for serving. To see token dropping increase the decode batch\n",
+    "  size, tune the GPU memory utilization together with the number of requests.\n",
+    "* Data moves between the LMCache server and the SDK through shared memory; if it\n",
+    "  is unavailable the SDK falls back to pickle.\n",
+    "* Run this notebook from its own directory; it imports `../utils.py`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cd06b97",
+   "metadata": {},
+   "source": [
+    "## Setup vLLM and LMCache server\n",
+    "Follow below instructions (1-4), then proceed to below Python cell.\n",
+    "\n",
+    "**1. Start LMCache server first**\n",
+    "\n",
+    "To use shared memory, specify the `--shm-name` and `--no-l1-use-lazy`\n",
+    "\n",
+    "```sh\n",
+    "lmcache server \\\n",
+    "    --l1-size-gb 400 \\\n",
+    "    --eviction-policy LRU \\\n",
+    "    --chunk-size 256 \\\n",
+    "    --port 6555 \\\n",
+    "    --http-port 8080 \\\n",
+    "    --shm-name lmcache_sdk \\\n",
+    "    --no-l1-use-lazy \\\n",
+    "    --enable transfer_query\n",
+    "```\n",
+    "\n",
+    "**2. Wait until LMCache server is ready**\n",
+    "\n",
+    "```sh\n",
+    "curl -sf http://localhost:8080/healthcheck && echo \" LMCache ready\"\n",
+    "```\n",
+    "\n",
+    "**3. Start vLLM once LMCache server is ready**\n",
+    "\n",
+    "We pass --no-enable-prefix-caching to disable vLLM's built-in prefix caching. \n",
+    "This ensures the prefilled KV cache is always served from LMCache rather than \n",
+    "vLLM, so the decoding throughput improvement can be attributed entirely to the \n",
+    "tokens dropped through LMCache.\n",
+    "\n",
+    "```sh\n",
+    "LMCACHE_TRANSFER_INTERMEDIATE_TENSORS=true \\\n",
+    "vllm serve Qwen/Qwen3-8B \\\n",
+    "    --port 8000 \\\n",
+    "    --served-model-name Qwen/Qwen3-8B \\\n",
+    "    --no-enable-prefix-caching \\\n",
+    "    --enforce-eager \\\n",
+    "    --gpu-memory-utilization 0.65 \\\n",
+    "    --kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":6555,\"lmcache.mp.transfer_intermediate_tensors\":true}}' \\\n",
+    "    --trust-remote-code \\\n",
+    "    --return-tokens-as-token-ids\n",
+    "```\n",
+    "\n",
+    "**4. Wait until vLLM is ready**\n",
+    "\n",
+    "```sh\n",
+    "curl -sf http://localhost:8000/v1/models && echo \" vLLM ready\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:19:02.781833Z",
+     "iopub.status.busy": "2026-08-01T06:19:02.781630Z",
+     "iopub.status.idle": "2026-08-01T06:19:09.643503Z",
+     "shell.execute_reply": "2026-08-01T06:19:09.642769Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:09,547] LMCache INFO:\u001b[0m torch_dev=<module 'torch.cuda' from '/home/sigma/github/LMCache/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py'>, torch_device_type=cuda \u001b[3m(_device_detect.py:143:lmcache.v1.platform._device_detect)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:09,634] LMCache INFO:\u001b[0m multi_layer_block_kv_transfer mode: ptr \u001b[3m(base.py:94:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " _     __  __    ____           _          \n",
+      "| |   |  \\/  |  / ___|__ _  ___| |__   ___      LMCache v0.5.3rc2.dev2 (g6018f8af)\n",
+      "| |   | |\\/| | | |   / _` |/ __| '_ \\ / _ \\     Website:  https://lmcache.ai/\n",
+      "| |___| |  | | | |__| (_| | (__| | | |  __/     Recipes:  https://docs.lmcache.ai/recipes\n",
+      "|_____|_|  |_|  \\____\\__,_|\\___|_| |_|\\___|     LinkedIn: https://www.linkedin.com/company/lmcache-lab\n",
+      "Set LMCACHE_DISABLE_BANNER=1 to hide this banner.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "\"\"\"End-to-end KV cache remapping driver for the SDK example.\"\"\"\n",
+    "\n",
+    "# Standard\n",
+    "from datasets import load_dataset\n",
+    "import math\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sys\n",
+    "from transformers import AutoTokenizer, AutoConfig\n",
+    "\n",
+    "# Third Party\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "\n",
+    "# First Party\n",
+    "from lmcache.logging import init_logger\n",
+    "import lmcache.sdk as lmc_sdk\n",
+    "from lmcache.banner import print_banner_once\n",
+    "\n",
+    "sys.path.append(\"..\")  # utils.py lives next to the main notebook\n",
+    "\n",
+    "from utils import (  # noqa: E402\n",
+    "    rerotate_k_cache,\n",
+    "    make_post_completion,\n",
+    "    score_answers,\n",
+    ")\n",
+    "\n",
+    "print_banner_once(sys.stdout)\n",
+    "logger = init_logger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5342c6c6",
+   "metadata": {},
+   "source": [
+    "## Setting up hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8f1065b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:19:09.649230Z",
+     "iopub.status.busy": "2026-08-01T06:19:09.649063Z",
+     "iopub.status.idle": "2026-08-01T06:19:09.651983Z",
+     "shell.execute_reply": "2026-08-01T06:19:09.651432Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_name = \"/data/models/Qwen3-8B\"\n",
+    "vllm_url = \"http://localhost:8000\"\n",
+    "lmcache_url = \"http://localhost:8080\"\n",
+    "lmcache_mq_url = \"tcp://localhost:6555\"\n",
+    "chunk_size = 256\n",
+    "max_tokens = 5120\n",
+    "temperature = 0.0  # greedy decode so generated answers are deterministic and scorable\n",
+    "timeout = 60  # timeout for context retrieval (seconds)\n",
+    "trust_remote_code = True\n",
+    "\n",
+    "# Streams prefilled per submission. LMCache's query ring buffer maps a forward\n",
+    "# step's query rows to ring slots positionally (qringbuffer.py\n",
+    "# build_q_step_state), assuming each request contributed exactly its store op's\n",
+    "# token count of rows. Continuous batching breaks that, so the captured queries\n",
+    "# are silently wrong or short. Measured query-row reproducibility across two\n",
+    "# identical runs: 100.0% at 1 stream, 99.7% at 4, 9.8% at 30. R-KV's importance\n",
+    "# term is entirely query-driven, so prefill is submitted one stream at a time.\n",
+    "prefill_group_size = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34eb19b4",
+   "metadata": {},
+   "source": [
+    "## Configuring the model and LMCache endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eac8beea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:19:09.656955Z",
+     "iopub.status.busy": "2026-08-01T06:19:09.656832Z",
+     "iopub.status.idle": "2026-08-01T06:20:09.659370Z",
+     "shell.execute_reply": "2026-08-01T06:20:09.658387Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:10,138] LMCache INFO:\u001b[0m Initialized LMCacheSDKContext with instance_id=2453739731939850693, model_name=/data/models/Qwen3-8B, chunk_size=256, shm_name=lmcache_l1_pool_lmcache_sdk, kind=LMCacheSDKCacheKind.KV \u001b[3m(context.py:122:lmcache.sdk.context)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:10,140] LMCache INFO:\u001b[0m Creating transfer context (device_type=cpu, mode=auto) \u001b[3m(worker_transfer.py:879:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:10,325] LMCache INFO:\u001b[0m Using AsyncEngineDrivenTransferContext for store path \u001b[3m(worker_transfer.py:105:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:10,331] LMCache INFO:\u001b[0m Engine KV Format: EngineKVFormat.NL_X_NB_TWO_NH_BS_HS NL x [NB, 2, NH, BS, HS] \u001b[3m(detection.py:69:lmcache.v1.gpu_connector.kv_format.detection)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:10,333] LMCache INFO:\u001b[0m Creating EngineDrivenContextShm (shm_name=lmcache_l1_pool_lmcache_sdk, pool_size=429496729600) \u001b[3m(base.py:235:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:10,450] LMCache INFO:\u001b[0m CudaPinMemoryBackend: using torch cudart \u001b[3m(pin_memory.py:89:lmcache.v1.platform.cuda.pin_memory)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:40,008] LMCache INFO:\u001b[0m SHM pinned=True for shm_name=lmcache_l1_pool_lmcache_sdk \u001b[3m(shm.py:118:lmcache.v1.multiprocess.transfer_context.shm)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:40,010] LMCache INFO:\u001b[0m Worker non-GPU transfer context registered (instance_id=2453739731939850693, mode=SHM) \u001b[3m(worker_transfer.py:745:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:40,016] LMCache INFO:\u001b[0m Initialized LMCacheSDKContext with instance_id=1669865050485988857, model_name=/data/models/Qwen3-8B##query, chunk_size=256, shm_name=lmcache_l1_pool_lmcache_sdk, kind=LMCacheSDKCacheKind.QUERY \u001b[3m(context.py:122:lmcache.sdk.context)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:40,017] LMCache INFO:\u001b[0m Creating transfer context (device_type=cpu, mode=auto) \u001b[3m(worker_transfer.py:879:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:40,018] LMCache INFO:\u001b[0m Using AsyncEngineDrivenTransferContext for store path \u001b[3m(worker_transfer.py:105:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:40,019] LMCache INFO:\u001b[0m Engine KV Format: EngineKVFormat.NL_X_NB_BS_HS NL x [NB, BS, HS] \u001b[3m(detection.py:69:lmcache.v1.gpu_connector.kv_format.detection)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:19:40,020] LMCache INFO:\u001b[0m Creating EngineDrivenContextShm (shm_name=lmcache_l1_pool_lmcache_sdk, pool_size=429496729600) \u001b[3m(base.py:235:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:20:09,654] LMCache INFO:\u001b[0m SHM pinned=True for shm_name=lmcache_l1_pool_lmcache_sdk \u001b[3m(shm.py:118:lmcache.v1.multiprocess.transfer_context.shm)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:20:09,656] LMCache INFO:\u001b[0m Worker non-GPU transfer context registered (instance_id=1669865050485988857, mode=SHM) \u001b[3m(worker_transfer.py:745:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(\n",
+    "    model_name, trust_remote_code=trust_remote_code\n",
+    ")\n",
+    "config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)\n",
+    "head_size = getattr(\n",
+    "    config, \"head_dim\", config.hidden_size // config.num_attention_heads\n",
+    ")\n",
+    "work_device = torch.device(\"cpu\")\n",
+    "post_completion = make_post_completion(vllm_url, model_name, timeout)\n",
+    "ctx = lmc_sdk.kvcache.connect(\n",
+    "    url=lmcache_mq_url,\n",
+    "    http_url=lmcache_url,\n",
+    "    model_name=model_name,\n",
+    "    timeout=timeout,\n",
+    ")\n",
+    "qctx = lmc_sdk.qcache.connect(\n",
+    "    url=lmcache_mq_url,\n",
+    "    http_url=lmcache_url,\n",
+    "    model_name=model_name,\n",
+    "    timeout=timeout,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2aaffa7",
+   "metadata": {},
+   "source": [
+    "## Constructing Prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "030145fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:20:09.665747Z",
+     "iopub.status.busy": "2026-08-01T06:20:09.665583Z",
+     "iopub.status.idle": "2026-08-01T06:21:31.818319Z",
+     "shell.execute_reply": "2026-08-01T06:21:31.817349Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 30 prompts from the dataset.\n",
+      "Total prompts length: 423428 tokens.\n",
+      "Mean prompt length: 14114.27 tokens.\n",
+      "Max prompt length: 16807 tokens.\n",
+      "Min prompt length: 10159 tokens.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompts = []\n",
+    "answers = []\n",
+    "ds = load_dataset(\"raniayu/token-dropping-demo\", split=\"train\")\n",
+    "for i, example in enumerate(ds):\n",
+    "    prompt = tokenizer.encode(ds[i][\"prompt\"], return_tensors=\"pt\").squeeze(0).tolist()\n",
+    "    prompts.append(prompt)\n",
+    "    answers.append(ds[i][\"answer\"])\n",
+    "\n",
+    "print(f\"Loaded {len(prompts)} prompts from the dataset.\")\n",
+    "print(f\"Total prompts length: {sum(len(p) for p in prompts)} tokens.\")\n",
+    "print(f\"Mean prompt length: {sum(len(p) for p in prompts) / len(prompts):.2f} tokens.\")\n",
+    "print(f\"Max prompt length: {max(len(p) for p in prompts)} tokens.\")\n",
+    "print(f\"Min prompt length: {min(len(p) for p in prompts)} tokens.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab00c77d",
+   "metadata": {},
+   "source": [
+    "## Baseline (without token dropping)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "eb3a2b00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:21:31.824385Z",
+     "iopub.status.busy": "2026-08-01T06:21:31.824233Z",
+     "iopub.status.idle": "2026-08-01T06:24:24.351265Z",
+     "shell.execute_reply": "2026-08-01T06:24:24.350509Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:21:46,997] LMCache INFO:\u001b[0m prefill: 15.16 s in groups of 1 \u001b[3m(420791162.py:24:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================= Batched Stream Metrics (decode) ========================\n",
+      "-------------------------------- Configuration ---------------------------------\n",
+      "Number of Request Streams:                                                    30\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                       157.35\n",
+      "Total Output Tokens:                                                      153365\n",
+      "Decode Throughput (tokens/s):                                             974.70\n",
+      "================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_ids = []\n",
+    "\n",
+    "batch = lmc_sdk.batch.LMCacheBatchedStream()\n",
+    "for i, prompt in enumerate(prompts):\n",
+    "    stream = lmc_sdk.request.create_request(\n",
+    "        contexts=[ctx, qctx],\n",
+    "        post_completion=post_completion,\n",
+    "        prompt_token_ids=prompt,\n",
+    "    )\n",
+    "    batch.add(stream)\n",
+    "    stream_ids.append(stream.request_stream_id)\n",
+    "\n",
+    "# temperature 0 here too: prefill emits one token that is APPENDED to the\n",
+    "# stream, so sampling it would make the whole greedy decode below depend on a\n",
+    "# random first token. Groups of `prefill_group_size` keep the query capture\n",
+    "# correct (see the hyperparameter cell).\n",
+    "prefill_seconds = 0.0\n",
+    "for g0 in range(0, len(stream_ids), prefill_group_size):\n",
+    "    results = batch.prefill(\n",
+    "        sampling_params={\"max_tokens\": 1, \"temperature\": 0.0, \"ignore_eos\": True},\n",
+    "        stream_ids=stream_ids[g0 : g0 + prefill_group_size],\n",
+    "    )\n",
+    "    prefill_seconds += results.to_dict()[\"metrics\"][\"results\"].get(\"duration\", 0.0)\n",
+    "logger.info(f\"prefill: {prefill_seconds:.2f} s in groups of {prefill_group_size}\")\n",
+    "\n",
+    "results = batch.decode(\n",
+    "    sampling_params={\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": temperature,\n",
+    "        \"ignore_eos\": True,\n",
+    "    }\n",
+    ")\n",
+    "results.emit()\n",
+    "before_drop_data = results.to_dict()\n",
+    "before_texts = [stream.output_text for stream in batch.request_streams.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "188ec71d",
+   "metadata": {},
+   "source": [
+    "## Clear LMCache\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "738112cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:24:24.356869Z",
+     "iopub.status.busy": "2026-08-01T06:24:24.356732Z",
+     "iopub.status.idle": "2026-08-01T06:24:24.531902Z",
+     "shell.execute_reply": "2026-08-01T06:24:24.531180Z"
+    },
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"status\":\"ok\",\"cleared\":{\"tier\":\"l1\"}}"
+     ]
+    }
+   ],
+   "source": [
+    "!curl -X POST {lmcache_url}/cache/clear\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "source": [
+    "## With R-KV Token Dropping — Route B, buffered / chunked, on the CPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:24:24.537243Z",
+     "iopub.status.busy": "2026-08-01T06:24:24.537083Z",
+     "iopub.status.idle": "2026-08-01T06:24:24.556989Z",
+     "shell.execute_reply": "2026-08-01T06:24:24.556419Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:24:24,553] LMCache INFO:\u001b[0m CPU thread plan: 96 usable cores -> budget 115, 30 workers -> torch.set_num_threads(3) (~90 runnable threads) \u001b[3m(3911048703.py:49:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Standard\n",
+    "import os\n",
+    "\n",
+    "# --- R-KV hyperparameters ----------------------------------------------------\n",
+    "# Scores are averaged over KV heads and summed over layers, so a request keeps\n",
+    "# ONE token subset. LMCache re-injects a single contiguous KV with a single\n",
+    "# kept-token list, so per-head eviction is not expressible here.\n",
+    "rkv_window_size = 8  # observation window: the last w queries vote on importance\n",
+    "rkv_drop_ratio = 0.5  # fraction of tokens to evict\n",
+    "rkv_kernel_size = 7  # max-pool width applied to the importance scores\n",
+    "rkv_mix_lambda = 0.07  # score = lambda * importance - (1 - lambda) * redundancy\n",
+    "rkv_sim_threshold = 0.5  # cosine above this counts as \"similar\"\n",
+    "\n",
+    "# --- CPU thread budget (shared by both CPU implementations) ------------------\n",
+    "cpu_thread_oversubscription = 1.25  # total intra-op threads / usable cores\n",
+    "cpu_reserve_cores = 4  # left for vLLM, the LMCache server and the OS\n",
+    "cpu_device = torch.device(\"cpu\")\n",
+    "\n",
+    "\n",
+    "def usable_cores():\n",
+    "    \"\"\"Cores this process may actually run on -- affinity and cgroup, not nproc.\"\"\"\n",
+    "    try:\n",
+    "        cores = len(os.sched_getaffinity(0))\n",
+    "    except AttributeError:\n",
+    "        cores = os.cpu_count() or 1\n",
+    "    try:\n",
+    "        with open(\"/sys/fs/cgroup/cpu.max\") as fh:\n",
+    "            quota, period = fh.read().split()\n",
+    "        if quota != \"max\":\n",
+    "            cores = min(cores, max(1, int(int(quota) // int(period))))\n",
+    "    except (OSError, ValueError):\n",
+    "        pass\n",
+    "    return max(1, cores)\n",
+    "\n",
+    "\n",
+    "def plan_cpu_threads():\n",
+    "    \"\"\"Set torch's intra-op threads so intra_op * workers ~= 1.25 * cores.\n",
+    "\n",
+    "    `batch.modify` runs one worker thread per stream and torch defaults to one\n",
+    "    intra-op thread per core inside each of them, which on a 96-core box means\n",
+    "    30 x 96 = 2880 runnable threads. Measured over 30 requests: 27.6 s at 96\n",
+    "    intra-op threads, 19.8 s at 4, 33.5 s at 1.\n",
+    "    \"\"\"\n",
+    "    cores = usable_cores()\n",
+    "    budget = max(1, round((cores - cpu_reserve_cores) * cpu_thread_oversubscription))\n",
+    "    workers = max(1, len(prompts))\n",
+    "    intra_op = max(1, min(budget // workers, budget))\n",
+    "    torch.set_num_threads(intra_op)\n",
+    "    logger.info(\n",
+    "        f\"CPU thread plan: {cores} usable cores -> budget {budget}, \"\n",
+    "        f\"{workers} workers -> torch.set_num_threads({intra_op}) \"\n",
+    "        f\"(~{intra_op * workers} runnable threads)\"\n",
+    "    )\n",
+    "    return intra_op\n",
+    "\n",
+    "\n",
+    "cpu_intraop_threads = plan_cpu_threads()\n",
+    "\n",
+    "\n",
+    "# --- Tensor plumbing ---------------------------------------------------------\n",
+    "def model_heads():\n",
+    "    \"\"\"(num_q_heads, num_kv_heads, head_dim) for the served model.\"\"\"\n",
+    "    q = config.num_attention_heads\n",
+    "    kv = getattr(config, \"num_key_value_heads\", q)\n",
+    "    return q, kv, getattr(config, \"head_dim\", config.hidden_size // q)\n",
+    "\n",
+    "\n",
+    "def to_heads(flat, rows, heads, head_dim, device=None):\n",
+    "    \"\"\"[rows, heads * head_dim] -> [1, heads, rows, head_dim] in fp32.\"\"\"\n",
+    "    t = (\n",
+    "        flat.to(dtype=torch.float32)\n",
+    "        if device is None\n",
+    "        else flat.to(device, torch.float32)\n",
+    "    )\n",
+    "    return t.reshape(rows, heads, head_dim).permute(1, 0, 2).unsqueeze(0)\n",
+    "\n",
+    "\n",
+    "def q_by_layer(q_tensor):\n",
+    "    \"\"\"Normalise the SDK's query tensor to [num_layers, T, q_heads * head_dim].\"\"\"\n",
+    "    if q_tensor.ndim == 4 and q_tensor.shape[0] == 1:\n",
+    "        return q_tensor[0]\n",
+    "    if q_tensor.ndim == 3:\n",
+    "        return q_tensor\n",
+    "    raise ValueError(f\"unexpected q_tensor shape {tuple(q_tensor.shape)}\")\n",
+    "\n",
+    "\n",
+    "def attention_logits(query, key, pooling=\"max\"):\n",
+    "    \"\"\"q @ k^T / sqrt(d), pooled from query heads down to KV heads (GQA).\n",
+    "\n",
+    "    query: [1, q_heads, q_len, d]   key: [1, kv_heads, kv_len, d]\n",
+    "    \"\"\"\n",
+    "    _, q_heads, q_len, d = query.shape\n",
+    "    kv_heads = key.shape[1]\n",
+    "    group = q_heads // kv_heads\n",
+    "    if group == 1:\n",
+    "        return torch.matmul(query, key.transpose(2, 3)) / math.sqrt(d)\n",
+    "    q = query.view(1, kv_heads, group, q_len, d)\n",
+    "    attn = torch.matmul(q, key.unsqueeze(2).transpose(3, 4)) / math.sqrt(d)\n",
+    "    return attn.mean(dim=2) if pooling == \"mean\" else attn.max(dim=2).values\n",
+    "\n",
+    "\n",
+    "def importance(k, q_win, past_len):\n",
+    "    \"\"\"How much the observation window attends to each past token.\n",
+    "\n",
+    "    Only the window queries are passed in, so this is O(w * n * d) rather than\n",
+    "    the O(n^2 * d) the reference spends before discarding all but the last w rows.\n",
+    "    \"\"\"\n",
+    "    attn = attention_logits(q_win, k)[:, :, :, :past_len]\n",
+    "    scores = F.softmax(attn, dim=-1, dtype=torch.float32).mean(dim=-2)\n",
+    "    return F.max_pool1d(\n",
+    "        scores, kernel_size=rkv_kernel_size, padding=rkv_kernel_size // 2, stride=1\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def redundancy_reference(key_states, threshold=rkv_sim_threshold):\n",
+    "    \"\"\"Literal R-KV redundancy: materialises the whole n x n matrix.\n",
+    "\n",
+    "    Only used as the correctness oracle in the self-tests -- never on a real\n",
+    "    prompt, where it would allocate kv_heads * n^2 floats per layer.\n",
+    "    \"\"\"\n",
+    "    _, _, n, _ = key_states.shape\n",
+    "    k = key_states / (key_states.norm(dim=-1, keepdim=True) + 1e-8)\n",
+    "    sim = torch.matmul(k, k.transpose(-1, -2))\n",
+    "    eye = torch.eye(n, dtype=torch.bool, device=k.device).view(1, 1, n, n)\n",
+    "    sim.masked_fill_(eye, 0.0)\n",
+    "\n",
+    "    # Per row, exempt the LARGEST column index that is above threshold (or\n",
+    "    # column 0 if none qualifies) -- R-KV's `similarity_retain` rule.\n",
+    "    mask = sim > threshold\n",
+    "    idx = torch.arange(n, device=k.device).view(1, 1, 1, n)\n",
+    "    retain = torch.where(mask, idx, torch.zeros_like(mask, dtype=torch.long))\n",
+    "    sim.scatter_(-1, retain.max(dim=-1)[0].unsqueeze(-1), 0)\n",
+    "    return sim.mean(dim=-2).softmax(dim=-1)\n",
+    "\n",
+    "\n",
+    "def prepare(tensors, token_source):\n",
+    "    \"\"\"Common bookkeeping shared by every drop_tokens_fn.\"\"\"\n",
+    "    kv = tensors[lmc_sdk.context.LMCacheSDKCacheKind.KV]  # [2, L, T, D]\n",
+    "    q = q_by_layer(tensors[lmc_sdk.context.LMCacheSDKCacheKind.QUERY])\n",
+    "    seq_len = min(kv.shape[2], q.shape[1], len(token_source))\n",
+    "    past_len = seq_len - rkv_window_size\n",
+    "    if past_len <= 0:\n",
+    "        raise ValueError(f\"seq_len {seq_len} must exceed window {rkv_window_size}\")\n",
+    "    keep_total = int(round(seq_len * (1 - rkv_drop_ratio)))\n",
+    "    keep_past = max(0, min(keep_total - rkv_window_size, past_len))\n",
+    "    q_win = q[:, past_len:seq_len, :]  # window only: ~2.4 MiB, not ~4.8 GiB\n",
+    "    return kv, q_win, seq_len, past_len, keep_past\n",
+    "\n",
+    "\n",
+    "def select(scores, past_len, seq_len, keep_past):\n",
+    "    \"\"\"Top-scoring past tokens plus the whole observation window.\"\"\"\n",
+    "    top = torch.topk(scores, k=keep_past).indices.sort().values\n",
+    "    tail = torch.arange(past_len, seq_len, device=scores.device)\n",
+    "    return torch.cat([top, tail]).to(torch.long).cpu()\n",
+    "\n",
+    "\n",
+    "def rerotate(kv_tensor, keep_idx, device):\n",
+    "    \"\"\"Gather the kept tokens and move their RoPE to the new positions.\"\"\"\n",
+    "    gathered = kv_tensor[:, :, keep_idx, :].clone().to(device)\n",
+    "    out = rerotate_k_cache(\n",
+    "        gathered,\n",
+    "        old_positions=keep_idx.to(device),\n",
+    "        new_positions=torch.arange(keep_idx.numel(), device=device),\n",
+    "        model_config=config,\n",
+    "    )\n",
+    "    return out.cpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "source": [
+    "### Route B, buffered / chunked, on the CPU\n",
+    "\n",
+    "> **Trades exactness for CPU speed.** The only implementation here that does\n",
+    "> not reproduce R-KV: it judges redundancy locally, which makes it the quickest\n",
+    "> CPU option but changes ~4% of the kept tokens.\n",
+    ">\n",
+    "> | | |\n",
+    "> |---|---|\n",
+    "> | **Buys you** | Fastest CPU compression (2.25× quicker than [`cpu_exact`](./rkv_variant_cpu_exact.ipynb)), no VRAM, straightforward code |\n",
+    "> | **Costs you** | **Exactness** — redundancy is judged only within a chunk, so ~4% of the kept tokens differ and answer quality can move |\n",
+    "> | Exact? | No — ~96% kept-token agreement with route A |\n",
+    "> | VRAM | None |\n",
+    "> | Compress 30 requests | 29.9 s |\n",
+    "> | Decode throughput | 1774 tok/s |\n",
+    "> | Pick it when | Compression latency matters more than reproducing R-KV exactly |\n",
+    "\n",
+    "The other three notebooks all compute route A: every token is judged against\n",
+    "the *whole* prompt. **Route B** is the other branch, the one the R-KV\n",
+    "serving ports take (`buffered_keep` in the SGLang port): cut the prompt into\n",
+    "chunks and compress within a chunk. It is an **approximation** — included here\n",
+    "so the trade-off is on the table when picking an option.\n",
+    "\n",
+    "## The idea: a block-diagonal similarity matrix\n",
+    "\n",
+    "Restricting the pairwise key comparison to tokens in the *same* chunk makes the\n",
+    "similarity matrix block-diagonal, so the redundancy term costs\n",
+    "\n",
+    "$$\\frac{n}{c} \\text{ blocks} \\times O(c^2 d) \\;=\\; O(n \\cdot c \\cdot d)$$\n",
+    "\n",
+    "— linear in $n$ for a fixed chunk size $c$, and the transient tensor shrinks\n",
+    "from $\\text{kv\\_heads} \\cdot n^2$ to $\\text{kv\\_heads} \\cdot n \\cdot c$.\n",
+    "\n",
+    "Two deliberate departures from SGLang's `buffered_keep`:\n",
+    "\n",
+    "* **Importance stays global.** It is already only $O(w n d)$, and keeping it\n",
+    "  global means every token is still ranked against the *true* final observation\n",
+    "  window. SGLang's sequential version scores against a mid-prefill window and\n",
+    "  therefore evicts tokens a later chunk would have attended to; this variant has\n",
+    "  **no premature eviction**. The locality of the redundancy term is the only\n",
+    "  approximation.\n",
+    "* **One global top-k**, not a per-chunk quota, so the budget can flow to the\n",
+    "  informative regions. Both cost the same — the score vector is global either\n",
+    "  way — so this is accuracy for free. Set `buffered_chunk_quota = True` for the\n",
+    "  literal \"compress each chunk independently, then concatenate\" reading.\n",
+    "\n",
+    "Scale is preserved so the term stays comparable against\n",
+    "$\\lambda \\cdot \\text{importance}$: each column is a mean over **its own chunk's\n",
+    "real rows** (the padded trailing chunk divides by its true length), followed by\n",
+    "a **single global softmax**.\n",
+    "\n",
+    "## What was optimized\n",
+    "\n",
+    "| # | Change | Why it mattered |\n",
+    "|---|---|---|\n",
+    "| 1 | **Chunking itself.** | The whole point: $O(n^2 d) \\to O(n c d)$. At $n = 16128$, $c = 512$ that is **13.9×** off the one-shot cost. |\n",
+    "| 2 | **One batched GEMM over all chunks**, `[1, kv_heads, n/c, c, c]`, instead of a Python loop over chunks. | Keeps oneDNN on a single large call rather than $n/c$ small ones. |\n",
+    "| 3 | **Thread budgeting** (see the shared cell above). | `batch.modify` gives 30-way outer parallelism while torch defaults to one intra-op thread per core *inside each worker* — 30 × 96 = 2880 runnable threads on a 96-core box. Measured over 30 requests: **27.6 s at 96 intra-op threads, 19.8 s at 4**, 33.5 s at 1. Worth ~1.4× on its own. |\n",
+    "| 4 | **fp32, not bf16.** | This Xeon has AMX-BF16, yet bf16 was *slower* (1.95 s vs 1.29 s at $c = 512$). Once chunked, the kernel is bound by the compare / flip / argmax / scatter — memory-bound ops AMX does not accelerate. |\n",
+    "\n",
+    "## Choosing the chunk size\n",
+    "\n",
+    "Measured on one request, $n = 16128$, $L = 36$, against the exact route-A result:\n",
+    "\n",
+    "| chunk `c` | s/request | vs. one-shot | kept-token agreement |\n",
+    "|---|---|---|---|\n",
+    "| 2048 | 3.27 s | 5.5× | 98.19% |\n",
+    "| 1024 | 1.78 s | 10.1× | 97.31% |\n",
+    "| **512** | **1.29 s** | **13.9×** | **95.89%** |\n",
+    "| 256 | 1.01 s | 17.8× | 94.08% |\n",
+    "\n",
+    "**Result: the fastest CPU option (29.9 s to compress 30 requests, 2.25× quicker\n",
+    "than the exact CPU version) at the cost of ~4% of the kept tokens.** Pick this\n",
+    "when compression latency matters more than reproducing R-KV exactly; pick [`cpu_exact`](./rkv_variant_cpu_exact.ipynb) or [`gpu_exact`](./rkv_variant_gpu_exact.ipynb) when\n",
+    "it does not.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8da9a2fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:24:24.562267Z",
+     "iopub.status.busy": "2026-08-01T06:24:24.562139Z",
+     "iopub.status.idle": "2026-08-01T06:24:25.114139Z",
+     "shell.execute_reply": "2026-08-01T06:24:25.113500Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:24:25,109] LMCache INFO:\u001b[0m Route B self-test (n=2048, chunk=512): kept-token agreement with route A = 96.16% \u001b[3m(549056236.py:124:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Knobs -------------------------------------------------------------------\n",
+    "buffered_chunk_size = 512  # smaller = faster, but a more local redundancy call\n",
+    "buffered_chunk_quota = False  # False = one global top-k; True = per-chunk quota\n",
+    "\n",
+    "\n",
+    "def _buffered_redundancy(key_states, chunk_size):\n",
+    "    \"\"\"Block-diagonal redundancy: keys are only compared inside their chunk.\n",
+    "\n",
+    "    Same reduction order as route A (mean down the columns, then softmax across\n",
+    "    them), but the row set for column j is limited to j's own chunk, which makes\n",
+    "    the cost O(n * c * d) instead of O(n^2 * d).\n",
+    "\n",
+    "    key_states: [1, kv_heads, n, d] -> [1, kv_heads, n]\n",
+    "    \"\"\"\n",
+    "    bsz, kv_heads, n, head_dim = key_states.shape\n",
+    "    c = max(1, min(chunk_size, n))\n",
+    "    n_chunks = (n + c - 1) // c\n",
+    "    pad = n_chunks * c - n\n",
+    "\n",
+    "    k = key_states / (key_states.norm(dim=-1, keepdim=True) + 1e-8)\n",
+    "    if pad:\n",
+    "        # Padded rows are exactly zero: they add nothing to a real column's sum\n",
+    "        # and never clear the similarity threshold.\n",
+    "        k = F.pad(k, (0, 0, 0, pad))\n",
+    "    kb = k.reshape(bsz, kv_heads, n_chunks, c, head_dim)\n",
+    "\n",
+    "    # One batched GEMM over every chunk, not a Python loop.\n",
+    "    sim = torch.matmul(kb, kb.transpose(-1, -2))  # [1, kv_heads, n_chunks, c, c]\n",
+    "    diag = torch.arange(c)\n",
+    "    sim[..., diag, diag] = 0.0  # a token is not redundant with itself\n",
+    "\n",
+    "    # Route A's `similarity_retain`, searched within the chunk only.\n",
+    "    over = sim > rkv_sim_threshold\n",
+    "    has = over.any(dim=-1)\n",
+    "    last = (c - 1) - over.flip(-1).to(torch.uint8).argmax(dim=-1)\n",
+    "    retain = torch.where(has, last, torch.zeros_like(last))\n",
+    "    sim.scatter_(-1, retain.unsqueeze(-1), 0.0)\n",
+    "\n",
+    "    col_sum = sim.sum(dim=-2)  # [1, kv_heads, n_chunks, c]\n",
+    "    del sim, over, has, last, retain\n",
+    "\n",
+    "    # Mean over each chunk's REAL rows; the padded trailing chunk is shorter and\n",
+    "    # dividing it by c would understate its redundancy.\n",
+    "    rows = torch.full((n_chunks,), float(c))\n",
+    "    if pad:\n",
+    "        rows[-1] = float(c - pad)\n",
+    "    col_sum = col_sum / rows.view(1, 1, n_chunks, 1)\n",
+    "\n",
+    "    col_sum = col_sum.reshape(bsz, kv_heads, n_chunks * c)[:, :, :n]\n",
+    "    return col_sum.softmax(dim=-1)  # one GLOBAL softmax keeps route A's scale\n",
+    "\n",
+    "\n",
+    "def _select_chunk_quota(scores, keep_past, chunk_size):\n",
+    "    \"\"\"Per-chunk top-k: each chunk keeps its own proportional share.\n",
+    "\n",
+    "    The literal \"compress every chunk independently\" reading, used when\n",
+    "    `buffered_chunk_quota` is True. Remainders go to the earlier chunks so the\n",
+    "    total is exactly `keep_past`.\n",
+    "    \"\"\"\n",
+    "    past_len = scores.numel()\n",
+    "    n_chunks = (past_len + chunk_size - 1) // chunk_size\n",
+    "    base, extra = divmod(keep_past, n_chunks)\n",
+    "\n",
+    "    picks = []\n",
+    "    for ci in range(n_chunks):\n",
+    "        lo, hi = ci * chunk_size, min((ci + 1) * chunk_size, past_len)\n",
+    "        quota = min(base + (1 if ci < extra else 0), hi - lo)\n",
+    "        if quota > 0:\n",
+    "            picks.append(torch.topk(scores[lo:hi], k=quota).indices + lo)\n",
+    "    return torch.cat(picks).sort().values\n",
+    "\n",
+    "\n",
+    "def drop_tokens_buffered(tensors, token_source):\n",
+    "    \"\"\"Route B token dropping, entirely on the CPU.\"\"\"\n",
+    "    kv, q_win, seq_len, past_len, keep_past = prepare(tensors, token_source)\n",
+    "    num_q, num_kv, head_dim = model_heads()\n",
+    "\n",
+    "    scores = torch.zeros(past_len, dtype=torch.float32)\n",
+    "    for layer in range(kv.shape[1]):\n",
+    "        k = to_heads(kv[0, layer, :seq_len, :], seq_len, num_kv, head_dim)\n",
+    "        qw = to_heads(q_win[layer], rkv_window_size, num_q, head_dim)\n",
+    "        imp = importance(k, qw, past_len)  # unchanged: still the true final window\n",
+    "        red = _buffered_redundancy(k, buffered_chunk_size)[:, :, :past_len]\n",
+    "        scores += (imp * rkv_mix_lambda - red * (1 - rkv_mix_lambda)).mean(1).squeeze(0)\n",
+    "\n",
+    "    if buffered_chunk_quota:\n",
+    "        top = _select_chunk_quota(scores, keep_past, buffered_chunk_size)\n",
+    "        tail = torch.arange(past_len, seq_len)\n",
+    "        keep_idx = torch.cat([top, tail]).to(torch.long)\n",
+    "    else:\n",
+    "        keep_idx = select(scores, past_len, seq_len, keep_past)\n",
+    "\n",
+    "    e_kv = rerotate(kv, keep_idx, cpu_device)\n",
+    "    logger.info(f\"compacted {e_kv.shape[2]}/{kv.shape[2]} tokens.\")\n",
+    "    return e_kv, [token_source[i] for i in keep_idx.tolist()]\n",
+    "\n",
+    "\n",
+    "def _selftest_buffered(n=2048, layers=4):\n",
+    "    \"\"\"Report agreement with route A -- this one is an approximation.\n",
+    "\n",
+    "    Unlike the exact implementations this cannot assert equality, so it checks\n",
+    "    the shapes and reports the overlap: a bug in the padding or the rescaling\n",
+    "    shows up as a collapse in agreement instead of passing silently.\n",
+    "    \"\"\"\n",
+    "    torch.manual_seed(0)\n",
+    "    num_q, num_kv, head_dim = model_heads()\n",
+    "    past_len = n - rkv_window_size\n",
+    "    keep = int(round(n * (1 - rkv_drop_ratio))) - rkv_window_size\n",
+    "    ref, got = torch.zeros(past_len), torch.zeros(past_len)\n",
+    "\n",
+    "    for _ in range(layers):\n",
+    "        k = torch.randn(1, num_kv, n, head_dim)\n",
+    "        qw = torch.randn(1, num_q, rkv_window_size, head_dim)\n",
+    "        imp = importance(k, qw, past_len)\n",
+    "        red_a = redundancy_reference(k)[:, :, :past_len]\n",
+    "        red_b = _buffered_redundancy(k, buffered_chunk_size)[:, :, :past_len]\n",
+    "        ref += (imp * rkv_mix_lambda - red_a * (1 - rkv_mix_lambda)).mean(1).squeeze(0)\n",
+    "        got += (imp * rkv_mix_lambda - red_b * (1 - rkv_mix_lambda)).mean(1).squeeze(0)\n",
+    "\n",
+    "    assert got.shape == ref.shape and torch.isfinite(got).all()\n",
+    "    a = set(torch.topk(ref, keep).indices.tolist())\n",
+    "    b = set(torch.topk(got, keep).indices.tolist())\n",
+    "    overlap = len(a & b) / len(a)\n",
+    "    logger.info(\n",
+    "        f\"Route B self-test (n={n}, chunk={buffered_chunk_size}): \"\n",
+    "        f\"kept-token agreement with route A = {overlap:.2%}\"\n",
+    "    )\n",
+    "    assert overlap > 0.80, f\"route B diverged too far from route A ({overlap:.2%})\"\n",
+    "\n",
+    "\n",
+    "_selftest_buffered()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0635516c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:24:25.120042Z",
+     "iopub.status.busy": "2026-08-01T06:24:25.119888Z",
+     "iopub.status.idle": "2026-08-01T06:26:36.669934Z",
+     "shell.execute_reply": "2026-08-01T06:26:36.669125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:24:40,374] LMCache INFO:\u001b[0m prefill: 15.21 s in groups of 1 \u001b[3m(2839406187.py:24:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:24:57,707] LMCache INFO:\u001b[0m compacted 4992/9984 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:24:58,846] LMCache INFO:\u001b[0m compacted 5120/10240 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:24:59,609] LMCache INFO:\u001b[0m compacted 5504/11008 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:24:59,733] LMCache INFO:\u001b[0m compacted 5376/10752 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:24:59,793] LMCache INFO:\u001b[0m compacted 5376/10752 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:00,263] LMCache INFO:\u001b[0m compacted 5632/11264 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:00,640] LMCache INFO:\u001b[0m compacted 5632/11264 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:01,251] LMCache INFO:\u001b[0m compacted 6272/12544 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:01,904] LMCache INFO:\u001b[0m compacted 6144/12288 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:03,146] LMCache INFO:\u001b[0m compacted 6400/12800 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:03,757] LMCache INFO:\u001b[0m compacted 6784/13568 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:03,808] LMCache INFO:\u001b[0m compacted 6656/13312 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:03,945] LMCache INFO:\u001b[0m compacted 6656/13312 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:05,244] LMCache INFO:\u001b[0m compacted 7296/14592 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:05,521] LMCache INFO:\u001b[0m compacted 6912/13824 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:05,912] LMCache INFO:\u001b[0m compacted 7680/15360 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:06,667] LMCache INFO:\u001b[0m compacted 7552/15104 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:07,386] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:07,796] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:07,804] LMCache INFO:\u001b[0m compacted 7552/15104 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:08,108] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:08,177] LMCache INFO:\u001b[0m compacted 7808/15616 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:08,383] LMCache INFO:\u001b[0m compacted 7808/15616 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:08,467] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:08,728] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:08,800] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:09,171] LMCache INFO:\u001b[0m compacted 8320/16640 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:09,238] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:09,627] LMCache INFO:\u001b[0m compacted 8192/16384 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:10,041] LMCache INFO:\u001b[0m compacted 8320/16640 tokens. \u001b[3m(549056236.py:94:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:25:10,281] LMCache INFO:\u001b[0m \n",
+      "\n",
+      " \u001b[3m(2839406187.py:29:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================== Batched Stream Modify Metrics =========================\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                        29.91\n",
+      "================================================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================= Batched Stream Metrics (decode) ========================\n",
+      "-------------------------------- Configuration ---------------------------------\n",
+      "Number of Request Streams:                                                    30\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                        86.38\n",
+      "Total Output Tokens:                                                      153268\n",
+      "Decode Throughput (tokens/s):                                            1774.36\n",
+      "================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_ids = []\n",
+    "\n",
+    "batch = lmc_sdk.batch.LMCacheBatchedStream()\n",
+    "for i, prompt in enumerate(prompts):\n",
+    "    stream = lmc_sdk.request.create_request(\n",
+    "        contexts=[ctx, qctx],\n",
+    "        post_completion=post_completion,\n",
+    "        prompt_token_ids=prompt,\n",
+    "    )\n",
+    "    batch.add(stream)\n",
+    "    stream_ids.append(stream.request_stream_id)\n",
+    "\n",
+    "# temperature 0 here too: prefill emits one token that is APPENDED to the\n",
+    "# stream, so sampling it would make the whole greedy decode below depend on a\n",
+    "# random first token. Groups of `prefill_group_size` keep the query capture\n",
+    "# correct (see the hyperparameter cell).\n",
+    "prefill_seconds = 0.0\n",
+    "for g0 in range(0, len(stream_ids), prefill_group_size):\n",
+    "    results = batch.prefill(\n",
+    "        sampling_params={\"max_tokens\": 1, \"temperature\": 0.0, \"ignore_eos\": True},\n",
+    "        stream_ids=stream_ids[g0 : g0 + prefill_group_size],\n",
+    "    )\n",
+    "    prefill_seconds += results.to_dict()[\"metrics\"][\"results\"].get(\"duration\", 0.0)\n",
+    "logger.info(f\"prefill: {prefill_seconds:.2f} s in groups of {prefill_group_size}\")\n",
+    "\n",
+    "results = batch.modify(drop_tokens_buffered)\n",
+    "results.emit()\n",
+    "\n",
+    "logger.info(\"\\n\\n\")\n",
+    "\n",
+    "results = batch.decode(\n",
+    "    sampling_params={\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": temperature,\n",
+    "        \"ignore_eos\": True,\n",
+    "    }\n",
+    ")\n",
+    "results.emit()\n",
+    "buffered_drop_data = results.to_dict()\n",
+    "buffered_texts = [stream.output_text for stream in batch.request_streams.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99dcfd4c",
+   "metadata": {},
+   "source": [
+    "### Accuracy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:26:36.676032Z",
+     "iopub.status.busy": "2026-08-01T06:26:36.675876Z",
+     "iopub.status.idle": "2026-08-01T06:26:36.680791Z",
+     "shell.execute_reply": "2026-08-01T06:26:36.680337Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:26:36,678] LMCache INFO:\u001b[0m Baseline (no drop): 11/30 correct (36.7%) \u001b[3m(3348946064.py:4:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:26:36,679] LMCache INFO:\u001b[0m R-KV buffered: 13/30 correct (43.3%) \u001b[3m(3348946064.py:8:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "before_correct, total, before_map = score_answers(answers, before_texts)\n",
+    "after_correct, total, after_map = score_answers(answers, buffered_texts)\n",
+    "\n",
+    "logger.info(\n",
+    "    f\"Baseline (no drop): {before_correct}/{total} correct \"\n",
+    "    f\"({100 * before_correct / total:.1f}%)\"\n",
+    ")\n",
+    "logger.info(\n",
+    "    f\"R-KV buffered: {after_correct}/{total} correct \"\n",
+    "    f\"({100 * after_correct / total:.1f}%)\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1038e21",
+   "metadata": {},
+   "source": [
+    "## Result Plot\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:26:36.685608Z",
+     "iopub.status.busy": "2026-08-01T06:26:36.685490Z",
+     "iopub.status.idle": "2026-08-01T06:26:36.777680Z",
+     "shell.execute_reply": "2026-08-01T06:26:36.777067Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEiCAYAAAD9DXUdAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAASbRJREFUeJzt3XdcU9f/P/BXWGEJMhRQVBCV5aqAigtRQaAOFHFUP2rVOuse1WrrbLVqrUXrrHsrzlq1LnAhTtyDISJDppggO3B+f/Djfr0mSBLCkvfz8cjjQU7e99z3DZB37jpHwBhjIIQQQv4/tcpOgBBCSNVChYEQQggPFQZCCCE8VBgIIYTwUGEghBDCQ4WBEEIIDxUGQgghPFQYCCGE8FBhIIQQwkOFgRBCCA8VBqIyeXl5CAwMRHh4eGWn8kU6fvw4Hj9+XNlpVBt5eXkIDQ3F0aNHce3aNQBAYGAgnjx5UsmZVX0CGiuJnD9/HmKxuNS4Ro0awcXFpcTXU1NTUadOHaxatQqzZs1SZYpKefz4MV6+fAkAEAgE0NbWhrGxMezt7VG7du3KTU4J2tra+P7777F69epKWf/p06eRk5PDPdfS0oKlpSUcHR0hFAorJaeSpKamomvXrsjNzUXLli3RqlUr/PzzzxAIBPjhhx+wYsUKLjYwMBB2dnZo3rx5JWZctWhUdgKk8v3777+Ij4/nnoeHh+Px48fo2rUrTExMuPYuXbp8tjBUNbt27cLvv/8Ob29v6OrqIi8vD2/fvsXjx4/x1VdfYc6cOejXr19lpym3/v37o2XLlpW2/jFjxkAikaBr164AgJycHDx8+BASiQQrV67E//73v0rL7VPr1q3DmzdvkJSUBB0dHa7dz88PLVq04MX6+/tLFYsajxHyiVWrVjEA7Nq1awotl5KSwgCwVatWlVNmipk5cyYDwKKjo3ntaWlpbPLkyQwAmz9/fuUkVw2ZmZmxjh078try8/NZnz59mLq6OouMjKykzKT179+fOTo6yhULgP3www/lnFH1QnsMRG4FBQV48OAB4uPjYWpqCmdnZ2hpaZW6nFgsxoULF2BsbAx3d3euXSQS4d69e8jMzESzZs1ga2vLWy40NBTv37+Hl5cXxGIxQkNDoampCVdXV2hrayu9HcbGxggICEBKSgp++eUX9O3bl9sT+nidGRkZuHXrFjQ0NLhvyYWFhXj48CHi4uJgZGQEZ2dnXi6FhYU4duwYHBwc4ODggJcvXyIiIgLW1tZwdHTk5aFILFB0jqFJkybcN95Pl4+KisLz58/RsGHDEvcscnNzcfPmTeTm5qJt27YwMjLCuXPnULt2bbRv317h91JDQwP+/v44deoUwsLCYGNjIxUTFRWFFy9eQEtLC87OzjAyMirxPZBnGz7Xp0gkwoULFxAREYHMzEwEBgZKLVt82CgrKwtnzpwBALx8+ZKLrV+/PlxdXRV+L74olV2ZSNUja4/h9u3brEmTJszU1JR5eHiwBg0aMDMzM/bPP/9wMbL2GKKjo5mjoyNr2rQpCw8PZ4wxVlBQwBYsWMC0tbVZq1atWI8ePZiBgQHz8fFh6enp3LJ+fn7MxsaGXbp0iTk6OjJPT09Wp04dZmlpyV6+fFnqdpS0x1Dszp07DACbOHGi1Dr//fdfZmdnx9zd3Vm3bt0YY4w9fPiQ2dvbM2NjY+bh4cGsrKyYqakpO3z4MLd8dnY2A8B+/vln9t1337E2bdqwzp07My0tLdanTx+WmZmpVCxjjAmFQjZz5kyp5RcuXMimT5/O2rRpw9zc3JiGhgbz8/NjhYWFvOVv3LjB6tWrx8zMzJinpyeztbVl//zzD7OxsWF+fn6lvp+y9hgYY+ynn35iANi9e/d47XFxcaxbt25MT0+Pde3albVt25bp6uqy1atXK70NpfUZHR3N/Pz8WN26dZmhoSHz8/PjPfDR3kFycjLXZmtry8X89ttvpb4XXzoqDETKp4UhJSWFmZiYsI4dOzKRSMQYYywvL48NHDiQaWlpscePH3NxHxeGkJAQVrduXebm5sbS0tK4/hctWsTU1NTYsWPHuLa4uDhmbW3N+4Dy8/NjpqambPTo0SwnJ4cxVvTPbGFhwfr161fqdpRWGCQSCdPU1GTt2rWTWuewYcNYdnY2Y4yx8PBwJhKJmIWFBXNycuK2RSKRsJEjRzINDQ12+/Ztxtj/fdDZ2NiwXbt2cf2GhoYyHR0dNm7cOK5NkVjGSi4Mtra2bO/evVz7wYMHGQB29OhRri09PZ3VqVOHubm5sQ8fPjDGGMvJyWHDhw9npqamchcGOzs7duTIEXbkyBG2d+9eNmPGDKavr8/LizHGcnNzmYODA7O3t2exsbFc++HDhxkAdvz4cYW3Qd4+GWOse/furFWrVlLbABmHjWS11XRUGIiUTwvD77//zgCwmzdv8uLevn3LNDU1uQ+wjwvDgQMHmLa2Nhs5ciTLy8vjlsnKymK6urpsyJAhUuvdvHkzA8D90xd/m4uJieHFTZ06leno6JS6HaUVBsYYMzExYU2bNuWeF6/zxYsXMnO7cOECr/3du3dMV1eXDR06lDH2fx90bdu2lVrX+PHjmaamJldcFYllrOTC0LlzZ96yhYWFrE6dOmzMmDFc26ZNmxgAFhoayouNjIxkAOQuDCYmJtw36z59+jB7e3tma2vLDhw4wIvdu3cvA8D+/fdfqX46d+7MunbtqvA2yNsnY1QYyorOMZBShYWFQV1dHc7Ozrx2c3NzWFlZ4f79+7z2Xbt24enTp1iyZAkWLFjAe+3hw4fIysqCnp4eTpw4Afb/r5ZmjCE5ORlA0WWmlpaWAABTU1M0bNiQ10fDhg2RnZ2N1NRUmJqalmnbsrOzoaenx2urVauW1PmOsLAwAEC7du147UZGRrC1tZV6D2RdvdW2bVts2rQJT548QYcOHZSKlcXJyYn3XCAQwNLSErGxsbz8BQIB2rRpw4u1sbGBoaHhZ/v/mJ2dndRx+9WrV2PIkCEQCAQYNGgQAODmzZsAgHfv3nG/5+Lftba2Nu7du6fwNijaJ1EeFQZSqry8PGhpaUFDQ/rPRU9PD7m5ubw2U1NTaGho4MGDB9yyxbKzswEAjx49Qnp6ulR/fn5+vJOTsj60ivv7+Jp6ZcTGxiIrKwvNmjXjtdepU0cqNi8vDwKBgHfpYzE9PT2IRCJem66urlRccdun75cisbKU9B59/P7k5eVBU1NT5u9Q1voVMX36dPz444/YsGEDVxiys7MhEAhw4sQJqXgDAwP07NlT4W1QtE+iPCoMpFRWVlbIzs5GfHw86tevz7VLJBJER0dzV+wU+/rrrzF37lz0798fvXv3xrFjx7hv5cVXrXz99df4+eefK2wbZDlw4AAAoG/fvrx2gUAgFWtlZQXGGKKionh7E4wxREZGSl1FFBUVJdVHZGQkAMDa2lrpWGVZWVkhLy8P8fHx3N4YAGRlZSEpKalMfaurq0NHR4fb4wOKfs+MMaxcuRKNGzcuU//l2SeRjYbEIKUaOHAgACAgIIDXvmPHDohEIgwePFhqmZ49e+LChQu4ffs2PDw8uL2Dhg0bwtPTE5s3b0ZaWprUcm/evCmHLZB2/fp1LFmyBK6urty33M8ZMGAA1NTUpN6DgwcPIjExUeo9uHTpEmJiYrjn2dnZ2LZtG1xcXGBlZaV0rLL8/PwgEAiwceNGXvuWLVugqalZpr5v374NsVjMO0w1bNgwaGtr49dff5W5zMeHiORVHn0CgImJidQeX01HewykVE5OTli8eDEWLlyI5ORkdOnSBY8fP8a6deswYsQImYUBADp06IArV66gZ8+e6Nq1K/777z+Ym5tj165d8Pb2RvPmzTF27Fg0adIESUlJuH37Nh49eoQXL16oNP+zZ8+iTp06yM/PR2JiIoKCgnD27Fn4+flh48aNUFdXL7UPe3t7rFy5ErNnz0Z6ejp69OiBly9fYu3atRgwYABGjRrFix8+fDiGDRuGvn37Qk9PD9u2bUN6ejqOHz8u1bciscpydHTEwoULsWjRIqSkpMDV1RUPHjwAAFhaWsrcS5IlLS2NO8cgkUgQERGB9evXo3Hjxvjll1+4uIYNG+LAgQMYNmwYIiMj4evrCyMjI7x69Qr//PMPevXqhSVLlii0DeXRJwB4enri2LFjaNmyJerUqUP3MYAKA5HB1tYWfn5+vBO7P//8Mzw8PBAYGIjz58/D1NQU//zzD7y8vLgYoVAIPz8/3qGWli1b4tq1a1iwYAH+/PNPLFu2DObm5rhz5w6OHz+OK1euIDIyEpaWlhgyZAh3eAcAXF1dYWFhIZVfkyZN4OfnV+qx8ZYtW8LPzw+XLl2CQCCAUCiEsbExfHx8EBAQIPPbeEnrBICZM2eia9euOHToEC5evIjatWvjyJEj6N27t9QHq7GxMQIDA7FhwwaEhYXBy8sL48aNQ4MGDaT6lTf20yEx1NXV4efnBwcHB6k+u3XrJrUnsHDhQri6uuLo0aO4evUqunXrhmHDhmHfvn1SJ+Bl6d27N9LT03Hw4EEARTe31atXD6tWrcKQIUOk1ufr64vIyEjs378fDx8+BFB0OGj37t3cuESKboM8fQJFw7dkZGRI9SlrSIxNmzZh48aNCAkJQU5ODlxcXGp8YaBB9AhRoZycHOjo6HDfzlUVW17ev38PIyMjLFmyBD/99FOl5ECqHjrHQEgNkZqaKtX2xx9/QCAQSJ2AJzUbHUoipIbYt28fzp49Cy8vL+jr6yM4OBj79u3DvHnzKnXUVlL1UGEgRIU+d8y8LLGqMHXqVDg6OuLChQuIi4tD3bp1ERQUJHW5MSF0joEQQggPnWMghBDCQ4WBEEIIDxUGwvPkyRP06NEDxsbG0NDQ4CYyIdLOnDkDDQ0N3Lhxo0LXu3LlSmhoaFT7u3Vbt25NV0NVUVQYCM+gQYOgpqaGyMhI5OTkwNvbu9zWdfjwYWhoaHAPXV1dWFhYwM3NDT///DNvmIiqqLCwEAUFBSjraTqRSMR7Hz732LBhg8rWW9kkEgkKCgoqNYf27dvT4HsyUGEgnOTkZDx79gy+vr7cHoO8QyUoo/gDbv/+/cjJyUF6ejru3r2LqVOn4vLly7Czs8OOHTvKbf1VhaGhIXJycniPvn37oqCgAJmZmbz2CRMmVHa6X5SqUJyqIioMhJOSkgKg7MMwK0pNTQ0aGhoQCoWoX78++vfvjytXrsDb2xtjxozhxuH/kn26Z1BckNXV1WW2E1KeqDAQAMDo0aPRqlUr7mcNDQ3eWEIPHz6Er68vTE1Noa+vDycnJ2zfvp3XR/Gx75SUFMyZMwf169dHrVq1lMpHXV0da9as4YZZ/lhcXBy+++47NGzYELq6umjatCmWLl0KiUQiFTd+/HhYW1tDX18frVq1QkBAAC9Onu0CikZj7dSpE/T19WFjY4MNGzaUmLu8+ZWVRCLBvHnzYGFhAUNDQ/Tv3x9v377lxZT2O9m2bRucnJygr68PU1NT+Pr64tGjR7w+TE1NMWnSJKn1Dxo0CHZ2dry2wsJCLF++HI0bN0atWrXg5uaGBw8eYOjQoWjSpInM7YiKioK3tzcMDAzQsGFD3mB8xYrPRzx79gzdu3eHgYEBrK2tsWzZMhQWFiqVr7m5Oe7du4fLly9zhVdVo9lWd1QYCABg69at3AxYW7duRU5ODjdPQFhYGDp06IDMzExcvXoVUVFRGDRoEL777jve+DrFh4ZmzpwJe3t7PHjwQOpDXRFWVlZo1qwZgoKCuLaYmBg4OzvjyZMnOHLkCBISErBu3Tps3LgRI0aM4OJevXoFJycn3L59Gzt37kRcXBz27duHqKgoXLlyRaHtunPnDnr06IG6desiLCwMV69eRUxMDHbu3CmVs7z5qcL8+fNhZ2eHJ0+e4MyZMwgNDcXo0aN5MZ/7nfz0008YO3YsBg4ciKioKFy9ehVZWVlwdXXlZqwDSj7cUlBQIFXsZs+ejUWLFmH27NmIjo5GQEAA5s+fj7dv38osjCKRCLNmzcKSJUvw+vVrTJ06FQsWLMD+/ft5cRKJBKmpqZgxYwZWrFiBV69e4ccff8SyZcswbdo0qVh58o2Pj4eTkxPc3d25Q3Wy5saokZSZD1QkErGzZ8+yrVu3sq1bt7Jz587x5qYl1dPjx48ZALZjxw5ee8+ePZmRkRETi8W89m+//ZZpaGiwuLg4xhhjy5cvZwDYwoUL5VrfgQMHGAB25MiREmO6d+/OALDMzEzGGGMDBw5kRkZGLCUlhRdXPCH8vXv3GGOM9e/fn9WqVYslJSWV2Le82+Xp6cksLCxYTk4OL65bt268ubEVya80xXNP5+fnS71W/D6vWLGC1148V/ebN2+kYj/9nSQkJDBNTU02cuRIXntGRgYzNjZmHh4eXJuhoSE3r/enOdrY2HDP4+Pjmbq6Ops6dSovLi4ujmlpabFGjRrx2h0dHZmmpqbUnNytW7dmXbp0kYpVU1Nj4eHhvPY5c+YwNTU19urVK4XzZYwxJycn1r17d6nYmk6hPYbg4GD06dMHxsbG8Pb2xowZMzBjxgx4eXnBxMQEvr6+3Lcx8mUoKChAcHAwPD09pQ4LDRw4EBKJROp37uvrq/I8BAIBCgsL8e+//6Jbt25Scz17enoCKPobLSwsxNmzZ9GzZ0/UrVtXZn/ybldxnJeXF4RCIS+uf//+vOfy5qcqvXv35j0vHu/o1atXUrGf/k6uXLmC/Px8+Pn58dr19fXh7e2N4OBghQ99Xb16FQUFBejTpw+vvX79+lJzOhdr3ry51OGbFi1ayNwGR0dHNG3alNfWv39/FBYW4vLlywrlSj5P7sLQr18/DBkyBHZ2drh8+TKysrIgFoshFouRmZmJixcvomnTphg8eLDUPwypvj58+IDc3FyZcxSYm5sD+L+T1sU+nv6zrOLj42FoaAgdHR1kZGQgMzMTJ06cgLa2NoRCIYRCIbS0tLgP4tTUVGRkZCA7O/uzeci7XRkZGcjLy4OZmVmJccXkzU9VPs3dwMAAQNFQ2p/69L0onj2vpO3Pz88v9T4J9snlssXbJuu9ktVW0voNDAxkbsPnfgfyvK+f5ktKJvcgel26dMHBgwelvjUBRVexuLm5wc3NDcuWLfvsiTlSvejr60NLS0vmvMDFbSYmJrz2sk4VWezNmzd4+fIl9w1UX18fQqEQgwcPxt9//y1zGTW1ou862traSEhIKLFveberVq1a0NTU5M1n/Gncx33Km58qlHSFkqwPwE9/J8bGxgCkt6G4TVNTkys0hoaG+PDhg1Tcp+9vcZ/JyclSc2DLev8U3YbP/Q4+/huUN19SMrn/SqdPny6zKHxKKBRi+vTpZUqKVB3q6uro3LkzLl68iKysLN5rx48fh7q6Otzc3FS+XsYY5syZA4FAgNmzZ3O5eHl54cKFC8jKypJ5A5iamhrU1NTQs2dPnD9/Xua80opsV3Hc+fPnkZ+fz4s7deqUVJ/y5FcVdOnSBerq6jh58iSvPSsrC+fPn0enTp24YtK4cWM8efKEF5eQkMBNDfpxn2pqajh79iyvPSkpibuwoSyePn2K169f89pOnToFgUDAGyFW3nwBQE9PD3l5eWXO7Uuj1F9pZmYmjh49yj0vHuN90qRJyMzMVFlypGr45ZdfIBKJMGTIEERHR0MkEmH9+vXYtm0bpk2bJnO6SmUwxvDu3TucPXsWPXr0wPHjx7Fx40Z07NiRi1m9ejXy8/PRu3dvhIaGIjs7G6mpqbh8+TL8/f3x+PFjAEWXaaqrq+Prr7/G7du3kZOTg8jISMydO5c7zi/vdi1ZsgSJiYkYOXIk4uLi8O7dOyxZsgRaWlpS2yBvfpWtfv36mDZtGrZv345169ZBJBIhOjoaQ4YMwfv377F8+XIudsyYMXj48CHWr1+PrKwsPH36FJMmTULbtm15fVpaWmLixIlYt24ddu3ahQ8fPiA8PBzjxo1Du3btypyzi4sLvv/+ezx9+hSZmZnYt28f1qxZg9GjR/MuhZU3X6DovMWTJ0+kCk6Np8wZ66lTp7J169Yxxhh79+4dq1WrFhs5ciRr06YNmzBhgorOi5OKVtJVSYwxFhoayjw9PZmenh5TV1dndnZ2LCAggBUWFnIxxVfApKeny7W+4quS1NTUmLq6OtPQ0GC1a9dmLi4ubPbs2SwiIkLmcrGxsWzs2LHM0tKSqaurs7p16zIPDw8WGBjICgoKuLioqCg2dOhQZmpqyjQ0NJidnR1buXIly83NVWi7GGPswoULrE2bNkxdXZ1ZWFiwlStXsn/++UfqqiRF8vscea5K+vR9vnnzJgPAjh8/XmosY4wVFhaygIAAZm9vzzQ0NJiuri7z8PBgt27dkopbuHAhq1OnDtPU1GQdO3ZkT548kXmVj0QiYT/99BMzNzdnmpqazMXFhd26dYv169ePNWvWjBfr6OjIvv76a6m8Jk2axPT09GTG3r9/n7Vr145pamoyMzMzNm/ePKn3SJF84+PjWffu3ZmOjg5TV1eXunKqplJqPgZLS0vcv38fdevWxcGDB7Fp0yYEBwcjKioKXbp0QXx8vCprF6lAEokE6urqSt1hyxhDQUEBNDTkO3VVHF9M3uWqCkW3VxGFhYUoLCyU2ffn1vvp76+8c2SMQV1dvdTYtm3bQkdHh3cFW0FBAQQCgdThNVn9Fl+9dPr06XLLt/hvUZ7t+dIpdShJJBJxu9GXL1/mBqEyNzev9iM+1nRlGXZBIBAo9AFUHF/8qG4U3V5FFA8Touh6P/39lXeO8nyIvn79GmFhYejSpQuvXV1dXeY5F3n7VVRp/aqrq1NR+P+UKgxt2rTBwoULcebMGRw6dAg+Pj4AgAcPHuCrr75SaYKEkOrj/Pnz+PXXXxEdHY2cnBzcvn0bfn5+qF27tsxhKkjVpFRhWLt2Lc6fP48BAwZgwoQJ3Bg7v/32G+bMmaPSBAkh1Ufnzp2RnZ0NLy8vGBgYoGfPnrCyssKNGzek7vsgVZdK53wWiUQwNDRUVXeEEAKg5PMRpHwo9C53794df/zxByIiImS+TkWBEFIeSjofQcqHQu+0n58fzp8/j5YtW8LW1hYzZ85EUFCQyocTJoQQUnmUOpSUlZWFCxcu4PTp0zhz5gwyMzPRs2dP9OrVC97e3lIDiJVEJBLh77//RkhICDQ0NNCpUyeMHTtW6g7rW7duYcOGDUhKSkKLFi0wZ84c1KlTp1xiPqewsBAJCQmoVasWTZhCCKlWGGPIyMhAvXr1St/7KuuNEIWFhezu3bts0aJFzNnZmWloaLAOHTqwX3/99bPLSSQS1qhRIzZr1ix29OhRtmfPHtasWTPm7u7OJBIJF3ft2jWmqanJZs6cyQIDA5m7uztr2rQp+/Dhg8pjShMbG8sA0IMe9KBHtX3ExsaW+lmn0pPPAJCYmIh///0Xp0+fxvHjxz8b++nJ6rCwMLRp0wY3b95E+/btAQBubm6oW7cujhw5AqBoVEwLCwssXbqUm6BDVTGlEYlEqF27NmJjY7kBxgghpDoQi8Vo0KAB3r9/X/r5YLm/Ln/kw4cPLDAwkHt+5swZ1rNnTzZx4kSFvoF/6tWrVwwAu3TpEmOMsczMTKampsZ2797Ni/P19WXe3t4qjZGHSCRiAGhSIkJItaPI55dSp/mLp+oDgPT0dAwaNAgWFhYIDQ3lRsJUxsqVK1G3bl1uwK24uDgUFhZKjSVfv359xMTEqDRGltzcXG7OieIHIYR86ZQqDIGBgRg4cCAA4L///kObNm2wY8cOHD58WGoYX3lt3rwZf//9N3bt2gU9PT0A4IbD1dHR4cXq6upyr6kqRpbly5fD0NCQe6hqFFFCCKnKqsRYSbt27cLkyZOxd+9eeHl5ce1GRkYAIDWmflpaGveaqmJkmTdvHkQiEfeIjY1VeNsIIaS6UWp0reKxknr27IlDhw7h6tWrAJQbK2nPnj0YO3Ysdu/ejUGDBvFeq1+/PurWrYv79++jV69eXPudO3fg6uqq0hhZiqdmJISUXUZGBu7cuYOGDRvy5k8AgMePH8ucTU5bWxudOnWSO+ZjjDEEBwdDW1v7s//nZV3mi6TMSYz79+8zOzs7pqOjw3744QeuvXfv3uzUqVNy97N3716mpaXFDhw4UGLMnDlzWIMGDVhiYiJjjLFTp04xACwkJETlMaWhk8+EKO7t27ds/PjxzNzcnOnq6vI+M4otXryYde/enffQ09Njzs7OCsV8bNWqVUxdXZ3Z2trKnasyy1QXinx+lfk+ho+9f/9eoVh1dXVmbGzM3NzceI/Tp09zcVlZWax3795MX1+ftWjRgmlra7M1a9bw+lJVTGmoMBCiuLt377K//vqLicVi5ujoKLMwfOrt27dMQ0ODrV+/XqmY27dvs4YNG7LRo0fL/SGvzDLViSKfXyodqF2RsZJ0dXVx8eJFma/Z2tpyP+vo6ODUqVN49eoVkpKSYGtry006ruoYQojqOTk5wcnJSaFldu3aBU1NTQwdOlThGLFYjG+++QZbtmxBUFCQXOtTZpkvmVKFIT09HUuWLMGNGzfw7t07qdcjIyNL7UNTU5M3gXdpGjdujMaNG1dIDCGkcm3fvh3+/v6oXbu2wjHjx4/H119/jZ49e8r9Ia/MMl8ypQrDd999h6dPn2L48OGfvaqHEEIUde3aNYSHh2Pbtm0Kx2zbtg2PHz/GnTt35F6fMst86ZQqDBcuXEBYWBh98yaEqNy2bdtgZ2cn80qjz8WkpqZiypQpWLp0Ka5fvw4AiImJQVZWFi5evIjWrVtLDfCpzDI1gVKFoXbt2rSnQAhRObFYjCNHjmDp0qUKx+Tl5cHV1RVnzpzBmTNnABQd1k5LS8OKFSvwyy+/SH3IK7NMTaBUYfD398fatWuxePFiVedDCKnBDhw4AIlEguHDhyscU69ePakLWubOnYsTJ07w2pOTk/Ho0SN07txZ7mVqGqUKw4MHD3Dp0iUcOnQINjY2UnMTnD59WiXJEUKqv7y8PO4m2MzMTMTExODixYswNDSEi4sLL3bbtm3o16/fZ7+lyxPzOVevXoW/vz9iY2NhaWmpVB9fOqUKQ/PmzdG8eXNV50II+QJlZmZixYoVAAAbGxukpKRgxYoVcHBw4BWGpKQkGBoaYvLkySX2JU/Mx5o2bYoOHTrw2szMzNC9e3doa2vLvUxNo/L5GL5kYrEYhoaGEIlENB8DIaRaUeTzq8yza2dnZ5e1C0IIIVWIUoUhPz8fCxYsgIWFBXR1dbn28ePHIyIiQmXJEUIIqXhKFYZly5bh5MmT+Ouvv3jt7u7udKUSIYRUc0qdY7C2tsapU6fQokULCAQCFHeRmJgIe3t7pKenqzzRqoDOMRBCqqtyP8eQkJAAGxsbAOBdqqquro6cnBxluiSEEFJFKFUYbG1tudvHPy4Mu3fvRqtWrVSTGSGEkEqh1H0M8+fPx7Bhw/Djjz8CAA4dOoRz585hz549OHr0qEoTJITIab+g9BjyZfimfO8yUKowDBo0CGpqali2bBkKCwsxePBgODg44MCBA+jbt6+qcySEEFKBlCoMERER8Pf3h7+/P/Ly8sAY4+ZGvnDhAjw8PFSaJCGEkIqj1DkGT09PJCQkAAC0tLR4RcHX11dlyRFCCKl4ShUGHx8feHp68mZvO3/+PPr27Yvff/9dZckRQgipeEoVhnXr1qFFixb4+uuvkZmZif/++w++vr74448/MH78eFXnSAghpAIpVRjU1NSwe/duGBoawt3dHf369cPatWsxbtw4VedHCCGkgsl98vnu3btSbfPmzcOwYcMwfPhwtGnThotxdnZWXYaEEEIqlNxDYnw6Gc/nfKkjedOQGKRKo/sYag4l7mNQ5PNL7j2GL3X8I0IIIXxyF4batWuXYxqEEEKqCqVucCt2/fp1PH/+HIwxODg4oFOnTqrKixBCSCVRqjAkJibCz88PISEhMDExgUAgQGpqKjp06ICjR4/C3Nxc1XkSQgipIEpdrjplyhRoaGggIiICqampSElJQUREBDQ0NDBlyhRV50gIIaQCKbXHcO7cOTx69AhWVlZcW5MmTbBz5060bt1aRakRQgipDErtMRQUFHDjI31MKBRCIpGUOSlCCCGVR6nC0LVrV0yePJl3Ceu7d+/w/fffw93dXWXJEUIIqXhKHUoKCAiAj48P6tWrh6ZNmwIoGoq7YcOGOHPmjEoTJIQQUrGUKgw2NjZ48uQJTp48iadPn0IgEMDBwQG+vr7Q0CjTFbCEEEIqmVKf4s2bN8eTJ08wYMAADBgwQOZrhBBCqielzjE8ffpUZntBQQFevnwpdz8FBQU4ceIEvLy8YGVlhdDQUKmY+fPnw8rKivfo2bOnVNzRo0fh5uYGOzs7+Pv7y8xDnhhCCKnpFNpjuH79usyfAaCwsBA3b95Eo0aN5O5v7ty5CA8Px6BBgzBq1Cjk5ORIxaSlpcHBwQEbNmzg2rS0tHgxJ0+exODBg/HHH3/A1dUVa9asQZcuXfD06VOYmprKHUMIIUSB0VWBz4+wKhAIUL9+faxduxZ+fn5y9SeRSKChoYG4uDg0aNAAQUFB6Nq1Ky9m/PjxSE1NRWBgYIn9ODk5oVWrVti+fTsAID8/HxYWFpg2bRoWLFggd0xpaHRVUqXR6Ko1RzmPrqrQoaTs7GxkZ2dDT0+P+7n4kZeXh9jYWLmLAgC5T1Rfu3YNDg4OcHV1xZw5cyASibjXMjIycP/+fd7hJU1NTXTv3h3BwcFyxxBCCCmi0KEkbW1tAMCHDx/KJRlZTExMsGDBAri5uSE+Ph7z58/HmTNncO/ePQiFQsTFxQGA1PhM5ubmePToEQDIFSNLbm4ucnNzuedisVgl20QIIVWZ3HsM7u7uuHHjRqlx165dkzocVBZLly7F5MmT0bJlS3h7e+P06dMIDw/HwYMHARSd2wCk9z40NTVRUFAgd4wsy5cvh6GhIfdo0KCByraLEEKqKrn3GEaOHIkBAwbA1NQUvXv3hpOTE8zMzMAYQ2JiIu7cuYN//vkH79+/x/Lly1WWoJoav3bVq1cPjRo1wrNnzwCAO3GclpbGi0tNTUWdOnXkjpFl3rx5mDFjBvdcLBZTcSCEfPHk3mMYMWIEoqKiMHnyZISGhmLYsGHo3LkzunTpguHDh+PevXuYOXMmXr16hZEjR5Zbwjk5OXj79i2MjY0BAGZmZmjYsCFCQkJ4cTdu3ICLi4vcMbIIhUIYGBjwHoQQ8qVT6OSzrq4uxo4di8uXLyMzMxNJSUlITk5GZmYmLl26hDFjxkBHR0dlyeXl5WH69OlITk4GUHRuY9y4cWCMYdCgQVzcxIkT8ffff+PJkydgjGHDhg14/fo1vvvuO4ViCCGElGEGNzU1NdStW7dMKw8MDMSsWbO44/yDBw+GtrY2pk2bhmnTpkFTUxNNmjSBs7MzsrOzIRaL4ezsjKCgIN6Q37Nnz0Z8fDycnZ0hFAqhra2N/fv3w9HRUaEYQgghCt7HoGofPnxAamqqVHvt2rWl5phOS0uDgYEBNDU1S+wvOzsb79+/h5mZmdS5CUViSkL3MZAqje5jqDnK+T6GSh3xTl9fH/r6+nLFmpiYlBqjo6NT6qEseWIIIaQmU2qsJEIIIV8upQpD8+bNlXqNEEJI1Vepo6sSQgipeip1dFVCCCFVj0KFoXPnzjJ/BvijqxJCCKm+FCoM2dnZAIqGmPj0MlMNDQ2a1pMQQr4AVX50VUIIIRVLqa/4586d++zrXl5eSiVDCCGk8ilVGHr16sV7zhjjhrZWV1eHRCIpe2aEEEIqhVKXq0okEt6joKAAkZGR6NatG3bu3KniFAkhhFQkld35bGNjgy1btmDFihWq6pIQQkglUOmQGKampnj9+rUquySEEFLBlDrHIOvDPz09HatXr6ZhrAkhpJpTqjBYW1vLbLe3t8f+/fvLlBAhhJDKpVRhiIiIkGozMjKSa2hsQgghVZtShaFJkyaqzoMQQkgVofQYFpGRkVi3bh2eP38OAHBwcMDkyZNhY2OjsuQIIYRUPKWuSjp58iTs7e1x69Yt2NrawtbWFqGhobC3t8c///yj6hwJIYRUIKX2GGbNmoVff/0Vs2fP5rWvWrUKM2fORO/evVWSHCGEkIqn1B5DQkICxo4dK9U+duxYJCQklDkpQgghlUepwuDo6IiwsDCp9vv379N9DIQQUs0pdShpyJAh8Pf3x+zZs+Hi4gLGGO7evYtVq1Zh/vz5uHv3Lhfr7OyssmQJIYSUPwFjjCm8kEAgd6wS3VdZYrEYhoaGEIlEMDAwqOx0yk10dDQuXbqEtLQ0ODs7o3v37rzXV69eLXNOjubNm2PAgAFS7S9fvsSBAwfQpk0b9OnTp8T1Ktov+cR++f8vSTX3jeKfq4p8fil1KCk9PV3uB6le9uzZA0dHR1y8eBFJSUkYNWoURowY8dllxGIxFi9ejBcvXki9lpOTA39/f6xduxanTp1SKJfP9UsIKT9K7THUVF/6HkN+fj6MjIwwb948zJ8/HwCQlJSEJk2aYP/+/SVebbZ582ZMmjQJMTExqF+/Pu+18ePHQ0NDAw8ePICdnR3+/vtvufP5XL9EBtpjqDnKeY9B6RvcEhMTcf/+fbx7907qtWHDhinbLalEMTExyMzMROfOnbk2MzMzNG3aFIcPHy6xMGzbtg0+Pj5SH95Hjx7F1atXce/ePXh4eCicT0n9EkLKl1KF4fDhw9zhBUNDQ6nXqTBUTw0aNIC2tjZu3LiBLl26AABSUlIQEREBNTXZRx0fP36MO3fuSB0miomJwaRJk3Du3Dno6OgonEtJ/RJCyp9SheHHH3/EsmXLMGPGDIVORJOqTSgU4o8//sDUqVPx+PFjWFhY4PTp07C2tpZ5UhgA/v77b9SrVw8+Pj5cm0QiwZAhQzBr1iy0bt1aqVxk9UsIqRhKnXxOSkrChAkTqCh8gcaPH4+HDx+ic+fOMDc3x9GjR9GiRQsYGxtLxebm5mLfvn0YNWoU1NXVufajR4/i0aNHyMjIwKJFi7Bo0SK8efMG9+/fx6JFi5CTk/PZHErqlxBSMZTaY2jRogWePXtG9yh8oezs7GBnZweg6HLj69evo3///lJxJ06cwLt37zB69Gheu62tLWbNmqX0+kvqlxBSMeS+Kunjm9ZCQkKwfv16LF68GE2aNJHac/hSC8aXflUSADx//hy2trbcOYUtW7ZgypQpePToEZo1a8aL9fT0hEAgwH///Vdqv506dZK6KuncuXN48eIFpk2bpnS/5CN0VVLNUVWuSnJxcZHO7ZtvZMbSFbDV17179zBixAi4ubkhOjoa586dw65du6SKQkxMDC5duoRDhw4pva5z587hxIkTvMKgin4JIWUjd2Ggm9VqhmHDhqF169Y4f/48mjZtinXr1sHCwkIqLjU1FQsXLkTfvn3l6nfUqFEwNTXltXl5ecHKyqpM/RJCVK9Sb3ATiUTYs2cPNm3ahBcvXuDSpUtwc3OTilu3bh3Wrl2LpKQktGjRAmvWrIGrq2u5xHxOTTiURKoxOpRUc1SVQ0kfO3fuXImvCYVCNG7cGI0aNSq1n1WrViE9PR2rV6+Gt7e3zENQO3bswA8//ID9+/fD1dUVK1euhKenJ549e4YGDRqoNIYQQoiSewza2trIzc39v04EAu5DXV1dHQUFBXB3d8fRo0dhZGRUan9xcXFo0KABgoKC0LVrV95rDg4O6NatG9avXw+g6PyFpaUlRowYgV9//VWlMaWhPQZSpdEeQ81RFQfRCwgIgIuLC0JCQpCTk4Ps7GzcuHEDTk5OWLduHR48eICsrCzMmTNHme456enpeP78Odzd3bk2gUAAd3d3hISEqDSGEEJIEaUKw5o1a7Bv3z64urpCKBRCKBSiQ4cO2L9/PwICAtCqVSts3bq1zJcbvn37FgBQt25dXnudOnWQmJio0hhZcnNzIRaLeQ9CCPnSKVUYXr9+LXOMJENDQ7x+/RoAYGVlhYyMjDIlVxI1NbVSL4lVRczy5cthaGjIPehcBCGkJlCqMLRu3RqzZs3iffBnZGRg5syZ3Ng4N2/eRIcOHcqUnLm5OYCigdw+lpycDDMzM5XGyDJv3jyIRCLuERsbW4atIYSQ6kGpwrBlyxZcuXIFFhYWcHJyQps2bWBhYYFr165h8+bNAICwsDCsWbOmTMkZGxujWbNmuHLlCtfGGENwcDBXdFQVI4tQKISBgQHvoQyBgB415UHIl0Cpy1VbtmyJiIgIHD9+HM+fP4dAIICdnR369esHLS0tAMAPP/ygkgRnzpyJGTNmwMfHB+3bt8fKlSvx7t07jB8/XuUxhBBCyjBRj5aWFgYNGlSmle/evRujRo3innfv3h0CgQA///wzfv75ZwDA2LFj8f79e3z77bdITk5G8+bNcebMGd4ds6qKIYQQAuXuY/jcDW5A0VAH8mCMoaCgQKpdTU2txIlhKpOy9zHQIYaao1KHCaP7GGqOqnjnc69evXjPGWMoLCwEUHSDm0QikasfgUAADQ2ld1oIIYSUA6W+lkskEt6joKAAkZGR6NatG3bu3KniFAkhhFQklR2vsbGxwZYtW7BixQpVdUkIIaQSqPRAvqmpKXeDGyGEkOpJqQP8sj78i0dJdXR0LGtOhBBCKpFShcHa2lpmu729Pfbv31+mhAghhFQupQpDRESEVJuRkRFMTEzKnBAhhJDKpVRhaNKkiarzIIQQUkWU6SaC69ev4/nz52CMwcHBAZ06dVJVXoQQQiqJUoUhMTERfn5+CAkJgYmJCQQCAVJTU9GhQwccPXqUG82UEEJI9aPU5apTpkyBhoYGIiIikJqaipSUFEREREBDQwNTpkxRdY6EEEIqkFJ7DOfOncOjR494A9A1adIEO3fu5OZjIIQQUj0ptcdQUFAAoVAo1S4UCuUeJ4kQQkjVpFRh6Nq1KyZPnoz09HSu7d27d/j+++/h7u6usuQIIYRUPKUOJQUEBMDHxwf16tVD06ZNARTd29CwYUOcOXNGpQkSQgipWEoVBhsbGzx58gQnT57E06dPIRAI4ODgAF9fXxpGmxBCqjmlPsU9PDxw4cIFDBgwAAMGDFB1ToQQQiqRUucYQkNDkZmZqepcCCGEVAFKFQYvLy8cOnRI1bkQQgipApQ6lGRkZITvvvsOx44dg4ODA7S0tHivL1u2TCXJEUIIqXhKFYbw8HB07twZHz58wO3bt1WdEyGEkEqkVGEIDg5WcRqEEEKqCpVO7UkIIaT6U2qPoaCgAHv37sWNGzfw7t07qdcDAwPLnBghhJDKoVRhmD59Onbu3Alvb2+YmpqqOidCCCGVSKnCcODAAVy8eBFt27ZVdT6EEEIqmVLnGNTU1ODg4KDqXAghhFQBShWGHj164OTJk6rOhRBCSBUg96GkBQsWcD/r6+tj5MiROHXqFJo0aQKBQMCLpRvcCCGk+pK7MFy/fp33vGPHjkhKSkJSUpLKkyKEEFJ55C4MdFMbIYTUDAqdY/j+++/LKw9CCCFVhEKF4a+//iqvPAghhFQRVX66tffv3+PDhw+8Nk1NTZiZmUnF5uXlQSwWw8TEROqEuCIxhBBSk1X5sZLmzp2LZs2aoX379txj6NChvJjCwkLMnDkTtWvXhpWVFSwtLXH8+HGFYwghhCixx6Cvr19qzKff8MvKx8fns+Mv/f7779ixYwdCQkLQsmVLrF+/HoMGDcLDhw9hb28vdwwhhBAlCkNl3aPw7t076OvrS00KBBSd+xgzZgxat24NAJgyZQoCAgKwZcsW/PHHH3LHEEIIUaIwTJs2rRzS+Lzjx4/jwoULyM7OhrOzM9avX482bdoAAJKTkxETE4OOHTvylunUqRM3iZA8MYQQQopU+XMMzs7OuHv3LkQiEVJSUtC4cWN4eHggMTERAJCSkgIAUqO8mpqacq/JEyNLbm4uxGIx70EIIV+6Kl8YxowZg6+++goAYGhoiK1btyI3N5c756CmVrQJEomEt1x+fj7U1dXljpFl+fLlMDQ05B4NGjRQzUYRQkgVplBhSE9PL6885KajowMLCwu8fv0aAFC/fn0A4PYgiiUlJXGvyRMjy7x58yASibhHbGysqjaDEEKqLIUKQ+3atcspjZIxxnjP3759i5iYGDRu3BgAYGBggNatW+PChQtcjEQiwaVLl9ClSxe5Y2QRCoUwMDDgPQgh5EtXpW9wy83NRdeuXTF79mw4OjrizZs3mDdvHiwtLTFs2DAu7qeffsKgQYPg4uICV1dXrF69GgAwYcIEhWIIIYRU8XMMQqEQGzduRGBgIHx9fbFw4UJ0794d9+7d431779+/P/bu3Ytdu3ahX79+EIvFuHLlCurUqaNQDCGEEEDAPj1WQ0okFothaGgIkUik0GElGnmj5qjU/6b99IdWY3yj+B+aIp9fSu8xBAYGwtvbG7a2tlzb8uXLP3v5JyGEkKpPqcKwfft2jB8/Hi4uLggPD+faa9WqheXLl6ssOUIIIRVPqcKwevVqBAYGYsmSJbz2Xr164eDBgypJjBBCSOVQqjC8evUK7dq1AwDe0NVGRkZIS0tTTWaEEEIqhVKFoV69enj27BkAfmE4d+4cbGxsVJMZIYSQSqFUYRg3bhxGjRqF4OBgCAQCvHz5En/++SfGjRtH9wUQQkg1p9QNbnPmzIFYLIaPjw8KCgpgZ2cHoVCIWbNm0bzQhBBSzZXpPoasrCw8ffoUhYWFcHBwQK1atVSZW5VD9zGQ0tB9DKRClPN9DGUaEkNXVxcuLi5l6YIQQkgVI3dhGD9+vNydbtq0SalkCCGEVD65C8P79++5nzMzM3H69GmYm5tzU2U+ePAAiYmJ6NWrl6pzJIQQUoHkLgwf37g2btw4fP/991izZg00NTUBFE16M2PGDOTn56s+S0IIIRVGqZPP9erVw+PHj2FiYsJrT0tLQ8uWLREfH6+yBKsSOvlMSkMnn0mFqIqD6InFYsTFxUm1x8bG0rzIhBBSzSlVGPz9/eHv749jx44hNjYWb968wbFjxzBw4EAMHDhQ1TkSQgipQEpdrvrXX39hzpw5GDJkCPLy8gAAWlpaGDt2LFauXKnSBAkhhFSsMt3g9uHDB0RFRQEAbGxsoK+vr7LEqiI6x0BKQ+cYSIWoyje46evro1WrVmXpghBCSBWjdGF48+YNAgIC8Pz5czDG4ODggClTpqBhw4aqzI8QQkgFU+rkc3BwMGxtbfHff//BwsIC9evXx3///QdbW1sEBwerOEVCCCEVSenRVWfNmoWlS5fy2n/66SfMmTMHt2/fVklyhBBCKp5SJ5+FQiESExNhZGTEa09PT4eFhQVycnJUlmBVQiefSWno5DOpEFXxBrfatWtzVyN9LCIiArVr11amS0IIIVWEUoVh6NChGDhwIA4ePIhXr17h1atXOHDgAAYOHIhvvvlG1TkSQgipQEqdY1i+fDkAYMSIEbwb3CZNmoQVK1aoLjtCCCEVrkw3uGVmZiIyMhICgQA2NjbQ09NTZW5VDp1jIKWhcwykQlTlG9z09PToBjdCCPnCKHWOISQkBJMmTZJqnzRpEm7evFnmpAghhFQepQrD9OnTMWLECKn2ESNGYObMmWVOihBCSOVRqjA8fPgQ9vb2Uu329vZ48OBBWXMihBBSiZQqDJaWlrh69apUe3BwMCwsLMqcFCGEkMqjVGEYO3YsRo8eje3btyMyMhIRERHYtm0bRo8ejbFjx6o6R0IIIRVIqauSZs2ahbS0NEycOBG5ubkAiobJmDp1KmbPnq3SBAkhhFSsMt3HkJGRgWfPnkEgEMDBwaFaTNQTGxuLpKQkNGvWTKF7EQC6j4GUju5jIBWiKo6VVKxWrVpo164d2rZtW+WLQk5ODvz8/GBra4v//e9/MDc3x7p16yo7LUIIqXKULgyBgYHw9vaGra0t17Z8+XKkpKSoJDFVW7x4MW7fvo2oqCg8f/4c+/fvx5QpU3Dr1q3KTo0QQqoUpQrD9u3bMX78eLi4uCA8PJxrr1WrFjeOUlWzY8cOjBkzhrtqytfXF82bN8eOHTsqOTNCCKlalDr5vHr1agQGBqJr1668yXp69eqFDh06YM2aNSpLUBUSEhKQlJQEJycnXnvbtm0RFhZW4nK5ubncyXUAEIlEAIqO1REiS6X+aWRV4rpJxVLiD634c0ue08pKFYZXr16hXbt2AADBR2dWjYyMkJaWpkyX5erdu3cAABMTE167iYkJ95osy5cvx+LFi6XaGzRooNoEyRfD0LCyMyA1wnfK/6FlZGTAsJQ/VKUKQ7169fDs2TM4OTnxCsO5c+dgY2OjTJflSlNTEwCkZpbLzs6GlpZWicvNmzcPM2bM4J4XFhbi3bt3MDEx4W03kSYWi9GgQQPExsYqfPUXIfKivzP5McaQkZGBevXqlRqrVGEYN24cRo0ahT///BMCgQAvX77EuXPnsHDhQql5oKuCBg0aQE1NDfHx8bz2+Ph4NGzYsMTlhEIhhEIhr41mqFOMgYEB/cOSckd/Z/IpbU+hmFKFYc6cORCLxfDx8UFBQQHs7OwgFAoxa9YsfP/998p0Wa50dXXRoUMHnDp1CsOGDQNQNJfExYsXsWjRospNjhBCqpgy3eCWlZWFp0+forCwEA4ODqhVq5Yqc1OpK1euwMPDAzNnzoSrqyvWrVuH6OhoPHjwoMrfg1EdKXszICGKoL+z8lGmiXp0dXXh4uKiqlzKlZubG4KCgvDXX3/h9u3baNGiBfbs2UNFoZwIhUIsXLhQ6lAcIapEf2flQ+E9hpycHPz11184duwYoqOjIRAIYG1tDT8/P0ycOJF+QYQQUs0pVBjy8/PRvXt33Lp1C56entxdzy9evMD58+fRsWNHXLhwARoaZdoRIYQQUokU+gTfunUrYmJi8OzZM6nLUiMiIuDu7o7t27fT0NuEEFKNKTQkxpEjR/Drr7/KvFehadOmWL58OQ4dOqSy5AghhFQ8hQrDkydP0KNHjxJf79GjB548eVLmpEjVc/z4cfj7+382Zv/+/Rg+fHgFZUQIKS8KFYb09HTUqVOnxNfNzMw+O8QEqXxDhgxBQEAAr+3s2bNo3749Tp06xWvftGkTfH19AQBJSUm8caUCAwMxePBgXnxCQgIePXpUPol/Qtb6CSGqoVBhKCgogJpayYuoqalBIpGUOSlSfnR1dXHw4EFe26lTp/D8+XOcOHGC137o0CHo6OgAAPr374/AwEDutcTERDx48KC80y1RZa+fqM7UqVNhZ2cHOzs7tGzZEj4+Pti5cycKCws/u9z9+/dhZ2eHN2/ecG0SiQRjx45F586dsWfPHjg4OCA5OVnm8iNHjsSkSZNUui1fCoUvH/rcoSRS9XXr1g27d+/Ghw8fuHs4goKCMHnyZOzbt4+Ly8nJQWhoKP78808AwI0bN7B//34cOXIEFy9exO+//47ExES0b98eADB9+nRu2YsXL2LXrl1ITExEx44dMXfuXGhra3OvP3r0CGvWrMGrV69Qv359TJw4EZ07d+Ze37BhA168eMHbs/n333+xefNmnDp1qsT1Dxo0qBzeMVLe4uPjYWFhgY0bNyI/Px/Xr1/H2LFjkZaWhpkzZ5a4XFZWFl6+fIm8vDwARWOfDRw4EA8fPsT58+fRqFEjTJ48GXv27JHqJy4uDnv27JH6kkSKKLTHMHToUJibm3/2MXTo0PLKlaiAu7s7JBIJrl+/DgB4+/YtoqKiMH36dCQlJeH169cAgJs3byInJwfdunUDwD+U9NVXX8HPzw9mZmZYu3Yt1q5dCzc3NwBFly4vWrQI/v7+mDBhAnbs2IG5c+dy63/58iVcXV2hra2NBQsWwNraGt27d0dwcDAX8+bNGzx79oyXd0pKCu7fv1/q+kn1pKenBzs7O7Ro0QITJkyAv78/9u7dK/fyIpEInp6eiIqKQkhICOzs7KCjo4MhQ4Zg+/btUvE7d+6EsbEx+vbtq8rN+GIotMegyC+KVE316tVDs2bNEBQUBC8vLwQFBaFNmzYwMTGBq6srgoKC8O233yIoKAgNGjRAkyZNpPowMTGBlZUVtLW1uW/sxQQCAU6ePMkNcZ6UlISVK1di7dq1AIpm0mvfvj02bdoEAPD09ERCQgJ+/PFHhISEyLUNn1s/+TIYGhoiPT1drtjExEQMGDAAQqEQ165d4w2vP2bMGGzatAmhoaHc3wpjDDt37sT//ve/z46uXJOVac5nUj25u7tz39CDg4PRtWtXAEXDhnzc7u7urnDfjRs35v1jWlpaIjExkXt+584deHl58Zbx8fHB/fv3Sz2mTGqGN2/e4OTJk3Iftvb19YW+vj4uXbokNeeKk5MTWrduzdtrCA4ORlRUFEaPHq3SvL8kVBhqIHd3d9y7dw9isRhBQUG8whAUFITs7GzcunWLO4ykiOK5L4oJBALejFEZGRlS41Pp6+sjLy+PN1seqVmCg4NhZ2cHGxsb2NjYwMXFhTu/VZqmTZvi2bNnePnypczXR48ejYMHDyIrq2iKu23btqF9+/ZwdHRUWf5fGioMNZC7uzsKCgpw4MABvH79Gp06dQIAtG/fHikpKdi1axfy8vI+u8egpqYm1xSBn7KxscHz5895bc+fP0e9evW4K6D09PS4f+JiH+91lGX9pGpycXHBiRMncPToUcyYMQOXL1/mfdC7urpyVy59eh5zx44d8PDwQI8ePXD79m2pvocNG4b8/HwcOXIE79+/x7FjxzBmzJhy36bqjAY1qoHq1q0LR0dH/PLLL2jTpg03XLpQKES7du24u9s/N4mRmZkZkpOTkZ+fL7WX8DmjR4/GjBkzMG7cODg6OiIuLg4BAQG83foWLVpg+fLliI6OhrW1NRISErBlyxaVrJ9UTcUnnwGgdevWiI6OxrfffouwsDCoqalhz5493KXwurq6vGU1NDS4mys9PDzw33//8c491a5dG/3798f27duRmZkJdXV1uoKtFLTHUEO5u7sjNjaWO4xUzM3NDbGxsaUeRurZsyfMzc3RuHFjtG/fXu6hUEaOHIlhw4bB2dkZjo6OaNasGdq1a8e7cqlPnz7w8fFBixYt0LJlS7i6ukqdZFZ2/aR6+O233/DixQvs2rULANCkSRNuj0HWFxZ1dXXs2bMHvr6+8PT0xI0bN3ivjxkzBlevXsWqVaswaNAgGm6/NIzUSImJiezmzZssOTmZ156amspu3rzJEhISeO1JSUksLCyM1yaRSNjLly9ZaGgoe/v2LUtISGCPHj3ixaSnp7Nbt25JrT81NZXdu3ePvX37tsQcY2Nj2YsXL5hEImHJycns/v37n10/qZ78/PzY119/LdU+bdo0ZmlpybKzs2Uud+3aNQaARUREcG0FBQVs1KhRTF9fn129epVrLywsZDY2NgwACwkJUf1GfGHKNIMbIYSUVUJCAgoLC2Fpaclrz87ORkxMDBo1asSdf5L1uo2NDe9wImMM4eHh0NbWRqNGjbj2t2/fQiwWc9MFkJJRYSCEEMJD5xgIIYTwUGEghBDCQ4WBEEIIDxUGQgghPFQYCCEqcfr0aYwYMUIlfT19+hRjxoxBz549sW3bNgBFkzMNGjQIHh4elTZT5KpVq7Bq1apKWXdFojufCSEqERcXJ3VjmTIYY/D29kafPn0wa9YsWFtbIywsDN988w02bdqEhg0bokGDBirIWHFPnz6tlPVWNCoMhJAqJSEhAbGxsZg2bRo37PvmzZvRuHFjjBo1qpKzqxmoMBBCVCokJAS7d+9GfHw83NzcMHXqVO4GtH379uHWrVu82fmuXbuG33//HSdOnEBwcDDmz58PoGj4lOKZ/2JjYxEfH48ePXrA2NgYhw8fBgCkpaVh/fr1uHv3LoyNjdGnTx/4+flxfZ8+fRpHjhzBxIkTsWHDBrx9+xaBgYEwMDBAWFgYtmzZgtjYWFhbW2PChAlwcHDgbcuRI0dw4MAB6Ovrw9vbu1zft6qEzjEQQlQmLi4Ow4YNQ7t27dC/f3+sXbsWEyZM4F6Pjo6WGgE1KSmJmwfE3t4e48aNAwBMmDABc+fOxdy5c9G9e3fUqVMHc+fOxeTJkwEUzern4uKCqKgojBo1Cl26dMGMGTOwdOlSXj6HDh3C6NGj0a1bN8yZMwc6Ojo4c+YMevTogfr162PcuHEwNjZGu3btcPfuXW7ZnTt3Yvjw4WjXrh169eqF9evX4+jRo+X11lUtlTkeByHky7Fx40YGgN24cYNru3r1KlNTU2Ph4eGMMcaWLl3K2rVrx1vuyJEjzNDQkHseERHBALDo6Giu7Y8//mCOjo685aZMmcJ8fHx4bZcvX2ZaWlosJyeHl9OLFy+4mMLCQmZlZcW2bt0q1V/fvn0ZY0VjLtWvX5/99ttv3Ovv379nBgYGbMSIEfK9IdUYHUoihKiMgYEBOnTowD3v3Lkz9PT0cPfuXTRt2lSl67p06RJyc3Ph5eUFxhgYY8jNzUVeXh4iIyO5iXjMzMx44yNFRUXh9evX2LlzJwIDA7ll4+LikJ+fD6BoTyM+Pp53+MjQ0BAdO3ZU6TZUVVQYCCEqUzy3x6dt79+/V/m6xGIxPD09MXjwYKnXPh6a+9MhtsViMQBg1KhRUkN4F5/TEIlEAKS3R9b2fYmoMBBCVCYxMREfPnzgPozFYjGSkpJgbW0NANDR0UFOTg5vmeTkZKXWZW1tDZFIJPfc0MUaNWoEgUAAoVBY4rJWVlYAgIiICO7n4uctW7ZUKt/qhE4+E0JUpqCgAMuWLeOeL126FObm5tw0sY6Ojnj+/DlevXoFAHj//j02b96s1LrGjx+PY8eO4dSpU1zbhw8fSp0r2sTEBP7+/li0aBFev37NtYeHh3NXO9WqVQt9+/bFb7/9xs1FfvLkSYSFhSmVa3VDewyEEJUxNzfHnTt3YGdnB8YYkpKScPjwYQiFQgBFM+/16tULX331FRwdHREbGwtXV1fExMQovK4hQ4YgLi4O33zzDSwtLaGnp4f4+HjMmDGj1GW3bt2KUaNGwcHBAY6OjhCJRNDS0sL69eu5mLVr18LT0xNWVlaoV68ePnz4IDWT4JeK5mMghKhEfHw8YmJi4OrqitevXyMhIQEtW7aUeVw+PDwcYrEY9vb2yMzMxPPnz+Hm5gagaAKeGzduoFOnTlL3Mcj6YM7KysKjR48gFAphb2/PLfNxTh+fEP/Y27dvERkZCQsLC9jY2EAgEPBel0gkuHfvHvT19WFra4vw8HAAkLrf4UtDhYEQQggPnWMghBDCQ4WBEEIIDxUGQgghPFQYCCGE8FBhIIQQwkOFgRBCCA8VBkIIITxUGAghhPBQYSCEEMJDhYEQQggPFQZCCCE8VBgIIYTwUGEghBDC8/8A4aDYao5BnYoAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 400x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "labels = [\"Without\", \"R-KV\\nbuffered\"]\n",
+    "data = [\n",
+    "    before_drop_data[\"metrics\"][\"results\"][\"output_tput\"],\n",
+    "    buffered_drop_data[\"metrics\"][\"results\"][\"output_tput\"],\n",
+    "]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(4, 3))\n",
+    "bars = ax.bar(labels, data, color=[\"blue\", \"orange\"])\n",
+    "ax.bar_label(bars, fmt=\"%.1f\", padding=3)\n",
+    "ax.set_ylabel(\"Decode Throughput (tokens/s)\")\n",
+    "ax.set_title(\"Token Dropping Benefit\\nfor Decode Throughput\")\n",
+    "ax.margins(y=0.15)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f0467f9",
+   "metadata": {},
+   "source": [
+    "## Reading these numbers\n",
+    "\n",
+    "All four notebooks were run back to back on one machine against the same vLLM\n",
+    "and LMCache servers, and each re-measures its own no-drop baseline. That gives\n",
+    "four independent measurements of an **identical** configuration — a direct read\n",
+    "on how much of any difference is real:\n",
+    "\n",
+    "| | one-shot | gpu_exact | cpu_exact | buffered_cpu |\n",
+    "|---|---|---|---|---|\n",
+    "| baseline decode | 969 tok/s | 1008 tok/s | 1002 tok/s | 975 tok/s |\n",
+    "| baseline accuracy | 10/30 | 10/30 | 11/30 | 11/30 |\n",
+    "| decode after dropping | 1766 tok/s | 1774 tok/s | 1785 tok/s | 1774 tok/s |\n",
+    "| accuracy after dropping | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "\n",
+    "Three things follow.\n",
+    "\n",
+    "1. **Decode throughput after dropping is the solid number.** It lands in\n",
+    "   1766–1785 tok/s — a 1.1% spread — although the four notebooks compress with\n",
+    "   completely different code. That is the claim this example makes: the speed-up\n",
+    "   comes from halving the KV cache, not from how the halving is computed.\n",
+    "\n",
+    "2. **Don't quote a speed-up ratio.** The no-drop baseline swung 969–1008 tok/s\n",
+    "   here, and 894–1076 tok/s — **20%** — over an earlier sweep of the same four\n",
+    "   notebooks, so the ratio moves between 1.6x and 2.0x on noise alone. Compare\n",
+    "   the absolute post-drop throughput instead.\n",
+    "\n",
+    "3. **Don't rank the variants by accuracy.** R-KV beat the same-run baseline in\n",
+    "   all four runs (+3 to +4 of 30), which is the meaningful result. But the 1/30\n",
+    "   spread *between* variants is the same size as the baseline's own spread, so\n",
+    "   it says nothing about the algorithms.\n",
+    "\n",
+    "### Why identical inputs give different text\n",
+    "\n",
+    "Decoding is greedy — `temperature = 0.0` for both prefill and decode — yet the\n",
+    "generated text still differs between runs. `temperature = 0` fixes the *rule*\n",
+    "(take the argmax); it does not make the argmax stable.\n",
+    "\n",
+    "Prefill is submitted one stream at a time (`prefill_group_size = 1`) and it\n",
+    "**is** reproducible: 15.19 s and 15.21 s, to the same hundredth of a second, in\n",
+    "every notebook. Decode is not. `batch.decode` hands all 30 streams to vLLM at\n",
+    "once, so continuous batching gives the decode batch a different composition on\n",
+    "every run. GPU reductions are not batch-invariant, logits move by ~1e-6,\n",
+    "near-ties flip, and autoregression amplifies the divergence.\n",
+    "\n",
+    "This is a property of the serving stack, not of token dropping — but it is the\n",
+    "reason a single accuracy number here should not be read as a ranking.\n",
+    "\n",
+    "### The exact variants pick the same tokens — their caches still differ\n",
+    "\n",
+    "Verified directly on real requests: `cpu_exact` and `gpu_exact` produce score\n",
+    "vectors that differ by ~1e-6, but the top-k they select was identical on every\n",
+    "request tested, and so were the kept token ids. Their compacted caches are\n",
+    "nevertheless not byte-identical:\n",
+    "\n",
+    "| | differing elements | largest difference |\n",
+    "|---|---|---|\n",
+    "| V — a pure gather | **0** | 0 |\n",
+    "| K — goes through the RoPE re-rotation | 0.004% | one to two bfloat16 ULP |\n",
+    "\n",
+    "Every difference is in K, and it is the *device*: `cpu_exact` re-rotates on the\n",
+    "CPU, `gpu_exact` on the GPU, and their sin/cos implementations and fused\n",
+    "multiply-adds round differently before the result is stored back as bfloat16.\n",
+    "Feeding one identical tensor to `rerotate_k_cache` on each device reproduces the\n",
+    "same signature exactly, so nothing else is involved.\n",
+    "\n",
+    "One ULP in K is enough to move an attention logit, flip a near-tied greedy\n",
+    "argmax, and diverge from there. That is why two implementations which provably\n",
+    "select the same tokens still generate different text, and can land on a\n",
+    "different answer for one or two of the 30 questions.\n",
+    "\n",
+    "#### Why the re-rotation runs in fp32\n",
+    "\n",
+    "`utils.rerotate_k_cache` detaches one RoPE and attaches another: six multiplies\n",
+    "and two adds per element. Carrying that out in the cache's own bfloat16 rounds\n",
+    "at every step. Measured on keys with a standard deviation of 3:\n",
+    "\n",
+    "| arithmetic | keys changed vs fp32 | rotate-away-and-back error | re-rotate 30 requests |\n",
+    "|---|---|---|---|\n",
+    "| bfloat16 | 50% | 2.5e-1 | 3.2 s |\n",
+    "| **fp32** (used here) | — | **6.3e-2** | 6.1 s |\n",
+    "\n",
+    "fp32 costs 1.9x on the re-rotation step itself, because it moves twice the\n",
+    "bytes. End to end that is much less than it sounds: compressing the 30 requests\n",
+    "went from 41.4 to 41.6 s (one-shot), 37.3 to 37.5 s (`gpu_exact`) and 67.1 to\n",
+    "67.3 s (`cpu_exact`) — around +0.2 s, because `modify` spends most of its time\n",
+    "waiting on LMCache and the extra arithmetic fits in that slack. Only\n",
+    "`buffered_cpu` shows it, 27.9 to 29.9 s (+7%), because its compression is the\n",
+    "shortest so the re-rotation is the largest share of it. That buys a 4x better\n",
+    "round trip and takes an extra ULP of error off half the keys, so it is the\n",
+    "default. It does **not** remove the CPU/GPU split above: that is\n",
+    "the final rounding back to bfloat16, which is there whatever precision the\n",
+    "rotation is computed in.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03cca85b",
+   "metadata": {},
+   "source": [
+    "## Close both contexts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f83db925",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:26:36.782689Z",
+     "iopub.status.busy": "2026-08-01T06:26:36.782563Z",
+     "iopub.status.idle": "2026-08-01T06:26:36.785277Z",
+     "shell.execute_reply": "2026-08-01T06:26:36.784813Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Only close the context when done.\n",
+    "ctx.close()\n",
+    "qctx.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "defaultInterpreterPath: 3.12.3.final.0",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/token_dropping/rkv_variants/rkv_variant_cpu_exact.ipynb
+++ b/examples/token_dropping/rkv_variants/rkv_variant_cpu_exact.ipynb
@@ -1,0 +1,1565 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# R-KV Token Dropping — Route A, exact and linear, on the CPU\n",
+    "---\n",
+    "\n",
+    "Long prompts create large KV caches. They eat GPU memory, limit how many requests\n",
+    "fit in a batch, and a smaller batch means lower decode throughput. *Token\n",
+    "dropping* shrinks each request's KV cache — by half in this notebook — so more\n",
+    "requests fit and decoding runs faster.\n",
+    "\n",
+    "This notebook uses the LMCache SDK to pull a request's KV cache out after\n",
+    "prefill, compress it, and put it back before decode. The compression algorithm\n",
+    "is **R-KV**: it ranks past tokens by **attention importance**, like SnapKV, and\n",
+    "subtracts a second term, **redundancy** — how similar a token's key is to the\n",
+    "*other* keys:\n",
+    "\n",
+    "$$\\text{score}(j) \\;=\\; \\lambda \\cdot \\underbrace{\\text{importance}(j)}_{\\text{attended to?}} \\;-\\; (1-\\lambda) \\cdot \\underbrace{\\text{redundancy}(j)}_{\\text{says something new?}}$$\n",
+    "\n",
+    "Keeping tokens that are both attended-to **and** non-redundant works especially\n",
+    "well on the repetitive output of reasoning models. The catch is that the\n",
+    "redundancy term compares **all pairs of keys**: $O(n^2 d)$ per layer, against\n",
+    "$O(w n d)$ for SnapKV's importance term. At $n = 16128$ with window $w = 64$\n",
+    "that is ~250x more arithmetic per layer, and a literal implementation also\n",
+    "materializes an $n \\times n$ matrix per layer.\n",
+    "\n",
+    "## This notebook\n",
+    "\n",
+    "It implements the redundancy term **exactly, in linear time, entirely on the\n",
+    "CPU**. R-KV never actually needs the $n \\times n$ matrix — the only thing that\n",
+    "leaves it is a column sum, and a column sum of an inner product factors into a\n",
+    "single dot product. The result is bit-for-bit the same tokens as the reference\n",
+    "at $O(n d)$ plus a short scan, with the GPU left entirely to the serving engine.\n",
+    "\n",
+    "It is one of four independent notebooks that keep the same 50% of the tokens and\n",
+    "therefore deliver the **same decode speed-up** — 1766–1785 tok/s, a 1.1% spread, even\n",
+    "though they compress with completely different code. What separates them is the **cost of\n",
+    "compressing**:\n",
+    "\n",
+    "| | [one-shot](../rkv_token_dropping.ipynb) | [cpu_exact](./rkv_variant_cpu_exact.ipynb) | [gpu_exact](./rkv_variant_gpu_exact.ipynb) | [buffered_cpu](./rkv_variant_buffered_cpu.ipynb) |\n",
+    "|---|---|---|---|---|\n",
+    "| Formulation | route A, literal | route A, linear | route A, linear | route B, chunked |\n",
+    "| Exact? | yes (the reference) | yes, rel. err ~2e-6 | yes, rel. err ~5e-7 | **no**, ~96% agreement |\n",
+    "| Redundancy cost | $O(n^2 d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ |\n",
+    "| VRAM | ~9.8 GiB | none | **1.55 GiB** | none |\n",
+    "| Compress 30 requests | 41.6 s | 67.3 s | **37.5 s** | **29.9 s** |\n",
+    "| Decode throughput | 1766 tok/s | 1785 tok/s | 1774 tok/s | 1774 tok/s |\n",
+    "| Accuracy (baseline 10–11/30) | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "\n",
+    "\n",
+    "Start with the [one-shot notebook](../rkv_token_dropping.ipynb): it is R-KV\n",
+    "written the way the paper describes it, and it is the reference the exact\n",
+    "variants here are checked against.\n",
+    "\n",
+    "Numbers above were measured on 30 LongBench-v2 prompts (~16k tokens each) with\n",
+    "Qwen3-8B on one H200 and a 96-core Xeon. They are hardware- and\n",
+    "workload-dependent; treat them as reference measurements, not guarantees.\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "* A small ~10-line modification to vLLM exposes intermediate tensors to LMCache.\n",
+    "  See [README.md](../README.md).\n",
+    "* A GPU is required for serving. To see token dropping increase the decode batch\n",
+    "  size, tune the GPU memory utilization together with the number of requests.\n",
+    "* Data moves between the LMCache server and the SDK through shared memory; if it\n",
+    "  is unavailable the SDK falls back to pickle.\n",
+    "* Run this notebook from its own directory; it imports `../utils.py`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cd06b97",
+   "metadata": {},
+   "source": [
+    "## Setup vLLM and LMCache server\n",
+    "Follow below instructions (1-4), then proceed to below Python cell.\n",
+    "\n",
+    "**1. Start LMCache server first**\n",
+    "\n",
+    "To use shared memory, specify the `--shm-name` and `--no-l1-use-lazy`\n",
+    "\n",
+    "```sh\n",
+    "lmcache server \\\n",
+    "    --l1-size-gb 400 \\\n",
+    "    --eviction-policy LRU \\\n",
+    "    --chunk-size 256 \\\n",
+    "    --port 6555 \\\n",
+    "    --http-port 8080 \\\n",
+    "    --shm-name lmcache_sdk \\\n",
+    "    --no-l1-use-lazy \\\n",
+    "    --enable transfer_query\n",
+    "```\n",
+    "\n",
+    "**2. Wait until LMCache server is ready**\n",
+    "\n",
+    "```sh\n",
+    "curl -sf http://localhost:8080/healthcheck && echo \" LMCache ready\"\n",
+    "```\n",
+    "\n",
+    "**3. Start vLLM once LMCache server is ready**\n",
+    "\n",
+    "We pass --no-enable-prefix-caching to disable vLLM's built-in prefix caching. \n",
+    "This ensures the prefilled KV cache is always served from LMCache rather than \n",
+    "vLLM, so the decoding throughput improvement can be attributed entirely to the \n",
+    "tokens dropped through LMCache.\n",
+    "\n",
+    "```sh\n",
+    "LMCACHE_TRANSFER_INTERMEDIATE_TENSORS=true \\\n",
+    "vllm serve Qwen/Qwen3-8B \\\n",
+    "    --port 8000 \\\n",
+    "    --served-model-name Qwen/Qwen3-8B \\\n",
+    "    --no-enable-prefix-caching \\\n",
+    "    --enforce-eager \\\n",
+    "    --gpu-memory-utilization 0.65 \\\n",
+    "    --kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":6555,\"lmcache.mp.transfer_intermediate_tensors\":true}}' \\\n",
+    "    --trust-remote-code \\\n",
+    "    --return-tokens-as-token-ids\n",
+    "```\n",
+    "\n",
+    "**4. Wait until vLLM is ready**\n",
+    "\n",
+    "```sh\n",
+    "curl -sf http://localhost:8000/v1/models && echo \" vLLM ready\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:10:38.233333Z",
+     "iopub.status.busy": "2026-08-01T06:10:38.233176Z",
+     "iopub.status.idle": "2026-08-01T06:10:44.760575Z",
+     "shell.execute_reply": "2026-08-01T06:10:44.759993Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:44,673] LMCache INFO:\u001b[0m torch_dev=<module 'torch.cuda' from '/home/sigma/github/LMCache/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py'>, torch_device_type=cuda \u001b[3m(_device_detect.py:143:lmcache.v1.platform._device_detect)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:44,752] LMCache INFO:\u001b[0m multi_layer_block_kv_transfer mode: ptr \u001b[3m(base.py:94:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " _     __  __    ____           _          \n",
+      "| |   |  \\/  |  / ___|__ _  ___| |__   ___      LMCache v0.5.3rc2.dev2 (g6018f8af)\n",
+      "| |   | |\\/| | | |   / _` |/ __| '_ \\ / _ \\     Website:  https://lmcache.ai/\n",
+      "| |___| |  | | | |__| (_| | (__| | | |  __/     Recipes:  https://docs.lmcache.ai/recipes\n",
+      "|_____|_|  |_|  \\____\\__,_|\\___|_| |_|\\___|     LinkedIn: https://www.linkedin.com/company/lmcache-lab\n",
+      "Set LMCACHE_DISABLE_BANNER=1 to hide this banner.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "\"\"\"End-to-end KV cache remapping driver for the SDK example.\"\"\"\n",
+    "\n",
+    "# Standard\n",
+    "from datasets import load_dataset\n",
+    "import math\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sys\n",
+    "from transformers import AutoTokenizer, AutoConfig\n",
+    "\n",
+    "# Third Party\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "\n",
+    "# First Party\n",
+    "from lmcache.logging import init_logger\n",
+    "import lmcache.sdk as lmc_sdk\n",
+    "from lmcache.banner import print_banner_once\n",
+    "\n",
+    "sys.path.append(\"..\")  # utils.py lives next to the main notebook\n",
+    "\n",
+    "from utils import (  # noqa: E402\n",
+    "    rerotate_k_cache,\n",
+    "    make_post_completion,\n",
+    "    score_answers,\n",
+    ")\n",
+    "\n",
+    "print_banner_once(sys.stdout)\n",
+    "logger = init_logger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5342c6c6",
+   "metadata": {},
+   "source": [
+    "## Setting up hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8f1065b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:10:44.766216Z",
+     "iopub.status.busy": "2026-08-01T06:10:44.766072Z",
+     "iopub.status.idle": "2026-08-01T06:10:44.768750Z",
+     "shell.execute_reply": "2026-08-01T06:10:44.768199Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_name = \"/data/models/Qwen3-8B\"\n",
+    "vllm_url = \"http://localhost:8000\"\n",
+    "lmcache_url = \"http://localhost:8080\"\n",
+    "lmcache_mq_url = \"tcp://localhost:6555\"\n",
+    "chunk_size = 256\n",
+    "max_tokens = 5120\n",
+    "temperature = 0.0  # greedy decode so generated answers are deterministic and scorable\n",
+    "timeout = 60  # timeout for context retrieval (seconds)\n",
+    "trust_remote_code = True\n",
+    "\n",
+    "# Streams prefilled per submission. LMCache's query ring buffer maps a forward\n",
+    "# step's query rows to ring slots positionally (qringbuffer.py\n",
+    "# build_q_step_state), assuming each request contributed exactly its store op's\n",
+    "# token count of rows. Continuous batching breaks that, so the captured queries\n",
+    "# are silently wrong or short. Measured query-row reproducibility across two\n",
+    "# identical runs: 100.0% at 1 stream, 99.7% at 4, 9.8% at 30. R-KV's importance\n",
+    "# term is entirely query-driven, so prefill is submitted one stream at a time.\n",
+    "prefill_group_size = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34eb19b4",
+   "metadata": {},
+   "source": [
+    "## Configuring the model and LMCache endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eac8beea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:10:44.773782Z",
+     "iopub.status.busy": "2026-08-01T06:10:44.773653Z",
+     "iopub.status.idle": "2026-08-01T06:11:45.158442Z",
+     "shell.execute_reply": "2026-08-01T06:11:45.157799Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:45,198] LMCache INFO:\u001b[0m Initialized LMCacheSDKContext with instance_id=2954723088406771601, model_name=/data/models/Qwen3-8B, chunk_size=256, shm_name=lmcache_l1_pool_lmcache_sdk, kind=LMCacheSDKCacheKind.KV \u001b[3m(context.py:122:lmcache.sdk.context)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:45,201] LMCache INFO:\u001b[0m Creating transfer context (device_type=cpu, mode=auto) \u001b[3m(worker_transfer.py:879:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:45,369] LMCache INFO:\u001b[0m Using AsyncEngineDrivenTransferContext for store path \u001b[3m(worker_transfer.py:105:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:45,374] LMCache INFO:\u001b[0m Engine KV Format: EngineKVFormat.NL_X_NB_TWO_NH_BS_HS NL x [NB, 2, NH, BS, HS] \u001b[3m(detection.py:69:lmcache.v1.gpu_connector.kv_format.detection)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:45,376] LMCache INFO:\u001b[0m Creating EngineDrivenContextShm (shm_name=lmcache_l1_pool_lmcache_sdk, pool_size=429496729600) \u001b[3m(base.py:235:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:45,492] LMCache INFO:\u001b[0m CudaPinMemoryBackend: using torch cudart \u001b[3m(pin_memory.py:89:lmcache.v1.platform.cuda.pin_memory)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:15,466] LMCache INFO:\u001b[0m SHM pinned=True for shm_name=lmcache_l1_pool_lmcache_sdk \u001b[3m(shm.py:118:lmcache.v1.multiprocess.transfer_context.shm)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:15,468] LMCache INFO:\u001b[0m Worker non-GPU transfer context registered (instance_id=2954723088406771601, mode=SHM) \u001b[3m(worker_transfer.py:745:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:15,473] LMCache INFO:\u001b[0m Initialized LMCacheSDKContext with instance_id=2015722103783686033, model_name=/data/models/Qwen3-8B##query, chunk_size=256, shm_name=lmcache_l1_pool_lmcache_sdk, kind=LMCacheSDKCacheKind.QUERY \u001b[3m(context.py:122:lmcache.sdk.context)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:15,474] LMCache INFO:\u001b[0m Creating transfer context (device_type=cpu, mode=auto) \u001b[3m(worker_transfer.py:879:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:15,475] LMCache INFO:\u001b[0m Using AsyncEngineDrivenTransferContext for store path \u001b[3m(worker_transfer.py:105:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:15,475] LMCache INFO:\u001b[0m Engine KV Format: EngineKVFormat.NL_X_NB_BS_HS NL x [NB, BS, HS] \u001b[3m(detection.py:69:lmcache.v1.gpu_connector.kv_format.detection)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:15,477] LMCache INFO:\u001b[0m Creating EngineDrivenContextShm (shm_name=lmcache_l1_pool_lmcache_sdk, pool_size=429496729600) \u001b[3m(base.py:235:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:45,154] LMCache INFO:\u001b[0m SHM pinned=True for shm_name=lmcache_l1_pool_lmcache_sdk \u001b[3m(shm.py:118:lmcache.v1.multiprocess.transfer_context.shm)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:11:45,156] LMCache INFO:\u001b[0m Worker non-GPU transfer context registered (instance_id=2015722103783686033, mode=SHM) \u001b[3m(worker_transfer.py:745:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(\n",
+    "    model_name, trust_remote_code=trust_remote_code\n",
+    ")\n",
+    "config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)\n",
+    "head_size = getattr(\n",
+    "    config, \"head_dim\", config.hidden_size // config.num_attention_heads\n",
+    ")\n",
+    "work_device = torch.device(\"cpu\")\n",
+    "post_completion = make_post_completion(vllm_url, model_name, timeout)\n",
+    "ctx = lmc_sdk.kvcache.connect(\n",
+    "    url=lmcache_mq_url,\n",
+    "    http_url=lmcache_url,\n",
+    "    model_name=model_name,\n",
+    "    timeout=timeout,\n",
+    ")\n",
+    "qctx = lmc_sdk.qcache.connect(\n",
+    "    url=lmcache_mq_url,\n",
+    "    http_url=lmcache_url,\n",
+    "    model_name=model_name,\n",
+    "    timeout=timeout,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2aaffa7",
+   "metadata": {},
+   "source": [
+    "## Constructing Prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "030145fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:11:45.164020Z",
+     "iopub.status.busy": "2026-08-01T06:11:45.163872Z",
+     "iopub.status.idle": "2026-08-01T06:13:07.341050Z",
+     "shell.execute_reply": "2026-08-01T06:13:07.340331Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 30 prompts from the dataset.\n",
+      "Total prompts length: 423428 tokens.\n",
+      "Mean prompt length: 14114.27 tokens.\n",
+      "Max prompt length: 16807 tokens.\n",
+      "Min prompt length: 10159 tokens.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompts = []\n",
+    "answers = []\n",
+    "ds = load_dataset(\"raniayu/token-dropping-demo\", split=\"train\")\n",
+    "for i, example in enumerate(ds):\n",
+    "    prompt = tokenizer.encode(ds[i][\"prompt\"], return_tensors=\"pt\").squeeze(0).tolist()\n",
+    "    prompts.append(prompt)\n",
+    "    answers.append(ds[i][\"answer\"])\n",
+    "\n",
+    "print(f\"Loaded {len(prompts)} prompts from the dataset.\")\n",
+    "print(f\"Total prompts length: {sum(len(p) for p in prompts)} tokens.\")\n",
+    "print(f\"Mean prompt length: {sum(len(p) for p in prompts) / len(prompts):.2f} tokens.\")\n",
+    "print(f\"Max prompt length: {max(len(p) for p in prompts)} tokens.\")\n",
+    "print(f\"Min prompt length: {min(len(p) for p in prompts)} tokens.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab00c77d",
+   "metadata": {},
+   "source": [
+    "## Baseline (without token dropping)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "eb3a2b00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:13:07.346660Z",
+     "iopub.status.busy": "2026-08-01T06:13:07.346513Z",
+     "iopub.status.idle": "2026-08-01T06:15:55.685132Z",
+     "shell.execute_reply": "2026-08-01T06:15:55.684441Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:13:22,563] LMCache INFO:\u001b[0m prefill: 15.21 s in groups of 1 \u001b[3m(420791162.py:24:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================= Batched Stream Metrics (decode) ========================\n",
+      "-------------------------------- Configuration ---------------------------------\n",
+      "Number of Request Streams:                                                    30\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                       153.11\n",
+      "Total Output Tokens:                                                      153392\n",
+      "Decode Throughput (tokens/s):                                            1001.81\n",
+      "================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_ids = []\n",
+    "\n",
+    "batch = lmc_sdk.batch.LMCacheBatchedStream()\n",
+    "for i, prompt in enumerate(prompts):\n",
+    "    stream = lmc_sdk.request.create_request(\n",
+    "        contexts=[ctx, qctx],\n",
+    "        post_completion=post_completion,\n",
+    "        prompt_token_ids=prompt,\n",
+    "    )\n",
+    "    batch.add(stream)\n",
+    "    stream_ids.append(stream.request_stream_id)\n",
+    "\n",
+    "# temperature 0 here too: prefill emits one token that is APPENDED to the\n",
+    "# stream, so sampling it would make the whole greedy decode below depend on a\n",
+    "# random first token. Groups of `prefill_group_size` keep the query capture\n",
+    "# correct (see the hyperparameter cell).\n",
+    "prefill_seconds = 0.0\n",
+    "for g0 in range(0, len(stream_ids), prefill_group_size):\n",
+    "    results = batch.prefill(\n",
+    "        sampling_params={\"max_tokens\": 1, \"temperature\": 0.0, \"ignore_eos\": True},\n",
+    "        stream_ids=stream_ids[g0 : g0 + prefill_group_size],\n",
+    "    )\n",
+    "    prefill_seconds += results.to_dict()[\"metrics\"][\"results\"].get(\"duration\", 0.0)\n",
+    "logger.info(f\"prefill: {prefill_seconds:.2f} s in groups of {prefill_group_size}\")\n",
+    "\n",
+    "results = batch.decode(\n",
+    "    sampling_params={\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": temperature,\n",
+    "        \"ignore_eos\": True,\n",
+    "    }\n",
+    ")\n",
+    "results.emit()\n",
+    "before_drop_data = results.to_dict()\n",
+    "before_texts = [stream.output_text for stream in batch.request_streams.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "188ec71d",
+   "metadata": {},
+   "source": [
+    "## Clear LMCache\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "738112cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:15:55.690661Z",
+     "iopub.status.busy": "2026-08-01T06:15:55.690522Z",
+     "iopub.status.idle": "2026-08-01T06:15:55.861744Z",
+     "shell.execute_reply": "2026-08-01T06:15:55.861002Z"
+    },
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"status\":\"ok\",\"cleared\":{\"tier\":\"l1\"}}"
+     ]
+    }
+   ],
+   "source": [
+    "!curl -X POST {lmcache_url}/cache/clear\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "source": [
+    "## With R-KV Token Dropping — Route A, exact and linear, on the CPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:15:55.867163Z",
+     "iopub.status.busy": "2026-08-01T06:15:55.867005Z",
+     "iopub.status.idle": "2026-08-01T06:15:55.887103Z",
+     "shell.execute_reply": "2026-08-01T06:15:55.886555Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:15:55,884] LMCache INFO:\u001b[0m CPU thread plan: 96 usable cores -> budget 115, 30 workers -> torch.set_num_threads(3) (~90 runnable threads) \u001b[3m(3911048703.py:49:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Standard\n",
+    "import os\n",
+    "\n",
+    "# --- R-KV hyperparameters ----------------------------------------------------\n",
+    "# Scores are averaged over KV heads and summed over layers, so a request keeps\n",
+    "# ONE token subset. LMCache re-injects a single contiguous KV with a single\n",
+    "# kept-token list, so per-head eviction is not expressible here.\n",
+    "rkv_window_size = 8  # observation window: the last w queries vote on importance\n",
+    "rkv_drop_ratio = 0.5  # fraction of tokens to evict\n",
+    "rkv_kernel_size = 7  # max-pool width applied to the importance scores\n",
+    "rkv_mix_lambda = 0.07  # score = lambda * importance - (1 - lambda) * redundancy\n",
+    "rkv_sim_threshold = 0.5  # cosine above this counts as \"similar\"\n",
+    "\n",
+    "# --- CPU thread budget (shared by both CPU implementations) ------------------\n",
+    "cpu_thread_oversubscription = 1.25  # total intra-op threads / usable cores\n",
+    "cpu_reserve_cores = 4  # left for vLLM, the LMCache server and the OS\n",
+    "cpu_device = torch.device(\"cpu\")\n",
+    "\n",
+    "\n",
+    "def usable_cores():\n",
+    "    \"\"\"Cores this process may actually run on -- affinity and cgroup, not nproc.\"\"\"\n",
+    "    try:\n",
+    "        cores = len(os.sched_getaffinity(0))\n",
+    "    except AttributeError:\n",
+    "        cores = os.cpu_count() or 1\n",
+    "    try:\n",
+    "        with open(\"/sys/fs/cgroup/cpu.max\") as fh:\n",
+    "            quota, period = fh.read().split()\n",
+    "        if quota != \"max\":\n",
+    "            cores = min(cores, max(1, int(int(quota) // int(period))))\n",
+    "    except (OSError, ValueError):\n",
+    "        pass\n",
+    "    return max(1, cores)\n",
+    "\n",
+    "\n",
+    "def plan_cpu_threads():\n",
+    "    \"\"\"Set torch's intra-op threads so intra_op * workers ~= 1.25 * cores.\n",
+    "\n",
+    "    `batch.modify` runs one worker thread per stream and torch defaults to one\n",
+    "    intra-op thread per core inside each of them, which on a 96-core box means\n",
+    "    30 x 96 = 2880 runnable threads. Measured over 30 requests: 27.6 s at 96\n",
+    "    intra-op threads, 19.8 s at 4, 33.5 s at 1.\n",
+    "    \"\"\"\n",
+    "    cores = usable_cores()\n",
+    "    budget = max(1, round((cores - cpu_reserve_cores) * cpu_thread_oversubscription))\n",
+    "    workers = max(1, len(prompts))\n",
+    "    intra_op = max(1, min(budget // workers, budget))\n",
+    "    torch.set_num_threads(intra_op)\n",
+    "    logger.info(\n",
+    "        f\"CPU thread plan: {cores} usable cores -> budget {budget}, \"\n",
+    "        f\"{workers} workers -> torch.set_num_threads({intra_op}) \"\n",
+    "        f\"(~{intra_op * workers} runnable threads)\"\n",
+    "    )\n",
+    "    return intra_op\n",
+    "\n",
+    "\n",
+    "cpu_intraop_threads = plan_cpu_threads()\n",
+    "\n",
+    "\n",
+    "# --- Tensor plumbing ---------------------------------------------------------\n",
+    "def model_heads():\n",
+    "    \"\"\"(num_q_heads, num_kv_heads, head_dim) for the served model.\"\"\"\n",
+    "    q = config.num_attention_heads\n",
+    "    kv = getattr(config, \"num_key_value_heads\", q)\n",
+    "    return q, kv, getattr(config, \"head_dim\", config.hidden_size // q)\n",
+    "\n",
+    "\n",
+    "def to_heads(flat, rows, heads, head_dim, device=None):\n",
+    "    \"\"\"[rows, heads * head_dim] -> [1, heads, rows, head_dim] in fp32.\"\"\"\n",
+    "    t = (\n",
+    "        flat.to(dtype=torch.float32)\n",
+    "        if device is None\n",
+    "        else flat.to(device, torch.float32)\n",
+    "    )\n",
+    "    return t.reshape(rows, heads, head_dim).permute(1, 0, 2).unsqueeze(0)\n",
+    "\n",
+    "\n",
+    "def q_by_layer(q_tensor):\n",
+    "    \"\"\"Normalise the SDK's query tensor to [num_layers, T, q_heads * head_dim].\"\"\"\n",
+    "    if q_tensor.ndim == 4 and q_tensor.shape[0] == 1:\n",
+    "        return q_tensor[0]\n",
+    "    if q_tensor.ndim == 3:\n",
+    "        return q_tensor\n",
+    "    raise ValueError(f\"unexpected q_tensor shape {tuple(q_tensor.shape)}\")\n",
+    "\n",
+    "\n",
+    "def attention_logits(query, key, pooling=\"max\"):\n",
+    "    \"\"\"q @ k^T / sqrt(d), pooled from query heads down to KV heads (GQA).\n",
+    "\n",
+    "    query: [1, q_heads, q_len, d]   key: [1, kv_heads, kv_len, d]\n",
+    "    \"\"\"\n",
+    "    _, q_heads, q_len, d = query.shape\n",
+    "    kv_heads = key.shape[1]\n",
+    "    group = q_heads // kv_heads\n",
+    "    if group == 1:\n",
+    "        return torch.matmul(query, key.transpose(2, 3)) / math.sqrt(d)\n",
+    "    q = query.view(1, kv_heads, group, q_len, d)\n",
+    "    attn = torch.matmul(q, key.unsqueeze(2).transpose(3, 4)) / math.sqrt(d)\n",
+    "    return attn.mean(dim=2) if pooling == \"mean\" else attn.max(dim=2).values\n",
+    "\n",
+    "\n",
+    "def importance(k, q_win, past_len):\n",
+    "    \"\"\"How much the observation window attends to each past token.\n",
+    "\n",
+    "    Only the window queries are passed in, so this is O(w * n * d) rather than\n",
+    "    the O(n^2 * d) the reference spends before discarding all but the last w rows.\n",
+    "    \"\"\"\n",
+    "    attn = attention_logits(q_win, k)[:, :, :, :past_len]\n",
+    "    scores = F.softmax(attn, dim=-1, dtype=torch.float32).mean(dim=-2)\n",
+    "    return F.max_pool1d(\n",
+    "        scores, kernel_size=rkv_kernel_size, padding=rkv_kernel_size // 2, stride=1\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def redundancy_reference(key_states, threshold=rkv_sim_threshold):\n",
+    "    \"\"\"Literal R-KV redundancy: materialises the whole n x n matrix.\n",
+    "\n",
+    "    Only used as the correctness oracle in the self-tests -- never on a real\n",
+    "    prompt, where it would allocate kv_heads * n^2 floats per layer.\n",
+    "    \"\"\"\n",
+    "    _, _, n, _ = key_states.shape\n",
+    "    k = key_states / (key_states.norm(dim=-1, keepdim=True) + 1e-8)\n",
+    "    sim = torch.matmul(k, k.transpose(-1, -2))\n",
+    "    eye = torch.eye(n, dtype=torch.bool, device=k.device).view(1, 1, n, n)\n",
+    "    sim.masked_fill_(eye, 0.0)\n",
+    "\n",
+    "    # Per row, exempt the LARGEST column index that is above threshold (or\n",
+    "    # column 0 if none qualifies) -- R-KV's `similarity_retain` rule.\n",
+    "    mask = sim > threshold\n",
+    "    idx = torch.arange(n, device=k.device).view(1, 1, 1, n)\n",
+    "    retain = torch.where(mask, idx, torch.zeros_like(mask, dtype=torch.long))\n",
+    "    sim.scatter_(-1, retain.max(dim=-1)[0].unsqueeze(-1), 0)\n",
+    "    return sim.mean(dim=-2).softmax(dim=-1)\n",
+    "\n",
+    "\n",
+    "def prepare(tensors, token_source):\n",
+    "    \"\"\"Common bookkeeping shared by every drop_tokens_fn.\"\"\"\n",
+    "    kv = tensors[lmc_sdk.context.LMCacheSDKCacheKind.KV]  # [2, L, T, D]\n",
+    "    q = q_by_layer(tensors[lmc_sdk.context.LMCacheSDKCacheKind.QUERY])\n",
+    "    seq_len = min(kv.shape[2], q.shape[1], len(token_source))\n",
+    "    past_len = seq_len - rkv_window_size\n",
+    "    if past_len <= 0:\n",
+    "        raise ValueError(f\"seq_len {seq_len} must exceed window {rkv_window_size}\")\n",
+    "    keep_total = int(round(seq_len * (1 - rkv_drop_ratio)))\n",
+    "    keep_past = max(0, min(keep_total - rkv_window_size, past_len))\n",
+    "    q_win = q[:, past_len:seq_len, :]  # window only: ~2.4 MiB, not ~4.8 GiB\n",
+    "    return kv, q_win, seq_len, past_len, keep_past\n",
+    "\n",
+    "\n",
+    "def select(scores, past_len, seq_len, keep_past):\n",
+    "    \"\"\"Top-scoring past tokens plus the whole observation window.\"\"\"\n",
+    "    top = torch.topk(scores, k=keep_past).indices.sort().values\n",
+    "    tail = torch.arange(past_len, seq_len, device=scores.device)\n",
+    "    return torch.cat([top, tail]).to(torch.long).cpu()\n",
+    "\n",
+    "\n",
+    "def rerotate(kv_tensor, keep_idx, device):\n",
+    "    \"\"\"Gather the kept tokens and move their RoPE to the new positions.\"\"\"\n",
+    "    gathered = kv_tensor[:, :, keep_idx, :].clone().to(device)\n",
+    "    out = rerotate_k_cache(\n",
+    "        gathered,\n",
+    "        old_positions=keep_idx.to(device),\n",
+    "        new_positions=torch.arange(keep_idx.numel(), device=device),\n",
+    "        model_config=config,\n",
+    "    )\n",
+    "    return out.cpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "source": [
+    "### Route A, exact and linear, on the CPU\n",
+    "\n",
+    "> **Trades compression latency for zero VRAM.** Exactly the same tokens as\n",
+    "> the [one-shot notebook](../rkv_token_dropping.ipynb), computed in linear time, without touching the GPU at all —\n",
+    "> but it is the slowest of the four and it does spend the machine's cores.\n",
+    ">\n",
+    "> | | |\n",
+    "> |---|---|\n",
+    "> | **Buys you** | **No VRAM at all** — the whole GPU stays with the serving engine; still exact; linear in $n$ |\n",
+    "> | **Costs you** | The slowest compression of the four, and ~90 CPU threads while it runs |\n",
+    "> | Exact? | Yes — relative error ~2e-6, identical kept-token set |\n",
+    "> | VRAM | None |\n",
+    "> | Compress 30 requests | 67.3 s |\n",
+    "> | Decode throughput | 1785 tok/s |\n",
+    "> | Pick it when | The GPU is saturated by serving and you have CPU to spare |\n",
+    "\n",
+    "The [one-shot implementation](../rkv_token_dropping.ipynb) is expensive\n",
+    "because it takes the $n \\times n$ matrix literally. It turns out **R-KV never needs that matrix**. What follows produces\n",
+    "*bit-for-bit the same scores* at $O(n \\cdot d)$ plus a short scan — no\n",
+    "approximation, no GPU.\n",
+    "\n",
+    "## What redundancy actually is\n",
+    "\n",
+    "Write $\\hat{k}_i$ for token $i$'s key, normalised to unit length, so that\n",
+    "$\\langle \\hat{k}_i, \\hat{k}_j \\rangle$ is exactly the cosine similarity between\n",
+    "tokens $i$ and $j$. R-KV builds the matrix $S_{ij} = \\langle \\hat{k}_i, \\hat{k}_j \\rangle$\n",
+    "and then:\n",
+    "\n",
+    "1. zeroes the diagonal — a token is not redundant with itself;\n",
+    "2. for each **row** $i$, finds the *largest* column index $j$ with $S_{ij} > \\tau$\n",
+    "   and zeroes that one entry (the `similarity_retain` rule: a token's single\n",
+    "   most recent look-alike is spared, so a pair of duplicates does not delete\n",
+    "   each other);\n",
+    "3. reduces with a **mean down each column**, then a softmax across columns.\n",
+    "\n",
+    "Step 3 is the important one. The only thing that leaves the matrix is a **column\n",
+    "sum**. Every individual $S_{ij}$ is discarded.\n",
+    "\n",
+    "## Turning the column sum into one dot product\n",
+    "\n",
+    "A column sum of an inner product can be factored, because the inner product is\n",
+    "linear in its first argument:\n",
+    "\n",
+    "$$\n",
+    "\\sum_i \\langle \\hat{k}_i, \\hat{k}_j \\rangle\n",
+    "\\;=\\; \\Big\\langle \\underbrace{\\sum_i \\hat{k}_i}_{\\text{one vector, } s} ,\\; \\hat{k}_j \\Big\\rangle\n",
+    "$$\n",
+    "\n",
+    "Sum the keys **first** ($O(n \\cdot d)$), then take one dot product per token\n",
+    "($O(n \\cdot d)$). The $n^2$ matrix disappears.\n",
+    "\n",
+    "The two zeroing steps are then exact corrections on top:\n",
+    "\n",
+    "* **the diagonal** — subtract $\\langle \\hat{k}_j, \\hat{k}_j \\rangle$ from column $j$;\n",
+    "* **the retain rule** — row $i$ removed one entry, in column $r(i)$, of value\n",
+    "  $S_{i,r(i)}$. Subtract each of those from its column. Several rows can share a\n",
+    "  column, so this is a `scatter_add`, not an assignment.\n",
+    "\n",
+    "## The one part that still needs pairs\n",
+    "\n",
+    "Finding $r(i)$ — the largest column above threshold in row $i$ — genuinely needs\n",
+    "pairwise comparisons. But it can be searched **right to left in column blocks**:\n",
+    "because blocks further right are visited first, the *first* hit a row sees is\n",
+    "already its answer, and that row can be retired.\n",
+    "\n",
+    "That is cheap on real data because language-model key vectors are strongly\n",
+    "anisotropic — they share a large common direction, so most pairs are similar.\n",
+    "Measured on this model's own KV cache:\n",
+    "\n",
+    "| layer | mean pairwise cosine | rows that hit inside the last 1024 columns |\n",
+    "|---|---|---|\n",
+    "| 0 | 0.988 | 100.00% |\n",
+    "| 8 | 0.753 | 99.99% |\n",
+    "| 17 | 0.433 | 93.63% |\n",
+    "| 26 | 0.403 | 87.80% |\n",
+    "| 35 | 0.730 | 99.99% |\n",
+    "\n",
+    "With a 2048-column first block, only **~2%** of rows survive it. The total cost\n",
+    "is $O(n \\cdot \\text{col\\_block} \\cdot d)$ plus a negligible tail — **linear in\n",
+    "$n$**, so the advantage grows with prompt length.\n",
+    "\n",
+    "## What was optimized\n",
+    "\n",
+    "| # | Change | Why it mattered |\n",
+    "|---|---|---|\n",
+    "| 1 | **Batch the first block over heads; gather only the residual.** | A first attempt looped over heads for *every* block and was **not faster than the reference** despite touching only 10% of the matrix: in the first block every row is active, so gathering them copied the whole tensor for nothing and threw away the batched GEMM. Fixing this took it from 1.5× to 4.2×. |\n",
+    "| 2 | **Per-head active sets in the residual scan.** | Sharing one row set across heads looks tidier, but with per-head hit rates around 0.88 the chance that *all 8* heads are done with a row is $0.88^8 \\approx 0.36$ — two thirds of rows stay \"active\" although nearly every head has retired them. |\n",
+    "| 3 | **`col_block = 2048`.** | Smaller blocks touch less of the matrix but pay more Python and gather overhead: 3.4% of the matrix at 256 took **0.99 s/layer**, while 20.5% at 2048 took **0.062 s/layer**. |\n",
+    "| 4 | **fp32, not bf16.** | This Xeon has AMX-BF16, yet bf16 was *slower*. Once the matrix is gone the kernel is bound by the compare / flip / argmax / scatter — memory-bound ops AMX does not help — and fp32 keeps the threshold comparison exact. |\n",
+    "| 5 | **Thread planning.** | `batch.modify` already gives 30-way outer parallelism and torch defaults to one intra-op thread *per core inside each worker* — 30 × 96 = 2880 runnable threads. Measured: 27.6 s at 96 intra-op threads, **19.8 s at 4**, 33.5 s at 1. The optimum sits near 1.25 × cores in total, derived from the cores this process may *actually* use (CPU affinity and cgroup quota, not the raw count). |\n",
+    "\n",
+    "**Result: 8.0 s → 1.9 s per request (4.2×), relative error ~2e-6, no GPU.**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5e9049b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:15:55.892168Z",
+     "iopub.status.busy": "2026-08-01T06:15:55.892020Z",
+     "iopub.status.idle": "2026-08-01T06:15:56.914558Z",
+     "shell.execute_reply": "2026-08-01T06:15:56.913951Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:15:56,909] LMCache INFO:\u001b[0m CPU exact self-test: max relative error 5.71e-07, kept-token set IDENTICAL \u001b[3m(301996112.py:112:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Knobs -------------------------------------------------------------------\n",
+    "# Columns scanned per block. Bigger blocks retire more rows up front but touch\n",
+    "# more of the matrix; 2048 was the measured optimum. (Threads are budgeted once\n",
+    "# in the shared cell above.)\n",
+    "cpu_col_block = 2048\n",
+    "\n",
+    "\n",
+    "def _linear_redundancy(key_states, col_block):\n",
+    "    \"\"\"Exact route A redundancy in O(n * col_block * d).\n",
+    "\n",
+    "    key_states: [1, kv_heads, n, d] -> [1, kv_heads, n]\n",
+    "    \"\"\"\n",
+    "    _, kv_heads, n, _ = key_states.shape\n",
+    "    k = key_states[0]\n",
+    "    k = k / (k.norm(dim=-1, keepdim=True) + 1e-8)\n",
+    "    cb = max(1, min(col_block, n))\n",
+    "\n",
+    "    # The whole column sum, without the matrix: sum_i <k_i, k_j> = <sum_i k_i, k_j>.\n",
+    "    s = k.sum(dim=-2, keepdim=True)\n",
+    "    col_sum = (k * s).sum(dim=-1) - (k * k).sum(dim=-1)  # minus the diagonal\n",
+    "\n",
+    "    # Rows that never clear the threshold exempt column 0, whose values are\n",
+    "    # another O(n d) product. Row 0's own diagonal was already removed.\n",
+    "    retain_col = torch.zeros((kv_heads, n), dtype=torch.long)\n",
+    "    retain_val = torch.matmul(k, k[:, :1, :].transpose(-1, -2)).squeeze(-1).clone()\n",
+    "    retain_val[:, 0] = 0.0\n",
+    "\n",
+    "    # Rightmost block: every row is active, so run it batched with no gather.\n",
+    "    c0 = max(0, n - cb)\n",
+    "    width = n - c0\n",
+    "    blk = torch.matmul(k, k[:, c0:n, :].transpose(-1, -2))\n",
+    "    diag = torch.arange(c0, n)\n",
+    "    blk[:, diag, diag - c0] = 0.0\n",
+    "    over = blk > rkv_sim_threshold\n",
+    "    has = over.any(dim=-1)\n",
+    "    last = (width - 1) - over.flip(-1).to(torch.uint8).argmax(dim=-1)\n",
+    "    val = blk.gather(-1, last.unsqueeze(-1)).squeeze(-1)\n",
+    "    retain_col = torch.where(has, last + c0, retain_col)\n",
+    "    retain_val = torch.where(has, val, retain_val)\n",
+    "    del blk, over, last, val\n",
+    "\n",
+    "    # Residual rows only, per head -- typically ~2% of them.\n",
+    "    for h in range(kv_heads):\n",
+    "        act = (~has[h]).nonzero(as_tuple=False).squeeze(-1)\n",
+    "        kh = k[h]\n",
+    "        for c1 in range(c0, 0, -cb):\n",
+    "            if act.numel() == 0:\n",
+    "                break\n",
+    "            c0b, w = max(0, c1 - cb), c1 - max(0, c1 - cb)\n",
+    "            sub = torch.matmul(kh[act], kh[c0b:c1].transpose(0, 1))\n",
+    "            inb = (act >= c0b) & (act < c1)\n",
+    "            if bool(inb.any()):\n",
+    "                rr = inb.nonzero(as_tuple=False).squeeze(-1)\n",
+    "                sub[rr, act[rr] - c0b] = 0.0\n",
+    "            ov = sub > rkv_sim_threshold\n",
+    "            hs = ov.any(dim=-1)\n",
+    "            lst = (w - 1) - ov.flip(-1).to(torch.uint8).argmax(dim=-1)\n",
+    "            # Blocks further right were scanned first, so this IS the maximum.\n",
+    "            retain_col[h, act[hs]] = lst[hs] + c0b\n",
+    "            retain_val[h, act[hs]] = sub.gather(-1, lst.unsqueeze(-1)).squeeze(-1)[hs]\n",
+    "            act = act[~hs]\n",
+    "            del sub, ov, hs, lst\n",
+    "\n",
+    "    col_sum.scatter_add_(-1, retain_col, -retain_val)\n",
+    "    return (col_sum / n).softmax(dim=-1).unsqueeze(0)\n",
+    "\n",
+    "\n",
+    "def drop_tokens_cpu_exact(tensors, token_source):\n",
+    "    \"\"\"Exact route A token dropping, entirely on the CPU.\"\"\"\n",
+    "    kv, q_win, seq_len, past_len, keep_past = prepare(tensors, token_source)\n",
+    "    num_q, num_kv, head_dim = model_heads()\n",
+    "\n",
+    "    scores = torch.zeros(past_len, dtype=torch.float32)\n",
+    "    for layer in range(kv.shape[1]):\n",
+    "        k = to_heads(kv[0, layer, :seq_len, :], seq_len, num_kv, head_dim)\n",
+    "        qw = to_heads(q_win[layer], rkv_window_size, num_q, head_dim)\n",
+    "        imp = importance(k, qw, past_len)\n",
+    "        red = _linear_redundancy(k, cpu_col_block)[:, :, :past_len]\n",
+    "        scores += (imp * rkv_mix_lambda - red * (1 - rkv_mix_lambda)).mean(1).squeeze(0)\n",
+    "\n",
+    "    keep_idx = select(scores, past_len, seq_len, keep_past)\n",
+    "    e_kv = rerotate(kv, keep_idx, cpu_device)\n",
+    "    logger.info(f\"compacted {e_kv.shape[2]}/{kv.shape[2]} tokens.\")\n",
+    "    return e_kv, [token_source[i] for i in keep_idx.tolist()]\n",
+    "\n",
+    "\n",
+    "def _selftest_cpu_exact(n=3000, layers=3):\n",
+    "    \"\"\"This is a rewrite, not an approximation, so demand equality.\n",
+    "\n",
+    "    n is deliberately not a multiple of col_block so the ragged block is used.\n",
+    "    \"\"\"\n",
+    "    torch.manual_seed(0)\n",
+    "    _, num_kv, head_dim = model_heads()\n",
+    "    keep = int(round(n * (1 - rkv_drop_ratio))) - rkv_window_size\n",
+    "    worst, ref_tot, got_tot = 0.0, torch.zeros(n), torch.zeros(n)\n",
+    "\n",
+    "    for i in range(layers):\n",
+    "        # Mix in a shared direction so some pairs clear the threshold and the\n",
+    "        # retain path is actually exercised.\n",
+    "        mu = torch.randn(1, num_kv, 1, head_dim)\n",
+    "        k = torch.randn(1, num_kv, n, head_dim)\n",
+    "        k = 0.6 * mu + 0.4 * k if i % 2 == 0 else k\n",
+    "        ref, got = redundancy_reference(k), _linear_redundancy(k, cpu_col_block)\n",
+    "        worst = max(worst, ((ref - got).abs().max() / ref.abs().max()).item())\n",
+    "        ref_tot += ref.mean(dim=1).squeeze(0)\n",
+    "        got_tot += got.mean(dim=1).squeeze(0)\n",
+    "\n",
+    "    same = torch.equal(\n",
+    "        torch.topk(ref_tot, keep).indices.sort().values,\n",
+    "        torch.topk(got_tot, keep).indices.sort().values,\n",
+    "    )\n",
+    "    logger.info(\n",
+    "        f\"CPU exact self-test: max relative error {worst:.2e}, \"\n",
+    "        f\"kept-token set {'IDENTICAL' if same else 'DIFFERS'}\"\n",
+    "    )\n",
+    "    assert worst < 1e-4 and same, \"the linear rewrite is not route A\"\n",
+    "\n",
+    "\n",
+    "_selftest_cpu_exact()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "25821a55",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:15:56.920243Z",
+     "iopub.status.busy": "2026-08-01T06:15:56.920075Z",
+     "iopub.status.idle": "2026-08-01T06:18:45.411225Z",
+     "shell.execute_reply": "2026-08-01T06:18:45.410331Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:16:12,184] LMCache INFO:\u001b[0m prefill: 15.23 s in groups of 1 \u001b[3m(3598385456.py:24:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:16:56,624] LMCache INFO:\u001b[0m compacted 5120/10240 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:16:57,228] LMCache INFO:\u001b[0m compacted 4992/9984 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:16:58,349] LMCache INFO:\u001b[0m compacted 5632/11264 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:00,456] LMCache INFO:\u001b[0m compacted 5376/10752 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:00,599] LMCache INFO:\u001b[0m compacted 5376/10752 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:02,206] LMCache INFO:\u001b[0m compacted 5504/11008 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:02,272] LMCache INFO:\u001b[0m compacted 5632/11264 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:04,809] LMCache INFO:\u001b[0m compacted 6144/12288 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:07,956] LMCache INFO:\u001b[0m compacted 6272/12544 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:08,077] LMCache INFO:\u001b[0m compacted 6400/12800 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:08,093] LMCache INFO:\u001b[0m compacted 6656/13312 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:08,797] LMCache INFO:\u001b[0m compacted 6784/13568 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:09,481] LMCache INFO:\u001b[0m compacted 6656/13312 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:10,600] LMCache INFO:\u001b[0m compacted 6912/13824 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:13,046] LMCache INFO:\u001b[0m compacted 7296/14592 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:13,978] LMCache INFO:\u001b[0m compacted 7680/15360 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:14,027] LMCache INFO:\u001b[0m compacted 7552/15104 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:14,659] LMCache INFO:\u001b[0m compacted 7552/15104 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:15,664] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:16,140] LMCache INFO:\u001b[0m compacted 7808/15616 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:16,355] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:16,385] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:16,452] LMCache INFO:\u001b[0m compacted 7808/15616 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:17,647] LMCache INFO:\u001b[0m compacted 8320/16640 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:17,656] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:17,729] LMCache INFO:\u001b[0m compacted 8192/16384 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:17,826] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:18,604] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:18,850] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:19,244] LMCache INFO:\u001b[0m compacted 8320/16640 tokens. \u001b[3m(301996112.py:83:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:17:19,497] LMCache INFO:\u001b[0m \n",
+      "\n",
+      " \u001b[3m(3598385456.py:29:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================== Batched Stream Modify Metrics =========================\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                        67.31\n",
+      "================================================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================= Batched Stream Metrics (decode) ========================\n",
+      "-------------------------------- Configuration ---------------------------------\n",
+      "Number of Request Streams:                                                    30\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                        85.90\n",
+      "Total Output Tokens:                                                      153359\n",
+      "Decode Throughput (tokens/s):                                            1785.26\n",
+      "================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_ids = []\n",
+    "\n",
+    "batch = lmc_sdk.batch.LMCacheBatchedStream()\n",
+    "for i, prompt in enumerate(prompts):\n",
+    "    stream = lmc_sdk.request.create_request(\n",
+    "        contexts=[ctx, qctx],\n",
+    "        post_completion=post_completion,\n",
+    "        prompt_token_ids=prompt,\n",
+    "    )\n",
+    "    batch.add(stream)\n",
+    "    stream_ids.append(stream.request_stream_id)\n",
+    "\n",
+    "# temperature 0 here too: prefill emits one token that is APPENDED to the\n",
+    "# stream, so sampling it would make the whole greedy decode below depend on a\n",
+    "# random first token. Groups of `prefill_group_size` keep the query capture\n",
+    "# correct (see the hyperparameter cell).\n",
+    "prefill_seconds = 0.0\n",
+    "for g0 in range(0, len(stream_ids), prefill_group_size):\n",
+    "    results = batch.prefill(\n",
+    "        sampling_params={\"max_tokens\": 1, \"temperature\": 0.0, \"ignore_eos\": True},\n",
+    "        stream_ids=stream_ids[g0 : g0 + prefill_group_size],\n",
+    "    )\n",
+    "    prefill_seconds += results.to_dict()[\"metrics\"][\"results\"].get(\"duration\", 0.0)\n",
+    "logger.info(f\"prefill: {prefill_seconds:.2f} s in groups of {prefill_group_size}\")\n",
+    "\n",
+    "results = batch.modify(drop_tokens_cpu_exact)\n",
+    "results.emit()\n",
+    "\n",
+    "logger.info(\"\\n\\n\")\n",
+    "\n",
+    "results = batch.decode(\n",
+    "    sampling_params={\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": temperature,\n",
+    "        \"ignore_eos\": True,\n",
+    "    }\n",
+    ")\n",
+    "results.emit()\n",
+    "cpu_exact_drop_data = results.to_dict()\n",
+    "cpu_exact_texts = [stream.output_text for stream in batch.request_streams.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99dcfd4c",
+   "metadata": {},
+   "source": [
+    "### Accuracy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:18:45.417049Z",
+     "iopub.status.busy": "2026-08-01T06:18:45.416914Z",
+     "iopub.status.idle": "2026-08-01T06:18:45.421872Z",
+     "shell.execute_reply": "2026-08-01T06:18:45.421318Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:18:45,419] LMCache INFO:\u001b[0m Baseline (no drop): 11/30 correct (36.7%) \u001b[3m(1792173437.py:4:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:18:45,420] LMCache INFO:\u001b[0m R-KV CPU exact: 14/30 correct (46.7%) \u001b[3m(1792173437.py:8:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "before_correct, total, before_map = score_answers(answers, before_texts)\n",
+    "after_correct, total, after_map = score_answers(answers, cpu_exact_texts)\n",
+    "\n",
+    "logger.info(\n",
+    "    f\"Baseline (no drop): {before_correct}/{total} correct \"\n",
+    "    f\"({100 * before_correct / total:.1f}%)\"\n",
+    ")\n",
+    "logger.info(\n",
+    "    f\"R-KV CPU exact: {after_correct}/{total} correct \"\n",
+    "    f\"({100 * after_correct / total:.1f}%)\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1038e21",
+   "metadata": {},
+   "source": [
+    "## Result Plot\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:18:45.426488Z",
+     "iopub.status.busy": "2026-08-01T06:18:45.426368Z",
+     "iopub.status.idle": "2026-08-01T06:18:45.536991Z",
+     "shell.execute_reply": "2026-08-01T06:18:45.536512Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEiCAYAAAD9DXUdAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAATLBJREFUeJzt3XdUVFf3N/DvMPReVaSIAoKi2BALIqiI2EDFmmhsaHyjRmPXaIzGxBqfPGrEGGxRo7FGsRdAsGBFxYaIBRAFlCod5rx/8OM+Xocycxmq+7PWrOWc2ffcfQe8m9vOETHGGAghhJD/o1TTCRBCCKldqDAQQgjhocJACCGEhwoDIYQQHioMhBBCeKgwEEII4aHCQAghhIcKAyGEEB4qDIQQQnioMBBCCOGhwkAUJj8/H4cOHcLTp09rOpV66ejRo4iMjKzpNOqM/Px8hIeH4/DhwwgLCwMAHDp0CA8ePKjhzGo/EY2VRM6dO4eMjIwK45o0aYKOHTuW+fm7d+9gYmKCtWvXYs6cOYpMUZDIyEhERUUBAEQiEdTV1WFoaIgWLVpAX1+/ZpMTQF1dHdOmTcO6detqZP0nTpxAbm4u915VVRXm5uZwcHCAmppajeRUlnfv3sHd3R15eXlwdHREmzZt8MMPP0AkEmH+/PlYtWoVF3vo0CHY29ujVatWNZhx7aJc0wmQmnfy5Em8fv2ae//06VNERkbC3d0dRkZGXHv37t3LLQy1za5du/Drr7+ib9++0NTURH5+Pt68eYPIyEi0a9cO8+bNw+DBg2s6TZkNGTIEjo6ONbZ+Pz8/FBYWwt3dHQCQm5uLe/fuobCwEGvWrMGYMWNqLLdPbdy4EbGxsUhMTISGhgbX7uvri9atW/Nihw0bJlUsPnuMkE+sXbuWAWBhYWFyLZecnMwAsLVr11ZRZvKZPXs2A8BevHjBa3///j2bPn06A8C+//77mkmuDmrYsCFzcXHhtRUUFDBvb28mFovZs2fPaigzaUOGDGEODg4yxQJg8+fPr+KM6hY6YiAyKyoqwt27d/H69WsYGxvDyckJqqqqFS6XkZGB8+fPw9DQED169ODa09PTcfv2bWRlZaF58+aws7PjLRceHo60tDR4eXkhIyMD4eHhUFFRQZcuXaCuri54OwwNDbFhwwYkJyfj559/ho+PD3ck9PE6MzMzcf36dSgrK3N/JUskEty7dw/x8fEwMDCAk5MTLxeJRIIjR46gZcuWaNmyJaKiohAdHY2mTZvCwcGBl4c8sUDxNQYbGxvuL95Pl4+JicHjx49haWlZ5pFFXl4erl27hry8PDg7O8PAwABnzpyBvr4+OnfuLPd3qaysjGHDhuH48eOIiIiAtbW1VExMTAyePHkCVVVVODk5wcDAoMzvQJZtKK/P9PR0nD9/HtHR0cjKysKhQ4ekli05bZSdnY1Tp04BAKKiorhYMzMzdOnSRe7vol6p6cpEap/Sjhhu3LjBbGxsmLGxMevduzezsLBgDRs2ZIGBgVxMaUcML168YA4ODszW1pY9ffqUMcZYUVERW7x4MVNXV2dt2rRhHh4eTFdXl/Xr14+lpqZyy/r6+jJra2t28eJF5uDgwDw9PZmJiQkzNzdnUVFRFW5HWUcMJW7evMkAsG+++UZqnSdPnmT29vasR48erGfPnowxxu7du8datGjBDA0NWe/evZmVlRUzNjZmBw4c4JbPyclhANgPP/zAJk2axNq3b89cXV2Zqqoq8/b2ZllZWYJiGWNMTU2NzZ49W2r5pUuXsu+++461b9+eubm5MWVlZebr68skEglv+StXrrDGjRuzhg0bMk9PT2ZnZ8cCAwOZtbU18/X1rfD7LO2IgTHGlixZwgCw27dv89rj4+NZz549mZaWFnN3d2fOzs5MU1OTrVu3TvA2VNTnixcvmK+vL2vQoAHT09Njvr6+vBc+OjpISkri2uzs7LiY1atXV/hd1HdUGIiUTwtDcnIyMzIyYi4uLiw9PZ0xxlh+fj4bPnw4U1VVZZGRkVzcx4Xh6tWrrEGDBszNzY29f/+e6//HH39kSkpK7MiRI1xbfHw8a9q0KW8H5evry4yNjdnEiRNZbm4uY6z4P7OpqSkbPHhwhdtRUWEoLCxkKioqrFOnTlLrHD16NMvJyWGMMfb06VOWnp7OTE1NWYcOHbhtKSwsZOPGjWPKysrsxo0bjLH/7eisra3Zrl27uH7Dw8OZhoYG+/rrr7k2eWIZK7sw2NnZsT179nDt+/fvZwDY4cOHubbU1FRmYmLC3Nzc2IcPHxhjjOXm5rKvvvqKGRsby1wY7O3t2cGDB9nBgwfZnj172KxZs5i2tjYvL8YYy8vLYy1btmQtWrRgcXFxXPuBAwcYAHb06FG5t0HWPhljrFevXqxNmzZS24BSThuV1va5o8JApHxaGH799VcGgF27do0X9+bNG6aiosLtwD4uDPv27WPq6ups3LhxLD8/n1smOzubaWpqslGjRkmt948//mAAuP/0JX/NvXr1ihc3Y8YMpqGhUeF2VFQYGGPMyMiI2dracu9L1vnkyZNSczt//jyvPSUlhWlqarIvv/ySMfa/HZ2zs7PUuqZMmcJUVFS44ipPLGNlFwZXV1feshKJhJmYmDA/Pz+ubcuWLQwACw8P58U+e/aMAZC5MBgZGXF/WXt7e7MWLVowOzs7tm/fPl7snj17GAB28uRJqX5cXV2Zu7u73Nsga5+MUWGoLLrGQCoUEREBsVgMJycnXnujRo1gZWWFO3fu8Np37dqFhw8fYvny5Vi8eDHvs3v37iE7OxtaWlr4999/wf7vbmnGGJKSkgAU32Zqbm4OADA2NoalpSWvD0tLS+Tk5ODdu3cwNjau1Lbl5ORAS0uL16ajoyN1vSMiIgIA0KlTJ167gYEB7OzspL6D0u7ecnZ2xpYtW/DgwQN07dpVUGxpOnTowHsvEolgbm6OuLg4Xv4ikQjt27fnxVpbW0NPT6/c/j9mb28vdd5+3bp1GDVqFEQiEUaMGAEAuHbtGgAgJSWF+zmX/KzV1dVx+/ZtubdB3j6JcFQYSIXy8/OhqqoKZWXpXxctLS3k5eXx2oyNjaGsrIy7d+9yy5bIyckBANy/fx+pqalS/fn6+vIuTpa20yrp7+N76oWIi4tDdnY2mjdvzms3MTGRis3Pz4dIJOLd+lhCS0sL6enpvDZNTU2puJK2T78veWJLU9Z39PH3k5+fDxUVlVJ/hqWtXx7fffcdFi1ahM2bN3OFIScnByKRCP/++69UvK6uLvr06SP3NsjbJxGOCgOpkJWVFXJycvD69WuYmZlx7YWFhXjx4gV3x06J/v37Y8GCBRgyZAgGDhyII0eOcH+Vl9y10r9/f/zwww/Vtg2l2bdvHwDAx8eH1y4SiaRirayswBhDTEwM72iCMYZnz55J3UUUExMj1cezZ88AAE2bNhUcK5SVlRXy8/Px+vVr7mgMALKzs5GYmFipvsViMTQ0NLgjPqD458wYw5o1a9CsWbNK9V+VfZLS0ZAYpELDhw8HAGzYsIHXvmPHDqSnp2PkyJFSy/Tp0wfnz5/HjRs30Lt3b+7owNLSEp6envjjjz/w/v17qeViY2OrYAukXb58GcuXL0eXLl24v3LLM3ToUCgpKUl9B/v378fbt2+lvoOLFy/i1atX3PucnBxs27YNHTt2hJWVleBYoXx9fSESieDv789r37p1K1RUVCrV940bN5CRkcE7TTV69Gioq6vjl19+KXWZj08Ryaoq+gQAIyMjqSO+zx0dMZAKdejQAcuWLcPSpUuRlJSE7t27IzIyEhs3bsTYsWNLLQwA0LVrV1y6dAl9+vSBu7s7zp49i0aNGmHXrl3o27cvWrVqhcmTJ8PGxgaJiYm4ceMG7t+/jydPnig0/9OnT8PExAQFBQV4+/YtgoODcfr0afj6+sLf3x9isbjCPlq0aIE1a9Zg7ty5SE1NhYeHB6KiovDbb79h6NChmDBhAi/+q6++wujRo+Hj4wMtLS1s27YNqampOHr0qFTf8sQK5eDggKVLl+LHH39EcnIyunTpgrt37wIAzM3NSz1KKs379++5awyFhYWIjo7Gpk2b0KxZM/z8889cnKWlJfbt24fRo0fj2bNnGDRoEAwMDPD8+XMEBgZiwIABWL58uVzbUBV9AoCnpyeOHDkCR0dHmJiY0HMMoMJASmFnZwdfX1/ehd0ffvgBvXv3xqFDh3Du3DkYGxsjMDAQXl5eXIyamhp8fX15p1ocHR0RFhaGxYsX47///S9WrFiBRo0a4ebNmzh69CguXbqEZ8+ewdzcHKNGjeJO7wBAly5dYGpqKpWfjY0NfH19Kzw37ujoCF9fX1y8eBEikQhqamowNDREv379sGHDhlL/Gi9rnQAwe/ZsuLu7459//sGFCxegr6+PgwcPYuDAgVI7VkNDQxw6dAibN29GREQEvLy88PXXX8PCwkKqX1ljPx0SQywWw9fXFy1btpTqs2fPnlJHAkuXLkWXLl1w+PBhhIaGomfPnhg9ejT27t0rdQG+NAMHDkRqair2798PoPjhtsaNG2Pt2rUYNWqU1PoGDRqEZ8+e4e+//8a9e/cAFJ8O+uuvv7hxieTdBln6BIqHb8nMzJTqs7QhMbZs2QJ/f39cvXoVubm56Nix42dfGGgQPUIUKDc3FxoaGtxf54qKrSppaWkwMDDA8uXLsWTJkhrJgdQ+dI2BkM/Eu3fvpNr+85//QCQSSV2AJ583OpVEyGdi7969OH36NLy8vKCtrY2QkBDs3bsXCxcurNFRW0ntQ4WBEAUq75x5ZWIVYcaMGXBwcMD58+cRHx+PBg0aIDg4WOp2Y0LoGgMhhBAeusZACCGEhwoDIYQQHioMhOfBgwfw8PCAoaEhlJWVuYlMiLRTp05BWVkZV65cqdb1rlmzBsrKynX+ad22bdvS3VC1FBUGwjNixAgoKSnh2bNnyM3NRd++fatsXQcOHICysjL30tTUhKmpKdzc3PDDDz/whomojSQSCYqKilDZy3Tp6em876G81+bNmxW23ppWWFiIoqKiGs2hc+fONPheKagwEE5SUhIePXqEQYMGcUcMsg6VIETJDu7vv/9Gbm4uUlNTcevWLcyYMQNBQUGwt7fHjh07qmz9tYWenh5yc3N5Lx8fHxQVFSErK4vX/v/+3/+r6XTrldpQnGojKgyEk5ycDKDywzDLS0lJCcrKylBTU4OZmRmGDBmCS5cuoW/fvvDz8+PG4a/PPj0yKCnIYrG41HZCqhIVBgIAmDhxItq0acP9W1lZmTeW0L179zBo0CAYGxtDW1sbHTp0wPbt23l9lJz7Tk5Oxrx582BmZgYdHR1B+YjFYqxfv54bZvlj8fHxmDRpEiwtLaGpqQlbW1v89NNPKCwslIqbMmUKmjZtCm1tbbRp0wYbNmzgxcmyXUDxaKzdunWDtrY2rK2tsXnz5jJzlzW/yiosLMTChQthamoKPT09DBkyBG/evOHFVPQz2bZtGzp06ABtbW0YGxtj0KBBuH//Pq8PY2NjTJ06VWr9I0aMgL29Pa9NIpFg5cqVaNasGXR0dODm5oa7d+/iyy+/hI2NTanbERMTg759+0JXVxeWlpa8wfhKlFyPePToEXr16gVdXV00bdoUK1asgEQiEZRvo0aNcPv2bQQFBXGFV1Gj2dZ1VBgIAODPP//kZsD6888/kZuby80TEBERga5duyIrKwuhoaGIiYnBiBEjMGnSJN74OiWnhmbPno0WLVrg7t27Ujt1eVhZWaF58+YIDg7m2l69egUnJyc8ePAABw8eREJCAjZu3Ah/f3+MHTuWi3v+/Dk6dOiAGzduYOfOnYiPj8fevXsRExODS5cuybVdN2/ehIeHBxo0aICIiAiEhobi1atX2Llzp1TOsuanCN9//z3s7e3x4MEDnDp1CuHh4Zg4cSIvpryfyZIlSzB58mQMHz4cMTExCA0NRXZ2Nrp06cLNWAeUfbqlqKhIqtjNnTsXP/74I+bOnYsXL15gw4YN+P777/HmzZtSC2N6ejrmzJmD5cuX4+XLl5gxYwYWL16Mv//+mxdXWFiId+/eYdasWVi1ahWeP3+ORYsWYcWKFZg5c6ZUrCz5vn79Gh06dECPHj24U3WlzY3xWRI6J2hKSgqLjIxkkZGRLCUlpRKzi5LaIjIykgFgO3bs4LX36dOHGRgYsIyMDF77+PHjmbKyMouPj2eMMbZy5UoGgC1dulSm9e3bt48BYAcPHiwzplevXgwAy8rKYowxNnz4cGZgYMCSk5N5cSUTwt++fZsxxtiQIUOYjo4OS0xMLLNvWbfL09OTmZqastzcXF5cz549eXNjy5NfRUrmni4oKJD6rOR7XrVqFa+9ZK7u2NhYqdhPfyYJCQlMRUWFjRs3jteemZnJDA0NWe/evbk2PT09bl7vT3O0trbm3r9+/ZqJxWI2Y8YMXlx8fDxTVVVlTZo04bU7ODgwFRUVqTm527Zty7p37y4Vq6SkxJ4+fcprnzdvHlNSUmLPnz+XO1/GGOvQoQPr1auXVOznTq4jhuTkZPzyyy9wdHSEkZERWrdujdatW8PIyAht2rTBqlWrSh2oi9RdRUVFCAkJgaenp9RpoeHDh6OwsJD7C7zEoEGDFJ6HSCSCRCLByZMn0bNnT6m5nj09PQEAISEhkEgkOH36NPr06YMGDRqU2p+s21US5+XlBTU1NV7ckCFDeO9lzU9RBg4cyHtfMt7R8+fPpWI//ZlcunQJBQUF8PX15bVra2ujb9++CAkJkfvUV2hoKIqKiuDt7c1rNzMzk5rTuUSrVq2kTt+0bt261G1wcHCAra0tr23IkCGQSCQICgqSK1dSPpkLw+rVq2FtbY0zZ85g9OjRuHjxIh4+fIiHDx/i4sWL+OKLL3Dy5ElYW1tX6vQBqV0+fPiAvLy8UucoaNSoEYD/XbQu8fH0n5X1+vVr6OnpQUNDA5mZmcjKysK///4LdXV1qKmpQU1NDaqqqtyO+N27d8jMzEROTk65eci6XZmZmcjPz0fDhg3LjCsha36K8mnuurq6AIqH0v7Up99Fyex5ZW1/QUFBhc9JsE9uly3ZttK+q9Laylq/rq5uqdtQ3s9Alu/103xJ2WQeRO/OnTu4ceOG1MUmAGjZsiV69OiB+fPn48mTJ1i6dKlCkyQ1R1tbG6qqqqXOC1zSZmRkxGuv7FSRJWJjYxEVFcX9BaqtrQ01NTWMHDkSAQEBpS6jpFT8t466ujoSEhLK7FvW7dLR0YGKigpvPuNP4z7uU9b8FKGsO5RK2wF++jMxNDQEIL0NJW0qKipcodHT08OHDx+k4j79fkv6TEpKkpoDu7TvT95tKO9n8PHvoKz5krLJ/Fv6zz//lFoUPmVvb49//vmnUkmR2kMsFsPV1RUXLlxAdnY277OjR49CLBbDzc1N4etljGHevHkQiUSYO3cul4uXlxfOnz+P7OzsUh8AU1JSgpKSEvr06YNz586VOq+0PNtVEnfu3DkUFBTw4o4fPy7Vpyz51Qbdu3eHWCzGsWPHeO3Z2dk4d+4cunXrxhWTZs2a4cGDB7y4hIQEbmrQj/tUUlLC6dOnee2JiYncjQ2V8fDhQ7x8+ZLXdvz4cYhEIt4IsbLmCwBaWlrIz8+vdG71jaDfUolEgujoaO59TEwMfvzxR+zevVthiZHa4+eff0Z6ejpGjRqFFy9eID09HZs2bcK2bdswc+bMUqerFIIxhpSUFJw+fRoeHh44evQo/P394eLiwsWsW7cOBQUFGDhwIMLDw5GTk4N3794hKCgIw4YNQ2RkJIDi2zTFYjH69++PGzduIDc3F8+ePcOCBQu48/yybtfy5cvx9u1bjBs3DvHx8UhJScHy5cuhqqoqtQ2y5lfTzMzMMHPmTGzfvh0bN25Eeno6Xrx4gVGjRiEtLQ0rV67kYv38/HDv3j1s2rQJ2dnZePjwIaZOnQpnZ2den+bm5vjmm2+wceNG7Nq1Cx8+fMDTp0/x9ddfo1OnTpXOuWPHjpg2bRoePnyIrKws7N27F+vXr8fEiRN5t8LKmi9QfN3iwYMHUgXnsyfkivV///tf9t133zHGGMvNzWWWlpasZcuWzMDAgK1evVpB18VJdSvrriTGGAsPD2eenp5MS0uLicViZm9vzzZs2MAkEgkXU3IHTGpqqkzrK7krSUlJiYnFYqasrMz09fVZx44d2dy5c1l0dHSpy8XFxbHJkyczc3NzJhaLWYMGDVjv3r3ZoUOHWFFRERcXExPDvvzyS2ZsbMyUlZWZvb09W7NmDcvLy5Nruxhj7Pz586x9+/ZMLBYzU1NTtmbNGhYYGCh1V5I8+ZVHlruSPv2er127xgCwo0ePVhjLGGMSiYRt2LCBtWjRgikrKzNNTU3Wu3dvdv36dam4pUuXMhMTE6aiosJcXFzYgwcPSr3Lp7CwkC1ZsoQ1atSIqaiosI4dO7Lr16+zwYMHs+bNm/NiHRwcWP/+/aXymjp1KtPS0io19s6dO6xTp05MRUWFNWzYkC1cuFDqO5In39evX7NevXoxDQ0NJhaLpe6c+lwJmo/Bzs4Op0+fRrNmzXD69GnMmTMHDx48wPXr1zFmzBje0QSpWwoLCyEWiwU9YcsYQ1FREZSVZbt0VRJfQtblagt5t1ceEokEEomk1L7LW++nP7+qzpExBrFYXGGss7MzNDQ0eHewFRUVQSQSSZ1eK63fkruXTpw4UWX5lvwuyrI99Z2gU0lxcXHc3QRBQUHw9vaGSCRC27Zt8fr1a4UmSKpXZYZdEIlEcu2ASuJLXnWNvNsrj5JhQuRd76c/v6rOUZad6MuXLxEREYHu3bvz2sVicanXXGTtV14V9SsWi6ko/B9BhcHa2hr79+/H+/fvceDAAfTu3RsAEB0dXeZj74SQ+u/cuXP45Zdf8OLFC+Tm5uLGjRvw9fWFvr5+qcNUkNpJUGFYtmwZvv76axgbG8PGxoa7I2Dr1q34+uuvFZkfIaQOcXV1RU5ODry8vKCrq4s+ffrAysoKV65ckXrug9Regud8Tk5Oxps3b+Dg4MAdfgUFBcHV1VVh97ETQghQ9vUIUjXkKgzff/89BgwYgE6dOtEPiBBC6im59u5xcXHw9vZGo0aNMHbsWBw8eBAZGRlVlRshhJAaIPepJIlEgmvXruHEiRM4ceIEoqKi4OrqigEDBmDAgAFSg1zVJxKJBAkJCdDR0aEJUwghdQpjDJmZmWjcuHGFZ3wEX2MoERsbi8DAQJw4cQIhISGwtLTkikSPHj3KXbawsBCHDx/G1atXoaysjG7dumHQoEFSO92YmBhs374diYmJaN26NSZPngwNDY0qiSlPfHy8wp7yJYSQmhAXFwdzc/NyYypdGD6WnZ2N8+fP48SJEzh16lS5zzRIJBLY29ujQ4cO6NKlC7Kzs/Hbb7/Bzc2NN9bS/fv30a1bN/Tv3x+dO3fG9u3boaamhsuXL3NDEigqpiLp6enQ19dHXFwcN8AYIYTUBRkZGbCwsEBaWhr09PTKDxbyuHRRURFvwoxnz56xpUuXsr/++otr+3RIgU9JJBKpCTpCQ0OlJjPp27cv8/T05N4nJiYydXV1tnXrVoXHVCQ9PZ0BYOnp6TIvQwghtYE8+y9BtxZt2rQJ/v7+AIC8vDz07NkTBw8exIwZM7i5GCo6By8SiaQm6GjWrBmA/42tnp+fjwsXLmD48OFcTIMGDdCzZ0/u0XhFxRBCCCkmqDD8/vvvmDZtGoDiZxe0tbW5eWf//PNPwcls3rwZOjo63CiIsbGxKCgoQJMmTXhxTZo04WZ4UlRMafLy8pCRkcF7EUJIfVdrxkr6999/sXr1avj7+0NfXx8AkJOTA6B4ApSP6ejocJ8pKqY0K1euhJ6eHveiC8+EkM+BoNG1SsZK8vb2xoEDB7Bjxw4AwsdKOnPmDEaOHIlff/0VX375JddecoEkNTWVF5+SksJ9pqiY0ixcuBCzZs3i3pdcvCGEyC83Nxf379+Hqamp1P+j6OjoUidVUlNTQ7t27Xht79+/R3x8PAwNDaX6SU1NRVRUlFQ/7du3r/Amk7S0NMTGxsLc3Jybje6zJeQixuHDh5mKigoDwHr27MmNMT9t2jS2adMmufo6c+YMU1dXZ+vXr5f6TCKRMH19fbZmzRpee6dOndjYsWMVGiMLuvhMiPySkpLYnDlzWOPGjZm6ujqbP3++VMzChQtZp06deC8NDQ3Wtm1bLiYrK4sNHjyYaWpqMkdHR2ZoaMjatGnDnjx5wsUcPXqUKSkpSfWVlJRUZn5RUVGsf//+zMTEhLVu3ZppaGiwQYMGsYyMDMV+ETVMnv2XoMLAWPEP+969e6ywsJBru3jxIsvPz5e5j3PnzpVZFEpMmTKF2dnZcT+kK1euMJFIxM6ePavwmIpQYSBEftevX2erV69mycnJzMHBodTC8KmkpCSmoqLC/vOf/3BtP/30EzMyMmLx8fGMMcZycnKYq6sr8/Dw4GKOHj0qNclPRU6ePMlCQkK49wkJCczMzIzNmTNHrn5qO3n2X4IHajcxMYGJiQmvrWfPnjIvn5mZCR8fH+jq6uL27dsYPXo095mfnx83Yusvv/wCT09PtGrVCg4ODggLC8N3330HT09PLl5RMYQQxXN2di51Ws3y7N69G0pKShgzZgzXlpiYiKZNm8LMzAwAoK6ujk6dOuHs2bNSy0dHR6OwsBDW1tYVnkLq168f772pqSlatWqFuLg4uXKuTwQVBsYYDhw4gCtXriAlJUXq8z179lTYh6qqKrZu3VrqZx+fNzQwMEB4eDiuXLmCxMRErF+/Hvb29rx4RcUQQmqHbdu2YciQITAyMuLapk2bhqNHj2LZsmVwc3NDTEwM9uzZg99//523bFZWFjdHTHJyMhYvXoyFCxdWuM7w8HDk5eXh8uXLuH379md9K7ugwjBnzhxs2bIFHh4eMDAwELRiNTU13lFCecRisdTsT1UVQwipWdeuXcOjR4+wadMmXrutrS2mTJmCNWvW4PDhw4iPj0efPn14ZyrMzc0RHh6OTp06AQACAwMxePBgNG7cGGPHji13vTNnzkR2djaio6MxZcoUtG3bVuHbVmcIOVdlYmLCrly5ImTROo2uMRBSObJcY5g4cSKzsbGRGj1h0aJFzMzMjMXFxTHGGMvOzmZeXl7M1dW13P58fX15ox5UJD4+ntna2rIJEybIvExdUOVPPjPG0KZNG8VWKELIZy8rKwv//PMP/Pz8pEZPOH78OHx9fbkB4DQ0NDBp0iSEhYWVekq7RKNGjeR6vsrMzAxjx47FyZMnhW1EPSCoMPTs2fOz/tIIIVXjn3/+QV5eHsaNGyf1mbGxsdQOPiEhAaqqqtDR0QFQPJDnxwoLCxESEgIHBweuLSUlBeHh4cjPzy91GQB4/vw57/rG50bQNQYTExOMGTMGJ0+ehI2NjVRlX7x4sUKSI4TUfQUFBbh9+zaA4lEIEhISEB4eDh0dHd4OGyi+6Ozt7Y2GDRtK9TNt2jQMGzYMS5YsQY8ePRAdHY2lS5di8uTJ3HTC48ePh7W1Nbp164aCggL4+/sjLi4O+/bt4/oJCgrCsGHDuOGnv/rqK7Ro0QJdunSBkpISzp07h127dmH37t1V+K3UboKG3e7cuXO5n4eHhwtOqDbLyMiAnp4e0tPTadhtQmSUkpIidUsoALRq1QoBAQHc+8TERAwaNAgrV67kblf/VEhICHbs2IHY2FgYGxujX79++Oqrr7h553Nzc7FlyxYEBQVBIpGgVatWmDlzJho1asT1ERwcjIULFyIwMBAmJibIycnBH3/8geDgYOTl5cHGxgaTJ0+Go6OjYr+IGibP/kuh8zHUd1QYCCF1lTz7L0HXGAghhNRfggvDiRMnMHjwYN7dSevWrSv37gBCCCG1n6DCsHv3bowePRq2tra4f/8+166iooJVq1YpLDlCCCHVT9A1hlatWuG3336Dh4cHRCIRSrp4/vw5unfvjvj4eIUnWhvQNQZCSF1V5dcYnj17BhcXFwD8KTyNjY2RnJwspEtCCCG1hKDC0KhRI24yjI8Lw/nz59G0aVPFZEYIIaRGCHrAzc/PD35+fti0aRNEIhFevXqFM2fOYNGiRfRwGyE15W9RxTGkfviiap8yEFQYFi1ahNTUVLi5uaGoqAhWVlZQVlbGjBkzMHPmTAWnSAghpDoJuvicmZkJHR0dpKWlITIyEhKJBK1bt4ahoSGeP3+OZs2aVUWuNY4uPpNajY4YPh8Cjhiq/OKzt7c38vLyoK+vD1dXV7i5uXFFoaxH2QkhhNQNgofdHjlyJIqKiri2mJgYuLu7w8PDQ2HJEUIIqX6CCsPx48fx8uVLTJo0CcD/ioKnpye2bdum0AQJIYRUL0GFQVdXF2fPnkVYWBj8/Pzg7u4OLy8v/Pnnn1JDcBNCCKlbBN2VBAANGjTA+fPn4eLigv79++OPP/6gokAIIfWAzHclKSuXXkMkEgmUlPgHHoWFhZXPrBaiu5JIrUZ3JX0+qviuJJmPGE6cOCF3IoQQQuoemQuDl5dXVeZBCCGklhB8jQEonkQ7JiYGjDHY2NhAU1NTUXkRQgipIYLuSsrPz8fs2bNhYGAAR0dHtGnTBgYGBpg9ezby8/MVnSMhhJBqJOiIYcGCBTh8+DC2bduGzp07QyQS4dq1a1i0aBEA4Ndff1VokoQQQqqPoMKwd+9eBAYGwtnZmWuztraGra0tfHx8qDAQQkgdJuhUUlpaGmxtbaXamzdvjrS0tMrmRAghpAYJKgxt2rTBxo0bpdp/++03ODo6VjopQgghNUfQqaQ1a9agb9++OHLkCHc66fr163j69ClOnz6t0AQJIYRUL0FHDO7u7njy5Ak8PDwQFxeH+Ph49O7dG1FRUTTsNiGE1HGCp/YMCAjAunXryvyMEEJI3SRoBjeRSITSFmOMQSwWQyKRKCS52obGSiK1Go2V9PmoTTO4FRYWcgPklfy75JWfn4/g4GA0bNhQ5v7y8vKwZ88edOvWDcbGxrhy5YpUzJw5c2BsbMx7ubq6SsX99ddf6NChA8zNzdG3b1/cv39fUAwhhHzu5CoMKioqUFFR4f275KWmpoZevXrhm2++kbm/JUuW4PTp05g+fTrev3+PgoICqZgPHz6ga9euePLkCfcKDAzkxRw4cAB+fn6YPn06Ll68CHNzc/To0QOJiYlyxRBCCJHzVFJISAgAoEePHggODuZ9pqKigiZNmsDc3FzmlTPGIBKJEB8fDwsLCwQHB0tdvJ4yZQrevXuHQ4cOldlPmzZt0LlzZ/zxxx8AgKKiIjRu3BhTpkzBsmXLZI6pCJ1KIrUanUr6fNSWYbcBcDvtyMhItGrVSu7EPiXrxD7BwcGwtLSEnp4eXF1dsWzZMpiYmAAA0tPTcf/+fSxevJiLF4vF6NmzJ8LCwmSOIYQQUkzmU0kLFy7knmouryikpqZi4cKFlU6shKmpKdatW4eQkBBs3rwZERERcHFxQXZ2NgAgISEBAKSubTRs2BBv3ryROaY0eXl5yMjI4L0IIaS+k7kwpKWlwcrKCpMmTcLx48fx+vVrFBQUoKCgAHFxcThy5AjGjRsHKysrpKamKizBpUuXYvz48WjWrBlcXV1x7NgxvHr1Cvv37wcA7u4osVjMW05ZWZm7O0qWmNKsXLkSenp63MvCwkJh20UIIbWVzIXB398fly9fRlFREUaPHg1zc3OoqqpCVVUVlpaWGD9+PJSVlXHlyhVs2bKlyhJu0KABLC0t8eTJEwDgTiklJyfz4pKTk7nPZIkpzcKFC5Gens694uLiFLYdhBBSW8l1jaFVq1bYvn07/vzzT9y/fx9xcXEQiUQwNzeHo6Oj1F/kVSE7OxsJCQm8nX7Tpk1x+fJlDBo0iIsLDQ3FkCFDZI4pjZqaGtTU1KpkOwghpLYSNCSGWCxGu3bt4O3tjYEDB6Jdu3ZVUhTy8vIwadIkPH/+HEDxX/jjxo2DsrIyRo0axcV9++23CAgIwPXr11FYWIg1a9YgISEBX3/9tVwxhBBCKjm1Z2Xt378f06ZN487z+/j4QEVFBfPmzcO8efOgpqaGbt26YcCAAXj16hUAoFu3bggLC+PdFjtjxgwkJSXBw8MDeXl5MDMzw5EjR9C8eXO5YgghhAgcEkNR8vLykJmZKdWuqakpNX90bm4u1NXVy+1PIpEgKysLOjo6lYopCz3HQGo1eo7h81GbnmNQNHnO4VdUFABASUmpwh2+LDGEEPI5E3SNwc/PT9BnhBBCaj8aXVUOdCqJ1Gp0KunzUZtOJZWMrPrpv4Hic/eXL1+Wa3RVQgghtY9chaFkZNVP//2x5cuXVy4jQgghNUquwlAyoqqiRlclhBBS+9To6KqEEEJqH0G3q5qbm3MjrZZGX19fYDqEEEJqmqDCYGBgUO7nNfjMHCGEkEoSVBhu3rzJey+RSBAdHY0lS5Zg1qxZCkmMEEJIzRBUGJycnKTanJ2dYWNjg1mzZmHatGmVTowQQkjNEPTkc1latWqF+/fvK7JLQggh1UxhhUEikcDf3x+mpqaK6pIQQkgNEHQqqVGjRlJt6enpEIlE2L17d6WTIoQQUnMEFYZ169ZJtRkYGMDJyYmGxCCEkDpOUGEYPXq0ovMghBBSSwiejyE/Px+HDx/G48ePAQAtW7bEkCFDoKqqqrDkCCGEVD9BF58jIyNha2uLyZMn4/Tp0zh9+jQmTZqE5s2b4+HDh4rOkRBCSDUSVBgmT54MV1dXJCQk4ObNm7h58yYSEhLQrVs3TJo0SdE5EkIIqUaCTiXdvXsXx44d402RqaOjg/Xr16NJkyYKS44QQkj1E3TEYGVlhdTUVKn2lJQUNG3atNJJker36tUrvHr1qtyYuLg4JCcnVzpGlnV9TCKR4PXr1xX2SwhRDEGFYc6cORg1ahRCQ0ORnZ2N7OxshIaGYtSoUZgzZ46icyRVhDGGXbt2oXPnzrCzs4Ovr2+pcbdv30bz5s3RunVrWFhYoGfPnkhKSpIrRtZ1fWrDhg0wNjaGs7Mz7OzsYG1tjbNnzwrfaEJIhQQVhq+//hoRERFwc3ODlpYWtLS04Obmhrt372Ly5MlQVlbmXqT2KigoQFBQENavX48pU6aUGpOdnQ1vb2/06NED79+/R3JyMrKysjB27Fi5YmRZ16fu3LmDGTNm4Pfff8fr16/x7t07DBgwAEOHDkV+fn7lNp4QUiZBe+4TJ04oOg9SA1RVVbFr1y4AwIEDB0qNCQwMRGJiIlasWAGxWAwdHR0sXrwY3t7eePXqFZo0aSJTjCzr+lTJ6aYBAwYAAJSUlNC/f39s2LABKSkppT6BTwipPEGFwcvLS9F5kFrq5s2baNasGUxMTLi2rl27Aig+fdSkSROZYoTo06cP2rVrh2+//RZTp05FVlYWli1bhgkTJlBRIKQKVepcT0pKClJSUqTabWxsKtMtqUXev38PY2NjXpuBgQGUlJTw7t07mWOE0NTUxNq1azF69GicOXMGOTk5sLa2xsKFCwX3SQipmKBrDLdv30aLFi1gZGQEW1tbqRepP8RisdT5/MLCQkgkEu4akiwxQly9ehVeXl7YsGED3rx5g5SUFPTq1Qtdu3Yt9a44QohiCCoMU6ZMgZOTE+7cuYMXL15IvUj9YWFhgTdv3vDa3r59C6B47m9ZY4Q4dOgQbGxsMGzYMADF1xi+//57JCcn48KFC4L7JYSUT1BhePToETZt2oR27drByspK6kXqD3d3dyQkJCAyMpJrO3nyJNTV1dG5c2eZY2QhkUjw5MkTpKenAwD09fWRlpaGoqIiLqbk1JS+vn5lNosQUg5BhaFp06Z0KF9PvHjxAk+ePEFqaipyc3Px5MkTPHnyBIwxAICbmxt69eqFMWPG4OLFizh48CC+//57zJ49G7q6ujLHyLKujIwMtGjRAkePHgUAjBo1CpmZmZgwYQKuX7+OoKAgjBkzBnZ2dujWrVs1f1OEfD5ErOR/pRx2796NvXv3wt/f/7N60jkjIwN6enpIT0/n7fDqMm9vbzx9+lSq/c6dO9DU1AQAZGZmYvny5QgKCoKamhpGjBiB6dOnQ0npf39XyBJT0boyMzPRsWNHrFy5EoMHDwZQPGDjunXr8PjxY6iqqsLZ2Rnz5s2ju5JK87eopjMg1eULuXfbcu2/ZC4Mn15ELDm8V1JSgkjE/4UsLCyUJ986oz4WBlKPUGH4fFRxYZD5lhF6qI0QQj4PMheGqnyoLSkpCc+fP0fLli3LrGQJCQlISkqCjY0NtLW1qzSGEEI+Z4IuPqelpZX5ysnJkbmfiIgIjBw5Eg4ODujSpQvu3LkjFZOXl4cRI0bA2toaw4YNQ8OGDeHv718lMYQQQgQWBgMDgzJfmpqaMDU1xaJFiyq81hAREQEfHx9cv369zJiffvoJly9fxrNnzxAdHY2//voLU6dOxc2bNxUeQwghRGBh+O2339CwYUOsX78eISEhuHTpEn799Vc0aNAAq1atwo8//ohdu3Zh1apV5fYzYcIEjBo1qtx5ordt2wY/Pz+YmZkBAHx9fdGyZUts375d4TGEEEIEjpW0Z88eHDp0iHcveffu3eHk5IQ5c+bgxo0bsLGxwTfffIPFixcLTi4hIQFv375Fx44dee2dOnVCRESEQmMIIYQUE1QYHj16hNatW0u1t2nTBo8ePQJQvNN9/fp1pZIrGaDP0NCQ125kZIT3798rNKY0eXl5yMvL495nZGQI2QyI6C7Cz4b8TwURUvsIOpXUuHFjBAQESLVv3boVjRs3BgBERUWVWjzkoaKiAgC8nTMA5OTkcJ8pKqY0K1euhJ6eHveysLCoxNYQQkjdIOiIYe3atRg2bBgOHDgAJycnMMZw69YtRERE4ODBgwCKn45etmxZpZKzsLCAkpISEhISeO0JCQncGP+KiinNwoULMWvWLO59RkYGFQdCSL0n6Ihh0KBBePz4Mbp27YqYmBi8ePECLi4uePz4MQYNGgSg+AK1p6dnpZLT1NRE586dERgYyLVlZ2fjwoUL6NWrl0JjSqOmpgZdXV3eixBC6jtBYyUpSnJyMmJiYpCcnAxvb2/8/vvvaN++PczNzbnhmoODg+Hp6YkFCxagS5cu2LBhA6KionDv3j1uR62omIoIHRKDrjF8Pmr0GgMNifH5qC1jJX0sLS2t3M9lHRL55MmT+Omnn6Ta/fz84Ofnx70PDQ3Fpk2bkJiYiNatW2PRokXctQxFx5SHCgOpCBUGUi1qY2H4dNC8T9XgQUiVosJAKkKFgVSL2jKI3sc+fVpYIpEgOjoaS5Ys4V2sJYQQUvcIKgxOTk5Sbc7OzrCxscGsWbMwbdq0SidGCCGkZgi6K6ksrVq1wv379xXZJSGEkGqmsMIgkUjg7+8PU1NTRXVJCCGkBgg6lVTatIrp6ekQiUTYvXt3pZMihBBScwQVhnXr1km1GRgYwMnJCQ0bNqx0UoQQQmqOoMIwevRoRedBCCGklhBUGEpkZ2cjJiYGjDHY2NhAU1NTUXkRQgipIYIuPufn52P27NkwMDCAo6Mj2rRpAwMDA8yePRv5+fmKzpEQQkg1EnTEsGDBAhw+fBjbtm1D586dIRKJcO3aNSxatAgA8Ouvvyo0SUIIIdVHUGHYu3cvAgMD4ezszLVZW1vD1tYWPj4+VBgIIaQOE3QqKS0tDba2tlLtzZs3r3CAPUIIIbWboMLQpk0bbNy4Uar9t99+g6OjY6WTIoQQUnMEnUpas2YN+vbtiyNHjnCnk65fv46nT5/i9OnTCk2QEEJI9RJ0xODu7o4nT57Aw8MDcXFxiI+PR+/evREVFQV3d3cFp0gIIaQ6CTpiWLx4MVasWFHqE9CEEELqNkFHDOvWrUNBQYGicyGEEFILCCoMHTp0QGhoqKJzIYQQUgsIOpXUv39/jBw5EjNmzEDLli2hqqrK+3zAgAEKSY4QQkj1EzTns7q6ermf5+bmCk6oNqM5n0lFaM5nUi1q45zP9XXHTwghRMFTexJCCKn7BA+7/ejRI4SHhyMlJUXqszlz5lQqKUIIITVHUGHYsmULpk6dCnNzcxgYGEh9ToWBEELqLkGFYeXKldi5cyfGjBmj6HwIIYTUMMGjq/r6+io6F0IIIbWAoMLg5OSEW7duKToXQgghtYDMp5JOnDjB/dvDwwMjR47E3LlzYWNjA9EnN+rTA26EEFJ3yfyAW0UPtX2svj7nQA+4kYrQA26kWtSWB9zq686eEEIIn1zXGPbs2VNVeRBCCKkl5CoMdHsqIYTUfzQkBiGEEB7BQ2JUlxMnTkjdGtugQQN88803vLb09HQcOXIEiYmJaN26Nfr16yd1t5QsMYQQ8rmTuzB4eHhUGHPhwgVByZTmxIkTCA0NxfDhw8uMiY2NRbdu3WBmZgYnJyds3LgRzs7OOHLkCLfjlyWGEEKIgMJgbGxcFXmUq2XLlvjxxx/L/Hz+/PkwNTVFWFgYlJWVMX36dLRs2RKHDh3CsGHDZI4hhBAioDDs37+/KvIoV2xsLNasWQM9PT24uLigVatW3GdFRUU4duwY1qxZA2Xl4s1p3rw5unfvzu30ZYkhhBBSrE5cfC4qKsLbt28RFBSEDh06YPHixdxnsbGxyMnJga2tLW8ZW1tbREVFyRxTmry8PGRkZPBehBBS39X6i88zZ86Evb099z4wMBDe3t7o06cPXF1d8eHDBwCAnp4ebzl9fX3uM1liSrNy5UosW7ZMIdtBCCF1hVxHDKdPn66qPMr0cVEAgIEDB6Jx48YICQkBAGhrawMovuPoY2lpadxnssSUZuHChUhPT+decXFxldoWQgipC+QqDF5eXlWVh1wYY8jOzgYAWFhYQENDA9HR0byY6Oho2NnZyRxTGjU1Nejq6vJehBBS39XqawxFRUWIiIjgtQUGBuLNmzfo0aMHAEBZWRk+Pj7YvXs3CgsLAQBPnz5FaGgoN2eELDGEEEKKyTy6ak0oLCxE9+7doa+vDwcHB8TGxuLYsWOYNm0a1q1bx8XFxsbCxcUFFhYWcHJywpEjR9CxY0ep5xgqiqkIja5KKkKjq5JqUcWjq9bqwlAiKCgIERERMDAwQNeuXaWuOwDF1w8OHz7MPdXcv3//Up98riimPFQYSEWoMJBqUVsLQ3R0NP7++288f/4cu3btAgAcO3YMXl5eUFNTE9JlrUeFgVSECgOpFlVcGARdY7h06RLatm2LK1eu4K+//uLar169is2bNwvpkhBCSC0hqDAsWLAAGzduxLlz53jtY8eOhb+/v0ISI4QQUjMEFYbIyEiMGDECAHjn6Js0aYKXL18qJDFCCCE1Q1Bh0NLSQlJSEgB+Ybhz5w4aNWqkmMwIIYTUCEGFwdfXF3PmzEFmZibXdv36dfj5+ZU7PDYhhJDaT1BhWL16NdLT02FkZASJRAJDQ0N07twZFhYWWL58uaJzJIQQUo0EDaKno6ODCxcu4Nq1a7h16xYkEgnat28PV1dXRedHCCGkmlVqdNUuXbqgS5cuisqFEEJILSBzYdi5c6fMnY4bN05AKoQQQmoDmQvDx1NrMsYQGxsLoHhOA6B4CGsAsLS0pMJACCF1mMwXn1++fMm9vvnmG7i7uyM6OhqpqalITU1FdHQ03N3dMXXq1KrMlxBCSBUTNFaSjY0NgoKCYGlpyWuPjY1Fr169pOY9qC9orCRSERoriVSL2jhW0uvXr6GkJL2okpIS4uPjhXRJCCGklhBUGFxcXDBp0iReEYiPj8ekSZPollVCCKnjBBWGgIAAvHv3Dk2aNIGZmRkaN26MJk2a4P379wgICFB0joQQQqqRoOcYrKyscPPmTYSFheHRo0cAgJYtW9LRAiGE1AOVesDN1dWVigEhhNQzggtDYWEh/v33Xzx+/BiMMbRs2RKDBg2CsnKlag0hhJAaJmgvHhMTg379+iE2NhbW1tYQiUR49uwZLC0tcerUKVhbWys6T0IIIdVE0MXnGTNmoEWLFoiLi8ODBw8QGRmJuLg4tGjRAjNmzFB0joQQQqqRoCOG4OBgREdHw9jYmGszNjbG5s2bYWtrq7DkCCGEVD9BRwxisRgFBQVS7fn5+XSNgRBC6jhBhcHLywsTJkzAixcvuLbnz59j/Pjx6NOnj8KSI4QQUv0EFYYNGzYgNzcXzZo1Q4MGDdCgQQNYW1sjPz8fGzZsUHSOhBBCqpGg8z6NGjXClStXcPnyZTx8+BAikQgtW7ZEt27dFJ0fIYSQalapCwLdunWjYkAIIfWMoFNJr169wqpVq6TaV61axU3gQwghpG4SVBimT5+OVq1aSbU7ODjg22+/rXRShBBCao6gwhAUFAQ3Nzepdjc3NwQHB1c6KUIIITVHUGHQ0dHB06dPpdqfPn0KDQ2NSidFCCGk5ggqDEOGDMGkSZO4IbcB4OHDh/Dz88OQIUMUlhwhhJDqJ6gwrFq1Crq6unBwcICxsTGMjIzQqlUr6OvrY/Xq1YrOkRBCSDUSdLuqjo4OQkJCEBYWhjt37kAkEqFdu3Y0NwMhhNQDn9VEPaGhofj999+RmJiI1q1bY9GiRTA1Na3ptAghpFYRdCoJAKKjo7Fs2TKMHTuWazt27Bjy8vIUkpiiBQcHo1evXrC1tcXcuXMRHR0NFxcXZGZm1nRqhBBSqwgqDJcuXULbtm1x5coV/PXXX1z71atXsXnzZoUlp0iLFy+Gr68vVqxYgf79++PIkSN4//49tm7dWtOpEUJIrSKoMCxYsAAbN27EuXPneO1jx46Fv7+/QhJTpOzsbISHh2PgwIFcm6amJjw8PHDhwoUazIwQQmofQdcYIiMjMWLECACASCTi2ps0aYKXL18qJDFFiouLg0QiQePGjXntjRs3xsWLF8tcLi8vj3dqLD09HQCQkZFRNYmSOq9GfzWya3DdpHoJ+EUr2W8xxiqMFVQYtLS0kJSUhKZNm/IKw507d9CoUSMhXVapkkmF1NTUeO0aGhqlTjhUYuXKlVi2bJlUu4WFhWITJPWGnl5NZ0A+C5OE/6JlZmZCr4JfVEGFwdfXF3PmzMHOnTu5tuvXr8PPzw/Dhw8X0mWVMjQ0BACkpKTw2t+/fw8jI6Myl1u4cCFmzZrFvZdIJEhJSYGRkRGvIBJpGRkZsLCwQFxcHHR1dWs6HVJP0e+Z7BhjyMzMlDpzUhpBhWH16tUYPHgwjIyMIJFIYGhoiNTUVPTq1QvLly8X0mWVaty4MRo1aoSbN29iwIABXPv169fLvd1WTU1N6ihDX1+/qtKsl3R1dek/LKly9Hsmm4qOFEoIfsDtwoULuHbtGm7dugWJRIL27dvX6mcaJkyYgICAAEyePBlmZmY4fPgwHj16hB07dtR0aoQQUqtU6gG3Ll26oEuXLorKpUr98MMPiI6Oho2NDSwsLBAfH49NmzahY8eONZ0aIYTUKoIKw5UrV3DkyBG8ePECIpEITZs2xZAhQ9C1a1dF56cwampqOHDgABISEpCYmAgbGxvo6OjUdFr1lpqaGpYuXSp1Ko4QRaLfs6ohYrLcu/SRb7/9Fhs3bkSDBg1ga2sLoHi47eTkZHz33XdYv359lSRKCCGkesh1xHDs2DFs374dBw4cwNChQ7k7cxhjOHDgAMaPH49evXqhf//+VZIsIYSQqifXEYOPjw9cXV0xZ86cUj9fvXo1rl+/jiNHjigsQUIIIdVLriExbt++DV9f3zI/HzZsGG7dulXppEjtExMTg5MnT5YbExUVhbNnz1ZTRoSQqiJXYUhOTi73qV8LCwskJSVVOilSdY4fP46HDx/y2l6/fo39+/cjLi6O1/748WPu6O/8+fOYMWMG91l0dDROnTrFiw8MDMT8+fOrKHO+0tZPCFEMuQpDfn4+lJXLviyhoqJSa4fdJsV+//13qWE+du7ciVGjRuHPP//ktf/yyy/czQQ2Nja8hwPPnj3Leyq8utX0+oniXLx4EQEBAQgICMBff/2FoKAg5ObmVrhcYmIiAgICpMYui4iIQEBAAIKCgrB9+3ZIJJJSlw8ODsbx48cVsg31jdy3qy5evLgq8iDVpEePHli/fj0YY9zNAyVzVQQHB/NiQ0JCMH78eABA06ZN0bt3bwBAbGws7ty5g8zMTOzfvx8A0L59e265wsJC3Lt3D2/fvkW7du1KfQT/7t27eP78OczMzODs7MwbYuT+/ftISUmBu7s71/bixQtERkbC29u7zPU3b95cAd8QqW7+/v64ceMGPD09UVBQgPDwcGRlZeHMmTNo1apVmctFR0dj0qRJcHd35556Pn36NIYOHYrp06ejW7du6NWrF8zMzNCnTx/esoWFhfjiiy/g5+cHb2/vKt2+OonJwdraWqYXqb3Cw8MZAPbgwQPGGGN5eXlMU1OThYaGMlVVVZaVlcUYYyw6OpoBYEFBQYwxxvz9/bmf7dWrV1n79u2Zjo4OGzFiBBsxYgQ7deoUW7t2LTM3N2dOTk6sR48ezNXVlWloaLAzZ85w68/Ly2P9+/dnhoaGrG/fvszU1JR16tSJpaSkcDHz589nvXr14uW9Y8cOZmZmVu76Sd3k6+vL+vfvz70vKChgbdu2Zf369St3ubCwMAaARUdHM8YY27t3L1NVVWW//vorF+Pi4sKGDx8utey///7LRCIRe/78uYK2on6RqzCQuq+wsJDp6uqyjRs3MsYYCw0NZY0bN2aMMWZnZ8fOnz/PGGNs69atTF1dneXk5DDG+IWBMcY2btzI7OzseH2vXbuWAWAnTpzg2qZNm8acnZ259+vWrWMNGzZkr1+/ZowxlpaWxuzt7dn06dO5mIoKQ1nrJ3XTp4WBMca+/fZbZmlpWe5yHxeGjRs3MhUVFbZz505ezI4dO5iamhp7//49r33gwIHMw8NDMRtQDwme2pPUTWKxGK6urtxpo+DgYO6UjZubG6+9S5cuUFdXl6t/CwsL3nMs7u7uiIqK4t7v378fY8eO5U4v6enpYdq0adwpIUKA4hsfZBkFFABWrFiBefPm4dChQ7yphgFg+PDhUFNTw549e7i2t2/f4vTp05g4caJCc65PqDB8hnr06IFLly6BMVZmYQgJCUHPnj3l7rtkiPMSampqvAuJr169QrNmzXgx1tbWSE5ORnY2zTTzuYqLi0NAQAD8/f3x5Zdf4urVq1ixYoVMy/79999wcXFBv379pD7T1NTEyJEjsX37dq5t165d0NXVxeDBgxWWf31DheEz1KNHD7x//x43btxAeHg4rzDcvHkTt27dwps3bwQVhooYGxtLzYuRkpICLS0taGpqAgCUlJSk7iSR5S4VUnelpqYiPDwcV65cQVBQEDw9PXmjNe/Zs4e7c+nEiRO8ZXft2oVbt25h1KhRKCwslOp74sSJuHfvHu7cuQMA2L59O0aPHk3jK5WDCsNnqG3btjAwMMAvv/wCQ0NDbswrMzMzNGnSBD/99BO0tLTKHXlWW1tb0M66W7duOHr0KG96wYMHD8LFxYV7b2ZmhufPn/NiPr1jSuj6Se3k6OiIgIAA7NmzB/fv38eNGzewcOFC7vPbt28jPDwc4eHhUs/hdOzYERcvXkRQUBCGDx8uNSujs7MzHB0dsW3bNoSFheHp06fw8/Orlu2qqyo17Dapm5SUlODm5oZ///0XX3zxBe8zNzc3bN++HV5eXlBRUSmzjw4dOiAuLg6rVq2ClZUV73bV8ixduhTt2rXDwIED4ePjg0uXLuH8+fO4fPkyFzNkyBAsWLAAY8aMQc+ePXHp0iWEhITw8ilt/XS7av1gYmKCtWvX4quvvsLkyZNhZ2eH//znP+Uu0759ewQFBcHDwwNDhw7FwYMHoaqqyn0+ceJELF26FO/fv4ezszNat25d1ZtRp9ERw2dq3LhxGDFiBEaPHs1rHzVqFEaMGCF1Ye7TB9xat26NY8eOITY2FseOHUNMTAzs7e3h5eXFW87MzIw33auZmRnu3r0LJycnhIWFwdzcHBEREWjbti0XY2pqihs3bnCz7vXq1Qv//PMPfHx8yl0/qT9GjhyJNm3aYNGiRTIv06ZNGwQHByM8PBy+vr68h21Hjx6NnJwc/PPPP3TRWQZyD7tNCCGKtGXLFhQUFGD69Om89mvXrmH79u1YvXq11E0NAPDs2TOsWrUKK1euhImJCdf++PFjrF+/Hp6enhg2bBjX/p///AePHj3C+vXraS6WClBhIIQQwkOnkgghhPBQYSCEEMJDhYEQQggPFQZCCCE8VBgIIYTw0ANuhBDBHj16hN27d+Px48dQUVGBnZ0dxo0bBxsbGwBAWFgYNzGUSCRCw4YN4eLigokTJ0JVVRV79+7FsWPHcODAAV6/WVlZ8PHxwdKlS3lDY9Q2P//8MzQ0NOrdpFF0xEAIEeS///0v2rVrh5SUFIwePRqjRo2ClpYWfHx8EBISAqB4lrWLFy9i5syZmD9/Prp164bly5djyJAhAIonYAoNDZXqu6CgABcvXkRiYmJ1bpLcIiMj8ejRo5pOQ+HoiIEQIrfQ0FB89913CAgIwIQJE3ifzZs3Dx8+fOC1ubu7Q1tbGx4eHtDT08MXX3yB58+fVyqH5ORkbNy4ERERETA2NsagQYO4p+PT09MxZswYfPXVVxg6dCgAIDMzE2PGjMHIkSMxcuRIbN26lTtSMTAwQMeOHfHtt99KDTX/4MED/PHHH3j58iVatGiBuXPnwsTEBJs2bUJISAjEYjE8PDwAAJs3b64XQ7NQYSCEyG3Tpk2ws7Pjpn79mFgshp6eXpnLWlhYAADevXsneP1v3rxBp06d0Lt3b0yYMAHJycmYOnUqnj59irlz50JPTw99+vSBn58fnJycYGVlhalTpyImJgaDBg0CUDzKcMkQ8CVF5ty5c7hw4QK3nrNnz8LHxwdjx47F+PHjERMTg5EjR+LixYvo3bs3Dh8+zDuVZGpqKnibapUanCSIEFJHWVtbs1GjRlUYd/DgQQaAZWZmMsYYk0gkbMqUKUxbW5tlZGSwn376iTVs2FBqudTUVAaAHTx4sNR+J0+ezHx9fXltp06dYpqamqywsJBrGzBgAHNxcWG7d+9mampq7P79+2XmmpaWxpSVldm9e/d42zl16lReXEZGBvfvESNGsIkTJ5bzDdRNdMRACJFbdnY29PX1ZY4fOHAgxGIxXrx4gYyMDOzatatS4xVdvHgRYrEYXl5eYMVTFCMnJwfZ2dl4+fIlrK2tARTPvdC6dWuMHTsW69ev542qmpOTgx07duDq1atISkqCRCKBkpISnj17BkdHR7x69QoxMTG8QSABfBbjLFFhIITIzczMDC9fvpQ5fvbs2dDQ0ICJiQmaN2/OncdXVVVFfn6+VHzJyKhlTaaTkZGBoUOHchexP9aoUSPu39ra2jAwMEBiYqLU/CIjR47Ey5cvMW3aNJiZmUFVVRU3b97kZhLMysoCALkKYH1BhYEQIrf+/ftj7dq1SEhIkGlu5pKLz59q1qwZUlNTkZ6ezrsuUVJ0Pp0GtkTTpk2RmZnJXfQty+zZsyGRSODn54cxY8bg7t270NHRQVZWFgIDAxEeHg5nZ2cAQFpaGjIyMrhlLS0toaysjEePHsHR0bHU/pWU6ueNnfVzqwghVWrGjBlo2LAhvvrqK94tpYwxHDlyBLdu3ZKpn549e8LY2BgrVqzgZuzLy8vD6tWr4ejoCHt7+1KXmzJlCvbv348zZ85wbRkZGdiwYQP3/sSJEwgICMDevXuxceNGqKur49tvvwVQfKSiqqqKqKgoAIBEIsG8efN469DW1saIESPw008/4c2bN1zczp07uRgTExO8fftWpm2tS6gwEELkZmBggLCwMGhpacHKygodO3ZEp06dYGxsjP3798t8d46hoSEOHjyIo0ePokmTJnBxcYGFhQXi4+Oxb98+iMXiUpcbP348li5dCl9fX7Rs2RLt27eHnZ0dN1d4YmIiJk6ciB9//BFOTk5QV1fH33//jX379uHQoUNQUVHB6tWr4efnh86dO8PKygoxMTFSp402b94Ma2tr2NjYwNnZGebm5oiNjeU+/+KLLxAaGgpnZ2d4eHjg6dOnwr7QWobmYyCEVEpKSgqioqKgoqKC5s2bQ1dXl/ssKSkJ9+/fR48ePcrcyQNAUVERXr58icTERFhYWMDc3BwikajCdX/48AGRkZHQ1NSEvb09d00iNjYW0dHR6NGjB+90z71791BQUAAnJycAxbe9Pnv2DA0bNkTz5s0RFhYGW1tb3nUKAHj16hXi4+Nhb28PIyMj3mdpaWl48uQJPnz4gE6dOtWLi9NUGAghhPDQqSRCCCE8VBgIIYTwUGEghBDCQ4WBEEIIDxUGQgghPFQYCCGE8FBhIIQQwkOFgRBCCA8VBkIIITxUGAghhPBQYSCEEMJDhYEQQggPFQZCCCE8/x8V5dk73akNlwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 400x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "labels = [\"Without\", \"R-KV\\nCPU exact\"]\n",
+    "data = [\n",
+    "    before_drop_data[\"metrics\"][\"results\"][\"output_tput\"],\n",
+    "    cpu_exact_drop_data[\"metrics\"][\"results\"][\"output_tput\"],\n",
+    "]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(4, 3))\n",
+    "bars = ax.bar(labels, data, color=[\"blue\", \"orange\"])\n",
+    "ax.bar_label(bars, fmt=\"%.1f\", padding=3)\n",
+    "ax.set_ylabel(\"Decode Throughput (tokens/s)\")\n",
+    "ax.set_title(\"Token Dropping Benefit\\nfor Decode Throughput\")\n",
+    "ax.margins(y=0.15)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "736c1e35",
+   "metadata": {},
+   "source": [
+    "## Reading these numbers\n",
+    "\n",
+    "All four notebooks were run back to back on one machine against the same vLLM\n",
+    "and LMCache servers, and each re-measures its own no-drop baseline. That gives\n",
+    "four independent measurements of an **identical** configuration — a direct read\n",
+    "on how much of any difference is real:\n",
+    "\n",
+    "| | one-shot | gpu_exact | cpu_exact | buffered_cpu |\n",
+    "|---|---|---|---|---|\n",
+    "| baseline decode | 969 tok/s | 1008 tok/s | 1002 tok/s | 975 tok/s |\n",
+    "| baseline accuracy | 10/30 | 10/30 | 11/30 | 11/30 |\n",
+    "| decode after dropping | 1766 tok/s | 1774 tok/s | 1785 tok/s | 1774 tok/s |\n",
+    "| accuracy after dropping | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "\n",
+    "Three things follow.\n",
+    "\n",
+    "1. **Decode throughput after dropping is the solid number.** It lands in\n",
+    "   1766–1785 tok/s — a 1.1% spread — although the four notebooks compress with\n",
+    "   completely different code. That is the claim this example makes: the speed-up\n",
+    "   comes from halving the KV cache, not from how the halving is computed.\n",
+    "\n",
+    "2. **Don't quote a speed-up ratio.** The no-drop baseline swung 969–1008 tok/s\n",
+    "   here, and 894–1076 tok/s — **20%** — over an earlier sweep of the same four\n",
+    "   notebooks, so the ratio moves between 1.6x and 2.0x on noise alone. Compare\n",
+    "   the absolute post-drop throughput instead.\n",
+    "\n",
+    "3. **Don't rank the variants by accuracy.** R-KV beat the same-run baseline in\n",
+    "   all four runs (+3 to +4 of 30), which is the meaningful result. But the 1/30\n",
+    "   spread *between* variants is the same size as the baseline's own spread, so\n",
+    "   it says nothing about the algorithms.\n",
+    "\n",
+    "### Why identical inputs give different text\n",
+    "\n",
+    "Decoding is greedy — `temperature = 0.0` for both prefill and decode — yet the\n",
+    "generated text still differs between runs. `temperature = 0` fixes the *rule*\n",
+    "(take the argmax); it does not make the argmax stable.\n",
+    "\n",
+    "Prefill is submitted one stream at a time (`prefill_group_size = 1`) and it\n",
+    "**is** reproducible: 15.19 s and 15.21 s, to the same hundredth of a second, in\n",
+    "every notebook. Decode is not. `batch.decode` hands all 30 streams to vLLM at\n",
+    "once, so continuous batching gives the decode batch a different composition on\n",
+    "every run. GPU reductions are not batch-invariant, logits move by ~1e-6,\n",
+    "near-ties flip, and autoregression amplifies the divergence.\n",
+    "\n",
+    "This is a property of the serving stack, not of token dropping — but it is the\n",
+    "reason a single accuracy number here should not be read as a ranking.\n",
+    "\n",
+    "### The exact variants pick the same tokens — their caches still differ\n",
+    "\n",
+    "Verified directly on real requests: `cpu_exact` and `gpu_exact` produce score\n",
+    "vectors that differ by ~1e-6, but the top-k they select was identical on every\n",
+    "request tested, and so were the kept token ids. Their compacted caches are\n",
+    "nevertheless not byte-identical:\n",
+    "\n",
+    "| | differing elements | largest difference |\n",
+    "|---|---|---|\n",
+    "| V — a pure gather | **0** | 0 |\n",
+    "| K — goes through the RoPE re-rotation | 0.004% | one to two bfloat16 ULP |\n",
+    "\n",
+    "Every difference is in K, and it is the *device*: `cpu_exact` re-rotates on the\n",
+    "CPU, `gpu_exact` on the GPU, and their sin/cos implementations and fused\n",
+    "multiply-adds round differently before the result is stored back as bfloat16.\n",
+    "Feeding one identical tensor to `rerotate_k_cache` on each device reproduces the\n",
+    "same signature exactly, so nothing else is involved.\n",
+    "\n",
+    "One ULP in K is enough to move an attention logit, flip a near-tied greedy\n",
+    "argmax, and diverge from there. That is why two implementations which provably\n",
+    "select the same tokens still generate different text, and can land on a\n",
+    "different answer for one or two of the 30 questions.\n",
+    "\n",
+    "#### Why the re-rotation runs in fp32\n",
+    "\n",
+    "`utils.rerotate_k_cache` detaches one RoPE and attaches another: six multiplies\n",
+    "and two adds per element. Carrying that out in the cache's own bfloat16 rounds\n",
+    "at every step. Measured on keys with a standard deviation of 3:\n",
+    "\n",
+    "| arithmetic | keys changed vs fp32 | rotate-away-and-back error | re-rotate 30 requests |\n",
+    "|---|---|---|---|\n",
+    "| bfloat16 | 50% | 2.5e-1 | 3.2 s |\n",
+    "| **fp32** (used here) | — | **6.3e-2** | 6.1 s |\n",
+    "\n",
+    "fp32 costs 1.9x on the re-rotation step itself, because it moves twice the\n",
+    "bytes. End to end that is much less than it sounds: compressing the 30 requests\n",
+    "went from 41.4 to 41.6 s (one-shot), 37.3 to 37.5 s (`gpu_exact`) and 67.1 to\n",
+    "67.3 s (`cpu_exact`) — around +0.2 s, because `modify` spends most of its time\n",
+    "waiting on LMCache and the extra arithmetic fits in that slack. Only\n",
+    "`buffered_cpu` shows it, 27.9 to 29.9 s (+7%), because its compression is the\n",
+    "shortest so the re-rotation is the largest share of it. That buys a 4x better\n",
+    "round trip and takes an extra ULP of error off half the keys, so it is the\n",
+    "default. It does **not** remove the CPU/GPU split above: that is\n",
+    "the final rounding back to bfloat16, which is there whatever precision the\n",
+    "rotation is computed in.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03cca85b",
+   "metadata": {},
+   "source": [
+    "## Close both contexts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f83db925",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:18:45.542006Z",
+     "iopub.status.busy": "2026-08-01T06:18:45.541884Z",
+     "iopub.status.idle": "2026-08-01T06:18:45.544490Z",
+     "shell.execute_reply": "2026-08-01T06:18:45.543966Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Only close the context when done.\n",
+    "ctx.close()\n",
+    "qctx.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "defaultInterpreterPath: 3.12.3.final.0",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/token_dropping/rkv_variants/rkv_variant_gpu_exact.ipynb
+++ b/examples/token_dropping/rkv_variants/rkv_variant_gpu_exact.ipynb
@@ -1,0 +1,1572 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# R-KV Token Dropping — Route A, exact and linear, on the GPU\n",
+    "---\n",
+    "\n",
+    "Long prompts create large KV caches. They eat GPU memory, limit how many requests\n",
+    "fit in a batch, and a smaller batch means lower decode throughput. *Token\n",
+    "dropping* shrinks each request's KV cache — by half in this notebook — so more\n",
+    "requests fit and decoding runs faster.\n",
+    "\n",
+    "This notebook uses the LMCache SDK to pull a request's KV cache out after\n",
+    "prefill, compress it, and put it back before decode. The compression algorithm\n",
+    "is **R-KV**: it ranks past tokens by **attention importance**, like SnapKV, and\n",
+    "subtracts a second term, **redundancy** — how similar a token's key is to the\n",
+    "*other* keys:\n",
+    "\n",
+    "$$\\text{score}(j) \\;=\\; \\lambda \\cdot \\underbrace{\\text{importance}(j)}_{\\text{attended to?}} \\;-\\; (1-\\lambda) \\cdot \\underbrace{\\text{redundancy}(j)}_{\\text{says something new?}}$$\n",
+    "\n",
+    "Keeping tokens that are both attended-to **and** non-redundant works especially\n",
+    "well on the repetitive output of reasoning models. The catch is that the\n",
+    "redundancy term compares **all pairs of keys**: $O(n^2 d)$ per layer, against\n",
+    "$O(w n d)$ for SnapKV's importance term. At $n = 16128$ with window $w = 64$\n",
+    "that is ~250x more arithmetic per layer, and a literal implementation also\n",
+    "materializes an $n \\times n$ matrix per layer.\n",
+    "\n",
+    "## This notebook\n",
+    "\n",
+    "It implements the same exact linear rewrite as\n",
+    "[`cpu_exact`](./rkv_variant_cpu_exact.ipynb), moved to the **GPU** and tiled over rows so\n",
+    "the memory footprint becomes a knob instead of a function of prompt length. It\n",
+    "is the **default choice**: simultaneously the fastest and the smallest of the\n",
+    "four, exact, in ~1.55 GiB of VRAM.\n",
+    "\n",
+    "It is one of four independent notebooks that keep the same 50% of the tokens and\n",
+    "therefore deliver the **same decode speed-up** — 1766–1785 tok/s, a 1.1% spread, even\n",
+    "though they compress with completely different code. What separates them is the **cost of\n",
+    "compressing**:\n",
+    "\n",
+    "| | [one-shot](../rkv_token_dropping.ipynb) | [cpu_exact](./rkv_variant_cpu_exact.ipynb) | [gpu_exact](./rkv_variant_gpu_exact.ipynb) | [buffered_cpu](./rkv_variant_buffered_cpu.ipynb) |\n",
+    "|---|---|---|---|---|\n",
+    "| Formulation | route A, literal | route A, linear | route A, linear | route B, chunked |\n",
+    "| Exact? | yes (the reference) | yes, rel. err ~2e-6 | yes, rel. err ~5e-7 | **no**, ~96% agreement |\n",
+    "| Redundancy cost | $O(n^2 d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ | $O(n \\cdot c \\cdot d)$ |\n",
+    "| VRAM | ~9.8 GiB | none | **1.55 GiB** | none |\n",
+    "| Compress 30 requests | 41.6 s | 67.3 s | **37.5 s** | **29.9 s** |\n",
+    "| Decode throughput | 1766 tok/s | 1785 tok/s | 1774 tok/s | 1774 tok/s |\n",
+    "| Accuracy (baseline 10–11/30) | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "\n",
+    "\n",
+    "Start with the [one-shot notebook](../rkv_token_dropping.ipynb): it is R-KV\n",
+    "written the way the paper describes it, and it is the reference the exact\n",
+    "variants here are checked against.\n",
+    "\n",
+    "Numbers above were measured on 30 LongBench-v2 prompts (~16k tokens each) with\n",
+    "Qwen3-8B on one H200 and a 96-core Xeon. They are hardware- and\n",
+    "workload-dependent; treat them as reference measurements, not guarantees.\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "* A small ~10-line modification to vLLM exposes intermediate tensors to LMCache.\n",
+    "  See [README.md](../README.md).\n",
+    "* A GPU is required for serving. To see token dropping increase the decode batch\n",
+    "  size, tune the GPU memory utilization together with the number of requests.\n",
+    "* Data moves between the LMCache server and the SDK through shared memory; if it\n",
+    "  is unavailable the SDK falls back to pickle.\n",
+    "* Run this notebook from its own directory; it imports `../utils.py`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cd06b97",
+   "metadata": {},
+   "source": [
+    "## Setup vLLM and LMCache server\n",
+    "Follow below instructions (1-4), then proceed to below Python cell.\n",
+    "\n",
+    "**1. Start LMCache server first**\n",
+    "\n",
+    "To use shared memory, specify the `--shm-name` and `--no-l1-use-lazy`\n",
+    "\n",
+    "```sh\n",
+    "lmcache server \\\n",
+    "    --l1-size-gb 400 \\\n",
+    "    --eviction-policy LRU \\\n",
+    "    --chunk-size 256 \\\n",
+    "    --port 6555 \\\n",
+    "    --http-port 8080 \\\n",
+    "    --shm-name lmcache_sdk \\\n",
+    "    --no-l1-use-lazy \\\n",
+    "    --enable transfer_query\n",
+    "```\n",
+    "\n",
+    "**2. Wait until LMCache server is ready**\n",
+    "\n",
+    "```sh\n",
+    "curl -sf http://localhost:8080/healthcheck && echo \" LMCache ready\"\n",
+    "```\n",
+    "\n",
+    "**3. Start vLLM once LMCache server is ready**\n",
+    "\n",
+    "We pass --no-enable-prefix-caching to disable vLLM's built-in prefix caching. \n",
+    "This ensures the prefilled KV cache is always served from LMCache rather than \n",
+    "vLLM, so the decoding throughput improvement can be attributed entirely to the \n",
+    "tokens dropped through LMCache.\n",
+    "\n",
+    "```sh\n",
+    "LMCACHE_TRANSFER_INTERMEDIATE_TENSORS=true \\\n",
+    "vllm serve Qwen/Qwen3-8B \\\n",
+    "    --port 8000 \\\n",
+    "    --served-model-name Qwen/Qwen3-8B \\\n",
+    "    --no-enable-prefix-caching \\\n",
+    "    --enforce-eager \\\n",
+    "    --gpu-memory-utilization 0.65 \\\n",
+    "    --kv-transfer-config '{\"kv_connector\":\"LMCacheMPConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"lmcache.mp.port\":6555,\"lmcache.mp.transfer_intermediate_tensors\":true}}' \\\n",
+    "    --trust-remote-code \\\n",
+    "    --return-tokens-as-token-ids\n",
+    "```\n",
+    "\n",
+    "**4. Wait until vLLM is ready**\n",
+    "\n",
+    "```sh\n",
+    "curl -sf http://localhost:8000/v1/models && echo \" vLLM ready\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:02:41.715660Z",
+     "iopub.status.busy": "2026-08-01T06:02:41.715489Z",
+     "iopub.status.idle": "2026-08-01T06:02:49.120426Z",
+     "shell.execute_reply": "2026-08-01T06:02:49.119730Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:49,027] LMCache INFO:\u001b[0m torch_dev=<module 'torch.cuda' from '/home/sigma/github/LMCache/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py'>, torch_device_type=cuda \u001b[3m(_device_detect.py:143:lmcache.v1.platform._device_detect)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:49,111] LMCache INFO:\u001b[0m multi_layer_block_kv_transfer mode: ptr \u001b[3m(base.py:94:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " _     __  __    ____           _          \n",
+      "| |   |  \\/  |  / ___|__ _  ___| |__   ___      LMCache v0.5.3rc2.dev2 (g6018f8af)\n",
+      "| |   | |\\/| | | |   / _` |/ __| '_ \\ / _ \\     Website:  https://lmcache.ai/\n",
+      "| |___| |  | | | |__| (_| | (__| | | |  __/     Recipes:  https://docs.lmcache.ai/recipes\n",
+      "|_____|_|  |_|  \\____\\__,_|\\___|_| |_|\\___|     LinkedIn: https://www.linkedin.com/company/lmcache-lab\n",
+      "Set LMCACHE_DISABLE_BANNER=1 to hide this banner.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SPDX-License-Identifier: Apache-2.0\n",
+    "\"\"\"End-to-end KV cache remapping driver for the SDK example.\"\"\"\n",
+    "\n",
+    "# Standard\n",
+    "from datasets import load_dataset\n",
+    "import math\n",
+    "import matplotlib.pyplot as plt\n",
+    "import sys\n",
+    "from transformers import AutoTokenizer, AutoConfig\n",
+    "\n",
+    "# Third Party\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "\n",
+    "# First Party\n",
+    "from lmcache.logging import init_logger\n",
+    "import lmcache.sdk as lmc_sdk\n",
+    "from lmcache.banner import print_banner_once\n",
+    "\n",
+    "sys.path.append(\"..\")  # utils.py lives next to the main notebook\n",
+    "\n",
+    "from utils import (  # noqa: E402\n",
+    "    rerotate_k_cache,\n",
+    "    make_post_completion,\n",
+    "    score_answers,\n",
+    ")\n",
+    "\n",
+    "print_banner_once(sys.stdout)\n",
+    "logger = init_logger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5342c6c6",
+   "metadata": {},
+   "source": [
+    "## Setting up hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8f1065b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:02:49.126482Z",
+     "iopub.status.busy": "2026-08-01T06:02:49.126315Z",
+     "iopub.status.idle": "2026-08-01T06:02:49.129208Z",
+     "shell.execute_reply": "2026-08-01T06:02:49.128671Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_name = \"/data/models/Qwen3-8B\"\n",
+    "vllm_url = \"http://localhost:8000\"\n",
+    "lmcache_url = \"http://localhost:8080\"\n",
+    "lmcache_mq_url = \"tcp://localhost:6555\"\n",
+    "chunk_size = 256\n",
+    "max_tokens = 5120\n",
+    "temperature = 0.0  # greedy decode so generated answers are deterministic and scorable\n",
+    "timeout = 60  # timeout for context retrieval (seconds)\n",
+    "trust_remote_code = True\n",
+    "\n",
+    "# Streams prefilled per submission. LMCache's query ring buffer maps a forward\n",
+    "# step's query rows to ring slots positionally (qringbuffer.py\n",
+    "# build_q_step_state), assuming each request contributed exactly its store op's\n",
+    "# token count of rows. Continuous batching breaks that, so the captured queries\n",
+    "# are silently wrong or short. Measured query-row reproducibility across two\n",
+    "# identical runs: 100.0% at 1 stream, 99.7% at 4, 9.8% at 30. R-KV's importance\n",
+    "# term is entirely query-driven, so prefill is submitted one stream at a time.\n",
+    "prefill_group_size = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34eb19b4",
+   "metadata": {},
+   "source": [
+    "## Configuring the model and LMCache endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eac8beea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:02:49.134774Z",
+     "iopub.status.busy": "2026-08-01T06:02:49.134643Z",
+     "iopub.status.idle": "2026-08-01T06:03:51.326729Z",
+     "shell.execute_reply": "2026-08-01T06:03:51.326180Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:49,617] LMCache INFO:\u001b[0m Initialized LMCacheSDKContext with instance_id=2349002640530548822, model_name=/data/models/Qwen3-8B, chunk_size=256, shm_name=lmcache_l1_pool_lmcache_sdk, kind=LMCacheSDKCacheKind.KV \u001b[3m(context.py:122:lmcache.sdk.context)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:49,619] LMCache INFO:\u001b[0m Creating transfer context (device_type=cpu, mode=auto) \u001b[3m(worker_transfer.py:879:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:49,791] LMCache INFO:\u001b[0m Using AsyncEngineDrivenTransferContext for store path \u001b[3m(worker_transfer.py:105:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:49,796] LMCache INFO:\u001b[0m Engine KV Format: EngineKVFormat.NL_X_NB_TWO_NH_BS_HS NL x [NB, 2, NH, BS, HS] \u001b[3m(detection.py:69:lmcache.v1.gpu_connector.kv_format.detection)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:49,798] LMCache INFO:\u001b[0m Creating EngineDrivenContextShm (shm_name=lmcache_l1_pool_lmcache_sdk, pool_size=429496729600) \u001b[3m(base.py:235:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:02:49,915] LMCache INFO:\u001b[0m CudaPinMemoryBackend: using torch cudart \u001b[3m(pin_memory.py:89:lmcache.v1.platform.cuda.pin_memory)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:20,643] LMCache INFO:\u001b[0m SHM pinned=True for shm_name=lmcache_l1_pool_lmcache_sdk \u001b[3m(shm.py:118:lmcache.v1.multiprocess.transfer_context.shm)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:20,644] LMCache INFO:\u001b[0m Worker non-GPU transfer context registered (instance_id=2349002640530548822, mode=SHM) \u001b[3m(worker_transfer.py:745:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:20,651] LMCache INFO:\u001b[0m Initialized LMCacheSDKContext with instance_id=1490455064779272988, model_name=/data/models/Qwen3-8B##query, chunk_size=256, shm_name=lmcache_l1_pool_lmcache_sdk, kind=LMCacheSDKCacheKind.QUERY \u001b[3m(context.py:122:lmcache.sdk.context)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:20,652] LMCache INFO:\u001b[0m Creating transfer context (device_type=cpu, mode=auto) \u001b[3m(worker_transfer.py:879:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:20,653] LMCache INFO:\u001b[0m Using AsyncEngineDrivenTransferContext for store path \u001b[3m(worker_transfer.py:105:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:20,653] LMCache INFO:\u001b[0m Engine KV Format: EngineKVFormat.NL_X_NB_BS_HS NL x [NB, BS, HS] \u001b[3m(detection.py:69:lmcache.v1.gpu_connector.kv_format.detection)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:20,655] LMCache INFO:\u001b[0m Creating EngineDrivenContextShm (shm_name=lmcache_l1_pool_lmcache_sdk, pool_size=429496729600) \u001b[3m(base.py:235:lmcache.v1.multiprocess.transfer_context.base)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:51,323] LMCache INFO:\u001b[0m SHM pinned=True for shm_name=lmcache_l1_pool_lmcache_sdk \u001b[3m(shm.py:118:lmcache.v1.multiprocess.transfer_context.shm)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:03:51,324] LMCache INFO:\u001b[0m Worker non-GPU transfer context registered (instance_id=1490455064779272988, mode=SHM) \u001b[3m(worker_transfer.py:745:lmcache.v1.multiprocess.transfer_context.worker_transfer)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(\n",
+    "    model_name, trust_remote_code=trust_remote_code\n",
+    ")\n",
+    "config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)\n",
+    "head_size = getattr(\n",
+    "    config, \"head_dim\", config.hidden_size // config.num_attention_heads\n",
+    ")\n",
+    "work_device = torch.device(\"cpu\")\n",
+    "post_completion = make_post_completion(vllm_url, model_name, timeout)\n",
+    "ctx = lmc_sdk.kvcache.connect(\n",
+    "    url=lmcache_mq_url,\n",
+    "    http_url=lmcache_url,\n",
+    "    model_name=model_name,\n",
+    "    timeout=timeout,\n",
+    ")\n",
+    "qctx = lmc_sdk.qcache.connect(\n",
+    "    url=lmcache_mq_url,\n",
+    "    http_url=lmcache_url,\n",
+    "    model_name=model_name,\n",
+    "    timeout=timeout,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2aaffa7",
+   "metadata": {},
+   "source": [
+    "## Constructing Prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "030145fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:03:51.332256Z",
+     "iopub.status.busy": "2026-08-01T06:03:51.332102Z",
+     "iopub.status.idle": "2026-08-01T06:05:13.437776Z",
+     "shell.execute_reply": "2026-08-01T06:05:13.436997Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 30 prompts from the dataset.\n",
+      "Total prompts length: 423428 tokens.\n",
+      "Mean prompt length: 14114.27 tokens.\n",
+      "Max prompt length: 16807 tokens.\n",
+      "Min prompt length: 10159 tokens.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompts = []\n",
+    "answers = []\n",
+    "ds = load_dataset(\"raniayu/token-dropping-demo\", split=\"train\")\n",
+    "for i, example in enumerate(ds):\n",
+    "    prompt = tokenizer.encode(ds[i][\"prompt\"], return_tensors=\"pt\").squeeze(0).tolist()\n",
+    "    prompts.append(prompt)\n",
+    "    answers.append(ds[i][\"answer\"])\n",
+    "\n",
+    "print(f\"Loaded {len(prompts)} prompts from the dataset.\")\n",
+    "print(f\"Total prompts length: {sum(len(p) for p in prompts)} tokens.\")\n",
+    "print(f\"Mean prompt length: {sum(len(p) for p in prompts) / len(prompts):.2f} tokens.\")\n",
+    "print(f\"Max prompt length: {max(len(p) for p in prompts)} tokens.\")\n",
+    "print(f\"Min prompt length: {min(len(p) for p in prompts)} tokens.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab00c77d",
+   "metadata": {},
+   "source": [
+    "## Baseline (without token dropping)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "eb3a2b00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:05:13.443264Z",
+     "iopub.status.busy": "2026-08-01T06:05:13.443063Z",
+     "iopub.status.idle": "2026-08-01T06:08:00.836175Z",
+     "shell.execute_reply": "2026-08-01T06:08:00.835301Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:05:28,663] LMCache INFO:\u001b[0m prefill: 15.21 s in groups of 1 \u001b[3m(420791162.py:24:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================= Batched Stream Metrics (decode) ========================\n",
+      "-------------------------------- Configuration ---------------------------------\n",
+      "Number of Request Streams:                                                    30\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                       152.16\n",
+      "Total Output Tokens:                                                      153419\n",
+      "Decode Throughput (tokens/s):                                            1008.24\n",
+      "================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_ids = []\n",
+    "\n",
+    "batch = lmc_sdk.batch.LMCacheBatchedStream()\n",
+    "for i, prompt in enumerate(prompts):\n",
+    "    stream = lmc_sdk.request.create_request(\n",
+    "        contexts=[ctx, qctx],\n",
+    "        post_completion=post_completion,\n",
+    "        prompt_token_ids=prompt,\n",
+    "    )\n",
+    "    batch.add(stream)\n",
+    "    stream_ids.append(stream.request_stream_id)\n",
+    "\n",
+    "# temperature 0 here too: prefill emits one token that is APPENDED to the\n",
+    "# stream, so sampling it would make the whole greedy decode below depend on a\n",
+    "# random first token. Groups of `prefill_group_size` keep the query capture\n",
+    "# correct (see the hyperparameter cell).\n",
+    "prefill_seconds = 0.0\n",
+    "for g0 in range(0, len(stream_ids), prefill_group_size):\n",
+    "    results = batch.prefill(\n",
+    "        sampling_params={\"max_tokens\": 1, \"temperature\": 0.0, \"ignore_eos\": True},\n",
+    "        stream_ids=stream_ids[g0 : g0 + prefill_group_size],\n",
+    "    )\n",
+    "    prefill_seconds += results.to_dict()[\"metrics\"][\"results\"].get(\"duration\", 0.0)\n",
+    "logger.info(f\"prefill: {prefill_seconds:.2f} s in groups of {prefill_group_size}\")\n",
+    "\n",
+    "results = batch.decode(\n",
+    "    sampling_params={\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": temperature,\n",
+    "        \"ignore_eos\": True,\n",
+    "    }\n",
+    ")\n",
+    "results.emit()\n",
+    "before_drop_data = results.to_dict()\n",
+    "before_texts = [stream.output_text for stream in batch.request_streams.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "188ec71d",
+   "metadata": {},
+   "source": [
+    "## Clear LMCache\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "738112cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:08:00.842578Z",
+     "iopub.status.busy": "2026-08-01T06:08:00.842398Z",
+     "iopub.status.idle": "2026-08-01T06:08:01.016566Z",
+     "shell.execute_reply": "2026-08-01T06:08:01.015763Z"
+    },
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"status\":\"ok\",\"cleared\":{\"tier\":\"l1\"}}"
+     ]
+    }
+   ],
+   "source": [
+    "!curl -X POST {lmcache_url}/cache/clear\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "source": [
+    "## With R-KV Token Dropping — Route A, exact and linear, on the GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:08:01.022949Z",
+     "iopub.status.busy": "2026-08-01T06:08:01.022806Z",
+     "iopub.status.idle": "2026-08-01T06:08:01.040874Z",
+     "shell.execute_reply": "2026-08-01T06:08:01.040290Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Standard\n",
+    "import contextlib\n",
+    "import threading\n",
+    "\n",
+    "# --- R-KV hyperparameters ----------------------------------------------------\n",
+    "# Scores are averaged over KV heads and summed over layers, so a request keeps\n",
+    "# ONE token subset. LMCache re-injects a single contiguous KV with a single\n",
+    "# kept-token list, so per-head eviction is not expressible here.\n",
+    "rkv_window_size = 8  # observation window: the last w queries vote on importance\n",
+    "rkv_drop_ratio = 0.5  # fraction of tokens to evict\n",
+    "rkv_kernel_size = 7  # max-pool width applied to the importance scores\n",
+    "rkv_mix_lambda = 0.07  # score = lambda * importance - (1 - lambda) * redundancy\n",
+    "rkv_sim_threshold = 0.5  # cosine above this counts as \"similar\"\n",
+    "\n",
+    "\n",
+    "# --- Tensor plumbing ---------------------------------------------------------\n",
+    "def model_heads():\n",
+    "    \"\"\"(num_q_heads, num_kv_heads, head_dim) for the served model.\"\"\"\n",
+    "    q = config.num_attention_heads\n",
+    "    kv = getattr(config, \"num_key_value_heads\", q)\n",
+    "    return q, kv, getattr(config, \"head_dim\", config.hidden_size // q)\n",
+    "\n",
+    "\n",
+    "def to_heads(flat, rows, heads, head_dim, device=None):\n",
+    "    \"\"\"[rows, heads * head_dim] -> [1, heads, rows, head_dim] in fp32.\"\"\"\n",
+    "    t = (\n",
+    "        flat.to(dtype=torch.float32)\n",
+    "        if device is None\n",
+    "        else flat.to(device, torch.float32)\n",
+    "    )\n",
+    "    return t.reshape(rows, heads, head_dim).permute(1, 0, 2).unsqueeze(0)\n",
+    "\n",
+    "\n",
+    "def q_by_layer(q_tensor):\n",
+    "    \"\"\"Normalise the SDK's query tensor to [num_layers, T, q_heads * head_dim].\"\"\"\n",
+    "    if q_tensor.ndim == 4 and q_tensor.shape[0] == 1:\n",
+    "        return q_tensor[0]\n",
+    "    if q_tensor.ndim == 3:\n",
+    "        return q_tensor\n",
+    "    raise ValueError(f\"unexpected q_tensor shape {tuple(q_tensor.shape)}\")\n",
+    "\n",
+    "\n",
+    "def attention_logits(query, key, pooling=\"max\"):\n",
+    "    \"\"\"q @ k^T / sqrt(d), pooled from query heads down to KV heads (GQA).\n",
+    "\n",
+    "    query: [1, q_heads, q_len, d]   key: [1, kv_heads, kv_len, d]\n",
+    "    \"\"\"\n",
+    "    _, q_heads, q_len, d = query.shape\n",
+    "    kv_heads = key.shape[1]\n",
+    "    group = q_heads // kv_heads\n",
+    "    if group == 1:\n",
+    "        return torch.matmul(query, key.transpose(2, 3)) / math.sqrt(d)\n",
+    "    q = query.view(1, kv_heads, group, q_len, d)\n",
+    "    attn = torch.matmul(q, key.unsqueeze(2).transpose(3, 4)) / math.sqrt(d)\n",
+    "    return attn.mean(dim=2) if pooling == \"mean\" else attn.max(dim=2).values\n",
+    "\n",
+    "\n",
+    "def importance(k, q_win, past_len):\n",
+    "    \"\"\"How much the observation window attends to each past token.\n",
+    "\n",
+    "    Only the window queries are passed in, so this is O(w * n * d) rather than\n",
+    "    the O(n^2 * d) the reference spends before discarding all but the last w rows.\n",
+    "    \"\"\"\n",
+    "    attn = attention_logits(q_win, k)[:, :, :, :past_len]\n",
+    "    scores = F.softmax(attn, dim=-1, dtype=torch.float32).mean(dim=-2)\n",
+    "    return F.max_pool1d(\n",
+    "        scores, kernel_size=rkv_kernel_size, padding=rkv_kernel_size // 2, stride=1\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def redundancy_reference(key_states, threshold=rkv_sim_threshold):\n",
+    "    \"\"\"Literal R-KV redundancy: materialises the whole n x n matrix.\n",
+    "\n",
+    "    Only used as the correctness oracle in the self-tests -- never on a real\n",
+    "    prompt, where it would allocate kv_heads * n^2 floats per layer.\n",
+    "    \"\"\"\n",
+    "    _, _, n, _ = key_states.shape\n",
+    "    k = key_states / (key_states.norm(dim=-1, keepdim=True) + 1e-8)\n",
+    "    sim = torch.matmul(k, k.transpose(-1, -2))\n",
+    "    eye = torch.eye(n, dtype=torch.bool, device=k.device).view(1, 1, n, n)\n",
+    "    sim.masked_fill_(eye, 0.0)\n",
+    "\n",
+    "    # Per row, exempt the LARGEST column index that is above threshold (or\n",
+    "    # column 0 if none qualifies) -- R-KV's `similarity_retain` rule.\n",
+    "    mask = sim > threshold\n",
+    "    idx = torch.arange(n, device=k.device).view(1, 1, 1, n)\n",
+    "    retain = torch.where(mask, idx, torch.zeros_like(mask, dtype=torch.long))\n",
+    "    sim.scatter_(-1, retain.max(dim=-1)[0].unsqueeze(-1), 0)\n",
+    "    return sim.mean(dim=-2).softmax(dim=-1)\n",
+    "\n",
+    "\n",
+    "def prepare(tensors, token_source):\n",
+    "    \"\"\"Common bookkeeping shared by every drop_tokens_fn.\"\"\"\n",
+    "    kv = tensors[lmc_sdk.context.LMCacheSDKCacheKind.KV]  # [2, L, T, D]\n",
+    "    q = q_by_layer(tensors[lmc_sdk.context.LMCacheSDKCacheKind.QUERY])\n",
+    "    seq_len = min(kv.shape[2], q.shape[1], len(token_source))\n",
+    "    past_len = seq_len - rkv_window_size\n",
+    "    if past_len <= 0:\n",
+    "        raise ValueError(f\"seq_len {seq_len} must exceed window {rkv_window_size}\")\n",
+    "    keep_total = int(round(seq_len * (1 - rkv_drop_ratio)))\n",
+    "    keep_past = max(0, min(keep_total - rkv_window_size, past_len))\n",
+    "    q_win = q[:, past_len:seq_len, :]  # window only: ~2.4 MiB, not ~4.8 GiB\n",
+    "    return kv, q_win, seq_len, past_len, keep_past\n",
+    "\n",
+    "\n",
+    "def select(scores, past_len, seq_len, keep_past):\n",
+    "    \"\"\"Top-scoring past tokens plus the whole observation window.\"\"\"\n",
+    "    top = torch.topk(scores, k=keep_past).indices.sort().values\n",
+    "    tail = torch.arange(past_len, seq_len, device=scores.device)\n",
+    "    return torch.cat([top, tail]).to(torch.long).cpu()\n",
+    "\n",
+    "\n",
+    "def rerotate(kv_tensor, keep_idx, device):\n",
+    "    \"\"\"Gather the kept tokens and move their RoPE to the new positions.\"\"\"\n",
+    "    gathered = kv_tensor[:, :, keep_idx, :].clone().to(device)\n",
+    "    out = rerotate_k_cache(\n",
+    "        gathered,\n",
+    "        old_positions=keep_idx.to(device),\n",
+    "        new_positions=torch.arange(keep_idx.numel(), device=device),\n",
+    "        model_config=config,\n",
+    "    )\n",
+    "    return out.cpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "source": [
+    "### Route A, exact and linear, on the GPU\n",
+    "\n",
+    "> **Trades implementation complexity for everything else.** Nothing is\n",
+    "> sacrificed at run time — it is exact, the fastest, and the smallest. What it\n",
+    "> costs is the most intricate code of the four.\n",
+    ">\n",
+    "> | | |\n",
+    "> |---|---|\n",
+    "> | **Buys you** | Fastest exact option, **~6× less VRAM than the [one-shot notebook](../rkv_token_dropping.ipynb)**, linear in $n$ |\n",
+    "> | **Costs you** | The most implementation complexity: row tiling, a device-specific active-set choice, layer-tiled re-rotation, a carefully narrowed lock |\n",
+    "> | Exact? | Yes — relative error ~5e-7, identical kept-token set |\n",
+    "> | VRAM | **~1.55 GiB** at `cap = 2` (the default); 1.13 GiB at `cap = 1` |\n",
+    "> | Compress 30 requests | 37.5 s |\n",
+    "> | Decode throughput | 1774 tok/s |\n",
+    "> | Pick it when | Default choice — unless you have no VRAM to spare at all |\n",
+    "\n",
+    "The same rewrite as [`cpu_exact`](./rkv_variant_cpu_exact.ipynb), moved to the GPU. This is the one to use:\n",
+    "it is **simultaneously the smallest and the fastest** of the four.\n",
+    "\n",
+    "The reason both improve at once is that they are the same fact. The one-shot\n",
+    "notebook needs ~10 GiB because the $n \\times n$ matrix *is* the memory; once it is gone,\n",
+    "what remains is a single similarity block whose size is a **knob** rather than a\n",
+    "function of prompt length.\n",
+    "\n",
+    "## VRAM: how small, and why it is bounded\n",
+    "\n",
+    "The only large tensor left is the scan block, so the footprint follows directly\n",
+    "from the tile sizes and nothing else:\n",
+    "\n",
+    "$$\\text{peak} \\;\\approx\\; \\text{kv\\_heads} \\times \\text{row\\_tile} \\times \\text{col\\_block} \\times 7 \\text{ bytes}$$\n",
+    "\n",
+    "(fp32 block plus the boolean and `uint8` compare temporaries). `n` does not\n",
+    "appear. Measured with 30 concurrent requests at $n = 16807$, $L = 36$:\n",
+    "\n",
+    "| col_block | row_tile | cap | peak | wall | s/req |\n",
+    "|---|---|---|---|---|---|\n",
+    "| 2048 | 4096 | 1 | 1.54 GiB | 4.8 s | 0.16 |\n",
+    "| **1024** | **2048** | **1** | **1.23 GiB** | **4.8 s** | **0.16** |\n",
+    "| 1024 | 2048 | 2 | 1.49 GiB | 5.2 s | 0.17 |\n",
+    "| 1024 | 1024 | 4 | 1.79 GiB | 11.6 s | 0.39 |\n",
+    "\n",
+    "End to end, with the RoPE re-rotation included, the measured peak was\n",
+    "**1.13 GiB** at `cap = 1` and **1.54–1.55 GiB** at `cap = 2` (the default,\n",
+    "reproduced across three full runs). Below ~1024 the kernel launch overhead starts\n",
+    "to dominate, which is why the tiles are not pushed further down.\n",
+    "\n",
+    "Note that `cap = 1` is as fast as `cap = 2` or `4`: a **single request already\n",
+    "saturates the GPU**, so extra concurrency buys nothing but memory pressure.\n",
+    "That inverts the one-shot notebook, where the cap exists to survive at all — here it\n",
+    "exists to keep the footprint at its floor.\n",
+    "\n",
+    "## What was optimized\n",
+    "\n",
+    "| # | Change | Why it mattered |\n",
+    "|---|---|---|\n",
+    "| 1 | **Row tiling.** Score `row_tile` rows at a time instead of all $n$. | This is what makes the footprint a knob. The [CPU version](./rkv_variant_cpu_exact.ipynb) scores the whole first block at once: `[kv_heads, n, col_block]` is 1.1 GiB at $n = 16807$. |\n",
+    "| 2 | **Shared active set across heads — the opposite of the CPU choice.** | Deliberate. On the CPU, FLOPs are scarce, so per-head sets are essential. On the GPU, *kernel launches* are scarce: one shared set does ~7× the residual FLOPs ($0.98^8 \\approx 0.85$, so ~15% of rows stay active rather than 2%) while issuing an eighth of the launches — and the residual is a rounding error on an H200 either way. Same algorithm, opposite tuning. |\n",
+    "| 3 | **Layer-tiled re-rotation.** Ship 4 layers to the device at a time. | Moving all `[2, 36, keep, 1024]` at once is 1.24 GiB — larger than the entire scoring peak — for no speed gain. |\n",
+    "| 4 | **Narrow the lock.** Only the device sections hold the semaphore. | The first version held it across the whole function and took **41.0 s** of compression although the benchmark put all 30 requests' GPU work at 4.8 s. The culprit was `kv_tensor[:, :, keep_idx, :]` — a ~1 GiB strided gather out of shared memory that is pure *host* work, serialised behind a GPU slot for nothing. Moving it outside the gate: **41.0 s → 29.9 s**. |\n",
+    "| 5 | **TF32 off.** | It was worth 1.45× when redundancy was a full $O(n^2)$ GEMM. This kernel is no longer GEMM-bound, so strict fp32 is nearly free and takes the relative error from ~3e-4 down to ~5e-7. |\n",
+    "\n",
+    "**Result: ~1.55 GiB of VRAM (6× less than the one-shot notebook) and 37.5 s to\n",
+    "compress 30 requests — the fastest of the three exact implementations.**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "900f008d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:08:01.045955Z",
+     "iopub.status.busy": "2026-08-01T06:08:01.045822Z",
+     "iopub.status.idle": "2026-08-01T06:08:01.399776Z",
+     "shell.execute_reply": "2026-08-01T06:08:01.399098Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:01,073] LMCache INFO:\u001b[0m GPU exact on cuda:0: 37.4/139.8 GiB free, targeting ~1.55 GiB, TF32 off \u001b[3m(924240580.py:187:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:01,396] LMCache INFO:\u001b[0m GPU exact self-test on cuda:0: max relative error 5.72e-07, kept-token set IDENTICAL, 1 distinct result(s) over 5 identical calls \u001b[3m(924240580.py:174:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Knobs -------------------------------------------------------------------\n",
+    "# peak ~= kv_heads * row_tile * col_block * 7 bytes, independent of n.\n",
+    "gpu_device = \"cuda:0\"\n",
+    "gpu_col_block = 1024\n",
+    "gpu_row_tile = 2048\n",
+    "gpu_layer_tile = 4  # layers shipped to the device per re-rotation step\n",
+    "gpu_concurrency = 2  # 1 is equally fast; 2 overlaps rerotate with scoring\n",
+    "gpu_allow_tf32 = False  # no longer GEMM-bound, so strict fp32 is nearly free\n",
+    "gpu_budget_gib = 2.0  # advisory, reported against the measured peak\n",
+    "\n",
+    "\n",
+    "def _gpu_redundancy(key_states, col_block, row_tile):\n",
+    "    \"\"\"Exact route A redundancy on the device, memory bounded by the tiles.\"\"\"\n",
+    "    _, kv_heads, n, _ = key_states.shape\n",
+    "    k = key_states[0]\n",
+    "    k = k / (k.norm(dim=-1, keepdim=True) + 1e-8)\n",
+    "    dev = k.device\n",
+    "    cb = max(1, min(col_block, n))\n",
+    "\n",
+    "    s = k.sum(dim=-2, keepdim=True)\n",
+    "    col_sum = (k * s).sum(dim=-1) - (k * k).sum(dim=-1)\n",
+    "\n",
+    "    retain_col = torch.zeros((kv_heads, n), dtype=torch.long, device=dev)\n",
+    "    retain_val = torch.matmul(k, k[:, :1, :].transpose(-1, -2)).squeeze(-1).clone()\n",
+    "    retain_val[:, 0] = 0.0\n",
+    "    has = torch.zeros((kv_heads, n), dtype=torch.bool, device=dev)\n",
+    "\n",
+    "    def scan(rows, c0, c1):\n",
+    "        \"\"\"Score `rows` against columns [c0, c1), row_tile rows at a time.\"\"\"\n",
+    "        width = c1 - c0\n",
+    "        kcols = k[:, c0:c1, :].transpose(-1, -2)\n",
+    "        for t0 in range(0, rows.numel(), row_tile):\n",
+    "            r = rows[t0 : t0 + row_tile]\n",
+    "            blk = torch.matmul(k[:, r, :], kcols)  # the only large transient\n",
+    "            inb = (r >= c0) & (r < c1)\n",
+    "            if bool(inb.any()):\n",
+    "                rr = inb.nonzero(as_tuple=False).squeeze(-1)\n",
+    "                blk[:, rr, r[rr] - c0] = 0.0\n",
+    "            over = blk > rkv_sim_threshold\n",
+    "            hit = over.any(dim=-1)\n",
+    "            last = (width - 1) - over.flip(-1).to(torch.uint8).argmax(dim=-1)\n",
+    "            val = blk.gather(-1, last.unsqueeze(-1)).squeeze(-1)\n",
+    "            # Right-hand blocks ran first, so a row's FIRST hit is its answer.\n",
+    "            sel = hit & ~has[:, r]\n",
+    "            retain_col[:, r] = torch.where(sel, last + c0, retain_col[:, r])\n",
+    "            retain_val[:, r] = torch.where(sel, val, retain_val[:, r])\n",
+    "            has[:, r] |= hit\n",
+    "            del blk, over, hit, last, val, sel\n",
+    "\n",
+    "    c0 = max(0, n - cb)\n",
+    "    scan(torch.arange(n, device=dev), c0, n)\n",
+    "\n",
+    "    # One shared active set across heads: more FLOPs, far fewer launches.\n",
+    "    while c0 > 0:\n",
+    "        act = (~has).any(dim=0).nonzero(as_tuple=False).squeeze(-1)\n",
+    "        if act.numel() == 0:\n",
+    "            break\n",
+    "        c1, c0 = c0, max(0, c0 - cb)\n",
+    "        scan(act, c0, c1)\n",
+    "\n",
+    "    # `retain_col` has many duplicate indices, and scatter_add_ with duplicates\n",
+    "    # is NONDETERMINISTIC on CUDA (float accumulation order is unspecified) --\n",
+    "    # verified: 5 runs on identical input gave 5 different results. These\n",
+    "    # tensors are tiny (~0.5 MiB), so the correction runs on the host, where the\n",
+    "    # reduction order is fixed.\n",
+    "    corr = torch.zeros(col_sum.shape, dtype=col_sum.dtype)\n",
+    "    corr.scatter_add_(-1, retain_col.cpu(), -retain_val.detach().cpu())\n",
+    "    col_sum = col_sum + corr.to(dev)\n",
+    "    return (col_sum / n).softmax(dim=-1).unsqueeze(0)\n",
+    "\n",
+    "\n",
+    "def _rerotate_tiled(gathered, keep_idx, device, layer_tile):\n",
+    "    \"\"\"Re-rotate a few layers at a time; `gathered` stays on the host.\"\"\"\n",
+    "    old_pos = keep_idx.to(device)\n",
+    "    new_pos = torch.arange(keep_idx.numel(), device=device)\n",
+    "    for l0 in range(0, gathered.shape[1], layer_tile):\n",
+    "        l1 = min(l0 + layer_tile, gathered.shape[1])\n",
+    "        sub = gathered[:, l0:l1].contiguous().to(device)\n",
+    "        sub = rerotate_k_cache(\n",
+    "            sub, old_positions=old_pos, new_positions=new_pos, model_config=config\n",
+    "        )\n",
+    "        gathered[:, l0:l1] = sub.cpu()\n",
+    "        del sub\n",
+    "    return gathered\n",
+    "\n",
+    "\n",
+    "_gpu_dev = torch.device(gpu_device)\n",
+    "if _gpu_dev.type == \"cuda\" and not torch.cuda.is_available():\n",
+    "    logger.warning(\"CUDA unavailable; exact route A stays on the CPU.\")\n",
+    "    _gpu_dev = torch.device(\"cpu\")\n",
+    "_gpu_slot = (\n",
+    "    threading.Semaphore(gpu_concurrency)\n",
+    "    if gpu_concurrency\n",
+    "    else contextlib.nullcontext()\n",
+    ")\n",
+    "_gpu_peak_logged = False\n",
+    "\n",
+    "\n",
+    "def drop_tokens_gpu_exact(tensors, token_source):\n",
+    "    \"\"\"Exact route A token dropping on the GPU, in a bounded footprint.\"\"\"\n",
+    "    global _gpu_peak_logged\n",
+    "    kv, q_win, seq_len, past_len, keep_past = prepare(tensors, token_source)\n",
+    "    num_q, num_kv, head_dim = model_heads()\n",
+    "    dev = _gpu_dev\n",
+    "\n",
+    "    # Device section 1: scoring.\n",
+    "    with _gpu_slot:\n",
+    "        if dev.type == \"cuda\" and not _gpu_peak_logged:\n",
+    "            torch.cuda.reset_peak_memory_stats(dev)\n",
+    "        q_win = q_win.to(dev, non_blocking=True)\n",
+    "        scores = torch.zeros(past_len, dtype=torch.float32, device=dev)\n",
+    "        for layer in range(kv.shape[1]):\n",
+    "            k = to_heads(kv[0, layer, :seq_len, :], seq_len, num_kv, head_dim, dev)\n",
+    "            qw = to_heads(q_win[layer], rkv_window_size, num_q, head_dim, dev)\n",
+    "            imp = importance(k, qw, past_len)\n",
+    "            red = _gpu_redundancy(k, gpu_col_block, gpu_row_tile)[:, :, :past_len]\n",
+    "            scores += (\n",
+    "                (imp * rkv_mix_lambda - red * (1 - rkv_mix_lambda)).mean(1).squeeze(0)\n",
+    "            )\n",
+    "            del k, qw, imp, red\n",
+    "        keep_idx = select(scores, past_len, seq_len, keep_past)\n",
+    "        del scores, q_win\n",
+    "\n",
+    "    # Host section, deliberately outside the gate: a ~1 GiB strided gather that\n",
+    "    # needs no device at all. Locking it cost 11 s of wall clock.\n",
+    "    gathered = kv[:, :, keep_idx, :].clone()\n",
+    "\n",
+    "    # Device section 2: RoPE re-rotation.\n",
+    "    with _gpu_slot:\n",
+    "        e_kv = _rerotate_tiled(gathered, keep_idx, dev, gpu_layer_tile)\n",
+    "        if dev.type == \"cuda\" and not _gpu_peak_logged:\n",
+    "            _gpu_peak_logged = True\n",
+    "            logger.info(\n",
+    "                f\"GPU exact measured peak: \"\n",
+    "                f\"{torch.cuda.max_memory_allocated(dev) / 2**30:.2f} GiB \"\n",
+    "                f\"(budget {gpu_budget_gib:.1f} GiB, col_block={gpu_col_block}, \"\n",
+    "                f\"row_tile={gpu_row_tile}, concurrency={gpu_concurrency})\"\n",
+    "            )\n",
+    "\n",
+    "    logger.info(f\"compacted {e_kv.shape[2]}/{kv.shape[2]} tokens.\")\n",
+    "    return e_kv, [token_source[i] for i in keep_idx.tolist()]\n",
+    "\n",
+    "\n",
+    "def _selftest_gpu_exact(n=3000, layers=3):\n",
+    "    \"\"\"Must be the same function as the reference, and REPRODUCIBLE.\"\"\"\n",
+    "    torch.manual_seed(0)\n",
+    "    _, num_kv, head_dim = model_heads()\n",
+    "    keep = int(round(n * (1 - rkv_drop_ratio))) - rkv_window_size\n",
+    "    worst = 0.0\n",
+    "    ref_tot = torch.zeros(n, device=_gpu_dev)\n",
+    "    got_tot = torch.zeros(n, device=_gpu_dev)\n",
+    "\n",
+    "    for i in range(layers):\n",
+    "        mu = torch.randn(1, num_kv, 1, head_dim, device=_gpu_dev)\n",
+    "        k = torch.randn(1, num_kv, n, head_dim, device=_gpu_dev)\n",
+    "        k = 0.6 * mu + 0.4 * k if i % 2 == 0 else k\n",
+    "        ref = redundancy_reference(k)\n",
+    "        got = _gpu_redundancy(k, gpu_col_block, gpu_row_tile)\n",
+    "        worst = max(worst, ((ref - got).abs().max() / ref.abs().max()).item())\n",
+    "        ref_tot += ref.mean(dim=1).squeeze(0)\n",
+    "        got_tot += got.mean(dim=1).squeeze(0)\n",
+    "\n",
+    "    same = torch.equal(\n",
+    "        torch.topk(ref_tot, keep).indices.sort().values,\n",
+    "        torch.topk(got_tot, keep).indices.sort().values,\n",
+    "    )\n",
+    "    # Repeat on byte-identical input: this caught a CUDA scatter_add_ that gave\n",
+    "    # a different answer every call.\n",
+    "    k = torch.randn(1, num_kv, 512, head_dim, device=_gpu_dev)\n",
+    "    repeats = {\n",
+    "        _gpu_redundancy(k, gpu_col_block, gpu_row_tile).cpu().numpy().tobytes()\n",
+    "        for _ in range(5)\n",
+    "    }\n",
+    "    logger.info(\n",
+    "        f\"GPU exact self-test on {_gpu_dev}: max relative error {worst:.2e}, \"\n",
+    "        f\"kept-token set {'IDENTICAL' if same else 'DIFFERS'}, \"\n",
+    "        f\"{len(repeats)} distinct result(s) over 5 identical calls\"\n",
+    "    )\n",
+    "    assert worst < 1e-4 and same, \"the GPU rewrite is not route A\"\n",
+    "    assert len(repeats) == 1, \"the GPU path is not reproducible\"\n",
+    "\n",
+    "\n",
+    "if _gpu_dev.type == \"cuda\":\n",
+    "    torch.backends.cuda.matmul.allow_tf32 = gpu_allow_tf32\n",
+    "    torch.backends.cudnn.allow_tf32 = gpu_allow_tf32\n",
+    "    free_b, total_b = torch.cuda.mem_get_info(_gpu_dev)\n",
+    "    logger.info(\n",
+    "        f\"GPU exact on {_gpu_dev}: {free_b / 2**30:.1f}/\"\n",
+    "        f\"{total_b / 2**30:.1f} GiB free, \"\n",
+    "        f\"targeting ~1.55 GiB, TF32 {'on' if gpu_allow_tf32 else 'off'}\"\n",
+    "    )\n",
+    "\n",
+    "_selftest_gpu_exact()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2c689f98",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:08:01.405106Z",
+     "iopub.status.busy": "2026-08-01T06:08:01.404958Z",
+     "iopub.status.idle": "2026-08-01T06:10:20.648577Z",
+     "shell.execute_reply": "2026-08-01T06:10:20.647711Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:16,671] LMCache INFO:\u001b[0m prefill: 15.24 s in groups of 1 \u001b[3m(4090501894.py:24:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:40,806] LMCache INFO:\u001b[0m GPU exact measured peak: 1.55 GiB (budget 2.0 GiB, col_block=1024, row_tile=2048, concurrency=2) \u001b[3m(924240580.py:133:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:40,808] LMCache INFO:\u001b[0m compacted 5120/10240 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:41,196] LMCache INFO:\u001b[0m compacted 5376/10752 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:41,568] LMCache INFO:\u001b[0m compacted 4992/9984 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:41,973] LMCache INFO:\u001b[0m compacted 5504/11008 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:42,402] LMCache INFO:\u001b[0m compacted 5376/10752 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:42,827] LMCache INFO:\u001b[0m compacted 5632/11264 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:43,511] LMCache INFO:\u001b[0m compacted 5632/11264 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:43,702] LMCache INFO:\u001b[0m compacted 6144/12288 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:44,333] LMCache INFO:\u001b[0m compacted 6656/13312 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:44,545] LMCache INFO:\u001b[0m compacted 6656/13312 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:45,082] LMCache INFO:\u001b[0m compacted 6272/12544 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:45,407] LMCache INFO:\u001b[0m compacted 6400/12800 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:45,911] LMCache INFO:\u001b[0m compacted 7296/14592 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:46,301] LMCache INFO:\u001b[0m compacted 6912/13824 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:46,825] LMCache INFO:\u001b[0m compacted 6784/13568 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:47,158] LMCache INFO:\u001b[0m compacted 7680/15360 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:47,819] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:48,223] LMCache INFO:\u001b[0m compacted 7552/15104 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:48,802] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:49,137] LMCache INFO:\u001b[0m compacted 7552/15104 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:49,797] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:50,172] LMCache INFO:\u001b[0m compacted 8192/16384 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:50,773] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:51,132] LMCache INFO:\u001b[0m compacted 7936/15872 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:51,826] LMCache INFO:\u001b[0m compacted 7808/15616 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:52,116] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:52,829] LMCache INFO:\u001b[0m compacted 7808/15616 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:53,077] LMCache INFO:\u001b[0m compacted 8064/16128 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:53,955] LMCache INFO:\u001b[0m compacted 8320/16640 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:54,089] LMCache INFO:\u001b[0m compacted 8320/16640 tokens. \u001b[3m(924240580.py:140:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:08:54,197] LMCache INFO:\u001b[0m \n",
+      "\n",
+      " \u001b[3m(4090501894.py:29:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================== Batched Stream Modify Metrics =========================\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                        37.52\n",
+      "================================================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================= Batched Stream Metrics (decode) ========================\n",
+      "-------------------------------- Configuration ---------------------------------\n",
+      "Number of Request Streams:                                                    30\n",
+      "----------------------------------- Results ------------------------------------\n",
+      "Total Duration (s):                                                        86.44\n",
+      "Total Output Tokens:                                                      153329\n",
+      "Decode Throughput (tokens/s):                                            1773.76\n",
+      "================================================================================\n"
+     ]
+    }
+   ],
+   "source": [
+    "stream_ids = []\n",
+    "\n",
+    "batch = lmc_sdk.batch.LMCacheBatchedStream()\n",
+    "for i, prompt in enumerate(prompts):\n",
+    "    stream = lmc_sdk.request.create_request(\n",
+    "        contexts=[ctx, qctx],\n",
+    "        post_completion=post_completion,\n",
+    "        prompt_token_ids=prompt,\n",
+    "    )\n",
+    "    batch.add(stream)\n",
+    "    stream_ids.append(stream.request_stream_id)\n",
+    "\n",
+    "# temperature 0 here too: prefill emits one token that is APPENDED to the\n",
+    "# stream, so sampling it would make the whole greedy decode below depend on a\n",
+    "# random first token. Groups of `prefill_group_size` keep the query capture\n",
+    "# correct (see the hyperparameter cell).\n",
+    "prefill_seconds = 0.0\n",
+    "for g0 in range(0, len(stream_ids), prefill_group_size):\n",
+    "    results = batch.prefill(\n",
+    "        sampling_params={\"max_tokens\": 1, \"temperature\": 0.0, \"ignore_eos\": True},\n",
+    "        stream_ids=stream_ids[g0 : g0 + prefill_group_size],\n",
+    "    )\n",
+    "    prefill_seconds += results.to_dict()[\"metrics\"][\"results\"].get(\"duration\", 0.0)\n",
+    "logger.info(f\"prefill: {prefill_seconds:.2f} s in groups of {prefill_group_size}\")\n",
+    "\n",
+    "results = batch.modify(drop_tokens_gpu_exact)\n",
+    "results.emit()\n",
+    "\n",
+    "logger.info(\"\\n\\n\")\n",
+    "\n",
+    "results = batch.decode(\n",
+    "    sampling_params={\n",
+    "        \"max_tokens\": max_tokens,\n",
+    "        \"temperature\": temperature,\n",
+    "        \"ignore_eos\": True,\n",
+    "    }\n",
+    ")\n",
+    "results.emit()\n",
+    "gpu_exact_drop_data = results.to_dict()\n",
+    "gpu_exact_texts = [stream.output_text for stream in batch.request_streams.values()]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99dcfd4c",
+   "metadata": {},
+   "source": [
+    "### Accuracy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:10:20.655306Z",
+     "iopub.status.busy": "2026-08-01T06:10:20.655137Z",
+     "iopub.status.idle": "2026-08-01T06:10:20.660574Z",
+     "shell.execute_reply": "2026-08-01T06:10:20.660019Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:20,658] LMCache INFO:\u001b[0m Baseline (no drop): 10/30 correct (33.3%) \u001b[3m(3935640946.py:4:__main__)\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32;20m[2026-08-01 06:10:20,658] LMCache INFO:\u001b[0m R-KV GPU exact: 14/30 correct (46.7%) \u001b[3m(3935640946.py:8:__main__)\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "before_correct, total, before_map = score_answers(answers, before_texts)\n",
+    "after_correct, total, after_map = score_answers(answers, gpu_exact_texts)\n",
+    "\n",
+    "logger.info(\n",
+    "    f\"Baseline (no drop): {before_correct}/{total} correct \"\n",
+    "    f\"({100 * before_correct / total:.1f}%)\"\n",
+    ")\n",
+    "logger.info(\n",
+    "    f\"R-KV GPU exact: {after_correct}/{total} correct \"\n",
+    "    f\"({100 * after_correct / total:.1f}%)\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1038e21",
+   "metadata": {},
+   "source": [
+    "## Result Plot\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:10:20.665623Z",
+     "iopub.status.busy": "2026-08-01T06:10:20.665503Z",
+     "iopub.status.idle": "2026-08-01T06:10:20.764615Z",
+     "shell.execute_reply": "2026-08-01T06:10:20.764076Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEiCAYAAAD9DXUdAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAATSRJREFUeJzt3XdYFNf3P/D30nsXpSkIqIiABVFUBBERNTaILSFqomg+0cQkYuw1JpaoSdRYEmyxxN4NiQpYQ7EiNqSoFA0oIBA67P394Y/5Ou4Cu8NSPa/n2edx75yZObPgHmbuzL0ixhgDIYQQ8v8pNXQChBBCGhcqDIQQQnioMBBCCOGhwkAIIYSHCgMhhBAeKgyEEEJ4qDAQQgjhocJACCGEhwoDIYQQHioMhBBCeKgwEIUpLS3F4cOH8ejRo4ZOpVk6duwY4uLiGjqNJqO0tBRRUVE4cuQILl++DAA4fPgw7t6928CZNX4iGiuJnD17Fnl5eTXGtWnTBt27d69y+cuXL9GiRQv88MMPCA4OVmSKgsTFxSE+Ph4AIBKJoKGhASMjIzg4OMDAwKBhkxNAQ0MD06dPx5o1axpk/6dPn0ZxcTH3Xk1NDZaWlnB0dIS6unqD5FSVly9fwsvLCyUlJXB2doaLiwsWLVoEkUiE2bNnY+XKlVzs4cOH0aFDB3Tq1KkBM25cVBo6AdLwzpw5g/T0dO79o0ePEBcXBy8vLxgbG3Ptffv2rbYwNDa7du3C2rVrMWjQIGhpaaG0tBTPnz9HXFwcunTpgm+++QYjR45s6DRl5u/vD2dn5wbb/+TJk1FeXg4vLy8AQHFxMWJjY1FeXo7Vq1fjo48+arDc3rZhwwakpKQgIyMDmpqaXHtAQACcnJx4saNGjZIoFu88RshbfvjhBwaAXb58Wa71Xrx4wQCwH374oY4yk8/MmTMZAPb48WNee1ZWFvv8888ZADZ//vyGSa4JatmyJevduzevraysjA0bNowpKyuzxMTEBspMkr+/P3N0dJQpFgCbPXt2HWfUtNAZA5FZRUUFbt++jfT0dJiYmMDV1RVqamo1rpeXl4dz587ByMgI/fr149pzc3Nx48YNFBQUoF27dmjfvj1vvaioKLx69Qp+fn7Iy8tDVFQUVFVV4e7uDg0NDcHHYWRkhPXr1+PFixf47rvvMHz4cO5M6M195ufnIzo6GioqKtxfyWKxGLGxsUhLS4OhoSFcXV15uYjFYhw9ehQdO3ZEx44dER8fj4SEBNjY2MDR0ZGXhzyxwOs+Bjs7O+4v3rfXT0pKwoMHD9C6desqzyxKSkoQGRmJkpISuLm5wdDQEH/99RcMDAzQs2dPuT9LFRUVjBo1CidPnsStW7dga2srEZOUlISHDx9CTU0Nrq6uMDQ0rPIzkOUYqttmbm4uzp07h4SEBBQUFODw4cMS61ZeNiosLMSff/4JAIiPj+diLSws4O7uLvdn0aw0dGUijY+0M4aYmBhmZ2fHTExM2IABA5iVlRVr2bIlO3XqFBcj7Yzh8ePHzNHRkdnb27NHjx4xxhirqKhgCxYsYBoaGszFxYX5+PgwPT09NnjwYJaTk8OtGxAQwGxtbVlYWBhzdHRkvr6+rEWLFszS0pLFx8fXeBxVnTFUunbtGgPAPvvsM4l9njlzhnXo0IH169ePeXt7M8YYi42NZQ4ODszIyIgNGDCAWVtbMxMTE3bw4EFu/aKiIgaALVq0iAUFBbGuXbsyDw8PpqamxoYNG8YKCgoExTLGmLq6Ops5c6bE+osXL2ZfffUV69q1K/P09GQqKiosICCAicVi3vpXr15l5ubmrGXLlszX15e1b9+enTp1itna2rKAgIAaP09pZwyMMbZw4UIGgN24cYPXnpaWxry9vZm2tjbz8vJibm5uTEtLi61Zs0bwMdS0zcePH7OAgABmamrK9PX1WUBAAO+FN84OMjMzubb27dtzMatWrarxs2juqDAQCW8XhhcvXjBjY2PWu3dvlpubyxhjrLS0lI0ePZqpqamxuLg4Lu7NwvDPP/8wU1NT5unpybKysrjtL1myhCkpKbGjR49ybWlpaczGxob3BRUQEMBMTEzYpEmTWHFxMWPs9X9mMzMzNnLkyBqPo6bCUF5ezlRVVVmPHj0k9hkYGMiKiooYY4w9evSI5ebmMjMzM9atWzfuWMrLy9nEiROZiooKi4mJYYz93xedra0t27VrF7fdqKgopqmpyaZOncq1yRPLWNWFoX379mzPnj1c+/79+xkAduTIEa4tJyeHtWjRgnl6erL//vuPMcZYcXExGz9+PDMxMZG5MHTo0IEdOnSIHTp0iO3Zs4d9/fXXTEdHh5cXY4yVlJSwjh07MgcHB5aamsq1Hzx4kAFgx44dk/sYZN0mY4z179+fubi4SBwDpFw2ktb2rqPCQCS8XRjWrl3LALDIyEhe3PPnz5mqqir3BfZmYfjjjz+YhoYGmzhxIistLeXWKSwsZFpaWmzcuHES+926dSsDwP2nr/xr7unTp7y4GTNmME1NzRqPo6bCwBhjxsbGzN7enntfuc+HDx9Kze3cuXO89uzsbKalpcU+/PBDxtj/fdG5ublJ7OvTTz9lqqqqXHGVJ5axqguDh4cHb12xWMxatGjBJk+ezLVt2bKFAWBRUVG82MTERAZA5sJgbGzM/WU9bNgw5uDgwNq3b8/++OMPXuyePXsYAHbmzBmJ7Xh4eDAvLy+5j0HWbTJGhaG2qI+B1OjWrVtQVlaGq6srr71Vq1awtrbGzZs3ee27du3CvXv3sGzZMixYsIC3LDY2FoWFhdDW1sbx48fB/v/d0owxZGZmAnh9m6mlpSUAwMTEBK1bt+Zto3Xr1igqKsLLly9hYmJSq2MrKiqCtrY2r01XV1eiv+PWrVsAgB49evDaDQ0N0b59e4nPQNrdW25ubtiyZQvu3r2LXr16CYqVplu3brz3IpEIlpaWSE1N5eUvEonQtWtXXqytrS309fWr3f6bOnToIHHdfs2aNRg3bhxEIhHGjBkDAIiMjAQAZGdncz/nyp+1hoYGbty4IfcxyLtNIhwVBlKj0tJSqKmpQUVF8tdFW1sbJSUlvDYTExOoqKjg9u3b3LqVioqKAAB37txBTk6OxPYCAgJ4nZPSvrQqt/fmPfVCpKamorCwEO3ateO1t2jRQiK2tLQUIpGId+tjJW1tbeTm5vLatLS0JOIq297+vOSJlaaqz+jNz6e0tBSqqqpSf4bS9i+Pr776CvPmzcOmTZu4wlBUVASRSITjx49LxOvp6WHgwIFyH4O82yTCUWEgNbK2tkZRURHS09NhYWHBtZeXl+Px48fcHTuVhgwZgjlz5sDf3x9Dhw7F0aNHub/KK+9aGTJkCBYtWlRvxyDNH3/8AQAYPnw4r10kEknEWltbgzGGpKQk3tkEYwyJiYkSdxElJSVJbCMxMREAYGNjIzhWKGtra5SWliI9PZ07GwOAwsJCZGRk1GrbysrK0NTU5M74gNc/Z8YYVq9ejbZt29Zq+3W5TSIdDYlBajR69GgAwPr163ntO3bsQG5uLsaOHSuxzsCBA3Hu3DnExMRgwIAB3NlB69at4evri61btyIrK0tivZSUlDo4AklXrlzBsmXL4O7uzv2VW533338fSkpKEp/B/v378e+//0p8BmFhYXj69Cn3vqioCNu2bUP37t1hbW0tOFaogIAAiEQibN68mdf+66+/QlVVtVbbjomJQV5eHu8yVWBgIDQ0NPD9999LXefNS0SyqottAoCxsbHEGd+7js4YSI26deuGpUuXYvHixcjMzETfvn0RFxeHDRs2YMKECVILAwD06tULFy9exMCBA+Hl5YW///4brVq1wq5duzBo0CB06tQJU6ZMgZ2dHTIyMhATE4M7d+7g4cOHCs0/NDQULVq0QFlZGf79919EREQgNDQUAQEB2Lx5M5SVlWvchoODA1avXo1Zs2YhJycHPj4+iI+Px08//YT3338fn3zyCS9+/PjxCAwMxPDhw6GtrY1t27YhJycHx44dk9i2PLFCOTo6YvHixViyZAlevHgBd3d33L59GwBgaWkp9SxJmqysLK6Poby8HAkJCdi4cSPatm2L7777jotr3bo1/vjjDwQGBiIxMREjRoyAoaEhkpOTcerUKbz33ntYtmyZXMdQF9sEAF9fXxw9ehTOzs5o0aIFPccAKgxEivbt2yMgIIDXsbto0SIMGDAAhw8fxtmzZ2FiYoJTp07Bz8+Pi1FXV0dAQADvUouzszMuX76MBQsW4Oeff8by5cvRqlUrXLt2DceOHcPFixeRmJgIS0tLjBs3jru8AwDu7u4wMzOTyM/Ozg4BAQE1Xht3dnZGQEAAwsLCIBKJoK6uDiMjIwwePBjr16+X+td4VfsEgJkzZ8LLywsHDhzA+fPnYWBggEOHDmHo0KESX6xGRkY4fPgwNm3ahFu3bsHPzw9Tp06FlZWVxHZljX17SAxlZWUEBASgY8eOEtv09vaWOBNYvHgx3N3dceTIEVy6dAne3t4IDAzE3r17JTrgpRk6dChycnKwf/9+AK8fbjM3N8cPP/yAcePGSexvxIgRSExMxL59+xAbGwvg9eWg33//nRuXSN5jkGWbwOvhW/Lz8yW2KW1IjC1btmDz5s34559/UFxcjO7du7/zhYEG0SNEgYqLi6Gpqcn9da6o2Lry6tUrGBoaYtmyZVi4cGGD5EAaH+pjIOQd8fLlS4m2H3/8ESKRSKIDnrzb6FISIe+IvXv3IjQ0FH5+ftDR0cGFCxewd+9ezJ07t0FHbSWNDxUGQhSoumvmtYlVhBkzZsDR0RHnzp1DWloaTE1NERERIXG7MSHUx0AIIYSH+hgIIYTwUGEghBDCQ4WB8Ny9exc+Pj4wMjKCiooKN5EJkfTnn39CRUUFV69erdf9rl69GioqKk3+ad3OnTvT3VCNFBUGwjNmzBgoKSkhMTERxcXFGDRoUJ3t6+DBg1BRUeFeWlpaMDMzg6enJxYtWsQbJqIxEovFqKioQG276XJzc3mfQ3WvTZs2KWy/Da28vBwVFRUNmkPPnj1p8D0pqDAQTmZmJu7fv48RI0ZwZwyyDpUgROUX3L59+1BcXIycnBxcv34dM2bMQHh4ODp06IAdO3bU2f4bC319fRQXF/New4cPR0VFBQoKCnjt//vf/xo63WalMRSnxogKA+G8ePECQO2HYZaXkpISVFRUoK6uDgsLC/j7++PixYsYNGgQJk+ezI3D35y9fWZQWZCVlZWlthNSl6gwEADApEmT4OLiwv1bRUWFN5ZQbGwsRowYARMTE+jo6KBbt27Yvn07bxuV175fvHiBb775BhYWFtDV1RWUj7KyMtatW8cNs/ymtLQ0BAUFoXXr1tDS0oK9vT2+/fZblJeXS8R9+umnsLGxgY6ODlxcXLB+/XpenCzHBbwejbVPnz7Q0dGBra0tNm3aVGXusuZXW+Xl5Zg7dy7MzMygr68Pf39/PH/+nBdT089k27Zt6NatG3R0dGBiYoIRI0bgzp07vG2YmJhg2rRpEvsfM2YMOnTowGsTi8VYsWIF2rZtC11dXXh6euL27dv48MMPYWdnJ/U4kpKSMGjQIOjp6aF169a8wfgqVfZH3L9/H/3794eenh5sbGywfPlyiMViQfm2atUKN27cQHh4OFd4FTWabVNHhYEAAH777TduBqzffvsNxcXF3DwBt27dQq9evVBQUIBLly4hKSkJY8aMQVBQEG98ncpLQzNnzoSDgwNu374t8aUuD2tra7Rr1w4RERFc29OnT+Hq6oq7d+/i0KFDePbsGTZs2IDNmzdjwoQJXFxycjK6deuGmJgY7Ny5E2lpadi7dy+SkpJw8eJFuY7r2rVr8PHxgampKW7duoVLly7h6dOn2Llzp0TOsuanCPPnz0eHDh1w9+5d/Pnnn4iKisKkSZN4MdX9TBYuXIgpU6Zg9OjRSEpKwqVLl1BYWAh3d3duxjqg6sstFRUVEsVu1qxZWLJkCWbNmoXHjx9j/fr1mD9/Pp4/fy61MObm5iI4OBjLli3DkydPMGPGDCxYsAD79u3jxZWXl+Ply5f4+uuvsXLlSiQnJ2PevHlYvnw5vvzyS4lYWfJNT09Ht27d0K9fP+5SnbS5Md5JQucEzc7OZnFxcSwuLo5lZ2fXYnZR0ljExcUxAGzHjh289oEDBzJDQ0OWl5fHa//444+ZiooKS0tLY4wxtmLFCgaALV68WKb9/fHHHwwAO3ToUJUx/fv3ZwBYQUEBY4yx0aNHM0NDQ/bixQteXOWE8Ddu3GCMMebv7890dXVZRkZGlduW9bh8fX2ZmZkZKy4u5sV5e3vz5saWJ7+aVM49XVZWJrGs8nNeuXIlr71yru6UlBSJ2Ld/Js+ePWOqqqps4sSJvPb8/HxmZGTEBgwYwLXp6+tz83q/naOtrS33Pj09nSkrK7MZM2bw4tLS0piamhpr06YNr93R0ZGpqqpKzMnduXNn1rdvX4lYJSUl9ujRI177N998w5SUlFhycrLc+TLGWLdu3Vj//v0lYt91cp0xvHjxAt9//z2cnZ1hbGwMJycnODk5wdjYGC4uLli5cqXUgbpI01VRUYELFy7A19dX4rLQ6NGjUV5ezv0FXmnEiBEKz0MkEkEsFuPMmTPw9vaWmOvZ19cXAHDhwgWIxWKEhoZi4MCBMDU1lbo9WY+rMs7Pzw/q6uq8OH9/f957WfNTlKFDh/LeV453lJycLBH79s/k4sWLKCsrQ0BAAK9dR0cHgwYNwoULF+S+9HXp0iVUVFRg2LBhvHYLCwuJOZ0rderUSeLyjZOTk9RjcHR0hL29Pa/N398fYrEY4eHhcuVKqidzYVi1ahVsbW3x119/ITAwEGFhYbh37x7u3buHsLAwfPDBBzhz5gxsbW1rdfmANC7//fcfSkpKpM5R0KpVKwD/12ld6c3pP2srPT0d+vr60NTURH5+PgoKCnD8+HFoaGhAXV0d6urqUFNT476IX758ifz8fBQVFVWbh6zHlZ+fj9LSUrRs2bLKuEqy5qcob+eup6cH4PVQ2m97+7OonD2vquMvKyur8TkJ9tbtspXHJu2zktZW1f719PSkHkN1PwNZPte38yVVk3kQvZs3byImJkaiswkAOnbsiH79+mH27Nl4+PAhFi9erNAkScPR0dGBmpqa1HmBK9uMjY157bWdKrJSSkoK4uPjub9AdXR0oK6ujrFjxyIkJETqOkpKr//W0dDQwLNnz6rctqzHpaurC1VVVd58xm/HvblNWfNThKruUJL2Bfj2z8TIyAiA5DFUtqmqqnKFRl9fH//9959E3Nufb+U2MzMzJebAlvb5yXsM1f0M3vwdlDVfUjWZf0sPHDggtSi8rUOHDjhw4ECtkiKNh7KyMjw8PHD+/HkUFhbylh07dgzKysrw9PRU+H4ZY/jmm28gEokwa9YsLhc/Pz+cO3cOhYWFUh8AU1JSgpKSEgYOHIizZ89KnVdanuOqjDt79izKysp4cSdPnpTYpiz5NQZ9+/aFsrIyTpw4wWsvLCzE2bNn0adPH66YtG3bFnfv3uXFPXv2jJsa9M1tKikpITQ0lNeekZHB3dhQG/fu3cOTJ094bSdPnoRIJOKNECtrvgCgra2N0tLSWufW3Aj6LRWLxUhISODeJyUlYcmSJdi9e7fCEiONx3fffYfc3FyMGzcOjx8/Rm5uLjZu3Iht27bhyy+/lDpdpRCMMWRnZyM0NBQ+Pj44duwYNm/ejN69e3Mxa9asQVlZGYYOHYqoqCgUFRXh5cuXCA8Px6hRoxAXFwfg9W2aysrKGDJkCGJiYlBcXIzExETMmTOHu84v63EtW7YM//77LyZOnIi0tDRkZ2dj2bJlUFNTkzgGWfNraBYWFvjyyy+xfft2bNiwAbm5uXj8+DHGjRuHV69eYcWKFVzs5MmTERsbi40bN6KwsBD37t3DtGnT4ObmxtumpaUlPvvsM2zYsAG7du3Cf//9h0ePHmHq1Kno0aNHrXPu3r07pk+fjnv37qGgoAB79+7FunXrMGnSJN6tsLLmC7zut7h7965EwXnnCemx/vnnn9lXX33FGGOsuLiYtW7dmnXs2JEZGhqyVatWKahfnNS3qu5KYoyxqKgo5uvry7S1tZmysjLr0KEDW79+PROLxVxM5R0wOTk5Mu2v8q4kJSUlpqyszFRUVJiBgQHr3r07mzVrFktISJC6XmpqKpsyZQqztLRkysrKzNTUlA0YMIAdPnyYVVRUcHFJSUnsww8/ZCYmJkxFRYV16NCBrV69mpWUlMh1XIwxdu7cOda1a1emrKzMzMzM2OrVq9mpU6ck7kqSJ7/qyHJX0tufc2RkJAPAjh07VmMsY4yJxWK2fv165uDgwFRUVJiWlhYbMGAAi46OlohbvHgxa9GiBVNVVWW9e/dmd+/elXqXT3l5OVu4cCFr1aoVU1VVZd27d2fR0dFs5MiRrF27drxYR0dHNmTIEIm8pk2bxrS1taXG3rx5k/Xo0YOpqqqyli1bsrlz50p8RvLkm56ezvr37880NTWZsrKyxJ1T7ypB8zG0b98eoaGhaNu2LUJDQxEcHIy7d+8iOjoaH330Ee9sgjQt5eXlUFZWFvSELWMMFRUVUFGRreuqMr6SrOs1FvIerzzEYjHEYrHUbVe337d/fnWdI2MMysrKNca6ublBU1OTdwdbRUUFRCKRxOU1adutvHvp9OnTdZZv5e+iLMfT3Am6lJSamsrdTRAeHo5hw4ZBJBKhc+fOSE9PV2iCpH7VZtgFkUgk1xdQZXzlq6mR93jlUTlMiLz7ffvnV9c5yvIl+uTJE9y6dQt9+/bltSsrK0vtc5F1u/KqabvKyspUFP4/QYXB1tYW+/fvR1ZWFg4ePIgBAwYAABISEqp87J0Q0vydPXsW33//PR4/fozi4mLExMQgICAABgYGUoepII2ToMKwdOlSTJ06FSYmJrCzs+PuCPj1118xdepUReZHCGlCPDw8UFRUBD8/P+jp6WHgwIGwtrbG1atXJZ77II2X4DmfX7x4gefPn8PR0ZE7/QoPD4eHh4fC7mMnhBCg6v4IUjfkKgzz58/He++9hx49etAPiBBCmim5vt1TU1MxbNgwtGrVChMmTMChQ4eQl5dXV7kRQghpAHJfShKLxYiMjMTp06dx+vRpxMfHw8PDA++99x7ee+89iUGuqpOZmYnNmzfjn3/+gYqKCvr06YMvvvgC2travLiIiAhs3LgRGRkZcHJywoIFCyTGflFUTE3H/uzZM+jq6tKEKYSQJoUxhvz8fJibm9d8xae2D0I8ffqUbdy4kfn5+TENDQ3Wrl079vXXX7Pw8PBq1ysvL2fW1tZsyZIl7O+//2bHjh1jnTp1Yu7u7qy0tJSLO3/+PFNRUWGLFy9mf/31Fxs8eDBr06YNy83NVXhMTVJTUxkAetGLXvRqsq/U1NQav+sEdz5LU1hYiHPnzuH06dP4888/a3ymobCwkDeNZFxcHJydnXHlyhVuGIRevXrB2tqam7ijqKgIZmZmmD9/PjeGjqJiapKbmwsDAwOkpqZyA4wRQkhTkJeXBysrK7x69Qr6+vrVB8v85/IbKioqeBNmJCYmssWLF7Pff/+da3t7SAFZJCYmMgAsIiKCMcbYf//9x0QiEduzZw8vzt/fnw0cOFChMbLIzc1lAOQ6yyCEkMZAnu8vQY9Ebty4EU+ePMG6detQUlICb29v6Ojo4Pnz53j+/Dk3Kqa8vv32W5ibm3MDbqWlpYExBnNzc16cubk5wsLCFBojTUlJCUpKSrj31NFOCHkXCLrn9JdffsH06dMBvH52QUdHh5t39rfffhOUyI8//og//vgDe/fuhaamJgBwwxy/PXOWpqYmt0xRMdKsWLEC+vr63EtRo4gSQkhj1ijGStq0aRPmzJmDw4cP88ZVr5x84+0x9V++fMktU1SMNHPnzkVubi73Sk1NlfvYCCGkqRF0KalyrKRhw4bh4MGD2LFjBwBhYyVt2bIFX331FQ4dOiQxh62ZmRnMzMxw7do13rLo6GhuchhFxUhTOTUjIaT2iouLcefOHZiZmUmcfSckJEidVEldXR1dunSROabSq1evkJKSAktLS25muZpkZWUhLS0NRkZGdHVASCfGkSNHmKqqKgPAvL29uTHmp0+fzjZu3Cjzdn799Vemrq7OTpw4UWXMggULmJmZGUtJSWGMMbZ//34mEonY9evXFR5TE+p8JkR+mZmZLDg4mJmbmzMNDQ02e/ZsiZi5c+eyHj168F6ampqsc+fOcsXEx8ezIUOGsBYtWjAnJyemqanJRowYwfLy8qrMr6CggI0cOZJpaWkxZ2dnZmRkxFxcXNjDhw8V+0E0MHm+vwQ/x5CZmcliY2NZeXk51xYWFsZ7BqE6OTk5TCQSMQMDA9atWzfe6/jx41xcSUkJGzduHFNXV2c2NjZMW1ubbd26lbctRcXUhAoDIfKLjo5mq1atYi9evGCOjo5SC8PbMjMzmaqqKvvxxx/lijlz5gy7cOEC9/7Zs2fMwsKCBQcHV7mdb7/9lhkbG7O0tDTGGGNFRUXMw8OD+fj41HxwTUid35UEAC1atECLFi14bd7e3jKvr6Ojg5iYGKnLrK2tuX+rqalh3759yMjIQGZmJmxtbXnPPigyhhCieG5ublKn1azO7t27oaSkhI8++kiumMGDB/NizMzM0KlTp2r7BzMyMmBjY8ONgqChoYEePXrg77//livn5kRQYWCM4eDBg7h69Sqys7Mllu/Zs6fmHauowNXVVeZ9tmzZEi1btqyXGEJIw9q2bRv8/f2rvTmkupioqCiUlJTgypUruHHjRrUzv02fPh3Hjh3D0qVL4enpiaSkJOzZswe//PKLQo6lKRJUGIKDg7Flyxb4+PjA0NBQ0TkRQt5hkZGRuH//PjZu3Cg45ssvv0RhYSESEhLw6aefonPnzlVuy97eHp9++ilWr16NI0eOIC0tDQMHDpTrCkhzI6gw7N69G+fOnUOvXr0UnQ8h5B23bds23gRgQmKioqIAAOnp6ejXrx/y8vKwbds2qbELFy7Erl27cP/+fVhaWqKoqAj+/v4YNmwYLl26VNvDaZIEPcfAGIOLi4uicyGEvOMKCgpw4MABTJ48ucrRE2SJqWRhYYEJEybgzJkzVcacPHkSAQEBsLS0BPD6wdegoCBcvnxZ6qXyd4GgwuDt7V3tB00IIUIcOHAAJSUlmDhxoqCYwsJCibbk5GReP0R2djaioqJQWloKADAxMZF4MPfZs2dQU1ODrq6usANp4gRdSmrRogU++ugjnDlzBnZ2dhJVe8GCBQpJjhDS9JWVleHGjRsAXo9q/OzZM0RFRUFXVxeOjo682G3btmHYsGHV3iBSXcz48ePh4OAAd3d3KCkp4ezZs9i1axd2797NxYSHh2PUqFFITU2FpaUlpk+fjlGjRmHhwoXo168fEhISsHjxYkyZMuWdnaZY0LDbPXv2rHZ55fW95iYvLw/6+vrIzc2lYbcJkVF2drbEbaQA0KlTJ4SEhHDvMzIyMGLECKxYsaLKvoOaYoqKirB161ZERESgpKQEdnZ2mDJlCpydnbmYiIgIzJ07F6dOneJuub9w4QJ27NiBlJQUmJiYYPDgwRg/fjw3n31zIM/3l0LnY2juqDAQQpoqeb6/BPUxEEIIab4EF4bTp09j5MiRvLuT1qxZ88724hNCSHMhqDDs3r0bgYGBsLe3x507d7h2VVVVrFy5UmHJEUIIqX+C+hg6deqEn376CT4+PhCJRKjcRHJyMvr27Yu0tDSFJ9oYUB8DIaSpqvM+hsTERPTu3RsAeLeqmpiY4MWLF0I2SQghpJEQVBhatWqF+Ph4APzCcO7cOdjY2CgmM0IIIQ1C0ANukydPxuTJk7Fx40aIRCI8ffoUf/31F+bNm0cPtxHSUPZVPzwEaUY+qNunDAQVhnnz5iEnJweenp6oqKiAtbU1VFRUMGPGDHz55ZcKTpEQQkh9EtT5nJ+fD11dXbx69QpxcXEQi8VwcnKCkZERkpOT0bZt27rItcFR5zNp1OiM4d0h4Iyhzjufhw0bhpKSEhgYGMDDwwOenp5cUahuqFxCCCGNn+Bht8eOHYuKigquLSkpCV5eXvDx8VFYcoQQQuqfoMJw8uRJPHnyBEFBQQD+ryj4+vpWORkGIYSQpkFQYdDT08Pff/+Ny5cvY/LkyfDy8oKfnx9+++23GifOIIQQ0rgJuisJAExNTXHu3Dn07t0bQ4YMwdatW6koEEJIMyDzXUkqKtJriFgshpIS/8SjvLy89pk1QnRXEmnU6K6kd0cd35Uk8xnD6dOn5U6EEEJI0yNzYfDz86vLPAghhDQSgvsYgNcTbyclJYExBjs7O2hpaSkqL0IIIQ1E0F1JpaWlmDlzJgwNDeHs7AwXFxcYGhpi5syZKC0tVXSOhBBC6pGgM4Y5c+bgyJEj2LZtG3r27AmRSITIyEjMmzcPALB27VqFJkkIIaT+CCoMe/fuxalTp+Dm5sa12drawt7eHsOHD6fCQAghTZigS0mvXr2Cvb29RHu7du3w6tWr2uZECCGkAQkqDC4uLtiwYYNE+08//QRnZ+daJ0UIIaThCLqUtHr1agwaNAhHjx7lLidFR0fj0aNHCA0NVWiChBBC6pegMwYvLy88fPgQPj4+SE1NRVpaGgYMGID4+HgadpsQQpo4wVN7hoSEYM2aNVUuI4QQ0jQJOmOoamhtxhi2b98u17auXLmCwMBAuLq64saNGxLLV6xYAVdXV95r7NixEnEREREICAhAnz598L///Q/p6emCYggh5F0nV2EoLy/nBsir/Hflq7S0FBEREWjZsqXM25s3bx5mz56NLl264MaNG8jPz5eIefr0KfT19bFlyxbutXDhQl5MWFgYfH194eTkhIULFyIlJQW9e/dGXl6eXDGEEELknPNZlmG1ly1bJvHFXZXKuaPT0tJgZWWFiIgIiT6KTz/9FC9fvsThw4er3E6vXr1gbW2Nffv2AQCKiopgZmaG+fPnY9asWTLH1IRGVyWNGo2u+u5oLKOrAq8vxQBAv379uH9XUlVVRZs2bWBpaSnz9nR1dWWKi46ORt++faGvrw8PDw/MmDED6urqAICCggJERUVh2rRpXLympib69++PsLAwzJo1S6YYQgghr8lVGCr/mo+Li0OnTp3qIh8JOjo6+OSTT+Dp6Yn09HQsW7YMR48exZUrV6CiooK0tDQwxmBubs5bz9zcHGFhYQAgU4w0JSUlKCkp4d7TZSdCyLtA5j6GuXPnck81V1cUcnJyMHfu3FonVun777/H0qVL4e3tjY8++gh///03rl+/jkOHDgEAysrKAIA7g6ikqanJLZMlRpoVK1ZAX1+fe1lZWSnsuAghpLGSuTC8evUK1tbWCAoKwsmTJ5Geno6ysjKUlZUhNTUVR48excSJE2FtbY2cnByFJaimpsZ737ZtW1hbW+POnTsAAGNjYwBAVlYWL+7ly5fcMllipJk7dy5yc3O5V2pqau0OhhBCmgCZC8PmzZtx5coVVFRUIDAwEJaWllBTU4Oamhpat26Njz/+GCoqKrh69Sq2bNlSZwmXl5fjxYsX0NHRAQCYmZnBzMwM165d48VFR0eja9euMsdIo66uDj09Pd6LEEKaO7luV+3UqRO2b9+OnJwc3Lx5EydOnMDJkydx8+ZNZGdnIyQkRKF9D6Wlpfjuu+9QXFwM4PUloeDgYBQVFeH999/n4iZNmoSQkBDuL/oDBw7gwYMHmDRpklwxhBBCBD75rKysjC5duqBLly612vnp06exZMkS7jr/1KlToauriylTpmDKlClQVVVFeXk5LC0t0aJFC/z7778wNTXFmTNn0L59e247CxcuRFJSEuzt7WFubo7MzExs2bIF3bp1kyuGEEKInM8xKFpWVhYeP34s0W5ubs67g6i8vBxJSUkwNDSEqalpldvLyMhAZmYmbG1tq5xmVJaYqtBzDKRRo+cY3h2N6TkGRTM2Nq6287eSiooK7wyhKi1btqzxyWtZYggh5F0maKwkQgghzZegwjB58mRBywghhDR+gvoYRCIRpK3GGIOysjLEYrFCkmtsqI+BNGrUx/DuaEx9DJUjq779bwAQi8W4cuUKXb8nhJAmTq7CoKqqKvXfb1q2bFntMiKEENKgGnR0VUIIIY1Pox9dlRBCSP0S9ByDpaUlN9KqNAYGBgLTIYQQ0tAEFQZDQ8Nqlzfgw9SEEEJqSVBheHuUUrFYjISEBCxcuBBff/21QhIjhBDSMAQVBldXV4k2Nzc32NnZ4euvv8b06dNrnRghhJCGodAhMTp16sRNoEMIIaRpUlhhEIvF2Lx5M8zMzBS1SUIIIQ1A0KWkVq1aSbTl5uZCJBJh9+7dtU6KEEJIwxFUGNasWSPRZmhoCFdXVxoSgxBCmjhBhSEwMFDReRBCCGkkBE/UU1paiiNHjuDBgwcAgI4dO8Lf3x9qamoKS44QQkj9E9T5HBcXB3t7e0yZMgWhoaEIDQ1FUFAQ2rVrh3v37ik6R0IIIfVIUGGYMmUKPDw88OzZM1y7dg3Xrl3Ds2fP0KdPHwQFBSk6R0IIIfVI0KWk27dv48SJE9DV1eXadHV1sW7dOrRp00ZhyZH6UVpaioiICGhoaMDT01NqTG5uLmJiYqChoYEePXpIvWQoS0x6ejoePnwINTU1dOrUqcbhVQAgKSkJycnJsLKyQocOHeQ/QEKIXAQVBmtra+Tk5MDU1JTXnp2dDRsbG4UkRuqeWCzG/PnzsXv3blRUVMDCwgLXr1+XiDtx4gQ++ugjtGvXDrm5uSgrK0NoaCgcHBxkjmGMYfr06dixYwfc3d3x33//4d69e1i7di2mTp0qNb8bN25g+vTpePHiBWxsbBAbG4v27dvj2LFjMDExqZsPhRAi7FJScHAwxo0bh0uXLqGwsBCFhYW4dOkSxo0bh+DgYEXnSOpIRUUF9PT0cOPGDYwZM0ZqTFZWFsaPH485c+bg+vXriI+Ph5OTE8aPHy9XzKVLl7Bp0yacP38eYWFhiI6OxpIlSzB9+nQUFBRI3XdOTg5++uknJCYm4ty5c0hMTER2dja++uorxX4QhBAeQWcMU6dORUVFhdTLDlOmTMGUKVO4929PAUoaD1VVVcydO7famBMnTqCkpASff/45AEBJSQkzZ85Ev3798ODBAzg4OMgUU/nl3759e27bHTp0gFgsRnFxMbS1tSX27ePjw3uvp6eHIUOG4PTp07U6bkJI9QQVBvqP+e6IjY1F27Ztef1JnTt3BgDcuXMHDg4OMsUMHDgQ77//PkaNGoVPPvkEBQUF+Omnn/Ddd9/B2NhYplwYY7h06RLvEhYhRPEEFQY/Pz9F50EaqdzcXIkOYgMDAygpKXGTNckSo6ysDD8/PyxduhTbtm1DQUEBVFVV4e7uLnMuK1euxO3bt7F169ZaHRMhpHqCH3ADXnc2Z2dnS7Tb2dnVZrOkEVFTU0NhYSGvrbi4GGKxGOrq6jLHnDx5Ep9++ikiIyO5Ydu3bt2KQYMG4dGjRzXOFR4SEoLFixdj//79cHFxUdThEUKkENT5fOPGDTg4OMDY2Bj29vYSL9J8tG3bFmlpabxZ+VJSUgCAuwNNlpjw8HC0b9+eN5fHhx9+iKKiIly5cqXaHLZv345p06Zh79698Pf3V8yBEUKqJKgwfPrpp3B1dcXNmzfx+PFjiRdpPvz8/PDy5UtcunSJazt06BAMDAzQs2dPmWPMzc3x7Nkz3pnFo0ePuGUAUFZWhuPHj3NFBQB27tyJ//3vf9i9ezdGjRpVdwdKCOEIupR0//59nD9/Hvr6+orOh9Sz8PBw5OXlISkpCa9evcLx48cBAEOHDoWysjI6d+6MiRMn4oMPPsC8efOQnZ2N5cuXY/369dxlIlliJk6ciB9//BF+fn6YNGkSCgoKsHbtWnh4eKB3794AgIKCAowcORI7duzAxIkTceLECUyaNAkffvgh1NTUuNxUVVUxZMiQev+sCHlXCCoMNjY2yMnJocLQDJw4cQJPnz6FsrIyOnXqhJ07dwJ4fRagrKwMANi2bRt27NiB8PBwqKur4+TJkxg4cCBvOzXFmJqa4t69e9i6dSvCwsKgpqaG2bNnY+LEidx+VFVVMXz4cLRu3RoAkJeXh6FDhyIvL4/LCwC0tbWpMBBSh0TszQvDMtq9ezf27t2LzZs3v1NPOufl5UFfXx+5ubnQ09Nr6HQI4dsnaugMSH35QO6vbbm+v2Q+Y1BR4YdWVFSgbdu2UFJSgkjE/4Wkh9oIIaTpkrkw0ENthBDybpC5MNTVQ21XrlzBli1b8PDhQ2zduhXdunWTiImIiMDGjRuRkZEBJycnLFiwABYWFnUSQwgh7zpBt6u+evWqyldRUZHM25k3bx5mz56NLl264MaNG8jPz5eICQsLg6+vL5ycnLBw4UKkpKSgd+/eyMvLU3gMIYQQgZ3Pb/cpvK1Vq1b4+OOPsWzZMom+iTfl5+dDV1cXaWlpsLKyQkREBLy8vHgxvXr1grW1Nfbt2wcAKCoqgpmZGebPn49Zs2YpNKYm1PlMGjXqfH531HHns6Azhp9++gktW7bEunXrcOHCBVy8eBFr166FqakpVq5ciSVLlmDXrl1YuXJltdt5c9A1aQoKChAVFcW7NVFTUxP9+/dHWFiYQmMIIYS8Jug5hj179uDw4cPo06cP19a3b1+4uroiODgYMTExsLOzw2effYYFCxYITq5ymIXKJ2MrmZubc1/oioqRpqSkBCUlJdx7oZedajjBIs2I/OffhDQ+gs4Y7t+/DycnJ4l2FxcX3L9/HwDQo0cPpKen1yq5srIyAOCenq2kqanJLVNUjDQrVqyAvr4+97KysqrF0RBCSNMgqDCYm5sjJCREov3XX3/l/iqvnMWrNirH6c/KyuK1v3z5klumqBhp5s6di9zcXO6Vmppai6MhhJCmQdClpB9++AGjRo3CwYMH4erqCsYYrl+/jlu3buHQoUMAXj8dvXTp0lolZ2ZmBjMzM1y7dg1Dhw7l2qOjo7nZ4xQVI426urrEWQYhhDR3gs4YRowYgQcPHqBXr15ISkrC48eP0bt3bzx48AAjRowA8LqD2tfXt9YJTpo0CSEhIdxf6wcOHMCDBw8wadIkhccQQgipxUQ9dnZ2+PHHH2u189OnT2PJkiXcdf6pU6dCV1eXN2/0woULkZSUBHt7e5ibmyMzMxNbtmzhPQinqBhCCCECn2OonK6xKgYGBjJtJysrS+r8Debm5hJ3EGVkZCAzMxO2trbQ0tKSuj1FxVRF6HMMdFfSu6NB70qi5xjeHXX8HEOdPOAmYJNNAhUGUhMqDKReNJbRVd907do13nuxWIyEhAQsXLgQX3/9tZBNEkIIaSQEFYY35+2t5ObmBjs7O3z99deYPn16rRMjhBDSMATdlVSVTp064c6dO4rcJCGEkHqmsMIgFouxefNmmJmZKWqThBBCGoCgS0mtWrWSaMvNzYVIJMLu3btrnRQhhJCGI6gwrFmzRqLN0NAQrq6uaNmyZa2TIoQQ0nAEFYbAwEBF50EIIaSREPzkMwAUFhYiKSkJjDHY2dnJ/cAYIYSQxkdQ53NpaSlmzpwJQ0NDODs7w8XFBYaGhpg5cyZKS0sVnSMhhJB6JOiMYc6cOThy5Ai2bduGnj17QiQSITIyEvPmzQMArF27VqFJEkIIqT+CCsPevXtx6tQpuLm5cW22trawt7fH8OHDqTAQQkgTJuhS0qtXr2Bvby/R3q5duxoH2COEENK4CSoMLi4u2LBhg0T7Tz/9BGdn51onRQghpOEIupS0evVqDBo0CEePHuUuJ0VHR+PRo0cIDQ1VaIKEEELql6AzBi8vLzx8+BA+Pj5ITU1FWloaBgwYgPj4eHh5eSk4RUIIIfVJ0BnDggULsHz5cqlPQBNCCGnaBJ0xrFmzhpuOkxBCSPMiqDB069YNly5dUnQuhBBCGgFBl5KGDBmCsWPHYsaMGejYsSPU1NR4y9977z2FJEcIIaT+CZrzWUNDo9rlxcXFghNqzGjOZ1ITmvOZ1IvGOOdzc/3iJ4QQouCpPQkhhDR9gofdvn//PqKiopCdnS2xLDg4uFZJEUIIaTiCCsOWLVswbdo0WFpawtDQUGI5FQZCCGm6BBWGFStWYOfOnfjoo48UnQ8hhJAGJnh01YCAAEXnQgghpBEQVBhcXV1x/fp1RedCCCGkEZD5UtLp06e5f/v4+GDs2LGYNWsW7OzsIHrrRn16wI0QQpoumR9wq+mhtjc11+cc6AE3UhN6wI3Ui8bygFtz/bInhBDCJ1cfw549e+oqD0IIIY2EXIWBbk8lhJDmj4bEIIQQwiN4SIz6snr1ahw9epTXZmtri7179/LaLl26hF9++QUZGRlwcnLCvHnzYGZmJncMIYS86+QuDD4+PjXGnD9/XlAy0iQnJ0NLSwvff/8916alpcWLiYiIgK+vL2bPno3x48djw4YN6N27N2JjY6GrqytzDCGEEAGFwcTEpC7yqJaRkRF69uxZ5fIFCxYgICAAy5cvBwD069cPZmZm+PXXXzFz5kyZYwghhAgoDPv376+LPKp17do1eHt7Q19fHx4eHpg+fTo3a1xhYSGioqLw2WefcfFaWlrw8fHB+fPnMXPmTJliCCGEvNboO5+1tLQQGBiIOXPmYNiwYfjll1/Qr18/VFRUAABSU1MhFothbm7OW8/c3BxPnz6VOUaakpIS5OXl8V6EENLcNfrO5xUrVkBdXZ177+HhgQ4dOuDQoUMYO3YsysrKAIAXAwCamprcMlliqtr30qVLFXIchBDSVMh1xhAaGlpXeVTp7S9zOzs7WFtbIzY2FsDr/gcAEhMGZWVlwdjYWOYYaebOnYvc3FzulZqaWruDIYSQJkCuwuDn51dXecisvLwcL1++hLa2NoDXl4NatWqFa9eu8eKio6PRpUsXmWOkUVdXh56eHu9FCCHNXaPuYygtLcWqVatQWloK4HVRmD17NgoLC3nzQXzyyScICQlBeno6AODIkSO4f/8+PvnkE7liCCGENPI+BlVVVfz3338wNzeHmZkZnj9/DgMDA5w4cQIODg5c3KJFi5CQkAA7OztYWVkhLS0NGzduRPfu3eWKIYQQIsew2w2ptLQUCQkJMDQ0hJmZmcT8D5WePXuGjIwM2NnZVfnQmiwxVaFht0lNaNhtUi8ay7Dbb0tISMC+ffuQnJyMXbt2AQBOnDgBPz8/iQ7j2lJTU4Ojo2ONcebm5hK3pAqJIYSQd5mgPoaLFy+ic+fOuHr1Kn7//Xeu/Z9//sGmTZsUlhwhhJD6J6gwzJkzBxs2bMDZs2d57RMmTMDmzZsVkhghhJCGIagwxMXFYcyYMQDAu97fpk0bPHnyRCGJEUIIaRiCCoO2tjYyMzMB8AvDzZs30apVK8VkRgghpEEIKgwBAQEIDg5Gfn4+1xYdHY3Jkydj9OjRCkuOEEJI/RNUGFatWoXc3FwYGxtDLBZzw2JbWVlh2bJlis6REEJIPRJ0u6quri7Onz+PyMhIXL9+HWKxGF27doWHh4ei8yOEEFLPavXks7u7O9zd3RWVCyGEkEZA5sKwc+dOmTc6ceJEAakQQghpDGQuDEuWLOH+zRhDSkoKAMDAwAAA8OrVKwBA69atqTAQQkgTJnPn85MnT7jXZ599Bi8vLyQkJCAnJwc5OTlISEiAl5cXpk2bVpf5EkIIqWOCBtGzs7NDeHg4WrduzWtPSUlB//79kZCQoLAEGxMaRI/UhAbRI/WijgfRE3S7anp6OpSUJFdVUlJCWlqakE0SQghpJAQVht69eyMoKIhXBNLS0hAUFES3rBJCSBMnqDCEhITg5cuXaNOmDSwsLGBubo42bdogKysLISEhis6REEJIPRL0HIO1tTWuXbuGy5cv4/79+wCAjh070tkCIYQ0A7V6wM3Dw4OKASGENDOCC0N5eTmOHz+OBw8egDGGjh07YsSIEVBRadTTSBNCCKmBoG/xpKQkDB48GCkpKbC1tYVIJEJiYiJat26NP//8E7a2torOkxBCSD0R1Pk8Y8YMODg4IDU1FXfv3kVcXBxSU1Ph4OCAGTNmKDpHQggh9UjQGUNERAQSEhJgYmLCtZmYmGDTpk2wt7dXWHKEEELqn6AzBmVlZZSVlUm0l5aWUh8DIYQ0cYIKg5+fHz755BM8fvyYa0tOTsbHH3+MgQMHKiw5Qggh9U9QYVi/fj2Ki4vRtm1bmJqawtTUFLa2tigtLcX69esVnSMhhJB6JOi6T6tWrXD16lVcuXIF9+7dg0gkQseOHdGnTx9F50cIIaSe1apDoE+fPlQMCCGkmRF0Kenp06dYuXKlRPvKlSu5CXwIIYQ0TYIKw+eff45OnTpJtDs6OuKLL76odVKEEEIajqDCEB4eDk9PT4l2T09PRERE1DopQgghDUdQYdDV1cWjR48k2h89egRNTc1aJ0UIIaThCCoM/v7+CAoK4obcBoB79+5h8uTJ8Pf3V1hyhBBC6p+gwrBy5Uro6enB0dERJiYmMDY2RqdOnWBgYIBVq1YpOkdCCCH1SNDtqrq6urhw4QIuX76MmzdvQiQSoUuXLjQ3AyGENAPv1EQ9ly5dwi+//IKMjAw4OTlh3rx5MDMza+i0CCGkURF0KQkAEhISsHTpUkyYMIFrO3HiBEpKShSSmKJFRESgf//+sLe3x6xZs5CQkIDevXsjPz+/oVMjhJBGRVBhuHjxIjp37oyrV6/i999/59r/+ecfbNq0SWHJKdKCBQsQEBCA5cuXY8iQITh69CiysrLw66+/NnRqhBDSqAgqDHPmzMGGDRtw9uxZXvuECROwefNmhSSmSIWFhYiKisLQoUO5Ni0tLfj4+OD8+fMNmBkhhDQ+gvoY4uLiMGbMGACASCTi2tu0aYMnT54oJDFFSk1NhVgshrm5Oa/d3NwcYWFhVa5XUlLCuzSWm5sLAMjLy6ubREmT16C/GoUNuG9SvwT8olV+bzHGaowVVBi0tbWRmZkJGxsbXmG4efMmWrVqJWSTdapyUiF1dXVeu6amptQJhyqtWLECS5culWi3srJSbIKk2dDXb+gMyDshSPgvWn5+PvRr+EUVVBgCAgIQHByMnTt3cm3R0dGYPHkyRo8eLWSTdcrIyAgAkJ2dzWvPysqCsbFxlevNnTsXX3/9NfdeLBYjOzsbxsbGvIJIJOXl5cHKygqpqanQ09Nr6HRIM0W/Z7JjjCE/P1/iyok0ggrDqlWrMHLkSBgbG0MsFsPIyAg5OTno378/li1bJmSTdcrc3BytWrXCtWvX8N5773Ht0dHR1d5uq66uLnGWYWBgUFdpNkt6enr0H5bUOfo9k01NZwqVBD/gdv78eURGRuL69esQi8Xo2rVro36m4ZNPPkFISAimTJkCCwsLHDlyBPfv38eOHTsaOjVCCGlUavWAm7u7O9zd3RWVS51atGgREhISYGdnBysrK6SlpWHjxo3o3r17Q6dGCCGNiqDCcPXqVRw9ehSPHz+GSCSCjY0N/P390atXL0XnpzDq6uo4ePAgnj17hoyMDNjZ2UFXV7eh02q21NXVsXjxYolLcYQoEv2e1Q0Rk+XepTd88cUX2LBhA0xNTWFvbw/g9XDbL168wFdffYV169bVSaKEEELqh1xnDCdOnMD27dtx8OBBvP/++9ydOYwxHDx4EB9//DH69++PIUOG1EmyhBBC6p5cZwzDhw+Hh4cHgoODpS5ftWoVoqOjcfToUYUlSAghpH7JNSTGjRs3EBAQUOXyUaNG4fr167VOijQ+SUlJOHPmTLUx8fHx+Pvvv+spI0JIXZGrMLx48aLap36trKyQmZlZ66RI3Tl58iTu3bvHa0tPT8f+/fuRmprKa3/w4AF39nfu3DnMmDGDW5aQkIA///yTF3/q1CnMnj27jjLnk7Z/QohiyFUYSktLoaJSdbeEqqpqox12m7z2yy+/SAzzsXPnTowbNw6//fYbr/3777/nbiaws7PjPRz4999/854Kr28NvX+iOGFhYQgJCUFISAh+//13hIeHo7i4uMb1MjIyEBISIjF22a1btxASEoLw8HBs374dYrFY6voRERE4efKkQo6huZH7dtUFCxbURR6knvTr1w/r1q0DY4y7eaByroqIiAhe7IULF/Dxxx8DAGxsbDBgwAAAQEpKCm7evIn8/Hzs378fANC1a1duvfLycsTGxuLff/9Fly5dpD6Cf/v2bSQnJ8PCwgJubm68IUbu3LmD7OxseHl5cW2PHz9GXFwchg0bVuX+27Vrp4BPiNS3zZs3IyYmBr6+vigrK0NUVBQKCgrw119/oVOnTlWul5CQgKCgIHh5eXFPPYeGhuL999/H559/jj59+qB///6wsLDAwIEDeeuWl5fjgw8+wOTJkzFs2LA6Pb4micnB1tZWphdpvKKiohgAdvfuXcYYYyUlJUxLS4tdunSJqampsYKCAsYYYwkJCQwACw8PZ4wxtnnzZu5n+88//7CuXbsyXV1dNmbMGDZmzBj2559/sh9++IFZWloyV1dX1q9fP+bh4cE0NTXZX3/9xe2/pKSEDRkyhBkZGbFBgwYxMzMz1qNHD5adnc3FzJ49m/Xv35+X944dO5iFhUW1+ydNU0BAABsyZAj3vqysjHXu3JkNHjy42vUuX77MALCEhATGGGN79+5lampqbO3atVxM79692ejRoyXWPX78OBOJRCw5OVlBR9G8yFUYSNNXXl7O9PT02IYNGxhjjF26dImZm5szxhhr3749O3fuHGOMsV9//ZVpaGiwoqIixhi/MDDG2IYNG1j79u152/7hhx8YAHb69Gmubfr06czNzY17v2bNGtayZUuWnp7OGGPs1atXrEOHDuzzzz/nYmoqDFXtnzRNbxcGxhj74osvWOvWratd783CsGHDBqaqqsp27tzJi9mxYwdTV1dnWVlZvPahQ4cyHx8fxRxAMyR4ak/SNCkrK8PDw4O7bBQREcFdsvH09OS1u7u7Q0NDQ67tW1lZ8Z5j8fLyQnx8PPd+//79mDBhAnd5SV9fH9OnT+cuCRECvL7xQZZRQAFg+fLl+Oabb3D48GHeVMMAMHr0aKirq2PPnj1c27///ovQ0FBMmjRJoTk3J1QY3kH9+vXDxYsXwRirsjBcuHAB3t7ecm+7cojzSurq6ryOxKdPn6Jt27a8GFtbW7x48QKFhTTTzLsqNTUVISEh2Lx5Mz788EP8888/WL58uUzr7tu3D71798bgwYMllmlpaWHs2LHYvn0717Zr1y7o6elh5MiRCsu/uaHC8A7q168fsrKyEBMTg6ioKF5huHbtGq5fv47nz58LKgw1MTExkZgXIzs7G9ra2tDS0gIAKCkpSdxJIstdKqTpysnJQVRUFK5evYrw8HD4+vryRmves2cPd+fS6dOneevu2rUL169fx7hx41BeXi6x7UmTJiE2NhY3b94EAGzfvh2BgYE0vlI1qDC8gzp37gxDQ0N8//33MDIy4sa8srCwQJs2bfDtt99CW1u72pFndXR0BH1Z9+nTB8eOHeNNL3jo0CH07t2be29hYYHk5GRezNt3TAndP2mcnJ2dERISgj179uDOnTuIiYnB3LlzueU3btxAVFQUoqKiJJ7D6d69O8LCwhAeHo7Ro0dLzMro5uYGZ2dnbNu2DZcvX8ajR48wefLkejmupqpWw26TpklJSQmenp44fvw4PvjgA94yT09PbN++HX5+flBVVa1yG926dUNqaipWrlwJa2tr3u2q1Vm8eDG6dOmCoUOHYvjw4bh48SLOnTuHK1eucDH+/v6YM2cOPvroI3h7e+PixYu4cOECLx9p+6fbVZuHFi1a4IcffsD48eMxZcoUtG/fHj/++GO163Tt2hXh4eHw8fHB+++/j0OHDkFNTY1bPmnSJCxevBhZWVlwc3ODk5NTXR9Gk0ZnDO+oiRMnYsyYMQgMDOS1jxs3DmPGjJHomHv7ATcnJyecOHECKSkpOHHiBJKSktChQwf4+fnx1rOwsOBN92phYYHbt2/D1dUVly9fhqWlJW7duoXOnTtzMWZmZoiJieFm3evfvz8OHDiA4cOHV7t/0nyMHTsWLi4umDdvnszruLi4ICIiAlFRUQgICOA9bBsYGIiioiIcOHCAOp1lIPew24QQokhbtmxBWVkZPv/8c157ZGQktm/fjlWrVknc1AAAiYmJWLlyJVasWIEWLVpw7Q8ePMC6devg6+uLUaNGce0//vgj7t+/j3Xr1tFcLDWgwkAIIYSHLiURQgjhocJACCGEhwoDIYQQHioMhBBCeKgwEEII4aEH3AghgpSVleHgwYMICwtDRkYGTE1N4eDggAkTJqBly5ZcXFBQEB4/fgwA0NTURNu2bREUFMTNtTBw4EB8/vnnvOdkgNfzNNy8eVNiAqnGJDU1FR9//DH2798PExOThk5HYeiMgRAit+fPn8PV1RXffvstnJ2d8dlnn8Hb2xuvXr1Cz549ERsby8VGRkbCyMgIc+bMQVBQELKystClSxdERUUBeD2DW1pamsQ+4uPjERkZWW/HJERBQQHCwsKa3fAsdMZACJFbYGAgSktLcePGDWhra/OWLV68WGK8otatW8PHxwcAMHToUFy/fh2bNm1Cz549a5XH6dOnceDAAeTn58PR0RFfffUV95d7SEgIzp49i927d3MD5u3cuROnTp3Cnj17IBKJuLMUFRUVWFtb4+OPP0aPHj14+ygtLcX27dsRFhYGFRUVjBo1Cv7+/sjLy8Mnn3wC4PWIAerq6ujZs6fMo8I2ZlQYCCFyuXfvHsLDw/HHH39IFAXg9VDr1Y1cKhKJYGlpiZcvX9Yqj+XLlyMkJASzZ8+Gubk5jh07hs6dO+Pu3bswMDDAmDFjsGLFCnzzzTf4+eefce/ePXz22Wf47bffoKmpiYqKCsyZMwfA68tiMTEx6NevH0JDQ+Hp6Qng9RSggwcPRnJyMmbPng0DAwPs3bsXwOsCFxQUhMjISEybNg0mJia8J7CbtAacJIgQ0gT9/vvvDACLj4+XKd7R0ZHNnDmTe//o0SOmo6PDFi1axBhjTFlZmW3evFlivRkzZjBHR0ep20xJSWHKysosLi6O196jRw+2YsUK7n1kZCRTVVVlx44dY87OzuyDDz6oNtfg4GA2cuRI7v3vv//ONDQ0WEpKCi8uLy+PMcbYgwcPGACWmppa7XabGjpjIITIpaioCABgYGDAtWVkZODDDz/k3o8fPx7jx4/n3h86dAi3b99GUVERbt26BW9vb8yePVtwDpUTTQUHBwMA2OtpipGamsoblrtnz55YsGABAgICYGVlhU2bNvG2c/v2bezYsQOPHz9GYWEh0tPTeaP4hoeHw93dHVZWVrz1mvtYS1QYCCFyqZxy88mTJzA1NQXweorWyssygYGBSE5O5q3To0cPTJkyBRoaGrCxsYGFhQW3TE1NDaWlpRL7KSkpqfKSVF5eHjQ1NbnC8KY374gCAEtLS4jFYrRv3x76+vpce0xMDPr27Ytp06ZhwoQJ0NPTw8mTJxEaGsrFFBQU8Argu4IKAyFELn379oWOjg4OHDgANzc3AICGhgbXuSxtnvA3O5/f1rZtW+521jc9efJEYhrYSjY2NigoKICNjQ1sbW2rzDUpKQkzZszAwoUL8dNPP2HTpk347LPPAABHjhyBt7c31q5dy8WfOXNGIrfjx49XuX0lpeZ5Y2fzPCpCSJ3R09PDt99+i40bN2Lr1q28mfYKCwul/vVfnTFjxmDPnj28s4zIyEicO3cOY8aMkbqOj48P7Ozs8Pnnn+O///7j2i9cuMBN+lReXo7AwEAMGDAAy5Ytw8aNGxEcHIwHDx4AALS1tfHkyRNu3oZ79+5hx44dvP2MHz8eycnJ+Pnnn7m2Bw8ecLfRVnY2//vvv3Idc6PXsF0chJCmatu2bczCwoIZGhqyHj16sO7duzN9fX02YsQIFhsby8W93fn8tuLiYjZ16lSmpaXFunXrxpycnJiOjg5btmxZtfuPj49n3bp1YwYGBqxnz57MwsKC9e/fnyUmJjLGGFu0aBEzMzNjL1++5NYZO3Ys69KlCyspKWGZmZnMwcGBmZubMzc3N2ZsbMx8fX2Zra0tbz+HDh1ixsbGzMbGhnXu3Jk5OzuzR48eccvff/99Zmpqyvr168fmz58v12fYWNF8DIQQwRhjiI+PR2ZmJkxMTNCmTRuJW1ijoqJgbGzMzS1elVevXiExMRGqqqqwt7eHlpaWTDkkJCQgIyMDtra2MDMz49ovXLgAS0tL2NnZcW35+fmIjo5G165dYWRkhLKyMsTFxaGkpAROTk7Izc3F06dP0atXL94+SkpKEBsbC01NTXTs2BHKysq85Q8fPsTz589hZGQEFxcXmfJuzKgwEEII4aE+BkIIITxUGAghhPBQYSCEEMJDhYEQQggPFQZCCCE8VBgIIYTwUGEghBDCQ4WBEEIIDxUGQgghPFQYCCGE8FBhIIQQwkOFgRBCCA8VBkIIITz/D7HmZHzOCe1pAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 400x300 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "labels = [\"Without\", \"R-KV\\nGPU exact\"]\n",
+    "data = [\n",
+    "    before_drop_data[\"metrics\"][\"results\"][\"output_tput\"],\n",
+    "    gpu_exact_drop_data[\"metrics\"][\"results\"][\"output_tput\"],\n",
+    "]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(4, 3))\n",
+    "bars = ax.bar(labels, data, color=[\"blue\", \"orange\"])\n",
+    "ax.bar_label(bars, fmt=\"%.1f\", padding=3)\n",
+    "ax.set_ylabel(\"Decode Throughput (tokens/s)\")\n",
+    "ax.set_title(\"Token Dropping Benefit\\nfor Decode Throughput\")\n",
+    "ax.margins(y=0.15)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc6b0b56",
+   "metadata": {},
+   "source": [
+    "## Reading these numbers\n",
+    "\n",
+    "All four notebooks were run back to back on one machine against the same vLLM\n",
+    "and LMCache servers, and each re-measures its own no-drop baseline. That gives\n",
+    "four independent measurements of an **identical** configuration — a direct read\n",
+    "on how much of any difference is real:\n",
+    "\n",
+    "| | one-shot | gpu_exact | cpu_exact | buffered_cpu |\n",
+    "|---|---|---|---|---|\n",
+    "| baseline decode | 969 tok/s | 1008 tok/s | 1002 tok/s | 975 tok/s |\n",
+    "| baseline accuracy | 10/30 | 10/30 | 11/30 | 11/30 |\n",
+    "| decode after dropping | 1766 tok/s | 1774 tok/s | 1785 tok/s | 1774 tok/s |\n",
+    "| accuracy after dropping | 13/30 | 14/30 | 14/30 | 13/30 |\n",
+    "\n",
+    "Three things follow.\n",
+    "\n",
+    "1. **Decode throughput after dropping is the solid number.** It lands in\n",
+    "   1766–1785 tok/s — a 1.1% spread — although the four notebooks compress with\n",
+    "   completely different code. That is the claim this example makes: the speed-up\n",
+    "   comes from halving the KV cache, not from how the halving is computed.\n",
+    "\n",
+    "2. **Don't quote a speed-up ratio.** The no-drop baseline swung 969–1008 tok/s\n",
+    "   here, and 894–1076 tok/s — **20%** — over an earlier sweep of the same four\n",
+    "   notebooks, so the ratio moves between 1.6x and 2.0x on noise alone. Compare\n",
+    "   the absolute post-drop throughput instead.\n",
+    "\n",
+    "3. **Don't rank the variants by accuracy.** R-KV beat the same-run baseline in\n",
+    "   all four runs (+3 to +4 of 30), which is the meaningful result. But the 1/30\n",
+    "   spread *between* variants is the same size as the baseline's own spread, so\n",
+    "   it says nothing about the algorithms.\n",
+    "\n",
+    "### Why identical inputs give different text\n",
+    "\n",
+    "Decoding is greedy — `temperature = 0.0` for both prefill and decode — yet the\n",
+    "generated text still differs between runs. `temperature = 0` fixes the *rule*\n",
+    "(take the argmax); it does not make the argmax stable.\n",
+    "\n",
+    "Prefill is submitted one stream at a time (`prefill_group_size = 1`) and it\n",
+    "**is** reproducible: 15.19 s and 15.21 s, to the same hundredth of a second, in\n",
+    "every notebook. Decode is not. `batch.decode` hands all 30 streams to vLLM at\n",
+    "once, so continuous batching gives the decode batch a different composition on\n",
+    "every run. GPU reductions are not batch-invariant, logits move by ~1e-6,\n",
+    "near-ties flip, and autoregression amplifies the divergence.\n",
+    "\n",
+    "This is a property of the serving stack, not of token dropping — but it is the\n",
+    "reason a single accuracy number here should not be read as a ranking.\n",
+    "\n",
+    "### The exact variants pick the same tokens — their caches still differ\n",
+    "\n",
+    "Verified directly on real requests: `cpu_exact` and `gpu_exact` produce score\n",
+    "vectors that differ by ~1e-6, but the top-k they select was identical on every\n",
+    "request tested, and so were the kept token ids. Their compacted caches are\n",
+    "nevertheless not byte-identical:\n",
+    "\n",
+    "| | differing elements | largest difference |\n",
+    "|---|---|---|\n",
+    "| V — a pure gather | **0** | 0 |\n",
+    "| K — goes through the RoPE re-rotation | 0.004% | one to two bfloat16 ULP |\n",
+    "\n",
+    "Every difference is in K, and it is the *device*: `cpu_exact` re-rotates on the\n",
+    "CPU, `gpu_exact` on the GPU, and their sin/cos implementations and fused\n",
+    "multiply-adds round differently before the result is stored back as bfloat16.\n",
+    "Feeding one identical tensor to `rerotate_k_cache` on each device reproduces the\n",
+    "same signature exactly, so nothing else is involved.\n",
+    "\n",
+    "One ULP in K is enough to move an attention logit, flip a near-tied greedy\n",
+    "argmax, and diverge from there. That is why two implementations which provably\n",
+    "select the same tokens still generate different text, and can land on a\n",
+    "different answer for one or two of the 30 questions.\n",
+    "\n",
+    "#### Why the re-rotation runs in fp32\n",
+    "\n",
+    "`utils.rerotate_k_cache` detaches one RoPE and attaches another: six multiplies\n",
+    "and two adds per element. Carrying that out in the cache's own bfloat16 rounds\n",
+    "at every step. Measured on keys with a standard deviation of 3:\n",
+    "\n",
+    "| arithmetic | keys changed vs fp32 | rotate-away-and-back error | re-rotate 30 requests |\n",
+    "|---|---|---|---|\n",
+    "| bfloat16 | 50% | 2.5e-1 | 3.2 s |\n",
+    "| **fp32** (used here) | — | **6.3e-2** | 6.1 s |\n",
+    "\n",
+    "fp32 costs 1.9x on the re-rotation step itself, because it moves twice the\n",
+    "bytes. End to end that is much less than it sounds: compressing the 30 requests\n",
+    "went from 41.4 to 41.6 s (one-shot), 37.3 to 37.5 s (`gpu_exact`) and 67.1 to\n",
+    "67.3 s (`cpu_exact`) — around +0.2 s, because `modify` spends most of its time\n",
+    "waiting on LMCache and the extra arithmetic fits in that slack. Only\n",
+    "`buffered_cpu` shows it, 27.9 to 29.9 s (+7%), because its compression is the\n",
+    "shortest so the re-rotation is the largest share of it. That buys a 4x better\n",
+    "round trip and takes an extra ULP of error off half the keys, so it is the\n",
+    "default. It does **not** remove the CPU/GPU split above: that is\n",
+    "the final rounding back to bfloat16, which is there whatever precision the\n",
+    "rotation is computed in.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03cca85b",
+   "metadata": {},
+   "source": [
+    "## Close both contexts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f83db925",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-01T06:10:20.769775Z",
+     "iopub.status.busy": "2026-08-01T06:10:20.769643Z",
+     "iopub.status.idle": "2026-08-01T06:10:20.772161Z",
+     "shell.execute_reply": "2026-08-01T06:10:20.771690Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Only close the context when done.\n",
+    "ctx.close()\n",
+    "qctx.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "defaultInterpreterPath: 3.12.3.final.0",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/token_dropping/utils.py
+++ b/examples/token_dropping/utils.py
@@ -105,7 +105,16 @@ def _rerotate_k_cache(
     head_size: int,
     is_neox_style: bool,
 ) -> torch.Tensor:
-    """Move key cache RoPE from old positions to new positions."""
+    """Move key cache RoPE from old positions to new positions.
+
+    The rotation detaches one RoPE and attaches another, which is six multiplies
+    and two adds per element. Running that in the cache's own dtype rounds at
+    every step: in bfloat16 (an 8-bit mantissa) it perturbs ~50% of the keys
+    relative to the same rotation computed in fp32, and a rotate-away-and-back
+    round trip drifts by up to 2.5e-1 on keys with a standard deviation of 3.
+    The arithmetic therefore runs in fp32 and is rounded back to the cache dtype
+    exactly once, at the end, which brings that round trip to ~1e-6.
+    """
     num_tokens = k_flat.shape[0]
     k = k_flat.view(num_tokens, -1, head_size)
 
@@ -114,7 +123,8 @@ def _rerotate_k_cache(
     if rotary_dim % 2 != 0:
         raise ValueError(f"rotary_dim must be even, got {rotary_dim}")
 
-    k_rot = k[..., :rotary_dim]
+    compute_dtype = torch.float32
+    k_rot = k[..., :rotary_dim].to(compute_dtype)
     k_pass = k[..., rotary_dim:]
 
     old_cos, old_sin, old_scale = _rope_cos_sin(
@@ -122,14 +132,14 @@ def _rerotate_k_cache(
         positions=old_positions,
         rotary_dim=rotary_dim,
         device=k.device,
-        dtype=k.dtype,
+        dtype=compute_dtype,
     )
     new_cos, new_sin, new_scale = _rope_cos_sin(
         config=config,
         positions=new_positions,
         rotary_dim=rotary_dim,
         device=k.device,
-        dtype=k.dtype,
+        dtype=compute_dtype,
     )
 
     rotate_half = _rotate_half_neox if is_neox_style else _rotate_half_interleaved
@@ -141,7 +151,7 @@ def _rerotate_k_cache(
     # Attach new RoPE.
     k_new = new_scale * ((k_plain * new_cos) + (rotate_half(k_plain) * new_sin))
 
-    return torch.cat((k_new, k_pass), dim=-1).reshape_as(k_flat)
+    return torch.cat((k_new.to(k.dtype), k_pass), dim=-1).reshape_as(k_flat)
 
 
 def rerotate_k_cache(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ follow_imports = "silent"
 [tool.codespell]
 ignore-words-list = "afterall,allready,notin,te"
 skip = "operator/config/crd/bases/*,lmcache/integration/vllm/lmcache_mp_connector_*.py"
+# Base64 image payloads in executed notebooks are random-looking and will
+# eventually contain something that looks like a typo.
+ignore-regex = '"image/[^"]+": "[A-Za-z0-9+/=]+"'
 
 [tool.cibuildwheel]
 build = "cp3*-manylinux_x86_64"


### PR DESCRIPTION

<!--  Thanks for your contribution to LMCache!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/LMCache/LMCache/blob/dev/CONTRIBUTING.md
2. If this PR closes another issue, add 'Fixes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'Refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

This PR adds an end-to-end example of **R-KV token dropping** through the LMCache
SDK. The notebook retrieves a request's KV cache and query states after prefill,
scores every past token, drops half of them, remaps the survivors, and continues
decoding from the compressed cache.

R-KV extends SnapKV's attention-importance term with a **redundancy** term, so a
token is kept only if it is both attended-to *and* says something new:

$$\text{score}(j) = \lambda \cdot \text{importance}(j) - (1-\lambda) \cdot \text{redundancy}(j)$$

The redundancy term compares **all pairs of keys** — $O(n^2 d)$ per layer against
$O(w n d)$ for SnapKV. At $n = 16128$ that is ~250x more arithmetic per layer, and
a literal implementation also materializes an $n \times n$ matrix per layer. A
direct port of the reference code needed **over an hour** for the 30 prompts used
here. Making R-KV practical is what the example is about.

### Layout

Per review feedback, the readable version is the notebook and the optimized ones
live in a subdirectory:

| File | Implementation |
| --- | --- |
| `examples/token_dropping/rkv_token_dropping.ipynb` | Route A, literal all-pairs formulation — the reference, and the one to read first |
| `examples/token_dropping/rkv_variants/rkv_variant_cpu_exact.ipynb` | Route A, exact and linear, on the CPU |
| `examples/token_dropping/rkv_variants/rkv_variant_gpu_exact.ipynb` | Route A, exact and linear, on the GPU |
| `examples/token_dropping/rkv_variants/rkv_variant_buffered_cpu.ipynb` | Route B, buffered / chunked, on the CPU |

Each of the four is **standalone** — same setup, same prompts, its own baseline,
its own accuracy and plot — and each documents the trade-off it is making. The
main notebook links to the other three, and they link back.

### Measured results

All four were executed end to end on 30 LongBench-v2 prompts (mean 14114 tokens)
with Qwen3-8B on one H200 and a 96-core Xeon, dropping 50% of tokens. The numbers
in the notebooks are those measurements, and the executed outputs are committed.

| | one-shot | `cpu_exact` | `gpu_exact` | `buffered_cpu` |
| --- | --- | --- | --- | --- |
| Formulation | route A, literal | route A, linear | route A, linear | route B, chunked |
| Exact? | yes (the reference) | yes, rel. err ~6e-7 | yes, rel. err ~6e-7 | no, 96.2% agreement |
| Redundancy cost | $O(n^2 d)$ | $O(n c d)$ | $O(n c d)$ | $O(n c d)$ |
| VRAM | ~9.8 GiB | none | **1.55 GiB** | none |
| Compress 30 requests | 41.6 s | 67.3 s | **37.5 s** | **29.9 s** |
| Decode throughput | 1766 tok/s | 1785 tok/s | 1774 tok/s | 1774 tok/s |
| Accuracy (baseline 10–11/30) | 13/30 | 14/30 | 14/30 | 13/30 |

Every implementation compacted all 30 requests to exactly 50%. The self-tests
pass: the tiled reference matches the literal one to 4.7e-10, both exact variants
reproduce the reference redundancy to ~6e-7 with a **bit-identical kept-token
set**, `gpu_exact` returns one distinct result over five identical calls, and the
buffered variant agrees with route A on 96.16% of kept tokens.

### Fix to `examples/token_dropping/utils.py`

That investigation found that `rerotate_k_cache` carried out the rotation — six
multiplies and two adds per element — in the cache's own dtype. In bfloat16 that
rounds at every step. Measured on keys with a standard deviation of 3:

| arithmetic | keys changed vs fp32 | rotate-away-and-back error |
| --- | --- | --- |
| bfloat16 | 50% | 2.5e-1 |
| **fp32** (this PR) | — | **6.3e-2** |

The arithmetic now runs in fp32 and is rounded back to the cache dtype exactly
once. Measured cost of the change: **+0.2 s** to compress 30 requests for three of
the four notebooks — `modify` is dominated by waiting on LMCache, so the extra
arithmetic fits in that slack — and **+2.0 s (+7%)** for `buffered_cpu`, whose
compression is short enough that the re-rotation is a visible share of it. This
does *not* remove the CPU/GPU split above, which is the final rounding back to
bfloat16.

This file is shared with the SnapKV and random-dropping notebooks, which benefit
from the same fix.

### Also

`pyproject.toml` gains a `codespell` `ignore-regex` for base64 image payloads.
Executed notebooks embed matplotlib plots, and that data will eventually contain
something that looks like a typo — it already did here (`fPr`). The existing
notebooks in `dev` have the same exposure and have simply been lucky.

**Special notes for your reviewers**:

- The notebooks require an LMCache server started with `--enable transfer_query`
  and a vLLM server with `lmcache.mp.transfer_intermediate_tensors` enabled. Setup
  commands are in the first cell of each notebook; the vLLM patch is described in
  [`examples/token_dropping/README.md`](../blob/dev/examples/token_dropping/README.md).
- vLLM prefix caching is disabled so the measured decode-throughput change is
  attributable to the tokens dropped through LMCache rather than to vLLM's own
  cache.
- The four implementations use the same global R-KV formulation except
  `buffered_cpu`, which evaluates redundancy within chunks and is intentionally
  approximate.
- The benchmark numbers are hardware- and workload-dependent. Please read them
  together with the "Reading these numbers" section rather than as guarantees.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
