### PR TITLE
fix(cli): make bench server pair runs fail close

### DIFF
--- a/docs/source/cli/bench.rst
+++ b/docs/source/cli/bench.rst
@@ -700,6 +700,24 @@ mismatch between producer and consumer surfaces as a loud
 ``CHECKSUM MISMATCH`` log line.
 
 
+Run validity and failure handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The benchmark is *fail-close*: it never reports latency for a run it cannot
+vouch for. A successful run prints its usual per-operation summary with
+``Valid: yes`` and exits ``0``. Otherwise:
+
+* A ``LOOKUP`` / prefetch-poll / ``STORE`` / ``RETRIEVE`` failure or timeout,
+  or a checksum mismatch, marks the run **invalid**: the performance summary
+  is suppressed (``Valid: no``) and the command exits non-zero, so a broken
+  run is never mistaken for a fast one.
+* If a cleanup RPC cannot be confirmed -- an unacknowledged ``END_SESSION`` or
+  ``UNREGISTER_KV_CACHE`` -- the run additionally reports
+  ``Server reuse safe: no``: the dedicated server may still hold residual
+  state and should be restarted before the next run.
+* ``Ctrl-C`` stops the run, tears the session down, and exits ``130``.
+
+
 Quick start
 ~~~~~~~~~~~
 

