### PR TITLE
test: align top-level tests with selected accelerator backend

### DIFF
--- a/.buildkite/k3_tests/xpu/run.sh
+++ b/.buildkite/k3_tests/xpu/run.sh
@@ -36,6 +36,7 @@ uv pip install -r requirements/common.txt -r requirements/test.txt
 
 discover_xpu_tests() {
   python - <<'PY'
+from fnmatch import fnmatch
 from pathlib import Path
 
 root = Path("tests")
@@ -50,21 +51,17 @@ root = Path("tests")
 #      are not ready yet.
 #   4. As tests become ready, shrink blocklist until XPU jobs run the full set.
 allowlist = {
-  "tests/benchmarks/test_cachegen.py",
-  "tests/benchmarks/test_xpu_connector_benchmark.py",
-  "tests/benchmarks/test_xpu_kernels_microbench.py",
-  "tests/benchmarks/test_xpu_layerwise_connector_benchmark.py",
-  "tests/test_serde.py",
+  "tests/benchmarks/test_*.py",
+  "tests/test_*.py",
   "tests/v1/multiprocess/test_engine_driven_transfer.py",
   "tests/v1/test_python_ops_fallback.py",
   "tests/v1/test_xpu_connector.py",
   "tests/v1/test_torch_ops.py",
-  "tests/test_usage_telemetry.py",
 }
 selected: set[str] = set()
 
 def is_allowlisted(rel: str) -> bool:
-  return rel in allowlist
+  return any(fnmatch(rel, pattern) for pattern in allowlist)
 
 for path in root.rglob("test_*.py"):
     rel = path.as_posix()

--- a/.buildkite/k3_tests/xpu/run.sh
+++ b/.buildkite/k3_tests/xpu/run.sh
@@ -58,6 +58,8 @@ allowlist = {
   "tests/v1/multiprocess/test_engine_driven_transfer.py",
   "tests/v1/test_python_ops_fallback.py",
   "tests/v1/test_xpu_connector.py",
+  "tests/v1/test_torch_ops.py",
+  "tests/test_usage_telemetry.py",
 }
 selected: set[str] = set()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,8 @@ log_cli_level = INFO
 markers =
     no_shared_allocator: Disable the shared-allocator monkeypatch for this test
     integration: Mark integration tests
+    gpu: Tests that require GPU runtime (CUDA or ROCm)
+    xpu: Tests that require XPU runtime
+    musa: Tests that require MUSA runtime
+    sglang: Tests for SGLang connector/integration
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def patch_mixed_allocator():
 
     def fake_mixed_close(self):
         if not self._unregistered:
-            torch.cuda.synchronize()
+            getattr(torch, torch_device_type).synchronize()
             # torch.cuda.cudart().cudaHostUnregister(self.buffer.data_ptr())
             self._unregistered = True
 
@@ -147,7 +147,7 @@ def patch_pin_allocator():
 
     def fake_pin_close(self):
         if not self._unregistered:
-            torch.cuda.synchronize()
+            getattr(torch, torch_device_type).synchronize()
             # torch.cuda.cudart().cudaHostUnregister(self.buffer.data_ptr())
             self._unregistered = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def patch_mixed_allocator():
 
     def fake_mixed_close(self):
         if not self._unregistered:
-            getattr(torch, torch_device_type).synchronize()
+            torch_dev.synchronize()
             # torch.cuda.cudart().cudaHostUnregister(self.buffer.data_ptr())
             self._unregistered = True
 
@@ -147,7 +147,7 @@ def patch_pin_allocator():
 
     def fake_pin_close(self):
         if not self._unregistered:
-            getattr(torch, torch_device_type).synchronize()
+            torch_dev.synchronize()
             # torch.cuda.cudart().cudaHostUnregister(self.buffer.data_ptr())
             self._unregistered = True
 

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -4,19 +4,14 @@ import pytest
 import torch
 
 # First Party
-from lmcache import torch_device_type
+from lmcache import torch_dev, torch_device_type
 from lmcache.storage_backend.serde.cachegen_basics import CacheGenEncoderOutput
 from lmcache.storage_backend.serde.cachegen_decoder import CacheGenDeserializer
 from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.metadata import LMCacheMetadata
 
-TORCH_DEVICE_AVAILABLE = (
-    hasattr(torch, torch_device_type)
-    and getattr(torch, torch_device_type).is_available()
-)
-
-if not TORCH_DEVICE_AVAILABLE:
+if not torch_dev.is_available():
     pytest.skip(
         f"Requires available {torch_device_type} runtime",
         allow_module_level=True,

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -11,12 +11,19 @@ from lmcache.storage_backend.serde.cachegen_encoder import CacheGenSerializer
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.metadata import LMCacheMetadata
 
-# CacheGen has hand-written CUDA and SYCL kernels only; gate the test on
-# those backends explicitly (whitelist), so HPU / CPU-only CI / future
-# backends without a CacheGen kernel are skipped automatically.
-# torch_device_type is set to "cuda"/"xpu" only after is_available() passes
-# in lmcache.__init__, so no extra availability check is needed here.
-_GPU_AVAILABLE = torch_device_type == "cuda" or torch_device_type == "xpu"
+TORCH_DEVICE_AVAILABLE = (
+    hasattr(torch, torch_device_type)
+    and getattr(torch, torch_device_type).is_available()
+)
+
+if not TORCH_DEVICE_AVAILABLE:
+    pytest.skip(
+        f"Requires available {torch_device_type} runtime",
+        allow_module_level=True,
+    )
+
+# CacheGen tests apply to accelerator backends (CUDA/XPU).
+pytestmark = [pytest.mark.gpu, pytest.mark.xpu]
 
 
 def generate_kv_cache(num_tokens, device):
@@ -42,10 +49,6 @@ def to_blob(kv_tuples):
 
 
 @pytest.mark.parametrize("chunk_size", [16, 128, 256])
-@pytest.mark.skipif(
-    not _GPU_AVAILABLE,
-    reason="No GPU backend (CUDA or XPU) available",
-)
 def test_cachegen_encoder(chunk_size):
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
     metadata = LMCacheMetadata(
@@ -82,10 +85,6 @@ def test_cachegen_encoder(chunk_size):
 
 
 @pytest.mark.parametrize("chunk_size", [16, 128, 256])
-@pytest.mark.skipif(
-    not _GPU_AVAILABLE,
-    reason="No GPU backend (CUDA or XPU) available",
-)
 def test_cachegen_decoder(chunk_size):
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)
     metadata = LMCacheMetadata(
@@ -108,10 +107,6 @@ def test_cachegen_decoder(chunk_size):
     assert decoded_kv.mean() != 0
 
 
-@pytest.mark.skipif(
-    not _GPU_AVAILABLE,
-    reason="No GPU backend (CUDA or XPU) available",
-)
 def test_cachegen_unmatched_size():
     chunk_size = 256
     config = LMCacheEngineConfig.from_defaults(chunk_size=chunk_size)

--- a/tests/test_usage_telemetry.py
+++ b/tests/test_usage_telemetry.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 
 # First Party
+from lmcache import torch_device_type
 from lmcache.usage_telemetry import (
     USAGE_SCHEMA_VERSION,
     ContinuousUsageContext,
@@ -336,7 +337,7 @@ def publish_mp_traffic(bus: EventBus) -> None:
             event_type=EventType.MP_RETRIEVE_END,
             metadata={
                 "retrieved_count": 4,
-                "device": "cuda:0",
+                "device": f"{torch_device_type}:0",
                 "engine_id": 1,
                 "model_name": "test_model",
                 "cache_salt": "",
@@ -349,7 +350,7 @@ def publish_mp_traffic(bus: EventBus) -> None:
             event_type=EventType.MP_STORE_END,
             metadata={
                 "stored_count": 2,
-                "device": "cuda:0",
+                "device": f"{torch_device_type}:0",
                 "engine_id": 1,
                 "model_name": "test_model",
                 "total_bytes": 1000,


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add/align pytest markers in pytest.ini for accelerator-related test selection: gpu, xpu, musa, sglang.
- Replace CUDA-only synchronize calls in tests/conftest.py with device-agnostic synchronize via torch_device_type.
- In tests/test_serde.py, switch from repeated per-test skipif to a single module-level accelerator availability gate and module markers (gpu/xpu).
- In tests/test_usage_telemetry.py, replace hardcoded device metadata (cuda:0) with torch_device_type-based device strings.

**Special notes for your reviewers**:
- Test-only changes.
- Goal is backend-agnostic behavior across CUDA/XPU/MUSA environments.

**If applicable**:
- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests

**Overall goal and execution steps**:
- https://github.com/LMCache/LMCache/issues/4276
