### PR TITLE
[Fix][Native Connector] Include errno in Redis socket error messages

### DIFF
--- a/csrc/storage_backends/redis/connector.cpp
+++ b/csrc/storage_backends/redis/connector.cpp
@@ -4,6 +4,7 @@
 #include <cerrno>
 #include <stdexcept>
 #include <string_view>
+#include <system_error>
 
 namespace lmcache {
 namespace connector {
@@ -15,7 +16,8 @@ void WorkerConn::connect(const std::string& h, int p) {
   // 1. create socket
   fd = socket(AF_INET, SOCK_STREAM, 0);
   if (fd < 0) {
-    throw std::runtime_error("failed to create socket");
+    throw std::runtime_error("failed to create socket: " +
+                             std::system_category().message(errno));
   }
 
   // 2. resolve host
@@ -34,9 +36,12 @@ void WorkerConn::connect(const std::string& h, int p) {
 
   // 3. connect to host
   if (::connect(fd, result->ai_addr, result->ai_addrlen) < 0) {
+    // capture errno before freeaddrinfo/close can overwrite it
+    const int connect_errno = errno;
     freeaddrinfo(result);
     ::close(fd);
-    throw std::runtime_error("connection failed");
+    throw std::runtime_error("connection failed: " +
+                             std::system_category().message(connect_errno));
   }
 
   freeaddrinfo(result);
@@ -52,7 +57,8 @@ void WorkerConn::send_all(const void* data, size_t len) {
       if (errno == EINTR) {
         continue;  // retry on EINTR
       }
-      throw std::runtime_error("socket send failed");
+      throw std::runtime_error("socket send failed: " +
+                               std::system_category().message(errno));
     }
     if (n == 0) {
       throw std::runtime_error("socket send failed: connection closed");
@@ -86,7 +92,8 @@ void WorkerConn::send_multipart(
       if (errno == EINTR) {
         continue;
       }
-      throw std::runtime_error("socket writev failed");
+      throw std::runtime_error("socket writev failed: " +
+                               std::system_category().message(errno));
     }
     if (n == 0) {
       throw std::runtime_error("socket writev failed: connection closed");
@@ -119,7 +126,8 @@ void WorkerConn::recv_exactly(void* buf, size_t len) {
       if (errno == EINTR) {
         continue;
       }
-      throw std::runtime_error("socket recv failed");
+      throw std::runtime_error("socket recv failed: " +
+                               std::system_category().message(errno));
     }
     if (n == 0) {
       throw std::runtime_error("socket recv failed: connection closed");


### PR DESCRIPTION
<!-- Refs #3565 for the same class of defect on the Python LMCServerConnector path. -->

**What this PR does / why we need it**:

Socket failures in the Redis native connector are currently unactionable. Every failing syscall raises a bare message, so an L2 store failure reaches the MP server log as:

```
LMCache WARNING: Native store sub-batch failed (9 keys): socket writev failed
```

That line does not say whether the peer closed the connection (EPIPE), reset it (ECONNRESET), the send buffer filled (EAGAIN), or the server stopped responding (ETIMEDOUT). Each points at a different fix, and there is nothing in the log to choose between them.

I hit this on a Gemma serving deployment where every L2 store failed for the whole log window: 391 store tasks, 9486 keys, 0 succeeded, `L2 usage 0.00` throughout. Working out which syscall produced the message meant reading the C++ source, and the errno itself was already gone by then.

This appends the errno description to the five socket syscalls (`socket`, `connect`, `send`, `writev`, `recv`). The same line then reads:

```
LMCache WARNING: Native store sub-batch failed (9 keys): socket writev failed: Broken pipe
```

**Special notes for your reviewers**:

1. The `Native store sub-batch failed` prefix above comes from #4211 and is not on `dev` yet, where the adapter drops the native error string without logging it. This PR stands alone regardless: it changes what the C++ side puts in the exception, so the errno text shows up at whatever call site prints it.

2. `connect()` copies errno into a local before `freeaddrinfo` and `close` run. Both can overwrite errno, which would report an unrelated code in place of the connect failure.

3. This uses `std::system_category().message()` rather than `strerror()`. `csrc/storage_backends/fs/connector.cpp` already appends `strerror(errno)` in the same position, but that backend is single-threaded. `RedisConnector` runs one worker thread per connection and `strerror` returns a shared static buffer, so simultaneous worker failures would race on it. In the log above the failure rate held around 120/second across workers, so it is reachable in practice.

Message text is the only change. Exception types stay the same, so existing catch sites are unaffected.

**If applicable**:

- [ ] this PR contains user facing changes - docs added
- [ ] this PR contains unit tests
