### PR TITLE
[good-first-issue] storage: convert f-string log calls in s3-adapter.py to %-format (#4327)

### DIFF
--- a/lmcache/v1/storage_backend/connector/s3_adapter.py
+++ b/lmcache/v1/storage_backend/connector/s3_adapter.py
@@ -41,7 +41,7 @@ class S3ConnectorAdapter(ConnectorAdapter):
         if context.metadata is None:
             raise ValueError("metadata is required for S3Connector")
 
-        logger.info(f"Creating S3 connector for URL: {context.url}")
+        logger.info("Creating S3 connector for URL: %s", context.url)
 
         s3_endpoint = context.url
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #4327
Refs #3372

Convert `logger.*(f\"...\")` calls in `lmcache/v1/storage_backend/connector/s3_adapter.py` to lazy `%-format` (ruff G004). No behavior change.

**Special notes for your reviewers**:
- Follow-up to the same lazy-logging pattern as #4142.
- Ran `ruff check --select G004` / `ruff format` / `ruff check` — all green.
- Commit includes DCO sign-off (`-s`).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

Made with [Cursor](https://cursor.com)