### PR TITLE
feat: IPC memory management — explicit ref release, periodic ipc_collect, checkin timeout, max_batch_size

### DIFF
--- a/lmcache/v1/multiprocess/config.py
+++ b/lmcache/v1/multiprocess/config.py
@@ -50,6 +50,13 @@ class MPServerConfig:
     sliding-window size at KV-cache registration (hybrid models). When False,
     all kernel groups share a single full-attention object group."""
 
+    max_batch_size: int = 4
+    """Maximum number of chunks the temporary GPU staging buffer can hold
+    simultaneously. Each chunk occupies ``chunk_size × hidden_dim × num_layers
+    × dtype_size`` bytes of GPU memory. Reducing this value (e.g. to 2)
+    decreases GPU staging memory at the cost of batched-transfer throughput.
+    Default is 4."""
+
     enable_segmented_prefix: bool = False
     """CacheBlend only (engine_type='blend'): on a mid-prefix L2 retrieve
     failure, retain the gapped contiguous prefix so the post-gap chunks stay
@@ -352,6 +359,15 @@ def add_mp_server_args(
         "at KV-cache registration (for hybrid models). (Default is True)",
     )
     mp_group.add_argument(
+        "--max-batch-size",
+        type=int,
+        default=4,
+        help="Maximum number of chunks the temporary GPU staging buffer "
+        "can hold simultaneously. Reducing this value (e.g. to 2) "
+        "decreases GPU staging memory at the cost of batched-transfer "
+        "throughput. Default is 4.",
+    )
+    mp_group.add_argument(
         "--worker-reap-timeout-seconds",
         type=float,
         default=120.0,
@@ -407,6 +423,7 @@ def parse_args_to_mp_server_config(
         hash_algorithm=args.hash_algorithm,
         engine_type=args.engine_type,
         separate_object_groups=args.separate_object_groups,
+        max_batch_size=args.max_batch_size,
         enable_segmented_prefix=args.enable_segmented_prefix,
         supported_transfer_mode=args.supported_transfer_mode,
         runtime_plugin_config=RuntimePluginConfig(

--- a/lmcache/v1/multiprocess/engine_context.py
+++ b/lmcache/v1/multiprocess/engine_context.py
@@ -181,10 +181,12 @@ class MPCacheServerContext:
         hash_algorithm: str = "blake3",
         separate_object_groups: bool = True,
         full_sw_kv: bool = False,
+        max_batch_size: int = 4,
     ) -> None:
         self._chunk_size = chunk_size
         self._separate_object_groups = separate_object_groups
         self._full_sw_kv = full_sw_kv
+        self._max_batch_size = max_batch_size
 
         # Initialize the process-global GDS context.
         # No-op when GDS L1 is disabled (config is None).
@@ -225,6 +227,11 @@ class MPCacheServerContext:
     def full_sw_kv(self) -> bool:
         """Whether sliding-window groups cache full per-chunk KV (no window cutting)."""
         return self._full_sw_kv
+
+    @property
+    def max_batch_size(self) -> int:
+        """Max chunks the GPU staging buffer holds simultaneously."""
+        return self._max_batch_size
 
     @property
     def storage_manager(self) -> StorageManager:

--- a/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
+++ b/lmcache/v1/multiprocess/modules/lmcache_driven_transfer.py
@@ -5,6 +5,7 @@
 from dataclasses import dataclass
 from itertools import islice
 from typing import Generator, Sequence
+import functools
 import threading
 import time
 
@@ -54,8 +55,40 @@ from lmcache.v1.platform.base.event_ipc import (
 )
 from lmcache.v1.platform.cache_context import create_cache_context
 import lmcache.c_ops as lmc_ops
+from lmcache.v1.periodic_thread import (
+    PeriodicThread,
+    PeriodicThreadRegistry,
+    ThreadLevel,
+    ThreadRunSummary,
+    create_periodic_thread,
+)
 
 logger = init_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# IPC memory management constants
+# ---------------------------------------------------------------------------
+
+# How often (seconds) the periodic IPC-collection thread runs.  Between
+# cycles, IPC handles orphaned by normal operation (e.g. a worker that
+# crashed before its unregister) accumulate.  This thread reclaims them
+# by calling ``empty_cache()`` + ``ipc_collect()`` so the handles do not
+# pin GPU memory indefinitely.  60 s is a reasonable default: frequent
+# enough to keep handle count bounded, infrequent enough to avoid
+# interfering with active transfers.
+_IPC_COLLECT_INTERVAL_S = 60.0
+
+# Grace period (seconds) before a dead-but-in-use context entry is
+# force-released.  When a worker is reaped/unregistered while a store or
+# retrieve is in-flight, the entry is marked ``dead=True`` and its release
+# is deferred until the transfer finishes and calls ``checkin_context_entry``.
+# If the transfer handler raises before reaching the ``finally`` block
+# (or the worker process is killed mid-transfer), the checkin never
+# happens and the entry -- and its IPC handles -- leak permanently.
+# This timeout is a safety net: after the grace period the entry is
+# force-released regardless, accepting the small risk of unmapping a
+# segment that a zombie CUDA stream might still reference.
+_CHECKIN_TIMEOUT_S = 120.0
 _HAS_NATIVE_OBJECT_GROUP_TRANSFER: bool = hasattr(
     lmc_ops, "execute_object_group_transfer"
 )
@@ -576,7 +609,13 @@ def transfer_kv_per_object_group(
                 )
 
 
-@dataclass
+# Hashable by identity: ContextEntry is used as a key in _dead_entries
+# (the dead-entry tracker populated by _retire_entries). A plain @dataclass
+# sets __hash__ = None, which would crash _retire_entries the first time a
+# busy (in_use > 0) entry is retired and added to the tracker. eq=False keeps
+# the default identity-based hash/equality, which is correct here since the
+# tracker keys entries by object identity, not by field value.
+@dataclass(eq=False)
 class ContextEntry:
     """Registered cache context metadata for a single worker instance.
 
@@ -606,6 +645,21 @@ class ContextEntry:
     last_seen: float = 0.0
     has_liveness_signal: bool = False
     event_backend: EventIPCBackend | None = None
+    # Transfer-vs-teardown guard: ``in_use`` counts store/retrieve operations
+    # currently holding this entry's cache_context; ``dead`` marks an entry
+    # removed from the registry (reap / unregister) whose release must wait
+    # for the last such operation. Closing the context mid-copy unmaps the
+    # IPC/SHM segments under an active tensor copy and the server dies with
+    # SIGSEGV in the copy kernel (observed 2026-07-21 on every engine
+    # death/restart under load). Both fields are guarded by the module lock.
+    in_use: int = 0
+    dead: bool = False
+    # Guard against double-release: set to True the first time
+    # _release_entries runs for this entry.  Both checkin_context_entry and
+    # _ipc_collect_cycle can reach _release_entries for the same dead entry;
+    # without this flag, cache_context.close() and layout_desc_registry
+    # .unregister() would be called twice.
+    released: bool = False
 
 
 class LMCacheDrivenTransferModule(InstanceLivenessTarget):
@@ -643,6 +697,22 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         )
         self._device_host_func_dispatcher.start()
 
+        # ------------------------------------------------------------------
+        # Periodic IPC memory management
+        # ------------------------------------------------------------------
+        # Dead entries deferred by _retire_entries (in_use > 0 at reap time)
+        # keyed by the entry itself → monotonic timestamp when marked dead.
+        # The periodic thread scans this dict and force-releases entries
+        # that have been stuck past _CHECKIN_TIMEOUT_S.
+        self._dead_entries: dict[ContextEntry, float] = {}
+        self._ipc_collector: PeriodicThread | None = create_periodic_thread(
+            name="lmcache-ipc-collector",
+            interval=_IPC_COLLECT_INTERVAL_S,
+            execute_fn=self._ipc_collect_cycle,
+            level=ThreadLevel.LOW,
+        )
+        self._ipc_collector.start()
+
     @property
     def context(self) -> MPCacheServerContext:
         """Return the shared engine context. Exposed for testing only."""
@@ -667,6 +737,103 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             if entry is not None:
                 entry.last_seen = now
             return entry
+
+    def checkout_context_entry(self, instance_id: int) -> ContextEntry | None:
+        """Like get_and_touch_context_entry, but pins the entry against release.
+
+        The caller MUST pair this with :meth:`checkin_context_entry` (via
+        try/finally) once its transfer no longer touches the entry's
+        cache_context. While pinned, reap/unregister defer the context
+        close instead of unmapping segments under the caller's copy.
+
+        Args:
+            instance_id: The worker instance ID.
+
+        Returns:
+            The pinned entry, or None if the instance is not tracked.
+        """
+        now = time.monotonic()
+        with self._lock:
+            entry = self._cache_contexts.get(instance_id)
+            if entry is None:
+                return None
+            entry.last_seen = now
+            entry.in_use += 1
+            return entry
+
+    def checkin_context_entry(self, entry: ContextEntry) -> None:
+        """Release a pin taken by :meth:`checkout_context_entry`.
+
+        The last checkin of a dead (reaped/unregistered) entry performs the
+        deferred context release.
+
+        Args:
+            entry: The entry returned by checkout_context_entry.
+        """
+        with self._lock:
+            if entry.released:
+                # Already force-released by the periodic collector's timeout
+                # sweep.  The checkout pin is consumed; don't decrement
+                # in_use (the collector already reset it to 0).
+                return
+            entry.in_use -= 1
+            release_now = entry.dead and entry.in_use <= 0 and not entry.released
+            if release_now:
+                entry.released = True
+                self._dead_entries.pop(entry, None)
+        if not release_now:
+            return
+        logger.info(
+            "Deferred release of instance context (model=%s) after last "
+            "in-flight transfer drained",
+            entry.model_name,
+        )
+        # Hand the sole reference to the release list — a lingering local
+        # binding would keep the entry alive through ipc_collect and the
+        # IPC segments would never unmap (LMCache#4014).
+        to_release = [entry]
+        del entry
+        self._release_entries(to_release)
+
+    def _retire_entries(self, entries: list[ContextEntry]) -> None:
+        """Mark removed entries dead; release the idle ones immediately.
+
+        Busy entries (in_use > 0) are released by the final
+        checkin_context_entry instead — closing them here would unmap
+        IPC/SHM segments under an in-flight tensor copy (SIGSEGV).
+
+        Args:
+            entries: Entries already popped from the registry. The list is
+                cleared before release so no binding pins a released entry.
+        """
+        idle: list[ContextEntry] = []
+        busy_entries: list[ContextEntry] = []
+        with self._lock:
+            for entry in entries:
+                entry.dead = True
+                if entry.in_use <= 0:
+                    idle.append(entry)
+                else:
+                    busy_entries.append(entry)
+            if entries:
+                # Drop the last local binding so the released entry is not
+                # kept alive through ipc_collect (LMCache#4014).
+                del entry
+            entries.clear()
+        if busy_entries:
+            logger.warning(
+                "Deferring release of %d instance context(s) with in-flight "
+                "transfers; they close when the last transfer drains",
+                len(busy_entries),
+            )
+            # Track dead entries so the periodic IPC-collector thread can
+            # force-release them if checkin never happens (handler crash /
+            # worker kill mid-transfer).  Without this, busy dead entries
+            # leak permanently — the store/retrieve finally block never runs.
+            now = time.monotonic()
+            for entry in busy_entries:
+                self._dead_entries[entry] = now
+        self._release_entries(idle)
 
     def context_entries_snapshot(self) -> dict[int, ContextEntry]:
         """Return a shallow copy of the registry for iteration or status.
@@ -742,7 +909,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         if reaped:
             del e  # a bound name would pin the final entry (see _release_entries)
             reaped.clear()
-            self._release_entries(entries)
+            self._retire_entries(entries)
         return reaped_ids
 
     def _release_entries(self, entries: list[ContextEntry]) -> None:
@@ -768,6 +935,74 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         if ipc_collect is not None:
             # Backends without IPC collection omit this optional operation.
             ipc_collect()
+
+    def _ipc_collect_cycle(self) -> ThreadRunSummary:
+        """Periodic IPC handle reclamation and dead-entry timeout sweep.
+
+        Runs every ``_IPC_COLLECT_INTERVAL_S`` seconds.  Two jobs:
+
+        1. **Dead-entry sweep** — force-release context entries that were
+           marked dead by ``_retire_entries`` but never checked in (the
+           store/retrieve handler raised or the worker was killed
+           mid-transfer).  Without this safety net, such entries and
+           their IPC handles leak permanently.
+
+        2. **Global IPC collection** — call ``empty_cache()`` +
+           ``ipc_collect()`` to reclaim any CUDA-IPC-imported segments
+           whose Python references were dropped since the last cycle
+           but whose underlying handles have not yet been collected by
+           the CUDA driver.  This bounds handle growth between explicit
+           release events (reap / unregister / close).
+
+        Returns:
+            A summary recording how many dead entries were force-released.
+        """
+        # 1. Sweep dead entries past the checkin timeout.
+        now = time.monotonic()
+        expired: list[ContextEntry] = []
+        with self._lock:
+            # Snapshot to avoid mutating while iterating; entries to release
+            # are removed from _dead_entries before _release_entries is called
+            # (which itself acquires no lock — leaf-lock invariant).
+            for entry, dead_since in list(self._dead_entries.items()):
+                if now - dead_since > _CHECKIN_TIMEOUT_S:
+                    self._dead_entries.pop(entry, None)
+                    # Force the in_use counter to zero so _release_entries
+                    # proceeds; the transfer that pinned it is certainly dead
+                    # by now (it has been _CHECKIN_TIMEOUT_S seconds).
+                    entry.in_use = 0
+                    entry.released = True
+                    expired.append(entry)
+
+        force_released = 0
+        if expired:
+            logger.warning(
+                "Force-releasing %d dead context entry(s) that exceeded "
+                "checkin timeout of %.0fs",
+                len(expired),
+                _CHECKIN_TIMEOUT_S,
+            )
+            # _release_entries clears the list (drops refs before ipc_collect),
+            # so capture the count before the call.
+            force_released = len(expired)
+            self._release_entries(expired)
+
+        # 2. Global IPC collection (best-effort, never fatal).
+        #    Skip when force_released > 0 because _release_entries already
+        #    ran empty_cache() + ipc_collect() for the expired entries.
+        if force_released == 0:
+            try:
+                torch_dev.empty_cache()
+                ipc_collect = getattr(torch_dev, "ipc_collect", None)
+                if ipc_collect is not None:
+                    ipc_collect()
+            except Exception as e:
+                logger.debug("Periodic ipc_collect failed (non-fatal): %s", e)
+
+        return ThreadRunSummary(
+            success=True,
+            message=f"force_released={force_released}",
+        )
 
     def get_handlers(self) -> list[HandlerSpec]:
         """Return handler specs for all request types this module serves.
@@ -825,6 +1060,15 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
 
     def close(self) -> None:
         """Release GPU resources owned by this module."""
+        # Stop the periodic IPC collector before releasing entries so it
+        # does not race with the final cleanup.
+        if self._ipc_collector is not None:
+            PeriodicThreadRegistry.get_instance().unregister(
+                self._ipc_collector.name
+            )
+            self._ipc_collector.stop()
+            self._ipc_collector = None
+
         # Stop the drain thread before storage_manager.close() so any
         # in-flight completions reach a live storage manager.
         self._device_host_func_dispatcher.stop()
@@ -832,7 +1076,10 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         with self._lock:
             entries = list(self._cache_contexts.values())
             self._cache_contexts.clear()
-        self._release_entries(entries)
+            # Also grab any dead entries that were deferred.
+            entries.extend(self._dead_entries.keys())
+            self._dead_entries.clear()
+        self._retire_entries(entries)
 
     def register_kv_cache(
         self,
@@ -883,6 +1130,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             engine_type=engine_type,
             separate_object_groups=self._ctx.separate_object_groups,
             full_sw_kv=self._ctx.full_sw_kv,
+            max_batch_size=self._ctx.max_batch_size,
         )
         event_backend = get_event_ipc_backend(cache_context.device)
         event_backend.check_event_support(cache_context.device)
@@ -930,17 +1178,43 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
             return
 
         # No scalar binding: `popped` must stay the only reference so
-        # _release_entries' reclaim actually unmaps the IPC segments.
-        self._release_entries(popped)
+        # the release's reclaim actually unmaps the IPC segments.
+        self._retire_entries(popped)
         logger.info("Unregistered KV cache for GPU ID %d", instance_id)
 
+    @staticmethod
+    def _pins_context_entry(fn):
+        """Pin the instance's context entry for the duration of ``fn``.
+
+        Reap/unregister during the call then defers the context close to the
+        checkin below instead of unmapping IPC/SHM segments under the
+        operation's tensor copies (SIGSEGV otherwise).
+        """
+
+        @functools.wraps(fn)
+        def wrapper(self, key, instance_id, *args, **kwargs):
+            entry = self.checkout_context_entry(instance_id)
+            if entry is None:
+                raise ValueError(
+                    f"No GPU context registered for instance ID {instance_id}"
+                )
+            try:
+                return fn(self, key, instance_id, *args, _pinned_entry=entry, **kwargs)
+            finally:
+                self.checkin_context_entry(entry)
+
+        return wrapper
+
     @_lmcache_nvtx_annotate
+    @_pins_context_entry
     def store(
         self,
         key: IPCCacheServerKey,
         instance_id: int,
         gpu_block_ids: list[list[int]],
         event_ipc_handle: bytes,
+        *,
+        _pinned_entry: ContextEntry | None = None,
     ) -> tuple[bytes, bool]:
         """Store the GPU KV cache blocks to CPU.
 
@@ -973,9 +1247,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         """
         st = time.perf_counter()
 
-        entry = self.get_and_touch_context_entry(instance_id)
-        if entry is None:
-            raise ValueError(f"No GPU context registered for instance ID {instance_id}")
+        entry = _pinned_entry
         cache_context = entry.cache_context
         model_name = entry.model_name
         event_backend = entry.event_backend
@@ -1145,6 +1417,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         )
 
     @_lmcache_nvtx_annotate
+    @_pins_context_entry
     def retrieve(
         self,
         key: IPCCacheServerKey,
@@ -1152,6 +1425,8 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         gpu_block_ids: list[list[int]],
         event_ipc_handle: bytes,
         skip_first_n_tokens: int = 0,
+        *,
+        _pinned_entry: ContextEntry | None = None,
     ) -> tuple[bytes, bool]:
         """Retrieve the CPU KV cache and put into GPU blocks.
 
@@ -1178,9 +1453,7 @@ class LMCacheDrivenTransferModule(InstanceLivenessTarget):
         """
         st = time.perf_counter()
 
-        entry = self.get_and_touch_context_entry(instance_id)
-        if entry is None:
-            raise ValueError(f"No GPU context registered for instance ID {instance_id}")
+        entry = _pinned_entry
         cache_context = entry.cache_context
         model_name = entry.model_name
         event_backend = entry.event_backend

--- a/lmcache/v1/multiprocess/server.py
+++ b/lmcache/v1/multiprocess/server.py
@@ -358,6 +358,7 @@ def run_cache_server(
         hash_algorithm=mp_config.hash_algorithm,
         separate_object_groups=mp_config.separate_object_groups and not is_blend,
         full_sw_kv=is_blend,
+        max_batch_size=mp_config.max_batch_size,
     )
 
     modules = _build_modules(ctx, mp_config, coordinator_config)

--- a/lmcache/v1/platform/cache_context.py
+++ b/lmcache/v1/platform/cache_context.py
@@ -67,6 +67,7 @@ def create_cache_context(
     engine_type: EngineType = EngineType.VLLM,
     separate_object_groups: bool = True,
     full_sw_kv: bool = False,
+    max_batch_size: int = 4,
 ) -> BaseCacheContext:
     """Create the appropriate cache context for *kv_caches*.
 
@@ -95,6 +96,11 @@ def create_cache_context(
             per-chunk KV (no sub-chunk window cutting) so chunks stay valid for
             reuse at any position; see
             :meth:`KVLayerGroupsManager.enable_full_sw_kv`.
+        max_batch_size: Maximum number of chunks the temporary GPU staging
+            buffer can hold simultaneously. Each chunk occupies
+            ``chunk_size × hidden_dim × num_layers × dtype_size`` bytes.
+            Reducing this value halves/quarters GPU staging memory at the
+            cost of throughput for batched transfers. Default is 4.
 
     Returns:
         A concrete cache context instance.
@@ -123,4 +129,5 @@ def create_cache_context(
         engine_type,
         separate_object_groups,
         full_sw_kv,
+        max_batch_size,
     )

--- a/lmcache/v1/platform/cpu/cache_context.py
+++ b/lmcache/v1/platform/cpu/cache_context.py
@@ -72,6 +72,7 @@ class CPUCacheContext(BaseCacheContext):
         engine_type: EngineType = EngineType.VLLM,
         separate_object_groups: bool = True,
         full_sw_kv: bool = False,
+        max_batch_size: int = 4,
     ) -> None:
         if not kv_caches:
             raise ValueError(
@@ -149,7 +150,7 @@ class CPUCacheContext(BaseCacheContext):
 
         # Temporary buffer for transfers (same layout as
         # GPUCacheContext but on CPU).
-        self._max_batch_size = 4
+        self._max_batch_size = max_batch_size
         self.tmp_chunk_group_offsets_: list[int] = [0]
         for group_idx, group in enumerate(self.kv_layer_groups_manager_.kernel_groups):
             shape = self.get_kv_buffer_shape(lmcache_tokens_per_chunk, group_idx)
@@ -215,8 +216,18 @@ class CPUCacheContext(BaseCacheContext):
             )
 
     def close(self) -> None:
-        """Release resources. No-op for CPU context (no GDS staging buffer)."""
-        pass
+        """Release SHM-backed tensor references.
+
+        Although CPU contexts have no GDS staging buffer, the unwrapped
+        KV tensors are backed by POSIX SHM segments whose lifetime is tied
+        to the tensor's storage.  Dropping these references lets the
+        SHM segments be munmapped and unlinked by the finalize hooks in
+        :mod:`lmcache.v1.platform.cpu.shm`.
+        """
+        self.group_kv_pointers_ = None
+        self.kv_caches_ = None
+        self.kv_cache_pointers_ = None
+        self._temp_buffer = None
 
     # -- Properties (same API as GPUCacheContext) --
 

--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -355,6 +355,7 @@ class GPUCacheContext(BaseCacheContext):
         engine_type: EngineType = EngineType.VLLM,
         separate_object_groups: bool = True,
         full_sw_kv: bool = False,
+        max_batch_size: int = 4,
     ):
         unwrapped = unwrap_kv_cache_tensors(kv_caches)
         kv_caches_norm, engine_kv_formats = normalize_and_discover_per_layer_formats(
@@ -407,7 +408,7 @@ class GPUCacheContext(BaseCacheContext):
             kv_layer_groups_manager=self.kv_layer_groups_manager_,
             lmcache_tokens_per_chunk=lmcache_tokens_per_chunk,
             device=self.device_,
-            max_batch_size=4,
+            max_batch_size=max_batch_size,
         )
 
         # GPU streams
@@ -434,11 +435,38 @@ class GPUCacheContext(BaseCacheContext):
         )
 
     def close(self) -> None:
