### PR TITLE
[good-first-issue] storage: convert f-string log calls in redis_adapter.py to %-format (#4311)

### DIFF
--- a/lmcache/v1/storage_backend/connector/redis_adapter.py
+++ b/lmcache/v1/storage_backend/connector/redis_adapter.py
@@ -102,7 +102,7 @@ class RedisConnectorAdapter(ConnectorAdapter):
             ) or extra_config.get("redis_url")
             url = cfg_redis_url or remote_url or "redis://localhost:6379"
 
-        logger.info(f"Creating Redis connector for URL: {url}")
+        logger.info("Creating Redis connector for URL: %s", url)
         return RedisConnector(
             url=url,
             loop=context.loop,
@@ -120,7 +120,7 @@ class RedisSentinelConnectorAdapter(ConnectorAdapter):
         # Local
         from .redis_connector import RedisSentinelConnector
 
-        logger.info(f"Creating Redis Sentinel connector for URL: {context.url}")
+        logger.info("Creating Redis Sentinel connector for URL: %s", context.url)
         url = context.url[len(self.schema) :]
 
         # Parse username and password
@@ -165,7 +165,7 @@ class RedisClusterConnectorAdapter(ConnectorAdapter):
         # Local
         from .redis_connector import RedisClusterConnector
 
-        logger.info(f"Creating Redis Cluster connector for URL: {context.url}")
+        logger.info("Creating Redis Cluster connector for URL: %s", context.url)
         url = context.url[len(self.schema) :]
 
         # Parse username and password


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #4311
Refs #3372

Convert `logger.*(f\"...\")` calls in `lmcache/v1/storage_backend/connector/redis_adapter.py` to lazy `%-format` so arguments are interpolated only when the log record is emitted (ruff G004). No behavior change.

**Special notes for your reviewers**:
- Follow-up to the same lazy-logging pattern as #4142.
- Ran `ruff check --select G004` on the touched file — all green.
- Ran `ruff format` / `ruff check` on the touched file — all green.
- Commit includes DCO sign-off (`-s`).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

Made with [Cursor](https://cursor.com)