### PR TITLE
[Fix][NIXL] Fail store tasks atomically on pool exhaustion

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -713,9 +713,9 @@ class NixlStoreL2Adapter(L2AdapterInterface):
 
         For each key-object pair, memory page indices are mapped to storage
         slot indices and a single batched DMA write is issued. On success the
-        key-to-storage mapping is recorded in ``_memory_objects``. On transfer
-        failure, all allocated storage slots are freed and the task is marked
-        as failed.
+        key-to-storage mapping is recorded in ``_memory_objects``. On preparation
+        or transfer failure, all allocated storage slots are freed and the
+        task is marked as failed.
 
         Args:
             keys: Keys identifying each object to store.
@@ -744,8 +744,8 @@ class NixlStoreL2Adapter(L2AdapterInterface):
                     num_objs=len(mem_indices)
                 )
 
-                if storage_indices == []:
-                    break
+                if not storage_indices:
+                    raise RuntimeError("Insufficient NIXL storage capacity")
 
                 mem_indices_flat.extend(mem_indices)
                 storage_indices_flat.extend(storage_indices)
@@ -764,7 +764,7 @@ class NixlStoreL2Adapter(L2AdapterInterface):
                 )
 
             if not mem_indices_flat:
-                # Nothing to store (all keys already existed or pool empty)
+                # Nothing to store because all keys already existed
                 with self._lock:
                     self._completed_store_tasks[task_id] = L2StoreResult(True, 0)
                 self._signal_store_event()
@@ -782,21 +782,17 @@ class NixlStoreL2Adapter(L2AdapterInterface):
                 for key, storage_obj in zip(stored_keys, storage_objs, strict=False):
                     self._memory_objects[key] = storage_obj
                     storage_obj.decrease_pin_count()
-            # ``stored_keys`` and ``storage_objs`` are built together in the
-            # pre-alloc loop above, so the size lists stay aligned even
-            # when the pool ran out of slots mid-batch.
             if stored_keys:
                 stored_sizes = [obj.size for obj in storage_objs]
                 self._notify_keys_stored(stored_keys, stored_sizes)
             bytes_transferred = sum(obj.size for obj in storage_objs)
 
-        # success is only set to false for transfer failures
         except Exception:
             logger.exception("NIXL store task %d failed", task_id)
             success = False
             bytes_transferred = 0
 
-            # free storage indices if transfer fails
+            # Free storage indices after preparation or transfer failures.
             self.nixl_agent.pool.batched_free(storage_indices_flat)
 
         with self._lock:

--- a/tests/v1/distributed/test_nixl_store_l2_adapter.py
+++ b/tests/v1/distributed/test_nixl_store_l2_adapter.py
@@ -319,6 +319,108 @@ class TestStoreInterface:
         assert task_id in completed
         assert completed[task_id].is_successful()
 
