### PR TITLE
fix(vllm/mp): accept a single server URL string from older connectors (#4267)

### DIFF
--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
+++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
@@ -398,6 +398,26 @@ def _normalize_adapter_init_args(
     return int(legacy_block_size), strategy, mq_timeout
 
 
+def _normalize_server_urls(server_urls: Sequence[str] | str) -> list[str]:
+    """Normalize the server URL argument from old and new vLLM connectors.
+
+    Current connectors pass a sequence of server URLs. Older ones pass a
+    single URL as a bare string; ``list()`` would split that into one
+    character per element and hand each character to
+    :class:`MessageQueueClient` as if it were a URL, which surfaces as an
+    opaque ``ZMQError: Invalid argument (addr='t')``.
+
+    Args:
+        server_urls: A sequence of server URLs, or a single URL string.
+
+    Returns:
+        The server URLs as a list.
+    """
+    if isinstance(server_urls, str):
+        return [server_urls]
+    return list(server_urls)
+
+
 class HeartbeatThread(PeriodicThread):
     """Periodically checks server health via PING.
 
@@ -562,7 +582,7 @@ LookupResult = int
 class LMCacheMPSchedulerAdapter:
     def __init__(
         self,
-        server_urls: list[str],
+        server_urls: Sequence[str] | str,
         context: zmq.Context,
         model_name: str,
         vllm_block_size: int,
@@ -575,7 +595,8 @@ class LMCacheMPSchedulerAdapter:
     ):
         """
         Args:
-            server_urls: The servers URL for the LMCache message queue
+            server_urls: The server URLs for the LMCache message queue.
+                Older vLLM connectors pass a single URL string.
             context: The ZMQ context
             model_name: The model name used for LMCache keys
             vllm_block_size: The block size used in vLLM
@@ -599,8 +620,9 @@ class LMCacheMPSchedulerAdapter:
             legacy_block_size,
             mq_timeout,
         )
+        server_urls = _normalize_server_urls(server_urls)
         assert len(server_urls) >= 1, "At least one server url required"
-        self._server_urls: list[str] = list(server_urls)
+        self._server_urls: list[str] = server_urls
         self.mq_clients: dict[str, MessageQueueClient] = {
             url: MessageQueueClient(url, context) for url in self._server_urls
         }

--- a/tests/v1/multiprocess/test_mp_server_urls.py
+++ b/tests/v1/multiprocess/test_mp_server_urls.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for server-URL normalization in the multiprocess vLLM adapters."""
+
+
+def test_normalize_server_urls_wraps_a_single_url_string():
+    """A bare URL string must stay one URL, not become one URL per character."""
+    # First Party
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        _normalize_server_urls,
+    )
+
+    url = "tcp://127.0.0.1:5555"
+    assert _normalize_server_urls(url) == [url]
+
+
+def test_normalize_server_urls_keeps_sequences():
+    """Sequences of URLs are returned as an equivalent list."""
+    # First Party
+    from lmcache.integration.vllm.vllm_multi_process_adapter import (
+        _normalize_server_urls,
+    )
+
+    urls = ["tcp://127.0.0.1:5555", "tcp://127.0.0.1:5556"]
+    assert _normalize_server_urls(urls) == urls
+    assert _normalize_server_urls(tuple(urls)) == urls


### PR DESCRIPTION
## Summary

Fixes #4267.

vLLM connectors older than 0.24 pass `lmcache_mp_server_url` to `LMCacheMPSchedulerAdapter` as a **bare string**, not a sequence — see [`lmcache_mp_connector.py#L96-L111` in vLLM v0.17.1](https://github.com/vllm-project/vllm/blob/v0.17.1/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py#L96-L111) (as @zhengfeihe pointed out on the issue).

The constructor normalized that argument with `list(server_urls)`:

```python
assert len(server_urls) >= 1, "At least one server url required"
self._server_urls: list[str] = list(server_urls)
self.mq_clients: dict[str, MessageQueueClient] = {
    url: MessageQueueClient(url, context) for url in self._server_urls
}
```

`list("tcp://127.0.0.1:5555")` is `["t", "c", "p", ...]`, so the adapter built one `MessageQueueClient` per **character** and the first `socket.connect()` failed with the reporter's error:

```
zmq.error.ZMQError: Invalid argument (addr='t')
```

The `len(...) >= 1` assertion doesn't catch it either — a non-empty string has a length too.

## Change

Added `_normalize_server_urls()` next to the existing `_normalize_adapter_init_args()` and called it from `LMCacheMPSchedulerAdapter.__init__`. A bare string is wrapped as a single-element list; any other sequence keeps the previous `list()` behavior.

This follows the shape already used in this class for the other legacy-connector arguments (`parallel_strategy: ParallelStrategy | int`, `legacy_block_size`), so the parameter annotation is widened to `Sequence[str] | str` to match what callers actually pass. `LMCacheMPWorkerAdapter` is unaffected — it takes a singular `server_url: str` and never lists it.

## Tests

`tests/v1/multiprocess/test_mp_server_urls.py` covers both directions: a single URL string stays one URL, and list/tuple inputs are returned as an equivalent list.

## Note on the base

My fork's `dev` is behind upstream, and I can't fast-forward it (the sync touches `.github/workflows/`, which my token isn't scoped for). This branch is therefore a single commit on that older `dev`; the diff is only the two files above, and the touched region is unchanged upstream, so it applies cleanly. Happy to rebase if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