+        """Deregister GDS staging buffer and release all IPC tensor references.
+
+        Beyond deregistering the GDS staging buffer, this method explicitly
+        drops references to every object that holds a CUDA-IPC-imported
+        tensor (``kv_caches_``), GPU temporary buffers, and CUDA/CuPy
+        streams.  Without this, CuPy's ``ExternalStream`` creates a
+        reference cycle (stream → context → stream) that prevents CPython's
+        reference-counting from collecting the wrapper, so the IPC handle
+        stays open until the next full GC pass — and if ``py_enable_gc``
+        is ``False`` the handle leaks permanently.
+
+        Called by :meth:`LMCacheDrivenTransferModule._release_entries` when
+        a worker instance is reaped, unregistered, or at server shutdown.
         """
-        Deregister this context's GDS staging buffer (reverse of __init__).
-        """
-        with torch_dev.stream(self.cuda_stream_):
-            get_gds_context().deregister_gpu_buffer(self._temp_buffer.buffer)
+        # 1. Deregister the GDS staging buffer (reverse of __init__).
+        #    Must happen before we drop the stream reference.
+        try:
+            with torch_dev.stream(self.cuda_stream_):
+                get_gds_context().deregister_gpu_buffer(self._temp_buffer.buffer)
+        except Exception as e:
+            logger.warning("GPUCacheContext.close: GDS deregister failed: %s", e)
+
+        # 2. Explicitly release every reference that pins CUDA-IPC-imported
+        #    memory or holds a GPU stream handle.  The CuPy ExternalStream
+        #    creates a reference cycle (cupy_stream_ → cuda_stream_ → self)
+        #    that blocks refcount-based collection; nulling these fields
+        #    breaks the cycle so the IPC handle is freed promptly.
+        self.group_kv_pointers_ = None
+        self.kv_caches_ = None
+        self._temp_buffer = None
+        self.cupy_stream_ = None
+        self.cuda_stream_ = None
 
     @property
     def stream(self) -> Any:
@@ -575,6 +603,19 @@ class PlainGPUCacheContext:
             ),
             logger,
         )
+
+    def close(self) -> None:
+        """Release IPC tensor references and GPU stream handles.
+
+        Mirrors :meth:`GPUCacheContext.close`: nulls every field that
+        pins CUDA-IPC-imported memory or holds a GPU stream, breaking the
+        CuPy ExternalStream reference cycle so IPC handles are freed
+        promptly instead of waiting for a (possibly disabled) GC pass.
+        """
+        self._kv_cache = None
+        self._tmp_gpu_buffer = None
+        self._cupy_stream = None
+        self._cuda_stream = None
 
     def get_kv_buffer_shape(self, num_tokens: int) -> torch.Size:
         """

