### PR TITLE
[Fix][P2P] Let StorageManager own the periodic notifier

### DIFF
--- a/lmcache/v1/distributed/config.py
+++ b/lmcache/v1/distributed/config.py
@@ -283,8 +283,9 @@ def normalize_storage_manager_config(config: StorageManagerConfig) -> None:
 def validate_storage_manager_config(config: StorageManagerConfig) -> None:
     """Validate storage manager configuration.
 
-    This rejects L2 adapters that require a single contiguous L1 memory
-    descriptor when hybrid L1 Device-DAX overflow is enabled.
+    This rejects non-positive notifier intervals and L2 adapters that require
+    a single contiguous L1 memory descriptor when hybrid L1 Device-DAX
+    overflow is enabled.
 
     Args:
         config: Storage manager configuration to validate.
@@ -293,9 +294,13 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
         None.
 
     Raises:
-        ValueError: If mutually exclusive L1 tiers are both configured, or
-            hybrid L1 is paired with incompatible L2 adapters.
+        ValueError: If the notifier interval is not positive, mutually
+            exclusive L1 tiers are both configured, or hybrid L1 is paired
+            with incompatible L2 adapters.
     """
+    if config.periodic_notifier_interval_ms <= 0:
+        raise ValueError("periodic_notifier_interval_ms must be greater than 0")
+
     if (
         config.l1_manager_config.gds_l1_config is not None
         and config.l1_manager_config.memory_config.devdax_path

--- a/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
+++ b/lmcache/v1/distributed/l2_adapters/p2p_l2_adapter.py
@@ -44,7 +44,7 @@ from lmcache.v1.platform import HAS_EVENTFD, create_event_notifier
 logger = init_logger(__name__)
 
 _LOOKUP_RPC_TIMEOUT_S = 3.0
-_PERIODIC_NOTIFIER_INTERVAL_MS = 5
+_FALLBACK_NOTIFIER_INTERVAL_MS = 5
 
 
 @dataclass
@@ -144,10 +144,13 @@ class P2PL2Adapter(L2AdapterInterface):
         self._lookup_efd = create_event_notifier()
         self._load_efd = create_event_notifier()
 
-        PeriodicEventNotifier.create(
-            interval_ms=_PERIODIC_NOTIFIER_INTERVAL_MS, use_eventfd=HAS_EVENTFD
-        )
         notifier = PeriodicEventNotifier.get()
+        if notifier is None:
+            PeriodicEventNotifier.create(
+                interval_ms=_FALLBACK_NOTIFIER_INTERVAL_MS,
+                use_eventfd=HAS_EVENTFD,
+            )
+            notifier = PeriodicEventNotifier.get()
         if notifier is None:
             raise RuntimeError("PeriodicEventNotifier is unavailable after create()")
         self._notifier = notifier

--- a/lmcache/v1/distributed/storage_manager.py
+++ b/lmcache/v1/distributed/storage_manager.py
@@ -89,15 +89,16 @@ class StorageManager:
         self._registered_l2_listeners: list[L2AdapterListener] = []
         self._l2_adapters: dict[int, L2AdapterInterface] = {}
         self._adapter_descriptors: dict[int, AdapterDescriptor] = {}
-        for ac in config.l2_adapter_config.adapters:
-            adapter_id, adapter, descriptor = self._build_l2_adapter(ac)
-            self._l2_adapters[adapter_id] = adapter
-            self._adapter_descriptors[adapter_id] = descriptor
 
         PeriodicEventNotifier.create(
             interval_ms=config.periodic_notifier_interval_ms,
             use_eventfd=HAS_EVENTFD,
         )
+
+        for ac in config.l2_adapter_config.adapters:
+            adapter_id, adapter, descriptor = self._build_l2_adapter(ac)
+            self._l2_adapters[adapter_id] = adapter
+            self._adapter_descriptors[adapter_id] = descriptor
 
         # Per-cache_salt quota registry. Shared across the L2 eviction
         # controller (reads quotas each cycle) and the HTTP quota
@@ -969,10 +970,10 @@ class StorageManager:
         self._eviction_controller.stop()
         self._l2_eviction_controller.stop()
 
-        PeriodicEventNotifier.shutdown()
-
         for adapter in self._l2_adapters.values():
             adapter.close()
+
+        PeriodicEventNotifier.shutdown()
 
         self._l1_manager.close()
 

--- a/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py
+++ b/tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py
@@ -2,6 +2,7 @@
 """Unit tests for the P2P L2 adapter (mocked MQ client + transfer channel)."""
 
 # Standard
+from collections.abc import Iterator
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 import time
@@ -71,6 +72,31 @@ def _adapter(lookup_timeout_s: float = 10.0, load_timeout_s: float = 10.0):
         adapter = P2PL2Adapter(config)
         try:
             yield adapter, mq, tc_ctx, tc_client, notifier
+        finally:
+            adapter.close()
+
+
+@contextmanager
+def _adapter_with_notifier_class(
+    notifier_exists: bool,
+) -> Iterator[tuple[P2PL2Adapter, MagicMock]]:
+    mq = MagicMock()
+    tc_ctx = MagicMock()
+    tc_ctx.get_transfer_channel_client.return_value = MagicMock()
+    notifier = MagicMock()
+
+    with (
+        patch.object(p2p_mod, "MessageQueueClient", return_value=mq),
+        patch.object(p2p_mod, "get_transfer_channel_context", return_value=tc_ctx),
+        patch.object(p2p_mod, "PeriodicEventNotifier") as mock_pen,
+    ):
+        if notifier_exists:
+            mock_pen.get.return_value = notifier
+        else:
+            mock_pen.get.side_effect = [None, notifier]
+        adapter = P2PL2Adapter(P2PL2AdapterConfig("tcp://peer:5555", "peer:7600"))
+        try:
+            yield adapter, mock_pen
         finally:
             adapter.close()
 
@@ -146,6 +172,20 @@ def test_factory_creates_adapter():
 # ---------------------------------------------------------------------------
 # Event fds + notifier registration
 # ---------------------------------------------------------------------------
+
+
+def test_existing_notifier_is_reused_without_changing_its_interval() -> None:
+    with _adapter_with_notifier_class(notifier_exists=True) as (_adapter, mock_pen):
+        mock_pen.create.assert_not_called()
+
+
+def test_standalone_adapter_creates_fallback_notifier() -> None:
+    with _adapter_with_notifier_class(notifier_exists=False) as (_adapter, mock_pen):
+        mock_pen.create.assert_called_once_with(
+            interval_ms=5,
+            use_eventfd=p2p_mod.HAS_EVENTFD,
+        )
+        assert mock_pen.get.call_count == 2
 
 
 def test_event_fds_are_distinct_and_registered():
@@ -318,7 +358,13 @@ def test_load_not_finished_returns_none():
 
 def test_load_deadline_expired_yields_failure():
     keys = [_key(0)]
-    with _adapter(load_timeout_s=0.01) as (adapter, _mq, _tc_ctx, tc_client, _notifier):
+    with _adapter(load_timeout_s=0.01) as (
+        adapter,
+        _mq,
+        _tc_ctx,
+        tc_client,
+        _notifier,
+    ):
         adapter._remote_addresses[keys[0]] = TransferChannelAddress(offset=100, size=10)
         tc_client.submit_read.return_value = 1
         task_id = adapter.submit_load_task(

--- a/tests/v1/distributed/test_periodic_notifier_ownership.py
+++ b/tests/v1/distributed/test_periodic_notifier_ownership.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for PeriodicEventNotifier ownership in the distributed storage path."""
+
+# Standard
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+# Third Party
+import pytest
+
+# First Party
+from lmcache.v1.distributed import storage_manager as storage_manager_mod
+from lmcache.v1.distributed.config import (
+    EvictionConfig,
+    L1ManagerConfig,
+    L1MemoryManagerConfig,
+    StorageManagerConfig,
+)
+from lmcache.v1.distributed.l2_adapters import p2p_l2_adapter as p2p_mod
+from lmcache.v1.distributed.l2_adapters.config import (
+    L2AdapterConfigBase,
+    L2AdaptersConfig,
+)
+from lmcache.v1.distributed.l2_adapters.p2p_l2_adapter import P2PL2AdapterConfig
+from lmcache.v1.distributed.storage_manager import StorageManager
+from lmcache.v1.platform import HAS_EVENTFD
+
+
+def _p2p_config() -> P2PL2AdapterConfig:
+    return P2PL2AdapterConfig(
+        peer_mq_server_url="tcp://peer:5555",
+        peer_transfer_channel_server_url="peer:7600",
+    )
+
+
+def _storage_config(
+    adapters: list[L2AdapterConfigBase],
+    interval_ms: int,
+) -> StorageManagerConfig:
+    return StorageManagerConfig(
+        l1_manager_config=L1ManagerConfig(
+            memory_config=L1MemoryManagerConfig(
+                size_in_bytes=4096,
+                use_lazy=False,
+                init_size_in_bytes=4096,
+            ),
+            write_ttl_seconds=600,
+            read_ttl_seconds=300,
+        ),
+        eviction_config=EvictionConfig(eviction_policy="LRU"),
+        l2_adapter_config=L2AdaptersConfig(adapters),
+        periodic_notifier_interval_ms=interval_ms,
+    )
+
+
+@contextmanager
+def _manager_with_mocked_runtime(
+    config: StorageManagerConfig,
+) -> Iterator[tuple[StorageManager, MagicMock, MagicMock]]:
+    l1_manager = MagicMock()
+    notifier = MagicMock()
+    notifier_class = MagicMock()
+    notifier_class.get.side_effect = lambda: (
+        notifier if notifier_class.create.called else None
+    )
+
+    transfer_context = MagicMock()
+    transfer_context.get_transfer_channel_client.return_value = MagicMock()
+
+    with (
+        patch.object(storage_manager_mod, "L1Manager", return_value=l1_manager),
+        patch.object(storage_manager_mod, "L1EvictionController"),
+        patch.object(storage_manager_mod, "L2EvictionController"),
+        patch.object(storage_manager_mod, "StoreController"),
+        patch.object(storage_manager_mod, "PrefetchController"),
+        patch.object(storage_manager_mod, "PeriodicEventNotifier", notifier_class),
+        patch.object(storage_manager_mod, "get_event_bus"),
+        patch.object(storage_manager_mod, "register_gauge"),
+        patch.object(p2p_mod, "PeriodicEventNotifier", notifier_class),
+        patch.object(p2p_mod, "MessageQueueClient", return_value=MagicMock()),
+        patch.object(
+            p2p_mod,
+            "get_transfer_channel_context",
+            return_value=transfer_context,
+        ),
+    ):
+        manager = StorageManager(config)
+        try:
+            yield manager, notifier_class, notifier
+        finally:
+            if notifier_class.shutdown.call_count == 0:
+                manager.close()
+
+
+def test_initial_p2p_adapter_uses_storage_manager_interval() -> None:
+    config = _storage_config([_p2p_config()], interval_ms=73)
+
+    with _manager_with_mocked_runtime(config) as (
+        _manager,
+        notifier_class,
+        _notifier,
+    ):
+        notifier_class.create.assert_called_once_with(
+            interval_ms=73,
+            use_eventfd=HAS_EVENTFD,
+        )
+
+
+def test_runtime_p2p_adapter_does_not_change_existing_interval() -> None:
+    config = _storage_config([], interval_ms=91)
+
+    with _manager_with_mocked_runtime(config) as (
+        manager,
+        notifier_class,
+        _notifier,
+    ):
+        manager.add_l2_adapter(_p2p_config())
+
+        notifier_class.create.assert_called_once_with(
+            interval_ms=91,
+            use_eventfd=HAS_EVENTFD,
+        )
+
+
+def test_p2p_fds_are_unregistered_before_notifier_shutdown() -> None:
+    config = _storage_config([_p2p_config()], interval_ms=5)
+    lifecycle_calls: list[tuple[str, int | None]] = []
+
+    with _manager_with_mocked_runtime(config) as (
+        manager,
+        notifier_class,
+        notifier,
+    ):
+        notifier.unregister_fd.side_effect = lambda fd: lifecycle_calls.append(
+            ("unregister", fd)
+        )
+        notifier_class.shutdown.side_effect = lambda: lifecycle_calls.append(
+            ("shutdown", None)
+        )
+
+        manager.close()
+
+        assert lifecycle_calls[-1] == ("shutdown", None)
+        assert [name for name, _fd in lifecycle_calls].count("unregister") == 2
+
+
+@pytest.mark.parametrize("interval_ms", [0, -1])
+def test_storage_manager_config_rejects_nonpositive_notifier_interval(
+    interval_ms: int,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="periodic_notifier_interval_ms must be greater than 0",
+    ):
+        _storage_config([], interval_ms=interval_ms)


### PR DESCRIPTION
**What this PR does / why we need it**:

When P2P was configured as an initial L2 adapter, it created the process-wide notifier with a hard-coded 5 ms interval before `StorageManager` could apply `periodic_notifier_interval_ms`. Because subsequent notifier creation is a no-op, the configured interval was silently ignored. During shutdown, `StorageManager` also destroyed the native notifier before P2P adapters unregistered their file descriptors, leaving those adapters with an invalid native reference during `close()`.

- Create the periodic notifier before constructing initial L2 adapters so the configured interval takes precedence.
- Reuse the existing notifier in P2P adapters, creating a 5 ms fallback only when an adapter is constructed without one.
- Avoid notifier creation attempts when P2P adapters are added at runtime.
- Close L2 adapters and unregister their file descriptors before shutting down the native notifier.
- Reject zero and negative periodic notifier intervals.
- Add regression coverage for initial and runtime P2P construction, fallback behavior, shutdown ordering, and invalid intervals.

**Special notes for your reviewers**:

- The notifier remains process-wide; the P2P fallback supports direct adapter construction when no manager-created notifier exists.
- Tested by:

```bash
pytest -xvs tests/v1/distributed/l2_adapters/test_p2p_l2_adapter.py tests/v1/distributed/test_periodic_notifier_ownership.py
```

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [x] this PR contains unit tests
