### PR TITLE
docs: daily drift check — multi-process mode (2026-07-29)

### DIFF
--- a/docs/design/v1/mp_coordinator/README.md
+++ b/docs/design/v1/mp_coordinator/README.md
@@ -3,9 +3,10 @@
 The mp coordinator is a standalone **FastAPI / REST** process that coordinates
 LMCache multi-process (mp) cache servers running across nodes as a fleet. This
 document describes the backbone: the REST API, the instance registry, the
-health-check and eviction loops, and the four domain capabilities that hang off
+health-check and eviction loops, and the five domain capabilities that hang off
 it (fleet membership, quota + fleet-wide L2 eviction, cache control including
-warm prefetch / pin / delete, and the global CacheBlend fingerprint directory).
+warm prefetch / pin / delete, the global CacheBlend fingerprint directory, and
+the fleet-wide [key directory](./key_directory.md) built from cache events).
 
 Code: `lmcache/v1/mp_coordinator/`.
 
@@ -42,6 +43,10 @@ fingerprints in the same shape.
 | `POST /blend/fingerprints` | mp → coordinator | publish stored blend chunk fingerprints |
 | `DELETE /blend/fingerprints` | mp → coordinator | evict blend fingerprints by storage key |
 | `POST /blend/match` | mp → coordinator | rolling-hash match a request against the directory |
+| `POST /directory/events` | mp → coordinator | apply a batch of cache-event batches to the key directory |
+| `POST /directory/lookup` | consumer → coordinator | resolve keys to their known fleet-wide placements |
+| `POST /directory/lookup_tokens` | consumer → coordinator | resolve a token sequence to keys and return their placements |
+| `GET /directory/stats` | operator/tools | point-in-time key/placement counts + per-instance stream state |
 
 For server-initiated work (fleet-wide eviction, warm prefetch) a coordinator
 router resolves an instance's address from the registry (`ip` + `http_port`)
@@ -57,11 +62,13 @@ lmcache/v1/mp_coordinator/
   app.py                # create_app + lifespan + router discovery + health/eviction loops
   __main__.py           # uvicorn entrypoint (`python -m lmcache.v1.mp_coordinator`)
   config.py             # MPCoordinatorConfig (LMCACHE_MP_COORDINATOR_*)
+  api.py                # cross-module contract vocabulary (CacheEvent* types)
   registry.py           # InstanceRegistry + MPInstance (pure membership)
   schemas.py            # Pydantic request/response models (shared wire contract)
   registrar.py          # mp-server-side register/heartbeat/deregister helpers
   blend_directory.py    # GlobalBlendMatcher (chunked rolling-hash directory)
   blend_client.py       # mp-server-side blend publish/evict/match client
+  key_directory.py      # KeyDirectory (fleet-wide placement directory from cache events)
   cache_control/
     __init__.py
     event_listener.py   # in-process forwarding of MP-server L2 events
@@ -71,12 +78,15 @@ lmcache/v1/mp_coordinator/
     resync_manager.py   # startup resync of usage/eviction from an MP server's GET /cache/objects
   http_apis/
     __init__.py
-    dependencies.py     # shared FastAPI dependencies (registry, blend directory, ...)
+    dependencies.py     # shared FastAPI dependencies + typed CoordinatorContext
     instances_api.py    # /instances REST resource
     health_api.py       # /healthz
     quota_api.py        # /quota/config, /quota/{cache_salt}, /quota, /quota/events
     cache_api.py        # /cache/prefetches, /cache/pins, /cache/delete
     blend_directory_api.py  # /blend/fingerprints, /blend/match
+    directory_api.py    # /directory/events, /directory/lookup, /directory/lookup_tokens, /directory/stats
+  utils/
+    __init__.py
 ```
 
 ## Request flow
@@ -185,6 +195,24 @@ evicts entries when the backing L2 objects are dropped so matches do not go
 stale. The mp-server-side client lives in `blend_client.py`; the wire types
 (`StoreRangeModel`, `BlendMatchRequest`, `GlobalMatchModel`, …) live in
 `schemas.py`.
+
+## Key directory (`key_directory.py`)
+
+`KeyDirectory` is the fleet-wide directory mapping each `ObjectKey` to its
+known placements (which instance holds it, on which tier / backend, at what
+size). It is built purely from `CacheEvent` batches emitted by MP servers to
+`POST /directory/events`, is **eventually consistent, soft state, and never
+on the serving hot path**: every answer is a hint that consumers (P2P
+discovery, cache control, prefetch planning) must validate at the owning
+MP server before touching bytes. Consumers query placements by key
+(`POST /directory/lookup`) or by token sequence (`POST /directory/lookup_tokens`,
+which hashes the token buffer with the fleet's token hasher before looking
+up); `GET /directory/stats` returns key/placement counts plus per-instance
+stream state (incarnation, last applied seq, gap flag). The event vocabulary
+(`CacheEventType`, `CacheEventEntry`, `CacheEventBatch`) lives in `api.py`;
+the HTTP envelopes live in `schemas.py`. See
+[key_directory.md](./key_directory.md) for event application semantics
+(incarnation fencing, seq dedup, gap detection) and structures.
 
 ## Concurrency & lifecycle
 

--- a/docs/source/mp/coordinator.rst
+++ b/docs/source/mp/coordinator.rst
@@ -176,6 +176,16 @@ The coordinator's HTTP surface (base URL ``http://localhost:9300``) groups into:
 - **CacheBlend fingerprint directory** -- the ``/blend`` group: the fleet-wide
   fingerprint index blend-enabled MP servers publish to on STORE and query on
   LOOKUP. Server-to-coordinator only; not usually called by hand.
+- **Key directory** -- the ``/directory`` group: a fleet-wide, eventually
+  consistent directory of key placements built from cache events emitted by
+  MP servers (``POST /directory/events``). Consumers resolve placements by
+  key (``POST /directory/lookup``) or by token sequence
+  (``POST /directory/lookup_tokens``); ``GET /directory/stats`` exposes
+  key/placement counts and per-instance stream state. Every lookup returns a
+  hint that must be validate-on-use at the owning MP server; never on the
+  serving hot path. See the design doc at
+  ``docs/design/v1/mp_coordinator/key_directory.md`` for event-application
+  semantics (incarnation fencing, seq dedup, gap detection).
 
 Each endpoint is documented below. Success is ``200`` unless noted, and
 ``{cache_salt}`` uses the ``_default`` sentinel for the empty salt. The wire


### PR DESCRIPTION
**What this PR does / why we need it**:

Daily drift check between LMCache/LMCache documentation and current
`dev` code (`upstream/dev` HEAD [`b02e3ac9`](https://github.com/LMCache/LMCache/commit/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01)),
focused on the multi-process mode. Two drift items found today, both
introduced by yesterday's [#4275](https://github.com/LMCache/LMCache/pull/4275)
(commit [`0fc6cd8b`](https://github.com/LMCache/LMCache/commit/0fc6cd8bfd24a5f2096e5df429d2b5373689d7a3),
*"[MP][Coordinator] Fleet-wide key directory built from cache events"*),
which added the fleet-wide `KeyDirectory` module + four
`/directory/*` HTTP endpoints + its own design doc, but did not update
either of the coordinator's user-facing / backbone docs to mention the
new capability.

Prior open drift-check PRs from earlier days —
[#4285](https://github.com/LMCache/LMCache/pull/4285),
[#4269](https://github.com/LMCache/LMCache/pull/4269),
[#4249](https://github.com/LMCache/LMCache/pull/4249),
[#4236](https://github.com/LMCache/LMCache/pull/4236), and
[#4199](https://github.com/LMCache/LMCache/pull/4199) — still track
their earlier items; this PR does not overlap them.

Docs-only. No code touched.

## Drift items

### `docs/source/`

- **`docs/source/mp/coordinator.rst`** — the "HTTP endpoints" intro
  paragraph lists the coordinator's HTTP surface as **four groups**
  (fleet membership + health, `/quota`, `/cache`, `/blend`). Since
  [#4275](https://github.com/LMCache/LMCache/pull/4275) landed, a
  fifth group is live at runtime — the `/directory` group — and the
  intro no longer lists it, so a reader scanning the user-facing doc
  for the coordinator's HTTP surface will believe the coordinator has
  no key-directory endpoints.

  The four `/directory/*` routes are wired via
  [`lmcache/v1/mp_coordinator/http_apis/directory_api.py:30`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/mp_coordinator/http_apis/directory_api.py#L30),
  [`:59`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/mp_coordinator/http_apis/directory_api.py#L59),
  [`:84`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/mp_coordinator/http_apis/directory_api.py#L84),
  and [`:129`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/mp_coordinator/http_apis/directory_api.py#L129);
  they are auto-discovered by `create_app` in
  [`app.py:189-192`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/mp_coordinator/app.py#L189-L192)
  via the same `discover_api_routers` convention every other coordinator
  route uses, so they are just as live as `/quota` or `/blend`.

  | Stale doc location | Was | Now |
  |---|---|---|
  | `docs/source/mp/coordinator.rst` — HTTP endpoints intro ([lines 167-178](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/source/mp/coordinator.rst#L167-L178)) | Four groups: fleet membership + health, `/quota`, `/cache`, `/blend`. | Adds a fifth "**Key directory**" bullet describing the `/directory` group — `POST /directory/events` (cache-event ingest from MP servers), `POST /directory/lookup`, `POST /directory/lookup_tokens`, `GET /directory/stats` — with the validate-on-use contract noted and a pointer to the design doc for event-application semantics. |

### `docs/design/`

- **`docs/design/v1/mp_coordinator/README.md`** — the backbone design
  doc had three concrete places where the fifth capability was
  missing:

  1. **Opening paragraph** claims "four domain capabilities" and
     enumerates them at
     [lines 3-8](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/design/v1/mp_coordinator/README.md#L3-L8).
     The key directory is now the fifth.
  2. **Transport table** (`Method & path` → `Direction` → `Purpose`) at
     [lines 27-44](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/design/v1/mp_coordinator/README.md#L27-L44)
     listed 16 endpoints, none from the `/directory` group.
  3. **Layout box** at
     [lines 55-80](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/design/v1/mp_coordinator/README.md#L55-L80)
     did not include the new `key_directory.py` module, the new
     `api.py` cross-module contract-vocabulary module, the new
     `http_apis/directory_api.py`, or the `utils/` sub-package. Files
     that a contributor reading the layout box to find where to add a
     capability would need to see.

  All three are shipped as of [`b02e3ac9`](https://github.com/LMCache/LMCache/commit/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01):
  [`lmcache/v1/mp_coordinator/key_directory.py`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/mp_coordinator/key_directory.py),
  [`api.py`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/mp_coordinator/api.py),
  [`http_apis/directory_api.py`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/mp_coordinator/http_apis/directory_api.py),
  and `utils/__init__.py`. There was also no section describing the
  key directory alongside the existing "Global CacheBlend directory"
  and "Cache control" sections at
  [lines 156-187](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/design/v1/mp_coordinator/README.md#L156-L187).

  | Stale doc location | Was | Now |
  |---|---|---|
  | Opening paragraph ([lines 3-8](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/design/v1/mp_coordinator/README.md#L3-L8)) | *"…the **four** domain capabilities that hang off it (fleet membership, quota + fleet-wide L2 eviction, cache control including warm prefetch / pin / delete, and the global CacheBlend fingerprint directory)."* | *"…the **five** domain capabilities that hang off it (…, and the fleet-wide [key directory](./key_directory.md) built from cache events)."* |
  | Transport table ([lines 27-44](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/design/v1/mp_coordinator/README.md#L27-L44)) | 16 rows; none from `/directory`. | Adds four rows: `POST /directory/events` (mp → coordinator), `POST /directory/lookup` (consumer → coordinator), `POST /directory/lookup_tokens` (consumer → coordinator), `GET /directory/stats` (operator/tools). |
  | Layout box ([lines 55-80](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/design/v1/mp_coordinator/README.md#L55-L80)) | Missing `api.py`, `key_directory.py`, `http_apis/directory_api.py`, `utils/`. | All four are listed with a one-line description; the `dependencies.py` comment is updated to note the typed `CoordinatorContext`, which the `directory_api.py` handlers resolve via `get_context`. |
  | No key-directory section between the CacheBlend section (line 177) and `Concurrency & lifecycle` (line 189) | — | New "Key directory (`key_directory.py`)" section summarising the eventually-consistent + validate-on-use contract, the four `/directory/*` endpoints, and the `api.py` vs `schemas.py` split, with a link to the existing [`key_directory.md`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/docs/design/v1/mp_coordinator/key_directory.md) design doc for event-application semantics. |

## Proposed fix

Already applied in the PR diff — see the "Files changed" tab. Two
files touched:

- `docs/source/mp/coordinator.rst`
- `docs/design/v1/mp_coordinator/README.md`

## Code bugs surfaced (not fixed here)

None new from today's check. (The pre-existing
`lmcache_mp_connector_0180.py` docstring inversion flagged by the
2026-07-22 check ([#4199](https://github.com/LMCache/LMCache/pull/4199))
is still open at
[`lmcache_mp_connector_0180.py:456-458`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/integration/vllm/lmcache_mp_connector_0180.py#L456-L458);
and the `--runtime-plugin-config` CLI `--help` string mismatch flagged
by the 2026-07-27 check ([#4269](https://github.com/LMCache/LMCache/pull/4269))
at
[`config.py:325-327`](https://github.com/LMCache/LMCache/blob/b02e3ac91d2eba5af3210ec7038dfb4950cfbd01/lmcache/v1/multiprocess/config.py#L325-L327)
is still open. This PR does not re-flag them.)

**Special notes for your reviewers**:

Auto-generated by the daily docs drift-check routine. Needs human
review before merge. Kept as **draft**; not marked "Ready for review".
No code files touched.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea99NhaRC5etSivYb68UkU)_