--- a/tests/v1/multiprocess/test_ipc_memory_reclaim.py
+++ b/tests/v1/multiprocess/test_ipc_memory_reclaim.py
@@ -17,6 +17,9 @@ module (``torch_dev``).
 # Standard
 # Standard Library
 from types import SimpleNamespace
+
+# Third Party
+import pytest
 from unittest.mock import MagicMock
 import time
 import weakref
@@ -45,9 +48,28 @@ class _FakeTorchDev:
             )
 
 
+class _StoppedPeriodicThread:
+    """Stub for create_periodic_thread — never starts the background loop.
+
+    The periodic IPC collector thread fires _ipc_collect_cycle every 60 s
+    in the background.  Without this stub, background calls to
+    empty_cache/ipc_collect race with the test assertions on dev.calls.
+    Tests that need the collector call module._ipc_collect_cycle() directly.
+    """
+
+    name = "lmcache-ipc-collector-stub"
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+
 def _module(monkeypatch) -> LMCacheDrivenTransferModule:
     """Construct the module through the real __init__ with stubbed deps."""
     monkeypatch.setattr(gpu_mod, "DeviceHostFuncDispatcher", MagicMock())
+    monkeypatch.setattr(gpu_mod, "create_periodic_thread", lambda **kw: _StoppedPeriodicThread())
     return LMCacheDrivenTransferModule(MagicMock(name="ctx"))
 
 
