### PR TITLE
[Fix][RawBlock] Report recovered slot sizes to L2 listeners

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/raw_block_l2_adapter.py
@@ -556,7 +556,8 @@ class RawBlockL2Adapter(L2AdapterInterface):
         if not keys:
             return
         try:
-            listener.on_l2_keys_stored(keys, [0] * len(keys))
+            slot_bytes = int(self._core.slot_bytes)
+            listener.on_l2_keys_stored(keys, [slot_bytes] * len(keys))
         except Exception as e:
             logger.warning(
                 "RawBlockL2Adapter listener recovery bootstrap failed: %s", e


### PR DESCRIPTION
**What this PR does / why we need it**:

When a raw-block adapter recovers indexed keys from a checkpoint, listener registration currently reports each key with a size of `0`. The MP server's `L2EventListener` copies that value into `UsageEvent.bytes`, and the coordinator passes it to `L2UsageManager.record_stored()`.

In the coordinator, `0` is treated as the key's actual recorded size—not as an unknown-size placeholder. The key is added to the per-key ledger, but it contributes zero bytes to per-cache-salt and total L2 usage. As a result, quota and eviction accounting underestimate storage recovered from the checkpoint.

- Replace the reported `0` with the real raw-block storage charge: one `slot_bytes` value for each recovered key.
- Keep coordinator accounting consistent with the raw-block adapter's existing slot-based usage accounting.

**Special notes for your reviewers**:

- Each raw-block entry occupies one fixed-size slot, so `slot_bytes` is the correct accounting value regardless of the logical payload size.
- The adapter already restores its local usage counters from the checkpoint.
- Listener bootstrap invokes the listener directly instead of `_notify_keys_stored`, avoiding a second increment of those local counters.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
