### PR TITLE
docs: daily drift check — multi-process mode (2026-07-28)

### DIFF
--- a/docs/design/v1/multiprocess/engine_driven_transfer_design.md
+++ b/docs/design/v1/multiprocess/engine_driven_transfer_design.md
@@ -105,10 +105,13 @@ Overall data flow:
 
 ### 2.2 Worker Side: TransferContext
 
-`TransferContext` is the worker-side transport abstraction with four methods:
-`register`, `submit_store`, `submit_retrieve`, and `close`.
+`TransferContext` is the worker-side transport abstraction with five methods:
+`register`, `submit_store`, `submit_retrieve`, `close`, and
+`flush_inflight_stores`. `flush_inflight_stores` synchronizes any in-flight
+gather operations so vLLM cannot overwrite paged KV blocks before deferred
+stores read them; contexts with no deferred work implement it as a no-op.
 The contract is intentionally minimal so worker adapters only depend on these
-four lifecycle and transfer operations.
+five lifecycle and transfer operations.
 
 - **LMCacheDrivenTransferContext** keeps the original CUDA IPC behavior:
   worker sends a handle and server performs direct GPU-side transfer.

--- a/docs/source/mp/index.rst
+++ b/docs/source/mp/index.rst
@@ -414,11 +414,14 @@ The ``L2AdapterInterface`` (in ``base.py``) defines three async task methods:
 - ``submit_lookup_and_lock_task(keys)`` -- Check if keys exist in L2.
 - ``submit_load_task(keys, layout_desc)`` -- Load data from L2 into L1.
 
-The factory function ``create_l2_adapter()`` (in ``__init__.py``) uses
-``isinstance()`` on the config type to instantiate the correct adapter.
+The factory function ``create_l2_adapter()`` (in ``__init__.py``) delegates
+to a factory registry keyed by the config's registered type name
+(``create_l2_adapter_from_registry`` in ``factory.py``, which resolves the
+name via ``get_type_name_for_config`` and dispatches through the
+``_L2_ADAPTER_FACTORY_REGISTRY``).
 
 New adapter types are registered via ``register_l2_adapter_type()`` in
