### PR TITLE
[good-first-issue] storage: convert f-string log calls in lm-adapter.py to %-format (#4328)

### DIFF
--- a/lmcache/v1/storage_backend/connector/lm_adapter.py
+++ b/lmcache/v1/storage_backend/connector/lm_adapter.py
@@ -21,7 +21,7 @@ class LMServerConnectorAdapter(ConnectorAdapter):
         # Local
         from .lm_connector import LMCServerConnector
 
-        logger.info(f"Creating LM Server connector for URL: {context.url}")
+        logger.info("Creating LM Server connector for URL: %s", context.url)
         parse_url = parse_remote_url(context.url)
         return LMCServerConnector(
             host=parse_url.host,


### PR DESCRIPTION
**What this PR does / why we need it**:
Closes #4328
Refs #3372

Convert `logger.*(f\"...\")` calls in `lmcache/v1/storage_backend/connector/lm_adapter.py` to lazy `%-format` (ruff G004). No behavior change.

**Special notes for your reviewers**:
- Follow-up to the same lazy-logging pattern as #4142.
- Ran `ruff check --select G004` / `ruff format` / `ruff check` — all green.
- Commit includes DCO sign-off (`-s`).

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests

Made with [Cursor](https://cursor.com)