### PR TITLE
[good-first-issue] storage: convert f-string log calls in external_adapter.py to %-format (#4317)

### DIFF
--- a/lmcache/v1/storage_backend/connector/external_adapter.py
+++ b/lmcache/v1/storage_backend/connector/external_adapter.py
@@ -26,7 +26,7 @@ class ExternalConnectorAdapter(ConnectorAdapter):
         Examples:
         - external://host:0/external_log_connector.lmc_external_log_connector/?connector_name=ExternalLogConnector
         """
-        logger.info(f"Creating External connector for URL: {context.url}")
+        logger.info("Creating External connector for URL: %s", context.url)
         logger.warning(
             "External connector is due for deprecation in release v0.5.0. "
             "Please use the Remote Storage Plugin Framework instead."
@@ -67,7 +67,7 @@ class ExternalConnectorAdapter(ConnectorAdapter):
                 local_cpu_backend=context.local_cpu_backend,
                 config=context.config,
             )
-            logger.info(f"Loaded external connector: {module_path}.{connector_name}")
+            logger.info("Loaded external connector: %s.%s", module_path, connector_name)
             return connector
         except ImportError as e:
             raise ImportError(


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #4317
Refs #3372

Convert `logger.*(f\"...\")` calls in `lmcache/v1/storage_backend/connector/external_adapter.py` to lazy `%-format` so arguments are interpolated only when the log record is emitted (ruff G004). No behavior change.

**Special notes for your reviewers**:
- Follow-up to the same lazy-logging pattern as #4142.
- Ran `ruff check --select G004` on the touched file — all green.
- Ran `ruff format` / `ruff check` on the touched file — all green.
- Commit includes DCO sign-off (`-s`).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

Made with [Cursor](https://cursor.com)