@@ -234,3 +256,235 @@ def test_close_with_empty_registry_does_not_reclaim(monkeypatch) -> None:
     module.close()
 
     assert dev.calls == []
+
+
+# =============================================================================
+# Store/retrieve through @_pins_context_entry decorator
+# =============================================================================
+# Regression guard for the bug where the decorator never passed the pinned
+# entry to the method body, causing `entry = _pinned_entry` (None) to crash
+# with AttributeError at `entry.cache_context`.  These tests drive the real
+# decorated store/retrieve through the public API and prove the body receives
+# a non-None pinned entry by reaching a sentinel deep in the body.
+
+
+class _SentinelError(Exception):
+    """Raised by a stubbed ctx method to prove the body reached that line."""
+
+
+def _module_with_sentinel_at_resolve(monkeypatch):
+    """Build a module whose ``ctx.resolve_obj_keys`` raises ``_SentinelError``.
+
+    Both store and retrieve call ``self._ctx.resolve_obj_keys(key, ...)`` right
+    after ``cache_context = entry.cache_context``.  If ``_pinned_entry`` were
+    None, the body would crash with ``AttributeError`` *before* reaching
+    resolve_obj_keys.  So a ``_SentinelError`` from resolve_obj_keys proves the
+    pinned entry was passed and its cache_context was accessed successfully.
+    """
+    module = _module(monkeypatch)
+    module._ctx.resolve_obj_keys.side_effect = _SentinelError
+    return module
+
+
+def test_store_receives_pinned_entry_not_none(monkeypatch) -> None:
+    """store() body must get the pinned entry, not None (bug4 regression)."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module_with_sentinel_at_resolve(monkeypatch)
+    _register(module, monkeypatch, 1)
+
+    raised = False
+    try:
+        module.store(
+            key=MagicMock(name="key"),
+            instance_id=1,
+            gpu_block_ids=[[0]],
+            event_ipc_handle=b"\x00",
+        )
+    except _SentinelError:
+        raised = True
+    except AttributeError as e:
+        pytest.fail(
+            f"store got _pinned_entry=None (bug4 regression): {e}"
+        )
+    assert raised, "store body never reached resolve_obj_keys"
+    # checkin must have run (pin released)
+    assert module.context_entries_snapshot()[1].in_use == 0
+
+
+def test_retrieve_receives_pinned_entry_not_none(monkeypatch) -> None:
+    """retrieve() body must get the pinned entry, not None (bug4 regression)."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module_with_sentinel_at_resolve(monkeypatch)
+    _register(module, monkeypatch, 2)
+
+    raised = False
+    try:
+        module.retrieve(
+            key=MagicMock(name="key"),
+            instance_id=2,
+            gpu_block_ids=[[0]],
+            event_ipc_handle=b"\x00",
+        )
+    except _SentinelError:
+        raised = True
+    except AttributeError as e:
+        pytest.fail(
+            f"retrieve got _pinned_entry=None (bug4 regression): {e}"
+        )
+    assert raised, "retrieve body never reached resolve_obj_keys"
+    assert module.context_entries_snapshot()[2].in_use == 0
+
+
+def test_store_raises_value_error_for_unknown_instance(monkeypatch) -> None:
+    """store() on an unregistered instance must raise ValueError, not crash."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module(monkeypatch)
+
+    with pytest.raises(ValueError, match="instance ID 999"):
+        module.store(
+            key=MagicMock(name="key"),
+            instance_id=999,
+            gpu_block_ids=[[0]],
+            event_ipc_handle=b"\x00",
+        )
+
+
+# =============================================================================
+# Dead-entry safety net: busy entry retirement + deferred release
+# =============================================================================
+
+
+def test_busy_retire_enters_dead_entries(monkeypatch) -> None:
+    """A checked-out entry retired by unregister must enter _dead_entries."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module(monkeypatch)
+    _register(module, monkeypatch, 1)
+
+    # Pin the entry (simulate an in-flight transfer)
+    entry = module.checkout_context_entry(1)
+    assert entry is not None
+    assert entry.in_use == 1
+
+    # Retire while busy — should defer, not release
+    module.unregister_kv_cache(1)
+
+    assert entry in module._dead_entries, "busy entry should be in _dead_entries"
+    assert entry.dead is True
+    # Context not yet closed (transfer may still be using it)
+    entry.cache_context.close.assert_not_called()
+    assert module.context_entries_snapshot() == {}
+
+    # Clean up: checkin to release
+    module.checkin_context_entry(entry)
+    entry.cache_context.close.assert_called_once()
+
+
+def test_dead_entry_checkin_releases_exactly_once(monkeypatch) -> None:
+    """After retire + checkin, the context is closed exactly once."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module(monkeypatch)
+    ctx = _register(module, monkeypatch, 1)
+
+    entry = module.checkout_context_entry(1)
+    module.unregister_kv_cache(1)
+
+    assert entry in module._dead_entries
+
+    module.checkin_context_entry(entry)
+
+    ctx.close.assert_called_once()
+    assert entry not in module._dead_entries
+    assert entry.released is True
+    assert dev.calls == ["empty_cache", "ipc_collect"]
+
+
+def test_dead_entry_timeout_force_releases(monkeypatch) -> None:
+    """_ipc_collect_cycle force-releases entries past _CHECKIN_TIMEOUT_S."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module(monkeypatch)
+    ctx = _register(module, monkeypatch, 1)
+
+    entry = module.checkout_context_entry(1)
+    module.unregister_kv_cache(1)
+    assert entry in module._dead_entries
+
+    # Backdate the dead-entry timestamp to simulate timeout
+    module._dead_entries[entry] = time.monotonic() - 999.0
+
+    summary = module._ipc_collect_cycle()
+
+    ctx.close.assert_called_once()
+    assert entry not in module._dead_entries
+    assert entry.released is True
+    assert "force_released=1" in summary.message
+    assert dev.calls == ["empty_cache", "ipc_collect"]
+
+
+def test_ipc_collect_noop_when_no_dead_entries(monkeypatch) -> None:
+    """_ipc_collect_cycle with no dead entries just runs global collect."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module(monkeypatch)
+    _register(module, monkeypatch, 1)
+
+    summary = module._ipc_collect_cycle()
+
+    assert "force_released=0" in summary.message
+    assert dev.calls == ["empty_cache", "ipc_collect"]
+
+
+# =============================================================================
+# Double-release race: checkin vs _ipc_collect_cycle
+# =============================================================================
+
+
+def test_no_double_release_when_checkin_wins(monkeypatch) -> None:
+    """If checkin releases first, the collector must not release again."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module(monkeypatch)
+    ctx = _register(module, monkeypatch, 1)
+
+    entry = module.checkout_context_entry(1)
+    module.unregister_kv_cache(1)
+    # Backdate so the collector *would* fire if the entry were still tracked
+    module._dead_entries[entry] = time.monotonic() - 999.0
+
+    # checkin wins the race: releases and pops from _dead_entries
+    module.checkin_context_entry(entry)
+    assert ctx.close.call_count == 1
+    assert entry not in module._dead_entries
+    assert entry.released is True
+
+    # Now the collector runs — should find nothing to release
+    module._ipc_collect_cycle()
+    assert ctx.close.call_count == 1, "collector must not double-release"
+
+
+def test_no_double_release_when_collector_wins(monkeypatch) -> None:
+    """If the collector releases first, a late checkin must not release again."""
+    dev = _FakeTorchDev()
+    monkeypatch.setattr(gpu_mod, "torch_dev", dev)
+    module = _module(monkeypatch)
+    ctx = _register(module, monkeypatch, 1)
+
+    entry = module.checkout_context_entry(1)
+    module.unregister_kv_cache(1)
+    module._dead_entries[entry] = time.monotonic() - 999.0
+
+    # Collector wins the race
+    module._ipc_collect_cycle()
+    assert ctx.close.call_count == 1
+    assert entry.released is True
+    assert entry not in module._dead_entries
+
+    # Late checkin: must detect released=True and NOT release again
+    module.checkin_context_entry(entry)
+    assert ctx.close.call_count == 1, "late checkin must not double-release"
+    assert entry.in_use == 0


