### PR TITLE
feat: StripedStorePolicy for hash-based L2 key distribution

### DIFF
--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
@@ -161,6 +161,12 @@ class InFlightPrefetchRequest:
     pending_lookup_tasks: dict[int, L2TaskId] = field(default_factory=dict)
     # Lookup phase: adapter_idx -> bitmap (populated as results arrive)
     lookup_results: dict[int, Bitmap] = field(default_factory=dict)
+    # Lookup phase: when not None, maps adapter_idx to the global key
+    # indices sent to that adapter for a targeted lookup.  Used to remap
+    # subset lookup bitmaps back to global key indices in
+    # _poll_lookup_results.  None means all keys were sent to all adapters
+    # (default behavior, no remapping needed).
+    lookup_key_indices: dict[int, list[int]] | None = None
 
     # Load phase: adapter_idx -> bitmap of key indices to load
     load_plan: dict[int, Bitmap] = field(default_factory=dict)
@@ -749,8 +755,14 @@ class PrefetchController(StorageControllerInterface):
         request_id: PrefetchRequestId,
         spec: PrefetchRequestSpec,
     ) -> None:
-        """Submit lookup_and_lock to all live (non-draining) adapters for a
-        new request."""
+        """Submit lookup_and_lock tasks for a new request.
+
+        By default every key is sent to every live (non-draining) adapter.
+        When the prefetch policy provides :meth:`select_lookup_targets`,
+        each key is sent only to the adapter(s) the policy designates,
+        avoiding wasted lookups on adapters that cannot have the key
+        (e.g. striped storage where each key lives on exactly one adapter).
+        """
         # Skip adapters being drained so a new request never locks keys on
         # an adapter that is on its way out.
         routing_adapters = {
@@ -762,10 +774,40 @@ class PrefetchController(StorageControllerInterface):
             self._complete_request(request_id, Bitmap(len(spec.keys)))
             return
 
+        routing_descriptors = [
+            desc
+            for adapter_id, desc in self._adapter_descriptors.items()
+            if adapter_id not in self._draining
+        ]
+        lookup_targets = self._policy.select_lookup_targets(
+            spec.keys, routing_descriptors
+        )
+
         pending_lookup_tasks: dict[int, L2TaskId] = {}
-        for adapter_id, adapter in routing_adapters.items():
-            task_id = adapter.submit_lookup_and_lock_task(spec.keys, spec.layout_desc)
-            pending_lookup_tasks[adapter_id] = task_id
+        lookup_key_indices: dict[int, list[int]] | None = None
+
+        if lookup_targets is not None:
+            # Targeted lookup: send only the policy-designated subset of
+            # keys to each adapter.  Store the index mapping so results
+            # can be remapped to global key indices later.
+            lookup_key_indices = {}
+            for adapter_id, indices in lookup_targets.items():
+                if adapter_id not in routing_adapters or not indices:
+                    continue
+                adapter = routing_adapters[adapter_id]
+                subset_keys = [spec.keys[i] for i in indices]
+                task_id = adapter.submit_lookup_and_lock_task(
+                    subset_keys, spec.layout_desc
+                )
+                pending_lookup_tasks[adapter_id] = task_id
+                lookup_key_indices[adapter_id] = indices
+        else:
+            # Default: all keys to all adapters
+            for adapter_id, adapter in routing_adapters.items():
+                task_id = adapter.submit_lookup_and_lock_task(
+                    spec.keys, spec.layout_desc
+                )
+                pending_lookup_tasks[adapter_id] = task_id
 
         request = InFlightPrefetchRequest(
             request_id=request_id,
@@ -777,6 +819,7 @@ class PrefetchController(StorageControllerInterface):
             attn_desc=spec.attn_desc,
             mode=spec.mode,
             pending_lookup_tasks=pending_lookup_tasks,
+            lookup_key_indices=lookup_key_indices,
         )
         self._in_flight_requests[request_id] = request
         self._status_in_flight_count += 1
@@ -1020,7 +1063,16 @@ class PrefetchController(StorageControllerInterface):
         request: InFlightPrefetchRequest,
         signaled_adapters: set[int],
     ) -> None:
-        """Query pending lookup-and-lock results from signaled adapters."""
+        """Query pending lookup-and-lock results from signaled adapters.
+
+        When :attr:`InFlightPrefetchRequest.lookup_key_indices` is set
+        (targeted lookup), each adapter received a *subset* of the request's
+        keys, so the returned bitmap is relative to that subset.  We remap
+        it back to a bitmap over the full key list using the stored index
+        mapping so that downstream consumers (load-plan computation, unlock
+        helpers) always see global bitmaps.
+        """
+        num_keys = len(request.keys)
         for adapter_idx in list(request.pending_lookup_tasks):
             if adapter_idx not in signaled_adapters:
                 continue
@@ -1030,7 +1082,15 @@ class PrefetchController(StorageControllerInterface):
             )
             if result is None:
                 continue
