### PR TITLE
fix: dedup finished_sending/finished_recving in get_finished() healthy path to prevent EngineDeadError on request abort

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -1682,6 +1682,7 @@ class LMCacheMPWorkerAdapter:
                 kv_rank=self.worker_id,
             )
 
+        ret_stores -= finished_retrieves
         return ret_stores, finished_retrieves
 
     def num_blocks_per_chunk(self) -> int:


### PR DESCRIPTION
### Problem

When a client disconnects mid-stream, vLLM aborts the request. If that request has an in-flight LMCache retrieve (KV load), the healthy path of `get_finished()` may place the same `request_id` into both `ret_stores` (finished_sending) and `finished_retrieves` (finished_recving).

The scheduler processes `finished_recving` first and deletes the request from `self.requests`, then hits `assert req_id in self.requests` when processing `finished_sending`, causing `AssertionError` → `EngineDeadError`.

### Root cause

The unhealthy path already has `ret_stores -= finished_retrieves` for dedup, but the healthy path was missing it. The omission becomes visible when a request is aborted while its retrieve_future completes in the same engine step; the probability spikes with batch aborts.

### Fix

Add `ret_stores -= finished_retrieves` before the return in the healthy path, matching the unhealthy path.

### Trigger conditions

1. Request uses LMCache KV transfer (retrieve/store)
2. Request is aborted by client disconnect during generation
3. The request's retrieve_future completes in the same engine step
4. Probability increases significantly with batch aborts