### PR TITLE
fix(l1): reject duplicate write reservation keys

### DIFF
--- a/lmcache/v1/distributed/l1_manager.py
+++ b/lmcache/v1/distributed/l1_manager.py
@@ -462,7 +462,13 @@ class L1Manager:
         Errors:
             KEY_NOT_WRITABLE: The key exists but is not writable.
             OUT_OF_MEMORY: Not enough memory to allocate for the object.
+
+        Raises:
+            ValueError: If ``keys`` contains the same object key more than once.
         """
+        if len(keys) != len(set(keys)):
+            raise ValueError("keys must be unique when reserving L1 writes")
+
         need_to_allocate: list[tuple[ObjectKey, bool]] = []
         ret: dict[ObjectKey, L1OperationResult] = {}
         successful_keys: list[ObjectKey] = []

--- a/tests/v1/distributed/test_l1_manager.py
+++ b/tests/v1/distributed/test_l1_manager.py
@@ -879,6 +879,21 @@ class TestReserveWrite:
 
         manager.close()
 
+    def test_reserve_write_rejects_duplicate_keys_before_allocating(
+        self, basic_l1_config, basic_layout
+    ):
+        """Duplicate keys must not mutate L1 state or consume an allocation."""
+        manager = L1Manager(basic_l1_config)
+        key = make_object_key(12345)
+
+        with pytest.raises(ValueError, match="keys must be unique"):
+            manager.reserve_write([key, key], [False, False], basic_layout)
+
+        assert manager.get_object_state(key) is None
+        assert manager.get_memory_usage()[0] == 0
+
+        manager.close()
+
     def test_reserve_write_out_of_memory(self, small_l1_config, large_layout):
         """Test that reserve_write returns OUT_OF_MEMORY when allocation fails."""
         manager = L1Manager(small_l1_config)


### PR DESCRIPTION
## Summary

- Reject duplicate object keys before an L1 write reservation changes locks or allocates memory.
- Cover the failure path by asserting that L1 state and allocation usage remain unchanged.

## Validation

- python3 -m py_compile lmcache/v1/distributed/l1_manager.py tests/v1/distributed/test_l1_manager.py
- uvx ruff check lmcache/v1/distributed/l1_manager.py tests/v1/distributed/test_l1_manager.py