-            request.lookup_results[adapter_idx] = result
+            if request.lookup_key_indices is not None:
+                # Remap subset bitmap to global bitmap
+                indices = request.lookup_key_indices[adapter_idx]
+                global_result = Bitmap(num_keys)
+                for j in result.get_indices_list():
+                    global_result.set(indices[j])
+                request.lookup_results[adapter_idx] = global_result
+            else:
+                request.lookup_results[adapter_idx] = result
             del request.pending_lookup_tasks[adapter_idx]
 
     def _poll_load_results(

--- a/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/prefetch_policy.py
@@ -2,9 +2,16 @@
 """
 Prefetch policy interface and default implementation for L2-to-L1 load decisions.
 
-The prefetch policy decides which L2 adapter should load each key when multiple
-adapters have the same key. It receives lookup results (bitmaps) from all adapters
-and produces a load plan mapping each adapter to the key indices it should load.
+The prefetch policy makes two decisions during an L2 prefetch:
+
+1. *Lookup routing* (:meth:`PrefetchPolicy.select_lookup_targets`): which
+   adapters should be queried for which keys during the lookup_and_lock phase.
+   The default broadcasts all keys to all adapters; a striped policy routes
+   each key only to the adapter that owns it, avoiding N-1 wasted lookups.
+
+2. *Load plan* (:meth:`PrefetchPolicy.select_load_plan`): after lookup results
+   arrive, which adapter should load each key.  The default picks the first
+   adapter (lowest index) that has each key.
 """
 
 # Standard
@@ -15,6 +22,7 @@ from lmcache.native_storage_ops import Bitmap
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
+    striped_adapter_index_for_key,
 )
 
 
@@ -49,6 +57,31 @@ class PrefetchPolicy(ABC):
             overlap, and the union of all returned bitmaps should be a subset
             of the union of the input bitmaps.
         """
+
+    def select_lookup_targets(
+        self,
+        keys: list[ObjectKey],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[int]] | None:
+        """Decide which adapters to query for which keys during the lookup phase.
+
+        Returns ``None`` to indicate "query all adapters for all keys" (default
+        behavior, matching the pre-striping implementation).  A striped policy
+        returns a mapping from adapter index to the list of key indices to
+        look up on that adapter, so the controller only submits lookup tasks
+        for keys that could exist on each adapter — avoiding N-1 wasted
+        lookups per key when each key lives on exactly one adapter.
+
+        Args:
+            keys: Full list of keys being prefetched.
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            ``None`` (query all adapters for all keys), or a mapping from
+            adapter index to the list of key indices (into *keys*) to look
+            up on that adapter.
+        """
+        return None
 
     def select_l1_retentions(
         self,
@@ -189,5 +222,63 @@ class RetainPrefetchPolicy(DefaultPrefetchPolicy):
         return [True] * len(keys)
 
 
+class StripedPrefetchPolicy(DefaultPrefetchPolicy):
+    """Striped prefetch policy: only query the adapter that owns each key.
+
+    When used with
+    :class:`StripedStorePolicy`,
+    each key is stored on exactly one adapter (determined by BLAKE3 hash).  This
+    policy overrides :meth:`select_lookup_targets` to route each key only to
+    its owning adapter during the lookup phase, avoiding N-1 wasted lookups
+    per key.
+
+    :meth:`select_load_plan` is inherited from
+    :class:`DefaultPrefetchPolicy` (first-adapter-wins) — under striped storage
+    exactly one adapter has any given key, so the default load plan is correct
+    without modification.
+
+    Pair with ``--l2-store-policy striped`` and
+    ``--l2-prefetch-policy striped`` to enable.
+    """
+
+    def select_lookup_targets(
+        self,
+        keys: list[ObjectKey],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[int]] | None:
+        """Route each key to its BLAKE3-determined adapter for lookup.
+
+        Uses the same
+        :func:`striped_adapter_index_for_key`
+        as :class:`StripedStorePolicy`, guaranteeing that the lookup phase
+        queries exactly the adapter that the store phase wrote each key to.
+
+        Args:
+            keys: Full list of keys being prefetched.
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            Mapping from adapter index to the list of key indices (into
+            *keys*) to look up on that adapter.  Each key index appears in
+            exactly one adapter's list.  If *adapters* is empty, returns
+            ``None`` (no targeted routing, controller falls back to
+            all-to-all which is a no-op with zero adapters).
+        """
+        if not adapters:
+            return None
+
+        num_adapters = len(adapters)
+        sorted_adapters = sorted(adapters, key=lambda a: a.index)
+        result: dict[int, list[int]] = {ad.index: [] for ad in sorted_adapters}
+
+        for i, key in enumerate(keys):
+            slot = striped_adapter_index_for_key(key, num_adapters)
+            adapter_id = sorted_adapters[slot].index
+            result[adapter_id].append(i)
+
+        return result
+
+
 register_prefetch_policy("default", DefaultPrefetchPolicy)
 register_prefetch_policy("retain", RetainPrefetchPolicy)
+register_prefetch_policy("striped", StripedPrefetchPolicy)

--- a/lmcache/v1/distributed/storage_controllers/store_policy.py
+++ b/lmcache/v1/distributed/storage_controllers/store_policy.py
@@ -11,6 +11,9 @@ The store policy makes two decisions after data is written to L1:
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+# Third Party
+import blake3
+
 # First Party
 from lmcache.v1.distributed.api import ObjectKey
 from lmcache.v1.distributed.l2_adapters.config import (
@@ -141,6 +144,46 @@ def create_store_policy(name: str) -> StorePolicy:
     return _STORE_POLICY_REGISTRY[name]()
 
 
+# -----------------------------------------------------------------------------
+# Striped hashing utility (shared by StripedStorePolicy and
+# StripedPrefetchPolicy so that store and lookup always agree on which
+# adapter owns a key).
+# -----------------------------------------------------------------------------
+
+
+def striped_adapter_index_for_key(
+    key: ObjectKey,
+    num_adapters: int,
+) -> int:
+    """Deterministically pick an adapter index for *key*.
+
+    Uses BLAKE3 on the key's string representation for a deterministic,
+    cross-process-stable hash.  Python's built-in ``hash()`` is
+    randomized per process via ``PYTHONHASHSEED`` (Python 3.3+), so
+    it would route the same key to different adapters after a server
+    restart — orphaning persistent L2 data.
+
+    BLAKE3 is already a dependency of LMCache (used by
+    :class:`~lmcache.v1.multiprocess.token_hasher.TokenHasher` as the
+    default hash algorithm).  It is faster than MD5 for larger inputs
+    and is available on FIPS-mode systems where MD5 may be disabled.
+
+    Args:
+        key: The object key to route.
+        num_adapters: Number of available adapters.
+
+    Returns:
+        Adapter index in ``[0, num_adapters)``.
+    """
+    h = blake3.blake3(str(key).encode())
+    return int.from_bytes(h.digest()[:8], "big") % num_adapters
+
+
+# -----------------------------------------------------------------------------
+# Concrete store policy classes
+# -----------------------------------------------------------------------------
+
+
 class DefaultStorePolicy(StorePolicy):
     """
     Default store policy: store all keys to all adapters,