### PR DESCRIPTION
## IPC Memory Management

Fix CUDA-IPC memory leaks in the lmcache-driven transfer path.

### 1. IPC Memory Management

| File | Change |
|------|--------|
| `platform/cuda/cache_context.py` | `GPUCacheContext.close()` explicitly nulls IPC tensor refs + breaks CuPy ExternalStream reference cycle; `PlainGPUCacheContext` gains `close()` |
| `platform/cpu/cache_context.py` | `CPUCacheContext.close()` releases SHM-backed tensor refs (was no-op) |
| `multiprocess/modules/lmcache_driven_transfer.py` | Periodic IPC collector thread (60s); checkout/checkin pinning; `_retire_entries` deferred release; 120s checkin timeout safety net |
| `multiprocess/config.py` / `engine_context.py` / `server.py` / `platform/cache_context.py` | `max_batch_size` configurable via `--max-batch-size` CLI (was hardcoded 4) |

### 2. Bug Fixes (from code review)

- **Bug1** (critical): `_retire_entries` cleared `entries` list before populating `_dead_entries` — timeout safety net was dead code
- **Bug3** (latent): `checkin_context_entry` vs `_ipc_collect_cycle` double-release race fixed with `released` flag
- **Bug4** (regression): `_pins_context_entry` decorator never passed `_pinned_entry` to the method body — crashed store/retrieve
- **Bug5**: skip redundant `empty_cache()` when `force_released > 0`
- `ContextEntry` → `@dataclass(eq=False)` for identity-based hashing (used as dict key)
- `_retire_entries`: guard against `del entry` on empty list

### 3. Tests

- `tests/v1/multiprocess/test_ipc_memory_reclaim.py`: decorator regression, dead-entry safety net, double-release race, timeout path