-``config.py``.
+``config.py`` and ``register_l2_adapter_factory()`` in ``factory.py``.
 
 Controllers
 ~~~~~~~~~~~


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current
`dev` code (`upstream/dev` HEAD [`c6b89ab`](https://github.com/LMCache/LMCache/commit/c6b89abca781075d1bf6095cebeadbb5710a0234)),
focused on the multi-process mode. Two drift items found today, one in
`docs/source/` and one in `docs/design/`. Prior open drift-check PRs
from earlier days — [#4269](https://github.com/LMCache/LMCache/pull/4269),
[#4249](https://github.com/LMCache/LMCache/pull/4249),
[#4236](https://github.com/LMCache/LMCache/pull/4236), and
[#4199](https://github.com/LMCache/LMCache/pull/4199) — still track
their earlier items.

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/mp/index.rst`** — the L2 Adapter factory description
  claimed `create_l2_adapter()` dispatches by `isinstance()` on the
  config type. That path is gone: the factory now delegates to a
  string-keyed registry.

  `create_l2_adapter` in [`lmcache/v1/distributed/l2_adapters/__init__.py:37-61`](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/v1/distributed/l2_adapters/__init__.py#L37-L61)
  is a one-line wrapper around `create_l2_adapter_from_registry`, and
  [`factory.py:165-205`](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/v1/distributed/l2_adapters/factory.py#L165-L205)
  resolves the adapter by:

  ```python
  name = get_type_name_for_config(config)
  ensure_adapter_loaded(name)
  factory = _L2_ADAPTER_FACTORY_REGISTRY.get(name)
  ...
  return factory(config, l1_memory_desc)
  ```

  There is no `isinstance()` branch anywhere in the dispatch. New
  adapters register both a config type (via `register_l2_adapter_type`
  in [`config.py:57`](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/v1/distributed/l2_adapters/config.py#L57))
  and a factory (via `register_l2_adapter_factory` in
  [`factory.py:62`](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/v1/distributed/l2_adapters/factory.py#L62)).

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/source/mp/index.rst` — L2 Adapters section ([lines 417-421](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/docs/source/mp/index.rst#L417-L421)) | *"The factory function `create_l2_adapter()` (in `__init__.py`) uses `isinstance()` on the config type to instantiate the correct adapter. New adapter types are registered via `register_l2_adapter_type()` in `config.py`."* | Points at `create_l2_adapter_from_registry` in `factory.py`, names `get_type_name_for_config` and `_L2_ADAPTER_FACTORY_REGISTRY` as the resolution path, and adds `register_l2_adapter_factory()` alongside `register_l2_adapter_type()` for new adapters. |

### `docs/design/`

- **`docs/design/v1/multiprocess/engine_driven_transfer_design.md`** —
  Section 2.2 described `TransferContext` as "the worker-side transport
  abstraction with **four methods**: `register`, `submit_store`,
  `submit_retrieve`, and `close`". The ABC actually has **five**
  `@abstractmethod`s: `flush_inflight_stores` is the fifth
  ([`worker_transfer.py:212-326`](``https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L212-L326)):``

  ```python
  @abstractmethod
  def flush_inflight_stores(self) -> None:
      """Synchronize any in-flight gather operations.

      Subclasses must implement this method. Contexts with no deferred
      operations should implement it as a no-op. Async contexts that
      defer GPU->CPU gather work must block until all in-flight stores
      have completed, so that vLLM cannot overwrite paged KV blocks
      before they are read.
      """
  ```

  Both concrete subclasses on this branch implement it
  ([`LMCacheDrivenTransferContext.flush_inflight_stores`](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L500)
  and
  [`EngineDrivenTransferContext.flush_inflight_stores`](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/v1/multiprocess/transfer_context/worker_transfer.py#L711)),
  and it is architecturally load-bearing: without it an
  `AsyncEngineDrivenTransferContext` cannot guarantee vLLM won't
  overwrite paged blocks before a deferred gather reads them.

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/design/v1/multiprocess/engine_driven_transfer_design.md` — Section 2.2 ([lines 108-111](``https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/docs/design/v1/multiprocess/engine_driven_transfer_design.md#L108-L111``)) | *"...transport abstraction with **four methods**: `register`, `submit_store`, `submit_retrieve`, and `close`. The contract is intentionally minimal so worker adapters only depend on these **four** lifecycle and transfer operations."* | Names five methods (adds `flush_inflight_stores` with a one-sentence description) and updates the "four" → "five" in the follow-up sentence. |

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. Two
files touched:

- `docs/source/mp/index.rst`
- `docs/design/v1/multiprocess/engine_driven_transfer_design.md`

## Code bugs surfaced (not fixed here)

None new from today's check. (The pre-existing
`lmcache_mp_connector_0180.py` docstring inversion flagged by the
2026-07-22 check ([#4199](https://github.com/LMCache/LMCache/pull/4199))
is still open at
[`lmcache_mp_connector_0180.py:456-458`](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/integration/vllm/lmcache_mp_connector_0180.py#L456-L458);
and the `--runtime-plugin-config` CLI `--help` string mismatch flagged
by the 2026-07-27 check
([#4269](https://github.com/LMCache/LMCache/pull/4269)) at
[`config.py:325-327`](https://github.com/LMCache/LMCache/blob/c6b89abca781075d1bf6095cebeadbb5710a0234/lmcache/v1/multiprocess/config.py#L325-L327)
is still open. This PR does not re-flag them.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine. Needs human
review before merge. Kept as **draft**; not marked "Ready for review".
No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mr92GVbAamPtTudVGDAvJj)_