### PR TITLE
[Fix][NIXL] Fix close() deadlock when it races event loop startup

### DIFF
--- a/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/nixl_store_l2_adapter.py
@@ -593,12 +593,18 @@ class NixlStoreL2Adapter(L2AdapterInterface):
             if tasks:
                 await asyncio.gather(*tasks, return_exceptions=True)
 
-        if self._loop.is_running():
-            future = asyncio.run_coroutine_threadsafe(_stop_tasks(), self._loop)
+        # Gate on is_closed() rather than is_running(): the loop thread may not
+        # have reached run_forever() yet, and skipping the stop below would leave
+        # join() blocking forever. Both threadsafe calls are valid on a loop that
+        # has not started; their callbacks run once it does.
+        if not self._loop.is_closed():
+            try:
+                future = asyncio.run_coroutine_threadsafe(_stop_tasks(), self._loop)
 
-            future.result(timeout=5)  # Wait for tasks to be cancelled, with a timeout
-
-            self._loop.call_soon_threadsafe(self._loop.stop)
+                # Wait for tasks to be cancelled, with a timeout
+                future.result(timeout=5)
+            finally:
+                self._loop.call_soon_threadsafe(self._loop.stop)
 
         self._loop_thread.join()
         try:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix for passing  test_close_does_not_raise in nixl unit test.This flaky ut is affecting a lot of prs. 

The adapter starts its event loop thread as the last statement of __init__, so close() could check is_running() before the thread reached run_forever() and skip the only call that stops the loop, leaving the untimed join() blocked forever

**Special notes for your reviewers**:

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
