### PR TITLE
fix(vllm): handle the vLLM 0.26.0 fused KV cache layout in group edits

### DIFF
--- a/docs/design/integration/vllm/kv_cache_group_edits.md
+++ b/docs/design/integration/vllm/kv_cache_group_edits.md
@@ -52,11 +52,16 @@ vLLM unifies page sizes across hybrid groups by inflating the attention
 *logical* block size (`vllm/platforms/interface.py:_align_hybrid_block_size`;
 Qwen3.5-0.8B: 544), while the attention backend re-pages the physical tensor
 at its own *kernel* block size (`vllm/v1/worker/utils.py:
-prepare_kernel_block_sizes`; FlashAttention on hybrids: 32). Logical block `n`
-then occupies the `k = logical/kernel` contiguous kernel pages
-`n*k .. n*k+k-1` (vLLM expands the worker-side block table the same way,
-`BlockTable.map_to_kernel_blocks`); the scheduler-side block IDs LMCache
-receives stay logical.
+prepare_kernel_block_sizes`). Logical block `n` then occupies the
+`k = logical/kernel` contiguous kernel pages `n*k .. n*k+k-1` (vLLM expands
+the worker-side block table the same way, `BlockTable.map_to_kernel_blocks`);
+the scheduler-side block IDs LMCache receives stay logical.
+
+Whether `k > 1` is a property of the backend, not the model:
+`select_common_block_size` returns the largest *advertised* kernel size
+dividing the logical one, so backends advertising fixed ints sub-page
+(FlashInfer `[16, 32, 64]`, ROCm AITER FA `[16, 32]`), while `MultipleOf(16)`
+(FlashAttention) pages at the logical size and never needs the edit.
 
 Registering the raw kernel-paged tensor makes LMCache discover
 `block_size == kernel < logical`, and `_derive_compression_metadata`
@@ -66,6 +71,40 @@ page space. The edit re-views the tensor as
 `(num_kernel_pages / k, 2, logical_block_size, 1, head_size)` — a pure
 `view()`, valid because `k` kernel pages tile each logical page's bytes
 exactly (enforced; see Invariants).
+
+Two registered layouts must be recognized, distinguished only by rank (the
+block dim is index 2 in both):
+
+| vLLM | shape | rank |
+|---|---|---|
+| `<= 0.25.x` | `(num_blocks, 2, block_size, num_heads, head_size)` | 5 |
+| `>= 0.26.0` | `(num_blocks, num_heads, block_size, 2 * head_size)` | 4 |
+
+0.26.0 packs K and V into the content dim across the mainline non-MLA backends
+(`flash_attn.py`, `flashinfer.py`, `triton_attn.py`, `flex_attention.py`,
+`rocm_aiter_fa.py`) — but not all: `hpc_attn.py` is unchanged and still rank 5,
+so both ranks stay reachable and both must be handled. Gating the rule on rank
+5 alone silently disabled it on 0.26.0 and corrupted store/retrieve with no
+error. The re-view only reinterprets byte ranges, so it is otherwise
+indifferent to which layout it is handed.
+
+The registered tensor is also a `permute` view of the backend's physical
+layout (`get_kv_cache_stride_order`, `vllm/v1/worker/gpu/attn_utils.py`), so it
+is generally *not* contiguous in logical dim order — under NHD the 0.26.0
+rank-4 stride order `(0, 2, 1, 3)` is a transpose. Pages only tile by byte
+range in memory order, so the **rank-4** branch re-views in descending-stride
+order.
+
+**Rank 5 deliberately keeps the stricter logical-order contiguity guard.** The
+edited view is NHD-shaped by construction, so under an HND hint the detector
+selects `NL_X_NB_TWO_NH_BS_HS`, whose `block_size()` reads the synthetic
+`num_heads` axis and resolves 1 — extending the rank-4 memory-order
+normalization to rank 5 would replace a loud startup failure with exactly that
+silent wrong block size. This is a **general limitation** of the edits, not a
+rank-5 one: under an explicit `VLLM_KV_CACHE_LAYOUT=HND` every edited group,
+Mamba included, resolves `block_size` to 1. Not reached by default
+(`get_required_kvcache_layout` returns `None`, so vLLM falls back to NHD);
+tracked separately.
 
 ## Startup validation
 
@@ -142,9 +181,12 @@ bijective block-id → bytes mapping. Consequences:
 | Compression-ratio derivation (downstream consumer) | `lmcache/v1/kv_layer_groups.py` |
 | vLLM block-size inflation | `vllm/platforms/interface.py` (`_align_hybrid_block_size`) |
 | vLLM kernel-page split + block-table expansion | `vllm/v1/worker/utils.py`, `vllm/v1/worker/block_table.py` |
+| Unit tests | `tests/v1/test_vllm_kv_cache_group_edits.py` |
 | End-to-end test | `.buildkite/k3_tests/multiprocess/scripts/run-single-test.sh` (`hma_lm_eval_qwen3_5`) |
 
-Testing is end-to-end only (the `hma_lm_eval_qwen3_5` store-vs-retrieve gsm8k
-check): the edit internals are expected to change as more group kinds are
-covered, so tests pin the observable contract — faithful retrieve — rather
-than view shapes.
+The end-to-end `hma_lm_eval_qwen3_5` gsm8k store-vs-retrieve check pins the
+observable contract — faithful retrieve — but needs a GPU, so it cannot gate
+*which rules fire* for a given vLLM version; the 0.26.0 regression was exactly
+that. `tests/v1/test_vllm_kv_cache_group_edits.py` covers the gap on CPU: it
+pins the matching gate per registered layout and the block-granularity
+invariant, not internal view shapes.

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -64,6 +64,22 @@ RegisteredKVCache: TypeAlias = torch.Tensor | list[torch.Tensor]
 # to fill the page.
 _SYNTHETIC_NUM_HEADS = 1
 
+# Ranks of the two attention KV layouts vLLM registers, and the dim holding
+# the paging granularity in each. Through vLLM 0.25.x every non-MLA backend
+# split K and V into their own dim:
+#
+#     (num_blocks, 2, block_size, num_heads, head_size)          -- rank 5
+#
+# vLLM 0.26.0 packs them into the content dim instead (flash_attn.py,
+# flashinfer.py, triton_attn.py, flex_attention.py, rocm_aiter_fa.py):
+#
+#     (num_blocks, num_heads, block_size, 2 * head_size)         -- rank 4
+#
+# The block dim is index 2 in both, so only the rank distinguishes them.
+_SPLIT_KV_NDIM = 5
+_FUSED_KV_NDIM = 4
+_ATTENTION_BLOCK_DIM = 2
+
 # Standard-paged (non-MLA) attention kinds eligible for the sub-paged edit.
 _SUBPAGEABLE_ATTENTION_KINDS = frozenset(
     {
@@ -162,6 +178,30 @@ def _synthetic_attention_shape(elems_per_page: int, block_size: int) -> tuple[in
             f"(2, block_size={block_size}, num_heads={_SYNTHETIC_NUM_HEADS}, head_size)"
         )
     return _SYNTHETIC_NUM_HEADS, elems_per_page // denom
+
+
+def _in_memory_order(kv_cache: torch.Tensor) -> torch.Tensor:
+    """Return ``kv_cache`` permuted so its dims run in descending stride order.
+
+    vLLM allocates the KV tensor in its backend's preferred physical layout and
+    hands back a ``permute`` view of it (``get_kv_cache_stride_order`` /
+    ``vllm/v1/worker/gpu/attn_utils.py``), so the registered tensor's *logical*
+    dim order is generally not its memory order and it need not be contiguous.
+    Re-viewing pages by byte range is only meaningful in memory order.
+
+    Used for the rank-4 fused layout only; see :meth:`
+    _SubpagedAttentionViewEdit.apply` for why rank 5 keeps a stricter guard.
+
+    A no-op for an already-contiguous tensor, whose strides are descending.
+
+    Args:
+        kv_cache: Registered attention KV tensor.
+
+    Returns:
+        A view of ``kv_cache`` whose dims are ordered outermost-first in memory.
+    """
+    order = sorted(range(kv_cache.ndim), key=kv_cache.stride, reverse=True)
+    return kv_cache.permute(*order)
 
 
 class KVCacheGroupEdit(ABC):
@@ -267,11 +307,13 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
     """Re-view a kernel-paged attention tensor as logical-block pages.
 
     For a Mamba-hybrid model vLLM inflates the attention block size to align
-    with the Mamba page (e.g. 544 for Qwen3.5-0.8B), and that size is used for
-    all prefix-caching logic at the scheduler. But at the worker the attention
-    kernel has to run at block size 32 for numerical stability (vLLM #27753,
-    working around the NaN-propagation issue
-    Dao-AILab/flash-attention#1974), so the registered tensor is paged as
+    with the Mamba page (``vllm/platforms/interface.py:_align_hybrid_block_size``;
+    e.g. 544 for Qwen3.5-0.8B), and that size is used for all prefix-caching
+    logic at the scheduler. But the backend can only page the physical tensor
+    at a *kernel* block size it actually supports: ``select_common_block_size``
+    (``vllm/v1/worker/utils.py``) returns the largest advertised size dividing
+    the logical one, so a backend advertising fixed sizes (FlashInfer's
+    ``[16, 32, 64]``, ROCm AITER FA's ``[16, 32]``) re-pages the tensor as
 
         ``[#blocks, 2, 32, #heads, head_size]``
 
@@ -281,6 +323,14 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
     block size (one logical block = its 17 contiguous kernel pages),
 
         ``[#blocks / 17, 2, 544, 1, head_size']``
+
+    Backends advertising ``MultipleOf(16)`` (FlashAttention) page at the
+    logical size directly and never need the edit.
+
+    Both attention KV layouts are handled: the rank-5 K/V-split layout of
+    vLLM <= 0.25.x and the rank-4 fused layout of vLLM >= 0.26.0 (see
+    ``_SPLIT_KV_NDIM`` / ``_FUSED_KV_NDIM``). The re-view is a byte-range
+    reinterpretation, so it is indifferent to which one it is given.
 
     Cost: before this fix ``kv_caches[:, 0]`` is just the K tensor; after, it
     interleaves K and V at kernel-page granularity. The bytes round-trip
@@ -296,12 +346,13 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
             # compression (DeepSeek) belong to other transfer paths.
             get_kv_cache_spec_kind(spec) in _SUBPAGEABLE_ATTENTION_KINDS
             and not _declares_slot_compression(spec)
-            # (num_blocks, 2, block_size, num_heads, head_size) layout whose
-            # block dim disagrees with the scheduler block-id unit -- the
-            # backend re-paged the tensor at its kernel block size.
+            # A paged attention layout -- rank 5 (K/V split, vLLM <= 0.25.x) or
+            # rank 4 (K/V fused, vLLM >= 0.26.0) -- whose block dim disagrees
+            # with the scheduler block-id unit, i.e. the backend re-paged the
+            # tensor at its kernel block size.
             and isinstance(kv_cache, torch.Tensor)
-            and kv_cache.ndim == 5
-            and kv_cache.shape[2] != spec.block_size
+            and kv_cache.ndim in (_SPLIT_KV_NDIM, _FUSED_KV_NDIM)
+            and kv_cache.shape[_ATTENTION_BLOCK_DIM] != spec.block_size
         )
 
     def apply(
@@ -312,18 +363,28 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
     ) -> torch.Tensor:
         """Re-view ``kv_cache`` at logical-block granularity.
 
-        The tensor is kernel-paged as ``(num_kernel_pages, 2,
-        kernel_block_size, num_kv_heads, head_size)``; the result is
-        ``(num_logical_blocks, 2, spec.block_size, num_heads, head_size)``
-        over the same storage.
+        The tensor is kernel-paged, either as ``(num_kernel_pages, 2,
+        kernel_block_size, num_kv_heads, head_size)`` (vLLM <= 0.25.x) or as
+        ``(num_kernel_pages, num_kv_heads, kernel_block_size, 2 * head_size)``
+        (vLLM >= 0.26.0); the result is ``(num_logical_blocks, 2,
+        spec.block_size, num_heads, head_size)`` over the same storage.
+
+        A rank-4 tensor is re-viewed in memory order, since vLLM registers it
+        as a permute view of the backend's physical layout. A rank-5 tensor
+        must already be contiguous in logical order.
 
         Raises:
-            ValueError: If the layout is not the expected kernel-paged shape,
-                the sizes do not divide evenly, or the kernel pages of one
-                logical block do not tile its page bytes exactly (which would
-                indicate an undeclared packed layout that must not be edited).
+            ValueError: If the layout is not a recognized kernel-paged shape,
+                the sizes do not divide evenly, the pages are not contiguous
+                (in memory order for rank 4, logical order for rank 5), or the
+                kernel pages of one logical block do not tile its page bytes
+                exactly (which would indicate an undeclared packed layout that
+                must not be edited).
         """
-        if not isinstance(kv_cache, torch.Tensor) or kv_cache.shape[1] != 2:
+        if not isinstance(kv_cache, torch.Tensor) or kv_cache.ndim not in (
+            _SPLIT_KV_NDIM,
+            _FUSED_KV_NDIM,
+        ):
             got = (
                 tuple(kv_cache.shape)
                 if isinstance(kv_cache, torch.Tensor)
@@ -331,10 +392,16 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
             )
             raise ValueError(
                 f"expected a (num_blocks, 2, block_size, num_heads, head_size) "
+                f"or (num_blocks, num_heads, block_size, 2 * head_size) "
                 f"attention KV tensor, got {got}"
             )
+        if kv_cache.ndim == _SPLIT_KV_NDIM and kv_cache.shape[1] != 2:
+            raise ValueError(
+                f"expected a (num_blocks, 2, block_size, num_heads, head_size) "
+                f"attention KV tensor, got {tuple(kv_cache.shape)}"
+            )
         logical_block_size = spec.block_size
-        kernel_block_size = kv_cache.shape[2]
+        kernel_block_size = kv_cache.shape[_ATTENTION_BLOCK_DIM]
         if logical_block_size % kernel_block_size != 0:
             raise ValueError(
                 f"logical block size {logical_block_size} is not a multiple of "
@@ -354,18 +421,45 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
                 f"{ratio} kernel pages ({kernel_page_bytes * ratio} bytes) do "
                 f"not tile the logical page ({spec.page_size_bytes} bytes)"
             )
-        if not kv_cache.is_contiguous():
-            raise ValueError(
-                "kernel-paged attention KV tensor must be contiguous to "
-                "re-view as logical pages"
-            )
+        if kv_cache.ndim == _FUSED_KV_NDIM:
+            # A rank-4 tensor is a permute view of the backend's physical
+            # layout (under NHD, stride order ``(0, 2, 1, 3)``), so it is
+            # contiguous in memory order rather than logical order. Pages only
+            # tile by byte range in memory order.
+            ordered = _in_memory_order(kv_cache)
+            if not ordered.is_contiguous():
+                raise ValueError(
+                    "kernel-paged attention KV tensor must be contiguous in "
+                    "memory order to re-view as logical pages (shape "
+                    f"{tuple(kv_cache.shape)}, strides {tuple(kv_cache.stride())})"
+                )
+            if ordered.shape[0] != num_kernel_pages:
+                raise ValueError(
+                    f"expected a num-blocks-first KV cache layout; outermost "
+                    f"memory dim is {ordered.shape[0]}, not the kernel page "
+                    f"count {num_kernel_pages}"
+                )
+        else:
+            # Rank 5 deliberately keeps the stricter logical-order guard.
+            # Extending the rank-4 memory-order normalization to rank 5 would
+            # let a permuted tensor (vLLM <= 0.25.x under HND) re-view
+            # successfully and then be misread downstream: the edited view is
+            # NHD-shaped, so the HND detector branch reads its block size from
+            # the synthetic ``num_heads`` axis and resolves 1. Failing loudly
+            # here is strictly better than that silent corruption.
+            ordered = kv_cache
+            if not ordered.is_contiguous():
+                raise ValueError(
+                    "kernel-paged attention KV tensor must be contiguous to "
+                    "re-view as logical pages"
+                )
 
         num_blocks = num_kernel_pages // ratio
         elems_per_page = spec.page_size_bytes // kv_cache.element_size()
         num_heads, head_size = _synthetic_attention_shape(
             elems_per_page, logical_block_size
         )
-        return kv_cache.view(num_blocks, 2, logical_block_size, num_heads, head_size)
+        return ordered.view(num_blocks, 2, logical_block_size, num_heads, head_size)
 
 
 class _MambaUnifiedViewEdit(KVCacheGroupEdit):

--- a/lmcache/integration/vllm/kv_cache_group_edits.py
+++ b/lmcache/integration/vllm/kv_cache_group_edits.py
@@ -64,6 +64,22 @@ RegisteredKVCache: TypeAlias = torch.Tensor | list[torch.Tensor]
 # to fill the page.
 _SYNTHETIC_NUM_HEADS = 1
 
+# Ranks of the two attention KV layouts vLLM registers, and the dim holding
+# the paging granularity in each. Through vLLM 0.25.x every non-MLA backend
+# split K and V into their own dim:
+#
+#     (num_blocks, 2, block_size, num_heads, head_size)          -- rank 5
+#
+# vLLM 0.26.0 packs them into the content dim instead (flash_attn.py,
+# flashinfer.py, triton_attn.py, flex_attention.py, rocm_aiter_fa.py):
+#
+#     (num_blocks, num_heads, block_size, 2 * head_size)         -- rank 4
+#
+# The block dim is index 2 in both, so only the rank distinguishes them.
+_SPLIT_KV_NDIM = 5
+_FUSED_KV_NDIM = 4
+_ATTENTION_BLOCK_DIM = 2
+
 # Standard-paged (non-MLA) attention kinds eligible for the sub-paged edit.
 _SUBPAGEABLE_ATTENTION_KINDS = frozenset(
     {
@@ -162,6 +178,30 @@ def _synthetic_attention_shape(elems_per_page: int, block_size: int) -> tuple[in
             f"(2, block_size={block_size}, num_heads={_SYNTHETIC_NUM_HEADS}, head_size)"
         )
     return _SYNTHETIC_NUM_HEADS, elems_per_page // denom
+
+
+def _in_memory_order(kv_cache: torch.Tensor) -> torch.Tensor:
+    """Return ``kv_cache`` permuted so its dims run in descending stride order.
+
+    vLLM allocates the KV tensor in its backend's preferred physical layout and
+    hands back a ``permute`` view of it (``get_kv_cache_stride_order`` /
+    ``vllm/v1/worker/gpu/attn_utils.py``), so the registered tensor's *logical*
+    dim order is generally not its memory order and it need not be contiguous.
+    Re-viewing pages by byte range is only meaningful in memory order.
+
+    Used for the rank-4 fused layout only; see :meth:`
+    _SubpagedAttentionViewEdit.apply` for why rank 5 keeps a stricter guard.
+
+    A no-op for an already-contiguous tensor, whose strides are descending.
+
+    Args:
+        kv_cache: Registered attention KV tensor.
+
+    Returns:
+        A view of ``kv_cache`` whose dims are ordered outermost-first in memory.
+    """
+    order = sorted(range(kv_cache.ndim), key=kv_cache.stride, reverse=True)
+    return kv_cache.permute(*order)
 
 
 class KVCacheGroupEdit(ABC):
@@ -267,11 +307,13 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
     """Re-view a kernel-paged attention tensor as logical-block pages.
 
     For a Mamba-hybrid model vLLM inflates the attention block size to align
-    with the Mamba page (e.g. 544 for Qwen3.5-0.8B), and that size is used for
-    all prefix-caching logic at the scheduler. But at the worker the attention
-    kernel has to run at block size 32 for numerical stability (vLLM #27753,
-    working around the NaN-propagation issue
-    Dao-AILab/flash-attention#1974), so the registered tensor is paged as
+    with the Mamba page (``vllm/platforms/interface.py:_align_hybrid_block_size``;
+    e.g. 544 for Qwen3.5-0.8B), and that size is used for all prefix-caching
+    logic at the scheduler. But the backend can only page the physical tensor
+    at a *kernel* block size it actually supports: ``select_common_block_size``
+    (``vllm/v1/worker/utils.py``) returns the largest advertised size dividing
+    the logical one, so a backend advertising fixed sizes (FlashInfer's
+    ``[16, 32, 64]``, ROCm AITER FA's ``[16, 32]``) re-pages the tensor as
 
         ``[#blocks, 2, 32, #heads, head_size]``
 
@@ -281,6 +323,14 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
     block size (one logical block = its 17 contiguous kernel pages),
 
         ``[#blocks / 17, 2, 544, 1, head_size']``
+
+    Backends advertising ``MultipleOf(16)`` (FlashAttention) page at the
+    logical size directly and never need the edit.
+
+    Both attention KV layouts are handled: the rank-5 K/V-split layout of
+    vLLM <= 0.25.x and the rank-4 fused layout of vLLM >= 0.26.0 (see
+    ``_SPLIT_KV_NDIM`` / ``_FUSED_KV_NDIM``). The re-view is a byte-range
+    reinterpretation, so it is indifferent to which one it is given.
 
     Cost: before this fix ``kv_caches[:, 0]`` is just the K tensor; after, it
     interleaves K and V at kernel-page granularity. The bytes round-trip
@@ -296,12 +346,13 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
             # compression (DeepSeek) belong to other transfer paths.
             get_kv_cache_spec_kind(spec) in _SUBPAGEABLE_ATTENTION_KINDS
             and not _declares_slot_compression(spec)
-            # (num_blocks, 2, block_size, num_heads, head_size) layout whose
-            # block dim disagrees with the scheduler block-id unit -- the
-            # backend re-paged the tensor at its kernel block size.
+            # A paged attention layout -- rank 5 (K/V split, vLLM <= 0.25.x) or
+            # rank 4 (K/V fused, vLLM >= 0.26.0) -- whose block dim disagrees
+            # with the scheduler block-id unit, i.e. the backend re-paged the
+            # tensor at its kernel block size.
             and isinstance(kv_cache, torch.Tensor)
-            and kv_cache.ndim == 5
-            and kv_cache.shape[2] != spec.block_size
+            and kv_cache.ndim in (_SPLIT_KV_NDIM, _FUSED_KV_NDIM)
+            and kv_cache.shape[_ATTENTION_BLOCK_DIM] != spec.block_size
         )
 
     def apply(
@@ -312,18 +363,28 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
     ) -> torch.Tensor:
         """Re-view ``kv_cache`` at logical-block granularity.
 
-        The tensor is kernel-paged as ``(num_kernel_pages, 2,
-        kernel_block_size, num_kv_heads, head_size)``; the result is
-        ``(num_logical_blocks, 2, spec.block_size, num_heads, head_size)``
-        over the same storage.
+        The tensor is kernel-paged, either as ``(num_kernel_pages, 2,
+        kernel_block_size, num_kv_heads, head_size)`` (vLLM <= 0.25.x) or as
+        ``(num_kernel_pages, num_kv_heads, kernel_block_size, 2 * head_size)``
+        (vLLM >= 0.26.0); the result is ``(num_logical_blocks, 2,
+        spec.block_size, num_heads, head_size)`` over the same storage.
+
+        A rank-4 tensor is re-viewed in memory order, since vLLM registers it
+        as a permute view of the backend's physical layout. A rank-5 tensor
+        must already be contiguous in logical order.
 
         Raises:
-            ValueError: If the layout is not the expected kernel-paged shape,
-                the sizes do not divide evenly, or the kernel pages of one
-                logical block do not tile its page bytes exactly (which would
-                indicate an undeclared packed layout that must not be edited).
+            ValueError: If the layout is not a recognized kernel-paged shape,
+                the sizes do not divide evenly, the pages are not contiguous
+                (in memory order for rank 4, logical order for rank 5), or the
+                kernel pages of one logical block do not tile its page bytes
+                exactly (which would indicate an undeclared packed layout that
+                must not be edited).
         """
-        if not isinstance(kv_cache, torch.Tensor) or kv_cache.shape[1] != 2:
+        if not isinstance(kv_cache, torch.Tensor) or kv_cache.ndim not in (
+            _SPLIT_KV_NDIM,
+            _FUSED_KV_NDIM,
+        ):
             got = (
                 tuple(kv_cache.shape)
                 if isinstance(kv_cache, torch.Tensor)
@@ -331,10 +392,16 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
             )
             raise ValueError(
                 f"expected a (num_blocks, 2, block_size, num_heads, head_size) "
+                f"or (num_blocks, num_heads, block_size, 2 * head_size) "
                 f"attention KV tensor, got {got}"
             )
+        if kv_cache.ndim == _SPLIT_KV_NDIM and kv_cache.shape[1] != 2:
+            raise ValueError(
+                f"expected a (num_blocks, 2, block_size, num_heads, head_size) "
+                f"attention KV tensor, got {tuple(kv_cache.shape)}"
+            )
         logical_block_size = spec.block_size
-        kernel_block_size = kv_cache.shape[2]
+        kernel_block_size = kv_cache.shape[_ATTENTION_BLOCK_DIM]
         if logical_block_size % kernel_block_size != 0:
             raise ValueError(
                 f"logical block size {logical_block_size} is not a multiple of "
@@ -354,18 +421,45 @@ class _SubpagedAttentionViewEdit(KVCacheGroupEdit):
                 f"{ratio} kernel pages ({kernel_page_bytes * ratio} bytes) do "
                 f"not tile the logical page ({spec.page_size_bytes} bytes)"
             )
-        if not kv_cache.is_contiguous():
-            raise ValueError(
-                "kernel-paged attention KV tensor must be contiguous to "
-                "re-view as logical pages"
-            )
+        if kv_cache.ndim == _FUSED_KV_NDIM:
+            # A rank-4 tensor is a permute view of the backend's physical
+            # layout (under NHD, stride order ``(0, 2, 1, 3)``), so it is
+            # contiguous in memory order rather than logical order. Pages only
+            # tile by byte range in memory order.
+            ordered = _in_memory_order(kv_cache)
+            if not ordered.is_contiguous():
+                raise ValueError(
+                    "kernel-paged attention KV tensor must be contiguous in "
+                    "memory order to re-view as logical pages (shape "
+                    f"{tuple(kv_cache.shape)}, strides {tuple(kv_cache.stride())})"
+                )
+            if ordered.shape[0] != num_kernel_pages:
+                raise ValueError(
+                    f"expected a num-blocks-first KV cache layout; outermost "
+                    f"memory dim is {ordered.shape[0]}, not the kernel page "
+                    f"count {num_kernel_pages}"
+                )
+        else:
+            # Rank 5 deliberately keeps the stricter logical-order guard.
+            # Extending the rank-4 memory-order normalization to rank 5 would
+            # let a permuted tensor (vLLM <= 0.25.x under HND) re-view
+            # successfully and then be misread downstream: the edited view is
+            # NHD-shaped, so the HND detector branch reads its block size from
+            # the synthetic ``num_heads`` axis and resolves 1. Failing loudly
+            # here is strictly better than that silent corruption.
+            ordered = kv_cache
+            if not ordered.is_contiguous():
+                raise ValueError(
+                    "kernel-paged attention KV tensor must be contiguous to "
+                    "re-view as logical pages"
+                )
 
         num_blocks = num_kernel_pages // ratio
         elems_per_page = spec.page_size_bytes // kv_cache.element_size()
         num_heads, head_size = _synthetic_attention_shape(
             elems_per_page, logical_block_size
         )
-        return kv_cache.view(num_blocks, 2, logical_block_size, num_heads, head_size)
+        return ordered.view(num_blocks, 2, logical_block_size, num_heads, head_size)
 
 
 ######################

--- a/tests/v1/test_vllm_kv_cache_group_edits.py
+++ b/tests/v1/test_vllm_kv_cache_group_edits.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``lmcache.integration.vllm.kv_cache_group_edits``.
+
+Regression coverage for the vLLM 0.26.0 KV layout change: the mainline
+non-MLA attention backends moved from the rank-5 K/V-split KV layout
+
+    ``(num_blocks, 2, block_size, num_kv_heads, head_size)``
+
+to the rank-4 K/V-fused layout
+
+    ``(num_blocks, num_kv_heads, block_size, 2 * head_size)``
+
+(``vllm/v1/attention/backends/flash_attn.py``, ``flashinfer.py``,
+``triton_attn.py``, ``flex_attention.py``, ``rocm_aiter_fa.py``). Not every
+backend moved -- ``hpc_attn.py`` is still rank 5 -- so both layouts are
+covered here. The sub-paged attention edit gated on ``ndim == 5`` and so
+silently stopped
+firing, leaving the attention group paged at the backend's kernel block size
+while LMCache addressed it in scheduler block-id units -- a silent
+store/retrieve corruption with no exception and no log line.
+
+These tests run on CPU and without vLLM installed: the module's vLLM imports
+are stubbed before import, mirroring ``test_vllm_kv_cache_groups.py``.
+"""
+
+# Standard
+from dataclasses import dataclass
+from enum import Enum
+from types import ModuleType
+from typing import TypeAlias
+from unittest.mock import patch
+import sys
+
+# Third Party
+import pytest
+import torch
+
+# One registered cache value, mirroring the module's own ``RegisteredKVCache``:
+# a paged KV tensor, or ``[conv_state, ssm_state]`` for Mamba layers.
+_RegisteredKVCache: TypeAlias = torch.Tensor | list[torch.Tensor]
+
+# A reported geometry: a Mamba/GDN hybrid whose attention
+# block size vLLM inflated to 1600 to align with the Mamba page, served by a
+# backend advertising fixed kernel block sizes (FlashInfer's [16, 32, 64]),
+# so ``select_common_block_size`` re-pages at 64 -- the largest advertised
+# size dividing 1600.
+LOGICAL_BLOCK_SIZE = 1600
+KERNEL_BLOCK_SIZE = 64
+SUBPAGE_RATIO = LOGICAL_BLOCK_SIZE // KERNEL_BLOCK_SIZE  # 25
+NUM_LOGICAL_BLOCKS = 4
+NUM_KERNEL_PAGES = NUM_LOGICAL_BLOCKS * SUBPAGE_RATIO
+NUM_KV_HEADS = 2
+HEAD_SIZE = 8
+NUM_MAMBA_GROUPS = 4
+
+
+class _SpecKind(Enum):
+    """Stand-in for ``vllm.v1.kv_cache_interface.KVCacheSpecKind``."""
+
+    FULL_ATTENTION = "full_attention"
+    SLIDING_WINDOW = "sliding_window"
+    CHUNKED_LOCAL_ATTENTION = "chunked_local_attention"
+    SINK_FULL_ATTENTION = "sink_full_attention"
+    CROSS_ATTENTION = "cross_attention"
+    MAMBA = "mamba"
+
+
+@dataclass
+class _Spec:
+    """Stand-in for a vLLM ``KVCacheSpec`` leaf."""
+
+    kind: _SpecKind
+    block_size: int
+    page_size_bytes: int
+    mamba_cache_mode: str = "align"
+
+
+@dataclass
+class _Group:
+    layer_names: list[str]
+    kv_cache_spec: _Spec
+
+
+@dataclass
+class _Config:
+    kv_cache_groups: list[_Group]
+    has_mamba_layers: bool = True
+
+
+@pytest.fixture(scope="module")
+def edits():
+    """Import the module under test with its vLLM dependencies stubbed."""
+    stub = ModuleType("vllm.v1.kv_cache_interface")
+    stub.KVCacheConfig = _Config
+    stub.KVCacheSpec = _Spec
+    stub.KVCacheSpecKind = _SpecKind
+    stub.get_kv_cache_spec_kind = lambda spec: spec.kind
+
+    vllm_pkg = ModuleType("vllm")
+    vllm_v1 = ModuleType("vllm.v1")
+    with patch.dict(
+        sys.modules,
+        {
+            "vllm": vllm_pkg,
+            "vllm.v1": vllm_v1,
+            "vllm.v1.kv_cache_interface": stub,
+        },
+    ):
+        sys.modules.pop("lmcache.integration.vllm.kv_cache_group_edits", None)
+        # First Party
+        from lmcache.integration.vllm import kv_cache_group_edits
+
+        yield kv_cache_group_edits
+    sys.modules.pop("lmcache.integration.vllm.kv_cache_group_edits", None)
+
+
+def _attention_page_bytes() -> int:
+    """Bytes in one *logical* attention page, for either layout."""
+    elems = 2 * LOGICAL_BLOCK_SIZE * NUM_KV_HEADS * HEAD_SIZE
+    return elems * torch.finfo(torch.bfloat16).bits // 8
+
+
+def _attention_spec() -> _Spec:
+    return _Spec(
+        kind=_SpecKind.FULL_ATTENTION,
+        block_size=LOGICAL_BLOCK_SIZE,
+        page_size_bytes=_attention_page_bytes(),
+    )
+
+
+def _fused_kv_cache(kernel_block_size: int = KERNEL_BLOCK_SIZE) -> torch.Tensor:
+    """A vLLM >= 0.26.0 rank-4 fused-K/V attention tensor.
+
+    Shape ``(num_kernel_pages, num_kv_heads, kernel_block_size,
+    2 * head_size)`` -- ``flash_attn.py:141`` / ``flashinfer.py:408``.
+    """
+    pages = NUM_LOGICAL_BLOCKS * (LOGICAL_BLOCK_SIZE // kernel_block_size)
+    return torch.arange(
+        pages * NUM_KV_HEADS * kernel_block_size * 2 * HEAD_SIZE,
+        dtype=torch.bfloat16,
+    ).view(pages, NUM_KV_HEADS, kernel_block_size, 2 * HEAD_SIZE)
+
+
+def _split_kv_cache(kernel_block_size: int = KERNEL_BLOCK_SIZE) -> torch.Tensor:
+    """A vLLM <= 0.25.x rank-5 K/V-split attention tensor.
+
+    Shape ``(num_kernel_pages, 2, kernel_block_size, num_kv_heads,
+    head_size)`` -- ``flash_attn.py:132`` / ``flashinfer.py:392``.
+    """
+    pages = NUM_LOGICAL_BLOCKS * (LOGICAL_BLOCK_SIZE // kernel_block_size)
+    return torch.arange(
+        pages * 2 * kernel_block_size * NUM_KV_HEADS * HEAD_SIZE,
+        dtype=torch.bfloat16,
+    ).view(pages, 2, kernel_block_size, NUM_KV_HEADS, HEAD_SIZE)
+
+
+def _mamba_spec(page_bytes: int) -> _Spec:
+    return _Spec(
+        kind=_SpecKind.MAMBA,
+        block_size=LOGICAL_BLOCK_SIZE,
+        page_size_bytes=page_bytes,
+        mamba_cache_mode="align",
+    )
+
+
+def _mamba_kv_cache() -> tuple[list[torch.Tensor], int]:
+    """A Mamba ``[conv_state, ssm_state]`` pair sharing one padded page.
+
+    Returns the pair and the page size in bytes. ``conv_state`` starts at the
+    page base and its per-block stride spans the whole page (``conv | ssm |
+    pad``), which is what ``_MambaPageViewEdit.apply`` re-strides over.
+    """
+    elem = torch.finfo(torch.bfloat16).bits // 8
+    # Page must factor as (2, block_size, 1, head_size) for the synthetic view.
+    elems_per_page = 2 * LOGICAL_BLOCK_SIZE * 3
+    conv_elems, ssm_elems = 2 * LOGICAL_BLOCK_SIZE, 2 * LOGICAL_BLOCK_SIZE
+
+    storage = torch.arange(NUM_LOGICAL_BLOCKS * elems_per_page, dtype=torch.bfloat16)
+    conv_state = storage.as_strided(
+        (NUM_LOGICAL_BLOCKS, conv_elems), (elems_per_page, 1)
+    )
+    ssm_state = storage.as_strided(
+        (NUM_LOGICAL_BLOCKS, ssm_elems), (elems_per_page, 1), storage_offset=conv_elems
+    )
+    return [conv_state, ssm_state], elems_per_page * elem
+
+
+def _hybrid_config(
+    attention_cache: torch.Tensor, attention_spec: _Spec | None = None
+) -> tuple[_Config, dict[str, _RegisteredKVCache]]:
+    """Build the hybrid group layout: 4 Mamba groups + 1 attention group.
+
+    Args:
+        attention_cache: Registered tensor for the single attention layer.
+        attention_spec: Spec for the attention group; defaults to the
+            inflated block size 1600.
+
+    Returns:
+        The vLLM-shaped config and the registered ``kv_caches`` mapping.
+    """
+    mamba_caches, mamba_page_bytes = _mamba_kv_cache()
+    groups = [
+        _Group(layer_names=[f"mamba.{i}"], kv_cache_spec=_mamba_spec(mamba_page_bytes))
+        for i in range(NUM_MAMBA_GROUPS)
+    ]
+    groups.append(
+        _Group(
+            layer_names=["attn.0"],
+            kv_cache_spec=attention_spec or _attention_spec(),
+        )
+    )
+
+    kv_caches: dict[str, _RegisteredKVCache] = {
+        f"mamba.{i}": list(mamba_caches) for i in range(NUM_MAMBA_GROUPS)
+    }
+    kv_caches["attn.0"] = attention_cache
+    return _Config(kv_cache_groups=groups), kv_caches
+
+
+def _edit_attention(
+    edits, attention_cache: torch.Tensor, attention_spec: _Spec | None = None
+) -> torch.Tensor:
+    """Run the public entry point and return the edited attention tensor.
+
+    Args:
+        edits: The module under test.
+        attention_cache: Registered tensor for the attention layer.
+        attention_spec: Optional attention spec override.
+
+    Returns:
+        The attention layer's entry in the edited mapping. It is the *same
+        object* as ``attention_cache`` when no rule matched.
+    """
+    config, kv_caches = _hybrid_config(attention_cache, attention_spec)
+    edited = edits.apply_kv_cache_group_edits(config, kv_caches, layout_hints={})
+    return edited["attn.0"]
+
+
+# --------------------------------------------------------------------------
+# Which layouts the sub-paged rule fires on -- the 0.26.0 regression gate
+# --------------------------------------------------------------------------
+
+
+def test_subpaged_edit_fires_on_fused_kv_layout(edits):
+    """vLLM >= 0.26.0 rank-4 fused layout must be re-paged.
+
+    Before the fix the rule required ``ndim == 5``, so it silently skipped
+    this layout and left the group at the kernel block size.
+    """
+    cache = _fused_kv_cache()
+    assert _edit_attention(edits, cache).shape[2] == LOGICAL_BLOCK_SIZE
+
+
+def test_subpaged_edit_fires_on_split_kv_layout(edits):
+    """vLLM <= 0.25.x rank-5 split layout must still be re-paged."""
+    cache = _split_kv_cache()
+    assert _edit_attention(edits, cache).shape[2] == LOGICAL_BLOCK_SIZE
+
+
+@pytest.mark.parametrize("make_cache", [_fused_kv_cache, _split_kv_cache])
+def test_subpaged_edit_skips_unsubpaged_tensor(edits, make_cache):
+    """A backend paging at the logical block size needs no edit.
+
+    FlashAttention advertises ``MultipleOf(16)``, so ``select_common_block_size``
+    returns the logical block size unchanged and the registered block dim
+    already equals ``spec.block_size``. The tensor must pass through untouched.
+    """
+    cache = make_cache(kernel_block_size=LOGICAL_BLOCK_SIZE)
+    assert _edit_attention(edits, cache) is cache
+
+
+def test_subpaged_edit_skips_declared_compression(edits):
+    """Declared slot compression belongs to the compression path, not here."""
+    spec = _attention_spec()
+    spec.compress_ratio = 2
+    cache = _fused_kv_cache()
+    assert _edit_attention(edits, cache, attention_spec=spec) is cache
+
+
+# --------------------------------------------------------------------------
+# The re-view itself
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("make_cache", [_fused_kv_cache, _split_kv_cache])
+def test_subpaged_edit_restores_block_granularity(edits, make_cache):
+    """The edited view's block dim must equal the scheduler block size.
+
+    This is the invariant the design doc states edits exist to restore:
+    "the registered tensor's paging granularity must equal the block-id
+    granularity".
+    """
+    cache = make_cache()
+    viewed = _edit_attention(edits, cache)
+
+    assert viewed.ndim == 5
+    assert viewed.shape[0] == NUM_LOGICAL_BLOCKS
+    assert viewed.shape[2] == LOGICAL_BLOCK_SIZE
+    # Same storage, never a copy.
+    assert viewed.untyped_storage().data_ptr() == cache.untyped_storage().data_ptr()
+    assert viewed.numel() == cache.numel()
+
+
+@pytest.mark.parametrize("make_cache", [_fused_kv_cache, _split_kv_cache])
+def test_subpaged_edit_preserves_byte_order(edits, make_cache):
+    """The re-view must be a pure reinterpretation of the same bytes.
+
+    Store and retrieve share this mapping, so byte order is what has to
+    round-trip -- the dims are addressing metadata only.
+    """
+    cache = make_cache()
+    torch.testing.assert_close(
+        _edit_attention(edits, cache).reshape(-1), cache.reshape(-1)
+    )
+
+
+@pytest.mark.parametrize("make_cache", [_fused_kv_cache, _split_kv_cache])
+def test_subpaged_edit_groups_contiguous_kernel_pages(edits, make_cache):
+    """Logical block ``n`` must cover kernel pages ``n*k .. n*k+k-1``.
+
+    vLLM expands the worker-side block table the same way
+    (``BlockTable.map_to_kernel_blocks``), so this grouping is what makes
+    scheduler block IDs address the right bytes.
+    """
+    cache = make_cache()
+    viewed = _edit_attention(edits, cache)
+
+    for block in range(NUM_LOGICAL_BLOCKS):
+        expected = cache[block * SUBPAGE_RATIO : (block + 1) * SUBPAGE_RATIO]
+        torch.testing.assert_close(viewed[block].reshape(-1), expected.reshape(-1))
+
+
+def test_subpaged_edit_handles_permuted_fused_registration(edits):
+    """vLLM hands back a permute view, which need not be logically contiguous.
+
+    With a KV connector attached and no override, ``get_kv_cache_layout()``
+    defaults to NHD; FlashInfer's NHD stride order ``(0, 2, 1, 3)`` means the
+    registered rank-4 tensor is a transposed -- non-contiguous -- view of a
+    contiguous allocation.
+    """
+    physical = torch.arange(
+        NUM_KERNEL_PAGES * KERNEL_BLOCK_SIZE * NUM_KV_HEADS * 2 * HEAD_SIZE,
+        dtype=torch.bfloat16,
+    ).view(NUM_KERNEL_PAGES, KERNEL_BLOCK_SIZE, NUM_KV_HEADS, 2 * HEAD_SIZE)
+    registered = physical.permute(0, 2, 1, 3)
+
+    assert not registered.is_contiguous()
+    assert registered.shape[2] == KERNEL_BLOCK_SIZE
+
+    viewed = _edit_attention(edits, registered)
+    assert viewed.shape[0] == NUM_LOGICAL_BLOCKS
+    assert viewed.shape[2] == LOGICAL_BLOCK_SIZE
+    torch.testing.assert_close(viewed.reshape(-1), physical.reshape(-1))
+
+
+def test_subpaged_edit_rejects_permuted_split_registration(edits):
+    """A permuted rank-5 tensor must fail loudly rather than be re-viewed.
+
+    vLLM <= 0.25.x under HND registers rank 5 with stride order
+    ``(0, 1, 3, 2, 4)``. Re-viewing it in memory order would succeed and then
+    be misread downstream -- the edited view is NHD-shaped, so the HND
+    detector branch reads its block size from the synthetic ``num_heads`` axis
+    and resolves 1. This rule's whole purpose is to prevent a silently wrong
+    block size, so it must not introduce one.
+    """
+    physical = torch.zeros(
+        NUM_KERNEL_PAGES,
+        2,
+        NUM_KV_HEADS,
+        KERNEL_BLOCK_SIZE,
+        HEAD_SIZE,
+        dtype=torch.bfloat16,
+    )
+    registered = physical.permute(0, 1, 3, 2, 4)
+
+    assert not registered.is_contiguous()
+    assert registered.shape[2] == KERNEL_BLOCK_SIZE
+    with pytest.raises(ValueError, match="must be contiguous"):
+        _edit_attention(edits, registered)
+
+
+def test_subpaged_edit_rejects_untiled_page(edits):
+    """An undeclared packed layout must fail loudly, not transfer wrongly."""
+    spec = _attention_spec()
+    spec.page_size_bytes *= 2
+    with pytest.raises(ValueError, match="do not tile the logical page"):
+        _edit_attention(edits, _fused_kv_cache(), attention_spec=spec)
+
+
+def test_subpaged_apply_rejects_unknown_rank(edits):
+    """Ranks other than 4 and 5 are not attention KV layouts.
+
+    Driven against the rule directly rather than through
+    ``apply_kv_cache_group_edits``: the rule's own gate screens on rank, so a
+    rank-3 tensor is passed through untouched and can never reach ``apply``
+    via the public entry point. The guard is only reachable if a future rank
+    is added to the gate without updating ``apply``, which is exactly what
+    this pins.
+    """
+    edit = edits._SubpagedAttentionViewEdit()
+    with pytest.raises(ValueError, match="attention KV tensor"):
+        edit.apply(_attention_spec(), torch.zeros(4, 8, 8), {})
+
+
+# --------------------------------------------------------------------------
+# End to end: both edits fire together on the hybrid geometry
+# --------------------------------------------------------------------------
+
+
+def test_both_edits_fire_on_fused_kv_hybrid(edits):
+    """The end-to-end assertion for the 0.26.0 regression.
+
+    Before the fix the startup log for this geometry read
+    ``KV cache group edits applied: {'mamba-page-view': 4}`` -- the attention
+    edit left no key because a non-matching rule never increments the counter.
+    Both rules must now fire.
+    """
+    config, kv_caches = _hybrid_config(_fused_kv_cache())
+    edited = edits.apply_kv_cache_group_edits(config, kv_caches, layout_hints={})
+
+    attention = edited["attn.0"]
+    assert attention.shape[2] == LOGICAL_BLOCK_SIZE, (
+        "attention group still paged at the kernel block size; LMCache would "
+        "misread it as slot-compressed"
+    )
+    for i in range(NUM_MAMBA_GROUPS):
+        assert edited[f"mamba.{i}"].shape[2] == LOGICAL_BLOCK_SIZE
+
+
+def test_edit_counts_include_both_rules(edits):
+    """Both rule names must appear in the applied-edits counts.
+
+    This log line is the only startup signal that a rule fired, so it is the
+    one place a silently non-matching rule is observable.
+
+    LMCache loggers set ``propagate = False``, so assert on the module logger
+    directly rather than via the ``caplog`` (root-logger) fixture.
+    """
+    config, kv_caches = _hybrid_config(_fused_kv_cache())
+    with patch.object(edits.logger, "info") as mock_info:
+        edits.apply_kv_cache_group_edits(config, kv_caches, layout_hints={})
+
+    counts = mock_info.call_args.args[1]
+    assert counts == {
+        "mamba-page-view": NUM_MAMBA_GROUPS,
+        "subpaged-attention-view": 1,
+    }
+
+
+def test_every_group_reaches_block_id_granularity(edits):
+    """The invariant edits exist to restore, across every group.
+
+    Design doc: "After edits, every registered tensor's block dim equals its
+    group's kv_cache_spec.block_size, so the server derives compress_ratio
+    == 1 for these groups."
+    """
+    config, kv_caches = _hybrid_config(_fused_kv_cache())
+    edited = edits.apply_kv_cache_group_edits(config, kv_caches, layout_hints={})
+
+    for group in config.kv_cache_groups:
+        for name in group.layer_names:
+            assert edited[name].shape[2] == group.kv_cache_spec.block_size
+
+
+def test_flash_attention_hybrid_needs_no_attention_edit(edits):
+    """A backend paging at the logical size leaves only the Mamba edit.
+
+    FlashAttention advertises ``MultipleOf(16)``, so its tensor arrives already
+    paged at 1600 in both vLLM versions -- there is no 0.25.1 -> 0.26.0 delta
+    on that path, and no attention edit to apply.
+    """
+    config, kv_caches = _hybrid_config(
+        _fused_kv_cache(kernel_block_size=LOGICAL_BLOCK_SIZE)
+    )
+    edited = edits.apply_kv_cache_group_edits(config, kv_caches, layout_hints={})
+
+    # Passed through untouched, and already at block-id granularity.
+    assert edited["attn.0"] is kv_caches["attn.0"]
+    assert edited["attn.0"].shape[2] == LOGICAL_BLOCK_SIZE

--- a/tests/v1/test_vllm_kv_cache_group_edits.py
+++ b/tests/v1/test_vllm_kv_cache_group_edits.py
@@ -19,8 +19,8 @@ firing, leaving the attention group paged at the backend's kernel block size
 while LMCache addressed it in scheduler block-id units -- a silent
 store/retrieve corruption with no exception and no log line.
 
-These tests run on CPU and without vLLM installed: the module's vLLM imports
-are stubbed before import, mirroring ``test_vllm_kv_cache_groups.py``.
+These tests run on CPU: the module's vLLM imports are stubbed before import,
+so they behave the same whether or not vLLM is installed.
 """
 
 # Standard
@@ -29,6 +29,7 @@ from enum import Enum
 from types import ModuleType
 from typing import TypeAlias
 from unittest.mock import patch
+import importlib
 import sys
 
 # Third Party
@@ -63,6 +64,7 @@ class _SpecKind(Enum):
     SINK_FULL_ATTENTION = "sink_full_attention"
     CROSS_ATTENTION = "cross_attention"
     MAMBA = "mamba"
+    MLA_ATTENTION = "mla_attention"
 
 
 @dataclass
@@ -87,6 +89,9 @@ class _Config:
     has_mamba_layers: bool = True
 
 
+_MODULE = "lmcache.integration.vllm.kv_cache_group_edits"
+
+
 @pytest.fixture(scope="module")
 def edits():
     """Import the module under test with its vLLM dependencies stubbed."""
@@ -98,20 +103,30 @@ def edits():
 
     vllm_pkg = ModuleType("vllm")
     vllm_v1 = ModuleType("vllm.v1")
-    with patch.dict(
-        sys.modules,
-        {
-            "vllm": vllm_pkg,
-            "vllm.v1": vllm_v1,
-            "vllm.v1.kv_cache_interface": stub,
-        },
-    ):
-        sys.modules.pop("lmcache.integration.vllm.kv_cache_group_edits", None)
-        # First Party
-        from lmcache.integration.vllm import kv_cache_group_edits
-
-        yield kv_cache_group_edits
-    sys.modules.pop("lmcache.integration.vllm.kv_cache_group_edits", None)
+    # ``from pkg import child`` returns the attribute ``pkg`` already holds, so
+    # dropping only the ``sys.modules`` entry would yield whatever binding an
+    # earlier importer left behind -- against real vLLM, no rule then matches.
+    parent = importlib.import_module("lmcache.integration.vllm")
+    previous = sys.modules.get(_MODULE)
+    try:
+        with patch.dict(
+            sys.modules,
+            {
+                "vllm": vllm_pkg,
+                "vllm.v1": vllm_v1,
+                "vllm.v1.kv_cache_interface": stub,
+            },
+        ):
+            sys.modules.pop(_MODULE, None)
+            module = importlib.import_module(_MODULE)
+            assert module.KVCacheSpecKind is _SpecKind
+            yield module
+    finally:
+        sys.modules.pop(_MODULE, None)
+        parent.__dict__.pop("kv_cache_group_edits", None)
+        if previous is not None:
+            sys.modules[_MODULE] = previous
+            parent.kv_cache_group_edits = previous
 
 
 def _attention_page_bytes() -> int:


### PR DESCRIPTION
Fixes #4247

**What this PR does / why we need it**:

`_SubpagedAttentionViewEdit` gates on `ndim == 5`. vLLM 0.26.0 registers the non-MLA KV cache as rank 4, so the edit silently stops firing and the attention group is left paged at the backend's kernel block size instead of the scheduler's. On a hybrid-Mamba model this corrupts store/retrieve with no exception and no log line. Confirmed fixed end-to-end on affected hardware — see Validation.

## Problem

vLLM 0.26.0 changed the registered non-MLA KV cache from a rank-5 K/V-split layout to a rank-4 K/V-fused layout. All paths under `vllm/v1/attention/backends/`:

| backend | 0.25.1 — `(num_blocks, 2, block_size, num_kv_heads, head_size)` | 0.26.0 — `(num_blocks, num_kv_heads, block_size, 2 * head_size)` |
| --- | --- | --- |
| `flash_attn` | `flash_attn.py:132` | `flash_attn.py:141` |
| `flashinfer` | `flashinfer.py:392` | `flashinfer.py:408` |
| `triton_attn` | `triton_attn.py:345` | `triton_attn.py:351` |
| `flex_attention` | `flex_attention.py:133` | `flex_attention.py:138` |

ROCm AITER FA moved the same way (`rocm_aiter_fa.py:767` → `775`). The change is **not** universal: `hpc_attn.py:293` is byte-identical in both tags and still rank 5, so both ranks stay reachable and both have to be handled rather than swapped. The block dim is index 2 in both layouts, so only the rank distinguishes them.

## Effect

On 0.26.0 the `ndim == 5` gate is unsatisfiable, so the edit never fires and the attention group keeps the backend's kernel block size.

This only bites where that differs from the scheduler block size — backends advertising fixed integer sizes, where `select_common_block_size` descends to the largest advertised divisor (FlashInfer `[16, 32, 64]`, ROCm AITER FA `[16, 32]`). Backends advertising `MultipleOf(16)`, such as `flash_attn`, resolve to the logical size directly, so `shape[2] == spec.block_size` and the edit correctly never needed to fire there.

## Why it is silent rather than loud

Two guards should have caught a kernel-paged group; neither can.

At `lmcache/v1/kv_layer_groups.py:403`, `tokens_per_block` falls back to `bs` — the physical slot count read off the registered tensor — whenever the engine group info is absent or non-positive, explicitly so the group is "treated as non-compressed". The group is then misread not as compressed but as *uncompressed at the wrong block size*, so the `slots_per_block != tokens_per_block` diagnostic at `:691` never fires and nothing downstream has anything left to disagree about. (Trace credit: @MikeWang0316tw — my original read assumed the compressed variant.) And where the info is present, every check in `_validate_block_chunk_size_config` is a pure modulo test: `select_common_block_size` only returns divisors (`vllm/v1/worker/utils.py:344`), so the ratio is integral by construction, and a guard rejecting only non-integer ratios can never reject a wrong-but-integer one.

The only observable signal was the applied-edits counter missing a key — `{'mamba-page-view': N}` with `subpaged-attention-view` absent rather than zero, since it increments only on a match.

## Fix

- `matches()` — accept rank 4 or rank 5, comparing `shape[2]` against `spec.block_size` in both.
- `apply()` — handle both ranks; validate the `shape[1] == 2` invariant only where it applies (rank 5).
- `_in_memory_order()` — new helper. vLLM registers the rank-4 tensor as a `permute` view of the backend's physical layout (`get_kv_cache_stride_order`), which under NHD is the transpose `(0, 2, 1, 3)`. It is not contiguous in logical dim order, and pages only tile by byte range in memory order, so the rank-4 branch re-views in descending-stride order.

**Why patch `matches()` rather than move the edit after normalization.** The comment at `lmcache/integration/vllm/lmcache_mp_connector.py:773` states the edit must precede both group-info creation and transfer registration so they see the same edited views. `apply_kv_cache_group_edits` rebinds `kv_caches` at `:776`, and both `create_engine_group_infos_from_vllm` (`:779`) and `worker_adapter.register_kv_caches` (`:784`) read the rebound local. Moving it later would build group infos from the un-repaged tensor — precisely the bug being fixed.

## Known limitations

1. **Rank 4 under HND still resolves `block_size` to 1.** The edit machinery emits an NHD-shaped synthetic view by construction (`num_heads` is a synthetic 1), while the HND detector branch selects `NL_X_NB_TWO_NH_BS_HS`, whose `block_size()` reads a different axis. Pre-existing and orthogonal to the rank gate — it affects every edited group, Mamba included — and not reached by default, since `get_required_kvcache_layout` returns `None` and vLLM falls back to NHD. Filing separately.

2. **Rank-5 behavior is deliberately unchanged, including its `is_contiguous()` guard.** Extending the memory-order normalization to rank 5 would let a permuted tensor (vLLM ≤ 0.25.x under HND) re-view successfully and then be misread downstream as `block_size == 1` — converting a loud `ValueError` into a silent wrong block size. That is the exact failure class this PR exists to remove.

**Rollout note:** after upgrading, clear legacy L2 objects. The object key carries no layout fingerprint and the filesystem backend does not overwrite an existing object on store, so stale entries written by the unpatched code would be served as-is.

**Special notes for your reviewers**:

## Validation

End-to-end confirmed by @MikeWang0316tw on affected hardware (GB10, FlashInfer, hybrid Mamba/GDN, `block_size=1600`). Stock vLLM `v0.26.0`, no local patches; two arms differing by this one file on the same LMCache build; greedy decoding verified bit-reproducible across two rounds.

| | patched | control |
| --- | --- | --- |
| `KV cache group edits applied` | `{'mamba-page-view': 48, 'subpaged-attention-view': 17}` | `{'mamba-page-view': 48}` |
| `Engine KV Format` | 5x `NL_X_NB_TWO_BS_NH_HS` | 4x `NL_X_NB_TWO_BS_NH_HS` + 1x `NL_X_NB_BS_NH_TWO_HS` |
| ran to `max_tokens` | 0/16 | 12/16 |
| flagged garbage | 0/16 | 2/16 |
| external prefix cache hit rate | 40–91% | 57–60% |

Both arms genuinely consumed external tokens, so this is not a no-op passing for the wrong reason.

The format row is the strongest signal and needs no generation: on 0.25.1 all five groups detect as format 2, and with this patch on 0.26.0 they do again. The fused format reaching the transfer layer is the bug's signature, not its cause — those kernels were being handed a group that should never have reached them unedited.

## Testing

`tests/v1/test_vllm_kv_cache_group_edits.py` — 19 tests, pure CPU, no GPU or vLLM install needed (vLLM and the spec-kind helpers are stubbed, and the module is re-imported under the stubs with a binding assert, so an installed vLLM cannot leak in; runs with or without vLLM present). Reverting the source fix turns 8 of them red with `assert 64 == 1600` and a log line reading `{'mamba-page-view': 4}`.

This module had no unit coverage before — testing was GPU end-to-end only, which pins faithful retrieve but cannot gate *which rules fire* for a given vLLM version. That is exactly why a rule silently not firing was undetectable in CI. The new tests pin the matching gate per registered layout and the resulting block granularity, not internal view shapes.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests