### PR TITLE
[MP][Investigation] #4287 not reproduced; close

### DIFF
--- a/lmcache/v1/platform/cuda/cache_context.py
+++ b/lmcache/v1/platform/cuda/cache_context.py
@@ -434,11 +434,19 @@ class GPUCacheContext(BaseCacheContext):
         )
 
     def close(self) -> None:
-        """
-        Deregister this context's GDS staging buffer (reverse of __init__).
-        """
+        """Release GPU resources owned by this context."""
+        if not hasattr(self, "_temp_buffer"):
+            return
+
         with torch_dev.stream(self.cuda_stream_):
             get_gds_context().deregister_gpu_buffer(self._temp_buffer.buffer)
+
+        del self._temp_buffer
+        del self.group_kv_pointers_
+        del self.block_ids_buffer_
+        del self.kv_caches_
+        del self.cupy_stream_
+        del self.cuda_stream_
 
     @property
     def stream(self) -> Any:

--- a/tests/v1/platform/test_gpu_cache_context.py
+++ b/tests/v1/platform/test_gpu_cache_context.py
@@ -20,6 +20,8 @@ Two layers are exercised:
 
 # Standard
 from collections.abc import Sequence
+import gc
+import weakref
 
 # Third Party
 import pytest
@@ -456,6 +458,21 @@ class TestGPUCacheContextBuffers:
         shape, dtype = ctx.get_kernel_group_shape_dtype(256, 0)
         assert shape == _expected_kernel_group_shape(manager, 256, 0)
         assert dtype == manager.kernel_groups[0].dtype
+
+    def test_close_releases_device_tensor_ownership(self) -> None:
+        ctx = _make_context(_SINGLE_GROUP)
+        refs = [
+            weakref.ref(ctx._temp_buffer.buffer),
+            weakref.ref(ctx.block_ids_buffer_),
+            *[weakref.ref(pointer) for pointer in ctx.group_kv_pointers_],
+            *[weakref.ref(kv_cache) for kv_cache in ctx.kv_caches_],
+        ]
+
+        ctx.close()
+        ctx.close()
+        gc.collect()
+
+        assert all(ref() is None for ref in refs)
 
 
 class TestGPUCacheContextPointers:


### PR DESCRIPTION
## Status

Closed after reproducing the reported worker-exit lifecycle. This patch is not a validated fix for #4287.

## Validation

Fresh single-GPU environment:

- LMCache 0.5.2 + vLLM 0.22.0
- L1 CPU only; no GDS or L2 backend
- 28 CUDA-IPC KV tensors registered; 12 concurrent long-prefill requests
- vLLM process group terminated with `SIGKILL`

The LMCache server rose from its ~646 MiB registered-client baseline to 7,704 MiB immediately after the kill. The stale-worker reaper logged the client as reaped after 138.7 s, and server VRAM returned to 570 MiB. The same model then started successfully and read 13 L1 chunks from the retained cache.

The identical lifecycle was also run with LMCache 0.5.1: 7,704 MiB immediately after kill, reaped after 133.5 s, then returned to its 648 MiB baseline.

The vLLM 0.22 test used `VLLM_USE_FLASHINFER_SAMPLER=0` only to work around the RTX 5090 sampler compatibility path; the LMCache MP/KV-transfer path and released package versions were unchanged.

## Why this is closed

The observed transient IPC allocation is reclaimed by the existing worker reaper in both tested releases. This change only deletes fields from `GPUCacheContext.close()`; it does not demonstrate a fix for the Kubernetes report and should not be merged with a `Fixes #4287` claim. The original issue remains open for maintainer review against the reporter's exact cluster image and configuration.