### PR TITLE
[good-first-issue] api_server: convert f-string log calls in api_server/__main__.py to %-format (#4315)

### DIFF
--- a/lmcache/v1/api_server/__main__.py
+++ b/lmcache/v1/api_server/__main__.py
@@ -78,7 +78,7 @@ def parse_extra_params(extra_args: list) -> Dict[str, Any]:
                     params[key] = value
             except ValueError:
                 params[key] = value
-            logger.info(f"Extra parameter: {key} = {params[key]}")
+            logger.info("Extra parameter: %s = %s", key, params[key])
     return params
 
 
@@ -517,19 +517,20 @@ def main():
         app = create_app(controller_urls, health_check_interval, lmcache_worker_timeout)
 
         logger.info(
-            f"Starting LMCache controller at "
-            f"{config.controller_host}:{config.controller_port}"
+            "Starting LMCache controller at %s:%s",
+            config.controller_host,
+            config.controller_port,
         )
         ports_message = f"Monitoring lmcache workers at ports {controller_urls}"
         logger.info(ports_message)
-        logger.info(f"Health check interval: {health_check_interval}s")
-        logger.info(f"Worker timeout: {lmcache_worker_timeout}s")
+        logger.info("Health check interval: %ss", health_check_interval)
+        logger.info("Worker timeout: %ss", lmcache_worker_timeout)
 
         uvicorn.run(app, host=config.controller_host, port=config.controller_port)
     except TimeoutError as e:
         logger.error(e)
     except Exception as e:
-        logger.error(f"Failed to start controller: {e}", exc_info=True)
+        logger.error("Failed to start controller: %s", e, exc_info=True)
         sys.exit(1)  # Exit with error code
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #4315
Refs #3372

Convert `logger.*(f\"...\")` calls in `lmcache/v1/api_server/__main__.py` to lazy `%-format` so arguments are interpolated only when the log record is emitted (ruff G004). No behavior change.

**Special notes for your reviewers**:
- Follow-up to the same lazy-logging pattern as #4142.
- Ran `ruff check --select G004` on the touched file — all green.
- Ran `ruff format` / `ruff check` on the touched file — all green.
- Commit includes DCO sign-off (`-s`).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

Made with [Cursor](https://cursor.com)