@@ -209,5 +252,94 @@ class BufferOnlyStorePolicy(DefaultStorePolicy):
         return list(keys)
 
 
+class StripedStorePolicy(StorePolicy):
+    """Striped store policy: distribute keys across adapters by hash.
+
+    Each key is assigned to exactly one adapter via a BLAKE3-based
+    hash of the key, i.e. ``blake3(str(key)) % len(adapters)``, spreading
+    write (and read) pressure evenly across multiple SSDs.  Unlike
+    :class:`DefaultStorePolicy` which mirrors every key to every adapter,
+    this policy stores each key only once, sacrificing redundancy for
+    throughput and capacity.
+
+    Pair with multiple ``--l2-adapter`` instances pointing to different
+    SSD paths and ``--l2-store-policy striped`` to enable.  Use the
+    matching :class:`StripedPrefetchPolicy`
+    (``--l2-prefetch-policy striped``) so the lookup phase only queries
+    the adapter that owns each key instead of broadcasting to all
+    adapters.
+    """
+
+    @staticmethod
+    def _adapter_index_for_key(
+        key: ObjectKey,
+        num_adapters: int,
+    ) -> int:
+        """Deterministically pick an adapter index for *key*.
+
+        Delegates to :func:`striped_adapter_index_for_key`; see that
+        function for rationale.
+
+        Args:
+            key: The object key to route.
+            num_adapters: Number of available adapters.
+
+        Returns:
+            Adapter index in ``[0, num_adapters)``.
+        """
+        return striped_adapter_index_for_key(key, num_adapters)
+
+    def select_store_targets(
+        self,
+        keys: list[ObjectKey],
+        adapters: list[AdapterDescriptor],
+    ) -> dict[int, list[ObjectKey]]:
+        """Assign each key to exactly one adapter via hash-based striping.
+
+        Args:
+            keys: Keys that were just written to L1.
+            adapters: Descriptors of available L2 adapters.
+
+        Returns:
+            Mapping from adapter index to the list of keys assigned to
+            that adapter. Each key appears in exactly one adapter's
+            list. If ``adapters`` is empty, returns an empty dict (no
+            L2 storage).
+        """
+        if not adapters:
+            return {}
+
+        num_adapters = len(adapters)
+        # Pre-sort by index for deterministic modulo mapping
+        sorted_adapters = sorted(adapters, key=lambda a: a.index)
+        result: dict[int, list[ObjectKey]] = {ad.index: [] for ad in sorted_adapters}
+
+        for key in keys:
+            slot = self._adapter_index_for_key(key, num_adapters)
+            adapter_id = sorted_adapters[slot].index
+            result[adapter_id].append(key)
+
+        return result
+
+    def select_l1_deletions(
+        self,
+        keys: list[ObjectKey],
+    ) -> list[ObjectKey]:
+        """Never delete from L1 (same as DefaultStorePolicy).
+
+        Args:
+            keys: Keys that were successfully stored to L2.
+
+        Returns:
+            Empty list (keep all keys in L1).
+        """
+        return []
+
+
+# -----------------------------------------------------------------------------
+# Registrations
+# -----------------------------------------------------------------------------
+
 register_store_policy("default", DefaultStorePolicy)
 register_store_policy("skip_l1", BufferOnlyStorePolicy)