--- a/lmcache/cli/commands/bench/server_bench/command.py
+++ b/lmcache/cli/commands/bench/server_bench/command.py
@@ -52,6 +52,8 @@ from lmcache import torch_dev
 from lmcache.cli.commands.bench.server_bench.helpers import (
     _DEFAULT_SHAPE_SPEC,
     DTYPE_MAP,
+    ServerTaintedError,
+    ServerTaintedInterrupt,
     _allocate_cpu_shm_kv_cache,
     _allocate_gpu_kv_cache,
     _get_chunk_size,
@@ -399,6 +401,13 @@ def run_server_bench(
     total_checksum_ok = 0
     total_checksum_fail = 0
 
+    # Fail-close run health. ``run_error`` is the first invalidating reason
+    # (empty => valid); ``server_tainted`` means cleanup could not confirm the
+    # server is safe to reuse; ``interrupted`` maps a Ctrl-C to exit 130.
+    run_error = ""
+    server_tainted = False
+    interrupted = False
+
     # Latency collectors: keyed by (pass_label, op_type).
     # Each entry is a list of latency values in ms.
     cold_lookup_ms: list[float] = []
@@ -577,6 +586,11 @@ def run_server_bench(
         # ``REGISTER_KV_CACHE`` protocol since ``CpuShmTensorWrapper``
         # is a ``DeviceIPCWrapper`` subclass on the wire. In data mode
         # we fall through to the non-GPU registration protocol.
+        # REGISTER is submit-then-unknown: once submitted the server may have
+        # created the context even if the reply times out. Mark it registered
+        # *before* the call so the ``finally`` best-effort UNREGISTERs it on
+        # any outcome (a no-op server-side if it was never created).
+        registered = True
         register_result = _send_register_kv_cache(
             client,
             layout_hints=layout_hints,
@@ -587,11 +601,14 @@ def run_server_bench(
         )
         log("REGISTER_KV_CACHE: %s" % ("OK" if register_result else "FAIL"))
         log("")
-        # Mark the registration so the ``finally`` block knows to send the
-        # matching UNREGISTER. The data-mode register returns a response
-        # object (truthy) and the handle-mode register returns a bool;
-        # either way a truthy result means the server holds our context.
-        registered = bool(register_result)
+        if not register_result:
+            # A failed / timed-out REGISTER invalidates the run and taints the
+            # server (its context state is unknown); the workload must not
+            # start, but teardown still best-effort UNREGISTERs.
+            run_error = (
+                "REGISTER_KV_CACHE failed (timeout or rejection); server effect unknown"
+            )
+            server_tainted = True
 
         # In data mode the server reply carries the SHM pool name
         # and size; the bench mmaps the same pool so STORE/RETRIEVE
@@ -608,6 +625,9 @@ def run_server_bench(
             seq_iter: itertools.count | range = range(args.start, args.end)
         else:
             seq_iter = itertools.count(args.start)
+        if run_error:
+            # Setup already failed (e.g. REGISTER): do not start the workload.
+            seq_iter = range(0)
 
         http_base = args.url.rstrip("/")
 
@@ -617,6 +637,12 @@ def run_server_bench(
         # RETRIEVE. Handle mode keeps the legacy server-side
         # ``/cache/checksums`` path.
         client_tensors = None if use_handle else client_kv_tensors
+
+        # Checksum verification is expected in data mode (client-side hashing)
+        # or whenever an HTTP endpoint is configured (server-side hashing). A
+        # run that expects it but cannot produce comparable digests is invalid:
+        # "unable to verify" must never pass as "verified".
+        checksum_expected = client_tensors is not None or bool(http_base)
 
         # Record only the steady-state load, not the one-time registration.
         if profiler is not None:
@@ -641,11 +667,25 @@ def run_server_bench(
                 client_tensors=client_tensors,
                 server_pool=server_pool,
             )
-            if cold_result is not None:
-                if cold_result.lookup_ms is not None:
-                    cold_lookup_ms.append(cold_result.lookup_ms)
-                if cold_result.store_ms is not None:
-                    cold_store_ms.append(cold_result.store_ms)
+            # A ``None`` result means the request was smaller than one chunk:
+            # a pair pass that stores / verifies nothing cannot be benchmarked,
+            # so the run is invalid rather than silently skipped.
+            if cold_result is None:
+                run_error = (
+                    "seq %d cold: request smaller than one chunk; nothing to "
+                    "benchmark" % seq_no
+                )
+                break
+            if cold_result.server_tainted:
+                server_tainted = True
+            if cold_result.failure:
+                # Fail-close: stop issuing requests against a broken server.
+                run_error = "seq %d cold: %s" % (seq_no, cold_result.failure)
+                break
+            if cold_result.lookup_ms is not None:
+                cold_lookup_ms.append(cold_result.lookup_ms)
+            if cold_result.store_ms is not None:
+                cold_store_ms.append(cold_result.store_ms)
 
             time.sleep(args.interval)
 
@@ -665,44 +705,97 @@ def run_server_bench(
                 client_tensors=client_tensors,
                 server_pool=server_pool,
             )
-            if warm_result is not None:
-                if warm_result.lookup_ms is not None:
-                    warm_lookup_ms.append(warm_result.lookup_ms)
-                if warm_result.retrieve_ms is not None:
-                    warm_retrieve_ms.append(warm_result.retrieve_ms)
+            if warm_result is None:
+                run_error = (
+                    "seq %d warm: request smaller than one chunk; nothing to "
+                    "benchmark" % seq_no
+                )
+                break
+            if warm_result.server_tainted:
+                server_tainted = True
+            if warm_result.failure:
+                run_error = "seq %d warm: %s" % (seq_no, warm_result.failure)
+                break
+            if warm_result.lookup_ms is not None:
+                warm_lookup_ms.append(warm_result.lookup_ms)
+            if warm_result.retrieve_ms is not None:
+                warm_retrieve_ms.append(warm_result.retrieve_ms)
 
-            # Compare checksums
             total_requests += 1
-            cold_checksums = cold_result.checksums if cold_result else None
-            warm_checksums = warm_result.checksums if warm_result else None
-            if cold_checksums and warm_checksums:
-                if cold_checksums == warm_checksums:
+
+            # Pair protocol: the cold pass just stored this sequence, so the
+            # warm pass must hit every chunk. A short hit means the STORE was
+            # not fully retrievable -- invalidate rather than report it clean.
+            if warm_result.hit_chunks < warm_result.total_chunks:
+                run_error = (
+                    "seq %d: warm pass hit %d/%d chunks; the cold STORE was not "
+                    "fully retrievable"
+                    % (seq_no, warm_result.hit_chunks, warm_result.total_chunks)
+                )
+                break
+
+            # Checksum oracle (fail-close). When verification is expected, both
+            # digests must be present, cover every chunk, and match exactly; a
+            # missing / short / mismatched digest all invalidate the run, so an
+            # unverifiable result can never pass as verified. When verification
+            # is not expected (handle mode with no HTTP endpoint) there is no
+            # oracle to enforce.
+            cold_checksums = cold_result.checksums
+            warm_checksums = warm_result.checksums
+            if checksum_expected:
+                expected = warm_result.total_chunks
+                verified = (
+                    cold_checksums is not None
+                    and warm_checksums is not None
+                    and len(cold_checksums) == expected
+                    and len(warm_checksums) == expected
+                    and cold_checksums == warm_checksums
+                )
+                if verified:
                     total_checksum_ok += 1
                     log("  [seq %d] CHECKSUM MATCH OK" % seq_no)
                 else:
                     total_checksum_fail += 1
-                    log("  [seq %d] CHECKSUM MISMATCH!" % seq_no)
-                    for i, (c, w) in enumerate(
-                        zip(
-                            cold_checksums,
-                            warm_checksums,
-                            strict=False,
-                        )
-                    ):
-                        log(
-                            "    chunk %d: cold=%s warm=%s %s"
-                            % (
-                                i,
-                                c[:12],
-                                w[:12],
-                                ("OK" if c == w else "FAIL"),
+                    log("  [seq %d] CHECKSUM VERIFICATION FAILED" % seq_no)
+                    if cold_checksums is not None and warm_checksums is not None:
+                        for i, (c, w) in enumerate(
+                            zip(cold_checksums, warm_checksums, strict=False)
+                        ):
+                            log(
+                                "    chunk %d: cold=%s warm=%s %s"
+                                % (i, c[:12], w[:12], ("OK" if c == w else "FAIL"))
                             )
+                    run_error = (
+                        "seq %d: checksum verification failed (cold=%s warm=%s, "
+                        "expected %d chunks)"
+                        % (
+                            seq_no,
+                            "none" if cold_checksums is None else len(cold_checksums),
+                            "none" if warm_checksums is None else len(warm_checksums),
+                            expected,
                         )
+                    )
+                    break
 
             log("")
             time.sleep(args.interval)
+    except ServerTaintedInterrupt as exc:
+        # A Ctrl-C whose cleanup could not be confirmed: keep exit 130 AND
+        # flag the server for restart.
+        interrupted = True
+        server_tainted = True
+        run_error = run_error or ("interrupted: %s" % exc)
+        log("\nStopping (server state unconfirmed)...")
     except KeyboardInterrupt:
+        # A plain Ctrl-C: the run is invalid and must exit 130.
+        interrupted = True
+        run_error = run_error or "interrupted by user (Ctrl-C)"
         log("\nStopping...")
+    except ServerTaintedError as exc:
+        # A request failed and its cleanup could not confirm clean state.
+        server_tainted = True
+        run_error = run_error or ("request failed: %s" % exc)
+        log("\n[error] %s" % exc)
     finally:
         # Stop recording once load ends, before teardown
         if profiler is not None:
@@ -713,6 +806,12 @@ def run_server_bench(
         # one context entry per bench run. Must run while the client is
         # still connected, hence before ``client.close()``.
         if registered:
+            # A cleanup that cannot be confirmed invalidates the run AND marks
+            # the server unsafe to reuse -- otherwise the summary could read
+            # "Valid: yes / Server reuse safe: no" with latency still shown.
+            # ``_call`` only converts a TimeoutError, so any other error (or a
+            # Ctrl-C) is caught here rather than allowed to skip the remaining
+            # mmap / client / SHM cleanup below.
             try:
                 ok = _send_unregister_kv_cache(
                     client,
@@ -720,7 +819,20 @@ def run_server_bench(
                     use_handle=use_handle,
                 )
                 log("UNREGISTER_KV_CACHE: %s" % ("OK" if ok else "FAIL"))
-            except zmq.ZMQError as exc:
+                if not ok:
+                    server_tainted = True
+                    run_error = run_error or (
+                        "UNREGISTER_KV_CACHE timed out; server may still hold "
+                        "the context (restart required)"
+                    )
+            except BaseException as exc:  # noqa: BLE001 - cleanup must not abort
+                server_tainted = True
+                if isinstance(exc, KeyboardInterrupt):
+                    interrupted = True
+                run_error = run_error or (
+                    "UNREGISTER_KV_CACHE failed (%s: %s); server state unknown"
+                    % (type(exc).__name__, exc)
+                )
                 log("  [warning] UNREGISTER_KV_CACHE failed: %s" % exc)
         # Release the bench-side mmap of the server SHM pool first
         # (data mode only; ``server_pool`` stays ``None`` otherwise).
@@ -741,19 +853,36 @@ def run_server_bench(
             except OSError:
                 pass
 
-    # Emit structured metrics summary.
+    # A run that completed no request pairs (an empty --start/--end range, or
+    # setup that failed before the first request) has nothing to report and is
+    # not a valid benchmark.
+    if total_requests == 0 and not run_error:
+        run_error = "no request pairs completed (empty --start/--end range?)"
+
+    # Emit the summary. On an invalid run the performance sections are
+    # suppressed -- the numbers are not trustworthy -- but the validity
+    # verdict and server-reuse-safety are always reported.
+    invalid = bool(run_error)
+    server_reuse_safe = not server_tainted
     _emit_server_bench_metrics(
         command=command,
         args=args,
         total_requests=total_requests,
         total_checksum_ok=total_checksum_ok,
         total_checksum_fail=total_checksum_fail,
+        valid=not invalid,
+        server_reuse_safe=server_reuse_safe,
+        run_error=run_error,
         cold_lookup_ms=cold_lookup_ms,
         cold_store_ms=cold_store_ms,
         warm_lookup_ms=warm_lookup_ms,
         warm_retrieve_ms=warm_retrieve_ms,
     )
     log("Done.")
+    if invalid:
+        # Fail-close exit: a Ctrl-C keeps the conventional 130, any other
+        # failure exits 1, so callers never read a broken run as success.
+        sys.exit(130 if interrupted else 1)
 
 
 def _emit_server_bench_metrics(
@@ -762,27 +891,36 @@ def _emit_server_bench_metrics(
     total_requests: int,
     total_checksum_ok: int,
     total_checksum_fail: int,
+    valid: bool = True,
+    server_reuse_safe: bool = True,
+    run_error: str = "",
     cold_lookup_ms: list[float] | None = None,
     cold_store_ms: list[float] | None = None,
     warm_lookup_ms: list[float] | None = None,
     warm_retrieve_ms: list[float] | None = None,
 ) -> None:
-    """Emit server bench summary using the CLI metrics system.
+    """Emit the server bench summary using the CLI metrics system.
+
+    The validity verdict is always reported, but the performance sections
+    (checksum pass rate and per-operation latencies) are emitted only for a
+    *valid* run: a failed / interrupted / server-tainted run must not present
+    confident-looking numbers.
 
     Args:
         command: The owning :class:`BaseCommand` instance.
         args: Parsed CLI arguments.
-        total_requests: Total number of request pairs processed.
+        total_requests: Total number of request pairs completed.
         total_checksum_ok: Number of requests with matching checksums.
         total_checksum_fail: Number of requests with mismatched checksums.
+        valid: Whether the run's numbers are trustworthy.
+        server_reuse_safe: Whether the dedicated server can be reused (``False``
+            when cleanup could not confirm clean state).
+        run_error: The first invalidating reason (empty when ``valid``).
         cold_lookup_ms: Per-request cold lookup latencies (ms).
         cold_store_ms: Per-request cold store latencies (ms).
         warm_lookup_ms: Per-request warm lookup latencies (ms).
         warm_retrieve_ms: Per-request warm retrieve latencies (ms).
     """
-    if total_requests == 0:
-        return
-
     metrics = command.create_metrics("Server Bench Result", args, width=64)
 
     cfg_section = metrics.add_section("config", "Configuration")
@@ -795,7 +933,17 @@ def _emit_server_bench_metrics(
     cfg_section.add("interval", "Interval (s)", args.interval)
 
     result_section = metrics.add_section("results", "Results")
+    result_section.add("valid", "Valid", "yes" if valid else "no")
+    result_section.add(
+        "server_reuse_safe", "Server reuse safe", "yes" if server_reuse_safe else "no"
+    )
     result_section.add("total_requests", "Total requests", total_requests)
+    if not valid:
+        # Suppress the performance summary: the run is not trustworthy.
+        result_section.add("error", "Error", run_error or "run invalid")
+        metrics.emit()
+        return
+
     result_section.add("checksum_ok", "Checksum OK", total_checksum_ok)
     result_section.add("checksum_fail", "Checksum FAIL", total_checksum_fail)
     if total_requests > 0:

--- a/lmcache/cli/commands/bench/server_bench/helpers.py
+++ b/lmcache/cli/commands/bench/server_bench/helpers.py
@@ -812,9 +812,22 @@ def _send_retrieve(
 def _send_end_session(
     client: MessageQueueClient,
     request_id: str,
-) -> None:
-    """END_SESSION — clean up server-side session state."""
-    _call(client, RequestType.END_SESSION, [request_id])
+) -> bool:
+    """END_SESSION -- clean up server-side session state.
+
+    Args:
+        client: The MP message-queue client.
+        request_id: The request whose session should be removed.
+
+    Returns:
+        ``True`` if the server acknowledged the call, ``False`` only on an
+        RPC *timeout* (the session may still be held server-side, so the
+        caller must fail the run and treat the server as tainted). A ZMQ /
+        server exception or a ``KeyboardInterrupt`` is *not* folded into
+        ``False`` -- those propagate to the caller's cleanup guard, which
+        turns them into a taint on the exception path.
+    """
+    return _call(client, RequestType.END_SESSION, [request_id]) is not _TIMEOUT
 
 
 # ------------------------------------------------------------------ #
@@ -886,12 +899,45 @@ def _query_checksum(
 # ------------------------------------------------------------------ #
 
 
+class ServerTaintedInterrupt(KeyboardInterrupt):
+    """A Ctrl-C whose request cleanup (END_SESSION) could not be confirmed.
+
+    A :class:`KeyboardInterrupt` subclass, so it keeps interrupt semantics
+    (the run still exits 130) while signalling that the server may hold
+    residual state and must be restarted. Raised from the
+    :func:`_process_request` cleanup guard when an interrupted request could
+    not acknowledge END_SESSION; the caller reports ``Server reuse safe: no``.
+    """
+
+
+class ServerTaintedError(RuntimeError):
+    """A request failed *and* its cleanup (END_SESSION) could not be confirmed.
+
+    Raised from :func:`_process_request` on the exception path -- when the
+    request body raised before a :class:`RequestResult` existed and the
+    subsequent END_SESSION timed out or itself raised. It carries the taint
+    out so the caller can both invalidate the run and flag the server for a
+    restart; the original body exception is preserved via ``raise ... from``.
+    """
+
+
 @dataclass
 class RequestResult:
     """Result of a single request pass (cold or warm).
 
-    Carries both the checksum list (for correctness verification) and
-    per-operation latency measurements (for metrics aggregation).
+    Carries the checksum list (for correctness verification), per-operation
+    latency measurements (for metrics aggregation), and the run-health signals
+    the driver uses to fail close.
+
+    Attributes:
+        failure: Non-empty, human-readable reason when this request
+            invalidates the run (a LOOKUP timeout, a prefetch-poll failure, or
+            a STORE / RETRIEVE failure or timeout). The driver aborts
+            (fail-close) on any non-empty value. Empty on success.
+        server_tainted: ``True`` when the request may have left indeterminate
+            server-side state (a leaked prefetch job on a poll timeout, or an
+            unacknowledged cleanup). Surfaces as ``Server reuse safe: no``; the
+            server must be restarted before reuse.
     """
 
     checksums: list[str] | None = None
@@ -902,6 +948,8 @@ class RequestResult:
     total_chunks: int = 0
     store_tokens: int = 0
     retrieve_tokens: int = 0
+    failure: str = ""
+    server_tainted: bool = False
 
 
 def _process_request(
@@ -919,26 +967,35 @@ def _process_request(
     client_tensors: list["torch.Tensor"] | None = None,
     server_pool: "mmap.mmap | None" = None,
 ) -> RequestResult | None:
-    """Run the full lookup -> retrieve/store flow.
+    """Run the full lookup -> retrieve/store flow, fail-close.
 
-    When ``client_tensors`` is provided (data-mode self-check), the
-    flow gains two extra steps:
+    Every stateful RPC is treated as submit-then-unknown: once it is
+    *submitted* the server may have acted on it whether or not a reply is
+    observed, so the outcome contract is:
 
-    * cold pass: hash the paged block range *before* ``STORE``, so
-      the digest captures the ground-truth KV bytes.
-    * warm pass: zero-fill the same block range *before*
-      ``RETRIEVE``, then hash *after* ``RETRIEVE``. cold == warm
-      proves the server returned the exact bytes we sent.
+    * ``None`` -- and only this -- when the request is a legal skip: fewer
+      than one full chunk, before any stateful RPC is submitted.
+    * ``RequestResult`` with ``failure`` set -- an RPC or correctness failure
+      after LOOKUP was submitted; ``server_tainted`` is also set when the
+      server may hold indeterminate state (a LOOKUP timeout, a prefetch-poll
+      failure, or a cleanup that could not be acknowledged).
+    * ``ServerTaintedError`` / ``ServerTaintedInterrupt`` -- the body raised
+      (an unexpected error or a Ctrl-C) and cleanup could not confirm clean
+      server state; the run is invalid and the server must be restarted.
 
-    Handle mode keeps the historical server-side
-    ``/cache/checksums`` path; client tensors are not consulted (in
-    handle mode the client and server share the same SHM/IPC
-    pages, so a client-side hash equals itself by construction).
+    A LOOKUP creates session state, so END_SESSION runs best-effort in a
+    ``finally`` on every post-submit exit. When ``client_tensors`` is provided
+    (data-mode self-check) the cold pass snapshots the block range before
+    STORE and the warm pass zero-fills it before RETRIEVE, so cold == warm
+    proves the server returned the exact bytes; handle mode uses the
+    server-side ``/cache/checksums`` path.
     """
     token_ids = _build_token_ids(seq_no, num_tokens)
     request_id = "req-%d-%s" % (seq_no, pass_label)
 
-    # Align end to chunk_size (only full chunks)
+    # A request shorter than one full chunk is a legal skip: nothing is
+    # looked up or transferred, so no stateful RPC is submitted and a bare
+    # ``None`` is unambiguous here -- and only here.
     num_full_tokens = (len(token_ids) // chunk_size) * chunk_size
     if num_full_tokens == 0:
         print(
@@ -947,202 +1004,251 @@ def _process_request(
         )
         return None
 
-    # Key for lookup (worker_id=None)
-    lookup_key = _make_key(
-        token_ids,
-        request_id,
-        start=0,
-        end=num_full_tokens,
-    )
-
-    # 1. LOOKUP
-    t0 = time.monotonic()
-    if not _send_lookup(client, lookup_key):
-        print("  [seq %d/%s] LOOKUP timeout" % (seq_no, pass_label))
-        return None
-
-    # 2. QUERY_PREFETCH_STATUS (poll by request_id)
-    hit_chunks = _poll_prefetch_status(client, lookup_key.request_id)
-    if hit_chunks is None:
-        hit_chunks = 0
-
+    lookup_key = _make_key(token_ids, request_id, start=0, end=num_full_tokens)
     total_chunks = num_full_tokens // chunk_size
-    miss_chunks = total_chunks - hit_chunks
-    hit_tokens = hit_chunks * chunk_size
-    lookup_ms = (time.monotonic() - t0) * 1000
-
-    print(
-        "  [seq %d/%s] LOOKUP: %d/%d chunks hit "
-        "(%.1f ms)"
-        % (
-            seq_no,
-            pass_label,
-            hit_chunks,
-            total_chunks,
-            lookup_ms,
-        )
-    )
-
-    # Block offset: each request uses a different block
-    # range so that different requests touch different data.
-    # Wrap with modulo and clamp so the entire range
-    # [block_offset, block_offset + num_blocks) stays
-    # within [0, total_blocks).
     num_blocks = num_full_tokens // block_size
-    usable = max(total_blocks - num_blocks, 1)
-    block_offset = (seq_no * num_blocks) % usable
 
-    # Client-side self-check (data mode only). cold pass: snapshot
-    # ground truth before STORE. warm pass: zero out the slice so
-    # a successful RETRIEVE must overwrite every byte.
-    cold_ground_truth: list[str] | None = None
-    if client_tensors is not None:
-        if pass_label == "cold" and miss_chunks > 0:
+    # Once LOOKUP is submitted the server holds session state (and, on a hit,
+    # read locks) plus a prefetch job, so from here every exit path runs the
+    # ``finally`` cleanup. ``result`` stays None only if the body raises
+    # before building one, which the cleanup guard uses to decide taint.
+    result: RequestResult | None = None
+    t0 = time.monotonic()
+    try:
+        # 1. LOOKUP -- submit-then-unknown: a timeout may still have created
+        #    session / prefetch state, so it fails AND taints.
+        if not _send_lookup(client, lookup_key):
+            print("  [seq %d/%s] LOOKUP timeout" % (seq_no, pass_label))
+            result = RequestResult(
+                total_chunks=total_chunks,
+                failure="LOOKUP timeout (seq %d, %s pass); server effect unknown"
+                % (seq_no, pass_label),
+                server_tainted=True,
+            )
+            return result
+
+        # 2. QUERY_PREFETCH_STATUS. A poll failure is never a miss: the server
+        #    keeps the prefetch job (END_SESSION does not cancel it), so it
+        #    fails AND taints rather than silently returning hit_chunks=0.
+        hit_chunks = _poll_prefetch_status(client, lookup_key.request_id)
+        if hit_chunks is None:
+            print("  [seq %d/%s] prefetch status poll failed" % (seq_no, pass_label))
+            result = RequestResult(
+                total_chunks=total_chunks,
+                failure="prefetch status poll failed (seq %d, %s pass)"
+                % (seq_no, pass_label),
+                server_tainted=True,
+            )
+            return result
+
+        miss_chunks = total_chunks - hit_chunks
+        hit_tokens = hit_chunks * chunk_size
+        lookup_ms = (time.monotonic() - t0) * 1000
+        print(
+            "  [seq %d/%s] LOOKUP: %d/%d chunks hit (%.1f ms)"
+            % (seq_no, pass_label, hit_chunks, total_chunks, lookup_ms)
+        )
+
+        # Block offset: each request uses a different block range so distinct
+        # sequences touch distinct data, wrapped so the whole range stays in
+        # [0, total_blocks).
+        usable = max(total_blocks - num_blocks, 1)
+        block_offset = (seq_no * num_blocks) % usable
+
+        # Client-side self-check (data mode only). cold pass: snapshot ground
+        # truth before STORE. warm pass: zero the slice so a real RETRIEVE
+        # must overwrite every byte.
+        cold_ground_truth: list[str] | None = None
+        if client_tensors is not None:
+            if pass_label == "cold" and miss_chunks > 0:
+                store_block_off = block_offset + (hit_tokens // block_size)
+                store_num_blocks = (num_full_tokens - hit_tokens) // block_size
+                cold_ground_truth = _compute_client_checksums(
+                    client_tensors,
+                    store_block_off,
+                    store_num_blocks,
+                    block_size,
+                    chunk_size,
+                )
+            if pass_label == "warm" and hit_chunks > 0:
+                retr_num_blocks = hit_tokens // block_size
+                _zero_fill_client_blocks(client_tensors, block_offset, retr_num_blocks)
+
+        # 3. RETRIEVE hit portion. A non-"retrieved" status fails the run
+        #    (fail-close) so the driver stops rather than measure a broken op.
+        retrieve_ms: float = 0.0
+        store_ms: float = 0.0
+        failure = ""
+        # A *timed-out* STORE / RETRIEVE is submit-then-unknown: the transfer
+        # runs on the server's AFFINITY pool while END_SESSION runs on the
+        # NORMAL pool, so an END_SESSION ack cannot prove a timed-out transfer
+        # completed or was cancelled -> taint. An explicit store_failed /
+        # retrieve_failed is a definite server-side rejection, so the server
+        # stays reuse-safe.
+        transfer_tainted = False
+        if hit_chunks > 0:
+            retrieve_key = _make_key(
+                token_ids, request_id, start=0, end=hit_tokens, worker_id=0
+            )
+            t1 = time.monotonic()
+            retrieve_status = _send_retrieve(
+                client,
+                retrieve_key,
+                chunk_size,
+                hit_chunks,
+                block_offset=block_offset,
+                block_size=block_size,
+                num_engine_group_infos=num_engine_group_infos,
+                use_gpu=use_gpu,
+                use_handle=use_handle,
+                client_tensors=client_tensors,
+                server_pool=server_pool,
+            )
+            retrieve_ms = (time.monotonic() - t1) * 1000
+            print(
+                "  [seq %d/%s] RETRIEVE: %s (%d tokens, %.1f ms)"
+                % (seq_no, pass_label, retrieve_status, hit_tokens, retrieve_ms)
+            )
+            if retrieve_status != "retrieved":
+                failure = "RETRIEVE %s (seq %d, %s pass)" % (
+                    retrieve_status,
+                    seq_no,
+                    pass_label,
+                )
+                transfer_tainted = transfer_tainted or retrieve_status == "timeout"
+
+        # 4. STORE miss portion (skipped once the pass already failed).
+        if not failure and miss_chunks > 0:
+            store_start = hit_tokens
+            store_end = num_full_tokens
+            store_key = _make_key(
+                token_ids, request_id, start=store_start, end=store_end, worker_id=0
+            )
+            t2 = time.monotonic()
             store_block_off = block_offset + (hit_tokens // block_size)
-            store_num_blocks = (num_full_tokens - hit_tokens) // block_size
-            cold_ground_truth = _compute_client_checksums(
-                client_tensors,
-                store_block_off,
-                store_num_blocks,
-                block_size,
-                chunk_size,
+            store_status = _send_store(
+                client,
+                store_key,
+                block_offset=store_block_off,
+                block_size=block_size,
+                num_engine_group_infos=num_engine_group_infos,
+                use_gpu=use_gpu,
+                use_handle=use_handle,
+                client_tensors=client_tensors,
+                chunk_size=chunk_size,
+                server_pool=server_pool,
             )
-        if pass_label == "warm" and hit_chunks > 0:
-            retr_num_blocks = hit_tokens // block_size
-            _zero_fill_client_blocks(
-                client_tensors,
-                block_offset,
-                retr_num_blocks,
+            store_ms = (time.monotonic() - t2) * 1000
+            print(
+                "  [seq %d/%s] STORE: %s (%d tokens, %.1f ms)"
+                % (seq_no, pass_label, store_status, store_end - store_start, store_ms)
+            )
+            if store_status != "stored":
+                failure = "STORE %s (seq %d, %s pass)" % (
+                    store_status,
+                    seq_no,
+                    pass_label,
+                )
+                transfer_tainted = transfer_tainted or store_status == "timeout"
+
+        # 5. Checksums (skipped once the pass failed). data mode: cold == warm
+        #    proves the exact bytes round-tripped; handle mode queries the
+        #    server-side /cache/checksums endpoint.
+        checksums: list[str] | None = None
+        if not failure:
+            if client_tensors is not None and num_full_tokens > 0:
+                if pass_label == "cold":
+                    checksums = cold_ground_truth
+                elif pass_label == "warm" and hit_chunks > 0:
+                    retr_num_blocks = hit_tokens // block_size
+                    checksums = _compute_client_checksums(
+                        client_tensors,
+                        block_offset,
+                        retr_num_blocks,
+                        block_size,
+                        chunk_size,
+                    )
+            elif http_base and num_full_tokens > 0:
+                checksums = _query_checksum(
+                    http_base, block_offset, num_blocks, block_size, chunk_size
+                )
+        if checksums:
+            digest = hashlib.md5("".join(checksums).encode()).hexdigest()[:16]
+            print(
+                "  [seq %d/%s] CHECKSUM: %s (%d chunks)"
+                % (seq_no, pass_label, digest, len(checksums))
             )
 
-    # 3. RETRIEVE hit portion
-    retrieve_ms: float = 0.0
-    store_ms: float = 0.0
-    if hit_chunks > 0:
-        retrieve_key = _make_key(
-            token_ids,
-            request_id,
-            start=0,
-            end=hit_tokens,
-            worker_id=0,
+        result = RequestResult(
+            checksums=checksums,
+            lookup_ms=lookup_ms,
+            retrieve_ms=retrieve_ms if hit_chunks > 0 else None,
+            store_ms=store_ms if miss_chunks > 0 else None,
+            hit_chunks=hit_chunks,
+            total_chunks=total_chunks,
+            store_tokens=(num_full_tokens - hit_tokens)
+            if (not failure and miss_chunks > 0)
+            else 0,
+            retrieve_tokens=hit_tokens if (not failure and hit_chunks > 0) else 0,
+            failure=failure,
+            server_tainted=transfer_tainted,
         )
-        t1 = time.monotonic()
-        status = _send_retrieve(
-            client,
-            retrieve_key,
-            chunk_size,
-            hit_chunks,
-            block_offset=block_offset,
-            block_size=block_size,
-            num_engine_group_infos=num_engine_group_infos,
-            use_gpu=use_gpu,
-            use_handle=use_handle,
-            client_tensors=client_tensors,
-            server_pool=server_pool,
-        )
-        retrieve_ms = (time.monotonic() - t1) * 1000
-        print(
-            "  [seq %d/%s] RETRIEVE: %s "
-            "(%d tokens, %.1f ms)"
-            % (
+        return result
+    finally:
+        # END_SESSION is itself submit-then-unknown: _call converts only a
+        # TimeoutError to the _TIMEOUT sentinel, so a ZMQ / server exception
+        # or a Ctrl-C while awaiting the reply propagates. Capture the body
+        # exception (if any) *before* cleanup, and collect a raised cleanup
+        # rather than re-raising it inline, so a cleanup failure can neither
+        # mask the body's cause nor downgrade its interrupt semantics (which
+        # decide exit 130).
+        body_exc = sys.exc_info()[1]
+        cleanup_exc: "BaseException | None" = None
+        end_ok = False
+        try:
+            end_ok = _send_end_session(client, request_id)
+        except BaseException as exc:  # noqa: BLE001 - re-raised below as a taint
+            cleanup_exc = exc
+
+        if result is not None and cleanup_exc is None:
+            # The body produced a result and cleanup did not raise. Only a
+            # timed-out END_SESSION adds taint; an acknowledged one leaves the
+            # result's own verdict intact. (A produced result implies the body
+            # did not raise, so ``body_exc`` is None here.)
+            if not end_ok:
+                result.server_tainted = True
+                result.failure = result.failure or (
+                    "END_SESSION timeout (seq %d, %s pass); server tainted, "
+                    "restart required" % (seq_no, pass_label)
+                )
+        else:
+            # The body raised (no result) and/or cleanup raised: the request
+            # was cut off, leaving indeterminate server state. Taint via a
+            # raise, preferring the body exception as the cause and honouring
+            # an interrupt from *either* the body or cleanup so a cleanup error
+            # can never turn a Ctrl-C into a plain failure.
+            interrupted_exc = isinstance(body_exc, KeyboardInterrupt) or isinstance(
+                cleanup_exc, KeyboardInterrupt
+            )
+            cause = body_exc if body_exc is not None else cleanup_exc
+            if cleanup_exc is not None:
+                cleanup_note = "END_SESSION raised (%s)" % type(cleanup_exc).__name__
+            elif not end_ok:
+                cleanup_note = "END_SESSION timed out"
+            else:
+                cleanup_note = (
+                    "END_SESSION acked but prefetch job / read locks / pending "
+                    "transfer may remain"
+                )
+            reason = "%s; %s (seq %d, %s pass); server restart required" % (
+                "interrupted" if interrupted_exc else "request failed",
+                cleanup_note,
                 seq_no,
                 pass_label,
-                status,
-                hit_tokens,
-                retrieve_ms,
             )
-        )
-
-    # 4. STORE miss portion
-    if miss_chunks > 0:
-        store_start = hit_tokens
-        store_end = num_full_tokens
-        store_key = _make_key(
-            token_ids,
-            request_id,
-            start=store_start,
-            end=store_end,
-            worker_id=0,
-        )
-        t2 = time.monotonic()
-        store_block_off = block_offset + (hit_tokens // block_size)
-        status = _send_store(
-            client,
-            store_key,
-            block_offset=store_block_off,
-            block_size=block_size,
-            num_engine_group_infos=num_engine_group_infos,
-            use_gpu=use_gpu,
-            use_handle=use_handle,
-            client_tensors=client_tensors,
-            chunk_size=chunk_size,
-            server_pool=server_pool,
-        )
-        store_ms = (time.monotonic() - t2) * 1000
-        print(
-            "  [seq %d/%s] STORE: %s "
-            "(%d tokens, %.1f ms)"
-            % (
-                seq_no,
-                pass_label,
-                status,
-                store_end - store_start,
-                store_ms,
-            )
-        )
-
-    # 5. Compute checksums.
-    #   * data mode (client_tensors set):
-    #       cold -> ground truth captured pre-STORE
-    #       warm -> hash post-RETRIEVE; cold == warm proves the
-    #               server returned the exact bytes we wrote.
-    #   * handle mode: query /cache/checksums on the server, which
-    #     reads the shared SHM/IPC pages directly.
-    checksums: list[str] | None = None
-    if client_tensors is not None and num_full_tokens > 0:
-        if pass_label == "cold":
-            checksums = cold_ground_truth
-        elif pass_label == "warm" and hit_chunks > 0:
-            retr_num_blocks = hit_tokens // block_size
-            checksums = _compute_client_checksums(
-                client_tensors,
-                block_offset,
-                retr_num_blocks,
-                block_size,
-                chunk_size,
-            )
-    elif http_base and num_full_tokens > 0:
-        checksums = _query_checksum(
-            http_base,
-            block_offset,
-            num_blocks,
-            block_size,
-            chunk_size,
-        )
-    if checksums:
-        digest = hashlib.md5("".join(checksums).encode()).hexdigest()[:16]
-        print(
-            "  [seq %d/%s] CHECKSUM: %s (%d chunks)"
-            % (
-                seq_no,
-                pass_label,
-                digest,
-                len(checksums),
-            )
-        )
-
-    # 6. END_SESSION
-    _send_end_session(client, request_id)
-    return RequestResult(
-        checksums=checksums,
-        lookup_ms=lookup_ms,
-        retrieve_ms=retrieve_ms if hit_chunks > 0 else None,
-        store_ms=store_ms if miss_chunks > 0 else None,
-        hit_chunks=hit_chunks,
-        total_chunks=total_chunks,
-        store_tokens=(num_full_tokens - hit_tokens) if miss_chunks > 0 else 0,
-        retrieve_tokens=hit_tokens if hit_chunks > 0 else 0,
-    )
+            if interrupted_exc:
+                raise ServerTaintedInterrupt(reason) from cause
+            raise ServerTaintedError(reason) from cause
 
 
 # ------------------------------------------------------------------ #

--- a/tests/cli/commands/bench/test_server_bench.py
+++ b/tests/cli/commands/bench/test_server_bench.py
@@ -9,6 +9,7 @@ Covers:
 
 # Standard
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import cast
 import argparse
 import json
 import threading
@@ -20,12 +21,19 @@ import torch
 import zmq
 
 # First Party
+from lmcache.cli.commands.base import BaseCommand
 from lmcache.cli.commands.bench import BenchCommand
+from lmcache.cli.commands.bench.server_bench import command as sv_cmd
+from lmcache.cli.commands.bench.server_bench import helpers as sv_helpers
 from lmcache.cli.commands.bench.server_bench.helpers import (
+    RequestResult,
+    ServerTaintedError,
+    ServerTaintedInterrupt,
     _allocate_kv_cache,
     _build_token_ids,
     _make_key,
     _poll_prefetch_status,
+    _process_request,
     _query_checksum,
     _send_lookup,
     _send_unregister_kv_cache,
@@ -623,3 +631,502 @@ class TestUnregisterKVCache:
             client.close()
         finally:
             router.stop()
+
+
+# ------------------------------------------------------------------ #
+#  _process_request fail-close lifecycle (mocked RPC layer)            #
+# ------------------------------------------------------------------ #
+
+# Stand-in client: every RPC is injected by patching ``sv_helpers._call``,
+# so nothing is ever called on the client object itself.
+_DUMMY_CLIENT = cast(MessageQueueClient, object())
+
+
+def _dispatching_call(behavior, calls=None):
+    """Build a ``_call`` replacement that dispatches on request type.
+
+    ``behavior`` maps ``RequestType`` -> value | callable(payloads) -> value.
+    A callable may raise to inject an exception / Ctrl-C at the real RPC wait
+    point. The sentinel ``sv_helpers._TIMEOUT`` simulates an RPC timeout;
+    unlisted types reply void (``None``). Every request type is appended to
+    ``calls`` (when given) for issued-operation assertions.
+    """
+
+    def _fake_call(client, request_type, payloads, timeout_s=10.0):
+        if calls is not None:
+            calls.append(request_type)
+        action = behavior.get(request_type)
+        if callable(action):
+            return action(payloads)
+        return action
+
+    return _fake_call
+
+
+def _pair_kwargs(**overrides):
+    """Baseline kwargs driving _process_request as a handle-mode pair request.
+
+    511 + 1 seq token = 512 tokens = 2 chunks of 256, so a poll hit of 1
+    exercises both the RETRIEVE (hit) and the STORE (miss) leg.
+    """
+    base = dict(
+        num_tokens=511,
+        chunk_size=256,
+        pass_label="cold",
+        http_base="",
+        block_size=16,
+        total_blocks=1024,
+        num_engine_group_infos=1,
+        use_gpu=False,
+        use_handle=True,
+        client_tensors=None,
+        server_pool=None,
+    )
+    base.update(overrides)
+    return base
+
+
+def _success_behavior():
+    """A fully successful handle-mode pair request; rows override one stage."""
+    return {
+        RequestType.LOOKUP: None,
+        RequestType.QUERY_PREFETCH_STATUS: 1,
+        RequestType.RETRIEVE: (0, True),
+        RequestType.STORE: (0, True),
+        RequestType.END_SESSION: None,
+    }
+
+
+def _raise(exc_type):
+    """A ``_call`` action that raises *exc_type* at the RPC wait point."""
+
+    def _action(_payloads):
+        raise exc_type
+
+    return _action
+
+
+class TestProcessRequestFailClose:
+    """The single-request contract: never a confident-but-wrong result.
+
+    Every stateful RPC is submit-then-unknown, so a failure after LOOKUP is
+    submitted invalidates the run (``failure`` set) and, when the server may
+    hold indeterminate state, taints it (``server_tainted``); a body error or
+    a cleanup that cannot be acknowledged is raised as ``ServerTaintedError``
+    / ``ServerTaintedInterrupt``. ``None`` is returned only for a legal skip
+    before any RPC is submitted.
+    """
+
+    def test_success_is_valid_and_untainted(self, monkeypatch) -> None:
+        calls: list = []
+        monkeypatch.setattr(
+            sv_helpers, "_call", _dispatching_call(_success_behavior(), calls)
+        )
+        result = _process_request(_DUMMY_CLIENT, 0, **_pair_kwargs())
+        assert result is not None
+        assert result.failure == ""
+        assert result.server_tainted is False
+        assert RequestType.RETRIEVE in calls
+        assert RequestType.STORE in calls
+        assert RequestType.END_SESSION in calls
+
+    def test_sub_chunk_request_is_legal_skip(self, monkeypatch) -> None:
+        calls: list = []
+        monkeypatch.setattr(sv_helpers, "_call", _dispatching_call({}, calls))
+        # 0 tokens -> a single seq token -> fewer than one full chunk.
+        result = _process_request(_DUMMY_CLIENT, 0, **_pair_kwargs(num_tokens=0))
+        assert result is None
+        assert calls == []
+
+    @pytest.mark.parametrize(
+        "inject, failure_substr, tainted",
+        [
+            ({RequestType.LOOKUP: sv_helpers._TIMEOUT}, "LOOKUP timeout", True),
+            (
+                {RequestType.QUERY_PREFETCH_STATUS: sv_helpers._TIMEOUT},
+                "prefetch status poll failed",
+                True,
+            ),
+            ({RequestType.RETRIEVE: (0, False)}, "RETRIEVE retrieve_failed", False),
+            ({RequestType.STORE: (0, False)}, "STORE store_failed", False),
+            ({RequestType.RETRIEVE: sv_helpers._TIMEOUT}, "RETRIEVE timeout", True),
+            ({RequestType.STORE: sv_helpers._TIMEOUT}, "STORE timeout", True),
+            (
+                {RequestType.END_SESSION: sv_helpers._TIMEOUT},
+                "END_SESSION timeout",
+                True,
+            ),
+        ],
+        ids=[
+            "lookup_timeout",
+            "poll_failure",
+            "retrieve_failure",
+            "store_failure",
+            "retrieve_timeout",
+            "store_timeout",
+            "end_session_timeout",
+        ],
+    )
+    def test_failure_rows_invalidate_and_maybe_taint(
+        self, monkeypatch, inject, failure_substr, tainted
+    ) -> None:
+        calls: list = []
+        behavior = _success_behavior()
+        behavior.update(inject)
+        monkeypatch.setattr(sv_helpers, "_call", _dispatching_call(behavior, calls))
+        result = _process_request(_DUMMY_CLIENT, 0, **_pair_kwargs())
+        # A post-LOOKUP failure is a RequestResult with a reason, never a bare
+        # None and never a silent success.
+        assert result is not None
+        assert failure_substr in result.failure
+        assert result.server_tainted is tainted
+        # END_SESSION cleanup is attempted on every post-LOOKUP exit.
+        assert RequestType.END_SESSION in calls
+
+    @pytest.mark.parametrize(
+        "body_end_session, exc_type, cause_type",
+        [
+            (_raise(RuntimeError), ServerTaintedError, RuntimeError),
+            (_raise(KeyboardInterrupt), ServerTaintedInterrupt, KeyboardInterrupt),
+        ],
+        ids=["end_session_exception", "end_session_ctrl_c"],
+    )
+    def test_cleanup_failure_after_success_raises_taint(
+        self, monkeypatch, body_end_session, exc_type, cause_type
+    ) -> None:
+        # The body succeeds, then END_SESSION raises: the run is tainted via a
+        # raise (Ctrl-C keeps interrupt semantics), chaining the cleanup error.
+        behavior = _success_behavior()
+        behavior[RequestType.END_SESSION] = body_end_session
+        monkeypatch.setattr(sv_helpers, "_call", _dispatching_call(behavior))
+        with pytest.raises(exc_type) as ei:
+            _process_request(_DUMMY_CLIENT, 0, **_pair_kwargs())
+        assert isinstance(ei.value.__cause__, cause_type)
+
+    @pytest.mark.parametrize(
+        "body_call, end_session, exc_type, cause_type",
+        [
+            (
+                _raise(KeyboardInterrupt),
+                _raise(RuntimeError),
+                ServerTaintedInterrupt,
+                KeyboardInterrupt,
+            ),
+            (
+                _raise(KeyboardInterrupt),
+                sv_helpers._TIMEOUT,
+                ServerTaintedInterrupt,
+                KeyboardInterrupt,
+            ),
+            (
+                _raise(RuntimeError),
+                _raise(RuntimeError),
+                ServerTaintedError,
+                RuntimeError,
+            ),
+        ],
+        ids=[
+            "body_ki+cleanup_error",
+            "body_ki+cleanup_timeout",
+            "body_error+cleanup_error",
+        ],
+    )
+    def test_body_and_cleanup_failure_combos(
+        self, monkeypatch, body_call, end_session, exc_type, cause_type
+    ) -> None:
+        # The body raises during the poll; END_SESSION then times out or
+        # raises. A cleanup failure must not mask the body cause nor downgrade
+        # a Ctrl-C (interrupt semantics + body cause are both preserved).
+        behavior = {
+            RequestType.LOOKUP: None,
+            RequestType.QUERY_PREFETCH_STATUS: body_call,
+            RequestType.END_SESSION: end_session,
+        }
+        monkeypatch.setattr(sv_helpers, "_call", _dispatching_call(behavior))
+        with pytest.raises(exc_type) as ei:
+            _process_request(_DUMMY_CLIENT, 0, **_pair_kwargs())
+        assert isinstance(ei.value.__cause__, cause_type)
+
+
+# ------------------------------------------------------------------ #
+#  Summary emission: valid vs invalid (performance suppression)        #
+# ------------------------------------------------------------------ #
+
+
+class _FakeSection:
+    def __init__(self) -> None:
+        self.values: dict = {}
+
+    def add(self, key, label, value) -> None:
+        self.values[key] = value
+
+
+class _FakeMetrics:
+    def __init__(self) -> None:
+        self.sections: dict = {}
+        self.emitted = False
+
+    def add_section(self, section_id, title) -> "_FakeSection":
+        section = _FakeSection()
+        self.sections[section_id] = section
+        return section
+
+    def emit(self) -> None:
+        self.emitted = True
+
+
+class _CapturingCommand:
+    def __init__(self) -> None:
+        self.metrics = _FakeMetrics()
+
+    def create_metrics(self, title, args, width=64) -> "_FakeMetrics":
+        return self.metrics
+
+
+def _bench_args(**overrides) -> argparse.Namespace:
+    ns = argparse.Namespace(
+        rpc_url="ipc:///tmp/x",
+        mode="cpu",
+        transfer_mode="auto",
+        num_tokens=511,
+        interval=0.0,
+    )
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+class TestEmitSummaryValidity:
+    """An invalid run must not present a trustworthy-looking summary."""
+
+    def test_valid_run_emits_performance_sections(self) -> None:
+        cmd = _CapturingCommand()
+        sv_cmd._emit_server_bench_metrics(
+            command=cast(BaseCommand, cmd),
+            args=_bench_args(),
+            total_requests=3,
+            total_checksum_ok=3,
+            total_checksum_fail=0,
+            valid=True,
+            server_reuse_safe=True,
+            cold_lookup_ms=[1.0, 2.0],
+            warm_retrieve_ms=[3.0],
+        )
+        results = cmd.metrics.sections["results"].values
+        assert cmd.metrics.emitted
+        assert results["valid"] == "yes"
+        assert results["server_reuse_safe"] == "yes"
+        assert "pass_rate" in results
+        # Latency sections are present for a valid run.
+        assert "cold_lookup" in cmd.metrics.sections
+        assert "warm_retrieve" in cmd.metrics.sections
+
+    def test_invalid_run_suppresses_performance_sections(self) -> None:
+        cmd = _CapturingCommand()
+        sv_cmd._emit_server_bench_metrics(
+            command=cast(BaseCommand, cmd),
+            args=_bench_args(),
+            total_requests=1,
+            total_checksum_ok=0,
+            total_checksum_fail=0,
+            valid=False,
+            server_reuse_safe=False,
+            run_error="seq 0 cold: LOOKUP timeout",
+            cold_lookup_ms=[1.0],
+            warm_retrieve_ms=[2.0],
+        )
+        results = cmd.metrics.sections["results"].values
+        assert cmd.metrics.emitted
+        assert results["valid"] == "no"
+        assert results["server_reuse_safe"] == "no"
+        assert results["error"] == "seq 0 cold: LOOKUP timeout"
+        # No performance numbers are presented for an invalid run.
+        assert "pass_rate" not in results
+        assert "cold_lookup" not in cmd.metrics.sections
+        assert "warm_retrieve" not in cmd.metrics.sections
+
+
+# ------------------------------------------------------------------ #
+#  run_server_bench() setup / teardown fail-close wiring               #
+# ------------------------------------------------------------------ #
+
+
+class _FakeMQClient:
+    """Stand-in MP client: created but never used (RPC helpers patched)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def _ok_pair_result(pass_label: str) -> RequestResult:
+    """A clean cold / warm pair result (full hit on warm, matching digest)."""
+    if pass_label == "cold":
+        return RequestResult(
+            checksums=["a", "b"],
+            lookup_ms=1.0,
+            store_ms=2.0,
+            hit_chunks=0,
+            total_chunks=2,
+        )
+    return RequestResult(
+        checksums=["a", "b"],
+        lookup_ms=1.0,
+        retrieve_ms=2.0,
+        hit_chunks=2,
+        total_chunks=2,
+    )
+
+
+def _run_args(**overrides) -> argparse.Namespace:
+    ns = argparse.Namespace(
+        rpc_url="tcp://localhost:5555",
+        mode="cpu",
+        transfer_mode="lmcache_driven",  # handle mode -> no server SHM pool
+        quiet=True,
+        kvcache_shape_spec=sv_cmd._DEFAULT_SHAPE_SPEC,
+        num_blocks=1024,
+        block_size=16,
+        num_tokens=511,
+        start=0,
+        end=2,
+        interval=0.0,
+        url="http://localhost:8080",  # http_base set -> checksum expected
+        flamegraph=False,
+    )
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+class TestRunServerBenchContract:
+    """End-to-end fail-close wiring in ``run_server_bench``: the setup and
+    teardown ends the ``_process_request`` unit tests cannot reach.
+
+    The MP client and RPC helpers are patched, so no real server is needed;
+    the drive loop, verdict, and teardown run against injected outcomes.
+    """
+
+    def _patch(
+        self,
+        monkeypatch,
+        *,
+        register=True,
+        unregister=True,
+        process=_ok_pair_result,
+        recorder=None,
+    ) -> None:
+        monkeypatch.setattr(
+            "lmcache.v1.multiprocess.mq.MessageQueueClient", _FakeMQClient
+        )
+        monkeypatch.setattr(sv_cmd, "_build_server_profiler", lambda args, log: None)
+        monkeypatch.setattr(sv_cmd, "_get_chunk_size", lambda client: 256)
+        monkeypatch.setattr(
+            sv_cmd,
+            "_allocate_cpu_shm_kv_cache",
+            lambda **kw: ([object()], [object()], []),
+        )
+
+        def _register(*a, **k):
+            if recorder is not None:
+                recorder.append("register")
+            return register
+
+        def _unregister(*a, **k):
+            if recorder is not None:
+                recorder.append("unregister")
+            return unregister
+
+        def _process(client, seq_no, num_tokens, chunk_size, pass_label, **k):
+            if recorder is not None:
+                recorder.append("process:%s" % pass_label)
+            return process(pass_label)
+
+        monkeypatch.setattr(sv_cmd, "_send_register_kv_cache", _register)
+        monkeypatch.setattr(sv_cmd, "_send_unregister_kv_cache", _unregister)
+        monkeypatch.setattr(sv_cmd, "_process_request", _process)
+
+    def test_success_run_is_valid(self, monkeypatch) -> None:
+        cmd = _CapturingCommand()
+        self._patch(monkeypatch)
+        # A clean run returns normally (no SystemExit).
+        sv_cmd.run_server_bench(cast(BaseCommand, cmd), _run_args())
+        results = cmd.metrics.sections["results"].values
+        assert results["valid"] == "yes"
+        assert results["server_reuse_safe"] == "yes"
+
+    def test_register_timeout_fails_close(self, monkeypatch) -> None:
+        cmd = _CapturingCommand()
+        recorder: list = []
+        self._patch(monkeypatch, register=False, recorder=recorder)
+        with pytest.raises(SystemExit) as ei:
+            sv_cmd.run_server_bench(cast(BaseCommand, cmd), _run_args())
+        assert ei.value.code == 1
+        results = cmd.metrics.sections["results"].values
+        assert results["valid"] == "no"
+        assert results["server_reuse_safe"] == "no"
+        # Workload never started, but teardown still attempted UNREGISTER.
+        assert not any(e.startswith("process:") for e in recorder)
+        assert "unregister" in recorder
+
+    def test_unregister_timeout_invalidates_and_flags_unsafe(self, monkeypatch) -> None:
+        cmd = _CapturingCommand()
+        self._patch(monkeypatch, unregister=False)
+        with pytest.raises(SystemExit) as ei:
+            sv_cmd.run_server_bench(cast(BaseCommand, cmd), _run_args())
+        assert ei.value.code == 1
+        results = cmd.metrics.sections["results"].values
+        # An unconfirmed cleanup invalidates the run AND flags the server, and
+        # the performance summary is suppressed.
+        assert results["valid"] == "no"
+        assert results["server_reuse_safe"] == "no"
+        assert "cold_lookup" not in cmd.metrics.sections
+
+    def test_missing_checksum_invalidates(self, monkeypatch) -> None:
+        cmd = _CapturingCommand()
+
+        def _no_checksum(pass_label: str) -> RequestResult:
+            result = _ok_pair_result(pass_label)
+            result.checksums = None  # endpoint / hashing unavailable
+            return result
+
+        self._patch(monkeypatch, process=_no_checksum)
+        with pytest.raises(SystemExit) as ei:
+            sv_cmd.run_server_bench(cast(BaseCommand, cmd), _run_args())
+        assert ei.value.code == 1
+        results = cmd.metrics.sections["results"].values
+        assert results["valid"] == "no"
+        # "unable to verify" is not "verified": no performance summary.
+        assert "cold_lookup" not in cmd.metrics.sections
+
+    def test_zero_request_range_is_invalid(self, monkeypatch) -> None:
+        cmd = _CapturingCommand()
+        self._patch(monkeypatch)
+        with pytest.raises(SystemExit) as ei:
+            sv_cmd.run_server_bench(cast(BaseCommand, cmd), _run_args(start=5, end=5))
+        assert ei.value.code == 1
+        results = cmd.metrics.sections["results"].values
+        assert results["valid"] == "no"
+
+    def test_transfer_timeout_flags_server_unsafe(self, monkeypatch) -> None:
+        # A STORE / RETRIEVE timeout is submit-then-unknown: invalid AND the
+        # server is unsafe to reuse (unlike a definite store/retrieve_failed).
+        def _timeout(pass_label: str) -> RequestResult:
+            if pass_label == "cold":
+                return RequestResult(
+                    total_chunks=2,
+                    failure="STORE timeout (seq 0, cold pass)",
+                    server_tainted=True,
+                )
+            return _ok_pair_result(pass_label)
+
+        cmd = _CapturingCommand()
+        self._patch(monkeypatch, process=_timeout)
+        with pytest.raises(SystemExit) as ei:
+            sv_cmd.run_server_bench(cast(BaseCommand, cmd), _run_args())
+        assert ei.value.code == 1
+        results = cmd.metrics.sections["results"].values
+        assert results["valid"] == "no"
+        assert results["server_reuse_safe"] == "no"


### PR DESCRIPTION
**What this PR does / why we need it**:

The single-client `lmcache bench server` path was fail-open: an RPC timeout, a
failed transfer, an unacknowledged cleanup, or a checksum mismatch would still
print a normal-looking latency summary and exit `0`. A broken run was
indistinguishable from a fast one. This hardens the request lifecycle so a run
only reports numbers it can actually vouch for.

- **A failed run stops and stays quiet.** An RPC or checksum failure — a
  `LOOKUP` / prefetch-poll / `STORE` / `RETRIEVE` timeout or error, or a
  cold/warm digest mismatch — stops the benchmark, marks it `Valid: no`,
  suppresses the performance summary, and exits non-zero.
- **Unconfirmed cleanup flags the server.** When a cleanup RPC cannot be
  confirmed (an unacknowledged `END_SESSION`, an `UNREGISTER_KV_CACHE` failure,
  or a transfer that timed out on the AFFINITY pool so its completion is
  unknown), the run additionally reports `Server reuse safe: no`, so the
  dedicated server is flagged for a restart before the next run.
- **Ctrl-C tears the session down and preserves exit `130`.**

**Special notes for your reviewers**:

- Scope is deliberately the existing single-client pair path only — no
  concurrency, runner, barriers, or worker bands. This is meant to be a small,
  self-contained safety floor that later benchmark work can build on.
- The taint semantics are intentional: a **timeout** on a stateful transfer
  taints the server (`reuse safe: no`) because an `END_SESSION` ack on the
  NORMAL pool does not prove a timed-out `STORE`/`RETRIEVE` on the AFFINITY
  pool completed or was cancelled. An **explicit** server-side rejection
  (`store_failed` / `retrieve_failed`) is a known state and does not taint.
- Verified against a real CPU MP server (cold `STORE` → warm `RETRIEVE`
  checksum pair): happy path exits `0` with a valid summary; an induced RPC
  timeout correctly yields `Valid: no` and a non-zero exit.

**If applicable**:

- [x] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
