### PR TITLE
ci(k3): mount 1Gi /dev/shm in multiprocess test pods

### DIFF
--- a/.buildkite/k3_tests/multiprocess/pipeline.yml
+++ b/.buildkite/k3_tests/multiprocess/pipeline.yml
@@ -16,6 +16,9 @@ x-flaky-retry: &flaky-retry
 
 # Keep the regular 1-GPU pod anchor available after the two lm_eval steps are
 # merged; engine_driven still needs its separate /dev/shm pod below.
+# Every pod mounts a 1Gi /dev/shm: the container runtime default is 64MB and
+# vLLM needs >160MB of shared memory. (The SHM-transport pods below mount a
+# much larger dshm volume instead.)
 x-pod-1gpu: &pod-1gpu
   containers:
     - name: container-0
@@ -24,8 +27,10 @@ x-pod-1gpu: &pod-1gpu
       resources: { limits: { "nvidia.com/gpu": "1" } }
       volumeMounts:
         - { name: hf-cache, mountPath: /root/.cache/huggingface }
+        - { name: dshm, mountPath: /dev/shm }
   volumes:
     - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
+    - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1Gi } }
 
 steps:
   - group: ":compression: Multiprocess (2-GPU)"
@@ -45,8 +50,10 @@ steps:
                     resources: { limits: { "nvidia.com/gpu": "2" } }
                     volumeMounts: &vol-mounts
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
+                      - { name: dshm, mountPath: /dev/shm }
                 volumes: &vols
                   - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
+                  - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1Gi } }
         artifact_paths: ["*.log"]
 
       - label: ":compression: long_doc_qa"
@@ -237,10 +244,12 @@ steps:
                       - { name: hf-cache, mountPath: /root/.cache/huggingface }
                       - { name: scratch, mountPath: /scratch }
                       - { name: udev, mountPath: /run/udev, readOnly: true }
+                      - { name: dshm, mountPath: /dev/shm }
                 volumes:
                   - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
                   - { name: scratch, hostPath: { path: /data/gds-scratch, type: DirectoryOrCreate } }
                   - { name: udev, hostPath: { path: /run/udev, type: Directory } }
+                  - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1Gi } }
         artifact_paths: ["*.log"]
 
   - group: ":compression: Multiprocess (CPU-only)"
@@ -318,6 +327,8 @@ steps:
                         key: GITHUB_TOKEN
                 volumeMounts:
                   - { name: hf-cache, mountPath: /root/.cache/huggingface }
+                  - { name: dshm, mountPath: /dev/shm }
             volumes:
               - { name: hf-cache, hostPath: { path: /data/huggingface, type: DirectoryOrCreate } }
+              - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1Gi } }
     artifact_paths: ["*.log"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the K3 multiprocess test failures caused by vLLM running out of shared memory. Pods without an explicit `/dev/shm` mount get the container runtime's 64MB default, but vLLM needs more than 160MB. This PR mounts a 1Gi memory-backed `emptyDir` at `/dev/shm` in the four pod specs that previously relied on the default:

- `pod-1gpu` anchor (hma_lm_eval_gemma4, fault_tolerance, restart_recovery, cache_stats, http_api)
- `pod-2gpu` anchor (vllm_bench, long_doc_qa, long_doc_qa_l2, deadlock, p2p, kimi_linear_tp)
- the `gds_smoke_test` pod
- the "Verify & pin vLLM nightly" pod

**Special notes for your reviewers**:

The SHM-transport pods (`pod-1gpu-dshm` at 128Gi, CPU-only e2e at 4Gi) already mount larger `/dev/shm` volumes and are unchanged.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)