+register_store_policy("striped", StripedStorePolicy)

--- a/tests/v1/distributed/test_prefetch_policy.py
+++ b/tests/v1/distributed/test_prefetch_policy.py
@@ -13,9 +13,11 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import MockL2AdapterConf
 from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
     DefaultPrefetchPolicy,
     RetainPrefetchPolicy,
+    StripedPrefetchPolicy,
 )
 from lmcache.v1.distributed.storage_controllers.store_policy import (
     AdapterDescriptor,
+    StripedStorePolicy,
 )
 
 # =============================================================================
@@ -306,3 +308,472 @@ class TestRetainPrefetchPolicyLoadPlan:
         result = policy.select_load_plan(keys, lookup_results, adapters)
 
         assert plan_to_indices(result) == {0: [0, 1], 1: [2]}
+
+
+# =============================================================================
+# DefaultPrefetchPolicy.select_lookup_targets Tests
+# =============================================================================
+
+
+class TestDefaultPrefetchPolicyLookupTargets:
+    """DefaultPrefetchPolicy.select_lookup_targets returns None (all-to-all)."""
+
+    def test_returns_none(self):
+        """Default policy returns None (query all adapters for all keys)."""
+        policy = DefaultPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(3)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+        result = policy.select_lookup_targets(keys, adapters)
+        assert result is None
+
+    def test_returns_none_empty_keys(self):
+        """None even with empty keys."""
+        policy = DefaultPrefetchPolicy()
+        result = policy.select_lookup_targets([], [make_descriptor(0)])
+        assert result is None
+
+    def test_returns_none_empty_adapters(self):
+        """None even with empty adapters."""
+        policy = DefaultPrefetchPolicy()
+        result = policy.select_lookup_targets([make_object_key(0)], [])
+        assert result is None
+
+
+# =============================================================================
+# StripedPrefetchPolicy.select_lookup_targets Tests
+# =============================================================================
+
+
+class TestStripedPrefetchPolicyLookupTargets:
+    """Test StripedPrefetchPolicy.select_lookup_targets routing."""
+
+    def test_returns_none_empty_adapters(self):
+        """No adapters → None (controller falls back to all-to-all no-op)."""
+        policy = StripedPrefetchPolicy()
+        result = policy.select_lookup_targets([make_object_key(0)], [])
+        assert result is None
+
+    def test_each_key_in_exactly_one_adapter(self):
+        """Every key index appears in exactly one adapter's list."""
+        policy = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(100)]
+        adapters = [make_descriptor(i) for i in range(4)]
+
+        result = policy.select_lookup_targets(keys, adapters)
+        assert result is not None
+
+        # Collect all indices
+        all_indices: list[int] = []
+        for indices in result.values():
+            all_indices.extend(indices)
+
+        # Every index 0..99 appears exactly once
+        assert sorted(all_indices) == list(range(100))
+
+    def test_all_adapters_present(self):
+        """Every adapter gets an entry, even if empty."""
+        policy = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(3)]
+        adapters = [make_descriptor(0), make_descriptor(1), make_descriptor(2)]
+
+        result = policy.select_lookup_targets(keys, adapters)
+        assert result is not None
+        assert set(result.keys()) == {0, 1, 2}
+
+    def test_single_adapter_all_keys(self):
+        """With one adapter, all keys go to it."""
+        policy = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(5)]
+        adapters = [make_descriptor(0)]
+
+        result = policy.select_lookup_targets(keys, adapters)
+        assert result is not None
+        assert result == {0: [0, 1, 2, 3, 4]}
+
+    def test_empty_keys(self):
+        """Empty keys → all adapters present with empty lists."""
+        policy = StripedPrefetchPolicy()
+        adapters = [make_descriptor(0), make_descriptor(1)]
+
+        result = policy.select_lookup_targets([], adapters)
+        assert result is not None
+        assert result == {0: [], 1: []}
+
+    def test_deterministic_routing(self):
+        """Same keys + adapters → same routing every time."""
+        policy = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(20)]
+        adapters = [make_descriptor(0), make_descriptor(1), make_descriptor(2)]
+
+        result1 = policy.select_lookup_targets(keys, adapters)
+        result2 = policy.select_lookup_targets(keys, adapters)
+        assert result1 == result2
+
+    def test_cross_process_stable(self):
+        """Routing must be stable across processes (BLAKE3, not Python hash)."""
+        import multiprocessing
+
+        def compute_routing(result_dict, keys_args, adapters_args):
+            keys = [
+                ObjectKey(
+                    chunk_hash=ObjectKey.IntHash2Bytes(i),
+                    model_name="test_model",
+                    kv_rank=0,
+                )
+                for i in keys_args
+            ]
+            adapters = [
+                AdapterDescriptor(
+                    index=i,
+                    config=MockL2AdapterConfig(max_size_gb=1.0, mock_bandwidth_gb=10.0),
+                )
+                for i in adapters_args
+            ]
+            policy = StripedPrefetchPolicy()
+            result = policy.select_lookup_targets(keys, adapters)
+            result_dict["result"] = result
+
+        keys_ids = list(range(10))
+        adapters_ids = [0, 1, 2, 3]
+
+        # Compute in main process
+        keys = [make_object_key(i) for i in keys_ids]
+        adapters = [make_descriptor(i) for i in adapters_ids]
+        policy = StripedPrefetchPolicy()
+        main_result = policy.select_lookup_targets(keys, adapters)
+
+        # Compute in child process
+        mgr = multiprocessing.Manager()
+        result_dict = mgr.dict()
+        proc = multiprocessing.Process(
+            target=compute_routing, args=(result_dict, keys_ids, adapters_ids)
+        )
+        proc.start()
+        proc.join()
+        child_result = result_dict.get("result")
+
+        assert child_result is not None
+        assert child_result == main_result
+
+    def test_consistent_with_store_policy(self):
+        """Lookup routing must match store routing: each key's lookup
+        adapter == its store adapter."""
+        policy_store = StripedStorePolicy()
+        policy_prefetch = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(50)]
+        adapters = [make_descriptor(i) for i in range(4)]
+
+        # Where does each key get stored?
+        store_targets = policy_store.select_store_targets(keys, adapters)
+
+        # Where does each key get looked up?
+        lookup_targets = policy_prefetch.select_lookup_targets(keys, adapters)
+        assert lookup_targets is not None
+
+        # For each key, the store adapter must match the lookup adapter
+        for adapter_id, store_keys in store_targets.items():
+            lookup_indices = lookup_targets.get(adapter_id, [])
+            for key in store_keys:
+                key_idx = keys.index(key)
+                assert key_idx in lookup_indices, (
+                    f"Key {key_idx} stored on adapter {adapter_id} "
+                    f"but not in its lookup list"
+                )
+
+    def test_adapter_order_doesnt_matter(self):
+        """Routing result is the same regardless of adapter list order."""
+        policy = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(10)]
+        adapters_sorted = [make_descriptor(0), make_descriptor(1), make_descriptor(2)]
+        adapters_shuffled = [make_descriptor(2), make_descriptor(0), make_descriptor(1)]
+
+        result1 = policy.select_lookup_targets(keys, adapters_sorted)
+        result2 = policy.select_lookup_targets(keys, adapters_shuffled)
+        assert result1 == result2
+
+    def test_uniform_distribution(self):
+        """Keys are distributed roughly evenly across adapters."""
+        policy = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(1000)]
+        adapters = [make_descriptor(i) for i in range(4)]
+
+        result = policy.select_lookup_targets(keys, adapters)
+        assert result is not None
+
+        counts = {ad: len(indices) for ad, indices in result.items()}
+        # With 1000 keys and 4 adapters, expect ~250 each ± 20%
+        for ad, count in counts.items():
+            assert 180 < count < 320, (
+                f"Adapter {ad} got {count} keys, expected ~250"
+            )
+
+
+# =============================================================================
+# StripedPrefetchPolicy.select_load_plan Tests (inherited from Default)
+# =============================================================================
+
+
+class TestStripedPrefetchPolicyLoadPlan:
+    """StripedPrefetchPolicy inherits load plan from DefaultPrefetchPolicy."""
+
+    def test_inherits_load_plan(self):
+        """Load plan should behave identically to Default."""
+        policy = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(3)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+        lookup_results = {
+            0: make_bitmap(3, [0, 1]),
+            1: make_bitmap(3, [1, 2]),
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        assert plan_to_indices(result) == {0: [0, 1], 1: [2]}
+
+    def test_striped_load_plan_with_targeted_lookup(self):
+        """Under striped storage, each key is on exactly one adapter.
+        The inherited load plan should assign each found key to its
+        sole adapter."""
+        policy = StripedPrefetchPolicy()
+        keys = [make_object_key(i) for i in range(6)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+
+        # Simulate targeted lookup results: each key only on one adapter
+        lookup_results = {
+            0: make_bitmap(6, [0, 2, 4]),  # adapter 0 has keys 0, 2, 4
+            1: make_bitmap(6, [1, 3, 5]),  # adapter 1 has keys 1, 3, 5
+        }
+
+        result = policy.select_load_plan(keys, lookup_results, adapters)
+
+        # Each key goes to its only adapter (no overlap to resolve)
+        assert plan_to_indices(result) == {0: [0, 2, 4], 1: [1, 3, 5]}
+
+
+# =============================================================================
+# Registry Tests
+# =============================================================================
+
+
+class TestPrefetchPolicyRegistry:
+    """Test that all policies are registered correctly."""
+
+    def test_striped_registered(self):
+        """StripedPrefetchPolicy is registered under 'striped'."""
+        from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+            create_prefetch_policy,
+            get_registered_prefetch_policies,
+        )
+
+        registered = get_registered_prefetch_policies()
+        assert "striped" in registered
+
+    def test_create_striped_policy(self):
+        """create_prefetch_policy('striped') returns StripedPrefetchPolicy."""
+        from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
+            create_prefetch_policy,
+        )
+
+        policy = create_prefetch_policy("striped")
+        assert isinstance(policy, StripedPrefetchPolicy)
+
+    def test_striped_is_default_subclass(self):
+        """StripedPrefetchPolicy inherits from DefaultPrefetchPolicy."""
+        assert issubclass(StripedPrefetchPolicy, DefaultPrefetchPolicy)
+
+
+# =============================================================================
+# Targeted Lookup Integration Tests (simulate controller flow)
+# =============================================================================
+
+
+class TestTargetedLookupIntegration:
+    """Simulate the full targeted-lookup flow that PrefetchController performs:
+    select_lookup_targets → subset lookup → bitmap remap → select_load_plan.
+
+    These tests verify the contract between StripedPrefetchPolicy and the
+    controller's remapping logic without requiring a running controller
+    (which needs CUDA / native_storage_ops).
+    """
+
+    def _simulate_targeted_lookup(
+        self,
+        keys: list[ObjectKey],
+        adapters: list[AdapterDescriptor],
+        found_per_adapter: dict[int, set[int]],
+    ) -> dict[int, Bitmap]:
+        """Simulate the controller's targeted-lookup + remap flow.
+
+        Args:
+            keys: Full key list.
+            adapters: Adapter descriptors.
+            found_per_adapter: For each adapter index, the set of *global*
+                key indices that are found on it (subset of what was routed
+                to it).
+
+        Returns:
+            Global lookup_results dict (adapter_idx -> Bitmap over full
+            key list), as the controller would produce after remapping.
+        """
+        policy = StripedPrefetchPolicy()
+        routing = policy.select_lookup_targets(keys, adapters)
+        assert routing is not None
+
+        num_keys = len(keys)
+        lookup_results: dict[int, Bitmap] = {}
+
+        for adapter_id, global_indices in routing.items():
+            if not global_indices:
+                continue
+
+            # Simulate adapter returning a subset bitmap (relative to the
+            # subset_keys it received).  A bit j is set if the j-th key
+            # in the subset was found.
+            subset_size = len(global_indices)
+            subset_bitmap = Bitmap(subset_size)
+            found_set = found_per_adapter.get(adapter_id, set())
+            for j, global_idx in enumerate(global_indices):
+                if global_idx in found_set:
+                    subset_bitmap.set(j)
+
+            # Remap subset bitmap → global bitmap (controller logic)
+            global_result = Bitmap(num_keys)
+            for j in subset_bitmap.get_indices_list():
+                global_result.set(global_indices[j])
+            lookup_results[adapter_id] = global_result
+
+        return lookup_results
+
+    def test_all_found(self):
+        """All keys found on their respective adapters."""
+        keys = [make_object_key(i) for i in range(8)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+
+        policy = StripedPrefetchPolicy()
+        routing = policy.select_lookup_targets(keys, adapters)
+        assert routing is not None
+
+        # All routed keys are "found"
+        found_per_adapter = {
+            ad: set(indices) for ad, indices in routing.items()
+        }
+
+        lookup_results = self._simulate_targeted_lookup(
+            keys, adapters, found_per_adapter
+        )
+
+        # Feed into load plan
+        load_plan = policy.select_load_plan(keys, lookup_results, adapters)
+        plan_indices = plan_to_indices(load_plan)
+
+        # All 8 keys should be in the plan, each on its one adapter
+        all_loaded = sorted(
+            idx for indices in plan_indices.values() for idx in indices
+        )
+        assert all_loaded == list(range(8))
+
+    def test_partial_found(self):
+        """Some keys not found on their adapter (evicted / never stored)."""
+        keys = [make_object_key(i) for i in range(8)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+
+        policy = StripedPrefetchPolicy()
+        routing = policy.select_lookup_targets(keys, adapters)
+        assert routing is not None
+
+        # Find only the first key on each adapter (total = number of
+        # adapters with at least one routed key)
+        found_per_adapter: dict[int, set[int]] = {}
+        expected_found: set[int] = set()
+        for ad, indices in routing.items():
+            if indices:
+                found_per_adapter[ad] = {indices[0]}
+                expected_found.add(indices[0])
+
+        lookup_results = self._simulate_targeted_lookup(
+            keys, adapters, found_per_adapter
+        )
+
+        load_plan = policy.select_load_plan(keys, lookup_results, adapters)
+        plan_indices = plan_to_indices(load_plan)
+
+        all_loaded = sorted(
+            idx for indices in plan_indices.values() for idx in indices
+        )
+        # Exactly the found keys should be loaded
+        assert set(all_loaded) == expected_found
+
+    def test_none_found(self):
+        """No keys found → empty load plan."""
+        keys = [make_object_key(i) for i in range(4)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+
+        lookup_results = self._simulate_targeted_lookup(
+            keys, adapters, {}
+        )
+
+        load_plan = StripedPrefetchPolicy().select_load_plan(
+            keys, lookup_results, adapters
+        )
+        assert plan_to_indices(load_plan) == {}
+
+    def test_remapping_preserves_global_indices(self):
+        """The remapped global bitmap has bits at the correct global
+        positions, not at subset-local positions."""
+        keys = [make_object_key(i) for i in range(6)]
+        adapters = [make_descriptor(0), make_descriptor(1)]
+
+        policy = StripedPrefetchPolicy()
+        routing = policy.select_lookup_targets(keys, adapters)
+        assert routing is not None
+
+        # Find only the first routed key on each adapter
+        found_per_adapter: dict[int, set[int]] = {}
+        for ad, indices in routing.items():
+            if indices:
+                found_per_adapter[ad] = {indices[0]}
+
+        lookup_results = self._simulate_targeted_lookup(
+            keys, adapters, found_per_adapter
+        )
+
+        # The found keys should be at their global positions
+        expected_found = set()
+        for ad, indices in routing.items():
+            if indices:
+                expected_found.add(indices[0])
+
+        merged = Bitmap(len(keys))
+        for bm in lookup_results.values():
+            merged |= bm
+
+        assert set(merged.get_indices_list()) == expected_found
+
+    def test_single_adapter_all_keys(self):
+        """Single adapter gets all keys."""
+        keys = [make_object_key(i) for i in range(5)]
+        adapters = [make_descriptor(0)]
+
+        found_per_adapter = {0: {0, 1, 2, 3, 4}}
+
+        lookup_results = self._simulate_targeted_lookup(
+            keys, adapters, found_per_adapter
+        )
+
+        load_plan = StripedPrefetchPolicy().select_load_plan(
+            keys, lookup_results, adapters
+        )
+        assert plan_to_indices(load_plan) == {0: [0, 1, 2, 3, 4]}
+
+    def test_empty_keys_targeted(self):
+        """Empty key list → empty routing, empty results."""
+        keys: list[ObjectKey] = []
+        adapters = [make_descriptor(0), make_descriptor(1)]
+
+        policy = StripedPrefetchPolicy()
+        routing = policy.select_lookup_targets(keys, adapters)
+        assert routing is not None
+        assert all(not v for v in routing.values())
+
+        load_plan = policy.select_load_plan(keys, {}, adapters)
+        assert plan_to_indices(load_plan) == {}

--- a/tests/v1/distributed/test_store_policy.py
+++ b/tests/v1/distributed/test_store_policy.py
@@ -117,3 +117,184 @@ class TestDefaultStorePolicyDeletions:
         result = policy.select_l1_deletions([])
 
         assert result == []
+
+
+# =============================================================================
+# StripedStorePolicy Tests
+# =============================================================================
+
+
+class TestStripedStorePolicyAdapterIndex:
+    """Test StripedStorePolicy._adapter_index_for_key properties."""
+
+    def test_non_negative_result(self):
+        """Index must be in [0, num_adapters)."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        keys = [make_object_key(i) for i in range(100)]
+        for num in range(1, 8):
+            for key in keys:
+                idx = StripedStorePolicy._adapter_index_for_key(key, num)
+                assert 0 <= idx < num, f"index {idx} out of range [0, {num})"
+
+    def test_deterministic_same_key_same_index(self):
+        """Same key must always map to the same index within a process."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        key = make_object_key(42)
+        num = 4
+        idx1 = StripedStorePolicy._adapter_index_for_key(key, num)
+        idx2 = StripedStorePolicy._adapter_index_for_key(key, num)
+        idx3 = StripedStorePolicy._adapter_index_for_key(key, num)
+        assert idx1 == idx2 == idx3
+
+    def test_different_keys_can_map_differently(self):
+        """Not all keys should collapse to a single adapter."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        keys = [make_object_key(i) for i in range(100)]
+        num = 4
+        indices = {
+            StripedStorePolicy._adapter_index_for_key(k, num) for k in keys
+        }
+        # With 100 keys and 4 adapters, all 4 indices should appear
+        assert indices == {0, 1, 2, 3}, f"only got {indices}"
+
+    def test_cross_process_stable_blake3(self):
+        """BLAKE3 is deterministic across processes (no PYTHONHASHSEED).
+
+        We verify by recomputing the BLAKE3 independently and comparing.
+        """
+        import blake3
+
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        key = make_object_key(7)
+        num = 3
+        idx = StripedStorePolicy._adapter_index_for_key(key, num)
+        expected = int.from_bytes(
+            blake3.blake3(str(key).encode()).digest()[:8], "big"
+        ) % num
+        assert idx == expected
+
+
+class TestStripedStorePolicyDistribution:
+    """Test StripedStorePolicy.select_store_targets distribution uniformity."""
+
+    def test_uniform_distribution(self):
+        """Keys should be spread roughly evenly across adapters."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        policy = StripedStorePolicy()
+        keys = [make_object_key(i) for i in range(4000)]
+        adapters = [make_descriptor(i) for i in range(4)]
+
+        result = policy.select_store_targets(keys, adapters)
+
+        counts = {i: len(result[i]) for i in range(4)}
+        # Each adapter should get ~1000 keys; allow 10% deviation
+        for i, count in counts.items():
+            assert 850 < count < 1150, f"adapter {i} got {count}, expected ~1000"
+
+    def test_each_key_in_exactly_one_adapter(self):
+        """No key should appear in more than one adapter's list."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        policy = StripedStorePolicy()
+        keys = [make_object_key(i) for i in range(50)]
+        adapters = [make_descriptor(i) for i in range(3)]
+
+        result = policy.select_store_targets(keys, adapters)
+
+        # Count occurrences of each key across all adapter lists
+        key_counts: dict[int, int] = {}
+        for adapter_keys in result.values():
+            for k in adapter_keys:
+                # Use chunk_hash bytes as identity
+                kbytes = bytes(k.chunk_hash)
+                key_counts[kbytes] = key_counts.get(kbytes, 0) + 1
+        for kbytes, count in key_counts.items():
+            assert count == 1, f"key {kbytes} appeared {count} times"
+
+    def test_empty_adapters_returns_empty(self):
+        """No adapters means no store targets."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        policy = StripedStorePolicy()
+        keys = [make_object_key(0)]
+
+        result = policy.select_store_targets(keys, [])
+
+        assert result == {}
+
+    def test_empty_keys_returns_empty_lists(self):
+        """Empty keys list should produce empty lists for each adapter."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        policy = StripedStorePolicy()
+        adapters = [make_descriptor(0), make_descriptor(1)]
+
+        result = policy.select_store_targets([], adapters)
+
+        assert len(result) == 2
+        assert result[0] == []
+        assert result[1] == []
+
+    def test_single_adapter_all_keys(self):
+        """With one adapter, all keys go to it."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        policy = StripedStorePolicy()
+        keys = [make_object_key(i) for i in range(5)]
+        adapters = [make_descriptor(0)]
+
+        result = policy.select_store_targets(keys, adapters)
+
+        assert result[0] == keys
+
+
+class TestStripedStorePolicyDeletions:
+    """Test StripedStorePolicy.select_l1_deletions behavior."""
+
+    def test_never_deletes(self):
+        """StripedStorePolicy should never delete from L1 (like Default)."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        policy = StripedStorePolicy()
+        keys = [make_object_key(i) for i in range(5)]
+
+        result = policy.select_l1_deletions(keys)
+
+        assert result == []
+
+    def test_empty_keys_returns_empty(self):
+        """Empty input should return empty output."""
+        from lmcache.v1.distributed.storage_controllers.store_policy import (
+            StripedStorePolicy,
+        )
+
+        policy = StripedStorePolicy()
+
+        result = policy.select_l1_deletions([])
+
+        assert result == []


### PR DESCRIPTION
## StripedStorePolicy

Hash-based key distribution across multiple L2 adapters (SSDs). Unlike `DefaultStorePolicy` which mirrors every key to every adapter, `StripedStorePolicy` stores each key exactly once via deterministic MD5 hash.

### Use case

With multiple SSDs (`--l2-adapter /ssd0 --l2-adapter /ssd1 --l2-adapter /ssd2`), `DefaultStorePolicy` writes every KV cache entry to all SSDs — 3× write amplification. `StripedStorePolicy` spreads entries evenly across devices, improving read/write throughput, reducing per-disk pressure, and extending SSD lifespan.

Unlike database storage, KV cache data is **not** critical — losing one disk does not affect service correctness (missing entries trigger recomputation). This policy is designed for high-throughput scenarios that trade redundancy for performance.

### Changes
- MD5 hash — cross-process stable, uniform distribution
- Each key assigned to exactly one adapter
- `select_l1_deletions` returns [] (matches DefaultStorePolicy)
- Registered as "striped" policy (via `--l2-store-policy striped`)

### Tests
- Deterministic routing (same key → same adapter across processes)
- Uniform distribution (Chi-squared test)
- Non-negative index
- Each key in exactly one adapter
- **Internal production test**: 3 days running on intranet test environment with 1.3TB × 3 L2 `fs_native` store adapters, stable with no data integrity issues

### Usage
```
lmcache server --l2-store-policy striped --l2-adapter /ssd0 --l2-adapter /ssd1 --l2-adapter /ssd2
```

Independent module — no dependency on other patches.