### PR TITLE
docs: daily drift check — multi-process mode (2026-07-27)

### DIFF
--- a/docs/source/mp/configuration.rst
+++ b/docs/source/mp/configuration.rst
@@ -82,7 +82,9 @@ Source: ``lmcache/v1/multiprocess/config.py``
    * - ``--runtime-plugin-config``
      - ``"{}"``
      - JSON string of extra key-value config forwarded to runtime
-       plugins via ``LMCACHE_RUNTIME_PLUGIN_EXTRA_CONFIG``. Example:
+       plugins as the top-level ``runtime_plugin_extra_config`` key
+       inside the aggregated ``LMCACHE_RUNTIME_PLUGIN_CONFIG`` env var
+       (there is no separate env var). Example:
        ``'{"plugin.frontend.heartbeat_url": "http://localhost:5000/heartbeat"}'``.
    * - ``--script-allowed-imports``
      - ``[]``


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current
`dev` code (`upstream/dev` HEAD [`20e87af0`](https://github.com/LMCache/LMCache/commit/20e87af0d7697fe6921dc724689634266335b5d3)),
focused on the multi-process mode. One drift item found today, in
`docs/source/`. `docs/design/` is clean today (the two open
drift-check PRs from earlier days — [#4249](https://github.com/LMCache/LMCache/pull/4249),
[#4236](https://github.com/LMCache/LMCache/pull/4236), and
[#4199](https://github.com/LMCache/LMCache/pull/4199) — still
track their earlier items).

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/mp/configuration.rst`** — the Configuration Reference
  row for `--runtime-plugin-config` named a non-existent env var.

  The row said the JSON extra config is *"forwarded to runtime plugins
  via `LMCACHE_RUNTIME_PLUGIN_EXTRA_CONFIG`"*. No such env var exists.
  `RuntimePluginLauncher._launch_plugin` only sets
  `LMCACHE_RUNTIME_PLUGIN_CONFIG`
  ([`lmcache/v1/plugin/runtime_plugin_launcher.py:112`](https://github.com/LMCache/LMCache/blob/20e87af0d7697fe6921dc724689634266335b5d3/lmcache/v1/plugin/runtime_plugin_launcher.py#L112)),
  and the MP launcher's `_MPPluginConfig.to_json` folds the extra
  config into that same JSON blob under the top-level key
  `runtime_plugin_extra_config`:

  ```python
  def to_json(self) -> str:
      merged = dict(self.configs_dict)
      if self.extra_config:
          merged["runtime_plugin_extra_config"] = make_json_safe(self.extra_config)
      return json.dumps(merged)
  ```
  ([`lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py:46-49`](https://github.com/LMCache/LMCache/blob/20e87af0d7697fe6921dc724689634266335b5d3/lmcache/v1/multiprocess/mp_runtime_plugin_launcher.py#L46-L49))

  The shipped frontend plugin's `_extra_cfg` confirms plugins read
  the extra config from that key inside `LMCACHE_RUNTIME_PLUGIN_CONFIG`:

  ```python
  raw = os.getenv("LMCACHE_RUNTIME_PLUGIN_CONFIG", "")
  ...
  return config.get("runtime_plugin_extra_config") or {}
  ```
  ([`lmcache/lmcache_frontend/lmcache_mp_plugin/lmcache_mp_frontend_plugin.py:76,87-100`](``https://github.com/LMCache/LMCache/blob/20e87af0d7697fe6921dc724689634266335b5d3/lmcache/lmcache_frontend/lmcache_mp_plugin/lmcache_mp_frontend_plugin.py#L76-L100))``

  The mirrored design page already documents the correct behavior
  (`docs/design/v1/multiprocess/mp_runtime_plugin.md` lines
  [164](https://github.com/LMCache/LMCache/blob/20e87af0d7697fe6921dc724689634266335b5d3/docs/design/v1/multiprocess/mp_runtime_plugin.md#L164)
  and [178](https://github.com/LMCache/LMCache/blob/20e87af0d7697fe6921dc724689634266335b5d3/docs/design/v1/multiprocess/mp_runtime_plugin.md#L178));
  the row in `configuration.rst` was the only place still naming a
  non-existent env var.

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/source/mp/configuration.rst` — Configuration Reference row for `--runtime-plugin-config` ([line 85](https://github.com/LMCache/LMCache/blob/20e87af0d7697fe6921dc724689634266335b5d3/docs/source/mp/configuration.rst#L85)) | *"JSON string of extra key-value config forwarded to runtime plugins via `LMCACHE_RUNTIME_PLUGIN_EXTRA_CONFIG`."* | *"JSON string of extra key-value config forwarded to runtime plugins as the top-level `runtime_plugin_extra_config` key inside the aggregated `LMCACHE_RUNTIME_PLUGIN_CONFIG` env var (there is no separate env var)."* |

### `docs/design/`

No new drift found today.

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. One
file touched:

- `docs/source/mp/configuration.rst`

## Code bugs surfaced (not fixed here)

The same wrong env-var name is baked into the CLI `--help` text at
[`lmcache/v1/multiprocess/config.py:325-327`](https://github.com/LMCache/LMCache/blob/20e87af0d7697fe6921dc724689634266335b5d3/lmcache/v1/multiprocess/config.py#L325-L327):

```python
help="JSON string of extra key-value config forwarded to runtime "
"plugins via LMCACHE_RUNTIME_PLUGIN_EXTRA_CONFIG. "
```

Flagged for a code follow-up; not touched here per this routine's
docs-only scope. (The pre-existing `lmcache_mp_connector_0180.py`
docstring inversion flagged by the 2026-07-22 check
([#4199](https://github.com/LMCache/LMCache/pull/4199)) is also
still open at [`lmcache_mp_connector_0180.py:456-458`](https://github.com/LMCache/LMCache/blob/20e87af0d7697fe6921dc724689634266335b5d3/lmcache/integration/vllm/lmcache_mp_connector_0180.py#L456-L458);
this PR does not re-flag it.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine. Needs human
review before merge. Kept as **draft**; not marked "Ready for review".
No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwqtQbE7XGz96gb3SpJS5H)_