+    def test_store_fails_atomically_when_batch_exceeds_pool(self, adapter):
+        """Pool exhaustion should roll back every allocation in the batch."""
+        adpt, buf = adapter
+        listener = _RecordingListener()
+        adpt.register_listener(listener)
+        initial_status = adpt.report_status()
+
+        keys = [create_object_key(i) for i in range(POOL_SIZE + 1)]
+        objs = [
+            create_memory_obj(buf, page_index=i % NUM_BUFFER_PAGES)
+            for i in range(POOL_SIZE + 1)
+        ]
+        store_fd = adpt.get_store_event_fd()
+
+        task_id = adpt.submit_store_task(keys, objs)
+        assert wait_for_event_fd(store_fd, timeout=5.0)
+
+        result = adpt.pop_completed_store_tasks()[task_id]
+        assert not result.is_successful()
+        assert result.bytes_transferred() == 0
+        assert (
+            adpt.report_status()["pool_free_slots"] == initial_status["pool_free_slots"]
+        )
+        assert adpt.get_usage().total_bytes_used == 0
+        assert listener.stored == []
+
+        lookup_fd = adpt.get_lookup_and_lock_event_fd()
+        lookup_task_id = adpt.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
+        assert wait_for_event_fd(lookup_fd, timeout=5.0)
+        bitmap = adpt.query_lookup_and_lock_result(lookup_task_id)
+        assert bitmap is not None
+        for index in range(len(keys)):
+            assert bitmap.test(index) is False
+
+    def test_store_fails_when_pool_is_full(self, adapter):
+        """Pool exhaustion should preserve existing data and accounting."""
+        adpt, buf = adapter
+        existing_key = create_object_key(1)
+        existing_obj = create_memory_obj(buf, page_index=0, num_pages=POOL_SIZE)
+        store_fd = adpt.get_store_event_fd()
+
+        initial_task_id = adpt.submit_store_task([existing_key], [existing_obj])
+        assert wait_for_event_fd(store_fd, timeout=5.0)
+        initial_result = adpt.pop_completed_store_tasks()[initial_task_id]
+        assert initial_result.is_successful()
+
+        status_before = adpt.report_status()
+        usage_before = adpt.get_usage()
+        new_key = create_object_key(2)
+        new_obj = create_memory_obj(buf, page_index=0)
+
+        task_id = adpt.submit_store_task([new_key], [new_obj])
+        assert wait_for_event_fd(store_fd, timeout=5.0)
+
+        result = adpt.pop_completed_store_tasks()[task_id]
+        assert not result.is_successful()
+        assert result.bytes_transferred() == 0
+        assert (
+            adpt.report_status()["pool_free_slots"] == status_before["pool_free_slots"]
+        )
+        assert adpt.get_usage() == usage_before
+
+        lookup_fd = adpt.get_lookup_and_lock_event_fd()
+        lookup_task_id = adpt.submit_lookup_and_lock_task(
+            [existing_key, new_key], _EMPTY_LAYOUT
+        )
+        assert wait_for_event_fd(lookup_fd, timeout=5.0)
+        bitmap = adpt.query_lookup_and_lock_result(lookup_task_id)
+        assert bitmap is not None
+        assert bitmap.test(0) is True
+        assert bitmap.test(1) is False
+        adpt.submit_unlock([existing_key])
+
+    def test_store_existing_keys_succeeds_without_allocating(self, adapter):
+        """A no-op store should succeed without consuming pool slots."""
+        adpt, buf = adapter
+        key = create_object_key(1)
+        obj = create_memory_obj(buf, page_index=0)
+        store_fd = adpt.get_store_event_fd()
+
+        initial_task_id = adpt.submit_store_task([key], [obj])
+        assert wait_for_event_fd(store_fd, timeout=5.0)
+        initial_result = adpt.pop_completed_store_tasks()[initial_task_id]
+        assert initial_result.is_successful()
+
+        listener = _RecordingListener()
+        adpt.register_listener(listener)
+        status_before = adpt.report_status()
+        usage_before = adpt.get_usage()
+
+        task_id = adpt.submit_store_task([key], [obj])
+        assert wait_for_event_fd(store_fd, timeout=5.0)
+
+        result = adpt.pop_completed_store_tasks()[task_id]
+        assert result.is_successful()
+        assert result.bytes_transferred() == 0
+        assert (
+            adpt.report_status()["pool_free_slots"] == status_before["pool_free_slots"]
+        )
+        assert adpt.get_usage() == usage_before
+        assert listener.stored == []
+
 
 # =============================================================================
 # Lookup and Lock Interface Tests


### PR DESCRIPTION
**What this PR does / why we need it**:

The static NIXL L2 adapter previously stopped preparing a store batch when its storage pool could not allocate enough slots. If no objects had been prepared, the task incorrectly succeeded with zero transferred bytes. If earlier objects had already received slots, the adapter transferred and published that partial batch while reporting the entire task as successful.

This change treats pool exhaustion as a task failure before any transfer occurs.

- Route empty storage allocations through the existing failure path.
- Free every provisional storage slot accumulated for the task.
- Return an unsuccessful result with zero transferred bytes.
- Avoid publishing keys, notifying listeners, or updating usage for failed batches.
- Preserve zero-byte success when every submitted key already exists.
- Add regression coverage for oversized batches, already-full pools, and existing-key-only stores.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests