### PR TITLE
[Core] validate async memcpy host ranges

### DIFF
--- a/csrc/mem_kernels.cu
+++ b/csrc/mem_kernels.cu
@@ -6,6 +6,7 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <algorithm>
+#include <limits>
 #ifdef USE_ROCM
   #include <hip/hip_fp8.h>
 #else
@@ -1104,8 +1105,11 @@ void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
                           size_t host_buffer_offset,
                           size_t host_buffer_alignments) {
   // Check that host_buffer_alignments is power of two
-  TORCH_CHECK((host_buffer_alignments & (host_buffer_alignments - 1)) == 0,
+  TORCH_CHECK(host_buffer_alignments != 0 &&
+                  (host_buffer_alignments & (host_buffer_alignments - 1)) == 0,
               "host_buffer_alignments must be power of two");
+  TORCH_CHECK(nbytes <= std::numeric_limits<size_t>::max() - host_buffer_offset,
+              "host_buffer_offset + nbytes must not overflow size_t");
 
   size_t offset = 0;
   const size_t mask = host_buffer_alignments - 1;
@@ -1118,13 +1122,12 @@ void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
     size_t current_src = src + offset;
     size_t current_dest = dest + offset;
 
-    size_t aligned_area_end =
-        ((offset + host_buffer_offset) & ~mask) + host_buffer_alignments;
+    const size_t position = host_buffer_offset + offset;
+    const size_t bytes_to_boundary = host_buffer_alignments - (position & mask);
     // Use std::min<size_t> so HIP's overload set cannot silently narrow
     // these values to int and produce a garbage length past the 2 GB mark.
-    size_t real_end =
-        std::min<size_t>(host_buffer_offset + nbytes, aligned_area_end);
-    size_t max_nbytes = real_end - offset - host_buffer_offset;
+    const size_t max_nbytes =
+        std::min<size_t>(nbytes - offset, bytes_to_boundary);
 
     CHECK_CUDA_CALL(cudaMemcpyAsync(reinterpret_cast<void*>(current_dest),
                                     reinterpret_cast<const void*>(current_src),

--- a/csrc/sycl/mem_kernels_sycl.cpp
+++ b/csrc/sycl/mem_kernels_sycl.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -993,8 +994,11 @@ void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
                           TransferDirection direction,
                           size_t host_buffer_offset,
                           size_t host_buffer_alignments) {
-  TORCH_CHECK((host_buffer_alignments & (host_buffer_alignments - 1)) == 0,
+  TORCH_CHECK(host_buffer_alignments != 0 &&
+                  (host_buffer_alignments & (host_buffer_alignments - 1)) == 0,
               "host_buffer_alignments must be power of two");
+  TORCH_CHECK(nbytes <= std::numeric_limits<size_t>::max() - host_buffer_offset,
+              "host_buffer_offset + nbytes must not overflow size_t");
 
   // SYCL USM memcpy infers direction from pointer allocation types;
   // the `direction` parameter is retained only for API compatibility.
@@ -1009,10 +1013,10 @@ void lmcache_memcpy_async(uintptr_t dest, uintptr_t src, size_t nbytes,
     size_t current_src = src + offset;
     size_t current_dest = dest + offset;
 
-    size_t aligned_area_end =
-        ((offset + host_buffer_offset) & ~mask) + host_buffer_alignments;
-    size_t real_end = std::min(host_buffer_offset + nbytes, aligned_area_end);
-    size_t max_nbytes = real_end - offset - host_buffer_offset;
+    const size_t position = host_buffer_offset + offset;
+    const size_t bytes_to_boundary = host_buffer_alignments - (position & mask);
+    const size_t max_nbytes =
+        std::min<size_t>(nbytes - offset, bytes_to_boundary);
 
     // USM memcpy is direction-agnostic.
     queue.memcpy(reinterpret_cast<void*>(current_dest),

--- a/tests/v1/test_mem_kernels.py
+++ b/tests/v1/test_mem_kernels.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from typing import List
+import ctypes
 import random
 
 # Third Party
@@ -841,6 +842,60 @@ def test_lmcache_memcpy_async():
     ptr = big_cpu_tensor.data_ptr()
     for i in range(num_chunks):
         rt.cudaHostUnregister(ptr + i * chunk_size)
+
+
+@pytest.mark.parametrize("host_buffer_alignments", [0, 3])
+def test_lmcache_memcpy_async_rejects_invalid_alignment(
+    host_buffer_alignments: int,
+) -> None:
+    with pytest.raises(RuntimeError, match="must be power of two"):
+        lmc_ops.lmcache_memcpy_async(
+            0,
+            0,
+            1,
+            lmc_ops.TransferDirection.H2D,
+            0,
+            host_buffer_alignments,
+        )
+
+
+def test_lmcache_memcpy_async_rejects_host_range_overflow() -> None:
+    size_t_max = ctypes.c_size_t(-1).value
+
+    with pytest.raises(RuntimeError, match="must not overflow size_t"):
+        lmc_ops.lmcache_memcpy_async(
+            0,
+            0,
+            2,
+            lmc_ops.TransferDirection.H2D,
+            size_t_max - 1,
+            64,
+        )
+
+
+def test_lmcache_memcpy_async_handles_size_t_boundary_without_overcopy() -> None:
+    size_t_max = ctypes.c_size_t(-1).value
+    cpu_tensor = torch.tensor(
+        [0xA5, 0x5A],
+        dtype=torch.uint8,
+        pin_memory=True,
+    )
+    gpu_tensor = torch.zeros(2, dtype=torch.uint8, device="cuda")
+
+    lmc_ops.lmcache_memcpy_async(
+        gpu_tensor.data_ptr(),
+        cpu_tensor.data_ptr(),
+        1,
+        lmc_ops.TransferDirection.H2D,
+        size_t_max - 1,
+        4,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(
+        gpu_tensor.cpu(),
+        torch.tensor([0xA5, 0], dtype=torch.uint8),
+    )
 
 
 def test_lmcache_memcpy_async_int8_hidden132():


### PR DESCRIPTION
Validate arguments passed to asynchronous memcpy kernels before calculating copy boundaries.

  - Rejects zero and non-power-of-two host buffer alignments.
  - Detects size_t overflow in host_buffer_offset + nbytes.
  - Computes copy sizes without overflowing aligned boundary calculations.
  - Applies the same validation to CUDA and SYCL implementations.

If applicable:

  - [ ] this PR contains user facing changes - docs added
  - [x] this PR contains unit tests
